### PR TITLE
style(api-reference): swap model title and description

### DIFF
--- a/.changeset/selfish-pens-smoke.md
+++ b/.changeset/selfish-pens-smoke.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+style: improve search result rendering

--- a/packages/api-reference/src/features/Search/SearchModal.vue
+++ b/packages/api-reference/src/features/Search/SearchModal.vue
@@ -61,8 +61,8 @@ const ENTRY_LABELS: { [x in EntryType]: string } = {
   heading: 'Document Heading',
   req: 'Request',
   tag: 'Tag',
-  model: '', // The title of the entry is already "Model"
-  webhook: '', // The title of the entry is already "Webhook"
+  model: 'Model',
+  webhook: 'Webhook',
 }
 
 const searchModalRef = ref<HTMLElement | null>(null)
@@ -237,7 +237,7 @@ function onSearchResultEnter() {
             aria-hidden="true"
             :method="entry.item.httpVerb ?? 'get'" />
           <span class="sr-only">
-            HTTP Method: {{ entry.item.httpVerb ?? 'get' }},
+            HTTP Method: {{ entry.item.httpVerb ?? 'get' }}
           </span>
         </template>
       </ScalarSearchResultItem>

--- a/packages/api-reference/src/features/Search/useSearchIndex.ts
+++ b/packages/api-reference/src/features/Search/useSearchIndex.ts
@@ -97,8 +97,8 @@ export function useSearchIndex({
         headings.forEach((heading) => {
           headingsData.push({
             type: 'heading',
-            title: `Info > ${heading.value}`,
-            description: '',
+            title: heading.value,
+            description: 'Introduction',
             href: `#${getHeadingId(heading)}`,
             tag: heading.slug,
             body: '',

--- a/packages/api-reference/src/features/Search/useSearchIndex.ts
+++ b/packages/api-reference/src/features/Search/useSearchIndex.ts
@@ -198,9 +198,9 @@ export function useSearchIndex({
         webhooks.forEach((webhook) => {
           webhookData.push({
             type: 'webhook',
-            title: 'Webhook',
+            title: `${webhook.name}`,
             href: `#${webhook.id}`,
-            description: `${webhook.name}`,
+            description: 'Webhook',
             httpVerb: webhook.httpVerb,
             tag: webhook.name,
             body: '',

--- a/packages/api-reference/src/features/Search/useSearchIndex.ts
+++ b/packages/api-reference/src/features/Search/useSearchIndex.ts
@@ -218,9 +218,9 @@ export function useSearchIndex({
         Object.keys(schemas).forEach((k) => {
           modelData.push({
             type: 'model',
-            title: 'Model',
+            title: `${(schemas[k] as any).title ?? k}`,
             href: `#${getModelId({ name: k })}`,
-            description: (schemas[k] as any).title ?? k,
+            description: 'Model',
             tag: k,
             body: '',
           })


### PR DESCRIPTION
**Before**

Isn’t the model name the important content, and “Model” something for the 2nd line?
And I think we can omit the `Info >` prefix, but rather show the headings come from the "Introduction”

<img width="565" alt="Screenshot 2025-06-26 at 14 55 10" src="https://github.com/user-attachments/assets/012ae1bf-6539-406a-b5a5-8e30aae80919" />

<img width="557" alt="Screenshot 2025-06-26 at 15 02 58" src="https://github.com/user-attachments/assets/996da334-cf60-4d20-aeee-fcd6fd2047a1" />

**After**

<img width="571" alt="Screenshot 2025-06-26 at 14 55 22" src="https://github.com/user-attachments/assets/89e8c814-0291-4575-893a-b721fea4f088" />

<img width="560" alt="Screenshot 2025-06-26 at 15 00 16" src="https://github.com/user-attachments/assets/10b1f346-c26a-467e-9bc3-4a300eb73133" />

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
