### PR TITLE
style: only quote properties as needed in biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -65,7 +65,7 @@
     "formatter": {
       "quoteStyle": "single",
       "trailingCommas": "all",
-      "quoteProperties": "preserve",
+      "quoteProperties": "asNeeded",
       "semicolons": "asNeeded",
       "arrowParentheses": "always",
       "bracketSameLine": true


### PR DESCRIPTION
**Problem**

Currently, when you paste in json, I have been manually removing quotes like a sucker.

Before:
```ts
  'javascript': {
    'formatter': {
      'quoteProperties': 'asNeeded',
    }
  },
```

After:
```ts
  javascript: {
    formatter: {
      quoteProperties: asNeeded,
    }
  },
```
**Solution**

With this PR we do what we had before with eslint/prettier and properties are only quoted as needed ie `'/paths'`. I will run this lint on the weekend to as not to  be distruptive

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
