### PR TITLE
fix(api-reference): treat `exclusiveMinimum` and `exclusiveMaximum` as numbers

### DIFF
--- a/.changeset/cold-waves-run.md
+++ b/.changeset/cold-waves-run.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: exclusiveMinimum and exclusiveMaximum are treated as boolean values

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -335,4 +335,102 @@ describe('SchemaPropertyHeading', () => {
     expect(detailsElement.text()).toContain('multiple of:')
     expect(detailsElement.text()).toContain('0.001')
   })
+
+  describe('exclusiveMinimum and exclusiveMaximum', () => {
+    it('renders exclusiveMinimum property', () => {
+      const wrapper = mount(SchemaPropertyHeading, {
+        props: {
+          value: {
+            type: 'number',
+            exclusiveMinimum: 5,
+          },
+        },
+      })
+      const detailsElement = wrapper.find('.property-heading')
+      expect(detailsElement.text()).toContain('greater than:')
+      expect(detailsElement.text()).toContain('5')
+    })
+
+    it('renders exclusiveMaximum property', () => {
+      const wrapper = mount(SchemaPropertyHeading, {
+        props: {
+          value: {
+            type: 'number',
+            exclusiveMaximum: 10,
+          },
+        },
+      })
+      const detailsElement = wrapper.find('.property-heading')
+      expect(detailsElement.text()).toContain('less than:')
+      expect(detailsElement.text()).toContain('10')
+    })
+
+    it('renders both exclusiveMinimum and exclusiveMaximum properties', () => {
+      const wrapper = mount(SchemaPropertyHeading, {
+        props: {
+          value: {
+            type: 'number',
+            exclusiveMinimum: 1,
+            exclusiveMaximum: 10,
+          },
+        },
+      })
+      const detailsElement = wrapper.find('.property-heading')
+      expect(detailsElement.text()).toContain('greater than:')
+      expect(detailsElement.text()).toContain('1')
+      expect(detailsElement.text()).toContain('less than:')
+      expect(detailsElement.text()).toContain('10')
+    })
+
+    it('renders minimum and maximum properties when exclusive values are not present', () => {
+      const wrapper = mount(SchemaPropertyHeading, {
+        props: {
+          value: {
+            type: 'number',
+            minimum: 0,
+            maximum: 100,
+          },
+        },
+      })
+      const detailsElement = wrapper.find('.property-heading')
+      expect(detailsElement.text()).toContain('min:')
+      expect(detailsElement.text()).toContain('0')
+      expect(detailsElement.text()).toContain('max:')
+      expect(detailsElement.text()).toContain('100')
+    })
+
+    it('renders exclusiveMinimum and maximum properties together', () => {
+      const wrapper = mount(SchemaPropertyHeading, {
+        props: {
+          value: {
+            type: 'number',
+            exclusiveMinimum: 1,
+            maximum: 100,
+          },
+        },
+      })
+      const detailsElement = wrapper.find('.property-heading')
+      expect(detailsElement.text()).toContain('greater than:')
+      expect(detailsElement.text()).toContain('1')
+      expect(detailsElement.text()).toContain('max:')
+      expect(detailsElement.text()).toContain('100')
+    })
+
+    it('renders minimum and exclusiveMaximum properties together', () => {
+      const wrapper = mount(SchemaPropertyHeading, {
+        props: {
+          value: {
+            type: 'number',
+            minimum: 0,
+            exclusiveMaximum: 10,
+          },
+        },
+      })
+      const detailsElement = wrapper.find('.property-heading')
+      expect(detailsElement.text()).toContain('min:')
+      expect(detailsElement.text()).toContain('0')
+      expect(detailsElement.text()).toContain('less than:')
+      expect(detailsElement.text()).toContain('10')
+    })
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -124,23 +124,19 @@ const modelName = computed(() => {
         <ScreenReader>Format:</ScreenReader>
         {{ value.format }}
       </SchemaPropertyDetail>
-      <SchemaPropertyDetail
-        v-if="isDefined(value.minimum) && value.exclusiveMinimum">
+      <SchemaPropertyDetail v-if="isDefined(value.exclusiveMinimum)">
         <template #prefix>greater than: </template>
-        {{ value.minimum }}
+        {{ value.exclusiveMinimum }}
       </SchemaPropertyDetail>
-      <SchemaPropertyDetail
-        v-if="isDefined(value.minimum) && !value.exclusiveMinimum">
+      <SchemaPropertyDetail v-if="isDefined(value.minimum)">
         <template #prefix>min: </template>
         {{ value.minimum }}
       </SchemaPropertyDetail>
-      <SchemaPropertyDetail
-        v-if="isDefined(value.maximum) && value.exclusiveMaximum">
+      <SchemaPropertyDetail v-if="isDefined(value.exclusiveMaximum)">
         <template #prefix>less than: </template>
-        {{ value.maximum }}
+        {{ value.exclusiveMaximum }}
       </SchemaPropertyDetail>
-      <SchemaPropertyDetail
-        v-if="isDefined(value.maximum) && !value.exclusiveMaximum">
+      <SchemaPropertyDetail v-if="isDefined(value.maximum)">
         <template #prefix>max: </template>
         {{ value.maximum }}
       </SchemaPropertyDetail>


### PR DESCRIPTION
**Problem**

In OpenAPI 3.0 `exclusiveMinum` and `exclusiveMaximum` were boolean values, but they became specific numbers in OpenAPI 3.1. The rendering still expected booleans.

**Solution**

With this PR we’re using them as numbers, not as booleans.

The upgrader already upgrades them to be numbers, not booleans.

Fixes #5624
Fixes #5966

**Preview**

<img width="282" alt="Screenshot 2025-07-02 at 12 37 44" src="https://github.com/user-attachments/assets/ba8fd488-e3f9-4624-b9de-6beaca99dbcf" />

**Example**

```json
{
  "openapi": "3.1.0",
  "info": {
    "title": "FooAPI",
    "version": "1.0.0"
  },
  "paths": {
    "/foo": {
      "get": {
        "summary": "Get Foo",
        "operationId": "",
        "parameters": [],
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "type": "object",
                "properties": {
                  "foo": {
                    "type": [
                      "integer"
                    ],
                    "exclusiveMinimum": 1,
                    "exclusiveMaximum": 10
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}
```

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
