### PR TITLE
fix(api-reference): operationsSorter backwards compatibility

### DIFF
--- a/.changeset/cyan-hats-invent.md
+++ b/.changeset/cyan-hats-invent.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: maintain backwards compatibility on sorting operations by httpVerb

--- a/packages/api-reference/src/features/traverse-schema/helpers/traverse-tags.test.ts
+++ b/packages/api-reference/src/features/traverse-schema/helpers/traverse-tags.test.ts
@@ -199,6 +199,31 @@ describe('traverseTags', () => {
     expect(result[1].title).toBe('Operation B')
   })
 
+  it('should handle custom operationSorter using httpVerb', () => {
+    const document = createMockDocument()
+    const tagsMap = new Map([
+      [
+        'default',
+        {
+          tag: createMockTag('default'),
+          entries: [createMockEntry('Operation B', 'post'), createMockEntry('Operation A', 'get')],
+        },
+      ],
+    ])
+    const titlesMap = new Map<string, string>()
+
+    const options = {
+      getTagId: (tag: OpenAPIV3_1.TagObject) => tag.name ?? '',
+      tagsSorter: 'alpha' as const,
+      operationsSorter: (a: OpenAPIV3_1.OperationObject, b: OpenAPIV3_1.OperationObject) =>
+        (a.httpVerb || '').localeCompare(b.httpVerb || ''),
+    }
+
+    const result = traverseTags(document, tagsMap, titlesMap, options)
+    expect(result[0].title).toBe('Operation A')
+    expect(result[1].title).toBe('Operation B')
+  })
+
   it('should handle internal tags', () => {
     const document = createMockDocument()
     const tagsMap = new Map([

--- a/packages/api-reference/src/features/traverse-schema/helpers/traverse-tags.ts
+++ b/packages/api-reference/src/features/traverse-schema/helpers/traverse-tags.ts
@@ -94,8 +94,8 @@ const getSortedTagEntries = (
         const operationB = 'operation' in b ? b.operation : b.webhook
 
         return operationsSorter(
-          { method: a.method, path: pathA, operation: operationA },
-          { method: b.method, path: pathB, operation: operationB },
+          { method: a.method, httpVerb: a.method, path: pathA, operation: operationA },
+          { method: b.method, httpVerb: b.method, path: pathB, operation: operationB },
         )
       })
     }


### PR DESCRIPTION
**Problem**

https://discord.com/channels/1135330207960678410/1385687477301547130

Currently, httpVerb was removed from operationsSorter

**Solution**

With this PR we add backwards compatibility

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
