### PR TITLE
fix(api-reference): enum values after element wrong color

### DIFF
--- a/.changeset/plenty-students-tie.md
+++ b/.changeset/plenty-students-tie.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: updates enum values style

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnumPropertyItem.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnumPropertyItem.vue
@@ -76,7 +76,7 @@ defineProps<{
   left: -12px;
   width: 8px;
   height: var(--scalar-border-width);
-  background: currentColor;
+  background: var(--scalar-color-2);
 }
 
 .property-enum-value:last-of-type::after {

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnumValues.vue
@@ -234,6 +234,7 @@ const shouldRender = computed(() => hasEnumValues.value && !isDiscriminator)
   font-size: var(--scalar-font-size-3);
   list-style: none;
   margin-top: 8px;
+  padding-left: 2px;
 }
 
 .enum-toggle-button {


### PR DESCRIPTION
**Solution**

#6208 introduced a small color glitch on after element within the enum values that this pr fixes.

| state | preview |
| -------|------|
| before | <img width="532" height="327" alt="image" src="https://github.com/user-attachments/assets/c845d1ca-f4ce-4131-b603-f3c7bc235c2d" /> |
| after | <img width="532" height="327" alt="image" src="https://github.com/user-attachments/assets/e4cacf8f-fdb4-4806-b8d6-5afd1ebbc443" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
