### PR TITLE
fix(api-reference): updates playwright api reference test

### DIFF
--- a/playwright/tests/testApiReference.ts
+++ b/playwright/tests/testApiReference.ts
@@ -7,7 +7,7 @@ export async function testApiReference(page: Page, isMobile: boolean) {
   // The heading
   await expect(page.getByRole('heading', { name: 'Scalar Galaxy' })).toBeVisible()
   // Body Text
-  await expect(page.getByText('The Scalar Galaxy')).toBeVisible()
+  await expect(page.getByText('The Scalar Galaxy is an example OpenAPI')).toBeVisible()
   // http client
   await expect(page.getByText('Client Libraries')).toBeVisible()
 


### PR DESCRIPTION
**Problem**

addition of #5927 introduced the same wording that is currently tested against in description through playwright, resulting in a double results hence breaking the test. 

**Solution**

this pr updates the playwright api reference test to be more specific against the tested description to avoid double result.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
