### PR TITLE
fix(nuxt): set config content after grabbing spec

### DIFF
--- a/.changeset/lovely-candles-beg.md
+++ b/.changeset/lovely-candles-beg.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nuxt': patch
+---
+
+fix(nuxt): set config content after grabbing spec

--- a/integrations/nuxt/src/runtime/components/ScalarApiReference.vue
+++ b/integrations/nuxt/src/runtime/components/ScalarApiReference.vue
@@ -34,6 +34,9 @@ const document =
         : (await useFetch<string>('/_openapi.json', { responseType: 'text' }))
             .data.value
 
+// Set the fetched spec to the config content to prevent ApiReferenceLayout from fetching it again on the client side
+props.configuration.content = document
+
 // Check for empty spec
 if (!document) {
   throw new Error('You must provide a document for Scalar API References')


### PR DESCRIPTION
**Problem**

Resolves #5891

**Solution**

Maybe this could be the best way to prevent the `ApiReferenceLayout` component from fetching again on the client. Since we are getting the specs from the server side we will assign the grabbed spec to the config content.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
