### PR TITLE
feat(api-reference): align api reference sidebar style with figma

### DIFF
--- a/.changeset/curly-snakes-hang.md
+++ b/.changeset/curly-snakes-hang.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/themes': patch
+---
+
+feat(api-reference): update and modernize sidebar design

--- a/packages/api-reference/src/components/DocumentSelector/DocumentSelector.vue
+++ b/packages/api-reference/src/components/DocumentSelector/DocumentSelector.vue
@@ -41,11 +41,8 @@ const selectedOption = computed({
         <div
           class="group/dropdown-label hover:bg-b-2 text-c-2 flex w-full cursor-pointer items-center rounded border py-1.5 pr-1.5 pl-1.5"
           tabindex="0">
-          <ScalarIconCaretUpDown
-            class="mr-1.5 size-3.5 text-current"
-            weight="bold" />
-          <span
-            class="text-c-1 overflow-hidden text-sm leading-4.75 font-medium text-ellipsis">
+          <ScalarIconCaretUpDown class="mr-1.5 size-4 text-current" />
+          <span class="text-c-1 overflow-hidden text-base text-ellipsis">
             {{ selectedOption?.label || 'Select API' }}
           </span>
         </div>

--- a/packages/api-reference/src/components/DocumentSelector/DocumentSelector.vue
+++ b/packages/api-reference/src/components/DocumentSelector/DocumentSelector.vue
@@ -39,9 +39,9 @@ const selectedOption = computed({
         :options="listboxOptions"
         resize>
         <div
-          class="group/dropdown-label hover:bg-b-2 text-c-2 flex w-full cursor-pointer items-center rounded border py-1.5 pr-1.5 pl-1.5"
+          class="group/dropdown-label hover:bg-b-2 text-c-2 flex w-full cursor-pointer items-center rounded border px-2 py-1.75"
           tabindex="0">
-          <ScalarIconCaretUpDown class="mr-1.5 size-4 text-current" />
+          <ScalarIconCaretUpDown class="mr-1 size-4 text-current" />
           <span class="text-c-1 overflow-hidden text-base text-ellipsis">
             {{ selectedOption?.label || 'Select API' }}
           </span>

--- a/packages/api-reference/src/components/Sidebar/Sidebar.vue
+++ b/packages/api-reference/src/components/Sidebar/Sidebar.vue
@@ -209,9 +209,9 @@ const hasChildren = (
 
 <style scoped>
 .sidebar {
-  --scalar-sidebar-indent-base: 12px;
+  --scalar-sidebar-indent-base: 20px;
   --scalar-sidebar-font-weight-active: var(--scalar-semibold);
-  --scalar-sidebar-font-weight: var(--scalar-semibold);
+  --scalar-sidebar-font-weight: var(--scalar-regular);
 }
 .sidebar {
   flex: 1;
@@ -225,7 +225,7 @@ const hasChildren = (
 }
 .sidebar-pages {
   flex: 1;
-  padding: 9px 12px;
+  padding: 6px 12px;
 }
 
 @media (max-width: 1000px) {

--- a/packages/api-reference/src/components/Sidebar/SidebarElement.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarElement.vue
@@ -150,11 +150,11 @@ const onAnchorClick = async (ev: Event) => {
 <style scoped>
 .sidebar-heading {
   display: flex;
-  gap: 6px;
+  gap: 4px;
 
   color: var(--scalar-sidebar-color-2, var(--scalar-color-2));
-  font-size: var(--scalar-mini);
-  font-weight: var(--scalar-semibold);
+  font-size: var(--scalar-small);
+  font-weight: var(--scalar-sidebar-font-weight, var(--scalar-regular));
   word-break: break-word;
   line-height: 1.385;
   max-width: 100%;
@@ -212,7 +212,7 @@ const onAnchorClick = async (ev: Event) => {
   content: '';
   position: absolute;
   top: 0;
-  left: calc((var(--scalar-sidebar-level) * 12px));
+  left: calc((var(--scalar-sidebar-level) * 15.5px));
   width: var(--scalar-border-width);
   height: 100%;
   background: var(--scalar-sidebar-indent-border);
@@ -240,7 +240,7 @@ const onAnchorClick = async (ev: Event) => {
   height: fit-content;
   display: flex;
   align-items: center;
-  font-weight: var(--scalar-sidebar-font-weight, var(--scalar-semibold));
+  font-weight: var(--scalar-sidebar-font-weight, var(--scalar-regular));
 }
 .sidebar-heading p:empty {
   display: none;
@@ -272,7 +272,8 @@ const onAnchorClick = async (ev: Event) => {
 /* Folder/page collapse icon */
 /* awkward pixel value to deal with hairspace alignment across browser*/
 .sidebar-heading-chevron {
-  margin: 5px -5.5px 5px -9px;
+  margin: 5px 0;
+  width: 16px;
 }
 .sidebar-heading-chevron .toggle-nested-icon:focus-visible {
   outline: none;
@@ -285,8 +286,8 @@ const onAnchorClick = async (ev: Event) => {
 }
 .toggle-nested-icon {
   color: var(--scalar-color-3);
-  width: 20px;
-  height: 20px;
+  width: 16px;
+  height: 16px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -332,7 +333,12 @@ const onAnchorClick = async (ev: Event) => {
   );
 }
 .sidebar-group-item__folder {
-  color: var(--scalar-sidebar-color-1, var(--scalar-color-1));
+  color: var(--scalar-sidebar-color-2, var(--scalar-color-2));
   text-transform: var(--scalar-tag-text-transform, initial);
+}
+.sidebar-group-item__folder:has(~ ul .sidebar-heading.active_page) {
+  --scalar-sidebar-font-weight: var(--scalar-sidebar-font-weight-active);
+  color: var(--scalar-sidebar-color-1, var(--scalar-color-1));
+  font-weight: var(--scalar-sidebar-font-weight-active, var(--scalar-semibold));
 }
 </style>

--- a/packages/api-reference/src/components/Sidebar/SidebarGroup.vue
+++ b/packages/api-reference/src/components/Sidebar/SidebarGroup.vue
@@ -21,7 +21,7 @@ defineProps<{
 /* We indent each level of nesting further */
 .sidebar-indent-nested :deep(.sidebar-heading) {
   /* prettier-ignore */
-  padding-left: calc((var(--scalar-sidebar-level) * var(--scalar-sidebar-indent-base)) + 12px) !important;
+  padding-left: calc((var(--scalar-sidebar-level) * var(--scalar-sidebar-indent-base)) + 8px) !important;
 }
 
 /* Collapse/expand icons must also be offset */

--- a/packages/api-reference/src/features/ExampleResponses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/ExampleResponses/ExampleResponses.vue
@@ -296,7 +296,7 @@ const showSchema = ref(false)
   border-radius: var(--scalar-radius);
   background-color: transparent;
   background-color: var(--scalar-background-3);
-  box-shadow: inset 0 0 0 1px var(--scalar-border-color);
+  box-shadow: inset 0 0 0 var(--scalar-border-width) var(--scalar-border-color);
 }
 .scalar-card-checkbox:has(.scalar-card-checkbox-input:checked) {
   color: var(--scalar-color-1);

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarSearchButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarSearchButton.vue
@@ -15,7 +15,7 @@ const { cx } = useBindCx()
     role="search"
     v-bind="
       cx(
-        'flex items-center rounded border text-base h-8 gap-1 px-1',
+        'flex items-center rounded border text-base h-8 gap-1 pl-2 pr-1',
         'bg-sidebar-b-search border-sidebar-border-search text-sidebar-c-search',
       )
     ">

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarSearchInput.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarSearchInput.vue
@@ -33,7 +33,7 @@ onMounted(() => autofocus && inputRef.value?.focus())
   <label
     v-bind="
       classCx(
-        'flex items-center rounded border text-base has-[:focus-visible]:bg-b-1 has-[:focus-visible]:outline h-8 gap-1 pl-1 pr-2',
+        'flex items-center rounded border text-base has-[:focus-visible]:bg-b-1 has-[:focus-visible]:outline h-8 gap-1 pl-2 pr-1.5',
         'bg-sidebar-b-search border-sidebar-border-search',
         model ? 'text-c-1' : 'text-sidebar-c-search',
       )

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -15,14 +15,14 @@
         {
           "name": "Introduction",
           "description": "Introduction to Scalar",
-          "icon": "phosphor/bold/house",
+          "icon": "phosphor/regular/house",
           "path": "documentation/guides/introduction.md",
           "type": "page"
         },
         {
           "name": "Scalar Docs",
           "type": "folder",
-          "icon": "phosphor/bold/brackets-curly",
+          "icon": "phosphor/regular/brackets-curly",
           "children": [
             {
               "path": "documentation/guides/docs/getting-started.md",
@@ -38,7 +38,7 @@
         {
           "name": "Scalar SDKs",
           "type": "folder",
-          "icon": "phosphor/bold/package",
+          "icon": "phosphor/regular/package",
           "children": [
             {
               "path": "documentation/guides/sdks/getting-started.md",
@@ -49,7 +49,7 @@
         {
           "name": "Scalar Registry",
           "type": "folder",
-          "icon": "phosphor/bold/brackets-curly",
+          "icon": "phosphor/regular/seal-check",
           "children": [
             {
               "path": "documentation/guides/registry/getting-started.md",
@@ -71,14 +71,14 @@
         },
         {
           "name": "Access",
-          "icon": "phosphor/bold/lock-simple",
+          "icon": "phosphor/regular/lock-simple",
           "path": "documentation/guides/access.md",
           "type": "page"
         },
         {
           "name": "Scalar CLI",
           "type": "folder",
-          "icon": "phosphor/bold/terminal",
+          "icon": "phosphor/regular/terminal",
           "children": [
             {
               "path": "documentation/guides/cli/getting-started.md",
@@ -93,8 +93,7 @@
         {
           "name": "Scalar API References",
           "type": "folder",
-          "slug": "api-reference",
-          "icon": "phosphor/bold/scroll",
+          "icon": "phosphor/regular/scroll",
           "children": [
             {
               "name": "Getting Started",
@@ -129,7 +128,7 @@
             {
               "name": "Integrations",
               "type": "folder",
-              "icon": "phosphor/bold/plug",
+              "icon": "phosphor/regular/plug",
               "children": [{
                   "name": "HTML/JS",
                   "slug": "html-js",


### PR DESCRIPTION
New sidebar styles

14px font now, font weight regular, and semibold when active + endpoint will get semibold when active

<img width="307" alt="image" src="https://github.com/user-attachments/assets/be5cc313-732e-45e1-82f6-6f5d510b5d63" />