### PR TITLE
fix(api-client): do not use relative URL as a server URL

### DIFF
--- a/.changeset/gorgeous-berries-pump.md
+++ b/.changeset/gorgeous-berries-pump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: uses relative document URL as server URL

--- a/packages/oas-utils/src/transforms/import-spec.test.ts
+++ b/packages/oas-utils/src/transforms/import-spec.test.ts
@@ -1110,6 +1110,37 @@ describe('getServersFromOpenApiDocument', () => {
     expect(result.servers).toMatchObject([{ url: 'https://example.com' }])
   })
 
+  it('does not use a relative document URL as a server', async () => {
+    const originalLocation = typeof window !== 'undefined' ? window.location : { origin: undefined }
+    vi.stubGlobal('window', {
+      location: {
+        origin: 'http://localhost:1234',
+      },
+    })
+
+    const result = await importSpecToWorkspace(
+      {
+        // no servers defined
+      },
+      {
+        documentUrl: '/docs/openapi.json',
+      },
+    )
+
+    if (result.error) {
+      throw result.error
+    }
+
+    expect(result.servers).toMatchObject([
+      {
+        url: 'http://localhost:1234',
+      },
+    ])
+
+    // Restore the original window.location
+    vi.stubGlobal('location', originalLocation)
+  })
+
   it('prefixes relative servers with window.location.origin', async () => {
     const originalLocation = typeof window !== 'undefined' ? window.location : { origin: undefined }
     vi.stubGlobal('window', {

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -550,13 +550,13 @@ export async function importSpecToWorkspace(
  * Extracts the base URL (protocol + hostname) from a document URL.
  * Falls back to the original URL if it's not a valid URL.
  */
-function getBaseUrlFromDocumentUrl(documentUrl: string): string {
+function getBaseUrlFromDocumentUrl(documentUrl: string): string | undefined {
   try {
     const url = new URL(documentUrl)
     return `${url.protocol}//${url.hostname}`
   } catch {
-    // If the documentUrl is not a valid URL, fall back to using it as-is
-    return documentUrl
+    // If the documentUrl is not a valid URL, we can't use it
+    return undefined
   }
 }
 
@@ -572,7 +572,11 @@ export function getServersFromOpenApiDocument(
 ): Server[] {
   // If the document doesn't have any servers, try to use the documentUrl as the default server.
   if (!servers?.length && documentUrl) {
-    return [serverSchema.parse({ url: getBaseUrlFromDocumentUrl(documentUrl) })]
+    const newServerUrl = getBaseUrlFromDocumentUrl(documentUrl)
+
+    if (newServerUrl) {
+      return [serverSchema.parse({ url: newServerUrl })]
+    }
   }
 
   // If the servers are not an array, return an empty array.
@@ -596,7 +600,11 @@ export function getServersFromOpenApiDocument(
           }
 
           if (documentUrl) {
-            parsedSchema.url = combineUrlAndPath(getBaseUrlFromDocumentUrl(documentUrl), parsedSchema.url)
+            const baseUrl = getBaseUrlFromDocumentUrl(documentUrl)
+
+            if (baseUrl) {
+              parsedSchema.url = combineUrlAndPath(baseUrl, parsedSchema.url)
+            }
 
             return parsedSchema
           }


### PR DESCRIPTION
**Problem**

When a document without servers is imported from a relative URL, the relative URL is used as a server URL.

Which is not good.

![image](https://github.com/user-attachments/assets/7cef9fc2-d3e8-4eef-8c95-72d0593bed9b)

**Solution**

With this PR we won’t use relative document URLs as server fallbacks anymore.

Fixes #6192

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
