### PR TITLE
fix(api-reference): button focus is not defined in search

### DIFF
--- a/.changeset/hip-toys-explain.md
+++ b/.changeset/hip-toys-explain.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/components': patch
+---
+
+fix: focus is not defined in search

--- a/packages/api-reference/src/features/Search/SearchButton.vue
+++ b/packages/api-reference/src/features/Search/SearchButton.vue
@@ -7,24 +7,19 @@ import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useApiClient } from '@/features/api-client-modal'
 import SearchModal from '@/features/Search/SearchModal.vue'
 
-const props = withDefaults(
-  defineProps<{
-    spec: Spec
-    searchHotKey?: string
-  }>(),
-  {
-    searchHotKey: 'k',
-  },
-)
+const { searchHotKey = 'k' } = defineProps<{
+  spec: Spec
+  searchHotKey?: string
+}>()
 
-const button = ref<HTMLButtonElement>()
+const button = ref<InstanceType<typeof ScalarSidebarSearchButton>>()
 const modalState = useModal()
 const { client } = useApiClient()
 
 const handleHotKey = (e: KeyboardEvent) => {
   if (
     (isMacOS() ? e.metaKey : e.ctrlKey) &&
-    e.key === props.searchHotKey &&
+    e.key === searchHotKey &&
     !client.value?.modalState.open
   ) {
     e.preventDefault()
@@ -39,7 +34,7 @@ watch(
     // Return focus to the button when the modal is closed
     if (!next && prev) {
       nextTick(() => {
-        button.value?.focus()
+        button.value?.$el.focus()
       })
     }
   },

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarSearchButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarSearchButton.vue
@@ -2,7 +2,7 @@
 import { ScalarIconMagnifyingGlass } from '@scalar/icons'
 import { useBindCx } from '@scalar/use-hooks/useBindCx'
 
-const { hotKey } = defineProps<{
+defineProps<{
   hotKey?: string
 }>()
 


### PR DESCRIPTION
**Problem**

<img width="1529" alt="Screenshot 2025-06-25 at 13 47 45" src="https://github.com/user-attachments/assets/74ef3048-03c9-49b3-866f-f8d6d6ed31a5" />

**Solution**

We were trying to focus a Vue component, but should rather try to focus the HTML element inside the Vue component.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
