### PR TITLE
fix(api-references): duplicate section ID for tags on page load

### DIFF
--- a/.changeset/pretty-carrots-cheer.md
+++ b/.changeset/pretty-carrots-cheer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-references): duplicate section ID for tags on page load

--- a/packages/api-reference/src/components/Content/Lazy/Loading.vue
+++ b/packages/api-reference/src/components/Content/Lazy/Loading.vue
@@ -193,6 +193,7 @@ onMounted(() => {
         v-if="tag.operations && tag.operations.length > 0"
         :collection="collection"
         :spec="parsedSpec"
+        id="lazy-{{ getTagId(tag) }}"
         :tag="tag">
         <Operation
           v-for="transformedOperation in tag.lazyOperations"


### PR DESCRIPTION
**Problem**
The tags section is rendered on initial page load using the same section ID as the main page content.

This causes potential conflicts or confusion when targeting or navigating to specific sections of the page, as both the page and the tags section share the same ID.

**Solution**

With this PR we give a unique id for the tag section so when the page finish loading we scroll to the correct section of the page

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [ ] I’ve added tests for the regression or new feature.
- [ ] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
