### PR TITLE
feat(api-reference): moves operation response property type to list item

### DIFF
--- a/.changeset/dry-onions-kneel.md
+++ b/.changeset/dry-onions-kneel.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: moves operation response property type to list item

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -44,6 +44,7 @@ const props = withDefaults(
     isDiscriminator?: boolean
     variant?: 'additionalProperties' | 'patternProperties'
     breadcrumb?: string[]
+    propertyHeading?: boolean
   }>(),
   {
     level: 0,
@@ -51,6 +52,7 @@ const props = withDefaults(
     compact: false,
     withExamples: true,
     hideModelNames: false,
+    propertyHeading: true,
   },
 )
 
@@ -238,7 +240,10 @@ const shouldHaveLink = computed(() => props.level <= 1)
       },
     ]">
     <SchemaPropertyHeading
-      v-if="displayPropertyHeading(optimizedValue, name, required)"
+      v-if="
+        displayPropertyHeading(optimizedValue, name, required) &&
+        propertyHeading
+      "
       :enum="getEnumFromValue(optimizedValue).length > 0"
       :required="required"
       :value="optimizedValue"

--- a/packages/api-reference/src/features/Operation/components/OperationResponses.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationResponses.vue
@@ -23,7 +23,8 @@ const { responses } = useResponses(props.responses)
     :collapsableItems="collapsableItems"
     :parameters="responses"
     :schemas="schemas"
-    :withExamples="false">
+    :withExamples="false"
+    :propertyHeading="false">
     <template #title>Responses</template>
   </ParameterList>
 </template>

--- a/packages/api-reference/src/features/Operation/components/ParameterList.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterList.vue
@@ -12,11 +12,13 @@ withDefaults(
     withExamples?: boolean
     schemas?: Record<string, OpenAPIV3_1.SchemaObject> | unknown
     breadcrumb?: string[]
+    propertyHeading?: boolean
   }>(),
   {
     showChildren: false,
     collapsableItems: false,
     withExamples: true,
+    propertyHeading: true,
   },
 )
 </script>
@@ -36,7 +38,8 @@ withDefaults(
         :parameter="item"
         :schemas="schemas"
         :showChildren="showChildren"
-        :withExamples="withExamples" />
+        :withExamples="withExamples"
+        :propertyHeading="propertyHeading" />
     </ul>
   </div>
 </template>

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -8,6 +8,7 @@ import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { computed, ref } from 'vue'
 
 import { SchemaProperty } from '@/components/Content/Schema'
+import SchemaPropertyHeading from '@/components/Content/Schema/SchemaPropertyHeading.vue'
 
 import ContentTypeSelect from './ContentTypeSelect.vue'
 import ParameterHeaders from './ParameterHeaders.vue'
@@ -22,11 +23,13 @@ const props = withDefaults(
     withExamples?: boolean
     schemas?: Record<string, OpenAPIV3_1.SchemaObject> | unknown
     breadcrumb?: string[]
+    propertyHeading?: boolean
   }>(),
   {
     showChildren: false,
     collapsableItems: false,
     withExamples: true,
+    propertyHeading: true,
   },
 )
 
@@ -84,6 +87,19 @@ const shouldShowParameter = computed(() => {
             v-if="parameter.description"
             class="markdown"
             :value="parameter.description" />
+          <SchemaPropertyHeading
+            :value="{
+              ...(parameter.content
+                ? parameter.content?.[selectedContentType]?.schema
+                : parameter.schema),
+              deprecated: parameter.deprecated,
+              ...(isDefined(parameter.example) && {
+                example: parameter.example,
+              }),
+            }"
+            :schemas="schemas"
+            :withExamples="false"
+            :hideModelNames="false" />
         </span>
       </DisclosureButton>
       <DisclosurePanel
@@ -115,6 +131,7 @@ const shouldShowParameter = computed(() => {
                 }
               : parameter.examples || parameter.schema?.examples,
           }"
+          :propertyHeading="propertyHeading"
           :withExamples="withExamples" />
       </DisclosurePanel>
     </Disclosure>
@@ -162,6 +179,8 @@ const shouldShowParameter = computed(() => {
 }
 
 .parameter-item-type {
+  display: flex;
+  align-items: center;
   font-size: var(--scalar-mini);
   color: var(--scalar-color-2);
   margin-right: 6px;
@@ -170,6 +189,12 @@ const shouldShowParameter = computed(() => {
   text-overflow: ellipsis;
   width: 100%;
   overflow: hidden;
+}
+
+.parameter-item-type:has(.property-detail) :deep(.property-heading)::before {
+  display: block;
+  content: '·';
+  margin: 0 0.5ch;
 }
 
 .parameter-item-trigger-open .parameter-item-type {


### PR DESCRIPTION
**Solution**

this pr hides the property name in the operation responses to make the information easier to grasp.

| state | preview |
| -------|------|
| before | <img width="569" height="264" alt="image" src="https://github.com/user-attachments/assets/3fa0f975-2b10-4267-99ba-87a7e586ac79" /> |
| after | <img width="569" height="253" alt="image" src="https://github.com/user-attachments/assets/200ae332-bfdb-456b-89d9-4fc02bb60bf4" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
