### PR TITLE
fix(api-reference): schema property array type object 

### DIFF
--- a/.changeset/ten-news-applaud.md
+++ b/.changeset/ten-news-applaud.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: adds better array type object properties rendering

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -391,6 +391,46 @@ describe('SchemaProperty sub-schema', () => {
     expect(wrapper.html()).toContain('foo (1)')
     expect(wrapper.html()).toContain('bar (1)')
   })
+
+  it('renders array type object with properties correctly', async () => {
+    const wrapper = mount(SchemaProperty, {
+      props: {
+        value: {
+          type: ['object', 'null'],
+          properties: {
+            galaxy: {
+              type: 'string',
+              description: 'Galaxy where the planet is located',
+            },
+            satellites: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              description: 'List of satellites orbiting the planet',
+            },
+            habitable: {
+              type: 'boolean',
+              description: 'Whether the planet can support life',
+            },
+          },
+        },
+      },
+    })
+
+    const button = wrapper.find('.schema-card-title')
+    await button.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const html = wrapper.html()
+
+    expect(html).toContain('galaxy')
+    expect(html).toContain('Galaxy where the planet is located')
+    expect(html).toContain('satellites')
+    expect(html).toContain('List of satellites orbiting the planet')
+    expect(html).toContain('habitable')
+    expect(html).toContain('Whether the planet can support life')
+  })
 })
 
 describe('SchemaProperty discriminator handling', () => {

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -220,6 +220,25 @@ const shouldRenderArrayItemComposition = (composition: string): boolean => {
 }
 
 const shouldRenderArrayOfObjects = computed(() => hasComplexArrayItems.value)
+
+/**
+ * Determine if object properties should be displayed
+ * Handles both single type ('object') and array types (['object', 'null'])
+ */
+const shouldRenderObjectProperties = computed(() => {
+  if (!optimizedValue.value) {
+    return false
+  }
+
+  const value = optimizedValue.value
+  const isObjectType =
+    value.type === 'object' ||
+    (Array.isArray(value.type) && value.type.includes('object'))
+
+  const hasPropertiesToRender = value.properties || value.additionalProperties
+
+  return isObjectType && hasPropertiesToRender
+})
 </script>
 <template>
   <component
@@ -334,10 +353,7 @@ const shouldRenderArrayOfObjects = computed(() => hasComplexArrayItems.value)
     </div>
     <!-- Object -->
     <div
-      v-if="
-        optimizedValue?.type === 'object' &&
-        (optimizedValue?.properties || optimizedValue?.additionalProperties)
-      "
+      v-if="shouldRenderObjectProperties"
       class="children">
       <Schema
         :compact="compact"


### PR DESCRIPTION
**Problem**

after recent changes, schema property object are not properly rendering properties when within array type.

**Solution**

this pr updates the type object to include array type to render properties. fixes #5939

| state | preview |
| -------|------|
| before | <img width="552" alt="image" src="https://github.com/user-attachments/assets/9210cac5-5265-4b63-9bae-92ca88d1d93c" /> |
| after | <img width="552" alt="image" src="https://github.com/user-attachments/assets/fa050724-d636-4e9f-a93b-081650d867b9" /> |

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
