### PR TITLE
feat(api-reference): export references useSidebar

### DIFF
--- a/.changeset/curvy-cats-invite.md
+++ b/.changeset/curvy-cats-invite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat(api-reference): export references useSidebar

--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -7,6 +7,8 @@ export { default as GettingStarted } from '@/components/GettingStarted.vue'
 export { createApiReference } from '@/standalone/lib/html-api'
 
 export { Sidebar } from '@/components/Sidebar'
+export { useSidebar } from '@/features/sidebar'
+
 export { Card, CardHeader, CardContent, CardFooter, CardTabHeader, CardTab } from '@/components/Card'
 
 // TODO: Ideally, we’d remove those exports or at least not export them through the root index.


### PR DESCRIPTION
**Problem**

Need useSidebar separately in org for now to handle some item actions

**Solution**

Export current useSidebar; it was exported previously but from hooks instead, and we got rid of that

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
