### PR TITLE
docs(Scalar.AspNetCore): unified Readme and docs improvements

### DIFF
--- a/.changeset/pink-readers-smile.md
+++ b/.changeset/pink-readers-smile.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+docs: simplified Readme

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -79,10 +79,11 @@ if (app.Environment.IsDevelopment())
 }
 ```
 
-You’re all set! 🎉 Visit `/scalar` to see the API Reference for the default OpenAPI document (`v1`).
+You’re all set! 🎉
 
-If you have multiple OpenAPI documents, you can set them up with `AddDocument` or `AddDocuments` (see [Multiple OpenAPI Documents](#multiple-openapi-documents)).
-To view a specific document, go to `/scalar/{documentName}` (like `/scalar/v1` or `/scalar/v2-beta`).
+By default, navigating to `/scalar` in your browser will display the API Reference for the `v1` OpenAPI document.
+
+To display a different document, simply add it using `AddDocument` or `AddDocuments` (see [Multiple OpenAPI Documents](#multiple-openapi-documents)). You can also access a specific document directly by visiting `/scalar/{documentName}` (for example, `/scalar/v2-beta`).
 
 ## Migration Guide
 

--- a/documentation/integrations/dotnet.md
+++ b/documentation/integrations/dotnet.md
@@ -1,11 +1,6 @@
-# .NET Integration
+# Scalar API Reference for .NET ASP.NET Core
 
-The `Scalar.AspNetCore` package provides a simple way to integrate the Scalar API reference into your .NET 8+ application.
-
-## Migration Guide
-
-If you are upgrading from `2.1.x` to `2.2.x`, please refer to the [migration guide](https://github.com/scalar/scalar/discussions/5468).
-If you are upgrading from `1.x.x` to `2.x.x`, please refer to the [migration guide](https://github.com/scalar/scalar/issues/4362).
+The `Scalar.AspNetCore` NuGet package provides an easy way to render beautiful API References based on OpenAPI/Swagger documents.
 
 ## Basic Setup
 
@@ -37,7 +32,7 @@ if (app.Environment.IsDevelopment())
 }
 ```
 
-For `Swashbuckle`:
+For `Swashbuckle.AspNetCore`:
 
 ```csharp
 builder.Services.AddEndpointsApiExplorer();
@@ -89,6 +84,11 @@ You’re all set! 🎉 Visit `/scalar` to see the API Reference for the default 
 If you have multiple OpenAPI documents, you can set them up with `AddDocument` or `AddDocuments` (see [Multiple OpenAPI Documents](#multiple-openapi-documents)).
 To view a specific document, go to `/scalar/{documentName}` (like `/scalar/v1` or `/scalar/v2-beta`).
 
+## Migration Guide
+
+If you are upgrading from `2.1.x` to `2.2.x`, please refer to the [migration guide](https://github.com/scalar/scalar/discussions/5468).
+If you are upgrading from `1.x.x` to `2.x.x`, please refer to the [migration guide](https://github.com/scalar/scalar/issues/4362).
+
 ## Configuration Options
 
 The `MapScalarApiReference` method accepts an optional `options` parameter, which you can use to customize Scalar using the fluent API or object initializer syntax. This parameter can be of type `Action<ScalarOptions>` or `Action<ScalarOptions, HttpContext>`.
@@ -130,7 +130,7 @@ app.MapScalarApiReference("/api-reference");
 
 ### OpenAPI Document Route
 
-Scalar expects the OpenAPI document to be available at `/openapi/{documentName}.json`, which aligns with the default route used by the `Microsoft.AspNetCore.OpenApi` package. If your OpenAPI document is hosted at a different path (such as when using `Swashbuckle` or `NSwag`), you can specify the correct path or URL using the `OpenApiRoutePattern` property:
+Scalar expects the OpenAPI document to be available at `/openapi/{documentName}.json`, which aligns with the default route used by the `Microsoft.AspNetCore.OpenApi` package. If your OpenAPI document is hosted at a different path (such as when using `Swashbuckle.AspNetCore` or `NSwag`), you can specify the correct path or URL using the `OpenApiRoutePattern` property:
 
 ```csharp
 app.MapScalarApiReference(options =>
@@ -205,7 +205,7 @@ Scalar allows you to pre-configure authentication details for your API, making i
 :::scalar-callout{ type=warning }
 **Before you start**: Your OpenAPI document must already include authentication security schemes for Scalar to work with them. Scalar can only pre-fill authentication details for schemes that are already defined in your OpenAPI specification.
 
-The security schemes are added by your OpenAPI generator (`NSwag`, `Swashbuckle`, or `Microsoft.AspNetCore.OpenApi`). If you don't see authentication options in Scalar, check your OpenAPI generator's documentation to learn how to properly define security schemes.
+The security schemes are added by your OpenAPI generator (`NSwag`, `Swashbuckle.AspNetCore`, or `Microsoft.AspNetCore.OpenApi`). If you don't see authentication options in Scalar, check your OpenAPI generator's documentation to learn how to properly define security schemes.
 :::
 
 :::scalar-callout{ type=danger }
@@ -579,7 +579,7 @@ app.MapOpenApi();
 app.MapScalarApiReference();
 ```
 
-#### For `Swashbuckle`
+#### For `Swashbuckle.AspNetCore`
 
 ```shell
 dotnet add package Scalar.AspNetCore.Swashbuckle
@@ -702,7 +702,7 @@ This guide explains how to integrate Scalar API Reference into .NET Framework an
 
 ### Prerequisites
 
-- An ASP.NET or ASP.NET Core application with OpenAPI/Swagger support (using Swashbuckle or NSwag)
+- An ASP.NET or ASP.NET Core application with OpenAPI/Swagger support (using `Swashbuckle.AspNetCore` or `NSwag`)
 
 
 ### Step 1: Enable Swagger/OpenAPI in your project

--- a/integrations/aspnetcore/README.md
+++ b/integrations/aspnetcore/README.md
@@ -1,149 +1,20 @@
-# Scalar .NET API Reference Integration
+# Scalar API Reference for .NET ASP.NET Core
 
 [![Version](https://img.shields.io/nuget/v/Scalar.AspNetCore)](https://www.nuget.org/packages/Scalar.AspNetCore)
 [![Downloads](https://img.shields.io/nuget/dt/Scalar.AspNetCore)](https://www.nuget.org/packages/Scalar.AspNetCore)
 [![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
-This .NET package `Scalar.AspNetCore` provides an easy way to render beautiful API references based on OpenAPI/Swagger documents.
+The `Scalar.AspNetCore` NuGet package provides an easy way to render beautiful API References based on OpenAPI/Swagger documents.
 
-Made possible by the wonderful work of [@captainsafia](https://github.com/captainsafia) on [building the integration and docs written](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/using-openapi-documents?view=aspnetcore-9.0#use-scalar-for-interactive-api-documentation) for the Scalar & .NET integration. Thanks to [@xC0dex](https://github.com/xC0dex) for making it awesome.
+## Documentation
 
-## Features
+[Read the documentation here](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md)
 
-- Stunning API Reference
-- Compatible with .NET 8 and above
-- Independent of OpenAPI document generators
-- Fully AOT (Ahead-of-Time) compatible
-
-![dotnet](https://raw.githubusercontent.com/scalar/scalar/refs/heads/main/integrations/aspnetcore/dotnet.jpg)
-
-## Migration Guide
-
-If you are upgrading from `2.1.x` to `2.2.x`, please refer to the [migration guide](https://github.com/scalar/scalar/discussions/5468).
-If you are upgrading from `1.x.x` to `2.x.x`, please refer to the [migration guide](https://github.com/scalar/scalar/issues/4362).
-
-## Usage
-
-1. **Install the package**
-
-```shell
-dotnet add package Scalar.AspNetCore
-```
-
-2. **Add the using directive**
-
-```csharp
-using Scalar.AspNetCore;
-```
-
-3. **Configure your application**
-
-Add the following to `Program.cs` based on your OpenAPI generator:
-
-For `Microsoft.AspNetCore.OpenApi`:
-
-```csharp
-builder.Services.AddOpenApi();
-
-if (app.Environment.IsDevelopment())
-{
-    app.MapOpenApi();
-    app.MapScalarApiReference();
-}
-```
-
-For `Swashbuckle`:
-
-```csharp
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
-
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger(options =>
-    {
-        options.RouteTemplate = "/openapi/{documentName}.json";
-    });
-    app.MapScalarApiReference();
-}
-```
-
-For `NSwag`:
-
-```csharp
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddOpenApiDocument();
-
-if (app.Environment.IsDevelopment())
-{
-    app.UseOpenApi(options =>
-    {
-        options.Path = "/openapi/{documentName}.json";
-    });
-    app.MapScalarApiReference();
-}
-```
-
-For `FastEndpoints`:
-
-```csharp
-builder.Services.SwaggerDocument();
-
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwaggerGen(options =>
-    {
-        options.Path = "/openapi/{documentName}.json";
-    });
-    app.MapScalarApiReference();
-}
-```
-
-You’re all set! 🎉 Visit `/scalar` to see the API Reference for the default OpenAPI document (`v1`).
-
-If you have multiple OpenAPI documents, you can set them up with `AddDocument` or `AddDocuments` (see [Multiple OpenAPI Documents](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md#multiple-openapi-documents)).  
-To view a specific document, go to `/scalar/{documentName}` (like `/scalar/v1` or `/scalar/v2-beta`).
-
-## Configuration
-
-For detailed configuration options, refer to the [integration documentation](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md). This documentation focuses on the features provided by the package.
-
-For more realistic examples and advanced usage scenarios, such as authentication, API versioning, and handling multiple documents, check out our [extended examples documentation](https://github.com/scalar/scalar/blob/main/integrations/aspnetcore/docs/README.md). This documentation is also useful if you need more context on what `Scalar.AspNetCore` is for.
-
-## OpenAPI extensions
-
-Scalar provides additional packages to enhance OpenAPI document generation:
-
-- **Scalar.AspNetCore.Microsoft**: Implements transformers for `Microsoft.AspNetCore.OpenApi`
-- **Scalar.AspNetCore.Swashbuckle**: Implements filters for `Swashbuckle`
-
-These packages enable advanced features like stability indicators and API Reference exclusions. See the [dotnet integration documentation](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md#scalar-openapi-extensions) for details.
-
-## Development
-
-### Local
-
-1. Download [.NET 9.0](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)
-2. Jump to the package folder: `cd integrations/aspnetcore`
-3. Do a fresh build: `dotnet build`
-4. Run the tests: `dotnet test`
-
-And see it in action here:
-
-1. Switch to the playground: `cd playground/Scalar.AspNetCore.Playground`
-2. Start the playground: `dotnet run`
-3. Open this URL in the browser: <http://localhost:5056/scalar/>
-
-### Docker
-
-If you don't have the SDK installed or want to run the playground under a subpath, you can use Docker Compose:
-
-1. Run Docker Compose: `docker compose up --build`
-2. Open this URL in the browser: <http://localhost:8080/api/scalar/>
+For more realistic examples and advanced usage scenarios, such as authentication, API versioning, and handling multiple documents, check out our [extended examples documentation](https://github.com/scalar/scalar/blob/main/integrations/aspnetcore/docs/README.md).
 
 ## Community
 
-We are API nerds. You too? Let’s chat on Discord: <https://discord.gg/scalar>
+We are API nerds. You too? Let's chat on Discord: <https://discord.gg/scalar>
 
 ## License
 

--- a/integrations/aspnetcore/README.md
+++ b/integrations/aspnetcore/README.md
@@ -8,7 +8,7 @@ The `Scalar.AspNetCore` NuGet package provides an easy way to render beautiful A
 
 ## Documentation
 
-[Read the documentation here](https://github.com/scalar/scalar/blob/main/documentation/integrations/dotnet.md)
+[Read the documentation here](https://guides.scalar.com/scalar/scalar-api-references/integrations/net-aspnet-core)
 
 For more realistic examples and advanced usage scenarios, such as authentication, API versioning, and handling multiple documents, check out our [extended examples documentation](https://github.com/scalar/scalar/blob/main/integrations/aspnetcore/docs/README.md).
 


### PR DESCRIPTION
This PR updates the README of the `Scalar.AspNetCore` integration to be like all the other integration README's.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
