### PR TITLE
fix(api-reference): authentication cards style

### DIFF
--- a/.changeset/green-maps-provide.md
+++ b/.changeset/green-maps-provide.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: updates introduction auth table style

--- a/packages/api-client/src/components/Server/ServerSelector.vue
+++ b/packages/api-client/src/components/Server/ServerSelector.vue
@@ -89,7 +89,7 @@ const serverUrlWithoutTrailingSlash = computed(() => {
     :target="target"
     :teleport="`#${target}`">
     <ScalarButton
-      class="text-c-1 h-auto w-full justify-start gap-0.75 overflow-x-auto rounded-b-lg px-3 py-1.5 text-xs font-normal whitespace-nowrap -outline-offset-1 lg:text-sm"
+      class="bg-b-1 text-c-1 h-auto w-full justify-start gap-0.75 overflow-x-auto rounded-t-none rounded-b-lg px-3 py-1.5 text-xs font-normal whitespace-nowrap -outline-offset-1 lg:text-sm"
       variant="ghost">
       <span class="sr-only">Server:</span>
       <span class="overflow-x-auto">{{ serverUrlWithoutTrailingSlash }}</span>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
@@ -90,7 +90,7 @@ watch(
     <DataTable
       v-if="activeScheme.length"
       class="flex-1"
-      :class="layout === 'reference' && 'rounded-b-lg border border-t-0'"
+      :class="layout === 'reference' && 'bg-b-1 rounded-b-lg border border-t-0'"
       :columns="['']"
       presentational>
       <RequestAuthTab

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -191,7 +191,6 @@ const introCardsSlot = computed(() =>
 .introduction-card {
   display: flex;
   flex-direction: column;
-  background: var(--scalar-background-1);
 }
 .introduction-card-item {
   display: flex;


### PR DESCRIPTION
**Problem**

current introduction auth table style is off when using some theming (e.g. mars)

**Solution**

this pr updates introduction auth table to work as expected.

| state | preview |
| -------|------|
| before | <img width="700" alt="image" src="https://github.com/user-attachments/assets/a11618e0-4642-4033-bb10-d1cf387bc2e2" /> |
| after | <img width="700" alt="image" src="https://github.com/user-attachments/assets/3d155ac1-2a35-46ae-b83b-d9cfb22f17e1" /> |
| description | background between cards get displayed + overflow |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
