### PR TITLE
fix(api-reference): only fetch document if we dont have content

### DIFF
--- a/.changeset/ninety-ears-double.md
+++ b/.changeset/ninety-ears-double.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: only fetch document if we dont have content

--- a/packages/api-reference/src/features/DocumentSource/hooks/useDocumentFetcher.ts
+++ b/packages/api-reference/src/features/DocumentSource/hooks/useDocumentFetcher.ts
@@ -46,8 +46,8 @@ export function useDocumentFetcher({
  * 5. Otherwise, return an empty string.
  */
 const getContent = async ({ url, content }: SpecConfiguration, proxyUrl?: string): Promise<string | undefined> => {
-  // Fetch from URL
-  if (url) {
+  // Fetch from URL only if we do not already have the content
+  if (url && !content) {
     try {
       const result = await measure(`fetch(${url})`, async () => await fetchDocument(url, proxyUrl))
 


### PR DESCRIPTION
**Problem**

Currently, if we provide both content and url we re-fetch the document.

**Solution**

With this PR we do not fetch if we have content already. URL is needed to share the document so sometimes both are provided and the content is fetched on the server, no need for a double fetch.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
