### PR TITLE
fix(oas-utils): include port in server URL

### DIFF
--- a/.changeset/soft-melons-turn.md
+++ b/.changeset/soft-melons-turn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: include port in server URL

--- a/packages/oas-utils/src/transforms/import-spec.ts
+++ b/packages/oas-utils/src/transforms/import-spec.ts
@@ -553,7 +553,7 @@ export async function importSpecToWorkspace(
 function getBaseUrlFromDocumentUrl(documentUrl: string): string | undefined {
   try {
     const url = new URL(documentUrl)
-    return `${url.protocol}//${url.hostname}`
+    return `${url.protocol}//${url.hostname}${url.port ? `:${url.port}` : ''}`
   } catch {
     // If the documentUrl is not a valid URL, we can't use it
     return undefined


### PR DESCRIPTION
**Problem**

Currently, the port is not considered when building the server URL.

**Solution**

Now the port will be appended if present.

Closes #6210

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
