### PR TITLE
fix(api-reference): `withDefaults` is used with destructured props

### DIFF
--- a/.changeset/cool-humans-taste.md
+++ b/.changeset/cool-humans-taste.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: withDefaults is used with destructured props

--- a/packages/api-reference/src/components/Content/Lazy/Loading.vue
+++ b/packages/api-reference/src/components/Content/Lazy/Loading.vue
@@ -41,16 +41,19 @@ import { getModels } from '@/libs/openapi'
  * - need to handle case of last operation/model
  * - need to find an event for codemirror loaded, currently using timeout for models
  */
-const { document, collection, server, layout, parsedSpec } = withDefaults(
-  defineProps<{
-    document: OpenAPIV3_1.Document
-    collection: Collection
-    server?: Server
-    layout?: 'modern' | 'classic'
-    parsedSpec: Spec
-  }>(),
-  { layout: 'modern' },
-)
+const {
+  document,
+  collection,
+  server,
+  layout = 'modern',
+  parsedSpec,
+} = defineProps<{
+  document: OpenAPIV3_1.Document
+  collection: Collection
+  server?: Server
+  layout?: 'modern' | 'classic'
+  parsedSpec: Spec
+}>()
 
 const hideTag = ref(false)
 


### PR DESCRIPTION
**Problem**

```bash
│ [@vue/compiler-sfc] withDefaults() is unnecessary when using destructure with defineProps().
│ Reactive destructure will be disabled when using withDefaults().
│ Prefer using destructure default values, e.g. const { foo = 1 } = defineProps(...).
│
│ /Users/hanspagel/Documents/Projects/scalar/packages/api-reference/src/components/Content/Lazy/Loading.vue
│ 42 |   * - need to find an event for codemirror loaded, currently using timeout for models
│ 43 |   */
│ 44 |  const { document, collection, server, layout, parsedSpec } = withDefaults(
│    |                                                               ^^^^^^^^^^^^
│ 45 |    defineProps<{
│ 46 |      document: OpenAPIV3_1.Document
```

**Solution**

Do what the warning says.

**Checklist**

I’ve gone through the following:

- [ ] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
