### PR TITLE
feat: add analytics to guides.scalar.com

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -163,6 +163,7 @@
     }
   ],
   "siteConfig": {
+    "headScript": "function addFathomAnalytics(){let t=document.createElement(\"script\");t.src=\"https:\/\/cdn.usefathom.com\/script.js\",t.setAttribute(\"data-spa\",\"auto\"),t.setAttribute(\"data-site\",\"RSYAEMNM\"),t.defer=!0,document.head.appendChild(t)}\"loading\"===document.readyState?document.addEventListener(\"DOMContentLoaded\",addFathomAnalytics):addFathomAnalytics();",
     "logo": {
       "darkMode": "https://scalar.com/logo-light.svg",
       "lightMode": "https://scalar.com/logo-dark.svg"


### PR DESCRIPTION
**Problem**

Currently we are missing analytics on guides.scalar.com

**Solution**

With this PR we add fathom :)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
