### PR TITLE
feat(components): sidebar component follow up

### DIFF
--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -40,15 +40,14 @@ const variants = cva({
     'group/button flex items-stretch rounded px-2 font-sidebar text-c-2 no-underline',
   ],
   variants: {
-    selected: {
-      true: 'group/button-selected cursor-auto bg-b-2 text-c-1 font-sidebar-active',
-    },
+    active: { true: 'text-c-1 font-sidebar-active' },
     disabled: { true: 'cursor-auto' },
+    selected: { true: 'cursor-auto bg-b-2 text-c-1 font-sidebar-active' },
   },
   compoundVariants: [
     { selected: false, disabled: false, class: 'hover:bg-b-2' },
   ],
-  defaultVariants: { selected: false, disabled: false },
+  defaultVariants: { selected: false, disabled: false, active: false },
 })
 defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
@@ -58,7 +57,7 @@ const { cx } = useBindCx()
     :is="is"
     :aria-selected="selected"
     :type="is === 'button' ? 'button' : undefined"
-    v-bind="cx(variants({ selected, disabled }))">
+    v-bind="cx(variants({ selected, disabled, active }))">
     <slot name="indent">
       <ScalarSidebarIndent
         :indent

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroup.vue
@@ -54,6 +54,7 @@ const { cx } = useBindCx()
         class="group/group-button"
         :aria-expanded="open"
         :indent="level"
+        :active
         :selected
         :disabled
         :icon
@@ -81,11 +82,3 @@ const { cx } = useBindCx()
     </component>
   </li>
 </template>
-<style>
-@reference "../../style.css";
-
-/* Set the font weight and color of the button when a subitem is selected */
-.group\/item:has(.group\/button-selected) > .group\/group-button {
-  @apply font-sidebar-active text-c-1;
-}
-</style>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarGroupToggle.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarGroupToggle.vue
@@ -18,11 +18,7 @@ import type { Component } from 'vue'
 
 import { type Icon, ScalarIconLegacyAdapter } from '../ScalarIcon'
 
-const {
-  is = 'div',
-  open = false,
-  icon = ScalarIconCaretRight,
-} = defineProps<{
+const { is = 'div', open = false } = defineProps<{
   /** Override the element tag */
   is?: Component | string
   /** Whether or not the toggle is open */
@@ -39,7 +35,7 @@ defineSlots<{
 }>()
 
 const variants = cva({
-  base: 'size-4 transition-transform duration-100',
+  base: 'size-4 flex items-center justify-center transition-transform duration-100',
   variants: { open: { true: 'rotate-90' } },
   defaultVariants: { open: false },
 })
@@ -52,7 +48,13 @@ const { cx } = useBindCx()
     :type="is === 'button' ? 'button' : undefined"
     v-bind="cx(variants({ open }))">
     <slot :open="open">
-      <ScalarIconLegacyAdapter :icon="icon" />
+      <ScalarIconLegacyAdapter
+        v-if="icon"
+        :icon="icon" />
+      <ScalarIconCaretRight
+        class="size-3"
+        weight="bold"
+        v-else />
     </slot>
     <span class="sr-only">
       <slot

--- a/packages/components/src/components/ScalarSidebar/types.ts
+++ b/packages/components/src/components/ScalarSidebar/types.ts
@@ -10,8 +10,19 @@ export type ScalarSidebarItemProps = {
   is?: Component | string
   /** Sets the icon for the item */
   icon?: Icon | ScalarIconComponent
-  /** Wether or not the item is selected */
+  /**
+   * Wether or not the item is active
+   *
+   * Should be true if the item or any of its children are being displayed on the page
+   */
+  active?: boolean
+  /**
+   * Wether or not the item is selected
+   *
+   * Should be true if the item is being displayed on the page
+   */
   selected?: boolean
+  /** Wether or not the item is disabled */
   disabled?: boolean
   /** The level of the sidebar group */
   indent?: SidebarGroupLevel


### PR DESCRIPTION
Two small follow up updates:

1. Changes the toggle icon to be 12x12 instead of 16x16
2. Sets the nested group active style via prop instead of with CSS

For the active style it would be nice to be able to do it with just CSS but it means that the contents always need to be rendered (instead of unmounted with a v-if) which will probably be untenable for large sidebars with many children. Alternatively we could use a `v-show` instead of a `v-if` for the subitems if we're okay with large dom structures being there even if they aren't being rendered.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
