### PR TITLE
fix(api-reference): introduction style

### DIFF
--- a/.changeset/selfish-clocks-sit.md
+++ b/.changeset/selfish-clocks-sit.md
@@ -1,0 +1,6 @@
+---
+'@scalar/code-highlight': patch
+'@scalar/api-reference': patch
+---
+
+fix: enhances introduction optical alignment

--- a/packages/api-reference/src/features/DownloadLink/DownloadLink.vue
+++ b/packages/api-reference/src/features/DownloadLink/DownloadLink.vue
@@ -51,7 +51,7 @@ const handleDownloadClick = (format: 'json' | 'yaml') => {
   display: flex;
   flex-direction: column;
   gap: 16px;
-  margin: 0 0 24px;
+  margin: 0 0.5px 24px;
   position: relative;
   width: fit-content;
   z-index: 0;

--- a/packages/code-highlight/src/css/markdown.css
+++ b/packages/code-highlight/src/css/markdown.css
@@ -263,7 +263,7 @@
     display: flex;
     align-items: top;
     height: 40px;
-    padding: 11px 0px 11px 40px;
+    padding: 11px 0px 11px 37px;
     position: relative;
     font-weight: var(--scalar-semibold);
     cursor: pointer;
@@ -285,7 +285,7 @@
     content: "";
     position: absolute;
     top: calc(var(--markdown-spacing-sm) + 1px);
-    left: 14px;
+    left: 10px;
     width: var(--markdown-spacing-md);
     height: var(--markdown-spacing-md);
     background-color: var(--scalar-color-3);


### PR DESCRIPTION
**Solution**

this pr updates the introduction section style to improve optically alignment of details element agains a list to maintain consistency + adds a slight margin to download link.

| state | preview |
| -------|------|
| before | <img width="614" alt="image" src="https://github.com/user-attachments/assets/125c2d0f-95da-4d45-b00b-24ce2c723500" /> |
| after | <img width="614" alt="image" src="https://github.com/user-attachments/assets/c0c2fe0a-6103-4368-bc0e-b43828552694" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
