### PR TITLE
fix(Scalar.Aspire.Playground):  prefix name with `@scalar-internal`

### DIFF
--- a/integrations/aspire/playground/Scalar.Aspire.UserService/package.json
+++ b/integrations/aspire/playground/Scalar.Aspire.UserService/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "scalar-aspire-user-service",
+  "name": "@scalar-internal/scalar-aspire-user-service",
   "version": "1.0.0",
   "description": "Simple REST API with Fastify and OpenAPI support",
   "main": "index.js",


### PR DESCRIPTION
This PR adds the prefix `@scalar-internal` to the playground service, so it's ignored by changeset.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
