### PR TITLE
fix(api-reference): classic layout does not show request body

### DIFF
--- a/.changeset/shaggy-elephants-boil.md
+++ b/.changeset/shaggy-elephants-boil.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: classic layout does not show request body

--- a/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
+++ b/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
@@ -88,6 +88,7 @@ const contentTypeSelect = cva({
   <div
     v-else
     :class="contentTypeSelect({ dropdown: false })"
+    class="selected-content-type"
     tabindex="0">
     <span>{{ selectedContentType }}</span>
   </div>

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -66,7 +66,9 @@ const handleDiscriminatorChange = (type: string) => {
 }
 </script>
 <template>
-  <div v-if="requestBody">
+  <div
+    v-if="requestBody"
+    class="request-body">
     <div class="request-body-header">
       <span class="request-body-title">
         <slot name="title" />
@@ -125,11 +127,13 @@ const handleDiscriminatorChange = (type: string) => {
 </template>
 
 <style scoped>
+.request-body {
+  margin-top: 24px;
+}
 .request-body-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-top: 24px;
   padding-bottom: 12px;
   border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
   flex-flow: wrap;

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -132,7 +132,8 @@ const handleDiscriminatorChange = (type: string) => {
       <div class="operation-details-card">
         <div class="operation-details-card-item">
           <OperationParameters
-            :parameters="operation.parameters"
+            :parameters="operation?.parameters"
+            :requestBody="operation?.requestBody"
             :schemas="schemas"
             @update:modelValue="handleDiscriminatorChange" />
         </div>
@@ -325,5 +326,40 @@ const handleDiscriminatorChange = (type: string) => {
   line-height: 1.33;
   padding: 9px;
   margin: 0;
+}
+
+.operation-details-card :deep(.request-body-description) {
+  margin-top: 0;
+  padding: 9px 9px 0 9px;
+  border-top: 1px solid var(--scalar-border-color);
+}
+
+.operation-details-card :deep(.request-body) {
+  margin-top: 0;
+  border-radius: var(--scalar-radius-lg);
+  border: 1px solid var(--scalar-border-color);
+}
+
+.operation-details-card :deep(.request-body-header) {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.operation-details-card :deep(.contents button) {
+  margin-right: 9px;
+}
+
+.operation-details-card :deep(.request-body-schema > .schema-card) {
+  border-radius: var(--scalar-radius-lg);
+  border: 1px solid var(--scalar-border-color);
+  margin: 9px;
+}
+
+.operation-details-card :deep(.request-body-schema .property--level-0) {
+  padding: 0;
+}
+
+.operation-details-card :deep(.selected-content-type) {
+  margin-right: 9px;
 }
 </style>


### PR DESCRIPTION
**Problem**

The classic layout does not show the request body anymore. We forgot to pass the relevant prop. 🤦 

See https://discord.com/channels/1135330207960678410/1391503347189682337

**Solution**

This PR renders the request body again. Turns out there were a bunch of style fixes needed to make it look good.

**Before**

Starts with responses …

<img width="931" alt="Screenshot 2025-07-07 at 15 03 29" src="https://github.com/user-attachments/assets/35a362db-56a4-40bf-b054-e27cf4d52e74" />

**After**

Shows the request body…

<img width="667" alt="Screenshot 2025-07-07 at 15 19 15" src="https://github.com/user-attachments/assets/d93cf98c-4d90-43e5-afe0-dfe45ab95c07" />

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
