### PR TITLE
fix(api-reference): ensure x-scalar-ignore applies to models

### DIFF
--- a/.changeset/big-cougars-matter.md
+++ b/.changeset/big-cougars-matter.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: ensure x-scalar-ignore applies to the schema models

--- a/packages/api-reference/src/libs/openapi.ts
+++ b/packages/api-reference/src/libs/openapi.ts
@@ -97,7 +97,7 @@ export function getModels(spec?: Spec) {
 
   // Filter out all schemas with `x-internal: true`
   Object.keys(models ?? {}).forEach((key) => {
-    if (models[key]?.['x-internal'] === true) {
+    if (models[key]?.['x-internal'] === true || models[key]?.['x-scalar-ignore'] === true) {
       delete models[key]
     }
   })


### PR DESCRIPTION
**Problem**

Currently, we do not ignore models correctly.

**Solution**

With this PR we apply x-scalar-ignore although we will be removing this all and using the sidebar logic soon which already contains this!

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
