### PR TITLE
feat(proxy): bypass cidr checks for dev

### DIFF
--- a/projects/proxy-scalar-com/.env.example
+++ b/projects/proxy-scalar-com/.env.example
@@ -1,1 +1,2 @@
 PORT=5051
+ENV=dev

--- a/projects/proxy-scalar-com/main.go
+++ b/projects/proxy-scalar-com/main.go
@@ -105,7 +105,7 @@ func main() {
 	}
 
 	// Create a new proxy server instance
-	proxyServer := NewProxyServer(false)
+	proxyServer := NewProxyServer(os.Getenv("ENV") == "dev")
 
 	// Set up routing using the default HTTP multiplexer
 	mux := http.NewServeMux()

--- a/projects/proxy-scalar-com/package.json
+++ b/projects/proxy-scalar-com/package.json
@@ -20,9 +20,9 @@
   },
   "scripts": {
     "build": "go build main.go",
-    "dev": "PORT=5051 go run main.go",
+    "dev": "ENV=dev PORT=5051 go run main.go",
     "docker:build": "docker build -t scalar-proxy-server .",
-    "docker:run": "pnpm docker:build && docker run -p 5051:9033 scalar-proxy-server",
+    "docker:run": "pnpm docker:build && docker run --env ENV=dev -p 5051:9033 scalar-proxy-server",
     "lint:check": "go fmt ./main.go",
     "lint:fix": "go fmt ./main.go",
     "preview": "pnpm dev",


### PR DESCRIPTION
**Problem**

We previously blocked this set of CIDR addresses for production usage of the proxy; since the proxy can also be ran locally to hit private CIDR ranges, we should ensure that these are bypassed by default.

Improved devex for https://github.com/scalar/scalar/pull/5812

**Solution**

- Introduce an env check which will bypass CIDR logic for dev
- Update default dev commands + docker to use dev env

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
