### PR TITLE
feat: add getting started sdk guides

### DIFF
--- a/documentation/guides/access.md
+++ b/documentation/guides/access.md
@@ -6,7 +6,7 @@ Make sure you have created a Scalar Account & are logged in ([see create account
 ## Create your first access group
 Now let's make our first access group
 
-From the dashboard left-most sidebar under Access > Groups, then click Create Access Group.
+From the [dashboard](https://dashboard.scalar.com) left-most sidebar under Access > Groups, then click Create Access Group.
 
 ![Scalar Access Group Page](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/fkz45YW1-1ncvfHnyDC_g.png "Scalar Access Group Page")
 

--- a/documentation/guides/registry/dashboard.md
+++ b/documentation/guides/registry/dashboard.md
@@ -6,7 +6,7 @@ Make sure you have created a Scalar Account & are logged in ([see create account
 ## Add an OpenAPI Document
 Now let's add an OpenAPI document to the registry ✨
 
-From the dashboard click Import API from the right hand pane, or navigate to registry in the sidebar under Products then click Create new API
+From the [dashboard](https://dashboard.scalar.com) click Import API from the right hand pane, or navigate to registry in the sidebar under Products then click Create new API
 
 ![Scalar Import OpenAPI Document Modal](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/WnMVG8hrR_f-6t-lOtDYb.png "Scalar Import OpenAPI Document")
 

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -1,1 +1,30 @@
 # Getting Started
+This guide will help you get started with generating world-class SDKs on scalar.com in several languages: TypeScript, Python, Golang & more powered by [Speakeasy](https://speakeasy.com).
+
+
+Make sure you have created a Scalar Account & are logged in ([see create account guide](/scalar/scalar-registry/getting-started#create-your-scalar-account))
+
+## Generating your first SDK
+From the [dashboard](https://dashboard.scalar.com) left-most sidebar under Products > SDKs, then click Create new SDK.
+
+![Create new SDK Page](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/_-IfCKbkQuZevciAtViRX.png "Create new SDK Page")
+
+#### Import OpenAPI Document (Optional) 
+If you don't already have an OpenAPI document on our registry, you can import it right in the modal.
+
+![Import OpenAPI Document (Optional)](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/WnMVG8hrR_f-6t-lOtDYb.png "Import OpenAPI Document (Optional)")
+
+Select as many SDKs as you would like, or just one language to start. Once you click "Continue" we will begin generating your SDKs.
+
+![Create TypeScript SDK](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/lH3Grvx1nPikw7-0sTE4Y.png "Create TypeScript SDK")
+
+
+Once created, you will get redirected to the SDK Overview page where you can:
+- Configure your SDK settings
+- Add our GitHub Integration
+- Downlad the SDK Client
+
+![SDK Overview Page](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/1TbvZqmSD170GGOw9O_iP.png "SDK Overview Page")
+
+## Link with GitHub
+

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -34,6 +34,18 @@
             }
           ]
         },
+
+        {
+          "name": "Scalar SDKs",
+          "type": "folder",
+          "icon": "solid/shopping-shipping-box-parcel-package",
+          "children": [
+            {
+              "path": "documentation/guides/sdks/getting-started.md",
+              "type": "page"
+            }
+          ]
+        },
         {
           "name": "Scalar Registry",
           "type": "folder",


### PR DESCRIPTION
**Problem**

Currently we are missing SDK guides

**Solution**

With this PR its just getting started

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
