### PR TITLE
feat(api-reference): update font styles across scalar

### DIFF
--- a/.changeset/unlucky-pumas-walk.md
+++ b/.changeset/unlucky-pumas-walk.md
@@ -1,0 +1,9 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/components': patch
+'@scalar/scripts': patch
+'@scalar/themes': patch
+---
+
+feat(api-reference): unify inconsistent font styles across scalar client and ref, and improve consistency"

--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -264,7 +264,7 @@ function updateRequestPath(url: string) {
   padding: 0;
   display: flex;
   align-items: center;
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
 }
 .scroll-timeline-x {
   scroll-timeline: --scroll-timeline x;

--- a/packages/api-client/src/components/CodeInput/CodeInput.vue
+++ b/packages/api-client/src/components/CodeInput/CodeInput.vue
@@ -430,7 +430,7 @@ export default {
   background-color: transparent;
   border-right: none;
   color: var(--scalar-color-3);
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
   line-height: 1.44;
   border-radius: 0 0 0 3px;
 }
@@ -514,7 +514,7 @@ export default {
   border-radius: 3px;
   display: inline-block;
   border-radius: 30px;
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
   background: color-mix(in srgb, var(--tw-bg-base), transparent 94%) !important;
 }
 .cm-pill.bg-grey {

--- a/packages/api-client/src/components/DataTable/DataTableCell.vue
+++ b/packages/api-client/src/components/DataTable/DataTableCell.vue
@@ -17,7 +17,7 @@ const { cx } = useBindCx()
     :is="is"
     v-bind="
       cx(
-        'box-content max-h-8 min-h-8 min-w-8 border-l-0 border-t border-b-0 border-r flex text-sm last:border-r-0 group-last:border-b-transparent p-0 m-0 relative',
+        'box-content max-h-8 min-h-8 min-w-8 border-l-0 border-t border-b-0 border-r flex text-base last:border-r-0 group-last:border-b-transparent p-0 m-0 relative',
       )
     "
     class="group-[.alert]:bg-b-alert group-[.error]:bg-b-danger">

--- a/packages/api-client/src/components/DataTable/DataTableInput.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInput.vue
@@ -160,7 +160,7 @@ const handleLabelClick = () => {
   background-color: transparent;
   display: flex;
   font-family: var(--scalar-font);
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
   padding: 6px 8px;
   width: 100%;
 }

--- a/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
+++ b/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
@@ -60,7 +60,7 @@ const handleCreateWorkspace = () => {
 }
 </script>
 <template>
-  <div class="flex w-[inherit] items-center text-sm">
+  <div class="flex w-[inherit] items-center text-base">
     <ScalarDropdown>
       <ScalarButton
         class="text-c-1 hover:bg-b-2 text-c-3 line-clamp-1 h-full w-fit justify-start px-1.5 py-1 font-normal"

--- a/packages/api-client/src/components/Server/ServerDropdown.vue
+++ b/packages/api-client/src/components/Server/ServerDropdown.vue
@@ -95,7 +95,7 @@ const updateServerVariable = (key: string, value: string) => {
 </script>
 <template>
   <ScalarPopover
-    class="max-h-[inherit] p-0 text-sm"
+    class="max-h-[inherit] p-0 text-base"
     focus
     :offset="0"
     placement="bottom-start"
@@ -103,7 +103,7 @@ const updateServerVariable = (key: string, value: string) => {
     :target="target"
     :teleport="`#${target}`">
     <ScalarButton
-      class="z-context-plus hover:bg-b-2 font-code text-c-2 ml-0.75 h-auto gap-0.75 rounded border px-1.5 text-xs whitespace-nowrap lg:text-sm"
+      class="z-context-plus hover:bg-b-2 font-code text-c-2 ml-0.75 h-auto gap-0.75 rounded border px-1.5 text-base whitespace-nowrap"
       variant="ghost">
       <template
         v-if="operation?.selectedServerUid || collection.selectedServerUid">

--- a/packages/api-client/src/components/Server/ServerSelector.vue
+++ b/packages/api-client/src/components/Server/ServerSelector.vue
@@ -89,7 +89,7 @@ const serverUrlWithoutTrailingSlash = computed(() => {
     :target="target"
     :teleport="`#${target}`">
     <ScalarButton
-      class="bg-b-1 text-c-1 h-auto w-full justify-start gap-0.75 overflow-x-auto rounded-t-none rounded-b-lg px-3 py-1.5 text-xs font-normal whitespace-nowrap -outline-offset-1 lg:text-sm"
+      class="bg-b-1 text-c-1 h-auto w-full justify-start gap-0.75 overflow-x-auto rounded-t-none rounded-b-lg px-3 py-1.5 text-base font-normal whitespace-nowrap -outline-offset-1"
       variant="ghost">
       <span class="sr-only">Server:</span>
       <span class="overflow-x-auto">{{ serverUrlWithoutTrailingSlash }}</span>
@@ -101,7 +101,7 @@ const serverUrlWithoutTrailingSlash = computed(() => {
   </ScalarListbox>
   <div
     v-else
-    class="text-c-1 flex h-auto w-full items-center gap-0.75 rounded-b-lg px-3 py-1.5 text-xs whitespace-nowrap lg:text-sm">
+    class="text-c-1 flex h-auto w-full items-center gap-0.75 rounded-b-lg px-3 py-1.5 text-base whitespace-nowrap">
     <span class="sr-only">Server:</span>
     <span class="overflow-x-auto">{{ serverUrlWithoutTrailingSlash }}</span>
   </div>

--- a/packages/api-client/src/components/TopNav/TopNav.vue
+++ b/packages/api-client/src/components/TopNav/TopNav.vue
@@ -213,7 +213,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
     <!-- Add a draggable overlay -->
     <div class="app-drag-region absolute inset-0" />
     <div
-      class="relative flex h-10 flex-1 items-center gap-1.5 overflow-hidden pr-2.5 text-sm font-medium">
+      class="relative flex h-10 flex-1 items-center gap-1.5 overflow-hidden pr-2.5 text-base font-medium">
       <template v-if="topNavItems.length === 1">
         <div class="h-full w-full overflow-hidden">
           <ScalarContextMenu

--- a/packages/api-client/src/components/TopNav/TopNavItem.vue
+++ b/packages/api-client/src/components/TopNav/TopNavItem.vue
@@ -52,7 +52,7 @@ defineEmits<{
               :icon="icon"
               size="xs"
               thickness="2.5" />
-            <span class="custom-scroll nav-item-copy text-xs">{{ label }}</span>
+            <span class="custom-scroll nav-item-copy text-sm">{{ label }}</span>
           </div>
           <button
             class="nav-item-close"

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -31,7 +31,7 @@ const id = useId()
         :class="layout === 'reference' && 'rounded-t-lg border border-b-0'">
         <DisclosureButton
           :class="[
-            'hover:text-c-1 group box-content flex max-h-8 flex-1 items-center gap-2.5 overflow-hidden px-1 py-1.5 text-sm font-medium outline-none md:px-1.5 xl:pr-0.5 xl:pl-2',
+            'hover:text-c-1 group box-content flex max-h-8 flex-1 items-center gap-2.5 overflow-hidden px-1 py-1.5 text-base font-medium outline-none md:px-1.5 xl:pr-0.5 xl:pl-2',
             { '!pl-3': layout === 'reference' },
           ]"
           :disabled="layout === 'reference'">

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -13,7 +13,7 @@ const { cx } = useBindCx()
     ">
     <div
       v-if="$slots.title"
-      class="request-response-header bg-b-1 -mb-1/2 sticky top-0 z-1 flex min-h-11 items-center border-b px-2.5 text-sm font-medium xl:rounded-none">
+      class="request-response-header bg-b-1 -mb-1/2 sticky top-0 z-1 flex min-h-11 items-center border-b px-2.5 text-base font-medium xl:rounded-none">
       <slot name="title" />
     </div>
     <slot />

--- a/packages/api-client/src/views/Collection/components/EnvironmentForm.vue
+++ b/packages/api-client/src/views/Collection/components/EnvironmentForm.vue
@@ -379,7 +379,7 @@ watch(
   background-color: transparent;
   display: flex;
   font-family: var(--scalar-font);
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
   padding: 6px 8px;
   width: 100%;
 }

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -262,12 +262,12 @@ const dataTableInputProps = {
       <DataTableRow>
         <div
           v-if="Object.keys(scheme.flows).length > 1"
-          class="flex min-h-8 border-t text-sm">
+          class="flex min-h-8 border-t text-base">
           <div class="flex h-8 max-w-full gap-2.5 overflow-x-auto px-3">
             <button
               v-for="(_, key, ind) in scheme?.flows"
               :key="key"
-              class="floating-bg text-c-3 relative cursor-pointer border-b-[1px] border-transparent py-1 text-sm font-medium"
+              class="floating-bg text-c-3 relative cursor-pointer border-b-[1px] border-transparent py-1 text-base font-medium"
               :class="{
                 '!text-c-1 !rounded-none border-b-[1px] !border-current':
                   layout !== 'reference' &&
@@ -301,7 +301,7 @@ const dataTableInputProps = {
     <!-- Open ID Connect -->
     <template v-else-if="scheme?.type === 'openIdConnect'">
       <div
-        class="text-c-3 bg-b-1 flex min-h-[calc(4rem+1px)] items-center justify-center border-t border-b-0 px-4 text-sm"
+        class="text-c-3 bg-b-1 flex min-h-[calc(4rem+1px)] items-center justify-center border-t border-b-0 px-4 text-base"
         :class="{ 'rounded-b-lg': layout === 'reference' }">
         Coming soon
       </div>

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -638,6 +638,6 @@ const selectedExample = computed({
 </template>
 <style scoped>
 :deep(.cm-content) {
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
 }
 </style>

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
@@ -272,6 +272,6 @@ const customCodeContent = computed(() => {
 </template>
 <style scoped>
 :deep(code.hljs *) {
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
 }
 </style>

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -229,7 +229,7 @@ const showDeleteButton = (item: RequestExampleParameter) => {
   background-color: transparent;
   display: flex;
   font-family: var(--scalar-font);
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
   padding: 6px 8px;
   width: 100%;
 }

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -398,7 +398,7 @@ const shouldShowItem = computed(() => {
       :id="item.entity.uid"
       ref="draggableRef"
       :ceiling="getDraggableOffsets.ceiling"
-      class="gap-1/2 flex flex-1 flex-col text-sm"
+      class="gap-1/2 flex flex-1 flex-col text-base"
       :floor="getDraggableOffsets.floor"
       :isDraggable="isDraggable"
       :isDroppable="isDroppable"
@@ -422,10 +422,10 @@ const shouldShowItem = computed(() => {
           :class="[
             highlightClasses,
             isExactActive || isDefaultActive
-              ? 'bg-sidebar-b-active text-sidebar-c-active transition-none'
+              ? 'bg-sidebar-b-active text-sidebar-c-active font-medium transition-none'
               : 'text-sidebar-c-2',
           ]">
-          <span class="line-clamp-1 w-full pl-2 font-medium break-all">
+          <span class="line-clamp-1 w-full pl-2 break-all">
             {{ item.title || 'Untitled' }}
           </span>
           <div class="flex flex-row items-center gap-1">

--- a/packages/api-client/src/views/Request/ResponseSection/RequestHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/RequestHeaders.vue
@@ -61,7 +61,7 @@ const findHeaderInfo = (name: string) => {
     <!-- Empty state -->
     <div
       v-else
-      class="text-c-3 bg-b-1 flex min-h-12 items-center justify-center rounded border px-4 text-sm">
+      class="text-c-3 bg-b-1 flex min-h-12 items-center justify-center rounded border px-4 text-base">
       No Headers
     </div>
   </ViewLayoutCollapse>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBody.vue
@@ -80,6 +80,6 @@ const mediaConfig = computed(() => getMediaTypeConfig(mimeType.value.essence))
 </template>
 <style scoped>
 .scalar-code-block:deep(.hljs *) {
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
 }
 </style>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
@@ -55,7 +55,7 @@ const getCurrentContent = () => {
 <style scoped>
 :deep(.cm-editor) {
   background-color: transparent;
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
   outline: none;
 }
 :deep(.cm-gutters) {

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
@@ -61,7 +61,7 @@ const findHeaderInfo = (name: string) => {
     <!-- Empty state -->
     <div
       v-else
-      class="text-c-3 bg-b-1 flex min-h-12 items-center justify-center rounded border px-4 text-sm">
+      class="text-c-3 bg-b-1 flex min-h-12 items-center justify-center rounded border px-4 text-base">
       No Headers
     </div>
   </ViewLayoutCollapse>

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -103,7 +103,7 @@ const deleteWorkspace = async () => {
 
 <template>
   <div>
-    <div class="flex w-[inherit] items-center text-sm">
+    <div class="flex w-[inherit] items-center text-base">
       <ScalarDropdown>
         <ScalarButton
           class="text-c-1 hover:bg-b-2 line-clamp-1 h-full w-fit justify-start px-1.5 py-1.5 font-normal"

--- a/packages/api-reference/src/components/Badge/Badge.vue
+++ b/packages/api-reference/src/components/Badge/Badge.vue
@@ -14,6 +14,25 @@
   border-radius: 12px;
   font-weight: var(--scalar-semibold);
   display: inline-block;
-  text-transform: uppercase;
+}
+.badge.text-orange {
+  background: color-mix(in srgb, var(--scalar-color-orange), transparent 90%);
+  border: transparent;
+}
+.badge.text-yellow {
+  background: color-mix(in srgb, var(--scalar-color-yellow), transparent 90%);
+  border: transparent;
+}
+.badge.text-red {
+  background: color-mix(in srgb, var(--scalar-color-red), transparent 90%);
+  border: transparent;
+}
+.badge.text-purple {
+  background: color-mix(in srgb, var(--scalar-color-purple), transparent 90%);
+  border: transparent;
+}
+.badge.text-green {
+  background: color-mix(in srgb, var(--scalar-color-green), transparent 90%);
+  border: transparent;
 }
 </style>

--- a/packages/api-reference/src/components/Card/CardHeader.vue
+++ b/packages/api-reference/src/components/Card/CardHeader.vue
@@ -20,9 +20,9 @@ const props = defineProps<CardContentProps>()
 </template>
 <style scoped>
 .scalar-card-header {
-  font-weight: var(--scalar-semibold);
-  font-size: var(--scalar-mini);
-  color: var(--scalar-color-3);
+  font-size: var(--scalar-small);
+  color: var(--scalar-color-1);
+  font-weight: var(--scalar-font-medium);
   padding: 9px 3px 9px 12px;
   flex-shrink: 0;
 }
@@ -36,7 +36,6 @@ const props = defineProps<CardContentProps>()
 }
 
 .scalar-card-header-title {
-  text-transform: uppercase;
   flex: 1;
   min-width: 0;
   text-overflow: ellipsis;

--- a/packages/api-reference/src/components/Card/CardTab.vue
+++ b/packages/api-reference/src/components/Card/CardTab.vue
@@ -19,11 +19,11 @@ import { Tab } from '@headlessui/vue'
 .tab {
   background: none;
   border: none;
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
   font-family: var(--scalar-font);
+  font-weight: var(--scalar-font-normal);
   color: var(--scalar-color-2);
-  font-weight: var(--scalar-semibold);
-  line-height: calc(var(--scalar-mini) + 2px);
+  line-height: calc(var(--scalar-small) + 2px);
   white-space: nowrap;
   cursor: pointer;
   padding: 0;
@@ -57,7 +57,15 @@ import { Tab } from '@headlessui/vue'
 }
 .tab-selected {
   color: var(--scalar-color-1);
-  text-decoration: underline;
-  text-underline-offset: var(--scalar-micro);
+  font-weight: var(--scalar-semibold);
+}
+.tab-selected:after {
+  content: '';
+  position: absolute;
+  background: currentColor;
+  width: 100%;
+  left: 0;
+  height: 1px;
+  bottom: calc(var(--tab-list-padding-y) * -1);
 }
 </style>

--- a/packages/api-reference/src/components/Card/CardTabHeader.vue
+++ b/packages/api-reference/src/components/Card/CardTabHeader.vue
@@ -29,7 +29,9 @@ const changeTab = (index: number) => {
   gap: 6px;
   position: relative;
   flex: 1;
-  padding: 9px 12px;
+  --tab-list-padding-y: 9px;
+  --tab-list-padding-x: 12px;
+  padding: var(--tab-list-padding-y) var(--tab-list-padding-x);
   overflow: auto;
 }
 .scalar-card-header.scalar-card-header-tabs {

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
@@ -159,7 +159,7 @@ const installationInstructions = computed(() => {
 <style scoped>
 .selected-client {
   color: var(--scalar-color-1);
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
   font-family: var(--scalar-font-code);
   padding: 9px 12px;
   border-top: none;
@@ -173,8 +173,8 @@ const installationInstructions = computed(() => {
   min-height: fit-content;
 }
 .client-libraries-heading {
-  font-weight: var(--scalar-semibold);
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
+  font-weight: var(--scalar-font-medium);
   color: var(--scalar-color-1);
   padding: 9px 12px;
   background-color: var(--scalar-background-2);

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -235,14 +235,14 @@ const isSelectedClient = (language: HttpClientState) => {
   }
 }
 .client-libraries .client-libraries-text {
-  font-size: var(--scalar-mini);
-  font-weight: var(--scalar-semibold);
+  font-size: var(--scalar-small);
   position: relative;
   display: flex;
   align-items: center;
 }
 .client-libraries__active .client-libraries-text {
   color: var(--scalar-color-1);
+  font-weight: var(--scalar-semibold);
 }
 .client-libraries__select select {
   background: var(--scalar-background-3);

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -72,6 +72,7 @@ const handleDiscriminatorChange = (type: string) => {
     tabindex="-1">
     <SectionContent :loading="config.isLoading">
       <Badge
+        class="capitalize"
         v-if="getOperationStability(operation)"
         :class="getOperationStabilityColor(operation)">
         {{ getOperationStability(operation) }}

--- a/packages/api-reference/src/features/Search/SearchModal.vue
+++ b/packages/api-reference/src/features/Search/SearchModal.vue
@@ -4,11 +4,17 @@ import {
   ScalarSearchInput,
   ScalarSearchResultItem,
   ScalarSearchResultList,
-  type Icon,
   type ModalState,
 } from '@scalar/components'
 import { isDefined } from '@scalar/helpers/array/is-defined'
 import { scrollToId } from '@scalar/helpers/dom/scroll-to-id'
+import {
+  ScalarIconBracketsCurly,
+  ScalarIconTag,
+  ScalarIconTerminalWindow,
+  ScalarIconTextAlignLeft,
+} from '@scalar/icons'
+import type { ScalarIconComponent } from '@scalar/icons/types'
 import type { Spec } from '@scalar/types/legacy'
 import type { FuseResult } from 'fuse.js'
 import { nanoid } from 'nanoid'
@@ -52,12 +58,12 @@ const {
   hideModels: props.hideModels,
 })
 
-const ENTRY_ICONS: { [x in EntryType]: Icon } = {
-  heading: 'DocsPage',
-  model: 'Brackets',
-  req: 'Terminal',
-  tag: 'CodeFolder',
-  webhook: 'Terminal',
+const ENTRY_ICONS: { [x in EntryType]: ScalarIconComponent } = {
+  heading: ScalarIconTextAlignLeft,
+  model: ScalarIconBracketsCurly,
+  req: ScalarIconTerminalWindow,
+  tag: ScalarIconTag,
+  webhook: ScalarIconTerminalWindow,
 }
 
 const ENTRY_LABELS: { [x in EntryType]: string } = {
@@ -224,24 +230,24 @@ function onSearchResultEnter() {
             entry.item.path !== entry.item.title
           "
           #description>
-          <span class="sr-only">Path:&nbsp;</span>
-          {{ entry.item.path }}
+          <span class="inline-flex items-center gap-1">
+            <template v-if="entry.item.type === 'req'">
+              <SidebarHttpBadge
+                aria-hidden="true"
+                :method="entry.item.httpVerb ?? 'get'" />
+              <span class="sr-only">
+                HTTP Method: {{ entry.item.httpVerb ?? 'get' }}
+              </span>
+            </template>
+            <span class="sr-only">Path:&nbsp;</span>
+            {{ entry.item.path }}
+          </span>
         </template>
         <template
           v-else-if="entry.item.description"
           #description>
           <span class="sr-only">Description:&nbsp;</span>
           {{ entry.item.description }}
-        </template>
-        <template
-          v-if="entry.item.type === 'req'"
-          #addon>
-          <SidebarHttpBadge
-            aria-hidden="true"
-            :method="entry.item.httpVerb ?? 'get'" />
-          <span class="sr-only">
-            HTTP Method: {{ entry.item.httpVerb ?? 'get' }}
-          </span>
         </template>
       </ScalarSearchResultItem>
       <template #query>
@@ -271,14 +277,13 @@ a {
 .ref-search-container {
   display: flex;
   flex-direction: column;
-  padding: 12px;
   padding-bottom: 0px;
 }
 .ref-search-results {
-  padding: 12px;
+  padding: 0 4px 4px 4px;
 }
 .ref-search-meta {
-  background: var(--scalar-background-3);
+  background: var(--scalar-background-1);
   border-bottom-left-radius: var(--scalar-radius-lg);
   border-bottom-right-radius: var(--scalar-radius-lg);
   padding: 6px 12px;
@@ -287,6 +292,7 @@ a {
   font-weight: var(--scalar-semibold);
   display: flex;
   gap: 12px;
+  border-top: var(--scalar-border-width) solid var(--scalar-border-color);
 }
 .deprecated {
   text-decoration: line-through;

--- a/packages/api-reference/src/features/base-url/BaseUrl.vue
+++ b/packages/api-reference/src/features/base-url/BaseUrl.vue
@@ -37,7 +37,7 @@ const updateServer = (newServer: string) => {
 </script>
 <template>
   <label
-    class="bg-b-2 flex h-8 items-center rounded-t-lg border border-b-0 px-3 py-2.5 text-sm font-medium">
+    class="bg-b-2 flex h-8 items-center rounded-t-lg border border-b-0 px-3 py-2.5 text-base font-medium">
     Server
   </label>
   <div

--- a/packages/api-reference/src/features/example-request/TextSelect.vue
+++ b/packages/api-reference/src/features/example-request/TextSelect.vue
@@ -92,7 +92,7 @@ const count = computed(
   appearance: none;
 }
 .text-select span {
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
   color: var(--scalar-color-2);
   font-weight: var(--scalar-semibold);
   white-space: nowrap;

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.vue
@@ -267,8 +267,8 @@ const showSchema = ref(false)
   min-height: 17px;
   cursor: pointer;
   user-select: none;
-  font-weight: var(--scalar-semibold);
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
+  font-weight: var(--scalar-font-normal);
   color: var(--scalar-color-2);
   width: fit-content;
   white-space: nowrap;
@@ -300,6 +300,7 @@ const showSchema = ref(false)
 }
 .scalar-card-checkbox:has(.scalar-card-checkbox-input:checked) {
   color: var(--scalar-color-1);
+  font-weight: var(--scalar-semibold);
 }
 
 .scalar-card-checkbox

--- a/packages/api-reference/src/features/sidebar/components/SidebarElement.vue
+++ b/packages/api-reference/src/features/sidebar/components/SidebarElement.vue
@@ -125,6 +125,7 @@ const onAnchorClick = async (ev: Event) => {
           &hairsp;
           <span class="sr-only">HTTP Method:&nbsp;</span>
           <SidebarHttpBadge
+            class="min-w-9.75 justify-end text-right"
             :active="isActive"
             :method="item.method">
             <template #default>

--- a/packages/api-reference/src/features/sidebar/components/SidebarHttpBadge.vue
+++ b/packages/api-reference/src/features/sidebar/components/SidebarHttpBadge.vue
@@ -10,7 +10,6 @@ defineProps<{
 <template>
   <HttpMethod
     :class="[
-      'flex items-center justify-end gap-1',
       'sidebar-heading-type',
       `sidebar-heading-type--${method.toLowerCase()}`,
       { 'sidebar-heading-type-active': active },
@@ -24,24 +23,17 @@ defineProps<{
 
 <style scoped>
 .sidebar-heading-type {
-  display: block;
-  min-width: 3.9em;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   overflow: hidden;
   line-height: 14px;
   flex-shrink: 0;
-  color: white;
-  color: color-mix(
-    in srgb,
-    var(--method-color, var(--scalar-color-1)),
-    transparent 0%
-  );
   text-transform: uppercase;
+  color: var(--method-color, var(--scalar-color-1));
   font-size: 10px;
   font-weight: var(--scalar-bold);
-  text-align: right;
-  position: relative;
   font-family: var(--scalar-font-code);
   white-space: nowrap;
-  margin-left: 3px;
 }
 </style>

--- a/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.vue
+++ b/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.vue
@@ -14,6 +14,7 @@
 export default {}
 </script>
 <script setup lang="ts">
+import { ScalarIconMagnifyingGlass } from '@scalar/icons'
 import { useBindCx } from '@scalar/use-hooks/useBindCx'
 import { ref } from 'vue'
 
@@ -43,10 +44,9 @@ const { classCx, otherAttrs } = useBindCx()
 <template>
   <label
     v-bind="
-      classCx(
-        'flex items-center rounded border text-sm font-medium has-[:focus-visible]:bg-b-1 bg-b-1.5 has-[:focus-visible]:outline h-10 p-3',
-      )
+      classCx('flex items-center text-lg font-medium h-10 p-3 pr-1 h-14 gap-2')
     ">
+    <ScalarIconMagnifyingGlass class="text-sidebar-c-search size-4" />
     <input
       ref="inputRef"
       :aria-label="label ?? 'Enter search query'"

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
@@ -19,7 +19,7 @@ const { cx } = useBindCx()
     tabindex="-1"
     v-bind="
       cx(
-        'group flex cursor-pointer gap-2.5 rounded px-3 py-1.5 no-underline hover:bg-b-2',
+        'group flex cursor-pointer gap-2 rounded px-2 py-1.5 no-underline hover:bg-b-2',
         { 'bg-b-2': selected },
       )
     ">
@@ -31,8 +31,7 @@ const { cx } = useBindCx()
         <ScalarIconLegacyAdapter
           v-if="icon"
           :icon="icon"
-          size="sm"
-          weight="bold" />
+          class="size-4" />
       </slot>
       <span>&hairsp;</span>
     </div>
@@ -40,18 +39,18 @@ const { cx } = useBindCx()
     <div class="flex min-w-0 flex-1 flex-col gap-0.75">
       <div class="flex items-center gap-1">
         <div
-          class="flex-1 truncate zoomed:!whitespace-normal break-words text-sm font-medium">
+          class="flex-1 truncate zoomed:!whitespace-normal break-words text-base font-medium">
           <slot />
         </div>
         <div
           v-if="$slots.addon"
-          class="text-sm text-c-2">
+          class="text-base text-c-2">
           <slot name="addon" />
         </div>
       </div>
       <div
         v-if="$slots.description"
-        class="truncate zoomed:!whitespace-normal break-words text-sm text-c-2">
+        class="truncate zoomed:!whitespace-normal break-words text-base text-c-2">
         <slot name="description" />
       </div>
     </div>

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultList.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultList.vue
@@ -16,9 +16,8 @@ const { cx } = useBindCx()
       v-if="noResults"
       name="noResults">
       <div class="flex flex-col items-center gap-2 px-3 py-4">
-        <div class="rotate-90 text-lg font-bold">:(</div>
         <div
-          class="text-sm font-medium text-c-2"
+          class="text-base font-medium text-c-2"
           role="alert">
           No results found
         </div>

--- a/packages/scripts/src/plugins/post-response-scripts/components/PostResponseScripts/ScriptEditor.vue
+++ b/packages/scripts/src/plugins/post-response-scripts/components/PostResponseScripts/ScriptEditor.vue
@@ -58,7 +58,7 @@ useCodeMirror({
 
 :deep(.cm-content) {
   font-family: var(--scalar-font-code);
-  font-size: var(--scalar-mini);
+  font-size: var(--scalar-small);
   padding: 8px 2px;
 }
 

--- a/packages/themes/src/base/variables.css
+++ b/packages/themes/src/base/variables.css
@@ -45,6 +45,7 @@
   --scalar-line-height-4: 18px;
   --scalar-line-height-5: 16px;
 
+  --scalar-font-normal: 400;
   --scalar-font-medium: 500;
   --scalar-font-bold: 700;
 


### PR DESCRIPTION
A whole bunch of very minor changes
Updated font sizes across from 13px -> 14px in:
- Api Client across the whole entire app
- API Ref in cards
- In Search
- Made card styles more consistent 
- Made active / inactive states on tabs more consistent 

More notably I did a slight refresh of Search beyond changing font sizes (ty @hwkr for the help :) )
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/60052e61-1c2b-43e1-bae4-c8adadbed00c" />

