### PR TITLE
fix(api-reference): shows composition description three times

### DIFF
--- a/.changeset/tasty-pigs-tan.md
+++ b/.changeset/tasty-pigs-tan.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: shows composition description three times

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -136,6 +136,15 @@ const shouldShowDescription = computed(() => {
     return false
   }
 
+  // Will be shown in the properties anyway
+  if (
+    !schema.value.properties &&
+    !schema.value.patternProperties &&
+    !schema.value.additionalProperties
+  ) {
+    return false
+  }
+
   // Merged allOf schemas at level 0 should not show individual descriptions
   // to prevent duplicates with the request body description
   if (props.level === 0) {

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -206,11 +206,6 @@ const shouldRenderSchema = computed(() => {
         </button>
       </ScalarListbox>
       <div class="composition-panel">
-        <div
-          v-if="compositionSchema?.description"
-          class="property-description border-x border-t p-2">
-          <ScalarMarkdown :value="compositionSchema.description" />
-        </div>
         <Schema
           v-if="shouldRenderSchema"
           :compact="compact"


### PR DESCRIPTION
**Problem**

For a composition we show the description three times, that’s too much.

**Solution**

With this PR, we just show it once. :) Fixes #5999

**Preview**

<img width="553" alt="Screenshot 2025-07-01 at 15 52 27" src="https://github.com/user-attachments/assets/ffa0e2e3-9942-4dd7-802a-16d2372f7352" />

**Example**

```json
{
  "openapi": "3.1.0",
  "info": {
    "title": "Hello World",
    "version": "1.0.0"
  },
  "paths": {
    "/foo": {
      "post": {
        "summary": "foo",
        "requestBody": {
          "description": "Foo body",
          "content": {
            "application/json": {
              "schema": {
                "type": "object",
                "properties": {
                  "foos": {
                    "oneOf": [
                      {
                        "type": "string",
                        "title": "foo1",
                        "description": "foo1 description"
                      },
                      {
                        "type": "array",
                        "title": "foo2",
                        "description": "foo2 description",
                        "items": {
                          "type": "string"
                        }
                      }
                    ]
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}
```

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
