### PR TITLE
chore(snippetz): move @scalar/types to dependencies

### DIFF
--- a/.changeset/unlucky-ads-unite.md
+++ b/.changeset/unlucky-ads-unite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+chore(snippetz): move @scalar/types to dependencies

--- a/packages/snippetz/package.json
+++ b/packages/snippetz/package.json
@@ -221,11 +221,11 @@
   ],
   "module": "./dist/index.js",
   "dependencies": {
-    "stringify-object": "^5.0.0"
+    "stringify-object": "^5.0.0",
+    "@scalar/types": "workspace:*"
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
-    "@scalar/types": "workspace:*",
     "vite": "catalog:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2274,6 +2274,9 @@ importers:
 
   packages/snippetz:
     dependencies:
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../types
       stringify-object:
         specifier: ^5.0.0
         version: 5.0.0
@@ -2281,9 +2284,6 @@ importers:
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../build-tooling
-      '@scalar/types':
-        specifier: workspace:*
-        version: link:../types
       vite:
         specifier: catalog:*
         version: 5.4.19(@types/node@22.15.3)(lightningcss@1.30.1)(terser@5.31.2)
@@ -17705,8 +17705,8 @@ packages:
   vue-component-type-helpers@2.2.10:
     resolution: {integrity: sha512-iDUO7uQK+Sab2tYuiP9D1oLujCWlhHELHMgV/cB13cuGbG4qwkLHvtfWb6FzvxrIOPDnU0oHsz2MlQjhYDeaHA==}
 
-  vue-component-type-helpers@3.0.0:
-    resolution: {integrity: sha512-J1HtqhZIqmYoNg4SLcYVFdCdsVUkMo4Z6/Wx4sQMfY8TFIIqDmd3mS2whfBIKzAA7dHMexarwYbvtB/fOUuEsw==}
+  vue-component-type-helpers@3.0.1:
+    resolution: {integrity: sha512-j23mCB5iEbGsyIhnVdXdWUOg+UdwmVxpKnYYf2j+4ppCt5VSFXKjwu9YFt0QYxUaf5G99PuHsVfRScjHCRSsGQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -24376,7 +24376,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.12(typescript@5.6.2)
-      vue-component-type-helpers: 3.0.0
+      vue-component-type-helpers: 3.0.1
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -37782,7 +37782,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.10: {}
 
-  vue-component-type-helpers@3.0.0: {}
+  vue-component-type-helpers@3.0.1: {}
 
   vue-demi@0.14.10(vue@3.5.12(typescript@5.6.2)):
     dependencies:


### PR DESCRIPTION
**Problem**

Currently, we are installing `@scalar/types` as a dev dependency, which is going to cause problems when we install this package.

**Solution**

With this PR we move `@scalar/types` to dependencies

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
