### PR TITLE
feat(mock-server): update galaxy.scalar.com to use default theme

### DIFF
--- a/packages/mock-server/playground/README.md
+++ b/packages/mock-server/playground/README.md
@@ -1,0 +1,3 @@
+# Mock Server Playground
+
+This provides a playground for the mock server and also is hosted at [`galaxy.scalar.com`](https://galaxy.scalar.com).

--- a/packages/mock-server/playground/src/index.ts
+++ b/packages/mock-server/playground/src/index.ts
@@ -10,7 +10,7 @@ const port = process.env.PORT || 5052
 
 /**
  * Load the specification from the workspace.
- * We do not want a circular depedency as galaxy uses mock server for its playground
+ * We do not want a circular dependency as galaxy uses mock server for its playground
  */
 const specification = await fs.readFile('../galaxy/src/documents/3.1.yaml', 'utf8').catch(() => {
   console.error('[@scalar/mock-server] Missing @scalar/galaxy. Please build it and try again.')
@@ -31,6 +31,7 @@ app.get(
   '/',
   Scalar({
     pageTitle: 'Scalar Galaxy',
+
     sources: [
       {
         title: 'Scalar Galaxy',
@@ -41,6 +42,7 @@ app.get(
         url: 'https://petstore31.swagger.io/api/v31/openapi.json',
       },
     ],
+    theme: 'default',
     proxyUrl: 'https://proxy.scalar.com',
     baseServerURL: `http://localhost:${port}`,
   }),


### PR DESCRIPTION
Should update `galaxy.scalar.com` to use the default theme instead of the Hono theme.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
