### PR TITLE
ci: generate code coverage report and upload to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,10 @@ jobs:
         run: |
           pnpm script wait -p 5051 5052 &&
           pnpm test:packages:ci
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: packages/api-reference/coverage/lcov.info
 
   test-integrations:
     needs: [build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
           pnpm script wait -p 5051 5052 &&
           pnpm test:packages:ci
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         with:
           files: packages/api-reference/coverage/lcov.info
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "test": "vitest",
     "test:ci": "pnpm test:integrations:ci && pnpm test:packages:ci",
     "test:integrations:ci": "CI=1 vitest integrations/* --silent",
-    "test:packages:ci": "CI=1 vitest packages/* --silent",
+    "test:packages:ci": "CI=1 vitest packages/* --silent --coverage",
     "test:e2e": "pnpm --filter playwright test:e2e",
     "test:e2e:ui": "pnpm --filter playwright test:e2e:ui",
     "test:e2e:jsdelivr": "pnpm --filter playwright test:e2e jsdelivr",

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -1,6 +1,7 @@
 # Scalar API Reference
 
 [![Version](https://img.shields.io/npm/v/%40scalar/api-reference)](https://www.npmjs.com/package/@scalar/api-reference)
+[![Code Coverage](https://codecov.io/gh/scalar/scalar/branch/main/graph/badge.svg)](https://codecov.io/gh/scalar/scalar)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/api-reference)](https://www.npmjs.com/package/@scalar/api-reference)
 [![Hits on jsdelivr](https://img.shields.io/jsdelivr/npm/hm/%40scalar%2Fapi-reference)](https://www.jsdelivr.com/package/npm/@scalar/api-reference)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fapi-reference)](https://www.npmjs.com/package/@scalar/api-reference)

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -37,7 +37,7 @@
     "playground:ssr": "cd ./playground/ssr && pnpm dev",
     "playground:vue": "vite ./playground/vue -c ./playground/vue/vite.config.ts",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest  --coverage",
     "types:build": "scalar-types-build-vue",
     "types:check": "scalar-types-check-vue"
   },

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -37,7 +37,8 @@
     "playground:ssr": "cd ./playground/ssr && pnpm dev",
     "playground:vue": "vite ./playground/vue -c ./playground/vue/vite.config.ts",
     "preview": "vite preview",
-    "test": "vitest  --coverage",
+    "test": "vitest",
+    "test:coverage": "vitest --coverage",
     "types:build": "scalar-types-build-vue",
     "types:check": "scalar-types-check-vue"
   },

--- a/packages/api-reference/vitest.config.ts
+++ b/packages/api-reference/vitest.config.ts
@@ -1,14 +1,15 @@
-import { fileURLToPath } from 'node:url'
-import { defineConfig, mergeConfig } from 'vitest/config'
+import { mergeConfig } from 'vitest/config'
 
 import viteConfig from './vite.config'
 
-export default mergeConfig(
-  viteConfig,
-  defineConfig({
-    test: {
-      environment: 'jsdom',
-      root: fileURLToPath(new URL('./', import.meta.url)),
+export default mergeConfig(viteConfig, {
+  test: {
+    environment: 'jsdom',
+    coverage: {
+      include: ['src/**'],
+      exclude: ['node_modules', 'dist', 'test', '**/*.preview.ts'],
+      reporter: ['text', 'lcov'],
+      reportsDirectory: './coverage',
     },
-  }),
-)
+  },
+})


### PR DESCRIPTION
**Problem**

We write more and more tests, but we want to have everything covered eventually.

**Solution**

I’m not the biggest fan of code coverage reports, but it might be a nice motivation and reminder to write tests, so let’s try it.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [ ] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
