### PR TITLE
feat(Scalar.Aspire): add support for multi-platform docker build

### DIFF
--- a/.changeset/proud-bears-protect.md
+++ b/.changeset/proud-bears-protect.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspire': patch
+---
+
+feat: add support for multi-platform docker build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -799,6 +799,10 @@ jobs:
           context: integrations/aspire
           file: integrations/aspire/src/Scalar.Aspire.Service/Dockerfile
           push: true
+          # With ARM
+          platforms: |
+            linux/amd64
+            linux/arm64
           tags: |
             scalarapi/aspire-api-reference:latest
             scalarapi/aspire-api-reference:${{ env.VERSION }}


### PR DESCRIPTION
This PR adds `linux/arm64` as a platform for the docker builds.

Closes #6089

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
