### PR TITLE
fix(oas-utils): doesn’t create example data for items without a type

### DIFF
--- a/.changeset/fast-colts-push.md
+++ b/.changeset/fast-colts-push.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: doesn’t create example data for schemas where items in an array don’t have a type

--- a/packages/oas-utils/src/spec-getters/get-example-from-schema.test.ts
+++ b/packages/oas-utils/src/spec-getters/get-example-from-schema.test.ts
@@ -1160,4 +1160,51 @@ describe('getExampleFromSchema', () => {
       name: 'test',
     })
   })
+
+  it('expands objects and arrays in arrays (without a type)', () => {
+    expect(
+      getExampleFromSchema({
+        'type': 'array',
+        'description': "The summary of user's quality of service (QoS) information.",
+        'items': {
+          // no `type: 'object'` here, but it’s an object
+          'properties': {
+            'type': {
+              'type': 'string',
+              'enum': ['audio_input', 'audio_output', 'video_input'],
+              'examples': ['audio_input'],
+            },
+            'details': {
+              'type': 'object',
+              'properties': {
+                'min_bitrate': {
+                  'type': 'string',
+                  'description': 'The minimum amount of bitrate, in Kbps.',
+                  'examples': ['27.15 Kbps'],
+                },
+              },
+            },
+            'foobar': {
+              'type': 'array',
+              'items': {
+                // no `type: 'array'` here, but it’s an array
+                'items': {
+                  'type': 'string',
+                  'example': 'foobar',
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).toStrictEqual([
+      {
+        'type': 'audio_input',
+        'details': {
+          'min_bitrate': '27.15 Kbps',
+        },
+        'foobar': [['foobar']],
+      },
+    ])
+  })
 })

--- a/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
+++ b/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
@@ -298,7 +298,12 @@ export const getExampleFromSchema = (
       }
     }
 
-    if (schema.items?.type) {
+    // if it has type: 'object', or properties, it’s an object
+    const isObject = schema.items?.type === 'object' || schema.items?.properties !== undefined
+    // if it has type: 'array', or items, it’s an array
+    const isArray = schema.items?.type === 'array' || schema.items?.items !== undefined
+
+    if (schema.items?.type || isObject || isArray) {
       const exampleFromSchema = getExampleFromSchema(schema.items, options, level + 1)
 
       return wrapItems ? [{ [itemsXmlTagName]: exampleFromSchema }] : [exampleFromSchema]


### PR DESCRIPTION
**Problem**

If a schema has an array, where the item has `properties` or `items`, but no `type: 'array|object'`, we don’t generate an example.

**Solution**

We can be clever and assume it’s supposed to be an object if it has `properties` and it’s supposed to be an array if it has `items`.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
