### PR TITLE
feat(api-reference): move search modal icons to use new icons

### DIFF
--- a/packages/api-reference/src/features/Search/SearchModal.vue
+++ b/packages/api-reference/src/features/Search/SearchModal.vue
@@ -4,10 +4,16 @@ import {
   ScalarSearchInput,
   ScalarSearchResultItem,
   ScalarSearchResultList,
-  type Icon,
   type ModalState,
 } from '@scalar/components'
 import { scrollToId } from '@scalar/helpers/dom/scroll-to-id'
+import {
+  ScalarIconBracketsCurly,
+  ScalarIconTag,
+  ScalarIconTerminalWindow,
+  ScalarIconTextAlignLeft,
+} from '@scalar/icons'
+import type { ScalarIconComponent } from '@scalar/icons/types'
 import type { Spec } from '@scalar/types/legacy'
 import type { FuseResult } from 'fuse.js'
 import { nanoid } from 'nanoid'
@@ -51,12 +57,12 @@ const {
   hideModels: props.hideModels,
 })
 
-const ENTRY_ICONS: { [x in EntryType]: Icon } = {
-  heading: 'DocsPage',
-  model: 'Brackets',
-  req: 'Terminal',
-  tag: 'CodeFolder',
-  webhook: 'Terminal',
+const ENTRY_ICONS: { [x in EntryType]: ScalarIconComponent } = {
+  heading: ScalarIconTextAlignLeft,
+  model: ScalarIconBracketsCurly,
+  req: ScalarIconTerminalWindow,
+  tag: ScalarIconTag,
+  webhook: ScalarIconTerminalWindow,
 }
 
 const ENTRY_LABELS: { [x in EntryType]: string } = {
@@ -223,24 +229,24 @@ function onSearchResultEnter() {
             entry.item.path !== entry.item.title
           "
           #description>
-          <span class="sr-only">Path:&nbsp;</span>
-          {{ entry.item.path }}
+          <span class="inline-flex items-center gap-1">
+            <template v-if="entry.item.type === 'req'">
+              <SidebarHttpBadge
+                aria-hidden="true"
+                :method="entry.item.httpVerb ?? 'get'" />
+              <span class="sr-only">
+                HTTP Method: {{ entry.item.httpVerb ?? 'get' }}
+              </span>
+            </template>
+            <span class="sr-only">Path:&nbsp;</span>
+            {{ entry.item.path }}
+          </span>
         </template>
         <template
           v-else-if="entry.item.description"
           #description>
           <span class="sr-only">Description:&nbsp;</span>
           {{ entry.item.description }}
-        </template>
-        <template
-          v-if="entry.item.type === 'req'"
-          #addon>
-          <SidebarHttpBadge
-            aria-hidden="true"
-            :method="entry.item.httpVerb ?? 'get'" />
-          <span class="sr-only">
-            HTTP Method: {{ entry.item.httpVerb ?? 'get' }}
-          </span>
         </template>
       </ScalarSearchResultItem>
       <template #query>

--- a/packages/api-reference/src/features/sidebar/components/SidebarElement.vue
+++ b/packages/api-reference/src/features/sidebar/components/SidebarElement.vue
@@ -125,6 +125,7 @@ const onAnchorClick = async (ev: Event) => {
           &hairsp;
           <span class="sr-only">HTTP Method:&nbsp;</span>
           <SidebarHttpBadge
+            class="min-w-9.75 justify-end text-right"
             :active="isActive"
             :method="item.method">
             <template #default>

--- a/packages/api-reference/src/features/sidebar/components/SidebarHttpBadge.vue
+++ b/packages/api-reference/src/features/sidebar/components/SidebarHttpBadge.vue
@@ -10,7 +10,6 @@ defineProps<{
 <template>
   <HttpMethod
     :class="[
-      'flex items-center justify-end gap-1',
       'sidebar-heading-type',
       `sidebar-heading-type--${method.toLowerCase()}`,
       { 'sidebar-heading-type-active': active },
@@ -24,24 +23,17 @@ defineProps<{
 
 <style scoped>
 .sidebar-heading-type {
-  display: block;
-  min-width: 3.9em;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   overflow: hidden;
   line-height: 14px;
   flex-shrink: 0;
-  color: white;
-  color: color-mix(
-    in srgb,
-    var(--method-color, var(--scalar-color-1)),
-    transparent 0%
-  );
+  color: var(--method-color, var(--scalar-color-1));
   text-transform: uppercase;
   font-size: 10px;
   font-weight: var(--scalar-bold);
-  text-align: right;
-  position: relative;
   font-family: var(--scalar-font-code);
   white-space: nowrap;
-  margin-left: 3px;
 }
 </style>

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
@@ -31,8 +31,7 @@ const { cx } = useBindCx()
         <ScalarIconLegacyAdapter
           v-if="icon"
           :icon="icon"
-          size="sm"
-          weight="bold" />
+          class="size-4" />
       </slot>
       <span>&hairsp;</span>
     </div>


### PR DESCRIPTION
For Cam to reference 🙏 

![google_chrome-2025-06-26-17-06-56_2x_720](https://github.com/user-attachments/assets/e939dcac-0c8f-4d2c-bb6a-19e4f2e50734)

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
