### PR TITLE
feat(workspace-store): add persistence layer to workspace store

### DIFF
--- a/.changeset/cool-mice-approve.md
+++ b/.changeset/cool-mice-approve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': minor
+---
+
+feat(workspace-store) add persistence layer to workspace store

--- a/packages/workspace-store/README.md
+++ b/packages/workspace-store/README.md
@@ -354,3 +354,18 @@ store.workspace.documents['api'].info.title = 'Updated API Title'
 // This will restore the original title since we did not commit the changes yet
 store.revertDocumentChanges()
 ```
+
+### Workspace State Persistence
+
+The workspace store provides methods to persist and restore the complete workspace state, including all documents, configurations, and metadata. This is useful for saving work between sessions or sharing workspace configurations.
+
+```ts
+const client = createWorkspaceStore()
+// Get the current workspace state
+const currentWorkspaceState = client.export()
+
+// Persist on some kind of storage
+
+// Reload the workspace state
+client.loadWorkspace(currentWorkspaceState)
+```

--- a/packages/workspace-store/README.md
+++ b/packages/workspace-store/README.md
@@ -362,7 +362,7 @@ The workspace store provides methods to persist and restore the complete workspa
 ```ts
 const client = createWorkspaceStore()
 // Get the current workspace state
-const currentWorkspaceState = client.export()
+const currentWorkspaceState = client.exportWorkspace()
 
 // Persist on some kind of storage
 

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -962,7 +962,7 @@ describe('create-workspace-store', () => {
     })
   })
 
-  describe.only('loadWorkspace', () => {
+  describe('loadWorkspace', () => {
     it('should load the workspace from a json document', () => {
       const store = createWorkspaceStore()
 

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -898,7 +898,7 @@ describe('create-workspace-store', () => {
         },
       })
 
-      expect(store.export()).toBe(
+      expect(store.exportWorkspace()).toBe(
         JSON.stringify({
           documents: {
             default: {

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -845,4 +845,229 @@ describe('create-workspace-store', () => {
       )
     })
   })
+
+  describe('export', () => {
+    it('should export the workspace internal state as a json document', () => {
+      const store = createWorkspaceStore({
+        documents: [
+          {
+            name: 'default',
+            document: {
+              openapi: '3.0.0',
+              info: {
+                title: 'My API',
+                version: '1.0.0',
+              },
+            },
+            config: {
+              'x-scalar-reference-config': {
+                features: {
+                  showModels: false,
+                  showDownload: false,
+                },
+              },
+            },
+            meta: {
+              'x-scalar-active-server': 'server-1',
+            },
+          },
+        ],
+        meta: {
+          'x-scalar-active-document': 'default',
+          'x-scalar-dark-mode': true,
+          'x-scalar-default-client': 'curl',
+          'x-scalar-theme': 'saturn',
+        },
+      })
+
+      store.addDocumentSync({
+        name: 'pet-store',
+        document: {
+          openapi: '3.0.0',
+          info: {
+            title: 'Pet Store API',
+            version: '1.0.0',
+          },
+          paths: {
+            '/users': {
+              get: {
+                description: 'Get all users',
+              },
+            },
+          },
+        },
+      })
+
+      expect(store.export()).toBe(
+        JSON.stringify({
+          documents: {
+            default: {
+              openapi: '3.1.1',
+              info: { title: 'My API', version: '1.0.0' },
+              'x-scalar-navigation': [],
+              'x-scalar-active-server': 'server-1',
+            },
+            'pet-store': {
+              openapi: '3.1.1',
+              info: { title: 'Pet Store API', version: '1.0.0' },
+              paths: { '/users': { get: { description: 'Get all users' } } },
+              'x-scalar-navigation': [
+                {
+                  id: '',
+                  title: '/users',
+                  path: '/users',
+                  method: 'get',
+                  ref: '#/paths/~1users/get',
+                  type: 'operation',
+                },
+              ],
+            },
+          },
+          meta: {
+            'x-scalar-active-document': 'default',
+            'x-scalar-dark-mode': true,
+            'x-scalar-default-client': 'curl',
+            'x-scalar-theme': 'saturn',
+          },
+          documentConfigs: {
+            default: { 'x-scalar-reference-config': { 'features': { 'showModels': false, 'showDownload': false } } },
+            'pet-store': {},
+          },
+          originalDocuments: {
+            default: {
+              openapi: '3.1.1',
+              info: { title: 'My API', version: '1.0.0' },
+              'x-scalar-active-server': 'server-1',
+            },
+            'pet-store': {
+              openapi: '3.1.1',
+              info: { title: 'Pet Store API', version: '1.0.0' },
+              paths: { '/users': { get: { description: 'Get all users' } } },
+            },
+          },
+          intermediateDocuments: {
+            default: {
+              openapi: '3.1.1',
+              info: { title: 'My API', version: '1.0.0' },
+              'x-scalar-active-server': 'server-1',
+            },
+            'pet-store': {
+              openapi: '3.1.1',
+              info: { title: 'Pet Store API', version: '1.0.0' },
+              'paths': { '/users': { 'get': { 'description': 'Get all users' } } },
+            },
+          },
+        }),
+      )
+    })
+  })
+
+  describe.only('loadWorkspace', () => {
+    it('should load the workspace from a json document', () => {
+      const store = createWorkspaceStore()
+
+      // Load the workspace form a json document
+      store.loadWorkspace(
+        JSON.stringify({
+          documents: {
+            default: {
+              openapi: '3.1.1',
+              info: { title: 'My API', version: '1.0.0' },
+              'x-scalar-navigation': [],
+              'x-scalar-active-server': 'server-1',
+            },
+            'pet-store': {
+              openapi: '3.1.1',
+              info: { title: 'Pet Store API', version: '1.0.0' },
+              paths: { '/users': { get: { description: 'Get all users' } } },
+              'x-scalar-navigation': [
+                {
+                  id: '',
+                  title: '/users',
+                  path: '/users',
+                  method: 'get',
+                  ref: '#/paths/~1users/get',
+                  type: 'operation',
+                },
+              ],
+            },
+          },
+          meta: {
+            'x-scalar-active-document': 'default',
+            'x-scalar-dark-mode': true,
+            'x-scalar-default-client': 'curl',
+            'x-scalar-theme': 'saturn',
+          },
+          documentConfigs: {
+            default: { 'x-scalar-reference-config': { 'features': { 'showModels': false, 'showDownload': false } } },
+            'pet-store': {},
+          },
+          originalDocuments: {
+            default: {
+              openapi: '3.1.1',
+              info: { title: 'My API', version: '1.0.0' },
+              'x-scalar-active-server': 'server-1',
+            },
+            'pet-store': {
+              openapi: '3.1.1',
+              info: { title: 'Pet Store API', version: '1.0.0' },
+              paths: { '/users': { get: { description: 'Get all users' } } },
+            },
+          },
+          intermediateDocuments: {
+            default: {
+              openapi: '3.1.1',
+              info: { title: 'My API', version: '1.0.0' },
+              'x-scalar-active-server': 'server-1',
+            },
+            'pet-store': {
+              openapi: '3.1.1',
+              info: { title: 'Pet Store API', version: '1.0.0' },
+              'paths': { '/users': { 'get': { 'description': 'Get all users' } } },
+            },
+          },
+        }),
+      )
+
+      // Should have loaded the workspace correctly
+      expect(store.workspace.activeDocument).toEqual({
+        openapi: '3.1.1',
+        info: { title: 'My API', version: '1.0.0' },
+        'x-scalar-navigation': [],
+        'x-scalar-active-server': 'server-1',
+      })
+
+      expect(store.config['x-scalar-reference-config'].features.showModels).toBe(false)
+      expect(store.config['x-scalar-reference-config'].features.showDownload).toBe(false)
+
+      expect(store.workspace.documents).toEqual({
+        default: {
+          openapi: '3.1.1',
+          info: { title: 'My API', version: '1.0.0' },
+          'x-scalar-navigation': [],
+          'x-scalar-active-server': 'server-1',
+        },
+        'pet-store': {
+          openapi: '3.1.1',
+          info: { title: 'Pet Store API', version: '1.0.0' },
+          paths: { '/users': { get: { description: 'Get all users' } } },
+          'x-scalar-navigation': [
+            {
+              id: '',
+              title: '/users',
+              path: '/users',
+              method: 'get',
+              ref: '#/paths/~1users/get',
+              type: 'operation',
+            },
+          ],
+        },
+      })
+
+      expect(store.workspace['x-scalar-theme']).toBe('saturn')
+      expect(store.workspace['x-scalar-dark-mode']).toBe(true)
+      expect(store.workspace['x-scalar-active-document']).toBe('default')
+      expect(store.workspace['x-scalar-default-client']).toBe('curl')
+    })
+  })
 })

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -17,7 +17,6 @@ import { OpenAPIDocumentSchema } from '@/schemas/v3.1/strict/openapi-document'
 import { defaultReferenceConfig } from '@/schemas/reference-config'
 import type { Config } from '@/schemas/workspace-specification/config'
 import { InMemoryWorkspaceSchema, type InMemoryWorkspace } from '@/schemas/inmemory-workspace'
-import { Value } from '@sinclair/typebox/value'
 
 /**
  * Input type for workspace document metadata and configuration.
@@ -521,7 +520,7 @@ export function createWorkspaceStore(workspaceProps?: WorkspaceProps) {
      * @param input - The serialized workspace JSON string to import.
      */
     loadWorkspace(input: string) {
-      const result = Value.Parse(InMemoryWorkspaceSchema, input)
+      const result = coerceValue(InMemoryWorkspaceSchema, JSON.parse(input))
 
       // Assign the magic proxy to the documents
       safeAssign(

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -490,7 +490,7 @@ export function createWorkspaceStore(workspaceProps?: WorkspaceProps) {
      * can be imported later to fully restore the workspace to this exact state, including all documents
      * and their configurations.
      *
-     * @returns {string} A JSON string representing the complete workspace state.
+     * @returns A JSON string representing the complete workspace state.
      */
     export() {
       return JSON.stringify({

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -6,7 +6,7 @@ import { fetchUrls } from '@scalar/openapi-parser/plugins-browser'
 import { createNavigation, type createNavigationOptions } from '@/navigation'
 import type { DeepTransform } from '@/types'
 import { createMagicProxy, getRaw } from '@/helpers/proxy'
-import { deepClone, isObject } from '@/helpers/general'
+import { deepClone, isObject, safeAssign } from '@/helpers/general'
 import { mergeObjects } from '@/helpers/merge-object'
 import { applySelectiveUpdates } from '@/helpers/apply-selective-updates'
 import { getValueByPath } from '@/helpers/json-path-utils'
@@ -16,6 +16,8 @@ import { coerceValue } from '@/schemas/typebox-coerce'
 import { OpenAPIDocumentSchema } from '@/schemas/v3.1/strict/openapi-document'
 import { defaultReferenceConfig } from '@/schemas/reference-config'
 import type { Config } from '@/schemas/workspace-specification/config'
+import { InMemoryWorkspaceSchema, type InMemoryWorkspace } from '@/schemas/inmemory-workspace'
+import { Value } from '@sinclair/typebox/value'
 
 /**
  * Input type for workspace document metadata and configuration.
@@ -480,6 +482,57 @@ export function createWorkspaceStore(workspaceProps?: WorkspaceProps) {
     commitDocument(documentName: string) {
       // TODO: Implement commit logic
       console.warn(`Commit operation for document '${documentName}' is not implemented yet.`)
+    },
+    /**
+     * Serializes the current workspace state to a JSON string for backup, persistence, or sharing.
+     *
+     * This method exports all workspace documents (removing Vue reactivity proxies), workspace metadata,
+     * document configurations, and both the original and intermediate document states. The resulting JSON
+     * can be imported later to fully restore the workspace to this exact state, including all documents
+     * and their configurations.
+     *
+     * @returns {string} A JSON string representing the complete workspace state.
+     */
+    export() {
+      return JSON.stringify({
+        documents: {
+          ...Object.fromEntries(
+            Object.entries(workspace.documents).map(([name, doc]) => [
+              name,
+              // Extract the raw document data for export, removing any Vue reactivity wrappers.
+              // When importing, the document can be wrapped again in a magic proxy.
+              toRaw(getRaw(doc)),
+            ]),
+          ),
+        },
+        meta: workspaceProps?.meta ?? {},
+        documentConfigs,
+        originalDocuments,
+        intermediateDocuments,
+      } as InMemoryWorkspace)
+    },
+    /**
+     * Imports a workspace from a serialized JSON string.
+     *
+     * This method parses the input string using the InMemoryWorkspaceSchema,
+     * then updates the current workspace state, including documents, metadata,
+     * and configuration, with the imported values.
+     *
+     * @param input - The serialized workspace JSON string to import.
+     */
+    loadWorkspace(input: string) {
+      const result = Value.Parse(InMemoryWorkspaceSchema, input)
+
+      // Assign the magic proxy to the documents
+      safeAssign(
+        workspace.documents,
+        Object.fromEntries(Object.entries(result.documents).map(([name, doc]) => [name, createMagicProxy(doc)])),
+      )
+
+      safeAssign(originalDocuments, result.originalDocuments)
+      safeAssign(intermediateDocuments, result.intermediateDocuments)
+      safeAssign(documentConfigs, result.documentConfigs)
+      safeAssign(workspace, result.meta)
     },
   }
 }

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -128,7 +128,7 @@ export type WorkspaceStore = {
   /** Similar to addDocument but requires and in-mem object to be provided and loads the document synchronously */
   addDocumentSync(input: ObjectDoc): void
   /** Returns the merged configuration for the active document */
-  readonly config: Config
+  readonly config: typeof defaultConfig
   /** Downloads the specified document in the requested format */
   exportDocument(documentName: string, format: 'json' | 'yaml'): string | undefined
   /** Persists the current state of the specified document back to the original documents map */
@@ -137,6 +137,10 @@ export type WorkspaceStore = {
   revertDocumentChanges(documentName: string): void
   /** Commits the specified document */
   commitDocument(documentName: string): void
+  /** Serializes the current workspace state to a JSON string for backup, persistence, or sharing. */
+  exportWorkspace(): string
+  /** Imports a workspace from a serialized JSON string. */
+  loadWorkspace(input: string): void
 }
 
 /**

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -492,7 +492,7 @@ export function createWorkspaceStore(workspaceProps?: WorkspaceProps) {
      *
      * @returns A JSON string representing the complete workspace state.
      */
-    export() {
+    exportWorkspace() {
       return JSON.stringify({
         documents: {
           ...Object.fromEntries(

--- a/packages/workspace-store/src/helpers/general.ts
+++ b/packages/workspace-store/src/helpers/general.ts
@@ -77,6 +77,30 @@ export const split = <T>(array: T[], condition: (element: T) => boolean) => {
   )
 }
 
+/**
+ * Safely assigns properties from a source object to a target object.
+ *
+ * This function uses Object.assign to copy enumerable properties from the source object
+ * to the target object. It's a type-safe wrapper around Object.assign that ensures
+ * the source object is compatible with the target object's type.
+ *
+ * @param target - The target object to assign properties to
+ * @param source - The source object containing properties to assign
+ * @template T - The type of the target object
+ *
+ * @example
+ * ```ts
+ * const target = { name: 'John', age: 30 }
+ * const source = { age: 31, city: 'New York' }
+ * safeAssign(target, source)
+ * // target is now: { name: 'John', age: 31, city: 'New York' }
+ *
+ * const config = { theme: 'dark', language: 'en' }
+ * const updates = { theme: 'light' }
+ * safeAssign(config, updates)
+ * // config is now: { theme: 'light', language: 'en' }
+ * ```
+ */
 export const safeAssign = <T extends Record<string, unknown>>(target: T, source: Partial<T>) => {
   Object.assign(target, source)
 }

--- a/packages/workspace-store/src/helpers/general.ts
+++ b/packages/workspace-store/src/helpers/general.ts
@@ -76,3 +76,7 @@ export const split = <T>(array: T[], condition: (element: T) => boolean) => {
     [[], []],
   )
 }
+
+export const safeAssign = <T extends Record<string, unknown>>(target: T, source: Partial<T>) => {
+  Object.assign(target, source)
+}

--- a/packages/workspace-store/src/navigation/helpers/get-tag.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/get-tag.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { getTag } from './get-tag'
-import type { TraversedEntry } from '@/navigation/types'
 import type { TagObject } from '@/schemas/v3.1/strict/tag'
+import type { TraversedEntry } from '@/schemas/navigation'
 
 describe('getTag', () => {
   it('returns existing tag from the dictionary', () => {

--- a/packages/workspace-store/src/navigation/helpers/traverse-description.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-description.ts
@@ -1,5 +1,6 @@
 import { getHeadingsFromMarkdown, getLowestHeadingLevel } from '@/navigation/helpers/utils'
-import type { Heading, TraversedDescription } from '@/navigation/types'
+import type { Heading } from '@/navigation/types'
+import type { TraversedDescription } from '@/schemas/navigation'
 
 export const DEFAULT_INTRODUCTION_SLUG = 'introduction'
 

--- a/packages/workspace-store/src/navigation/helpers/traverse-document.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-document.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { traverseDocument } from './traverse-document'
-import type { TraversedTag, TraverseSpecOptions } from '@/navigation/types'
+import type { TraverseSpecOptions } from '@/navigation/types'
 import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
+import type { TraversedTag } from '@/schemas/navigation'
 
 describe('traverseDocument', () => {
   const mockOptions: TraverseSpecOptions = {

--- a/packages/workspace-store/src/navigation/helpers/traverse-document.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-document.ts
@@ -1,9 +1,10 @@
+import type { TraversedEntry } from '@/schemas/navigation'
 import { traverseDescription } from './traverse-description'
 import { traversePaths } from './traverse-paths'
 import { traverseSchemas } from './traverse-schemas'
 import { traverseTags } from './traverse-tags'
 import { traverseWebhooks } from './traverse-webhooks'
-import type { TagsMap, TraversedEntry, TraverseSpecOptions } from '@/navigation/types'
+import type { TagsMap, TraverseSpecOptions } from '@/navigation/types'
 import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 
 /**

--- a/packages/workspace-store/src/navigation/helpers/traverse-paths.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-paths.ts
@@ -1,11 +1,12 @@
 import { getTag } from './get-tag'
-import type { TagsMap, TraversedOperation, TraverseSpecOptions } from '@/navigation/types'
+import type { TagsMap, TraverseSpecOptions } from '@/navigation/types'
 import { escapeJsonPointer } from '@scalar/openapi-parser'
 import { isHttpMethod } from '@scalar/helpers/http/is-http-method'
 import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 import { isReference } from '@/schemas/v3.1/type-guard'
 import type { TagObject } from '@/schemas/v3.1/strict/tag'
 import type { OperationObject } from '@/schemas/v3.1/strict/path-operations'
+import type { TraversedOperation } from '@/schemas/navigation'
 
 /**
  * Creates a traversed operation entry from an OpenAPI operation object.

--- a/packages/workspace-store/src/navigation/helpers/traverse-schemas.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-schemas.ts
@@ -1,5 +1,6 @@
 import { getTag } from '@/navigation/helpers/get-tag'
-import type { TagsMap, TraversedSchema, TraverseSpecOptions } from '@/navigation/types'
+import type { TagsMap, TraverseSpecOptions } from '@/navigation/types'
+import type { TraversedSchema } from '@/schemas/navigation'
 import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 import type { TagObject } from '@/schemas/v3.1/strict/tag'
 

--- a/packages/workspace-store/src/navigation/helpers/traverse-tags.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-tags.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import type { TraversedEntry, TraversedOperation, TraversedTag } from '@/navigation/types'
+import type { TraversedEntry, TraversedOperation, TraversedTag } from '@/schemas/navigation'
 import { traverseTags } from './traverse-tags'
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'

--- a/packages/workspace-store/src/navigation/helpers/traverse-tags.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-tags.ts
@@ -1,7 +1,8 @@
 import type { TagObject } from '@/schemas/v3.1/strict/tag'
 import { getTag } from './get-tag'
-import type { TagsMap, TraversedEntry, TraversedTag, TraverseSpecOptions } from '@/navigation/types'
+import type { TagsMap, TraverseSpecOptions } from '@/navigation/types'
 import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
+import type { TraversedEntry, TraversedTag } from '@/schemas/navigation'
 
 type Options = Pick<TraverseSpecOptions, 'getTagId' | 'tagsSorter' | 'operationsSorter'>
 

--- a/packages/workspace-store/src/navigation/helpers/traverse-webhooks.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-webhooks.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { traverseWebhooks } from './traverse-webhooks'
-import type { TraversedEntry, TagsMap, TraverseSpecOptions } from '@/navigation/types'
+import type { TagsMap, TraverseSpecOptions } from '@/navigation/types'
 import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 import type { TagObject } from '@/schemas/v3.1/strict/tag'
+import type { TraversedEntry } from '@/schemas/navigation'
 
 describe('traverse-webhooks', () => {
   const mockGetWebhookId: TraverseSpecOptions['getWebhookId'] = (params, tag) => {

--- a/packages/workspace-store/src/navigation/helpers/traverse-webhooks.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-webhooks.ts
@@ -1,5 +1,6 @@
+import type { TraversedWebhook } from '@/schemas/navigation'
 import { getTag } from './get-tag'
-import type { TagsMap, TraversedWebhook, TraverseSpecOptions } from '@/navigation/types'
+import type { TagsMap, TraverseSpecOptions } from '@/navigation/types'
 import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 import type { OperationObject } from '@/schemas/v3.1/strict/path-operations'
 import type { TagObject } from '@/schemas/v3.1/strict/tag'

--- a/packages/workspace-store/src/navigation/types.ts
+++ b/packages/workspace-store/src/navigation/types.ts
@@ -1,59 +1,9 @@
+import type { TraversedEntry } from '@/schemas/navigation'
 import type { OperationObject } from '@/schemas/v3.1/strict/path-operations'
 import type { TagObject } from '@/schemas/v3.1/strict/tag'
 
 /** Map of tagNames and their entries */
 export type TagsMap = Map<string, { tag: TagObject; entries: TraversedEntry[] }>
-
-type TraverseEntryBase = {
-  type: 'text' | 'operation' | 'model' | 'tag' | 'webhook'
-  id: string
-  title: string
-}
-
-/** Description entry returned form traversing the document */
-export type TraversedDescription = TraverseEntryBase & {
-  type: 'text'
-  children?: TraverseEntryBase[]
-}
-
-/** Operation entry returned form traversing the document */
-export type TraversedOperation = TraverseEntryBase & {
-  type: 'operation'
-  ref: string
-  method: string
-  path: string
-}
-
-/** Model entry returned form traversing the document */
-export type TraversedSchema = TraverseEntryBase & {
-  type: 'model'
-  ref: string
-  name: string
-}
-
-/** Tag entry returned form traversing the document, includes tagGroups */
-export type TraversedTag = TraverseEntryBase & {
-  type: 'tag'
-  name: string
-  children?: TraversedEntry[]
-  isGroup: boolean
-}
-
-/** Webhook entry returned form traversing the document, basically the same as an operation but with name instead of path */
-export type TraversedWebhook = TraverseEntryBase & {
-  type: 'webhook'
-  ref: string
-  method: string
-  name: string
-}
-
-/** Entries returned form traversing the document */
-export type TraversedEntry =
-  | TraversedDescription
-  | TraversedOperation
-  | TraversedSchema
-  | TraversedTag
-  | TraversedWebhook
 
 type OperationSortValue = { method: string; path: string; ref: string }
 

--- a/packages/workspace-store/src/schemas/inmemory-workspace.ts
+++ b/packages/workspace-store/src/schemas/inmemory-workspace.ts
@@ -1,0 +1,13 @@
+import { WorkspaceDocumentSchema, WorkspaceMetaSchema } from '@/schemas/workspace'
+import { ConfigSchema } from '@/schemas/workspace-specification/config'
+import { Type, type Static } from '@sinclair/typebox'
+
+export const InMemoryWorkspaceSchema = Type.Object({
+  meta: WorkspaceMetaSchema,
+  documentConfigs: Type.Record(Type.String(), ConfigSchema),
+  documents: Type.Record(Type.String(), WorkspaceDocumentSchema),
+  originalDocuments: Type.Record(Type.String(), WorkspaceDocumentSchema),
+  intermediateDocuments: Type.Record(Type.String(), WorkspaceDocumentSchema),
+})
+
+export type InMemoryWorkspace = Static<typeof InMemoryWorkspaceSchema>

--- a/packages/workspace-store/src/schemas/navigation.ts
+++ b/packages/workspace-store/src/schemas/navigation.ts
@@ -1,0 +1,71 @@
+import { compose } from '@/schemas/compose'
+import { Type, type Static } from '@sinclair/typebox'
+
+export const NavigationBaseSchema = Type.Object({
+  type: Type.Union([
+    Type.Literal('text'),
+    Type.Literal('operation'),
+    Type.Literal('model'),
+    Type.Literal('tag'),
+    Type.Literal('webhook'),
+  ]),
+  id: Type.String(),
+  title: Type.String(),
+})
+
+export const TraversedDescriptionSchema = compose(
+  NavigationBaseSchema,
+  Type.Object({
+    type: Type.Literal('text'),
+    children: Type.Optional(Type.Array(NavigationBaseSchema)),
+  }),
+)
+
+export const TraversedOperationSchema = compose(
+  NavigationBaseSchema,
+  Type.Object({
+    type: Type.Literal('operation'),
+    ref: Type.String(),
+    method: Type.String(),
+    path: Type.String(),
+  }),
+)
+
+export const TraversedSchemaSchema = compose(
+  NavigationBaseSchema,
+  Type.Object({
+    type: Type.Literal('model'),
+    ref: Type.String(),
+    name: Type.String(),
+  }),
+)
+
+export const TraversedTagSchema = compose(
+  NavigationBaseSchema,
+  Type.Object({
+    type: Type.Literal('tag'),
+    name: Type.String(),
+    children: Type.Optional(Type.Array(NavigationBaseSchema)),
+    isGroup: Type.Boolean(),
+  }),
+)
+
+export const TraversedWebhookSchema = compose(
+  NavigationBaseSchema,
+  Type.Object({
+    type: Type.Literal('webhook'),
+    ref: Type.String(),
+    method: Type.String(),
+    name: Type.String(),
+  }),
+)
+
+export const TraversedEntrySchema = Type.Union([
+  TraversedDescriptionSchema,
+  TraversedOperationSchema,
+  TraversedSchemaSchema,
+  TraversedTagSchema,
+  TraversedWebhookSchema,
+])
+
+export type TraversedEntry = Static<typeof TraversedEntrySchema>

--- a/packages/workspace-store/src/schemas/v3.1/strict/openapi-document.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/openapi-document.ts
@@ -20,6 +20,8 @@ import { compose } from '@/schemas/compose'
 import { PathItemObjectSchema } from '@/schemas/v3.1/strict/path-operations'
 import { xScalarClientConfigEnvironmentsSchema } from '@/schemas/v3.1/strict/client-config-extensions/x-scalar-client-config-environments'
 import { xScalarClientConfigCookiesSchema } from '@/schemas/v3.1/strict/client-config-extensions/x-scalar-client-config-cookies'
+import { extensions } from '@/schemas/extensions'
+import { TraversedEntrySchema } from '@/schemas/navigation'
 
 const OpenApiExtensionsSchema = Type.Partial(
   Type.Object({
@@ -36,6 +38,7 @@ const OpenApiExtensionsSchema = Type.Partial(
     'x-scalar-client-config-icon': Type.String(),
     'x-scalar-client-config-environments': xScalarClientConfigEnvironmentsSchema,
     'x-scalar-client-config-cookies': xScalarClientConfigCookiesSchema,
+    [extensions.document.navigation]: Type.Array(TraversedEntrySchema),
   }),
 )
 

--- a/packages/workspace-store/src/server.ts
+++ b/packages/workspace-store/src/server.ts
@@ -12,7 +12,7 @@ import type { OperationObject } from '@/schemas/v3.1/strict/path-operations'
 import { fetchUrls, readFiles } from '@scalar/openapi-parser/plugins'
 import { coerceValue } from '@/schemas/typebox-coerce'
 import type { ComponentsObject } from '@/schemas/v3.1/strict/components'
-import type { TraversedEntry } from '@/navigation/types'
+import type { TraversedEntry } from '@/schemas/navigation'
 
 const DEFAULT_ASSETS_FOLDER = 'assets'
 export const WORKSPACE_FILE_NAME = 'scalar-workspace.json'


### PR DESCRIPTION
**Problem**
There is currently no way to persist the entire workspace state between sessions. This limits the ability to save work, share it, or restore it later.

**Solution**
This PR adds support for exporting the complete internal workspace state as a JSON-like string. This exported state can be saved externally and later reloaded to fully restore the workspace, enabling seamless state persistence and recovery across sessions.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
