### PR TITLE
fix(documentation): wrong sidebar icon and add `defaultOpen: false`

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -22,7 +22,8 @@
         {
           "name": "Scalar Docs",
           "type": "folder",
-          "icon": "phosphor/regular/brackets-curly",
+          "defaultOpen": false,
+          "icon": "phosphor/regular/book",
           "children": [
             {
               "path": "documentation/guides/docs/getting-started.md",
@@ -38,6 +39,7 @@
         {
           "name": "Scalar SDKs",
           "type": "folder",
+          "defaultOpen": false,
           "icon": "phosphor/regular/package",
           "children": [
             {
@@ -49,6 +51,7 @@
         {
           "name": "Scalar Registry",
           "type": "folder",
+          "defaultOpen": false,
           "icon": "phosphor/regular/seal-check",
           "children": [
             {
@@ -78,6 +81,7 @@
         {
           "name": "Scalar CLI",
           "type": "folder",
+          "defaultOpen": false,
           "icon": "phosphor/regular/terminal",
           "children": [
             {
@@ -93,6 +97,7 @@
         {
           "name": "Scalar API References",
           "type": "folder",
+          "defaultOpen": false,
           "icon": "phosphor/regular/scroll",
           "children": [
             {
@@ -128,6 +133,7 @@
             {
               "name": "Integrations",
               "type": "folder",
+              "defaultOpen": true,
               "icon": "phosphor/regular/plug",
               "children": [{
                   "name": "HTML/JS",


### PR DESCRIPTION
**Problem**

picked the right icon for docs & added defaultOpen

**Solution**

With this PR …

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
