### PR TITLE
fix(api-reference): reduce incorrect schema names

### DIFF
--- a/.changeset/lovely-ducks-explain.md
+++ b/.changeset/lovely-ducks-explain.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: display correct schema type instead of false name

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -295,7 +295,7 @@ describe('SchemaPropertyHeading', () => {
     expect(detailsElement.text()).not.toContain('object')
   })
 
-  it.skip('matches array schema to component schema by type and items', () => {
+  it('matches array schema to component schema by type and items', () => {
     const wrapper = mount(SchemaPropertyHeading, {
       props: {
         value: {
@@ -339,7 +339,7 @@ describe('SchemaPropertyHeading', () => {
     expect(detailsElement.text()).not.toContain('Planet')
   })
 
-  it.todo('shows model name when hideModelNames is false', () => {
+  it('shows model name when hideModelNames is false', () => {
     const wrapper = mount(SchemaPropertyHeading, {
       props: {
         value: {

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -295,7 +295,7 @@ describe('SchemaPropertyHeading', () => {
     expect(detailsElement.text()).not.toContain('object')
   })
 
-  it('matches array schema to component schema by type and items', () => {
+  it.skip('matches array schema to component schema by type and items', () => {
     const wrapper = mount(SchemaPropertyHeading, {
       props: {
         value: {
@@ -339,7 +339,7 @@ describe('SchemaPropertyHeading', () => {
     expect(detailsElement.text()).not.toContain('Planet')
   })
 
-  it('shows model name when hideModelNames is false', () => {
+  it.todo('shows model name when hideModelNames is false', () => {
     const wrapper = mount(SchemaPropertyHeading, {
       props: {
         value: {

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 
-import { getModelNameFromSchema, getCompositionDisplay, getSchemaNameFromSchemas, getModelName } from './schema-name'
+import { getModelNameFromSchema, getCompositionDisplay, getModelName } from './schema-name'
 
 describe('schema-name', () => {
   describe('getModelNameFromSchema', () => {
@@ -68,84 +68,6 @@ describe('schema-name', () => {
     it('returns null for empty object', () => {
       const schema: OpenAPIV3_1.SchemaObject = {}
       expect(getModelNameFromSchema(schema)).toBe(null)
-    })
-  })
-
-  describe('getSchemaNameFromSchemas', () => {
-    it('finds schema name by matching object properties', () => {
-      const schema: OpenAPIV3_1.SchemaObject = {
-        type: 'object',
-        properties: {
-          name: { type: 'string' },
-          username: { type: 'string' },
-          deletedAt: { type: 'string', format: 'date-time', nullable: true },
-        },
-      }
-      const schemas = {
-        UserRequest: {
-          type: 'object',
-          properties: {
-            name: { type: 'string' },
-            username: { type: 'string' },
-            deletedAt: { type: 'string', format: 'date-time', nullable: true },
-          },
-        },
-        ProblemDetails: {
-          type: 'object',
-          properties: {
-            type: { type: 'string', format: 'uri' },
-            title: { type: 'string' },
-            status: { type: 'integer', format: 'int32' },
-          },
-        },
-      }
-      expect(getSchemaNameFromSchemas(schema, schemas)).toBe('UserRequest')
-    })
-
-    it('finds schema name by matching array types', () => {
-      const schema: OpenAPIV3_1.SchemaObject = {
-        type: 'array',
-        items: { type: 'string' },
-      }
-      const schemas = {
-        StringArray: {
-          type: 'array',
-          items: { type: 'string' },
-        },
-        NumberArray: {
-          type: 'array',
-          items: { type: 'number' },
-        },
-      }
-      expect(getSchemaNameFromSchemas(schema, schemas)).toBe('StringArray')
-    })
-
-    it('returns null when no matching schema found', () => {
-      const schema: OpenAPIV3_1.SchemaObject = {
-        type: 'object',
-        properties: { id: { type: 'string' } },
-      }
-      const schemas = {
-        User: {
-          type: 'object',
-          properties: { name: { type: 'string' } },
-        },
-      }
-      expect(getSchemaNameFromSchemas(schema, schemas)).toBe(null)
-    })
-
-    it('returns null when schemas is undefined', () => {
-      const schema: OpenAPIV3_1.SchemaObject = { type: 'object' }
-      expect(getSchemaNameFromSchemas(schema)).toBe(null)
-    })
-
-    it('does not return schema name for simple primitive types', () => {
-      const schema: OpenAPIV3_1.SchemaObject = { type: 'string' }
-      const schemas = {
-        foo: { type: 'string' },
-        bar: { type: 'number' },
-      }
-      expect(getSchemaNameFromSchemas(schema, schemas)).toBe(null)
     })
   })
 
@@ -249,6 +171,24 @@ describe('schema-name', () => {
       }
       const mockGetDiscriminatorSchemaName = () => 'DiscriminatorModel'
       expect(getModelName(value, {}, false, mockGetDiscriminatorSchemaName)).toBe('array DiscriminatorModel[]')
+    })
+
+    it('returns null when no matching schema found', () => {
+      const value = {
+        type: 'string',
+      }
+      const schemas = {
+        Timestamp: {
+          type: 'string',
+          format: 'date-time',
+          description: 'ISO-8601 Timestamp',
+          example: '2024-11-30T10:04:46+00:00',
+          readOnly: true,
+        },
+      }
+      const result = getModelName(value, schemas)
+      console.log(result)
+      expect(result).toBe(null)
     })
   })
 

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
@@ -187,7 +187,6 @@ describe('schema-name', () => {
         },
       }
       const result = getModelName(value, schemas)
-      console.log(result)
       expect(result).toBe(null)
     })
   })

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
@@ -251,7 +251,7 @@ describe('schema-name', () => {
       expect(getModelName(value, {}, false, mockGetDiscriminatorSchemaName)).toBe('array DiscriminatorModel[]')
     })
 
-    it.only('returns null when no matching schema found for a primitive type (string)', () => {
+    it('returns null when no matching schema found for a primitive type (string)', () => {
       const value = {
         type: 'string',
       }

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
@@ -86,13 +86,6 @@ export function getSchemaNameFromSchemas(schema: OpenAPIV3_1.SchemaObject, schem
       ) {
         return schemaName
       }
-
-      // Only return schema name if it has model name
-      if (schema.type !== 'array' && schema.type !== 'object') {
-        if (hasName(schemaName)) {
-          return schemaName
-        }
-      }
     }
   }
 

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
@@ -64,41 +64,6 @@ export function getModelNameFromSchema(schema: OpenAPIV3_1.SchemaObject, schemas
 }
 
 /**
- * Find schema name by matching against component schemas
- */
-export function getSchemaNameFromSchemas(schema: OpenAPIV3_1.SchemaObject, schemas?: Schemas): string | null {
-  if (!schema || !schemas || typeof schemas !== 'object') {
-    return null
-  }
-
-  for (const [schemaName, schemaValue] of Object.entries(schemas)) {
-    if (schemaValue.type === schema.type) {
-      if (schema.type === 'array' && schemaValue.items?.type === schema.items?.type) {
-        return schemaName
-      }
-
-      if (
-        schema.type === 'object' &&
-        schemaValue.properties &&
-        schema.properties &&
-        stringify(schemaValue.properties) === stringify(schema.properties)
-      ) {
-        return schemaName
-      }
-
-      // Only return schema name if it has model name
-      if (schema.type !== 'array' && schema.type !== 'object') {
-        if (hasName(schemaName)) {
-          return schemaName
-        }
-      }
-    }
-  }
-
-  return null
-}
-
-/**
  * Format the type and model name for display
  */
 export function formatTypeWithModel(type: string, modelName: string): string {
@@ -130,11 +95,6 @@ export function getModelName(
   const modelName = getModelNameFromSchema(value, schemas)
   if (modelName && (value.title || value.name)) {
     return value.type === 'array' ? `array ${modelName}[]` : modelName
-  }
-
-  const schemaName = getSchemaNameFromSchemas(value, schemas)
-  if (schemaName) {
-    return value.type === 'array' ? `array ${schemaName}[]` : schemaName
   }
 
   // Handle array types with item references only if no full schema match was found


### PR DESCRIPTION
**Problem**

closes #6001

Currently, we are matching the schema name based on a matching type.

**Solution**

That is unsafe as we can easily have multiple schemas with different names and the same types, specially for non-object or arrays. Previously it was matching strings which are quite common. Now it will only match if all array or object properties match which is a bit safer but not perfect.

## Update

Alright so after some digging I realize what @antlio meant. Once we de-reference we lose the name of the schema. I just made it a little safer by only property matching on objects or arrays, this should be slightly less error prone.

We should come back at this one in the new workspace store and keep some reference to the name @DemonHa as long as we have access to the ref string we should be good!

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
