### PR TITLE
feat(openapi-parser): add x-webhooks to the upgrader

### DIFF
--- a/.changeset/wild-experts-approve.md
+++ b/.changeset/wild-experts-approve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+feat: add x-webhooks upgrade to the upgrader

--- a/packages/openapi-parser/src/utils/upgrade-from-three-to-three-one.test.ts
+++ b/packages/openapi-parser/src/utils/upgrade-from-three-to-three-one.test.ts
@@ -489,4 +489,51 @@ describe('upgradeFromThreeToThreeOne', () => {
       })
     })
   })
+
+  describe('webhooks', () => {
+    it('correctly upgrades x-webhooks to webhooks', async () => {
+      const result = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        'x-webhooks': {
+          'test': {
+            post: {
+              requestBody: {
+                required: true,
+                content: {
+                  'multipart/form-data': {
+                    schema: {
+                      type: 'string',
+                      example: 'test',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(result['webhooks']).toEqual({
+        'test': {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                'multipart/form-data': {
+                  schema: {
+                    type: 'string',
+                    examples: ['test'],
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+    })
+  })
 })

--- a/packages/openapi-parser/src/utils/upgrade-from-three-to-three-one.ts
+++ b/packages/openapi-parser/src/utils/upgrade-from-three-to-three-one.ts
@@ -147,5 +147,11 @@ const applyChangesToDocument = (schema: UnknownObject, path: string[]) => {
     }
   }
 
+  // 6. Handle x-webhooks
+  if (schema['x-webhooks'] !== undefined) {
+    schema.webhooks = schema['x-webhooks']
+    delete schema['x-webhooks']
+  }
+
   return schema
 }


### PR DESCRIPTION
**Problem**

Currently, we just leave x-webhooks as is

**Solution**

With this PR we upgrade x-webhooks to webhooks which were introduced in the 3.1.0 spec

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
