### PR TITLE
feat(code-highlight): updates markdown details style

### DIFF
--- a/.changeset/small-moles-guess.md
+++ b/.changeset/small-moles-guess.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+feat: updates markdown details component style

--- a/packages/code-highlight/src/css/markdown.css
+++ b/packages/code-highlight/src/css/markdown.css
@@ -258,46 +258,63 @@
   }
 
   .markdown summary {
-    background-color: var(--scalar-background-2);
-    border-radius: var(--scalar-radius);
+    border-radius: 2.5px;
     display: flex;
-    align-items: top;
-    height: 40px;
-    padding: 11px 0px 11px 37px;
+    align-items: flex-start;
+    gap: 10px;
+    min-height: 40px;
+    padding: 7px 14px;
     position: relative;
     font-weight: var(--scalar-semibold);
+    line-height: var(--markdown-line-height);
     cursor: pointer;
     user-select: none;
+  }
+
+  .markdown summary:hover {
+    background-color: var(--scalar-background-2);
   }
 
   .markdown details[open] {
     padding-bottom: var(--markdown-spacing-md);
   }
 
-  .markdown details[open] summary {
+  .markdown details[open] > summary {
     border-bottom: var(--markdown-border);
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
   }
 
-  .markdown summary::after {
+  .markdown summary::before {
     display: block;
     content: "";
-    position: absolute;
-    top: calc(var(--markdown-spacing-sm) + 1px);
-    left: 10px;
+    flex-shrink: 0;
     width: var(--markdown-spacing-md);
     height: var(--markdown-spacing-md);
     background-color: var(--scalar-color-3);
-    mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 256 256"><path d="M184.49,136.49l-80,80a12,12,0,0,1-17-17L159,128,87.51,56.49a12,12,0,1,1,17-17l80,80A12,12,0,0,1,184.49,136.49Z"></path></svg>');
+    mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em"><path d="M181.66,133.66l-80,80a8,8,0,0,1-11.32-11.32L164.69,128,90.34,53.66a8,8,0,0,1,11.32-11.32l80,80A8,8,0,0,1,181.66,133.66Z"></path></svg>');
+    margin-top: 5px;
   }
 
-  .markdown summary:hover::after {
+  .markdown summary:hover::before {
     background-color: var(--scalar-color-1);
   }
 
-  .markdown details[open] summary::after {
+  .markdown details[open] > summary::before {
     transform: rotate(90deg);
+  }
+
+  .markdown details:has(+ details) {
+    border-bottom: 0;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    margin-bottom: 0;
+  }
+
+  .markdown details:has(+ details) + details,
+  .markdown details:has(+ details) + details > summary {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
   }
 
   /* Links */


### PR DESCRIPTION
**Solution**

this pr updates the markdown details component style to match behavior with static docs for sibling usage + enhance long content support.

| state | preview |
| -------|------|
| before | <img width="594" alt="image" src="https://github.com/user-attachments/assets/e870d4e4-4e16-490c-91fb-b1cab54d565e" /> |
| after | <img width="594" alt="image" src="https://github.com/user-attachments/assets/7fa52d83-72f7-45cd-8fdb-1d678ee3f461" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
