### PR TITLE
feat(api-reference): use schema title if available

### DIFF
--- a/.changeset/cyan-windows-own.md
+++ b/.changeset/cyan-windows-own.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: use schema title if available

--- a/packages/api-reference/src/features/traverse-schema/helpers/traverse-schemas.test.ts
+++ b/packages/api-reference/src/features/traverse-schema/helpers/traverse-schemas.test.ts
@@ -418,4 +418,61 @@ describe('traverseSchemas', () => {
       })
     })
   })
+
+  describe('title assignment', () => {
+    it('should use schema.title when provided', () => {
+      const content: OpenAPIV3_1.Document = {
+        openapi: '3.1.0',
+        info: {
+          title: 'Test API',
+          version: '1.0.0',
+        },
+        components: {
+          schemas: {
+            User: {
+              type: 'object',
+              title: 'User Profile',
+              properties: {
+                id: { type: 'string' },
+                name: { type: 'string' },
+              },
+            },
+          },
+        },
+      }
+
+      const result = traverseSchemas(content, mockTagsMap, mockTitlesMap, mockGetModelId)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].title).toBe('User Profile')
+      expect(result[0].name).toBe('User')
+    })
+
+    it('should fall back to name when schema.title is not provided', () => {
+      const content: OpenAPIV3_1.Document = {
+        openapi: '3.1.0',
+        info: {
+          title: 'Test API',
+          version: '1.0.0',
+        },
+        components: {
+          schemas: {
+            Product: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                price: { type: 'number' },
+              },
+            },
+          },
+        },
+      }
+
+      const result = traverseSchemas(content, mockTagsMap, mockTitlesMap, mockGetModelId)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].title).toBe('Product')
+      expect(result[0].name).toBe('Product')
+    })
+  })
 })

--- a/packages/api-reference/src/features/traverse-schema/helpers/traverse-schemas.ts
+++ b/packages/api-reference/src/features/traverse-schema/helpers/traverse-schemas.ts
@@ -13,10 +13,10 @@ const createModelEntry = (
 ): TraversedSchema => {
   const id = getModelId({ name }, tag)
   titlesMap.set(id, name)
-
+  const title = schema.title ?? name
   return {
     id,
-    title: name,
+    title,
     name,
     schema,
   }


### PR DESCRIPTION
With this PR, the schema title is used in the sidebar, if available.

Addition to https://github.com/scalar/scalar/pull/5375

Closes #6038

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
