### PR TITLE
docs: mention other CSS font variable to update to load custom fonts and fix CSS variables dead link

### DIFF
--- a/documentation/themes.md
+++ b/documentation/themes.md
@@ -32,6 +32,7 @@ To get started, overwrite our CSS variables. We won’t judge.
 <style>
   :root {
     --scalar-font: 'Comic Sans MS', 'Comic Sans', cursive;
+    --scalar-font-code: 'Comic Sans MS', 'Comic Sans', cursive;
   }
 </style>
 ```
@@ -39,7 +40,7 @@ To get started, overwrite our CSS variables. We won’t judge.
 > [!NOTE]\
 > By default, we’re using Inter and JetBrains Mono, served by our in-house CDN.
 
-If you want use a different font or want to use Google Fonts, pass `withDefaultFonts: false` to the configuration and overwrite the `--scalar-font` CSS variable. You will also need to provide the source of your new font which can be local or served over the network.
+If you want use a different font or want to use Google Fonts, pass `withDefaultFonts: false` to the configuration and overwrite the `--scalar-font` and `--scalar-font-code` CSS variables. You will also need to provide the source of your new font which can be local or served over the network.
 
 Here is an example of how to use the `Roboto` font from Google Fonts with the CDN API reference.
 
@@ -55,6 +56,7 @@ Here is an example of how to use the `Roboto` font from Google Fonts with the CD
     <style>
       :root {
         --scalar-font: 'Roboto', sans-serif;
+        --scalar-font-code: 'Roboto', sans-serif;
       }
     </style>
   </head>
@@ -72,7 +74,7 @@ Here is an example of how to use the `Roboto` font from Google Fonts with the CD
 </html>
 ```
 
-You can [use all variables](../packages/themes/src/variables.css) as well as overwrite the color theme.
+You can [use all variables](https://github.com/scalar/scalar/blob/main/packages/themes/src/base/variables.css) as well as overwrite the color theme.
 
 To build your own color themes, overwrite the night mode and day mode variables.
 Here are some basic variables to get you started:


### PR DESCRIPTION
**Problem**

Currently, if you followed the guide on how to not load Scalar's CDN fonts, it would still load the `https://fonts.scalar.com/mono-latin.woff2` font.

**Solution**

With this PR, this updates the documentation about the other variable that you need to override to load only local fonts or your own fonts.

In addition, the CSS variables link is dead (404) in the docs, updated it to point to the correct file on GitHub (as it didn't seem to be present anywhere in the docs website).

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`). - *unsure if there's a changeset needed for docs?*
- [x] I’ve added tests for the regression or new feature. - *not needed since its just docs*
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
