### PR TITLE
fix(api-reference): schema property discriminator recursion

### DIFF
--- a/.changeset/nine-rules-move.md
+++ b/.changeset/nine-rules-move.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: hides enum ui in discriminator presence

--- a/.changeset/rich-fishes-boil.md
+++ b/.changeset/rich-fishes-boil.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: prevents discrminator recursion in schema property

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -95,6 +95,7 @@ const schema = computed(() => {
   // If the merged schema is an object schema and the original schema is an object schema, return the merged schema
   if (
     mergedSchema &&
+    (props.level === 0 || props.hasDiscriminator) &&
     isObjectSchema(originalSchema) &&
     isObjectSchema(mergedSchema)
   ) {

--- a/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaDiscriminator.vue
@@ -52,7 +52,7 @@ const selectedDiscriminatorOption = computed({
     :options="discriminatorListboxOptions"
     resize>
     <button
-      class="bg-b-1.5 hover:bg-b-2 flex w-full items-center gap-1 rounded border px-2 py-1.25"
+      class="bg-b-1.5 hover:bg-b-2 mt-2 flex w-full items-center gap-1 rounded border px-2 py-1.25"
       type="button">
       <span class="composition-selector-label text-c-1 relative">
         {{ selectedDiscriminatorOption?.label || 'Schema' }}

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -135,6 +135,11 @@ const discriminatorContext = inject(DISCRIMINATOR_CONTEXT, null)
 
 /** Handle schema value according to discriminator context */
 const schema = computed(() => {
+  // Prevent recursion in discriminator context presence
+  if (props.level > 0) {
+    return optimizedValue.value
+  }
+
   if (discriminatorContext?.value?.mergedSchema) {
     return discriminatorContext.value.mergedSchema
   }

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -277,7 +277,7 @@ const shouldRenderArrayOfObjects = computed(() => hasComplexArrayItems.value)
     </div>
     <!-- Enum -->
     <div
-      v-if="getEnumFromValue(optimizedValue)?.length > 0"
+      v-if="getEnumFromValue(optimizedValue)?.length > 0 && !isDiscriminator"
       class="property-enum">
       <template v-if="Array.isArray(optimizedValue?.['x-enumDescriptions'])">
         <div class="property-list">


### PR DESCRIPTION
**Problem**

currently when using discriminator including nested schema, it causes a maximum call stack and recursivity.

**Solution**

this pr prevents the recursion in discriminator context. fixes #5919

| state | preview |
| -------|------|
| before | <img width="579" alt="image" src="https://github.com/user-attachments/assets/80b4fa28-1a26-436e-893f-c373e860b9e8" /> |
| after | <img width="579" alt="image" src="https://github.com/user-attachments/assets/27b1acd3-5c7f-4627-a52a-ca132fe9f319" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
