### PR TITLE
feat(workspace-store): server store input document from different sources

### DIFF
--- a/.changeset/green-mangos-repair.md
+++ b/.changeset/green-mangos-repair.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': minor
+---
+
+feat(workspace-store): server store input document from different sources

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -258,7 +258,7 @@ describe('create-workspace-store', () => {
     const PORT = 9988
     await server.listen({ port: PORT })
 
-    const serverStore = createServerWorkspaceStore({
+    const serverStore = await createServerWorkspaceStore({
       mode: 'ssr',
       baseUrl: `http://localhost:${PORT}`,
       documents: [
@@ -386,7 +386,7 @@ describe('create-workspace-store', () => {
     const PORT = 6672
     await server.listen({ port: PORT })
 
-    const serverStore = createServerWorkspaceStore({
+    const serverStore = await createServerWorkspaceStore({
       mode: 'ssr',
       baseUrl: `http://localhost:${PORT}`,
       documents: [

--- a/packages/workspace-store/src/server.test.ts
+++ b/packages/workspace-store/src/server.test.ts
@@ -41,7 +41,7 @@ describe('create-server-store', () => {
 
   describe('ssr', () => {
     test('should be able to pass a list of documents and get the workspace', async () => {
-      const store = createServerWorkspaceStore({
+      const store = await createServerWorkspaceStore({
         mode: 'ssr',
         baseUrl: 'https://example.com',
         documents: [
@@ -105,7 +105,7 @@ describe('create-server-store', () => {
     })
 
     test('should be able to get the document chunks', async () => {
-      const store = createServerWorkspaceStore({
+      const store = await createServerWorkspaceStore({
         mode: 'ssr',
         baseUrl: 'https://example.com',
         documents: [
@@ -131,7 +131,7 @@ describe('create-server-store', () => {
     })
 
     test('should be able to add more documents on the workspace', async () => {
-      const store = createServerWorkspaceStore({
+      const store = await createServerWorkspaceStore({
         mode: 'ssr',
         baseUrl: 'https://example.com',
         documents: [
@@ -149,7 +149,7 @@ describe('create-server-store', () => {
         ],
       })
 
-      store.addDocument(exampleDocument(), { name: 'doc-3', 'x-scalar-active-auth': 'test' })
+      await store.addDocument({ name: 'doc-3', meta: { 'x-scalar-active-auth': 'test' }, document: exampleDocument() })
       const workspace = store.getWorkspace()
 
       expect(workspace.documents['doc-1']).toEqual({
@@ -222,7 +222,7 @@ describe('create-server-store', () => {
     test('should generate the workspace file and also all the related chunks', async () => {
       const dir = 'temp'
 
-      const store = createServerWorkspaceStore({
+      const store = await createServerWorkspaceStore({
         mode: 'static',
         directory: dir,
         documents: [
@@ -243,10 +243,13 @@ describe('create-server-store', () => {
         },
       })
 
-      store.addDocument(exampleDocument(), {
+      await store.addDocument({
+        document: exampleDocument(),
         name: 'doc-2',
-        'x-scalar-active-auth': 'test',
-        'x-scalar-active-server': 'test',
+        meta: {
+          'x-scalar-active-auth': 'test',
+          'x-scalar-active-server': 'test',
+        },
       })
       await store.generateWorkspaceChunks()
 


### PR DESCRIPTION
**Problem**

The server-side store currently only supports loading documents passed as in-memory objects. This limits flexibility, especially when working with external sources like remote URLs or local files.

**Solution**

This PR extends the server-side store to support asynchronously loading documents from:

- a URL
- a local file path

in addition to directly passing an object.

To support this, the store API has been updated to work asynchronously:
- addDocument() now returns a Promise
- the store itself is initialized in an async context

> ⚠️ Breaking Change: These changes affect any code expecting addDocument or the store setup to be synchronous. Callers will now need to await these operations.

This improvement enables greater flexibility and unlocks use cases like lazy-loading large schemas or integrating external sources without prefetching them manually.



**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
