### PR TITLE
fix(api-reference): request example payload doesn't change on discriminator updates

### DIFF
--- a/.changeset/spicy-monkeys-boil.md
+++ b/.changeset/spicy-monkeys-boil.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates example request selected type presence check for discriminator

--- a/packages/api-reference/src/features/example-request/ExampleRequest.vue
+++ b/packages/api-reference/src/features/example-request/ExampleRequest.vue
@@ -327,7 +327,11 @@ function updateHttpClient(value: string) {
 }
 
 /** Update the selected example and the operation ID */
-function handleExampleUpdate(value: string) {
+function handleExampleUpdate(value: string | undefined) {
+  if (!value) {
+    return
+  }
+
   selectedExampleKey.value = value
   operationId.value = operation.operationId
 
@@ -363,8 +367,8 @@ const handleDiscriminatorChange = (type: string) => {
   try {
     isUpdating.value = true
 
-    // Update the example with the selected type and merged properties
-    const example = requestExamples[operation.examples[0]]
+    // Update the example with the selected type and merged properties only if we have an example
+    const example = requestExamples[request?.examples?.[0] ?? '']
     if (example && exampleContext?.generateExampleValue) {
       // Generate the new example value
       const currentValue = example.body?.raw?.value


### PR DESCRIPTION
**Problem**

when updating discriminator the request example payload doesn't get updated accordingly as it used to.

**Solution**

this pr updates the request example discriminator change function to ensure get example from request vs operation.

**Testing**
<details>
<summary>OpenAPI Discriminator Object</summary>

```yaml
openapi: 3.0.3
info:
  title: Polymorphic Object Example
  version: 1.0.0

paths:
  /vehicle:
    post:
      summary: Submit a vehicle
      requestBody:
        required: true
        content:
          application/json:
            schema:
              $ref: "#/components/schemas/Vehicle"
      responses:
        '200':
          description: Vehicle submitted successfully

components:
  schemas:
    Vehicle:
      type: object
      required:
        - type
        - manufacturer
      properties:
        type:
          type: string
          description: Type of vehicle
        manufacturer:
          type: string
          description: Name of the manufacturer
      discriminator:
        propertyName: type
        mapping:
          car: '#/components/schemas/Car'
          truck: '#/components/schemas/Truck'

    Car:
      allOf:
        - $ref: '#/components/schemas/Vehicle'
        - type: object
          required:
            - number_of_doors
          properties:
            type:
              type: string
              enum: [car]
            number_of_doors:
              type: integer
              description: Number of doors

    Truck:
      allOf:
        - $ref: '#/components/schemas/Vehicle'
        - type: object
          required:
            - payload_capacity
          properties:
            type:
              type: string
              enum: [truck]
            payload_capacity:
              type: integer
              description: Maximum payload in kg

```
</details>

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
