### PR TITLE
fix(components): scalar combobox options scroll on open

### DIFF
--- a/.changeset/tough-bugs-report.md
+++ b/.changeset/tough-bugs-report.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: rollback scalar combobox options timeout

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.test.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.test.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import ScalarCombobox from './ScalarCombobox.vue'
@@ -52,6 +52,8 @@ describe('ScalarCombobox', () => {
     })
 
     it('focuses the input when combobox is opened', async () => {
+      vi.useFakeTimers()
+
       const wrapper = mount(ScalarCombobox, {
         props: { options: singleOptions },
         slots: { default: '<button>Toggle</button>' },
@@ -59,12 +61,15 @@ describe('ScalarCombobox', () => {
       })
 
       await wrapper.find('button').trigger('click')
-      await nextTick()
+      // We use a time out to focus the input
+      await vi.runAllTimers()
 
       const input = wrapper.find('input[type="text"]')
       expect(input.element).toBe(document.activeElement)
 
       wrapper.unmount()
+
+      vi.useRealTimers()
     })
 
     it('closes combobox when tabbing out of the input', async () => {
@@ -190,17 +195,21 @@ describe('ScalarComboboxOptions', () => {
     })
 
     it('focuses the input when component is mounted', async () => {
+      vi.useFakeTimers()
+
       const wrapper = mount(ScalarComboboxOptions, {
         props: { options: singleOptions },
         attachTo: document.body,
       })
 
-      await nextTick()
+      await vi.runAllTimers()
 
       const input = wrapper.find('input[type="text"]')
       expect(input.element).toBe(document.activeElement)
 
       wrapper.unmount()
+
+      vi.useRealTimers()
     })
   })
 

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -131,11 +131,9 @@ function moveActive(dir: 1 | -1) {
 
 // Manual autofocus for the input
 const input = ref<HTMLInputElement | null>(null)
-onMounted(() => {
-  setTimeout(() => {
-    input.value?.focus()
-  }, 0)
-})
+
+// This must be a setTimeout to ensure there is no scroll jump. nextTick does not work here.
+onMounted(() => setTimeout(() => input.value?.focus(), 0))
 </script>
 <template>
   <div class="relative flex">

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -131,7 +131,11 @@ function moveActive(dir: 1 | -1) {
 
 // Manual autofocus for the input
 const input = ref<HTMLInputElement | null>(null)
-nextTick(() => input.value?.focus())
+onMounted(() => {
+  setTimeout(() => {
+    input.value?.focus()
+  }, 0)
+})
 </script>
 <template>
   <div class="relative flex">


### PR DESCRIPTION
**Problem**

Currently, the page jumps when you open a large combobox. It can be seen in:

https://github.com/scalar/scalar/pull/6191

**Solution**

With this PR we revert back to the timeout which does not cause a scroll (nextTick does).

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
