### PR TITLE
feat(Scalar.AspNetCore): add DocumentDownloadType configuration

### DIFF
--- a/.changeset/slow-dogs-sniff.md
+++ b/.changeset/slow-dogs-sniff.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': minor
+---
+
+feat: add `DocumentDownloadType` configuration and make `HideDownloadButton` obsolete

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Contract/ScalarConfiguration.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Contract/ScalarConfiguration.cs
@@ -65,7 +65,7 @@ internal sealed class ScalarConfiguration
     public required string? BaseServerUrl { get; init; }
 
     public required bool PersistAuth { get; init; }
-    
+
     public required string? DocumentDownloadType { get; init; }
 }
 

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Contract/ScalarConfiguration.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Contract/ScalarConfiguration.cs
@@ -14,8 +14,6 @@ internal sealed class ScalarConfiguration
 
     public required bool? HideModels { get; init; }
 
-    public required bool? HideDownloadButton { get; init; }
-
     public required bool? HideTestRequestButton { get; init; }
 
     public required bool? DarkMode { get; init; }
@@ -66,7 +64,9 @@ internal sealed class ScalarConfiguration
     [JsonPropertyName("baseServerURL")]
     public required string? BaseServerUrl { get; init; }
 
-    public required bool PersistAuth { get; set; }
+    public required bool PersistAuth { get; init; }
+    
+    public required string? DocumentDownloadType { get; init; }
 }
 
 [JsonSerializable(typeof(ScalarConfiguration))]

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/DocumentDownloadType.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/DocumentDownloadType.cs
@@ -1,0 +1,35 @@
+﻿using System.ComponentModel;
+using NetEscapades.EnumGenerators;
+
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Specifies the available download formats for API documentation.
+/// </summary>
+[EnumExtensions]
+public enum DocumentDownloadType
+{
+    /// <summary>
+    /// Download documentation in JSON format.
+    /// </summary>
+    [Description("json")]
+    Json,
+
+    /// <summary>
+    /// Download documentation in YAML format.
+    /// </summary>
+    [Description("yaml")]
+    Yaml,
+
+    /// <summary>
+    /// Download documentation in both JSON and YAML formats.
+    /// </summary>
+    [Description("both")]
+    Both,
+
+    /// <summary>
+    /// Do not allow documentation downloads.
+    /// </summary>
+    [Description("none")]
+    None
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -141,9 +141,22 @@ public static class ScalarOptionsExtensions
     /// <param name="options">The <see cref="ScalarOptions" /> to configure.</param>
     /// <param name="showDownloadButton">Whether to show the download button.</param>
     /// <returns>The <see cref="ScalarOptions" /> so that additional calls can be chained.</returns>
+    [Obsolete($"This method is obsolete and will be removed in a future release. Use '{nameof(WithDocumentDownloadType)}' instead.")]
     public static ScalarOptions WithDownloadButton(this ScalarOptions options, bool showDownloadButton = true)
     {
         options.HideDownloadButton = !showDownloadButton;
+        return options;
+    }
+
+    /// <summary>
+    /// Sets the document download type for the Scalar API reference.
+    /// </summary>
+    /// <param name="options">The <see cref="ScalarOptions" /> to configure.</param>
+    /// <param name="documentDownloadType">The document download type to set.</param>
+    /// <returns>The <see cref="ScalarOptions" /> so that additional calls can be chained.</returns>
+    public static ScalarOptions WithDocumentDownloadType(this ScalarOptions options, DocumentDownloadType documentDownloadType)
+    {
+        options.DocumentDownloadType = documentDownloadType;
         return options;
     }
 

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -39,7 +39,6 @@ internal static class ScalarOptionsMapper
             DarkMode = options.DarkMode,
             HideModels = options.HideModels,
             HideDarkModeToggle = options.HideDarkModeToggle,
-            HideDownloadButton = options.HideDownloadButton,
             HideTestRequestButton = options.HideTestRequestButton,
             DefaultOpenAllTags = options.DefaultOpenAllTags,
             ForceDarkModeState = options.ForceThemeMode?.ToStringFast(true),
@@ -62,7 +61,10 @@ internal static class ScalarOptionsMapper
             HideClientButton = options.HideClientButton,
             Sources = sources,
             BaseServerUrl = options.BaseServerUrl,
-            PersistAuth = options.PersistentAuthentication
+            PersistAuth = options.PersistentAuthentication,
+#pragma warning disable CS0618 // Type or member is obsolete
+            DocumentDownloadType = options.HideDownloadButton ? DocumentDownloadType.None.ToStringFast(true) : options.DocumentDownloadType?.ToStringFast(true)
+#pragma warning restore CS0618 // Type or member is obsolete
         };
     }
 

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -64,6 +64,7 @@ public sealed class ScalarOptions
     /// Gets or sets whether to hide the "Download OpenAPI Specification" button.
     /// </summary>
     /// <value>The default value is <c>false</c>.</value>
+    [Obsolete($"This property is obsolete and will be removed in a future release. Please use the '{nameof(DocumentDownloadType)}' property instead.")]
     public bool HideDownloadButton { get; set; }
 
     /// <summary>
@@ -280,4 +281,10 @@ public sealed class ScalarOptions
     /// When set to <c>true</c>, the authentication state will be stored in the browser's local storage and restored when the user returns to the page.
     /// </remarks>
     public bool PersistentAuthentication { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of document download available for the API documentation.
+    /// </summary>
+    /// <value>The default value is <c>null</c>.</value>
+    public DocumentDownloadType? DocumentDownloadType { get; set; }
 }

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -15,7 +15,7 @@ public class ScalarOptionsMapperTests
         configuration.ProxyUrl.Should().BeNull();
         configuration.ShowSidebar.Should().BeTrue();
         configuration.HideModels.Should().BeFalse();
-        configuration.HideDownloadButton.Should().BeFalse();
+        configuration.DocumentDownloadType.Should().BeNull();
         configuration.HideTestRequestButton.Should().BeFalse();
         configuration.DarkMode.Should().BeTrue();
         configuration.ForceDarkModeState.Should().BeNull();
@@ -47,7 +47,6 @@ public class ScalarOptionsMapperTests
             ProxyUrl = "http://localhost:8080",
             ShowSidebar = false,
             HideModels = true,
-            HideDownloadButton = true,
             HideTestRequestButton = true,
             DarkMode = false,
             ForceThemeMode = ThemeMode.Light,
@@ -60,9 +59,10 @@ public class ScalarOptionsMapperTests
             Metadata = new Dictionary<string, string> { ["key"] = "value" },
             DefaultHttpClient = new KeyValuePair<ScalarTarget, ScalarClient>(ScalarTarget.CSharp, ScalarClient.HttpClient),
             HiddenClients = true,
+#pragma warning disable CS0618 // Type or member is obsolete
+            HideDownloadButton = true,
             Authentication = new ScalarAuthenticationOptions
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 PreferredSecurityScheme = "my-scheme",
                 ApiKey = new ApiKeyOptions
                 {
@@ -87,7 +87,7 @@ public class ScalarOptionsMapperTests
         configuration.ProxyUrl.Should().Be("http://localhost:8080");
         configuration.ShowSidebar.Should().BeFalse();
         configuration.HideModels.Should().BeTrue();
-        configuration.HideDownloadButton.Should().BeTrue();
+        configuration.DocumentDownloadType.Should().Be("none");
         configuration.HideTestRequestButton.Should().BeTrue();
         configuration.DarkMode.Should().BeFalse();
         configuration.HideDarkModeToggle.Should().BeTrue();


### PR DESCRIPTION
This PR adds support for the new `documentDownloadType` property (https://github.com/scalar/scalar/pull/6009)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
