### PR TITLE
feat(workspace-store): keep sibling keywords when resolving $ref's

### DIFF
--- a/.changeset/tall-geckos-tie.md
+++ b/.changeset/tall-geckos-tie.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-reference': patch
+---
+
+feat: keep sibling keywords when resolving $refs

--- a/packages/workspace-store/src/helpers/proxy.test.ts
+++ b/packages/workspace-store/src/helpers/proxy.test.ts
@@ -2,7 +2,7 @@ import { createMagicProxy } from '@/helpers/proxy'
 import { describe, expect, it } from 'vitest'
 
 describe('createMagicProxy', () => {
-  it('should correctly proxy internal refs', () => {
+  it('proxies internal refs', () => {
     const input = {
       a: 'hello',
       b: {
@@ -15,7 +15,7 @@ describe('createMagicProxy', () => {
     expect(result.b).toBe('hello')
   })
 
-  it('should correctly proxy deep nested refs', () => {
+  it('proxies deep nested refs', () => {
     const input = {
       a: {
         b: {
@@ -35,7 +35,7 @@ describe('createMagicProxy', () => {
     expect(result.a.b.c.e.prop).toBe('hello')
   })
 
-  it('should correctly proxy multi refs', () => {
+  it('proxies multi-level refs', () => {
     const input = {
       a: {
         b: {
@@ -59,7 +59,7 @@ describe('createMagicProxy', () => {
     expect(result.d).toBe('hello')
   })
 
-  it('should preserve information about the ref when the ref is resolved', () => {
+  it('preserves ref information when resolving', () => {
     const input = {
       a: {
         b: {
@@ -82,7 +82,7 @@ describe('createMagicProxy', () => {
     })
   })
 
-  it('should preserve the first ref on nested refs', () => {
+  it('preserves first ref on nested refs', () => {
     const input = {
       a: {
         b: {
@@ -108,7 +108,7 @@ describe('createMagicProxy', () => {
     })
   })
 
-  it('should preserve sibling keywords alongside $ref (OpenAPI 3.1/JSON Schema 2020-12)', () => {
+  it('preserves sibling keywords alongside $ref (OpenAPI 3.1/JSON Schema 2020-12)', () => {
     const input = {
       components: {
         schemas: {

--- a/packages/workspace-store/src/helpers/proxy.test.ts
+++ b/packages/workspace-store/src/helpers/proxy.test.ts
@@ -157,4 +157,181 @@ describe('createMagicProxy', () => {
       'x-original-ref': '#/components/schemas/Foo',
     })
   })
+
+  it('merges sibling keywords with $ref', () => {
+    const input = {
+      components: {
+        schemas: {
+          User: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              email: { type: 'string', format: 'email' },
+            },
+            required: ['name', 'email'],
+            description: 'User registration data',
+            additionalProperties: false,
+          },
+        },
+      },
+      paths: {
+        '/users': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/User',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = createMagicProxy(input)
+    const resolvedSchema = result.paths['/users'].post.requestBody.content['application/json'].schema as any
+
+    // Should preserve the original ref information
+    expect(resolvedSchema['x-original-ref']).toBe('#/components/schemas/User')
+
+    // Should contain properties from the referenced schema
+    expect(resolvedSchema.type).toBe('object')
+    expect(resolvedSchema.properties).toEqual({
+      name: { type: 'string' },
+      email: { type: 'string', format: 'email' },
+    })
+
+    // Should merge sibling keywords, with sibling 'required' overriding the referenced one
+    expect(resolvedSchema.required).toEqual(['name', 'email'])
+    expect(resolvedSchema.description).toBe('User registration data')
+    expect(resolvedSchema.additionalProperties).toBe(false)
+  })
+
+  it('merges enum and default sibling keywords with $ref', () => {
+    const input = {
+      components: {
+        schemas: {
+          Status: {
+            type: 'string',
+            enum: ['active', 'inactive'],
+            default: 'active',
+          },
+        },
+      },
+      paths: {
+        '/status': {
+          get: {
+            responses: {
+              '200': {
+                description: 'Status',
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/Status',
+                      default: 'inactive',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = createMagicProxy(input)
+    const resolvedSchema = result.paths['/status'].get.responses['200'].content['application/json'].schema as any
+
+    expect(resolvedSchema['x-original-ref']).toBe('#/components/schemas/Status')
+    expect(resolvedSchema.type).toBe('string')
+    expect(resolvedSchema.enum).toEqual(['active', 'inactive'])
+    // Sibling default should override referenced default
+    expect(resolvedSchema.default).toBe('inactive')
+  })
+
+  it('merges multiple sibling constraints with $ref', () => {
+    const input = {
+      components: {
+        schemas: {
+          Number: {
+            type: 'number',
+            minimum: 0,
+            maximum: 10,
+          },
+        },
+      },
+      paths: {
+        '/number': {
+          get: {
+            responses: {
+              '200': {
+                description: 'Number',
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/Number',
+                      minimum: 5,
+                      maximum: 8,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = createMagicProxy(input)
+    const resolvedSchema = result.paths['/number'].get.responses['200'].content['application/json'].schema as any
+
+    expect(resolvedSchema['x-original-ref']).toBe('#/components/schemas/Number')
+    expect(resolvedSchema.type).toBe('number')
+    // Sibling minimum/maximum should override referenced ones
+    expect(resolvedSchema.minimum).toBe(5)
+    expect(resolvedSchema.maximum).toBe(8)
+  })
+
+  it('handles $ref with sibling allOf/oneOf/anyOf', () => {
+    const input = {
+      components: {
+        schemas: {
+          Base: {
+            type: 'object',
+            properties: { id: { type: 'string' } },
+          },
+        },
+      },
+      paths: {
+        '/allof': {
+          get: {
+            responses: {
+              '200': {
+                description: 'AllOf',
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/Base',
+                      allOf: [{ properties: { extra: { type: 'number' } } }],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = createMagicProxy(input)
+    const resolvedSchema = result.paths['/allof'].get.responses['200'].content['application/json'].schema as any
+
+    expect(resolvedSchema['x-original-ref']).toBe('#/components/schemas/Base')
+    expect(resolvedSchema.type).toBe('object')
+    expect(resolvedSchema.properties).toEqual({ id: { type: 'string' } })
+    expect(resolvedSchema.allOf).toEqual([{ properties: { extra: { type: 'number' } } }])
+  })
 })

--- a/packages/workspace-store/src/helpers/proxy.test.ts
+++ b/packages/workspace-store/src/helpers/proxy.test.ts
@@ -153,9 +153,8 @@ describe('createMagicProxy', () => {
     // This is the key issue: both constraints should be preserved and applied
     expect(resolvedSchema).toEqual({
       type: 'string',
-      pattern: 'bar$', // from the referenced schema
+      pattern: '^foo.*bar$', // merged pattern requiring both constraints
       'x-original-ref': '#/components/schemas/Foo',
-      'x-sibling-pattern': '^foo', // sibling keyword should be preserved separately
     })
   })
 })


### PR DESCRIPTION
**Problem**

JSON Schema draft 2020-12 allows keywords adjacent to $ref. Read more: #5582

**Solution**

With this PR we’re adding this behaviour to the new store that we’re about to migrate to.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
