### PR TITLE
fix(api-reference): show description for expandable enum values

### DIFF
--- a/.changeset/gold-parents-tap.md
+++ b/.changeset/gold-parents-tap.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: show description for expandable enum values

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnumPropertyItem.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnumPropertyItem.vue
@@ -39,7 +39,7 @@ defineProps<{
 .property-enum-value-label {
   display: flex;
   font-family: var(--scalar-font-code);
-  color: var(--scalar-color-2);
+  color: var(--scalar-color-1);
   position: relative;
 }
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnumPropertyItem.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnumPropertyItem.vue
@@ -1,0 +1,92 @@
+<script lang="ts" setup>
+import { ScalarMarkdown } from '@scalar/components'
+
+defineProps<{
+  label: string
+  description?: string
+}>()
+</script>
+
+<template>
+  <li class="property-enum-value">
+    <div class="property-enum-value-content">
+      <span class="property-enum-value-label">{{ label }}</span>
+      <span
+        v-if="description"
+        class="property-enum-value-description">
+        <ScalarMarkdown :value="description" />
+      </span>
+    </div>
+  </li>
+</template>
+
+<style scoped>
+.property-enum-value {
+  color: var(--scalar-color-3);
+  line-height: 1.5;
+  word-break: break-word;
+  display: flex;
+  align-items: stretch;
+  position: relative;
+}
+
+.property-enum-value-content {
+  display: flex;
+  flex-direction: column;
+  padding: 3px 0;
+}
+
+.property-enum-value-label {
+  display: flex;
+  font-family: var(--scalar-font-code);
+  color: var(--scalar-color-2);
+  position: relative;
+}
+
+.property-enum-value:last-of-type .property-enum-value-label {
+  padding-bottom: 0;
+}
+
+.property-enum-value::before {
+  content: '';
+  margin-right: 12px;
+  width: var(--scalar-border-width);
+  display: block;
+  background: currentColor;
+  color: var(--scalar-color-3);
+}
+
+.property-enum-value:last-child::before {
+  height: 14px;
+}
+
+.property-enum-value:not(:last-child)::before {
+  content: '';
+  margin-right: 12px;
+  width: var(--scalar-border-width);
+  display: block;
+  background: currentColor;
+  color: var(--scalar-color-3);
+}
+
+.property-enum-value-label::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: -12px;
+  width: 8px;
+  height: var(--scalar-border-width);
+  background: currentColor;
+}
+
+.property-enum-value:last-of-type::after {
+  bottom: 0;
+  height: 50%;
+  background: var(--scalar-background-1);
+  border-top: var(--scalar-border-width) solid currentColor;
+}
+
+.property-enum-value-description {
+  color: var(--scalar-color-3);
+}
+</style>

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.test.ts
@@ -356,49 +356,6 @@ describe('SchemaEnumValues', () => {
       expect(wrapper.text()).toContain('Sixth description')
       expect(wrapper.text()).toContain('Tenth description')
     })
-
-    it('shows both varnames and descriptions for hidden values when expanded', async () => {
-      const wrapper = mount(SchemaEnumValues, {
-        props: {
-          value: {
-            enum: [100, 200, 300, 400, 500, 600, 700, 800],
-            'x-enum-varnames': [
-              'OK',
-              'Created',
-              'Accepted',
-              'NoContent',
-              'BadRequest',
-              'Unauthorized',
-              'Forbidden',
-              'NotFound',
-            ],
-            'x-enum-descriptions': [
-              'Success',
-              'Resource created',
-              'Request accepted',
-              'No content',
-              'Bad request',
-              'Not authorized',
-              'Access forbidden',
-              'Resource not found',
-            ],
-          },
-        },
-      })
-
-      // Initially only first 5 should be visible
-      expect(wrapper.text()).toContain('Bad request')
-      expect(wrapper.text()).not.toContain('600 = Unauthorized')
-
-      // Click show more
-      await wrapper.find('.enum-toggle-button').trigger('click')
-
-      // Now hidden varnames and descriptions should be visible
-      expect(wrapper.text()).toContain('600 = Unauthorized')
-      expect(wrapper.text()).toContain('Not authorized')
-      expect(wrapper.text()).toContain('800 = NotFound')
-      expect(wrapper.text()).toContain('Resource not found')
-    })
   })
 
   describe('edge cases', () => {

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.test.ts
@@ -322,6 +322,83 @@ describe('SchemaEnumValues', () => {
       expect(wrapper.text()).toContain('value5')
       expect(wrapper.find('.enum-toggle-button').exists()).toBe(true)
     })
+
+    it('shows descriptions for hidden enum values when expanded', async () => {
+      const wrapper = mount(SchemaEnumValues, {
+        props: {
+          value: {
+            enum: [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000],
+            'x-enum-descriptions': [
+              'First description',
+              'Second description',
+              'Third description',
+              'Fourth description',
+              'Fifth description',
+              'Sixth description',
+              'Seventh description',
+              'Eighth description',
+              'Ninth description',
+              'Tenth description',
+            ],
+          },
+        },
+      })
+
+      // Initially only first 5 descriptions should be visible
+      expect(wrapper.text()).toContain('First description')
+      expect(wrapper.text()).toContain('Fifth description')
+      expect(wrapper.text()).not.toContain('Sixth description')
+      expect(wrapper.text()).not.toContain('Tenth description')
+
+      await wrapper.find('.enum-toggle-button').trigger('click')
+
+      // Now hidden descriptions should be visible
+      expect(wrapper.text()).toContain('Sixth description')
+      expect(wrapper.text()).toContain('Tenth description')
+    })
+
+    it('shows both varnames and descriptions for hidden values when expanded', async () => {
+      const wrapper = mount(SchemaEnumValues, {
+        props: {
+          value: {
+            enum: [100, 200, 300, 400, 500, 600, 700, 800],
+            'x-enum-varnames': [
+              'OK',
+              'Created',
+              'Accepted',
+              'NoContent',
+              'BadRequest',
+              'Unauthorized',
+              'Forbidden',
+              'NotFound',
+            ],
+            'x-enum-descriptions': [
+              'Success',
+              'Resource created',
+              'Request accepted',
+              'No content',
+              'Bad request',
+              'Not authorized',
+              'Access forbidden',
+              'Resource not found',
+            ],
+          },
+        },
+      })
+
+      // Initially only first 5 should be visible
+      expect(wrapper.text()).toContain('Bad request')
+      expect(wrapper.text()).not.toContain('600 = Unauthorized')
+
+      // Click show more
+      await wrapper.find('.enum-toggle-button').trigger('click')
+
+      // Now hidden varnames and descriptions should be visible
+      expect(wrapper.text()).toContain('600 = Unauthorized')
+      expect(wrapper.text()).toContain('Not authorized')
+      expect(wrapper.text()).toContain('800 = NotFound')
+      expect(wrapper.text()).toContain('Resource not found')
+    })
   })
 
   describe('edge cases', () => {

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.test.ts
@@ -345,7 +345,6 @@ describe('SchemaEnumValues', () => {
       })
 
       // Initially only first 5 descriptions should be visible
-      expect(wrapper.text()).toContain('First description')
       expect(wrapper.text()).toContain('Fifth description')
       expect(wrapper.text()).not.toContain('Sixth description')
       expect(wrapper.text()).not.toContain('Tenth description')

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.test.ts
@@ -205,7 +205,7 @@ describe('SchemaEnumValues', () => {
       })
 
       // When x-enumDescriptions is an object, it uses the special description format
-      expect(wrapper.find('.property-list').exists()).toBe(true)
+      expect(wrapper.find('.property-enum-values').exists()).toBe(true)
       expect(wrapper.text()).toContain('active')
       expect(wrapper.text()).toContain('inactive')
     })

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.vue
@@ -208,14 +208,14 @@ const shouldRender = computed(() => hasEnumValues.value && !isDiscriminator)
               v-for="(enumValue, index) in hiddenEnumValues"
               :key="enumValue"
               class="property-enum-value">
-              <span class="property-enum-value-label">
-                {{
-                  formatEnumValueWithName(
-                    enumValue,
-                    initialVisibleCount + index,
-                  )
-                }}
-              </span>
+              <div class="property-enum-value-content">
+                <span class="property-enum-value-label">
+                  {{ formatEnumValueWithName(enumValue, index) }}
+                </span>
+                <span class="property-enum-value-description">
+                  <ScalarMarkdown :value="getEnumValueDescription(index)" />
+                </span>
+              </div>
             </li>
           </DisclosurePanel>
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.vue
@@ -210,10 +210,18 @@ const shouldRender = computed(() => hasEnumValues.value && !isDiscriminator)
               class="property-enum-value">
               <div class="property-enum-value-content">
                 <span class="property-enum-value-label">
-                  {{ formatEnumValueWithName(enumValue, index) }}
+                  {{
+                    formatEnumValueWithName(
+                      enumValue,
+                      initialVisibleCount + index,
+                    )
+                  }}
                 </span>
                 <span class="property-enum-value-description">
-                  <ScalarMarkdown :value="getEnumValueDescription(index)" />
+                  <ScalarMarkdown
+                    :value="
+                      getEnumValueDescription(initialVisibleCount + index)
+                    " />
                 </span>
               </div>
             </li>

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.vue
@@ -1,7 +1,9 @@
 <script lang="ts" setup>
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
+import { ScalarIcon } from '@scalar/components'
 import { computed } from 'vue'
+
+import SchemaEnumPropertyItem from './SchemaEnumPropertyItem.vue'
 
 const ENUM_DISPLAY_THRESHOLD = 9
 const INITIAL_VISIBLE_COUNT = 5
@@ -160,71 +162,42 @@ const shouldRender = computed(() => hasEnumValues.value && !isDiscriminator)
     v-if="shouldRender"
     class="property-enum">
     <!-- Key-value description format -->
-    <template v-if="shouldShowDescriptionsAsKeyValue">
-      <div class="property-list">
-        <div
+    <template v-if="isObjectFormat">
+      <ul class="property-enum-values">
+        <SchemaEnumPropertyItem
           v-for="(enumValue, index) in enumValues"
           :key="enumValue"
-          class="property">
-          <div class="property-heading">
-            <div class="property-name">{{ enumValue }}</div>
-          </div>
-          <div class="property-description">
-            <ScalarMarkdown
-              :value="
-                isObjectFormat
-                  ? getEnumValueDescriptionFromObject(enumValue)
-                  : getEnumValueDescription(index)
-              " />
-          </div>
-        </div>
-      </div>
+          :label="enumValue"
+          :description="
+            isObjectFormat
+              ? getEnumValueDescriptionFromObject(enumValue)
+              : getEnumValueDescription(index)
+          " />
+      </ul>
     </template>
 
     <!-- Standard enum list format -->
     <template v-else>
       <ul class="property-enum-values">
-        <!-- Initially visible enum values -->
-        <li
+        <SchemaEnumPropertyItem
           v-for="(enumValue, index) in visibleEnumValues"
           :key="enumValue"
-          class="property-enum-value">
-          <div class="property-enum-value-content">
-            <span class="property-enum-value-label">
-              {{ formatEnumValueWithName(enumValue, index) }}
-            </span>
-            <span class="property-enum-value-description">
-              <ScalarMarkdown :value="getEnumValueDescription(index)" />
-            </span>
-          </div>
-        </li>
+          :label="formatEnumValueWithName(enumValue, index)"
+          :description="getEnumValueDescription(index)" />
 
-        <!-- Expandable section for remaining values -->
         <Disclosure
           v-if="shouldUseLongListDisplay"
           v-slot="{ open }">
           <DisclosurePanel>
-            <li
+            <SchemaEnumPropertyItem
               v-for="(enumValue, index) in hiddenEnumValues"
               :key="enumValue"
-              class="property-enum-value">
-              <div class="property-enum-value-content">
-                <span class="property-enum-value-label">
-                  {{
-                    formatEnumValueWithName(
-                      enumValue,
-                      initialVisibleCount + index,
-                    )
-                  }}
-                </span>
-                <span class="property-enum-value-description">
-                  <ScalarMarkdown
-                    :value="
-                      getEnumValueDescription(initialVisibleCount + index)
-                    " />
-                </span>
-              </div>
-            </li>
+              :label="
+                formatEnumValueWithName(enumValue, initialVisibleCount + index)
+              "
+              :description="
+                getEnumValueDescription(initialVisibleCount + index)
+              " />
           </DisclosurePanel>
 
           <DisclosureButton class="enum-toggle-button">
@@ -252,62 +225,38 @@ const shouldRender = computed(() => hasEnumValues.value && !isDiscriminator)
   border-radius: var(--scalar-radius);
   margin-top: 10px;
 }
+
 .property-list .property:last-of-type {
   padding-bottom: 10px;
 }
 
-.property-enum-value {
-  color: var(--scalar-color-3);
-  line-height: 1.5;
-  word-break: break-word;
-  display: flex;
-  align-items: stretch;
-  position: relative;
-}
-
-.property-enum-value-content {
-  display: flex;
-  flex-direction: column;
-  padding: 3px 0;
-}
-
-.property-enum-value-label {
-  display: flex;
-  font-family: var(--scalar-font-code);
-  color: var(--scalar-color-2);
-}
-.property-enum-value:last-of-type .property-enum-value-label {
-  padding-bottom: 0;
-}
-.property-enum-value::before {
-  content: '';
-  margin-right: 12px;
-  width: var(--scalar-border-width);
-  display: block;
-  background: currentColor;
-  color: var(--scalar-color-3);
-}
-.property-enum-value:after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 0;
-  width: 8px;
-  height: var(--scalar-border-width);
-  background: currentColor;
-}
-.property-enum-value:last-of-type::after {
-  bottom: 0;
-  height: 50%;
-  background: var(--scalar-background-1);
-  border-top: var(--scalar-border-width) solid currentColor;
-}
 .property-enum-values {
-  margin-top: 8px;
+  font-size: var(--scalar-font-size-3);
   list-style: none;
+  margin-top: 8px;
 }
 
-.property-enum-value-description {
-  color: var(--scalar-color-3);
+.enum-toggle-button {
+  align-items: center;
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
+  border-radius: 13.5px;
+  cursor: pointer;
+  color: var(--scalar-color-2);
+  display: flex;
+  font-weight: var(--scalar-semibold);
+  font-size: var(--scalar-font-size-5);
+  gap: 4px;
+  margin-top: 8px;
+  padding: 6px;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.enum-toggle-button:hover {
+  color: var(--scalar-color-1);
+}
+
+.enum-toggle-button-icon--open {
+  transform: rotate(45deg);
 }
 </style>

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -265,7 +265,7 @@ describe('SchemaProperty sub-schema', () => {
       },
     })
 
-    const enumList = wrapper.find('.property-enum .property-list')
+    const enumList = wrapper.find('.property-enum .property-enum-values')
     const html = enumList.html()
 
     expect(html).toContain('Ice giant')

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -500,24 +500,4 @@ const shouldRenderObjectProperties = computed(() => {
   font-family: var(--scalar-font-code);
   font-weight: var(--scalar-semibold);
 }
-.enum-toggle-button {
-  align-items: center;
-  border: var(--scalar-border-width) solid var(--scalar-border-color);
-  border-radius: 13.5px;
-  cursor: pointer;
-  color: var(--scalar-color-2);
-  display: flex;
-  font-weight: var(--scalar-semibold);
-  gap: 4px;
-  margin-top: 8px;
-  padding: 6px 10px;
-  user-select: none;
-  white-space: nowrap;
-}
-.enum-toggle-button:hover {
-  color: var(--scalar-color-1);
-}
-.enum-toggle-button-icon--open {
-  transform: rotate(45deg);
-}
 </style>


### PR DESCRIPTION
**Problem**

Currently, enum descriptions are not displayed for expandable enum values in the API Reference.

**Solution**

`Before`:
![image](https://github.com/user-attachments/assets/5249925f-2616-4bb4-9016-86d635e3ed7d)

`After`:

<img width="515" alt="image" src="https://github.com/user-attachments/assets/389e3ddd-6420-4ae5-a675-6d5a32d179ca" />

Closes #6199

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
