### PR TITLE
fix(snippetz): shell/curl does not add quotes for URLs with special character `$`

### DIFF
--- a/packages/snippetz/src/plugins/shell/curl/curl.test.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.test.ts
@@ -482,4 +482,44 @@ describe('shellCurl', () => {
   "simple": "value"
 }'`)
   })
+
+  it('handles URLs with dollar sign characters', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com/path$with$dollars',
+    })
+
+    expect(result).toBe(`curl 'https://example.com/path$with$dollars'`)
+  })
+
+  it('handles URLs with dollar signs in query parameters', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com',
+      queryString: [
+        {
+          name: 'price',
+          value: '$100',
+        },
+        {
+          name: 'currency',
+          value: 'USD$',
+        },
+      ],
+    })
+
+    expect(result).toBe(`curl 'https://example.com?price=%24100&currency=USD%24'`)
+  })
+
+  it('handles URLs with dollar signs in path and query', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com/api$v1/prices',
+      queryString: [
+        {
+          name: 'amount',
+          value: '$50.00',
+        },
+      ],
+    })
+
+    expect(result).toBe(`curl 'https://example.com/api$v1/prices?amount=%2450.00'`)
+  })
 })

--- a/packages/snippetz/src/plugins/shell/curl/curl.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.ts
@@ -33,7 +33,7 @@ export const shellCurl: Plugin = {
           .join('&')
       : ''
     const url = `${normalizedRequest.url}${queryString}`
-    const hasSpecialChars = /[\s<>[\]{}|\\^%]/.test(url)
+    const hasSpecialChars = /[\s<>[\]{}|\\^%$]/.test(url)
     const urlPart = queryString || hasSpecialChars ? `'${url}'` : url
     parts[0] = `curl ${urlPart}`
 


### PR DESCRIPTION
**Problem**

Currently, URL's with a `$` (dollar sign) special character are not being handled correctly by the curl shell package (i.e. not single quoting the URL) which results in the curl command not executing as expected when run in a terminal/shell (as it will interpret it as a variable). 

For further context on how this was discovered: I am implementing OpenAPI documentation (with Scalar) for a specification that uses `$` characters in their routes, e.g. [`/CodeSystem/$lookup`](https://www.hl7.org/fhir/R5/codesystem-operation-lookup.html). Example here https://sandbox.scalar.com/e/lCjAs

**Solution**

With this PR I have added the `$` to the special characters which are used to determine whether the URL needs to be single quoted (which resolves the issue when the curl command is run in the terminal).

**Checklist**

I've gone through the following:

- [X] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
