### PR TITLE
ci(renovate): add rangeStrategy bump to renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
   "prConcurrentLimit": 0,
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
+  "vulnerabilityAlerts": {
+    "rangeStrategy": "bump"
+  },
   "packageRules": [
     {
       "description": "Keep these package as low as possible for best compatibility",


### PR DESCRIPTION
This PR adds the `rangeStrategy: bump` to the renovate config.

[Related docs](https://docs.renovatebot.com/configuration-options/#rangestrategy):
> bump = e.g. bump the range even if the new version satisfies the existing range, e.g. ^1.0.0 -> ^1.1.0

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
