### PR TITLE
fix(api-reference): does not scroll to anchor on load

### DIFF
--- a/.changeset/fair-dots-yawn.md
+++ b/.changeset/fair-dots-yawn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: does not scroll to anchor on load

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -216,17 +216,22 @@ const sidebarOpened = ref(false)
 
 // Open a sidebar tag
 watch(dereferencedDocument, (newDoc) => {
+  // Scroll to given hash
   if (hash.value) {
     const hashSectionId = getSectionId(hash.value)
     if (hashSectionId) {
       setCollapsedSidebarItem(hashSectionId, true)
     }
-  } else {
+  }
+  // Open the first tag
+  else {
     const firstTag = newDoc.tags?.[0]
+
     if (firstTag) {
       setCollapsedSidebarItem(getTagId(firstTag), true)
     }
   }
+
   sidebarOpened.value = true
 })
 

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -216,10 +216,6 @@ const sidebarOpened = ref(false)
 
 // Open a sidebar tag
 watch(dereferencedDocument, (newDoc) => {
-  if (sidebarOpened.value || !newDoc.tags?.length) {
-    return
-  }
-
   if (hash.value) {
     const hashSectionId = getSectionId(hash.value)
     if (hashSectionId) {


### PR DESCRIPTION
**Problem**

If you open an URL with an operation id or something in the hash, we don’t scroll to it.

**Solution**

I’m trying the @amritk tactic and just deleted some code to make it work. 👀 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
