### PR TITLE
fix(api-reference): re-create client store on document change

### DIFF
--- a/.changeset/seven-rats-divide.md
+++ b/.changeset/seven-rats-divide.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: re-create client store on document change

--- a/packages/api-client/src/libs/create-client.ts
+++ b/packages/api-client/src/libs/create-client.ts
@@ -245,9 +245,21 @@ export const createApiClient = ({
     }
   }
 
+  /** Reset the client store */
+  const resetStore = () => {
+    store.collectionMutators.reset()
+    store.requestMutators.reset()
+    store.requestExampleMutators.reset()
+    store.securitySchemeMutators.reset()
+    store.serverMutators.reset()
+    store.tagMutators.reset()
+    workspaceMutators.edit(activeWorkspace.value?.uid, 'collections', [])
+  }
+
   return {
     /** The vue app instance for the modal, be careful with this */
     app,
+    resetStore,
     /**
      * Update the API client config
      *
@@ -270,13 +282,7 @@ export const createApiClient = ({
         newConfig.showSidebar
       ) {
         // Update the spec, reset the store first
-        store.collectionMutators.reset()
-        store.requestMutators.reset()
-        store.requestExampleMutators.reset()
-        store.securitySchemeMutators.reset()
-        store.serverMutators.reset()
-        store.tagMutators.reset()
-        workspaceMutators.edit(activeWorkspace.value?.uid, 'collections', [])
+        resetStore()
 
         /** Add any extra properties to the config */
         const config = {

--- a/packages/api-reference/src/features/DocumentSource/hooks/useDocumentSource.ts
+++ b/packages/api-reference/src/features/DocumentSource/hooks/useDocumentSource.ts
@@ -126,22 +126,6 @@ export function useDocumentSource({
     ...(toValue(configuration) ?? apiReferenceConfigurationSchema.parse({})),
   })
 
-  watch(
-    () => toValue(dereferencedDocument),
-    (newDocument) => {
-      return (
-        newDocument &&
-        workspaceStore.importSpecFile(undefined, 'default', {
-          dereferencedDocument: newDocument,
-          shouldLoad: false,
-          documentUrl: toValue(configuration)?.url,
-          useCollectionSecurity: true,
-          ...(toValue(configuration) ?? apiReferenceConfigurationSchema.parse({})),
-        })
-      )
-    },
-  )
-
   /** Active Entities Store */
   const activeEntitiesStore = createActiveEntitiesStore(workspaceStore)
 


### PR DESCRIPTION
**Problem**

Currently, we re-import the new document into the client store but to not remove the old one. Resulting in infinite collections.

**Solution**

With this PR we reset the store before importing

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
