### PR TITLE
docs: update `operationsSorter` example

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -915,7 +915,7 @@ Or specify a custom function to sort the tags.
 
 Learn more about Array sort functions: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
 
-### operationsSorter?: 'alpha' | 'method' | ((a: TransformedOperation, b: TransformedOperation) => number)
+### operationsSorter?: 'alpha' | 'method' | ((a: OperationSortValue, b: OperationSortValue) => number)
 
 ```js
 {
@@ -928,8 +928,8 @@ Or specify a custom function to sort the operations.
 ```js
 {
   operationsSorter: (a, b) => {
-    const methodOrder = ['GET', 'POST', 'PUT', 'DELETE']
-    const methodComparison = methodOrder.indexOf(a.httpVerb) - methodOrder.indexOf(b.httpVerb)
+    const methodOrder = ['get', 'post', 'put', 'delete']
+    const methodComparison = methodOrder.indexOf(a.method) - methodOrder.indexOf(b.method)
 
     if (methodComparison !== 0) {
       return methodComparison
@@ -939,6 +939,8 @@ Or specify a custom function to sort the operations.
   },
 }
 ```
+
+> Note: `method` is the HTTP method of the operation, represented as a lowercase string.
 
 ### theme?: string
 


### PR DESCRIPTION
Changed property from `httpVerb` to `method` (now lowercase)

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
