### PR TITLE
fix: wrong sidebar icon add defaultOpen

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -22,7 +22,8 @@
         {
           "name": "Scalar Docs",
           "type": "folder",
-          "icon": "phosphor/bold/brackets-curly",
+          "defaultOpen": false,
+          "icon": "phosphor/bold/book",
           "children": [
             {
               "path": "documentation/guides/docs/getting-started.md",
@@ -39,6 +40,7 @@
           "name": "Scalar SDKs",
           "type": "folder",
           "icon": "phosphor/bold/package",
+          "defaultOpen": false,
           "children": [
             {
               "path": "documentation/guides/sdks/getting-started.md",
@@ -50,6 +52,7 @@
           "name": "Scalar Registry",
           "type": "folder",
           "icon": "phosphor/bold/brackets-curly",
+          "defaultOpen": false,
           "children": [
             {
               "path": "documentation/guides/registry/getting-started.md",
@@ -71,6 +74,7 @@
         },
         {
           "name": "Access",
+          "defaultOpen": false,
           "icon": "phosphor/bold/lock-simple",
           "path": "documentation/guides/access.md",
           "type": "page"
@@ -78,6 +82,7 @@
         {
           "name": "Scalar CLI",
           "type": "folder",
+          "defaultOpen": false,
           "icon": "phosphor/bold/terminal",
           "children": [
             {
@@ -94,6 +99,7 @@
           "name": "Scalar API References",
           "type": "folder",
           "slug": "api-reference",
+          "defaultOpen": false,
           "icon": "phosphor/bold/scroll",
           "children": [
             {
@@ -130,6 +136,7 @@
               "name": "Integrations",
               "type": "folder",
               "icon": "phosphor/bold/plug",
+              "defaultOpen": true,
               "children": [{
                   "name": "HTML/JS",
                   "slug": "html-js",


### PR DESCRIPTION
**Problem**

picked the right icon for docs & added defaultOpen

**Solution**


**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
