### PR TITLE
fix(api-reference): sidebar darkmode toggle state

### DIFF
--- a/.changeset/mean-dancers-sort.md
+++ b/.changeset/mean-dancers-sort.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates api reference workspace dark mode watcher

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
@@ -69,8 +69,8 @@ watch(
 
 // Temporary mapping of isDarkMode until we update the standalone component
 watch(
-  () => isDarkMode,
-  () => store.update('x-scalar-dark-mode', isDarkMode.value),
+  () => isDarkMode.value,
+  (newValue) => store.update('x-scalar-dark-mode', newValue),
 )
 
 if (configuration.metaData) {


### PR DESCRIPTION
**Problem**

currently the darkmode toggle is not reactive anymore to dark mode change.

**Solution**

this pr updates the fresh api reference workspace dark mode watcher to add back the toggle state on dark mode change.

| state | preview |
| -------|------|
| before | <img width="302" alt="image" src="https://github.com/user-attachments/assets/c8775264-293f-4760-989b-f75b1856bb88" /> | 
| after | <img width="302" alt="image" src="https://github.com/user-attachments/assets/a60cbf01-b57a-4602-9f9a-4dca6948dee4" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
