### PR TITLE
feat(api-reference): use schema title for the sidebar (if available)

### DIFF
--- a/.changeset/famous-carrots-remember.md
+++ b/.changeset/famous-carrots-remember.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: use schema title for the sidebar, if available

--- a/packages/api-reference/src/features/sidebar/helpers/create-sidebar.test.ts
+++ b/packages/api-reference/src/features/sidebar/helpers/create-sidebar.test.ts
@@ -1,9 +1,9 @@
-import type { OpenAPIV3_1 } from '@scalar/openapi-types'
-import { describe, expect, it, vi } from 'vitest'
-import { toRef, toValue, ref } from 'vue'
-import { createSidebar } from './create-sidebar'
-import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
 import { useNavState } from '@/hooks/useNavState'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
+import { describe, expect, it, vi } from 'vitest'
+import { ref, toRef, toValue } from 'vue'
+import { createSidebar } from './create-sidebar'
 
 // Mock vue's inject
 vi.mock('vue', () => {
@@ -1208,6 +1208,30 @@ describe('createSidebar', () => {
             ],
           },
         ],
+      })
+    })
+
+    it('uses the title attribute of the schema', () => {
+      expect(
+        createSidebar(
+          ref({
+            openapi: '3.1.0',
+            info: {
+              title: 'Hello World',
+              version: '1.0.0',
+            },
+            components: {
+              schemas: {
+                Planet: {
+                  title: 'Foobar',
+                },
+              },
+            },
+          } as OpenAPIV3_1.Document),
+          mockOptions,
+        ).items.value,
+      ).toMatchObject({
+        entries: [{ title: 'Models', children: [{ title: 'Foobar' }] }],
       })
     })
 

--- a/packages/api-reference/src/features/traverse-schema/helpers/traverse-schemas.ts
+++ b/packages/api-reference/src/features/traverse-schema/helpers/traverse-schemas.ts
@@ -4,7 +4,7 @@ import type { UseNavState } from '@/hooks/useNavState'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 
 /** Handles creating entries for components.schemas */
-const createModelEntry = (
+const createSchemaEntry = (
   schema: OpenAPIV3_1.SchemaObject,
   name = 'Unkown',
   titlesMap: Map<string, string>,
@@ -12,11 +12,16 @@ const createModelEntry = (
   tag?: OpenAPIV3_1.TagObject,
 ): TraversedSchema => {
   const id = getModelId({ name }, tag)
-  titlesMap.set(id, name)
+
+  // Use schema.title if available, otherwise fall back to name
+  // @see https://json-schema.org/draft/2020-12/json-schema-core#section-4.3.5
+  const title = schema.title ?? name
+
+  titlesMap.set(id, title)
 
   return {
     id,
-    title: name,
+    title,
     name,
     schema,
   }
@@ -42,12 +47,12 @@ export const traverseSchemas = (
     if (schemas[name]['x-tags']?.length) {
       schemas[name]['x-tags'].forEach((tagName: string) => {
         const { tag } = getTag(tagsMap, tagName)
-        tagsMap.get(tagName)?.entries.push(createModelEntry(schemas[name], name, titlesMap, getModelId, tag))
+        tagsMap.get(tagName)?.entries.push(createSchemaEntry(schemas[name], name, titlesMap, getModelId, tag))
       })
     }
     // Add to untagged
     else {
-      untagged.push(createModelEntry(schemas[name], name, titlesMap, getModelId))
+      untagged.push(createSchemaEntry(schemas[name], name, titlesMap, getModelId))
     }
   }
 


### PR DESCRIPTION
**Problem**

We list the schemas in the sidebar, but we always use the key and ignore the title (if the schema has one):

https://json-schema.org/draft/2020-12/json-schema-core#section-4.3.5

**Solution**

With this PR we’re using the schema title (if it’s available) and fall back to the key of the schema.

Closes https://github.com/scalar/scalar/issues/6038

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
