### PR TITLE
feat(workspace-store): create extensions schemas for the api-client

### DIFF
--- a/.changeset/grumpy-apples-laugh.md
+++ b/.changeset/grumpy-apples-laugh.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': minor
+---
+
+feat(workspace-store): create extensions schemas for the api-client

--- a/packages/workspace-store/src/schemas/v3.1/strict/openapi-document.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/openapi-document.ts
@@ -18,6 +18,8 @@ import { ExternalDocumentationObjectSchema } from './external-documentation'
 import { ExtensionsSchema } from '@/schemas/v3.1/strict/extensions'
 import { compose } from '@/schemas/v3.1/compose'
 import { PathItemObjectSchema } from '@/schemas/v3.1/strict/path-operations'
+import { xScalarEnvironmentsSchema } from '@/schemas/v3.1/strict/x-scalar-environments'
+import { xScalarSecretsSchema } from '@/schemas/v3.1/strict/x-scalar-secrets'
 
 const OpenApiExtensionsSchema = Type.Partial(
   Type.Object({
@@ -29,6 +31,11 @@ const OpenApiExtensionsSchema = Type.Partial(
         TagObjectSchema,
       ),
     ),
+    'x-scalar-active-environment': Type.String(),
+    /** A custom icon representing the collection */
+    'x-scalar-icon': Type.String(),
+    'x-scalar-environments': xScalarEnvironmentsSchema,
+    'x-scalar-secrets': xScalarSecretsSchema,
   }),
 )
 

--- a/packages/workspace-store/src/schemas/v3.1/strict/x-scalar-environments.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/x-scalar-environments.ts
@@ -1,0 +1,26 @@
+import { Type, type Static } from '@sinclair/typebox'
+
+export const xScalarEnvVarSchema = Type.Union([
+  Type.Partial(
+    Type.Object({
+      description: Type.String(),
+      default: Type.String(),
+    }),
+  ),
+  Type.String(),
+])
+
+export type XScalarEnvVar = Static<typeof xScalarEnvVarSchema>
+
+export const xScalarEnvironmentSchema = Type.Object({
+  description: Type.Optional(Type.String()),
+  color: Type.Optional(Type.String()),
+  /** A map of variables by name */
+  variables: Type.Record(Type.String(), xScalarEnvVarSchema),
+})
+
+export type XScalarEnvironment = Static<typeof xScalarEnvironmentSchema>
+
+export const xScalarEnvironmentsSchema = Type.Record(Type.String(), xScalarEnvironmentSchema)
+
+export type XScalarEnvironments = Static<typeof xScalarEnvironmentsSchema>

--- a/packages/workspace-store/src/schemas/v3.1/strict/x-scalar-secrets.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/x-scalar-secrets.ts
@@ -1,0 +1,12 @@
+import { Type, type Static } from '@sinclair/typebox'
+
+export const xScalarSecretVarSchema = Type.Object({
+  description: Type.Optional(Type.String()),
+  example: Type.Optional(Type.String()),
+})
+
+export type XScalarSecretVar = Static<typeof xScalarSecretVarSchema>
+
+export const xScalarSecretsSchema = Type.Record(Type.String(), xScalarSecretVarSchema)
+
+export type XScalarSecrets = Static<typeof xScalarSecretsSchema.Type>


### PR DESCRIPTION
Add schema and types for the api-client extension keys

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
