### PR TITLE
fix(api-client): collection ui inconsistencies

### DIFF
--- a/.changeset/pink-files-compare.md
+++ b/.changeset/pink-files-compare.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates collection server form style

--- a/.changeset/violet-sheep-rescue.md
+++ b/.changeset/violet-sheep-rescue.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: updates collection form style inconsistencies

--- a/.changeset/warm-falcons-remember.md
+++ b/.changeset/warm-falcons-remember.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: updates scalar toggle background and width

--- a/packages/api-client/src/components/Form/Form.vue
+++ b/packages/api-client/src/components/Form/Form.vue
@@ -29,7 +29,7 @@ const { activeEnvVariables, activeEnvironment, activeWorkspace } =
 const id = useId()
 </script>
 <template>
-  <ViewLayoutSection class="rounded-b-lg">
+  <ViewLayoutSection class="last:rounded-b-lg">
     <template
       v-if="title || $slots.title"
       #title>

--- a/packages/api-client/src/components/Server/ServerVariablesSelect.vue
+++ b/packages/api-client/src/components/Server/ServerVariablesSelect.vue
@@ -32,7 +32,7 @@ const selected = computed<ScalarListboxOption | undefined>({
     :options="options">
     <ScalarButton
       :aria-controls="controls"
-      class="h-8 w-full p-0 py-1.5 font-normal"
+      class="h-8 p-0 py-1.5 font-normal"
       variant="ghost">
       <span :class="{ 'text-c-1': value }">
         <span

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -235,7 +235,7 @@ const openAuthCombobox = (event: Event) => {
 </script>
 <template>
   <ViewLayoutCollapse
-    class="group/params"
+    class="group/params relative"
     :itemCount="selectedSchemeOptions.length"
     :layout="layout"
     @update:modelValue="isViewLayoutOpen = $event">

--- a/packages/components/src/components/ScalarToggle/ScalarToggle.vue
+++ b/packages/components/src/components/ScalarToggle/ScalarToggle.vue
@@ -19,7 +19,7 @@ function toggle() {
 }
 
 const variants = cva({
-  base: 'relative h-3.5 w-6 cursor-pointer rounded-full bg-b-3 transition-colors duration-300',
+  base: 'relative h-3.5 min-w-6 w-6 cursor-pointer rounded-full bg-b-3 transition-colors duration-300',
   variants: {
     checked: { true: 'bg-c-accent' },
     disabled: { true: 'cursor-not-allowed opacity-40' },
@@ -35,7 +35,7 @@ const variants = cva({
     type="button"
     @click="toggle">
     <div
-      class="absolute left-px top-px flex h-3 w-3 items-center justify-center rounded-full bg-white text-c-accent transition-transform duration-300"
+      class="absolute left-px top-px flex h-3 w-3 items-center justify-center rounded-full bg-b-1 text-c-accent transition-transform duration-300"
       :class="{ 'translate-x-2.5': modelValue }" />
     <span
       v-if="label"


### PR DESCRIPTION
**Problem**

current api client collection setting pages contains few ui inconsistencies including forms, toggle, select position.

**Solution**

this pr updates the api client collection settings pages in order to fix them as seen below:


`auth`
| state | preview |
| -------|------|
| before | <img width="554" alt="image" src="https://github.com/user-attachments/assets/76cdc14e-3598-4da7-8ddd-6b2735e89a05" /> |
| after | <img width="554" alt="image" src="https://github.com/user-attachments/assets/21325f0f-8955-411c-ad3b-1d00878dbe9a" /> |

`form`
| state | preview |
| -------|------|
| before | <img width="554" alt="image" src="https://github.com/user-attachments/assets/94bb5d81-2e15-4db1-b7ca-054cc24efce4" /> |
| after | <img width="554" alt="image" src="https://github.com/user-attachments/assets/5fb6e6ba-e701-436e-b2f3-36f435a31c11" /> |

`toggle ui`
| state | preview |
| -------|------|
| before | <img width="554" alt="image" src="https://github.com/user-attachments/assets/99f85def-2e78-44f5-a8df-87234f0382b3" /> |
| after | <img width="554" alt="image" src="https://github.com/user-attachments/assets/0f41331f-2c13-4129-a8e6-cef520adf146" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
