### PR TITLE
feat(components): add sidebar sections

### DIFF
--- a/.changeset/plenty-countries-own.md
+++ b/.changeset/plenty-countries-own.md
@@ -1,0 +1,7 @@
+---
+'@scalar/components': patch
+'@scalar/use-hooks': patch
+'@scalar/themes': patch
+---
+
+feat(components): add sidebar sections

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
@@ -7,8 +7,8 @@ import ScalarSidebarItem from './ScalarSidebarItem.vue'
 import ScalarSidebarItems from './ScalarSidebarItems.vue'
 import { ScalarIconFileArchive, ScalarIconFileAudio, ScalarIconFileText } from '@scalar/icons'
 import ScalarSidebarSearchButton from './ScalarSidebarSearchButton.vue'
-import ScalarSidebarSearchInput from './ScalarSidebarSearchInput.vue'
 import ScalarSidebarSection from './ScalarSidebarSection.vue'
+import ScalarSidebarPlayground from './ScalarSidebarPlayground.vue'
 
 const meta: Meta = {
   component: ScalarSidebar,
@@ -27,17 +27,13 @@ const meta: Meta = {
     },
   },
   render: (args) => ({
-    components: { ScalarSidebar },
+    components: { ScalarSidebarPlayground },
     setup() {
       return { args }
     },
     template: `
-<div class="flex h-screen">
-  <ScalarSidebar v-bind="args">
-    <div class="placeholder flex-1">Sidebar content</div>
-  </ScalarSidebar>
-  <div class="placeholder flex-1">Main content</div>
-</div>
+<ScalarSidebarPlayground>
+</ScalarSidebarPlayground>
 `,
   }),
 }
@@ -47,128 +43,70 @@ type Story = StoryObj<typeof meta>
 
 export const Base: Story = {}
 
-export const WithNavItems: Story = {
-  args: {
-    icon: 'Scribble',
-  },
-  render: (args) => ({
-    components: {
-      ScalarSidebar,
-      ScalarSidebarItem,
-      ScalarSidebarItems,
-      ScalarSidebarGroup,
-    },
-    setup() {
-      const open = ref(false)
-      return { args, open }
-    },
-    template: `
-<div class="flex h-screen">
-  <ScalarSidebar>
-    <ScalarSidebarItems>
-      <ScalarSidebarItem href="#" :icon="args.icon" selected>Item 1 (Selected)</ScalarSidebarItem>
-      <ScalarSidebarItem href="#" :icon="args.icon">Item 2 </ScalarSidebarItem>
-      <ScalarSidebarItem href="#" :icon="args.icon">Item 3</ScalarSidebarItem>
-      <ScalarSidebarItem :icon="args.icon" disabled>Item 4 (Disabled)</ScalarSidebarItem>
-      <ScalarSidebarGroup v-model="open">
-        Item Group ({{ open ? 'Open' : 'Closed' }})
-        <template #items>
-          <ScalarSidebarItem href="#" :icon="args.icon">Subitem 1</ScalarSidebarItem>
-          <ScalarSidebarItem href="#" :icon="args.icon">Subitem 2</ScalarSidebarItem>
-          <ScalarSidebarItem href="#" :icon="args.icon">Subitem 3</ScalarSidebarItem>
-        </template>
-      </ScalarSidebarGroup>
-    </ScalarSidebarItems>
-  </ScalarSidebar>
-  <div class="placeholder flex-1">Main content</div>
-</div>
-`,
-  }),
-}
-
 export const WithNestedGroups: Story = {
-  argTypes: {
-    indent: { control: 'number' },
-  },
-  args: {
-    indent: 20,
-  },
+  argTypes: { indent: { control: 'number' } },
+  args: { indent: 20 },
   render: (args) => ({
     components: {
       ScalarSidebar,
       ScalarSidebarItem,
       ScalarSidebarItems,
       ScalarSidebarGroup,
+      ScalarSidebarPlayground,
     },
     setup() {
       const selected = ref('')
       return { args, selected }
     },
     template: `
-
-<div class="flex h-screen" 
-  :style="{ 
-    '--scalar-sidebar-indent': args.indent + 'px', 
-    '--scalar-sidebar-indent-border-hover': 'var(--scalar-color-3)',
-    '--scalar-sidebar-indent-border-active': 'var(--scalar-color-accent)'
-  }">
-  <ScalarSidebar>
-    <ScalarSidebarItems class="custom-scroll">
-      <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 1'" @click="selected = 'Item 1'">Item 1</ScalarSidebarItem>
-      <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 2'" @click="selected = 'Item 2'">Item 2</ScalarSidebarItem>
-      <ScalarSidebarGroup>  
-        Level 1 Group 
-        <template #items>
-          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 1'" @click="selected = 'Subitem 1'">Subitem 1</ScalarSidebarItem>
-          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 2'" @click="selected = 'Subitem 2'">Subitem 2</ScalarSidebarItem>
-            <ScalarSidebarGroup>
-              Level 2 Group
-              <template #items>
-                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 3'" @click="selected = 'Subitem 3'">Subitem 3</ScalarSidebarItem>
-                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 4'" @click="selected = 'Subitem 4'">Subitem 4</ScalarSidebarItem>
-                  <ScalarSidebarGroup>
-                  Level 3 Group
-                  <template #items>
-                    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 5'" @click="selected = 'Subitem 5'">Subitem 5</ScalarSidebarItem>
-                    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 6'" @click="selected = 'Subitem 6'">Subitem 6</ScalarSidebarItem>
-                      <ScalarSidebarGroup>
-                        Level 4 Group
-                        <template #items>
-                          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 7'" @click="selected = 'Subitem 7'">Subitem 7</ScalarSidebarItem>
-                          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 8'" @click="selected = 'Subitem 8'">Subitem 8</ScalarSidebarItem>
-                            <ScalarSidebarGroup>
-                              Level 5 Group
-                              <template #items>
-                                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 9'" @click="selected = 'Subitem 9'">Subitem 9</ScalarSidebarItem>
-                                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 10'" @click="selected = 'Subitem 10'">Subitem 10</ScalarSidebarItem>
-                                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 11'" @click="selected = 'Subitem 11'">Subitem 11</ScalarSidebarItem>
-                              </template>
-                            </ScalarSidebarGroup>
-                          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 12'" @click="selected = 'Subitem 12'">Subitem 12</ScalarSidebarItem>
-                        </template>
-                      </ScalarSidebarGroup>
-                    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 13'" @click="selected = 'Subitem 13'">Subitem 13</ScalarSidebarItem>
-                  </template>
-                </ScalarSidebarGroup>
-                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 14'" @click="selected = 'Subitem 14'">Subitem 14</ScalarSidebarItem>
-              </template>
-            </ScalarSidebarGroup>
-          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 15'" @click="selected = 'Subitem 15'">Subitem 15</ScalarSidebarItem>
-        </template>
-      </ScalarSidebarGroup>
-      <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 3'" @click="selected = 'Item 3'">Item 3</ScalarSidebarItem>
-      <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 4'" @click="selected = 'Item 4'">Item 4</ScalarSidebarItem>
-    </ScalarSidebarItems>
-  </ScalarSidebar>
-  <div class="flex items-center justify-center flex-1 text-c-2">
-    <template v-if="selected">
-      {{ selected }} Selected
-    </template>
-    <template v-else>
-      Select an item in the sidebar
-    </template>
-  </div>
-</div>
+<ScalarSidebarPlayground v-model:selected="selected" :indent="args.indent">
+  <ScalarSidebarItems>
+    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 1'" @click="selected = 'Item 1'">Item 1</ScalarSidebarItem>
+    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 2'" @click="selected = 'Item 2'">Item 2</ScalarSidebarItem>
+    <ScalarSidebarGroup>  
+      Level 1 Group 
+      <template #items>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 1'" @click="selected = 'Subitem 1'">Subitem 1</ScalarSidebarItem>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 2'" @click="selected = 'Subitem 2'">Subitem 2</ScalarSidebarItem>
+          <ScalarSidebarGroup>
+            Level 2 Group
+            <template #items>
+              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 3'" @click="selected = 'Subitem 3'">Subitem 3</ScalarSidebarItem>
+              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 4'" @click="selected = 'Subitem 4'">Subitem 4</ScalarSidebarItem>
+                <ScalarSidebarGroup>
+                Level 3 Group
+                <template #items>
+                  <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 5'" @click="selected = 'Subitem 5'">Subitem 5</ScalarSidebarItem>
+                  <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 6'" @click="selected = 'Subitem 6'">Subitem 6</ScalarSidebarItem>
+                    <ScalarSidebarGroup>
+                      Level 4 Group
+                      <template #items>
+                        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 7'" @click="selected = 'Subitem 7'">Subitem 7</ScalarSidebarItem>
+                        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 8'" @click="selected = 'Subitem 8'">Subitem 8</ScalarSidebarItem>
+                          <ScalarSidebarGroup>
+                            Level 5 Group
+                            <template #items>
+                              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 9'" @click="selected = 'Subitem 9'">Subitem 9</ScalarSidebarItem>
+                              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 10'" @click="selected = 'Subitem 10'">Subitem 10</ScalarSidebarItem>
+                              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 11'" @click="selected = 'Subitem 11'">Subitem 11</ScalarSidebarItem>
+                            </template>
+                          </ScalarSidebarGroup>
+                        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 12'" @click="selected = 'Subitem 12'">Subitem 12</ScalarSidebarItem>
+                      </template>
+                    </ScalarSidebarGroup>
+                  <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 13'" @click="selected = 'Subitem 13'">Subitem 13</ScalarSidebarItem>
+                </template>
+              </ScalarSidebarGroup>
+              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 14'" @click="selected = 'Subitem 14'">Subitem 14</ScalarSidebarItem>
+            </template>
+          </ScalarSidebarGroup>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 15'" @click="selected = 'Subitem 15'">Subitem 15</ScalarSidebarItem>
+      </template>
+    </ScalarSidebarGroup>
+    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 3'" @click="selected = 'Item 3'">Item 3</ScalarSidebarItem>
+    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 4'" @click="selected = 'Item 4'">Item 4</ScalarSidebarItem>
+  </ScalarSidebarItems>
+</ScalarSidebarPlayground>
 `,
   }),
 }
@@ -181,115 +119,89 @@ export const WithSections: Story = {
       ScalarSidebarItems,
       ScalarSidebarGroup,
       ScalarSidebarSection,
+      ScalarSidebarPlayground,
     },
     setup() {
       const selected = ref('')
       return { args, selected }
     },
     template: `
-<div class="flex h-screen">
-  <ScalarSidebar>
-    <ScalarSidebarItems>
-      <ScalarSidebarSection>
-        Section 1
-        <template #items>
-          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 1'" @click="selected = 'Item 1'">Item 1</ScalarSidebarItem>
-          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 2'" @click="selected = 'Item 2'">Item 2</ScalarSidebarItem>
-          <ScalarSidebarGroup>
-            Group
-            <template #items>
-              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 1'" @click="selected = 'Subitem 1'">Subitem 1</ScalarSidebarItem>
-                <ScalarSidebarSection>
-                Nested Section
-                <template #items>
-                  <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 4'" @click="selected = 'Subitem 4'">Subitem 4</ScalarSidebarItem>
-                  <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 5'" @click="selected = 'Subitem 5'">Subitem 5</ScalarSidebarItem>
-                  <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 6'" @click="selected = 'Subitem 6'">Subitem 6</ScalarSidebarItem>
-                </template>
-              </ScalarSidebarSection>
-              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 2'" @click="selected = 'Subitem 2'">Subitem 2</ScalarSidebarItem>
-              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 3'" @click="selected = 'Subitem 3'">Subitem 3</ScalarSidebarItem>
-            </template>
-          </ScalarSidebarGroup>
-          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 3'" @click="selected = 'Item 3'">Item 3</ScalarSidebarItem>
-        </template>
-      </ScalarSidebarSection>
-      <ScalarSidebarSection>
-        Section 2
-        <template #items>
-          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 4'" @click="selected = 'Item 4'">Item 4</ScalarSidebarItem>
-          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 5'" @click="selected = 'Item 5'">Item 5</ScalarSidebarItem>
-          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 6'" @click="selected = 'Item 6'">Item 6</ScalarSidebarItem>
-        </template>
-      </ScalarSidebarSection>
-    </ScalarSidebarItems>
-  </ScalarSidebar>
-  <div class="placeholder flex-1">Main content</div>
-</div>
+<ScalarSidebarPlayground v-model:selected="selected">
+  <ScalarSidebarItems>
+    <ScalarSidebarSection>
+      Section 1
+      <template #items>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 1'" @click="selected = 'Item 1'">Item 1</ScalarSidebarItem>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 2'" @click="selected = 'Item 2'">Item 2</ScalarSidebarItem>
+        <ScalarSidebarGroup>
+          Group
+          <template #items>
+            <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 1'" @click="selected = 'Subitem 1'">Subitem 1</ScalarSidebarItem>
+              <ScalarSidebarSection>
+              Nested Section
+              <template #items>
+                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 4'" @click="selected = 'Subitem 4'">Subitem 4</ScalarSidebarItem>
+                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 5'" @click="selected = 'Subitem 5'">Subitem 5</ScalarSidebarItem>
+                <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 6'" @click="selected = 'Subitem 6'">Subitem 6</ScalarSidebarItem>
+              </template>
+            </ScalarSidebarSection>
+            <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 2'" @click="selected = 'Subitem 2'">Subitem 2</ScalarSidebarItem>
+            <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 3'" @click="selected = 'Subitem 3'">Subitem 3</ScalarSidebarItem>
+          </template>
+        </ScalarSidebarGroup>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 3'" @click="selected = 'Item 3'">Item 3</ScalarSidebarItem>
+      </template>
+    </ScalarSidebarSection>
+    <ScalarSidebarSection>
+      Section 2
+      <template #items>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 4'" @click="selected = 'Item 4'">Item 4</ScalarSidebarItem>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 5'" @click="selected = 'Item 5'">Item 5</ScalarSidebarItem>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 6'" @click="selected = 'Item 6'">Item 6</ScalarSidebarItem>
+      </template>
+    </ScalarSidebarSection>
+  </ScalarSidebarItems>
+</ScalarSidebarPlayground>
 `,
   }),
 }
 
-export const WithFooter: Story = {
+export const WithFooterContent: Story = {
   render: (args) => ({
-    components: { ScalarSidebar, ScalarSidebarFooter },
+    components: { ScalarSidebarPlayground, ScalarSidebarFooter },
     setup() {
       return { args }
     },
     template: `
-<div class="flex h-screen">
-  <ScalarSidebar>
-    <div class="placeholder flex-1">Sidebar content</div>
+<ScalarSidebarPlayground>
+  <template #footer>
     <ScalarSidebarFooter v-bind="args">
-      <span class="placeholder">Footer content</span>
+      <span class="placeholder">Extra footer content</span>
     </ScalarSidebarFooter>
-  </ScalarSidebar>
-  <div class="placeholder flex-1">Main content</div>
-</div>
-`,
-  }),
-}
-
-export const WithSearchInput: Story = {
-  render: (args) => ({
-    components: { ScalarSidebar, ScalarSidebarSearchInput },
-    setup() {
-      return { args }
-    },
-    template: `
-<div class="flex h-screen">
-  <ScalarSidebar>
-    <div class="p-1 pb-0">
-      <ScalarSidebarSearchInput v-bind="args" />
-    </div>
-    <div class="placeholder flex-1">Sidebar content</div>
-  </ScalarSidebar>
-  <div class="placeholder flex-1">Main content</div>
-</div>
+  </template>
+</ScalarSidebarPlayground>
 `,
   }),
 }
 
 export const WithSearchButton: Story = {
   render: (args) => ({
-    components: { ScalarSidebar, ScalarSidebarSearchButton },
+    components: { ScalarSidebarPlayground, ScalarSidebarSearchButton },
     setup() {
       return { args }
     },
     template: `
-<div class="flex h-screen">
-  <ScalarSidebar>
-    <div class="flex flex-col p-1 pb-0">
+<ScalarSidebarPlayground>
+    <template #search>
+      <div class="flex flex-col px-3 pt-3 sticky top-0 bg-sidebar-b-1">
       <ScalarSidebarSearchButton v-bind="args">
         <template #shortcut>
           <span>⌘ K</span>
         </template>
       </ScalarSidebarSearchButton>
     </div>
-    <div class="placeholder flex-1">Sidebar content</div>
-  </ScalarSidebar>
-  <div class="placeholder flex-1">Main content</div>
-</div>
+  </template>
+</ScalarSidebarPlayground>
 `,
   }),
 }

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
@@ -8,6 +8,7 @@ import ScalarSidebarItems from './ScalarSidebarItems.vue'
 import { ScalarIconFileArchive, ScalarIconFileAudio, ScalarIconFileText } from '@scalar/icons'
 import ScalarSidebarSearchButton from './ScalarSidebarSearchButton.vue'
 import ScalarSidebarSearchInput from './ScalarSidebarSearchInput.vue'
+import ScalarSidebarSection from './ScalarSidebarSection.vue'
 
 const meta: Meta = {
   component: ScalarSidebar,
@@ -167,6 +168,63 @@ export const WithNestedGroups: Story = {
       Select an item in the sidebar
     </template>
   </div>
+</div>
+`,
+  }),
+}
+
+export const WithSections: Story = {
+  render: (args) => ({
+    components: {
+      ScalarSidebar,
+      ScalarSidebarItem,
+      ScalarSidebarItems,
+      ScalarSidebarGroup,
+      ScalarSidebarSection,
+    },
+    setup() {
+      const selected = ref('')
+      return { args, selected }
+    },
+    template: `
+<div class="flex h-screen">
+  <ScalarSidebar>
+    <ScalarSidebarItems>
+      <ScalarSidebarSection>
+        Section 1
+        <template #items>
+          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 1'" @click="selected = 'Item 1'">Item 1</ScalarSidebarItem>
+          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 2'" @click="selected = 'Item 2'">Item 2</ScalarSidebarItem>
+          <ScalarSidebarGroup>
+            Group
+            <template #items>
+              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 1'" @click="selected = 'Subitem 1'">Subitem 1</ScalarSidebarItem>
+                <ScalarSidebarSection>
+                Nested Section
+                <template #items>
+                  <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 4'" @click="selected = 'Subitem 4'">Subitem 4</ScalarSidebarItem>
+                  <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 5'" @click="selected = 'Subitem 5'">Subitem 5</ScalarSidebarItem>
+                  <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 6'" @click="selected = 'Subitem 6'">Subitem 6</ScalarSidebarItem>
+                </template>
+              </ScalarSidebarSection>
+              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 2'" @click="selected = 'Subitem 2'">Subitem 2</ScalarSidebarItem>
+              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 3'" @click="selected = 'Subitem 3'">Subitem 3</ScalarSidebarItem>
+            </template>
+          </ScalarSidebarGroup>
+          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 3'" @click="selected = 'Item 3'">Item 3</ScalarSidebarItem>
+        </template>
+      </ScalarSidebarSection>
+      <ScalarSidebarSection>
+        Section 2
+        <template #items>
+          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 4'" @click="selected = 'Item 4'">Item 4</ScalarSidebarItem>
+          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 5'" @click="selected = 'Item 5'">Item 5</ScalarSidebarItem>
+          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 6'" @click="selected = 'Item 6'">Item 6</ScalarSidebarItem>
+        </template>
+      </ScalarSidebarSection>
+    </ScalarSidebarItems>
+  </ScalarSidebar>
+  <div class="placeholder flex-1">Main content</div>
 </div>
 `,
   }),

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
@@ -90,7 +90,7 @@ export const WithNestedGroups: Story = {
     indent: { control: 'number' },
   },
   args: {
-    indent: 18,
+    indent: 20,
   },
   render: (args) => ({
     components: {

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -58,9 +58,9 @@ const { cx } = useBindCx()
     v-bind="cx(variants({ selected, disabled }))">
     <slot name="indent">
       <ScalarSidebarIndent
-        :indent="indent"
-        :selected="selected"
-        :disabled="disabled" />
+        :indent
+        :selected
+        :disabled />
     </slot>
     <div class="flex items-center gap-1 flex-1 py-2 leading-5">
       <div

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -36,9 +36,9 @@ const { is = 'a', indent = 0 } = defineProps<ScalarSidebarItemProps>()
 defineSlots<ScalarSidebarItemSlots>()
 
 const variants = cva({
-  base: ['group/button flex rounded px-1.5 font-medium text-c-2 no-underline'],
+  base: ['group/button flex rounded px-2 font-sidebar text-c-2 no-underline'],
   variants: {
-    selected: { true: 'cursor-auto bg-b-2 text-c-1' },
+    selected: { true: 'cursor-auto bg-b-2 text-c-1 font-sidebar-active' },
     disabled: { true: 'cursor-auto' },
   },
   compoundVariants: [
@@ -68,8 +68,7 @@ const { cx } = useBindCx()
         <slot name="icon">
           <ScalarIconLegacyAdapter
             v-if="icon"
-            :icon="icon"
-            weight="bold" />
+            :icon="icon" />
         </slot>
       </div>
       <slot />

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -59,7 +59,8 @@ const { cx } = useBindCx()
     <slot name="indent">
       <ScalarSidebarIndent
         :indent="indent"
-        :selected="selected" />
+        :selected="selected"
+        :disabled="disabled" />
     </slot>
     <div class="flex items-center gap-1 flex-1 py-2 leading-5">
       <div

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
@@ -52,6 +52,7 @@ const { cx } = useBindCx()
       :open="!!open">
       <ScalarSidebarButton
         is="button"
+        class="group/group-button"
         :aria-expanded="open"
         :indent="level"
         :selected="selected"
@@ -85,7 +86,7 @@ const { cx } = useBindCx()
 @reference "../../style.css";
 
 /* Set the font weight and color of the button when a subitem is selected */
-.group\/item:has(.font-sidebar-active) > .group\/button {
+.group\/item:has(.font-sidebar-active) > .group\/group-button {
   @apply font-sidebar-active text-c-1;
 }
 </style>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
@@ -17,6 +17,7 @@
 export default {}
 </script>
 <script setup lang="ts">
+import type { ScalarSidebarItemProps } from '@/components/ScalarSidebar/types'
 import { useBindCx } from '@scalar/use-hooks/useBindCx'
 import type { Component } from 'vue'
 
@@ -25,10 +26,7 @@ import ScalarSidebarGroupToggle from './ScalarSidebarGroupToggle.vue'
 import ScalarSidebarIndent from './ScalarSidebarIndent.vue'
 import { type SidebarGroupLevel, useSidebarGroups } from './useSidebarGroups'
 
-const { is = 'ul' } = defineProps<{
-  /** Override the element tag */
-  is?: Component | string
-}>()
+const { is = 'ul' } = defineProps<ScalarSidebarItemProps>()
 
 const open = defineModel<boolean>()
 
@@ -55,8 +53,10 @@ const { cx } = useBindCx()
       <ScalarSidebarButton
         is="button"
         :aria-expanded="open"
-        class="text-c-1 bg-b-1"
         :indent="level"
+        :selected="selected"
+        :disabled="disabled"
+        :icon="icon"
         @click="open = !open">
         <template #indent>
           <ScalarSidebarIndent
@@ -81,3 +81,11 @@ const { cx } = useBindCx()
     </component>
   </li>
 </template>
+<style>
+@reference "../../style.css";
+
+/* Set the font weight and color of the button when a subitem is selected */
+.group\/item:has(.font-sidebar-active) > .group\/button {
+  @apply font-sidebar-active text-c-1;
+}
+</style>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
@@ -18,6 +18,8 @@ const { indent = 0, selected = false } = defineProps<{
   indent?: SidebarGroupLevel
   /** Whether the indent is selected @default false */
   selected?: boolean
+  /** Whether the indent hover is disabled @default false */
+  disabled?: boolean
 }>()
 
 const indents = computed<number[]>(() => {
@@ -47,9 +49,11 @@ const { cx } = useBindCx()
         v-if="index === indents.length - 1"
         class="absolute left-1.5 inset-y-0 w-border"
         :class="
-          selected
-            ? 'bg-sidebar-indent-active'
-            : 'group-hover/button:bg-sidebar-indent-hover'
+          disabled
+            ? ''
+            : selected
+              ? 'bg-sidebar-indent-border-active'
+              : 'group-hover/button:bg-sidebar-indent-border-hover'
         " />
     </div>
   </div>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
@@ -31,7 +31,7 @@ const { cx } = useBindCx()
   <div
     v-bind="
       cx('scalar-sidebar-indent flex justify-center', {
-        'mr-[calc(18px-var(--scalar-sidebar-indent))]': indent > 0,
+        'mr-[calc(20px-var(--scalar-sidebar-indent))]': indent > 0,
         'scalar-sidebar-indent-selected': selected,
       })
     ">
@@ -41,11 +41,11 @@ const { cx } = useBindCx()
       class="relative w-[var(--scalar-sidebar-indent)]">
       <!-- Indent Border -->
       <div
-        class="scalar-sidebar-indent-border absolute left-1.75 inset-y-0 w-border bg-sidebar-indent-border" />
+        class="scalar-sidebar-indent-border absolute left-1.5 inset-y-0 w-border bg-sidebar-indent-border" />
       <!-- Indent Border Active or Hover -->
       <div
         v-if="index === indents.length - 1"
-        class="absolute left-1.75 inset-y-0 w-border"
+        class="absolute left-1.5 inset-y-0 w-border"
         :class="
           selected
             ? 'bg-sidebar-indent-active'

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
@@ -28,7 +28,7 @@ const { cx } = useBindCx()
 <template>
   <component
     :is="is"
-    v-bind="cx('flex flex-col text-base px-3 py-2.5 gap-px')">
+    v-bind="cx('flex flex-col text-base p-3 gap-px')">
     <slot />
   </component>
 </template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
@@ -28,7 +28,7 @@ const { cx } = useBindCx()
 <template>
   <component
     :is="is"
-    v-bind="cx('flex flex-col p-3 gap-px')">
+    v-bind="cx('flex flex-col text-base px-3 py-2.5 gap-px')">
     <slot />
   </component>
 </template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarPlayground.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarPlayground.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import ScalarSidebar from './ScalarSidebar.vue'
+import ScalarSidebarFooter from './ScalarSidebarFooter.vue'
+import ScalarSidebarSearchInput from './ScalarSidebarSearchInput.vue'
+
+const { indent = 20 } = defineProps<{
+  indent: number
+}>()
+
+const selected = defineModel<string>('selected')
+</script>
+<template>
+  <div class="flex h-screen">
+    <ScalarSidebar
+      class="t-doc__sidebar"
+      :style="{
+        '--scalar-sidebar-indent': indent + 'px',
+        '--scalar-sidebar-indent-border-hover': 'var(--scalar-color-3)',
+        '--scalar-sidebar-indent-border-active': 'var(--scalar-color-accent)',
+      }">
+      <div class="flex flex-col flex-1 min-h-0 custom-scroll">
+        <slot name="search">
+          <div class="px-3 pt-3 sticky z-1 top-0 bg-sidebar-b-1">
+            <ScalarSidebarSearchInput />
+          </div>
+        </slot>
+        <slot>
+          <div class="flex-1 grid p-3">
+            <div class="placeholder">Sidebar content</div>
+          </div>
+        </slot>
+      </div>
+      <slot name="footer">
+        <ScalarSidebarFooter />
+      </slot>
+    </ScalarSidebar>
+    <div class="flex items-center justify-center flex-1 text-c-2">
+      <template v-if="selected"> {{ selected }} Selected </template>
+      <template v-else> Select an item in the sidebar </template>
+    </div>
+  </div>
+</template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarSection.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarSection.vue
@@ -1,0 +1,84 @@
+<script lang="ts">
+/**
+ * Scalar Sidebar Section component
+ *
+ * A section of the sidebar that can contain subitems
+ *
+ * @example
+ * <ScalarSidebarSection>
+ *   <!-- Section title -->
+ *   <template #title>
+ *     My Section
+ *   </template>
+ *   <!-- Section items -->
+ *   <template #items>
+ *     <ScalarSidebarItem>...</ScalarSidebarItem>
+ *     <ScalarSidebarItem>...</ScalarSidebarItem>
+ *   </template>
+ * </ScalarSidebarSection>
+ */
+export default {}
+</script>
+<script setup lang="ts">
+import { useBindCx } from '@scalar/use-hooks/useBindCx'
+
+import ScalarSidebarButton from './ScalarSidebarButton.vue'
+import ScalarSidebarSpacer from './ScalarSidebarSpacer.vue'
+import type { ScalarSidebarItemProps } from './types'
+import { useSidebarGroups } from './useSidebarGroups'
+
+const { is = 'ul' } = defineProps<ScalarSidebarItemProps>()
+
+defineSlots<{
+  /** The text content of the toggle */
+  default?: () => any
+  /** The list of sidebar subitems */
+  items?: () => any
+}>()
+
+const { level } = useSidebarGroups({ increment: false })
+
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
+</script>
+<template>
+  <li class="group/sidebar-section contents">
+    <ScalarSidebarSpacer
+      class="group/spacer-before h-3"
+      :indent="level" />
+    <ScalarSidebarButton
+      is="div"
+      class="text-sm font-bold"
+      :indent="level"
+      :icon="icon"
+      disabled>
+      <slot />
+    </ScalarSidebarButton>
+    <component
+      :is="is"
+      v-bind="cx('flex flex-col gap-px')">
+      <slot name="items" />
+    </component>
+    <ScalarSidebarSpacer
+      class="group/spacer-after h-3"
+      :indent="level" />
+  </li>
+</template>
+<style>
+@reference "../../style.css";
+
+/* Don't add a spacer before the first section */
+.group\/sidebar-section:first-of-type > .group\/spacer-before {
+  @apply h-0;
+}
+
+/* Don't add a spacer after the last section */
+.group\/sidebar-section:last-of-type > .group\/spacer-after {
+  @apply h-0;
+}
+
+/* Only one spacer between sections */
+.group\/sidebar-section:has(+ .group\/sidebar-section) > .group\/spacer-after {
+  @apply h-0 -mb-px;
+}
+</style>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarSpacer.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarSpacer.vue
@@ -1,0 +1,29 @@
+<script lang="ts">
+/**
+ * Scalar Sidebar Spacer component
+ *
+ * Provide a styled spacer for the ScalarSidebar, handles the indent lines for nested groups
+ *
+ *
+ *
+ * @example
+ *   <ScalarSidebarSpacer />
+ */
+export default {}
+</script>
+<script setup lang="ts">
+import { useBindCx } from '@scalar/use-hooks/useBindCx'
+
+import ScalarSidebarIndent from './ScalarSidebarIndent.vue'
+import type { SidebarGroupLevel } from './useSidebarGroups'
+
+const { indent = 0 } = defineProps<{ indent: SidebarGroupLevel }>()
+
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
+</script>
+<template>
+  <div v-bind="cx('flex px-2 h-1')">
+    <ScalarSidebarIndent :indent="indent" />
+  </div>
+</template>

--- a/packages/themes/src/base/variables.css
+++ b/packages/themes/src/base/variables.css
@@ -52,7 +52,7 @@
   --scalar-text-decoration-hover: underline;
   --scalar-link-font-weight: inherit;
 
-  --scalar-sidebar-indent: 18px;
+  --scalar-sidebar-indent: 20px;
 }
 .dark-mode {
   color-scheme: dark;

--- a/packages/themes/src/tailwind/theme.css
+++ b/packages/themes/src/tailwind/theme.css
@@ -40,6 +40,8 @@
   --font-weight-normal: var(--scalar-regular);
   --font-weight-medium: var(--scalar-semibold);
   --font-weight-bold: var(--scalar-bold);
+  --font-weight-sidebar: var(--scalar-sidebar-font-weight, var(--scalar-regular));
+  --font-weight-sidebar-active: var(--scalar-sidebar-font-weight-active, var(--scalar-semibold));
 
   /* Colors */
   --color-\*: initial;

--- a/packages/use-hooks/src/useBindCx/cva.ts
+++ b/packages/use-hooks/src/useBindCx/cva.ts
@@ -14,6 +14,7 @@ const tw = extendTailwindMerge({
   extend: {
     classGroups: {
       'font-size': ['text-3xs', 'text-xxs'],
+      'font-weight': ['font-sidebar', 'font-sidebar-active'],
     },
   },
 })


### PR DESCRIPTION
Add sidebar sections and updates the sidebar to align with the figmas. To keep the work small going to try to get this merged this then do sub sidebars.

(Right side shows bounding boxes / spacing)

<img width="49%" src="https://github.com/user-attachments/assets/07ec02e5-a14c-4e9c-a5e7-fc087e7bb942" />
<img width="49%" src="https://github.com/user-attachments/assets/b6de206a-622e-4245-8b6b-90a3eed01fc0" />

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
