### PR TITLE
fix(api-reference): remove duplicate operations in x-tag-groups

### DIFF
--- a/.changeset/fresh-radios-enjoy.md
+++ b/.changeset/fresh-radios-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: remove duplicate operations in x-tag-groups

--- a/biome.json
+++ b/biome.json
@@ -65,7 +65,7 @@
     "formatter": {
       "quoteStyle": "single",
       "trailingCommas": "all",
-      "quoteProperties": "asNeeded",
+      "quoteProperties": "preserve",
       "semicolons": "asNeeded",
       "arrowParentheses": "always",
       "bracketSameLine": true

--- a/biome.json
+++ b/biome.json
@@ -65,7 +65,7 @@
     "formatter": {
       "quoteStyle": "single",
       "trailingCommas": "all",
-      "quoteProperties": "preserve",
+      "quoteProperties": "asNeeded",
       "semicolons": "asNeeded",
       "arrowParentheses": "always",
       "bracketSameLine": true

--- a/packages/api-reference/src/features/Search/useSearchIndex.test.ts
+++ b/packages/api-reference/src/features/Search/useSearchIndex.test.ts
@@ -75,7 +75,8 @@ describe('useSearchIndex', () => {
       {
         item: {
           operation: {
-            name: 'Get request',
+            description: 'Get request description',
+            summary: 'Get request',
           },
         },
       },

--- a/packages/api-reference/src/features/Search/useSearchIndex.ts
+++ b/packages/api-reference/src/features/Search/useSearchIndex.ts
@@ -1,4 +1,4 @@
-import type { Spec, TransformedOperation } from '@scalar/types/legacy'
+import type { OpenAPIV3_1, Spec, TransformedOperation } from '@scalar/types/legacy'
 import Fuse, { type FuseResult } from 'fuse.js'
 import { type Ref, computed, ref, watch } from 'vue'
 
@@ -7,6 +7,7 @@ import { type ParamMap, useOperation } from '@/hooks/useOperation'
 import { getHeadingsFromMarkdown } from '@/libs/markdown'
 import { extractRequestBody, getModels } from '@/libs/openapi'
 import { useConfig } from '@/hooks/useConfig'
+import { isHttpMethod } from '@scalar/helpers/http/is-http-method'
 
 export type EntryType = 'req' | 'webhook' | 'model' | 'heading' | 'tag'
 
@@ -88,13 +89,6 @@ export function useSearchIndex({
     (newSpec) => {
       fuseDataArray.value = []
 
-      // Likely an incomplete/invalid spec
-      // TODO: Or just an OpenAPI document without tags and webhooks?
-      if (!newSpec?.tags?.length && !newSpec?.webhooks?.length) {
-        fuse.setCollection([])
-        return
-      }
-
       // Headings from the description
       const headingsData: FuseData[] = []
       const headings = getHeadingsFromMarkdown(newSpec?.info?.description ?? '')
@@ -115,47 +109,86 @@ export function useSearchIndex({
       }
 
       // Tags
-      newSpec?.tags?.forEach((tag) => {
-        const tagData: FuseData = {
-          title: tag['x-displayName'] ?? tag.name,
-          href: `#${getTagId(tag)}`,
-          description: tag.description,
-          type: 'tag',
-          tag: tag.name,
-          body: '',
-        }
+      if (newSpec?.tags?.length) {
+        newSpec?.tags?.forEach((tag) => {
+          const tagData: FuseData = {
+            title: tag['x-displayName'] ?? tag.name,
+            href: `#${getTagId(tag)}`,
+            description: tag.description,
+            type: 'tag',
+            tag: tag.name,
+            body: '',
+          }
 
-        fuseDataArray.value.push(tagData)
+          fuseDataArray.value.push(tagData)
 
-        if (tag.operations) {
-          tag.operations.forEach((operation) => {
-            const { parameterMap } = useOperation(operation)
-            const bodyData = extractRequestBody(operation) || parameterMap.value
-            let body = null
-            if (typeof bodyData !== 'boolean') {
-              body = bodyData
+          if (tag.operations) {
+            tag.operations.forEach((operation) => {
+              const { parameterMap } = useOperation(operation)
+              const bodyData = extractRequestBody(operation) || parameterMap.value
+              let body = null
+              if (typeof bodyData !== 'boolean') {
+                body = bodyData
+              }
+
+              const operationData: FuseData = {
+                type: 'req',
+                title: operation.name ?? operation.path,
+                href: `#${operation.id}`,
+                operationId: operation.information?.operationId,
+                description: operation.description ?? '',
+                httpVerb: operation.httpVerb,
+                path: operation.path,
+                tag: tag.name,
+                operation,
+              }
+
+              if (body) {
+                operationData.body = body
+              }
+
+              fuseDataArray.value.push(operationData)
+            })
+          }
+        })
+      }
+      // Handle paths with no tags - super hacky but we'll fix it on new store
+      // @ts-expect-error not sure why spec doesn't have paths, but at this point I'm too afraid to ask
+      else if (newSpec?.paths) {
+        const paths = (newSpec as OpenAPIV3_1.Document).paths
+
+        Object.keys(paths ?? {}).forEach((path) => {
+          Object.keys(paths?.[path] ?? {}).forEach((method) => {
+            const operation = paths?.[path]?.[method]
+
+            if (isHttpMethod(method) && operation) {
+              const { parameterMap } = useOperation({ ...operation, information: operation })
+              const bodyData = extractRequestBody(operation) || parameterMap.value
+              let body = null
+              if (typeof bodyData !== 'boolean') {
+                body = bodyData
+              }
+
+              const operationData: FuseData = {
+                type: 'req',
+                title: operation.name ?? operation.path,
+                href: `#${operation.id}`,
+                operationId: operation.information?.operationId,
+                description: operation.description ?? '',
+                httpVerb: operation.httpVerb,
+                path: operation.path,
+                operation,
+              }
+
+              if (body) {
+                operationData.body = body
+              }
+
+              fuseDataArray.value.push(operationData)
             }
-
-            const operationData: FuseData = {
-              type: 'req',
-              title: operation.name ?? operation.path,
-              href: `#${operation.id}`,
-              operationId: operation.information?.operationId,
-              description: operation.description ?? '',
-              httpVerb: operation.httpVerb,
-              path: operation.path,
-              tag: tag.name,
-              operation,
-            }
-
-            if (body) {
-              operationData.body = body
-            }
-
-            fuseDataArray.value.push(operationData)
           })
-        }
-      })
+        })
+      }
 
       // Adding webhooks
       const webhooks = newSpec?.webhooks

--- a/packages/api-reference/src/helpers/parse.ts
+++ b/packages/api-reference/src/helpers/parse.ts
@@ -163,7 +163,7 @@ const transformResult = (originalSchema: OpenAPIV3_1.Document, items?: Traversed
       item.children.forEach(parseTag)
     }
     // Tags
-    if ('tag' in item) {
+    else if ('tag' in item) {
       parseTag(item)
     }
     // Webhooks


### PR DESCRIPTION
**Problem**

closes #5983 

Currently, using x-tag-groups duplicates the operations in the list

**Solution**

With this PR we prevent that duplication. Also it seems search was broken when you don't have any tags, fixed that as well.
**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
