### PR TITLE
fix(api-reference): rollback targets to avoid PropertyDefinition in AST

### DIFF
--- a/.changeset/tidy-starfishes-rule.md
+++ b/.changeset/tidy-starfishes-rule.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): rollback targets to avoid PropertyDefinition in AST

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -27,7 +27,6 @@ export default defineConfig({
       rollupOptions: {
         plugins: [autoCSSInject('references')],
       },
-      target: ['chrome90', 'edge90', 'firefox90', 'safari15'],
     },
   }),
 })

--- a/packages/api-reference/vite.standalone.config.ts
+++ b/packages/api-reference/vite.standalone.config.ts
@@ -59,7 +59,6 @@ export default defineConfig({
         max_line_len: 80,
       },
     },
-    target: ['chrome90', 'edge90', 'firefox90', 'safari15'],
     lib: {
       entry: ['src/standalone.ts'],
       name: '@scalar/api-reference',


### PR DESCRIPTION
**Problem**

Running `gulp-unassert` on the standalone app currently fails due to incompatible syntax in the generated AST.

**Solution**

This PR rolls back the targets field in the build configuration to ensure compatibility with older syntax supported by `escodegen`.

**Detailed explanation**
The issue arises because `escodegen` does not support the `PropertyDefinition` node type in the AST. With the current target configuration, the transpiled code includes class field declarations like:

```ts
class Example {
  foo;
}
```
See image below:

<img width="558" alt="image" src="https://github.com/user-attachments/assets/3f393c99-1a78-4189-b250-69d98fefcd9d" />

This results in a `PropertyDefinition` node, which causes `escodegen` to throw an error. By rolling back the targets setting, the generated code avoids this newer syntax, preventing the failure.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
