### PR TITLE
fix(openapi-parser): applyChangesToDocument undefined type check

### DIFF
--- a/packages/openapi-parser/src/utils/upgrade-from-three-to-three-one.test.ts
+++ b/packages/openapi-parser/src/utils/upgrade-from-three-to-three-one.test.ts
@@ -96,6 +96,48 @@ describe('upgradeFromThreeToThreeOne', () => {
         type: ['string', 'null'],
       })
     })
+
+    it('migrates nullable types with properties', async () => {
+      const result = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/test': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'foobar',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        nullable: true,
+                        properties: {
+                          name: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(result.paths['/test'].get.responses['200'].content['application/json'].schema).toEqual({
+        nullable: true,
+        properties: {
+          name: {
+            type: 'string',
+          },
+        },
+      })
+    })
   })
 
   describe('exclusiveMinimum and exclusiveMaximum', () => {

--- a/packages/openapi-parser/src/utils/upgrade-from-three-to-three-one.ts
+++ b/packages/openapi-parser/src/utils/upgrade-from-three-to-three-one.ts
@@ -58,7 +58,7 @@ export function upgradeFromThreeToThreeOne(originalContent: UnknownObject) {
 
 const applyChangesToDocument = (schema: UnknownObject, path: string[]) => {
   // 1. Handle nullable types
-  if (schema.type !== 'undefined' && schema.nullable === true) {
+  if (schema.type !== undefined && schema.nullable === true) {
     schema.type = [schema.type, 'null']
     delete schema.nullable
   }


### PR DESCRIPTION
**Problem**

we are currently checking for the string 'undefined' within the applyChangesToDocument function instead of the value, which can lead to not setting schema type properly.

**Solution**

this pr updates the function to check the value is defined instead.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
