### PR TITLE
chore: clean up api references docs and link to configuration

### DIFF
--- a/documentation/guides/api-references/getting-started.md
+++ b/documentation/guides/api-references/getting-started.md
@@ -1,0 +1,86 @@
+# Getting Started
+Reading this guide helps you to get started with our wonderful Open-Source API References as quick as possible.
+
+You’re just one HTML file away from having an awesome API reference:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <title>Scalar API Reference</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+  </head>
+
+  <body>
+    <div id="app"></div>
+
+    <!-- Load the Script -->
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+
+    <!-- Initialize the Scalar API Reference -->
+    <script>
+      Scalar.createApiReference('#app', {
+        // The URL of the OpenAPI/Swagger document
+        url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+        // Avoid CORS issues
+        proxyUrl: 'https://proxy.scalar.com',
+      })
+    </script>
+  </body>
+</html>
+```
+
+> Need a Custom Header? Check out this example: https://codepen.io/scalarorg/pen/VwOXqam
+
+### Customization
+
+| Topic                                           | Description                          |
+| ----------------------------------------------- | ------------------------------------ |
+| [Themes](themes)               | Predefined themes, layouts & styling |
+| [Configuration](configuration) | The universal configuration object   |
+| [Plugins](plugins)             | Extend the functionality             |
+| [OpenAPI](openapi)             | OpenAPI and our extensions to it     |
+| [Markdown](markdown)           | The supported Markdown syntax        |
+
+And there’s an ever-growing list of plugins and integrations:
+
+### Integrations
+
+- [HTML/JS API](integrations/html-js) (works everywhere)
+- [.NET](integrations/aspnetcore/README)
+- [AdonisJS](integrations/adonisjs)
+- [Django](https://github.com/m1guer/django-scalar)
+- [Django Ninja](integrations/django-ninja/README)
+- [Docusaurus](integrations/docusaurus/README)
+- [Express](integrations/express/README)
+- [FastAPI](integrations/fastapi/README)
+- [Fastify](integrations/fastify/README)
+- [Go](integrations/go)
+- [Hono](integrations/hono/README)
+- [Laravel Scribe](integrations/laravel-scribe)
+- [Micronaut](https://micronaut-projects.github.io/micronaut-openapi/latest/guide/index.html#scalar)
+- [NestJS](integrations/nestjs/README)
+- [Next.js](integrations/nextjs/README)
+- [Nuxt](integrations/nuxt/README)
+- [React](packages/api-reference-react/README)
+- [Ruby on Rails](https://github.com/dmytroshevchuk/scalar_ruby)
+- [Rust](integrations/rust)
+- [Scalar for Laravel](https://github.com/scalar/laravel)
+- [Ts.ED](https://tsed.dev/tutorials/scalar.html)
+- [Vue.js](packages/api-reference/README)
+- [Python](https://github.com/iagobalmeida/scalar_doc)
+
+
+### Built-in Support
+
+The following frameworks have chosen Scalar API Reference as their default OpenAPI documentation UI, recognizing its developer-friendly features and modern design:
+
+- [ElysiaJS](integrations/elysiajs)
+- [HappyX](https://github.com/HapticX/happyx)
+- [Litestar](https://docs.litestar.dev/latest/usage/openapi/ui_plugins.html)
+- [Nitro](integrations/nitro)
+- [Platformatic](integrations/platformatic)
+- [oRPC](https://orpc.unnoq.com/docs/openapi/plugins/openapi-reference)

--- a/documentation/guides/api-references/getting-started.md
+++ b/documentation/guides/api-references/getting-started.md
@@ -1,7 +1,8 @@
 # Getting Started
 Reading this guide helps you to get started with our wonderful Open-Source API References as quick as possible.
 
-You’re just one HTML file away from having an awesome API reference:
+
+Our most simplest example is using the CDN integration of our API References
 
 ```html
 <!doctype html>

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -84,79 +84,94 @@
           "icon": "brand/brand-software-development-github",
           "children": [
             {
-              "name": ".NET Integration",
-              "path": "documentation/integrations/dotnet.md",
+              "name": "Getting Started",
+              "path": "documentation/guides/api-references/getting-started.md",
               "type": "page"
             },
             {
-              "name": "AdonisJS",
-              "path": "documentation/integrations/adonisjs.md",
+              "name": "Configuration",
+              "path": "documentation/configuration.md",
               "type": "page"
             },
             {
-              "name": "Django",
-              "path": "documentation/integrations/django.md",
-              "type": "page"
-            },
-            {
-              "name": "Django Ninja",
-              "path": "documentation/integrations/django-ninja.md",
-              "type": "page"
-            },
-            {
-              "name": "Docusaurus",
-              "path": "documentation/integrations/docusaurus.md",
-              "type": "page"
-            },
-            {
-              "name": "ElysiaJS",
-              "path": "documentation/integrations/elysiajs.md",
-              "type": "page"
-            },
-            {
-              "name": "Fastify",
-              "path": "documentation/integrations/fastify.md",
-              "type": "page"
-            },
-            {
-              "name": "Go",
-              "path": "documentation/integrations/go.md",
-              "type": "page"
-            },
-            {
-              "name": "HTML/CDN",
-              "path": "documentation/integrations/html-js.md",
-              "type": "page"
-            },
-            {
-              "name": "Laravel Scribe",
-              "path": "documentation/integrations/laravel-scribe.md",
-              "type": "page"
-            },
-            {
-              "name": "Next.js",
-              "path": "documentation/integrations/nextjs.md",
-              "type": "page"
-            },
-            {
-              "name": "Nitro",
-              "path": "documentation/integrations/nitro.md",
-              "type": "page"
-            },
-            {
-              "name": "Platformatic",
-              "path": "documentation/integrations/platformatic.md",
-              "type": "page"
-            },
-            {
-              "name": "React",
-              "path": "documentation/integrations/react.md",
-              "type": "page"
-            },
-            {
-              "name": "Rust",
-              "path": "documentation/integrations/rust.md",
-              "type": "page"
+              "name": "Integrations",
+              "type": "folder",
+              "children": [{
+                  "name": ".NET",
+                  "path": "documentation/integrations/dotnet.md",
+                  "type": "page"
+                },
+                {
+                  "name": "AdonisJS",
+                  "path": "documentation/integrations/adonisjs.md",
+                  "type": "page"
+                },
+                {
+                  "name": "Django",
+                  "path": "documentation/integrations/django.md",
+                  "type": "page"
+                },
+                {
+                  "name": "Django Ninja",
+                  "path": "documentation/integrations/django-ninja.md",
+                  "type": "page"
+                },
+                {
+                  "name": "Docusaurus",
+                  "path": "documentation/integrations/docusaurus.md",
+                  "type": "page"
+                },
+                {
+                  "name": "ElysiaJS",
+                  "path": "documentation/integrations/elysiajs.md",
+                  "type": "page"
+                },
+                {
+                  "name": "Fastify",
+                  "path": "documentation/integrations/fastify.md",
+                  "type": "page"
+                },
+                {
+                  "name": "Go",
+                  "path": "documentation/integrations/go.md",
+                  "type": "page"
+                },
+                {
+                  "name": "HTML/CDN",
+                  "path": "documentation/integrations/html-js.md",
+                  "type": "page"
+                },
+                {
+                  "name": "Laravel Scribe",
+                  "path": "documentation/integrations/laravel-scribe.md",
+                  "type": "page"
+                },
+                {
+                  "name": "Next.js",
+                  "path": "documentation/integrations/nextjs.md",
+                  "type": "page"
+                },
+                {
+                  "name": "Nitro",
+                  "path": "documentation/integrations/nitro.md",
+                  "type": "page"
+                },
+                {
+                  "name": "Platformatic",
+                  "path": "documentation/integrations/platformatic.md",
+                  "type": "page"
+                },
+                {
+                  "name": "React",
+                  "path": "documentation/integrations/react.md",
+                  "type": "page"
+                },
+                {
+                  "name": "Rust",
+                  "path": "documentation/integrations/rust.md",
+                  "type": "page"
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
**Problem**

Currently our guides on api references are missing:
- getting started 
- each integration
- configuration
- openapi
- theme-ing and customization

**Solution**

With this PR I added them :) 

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/72819e43-0186-49c9-b5d4-df939a11efa8" />


**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
