### PR TITLE
feat(workspace-store): generate sidebar entries

### DIFF
--- a/.changeset/silent-files-divide.md
+++ b/.changeset/silent-files-divide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': minor
+---
+
+feat(workspace-store): generate sidebar entries

--- a/packages/workspace-store/package.json
+++ b/packages/workspace-store/package.json
@@ -57,7 +57,10 @@
     "@scalar/openapi-parser": "workspace:*",
     "@scalar/openapi-types": "workspace:*",
     "@sinclair/typebox": "catalog:*",
-    "vue": "catalog:*"
+    "vue": "catalog:*",
+    "@scalar/types": "workspace:*",
+    "@scalar/code-highlight": "workspace:*",
+    "github-slugger": "^2.0.0"
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",

--- a/packages/workspace-store/package.json
+++ b/packages/workspace-store/package.json
@@ -60,6 +60,7 @@
     "vue": "catalog:*",
     "@scalar/types": "workspace:*",
     "@scalar/code-highlight": "workspace:*",
+    "@scalar/helpers": "workspace:*",
     "github-slugger": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -26,9 +26,6 @@ type WorkspaceDocumentInput =
  * // Resolve from URL
  * const urlDoc = await loadDocument({ name: 'api', url: 'https://api.example.com/openapi.json' })
  *
- * // Resolve from local file
- * const fileDoc = await loadDocument({ name: 'local', path: './openapi.json' })
- *
  * // Resolve direct document
  * const directDoc = await loadDocument({
  *   name: 'inline',

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -211,7 +211,7 @@ export function createWorkspaceStoreSync(workspaceProps?: {
 
       const document = resolve.data
 
-      // If we already have a sparse document with already build sidebar server side we can skip this step
+      // Skip navigation generation if the document already has a server-side generated navigation structure
       if (document[SCALAR_NAVIGATION_EXTENSION_KEY] === undefined) {
         document[SCALAR_NAVIGATION_EXTENSION_KEY] = traverseDocument(document, input.config ?? {}).entries
       }

--- a/packages/workspace-store/src/server.test.ts
+++ b/packages/workspace-store/src/server.test.ts
@@ -86,9 +86,8 @@ describe('create-server-store', () => {
           {
             id: 'List planets',
             method: 'get',
-            operation: {
-              summary: 'List planets',
-            },
+            type: 'operation',
+            'ref': '#/paths/~1planets/get',
             path: '/planets',
             title: 'List planets',
           },
@@ -177,9 +176,8 @@ describe('create-server-store', () => {
           {
             id: 'List planets',
             method: 'get',
-            operation: {
-              summary: 'List planets',
-            },
+            type: 'operation',
+            'ref': '#/paths/~1planets/get',
             path: '/planets',
             title: 'List planets',
           },
@@ -210,9 +208,8 @@ describe('create-server-store', () => {
           {
             id: 'List planets',
             method: 'get',
-            operation: {
-              summary: 'List planets',
-            },
+            type: 'operation',
+            'ref': '#/paths/~1planets/get',
             path: '/planets',
             title: 'List planets',
           },
@@ -282,11 +279,10 @@ describe('create-server-store', () => {
               {
                 id: 'List planets',
                 method: 'get',
-                operation: {
-                  summary: 'List planets',
-                },
                 path: '/planets',
                 title: 'List planets',
+                type: 'operation',
+                'ref': '#/paths/~1planets/get',
               },
             ],
           },
@@ -312,9 +308,8 @@ describe('create-server-store', () => {
               {
                 id: 'List planets',
                 method: 'get',
-                operation: {
-                  summary: 'List planets',
-                },
+                type: 'operation',
+                'ref': '#/paths/~1planets/get',
                 path: '/planets',
                 title: 'List planets',
               },

--- a/packages/workspace-store/src/server.test.ts
+++ b/packages/workspace-store/src/server.test.ts
@@ -82,6 +82,17 @@ describe('create-server-store', () => {
             },
           },
         },
+        'x-scalar-navigation': [
+          {
+            id: 'List planets',
+            method: 'get',
+            operation: {
+              summary: 'List planets',
+            },
+            path: '/planets',
+            title: 'List planets',
+          },
+        ],
       })
 
       expect(store.getWorkspace()).toEqual({
@@ -162,6 +173,17 @@ describe('create-server-store', () => {
           },
         },
         'x-scalar-active-auth': 'test',
+        'x-scalar-navigation': [
+          {
+            id: 'List planets',
+            method: 'get',
+            operation: {
+              summary: 'List planets',
+            },
+            path: '/planets',
+            title: 'List planets',
+          },
+        ],
       })
 
       expect(workspace.documents['doc-3']).toEqual({
@@ -184,6 +206,17 @@ describe('create-server-store', () => {
           },
         },
         'x-scalar-active-auth': 'test',
+        'x-scalar-navigation': [
+          {
+            id: 'List planets',
+            method: 'get',
+            operation: {
+              summary: 'List planets',
+            },
+            path: '/planets',
+            title: 'List planets',
+          },
+        ],
       })
     })
   })
@@ -222,8 +255,10 @@ describe('create-server-store', () => {
 
       const basePath = `${cwd()}/${dir}`
 
+      const sparseWorkspace = await fs.readFile(`${basePath}/scalar-workspace.json`, { encoding: 'utf-8' })
+
       // check the workspace is the correct format
-      expect(JSON.parse(await fs.readFile(`${basePath}/scalar-workspace.json`, { encoding: 'utf-8' }))).toEqual({
+      expect(JSON.parse(sparseWorkspace)).toEqual({
         documents: {
           'doc-1': {
             'x-scalar-active-auth': 'test',
@@ -243,6 +278,17 @@ describe('create-server-store', () => {
                 planetId: { '$ref': 'temp/chunks/doc-1/components/parameters/planetId.json#', $global: true },
               },
             },
+            'x-scalar-navigation': [
+              {
+                id: 'List planets',
+                method: 'get',
+                operation: {
+                  summary: 'List planets',
+                },
+                path: '/planets',
+                title: 'List planets',
+              },
+            ],
           },
           'doc-2': {
             'x-scalar-active-auth': 'test',
@@ -262,6 +308,17 @@ describe('create-server-store', () => {
                 planetId: { '$ref': 'temp/chunks/doc-2/components/parameters/planetId.json#', $global: true },
               },
             },
+            'x-scalar-navigation': [
+              {
+                id: 'List planets',
+                method: 'get',
+                operation: {
+                  summary: 'List planets',
+                },
+                path: '/planets',
+                title: 'List planets',
+              },
+            ],
           },
         },
         'x-scalar-active-document': 'test',
@@ -288,7 +345,6 @@ describe('create-server-store', () => {
         ]),
       ).toBe(true)
 
-      // clean up generated files
       await fs.rmdir(basePath, { recursive: true })
     })
   })

--- a/packages/workspace-store/src/server.ts
+++ b/packages/workspace-store/src/server.ts
@@ -9,29 +9,25 @@ import { SCALAR_NAVIGATION_EXTENSION_KEY, traverseDocument, type TraverseSpecOpt
 const DEFAULT_ASSETS_FOLDER = 'assets'
 export const WORKSPACE_FILE_NAME = 'scalar-workspace.json'
 
+// TODO: support input document from different sources
+type CreateServerWorkspaceStoreBase = {
+  documents: {
+    name: string
+    document: Record<string, unknown> | string
+    meta?: WorkspaceDocumentMeta
+  }[]
+  meta?: WorkspaceMeta
+  config?: TraverseSpecOptions
+}
 type CreateServerWorkspaceStore =
-  | {
+  | ({
       directory?: string
       mode: 'static'
-      documents: {
-        name: string
-        document: Record<string, unknown> | string
-        meta?: WorkspaceDocumentMeta
-      }[]
-      meta?: WorkspaceMeta
-      config?: TraverseSpecOptions
-    }
-  | {
+    } & CreateServerWorkspaceStoreBase)
+  | ({
       baseUrl: string
       mode: 'ssr'
-      documents: {
-        name: string
-        document: Record<string, unknown> | string
-        meta?: WorkspaceDocumentMeta
-      }[]
-      meta?: WorkspaceMeta
-      config?: TraverseSpecOptions
-    }
+    } & CreateServerWorkspaceStoreBase)
 
 const httpMethods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'])
 

--- a/packages/workspace-store/src/server.ts
+++ b/packages/workspace-store/src/server.ts
@@ -4,6 +4,7 @@ import { getValueByPath, parseJsonPointer } from './helpers/json-path-utils'
 import type { WorkspaceDocumentMeta, WorkspaceMeta } from './schemas/server-workspace'
 import fs from 'node:fs/promises'
 import { cwd } from 'node:process'
+import type { TraverseSpecOptions } from '@/traverse-schema'
 
 const DEFAULT_ASSETS_FOLDER = 'assets'
 export const WORKSPACE_FILE_NAME = 'scalar-workspace.json'
@@ -18,6 +19,7 @@ type CreateServerWorkspaceStore =
         meta?: WorkspaceDocumentMeta
       }[]
       meta?: WorkspaceMeta
+      config: TraverseSpecOptions
     }
   | {
       baseUrl: string
@@ -28,6 +30,7 @@ type CreateServerWorkspaceStore =
         meta?: WorkspaceDocumentMeta
       }[]
       meta?: WorkspaceMeta
+      config: TraverseSpecOptions
     }
 
 const httpMethods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'])
@@ -169,6 +172,9 @@ export function externalizePathReferences(
 export function createServerWorkspaceStore(workspaceProps: CreateServerWorkspaceStore) {
   const documents = workspaceProps.documents.map((el) => {
     const document = upgrade(el.document).specification
+
+    // Here we create the sidebar
+    // TODO: run the sidebar creation
 
     return { ...el, document }
   })

--- a/packages/workspace-store/src/traverse-schema/helpers/get-tag.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/get-tag.test.ts
@@ -1,0 +1,60 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { describe, expect, it } from 'vitest'
+import { getTag } from './get-tag'
+
+describe('getTag', () => {
+  it('returns existing tag from the dictionary', () => {
+    const tagsDict = new Map<string, OpenAPIV3_1.TagObject>()
+    const existingTag = { name: 'test-tag', description: 'Test description' }
+    tagsDict.set('test-tag', existingTag)
+
+    const result = getTag(tagsDict, 'test-tag')
+
+    expect(result).toBe(existingTag)
+    expect(tagsDict.size).toBe(1)
+  })
+
+  it('creates and returns a new tag if it does not exist', () => {
+    const tagsDict = new Map<string, OpenAPIV3_1.TagObject>()
+    const tagName = 'new-tag'
+
+    const result = getTag(tagsDict, tagName)
+
+    expect(result).toEqual({ name: tagName })
+    expect(tagsDict.size).toBe(1)
+    expect(tagsDict.get(tagName)).toEqual({ name: tagName })
+  })
+
+  it('handles multiple tags in the dictionary', () => {
+    const tagsDict = new Map<string, OpenAPIV3_1.TagObject>()
+    const tag1 = { name: 'tag1', description: 'First tag' }
+    const tag2 = { name: 'tag2', description: 'Second tag' }
+    tagsDict.set('tag1', tag1)
+    tagsDict.set('tag2', tag2)
+
+    const result1 = getTag(tagsDict, 'tag1')
+    const result2 = getTag(tagsDict, 'tag2')
+    const result3 = getTag(tagsDict, 'tag3')
+
+    expect(result1).toBe(tag1)
+    expect(result2).toBe(tag2)
+    expect(result3).toEqual({ name: 'tag3' })
+    expect(tagsDict.size).toBe(3)
+  })
+
+  it('preserves existing tag properties when retrieving', () => {
+    const tagsDict = new Map<string, OpenAPIV3_1.TagObject>()
+    const existingTag = {
+      name: 'test-tag',
+      description: 'Test description',
+      externalDocs: { url: 'https://example.com' },
+    }
+    tagsDict.set('test-tag', existingTag)
+
+    const result = getTag(tagsDict, 'test-tag')
+
+    expect(result).toEqual(existingTag)
+    expect(result.description).toBe('Test description')
+    expect(result.externalDocs?.url).toBe('https://example.com')
+  })
+})

--- a/packages/workspace-store/src/traverse-schema/helpers/get-tag.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/get-tag.ts
@@ -1,0 +1,15 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
+/** Grabs the tag from the dict or creates one if it doesn't exist */
+export const getTag = (tagsDict: Map<string, OpenAPIV3_1.TagObject>, name: string) => {
+  // Ensure the tag exists in the spec
+  let tag = tagsDict.get(name)
+
+  // If not we add it
+  if (!tag) {
+    tag = { name }
+    tagsDict.set(name, tag)
+  }
+
+  return tag
+}

--- a/packages/workspace-store/src/traverse-schema/helpers/operation-id-params.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/operation-id-params.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest'
+import type { TransformedOperation } from '@scalar/types/legacy'
+import { operationIdParams } from './operation-id-params'
+
+describe('operationIdParams', () => {
+  it('should transform a basic operation correctly', () => {
+    const transformedOperation: TransformedOperation = {
+      path: '/users',
+      httpVerb: 'GET',
+      information: {
+        summary: 'Get users',
+        operationId: 'getUsers',
+        responses: {
+          '200': {
+            description: 'OK',
+          },
+        },
+      },
+    }
+
+    const result = operationIdParams(transformedOperation)
+
+    expect(result).toEqual({
+      summary: 'Get users',
+      operationId: 'getUsers',
+      responses: {
+        '200': {
+          description: 'OK',
+        },
+      },
+      path: '/users',
+      method: 'get',
+    })
+  })
+
+  it('should handle operations with parameters', () => {
+    const transformedOperation: TransformedOperation = {
+      path: '/users/{id}',
+      httpVerb: 'GET',
+      information: {
+        summary: 'Get user by ID',
+        operationId: 'getUserById',
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'OK',
+          },
+        },
+      },
+    }
+
+    const result = operationIdParams(transformedOperation)
+
+    expect(result).toEqual({
+      summary: 'Get user by ID',
+      operationId: 'getUserById',
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          schema: {
+            type: 'string',
+          },
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'OK',
+        },
+      },
+      path: '/users/{id}',
+      method: 'get',
+    })
+  })
+
+  it('should handle operations with request body', () => {
+    const transformedOperation: TransformedOperation = {
+      path: '/users',
+      httpVerb: 'POST',
+      information: {
+        summary: 'Create user',
+        operationId: 'createUser',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '201': {
+            description: 'Created',
+          },
+        },
+      },
+    }
+
+    const result = operationIdParams(transformedOperation)
+
+    expect(result).toEqual({
+      summary: 'Create user',
+      operationId: 'createUser',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        '201': {
+          description: 'Created',
+        },
+      },
+      path: '/users',
+      method: 'post',
+    })
+  })
+
+  it('should handle operations with security requirements', () => {
+    const transformedOperation: TransformedOperation = {
+      path: '/users/me',
+      httpVerb: 'GET',
+      information: {
+        summary: 'Get current user',
+        operationId: 'getCurrentUser',
+        security: [
+          {
+            bearerAuth: [],
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'OK',
+          },
+        },
+      },
+    }
+
+    const result = operationIdParams(transformedOperation)
+
+    expect(result).toEqual({
+      summary: 'Get current user',
+      operationId: 'getCurrentUser',
+      security: [
+        {
+          bearerAuth: [],
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'OK',
+        },
+      },
+      path: '/users/me',
+      method: 'get',
+    })
+  })
+
+  it('should handle operations with tags', () => {
+    const transformedOperation: TransformedOperation = {
+      path: '/users',
+      httpVerb: 'GET',
+      information: {
+        summary: 'Get users',
+        operationId: 'getUsers',
+        tags: ['users'],
+        responses: {
+          '200': {
+            description: 'OK',
+          },
+        },
+      },
+    }
+
+    const result = operationIdParams(transformedOperation)
+
+    expect(result).toEqual({
+      summary: 'Get users',
+      operationId: 'getUsers',
+      tags: ['users'],
+      responses: {
+        '200': {
+          description: 'OK',
+        },
+      },
+      path: '/users',
+      method: 'get',
+    })
+  })
+})

--- a/packages/workspace-store/src/traverse-schema/helpers/operation-id-params.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/operation-id-params.ts
@@ -1,0 +1,14 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { TransformedOperation } from '@scalar/types/legacy'
+
+/** Temp helper for converting transformed operation to operationId payload */
+export const operationIdParams = (
+  transformedOperation: TransformedOperation,
+): {
+  path: string
+  method: OpenAPIV3_1.HttpMethods
+} & OpenAPIV3_1.OperationObject => ({
+  ...(transformedOperation.information as OpenAPIV3_1.OperationObject),
+  path: transformedOperation.path,
+  method: transformedOperation.httpVerb.toLowerCase() as OpenAPIV3_1.HttpMethods,
+})

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-description.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-description.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest'
+import { traverseDescription } from './traverse-description'
+import type { Heading } from '@scalar/types/legacy'
+
+describe('traverseDescription', () => {
+  const getHeadingId = (heading: Heading) => `heading-${heading.value.toLowerCase().replace(/\s+/g, '-')}`
+
+  it('should return empty array for undefined description', () => {
+    const titlesMap = new Map<string, string>()
+    const result = traverseDescription(undefined, titlesMap, getHeadingId)
+    expect(result).toEqual([])
+    expect(titlesMap.size).toBe(0)
+  })
+
+  it('should return empty array for empty description', () => {
+    const titlesMap = new Map<string, string>()
+    const result = traverseDescription('', titlesMap, getHeadingId)
+    expect(result).toEqual([])
+    expect(titlesMap.size).toBe(0)
+  })
+
+  it('should return an introduction entry for description with no headings', () => {
+    const titlesMap = new Map<string, string>()
+    const description = 'This is a paragraph without any headings.'
+    const result = traverseDescription(description, titlesMap, getHeadingId)
+    expect(result).toEqual([{ id: 'heading-introduction', title: 'Introduction' }])
+    expect(titlesMap.size).toBe(1)
+  })
+
+  it('should create single level entries for h1 headings', () => {
+    const titlesMap = new Map<string, string>()
+    const description = `
+# First Heading
+Some content here
+# Second Heading
+More content
+# Third Heading
+Final content
+    `
+    const result = traverseDescription(description, titlesMap, getHeadingId)
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toEqual({
+      id: 'heading-first-heading',
+      title: 'First Heading',
+      children: [],
+    })
+    expect(result[1]).toEqual({
+      id: 'heading-second-heading',
+      title: 'Second Heading',
+      children: [],
+    })
+    expect(result[2]).toEqual({
+      id: 'heading-third-heading',
+      title: 'Third Heading',
+      children: [],
+    })
+    expect(titlesMap.size).toBe(3)
+    expect(titlesMap.get('heading-first-heading')).toBe('First Heading')
+  })
+
+  it('should create nested entries for h1 and h2 headings', () => {
+    const titlesMap = new Map<string, string>()
+    const description = `
+# Main Section
+Some content
+## Subsection 1
+Content for subsection 1
+## Subsection 2
+Content for subsection 2
+# Another Section
+More content
+## Another Subsection
+Final content
+    `
+    const result = traverseDescription(description, titlesMap, getHeadingId)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({
+      id: 'heading-main-section',
+      title: 'Main Section',
+      children: [
+        {
+          id: 'heading-subsection-1',
+          title: 'Subsection 1',
+        },
+        {
+          id: 'heading-subsection-2',
+          title: 'Subsection 2',
+        },
+      ],
+    })
+    expect(result[1]).toEqual({
+      id: 'heading-another-section',
+      title: 'Another Section',
+      children: [
+        {
+          id: 'heading-another-subsection',
+          title: 'Another Subsection',
+        },
+      ],
+    })
+    expect(titlesMap.size).toBe(5)
+  })
+
+  it('should handle h2 and h3 headings when they are the lowest levels', () => {
+    const titlesMap = new Map<string, string>()
+    const description = `
+## Section 1
+Content
+### Subsection 1.1
+Content
+### Subsection 1.2
+Content
+## Section 2
+Content
+### Subsection 2.1
+Content
+    `
+    const result = traverseDescription(description, titlesMap, getHeadingId)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({
+      id: 'heading-section-1',
+      title: 'Section 1',
+      children: [
+        {
+          id: 'heading-subsection-1.1',
+          title: 'Subsection 1.1',
+        },
+        {
+          id: 'heading-subsection-1.2',
+          title: 'Subsection 1.2',
+        },
+      ],
+    })
+    expect(result[1]).toEqual({
+      id: 'heading-section-2',
+      title: 'Section 2',
+      children: [
+        {
+          id: 'heading-subsection-2.1',
+          title: 'Subsection 2.1',
+        },
+      ],
+    })
+    expect(titlesMap.size).toBe(5)
+  })
+
+  it('should skip headings that are not at the lowest two levels', () => {
+    const titlesMap = new Map<string, string>()
+    const description = `
+# Level 1
+## Level 2
+### Level 3
+#### Level 4
+##### Level 5
+    `
+    const result = traverseDescription(description, titlesMap, getHeadingId)
+
+    // Should only include Level 1 and Level 2
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      id: 'heading-level-1',
+      title: 'Level 1',
+      children: [
+        {
+          id: 'heading-level-2',
+          title: 'Level 2',
+        },
+      ],
+    })
+    expect(titlesMap.size).toBe(2)
+  })
+
+  it('should handle special characters in headings', () => {
+    const titlesMap = new Map<string, string>()
+    const description = `
+# Section with @#$%^&*() chars
+## Sub-section with !@#$%^&*() chars
+    `
+    const result = traverseDescription(description, titlesMap, getHeadingId)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      id: 'heading-section-with-@#$%^&*()-chars',
+      title: 'Section with @#$%^&*() chars',
+      children: [
+        {
+          id: 'heading-sub-section-with-!@#$%^&*()-chars',
+          title: 'Sub-section with !@#$%^&*() chars',
+        },
+      ],
+    })
+    expect(titlesMap.size).toBe(2)
+  })
+})

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-description.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-description.ts
@@ -1,0 +1,67 @@
+import { getHeadingsFromMarkdown, getLowestHeadingLevel } from '@/traverse-schema/helpers/utils'
+import type { TraversedDescription } from '@/traverse-schema/types'
+import type { Heading } from '@scalar/types/legacy'
+
+export const DEFAULT_INTRODUCTION_SLUG = 'introduction'
+
+/**
+ * Creates sidebar entries from markdown headings in the OpenAPI description.
+ * Only includes the top two levels of headings for a clean hierarchy.
+ */
+export const traverseDescription = (
+  description: string | undefined,
+  /** Map of titles for the mobile header */
+  titlesMap: Map<string, string>,
+  getHeadingId: (heading: Heading) => string,
+): TraversedDescription[] => {
+  if (!description?.trim()) {
+    return []
+  }
+
+  const headings = getHeadingsFromMarkdown(description)
+  const lowestLevel = getLowestHeadingLevel(headings)
+
+  const entries: TraversedDescription[] = []
+  let currentParent: TraversedDescription | null = null
+
+  // Add "Introduction" as the first heading
+  if (description && !description.trim().startsWith('#')) {
+    const heading: Heading = {
+      depth: 1,
+      value: 'Introduction',
+      slug: DEFAULT_INTRODUCTION_SLUG,
+    }
+
+    const id = getHeadingId(heading)
+    const title = heading.value
+
+    entries.push({
+      id,
+      title,
+    })
+    titlesMap.set(id, title)
+  }
+
+  // Traverse for the rest
+  for (const heading of headings) {
+    if (heading.depth !== lowestLevel && heading.depth !== lowestLevel + 1) {
+      continue
+    }
+
+    const entry: TraversedDescription = {
+      id: getHeadingId(heading),
+      title: heading.value,
+    }
+    titlesMap.set(entry.id, entry.title)
+
+    if (heading.depth === lowestLevel) {
+      entry.children = []
+      entries.push(entry)
+      currentParent = entry
+    } else if (currentParent) {
+      currentParent.children?.push(entry)
+    }
+  }
+
+  return entries
+}

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-document.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-document.test.ts
@@ -8,7 +8,7 @@ describe('traverseDocument', () => {
     hideModels: false,
     operationsSorter: 'alpha',
     tagsSorter: 'alpha',
-    getHeadingId: (heading: { value: string }) => heading.value,
+    getHeadingId: (heading) => heading.value,
     getOperationId: (operation) => operation.summary ?? '',
     getWebhookId: (webhook) => webhook?.name ?? 'webhooks',
     getModelId: (model) => model?.name ?? '',

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-document.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-document.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { traverseDocument } from './traverse-document'
+import type { TraversedTag, TraverseSpecOptions } from '@/traverse-schema/types'
+
+describe('traverseDocument', () => {
+  const mockOptions: TraverseSpecOptions = {
+    hideModels: false,
+    operationsSorter: 'alpha',
+    tagsSorter: 'alpha',
+    getHeadingId: (heading: { value: string }) => heading.value,
+    getOperationId: (operation) => operation.summary ?? '',
+    getWebhookId: (webhook) => webhook?.name ?? 'webhooks',
+    getModelId: (model) => model?.name ?? '',
+    getTagId: (tag) => tag.name ?? '',
+  }
+
+  it('should handle empty document', () => {
+    const emptyDoc: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+    }
+
+    const result = traverseDocument(emptyDoc, mockOptions)
+    expect(result.entries).toHaveLength(0)
+    expect(result.titles).toBeInstanceOf(Map)
+    expect(result.titles.size).toBe(0)
+  })
+
+  it('should traverse document with description', () => {
+    const doc: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+        description: '# Test Description\n## Section 1\nContent',
+      },
+    }
+
+    const result = traverseDocument(doc, mockOptions)
+    expect(result.entries).toHaveLength(1)
+    expect(result.titles.get('Test Description')).toBe('Test Description')
+  })
+
+  it('should handle paths and operations', () => {
+    const doc: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      paths: {
+        '/test': {
+          get: {
+            tags: ['test'],
+            summary: 'Test Operation',
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+      tags: [
+        {
+          name: 'test',
+          description: 'Test Tag',
+        },
+      ],
+    }
+
+    const result = traverseDocument(doc, mockOptions)
+    expect(result.entries).toHaveLength(1) // One tag group
+    expect(result.titles.get('Test Operation')).toBe('Test Operation')
+  })
+
+  it('should handle webhooks', () => {
+    const doc: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      webhooks: {
+        'test-webhook': {
+          post: {
+            summary: 'Test Webhook',
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = traverseDocument(doc, mockOptions)
+    expect(result.entries).toHaveLength(1) // Webhooks section
+    expect(result.titles.get('test-webhook')).toBe('Test Webhook')
+    expect((result.entries[0] as TraversedTag).children).toHaveLength(1)
+    expect((result.entries[0] as TraversedTag).children?.[0].title).toBe('Test Webhook')
+  })
+
+  it('should handle schemas when not hidden', () => {
+    const doc: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      components: {
+        schemas: {
+          TestModel: {
+            type: 'object',
+            properties: {
+              id: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = traverseDocument(doc, mockOptions)
+    expect(result.entries).toHaveLength(1) // Models section
+    expect(result.titles.get('TestModel')).toBe('TestModel')
+  })
+
+  it('should not include schemas when hidden', () => {
+    const doc: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      components: {
+        schemas: {
+          TestModel: {
+            type: 'object',
+            properties: {
+              id: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const optionsWithHiddenModels = {
+      ...mockOptions,
+      hideModels: true,
+    }
+
+    const result = traverseDocument(doc, optionsWithHiddenModels)
+    expect(result.entries).toHaveLength(0)
+  })
+
+  it('should handle multiple tags and operations', () => {
+    const doc: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      paths: {
+        '/test1': {
+          get: {
+            tags: ['tag1'],
+            summary: 'Test Operation 1',
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+        '/test2': {
+          post: {
+            tags: ['tag2'],
+            summary: 'Test Operation 2',
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+      tags: [
+        {
+          name: 'tag1',
+          description: 'Tag 1',
+        },
+        {
+          name: 'tag2',
+          description: 'Tag 2',
+        },
+      ],
+    }
+
+    const result = traverseDocument(doc, mockOptions)
+    expect(result.entries).toHaveLength(2) // Two tag groups
+    expect(result.titles.get('Test Operation 1')).toBe('Test Operation 1')
+    expect(result.titles.get('Test Operation 2')).toBe('Test Operation 2')
+  })
+
+  it('should handle operations without tags', () => {
+    const doc: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      paths: {
+        '/test': {
+          get: {
+            summary: 'Untagged Operation',
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = traverseDocument(doc, mockOptions)
+    expect(result.entries).toHaveLength(1) // One tag group for untagged operations
+    expect(result.titles.get('Untagged Operation')).toBe('Untagged Operation')
+  })
+
+  it('should respect tag sorting configuration', () => {
+    const doc: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      paths: {
+        '/test1': {
+          get: {
+            tags: ['z-tag'],
+            summary: 'Test Operation 1',
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+        '/test2': {
+          post: {
+            tags: ['a-tag'],
+            summary: 'Test Operation 2',
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+      tags: [
+        {
+          name: 'z-tag',
+          description: 'Z Tag',
+        },
+        {
+          name: 'a-tag',
+          description: 'A Tag',
+        },
+      ],
+    }
+
+    const result = traverseDocument(doc, mockOptions)
+    expect(result.entries[0].title).toBe('a-tag')
+    expect(result.entries[1].title).toBe('z-tag')
+  })
+})

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-document.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-document.ts
@@ -55,6 +55,7 @@ export const traverseDocument = (
       id: getWebhookId(),
       title: 'Webhooks',
       children: webhooks,
+      type: 'webhook',
     })
   }
 
@@ -67,6 +68,7 @@ export const traverseDocument = (
         id: getModelId(),
         title: 'Models',
         children: models,
+        type: 'model',
       })
     }
   }

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-document.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-document.ts
@@ -19,15 +19,15 @@ import type { TraversedEntry, TraverseSpecOptions } from '@/traverse-schema/type
 export const traverseDocument = (
   document: OpenAPIV3_1.Document,
   {
-    hideModels,
-    tagsSorter,
-    operationsSorter,
-    getHeadingId,
-    getOperationId,
-    getWebhookId,
-    getModelId,
-    getTagId,
-  }: TraverseSpecOptions,
+    hideModels = false,
+    tagsSorter = 'alpha',
+    operationsSorter = 'alpha',
+    getHeadingId = (heading) => heading.value,
+    getOperationId = (operation) => operation.summary ?? '',
+    getWebhookId = (webhook) => webhook?.name ?? 'webhooks',
+    getModelId = (model) => model?.name ?? '',
+    getTagId = (tag) => tag.name ?? '',
+  }: Partial<TraverseSpecOptions>,
 ) => {
   /** Dictionary of name to tags */
   const tagsDict: Map<string, OpenAPIV3_1.TagObject> = new Map(

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-document.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-document.ts
@@ -55,7 +55,7 @@ export const traverseDocument = (
       id: getWebhookId(),
       title: 'Webhooks',
       children: webhooks,
-      type: 'webhook',
+      type: 'text',
     })
   }
 
@@ -68,7 +68,7 @@ export const traverseDocument = (
         id: getModelId(),
         title: 'Models',
         children: models,
-        type: 'model',
+        type: 'text',
       })
     }
   }

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-document.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-document.ts
@@ -1,0 +1,75 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
+import { traverseDescription } from './traverse-description'
+import { traversePaths } from './traverse-paths'
+import { traverseSchemas } from './traverse-schemas'
+import { traverseTags } from './traverse-tags'
+import { traverseWebhooks } from './traverse-webhooks'
+import type { TraversedEntry, TraverseSpecOptions } from '@/traverse-schema/types'
+
+/**
+ * Traverse the OpenAPI Document and ensure we only do it once
+ *
+ * We are generating the following:
+ * - the sidebar
+ * - the search index (todo)
+ *
+ * Currently its called by createSidebar, but we can move this into the de-reference process as a plugin for even more gains
+ */
+export const traverseDocument = (
+  document: OpenAPIV3_1.Document,
+  {
+    hideModels,
+    tagsSorter,
+    operationsSorter,
+    getHeadingId,
+    getOperationId,
+    getWebhookId,
+    getModelId,
+    getTagId,
+  }: TraverseSpecOptions,
+) => {
+  /** Dictionary of name to tags */
+  const tagsDict: Map<string, OpenAPIV3_1.TagObject> = new Map(
+    document.tags?.map((tag: OpenAPIV3_1.TagObject) => [tag.name ?? 'Untitled Tag', tag]) ?? [],
+  )
+
+  /** Map it ID to title for the mobile header */
+  const titles = new Map<string, string>()
+
+  const entries: TraversedEntry[] = traverseDescription(document.info?.description, titles, getHeadingId)
+  const tags = traversePaths(document, tagsDict, titles, getOperationId)
+  const webhooks = traverseWebhooks(document, tags, tagsDict, titles, getWebhookId)
+  const tagsEntries = traverseTags(document, tags, tagsDict, titles, {
+    getTagId,
+    tagsSorter: tagsSorter,
+    operationsSorter: operationsSorter,
+  })
+
+  // Add tagged operations, webhooks and tagGroups
+  entries.push(...tagsEntries)
+
+  // Add untagged webhooks
+  if (webhooks.length) {
+    entries.push({
+      id: getWebhookId(),
+      title: 'Webhooks',
+      children: webhooks,
+    })
+  }
+
+  // Add models if they are not hidden
+  if (!hideModels && document.components?.schemas) {
+    const models = traverseSchemas(document, titles, getModelId)
+
+    if (models.length) {
+      entries.push({
+        id: getModelId(),
+        title: 'Models',
+        children: models,
+      })
+    }
+  }
+
+  return { entries, titles }
+}

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-paths.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-paths.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { traversePaths } from './traverse-paths'
-import type { UseNavState } from '@/hooks/useNavState'
+import type { TraverseSpecOptions } from '@/traverse-schema/types'
 
 describe('traversePaths', () => {
   // Mock getOperationId function
-  const mockGetOperationId: UseNavState['getOperationId'] = ({ path, method }) => `${method.toUpperCase()}-${path}`
+  const mockGetOperationId: TraverseSpecOptions['getOperationId'] = ({ path, method }) =>
+    `${method.toUpperCase()}-${path}`
 
   // Helper to create a basic OpenAPI document
   const createBasicSpec = (): OpenAPIV3_1.Document => ({

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-paths.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-paths.test.ts
@@ -137,7 +137,16 @@ describe('traversePaths', () => {
 
     const result = traversePaths(spec, tagsDict, titlesMap, mockGetOperationId)
 
-    expect(result.get('Legacy')?.[0].operation.deprecated).toBe(true)
+    expect(result.get('Legacy')).toEqual([
+      {
+        id: 'GET-/old-endpoint',
+        method: 'get',
+        path: '/old-endpoint',
+        ref: '#/paths/~1old-endpoint/get',
+        title: 'Old endpoint',
+        type: 'operation',
+      },
+    ])
   })
 
   it('should skip internal operations', () => {

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-paths.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-paths.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from 'vitest'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { traversePaths } from './traverse-paths'
+import type { UseNavState } from '@/hooks/useNavState'
+
+describe('traversePaths', () => {
+  // Mock getOperationId function
+  const mockGetOperationId: UseNavState['getOperationId'] = ({ path, method }) => `${method.toUpperCase()}-${path}`
+
+  // Helper to create a basic OpenAPI document
+  const createBasicSpec = (): OpenAPIV3_1.Document => ({
+    openapi: '3.1.0',
+    info: {
+      title: 'Test API',
+      version: '1.0.0',
+    },
+    paths: {},
+  })
+
+  it('should handle empty paths', () => {
+    const spec = createBasicSpec()
+    const tagsDict = new Map<string, OpenAPIV3_1.TagObject>()
+    const titlesMap = new Map<string, string>()
+
+    const result = traversePaths(spec, tagsDict, titlesMap, mockGetOperationId)
+
+    expect(result.size).toBe(1) // Only default tag
+    expect(result.get('default')).toEqual([])
+  })
+
+  it('should correctly process operations with tags', () => {
+    const spec = createBasicSpec()
+    spec.paths = {
+      '/users': {
+        get: {
+          tags: ['Users'],
+          summary: 'Get users',
+          operationId: 'getUsers',
+        },
+        post: {
+          tags: ['Users'],
+          summary: 'Create user',
+          operationId: 'createUser',
+        },
+      },
+    }
+
+    const tagsDict = new Map<string, OpenAPIV3_1.TagObject>([
+      ['Users', { name: 'Users', description: 'User operations' }],
+    ])
+    const titlesMap = new Map<string, string>()
+
+    const result = traversePaths(spec, tagsDict, titlesMap, mockGetOperationId)
+
+    expect(result.size).toBe(2) // Users tag + default tag
+    expect(result.get('Users')?.length).toBe(2)
+    expect(result.get('default')?.length).toBe(0)
+
+    const usersEntries = result.get('Users') || []
+    expect(usersEntries[0]).toMatchObject({
+      title: 'Get users',
+      path: '/users',
+      method: 'get',
+    })
+  })
+
+  it('should handle operations without tags', () => {
+    const spec = createBasicSpec()
+    spec.paths = {
+      '/health': {
+        get: {
+          summary: 'Health check',
+          operationId: 'healthCheck',
+        },
+      },
+    }
+
+    const tagsDict = new Map<string, OpenAPIV3_1.TagObject>()
+    const titlesMap = new Map<string, string>()
+
+    const result = traversePaths(spec, tagsDict, titlesMap, mockGetOperationId)
+
+    expect(result.size).toBe(1)
+    expect(result.get('default')?.length).toBe(1)
+    expect(result.get('default')?.[0]).toMatchObject({
+      title: 'Health check',
+      path: '/health',
+      method: 'get',
+    })
+  })
+
+  it('should handle operations with tags', () => {
+    const spec = createBasicSpec()
+    spec.tags = [
+      {
+        name: 'Foobar',
+        description: 'Foobar',
+      },
+    ]
+    spec.paths = {
+      '/hello': {
+        get: {
+          summary: 'Get Hello World',
+          tags: ['Foobar'],
+        },
+        post: {
+          summary: 'Post Hello World',
+        },
+      },
+    }
+
+    const tagsDict = new Map<string, OpenAPIV3_1.TagObject>([['Foobar', { name: 'Foobar' }]])
+    const titlesMap = new Map<string, string>()
+
+    const result = traversePaths(spec, tagsDict, titlesMap, mockGetOperationId)
+    expect(result.get('Foobar')?.length).toBe(1)
+    expect(result.get('Foobar')?.[0].title).toBe('Get Hello World')
+    expect(result.get('default')?.length).toBe(1)
+    expect(result.get('default')?.[0].title).toBe('Post Hello World')
+  })
+
+  it('should handle deprecated operations', () => {
+    const spec = createBasicSpec()
+    spec.paths = {
+      '/old-endpoint': {
+        get: {
+          tags: ['Legacy'],
+          summary: 'Old endpoint',
+          deprecated: true,
+        },
+      },
+    }
+
+    const tagsDict = new Map<string, OpenAPIV3_1.TagObject>([['Legacy', { name: 'Legacy' }]])
+    const titlesMap = new Map<string, string>()
+
+    const result = traversePaths(spec, tagsDict, titlesMap, mockGetOperationId)
+
+    expect(result.get('Legacy')?.[0].operation.deprecated).toBe(true)
+  })
+
+  it('should skip internal operations', () => {
+    const spec = createBasicSpec()
+    spec.paths = {
+      '/internal': {
+        get: {
+          tags: ['Internal'],
+          summary: 'Internal endpoint',
+          operationId: 'internalEndpoint',
+          'x-internal': true,
+        },
+      },
+    }
+
+    const tagsDict = new Map<string, OpenAPIV3_1.TagObject>([['Internal', { name: 'Internal' }]])
+    const titlesMap = new Map<string, string>()
+
+    const result = traversePaths(spec, tagsDict, titlesMap, mockGetOperationId)
+    expect(result.get('Internal')).toBeUndefined()
+  })
+
+  it('should skip scalar-ignore operations', () => {
+    const spec = createBasicSpec()
+    spec.paths = {
+      '/ignored': {
+        get: {
+          tags: ['Ignored'],
+          summary: 'Ignored endpoint',
+          operationId: 'ignoredEndpoint',
+          'x-scalar-ignore': true,
+        },
+      },
+    }
+
+    const tagsDict = new Map<string, OpenAPIV3_1.TagObject>([['Ignored', { name: 'Ignored' }]])
+    const titlesMap = new Map<string, string>()
+
+    const result = traversePaths(spec, tagsDict, titlesMap, mockGetOperationId)
+    expect(result.get('Ignored')).toBeUndefined()
+  })
+
+  it('should handle operations with missing summary', () => {
+    const spec = createBasicSpec()
+    spec.paths = {
+      '/no-summary': {
+        get: {
+          tags: ['Misc'],
+          operationId: 'noSummary',
+        },
+      },
+    }
+
+    const tagsDict = new Map<string, OpenAPIV3_1.TagObject>([['Misc', { name: 'Misc' }]])
+    const titlesMap = new Map<string, string>()
+
+    const result = traversePaths(spec, tagsDict, titlesMap, mockGetOperationId)
+
+    expect(result.get('Misc')?.[0].title).toBe('/no-summary')
+  })
+
+  it('should populate titlesMap correctly', () => {
+    const spec = createBasicSpec()
+    spec.paths = {
+      '/test': {
+        get: {
+          tags: ['Test'],
+          summary: 'Test endpoint',
+          operationId: 'testEndpoint',
+        },
+      },
+    }
+
+    const tagsDict = new Map<string, OpenAPIV3_1.TagObject>([['Test', { name: 'Test' }]])
+    const titlesMap = new Map<string, string>()
+
+    traversePaths(spec, tagsDict, titlesMap, mockGetOperationId)
+
+    expect(titlesMap.get('GET-/test')).toBe('Test endpoint')
+  })
+})

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-paths.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-paths.ts
@@ -2,8 +2,10 @@ import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 
 import { getTag } from './get-tag'
 import type { TraversedOperation, TraverseSpecOptions } from '@/traverse-schema/types'
+import { escapeJsonPointer } from '@scalar/openapi-parser'
 
 const createOperationEntry = (
+  ref: string,
   operation: OpenAPIV3_1.OperationObject,
   method: OpenAPIV3_1.HttpMethods,
   path = 'Unknown',
@@ -19,7 +21,7 @@ const createOperationEntry = (
     title: operation.summary ?? path,
     path,
     method: method,
-    operation,
+    ref,
     type: 'operation',
   }
 }
@@ -51,6 +53,8 @@ export const traversePaths = (
         return
       }
 
+      const ref = `#/paths/${escapeJsonPointer(path)}/${method}`
+
       // Traverse tags
       if (operation.tags?.length) {
         operation.tags.forEach((tagName: string) => {
@@ -58,13 +62,13 @@ export const traversePaths = (
             tagsMap.set(tagName, [])
           }
           const tag = getTag(tagsDict, tagName)
-          tagsMap.get(tagName)?.push(createOperationEntry(operation, method, path, tag, titlesMap, getOperationId))
+          tagsMap.get(tagName)?.push(createOperationEntry(ref, operation, method, path, tag, titlesMap, getOperationId))
         })
       }
       // Add to default tag
       else {
         const tag = getTag(tagsDict, 'default')
-        tagsMap.get('default')?.push(createOperationEntry(operation, method, path, tag, titlesMap, getOperationId))
+        tagsMap.get('default')?.push(createOperationEntry(ref, operation, method, path, tag, titlesMap, getOperationId))
       }
     })
   })

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-paths.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-paths.ts
@@ -20,6 +20,7 @@ const createOperationEntry = (
     path,
     method: method,
     operation,
+    type: 'operation',
   }
 }
 

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-paths.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-paths.ts
@@ -1,0 +1,72 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
+import { getTag } from './get-tag'
+import type { TraversedOperation, TraverseSpecOptions } from '@/traverse-schema/types'
+
+const createOperationEntry = (
+  operation: OpenAPIV3_1.OperationObject,
+  method: OpenAPIV3_1.HttpMethods,
+  path = 'Unknown',
+  tag: OpenAPIV3_1.TagObject,
+  titlesMap: Map<string, string>,
+  getOperationId: TraverseSpecOptions['getOperationId'],
+): TraversedOperation => {
+  const id = getOperationId({ ...operation, method, path }, tag)
+  titlesMap.set(id, operation.summary ?? path)
+
+  return {
+    id,
+    title: operation.summary ?? path,
+    path,
+    method: method,
+    operation,
+  }
+}
+
+/**
+ * Traverse the paths of the spec and build a map of tags and operations
+ *
+ * Default tag is to match what we have now we can improve later
+ * TODO: filter out internal and scalar-ignore tags
+ */
+export const traversePaths = (
+  content: OpenAPIV3_1.Document,
+  /** Dictionary of tags from the spec */
+  tagsDict: Map<string, OpenAPIV3_1.TagObject>,
+  /** Map of titles for the mobile header */
+  titlesMap: Map<string, string>,
+  getOperationId: TraverseSpecOptions['getOperationId'],
+): Map<string, TraversedOperation[]> => {
+  const tagsMap = new Map<string, TraversedOperation[]>([['default', []]])
+
+  // Traverse paths
+  Object.entries(content.paths ?? {}).forEach(([path, pathItem]) => {
+    const pathEntries = Object.entries(pathItem ?? {}) as [OpenAPIV3_1.HttpMethods, OpenAPIV3_1.OperationObject][]
+
+    // Traverse operations
+    pathEntries.forEach(([method, operation]) => {
+      // Skip if the operation is internal or scalar-ignore
+      if (operation['x-internal'] || operation['x-scalar-ignore']) {
+        return
+      }
+
+      // Traverse tags
+      if (operation.tags?.length) {
+        operation.tags.forEach((tagName: string) => {
+          if (!tagsMap.has(tagName)) {
+            tagsMap.set(tagName, [])
+          }
+          const tag = getTag(tagsDict, tagName)
+          tagsMap.get(tagName)?.push(createOperationEntry(operation, method, path, tag, titlesMap, getOperationId))
+        })
+      }
+      // Add to default tag
+      else {
+        const tag = getTag(tagsDict, 'default')
+        tagsMap.get('default')?.push(createOperationEntry(operation, method, path, tag, titlesMap, getOperationId))
+      }
+    })
+  })
+
+  return tagsMap
+}

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-schemas.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-schemas.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import { traverseSchemas } from './traverse-schemas'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
-import type { UseNavState } from '@/hooks/useNavState'
+import type { TraverseSpecOptions } from '@/traverse-schema/types'
 
 describe('traverseSchemas', () => {
   // Mock getModelId function
-  const mockGetModelId: UseNavState['getModelId'] = (params) => {
+  const mockGetModelId: TraverseSpecOptions['getModelId'] = (params) => {
     if (!params) {
       return 'model'
     }

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-schemas.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-schemas.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'vitest'
+import { traverseSchemas } from './traverse-schemas'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { UseNavState } from '@/hooks/useNavState'
+
+describe('traverseSchemas', () => {
+  // Mock getModelId function
+  const mockGetModelId: UseNavState['getModelId'] = (params) => {
+    if (!params) {
+      return 'model'
+    }
+    return `model-${params.name}`
+  }
+
+  // Mock titlesMap
+  const mockTitlesMap = new Map<string, string>()
+
+  it('should return empty array when no schemas exist', () => {
+    const content: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+    }
+
+    const result = traverseSchemas(content, mockTitlesMap, mockGetModelId)
+    expect(result).toEqual([])
+  })
+
+  it('should create entries for valid schemas', () => {
+    const content: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      components: {
+        schemas: {
+          User: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              name: { type: 'string' },
+            },
+          },
+          Product: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              price: { type: 'number' },
+            },
+          },
+        },
+      },
+    }
+
+    const result = traverseSchemas(content, mockTitlesMap, mockGetModelId)
+
+    expect(result).toHaveLength(2)
+    expect(result).toEqual([
+      {
+        id: 'model-User',
+        title: 'User',
+        name: 'User',
+        schema: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+          },
+        },
+      },
+      {
+        id: 'model-Product',
+        title: 'Product',
+        name: 'Product',
+        schema: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            price: { type: 'number' },
+          },
+        },
+      },
+    ])
+
+    // Verify titlesMap was populated
+    expect(mockTitlesMap.get('model-User')).toBe('User')
+    expect(mockTitlesMap.get('model-Product')).toBe('Product')
+  })
+
+  it('should skip schemas with x-internal flag', () => {
+    const content: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      components: {
+        schemas: {
+          PublicUser: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+          InternalUser: {
+            'x-internal': true,
+            type: 'object',
+            properties: {
+              secret: { type: 'string' },
+            },
+          },
+        },
+      },
+    }
+
+    const result = traverseSchemas(content, mockTitlesMap, mockGetModelId)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('PublicUser')
+  })
+
+  it('should skip schemas with x-scalar-ignore flag', () => {
+    const content: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      components: {
+        schemas: {
+          ValidSchema: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+          IgnoredSchema: {
+            'x-scalar-ignore': true,
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+        },
+      },
+    }
+
+    const result = traverseSchemas(content, mockTitlesMap, mockGetModelId)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('ValidSchema')
+  })
+
+  it('should handle schemas with no properties', () => {
+    const content: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      components: {
+        schemas: {
+          EmptySchema: {
+            type: 'object',
+          },
+        },
+      },
+    }
+
+    const result = traverseSchemas(content, mockTitlesMap, mockGetModelId)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      id: 'model-EmptySchema',
+      title: 'EmptySchema',
+      name: 'EmptySchema',
+      schema: {
+        type: 'object',
+      },
+    })
+  })
+
+  it('should handle schemas with special characters in names', () => {
+    const content: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      components: {
+        schemas: {
+          'User-Profile': {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+        },
+      },
+    }
+
+    const result = traverseSchemas(content, mockTitlesMap, mockGetModelId)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('User-Profile')
+    expect(result[0].id).toBe('model-User-Profile')
+  })
+
+  it('should handle multiple filtering conditions', () => {
+    const content: OpenAPIV3_1.Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      components: {
+        schemas: {
+          ValidSchema: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+          InternalSchema: {
+            'x-internal': true,
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+          IgnoredSchema: {
+            'x-scalar-ignore': true,
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+        },
+      },
+    }
+
+    const result = traverseSchemas(content, mockTitlesMap, mockGetModelId)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('ValidSchema')
+  })
+})

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-schemas.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-schemas.test.ts
@@ -63,25 +63,15 @@ describe('traverseSchemas', () => {
         id: 'model-User',
         title: 'User',
         name: 'User',
-        schema: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-            name: { type: 'string' },
-          },
-        },
+        type: 'model',
+        'ref': '#/content/components/schemas/User',
       },
       {
         id: 'model-Product',
         title: 'Product',
         name: 'Product',
-        schema: {
-          type: 'object',
-          properties: {
-            id: { type: 'string' },
-            price: { type: 'number' },
-          },
-        },
+        type: 'model',
+        'ref': '#/content/components/schemas/Product',
       },
     ])
 
@@ -177,9 +167,8 @@ describe('traverseSchemas', () => {
       id: 'model-EmptySchema',
       title: 'EmptySchema',
       name: 'EmptySchema',
-      schema: {
-        type: 'object',
-      },
+      type: 'model',
+      'ref': '#/content/components/schemas/EmptySchema',
     })
   })
 

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-schemas.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-schemas.ts
@@ -1,0 +1,42 @@
+import type { TraversedSchema, TraverseSpecOptions } from '@/traverse-schema/types'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
+/** Handles creating entries for components.schemas */
+const createModelEntry = (
+  schema: OpenAPIV3_1.SchemaObject,
+  name = 'Unkown',
+  titlesMap: Map<string, string>,
+  getModelId: TraverseSpecOptions['getModelId'],
+): TraversedSchema => {
+  const id = getModelId({ name })
+  titlesMap.set(id, name)
+
+  return {
+    id,
+    title: name,
+    name,
+    schema,
+  }
+}
+
+/** Traverse components.schemas to create entries for models */
+export const traverseSchemas = (
+  content: OpenAPIV3_1.Document,
+  /** Map of titles for the mobile header */
+  titlesMap: Map<string, string>,
+  getModelId: TraverseSpecOptions['getModelId'],
+): TraversedSchema[] => {
+  const schemas = content.components?.schemas ?? {}
+  const untagged: TraversedSchema[] = []
+
+  // For loop has 2x the performance of forEach here
+  for (const name in schemas) {
+    if (schemas[name]['x-internal'] || schemas[name]['x-scalar-ignore'] || !Object.hasOwn(schemas, name)) {
+      continue
+    }
+
+    untagged.push(createModelEntry(schemas[name], name, titlesMap, getModelId))
+  }
+
+  return untagged
+}

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-schemas.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-schemas.ts
@@ -3,8 +3,8 @@ import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 
 /** Handles creating entries for components.schemas */
 const createModelEntry = (
-  schema: OpenAPIV3_1.SchemaObject,
-  name = 'Unkown',
+  ref: string,
+  name = 'Unknown',
   titlesMap: Map<string, string>,
   getModelId: TraverseSpecOptions['getModelId'],
 ): TraversedSchema => {
@@ -15,7 +15,8 @@ const createModelEntry = (
     id,
     title: name,
     name,
-    schema,
+    ref,
+    type: 'model',
   }
 }
 
@@ -35,7 +36,9 @@ export const traverseSchemas = (
       continue
     }
 
-    untagged.push(createModelEntry(schemas[name], name, titlesMap, getModelId))
+    const ref = `#/content/components/schemas/${name}`
+
+    untagged.push(createModelEntry(ref, name, titlesMap, getModelId))
   }
 
   return untagged

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-tags.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-tags.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { TagGroup } from '@scalar/types/legacy'
-import type { TraversedEntry, TraversedOperation, TraversedTag } from '@/features/traverse-schema/types'
+
 import { traverseTags } from './traverse-tags'
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
+import type { TraversedEntry, TraversedOperation, TraversedTag } from '@/traverse-schema/types'
 
 describe('traverseTags', () => {
   // Helper function to create a mock OpenAPI document

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-tags.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-tags.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from 'vitest'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { TagGroup } from '@scalar/types/legacy'
+import type { TraversedEntry, TraversedOperation, TraversedTag } from '@/features/traverse-schema/types'
+import { traverseTags } from './traverse-tags'
+import type { HttpMethod } from '@scalar/helpers/http/http-methods'
+
+describe('traverseTags', () => {
+  // Helper function to create a mock OpenAPI document
+  const createMockDocument = (tagGroups?: TagGroup[]): OpenAPIV3_1.Document => ({
+    openapi: '3.1.0',
+    info: { title: 'Test API', version: '1.0.0' },
+    paths: {},
+    ...(tagGroups && { 'x-tagGroups': tagGroups }),
+  })
+
+  // Helper function to create a mock tag
+  const createMockTag = (name: string, displayName?: string): OpenAPIV3_1.TagObject => ({
+    name,
+    ...(displayName && { 'x-displayName': displayName }),
+  })
+
+  // Helper function to create a mock sidebar entry
+  const createMockEntry = (title: string, method?: HttpMethod): TraversedEntry => ({
+    id: `entry-${title}`,
+    title,
+    ...(method && { method }),
+  })
+
+  it('should handle empty tags map', () => {
+    const document = createMockDocument()
+    const tagsMap = new Map<string, TraversedTag[]>()
+    const tagsDict = new Map<string, OpenAPIV3_1.TagObject>()
+    const titlesMap = new Map<string, string>()
+    const options = {
+      getTagId: (tag: OpenAPIV3_1.TagObject) => tag.name ?? '',
+      tagsSorter: 'alpha' as const,
+      operationsSorter: 'alpha' as const,
+    }
+
+    const result = traverseTags(document, tagsMap, tagsDict, titlesMap, options)
+    expect(result).toEqual([])
+  })
+
+  it('should handle single default tag', () => {
+    const document = createMockDocument()
+    const tagsMap = new Map([['default', [createMockEntry('Test Operation')]]])
+    const tagsDict = new Map([['default', createMockTag('default')]])
+    const titlesMap = new Map<string, string>()
+    const options = {
+      getTagId: (tag: OpenAPIV3_1.TagObject) => tag.name ?? '',
+      tagsSorter: 'alpha' as const,
+      operationsSorter: 'alpha' as const,
+    }
+
+    const result = traverseTags(document, tagsMap, tagsDict, titlesMap, options)
+    expect(result).toEqual([createMockEntry('Test Operation')])
+  })
+
+  it('should handle a mix of tags and default tag', () => {
+    const document = createMockDocument()
+    const tagsMap = new Map([
+      ['default', [createMockEntry('Test Operation')]],
+      ['tag1', [createMockEntry('Test Operation')]],
+    ])
+    const tagsDict = new Map([
+      ['default', createMockTag('default')],
+      ['tag1', createMockTag('tag1')],
+    ])
+    const titlesMap = new Map<string, string>()
+    const options = {
+      getTagId: (tag: OpenAPIV3_1.TagObject) => tag.name ?? '',
+      tagsSorter: 'alpha' as const,
+      operationsSorter: 'alpha' as const,
+    }
+
+    const result = traverseTags(document, tagsMap, tagsDict, titlesMap, options)
+    expect(result).toEqual([
+      {
+        id: 'tag1',
+        title: 'tag1',
+        name: 'tag1',
+        tag: { name: 'tag1' },
+        children: [createMockEntry('Test Operation')],
+        isGroup: false,
+      },
+      {
+        id: 'default',
+        title: 'default',
+        name: 'default',
+        tag: { name: 'default' },
+        children: [createMockEntry('Test Operation')],
+        isGroup: false,
+      },
+    ])
+  })
+
+  it('should sort tags alphabetically', () => {
+    const document = createMockDocument()
+    const tagsMap = new Map([
+      ['zebra', [createMockEntry('Zebra Operation')]],
+      ['alpha', [createMockEntry('Alpha Operation')]],
+    ])
+    const tagsDict = new Map([
+      ['zebra', createMockTag('zebra')],
+      ['alpha', createMockTag('alpha')],
+    ])
+    const titlesMap = new Map<string, string>()
+    const options = {
+      getTagId: (tag: OpenAPIV3_1.TagObject) => tag.name ?? '',
+      tagsSorter: 'alpha' as const,
+      operationsSorter: 'alpha' as const,
+    }
+
+    const result = traverseTags(document, tagsMap, tagsDict, titlesMap, options)
+    expect(result[0].title).toBe('alpha')
+    expect(result[1].title).toBe('zebra')
+  })
+
+  it('should handle tag groups', () => {
+    const tagGroups: TagGroup[] = [
+      {
+        name: 'Group A',
+        tags: ['tag1', 'tag2'],
+      },
+    ]
+    const document = createMockDocument(tagGroups)
+    const tagsMap = new Map([
+      ['tag1', [createMockEntry('Operation 1')]],
+      ['tag2', [createMockEntry('Operation 2')]],
+    ])
+    const tagsDict = new Map([
+      ['tag1', createMockTag('tag1')],
+      ['tag2', createMockTag('tag2')],
+    ])
+    const titlesMap = new Map<string, string>()
+    const options = {
+      getTagId: (tag: OpenAPIV3_1.TagObject) => tag.name ?? '',
+      tagsSorter: 'alpha' as const,
+      operationsSorter: 'alpha' as const,
+    }
+
+    const result = traverseTags(document, tagsMap, tagsDict, titlesMap, options)
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('Group A')
+    expect((result[0] as TraversedTag).children).toHaveLength(2)
+  })
+
+  it('should sort operations by HTTP method', () => {
+    const document = createMockDocument()
+    const tagsMap = new Map([
+      ['default', [createMockEntry('POST Operation', 'post'), createMockEntry('GET Operation', 'get')]],
+    ])
+    const tagsDict = new Map([['default', createMockTag('default')]])
+    const titlesMap = new Map<string, string>()
+    const options = {
+      getTagId: (tag: OpenAPIV3_1.TagObject) => tag.name ?? '',
+      tagsSorter: 'alpha',
+      operationsSorter: 'method',
+    } as const
+
+    const result = traverseTags(document, tagsMap, tagsDict, titlesMap, options)
+    expect((result[0] as TraversedOperation).method).toBe('get')
+    expect((result[1] as TraversedOperation).method).toBe('post')
+  })
+
+  it('should handle custom tag sorter', () => {
+    const document = createMockDocument()
+    const tagsMap = new Map([
+      ['tag1', [createMockEntry('Operation 1')]],
+      ['tag2', [createMockEntry('Operation 2')]],
+    ])
+    const tagsDict = new Map([
+      ['tag1', createMockTag('tag1', 'Zebra')],
+      ['tag2', createMockTag('tag2', 'Alpha')],
+    ])
+    const titlesMap = new Map<string, string>()
+    const options = {
+      getTagId: (tag: OpenAPIV3_1.TagObject) => tag.name ?? '',
+      tagsSorter: (a: OpenAPIV3_1.TagObject, b: OpenAPIV3_1.TagObject) =>
+        (a['x-displayName'] || '').localeCompare(b['x-displayName'] || ''),
+      operationsSorter: 'alpha' as const,
+    }
+
+    const result = traverseTags(document, tagsMap, tagsDict, titlesMap, options)
+    expect(result[0].title).toBe('Alpha')
+    expect(result[1].title).toBe('Zebra')
+  })
+
+  it('should handle custom operations sorter', () => {
+    const document = createMockDocument()
+    const tagsMap = new Map([
+      ['default', [createMockEntry('Operation B', 'post'), createMockEntry('Operation A', 'get')]],
+    ])
+    const tagsDict = new Map([['default', createMockTag('default')]])
+    const titlesMap = new Map<string, string>()
+
+    const options = {
+      getTagId: (tag: OpenAPIV3_1.TagObject) => tag.name ?? '',
+      tagsSorter: 'alpha' as const,
+      operationsSorter: (a: OpenAPIV3_1.OperationObject, b: OpenAPIV3_1.OperationObject) =>
+        (a.method || '').localeCompare(b.method || ''),
+    }
+
+    const result = traverseTags(document, tagsMap, tagsDict, titlesMap, options)
+    expect(result[0].title).toBe('Operation A')
+    expect(result[1].title).toBe('Operation B')
+  })
+
+  it('should handle internal tags', () => {
+    const document = createMockDocument()
+    const tagsMap = new Map([
+      ['internal', [createMockEntry('Internal Operation')]],
+      ['public', [createMockEntry('Public Operation')]],
+    ])
+    const tagsDict = new Map([
+      ['internal', { ...createMockTag('internal'), 'x-internal': true }],
+      ['public', createMockTag('public')],
+    ])
+    const titlesMap = new Map<string, string>()
+    const options = {
+      getTagId: (tag: OpenAPIV3_1.TagObject) => tag.name ?? '',
+      tagsSorter: 'alpha' as const,
+      operationsSorter: 'alpha' as const,
+    }
+
+    const result = traverseTags(document, tagsMap, tagsDict, titlesMap, options)
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('public')
+  })
+
+  it('should handle scalar-ignore tags', () => {
+    const document = createMockDocument()
+    const tagsMap = new Map([
+      ['ignored', [createMockEntry('Ignored Operation')]],
+      ['visible', [createMockEntry('Visible Operation')]],
+    ])
+    const tagsDict = new Map([
+      ['ignored', { ...createMockTag('ignored'), 'x-scalar-ignore': true }],
+      ['visible', createMockTag('visible')],
+    ])
+    const titlesMap = new Map<string, string>()
+    const options = {
+      getTagId: (tag: OpenAPIV3_1.TagObject) => tag.name ?? '',
+      tagsSorter: 'alpha' as const,
+      operationsSorter: 'alpha' as const,
+    }
+
+    const result = traverseTags(document, tagsMap, tagsDict, titlesMap, options)
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('visible')
+  })
+})

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-tags.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-tags.test.ts
@@ -25,7 +25,10 @@ describe('traverseTags', () => {
   const createMockEntry = (title: string, method?: HttpMethod): TraversedEntry => ({
     id: `entry-${title}`,
     title,
-    ...(method && { method }),
+    method: method ?? 'get',
+    type: 'operation',
+    path: '',
+    ref: '',
   })
 
   it('should handle empty tags map', () => {
@@ -81,17 +84,17 @@ describe('traverseTags', () => {
         id: 'tag1',
         title: 'tag1',
         name: 'tag1',
-        tag: { name: 'tag1' },
         children: [createMockEntry('Test Operation')],
         isGroup: false,
+        type: 'tag',
       },
       {
         id: 'default',
         title: 'default',
         name: 'default',
-        tag: { name: 'default' },
         children: [createMockEntry('Test Operation')],
         isGroup: false,
+        type: 'tag',
       },
     ])
   })

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-tags.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-tags.ts
@@ -22,7 +22,6 @@ const createTagEntry = (
     id,
     title,
     name: tag.name || title,
-    tag,
     children,
     isGroup,
     type: 'tag',
@@ -94,12 +93,9 @@ const getSortedTagEntries = (
         const pathA = a.type === 'operation' ? a.path : a.name
         const pathB = b.type === 'operation' ? b.path : b.name
 
-        const operationA = a.type === 'operation' ? a.operation : a.webhook
-        const operationB = b.type === 'operation' ? b.operation : b.webhook
-
         return operationsSorter(
-          { method: a.method, path: pathA, operation: operationA },
-          { method: b.method, path: pathB, operation: operationB },
+          { method: a.method, path: pathA, ref: a.ref },
+          { method: b.method, path: pathB, ref: b.ref },
         )
       })
     }

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-tags.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-tags.ts
@@ -25,6 +25,7 @@ const createTagEntry = (
     tag,
     children,
     isGroup,
+    type: 'tag',
   }
 }
 

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-tags.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-tags.ts
@@ -47,7 +47,7 @@ const getSortedTagEntries = (
   // Alpha sort
   if (tagsSorter === 'alpha') {
     keys.sort((a, b) => {
-      const nameA = getTag(tagsDict, a)['x-displayName'] || a || 'Untitle Tag'
+      const nameA = getTag(tagsDict, a)['x-displayName'] || a || 'Untitled Tag'
       const nameB = getTag(tagsDict, b)['x-displayName'] || b || 'Untitled Tag'
       return nameA.localeCompare(nameB)
     })
@@ -63,7 +63,7 @@ const getSortedTagEntries = (
 
   /**
    * Loop on tags and add to array if entries
-   * Because tagGroups can mix operations as well as tags we ensure we are sorting the correct entitiy in the sort
+   * Because tagGroups can mix operations as well as tags we ensure we are sorting the correct entity in the sort
    */
   return keys.flatMap((key) => {
     const tag = getTag(tagsDict, key)
@@ -86,16 +86,16 @@ const getSortedTagEntries = (
     else if (typeof operationsSorter === 'function') {
       entries.sort((a, b) => {
         // Guard against tags
-        if (!('method' in a) || !('method' in b)) {
+        if ((a.type !== 'operation' && a.type !== 'webhook') || (b.type !== 'operation' && b.type !== 'webhook')) {
           return 0
         }
 
         // Handle webhooks as well as operations
-        const pathA = 'path' in a ? a.path : a.name
-        const pathB = 'path' in b ? b.path : b.name
+        const pathA = a.type === 'operation' ? a.path : a.name
+        const pathB = b.type === 'operation' ? b.path : b.name
 
-        const operationA = 'operation' in a ? a.operation : a.webhook
-        const operationB = 'operation' in b ? b.operation : b.webhook
+        const operationA = a.type === 'operation' ? a.operation : a.webhook
+        const operationB = b.type === 'operation' ? b.operation : b.webhook
 
         return operationsSorter(
           { method: a.method, path: pathA, operation: operationA },

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-tags.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-tags.ts
@@ -1,0 +1,145 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { TagGroup } from '@scalar/types/legacy'
+
+import { getTag } from './get-tag'
+import type { TraversedEntry, TraversedTag, TraverseSpecOptions } from '@/traverse-schema/types'
+
+type Options = Pick<TraverseSpecOptions, 'getTagId' | 'tagsSorter' | 'operationsSorter'>
+
+/** Handles creating entries for tags */
+const createTagEntry = (
+  tag: OpenAPIV3_1.TagObject,
+  titlesMap: Map<string, string>,
+  getTagId: TraverseSpecOptions['getTagId'],
+  children: TraversedEntry[],
+  isGroup = false,
+): TraversedTag => {
+  const id = getTagId(tag)
+  const title = tag['x-displayName'] || tag.name || 'Untitled Tag'
+  titlesMap.set(id, title)
+
+  return {
+    id,
+    title,
+    name: tag.name || title,
+    tag,
+    children,
+    isGroup,
+  }
+}
+
+/** Sorts tags and returns entries */
+const getSortedTagEntries = (
+  _keys: string[],
+  /** Map of tags and their entries */
+  tagsMap: Map<string, TraversedEntry[]>,
+  /** Dictionary of OpenAPI tags by name */
+  tagsDict: Map<string, OpenAPIV3_1.TagObject>,
+  /** Map of titles for the mobile header */
+  titlesMap: Map<string, string>,
+  { getTagId, tagsSorter, operationsSorter }: Options,
+) => {
+  // Ensure that default is last if it exists
+  const hasDefault = _keys.includes('default')
+  const keys = hasDefault ? _keys.filter((key) => key !== 'default') : _keys
+
+  // Alpha sort
+  if (tagsSorter === 'alpha') {
+    keys.sort((a, b) => {
+      const nameA = getTag(tagsDict, a)['x-displayName'] || a || 'Untitle Tag'
+      const nameB = getTag(tagsDict, b)['x-displayName'] || b || 'Untitled Tag'
+      return nameA.localeCompare(nameB)
+    })
+  }
+  // Custom sort
+  else if (typeof tagsSorter === 'function') {
+    keys.sort((a, b) => tagsSorter(getTag(tagsDict, a), getTag(tagsDict, b)))
+  }
+
+  if (hasDefault) {
+    keys.push('default')
+  }
+
+  /**
+   * Loop on tags and add to array if entries
+   * Because tagGroups can mix operations as well as tags we ensure we are sorting the correct entitiy in the sort
+   */
+  return keys.flatMap((key) => {
+    const tag = getTag(tagsDict, key)
+    const entries = tagsMap.get(key) ?? []
+
+    // Skip if the tag is internal or scalar-ignore
+    if (tag['x-internal'] || tag['x-scalar-ignore']) {
+      return []
+    }
+
+    // Alpha sort
+    if (operationsSorter === 'alpha') {
+      entries.sort((a, b) => ('method' in a && 'method' in b ? a.title.localeCompare(b.title) : 0))
+    }
+    // Method sort
+    else if (operationsSorter === 'method') {
+      entries.sort((a, b) => ('method' in a && 'method' in b ? a.method.localeCompare(b.method) : 0))
+    }
+    // Custom sort
+    else if (typeof operationsSorter === 'function') {
+      entries.sort((a, b) => {
+        // Guard against tags
+        if (!('method' in a) || !('method' in b)) {
+          return 0
+        }
+
+        // Handle webhooks as well as operations
+        const pathA = 'path' in a ? a.path : a.name
+        const pathB = 'path' in b ? b.path : b.name
+
+        const operationA = 'operation' in a ? a.operation : a.webhook
+        const operationB = 'operation' in b ? b.operation : b.webhook
+
+        return operationsSorter(
+          { method: a.method, path: pathA, operation: operationA },
+          { method: b.method, path: pathB, operation: operationB },
+        )
+      })
+    }
+
+    return entries.length ? createTagEntry(tag, titlesMap, getTagId, entries) : []
+  })
+}
+
+/** Traverses our tags map creates entries, also handles sorting and tagGroups */
+export const traverseTags = (
+  content: OpenAPIV3_1.Document,
+  /** Map of tags and their entries */
+  tagsMap: Map<string, TraversedEntry[]>,
+  /** Dictionary of tags from the spec */
+  tagsDict: Map<string, OpenAPIV3_1.TagObject>,
+  /** Map of titles for the mobile title */
+  titlesMap: Map<string, string>,
+  { getTagId, tagsSorter, operationsSorter }: Options,
+): TraversedEntry[] => {
+  // x-tagGroups
+  if (content['x-tagGroups']) {
+    const tagGroups = content['x-tagGroups'] as TagGroup[]
+
+    return tagGroups.flatMap((tagGroup) => {
+      const entries = getSortedTagEntries(tagGroup.tags ?? [], tagsMap, tagsDict, titlesMap, {
+        getTagId,
+        tagsSorter,
+        operationsSorter,
+      })
+      return entries.length ? createTagEntry(tagGroup, titlesMap, getTagId, entries, true) : []
+    })
+  }
+
+  // Ungrouped regular tags
+  const keys = Array.from(tagsMap.keys())
+  const tags = getSortedTagEntries(keys, tagsMap, tagsDict, titlesMap, { getTagId, tagsSorter, operationsSorter })
+
+  // Flatten if we only have default tag
+  if (tags.length === 1 && tags[0].title === 'default') {
+    return tags[0].children ?? []
+  }
+
+  return tags
+}

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-webhooks.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-webhooks.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { TraversedEntry } from '@/features/traverse-schema/types'
+import type { UseNavState } from '@/hooks/useNavState'
+import { traverseWebhooks } from './traverse-webhooks'
+
+describe('traverse-webhooks', () => {
+  const mockGetWebhookId: UseNavState['getWebhookId'] = (params, tag) => {
+    if (!params) {
+      return 'untagged-unknown-unknown'
+    }
+    return `${tag?.name || 'untagged'}-${params.method || 'unknown'}-${params.name}`
+  }
+
+  const mockTagsDict = new Map<string, OpenAPIV3_1.TagObject>([
+    ['webhook-tag', { name: 'webhook-tag', description: 'Webhook tag' }],
+  ])
+
+  describe('traverseWebhooks', () => {
+    it('should handle empty webhooks', () => {
+      const content: OpenAPIV3_1.Document = {
+        openapi: '3.1.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+      }
+
+      const tagsMap = new Map<string, TraversedEntry[]>()
+      const titlesMap = new Map<string, string>()
+
+      const result = traverseWebhooks(content, tagsMap, mockTagsDict, titlesMap, mockGetWebhookId)
+
+      expect(result).toEqual([])
+      expect(tagsMap.size).toBe(0)
+      expect(titlesMap.size).toBe(0)
+    })
+
+    it('should process webhooks with tags', () => {
+      const content: OpenAPIV3_1.Document = {
+        openapi: '3.1.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+        webhooks: {
+          'test-webhook': {
+            post: {
+              summary: 'Test Webhook',
+              tags: ['webhook-tag'],
+              operationId: 'testWebhook',
+            },
+          },
+        },
+      }
+
+      const tagsMap = new Map<string, TraversedEntry[]>()
+      const titlesMap = new Map<string, string>()
+
+      const result = traverseWebhooks(content, tagsMap, mockTagsDict, titlesMap, mockGetWebhookId)
+
+      expect(result).toEqual([]) // Should be empty as webhook has a tag
+      expect(tagsMap.get('webhook-tag')).toHaveLength(1)
+      expect(tagsMap.get('webhook-tag')?.[0]).toEqual({
+        id: 'webhook-tag-post-test-webhook',
+        title: 'Test Webhook',
+        name: 'test-webhook',
+        method: 'post',
+        webhook: {
+          summary: 'Test Webhook',
+          operationId: 'testWebhook',
+          tags: ['webhook-tag'],
+        },
+      })
+      expect(titlesMap.get('webhook-tag-post-test-webhook')).toBe('Test Webhook')
+    })
+
+    it('should process untagged webhooks', () => {
+      const content: OpenAPIV3_1.Document = {
+        openapi: '3.1.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+        webhooks: {
+          'untagged-webhook': {
+            post: {
+              summary: 'Untagged Webhook',
+              operationId: 'untaggedWebhook',
+            },
+          },
+        },
+      }
+
+      const tagsMap = new Map<string, TraversedEntry[]>()
+      const titlesMap = new Map<string, string>()
+
+      const result = traverseWebhooks(content, tagsMap, mockTagsDict, titlesMap, mockGetWebhookId)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        id: 'untagged-post-untagged-webhook',
+        title: 'Untagged Webhook',
+        name: 'untagged-webhook',
+        method: 'post',
+        webhook: {
+          summary: 'Untagged Webhook',
+          operationId: 'untaggedWebhook',
+        },
+      })
+      expect(titlesMap.get('untagged-post-untagged-webhook')).toBe('Untagged Webhook')
+    })
+
+    it('should skip internal webhooks', () => {
+      const content: OpenAPIV3_1.Document = {
+        openapi: '3.1.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+        webhooks: {
+          'internal-webhook': {
+            post: {
+              summary: 'Internal Webhook',
+              'x-internal': true,
+              operationId: 'internalWebhook',
+            },
+          },
+        },
+      }
+
+      const tagsMap = new Map<string, TraversedEntry[]>()
+      const titlesMap = new Map<string, string>()
+
+      const result = traverseWebhooks(content, tagsMap, mockTagsDict, titlesMap, mockGetWebhookId)
+
+      expect(result).toEqual([])
+      expect(tagsMap.size).toBe(0)
+      expect(titlesMap.size).toBe(0)
+    })
+
+    it('should skip scalar-ignore webhooks', () => {
+      const content: OpenAPIV3_1.Document = {
+        openapi: '3.1.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+        webhooks: {
+          'ignored-webhook': {
+            post: {
+              summary: 'Ignored Webhook',
+              'x-scalar-ignore': true,
+              operationId: 'ignoredWebhook',
+            },
+          },
+        },
+      }
+
+      const tagsMap = new Map<string, TraversedEntry[]>()
+      const titlesMap = new Map<string, string>()
+
+      const result = traverseWebhooks(content, tagsMap, mockTagsDict, titlesMap, mockGetWebhookId)
+
+      expect(result).toEqual([])
+      expect(tagsMap.size).toBe(0)
+      expect(titlesMap.size).toBe(0)
+    })
+
+    it('should handle deprecated webhooks', () => {
+      const content: OpenAPIV3_1.Document = {
+        openapi: '3.1.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+        webhooks: {
+          'deprecated-webhook': {
+            post: {
+              summary: 'Deprecated Webhook',
+              deprecated: true,
+              operationId: 'deprecatedWebhook',
+            },
+          },
+        },
+      }
+
+      const tagsMap = new Map<string, TraversedEntry[]>()
+      const titlesMap = new Map<string, string>()
+
+      const result = traverseWebhooks(content, tagsMap, mockTagsDict, titlesMap, mockGetWebhookId)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        id: 'untagged-post-deprecated-webhook',
+        title: 'Deprecated Webhook',
+        name: 'deprecated-webhook',
+        method: 'post',
+        webhook: {
+          deprecated: true,
+          summary: 'Deprecated Webhook',
+          operationId: 'deprecatedWebhook',
+        },
+      })
+    })
+
+    it('should handle webhooks with multiple methods', () => {
+      const content: OpenAPIV3_1.Document = {
+        openapi: '3.1.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+        webhooks: {
+          'multi-method-webhook': {
+            post: {
+              summary: 'POST Webhook',
+              operationId: 'postWebhook',
+            },
+            get: {
+              summary: 'GET Webhook',
+              operationId: 'getWebhook',
+            },
+          },
+        },
+      }
+
+      const tagsMap = new Map<string, TraversedEntry[]>()
+      const titlesMap = new Map<string, string>()
+
+      const result = traverseWebhooks(content, tagsMap, mockTagsDict, titlesMap, mockGetWebhookId)
+
+      expect(result).toHaveLength(2)
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            id: 'untagged-post-multi-method-webhook',
+            title: 'POST Webhook',
+            name: 'multi-method-webhook',
+            method: 'post',
+            webhook: {
+              summary: 'POST Webhook',
+              operationId: 'postWebhook',
+            },
+          },
+          {
+            id: 'untagged-get-multi-method-webhook',
+            title: 'GET Webhook',
+            name: 'multi-method-webhook',
+            method: 'get',
+            webhook: {
+              summary: 'GET Webhook',
+              operationId: 'getWebhook',
+            },
+          },
+        ]),
+      )
+    })
+  })
+})

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-webhooks.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-webhooks.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
-import type { TraversedEntry } from '@/features/traverse-schema/types'
-import type { UseNavState } from '@/hooks/useNavState'
 import { traverseWebhooks } from './traverse-webhooks'
+import type { TraversedEntry, TraverseSpecOptions } from '@/traverse-schema/types'
 
 describe('traverse-webhooks', () => {
-  const mockGetWebhookId: UseNavState['getWebhookId'] = (params, tag) => {
+  const mockGetWebhookId: TraverseSpecOptions['getWebhookId'] = (params, tag) => {
     if (!params) {
       return 'untagged-unknown-unknown'
     }

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-webhooks.test.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-webhooks.test.ts
@@ -61,11 +61,8 @@ describe('traverse-webhooks', () => {
         title: 'Test Webhook',
         name: 'test-webhook',
         method: 'post',
-        webhook: {
-          summary: 'Test Webhook',
-          operationId: 'testWebhook',
-          tags: ['webhook-tag'],
-        },
+        ref: '#/webhooks/test-webhook/post',
+        type: 'webhook',
       })
       expect(titlesMap.get('webhook-tag-post-test-webhook')).toBe('Test Webhook')
     })
@@ -96,10 +93,8 @@ describe('traverse-webhooks', () => {
         title: 'Untagged Webhook',
         name: 'untagged-webhook',
         method: 'post',
-        webhook: {
-          summary: 'Untagged Webhook',
-          operationId: 'untaggedWebhook',
-        },
+        ref: '#/webhooks/untagged-webhook/post',
+        type: 'webhook',
       })
       expect(titlesMap.get('untagged-post-untagged-webhook')).toBe('Untagged Webhook')
     })
@@ -183,11 +178,8 @@ describe('traverse-webhooks', () => {
         title: 'Deprecated Webhook',
         name: 'deprecated-webhook',
         method: 'post',
-        webhook: {
-          deprecated: true,
-          summary: 'Deprecated Webhook',
-          operationId: 'deprecatedWebhook',
-        },
+        ref: '#/webhooks/deprecated-webhook/post',
+        type: 'webhook',
       })
     })
 
@@ -223,20 +215,16 @@ describe('traverse-webhooks', () => {
             title: 'POST Webhook',
             name: 'multi-method-webhook',
             method: 'post',
-            webhook: {
-              summary: 'POST Webhook',
-              operationId: 'postWebhook',
-            },
+            ref: '#/webhooks/multi-method-webhook/post',
+            type: 'webhook',
           },
           {
             id: 'untagged-get-multi-method-webhook',
             title: 'GET Webhook',
             name: 'multi-method-webhook',
             method: 'get',
-            webhook: {
-              summary: 'GET Webhook',
-              operationId: 'getWebhook',
-            },
+            ref: '#/webhooks/multi-method-webhook/get',
+            type: 'webhook',
           },
         ]),
       )

--- a/packages/workspace-store/src/traverse-schema/helpers/traverse-webhooks.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/traverse-webhooks.ts
@@ -22,6 +22,7 @@ const createWebhookEntry = (
     name,
     webhook: operation,
     method: method,
+    type: 'webhook',
   }
 }
 

--- a/packages/workspace-store/src/traverse-schema/helpers/utils.ts
+++ b/packages/workspace-store/src/traverse-schema/helpers/utils.ts
@@ -1,0 +1,39 @@
+import { getHeadings } from '@scalar/code-highlight/markdown'
+import type { Heading } from '@scalar/types/legacy'
+import GithubSlugger from 'github-slugger'
+
+const withSlugs = (headings: Heading[], slugger: GithubSlugger): Heading[] =>
+  headings.map((heading) => {
+    return {
+      ...heading,
+      slug: slugger.slug(heading.value),
+    }
+  })
+
+/**
+ * Extracts all headings from a Markdown string.
+ */
+export function getHeadingsFromMarkdown(input: string): Heading[] {
+  const slugger = new GithubSlugger()
+
+  const headings = getHeadings(input)
+
+  return withSlugs(headings as Heading[], slugger)
+}
+
+export type HeadingLevels = 1 | 2 | 3 | 4 | 5 | 6
+
+/**
+ * Returns the lowest heading level from a list of headings.
+ *
+ * If there are h1, h2, h3 … h1 is the lowest heading level.
+ */
+export const getLowestHeadingLevel = (headings: Heading[]): HeadingLevels => {
+  const lowestLevel = Math.min(...headings.map((heading) => heading.depth))
+
+  if (lowestLevel >= 1 && lowestLevel <= 6) {
+    return lowestLevel as HeadingLevels
+  }
+
+  return 1
+}

--- a/packages/workspace-store/src/traverse-schema/index.ts
+++ b/packages/workspace-store/src/traverse-schema/index.ts
@@ -2,3 +2,5 @@ export type { TraverseSpecOptions } from './types'
 
 export { traverseDocument } from './helpers/traverse-document'
 export { operationIdParams } from './helpers/operation-id-params'
+
+export const SCALAR_NAVIGATION_EXTENSION_KEY = 'x-scalar-navigation'

--- a/packages/workspace-store/src/traverse-schema/index.ts
+++ b/packages/workspace-store/src/traverse-schema/index.ts
@@ -1,0 +1,4 @@
+export type { TraverseSpecOptions } from './types'
+
+export { traverseDocument } from './helpers/traverse-document'
+export { operationIdParams } from './helpers/operation-id-params'

--- a/packages/workspace-store/src/traverse-schema/index.ts
+++ b/packages/workspace-store/src/traverse-schema/index.ts
@@ -1,6 +1,4 @@
 export type { TraverseSpecOptions } from './types'
 
 export { traverseDocument } from './helpers/traverse-document'
-export { operationIdParams } from './helpers/operation-id-params'
-
 export const SCALAR_NAVIGATION_EXTENSION_KEY = 'x-scalar-navigation'

--- a/packages/workspace-store/src/traverse-schema/types.ts
+++ b/packages/workspace-store/src/traverse-schema/types.ts
@@ -1,47 +1,47 @@
 import type { Heading } from '@scalar/types/legacy'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 
-/** Description entry returned form traversing the document */
-export type TraversedDescription = {
+type TraverseEntryBase = {
+  type: 'operation' | 'model' | 'tag' | 'webhook'
   id: string
   title: string
+}
+
+/** Description entry returned form traversing the document */
+export type TraversedDescription = TraverseEntryBase & {
   children?: TraversedDescription[]
 }
 
 /** Operation entry returned form traversing the document */
-export type TraversedOperation = {
-  id: string
-  title: string
+export type TraversedOperation = TraverseEntryBase & {
   method: OpenAPIV3_1.HttpMethods
   path: string
   operation: OpenAPIV3_1.OperationObject
+  type: 'operation'
 }
 
 /** Model entry returned form traversing the document */
-export type TraversedSchema = {
-  id: string
-  title: string
+export type TraversedSchema = TraverseEntryBase & {
   name: string
   schema: OpenAPIV3_1.SchemaObject
+  type: 'model'
 }
 
 /** Tag entry returned form traversing the document, includes tagGroups */
-export type TraversedTag = {
-  id: string
-  title: string
+export type TraversedTag = TraverseEntryBase & {
   name: string
   children?: TraversedEntry[]
   tag: OpenAPIV3_1.TagObject
   isGroup: boolean
+  type: 'tag'
 }
 
 /** Webhook entry returned form traversing the document, basically the same as an operaation but with name instead of path */
-export type TraversedWebhook = {
-  id: string
-  title: string
+export type TraversedWebhook = TraverseEntryBase & {
   method: OpenAPIV3_1.HttpMethods
   name: string
   webhook: OpenAPIV3_1.OperationObject
+  type: 'webhook'
 }
 
 /** Entries returned form traversing the document */
@@ -52,11 +52,12 @@ export type TraversedEntry =
   | TraversedTag
   | TraversedWebhook
 
+type OperationSortValue = { method: string; path: string; operation: OpenAPIV3_1.OperationObject }
+
 /** Create sidebar options */
 export type TraverseSpecOptions = {
   tagsSorter: 'alpha' | ((a: OpenAPIV3_1.TagObject, b: OpenAPIV3_1.TagObject) => number)
-  // TODO: fix the types here
-  operationsSorter: 'alpha' | 'method' | ((a: any, b: any) => number)
+  operationsSorter: 'alpha' | 'method' | ((a: OperationSortValue, b: OperationSortValue) => number)
   hideModels: boolean
   getHeadingId: (heading: Heading) => string
   getOperationId: (

--- a/packages/workspace-store/src/traverse-schema/types.ts
+++ b/packages/workspace-store/src/traverse-schema/types.ts
@@ -15,34 +15,33 @@ export type TraversedDescription = TraverseEntryBase & {
 
 /** Operation entry returned form traversing the document */
 export type TraversedOperation = TraverseEntryBase & {
+  type: 'operation'
+  ref: string
   method: OpenAPIV3_1.HttpMethods
   path: string
-  operation: OpenAPIV3_1.OperationObject
-  type: 'operation'
 }
 
 /** Model entry returned form traversing the document */
 export type TraversedSchema = TraverseEntryBase & {
-  name: string
-  schema: OpenAPIV3_1.SchemaObject
   type: 'model'
+  ref: string
+  name: string
 }
 
 /** Tag entry returned form traversing the document, includes tagGroups */
 export type TraversedTag = TraverseEntryBase & {
+  type: 'tag'
   name: string
   children?: TraversedEntry[]
-  tag: OpenAPIV3_1.TagObject
   isGroup: boolean
-  type: 'tag'
 }
 
 /** Webhook entry returned form traversing the document, basically the same as an operaation but with name instead of path */
 export type TraversedWebhook = TraverseEntryBase & {
+  type: 'webhook'
+  ref: string
   method: OpenAPIV3_1.HttpMethods
   name: string
-  webhook: OpenAPIV3_1.OperationObject
-  type: 'webhook'
 }
 
 /** Entries returned form traversing the document */
@@ -53,7 +52,7 @@ export type TraversedEntry =
   | TraversedTag
   | TraversedWebhook
 
-type OperationSortValue = { method: string; path: string; operation: OpenAPIV3_1.OperationObject }
+type OperationSortValue = { method: string; path: string; ref: string }
 
 /** Create sidebar options */
 export type TraverseSpecOptions = {

--- a/packages/workspace-store/src/traverse-schema/types.ts
+++ b/packages/workspace-store/src/traverse-schema/types.ts
@@ -1,0 +1,80 @@
+import type { Heading } from '@scalar/types/legacy'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
+/** Description entry returned form traversing the document */
+export type TraversedDescription = {
+  id: string
+  title: string
+  children?: TraversedDescription[]
+}
+
+/** Operation entry returned form traversing the document */
+export type TraversedOperation = {
+  id: string
+  title: string
+  method: OpenAPIV3_1.HttpMethods
+  path: string
+  operation: OpenAPIV3_1.OperationObject
+}
+
+/** Model entry returned form traversing the document */
+export type TraversedSchema = {
+  id: string
+  title: string
+  name: string
+  schema: OpenAPIV3_1.SchemaObject
+}
+
+/** Tag entry returned form traversing the document, includes tagGroups */
+export type TraversedTag = {
+  id: string
+  title: string
+  name: string
+  children?: TraversedEntry[]
+  tag: OpenAPIV3_1.TagObject
+  isGroup: boolean
+}
+
+/** Webhook entry returned form traversing the document, basically the same as an operaation but with name instead of path */
+export type TraversedWebhook = {
+  id: string
+  title: string
+  method: OpenAPIV3_1.HttpMethods
+  name: string
+  webhook: OpenAPIV3_1.OperationObject
+}
+
+/** Entries returned form traversing the document */
+export type TraversedEntry =
+  | TraversedDescription
+  | TraversedOperation
+  | TraversedSchema
+  | TraversedTag
+  | TraversedWebhook
+
+/** Create sidebar options */
+export type TraverseSpecOptions = {
+  tagsSorter: 'alpha' | ((a: OpenAPIV3_1.TagObject, b: OpenAPIV3_1.TagObject) => number)
+  // TODO: fix the types here
+  operationsSorter: 'alpha' | 'method' | ((a: any, b: any) => number)
+  hideModels: boolean
+  getHeadingId: (heading: Heading) => string
+  getOperationId: (
+    operation: {
+      path: string
+      method: OpenAPIV3_1.HttpMethods
+    } & OpenAPIV3_1.OperationObject,
+    parentTag: OpenAPIV3_1.TagObject,
+  ) => string
+  getWebhookId: (
+    webhook?: {
+      name: string
+      method?: string
+    },
+    parentTag?: OpenAPIV3_1.TagObject,
+  ) => string
+  getModelId: (model?: {
+    name: string
+  }) => string
+  getTagId: (tag: OpenAPIV3_1.TagObject) => string
+}

--- a/packages/workspace-store/src/traverse-schema/types.ts
+++ b/packages/workspace-store/src/traverse-schema/types.ts
@@ -2,14 +2,15 @@ import type { Heading } from '@scalar/types/legacy'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 
 type TraverseEntryBase = {
-  type: 'operation' | 'model' | 'tag' | 'webhook'
+  type: 'text' | 'operation' | 'model' | 'tag' | 'webhook'
   id: string
   title: string
 }
 
 /** Description entry returned form traversing the document */
 export type TraversedDescription = TraverseEntryBase & {
-  children?: TraversedDescription[]
+  type: 'text'
+  children?: TraverseEntryBase[]
 }
 
 /** Operation entry returned form traversing the document */

--- a/packages/workspace-store/src/traverse-schema/types.ts
+++ b/packages/workspace-store/src/traverse-schema/types.ts
@@ -36,7 +36,7 @@ export type TraversedTag = TraverseEntryBase & {
   isGroup: boolean
 }
 
-/** Webhook entry returned form traversing the document, basically the same as an operaation but with name instead of path */
+/** Webhook entry returned form traversing the document, basically the same as an operation but with name instead of path */
 export type TraversedWebhook = TraverseEntryBase & {
   type: 'webhook'
   ref: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2488,6 +2488,9 @@ importers:
       '@scalar/code-highlight':
         specifier: workspace:*
         version: link:../code-highlight
+      '@scalar/helpers':
+        specifier: workspace:*
+        version: link:../helpers
       '@scalar/openapi-parser':
         specifier: workspace:*
         version: link:../openapi-parser

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2485,15 +2485,24 @@ importers:
 
   packages/workspace-store:
     dependencies:
+      '@scalar/code-highlight':
+        specifier: workspace:*
+        version: link:../code-highlight
       '@scalar/openapi-parser':
         specifier: workspace:*
         version: link:../openapi-parser
       '@scalar/openapi-types':
         specifier: workspace:*
         version: link:../openapi-types
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../types
       '@sinclair/typebox':
         specifier: catalog:*
         version: 0.34.3
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       vue:
         specifier: catalog:*
         version: 3.5.12(typescript@5.6.2)


### PR DESCRIPTION
This PR introduces precomputation of sidebar entries to improve performance and consistency.

**Details**

- Sidebar entries are now precomputed on the server-side workspace when available.
- If the client store is operating without a server-side workspace, it will handle the precomputation locally on the client side.

> This ensures that the sidebar remains functional and consistent regardless of where the workspace is initialized.


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
