### PR TITLE
feat(api-client): use `documentUrl` as a fallback server

### DIFF
--- a/.changeset/smooth-books-exist.md
+++ b/.changeset/smooth-books-exist.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+---
+
+feat: use documentUrl as fallback server

--- a/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
@@ -17,9 +17,9 @@ import { useUrlPrefetcher } from '@/components/ImportCollection/hooks/useUrlPref
 import ImportNowButton from '@/components/ImportCollection/ImportNowButton.vue'
 import IntegrationLogo from '@/components/ImportCollection/IntegrationLogo.vue'
 import PrefetchError from '@/components/ImportCollection/PrefetchError.vue'
-import { getOpenApiDocumentVersion } from '@/components/ImportCollection/utils/getOpenApiDocumentVersion'
-import { isDocument } from '@/components/ImportCollection/utils/isDocument'
-import { isUrl } from '@/components/ImportCollection/utils/isUrl'
+import { getOpenApiVersion } from '@/components/ImportCollection/utils/get-openapi-version'
+import { isDocument } from '@/components/ImportCollection/utils/is-document'
+import { isUrl } from '@/components/ImportCollection/utils/is-url'
 import WorkspaceSelector from '@/components/ImportCollection/WorkspaceSelector.vue'
 import { useWorkspace } from '@/store'
 import { useActiveEntities } from '@/store/active-entities'
@@ -62,7 +62,7 @@ const title = computed(() => openApiDocument.value?.info?.title)
 
 /** The OpenAPI/Swagger version */
 const version = computed(() =>
-  getOpenApiDocumentVersion(prefetchResult.content || props.source || ''),
+  getOpenApiVersion(prefetchResult.content || props.source || ''),
 )
 
 const { darkLightMode } = useColorMode()
@@ -122,7 +122,7 @@ watch(
 
     if (!value) {
       modalState.hide()
-    } else if (isDocument(value) && getOpenApiDocumentVersion(value)) {
+    } else if (isDocument(value) && getOpenApiVersion(value)) {
       modalState.show()
     } else {
       modalState.hide()

--- a/packages/api-client/src/components/ImportCollection/OpenAppButton.vue
+++ b/packages/api-client/src/components/ImportCollection/OpenAppButton.vue
@@ -3,7 +3,7 @@
 import { ScalarButton, ScalarIcon } from '@scalar/components'
 import { computed } from 'vue'
 
-import { isUrl } from '@/components/ImportCollection/utils/isUrl'
+import { isUrl } from '@/components/ImportCollection/utils/is-url'
 
 const props = defineProps<{
   source?: string | null

--- a/packages/api-client/src/components/ImportCollection/utils/get-openapi-version.test.ts
+++ b/packages/api-client/src/components/ImportCollection/utils/get-openapi-version.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest'
+import { getOpenApiVersion } from './get-openapi-version'
+
+describe('get-openapi-version', () => {
+  describe('getOpenApiVersion', () => {
+    it('returns false for null input', () => {
+      const result = getOpenApiVersion(null)
+      expect(result).toBe(false)
+    })
+
+    it('returns false for empty string', () => {
+      const result = getOpenApiVersion('')
+      expect(result).toBe(false)
+    })
+
+    it('returns false for whitespace-only string', () => {
+      const result = getOpenApiVersion('   \n\t  ')
+      expect(result).toBe(false)
+    })
+
+    it('returns false for URL input', () => {
+      const result = getOpenApiVersion('https://example.com/openapi.json')
+      expect(result).toBe(false)
+    })
+
+    it('returns false for invalid JSON', () => {
+      const result = getOpenApiVersion('{ invalid json }')
+      expect(result).toBe(false)
+    })
+
+    it('returns false for invalid YAML', () => {
+      const result = getOpenApiVersion('invalid: yaml: content:')
+      expect(result).toBe(false)
+    })
+
+    it('returns false for JSON without openapi or swagger fields', () => {
+      const result = getOpenApiVersion('{"name": "test", "version": "1.0.0"}')
+      expect(result).toBe(false)
+    })
+
+    it('returns false for YAML without openapi or swagger fields', () => {
+      const result = getOpenApiVersion('name: test\nversion: 1.0.0')
+      expect(result).toBe(false)
+    })
+
+    it('identifies OpenAPI 3.0.0 JSON document', () => {
+      const input = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+      })
+      const result = getOpenApiVersion(input)
+      expect(result).toBe('OpenAPI 3.0.0 JSON')
+    })
+
+    it('identifies OpenAPI 3.1.0 JSON document', () => {
+      const input = JSON.stringify({
+        openapi: '3.1.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+      })
+      const result = getOpenApiVersion(input)
+      expect(result).toBe('OpenAPI 3.1.0 JSON')
+    })
+
+    it('identifies Swagger 2.0 JSON document', () => {
+      const input = JSON.stringify({
+        swagger: '2.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+      })
+      const result = getOpenApiVersion(input)
+      expect(result).toBe('Swagger 2.0 JSON')
+    })
+
+    it('identifies OpenAPI 3.0.0 YAML document', () => {
+      const input = `
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+`
+      const result = getOpenApiVersion(input)
+      expect(result).toBe('OpenAPI 3.0.0 YAML')
+    })
+
+    it('identifies OpenAPI 3.1.0 YAML document', () => {
+      const input = `
+openapi: 3.1.0
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+`
+      const result = getOpenApiVersion(input)
+      expect(result).toBe('OpenAPI 3.1.0 YAML')
+    })
+
+    it('identifies Swagger 2.0 YAML document', () => {
+      const input = `
+swagger: "2.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+`
+      const result = getOpenApiVersion(input)
+      expect(result).toBe('Swagger 2.0 YAML')
+    })
+
+    it('handles JSON with additional fields', () => {
+      const input = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+        servers: [{ url: 'https://api.example.com' }],
+        components: {},
+      })
+      const result = getOpenApiVersion(input)
+      expect(result).toBe('OpenAPI 3.0.0 JSON')
+    })
+
+    it('handles YAML with additional fields', () => {
+      const input = `
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+servers:
+  - url: https://api.example.com
+components: {}
+`
+      const result = getOpenApiVersion(input)
+      expect(result).toBe('OpenAPI 3.0.0 YAML')
+    })
+
+    it('prioritizes openapi over swagger in JSON', () => {
+      const input = JSON.stringify({
+        openapi: '3.0.0',
+        swagger: '2.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+      })
+      const result = getOpenApiVersion(input)
+      expect(result).toBe('OpenAPI 3.0.0 JSON')
+    })
+
+    it('prioritizes openapi over swagger in YAML', () => {
+      const input = `
+openapi: 3.0.0
+swagger: 2.0
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+`
+      const result = getOpenApiVersion(input)
+      expect(result).toBe('OpenAPI 3.0.0 YAML')
+    })
+
+    it('handles malformed JSON with valid openapi field', () => {
+      const input = '{"openapi": "3.0.0", "info": {, "paths": {}}'
+      const result = getOpenApiVersion(input)
+      expect(result).toBe(false)
+    })
+
+    it('handles malformed YAML with valid openapi field', () => {
+      const input = 'openapi: 3.0.0\ninfo:\n  title: Test API\n  version: 1.0.0\npaths: {'
+      const result = getOpenApiVersion(input)
+      expect(result).toBe(false)
+    })
+
+    it('handles non-string openapi value in JSON', () => {
+      const input = JSON.stringify({
+        openapi: 3.0,
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+      })
+      const result = getOpenApiVersion(input)
+      expect(result).toBe(false)
+    })
+
+    it('handles non-string swagger value in JSON', () => {
+      const input = JSON.stringify({
+        swagger: 2.0,
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+      })
+      const result = getOpenApiVersion(input)
+      expect(result).toBe(false)
+    })
+
+    it('handles non-string openapi value in YAML', () => {
+      const input = `
+openapi: 3.0
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+`
+      const result = getOpenApiVersion(input)
+      expect(result).toBe(false)
+    })
+
+    it('handles non-string swagger value in YAML', () => {
+      const input = `
+swagger: 2.0
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+`
+      const result = getOpenApiVersion(input)
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/packages/api-client/src/components/ImportCollection/utils/get-openapi-version.ts
+++ b/packages/api-client/src/components/ImportCollection/utils/get-openapi-version.ts
@@ -1,10 +1,10 @@
-import { isDocument } from '@/components/ImportCollection/utils/isDocument'
 import { parse } from 'yaml'
+import { isDocument } from './is-document'
 
 /**
  * Get the Swagger/OpenAPI version and format from the given string
  */
-export function getOpenApiDocumentVersion(input: string | null) {
+export function getOpenApiVersion(input: string | null) {
   if (!isDocument(input)) {
     return false
   }

--- a/packages/api-client/src/components/ImportCollection/utils/import-collection.ts
+++ b/packages/api-client/src/components/ImportCollection/utils/import-collection.ts
@@ -1,6 +1,6 @@
 import type { Collection } from '@scalar/oas-utils/entities/spec'
 
-import { isUrl } from '@/components/ImportCollection/utils/isUrl'
+import { isUrl } from '@/components/ImportCollection/utils/is-url'
 import type { WorkspaceStore } from '@/store'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 

--- a/packages/api-client/src/components/ImportCollection/utils/is-document.test.ts
+++ b/packages/api-client/src/components/ImportCollection/utils/is-document.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { isDocument } from './is-document'
+
+describe('is-document', () => {
+  describe('isDocument', () => {
+    it('returns true for OpenAPI document content', () => {
+      const openApiContent = `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      summary: Test endpoint`
+
+      expect(isDocument(openApiContent)).toBe(true)
+    })
+
+    it('returns true for JSON document content', () => {
+      const jsonContent = `{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0"
+  }
+}`
+
+      expect(isDocument(jsonContent)).toBe(true)
+    })
+
+    it('returns true for plain text content', () => {
+      const textContent = 'This is some plain text content'
+
+      expect(isDocument(textContent)).toBe(true)
+    })
+
+    it('returns false for empty string', () => {
+      expect(isDocument('')).toBe(false)
+    })
+
+    it('returns false for whitespace-only string', () => {
+      expect(isDocument('   \n\t  ')).toBe(false)
+    })
+
+    it('returns false for null input', () => {
+      expect(isDocument(null)).toBe(false)
+    })
+
+    it('returns false for undefined input', () => {
+      expect(isDocument(undefined as any)).toBe(false)
+    })
+
+    it('returns false for HTTP URL', () => {
+      expect(isDocument('http://example.com/api')).toBe(false)
+    })
+
+    it('returns false for HTTPS URL', () => {
+      expect(isDocument('https://api.example.com/openapi.json')).toBe(false)
+    })
+
+    it('returns false for URL with trailing whitespace', () => {
+      expect(isDocument('  https://example.com/api  ')).toBe(false)
+    })
+
+    it('returns false for URL with query parameters', () => {
+      expect(isDocument('https://example.com/api?version=1.0')).toBe(false)
+    })
+
+    it('returns false for URL with path parameters', () => {
+      expect(isDocument('https://example.com/api/v1/spec')).toBe(false)
+    })
+
+    it('returns false for URL with fragment', () => {
+      expect(isDocument('https://example.com/api#section')).toBe(false)
+    })
+
+    it('returns false for URL with port', () => {
+      expect(isDocument('https://example.com:8080/api')).toBe(false)
+    })
+
+    it('returns false for content that looks like URL but is not valid', () => {
+      expect(isDocument('http://')).toBe(false)
+    })
+
+    it('returns false for content that looks like URL but is not valid with whitespace', () => {
+      expect(isDocument('  https://  ')).toBe(false)
+    })
+  })
+})

--- a/packages/api-client/src/components/ImportCollection/utils/is-document.ts
+++ b/packages/api-client/src/components/ImportCollection/utils/is-document.ts
@@ -1,0 +1,16 @@
+/** Checks whether the given string could be an OpenAPI document */
+export function isDocument(input: string | null): boolean {
+  // Return false for null, undefined, empty strings, or whitespace-only strings
+  if (!input || input.trim().length === 0) {
+    return false
+  }
+
+  const trimmed = input.trim()
+
+  // Return false if it looks like a URL (starts with http:// or https://)
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return false
+  }
+
+  return true
+}

--- a/packages/api-client/src/components/ImportCollection/utils/is-url.test.ts
+++ b/packages/api-client/src/components/ImportCollection/utils/is-url.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { isUrl } from './is-url'
+
+describe('is-url', () => {
+  describe('isUrl', () => {
+    it('returns true for valid http URLs', () => {
+      expect(isUrl('http://example.com')).toBe(true)
+      expect(isUrl('http://api.example.com/path')).toBe(true)
+      expect(isUrl('http://localhost:3000')).toBe(true)
+      expect(isUrl('http://192.168.1.1')).toBe(true)
+    })
+
+    it('returns true for valid https URLs', () => {
+      expect(isUrl('https://example.com')).toBe(true)
+      expect(isUrl('https://api.example.com/path')).toBe(true)
+      expect(isUrl('https://localhost:3000')).toBe(true)
+      expect(isUrl('https://192.168.1.1')).toBe(true)
+    })
+
+    it('returns false for null input', () => {
+      expect(isUrl(null)).toBe(false)
+    })
+
+    it('returns false for empty string', () => {
+      expect(isUrl('')).toBe(false)
+    })
+
+    it('returns false for non-URL strings', () => {
+      expect(isUrl('not-a-url')).toBe(false)
+      expect(isUrl('example.com')).toBe(false)
+      expect(isUrl('ftp://example.com')).toBe(false)
+      expect(isUrl('file:///path/to/file')).toBe(false)
+      expect(isUrl('mailto:user@example.com')).toBe(false)
+    })
+
+    it('returns false for URLs without protocol', () => {
+      expect(isUrl('www.example.com')).toBe(false)
+      expect(isUrl('example.com/path')).toBe(false)
+      expect(isUrl('localhost:3000')).toBe(false)
+    })
+
+    it('returns false for malformed URLs', () => {
+      expect(isUrl('http:/example.com')).toBe(false)
+      expect(isUrl('https:/example.com')).toBe(false)
+      expect(isUrl('http:example.com')).toBe(false)
+      expect(isUrl('https:example.com')).toBe(false)
+    })
+
+    it('returns false for whitespace-only strings', () => {
+      expect(isUrl('   ')).toBe(false)
+      expect(isUrl('\t')).toBe(false)
+      expect(isUrl('\n')).toBe(false)
+    })
+
+    it('returns false for strings that start with http but are not URLs', () => {
+      expect(isUrl('http://')).toBe(false)
+      expect(isUrl('https://')).toBe(false)
+      expect(isUrl('http:// ')).toBe(false)
+      expect(isUrl('https:// ')).toBe(false)
+    })
+
+    it('handles URLs with query parameters and fragments', () => {
+      expect(isUrl('http://example.com?param=value')).toBe(true)
+      expect(isUrl('https://example.com/path?param=value#fragment')).toBe(true)
+      expect(isUrl('http://example.com#fragment')).toBe(true)
+    })
+
+    it('handles URLs with special characters', () => {
+      expect(isUrl('http://example.com/path with spaces')).toBe(true)
+      expect(isUrl('https://example.com/path-with-underscores')).toBe(true)
+      expect(isUrl('http://example.com/path.with.dots')).toBe(true)
+    })
+  })
+})

--- a/packages/api-client/src/components/ImportCollection/utils/is-url.ts
+++ b/packages/api-client/src/components/ImportCollection/utils/is-url.ts
@@ -1,0 +1,20 @@
+/**
+ * Checks whether the given string is an URL
+ **/
+export function isUrl(input: string | null): boolean {
+  // Quick check for null or undefined
+  if (!input) {
+    return false
+  }
+
+  // Trim whitespace
+  const trimmed = input.trim()
+
+  // If it's an URL, it must start with http:// or https://
+  if (!trimmed.startsWith('http://') && !trimmed.startsWith('https://')) {
+    return false
+  }
+
+  // But it must have more than just the protocol
+  return trimmed.replace(/^https?:\/\//, '').length > 0
+}

--- a/packages/api-client/src/components/ImportCollection/utils/isDocument.ts
+++ b/packages/api-client/src/components/ImportCollection/utils/isDocument.ts
@@ -1,6 +1,0 @@
-import { isUrl } from '@/components/ImportCollection/utils/isUrl'
-
-/** Checks whether the given string could be an OpenAPI document */
-export function isDocument(input: string | null) {
-  return input && !isUrl(input)
-}

--- a/packages/api-client/src/components/ImportCollection/utils/isUrl.ts
+++ b/packages/api-client/src/components/ImportCollection/utils/isUrl.ts
@@ -1,4 +1,0 @@
-/** Checks whether the given string is an URL */
-export function isUrl(input: string | null) {
-  return input && (input.startsWith('http://') || input.startsWith('https://'))
-}

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -186,7 +186,11 @@ export async function importSpecToWorkspace(
   // Add the base server url to collection servers
   const collectionServers: Server[] = getServersFromOpenApiDocument(configuredServers || schema.servers, {
     baseServerURL,
+    documentUrl,
   })
+
+  console.log('documentUrl', documentUrl)
+  console.log('collectionServers', collectionServers)
 
   // Store operation servers
   const operationServers: Server[] = []
@@ -546,12 +550,35 @@ export async function importSpecToWorkspace(
 }
 
 /**
+ * Extracts the base URL (protocol + hostname) from a document URL.
+ * Falls back to the original URL if it's not a valid URL.
+ */
+function getBaseUrlFromDocumentUrl(documentUrl: string): string {
+  try {
+    const url = new URL(documentUrl)
+    return `${url.protocol}//${url.hostname}`
+  } catch {
+    // If the documentUrl is not a valid URL, fall back to using it as-is
+    return documentUrl
+  }
+}
+
+/**
  * Retrieves a list of servers from an OpenAPI document and converts them to a list of Server entities.
  */
 export function getServersFromOpenApiDocument(
   servers: OpenAPIV3_1.ServerObject[] | undefined,
-  { baseServerURL }: Pick<ApiReferenceConfiguration, 'baseServerURL'> = {},
+  {
+    baseServerURL,
+    documentUrl,
+  }: Pick<ApiReferenceConfiguration, 'baseServerURL'> & Pick<ImportSpecToWorkspaceArgs, 'documentUrl'> = {},
 ): Server[] {
+  // If the document doesn't have any servers, try to use the documentUrl as the default server.
+  if (!servers?.length && documentUrl) {
+    return [serverSchema.parse({ url: getBaseUrlFromDocumentUrl(documentUrl) })]
+  }
+
+  // If the servers are not an array, return an empty array.
   if (!servers || !Array.isArray(servers)) {
     return []
   }
@@ -567,6 +594,12 @@ export function getServersFromOpenApiDocument(
           // Use the base server URL (if provided)
           if (baseServerURL) {
             parsedSchema.url = combineUrlAndPath(baseServerURL, parsedSchema.url)
+
+            return parsedSchema
+          }
+
+          if (documentUrl) {
+            parsedSchema.url = combineUrlAndPath(getBaseUrlFromDocumentUrl(documentUrl), parsedSchema.url)
 
             return parsedSchema
           }


### PR DESCRIPTION
**Problem**

When we import documents that don’t have a server, we just fallback to the URL of the API client (which will never be the actual API, because … it’s the API client).

Example: https://api.theirstack.com/

**Solution**

With this PR we’re using the `documentUrl` as a fallback, so if something was imported from https://example.com without a `servers` array, we just assume the API is on https://example.com (not on the URL of the API client).

I've also renamed the import helpers (kebab-case) and added tests.

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
