### PR TITLE
fix(api-reference): fix up search and document selector on classic layout

### DIFF
--- a/.changeset/chilly-cycles-brake.md
+++ b/.changeset/chilly-cycles-brake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): set sidebar search button leading

--- a/.changeset/long-feet-exercise.md
+++ b/.changeset/long-feet-exercise.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): set search button width

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -458,12 +458,12 @@ watch(hash, (newHash, oldHash) => {
               <ClassicHeader v-if="configuration.layout === 'classic'">
                 <div
                   v-if="$slots['document-selector']"
-                  class="w-64 empty:hidden">
+                  class="w-64 *:!p-0 empty:hidden">
                   <slot name="document-selector" />
                 </div>
                 <SearchButton
                   v-if="!configuration.hideSearch"
-                  class="t-doc__sidebar"
+                  class="t-doc__sidebar max-w-64"
                   :searchHotKey="configuration.searchHotKey"
                   :spec="parsedDocument" />
                 <template #dark-mode-toggle>

--- a/packages/api-reference/src/components/ClassicHeader.vue
+++ b/packages/api-reference/src/components/ClassicHeader.vue
@@ -2,7 +2,9 @@
 <template>
   <div class="references-classic-header-container">
     <div class="references-classic-header">
-      <slot />
+      <div class="references-classic-header-content">
+        <slot />
+      </div>
       <slot name="dark-mode-toggle" />
     </div>
   </div>
@@ -11,13 +13,18 @@
 .references-classic-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 12px;
 
   max-width: var(--refs-content-max-width);
   margin: auto;
   padding: 12px 0;
 }
+.references-classic-header-content {
+  display: flex;
+  gap: 12px;
+  flex-grow: 1;
+}
+
 .references-classic-header-container {
   padding: 0 60px;
 }

--- a/packages/api-reference/src/components/DocumentSelector/DocumentSelector.vue
+++ b/packages/api-reference/src/components/DocumentSelector/DocumentSelector.vue
@@ -38,14 +38,14 @@ const selectedOption = computed({
         v-model="selectedOption"
         :options="listboxOptions"
         resize>
-        <div
-          class="group/dropdown-label hover:bg-b-2 text-c-2 flex w-full cursor-pointer items-center rounded border px-2 py-1.75"
-          tabindex="0">
+        <button
+          class="group/dropdown-label hover:bg-b-2 text-c-2 flex h-8 w-full cursor-pointer items-center rounded border px-2 py-1.75"
+          type="button">
           <ScalarIconCaretUpDown class="mr-1 size-4 text-current" />
           <span class="text-c-1 overflow-hidden text-base text-ellipsis">
             {{ selectedOption?.label || 'Select API' }}
           </span>
-        </div>
+        </button>
       </ScalarListbox>
     </div>
   </template>

--- a/packages/api-reference/src/features/Search/SearchButton.vue
+++ b/packages/api-reference/src/features/Search/SearchButton.vue
@@ -58,6 +58,7 @@ function handleClick() {
 <template>
   <ScalarSidebarSearchButton
     ref="button"
+    class="w-full"
     @click="handleClick">
     <span class="sr-only">Open Search</span>
     <span

--- a/packages/api-reference/src/features/Search/SearchButton.vue
+++ b/packages/api-reference/src/features/Search/SearchButton.vue
@@ -59,6 +59,7 @@ function handleClick() {
   <ScalarSidebarSearchButton
     ref="button"
     class="w-full"
+    :class="$attrs.class"
     @click="handleClick">
     <span class="sr-only">Open Search</span>
     <span

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.vue
@@ -65,8 +65,7 @@ const { cx } = useBindCx()
       :placement="placement ?? 'bottom-start'">
       <ListboxButton
         :id="id"
-        as="template"
-        class="justify-start focus:outline-none focus-visible:ring-1 focus-visible:ring-c-accent">
+        as="template">
         <slot :open="open" />
       </ListboxButton>
       <template #floating="{ width }">

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarSearchButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarSearchButton.vue
@@ -25,7 +25,7 @@ const { cx } = useBindCx()
     </span>
     <span
       v-if="$slots.shortcut"
-      class="uppercase text-sidebar-c-2 bg-b-2 py-0.75 px-1.25 rounded">
+      class="uppercase text-sidebar-c-2 bg-b-2 leading-none py-1 px-1.25 rounded">
       <span class="sr-only">Keyboard Shortcut:</span>
       <kbd>
         <slot name="shortcut" />


### PR DESCRIPTION
Prevents inconsistent external line heights from affecting the search button layout and set the width to full for the references search button export.

Normally it's preferred to use the parent to manage layout (e.g. flexbox, grid) but this maintains the current behaviour.

Also:

* Removes the spacing around the document selector on the classic layout
* Manages the width of the search on classic layout
* Makes sure classes are being passed the the search on the classic layout

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
