### PR TITLE
fix(workspace-store): support local ref resolution on arrays

### DIFF
--- a/.changeset/shaggy-apricots-hope.md
+++ b/.changeset/shaggy-apricots-hope.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': minor
+---
+
+fix(workspace-store): support local ref resolution on arrays

--- a/packages/workspace-store/src/helpers/proxy.test.ts
+++ b/packages/workspace-store/src/helpers/proxy.test.ts
@@ -107,4 +107,39 @@ describe('createMagicProxy', () => {
       'x-original-ref': '#/a/b/c/d',
     })
   })
+
+  it('should resolve the references inside an array', () => {
+    const input = {
+      $defs: {
+        a: {
+          b: {
+            prop: 'hello',
+          },
+          c: {
+            someOtherProp: 'world',
+          },
+        },
+      },
+      a: {
+        b: [
+          {
+            $ref: '#/$defs/a/b',
+          },
+          {
+            $ref: '#/$defs/a/c',
+          },
+        ],
+      },
+    }
+
+    const result = createMagicProxy(input)
+    expect(JSON.stringify(result.a)).toEqual(
+      JSON.stringify({
+        'b': [
+          { 'prop': 'hello', 'x-original-ref': '#/$defs/a/b' },
+          { 'someOtherProp': 'world', 'x-original-ref': '#/$defs/a/c' },
+        ],
+      }),
+    )
+  })
 })

--- a/packages/workspace-store/src/helpers/proxy.ts
+++ b/packages/workspace-store/src/helpers/proxy.ts
@@ -15,9 +15,9 @@ export const TARGET_SYMBOL = Symbol('target')
  * @returns A proxy handler that automatically resolves $ref references
  */
 function createProxyHandler(
-  sourceDocument: UnknownObject,
-  resolvedProxyCache?: WeakMap<object, UnknownObject>,
-): ProxyHandler<UnknownObject> {
+  sourceDocument: UnknownObject | UnknownObject[],
+  resolvedProxyCache?: WeakMap<object, UnknownObject | UnknownObject[]>,
+): ProxyHandler<UnknownObject | UnknownObject[]> {
   return {
     get(target, property, receiver) {
       if (property === TARGET_SYMBOL) {
@@ -38,7 +38,7 @@ function createProxyHandler(
        *   - For all other objects: creates a proxy for lazy resolution
        */
       const deepResolveNestedRefs = (value: unknown, originalRef?: string) => {
-        if (!isObject(value)) {
+        if (!isObject(value) && !Array.isArray(value)) {
           return value
         }
 
@@ -172,12 +172,12 @@ function createProxyHandler(
  * // proxy1 and proxy2 are the same instance due to caching
  * console.log(proxy1 === proxy2) // true
  */
-export function createMagicProxy<T extends UnknownObject>(
+export function createMagicProxy<T extends UnknownObject | UnknownObject[]>(
   targetObject: T,
   sourceDocument: T = targetObject,
   resolvedProxyCache?: WeakMap<object, T>,
 ): T {
-  if (!isObject(targetObject)) {
+  if (!isObject(targetObject) && !Array.isArray(targetObject)) {
     return targetObject
   }
 


### PR DESCRIPTION
**Problem**

Currently, local $ref resolution does not work correctly when the $ref appears inside an array. This leads to incomplete or incorrect schema resolution in these cases.

**Solution**

This PR fixes the local $ref resolution logic to correctly handle $ref references nested within arrays, ensuring schemas are fully and accurately resolved regardless of their location.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
