### PR TITLE
fix(api-client): command palette action link path are not redirecting

### DIFF
--- a/.changeset/gorgeous-brooms-attend.md
+++ b/.changeset/gorgeous-brooms-attend.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates command palette action input style

--- a/.changeset/short-suits-walk.md
+++ b/.changeset/short-suits-walk.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: opens modal from command palette action navigation

--- a/packages/api-client/src/components/CommandPalette/CommandActionInput.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandActionInput.vue
@@ -51,6 +51,7 @@ function handleBack(event: KeyboardEvent) {
 </script>
 <template>
   <textarea
+    id="command-action-input"
     ref="input"
     v-model="model"
     class="min-h-8 w-full flex-1 resize-none border border-transparent py-1.5 pl-8.5 text-sm outline-none focus:border-b-1"

--- a/packages/api-client/src/components/CommandPalette/CommandActionInput.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandActionInput.vue
@@ -53,7 +53,7 @@ function handleBack(event: KeyboardEvent) {
   <textarea
     ref="input"
     v-model="model"
-    class="min-h-8 w-full flex-1 resize-none border-none py-1.5 pl-8 text-sm outline-none"
+    class="min-h-8 w-full flex-1 resize-none border border-transparent py-1.5 pl-8.5 text-sm outline-none focus:border-b-1"
     :placeholder="props.placeholder ?? ''"
     wrap="hard"
     v-bind="$attrs"

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -101,12 +101,22 @@ const availableCommands = [
       {
         name: 'Add Environment',
         icon: 'Brackets',
-        path: 'environment.default',
+        path: {
+          name: 'environment.default',
+          params: {
+            [PathId.Workspace]: activeWorkspace?.value?.uid ?? 'default',
+          },
+        },
       },
       {
         name: 'Add Cookie',
         icon: 'Cookie',
-        path: 'cookies.default',
+        path: {
+          name: 'cookies.default',
+          params: {
+            [PathId.Workspace]: activeWorkspace?.value?.uid ?? 'default',
+          },
+        },
       },
     ],
   },

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -106,6 +106,7 @@ const availableCommands = [
           params: {
             [PathId.Workspace]: activeWorkspace?.value?.uid ?? 'default',
           },
+          query: { openEnvironmentModal: 'true' },
         },
       },
       {
@@ -116,6 +117,7 @@ const availableCommands = [
           params: {
             [PathId.Workspace]: activeWorkspace?.value?.uid ?? 'default',
           },
+          query: { openCookieModal: 'true' },
         },
       },
     ],

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -400,7 +400,7 @@ onBeforeUnmount(() => {
         v-else
         class="flex-1 p-1.5">
         <button
-          class="hover:bg-b-3 text-c-3 active:text-c-1 absolute z-1 my-1.25 mr-1.5 rounded p-0.75"
+          class="hover:bg-b-3 text-c-3 active:text-c-1 absolute z-1 mt-[0.5px] rounded p-1.5"
           type="button"
           @click="activeCommand = null">
           <ScalarIcon

--- a/packages/api-client/src/views/Cookies/Cookies.vue
+++ b/packages/api-client/src/views/Cookies/Cookies.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useModal } from '@scalar/components'
 import { cookieSchema, type Cookie } from '@scalar/oas-utils/entities/cookie'
-import { computed, onBeforeUnmount, onMounted } from 'vue'
+import { computed, onBeforeUnmount, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { Sidebar } from '@/components'
@@ -131,6 +131,16 @@ const activeCookie = computed<Cookie | undefined>(
 
 const hasCookies = computed(
   () => Object.keys(cookies).length > 0 && activeCookie.value,
+)
+
+watch(
+  () => route.query.openCookieModal,
+  (newVal) => {
+    if (newVal === 'true') {
+      openCookieModal()
+    }
+  },
+  { immediate: true },
 )
 </script>
 <template>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -406,6 +406,16 @@ const { handleDragEnd, isDroppable } = environmentDragHandlerFactory(
   activeWorkspaceCollections,
   collectionMutators,
 )
+
+watch(
+  () => route.query.openEnvironmentModal,
+  (newVal) => {
+    if (newVal === 'true') {
+      openEnvironmentModal()
+    }
+  },
+  { immediate: true },
+)
 </script>
 <template>
   <ViewLayout>


### PR DESCRIPTION
**Problem**

currently the command palette input style if offish + action link are not redirecting to the right page

**Solution**

this pr:
- updates command palette action input style to increase consistency and alignment
- fixes and opens modal on command palette action link navigation
- adds missing id to textarea leading to console warning

| preview | state |
| -------|------|
| before | <img width="626" alt="image" src="https://github.com/user-attachments/assets/e795e8b9-a8d8-45e4-a1a4-30c9dfb3fcae" /> |
| after | <img width="626" alt="image" src="https://github.com/user-attachments/assets/820900e0-847e-43bf-b299-055e9a901cb1" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
