### PR TITLE
fix(api-reference): search tests are failing

### DIFF
--- a/packages/api-reference/src/features/Search/useSearchIndex.test.ts
+++ b/packages/api-reference/src/features/Search/useSearchIndex.test.ts
@@ -128,16 +128,16 @@ describe('useSearchIndex', () => {
           expect.objectContaining({
             item: expect.objectContaining({
               type: 'model',
-              title: 'Model',
-              description: 'User Model',
+              title: 'User Model',
+              description: 'Model',
               tag: 'User',
             }),
           }),
           expect.objectContaining({
             item: expect.objectContaining({
               type: 'model',
-              title: 'Model',
-              description: 'Product Model',
+              title: 'Product Model',
+              description: 'Model',
               tag: 'Product',
             }),
           }),
@@ -227,8 +227,8 @@ describe('useSearchIndex', () => {
         expect.objectContaining({
           item: expect.objectContaining({
             type: 'model',
-            title: 'Model',
-            description: 'User Model',
+            title: 'User Model',
+            description: 'Model',
             tag: 'User',
           }),
         }),


### PR DESCRIPTION
**Problem**

Oops, we merged two search PRs without rebasing them, resulting in failing tests in main.

**Solution**

This PR fixes the tests. :)

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
