### PR TITLE
fix(components): janky scroll on combobox autofocus

### DIFF
--- a/.changeset/yellow-bobcats-dance.md
+++ b/.changeset/yellow-bobcats-dance.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: autofocus scroll on popover panel

--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
@@ -5,8 +5,6 @@ import { prettyPrintJson } from '@scalar/oas-utils/helpers'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { computed } from 'vue'
 
-import { ScalarIcon } from '../ScalarIcon'
-
 /**
  * Uses highlight.js for syntax highlighting
  */

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.test.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.test.ts
@@ -50,6 +50,59 @@ describe('ScalarCombobox', () => {
       expect(wrapper.emitted('update:modelValue')).toBeTruthy()
       expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([singleOptions[0]])
     })
+
+    it('focuses the input when combobox is opened', async () => {
+      const wrapper = mount(ScalarCombobox, {
+        props: { options: singleOptions },
+        slots: { default: '<button>Toggle</button>' },
+        attachTo: document.body,
+      })
+
+      await wrapper.find('button').trigger('click')
+      await nextTick()
+
+      const input = wrapper.find('input[type="text"]')
+      expect(input.element).toBe(document.activeElement)
+
+      wrapper.unmount()
+    })
+
+    it('closes combobox when tabbing out of the input', async () => {
+      // Create a container with the combobox and another focusable element
+      const container = document.createElement('div')
+      container.innerHTML = '<button id="after-button">After Button</button>'
+      document.body.appendChild(container)
+
+      const wrapper = mount(ScalarCombobox, {
+        props: { options: singleOptions },
+        slots: { default: '<button>Toggle</button>' },
+        attachTo: container,
+      })
+
+      // Open the combobox
+      await wrapper.find('button').trigger('click')
+      await nextTick()
+
+      // Verify it's open by checking if the input is visible
+      const input = wrapper.find('input[type="text"]')
+      expect(input.isVisible()).toBe(true)
+
+      // Move focus to the button outside the combobox to simulate tabbing out
+      const afterButton = document.getElementById('after-button') as HTMLButtonElement
+      afterButton.focus()
+      await nextTick()
+
+      // Wait a bit for the popover to close
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      await nextTick()
+
+      // Check if the popover is closed by looking for the options list
+      const optionsList = wrapper.find('ul[role="listbox"]')
+      expect(optionsList.exists()).toBe(false)
+
+      wrapper.unmount()
+      document.body.removeChild(container)
+    })
   })
 
   describe('with grouped options', () => {
@@ -116,7 +169,6 @@ describe('ScalarComboboxMultiselect', () => {
 
       const emitted = wrapper.emitted('update:modelValue')
       expect(emitted).toBeTruthy()
-      console.log(JSON.stringify(emitted, null, 2))
       expect(emitted?.[emitted.length - 1]?.[0]).toHaveLength(2)
     })
   })
@@ -135,6 +187,20 @@ describe('ScalarComboboxOptions', () => {
       const filteredOptions = wrapper.findAllComponents(ScalarComboboxOption)
       expect(filteredOptions).toHaveLength(1)
       expect(filteredOptions[0].text()).toBe('Option 2')
+    })
+
+    it('focuses the input when component is mounted', async () => {
+      const wrapper = mount(ScalarComboboxOptions, {
+        props: { options: singleOptions },
+        attachTo: document.body,
+      })
+
+      await nextTick()
+
+      const input = wrapper.find('input[type="text"]')
+      expect(input.element).toBe(document.activeElement)
+
+      wrapper.unmount()
     })
   })
 

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -128,6 +128,14 @@ function moveActive(dir: 1 | -1) {
     block: 'nearest',
   })
 }
+
+// Manual autofocus for the input
+const input = ref<HTMLInputElement | null>(null)
+onMounted(() => {
+  setTimeout(() => {
+    input.value?.focus()
+  }, 0)
+})
 </script>
 <template>
   <div class="relative flex">
@@ -135,6 +143,7 @@ function moveActive(dir: 1 | -1) {
       class="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-c-3 size-4" />
     <input
       v-model="query"
+      ref="input"
       :aria-activedescendant="active ? getOptionId(active) : undefined"
       aria-autocomplete="list"
       :aria-controls="id"

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
 import { ScalarIconMagnifyingGlass } from '@scalar/icons'
-import { computed, onMounted, ref, useId, watch } from 'vue'
+import {
+  computed,
+  nextTick,
+  onMounted,
+  ref,
+  useId,
+  useTemplateRef,
+  watch,
+} from 'vue'
 
 import ComboboxOption from './ScalarComboboxOption.vue'
 import ComboboxOptionGroup from './ScalarComboboxOptionGroup.vue'
@@ -130,12 +138,8 @@ function moveActive(dir: 1 | -1) {
 }
 
 // Manual autofocus for the input
-const input = ref<HTMLInputElement | null>(null)
-onMounted(() => {
-  setTimeout(() => {
-    input.value?.focus()
-  }, 0)
-})
+const input = useTemplateRef('input')
+nextTick(() => input.value?.focus())
 </script>
 <template>
   <div class="relative flex">

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxPopover.vue
@@ -47,7 +47,6 @@ defineExpose({ popoverButtonRef })
         #floating="{ width }">
         <PopoverPanel
           v-slot="{ close }"
-          focus
           :style="{ width }"
           v-bind="
             cx('relative flex flex-col max-h-[inherit] w-40 rounded text-sm')


### PR DESCRIPTION
**Problem**

Currently, when you have long list of combobox options, it does a janky scroll on open.

**Solution**

With this PR we toss a timeout on the autofucus and it seems to fix the issue. @hwkr this is all yours now.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
