### PR TITLE
fix(api-reference): x-enumDescriptions should be an object

### DIFF
--- a/.changeset/sixty-humans-sparkle.md
+++ b/.changeset/sixty-humans-sparkle.md
@@ -1,0 +1,4 @@
+---
+'@scalar/api-reference': patch
+---
+fix: x-enumDescriptions should be an object

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -251,21 +251,16 @@ describe('SchemaProperty sub-schema', () => {
     const wrapper = mount(SchemaProperty, {
       props: {
         value: {
-          "type": "string",
-          "enum": [
-            "Ice giant",
-            "Dwarf",
-            "Gas",
-            "Iron"
-          ],
-          "title": "Planet",
-          "description": "The type of planet",
-          "x-enumDescriptions": {
-            "Ice giant": "A planet with a thick atmosphere of water, methane, and ammonia ice",
-            "Dwarf": "A planet that is not massive enough to clear its orbit",
-            "Gas": "A planet with a thick atmosphere of hydrogen and helium",
-            "Iron": "A planet made mostly of iron"
-          }
+          'type': 'string',
+          'enum': ['Ice giant', 'Dwarf', 'Gas', 'Iron'],
+          'title': 'Planet',
+          'description': 'The type of planet',
+          'x-enumDescriptions': {
+            'Ice giant': 'A planet with a thick atmosphere of water, methane, and ammonia ice',
+            'Dwarf': 'A planet that is not massive enough to clear its orbit',
+            'Gas': 'A planet with a thick atmosphere of hydrogen and helium',
+            'Iron': 'A planet made mostly of iron',
+          },
         },
       },
     })

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -247,6 +247,42 @@ describe('SchemaProperty sub-schema', () => {
     expect(enumValues).toHaveLength(1)
   })
 
+  it('show enum values ​​and descriptions', () => {
+    const wrapper = mount(SchemaProperty, {
+      props: {
+        value: {
+          "type": "string",
+          "enum": [
+            "Ice giant",
+            "Dwarf",
+            "Gas",
+            "Iron"
+          ],
+          "title": "Planet",
+          "description": "The type of planet",
+          "x-enumDescriptions": {
+            "Ice giant": "A planet with a thick atmosphere of water, methane, and ammonia ice",
+            "Dwarf": "A planet that is not massive enough to clear its orbit",
+            "Gas": "A planet with a thick atmosphere of hydrogen and helium",
+            "Iron": "A planet made mostly of iron"
+          }
+        },
+      },
+    })
+
+    const enumList = wrapper.find('.property-enum .property-list')
+    const html = enumList.html()
+
+    expect(html).toContain('Ice giant')
+    expect(html).toContain('Dwarf')
+    expect(html).toContain('Gas')
+    expect(html).toContain('Iron')
+    expect(html).toContain('A planet with a thick atmosphere of water, methane, and ammonia ice')
+    expect(html).toContain('A planet that is not massive enough to clear its orbit')
+    expect(html).toContain('A planet with a thick atmosphere of hydrogen and helium')
+    expect(html).toContain('A planet made mostly of iron')
+  })
+
   it('shows pattern properties for type object', async () => {
     const wrapper = mount(SchemaProperty, {
       props: {

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -239,6 +239,18 @@ const shouldRenderObjectProperties = computed(() => {
 
   return isObjectType && hasPropertiesToRender
 })
+
+const shouldShowEnumDescriptions = computed(() => {
+  if (!optimizedValue.value?.['x-enumDescriptions']) {
+    return false
+  }
+
+  const enumDescriptions = optimizedValue.value['x-enumDescriptions']
+
+  return (
+    typeof enumDescriptions === 'object' && !Array.isArray(enumDescriptions)
+  )
+})
 </script>
 <template>
   <component
@@ -298,7 +310,7 @@ const shouldRenderObjectProperties = computed(() => {
     <div
       v-if="getEnumFromValue(optimizedValue)?.length > 0 && !isDiscriminator"
       class="property-enum">
-      <template v-if="Array.isArray(optimizedValue?.['x-enumDescriptions'])">
+      <template v-if="shouldShowEnumDescriptions">
         <div class="property-list">
           <div
             v-for="enumValue in getEnumFromValue(optimizedValue)"
@@ -311,7 +323,7 @@ const shouldRenderObjectProperties = computed(() => {
             </div>
             <div class="property-description">
               <ScalarMarkdown
-                :value="optimizedValue['x-enumDescriptions'][enumValue]" />
+                :value="optimizedValue?.['x-enumDescriptions']?.[enumValue]" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
**Problem**

using `x-enumDescriptions` while being implemented, is not getting displayed in the api reference as expecting an array instead of an object.

**Solution**

this pr updates the current logic to get to display enum description accordingly. fixes #5934 #5938

| state | preview |
| -------|------|
| before | <img width="700" alt="image" src="https://github.com/user-attachments/assets/a60f141f-4075-49ff-8e4f-d8cfe5d51449" /> |
| after | <img width="700" alt="image" src="https://github.com/user-attachments/assets/858a10c2-4f1b-46ea-815c-85175beaaa82" /> | 

**Test**

<details>
<summary>OpenApi Document</summary>

```json
{
  "openapi": "3.1.0",
  "components": {
    "schemas": {
      "planet": {
        "type": "string",
        "enum": [
          "Ice giant",
          "Dwarf",
          "Gas",
          "Iron"
        ],
        "title": "Planet",
        "description": "The type of planet",
        "x-enumDescriptions": {
          "Ice giant": "A planet with a thick atmosphere of water, methane, and ammonia ice",
          "Dwarf": "A planet that is not massive enough to clear its orbit",
          "Gas": "A planet with a thick atmosphere of hydrogen and helium",
          "Iron": "A planet made mostly of iron"
        }
      }
    }
  }
}
```
</details>

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
