### PR TITLE
fix(workspace-store): add a couple missing http methods and add type annotations

### DIFF
--- a/.changeset/young-islands-pump.md
+++ b/.changeset/young-islands-pump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: add a few missing http methods and type annotations

--- a/packages/workspace-store/src/schemas/v3.1/strict/components.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/components.ts
@@ -31,17 +31,27 @@ import { CallbackObjectSchema, PathItemObjectSchema } from '@/schemas/v3.1/stric
 export type ComponentsObjectSchemaType = TIntersect<
   [
     TObject<{
+      /** Schema Objects that define input and output data types. These can be objects, primitives, and arrays, and are a superset of JSON Schema Specification Draft 2020-12. */
       schemas: TOptional<TRecord<TString, typeof SchemaObjectSchema>>
+      /** Response Objects that describe a single response from an API operation, including headers, content, and links. */
       responses: TOptional<TRecord<TString, TUnion<[typeof ResponseObjectSchema, typeof ReferenceObjectSchema]>>>
+      /** Parameter Objects that describe a single operation parameter with a unique combination of name and location (query, header, path, or cookie). */
       parameters: TOptional<TRecord<TString, TUnion<[typeof ParameterObjectSchema, typeof ReferenceObjectSchema]>>>
+      /** Example Objects that group example values with metadata for demonstrating usage of properties, parameters, and objects. */
       examples: TOptional<TRecord<TString, TUnion<[typeof ExampleObjectSchema, typeof ReferenceObjectSchema]>>>
+      /** Request Body Objects that describe a single request body with content and optional required flag. */
       requestBodies: TOptional<TRecord<TString, TUnion<[typeof RequestBodyObjectSchema, typeof ReferenceObjectSchema]>>>
+      /** Header Objects that describe HTTP response headers and multipart representation headers, following Parameter Object structure. */
       headers: TOptional<TRecord<TString, TUnion<[typeof HeaderObjectSchema, typeof ReferenceObjectSchema]>>>
+      /** Security Scheme Objects that define security mechanisms for API operations (apiKey, http, mutualTLS, oauth2, openIdConnect). */
       securitySchemes: TOptional<
         TRecord<TString, TUnion<[typeof SecuritySchemeObjectSchema, typeof ReferenceObjectSchema]>>
       >
+      /** Link Objects that represent design-time links for responses, providing relationships and traversal mechanisms between operations. */
       links: TOptional<TRecord<TString, TUnion<[typeof LinkObjectSchema, typeof ReferenceObjectSchema]>>>
+      /** Callback Objects that describe out-of-band callbacks related to parent operations, with Path Item Objects for request definitions. */
       callbacks: TOptional<TRecord<TString, TUnion<[typeof CallbackObjectSchema, typeof ReferenceObjectSchema]>>>
+      /** Path Item Objects that describe operations available on a single path, including HTTP methods and shared parameters. */
       pathItems: TOptional<TRecord<TString, typeof PathItemObjectSchema>>
     }>,
     typeof ExtensionsSchema,

--- a/packages/workspace-store/src/schemas/v3.1/strict/components.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/components.ts
@@ -1,4 +1,13 @@
-import { Type, type Static } from '@sinclair/typebox'
+import {
+  Type,
+  type Static,
+  type TIntersect,
+  type TObject,
+  type TOptional,
+  type TRecord,
+  type TString,
+  type TUnion,
+} from '@sinclair/typebox'
 import { SchemaObjectSchema } from './schema'
 import { ResponseObjectSchema } from './response'
 import { ReferenceObjectSchema } from './reference'
@@ -12,8 +21,35 @@ import { compose } from '@/schemas/compose'
 import { HeaderObjectSchema } from '@/schemas/v3.1/strict/media-header-encoding'
 import { CallbackObjectSchema, PathItemObjectSchema } from '@/schemas/v3.1/strict/path-operations'
 
+/**
+ * The type annotation is needed because the inferred type of this node exceeds the maximum length the compiler will serialize.
+ * This is due to the complex nested structure of the Components Object schema, which includes multiple optional fields,
+ * arrays, and nested objects. The explicit type annotation helps TypeScript handle this large type definition.
+ *
+ * @see https://github.com/microsoft/TypeScript/issues/43817#issuecomment-827746462
+ */
+export type ComponentsObjectSchemaType = TIntersect<
+  [
+    TObject<{
+      schemas: TOptional<TRecord<TString, typeof SchemaObjectSchema>>
+      responses: TOptional<TRecord<TString, TUnion<[typeof ResponseObjectSchema, typeof ReferenceObjectSchema]>>>
+      parameters: TOptional<TRecord<TString, TUnion<[typeof ParameterObjectSchema, typeof ReferenceObjectSchema]>>>
+      examples: TOptional<TRecord<TString, TUnion<[typeof ExampleObjectSchema, typeof ReferenceObjectSchema]>>>
+      requestBodies: TOptional<TRecord<TString, TUnion<[typeof RequestBodyObjectSchema, typeof ReferenceObjectSchema]>>>
+      headers: TOptional<TRecord<TString, TUnion<[typeof HeaderObjectSchema, typeof ReferenceObjectSchema]>>>
+      securitySchemes: TOptional<
+        TRecord<TString, TUnion<[typeof SecuritySchemeObjectSchema, typeof ReferenceObjectSchema]>>
+      >
+      links: TOptional<TRecord<TString, TUnion<[typeof LinkObjectSchema, typeof ReferenceObjectSchema]>>>
+      callbacks: TOptional<TRecord<TString, TUnion<[typeof CallbackObjectSchema, typeof ReferenceObjectSchema]>>>
+      pathItems: TOptional<TRecord<TString, typeof PathItemObjectSchema>>
+    }>,
+    typeof ExtensionsSchema,
+  ]
+>
+
 /** Holds a set of reusable objects for different aspects of the OAS. All objects defined within the Components Object will have no effect on the API unless they are explicitly referenced from outside the Components Object. */
-export const ComponentsObjectSchema = compose(
+export const ComponentsObjectSchema: ComponentsObjectSchemaType = compose(
   Type.Object({
     /** An object to hold reusable Schema Objects. */
     schemas: Type.Optional(Type.Record(Type.String(), SchemaObjectSchema)),

--- a/packages/workspace-store/src/schemas/v3.1/strict/path-item.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/path-item.ts
@@ -28,6 +28,12 @@ export const pathItemObjectSchemaBuilder = <O extends TSchema>(operation: O) =>
       delete: Type.Optional(operation),
       /** A definition of a PATCH operation on this path. */
       patch: Type.Optional(operation),
+      /** A definition of a CONNECT operation on this path. */
+      connect: Type.Optional(operation),
+      /** A definition of a OPTIONS operation on this path. */
+      options: Type.Optional(operation),
+      /** A definition of a HEAD operation on this path. */
+      head: Type.Optional(operation),
       /** A definition of a TRACE operation on this path. */
       trace: Type.Optional(operation),
       /** An alternative servers array to service all operations in this path. If a servers array is specified at the OpenAPI Object level, it will be overridden by this value. */


### PR DESCRIPTION
**Problem**

Currently, we were missing 2 http methods from the spec (head, options) and connect which we also support but isn't in the spec yet.

**Solution**

With this PR we simply add those 3 methods, however this put our generated type complexity over the top so we had to annotate a few things. 

A real fix would be to remove compose or something similar, @DemonHa is on that case. But unblocks blocks (lol)

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
