### PR TITLE
fix(api-reference): deprecated operations aren’t striked in the sidebar anymore

### DIFF
--- a/.changeset/pretty-timers-impress.md
+++ b/.changeset/pretty-timers-impress.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: deprecated operations aren’t striked in the sidebar anymore

--- a/packages/api-reference/src/features/sidebar/components/SidebarElement.test.ts
+++ b/packages/api-reference/src/features/sidebar/components/SidebarElement.test.ts
@@ -1,0 +1,327 @@
+import type { TraversedEntry, TraversedOperation } from '@/features/traverse-schema'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { XScalarStability } from '@scalar/types/legacy'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SidebarElement from './SidebarElement.vue'
+
+// Mock the dependencies
+vi.mock('@/libs/openapi', () => ({
+  isOperationDeprecated: vi.fn(),
+}))
+
+vi.mock('@/hooks/useConfig', () => ({
+  useConfig: () => ({
+    value: {
+      pathRouting: false,
+      defaultOpenAllTags: false,
+      onSidebarClick: vi.fn(),
+    },
+  }),
+}))
+
+vi.mock('@/hooks/useNavState', () => ({
+  useNavState: () => ({
+    getFullHash: vi.fn((id: string) => `#${id}`),
+    isIntersectionEnabled: { value: true },
+    replaceUrlState: vi.fn(),
+  }),
+}))
+
+vi.mock('@scalar/helpers/dom/scroll-to-id', () => ({
+  scrollToId: vi.fn(),
+}))
+
+vi.mock('@scalar/helpers/testing/sleep', () => ({
+  sleep: vi.fn(() => Promise.resolve()),
+}))
+
+describe('SidebarElement', () => {
+  // Reset all mocks before each test
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const createMockOperation = (overrides: Partial<OpenAPIV3_1.OperationObject> = {}): OpenAPIV3_1.OperationObject => ({
+    summary: 'Test Operation',
+    responses: {
+      200: {
+        description: 'Success',
+      },
+    },
+    ...overrides,
+  })
+
+  const createMockTraversedOperation = (
+    operation: OpenAPIV3_1.OperationObject,
+    overrides: Partial<TraversedOperation> = {},
+  ): TraversedOperation => ({
+    id: 'test-operation',
+    title: 'Test Operation',
+    method: 'get',
+    path: '/test',
+    operation,
+    ...overrides,
+  })
+
+  const createMockTraversedEntry = (overrides: Partial<TraversedEntry> = {}): TraversedEntry => ({
+    id: 'test-entry',
+    title: 'Test Entry',
+    ...overrides,
+  })
+
+  it('renders basic sidebar element', () => {
+    const item = createMockTraversedEntry()
+    const wrapper = mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+      },
+    })
+
+    expect(wrapper.find('.sidebar-group-item').exists()).toBe(true)
+    expect(wrapper.find('.sidebar-heading-link-title').text()).toBe('Test Entry')
+  })
+
+  it('renders operation with HTTP method badge', () => {
+    const operation = createMockOperation()
+    const item = createMockTraversedOperation(operation)
+    const wrapper = mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+      },
+    })
+
+    expect(wrapper.find('.sidebar-heading-link-method').exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'SidebarHttpBadge' }).exists()).toBe(true)
+  })
+
+  it('applies deprecated class when operation is deprecated via deprecated property', async () => {
+    const { isOperationDeprecated } = await import('@/libs/openapi')
+    vi.mocked(isOperationDeprecated).mockReturnValue(true)
+
+    const operation = createMockOperation({ deprecated: true })
+    const item = createMockTraversedOperation(operation)
+    const wrapper = mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+      },
+    })
+
+    expect(wrapper.find('.sidebar-heading.deprecated').exists()).toBe(true)
+    expect(isOperationDeprecated).toHaveBeenCalledWith(operation)
+  })
+
+  it('applies deprecated class when operation is deprecated via x-scalar-stability', async () => {
+    const { isOperationDeprecated } = await import('@/libs/openapi')
+    vi.mocked(isOperationDeprecated).mockReturnValue(true)
+
+    const operation = createMockOperation({
+      'x-scalar-stability': XScalarStability.Deprecated,
+    })
+    const item = createMockTraversedOperation(operation)
+    const wrapper = mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+      },
+    })
+
+    expect(wrapper.find('.sidebar-heading.deprecated').exists()).toBe(true)
+    expect(isOperationDeprecated).toHaveBeenCalledWith(operation)
+  })
+
+  it('does not apply deprecated class when operation is not deprecated', async () => {
+    const { isOperationDeprecated } = await import('@/libs/openapi')
+    vi.mocked(isOperationDeprecated).mockReturnValue(false)
+
+    const operation = createMockOperation()
+    const item = createMockTraversedOperation(operation)
+    const wrapper = mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+      },
+    })
+
+    expect(wrapper.find('.sidebar-heading.deprecated').exists()).toBe(false)
+    expect(isOperationDeprecated).toHaveBeenCalledWith(operation)
+  })
+
+  it('does not apply deprecated class for non-operation items', async () => {
+    const { isOperationDeprecated } = await import('@/libs/openapi')
+    vi.mocked(isOperationDeprecated).mockReturnValue(true)
+
+    const item = createMockTraversedEntry({ type: 'text' })
+    const wrapper = mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+      },
+    })
+
+    expect(wrapper.find('.sidebar-heading.deprecated').exists()).toBe(false)
+    expect(isOperationDeprecated).not.toHaveBeenCalled()
+  })
+
+  it('applies active class when isActive is true', () => {
+    const item = createMockTraversedEntry()
+    const wrapper = mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+        isActive: true,
+      },
+    })
+
+    expect(wrapper.find('.sidebar-heading.active_page').exists()).toBe(true)
+  })
+
+  it('applies folder class when hasChildren is true', () => {
+    const item = createMockTraversedEntry()
+    const wrapper = mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+        hasChildren: true,
+      },
+    })
+
+    expect(wrapper.find('.sidebar-heading.sidebar-group-item__folder').exists()).toBe(true)
+  })
+
+  it('emits toggleOpen when clicked with children', async () => {
+    const item = createMockTraversedEntry()
+    const wrapper = mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+        hasChildren: true,
+      },
+    })
+
+    await wrapper.find('.sidebar-heading').trigger('click')
+    expect(wrapper.emitted('toggleOpen')).toBeTruthy()
+  })
+
+  it('generates correct link with hash routing', () => {
+    const item = createMockTraversedEntry()
+    const wrapper = mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+      },
+    })
+
+    const link = wrapper.find('.sidebar-heading-link')
+    expect(link.attributes('href')).toBe('/#test-entry')
+  })
+
+  it('handles webhook operations correctly', () => {
+    const operation = createMockOperation()
+    const item = createMockTraversedOperation(operation, {
+      type: 'webhook',
+      name: 'test-webhook',
+      webhook: operation,
+    })
+    const wrapper = mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'ScalarIconWebhooksLogo' }).exists()).toBe(true)
+  })
+
+  it('calls isOperationDeprecated with correct operation object', async () => {
+    const { isOperationDeprecated } = await import('@/libs/openapi')
+    vi.mocked(isOperationDeprecated).mockReturnValue(false)
+
+    const operation = createMockOperation({
+      deprecated: true,
+      'x-scalar-stability': XScalarStability.Stable,
+    })
+    const item = createMockTraversedOperation(operation)
+
+    mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+      },
+    })
+
+    expect(isOperationDeprecated).toHaveBeenCalledWith(operation)
+  })
+
+  it('handles deprecated property taking precedence over x-scalar-stability', async () => {
+    const { isOperationDeprecated } = await import('@/libs/openapi')
+    vi.mocked(isOperationDeprecated).mockReturnValue(false)
+
+    const operation = createMockOperation({
+      deprecated: false,
+      'x-scalar-stability': XScalarStability.Deprecated,
+    })
+    const item = createMockTraversedOperation(operation)
+
+    mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+      },
+    })
+
+    expect(isOperationDeprecated).toHaveBeenCalledWith(operation)
+  })
+
+  it('renders action menu slot when provided', () => {
+    const item = createMockTraversedEntry()
+    const wrapper = mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+      },
+      slots: {
+        'action-menu': '<div class="test-action">Action</div>',
+      },
+    })
+
+    expect(wrapper.find('.action-menu').exists()).toBe(true)
+    expect(wrapper.find('.test-action').text()).toBe('Action')
+  })
+
+  it('renders children when open is true', () => {
+    const item = createMockTraversedEntry()
+    const wrapper = mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+        open: true,
+      },
+      slots: {
+        default: '<div class="test-child">Child</div>',
+      },
+    })
+
+    expect(wrapper.find('.test-child').exists()).toBe(true)
+  })
+
+  it('does not render children when open is false', () => {
+    const item = createMockTraversedEntry()
+    const wrapper = mount(SidebarElement, {
+      props: {
+        id: 'test-id',
+        item,
+        open: false,
+      },
+      slots: {
+        default: '<div class="test-child">Child</div>',
+      },
+    })
+
+    expect(wrapper.find('.test-child').exists()).toBe(false)
+  })
+})

--- a/packages/api-reference/src/features/sidebar/components/SidebarElement.test.ts
+++ b/packages/api-reference/src/features/sidebar/components/SidebarElement.test.ts
@@ -155,7 +155,7 @@ describe('SidebarElement', () => {
     const { isOperationDeprecated } = await import('@/libs/openapi')
     vi.mocked(isOperationDeprecated).mockReturnValue(true)
 
-    const item = createMockTraversedEntry({ type: 'text' })
+    const item = createMockTraversedEntry()
     const wrapper = mount(SidebarElement, {
       props: {
         id: 'test-id',
@@ -222,15 +222,14 @@ describe('SidebarElement', () => {
 
   it('handles webhook operations correctly', () => {
     const operation = createMockOperation()
-    const item = createMockTraversedOperation(operation, {
-      type: 'webhook',
-      name: 'test-webhook',
-      webhook: operation,
-    })
+    const item = createMockTraversedOperation(operation)
     const wrapper = mount(SidebarElement, {
       props: {
         id: 'test-id',
-        item,
+        item: {
+          ...item,
+          webhook: operation,
+        },
       },
     })
 

--- a/packages/api-reference/src/features/sidebar/components/SidebarElement.vue
+++ b/packages/api-reference/src/features/sidebar/components/SidebarElement.vue
@@ -9,6 +9,7 @@ import { combineUrlAndPath } from '@scalar/oas-utils/helpers'
 import type { TraversedEntry } from '@/features/traverse-schema'
 import { useConfig } from '@/hooks/useConfig'
 import { useNavState } from '@/hooks/useNavState'
+import { isOperationDeprecated } from '@/libs/openapi'
 
 import SidebarHttpBadge from './SidebarHttpBadge.vue'
 
@@ -90,7 +91,8 @@ const onAnchorClick = async (ev: Event) => {
       :class="{
         'sidebar-group-item__folder': hasChildren,
         'active_page': isActive,
-        'deprecated': 'deprecated' in item && item.deprecated,
+        'deprecated':
+          'operation' in item && isOperationDeprecated(item.operation),
       }"
       @click="handleClick">
       <!-- If children are detected then show the nesting icon -->

--- a/packages/api-reference/src/features/traverse-schema/index.ts
+++ b/packages/api-reference/src/features/traverse-schema/index.ts
@@ -1,4 +1,10 @@
-export type { TraverseSpecOptions, TraversedEntry, TraversedDescription, TraversedTag } from './types'
+export type {
+  TraverseSpecOptions,
+  TraversedOperation,
+  TraversedEntry,
+  TraversedDescription,
+  TraversedTag,
+} from './types'
 
 export { traverseDocument } from './helpers/traverse-document'
 export { DEFAULT_INTRODUCTION_SLUG } from './helpers/traverse-description'


### PR DESCRIPTION
**Problem**

With the recent sidebar refactor we introduced a regression: deprecated operations aren’t rendered with a strike-through style anymore.

**Solution**

Fixes #6129

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
