### PR TITLE
fix(api-reference): client libraries style

### DIFF
--- a/.changeset/large-stingrays-decide.md
+++ b/.changeset/large-stingrays-decide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates client libraries footer style

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
@@ -117,20 +117,21 @@ const installationInstructions = computed(() => {
           <div
             v-if="installationInstructions.description"
             class="selected-client card-footer -outline-offset-2"
+            :class="installationInstructions.source && 'rounded-b-none'"
             role="tabpanel"
             tabindex="0">
             <ScalarMarkdown :value="installationInstructions.description" />
           </div>
           <div
             v-if="installationInstructions.source"
-            class="selected-client card-footer -outline-offset-2"
+            class="selected-client card-footer border-t-0 p-0"
             role="tabpanel"
             tabindex="1">
             <ScalarCodeBlock
               lang="shell"
               :content="installationInstructions.source"
-              :copy="false"
-              class="min-h-6 p-1" />
+              :copy="true"
+              class="rounded-t-none rounded-b-lg px-3 py-2 -outline-offset-1 has-focus:outline" />
           </div>
         </template>
         <template v-else-if="httpClient && isFeatured(httpClient)">
@@ -183,5 +184,8 @@ const installationInstructions = computed(() => {
   border: var(--scalar-border-width) solid var(--scalar-border-color);
   border-top-left-radius: var(--scalar-radius-lg);
   border-top-right-radius: var(--scalar-radius-lg);
+}
+:deep(.scalar-codeblock-pre .hljs) {
+  margin-top: 8px;
 }
 </style>


### PR DESCRIPTION
**Problem**

currently the client libraries style appears inconsistant + doesn't offer copy capability (e.g. in SDK usage)

**Solution**

this pr updates the style accordingly and re-introduce the copy capability.

| state | preview |
| -------|------|
| before | <img width="700" alt="image" src="https://github.com/user-attachments/assets/7b53b090-1967-4d78-b747-99f8a118ea5f" /> |
| after | <img width="700" alt="image" src="https://github.com/user-attachments/assets/5066faad-5b79-4c38-83f6-152071d65788" /> | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
