### PR TITLE
feat(Scalar.AspNetCore): return scalar endpoint group instead of endpoint

### DIFF
--- a/.changeset/wicked-insects-push.md
+++ b/.changeset/wicked-insects-push.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': minor
+---
+
+feat: return scalar endpoint group instead of endpoint

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -132,7 +132,7 @@ public static class ScalarEndpointRouteBuilderExtensions
         // Handle static assets
         scalarEndpointGroup.MapStaticAssetsEndpoint();
 
-        return scalarEndpointGroup.MapGet("/{documentName?}", (HttpContext httpContext, IOptionsSnapshot<ScalarOptions> optionsSnapshot, string? documentName) =>
+        scalarEndpointGroup.MapGet("/{documentName?}", (HttpContext httpContext, IOptionsSnapshot<ScalarOptions> optionsSnapshot, string? documentName) =>
         {
             if (ShouldRedirectToTrailingSlash(httpContext, documentName, out var redirectUrl))
             {
@@ -187,6 +187,8 @@ public static class ScalarEndpointRouteBuilderExtensions
                   </html>
                   """, "text/html");
         });
+
+        return scalarEndpointGroup;
     }
 
     /// <summary>


### PR DESCRIPTION
**Problem**

Currently, we return only one endpoint instead of the whole endpoint group.

**Solution**

With this PR, we return the endpoint group instead of one endpoint.

Closes #6182

**Note**

I _think_ this shouldn't cause any issue. I checked a couple of scenarios.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
