### PR TITLE
feat(components): add nested sidebar component

### DIFF
--- a/.changeset/wicked-rats-watch.md
+++ b/.changeset/wicked-rats-watch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat(components): add nested sidebar component

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
@@ -11,6 +11,53 @@ import ScalarSidebarSection from './ScalarSidebarSection.vue'
 import ScalarSidebarPlayground from './ScalarSidebarPlayground.vue'
 import ScalarSidebarNestedItems from './ScalarSidebarNestedItems.vue'
 
+const nestedItemGroups = `
+<ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 1'" @click="selected = 'Item 1'">Item 1</ScalarSidebarItem>
+<ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 2'" @click="selected = 'Item 2'">Item 2</ScalarSidebarItem>
+<ScalarSidebarGroup>  
+  Level 1 Group 
+  <template #items>
+    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 1'" @click="selected = 'Subitem 1'">Subitem 1</ScalarSidebarItem>
+    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 2'" @click="selected = 'Subitem 2'">Subitem 2</ScalarSidebarItem>
+      <ScalarSidebarGroup>
+        Level 2 Group
+        <template #items>
+          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 3'" @click="selected = 'Subitem 3'">Subitem 3</ScalarSidebarItem>
+          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 4'" @click="selected = 'Subitem 4'">Subitem 4</ScalarSidebarItem>
+            <ScalarSidebarGroup>
+            Level 3 Group
+            <template #items>
+              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 5'" @click="selected = 'Subitem 5'">Subitem 5</ScalarSidebarItem>
+              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 6'" @click="selected = 'Subitem 6'">Subitem 6</ScalarSidebarItem>
+                <ScalarSidebarGroup>
+                  Level 4 Group
+                  <template #items>
+                    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 7'" @click="selected = 'Subitem 7'">Subitem 7</ScalarSidebarItem>
+                    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 8'" @click="selected = 'Subitem 8'">Subitem 8</ScalarSidebarItem>
+                      <ScalarSidebarGroup>
+                        Level 5 Group
+                        <template #items>
+                          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 9'" @click="selected = 'Subitem 9'">Subitem 9</ScalarSidebarItem>
+                          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 10'" @click="selected = 'Subitem 10'">Subitem 10</ScalarSidebarItem>
+                          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 11'" @click="selected = 'Subitem 11'">Subitem 11</ScalarSidebarItem>
+                        </template>
+                      </ScalarSidebarGroup>
+                    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 12'" @click="selected = 'Subitem 12'">Subitem 12</ScalarSidebarItem>
+                  </template>
+                </ScalarSidebarGroup>
+              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 13'" @click="selected = 'Subitem 13'">Subitem 13</ScalarSidebarItem>
+            </template>
+          </ScalarSidebarGroup>
+          <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 14'" @click="selected = 'Subitem 14'">Subitem 14</ScalarSidebarItem>
+        </template>
+      </ScalarSidebarGroup>
+    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 15'" @click="selected = 'Subitem 15'">Subitem 15</ScalarSidebarItem>
+  </template>
+</ScalarSidebarGroup>
+<ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 3'" @click="selected = 'Item 3'">Item 3</ScalarSidebarItem>
+<ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 4'" @click="selected = 'Item 4'">Item 4</ScalarSidebarItem>
+` as const
+
 const meta: Meta = {
   component: ScalarSidebar,
   tags: ['autodocs'],
@@ -62,50 +109,7 @@ export const WithNestedGroups: Story = {
     template: `
 <ScalarSidebarPlayground v-model:selected="selected" :indent="args.indent">
   <ScalarSidebarItems>
-    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 1'" @click="selected = 'Item 1'">Item 1</ScalarSidebarItem>
-    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 2'" @click="selected = 'Item 2'">Item 2</ScalarSidebarItem>
-    <ScalarSidebarGroup>  
-      Level 1 Group 
-      <template #items>
-        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 1'" @click="selected = 'Subitem 1'">Subitem 1</ScalarSidebarItem>
-        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 2'" @click="selected = 'Subitem 2'">Subitem 2</ScalarSidebarItem>
-          <ScalarSidebarGroup>
-            Level 2 Group
-            <template #items>
-              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 3'" @click="selected = 'Subitem 3'">Subitem 3</ScalarSidebarItem>
-              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 4'" @click="selected = 'Subitem 4'">Subitem 4</ScalarSidebarItem>
-                <ScalarSidebarGroup>
-                Level 3 Group
-                <template #items>
-                  <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 5'" @click="selected = 'Subitem 5'">Subitem 5</ScalarSidebarItem>
-                  <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 6'" @click="selected = 'Subitem 6'">Subitem 6</ScalarSidebarItem>
-                    <ScalarSidebarGroup>
-                      Level 4 Group
-                      <template #items>
-                        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 7'" @click="selected = 'Subitem 7'">Subitem 7</ScalarSidebarItem>
-                        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 8'" @click="selected = 'Subitem 8'">Subitem 8</ScalarSidebarItem>
-                          <ScalarSidebarGroup>
-                            Level 5 Group
-                            <template #items>
-                              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 9'" @click="selected = 'Subitem 9'">Subitem 9</ScalarSidebarItem>
-                              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 10'" @click="selected = 'Subitem 10'">Subitem 10</ScalarSidebarItem>
-                              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 11'" @click="selected = 'Subitem 11'">Subitem 11</ScalarSidebarItem>
-                            </template>
-                          </ScalarSidebarGroup>
-                        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 12'" @click="selected = 'Subitem 12'">Subitem 12</ScalarSidebarItem>
-                      </template>
-                    </ScalarSidebarGroup>
-                  <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 13'" @click="selected = 'Subitem 13'">Subitem 13</ScalarSidebarItem>
-                </template>
-              </ScalarSidebarGroup>
-              <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 14'" @click="selected = 'Subitem 14'">Subitem 14</ScalarSidebarItem>
-            </template>
-          </ScalarSidebarGroup>
-        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 15'" @click="selected = 'Subitem 15'">Subitem 15</ScalarSidebarItem>
-      </template>
-    </ScalarSidebarGroup>
-    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 3'" @click="selected = 'Item 3'">Item 3</ScalarSidebarItem>
-    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 4'" @click="selected = 'Item 4'">Item 4</ScalarSidebarItem>
+    ${nestedItemGroups}
   </ScalarSidebarItems>
 </ScalarSidebarPlayground>
 `,
@@ -132,29 +136,37 @@ export const WithNestedSidebars: Story = {
 <ScalarSidebarPlayground v-model:selected="selected" :indent="args.indent">
   <ScalarSidebarItems>
     <ScalarSidebarNestedItems>
-      Nested Items
+      Nested Items Level 1
       <template #items>
-        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Nested 1'" @click="selected = 'Nested 1'">Nested 1</ScalarSidebarItem>
-        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Nested 2'" @click="selected = 'Nested 2'">Nested 2</ScalarSidebarItem>
-        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Nested 3'" @click="selected = 'Nested 3'">Nested 3</ScalarSidebarItem>
-        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Nested 4'" @click="selected = 'Nested 4'">Nested 4</ScalarSidebarItem>
+        <ScalarSidebarNestedItems>
+          Nested Items Level 2
+          <template #items>
+            <ScalarSidebarNestedItems>
+              Nested Items Level 3
+              <template #items>
+                ${nestedItemGroups}
+              </template>
+            </ScalarSidebarNestedItems>
+            ${nestedItemGroups}
+          </template>
+        </ScalarSidebarNestedItems>
+        ${nestedItemGroups}
       </template>
     </ScalarSidebarNestedItems>
-
-    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 1'" @click="selected = 'Item 1'">Item 1</ScalarSidebarItem>
-    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 2'" @click="selected = 'Item 2'">Item 2</ScalarSidebarItem>
-
     <ScalarSidebarGroup>
-      Sidebar Group
+      Group with Nested Items
       <template #items>
-        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 5'" @click="selected = 'Subitem 5'">Subitem 5</ScalarSidebarItem>
-        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 6'" @click="selected = 'Subitem 6'">Subitem 6</ScalarSidebarItem>
-        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 7'" @click="selected = 'Subitem 7'">Subitem 7</ScalarSidebarItem>
-        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 8'" @click="selected = 'Subitem 8'">Subitem 8</ScalarSidebarItem>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 1'" @click="selected = 'Subitem 1'">Subitem 1</ScalarSidebarItem>
+        <ScalarSidebarNestedItems>
+          Nested Items in a Group
+          <template #items>
+            ${nestedItemGroups}
+          </template>
+        </ScalarSidebarNestedItems>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 2'" @click="selected = 'Subitem 2'">Subitem 2</ScalarSidebarItem>
       </template>
     </ScalarSidebarGroup>
-    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 3'" @click="selected = 'Item 3'">Item 3</ScalarSidebarItem>
-    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 4'" @click="selected = 'Item 4'">Item 4</ScalarSidebarItem>
+    ${nestedItemGroups}
   </ScalarSidebarItems>
 </ScalarSidebarPlayground>
 `,

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
@@ -170,6 +170,12 @@ export const WithNestedSidebars: Story = {
       </template>
     </ScalarSidebarGroup>
     ${nestedItemGroups}
+    <ScalarSidebarNestedItems>
+      More nested items
+      <template #items>
+        ${nestedItemGroups}
+      </template>
+    </ScalarSidebarNestedItems>
   </ScalarSidebarItems>
 </ScalarSidebarPlayground>
 `,

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
@@ -9,6 +9,7 @@ import { ScalarIconFileArchive, ScalarIconFileAudio, ScalarIconFileText } from '
 import ScalarSidebarSearchButton from './ScalarSidebarSearchButton.vue'
 import ScalarSidebarSection from './ScalarSidebarSection.vue'
 import ScalarSidebarPlayground from './ScalarSidebarPlayground.vue'
+import ScalarSidebarNestedItems from './ScalarSidebarNestedItems.vue'
 
 const meta: Meta = {
   component: ScalarSidebar,
@@ -111,6 +112,73 @@ export const WithNestedGroups: Story = {
   }),
 }
 
+export const WithNestedSidebars: Story = {
+  argTypes: { indent: { control: 'number' } },
+  args: { indent: 20 },
+  render: (args) => ({
+    components: {
+      ScalarSidebar,
+      ScalarSidebarItem,
+      ScalarSidebarItems,
+      ScalarSidebarGroup,
+      ScalarSidebarNestedItems,
+      ScalarSidebarPlayground,
+    },
+    setup() {
+      const selected = ref('')
+      return { args, selected }
+    },
+    template: `
+<ScalarSidebarPlayground v-model:selected="selected" :indent="args.indent">
+  <ScalarSidebarItems>
+    <ScalarSidebarNestedItems>
+      Nested Items
+      <template #items>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Nested 1'" @click="selected = 'Nested 1'">Nested 1</ScalarSidebarItem>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Nested 2'" @click="selected = 'Nested 2'">Nested 2</ScalarSidebarItem>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Nested 3'" @click="selected = 'Nested 3'">Nested 3</ScalarSidebarItem>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Nested 4'" @click="selected = 'Nested 4'">Nested 4</ScalarSidebarItem>
+      </template>
+    </ScalarSidebarNestedItems>
+
+    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 1'" @click="selected = 'Item 1'">Item 1</ScalarSidebarItem>
+    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 2'" @click="selected = 'Item 2'">Item 2</ScalarSidebarItem>
+
+    <ScalarSidebarGroup>
+      Sidebar Group
+      <template #items>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 5'" @click="selected = 'Subitem 5'">Subitem 5</ScalarSidebarItem>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 6'" @click="selected = 'Subitem 6'">Subitem 6</ScalarSidebarItem>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 7'" @click="selected = 'Subitem 7'">Subitem 7</ScalarSidebarItem>
+        <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Subitem 8'" @click="selected = 'Subitem 8'">Subitem 8</ScalarSidebarItem>
+      </template>
+    </ScalarSidebarGroup>
+    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 3'" @click="selected = 'Item 3'">Item 3</ScalarSidebarItem>
+    <ScalarSidebarItem is="button" :icon="args.icon" :selected="selected === 'Item 4'" @click="selected = 'Item 4'">Item 4</ScalarSidebarItem>
+  </ScalarSidebarItems>
+</ScalarSidebarPlayground>
+`,
+  }),
+}
+
+export const WithFooterContent: Story = {
+  render: (args) => ({
+    components: { ScalarSidebarPlayground, ScalarSidebarFooter },
+    setup() {
+      return { args }
+    },
+    template: `
+<ScalarSidebarPlayground>
+  <template #footer>
+    <ScalarSidebarFooter v-bind="args">
+      <span class="placeholder">Extra footer content</span>
+    </ScalarSidebarFooter>
+  </template>
+</ScalarSidebarPlayground>
+`,
+  }),
+}
+
 export const WithSections: Story = {
   render: (args) => ({
     components: {
@@ -161,24 +229,6 @@ export const WithSections: Story = {
       </template>
     </ScalarSidebarSection>
   </ScalarSidebarItems>
-</ScalarSidebarPlayground>
-`,
-  }),
-}
-
-export const WithFooterContent: Story = {
-  render: (args) => ({
-    components: { ScalarSidebarPlayground, ScalarSidebarFooter },
-    setup() {
-      return { args }
-    },
-    template: `
-<ScalarSidebarPlayground>
-  <template #footer>
-    <ScalarSidebarFooter v-bind="args">
-      <span class="placeholder">Extra footer content</span>
-    </ScalarSidebarFooter>
-  </template>
 </ScalarSidebarPlayground>
 `,
   }),

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.stories.ts
@@ -137,6 +137,9 @@ export const WithNestedSidebars: Story = {
   <ScalarSidebarItems>
     <ScalarSidebarNestedItems>
       Nested Items Level 1
+      <template #back-label>
+        Top Level Sidebar
+      </template>
       <template #items>
         <ScalarSidebarNestedItems>
           Nested Items Level 2

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -38,7 +38,9 @@ defineSlots<ScalarSidebarItemSlots>()
 const variants = cva({
   base: ['group/button flex rounded px-2 font-sidebar text-c-2 no-underline'],
   variants: {
-    selected: { true: 'cursor-auto bg-b-2 text-c-1 font-sidebar-active' },
+    selected: {
+      true: 'group/button-selected cursor-auto bg-b-2 text-c-1 font-sidebar-active',
+    },
     disabled: { true: 'cursor-auto' },
   },
   compoundVariants: [

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -36,7 +36,9 @@ const { is = 'a', indent = 0 } = defineProps<ScalarSidebarItemProps>()
 defineSlots<ScalarSidebarItemSlots>()
 
 const variants = cva({
-  base: ['group/button flex rounded px-2 font-sidebar text-c-2 no-underline'],
+  base: [
+    'group/button flex items-stretch rounded px-2 font-sidebar text-c-2 no-underline',
+  ],
   variants: {
     selected: {
       true: 'group/button-selected cursor-auto bg-b-2 text-c-1 font-sidebar-active',

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -52,7 +52,6 @@ const { cx } = useBindCx()
 <template>
   <component
     :is="is"
-    :aria-level="indent"
     :aria-selected="selected"
     :type="is === 'button' ? 'button' : undefined"
     v-bind="cx(variants({ selected, disabled }))">
@@ -74,7 +73,9 @@ const { cx } = useBindCx()
       </div>
       <slot />
     </div>
-    <div v-if="$slots.aside">
+    <div
+      v-if="$slots.aside"
+      class="flex items-center">
       <slot name="aside" />
     </div>
   </component>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -68,7 +68,7 @@ const { cx } = useBindCx()
     <div class="flex items-center gap-1 flex-1 py-2 leading-5">
       <div
         v-if="icon || $slots.icon"
-        class="size-3.5">
+        class="size-4">
         <slot name="icon">
           <ScalarIconLegacyAdapter
             v-if="icon"

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
@@ -19,7 +19,6 @@ export default {}
 <script setup lang="ts">
 import type { ScalarSidebarItemProps } from '@/components/ScalarSidebar/types'
 import { useBindCx } from '@scalar/use-hooks/useBindCx'
-import type { Component } from 'vue'
 
 import ScalarSidebarButton from './ScalarSidebarButton.vue'
 import ScalarSidebarGroupToggle from './ScalarSidebarGroupToggle.vue'
@@ -55,9 +54,9 @@ const { cx } = useBindCx()
         class="group/group-button"
         :aria-expanded="open"
         :indent="level"
-        :selected="selected"
-        :disabled="disabled"
-        :icon="icon"
+        :selected
+        :disabled
+        :icon
         @click="open = !open">
         <template #indent>
           <ScalarSidebarIndent

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
@@ -74,7 +74,7 @@ const { cx } = useBindCx()
     <component
       :is="is"
       v-if="open"
-      v-bind="cx('flex flex-col gap-px')">
+      v-bind="cx('group/items flex flex-col gap-px')">
       <slot
         name="items"
         :open="!!open" />

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
@@ -27,7 +27,7 @@ import { type SidebarGroupLevel, useSidebarGroups } from './useSidebarGroups'
 
 const { is = 'ul' } = defineProps<ScalarSidebarItemProps>()
 
-const open = defineModel<boolean>()
+const open = defineModel<boolean>({ default: false })
 
 defineSlots<{
   /** The text content of the toggle */
@@ -85,7 +85,7 @@ const { cx } = useBindCx()
 @reference "../../style.css";
 
 /* Set the font weight and color of the button when a subitem is selected */
-.group\/item:has(.font-sidebar-active) > .group\/group-button {
+.group\/item:has(.group\/button-selected) > .group\/group-button {
   @apply font-sidebar-active text-c-1;
 }
 </style>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroupToggle.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroupToggle.vue
@@ -52,9 +52,7 @@ const { cx } = useBindCx()
     :type="is === 'button' ? 'button' : undefined"
     v-bind="cx(variants({ open }))">
     <slot :open="open">
-      <ScalarIconLegacyAdapter
-        :icon="icon"
-        weight="bold" />
+      <ScalarIconLegacyAdapter :icon="icon" />
     </slot>
     <span class="sr-only">
       <slot

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroupToggle.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroupToggle.vue
@@ -39,7 +39,7 @@ defineSlots<{
 }>()
 
 const variants = cva({
-  base: 'size-3.5 -m-px transition-transform duration-100',
+  base: 'size-4 transition-transform duration-100',
   variants: { open: { true: 'rotate-90' } },
   defaultVariants: { open: false },
 })

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
@@ -43,11 +43,11 @@ const { cx } = useBindCx()
       class="relative w-[var(--scalar-sidebar-indent)]">
       <!-- Indent Border -->
       <div
-        class="scalar-sidebar-indent-border absolute left-1.5 inset-y-0 w-border bg-sidebar-indent-border" />
+        class="scalar-sidebar-indent-border absolute left-2 inset-y-0 w-border bg-sidebar-indent-border" />
       <!-- Indent Border Active or Hover -->
       <div
         v-if="index === indents.length - 1"
-        class="absolute left-1.5 inset-y-0 w-border"
+        class="absolute left-2 inset-y-0 w-border"
         :class="
           disabled
             ? ''

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarIndent.vue
@@ -61,20 +61,22 @@ const { cx } = useBindCx()
 <style scoped>
 @reference "../../style.css";
 
-.group\/item
-  > .group\/button
-  > .scalar-sidebar-indent
-  .scalar-sidebar-indent-border {
+/* Add extra height to the indent border to account for the px spacing between the items */
+.group\/item > * > .scalar-sidebar-indent .scalar-sidebar-indent-border {
   @apply -inset-y-px;
 }
+
+/* Push the border down for the first item in a group */
 .group\/item:first-child
-  > .group\/button
+  > *
   > .scalar-sidebar-indent
   .scalar-sidebar-indent-border {
   @apply top-0;
 }
+
+/* Push the border up for the last item in a group */
 .group\/item:last-child
-  > .group\/button
+  > *
   > .scalar-sidebar-indent
   .scalar-sidebar-indent-border {
   @apply bottom-0;

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
@@ -46,11 +46,15 @@ const { cx } = useBindCx()
 
 /* Hide the buttons from the keyboard when a nested item is open */
 .group\/items.-translate-x-full .group\/button {
+  /* Required to prevent the button from being focused */
   display: none;
+  /* Required to prevent the button from taking up scroll space */
+  max-height: 0;
 
-  transition-property: display;
+  transition-property: display, max-height;
   transition-behavior: allow-discrete;
-  transition-duration: 300s;
+  transition-duration: 0s;
+  transition-delay: 300ms;
 }
 
 /* Show the buttons within a nested item when it is open */
@@ -58,6 +62,7 @@ const { cx } = useBindCx()
   > *
   > .group\/items.translate-x-0
   .group\/button {
+  max-height: calc(infinity * 1px);
   display: flex;
 }
 </style>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
@@ -44,17 +44,20 @@ const { cx } = useBindCx()
 <style>
 @reference "../../style.css";
 
-.group\/items > .group\/item:not(.group\/nested-items) > * {
-  max-height: calc(infinity * 1px);
+/* Hide the buttons from the keyboard when a nested item is open */
+.group\/items.-translate-x-full .group\/button {
+  display: none;
+
+  transition-property: display;
+  transition-behavior: allow-discrete;
+  transition-duration: 300s;
 }
 
-.group\/items.-translate-x-full > .group\/item:not(.group\/nested-items) > * {
-  /* Squish the items so they don't affect the scrolling */
-  max-height: 0;
-
-  /* Delay the max height transition so it's after transform */
-  transition-property: max-height;
-  transition-duration: 0s;
-  transition-delay: 300ms;
+/* Show the buttons within a nested item when it is open */
+.group\/item.group\/nested-items-open
+  > *
+  > .group\/items.translate-x-0
+  .group\/button {
+  display: flex;
 }
 </style>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
@@ -28,7 +28,7 @@ const { cx } = useBindCx()
 <template>
   <component
     :is="is"
-    v-bind="cx('flex flex-col text-base p-3 gap-px')">
+    v-bind="cx('relative flex flex-col text-base p-3 gap-px')">
     <slot />
   </component>
 </template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
@@ -18,9 +18,13 @@ export default {}
 import { useBindCx } from '@scalar/use-hooks/useBindCx'
 import type { Component } from 'vue'
 
+import { useSidebarNestedItems } from './useSidebarNestedItems'
+
 const { is = 'ul' } = defineProps<{
   is?: Component | string
 }>()
+
+const { open } = useSidebarNestedItems()
 
 defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
@@ -28,7 +32,12 @@ const { cx } = useBindCx()
 <template>
   <component
     :is="is"
-    v-bind="cx('relative flex flex-col text-base p-3 gap-px')">
+    v-bind="
+      cx(
+        'relative flex flex-col text-base p-3 gap-px transition-transform duration-300',
+        open ? '-translate-x-full' : 'translate-x-0',
+      )
+    ">
     <slot />
   </component>
 </template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarItems.vue
@@ -34,10 +34,27 @@ const { cx } = useBindCx()
     :is="is"
     v-bind="
       cx(
-        'relative flex flex-col text-base p-3 gap-px transition-transform duration-300',
+        'group/items relative flex flex-col text-base p-3 gap-px transition-transform duration-300',
         open ? '-translate-x-full' : 'translate-x-0',
       )
     ">
     <slot />
   </component>
 </template>
+<style>
+@reference "../../style.css";
+
+.group\/items > .group\/item:not(.group\/nested-items) > * {
+  max-height: calc(infinity * 1px);
+}
+
+.group\/items.-translate-x-full > .group\/item:not(.group\/nested-items) > * {
+  /* Squish the items so they don't affect the scrolling */
+  max-height: 0;
+
+  /* Delay the max height transition so it's after transform */
+  transition-property: max-height;
+  transition-duration: 0s;
+  transition-delay: 300ms;
+}
+</style>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarNestedItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarNestedItems.vue
@@ -1,23 +1,23 @@
 <script lang="ts">
 /**
- * Scalar Sidebar Group component
+ * Scalar Sidebar Nested Items component
  *
- * A collapsible ScalarSidebarItem that can contain subitems
+ * A provides list of items thats presented over the parent list
+ * Needs to be nested inside a ScalarSidebarItems component
  *
  * @example
- * <ScalarSidebarGroup v-model="open">
- *   <!-- Group toggle text -->
+ * <ScalarSidebarNestedItems v-model="open">
+ *   <!-- Item text -->
  *   <template #items>
  *     <ScalarSidebarItem>...</ScalarSidebarItem>
  *     <ScalarSidebarItem>...</ScalarSidebarItem>
  *     <ScalarSidebarItem>...</ScalarSidebarItem>
  *   </template>
- * </ScalarSidebarGroup>
+ * </ScalarSidebarNestedItems>
  */
 export default {}
 </script>
 <script setup lang="ts">
-import type { ScalarSidebarItemProps } from '@/components/ScalarSidebar/types'
 import {
   ScalarIconArrowRight,
   ScalarIconCaretLeft,
@@ -28,11 +28,14 @@ import { ScalarIconLegacyAdapter } from '../ScalarIcon'
 import ScalarSidebarButton from './ScalarSidebarButton.vue'
 import ScalarSidebarItems from './ScalarSidebarItems.vue'
 import ScalarSidebarSpacer from './ScalarSidebarSpacer.vue'
+import type { ScalarSidebarItemProps } from './types'
 import { useSidebarGroups } from './useSidebarGroups'
+import { useSidebarNestedItem } from './useSidebarNestedItems'
 
 const { icon = ScalarIconListDashes } = defineProps<ScalarSidebarItemProps>()
 
-const open = defineModel<boolean>()
+const open = defineModel<boolean>({ default: false })
+useSidebarNestedItem(open)
 
 defineSlots<{
   /** The text content of the button */
@@ -75,25 +78,27 @@ defineOptions({ inheritAttrs: false })
         </template>
       </ScalarSidebarButton>
     </slot>
-    <ScalarSidebarItems
-      v-if="open"
-      class="absolute inset-0 bg-b-1"
-      v-bind="$attrs">
-      <slot name="back">
-        <ScalarSidebarButton
-          is="button"
-          @click="open = false"
-          class="text-c-1 font-sidebar-active">
-          <template #icon>
-            <ScalarIconCaretLeft class="size-4 -m-px text-c-2" />
-          </template>
-          Back
-        </ScalarSidebarButton>
-      </slot>
-      <ScalarSidebarSpacer class="h-3" />
-      <slot
-        name="items"
-        :open="!!open" />
-    </ScalarSidebarItems>
+    <!-- Make sure the div is around for the entire transition -->
+    <Transition :duration="300">
+      <div
+        v-if="open"
+        class="absolute inset-0 translate-x-full">
+        <ScalarSidebarItems v-bind="$attrs">
+          <slot name="back">
+            <ScalarSidebarButton
+              is="button"
+              @click="open = false"
+              class="text-c-1 font-sidebar-active">
+              <template #icon>
+                <ScalarIconCaretLeft class="size-4 -m-px text-c-2" />
+              </template>
+              Back
+            </ScalarSidebarButton>
+          </slot>
+          <ScalarSidebarSpacer class="h-3" />
+          <slot name="items" />
+        </ScalarSidebarItems>
+      </div>
+    </Transition>
   </li>
 </template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarNestedItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarNestedItems.vue
@@ -1,0 +1,99 @@
+<script lang="ts">
+/**
+ * Scalar Sidebar Group component
+ *
+ * A collapsible ScalarSidebarItem that can contain subitems
+ *
+ * @example
+ * <ScalarSidebarGroup v-model="open">
+ *   <!-- Group toggle text -->
+ *   <template #items>
+ *     <ScalarSidebarItem>...</ScalarSidebarItem>
+ *     <ScalarSidebarItem>...</ScalarSidebarItem>
+ *     <ScalarSidebarItem>...</ScalarSidebarItem>
+ *   </template>
+ * </ScalarSidebarGroup>
+ */
+export default {}
+</script>
+<script setup lang="ts">
+import type { ScalarSidebarItemProps } from '@/components/ScalarSidebar/types'
+import {
+  ScalarIconArrowRight,
+  ScalarIconCaretLeft,
+  ScalarIconListDashes,
+} from '@scalar/icons'
+
+import { ScalarIconLegacyAdapter } from '../ScalarIcon'
+import ScalarSidebarButton from './ScalarSidebarButton.vue'
+import ScalarSidebarItems from './ScalarSidebarItems.vue'
+import ScalarSidebarSpacer from './ScalarSidebarSpacer.vue'
+import { useSidebarGroups } from './useSidebarGroups'
+
+const { icon = ScalarIconListDashes } = defineProps<ScalarSidebarItemProps>()
+
+const open = defineModel<boolean>()
+
+defineSlots<{
+  /** The text content of the button */
+  default?: () => any
+  /** Override the entire button */
+  button?: () => any
+  /** Override the icon */
+  icon?: () => any
+  /** Override the back button */
+  back?: () => any
+  /** The list of sidebar subitems */
+  items?: () => any
+}>()
+
+const { level } = useSidebarGroups({ reset: true })
+
+defineOptions({ inheritAttrs: false })
+</script>
+<template>
+  <li class="group/item contents">
+    <slot name="button">
+      <ScalarSidebarButton
+        is="button"
+        class="text-c-1 font-sidebar-active"
+        :aria-expanded="open"
+        :indent="level"
+        :selected
+        :disabled
+        @click="open = true">
+        <template #icon>
+          <slot name="icon">
+            <ScalarIconLegacyAdapter
+              :icon="icon"
+              weight="bold" />
+          </slot>
+        </template>
+        <slot />
+        <template #aside>
+          <ScalarIconArrowRight class="size-4 text-c-2" />
+        </template>
+      </ScalarSidebarButton>
+    </slot>
+    <ScalarSidebarItems
+      v-if="open"
+      class="absolute inset-0 bg-b-1"
+      v-bind="$attrs">
+      <slot name="back">
+        <ScalarSidebarButton
+          is="button"
+          @click="open = false"
+          class="text-c-1 font-sidebar-active">
+          <template #icon>
+            <ScalarIconCaretLeft class="size-4 -m-px text-c-2" />
+          </template>
+          Back
+        </ScalarSidebarButton>
+      </slot>
+      <ScalarSidebarSpacer class="h-3" />
+      <slot
+        name="items"
+        :open="!!open" />
+    </ScalarSidebarItems>
+  </li>
+</template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarNestedItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarNestedItems.vue
@@ -41,19 +41,19 @@ useSidebarNestedItem(open)
 
 defineSlots<{
   /** The text content of the button */
-  'default'?: () => any
+  'default'?: () => unknown
   /** Override the entire button */
-  'button'?: () => any
+  'button'?: () => unknown
   /** Override the icon */
-  'icon'?: () => any
+  'icon'?: () => unknown
   /** Override the aside slot */
-  'aside'?: () => any
+  'aside'?: () => unknown
   /** Override the back button */
-  'back'?: () => any
+  'back'?: () => unknown
   /** Override the back button label */
-  'back-label'?: () => any
+  'back-label'?: () => unknown
   /** The list of sidebar subitems */
-  'items'?: () => any
+  'items'?: () => unknown
 }>()
 
 const { level } = useSidebarGroups({ reset: true })

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarNestedItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarNestedItems.vue
@@ -79,7 +79,8 @@ defineOptions({ inheritAttrs: false })
 <template>
   <li
     ref="el"
-    class="group/item group/nested-items contents">
+    class="group/item group/nested-items contents"
+    :class="{ 'group/nested-items-open': open }">
     <slot name="button">
       <ScalarSidebarButton
         is="button"

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarNestedItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarNestedItems.vue
@@ -55,7 +55,7 @@ const { level } = useSidebarGroups({ reset: true })
 defineOptions({ inheritAttrs: false })
 </script>
 <template>
-  <li class="group/item contents">
+  <li class="group/item group/nested-items contents">
     <slot name="button">
       <ScalarSidebarButton
         is="button"

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarNestedItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarNestedItems.vue
@@ -41,15 +41,19 @@ useSidebarNestedItem(open)
 
 defineSlots<{
   /** The text content of the button */
-  default?: () => any
+  'default'?: () => any
   /** Override the entire button */
-  button?: () => any
+  'button'?: () => any
   /** Override the icon */
-  icon?: () => any
+  'icon'?: () => any
+  /** Override the aside slot */
+  'aside'?: () => any
   /** Override the back button */
-  back?: () => any
+  'back'?: () => any
+  /** Override the back button label */
+  'back-label'?: () => any
   /** The list of sidebar subitems */
-  items?: () => any
+  'items'?: () => any
 }>()
 
 const { level } = useSidebarGroups({ reset: true })
@@ -94,7 +98,9 @@ defineOptions({ inheritAttrs: false })
         </template>
         <slot />
         <template #aside>
-          <ScalarIconArrowRight class="size-4 text-c-2" />
+          <slot name="aside">
+            <ScalarIconArrowRight class="size-4 text-c-2" />
+          </slot>
         </template>
       </ScalarSidebarButton>
     </slot>
@@ -116,7 +122,7 @@ defineOptions({ inheritAttrs: false })
               <template #icon>
                 <ScalarIconCaretLeft class="size-4 -m-px text-c-2" />
               </template>
-              Back
+              <slot name="back-label">Back</slot>
             </ScalarSidebarButton>
           </slot>
           <ScalarSidebarSpacer class="h-3" />

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarPlayground.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarPlayground.vue
@@ -18,7 +18,7 @@ const selected = defineModel<string>('selected')
         '--scalar-sidebar-indent-border-hover': 'var(--scalar-color-3)',
         '--scalar-sidebar-indent-border-active': 'var(--scalar-color-accent)',
       }">
-      <div class="flex flex-col flex-1 min-h-0 custom-scroll">
+      <div class="flex flex-col flex-1 min-h-0 custom-scroll overflow-x-clip">
         <slot name="search">
           <div class="px-3 pt-3 sticky z-1 top-0 bg-sidebar-b-1">
             <ScalarSidebarSearchInput />

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarSection.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarSection.vue
@@ -42,7 +42,7 @@ defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
 </script>
 <template>
-  <li class="group/sidebar-section contents">
+  <li class="group/item group/sidebar-section contents">
     <ScalarSidebarSpacer
       class="group/spacer-before h-3"
       :indent="level" />

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarSpacer.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarSpacer.vue
@@ -17,7 +17,7 @@ import { useBindCx } from '@scalar/use-hooks/useBindCx'
 import ScalarSidebarIndent from './ScalarSidebarIndent.vue'
 import type { SidebarGroupLevel } from './useSidebarGroups'
 
-const { indent = 0 } = defineProps<{ indent: SidebarGroupLevel }>()
+const { indent = 0 } = defineProps<{ indent?: SidebarGroupLevel }>()
 
 defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()

--- a/packages/components/src/components/ScalarSidebar/findScrollContainer.test.ts
+++ b/packages/components/src/components/ScalarSidebar/findScrollContainer.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { findScrollContainer } from './findScrollContainer'
+
+describe('findScrollContainer', () => {
+  beforeEach(() => {
+    // Reset DOM before each test
+    document.body.innerHTML = ''
+  })
+
+  it('returns document.documentElement when no scrollable parent is found', () => {
+    const element = document.createElement('div')
+    document.body.appendChild(element)
+
+    const result = findScrollContainer(element)
+    expect(result).toBe(document.documentElement)
+  })
+
+  it('finds a scrollable parent with overflow: auto', () => {
+    const scrollableParent = document.createElement('div')
+    scrollableParent.style.overflow = 'auto'
+
+    const child = document.createElement('div')
+    scrollableParent.appendChild(child)
+    document.body.appendChild(scrollableParent)
+
+    const result = findScrollContainer(child)
+    expect(result).toBe(scrollableParent)
+  })
+
+  it('finds a scrollable parent with overflow: scroll', () => {
+    const scrollableParent = document.createElement('div')
+    scrollableParent.style.overflow = 'scroll'
+
+    const child = document.createElement('div')
+    scrollableParent.appendChild(child)
+    document.body.appendChild(scrollableParent)
+
+    const result = findScrollContainer(child)
+    expect(result).toBe(scrollableParent)
+  })
+
+  it('finds the nearest scrollable parent, not a further ancestor', () => {
+    const outerScrollable = document.createElement('div')
+    outerScrollable.style.overflow = 'auto'
+
+    const innerScrollable = document.createElement('div')
+    innerScrollable.style.overflow = 'scroll'
+
+    const child = document.createElement('div')
+
+    outerScrollable.appendChild(innerScrollable)
+    innerScrollable.appendChild(child)
+    document.body.appendChild(outerScrollable)
+
+    const result = findScrollContainer(child)
+    expect(result).toBe(innerScrollable)
+  })
+
+  it('skips non-scrollable parents', () => {
+    const nonScrollable = document.createElement('div')
+    nonScrollable.style.overflow = 'visible'
+
+    const scrollableParent = document.createElement('div')
+    scrollableParent.style.overflow = 'auto'
+
+    const child = document.createElement('div')
+
+    scrollableParent.appendChild(nonScrollable)
+    nonScrollable.appendChild(child)
+    document.body.appendChild(scrollableParent)
+
+    const result = findScrollContainer(child)
+    expect(result).toBe(scrollableParent)
+  })
+
+  describe('direction handling', () => {
+    it('finds scrollable parent in y direction by default', () => {
+      const scrollableParent = document.createElement('div')
+      scrollableParent.style.overflowY = 'auto'
+      scrollableParent.style.overflowX = 'visible'
+
+      const child = document.createElement('div')
+      scrollableParent.appendChild(child)
+      document.body.appendChild(scrollableParent)
+
+      const result = findScrollContainer(child)
+      expect(result).toBe(scrollableParent)
+    })
+
+    it('finds scrollable parent in x direction when specified', () => {
+      const scrollableParent = document.createElement('div')
+      scrollableParent.style.overflowX = 'auto'
+      scrollableParent.style.overflowY = 'visible'
+
+      const child = document.createElement('div')
+      scrollableParent.appendChild(child)
+      document.body.appendChild(scrollableParent)
+
+      const result = findScrollContainer(child, 'x')
+      expect(result).toBe(scrollableParent)
+    })
+
+    it('ignores x scrollable parent when looking for y direction', () => {
+      const scrollableParent = document.createElement('div')
+      scrollableParent.style.overflowX = 'auto'
+      scrollableParent.style.overflowY = 'visible'
+
+      const child = document.createElement('div')
+      scrollableParent.appendChild(child)
+      document.body.appendChild(scrollableParent)
+
+      const result = findScrollContainer(child, 'y')
+      expect(result).toBe(document.documentElement)
+    })
+
+    it('ignores y scrollable parent when looking for x direction', () => {
+      const scrollableParent = document.createElement('div')
+      scrollableParent.style.overflowY = 'auto'
+      scrollableParent.style.overflowX = 'visible'
+
+      const child = document.createElement('div')
+      scrollableParent.appendChild(child)
+      document.body.appendChild(scrollableParent)
+
+      const result = findScrollContainer(child, 'x')
+      expect(result).toBe(document.documentElement)
+    })
+  })
+
+  describe('overflow shorthand handling', () => {
+    it('handles overflow shorthand with two values', () => {
+      const scrollableParent = document.createElement('div')
+      scrollableParent.style.overflow = 'auto scroll'
+
+      const child = document.createElement('div')
+      scrollableParent.appendChild(child)
+      document.body.appendChild(scrollableParent)
+
+      // First value is x, second is y
+      expect(findScrollContainer(child, 'x')).toBe(scrollableParent)
+      expect(findScrollContainer(child, 'y')).toBe(scrollableParent)
+    })
+
+    it('handles overflow shorthand with single value', () => {
+      const scrollableParent = document.createElement('div')
+      scrollableParent.style.overflow = 'auto'
+
+      const child = document.createElement('div')
+      scrollableParent.appendChild(child)
+      document.body.appendChild(scrollableParent)
+
+      // Single value applies to both directions
+      expect(findScrollContainer(child, 'x')).toBe(scrollableParent)
+      expect(findScrollContainer(child, 'y')).toBe(scrollableParent)
+    })
+
+    it('handles mixed overflow values', () => {
+      const scrollableParent = document.createElement('div')
+      scrollableParent.style.overflow = 'scroll visible'
+
+      const child = document.createElement('div')
+      scrollableParent.appendChild(child)
+      document.body.appendChild(scrollableParent)
+
+      // x is scroll, y is visible
+      expect(findScrollContainer(child, 'x')).toBe(scrollableParent)
+      expect(findScrollContainer(child, 'y')).toBe(document.documentElement)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles element with no parent', () => {
+      const element = document.createElement('div')
+      // Don't append to DOM, so it has no parent
+
+      const result = findScrollContainer(element)
+      expect(result).toBe(document.documentElement)
+    })
+
+    it('handles deeply nested elements', () => {
+      const scrollableParent = document.createElement('div')
+      scrollableParent.style.overflow = 'auto'
+
+      // Create a deep nesting
+      let current = scrollableParent
+      for (let i = 0; i < 10; i++) {
+        const div = document.createElement('div')
+        current.appendChild(div)
+        current = div
+      }
+
+      document.body.appendChild(scrollableParent)
+
+      const result = findScrollContainer(current)
+      expect(result).toBe(scrollableParent)
+    })
+
+    it('handles elements with hidden overflow', () => {
+      const hiddenParent = document.createElement('div')
+      hiddenParent.style.overflow = 'hidden'
+
+      const child = document.createElement('div')
+      hiddenParent.appendChild(child)
+      document.body.appendChild(hiddenParent)
+
+      const result = findScrollContainer(child)
+      expect(result).toBe(document.documentElement)
+    })
+  })
+})

--- a/packages/components/src/components/ScalarSidebar/findScrollContainer.ts
+++ b/packages/components/src/components/ScalarSidebar/findScrollContainer.ts
@@ -16,7 +16,7 @@ function getOverflowValues(element: HTMLElement) {
  */
 export function findScrollContainer(element?: HTMLElement | null, direction: 'x' | 'y' = 'y') {
   if (!element) {
-    return undefined
+    return document.documentElement
   }
 
   let parent = element.parentElement

--- a/packages/components/src/components/ScalarSidebar/findScrollContainer.ts
+++ b/packages/components/src/components/ScalarSidebar/findScrollContainer.ts
@@ -1,0 +1,34 @@
+/**
+ * Get the normalized overflow values for both directions from an element.
+ */
+function getOverflowValues(element: HTMLElement) {
+  const style = window.getComputedStyle(element)
+  const [x, y] = style.overflow.split(' ')
+
+  return {
+    x: style.overflowX || x,
+    y: style.overflowY || y || x,
+  }
+}
+
+/**
+ * Find the nearest scrollable parent of an element.
+ */
+export function findScrollContainer(element?: HTMLElement | null, direction: 'x' | 'y' = 'y') {
+  if (!element) {
+    return undefined
+  }
+
+  let parent = element.parentElement
+  while (parent) {
+    const overflowValues = getOverflowValues(parent)
+    const value = overflowValues[direction]
+
+    if (value === 'auto' || value === 'scroll') {
+      return parent
+    }
+    parent = parent.parentElement
+  }
+
+  return document.documentElement
+}

--- a/packages/components/src/components/ScalarSidebar/useSidebarGroups.ts
+++ b/packages/components/src/components/ScalarSidebar/useSidebarGroups.ts
@@ -1,5 +1,12 @@
 import { type InjectionKey, inject, provide } from 'vue'
 
+type SidebarGroupOptions = {
+  /** Increment the level of the sidebar groups */
+  increment?: boolean
+  /** Reset the level of the sidebar groups */
+  reset?: boolean
+}
+
 /**
  * The level of the sidebar groups
  *
@@ -17,17 +24,17 @@ export const SIDEBAR_GROUPS_SYMBOL = Symbol() as InjectionKey<SidebarGroupLevel>
 /**
  * Get the current level of the sidebar groups
  *
- * Optionally increments the level of the sidebar groups
+ * Optionally increments or resets the level of the sidebar groups
+ * Always returns the current level even if the level is incremented or reset
  */
-export const useSidebarGroups = ({
-  increment = false,
-}: {
-  /** Whether to increment the level of the sidebar groups */
-  increment?: boolean
-} = {}) => {
+export const useSidebarGroups = (options: SidebarGroupOptions = {}) => {
+  const { increment = false, reset = false } = options
+
   const level = inject(SIDEBAR_GROUPS_SYMBOL, 0)
 
-  if (increment && level < 6) {
+  if (reset) {
+    provide(SIDEBAR_GROUPS_SYMBOL, 0)
+  } else if (increment && level < 6) {
     provide(SIDEBAR_GROUPS_SYMBOL, (level + 1) as SidebarGroupLevel)
   } else {
     provide(SIDEBAR_GROUPS_SYMBOL, level)

--- a/packages/components/src/components/ScalarSidebar/useSidebarNestedItems.test.ts
+++ b/packages/components/src/components/ScalarSidebar/useSidebarNestedItems.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, inject, nextTick, ref, type Ref } from 'vue'
+import { useSidebarNestedItem } from './useSidebarNestedItems'
+
+// Mock vue's inject/provide
+vi.mock('vue', async () => {
+  const actual = await vi.importActual('vue')
+  return {
+    ...actual,
+    inject: vi.fn(),
+    provide: vi.fn(),
+  }
+})
+
+describe('useSidebarNestedItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should sync the open state of the nearest nested child items', async () => {
+    const childModel = ref(false)
+    const parentModel = ref<Ref<boolean>[]>([])
+    const open = computed(() => parentModel.value.some((child) => child.value))
+
+    vi.mocked(inject).mockReturnValue(parentModel)
+
+    // Shouldn't sync before the hook is used
+    childModel.value = true
+    await nextTick()
+    expect(open.value).toEqual(false) // Not synced yet
+
+    childModel.value = false
+    await nextTick()
+    expect(open.value).toEqual(false) // Not synced yet
+
+    useSidebarNestedItem(childModel)
+
+    childModel.value = true
+    await nextTick()
+    expect(open.value).toEqual(true) // Synced
+
+    childModel.value = false
+    await nextTick()
+    expect(open.value).toEqual(false) // Synced
+  })
+
+  it('should sync multiple child models', async () => {
+    const childModel1 = ref(false)
+    const childModel2 = ref(false)
+    const parentModel = ref<Ref<boolean>[]>([])
+    const open = computed(() => parentModel.value.some((child) => child.value))
+
+    vi.mocked(inject).mockReturnValue(parentModel)
+
+    useSidebarNestedItem(childModel1)
+    useSidebarNestedItem(childModel2)
+
+    childModel1.value = true
+    await nextTick()
+    expect(open.value).toEqual(true)
+
+    childModel2.value = true
+    await nextTick()
+    expect(open.value).toEqual(true)
+
+    childModel1.value = false
+    await nextTick()
+    expect(open.value).toEqual(true)
+
+    childModel2.value = false
+    await nextTick()
+    expect(open.value).toEqual(false)
+  })
+})

--- a/packages/components/src/components/ScalarSidebar/useSidebarNestedItems.ts
+++ b/packages/components/src/components/ScalarSidebar/useSidebarNestedItems.ts
@@ -1,0 +1,41 @@
+import { computed, inject, onBeforeUnmount, provide, ref, type InjectionKey, type Ref } from 'vue'
+
+/**
+ * Tracks the open state of the nearest nested child items
+ *
+ * @default false
+ */
+export const SIDEBAR_NESTED_ITEMS_SYMBOL = Symbol() as InjectionKey<Ref<Ref<boolean>[]>>
+
+/**
+ * Get the open / closed model for the nearest nested child items
+ */
+export const useSidebarNestedItem = (
+  /** The model defining the open state of the current nested items */
+  open: Ref<boolean>,
+) => {
+  const parentList = inject(SIDEBAR_NESTED_ITEMS_SYMBOL)
+  if (parentList) {
+    // Add this child to the parent list when the component is mounted
+    parentList.value.push(open)
+
+    onBeforeUnmount(() => {
+      // Remove this child from the parent list when the component is unmounted
+      parentList.value = parentList.value.filter((child) => child !== open)
+    })
+  }
+}
+/**
+ * Get whether or not any nested child items are open
+ */
+export const useSidebarNestedItems = () => {
+  // Create a new ref for any child nested items to update
+  const children = ref<Ref<boolean>[]>([])
+  const open = computed(() => children.value.some((child) => child.value))
+  provide(SIDEBAR_NESTED_ITEMS_SYMBOL, children)
+
+  return {
+    /** Whether or not any nested child items are open */
+    open,
+  }
+}


### PR DESCRIPTION
Creates a nested items component which allows you to create nested sidebars as elements within sidebars.

[**Storybook Demo**](https://9b839acd-2c4f-4048-9703-6bf951a41e37--scalar-components.netlify.app/iframe.html?args=&id=components-scalarsidebar--with-nested-sidebars&viewMode=story)

Features:

- Groups remain semantically correct in the DOM, that is to say the nested items follow a sublist relationship (`ul > li > ul > li` etc.)
- Items are animated gracefully in and out
- Scroll / overflow is handled between item groups and during animations
- Keyboard focus is handled between item groups 

https://github.com/user-attachments/assets/04014363-c781-445d-a815-906faa42bd42

Scroll handling between nested item groups:

https://github.com/user-attachments/assets/4f839b18-ea9b-4787-88c6-d76cace780d3

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.
- [x] I’ve added a changeset (`pnpm changeset`).
- [x] I’ve added tests for the regression or new feature.
- [x] I’ve updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
