### PR TITLE
ci: build, test and publish FastAPI integration

### DIFF
--- a/.changeset/wicked-goats-dance.md
+++ b/.changeset/wicked-goats-dance.md
@@ -1,0 +1,5 @@
+---
+'scalar-fastapi': patch
+---
+
+chore: trigger release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -837,7 +837,7 @@ jobs:
         working-directory: integrations/aspire/src/Scalar.Aspire
         run: dotnet nuget push nupkgs/*.nupkg -k ${{ secrets.NUGET_TOKEN }} -s https://api.nuget.org/v3/index.json
 
-  fastapi-build-test:
+  fastapi-build:
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
     needs: [build]
@@ -860,12 +860,6 @@ jobs:
         working-directory: integrations/fastapi
         run: python -m build
 
-      - name: Test package installation
-        working-directory: integrations/fastapi
-        run: |
-          pip install dist/*.whl
-          python -c "import scalar_fastapi; print('FastAPI package imported successfully')"
-
   fastapi-publish:
     if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
     runs-on: blacksmith-2vcpu-ubuntu-2204
@@ -881,7 +875,7 @@ jobs:
         types,
         test-packages,
         test-integrations,
-        fastapi-build-test,
+        fastapi-build,
       ]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -895,13 +895,6 @@ jobs:
               - integrations/fastapi/**
 
       - if: steps.changed-files.outputs.fastapi_integration_any_changed == 'true'
-        name: Extract version from setup.py
-        working-directory: integrations/fastapi
-        run: |
-          VERSION=$(python -c "import ast; print(ast.literal_eval(open('setup.py').read().split('version=')[1].split(',')[0]))")
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-      - if: steps.changed-files.outputs.fastapi_integration_any_changed == 'true'
         name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -836,3 +836,93 @@ jobs:
         name: Publish Scalar.Aspire NuGet package
         working-directory: integrations/aspire/src/Scalar.Aspire
         run: dotnet nuget push nupkgs/*.nupkg -k ${{ secrets.NUGET_TOKEN }} -s https://api.nuget.org/v3/index.json
+
+  fastapi-build-test:
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    timeout-minutes: 10
+    needs: [build]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Setup Python
+        uses: actions/setup-python@4d7c8a1b7a623a5ab0d00e87e3f3c2b3e4b5e6f7
+        with:
+          python-version: '3.11'
+
+      - name: Install build dependencies
+        working-directory: integrations/fastapi
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build Python package
+        working-directory: integrations/fastapi
+        run: python -m build
+
+      - name: Test package installation
+        working-directory: integrations/fastapi
+        run: |
+          pip install dist/*.whl
+          python -c "import scalar_fastapi; print('FastAPI package imported successfully')"
+
+  fastapi-publish:
+    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    timeout-minutes: 10
+    concurrency:
+      group: fastapi-publish
+      cancel-in-progress: false
+    needs:
+      [
+        harden_security,
+        build,
+        format,
+        types,
+        test-packages,
+        test-integrations,
+        fastapi-build-test,
+      ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Check for FastAPI integration changes
+        id: changed-files
+        uses: step-security/changed-files@95b56dadb92a30ca9036f16423fd3c088a71ee94
+        with:
+          files_yaml: |
+            fastapi_integration:
+              - integrations/fastapi/**
+
+      - if: steps.changed-files.outputs.fastapi_integration_any_changed == 'true'
+        name: Extract version from setup.py
+        working-directory: integrations/fastapi
+        run: |
+          VERSION=$(python -c "import ast; print(ast.literal_eval(open('setup.py').read().split('version=')[1].split(',')[0]))")
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - if: steps.changed-files.outputs.fastapi_integration_any_changed == 'true'
+        name: Setup Python
+        uses: actions/setup-python@4d7c8a1b7a623a5ab0d00e87e3f3c2b3e4b5e6f7
+        with:
+          python-version: '3.11'
+
+      - if: steps.changed-files.outputs.fastapi_integration_any_changed == 'true'
+        name: Install build dependencies
+        working-directory: integrations/fastapi
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - if: steps.changed-files.outputs.fastapi_integration_any_changed == 'true'
+        name: Build Python package
+        working-directory: integrations/fastapi
+        run: python -m build
+
+      - if: steps.changed-files.outputs.fastapi_integration_any_changed == 'true'
+        name: Publish to PyPI
+        working-directory: integrations/fastapi
+        run: |
+          twine upload --username __token__ --password ${{ secrets.PYPI_TOKEN }} dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -846,7 +846,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup Python
-        uses: actions/setup-python@4d7c8a1b7a623a5ab0d00e87e3f3c2b3e4b5e6f7
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.11'
 
@@ -905,7 +905,7 @@ jobs:
 
       - if: steps.changed-files.outputs.fastapi_integration_any_changed == 'true'
         name: Setup Python
-        uses: actions/setup-python@4d7c8a1b7a623a5ab0d00e87e3f3c2b3e4b5e6f7
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.11'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -837,7 +837,7 @@ jobs:
         working-directory: integrations/aspire/src/Scalar.Aspire
         run: dotnet nuget push nupkgs/*.nupkg -k ${{ secrets.NUGET_TOKEN }} -s https://api.nuget.org/v3/index.json
 
-  fastapi-build:
+  fastapi-test:
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
     needs: [build]
@@ -860,6 +860,10 @@ jobs:
         working-directory: integrations/fastapi
         run: python -m build
 
+      - name: Run tests
+        working-directory: integrations/fastapi
+        run: python run_tests.py
+
   fastapi-publish:
     if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
     runs-on: blacksmith-2vcpu-ubuntu-2204
@@ -875,7 +879,7 @@ jobs:
         types,
         test-packages,
         test-integrations,
-        fastapi-build,
+        fastapi-test,
       ]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -892,7 +892,7 @@ jobs:
         with:
           files_yaml: |
             fastapi_integration:
-              - integrations/fastapi/**
+              - integrations/fastapi/package.json
 
       - if: steps.changed-files.outputs.fastapi_integration_any_changed == 'true'
         name: Setup Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -837,7 +837,7 @@ jobs:
         working-directory: integrations/aspire/src/Scalar.Aspire
         run: dotnet nuget push nupkgs/*.nupkg -k ${{ secrets.NUGET_TOKEN }} -s https://api.nuget.org/v3/index.json
 
-  fastapi-test:
+  fastapi-build-test:
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
     needs: [build]
@@ -879,7 +879,7 @@ jobs:
         types,
         test-packages,
         test-integrations,
-        fastapi-test,
+        fastapi-build-test,
       ]
 
     steps:

--- a/integrations/fastapi/MANIFEST.in
+++ b/integrations/fastapi/MANIFEST.in
@@ -1,0 +1,5 @@
+include README.md
+include package.json
+include LICENSE
+recursive-include scalar_fastapi *.py
+recursive-include tests *.py

--- a/integrations/fastapi/package.json
+++ b/integrations/fastapi/package.json
@@ -10,6 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/fastapi"
   },
+  "private": true,
   "version": "1.2.0",
   "engines": {
     "node": ">=20"

--- a/integrations/fastapi/package.json
+++ b/integrations/fastapi/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "scalar-fastapi",
+  "description": "Scalar FastAPI integration",
+  "license": "MIT",
+  "author": "Scalar (https://github.com/scalar)",
+  "homepage": "https://github.com/scalar/scalar",
+  "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/scalar/scalar.git",
+    "directory": "integrations/fastapi"
+  },
+  "version": "1.2.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "test": "python3 run_tests.py"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/integrations/fastapi/pytest.ini
+++ b/integrations/fastapi/pytest.ini
@@ -1,0 +1,14 @@
+[tool:pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = 
+    -v
+    --tb=short
+    --strict-markers
+    --disable-warnings
+markers =
+    unit: Unit tests
+    integration: Integration tests
+    slow: Slow running tests 

--- a/integrations/fastapi/run_tests.py
+++ b/integrations/fastapi/run_tests.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Test runner for scalar-fastapi integration.
+This script runs all tests and provides a summary.
+"""
+
+import subprocess
+import sys
+import os
+from pathlib import Path
+
+
+def run_tests():
+    """Run all tests for the scalar-fastapi integration"""
+
+    # Get the directory where this script is located
+    script_dir = Path(__file__).parent
+    os.chdir(script_dir)
+
+    print("🧪 Running Scalar FastAPI Integration Tests")
+    print("=" * 50)
+
+    # Check if pytest is available
+    try:
+        import pytest
+    except ImportError:
+        print("❌ pytest is not installed. Installing test dependencies...")
+        subprocess.run([sys.executable, "-m", "pip", "install", "-r", "tests/requirements.txt"], check=True)
+
+    # Run the tests
+    print("📋 Running unit tests...")
+    result = subprocess.run([
+        sys.executable, "-m", "pytest",
+        "tests/",
+        "-v",
+        "--tb=short",
+        "--color=yes"
+    ])
+
+    if result.returncode == 0:
+        print("\n✅ All tests passed!")
+    else:
+        print("\n❌ Some tests failed!")
+        sys.exit(1)
+
+
+def run_specific_test(test_file=None, test_function=None):
+    """Run a specific test file or function"""
+
+    script_dir = Path(__file__).parent
+    os.chdir(script_dir)
+
+    cmd = [sys.executable, "-m", "pytest", "-v", "--tb=short", "--color=yes"]
+
+    if test_file:
+        cmd.append(f"tests/{test_file}")
+
+    if test_function:
+        cmd.append(f"-k {test_function}")
+
+    subprocess.run(cmd)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "--help" or sys.argv[1] == "-h":
+            print("Usage:")
+            print("  python run_tests.py                    # Run all tests")
+            print("  python run_tests.py test_file.py       # Run specific test file")
+            print("  python run_tests.py test_file.py func  # Run specific test function")
+        elif len(sys.argv) == 2:
+            run_specific_test(sys.argv[1])
+        elif len(sys.argv) == 3:
+            run_specific_test(sys.argv[1], sys.argv[2])
+    else:
+        run_tests()

--- a/integrations/fastapi/scalar_fastapi/__init__.py
+++ b/integrations/fastapi/scalar_fastapi/__init__.py
@@ -1,1 +1,1 @@
-from .scalar_fastapi import get_scalar_api_reference
+from .scalar_fastapi import get_scalar_api_reference, Layout, SearchHotKey

--- a/integrations/fastapi/setup.py
+++ b/integrations/fastapi/setup.py
@@ -4,15 +4,11 @@ setup(
     name='scalar_fastapi',
     version='1.2.0',
     packages=find_packages(),
-    install_requires=[
-        # Add your package dependencies here
-    ],
+    install_requires=[],
     author='Marc Laventure',
     author_email='marc@scalar.com',
     description='This plugin provides an easy way to render a beautiful API reference based on a OpenAPI/Swagger file with FastAPI.',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     url='https://github.com/scalar/scalar',
-    # classifiers=[
-    # ],
 )

--- a/integrations/fastapi/setup.py
+++ b/integrations/fastapi/setup.py
@@ -1,8 +1,17 @@
+import json
+import os
 from setuptools import setup, find_packages
+
+# Read version from package.json
+def get_version():
+    package_json_path = os.path.join(os.path.dirname(__file__), 'package.json')
+    with open(package_json_path, 'r') as f:
+        package_data = json.load(f)
+    return package_data['version']
 
 setup(
     name='scalar_fastapi',
-    version='1.2.0',
+    version=get_version(),
     packages=find_packages(),
     install_requires=[],
     author='Marc Laventure',

--- a/integrations/fastapi/tests/README.md
+++ b/integrations/fastapi/tests/README.md
@@ -1,0 +1,59 @@
+# Scalar FastAPI Integration Tests
+
+This directory contains comprehensive automated tests for the Scalar FastAPI integration.
+
+## Test Structure
+
+- `test_scalar_fastapi.py` - Unit tests for the `get_scalar_api_reference` function
+- `test_integration.py` - Integration tests for FastAPI applications with Scalar
+- `requirements.txt` - Test dependencies
+
+## Running Tests
+
+### Option 1: Using the test runner script (Recommended)
+
+```bash
+# Run all tests
+python run_tests.py
+
+# Run specific test file
+python run_tests.py test_scalar_fastapi.py
+
+# Run specific test function
+python run_tests.py test_scalar_fastapi.py test_basic_functionality
+
+# Get help
+python run_tests.py --help
+```
+
+### Option 2: Using pytest directly
+
+```bash
+# Install test dependencies
+pip install -r tests/requirements.txt
+
+# Run all tests
+pytest tests/ -v
+
+# Run specific test file
+pytest tests/test_scalar_fastapi.py -v
+
+# Run specific test class
+pytest tests/test_scalar_fastapi.py::TestGetScalarApiReference -v
+
+# Run specific test function
+pytest tests/test_scalar_fastapi.py::TestGetScalarApiReference::test_basic_functionality -v
+
+# Run with coverage
+pytest tests/ --cov=scalar_fastapi --cov-report=html
+```
+
+### Option 3: Using the playground for manual testing
+
+```bash
+cd playground
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+Then visit `http://127.0.0.1:8000/scalar` to see the Scalar interface.

--- a/integrations/fastapi/tests/__init__.py
+++ b/integrations/fastapi/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package for scalar-fastapi 

--- a/integrations/fastapi/tests/requirements.txt
+++ b/integrations/fastapi/tests/requirements.txt
@@ -1,0 +1,5 @@
+pytest==7.4.3
+pytest-asyncio==0.21.1
+fastapi==0.110.2
+httpx==0.25.2
+typing_extensions==4.11.0 

--- a/integrations/fastapi/tests/test_imports.py
+++ b/integrations/fastapi/tests/test_imports.py
@@ -1,0 +1,54 @@
+"""
+Simple test to verify that all imports work correctly.
+This is useful for catching import issues early.
+"""
+
+import pytest
+
+
+def test_scalar_fastapi_imports():
+    """Test that all scalar_fastapi imports work correctly"""
+    
+    # Test main function import
+    from scalar_fastapi import get_scalar_api_reference
+    assert callable(get_scalar_api_reference)
+    
+    # Test enum imports
+    from scalar_fastapi import Layout, SearchHotKey
+    assert Layout.MODERN.value == "modern"
+    assert Layout.CLASSIC.value == "classic"
+    assert SearchHotKey.K.value == "k"
+    assert SearchHotKey.A.value == "a"
+    assert SearchHotKey.Z.value == "z"
+
+
+def test_fastapi_imports():
+    """Test that FastAPI imports work correctly"""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from fastapi.responses import HTMLResponse
+    
+    # Verify we can create a FastAPI app
+    app = FastAPI()
+    assert app is not None
+    
+    # Verify we can create a test client
+    client = TestClient(app)
+    assert client is not None
+
+
+def test_pytest_imports():
+    """Test that pytest imports work correctly"""
+    import pytest
+    
+    # Verify pytest is available
+    assert pytest is not None
+
+
+def test_typing_imports():
+    """Test that typing imports work correctly"""
+    from typing_extensions import Annotated, Doc
+    
+    # Verify typing extensions are available
+    assert Annotated is not None
+    assert Doc is not None 

--- a/integrations/fastapi/tests/test_integration.py
+++ b/integrations/fastapi/tests/test_integration.py
@@ -1,0 +1,289 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from typing import Union
+
+from scalar_fastapi import get_scalar_api_reference, Layout, SearchHotKey
+
+
+@pytest.fixture
+def app():
+    """Create a test FastAPI application"""
+    app = FastAPI(title="Test API")
+    
+    @app.get("/")
+    def read_root():
+        return {"Hello": "World"}
+    
+    @app.get("/items/{item_id}")
+    def read_item(item_id: int, q: Union[str, None] = None):
+        return {"item_id": item_id, "q": q}
+    
+    @app.post("/items/")
+    def create_item(item: dict):
+        return {"item": item, "created": True}
+    
+    @app.get("/scalar", include_in_schema=False)
+    async def scalar_html():
+        return get_scalar_api_reference(
+            openapi_url=app.openapi_url,
+            title=app.title + " - Scalar",
+        )
+    
+    @app.get("/scalar-custom", include_in_schema=False)
+    async def scalar_custom_html():
+        return get_scalar_api_reference(
+            openapi_url=app.openapi_url,
+            title=app.title + " - Custom Scalar",
+            layout=Layout.CLASSIC,
+            dark_mode=False,
+            hide_download_button=True,
+            hide_models=True,
+            show_sidebar=False,
+            search_hot_key=SearchHotKey.S,
+            servers=[
+                {"name": "Production", "url": "https://api.example.com"},
+                {"name": "Development", "url": "http://localhost:8000"}
+            ],
+            authentication={
+                "apiKey": {
+                    "type": "apiKey",
+                    "in": "header",
+                    "name": "X-API-Key"
+                }
+            }
+        )
+    
+    return app
+
+
+@pytest.fixture
+def client(app):
+    """Create a test client for the FastAPI application"""
+    return TestClient(app)
+
+
+class TestFastAPIIntegration:
+    """Integration tests for FastAPI with Scalar"""
+    
+    def test_basic_endpoints_work(self, client):
+        """Test that basic API endpoints work"""
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.json() == {"Hello": "World"}
+        
+        response = client.get("/items/123?q=test")
+        assert response.status_code == 200
+        assert response.json() == {"item_id": 123, "q": "test"}
+        
+        response = client.post("/items/", json={"name": "test item"})
+        assert response.status_code == 200
+        assert response.json() == {"item": {"name": "test item"}, "created": True}
+
+    def test_scalar_endpoint_returns_html(self, client, app):
+        """Test that the scalar endpoint returns proper HTML"""
+        response = client.get("/scalar")
+        
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        
+        html_content = response.text
+        
+        # Check basic HTML structure
+        assert "<!DOCTYPE html>" in html_content
+        assert "<html>" in html_content
+        assert "<head>" in html_content
+        assert "<body>" in html_content
+        
+        # Check title
+        assert f"<title>{app.title} - Scalar</title>" in html_content
+        
+        # Check OpenAPI URL
+        assert f'data-url="{app.openapi_url}"' in html_content
+        
+        # Check default configuration
+        assert 'layout: "modern"' in html_content
+        assert 'showSidebar: true' in html_content
+        assert 'darkMode: true' in html_content
+        assert '_integration: "fastapi"' in html_content
+
+    def test_scalar_custom_endpoint(self, client, app):
+        """Test scalar endpoint with custom configuration"""
+        response = client.get("/scalar-custom")
+        
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        
+        html_content = response.text
+        
+        # Check custom configuration
+        assert 'layout: "classic"' in html_content
+        assert 'darkMode: false' in html_content
+        assert 'hideDownloadButton: true' in html_content
+        assert 'hideModels: true' in html_content
+        assert 'showSidebar: false' in html_content
+        assert 'searchHotKey: "s"' in html_content
+        
+        # Check servers configuration
+        assert '"name": "Production"' in html_content
+        assert '"url": "https://api.example.com"' in html_content
+        assert '"name": "Development"' in html_content
+        assert '"url": "http://localhost:8000"' in html_content
+        
+        # Check authentication configuration
+        assert '"type": "apiKey"' in html_content
+        assert '"in": "header"' in html_content
+        assert '"name": "X-API-Key"' in html_content
+
+    def test_openapi_schema_endpoint(self, client):
+        """Test that the OpenAPI schema endpoint works"""
+        response = client.get("/openapi.json")
+        
+        assert response.status_code == 200
+        assert "application/json" in response.headers["content-type"]
+        
+        schema = response.json()
+        
+        # Check basic OpenAPI structure
+        assert "openapi" in schema
+        assert "info" in schema
+        assert "paths" in schema
+        
+        # Check that our endpoints are in the schema
+        assert "/" in schema["paths"]
+        assert "/items/{item_id}" in schema["paths"]
+        assert "/items/" in schema["paths"]
+        
+        # Check that scalar endpoint is NOT in the schema (include_in_schema=False)
+        assert "/scalar" not in schema["paths"]
+        assert "/scalar-custom" not in schema["paths"]
+
+    def test_scalar_uses_correct_openapi_url(self, client, app):
+        """Test that scalar uses the correct OpenAPI URL"""
+        response = client.get("/scalar")
+        html_content = response.text
+        
+        # The scalar endpoint should reference the app's openapi_url
+        expected_url = app.openapi_url or "/openapi.json"
+        assert f'data-url="{expected_url}"' in html_content
+
+    def test_scalar_theme_included(self, client):
+        """Test that the default theme CSS is included"""
+        response = client.get("/scalar")
+        html_content = response.text
+        
+        # Check that theme CSS is included
+        assert "--scalar-color-1: #2a2f45;" in html_content
+        assert "--scalar-color-accent: #009485;" in html_content
+        assert "--scalar-background-1: #fff;" in html_content
+
+    def test_scalar_script_included(self, client):
+        """Test that the Scalar JavaScript is included"""
+        response = client.get("/scalar")
+        html_content = response.text
+        
+        # Check that the Scalar script is included
+        assert 'src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"' in html_content
+
+    def test_scalar_configuration_script(self, client):
+        """Test that the configuration script is properly generated"""
+        response = client.get("/scalar")
+        html_content = response.text
+        
+        # Check configuration script structure
+        assert 'var configuration = {' in html_content
+        assert 'document.getElementById(\'api-reference\').dataset.configuration =' in html_content
+        assert 'JSON.stringify(configuration)' in html_content
+
+    def test_scalar_noscript_message(self, client):
+        """Test that noscript message is included"""
+        response = client.get("/scalar")
+        html_content = response.text
+        
+        assert "<noscript>" in html_content
+        assert "Scalar requires Javascript to function" in html_content
+
+    def test_scalar_favicon_included(self, client):
+        """Test that favicon is included"""
+        response = client.get("/scalar")
+        html_content = response.text
+        
+        assert 'href="https://fastapi.tiangolo.com/img/favicon.png"' in html_content
+
+    def test_scalar_meta_tags(self, client):
+        """Test that proper meta tags are included"""
+        response = client.get("/scalar")
+        html_content = response.text
+        
+        assert '<meta charset="utf-8"/>' in html_content
+        assert '<meta name="viewport" content="width=device-width, initial-scale=1">' in html_content
+
+    def test_multiple_scalar_endpoints(self, client):
+        """Test that multiple scalar endpoints can coexist"""
+        # Test both scalar endpoints
+        response1 = client.get("/scalar")
+        response2 = client.get("/scalar-custom")
+        
+        assert response1.status_code == 200
+        assert response2.status_code == 200
+        
+        # They should have different titles
+        assert "Test API - Scalar" in response1.text
+        assert "Test API - Custom Scalar" in response2.text
+        
+        # They should have different configurations
+        assert 'layout: "modern"' in response1.text
+        assert 'layout: "classic"' in response2.text
+
+
+class TestScalarConfiguration:
+    """Test various Scalar configuration options"""
+    
+    def test_layout_configuration(self, client):
+        """Test different layout configurations"""
+        # Test modern layout (default)
+        response = client.get("/scalar")
+        assert 'layout: "modern"' in response.text
+        
+        # Test classic layout
+        response = client.get("/scalar-custom")
+        assert 'layout: "classic"' in response.text
+
+    def test_theme_configuration(self, client):
+        """Test theme configuration"""
+        response = client.get("/scalar")
+        html_content = response.text
+        
+        # Check that default theme is applied
+        assert "--scalar-color-1: #2a2f45;" in html_content
+        assert "--scalar-color-accent: #009485;" in html_content
+
+    def test_sidebar_configuration(self, client):
+        """Test sidebar configuration"""
+        # Default should show sidebar
+        response = client.get("/scalar")
+        assert 'showSidebar: true' in response.text
+        
+        # Custom should hide sidebar
+        response = client.get("/scalar-custom")
+        assert 'showSidebar: false' in response.text
+
+    def test_dark_mode_configuration(self, client):
+        """Test dark mode configuration"""
+        # Default should be dark mode
+        response = client.get("/scalar")
+        assert 'darkMode: true' in response.text
+        
+        # Custom should be light mode
+        response = client.get("/scalar-custom")
+        assert 'darkMode: false' in response.text
+
+    def test_search_hotkey_configuration(self, client):
+        """Test search hotkey configuration"""
+        # Default should be 'k'
+        response = client.get("/scalar")
+        assert 'searchHotKey: "k"' in response.text
+        
+        # Custom should be 's'
+        response = client.get("/scalar-custom")
+        assert 'searchHotKey: "s"' in response.text 

--- a/integrations/fastapi/tests/test_scalar_fastapi.py
+++ b/integrations/fastapi/tests/test_scalar_fastapi.py
@@ -1,0 +1,359 @@
+import json
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi.responses import HTMLResponse
+
+from scalar_fastapi import (
+    get_scalar_api_reference,
+    Layout,
+    SearchHotKey,
+)
+
+
+class TestLayout:
+    def test_layout_enum_values(self):
+        """Test that Layout enum has correct values"""
+        assert Layout.MODERN.value == "modern"
+        assert Layout.CLASSIC.value == "classic"
+
+
+class TestSearchHotKey:
+    def test_search_hot_key_enum_values(self):
+        """Test that SearchHotKey enum has correct values"""
+        assert SearchHotKey.K.value == "k"
+        assert SearchHotKey.A.value == "a"
+        assert SearchHotKey.Z.value == "z"
+
+
+class TestGetScalarApiReference:
+    def test_basic_functionality(self):
+        """Test basic functionality with minimal parameters"""
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API"
+        )
+        
+        assert isinstance(response, HTMLResponse)
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        
+        html_content = response.body.decode()
+        assert "<!DOCTYPE html>" in html_content
+        assert "<title>Test API</title>" in html_content
+        assert 'data-url="/openapi.json"' in html_content
+
+    def test_default_parameters(self):
+        """Test that default parameters are correctly set"""
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API"
+        )
+        
+        html_content = response.body.decode()
+        
+        # Check default values
+        assert 'data-proxy-url=""' in html_content
+        assert 'href="https://fastapi.tiangolo.com/img/favicon.png"' in html_content
+        assert 'src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"' in html_content
+        assert 'layout: "modern"' in html_content
+        assert 'showSidebar: true' in html_content
+        assert 'hideDownloadButton: false' in html_content
+        assert 'hideModels: false' in html_content
+        assert 'darkMode: true' in html_content
+        assert 'searchHotKey: "k"' in html_content
+        assert 'hiddenClients: []' in html_content
+        assert 'servers: []' in html_content
+        assert 'defaultOpenAllTags: false' in html_content
+        assert 'authentication: {}' in html_content
+        assert 'hideClientButton: false' in html_content
+        assert '_integration: "fastapi"' in html_content
+
+    def test_custom_parameters(self):
+        """Test custom parameter values"""
+        response = get_scalar_api_reference(
+            openapi_url="/custom/openapi.json",
+            title="Custom API",
+            scalar_js_url="https://custom.cdn.com/scalar.js",
+            scalar_proxy_url="https://proxy.example.com",
+            scalar_favicon_url="https://example.com/favicon.ico",
+            layout=Layout.CLASSIC,
+            show_sidebar=False,
+            hide_download_button=True,
+            hide_models=True,
+            dark_mode=False,
+            search_hot_key=SearchHotKey.S,
+            hidden_clients=["client1", "client2"],
+            servers=[{"name": "Production", "url": "https://api.example.com"}],
+            default_open_all_tags=True,
+            authentication={"apiKey": "test-key"},
+            hide_client_button=True,
+            integration="custom"
+        )
+        
+        html_content = response.body.decode()
+        
+        # Check custom values
+        assert 'data-url="/custom/openapi.json"' in html_content
+        assert "<title>Custom API</title>" in html_content
+        assert 'src="https://custom.cdn.com/scalar.js"' in html_content
+        assert 'data-proxy-url="https://proxy.example.com"' in html_content
+        assert 'href="https://example.com/favicon.ico"' in html_content
+        assert 'layout: "classic"' in html_content
+        assert 'showSidebar: false' in html_content
+        assert 'hideDownloadButton: true' in html_content
+        assert 'hideModels: true' in html_content
+        assert 'darkMode: false' in html_content
+        assert 'searchHotKey: "s"' in html_content
+        assert 'hiddenClients: ["client1", "client2"]' in html_content
+        assert 'servers: [{"name": "Production", "url": "https://api.example.com"}]' in html_content
+        assert 'defaultOpenAllTags: true' in html_content
+        assert 'authentication: {"apiKey": "test-key"}' in html_content
+        assert 'hideClientButton: true' in html_content
+        assert '_integration: "custom"' in html_content
+
+    def test_hidden_clients_dict_format(self):
+        """Test hidden_clients parameter with dictionary format"""
+        hidden_clients = {
+            "target1": True,
+            "target2": ["client1", "client2"],
+            "target3": False
+        }
+        
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API",
+            hidden_clients=hidden_clients
+        )
+        
+        html_content = response.body.decode()
+        expected_json = json.dumps(hidden_clients)
+        assert f'hiddenClients: {expected_json}' in html_content
+
+    def test_servers_parameter(self):
+        """Test servers parameter with multiple servers"""
+        servers = [
+            {"name": "Production", "url": "https://api.example.com"},
+            {"name": "Staging", "url": "https://staging-api.example.com"},
+            {"name": "Development", "url": "http://localhost:8000"}
+        ]
+        
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API",
+            servers=servers
+        )
+        
+        html_content = response.body.decode()
+        expected_json = json.dumps(servers)
+        assert f'servers: {expected_json}' in html_content
+
+    def test_authentication_parameter(self):
+        """Test authentication parameter with complex configuration"""
+        auth_config = {
+            "apiKey": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "X-API-Key"
+            },
+            "bearer": {
+                "type": "http",
+                "scheme": "bearer"
+            }
+        }
+        
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API",
+            authentication=auth_config
+        )
+        
+        html_content = response.body.decode()
+        expected_json = json.dumps(auth_config)
+        assert f'authentication: {expected_json}' in html_content
+
+    def test_custom_theme(self):
+        """Test custom theme CSS"""
+        custom_theme = """
+        .custom-theme {
+            --scalar-color-1: #ff0000;
+            --scalar-color-accent: #00ff00;
+        }
+        """
+        
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API",
+            scalar_theme=custom_theme
+        )
+        
+        html_content = response.body.decode()
+        assert custom_theme in html_content
+
+    def test_integration_none(self):
+        """Test setting integration to None"""
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API",
+            integration=None
+        )
+        
+        html_content = response.body.decode()
+        assert '_integration: null' in html_content
+
+    def test_html_structure(self):
+        """Test that the generated HTML has proper structure"""
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API"
+        )
+        
+        html_content = response.body.decode()
+        
+        # Check essential HTML elements
+        assert "<!DOCTYPE html>" in html_content
+        assert "<html>" in html_content
+        assert "<head>" in html_content
+        assert "<body>" in html_content
+        assert "</html>" in html_content
+        
+        # Check meta tags
+        assert '<meta charset="utf-8"/>' in html_content
+        assert '<meta name="viewport" content="width=device-width, initial-scale=1">' in html_content
+        
+        # Check script tags
+        assert 'id="api-reference"' in html_content
+        assert '<script src=' in html_content
+        
+        # Check noscript tag
+        assert "<noscript>" in html_content
+        assert "Scalar requires Javascript to function" in html_content
+
+    def test_configuration_script(self):
+        """Test that the configuration script is properly generated"""
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API"
+        )
+        
+        html_content = response.body.decode()
+        
+        # Check that configuration script exists
+        assert 'var configuration = {' in html_content
+        assert 'document.getElementById(\'api-reference\').dataset.configuration =' in html_content
+        assert 'JSON.stringify(configuration)' in html_content
+
+
+class TestFastAPIIntegration:
+    """Test the integration with FastAPI"""
+    
+    def test_fastapi_integration(self):
+        """Test that the function works with FastAPI"""
+        app = FastAPI()
+        
+        @app.get("/scalar", include_in_schema=False)
+        async def scalar_html():
+            return get_scalar_api_reference(
+                openapi_url=app.openapi_url,
+                title=app.title + " - Scalar",
+            )
+        
+        @app.get("/")
+        def read_root():
+            return {"Hello": "World"}
+        
+        client = TestClient(app)
+        
+        # Test the scalar endpoint
+        response = client.get("/scalar")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        
+        html_content = response.text
+        assert "<!DOCTYPE html>" in html_content
+        assert f"<title>{app.title} - Scalar</title>" in html_content
+        assert f'data-url="{app.openapi_url}"' in html_content
+
+    def test_fastapi_with_custom_config(self):
+        """Test FastAPI integration with custom configuration"""
+        app = FastAPI(title="Custom API")
+        
+        @app.get("/scalar", include_in_schema=False)
+        async def scalar_html():
+            return get_scalar_api_reference(
+                openapi_url=app.openapi_url,
+                title=app.title + " - Scalar",
+                layout=Layout.CLASSIC,
+                dark_mode=False,
+                hide_download_button=True
+            )
+        
+        client = TestClient(app)
+        
+        response = client.get("/scalar")
+        assert response.status_code == 200
+        
+        html_content = response.text
+        assert 'layout: "classic"' in html_content
+        assert 'darkMode: false' in html_content
+        assert 'hideDownloadButton: true' in html_content
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions"""
+    
+    def test_empty_strings(self):
+        """Test with empty string parameters"""
+        response = get_scalar_api_reference(
+            openapi_url="",
+            title="",
+            scalar_js_url="",
+            scalar_proxy_url="",
+            scalar_favicon_url=""
+        )
+        
+        assert isinstance(response, HTMLResponse)
+        html_content = response.body.decode()
+        assert 'data-url=""' in html_content
+        assert "<title></title>" in html_content
+
+    def test_special_characters_in_title(self):
+        """Test with special characters in title"""
+        title_with_special_chars = "API & Documentation <script>alert('xss')</script>"
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title=title_with_special_chars
+        )
+        
+        html_content = response.body.decode()
+        # The title should be properly escaped in the HTML
+        assert title_with_special_chars in html_content
+
+    def test_complex_json_in_configuration(self):
+        """Test with complex JSON structures in configuration"""
+        complex_auth = {
+            "oauth2": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "https://example.com/oauth/authorize",
+                        "tokenUrl": "https://example.com/oauth/token",
+                        "scopes": {
+                            "read": "Read access",
+                            "write": "Write access"
+                        }
+                    }
+                }
+            }
+        }
+        
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API",
+            authentication=complex_auth
+        )
+        
+        html_content = response.body.decode()
+        # The complex JSON should be properly serialized
+        assert "oauth2" in html_content
+        assert "authorizationCode" in html_content 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -819,6 +819,8 @@ importers:
         specifier: catalog:*
         version: 1.6.0(@types/node@22.15.3)(jsdom@25.0.1)(lightningcss@1.30.1)(terser@5.31.2)
 
+  integrations/fastapi: {}
+
   integrations/fastify:
     dependencies:
       '@scalar/core':


### PR DESCRIPTION
**Problem**

Currently, we’re manually publishing the FastAPI package (and by manually mean, we don’t publish it all).

*phone rings*
Hans: 👀 
*Hans picks up phone*
Hey, stoneage here, I want my workflow back!

**Solution**

With this PR we’ll catapult ourselves in the year 2025 and build, test and publish the FastAPI package in CI.

And yeah, we’ve finally got tests for the FastAPI integration. :)

✅ I’ve added the GitHub Action secret already.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
