### PR TITLE
feat(api-reference): use xml.name as a fallback for schema titles

### DIFF
--- a/.changeset/pink-camels-sit.md
+++ b/.changeset/pink-camels-sit.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: use xml.name as a fallback for the schema title

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -75,7 +75,11 @@ const models = computed(() => {
             <template #heading>
               <SectionHeaderTag :level="3">
                 <SchemaHeading
-                  :name="(schemas as any)[name].title ?? name"
+                  :name="
+                    (schemas as any)[name].title ??
+                    (schemas as any)[name].xml?.name ??
+                    name
+                  "
                   :value="(schemas as any)[name]" />
               </SectionHeaderTag>
             </template>

--- a/packages/api-reference/src/components/Content/Schema/helpers/get-schema-type.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/get-schema-type.test.ts
@@ -558,5 +558,254 @@ describe('get-schema-type', () => {
         expect(result).toBe('array string[]')
       })
     })
+
+    describe('xml.name property', () => {
+      it('returns xml.name when present and no title or name', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          type: 'object',
+          xml: {
+            name: 'XmlTag',
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('XmlTag')
+      })
+
+      it('prioritizes title over xml.name', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          title: 'Schema Title',
+          type: 'object',
+          xml: {
+            name: 'XmlTag',
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('Schema Title')
+      })
+
+      it('prioritizes name over xml.name', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          name: 'SchemaName',
+          type: 'object',
+          xml: {
+            name: 'XmlTag',
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('SchemaName')
+      })
+
+      it('prioritizes xml.name over type with content encoding', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          type: 'string',
+          contentEncoding: 'base64',
+          xml: {
+            name: 'XmlTag',
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('XmlTag')
+      })
+
+      it('prioritizes xml.name over type only', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          type: 'string',
+          xml: {
+            name: 'XmlTag',
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('XmlTag')
+      })
+
+      it('uses xml.name for an array type when items are not defined', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          type: 'array',
+          xml: {
+            name: 'XmlArray',
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('XmlArray')
+      })
+
+      it('ignores xml.name for an array type when items are defined', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+          xml: {
+            name: 'XmlArray',
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('array string[]')
+      })
+
+      it('handles xml.name with array type in type array', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          type: ['array', 'null'],
+          xml: {
+            name: 'NullableXmlArray',
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('array | null')
+      })
+
+      it('handles xml.name with complex array type', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          type: ['string', 'null'],
+          xml: {
+            name: 'NullableString',
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('string | null')
+      })
+
+      it('handles xml object without name property', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          type: 'object',
+          xml: {},
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('object')
+      })
+
+      it('handles xml.name with empty string', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          type: 'object',
+          xml: {
+            name: '',
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('object')
+      })
+
+      it('handles xml.name for different schema types', () => {
+        const schemas = [
+          { type: 'string', xml: { name: 'XmlString' }, expected: 'XmlString' },
+          { type: 'number', xml: { name: 'XmlNumber' }, expected: 'XmlNumber' },
+          { type: 'boolean', xml: { name: 'XmlBoolean' }, expected: 'XmlBoolean' },
+          { type: 'integer', xml: { name: 'XmlInteger' }, expected: 'XmlInteger' },
+        ]
+
+        schemas.forEach(({ type, xml, expected }) => {
+          const schema: OpenAPIV3_1.SchemaObject = { type, xml }
+          const result = getSchemaType(schema)
+          expect(result).toBe(expected)
+        })
+      })
+
+      it('handles xml.name with all properties present', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          type: 'string',
+          title: 'Schema Title',
+          name: 'SchemaName',
+          contentEncoding: 'base64',
+          xml: {
+            name: 'XmlTag',
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('Schema Title')
+      })
+
+      it('handles xml.name in array items', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          type: 'array',
+          items: {
+            type: 'object',
+            xml: {
+              name: 'XmlItem',
+            },
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('array XmlItem[]')
+      })
+
+      it('handles xml.name in nested array items', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          type: 'array',
+          items: {
+            type: 'array',
+            items: {
+              type: 'object',
+              xml: {
+                name: 'NestedXmlItem',
+              },
+            },
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('array array NestedXmlItem[][]')
+      })
+
+      it('prioritizes title over xml.name in array items', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          type: 'array',
+          items: {
+            type: 'object',
+            title: 'Item Title',
+            xml: {
+              name: 'XmlItem',
+            },
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('array Item Title[]')
+      })
+
+      it('prioritizes name over xml.name in array items', () => {
+        const schema: OpenAPIV3_1.SchemaObject = {
+          type: 'array',
+          items: {
+            type: 'object',
+            name: 'ItemName',
+            xml: {
+              name: 'XmlItem',
+            },
+          },
+        }
+
+        const result = getSchemaType(schema)
+
+        expect(result).toBe('array ItemName[]')
+      })
+    })
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/get-schema-type.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/get-schema-type.test.ts
@@ -716,8 +716,8 @@ describe('get-schema-type', () => {
         ]
 
         schemas.forEach(({ type, xml, expected }) => {
-          const schema: OpenAPIV3_1.SchemaObject = { type, xml }
-          const result = getSchemaType(schema)
+          const schema = { type, xml }
+          const result = getSchemaType(schema as OpenAPIV3_1.SchemaObject)
           expect(result).toBe(expected)
         })
       })

--- a/packages/api-reference/src/components/Content/Schema/helpers/get-schema-type.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/get-schema-type.ts
@@ -8,7 +8,7 @@ export const getSchemaType = (value: OpenAPIV3_1.SchemaObject): string => {
     // Handle array types that include 'array' - we need to process items
     if (value.type.includes('array') && value.items) {
       const itemType = getSchemaType(value.items)
-      const wrappedItemType = itemType && itemType.includes(' | ') ? `(${itemType})` : itemType
+      const wrappedItemType = itemType?.includes(' | ') ? `(${itemType})` : itemType
       const baseType = itemType ? `array ${wrappedItemType}[]` : 'array'
 
       // Remove 'array' from the type array and join the rest
@@ -26,7 +26,7 @@ export const getSchemaType = (value: OpenAPIV3_1.SchemaObject): string => {
   // Handle array schemas with items
   if (value?.type === 'array' && value.items) {
     const itemType = getSchemaType(value.items)
-    const wrappedItemType = itemType && itemType.includes(' | ') ? `(${itemType})` : itemType
+    const wrappedItemType = itemType?.includes(' | ') ? `(${itemType})` : itemType
     const baseType = itemType ? `array ${wrappedItemType}[]` : 'array'
 
     // Handle nullable arrays
@@ -43,6 +43,10 @@ export const getSchemaType = (value: OpenAPIV3_1.SchemaObject): string => {
 
   if (value?.name) {
     return value.name
+  }
+
+  if (value?.xml?.name) {
+    return value.xml.name
   }
 
   if (value?.type && value.contentEncoding) {


### PR DESCRIPTION
**Problem**

Currently, we render the schema title if it’s available.

**Solution**

With this PR we’re also using the `xml.name` as a fallback, as suggested in https://github.com/scalar/scalar/pull/5676#issuecomment-2892431645

Fixes #5682

We’ll still look into the `title` attribute first.

**Preview**

<img width="206" alt="Screenshot 2025-07-01 at 14 39 42" src="https://github.com/user-attachments/assets/2ca13016-ac76-4dc1-ad12-1c407bc5935c" />

**Example**

```json
{
  "openapi": "3.1.0",
  "info": {
    "title": "xml.name",
    "version": "1.0"
  },
  "components": {
    "schemas": {
      "ExampleSchema": {
        "type": "array",
        "items": {
          "type": "object",
          "properties": {
            "id": {
              "type": "integer"
            }
          },
          "xml": {
            "name": "XmlTag"
          }
        },
        "xml": {
          "name": "XmlName"
        }
      }
    }
  }
}
```

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
