### PR TITLE
feat(api-client): implement deleteRow function for RequestBody form data

### DIFF
--- a/.changeset/chilled-roses-tell.md
+++ b/.changeset/chilled-roses-tell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: implement deleteRow function for RequestBody form data

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
@@ -265,4 +265,105 @@ describe('RequestBody.vue', () => {
 
     wrapper.unmount()
   })
+
+  describe('delete row from form-data and urlencoded', () => {
+    it('deletes a row from form-data', async () => {
+      mockActiveExample.body = {
+        activeBody: 'formData',
+        formData: {
+          encoding: 'form-data',
+          value: [
+            { key: 'field1', value: 'value1', enabled: true },
+            { key: 'field2', value: 'value2', enabled: true },
+            { key: '', value: '', enabled: false },
+          ],
+        },
+      }
+
+      const wrapper = mount(RequestBody, props)
+
+      const requestTable = wrapper.findComponent({ name: 'RequestTable' })
+      await requestTable.vm.$emit('deleteRow', 1) // Delete the second row (index 1)
+
+      expect(mockRequestExampleMutators.edit).toHaveBeenCalledWith('mockExampleUid', 'body.formData.value', [
+        { key: 'field1', value: 'value1', enabled: true },
+        { key: '', value: '', enabled: false },
+      ])
+
+      wrapper.unmount()
+    })
+
+    it('does not delete row with invalid index', async () => {
+      mockActiveExample.body = {
+        activeBody: 'formData',
+        formData: {
+          encoding: 'form-data',
+          value: [{ key: 'field1', value: 'value1', enabled: true }],
+        },
+      }
+
+      const wrapper = mount(RequestBody, props)
+      const initialCallCount = mockRequestExampleMutators.edit.mock.calls.length
+
+      const requestTable = wrapper.findComponent({ name: 'RequestTable' })
+      await requestTable.vm.$emit('deleteRow', 5) // Invalid index
+
+      // Verify that edit was not called for the invalid deletion
+      expect(mockRequestExampleMutators.edit.mock.calls.length).toBe(initialCallCount)
+
+      wrapper.unmount()
+    })
+
+    it('deletes a row from form urlencoded', async () => {
+      mockActiveExample.body = {
+        activeBody: 'formData',
+        formData: {
+          encoding: 'urlencoded',
+          value: [
+            { key: 'field1', value: 'value1', enabled: true },
+            { key: '', value: '', enabled: false },
+          ],
+        },
+      }
+
+      const wrapper = mount(RequestBody, props)
+
+      const requestTable = wrapper.findComponent({ name: 'RequestTable' })
+      await requestTable.vm.$emit('deleteRow', 0)
+
+      expect(mockRequestExampleMutators.edit).toHaveBeenCalledWith('mockExampleUid', 'body.formData.value', [
+        { key: '', value: '', enabled: false },
+      ])
+
+      wrapper.unmount()
+    })
+
+    it('deletes row with file attachment', async () => {
+      const mockFile = new File(['test content'], 'test.txt', { type: 'text/plain' })
+
+      mockActiveExample.body = {
+        activeBody: 'formData',
+        formData: {
+          encoding: 'form-data',
+          value: [
+            { key: 'field1', value: 'value1', enabled: true },
+            { key: 'file_field', value: 'test.txt', enabled: true, file: mockFile },
+            { key: 'field3', value: 'value3', enabled: true },
+          ],
+        },
+      }
+
+      const wrapper = mount(RequestBody, props)
+
+      const requestTable = wrapper.findComponent({ name: 'RequestTable' })
+      await requestTable.vm.$emit('deleteRow', 1)
+
+      expect(mockRequestExampleMutators.edit).toHaveBeenCalledWith('mockExampleUid', 'body.formData.value', [
+        { key: 'field1', value: 'value1', enabled: true },
+        { key: 'field3', value: 'value3', enabled: true },
+      ])
+
+      wrapper.unmount()
+    })
+  })
 })

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -114,8 +114,18 @@ const codeInputLanguage = computed(() => {
   return contentTypeToLanguageMap[type] ?? 'plaintext'
 })
 
-function deleteRow() {
-  console.log('deleteRow')
+const deleteRow = (rowIdx: number) => {
+  const currentParams = formParams.value
+  if (currentParams.length > rowIdx) {
+    const updatedParams = [...currentParams]
+    updatedParams.splice(rowIdx, 1)
+
+    requestExampleMutators.edit(
+      example.uid,
+      'body.formData.value',
+      updatedParams,
+    )
+  }
 }
 
 /** Update a field in a parameter row */


### PR DESCRIPTION
**Problem**

Currently, deleting rows in the request body form-data is not yet implemented.

before:

https://github.com/user-attachments/assets/93385b82-427a-4070-be04-27fd79d5ad1c

after:

https://github.com/user-attachments/assets/ccc18063-a335-430f-a435-71818a0b3248



**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
