### PR TITLE
fix(api-reference): show content type description in schema property

### DIFF
--- a/.changeset/sour-mirrors-move.md
+++ b/.changeset/sour-mirrors-move.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: show content encoding description in schema

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -68,6 +68,7 @@ const descriptions: Record<string, Record<string, string>> = {
     'date-time':
       'the date-time notation as defined by RFC 3339, section 5.6, for example, 2017-07-21T17:32:28Z',
     'password': 'a hint to UIs to mask the input',
+    'base64': 'base64-encoded characters, for example, U3dhZ2dlciByb2Nrcw==',
     'byte': 'base64-encoded characters, for example, U3dhZ2dlciByb2Nrcw==',
     'binary': 'binary data, used to describe files',
   },
@@ -105,7 +106,9 @@ const generatePropertyDescription = (property?: Record<string, any>) => {
     return null
   }
 
-  return descriptions[property.type][property.format || '_default']
+  return descriptions[property.type][
+    property.format || property.contentEncoding || '_default'
+  ]
 }
 
 const getEnumFromValue = (value?: Record<string, any>): any[] | [] =>

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -80,6 +80,10 @@ const displayType = computed(() => {
     return value.name
   }
 
+  if (value?.type && value.contentEncoding) {
+    return `${value.type} • ${value.contentEncoding}`
+  }
+
   return value?.type ?? ''
 })
 

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
@@ -88,11 +88,7 @@ export function getSchemaNameFromSchemas(schema: OpenAPIV3_1.SchemaObject, schem
 
       // Only return schema name if it has model name
       if (schema.type !== 'array' && schema.type !== 'object') {
-        const hasAdditionalProperties = Object.keys(schemaValue).some(
-          (key) => key !== 'type' && !['title', 'description'].includes(key),
-        )
-
-        if (hasAdditionalProperties || hasName(schemaName)) {
+        if (hasName(schemaName)) {
           return schemaName
         }
       }


### PR DESCRIPTION
**Problem**

Currently, we don't use the content encoding from version 3.1 of the spec to show descriptions, it used to be called format in 3.0.

https://spec.openapis.org/oas/latest.html#migrating-binary-descriptions-from-oas-3-0

**Solution**

With this PR we fix this and show the content type.

@antlio so I removed the code which checks for additional properties. Not sure if it was meant to match all additional properties but either way I don't think that is safe. What was that part specifically fixing?

Then I added the content encoding to be displayed so it matches the old style.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
