### PR TITLE
fix(api-client): support path parameter matching in open() function

### DIFF
--- a/.changeset/yellow-jars-visit.md
+++ b/.changeset/yellow-jars-visit.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: allow client.open to use concrete paths

--- a/packages/api-client/src/libs/get-request-uid-by-path-method.ts
+++ b/packages/api-client/src/libs/get-request-uid-by-path-method.ts
@@ -1,4 +1,5 @@
 import type { OpenClientPayload } from '@/libs/create-client'
+import { findRequestByPathMethod } from '@/libs/find-request'
 import type { Operation } from '@scalar/oas-utils/entities/spec'
 
 /**
@@ -10,12 +11,30 @@ export const getRequestUidByPathMethod = (
 ) => {
   const { requestUid, method, path } = payload ?? {}
 
-  // Find the request from path + method
-  const resolvedRequestUid =
-    requestUid ||
-    Object.values(requests).find(
-      (item) => item.path.toLowerCase() === path?.toLowerCase() && item.method.toLowerCase() === method?.toLowerCase(),
-    )?.uid
+  // If requestUid is provided, return it directly
+  if (requestUid) {
+    return requestUid
+  }
 
-  return resolvedRequestUid || Object.keys(requests)[0]
+  // If no path or method provided, return first request uid
+  if (!path || !method) {
+    return Object.keys(requests)[0]
+  }
+
+  // Convert requests record to array for findRequestByPathMethod
+  const requestsArray = Object.values(requests)
+
+  // First try to find exact match (prioritize exact paths over pattern matches)
+  const exactMatch = requestsArray.find(
+    (item) => item.path.toLowerCase() === path.toLowerCase() && item.method.toLowerCase() === method.toLowerCase(),
+  )
+
+  if (exactMatch) {
+    return exactMatch.uid
+  }
+
+  // If no exact match, use pattern matching logic for path parameters
+  const { request } = findRequestByPathMethod(path, method, requestsArray)
+
+  return request?.uid || Object.keys(requests)[0]
 }

--- a/packages/api-client/src/libs/get-request-uid-by-path-method.ts
+++ b/packages/api-client/src/libs/get-request-uid-by-path-method.ts
@@ -16,6 +16,10 @@ export const getRequestUidByPathMethod = (
     return requestUid
   }
 
+  // In case theres no path or method provided, return the first
+  if (!path || !method) {
+    return Object.keys(requests)[0]
+  }
 
   // Convert requests record to array for findRequestByPathMethod
   const requestsArray = Object.values(requests)

--- a/packages/api-client/src/libs/get-request-uid-by-path-method.ts
+++ b/packages/api-client/src/libs/get-request-uid-by-path-method.ts
@@ -16,10 +16,6 @@ export const getRequestUidByPathMethod = (
     return requestUid
   }
 
-  // If no path or method provided, return first request uid
-  if (!path || !method) {
-    return Object.keys(requests)[0]
-  }
 
   // Convert requests record to array for findRequestByPathMethod
   const requestsArray = Object.values(requests)


### PR DESCRIPTION
Allow client.open() to match concrete paths against templated OpenAPI paths with parameters. Now supports matching '/foo/v3/bar/test' to '/foo/{version}/bar/{contentType}' while maintaining backward compatibility with exact path matching.

🤖 Generated with [Claude Code](https://claude.ai/code)

**Problem**

closes #5749
 
Currently, the client.open command doesn't work with filled in path paramerters.

**Solution**

With this PR we use pattern matching to allow filled in path parameters.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
