### PR TITLE
fix(api-reference): scroll to top to remove hash

### DIFF
--- a/.changeset/funny-moose-tie.md
+++ b/.changeset/funny-moose-tie.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: scroll to top to remove hash


### PR DESCRIPTION
**Problem**

Currently, our scroll listener was on a dom element

**Solution**

With this PR we move it to the window. I tested pathRouting but it doesn't seem like we even use hashPrefix anymore. Opened up another ticket to look into that one.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
