### PR TITLE
fix(api-client): input focus post collection description update

### DIFF
--- a/.changeset/violet-terms-draw.md
+++ b/.changeset/violet-terms-draw.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: sets request animation frame to markdown input to avoid input typing issue

--- a/packages/api-client/src/views/Collection/components/MarkdownInput.vue
+++ b/packages/api-client/src/views/Collection/components/MarkdownInput.vue
@@ -27,6 +27,13 @@ watch(mode, (newMode) => {
     })
   }
 })
+
+const handleBlur = () => {
+  // Delay mode switch until after DOM updates to avoid input typing issue
+  requestAnimationFrame(() => {
+    mode.value = 'preview'
+  })
+}
 </script>
 
 <template>
@@ -88,7 +95,7 @@ watch(mode, (newMode) => {
             :environment="environment"
             :modelValue="modelValue"
             :workspace="workspace"
-            @blur="mode = 'preview'"
+            @blur="handleBlur"
             @update:modelValue="emit('update:modelValue', $event)" />
         </template>
       </div>


### PR DESCRIPTION
**Problem**

currently when updating api client collection description and switching more to preview breaks the focus within input preventing usage of modal for instance.

**Solution**

this pr delays mode switch to avoid input typing issue. fixes #6103

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
