### PR TITLE
fix(api-reference): uses empty summary for the sidebar

### DIFF
--- a/.changeset/dirty-bulldogs-eat.md
+++ b/.changeset/dirty-bulldogs-eat.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: uses empty operation summary for the sidebar entry

--- a/packages/api-reference/src/features/sidebar/helpers/create-sidebar.test.ts
+++ b/packages/api-reference/src/features/sidebar/helpers/create-sidebar.test.ts
@@ -843,6 +843,30 @@ describe('createSidebar', () => {
       })
     })
 
+    it('uses the path when summary is an empty string', () => {
+      expect(
+        createSidebar(
+          ref({
+            openapi: '3.1.0',
+            info: {
+              title: 'Hello World',
+              version: '1.0.0',
+            },
+            paths: {
+              '/hello': {
+                get: {
+                  summary: '',
+                },
+              },
+            },
+          } as OpenAPIV3_1.Document),
+          mockOptions,
+        ).items.value,
+      ).toMatchObject({
+        entries: [{ title: '/hello' }],
+      })
+    })
+
     it('sorts operations alphabetically with summary', () => {
       const configWithSorter = ref({
         ...config.value,

--- a/packages/api-reference/src/features/traverse-schema/helpers/traverse-paths.ts
+++ b/packages/api-reference/src/features/traverse-schema/helpers/traverse-paths.ts
@@ -2,8 +2,8 @@ import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 
 import type { TraversedEntry, TraversedOperation } from '@/features/traverse-schema/types'
 import type { UseNavState } from '@/hooks/useNavState'
-import { getTag } from './get-tag'
 import { httpMethods } from '@scalar/helpers/http/http-methods'
+import { getTag } from './get-tag'
 
 const createOperationEntry = (
   operation: OpenAPIV3_1.OperationObject,
@@ -14,11 +14,13 @@ const createOperationEntry = (
   getOperationId: UseNavState['getOperationId'],
 ): TraversedOperation => {
   const id = getOperationId({ ...operation, method, path }, tag)
-  titlesMap.set(id, operation.summary ?? path)
+  const title = operation.summary?.trim() ? operation.summary : path
+
+  titlesMap.set(id, title)
 
   return {
     id,
-    title: operation.summary ?? path,
+    title,
     path,
     method: method,
     operation,


### PR DESCRIPTION
**Problem**

Currently, we’re using the operation summary for the sidebar entries, even if it’s just an empty string `''`.

Example: https://demo.scribe.knuckles.wtf

<img width="281" alt="Screenshot 2025-06-24 at 16 35 51" src="https://github.com/user-attachments/assets/2ed31fc8-9b7d-499a-aa84-26ce691135b8" />

**Solution**

With this PR we’ll use the path then. :)

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
