### PR TITLE
ci: review dependencies for known security issues

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,17 @@
+name: 'Dependency Review'
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Dependency Review
+        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9


### PR DESCRIPTION
**Problem**

I just found this official GitHub action that reviews dependencies for known security vulnerabilities.

**Solution**

This PR adds it as an additional workflow to further increase the security of our repository.

Note: Looks like it’s only reviewing touched files.

![Screenshot 2025-06-16 at 16 10 51](https://github.com/user-attachments/assets/684ed856-14dd-48d1-8353-eefb96838f76)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
