### PR TITLE
feat(api-reference):  lay groundwork for block implementation

### DIFF
--- a/.changeset/chilly-pants-buy.md
+++ b/.changeset/chilly-pants-buy.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-reference': patch
+---
+
+feat: lay the groundwork for the block implementation PR

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -18,6 +18,11 @@ defineProps<{
  * TODO: Reference config should set the appropriate workspace properties
  */
 const workspaceStore = createWorkspaceStore()
+
+if (typeof window !== 'undefined') {
+  // @ts-expect-error - For debugging purposes expose the store
+  window.dataDumpWorkspace = () => workspaceStore
+}
 </script>
 
 <template>

--- a/packages/api-reference/src/components/HttpMethod/HttpMethod.vue
+++ b/packages/api-reference/src/components/HttpMethod/HttpMethod.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { getHttpMethodInfo } from '@scalar/helpers/http/http-info'
+import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import { normalizeHttpMethod } from '@scalar/helpers/http/normalize-http-method'
-import type { OpenAPI } from '@scalar/openapi-types'
 import { computed, type Component } from 'vue'
 
 const props = defineProps<{
@@ -12,7 +12,7 @@ const props = defineProps<{
   /** Whether or not to abbreviated the slot content */
   short?: boolean
   /** The HTTP method to show */
-  method: OpenAPI.HttpMethod | string
+  method: HttpMethod | string
 }>()
 
 /** Grabs the method info object which contains abbreviation, color, and background color etc */

--- a/packages/api-reference/src/helpers/convert-security-scheme.test.ts
+++ b/packages/api-reference/src/helpers/convert-security-scheme.test.ts
@@ -1,0 +1,370 @@
+import { describe, expect, it } from 'vitest'
+import { securitySchemeSchema } from '@scalar/types/entities'
+
+import { convertSecurityScheme } from './convert-security-scheme'
+
+describe('convertSecurityScheme', () => {
+  describe('apiKey security scheme', () => {
+    it('converts apiKey scheme with value to include x-scalar-secret-token', () => {
+      const input = securitySchemeSchema.parse({
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'header',
+        uid: 'test-uid',
+        nameKey: 'apiKey',
+        value: 'secret-api-key-value',
+        description: 'API key for authentication',
+      })
+
+      const result = convertSecurityScheme(input)
+
+      expect(result).toEqual({
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'header',
+        uid: 'test-uid',
+        nameKey: 'apiKey',
+        value: 'secret-api-key-value',
+        description: 'API key for authentication',
+        'x-scalar-secret-token': 'secret-api-key-value',
+      })
+    })
+
+    it('converts apiKey scheme without description', () => {
+      const input = securitySchemeSchema.parse({
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'query',
+        uid: 'test-uid',
+        nameKey: 'apiKey',
+        value: 'secret-api-key-value',
+      })
+
+      const result = convertSecurityScheme(input)
+
+      expect(result).toEqual({
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'query',
+        uid: 'test-uid',
+        nameKey: 'apiKey',
+        value: 'secret-api-key-value',
+        'x-scalar-secret-token': 'secret-api-key-value',
+      })
+    })
+
+    it('converts apiKey scheme with empty value', () => {
+      const input = securitySchemeSchema.parse({
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'cookie',
+        uid: 'test-uid',
+        nameKey: 'apiKey',
+        value: '',
+      })
+
+      const result = convertSecurityScheme(input)
+
+      expect(result).toEqual({
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'cookie',
+        uid: 'test-uid',
+        nameKey: 'apiKey',
+        value: '',
+        'x-scalar-secret-token': '',
+      })
+    })
+  })
+
+  describe('http security scheme', () => {
+    it('converts http bearer scheme with all credentials', () => {
+      const input = securitySchemeSchema.parse({
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        uid: 'test-uid',
+        nameKey: 'httpBearer',
+        token: 'bearer-token-value',
+        username: 'test-user',
+        password: 'test-password',
+        description: 'Bearer token authentication',
+      })
+
+      const result = convertSecurityScheme(input)
+
+      expect(result).toEqual({
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        uid: 'test-uid',
+        nameKey: 'httpBearer',
+        token: 'bearer-token-value',
+        username: 'test-user',
+        password: 'test-password',
+        description: 'Bearer token authentication',
+        'x-scalar-secret-token': 'bearer-token-value',
+        'x-scalar-secret-username': 'test-user',
+        'x-scalar-secret-password': 'test-password',
+      })
+    })
+
+    it('converts http basic scheme with credentials', () => {
+      const input = securitySchemeSchema.parse({
+        type: 'http',
+        scheme: 'basic',
+        uid: 'test-uid',
+        nameKey: 'httpBasic',
+        token: 'basic-token-value',
+        username: 'admin',
+        password: 'secret123',
+      })
+
+      const result = convertSecurityScheme(input)
+
+      expect(result).toEqual({
+        type: 'http',
+        scheme: 'basic',
+        bearerFormat: 'JWT',
+        uid: 'test-uid',
+        nameKey: 'httpBasic',
+        token: 'basic-token-value',
+        username: 'admin',
+        password: 'secret123',
+        'x-scalar-secret-token': 'basic-token-value',
+        'x-scalar-secret-username': 'admin',
+        'x-scalar-secret-password': 'secret123',
+      })
+    })
+
+    it('converts http scheme with empty credentials', () => {
+      const input = securitySchemeSchema.parse({
+        type: 'http',
+        scheme: 'bearer',
+        uid: 'test-uid',
+        nameKey: 'httpBearer',
+        token: '',
+        username: '',
+        password: '',
+      })
+
+      const result = convertSecurityScheme(input)
+
+      expect(result).toEqual({
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        uid: 'test-uid',
+        nameKey: 'httpBearer',
+        token: '',
+        username: '',
+        password: '',
+        'x-scalar-secret-token': '',
+        'x-scalar-secret-username': '',
+        'x-scalar-secret-password': '',
+      })
+    })
+  })
+
+  describe('oauth2 security scheme', () => {
+    it('converts oauth2 scheme with implicit flow', () => {
+      const input = securitySchemeSchema.parse({
+        type: 'oauth2',
+        uid: 'test-uid',
+        nameKey: 'oauth2',
+        flows: {
+          implicit: {
+            type: 'implicit',
+            authorizationUrl: 'https://example.com/oauth/authorize',
+            refreshUrl: 'https://example.com/oauth/refresh',
+            scopes: {
+              'read:users': 'Read user information',
+              'write:users': 'Write user information',
+            },
+            selectedScopes: ['read:users'],
+            token: 'implicit-token-value',
+            'x-scalar-client-id': 'client-id',
+            'x-scalar-redirect-uri': 'https://app.example.com/callback',
+          },
+        },
+      })
+
+      const result = convertSecurityScheme(input)
+
+      expect(result).toEqual({
+        type: 'oauth2',
+        uid: 'test-uid',
+        nameKey: 'oauth2',
+        flows: {
+          implicit: {
+            type: 'implicit',
+            authorizationUrl: 'https://example.com/oauth/authorize',
+            refreshUrl: 'https://example.com/oauth/refresh',
+            scopes: {
+              'read:users': 'Read user information',
+              'write:users': 'Write user information',
+            },
+            selectedScopes: ['read:users'],
+            token: 'implicit-token-value',
+            'x-scalar-client-id': 'client-id',
+            'x-scalar-redirect-uri': 'https://app.example.com/callback',
+            'x-scalar-secret-token': 'implicit-token-value',
+          },
+        },
+      })
+    })
+
+    it('converts oauth2 scheme with multiple flows', () => {
+      const input = securitySchemeSchema.parse({
+        type: 'oauth2',
+        uid: 'test-uid',
+        nameKey: 'oauth2',
+        flows: {
+          authorizationCode: {
+            type: 'authorizationCode',
+            authorizationUrl: 'https://example.com/oauth/authorize',
+            tokenUrl: 'https://example.com/oauth/token',
+            refreshUrl: 'https://example.com/oauth/refresh',
+            scopes: {
+              'read:users': 'Read user information',
+            },
+            selectedScopes: ['read:users'],
+            token: 'auth-code-token-value',
+            'x-scalar-client-id': 'client-id',
+            'x-scalar-redirect-uri': 'https://app.example.com/callback',
+            clientSecret: 'client-secret',
+            'x-usePkce': 'no',
+          },
+          clientCredentials: {
+            type: 'clientCredentials',
+            tokenUrl: 'https://example.com/oauth/token',
+            refreshUrl: 'https://example.com/oauth/refresh',
+            scopes: {
+              'admin:all': 'Full admin access',
+            },
+            selectedScopes: ['admin:all'],
+            token: 'client-credentials-token-value',
+            'x-scalar-client-id': 'client-id',
+            clientSecret: 'client-secret',
+          },
+        },
+      })
+
+      const result = convertSecurityScheme(input)
+
+      expect(result).toEqual({
+        type: 'oauth2',
+        uid: 'test-uid',
+        nameKey: 'oauth2',
+        flows: {
+          authorizationCode: {
+            type: 'authorizationCode',
+            authorizationUrl: 'https://example.com/oauth/authorize',
+            tokenUrl: 'https://example.com/oauth/token',
+            refreshUrl: 'https://example.com/oauth/refresh',
+            scopes: {
+              'read:users': 'Read user information',
+            },
+            selectedScopes: ['read:users'],
+            token: 'auth-code-token-value',
+            'x-scalar-client-id': 'client-id',
+            'x-scalar-redirect-uri': 'https://app.example.com/callback',
+            clientSecret: 'client-secret',
+            'x-usePkce': 'no',
+            'x-scalar-secret-token': 'auth-code-token-value',
+          },
+          clientCredentials: {
+            type: 'clientCredentials',
+            tokenUrl: 'https://example.com/oauth/token',
+            refreshUrl: 'https://example.com/oauth/refresh',
+            scopes: {
+              'admin:all': 'Full admin access',
+            },
+            selectedScopes: ['admin:all'],
+            token: 'client-credentials-token-value',
+            'x-scalar-client-id': 'client-id',
+            clientSecret: 'client-secret',
+            'x-scalar-secret-token': 'client-credentials-token-value',
+          },
+        },
+      })
+    })
+
+    it('converts oauth2 scheme with empty flows', () => {
+      const input = securitySchemeSchema.parse({
+        type: 'oauth2',
+        uid: 'test-uid',
+        nameKey: 'oauth2',
+        flows: {},
+      })
+
+      const result = convertSecurityScheme(input)
+
+      expect(result).toEqual({
+        type: 'oauth2',
+        uid: 'test-uid',
+        nameKey: 'oauth2',
+        flows: {},
+      })
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles scheme with undefined optional properties', () => {
+      const input = securitySchemeSchema.parse({
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'header',
+        uid: 'test-uid',
+        nameKey: 'apiKey',
+        value: 'secret-value',
+        description: undefined,
+      })
+
+      const result = convertSecurityScheme(input)
+
+      expect(result).toEqual({
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'header',
+        uid: 'test-uid',
+        nameKey: 'apiKey',
+        value: 'secret-value',
+        description: undefined,
+        'x-scalar-secret-token': 'secret-value',
+      })
+    })
+
+    it('preserves all original properties when converting', () => {
+      const input = securitySchemeSchema.parse({
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        uid: 'test-uid',
+        nameKey: 'httpBearer',
+        token: 'bearer-token',
+        username: 'user',
+        password: 'pass',
+        description: 'Bearer authentication',
+      })
+
+      const result = convertSecurityScheme(input)
+
+      // Verify all original properties are preserved
+      expect(result.type).toBe('http')
+      expect((result as any).scheme).toBe('bearer')
+      expect((result as any).bearerFormat).toBe('JWT')
+      expect((result as any).uid).toBe('test-uid')
+      expect((result as any).nameKey).toBe('httpBearer')
+      expect((result as any).token).toBe('bearer-token')
+      expect((result as any).username).toBe('user')
+      expect((result as any).password).toBe('pass')
+      expect((result as any).description).toBe('Bearer authentication')
+
+      // Verify secret extensions are added
+      expect((result as any)['x-scalar-secret-token']).toBe('bearer-token')
+      expect((result as any)['x-scalar-secret-username']).toBe('user')
+      expect((result as any)['x-scalar-secret-password']).toBe('pass')
+    })
+  })
+})

--- a/packages/api-reference/src/helpers/convert-security-scheme.ts
+++ b/packages/api-reference/src/helpers/convert-security-scheme.ts
@@ -1,0 +1,47 @@
+import type { SecurityScheme } from '@scalar/oas-utils/entities/spec'
+import type { SecuritySchemeObject } from '@scalar/workspace-store/schemas/v3.1/strict/security-scheme'
+
+/**
+ * Convert the old security scheme to the new one with secret extensions
+ *
+ * Remove this once we are migrated to the workspace store
+ */
+export const convertSecurityScheme = (scheme: SecurityScheme): SecuritySchemeObject => {
+  // ApiKey
+  if (scheme.type === 'apiKey') {
+    return {
+      ...scheme,
+      'x-scalar-secret-token': scheme.value,
+    }
+  }
+
+  // HTTP
+  if (scheme.type === 'http') {
+    return {
+      ...scheme,
+      'x-scalar-secret-token': scheme.token,
+      'x-scalar-secret-username': scheme.username,
+      'x-scalar-secret-password': scheme.password,
+    }
+  }
+
+  // OAuth2
+  if (scheme.type === 'oauth2') {
+    return {
+      ...scheme,
+      flows: Object.fromEntries(
+        Object.entries(scheme.flows).map(([flowKey, flow]) => [
+          flowKey,
+          flow
+            ? {
+                ...flow,
+                'x-scalar-secret-token': flow.token,
+              }
+            : flow,
+        ]),
+      ),
+    }
+  }
+
+  return scheme
+}

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
@@ -45,6 +45,7 @@ import {
   useMultipleDocuments,
 } from '@/features/multiple-documents'
 import { NAV_STATE_SYMBOL } from '@/hooks/useNavState'
+import { isClient } from '@/v2/blocks/scalar-request-example-block/helpers/find-client'
 import { onCustomEvent } from '@/v2/events'
 
 const props = defineProps<{
@@ -184,23 +185,23 @@ onMounted(() => {
 // })
 
 onCustomEvent(root, 'scalar-update-dark-mode', (event) => {
-  store.update('x-scalar-dark-mode', event.data.value)
+  store.update('x-scalar-dark-mode', event.detail.value)
 })
 
 onCustomEvent(root, 'scalar-update-active-document', (event) => {
-  store.update('x-scalar-active-document', event.data.value)
+  store.update('x-scalar-active-document', event.detail.value)
 })
 
 onCustomEvent(root, 'scalar-update-selected-client', (event) => {
-  store.update('x-scalar-default-client', event.data)
-  safeLocalStorage().setItem(REFERENCE_LS_KEYS.SELECTED_CLIENT, event.data)
+  store.update('x-scalar-default-client', event.detail)
+  safeLocalStorage().setItem(REFERENCE_LS_KEYS.SELECTED_CLIENT, event.detail)
 })
 
 onMounted(() => {
   const storedClient = safeLocalStorage().getItem(
     REFERENCE_LS_KEYS.SELECTED_CLIENT,
   )
-  if (storedClient) {
+  if (isClient(storedClient)) {
     store.update('x-scalar-default-client', storedClient)
   }
 })

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/ExamplePicker.test.ts
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/ExamplePicker.test.ts
@@ -98,14 +98,8 @@ describe('ExamplePicker', () => {
       },
     })
 
-    // Access the component instance to test the getLabel method
-    const vm = wrapper.vm as any
-
     // Test with null key
-    expect(vm.getLabel(null)).toBe('Select an example')
-
-    // Test with undefined key
-    expect(vm.getLabel(undefined)).toBe('Select an example')
+    expect(wrapper.vm.getLabel(null)).toBe('Select an example')
   })
 
   it('updates selected example when model value changes', async () => {
@@ -150,8 +144,7 @@ describe('ExamplePicker', () => {
 
     // Verify the selectExample method was called with the correct option
     // This tests the internal logic of the component
-    const vm = wrapper.vm as any
-    expect(vm.selectedExampleKey).toBe('example-2')
+    expect(wrapper.vm.selectedExampleKey).toBe('example-2')
   })
 
   it('handles examples with special characters in keys', () => {
@@ -195,7 +188,7 @@ describe('ExamplePicker', () => {
       },
     })
 
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm
 
     // Test when an example is selected
     vm.selectedExampleKey = 'example-1'

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/ExamplePicker.vue
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/ExamplePicker.vue
@@ -44,6 +44,13 @@ const getLabel = (key: string | null) => {
 const selectExample = (option: ScalarComboboxOption) => {
   selectedExampleKey.value = option.id
 }
+
+// For testing
+defineExpose({
+  getLabel,
+  selectedExample,
+  selectedExampleKey,
+})
 </script>
 
 <template>

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/helpers/find-client.ts
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/helpers/find-client.ts
@@ -1,7 +1,10 @@
 import type { ClientOption, ClientOptionGroup } from '@/v2/blocks/scalar-request-example-block/types'
-import type { AvailableClients } from '@scalar/snippetz'
+import { AVAILABLE_CLIENTS, type AvailableClients } from '@scalar/snippetz'
 
 const DEFAULT_CLIENT = 'shell/curl'
+
+/** Type guard to check if a string is a valid client id */
+export const isClient = (id: any): id is AvailableClients[number] => AVAILABLE_CLIENTS.includes(id)
 
 /**
  * Finds and returns the appropriate client option from a list of client option groups.

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/index.ts
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/index.ts
@@ -1,1 +1,2 @@
 export { default as RequestExample } from './components/RequestExample.vue'
+export { default as ExamplePicker } from './components/ExamplePicker.vue'

--- a/packages/api-reference/src/v2/events/definitions.ts
+++ b/packages/api-reference/src/v2/events/definitions.ts
@@ -7,27 +7,27 @@ import type { AvailableClients } from '@scalar/snippetz'
  */
 export type ApiReferenceEvents = {
   'scalar-update-sidebar': {
-    data: {
+    detail: {
       value: boolean
     }
   }
   'scalar-update-dark-mode': {
-    data: {
+    detail: {
       value: boolean
     }
   }
   'scalar-update-active-document': {
-    data: {
+    detail: {
       value: string
     }
   }
   /** Controls the selected client in our code example blocks */
   'scalar-update-selected-client': {
-    data: AvailableClients[number]
+    detail: AvailableClients[number]
   }
   /** Controls the selected example key in our operation blocks + children */
   'scalar-update-selected-example': {
-    data: string
+    detail: string
   }
 }
 
@@ -41,9 +41,9 @@ export type ApiReferenceEvent = Prettify<keyof ApiReferenceEvents>
 export function emitCustomEvent<E extends ApiReferenceEvent>(
   target: HTMLElement,
   event: E,
-  data: ApiReferenceEvents[E]['data'],
+  detail: ApiReferenceEvents[E]['detail'],
 ) {
-  const instance = new CustomEvent(event, { detail: data, bubbles: true, composed: true, cancelable: true })
+  const instance = new CustomEvent(event, { detail, bubbles: true, composed: true, cancelable: true })
 
   target.dispatchEvent(instance)
 }

--- a/packages/api-reference/src/v2/hooks/useStore.ts
+++ b/packages/api-reference/src/v2/hooks/useStore.ts
@@ -1,0 +1,27 @@
+import type { WorkspaceStore } from '@scalar/workspace-store/client'
+import { inject, provide, type InjectionKey } from 'vue'
+
+const SYMBOL = Symbol() as InjectionKey<WorkspaceStore>
+
+/**
+ * Composable for accessing the new workspace store
+ *
+ * When called with a store it provides that store
+ * When called without parameters, it returns the injected store
+ */
+export const useStore = (store?: WorkspaceStore) => {
+  if (store) {
+    provide(SYMBOL, store)
+    return store
+  }
+
+  const injectedStore = inject(SYMBOL)
+  if (!injectedStore) {
+    throw new Error(
+      'useStore() was called without a store and no store instance was found. ' +
+        'Make sure to call useStore(store) in a parent component first.',
+    )
+  }
+
+  return injectedStore
+}

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -875,7 +875,7 @@ describe('create-workspace-store', () => {
         meta: {
           'x-scalar-active-document': 'default',
           'x-scalar-dark-mode': true,
-          'x-scalar-default-client': 'curl',
+          'x-scalar-default-client': 'c/libcurl',
           'x-scalar-theme': 'saturn',
         },
       })
@@ -926,7 +926,7 @@ describe('create-workspace-store', () => {
           meta: {
             'x-scalar-active-document': 'default',
             'x-scalar-dark-mode': true,
-            'x-scalar-default-client': 'curl',
+            'x-scalar-default-client': 'c/libcurl',
             'x-scalar-theme': 'saturn',
           },
           documentConfigs: {
@@ -995,7 +995,7 @@ describe('create-workspace-store', () => {
           meta: {
             'x-scalar-active-document': 'default',
             'x-scalar-dark-mode': true,
-            'x-scalar-default-client': 'curl',
+            'x-scalar-default-client': 'c/libcurl',
             'x-scalar-theme': 'saturn',
           },
           documentConfigs: {
@@ -1067,7 +1067,7 @@ describe('create-workspace-store', () => {
       expect(store.workspace['x-scalar-theme']).toBe('saturn')
       expect(store.workspace['x-scalar-dark-mode']).toBe(true)
       expect(store.workspace['x-scalar-active-document']).toBe('default')
-      expect(store.workspace['x-scalar-default-client']).toBe('curl')
+      expect(store.workspace['x-scalar-default-client']).toBe('c/libcurl')
     })
   })
 })

--- a/packages/workspace-store/src/schemas/v3.1/strict/callback.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/callback.ts
@@ -1,13 +1,14 @@
 import { Type, type TSchema } from '@sinclair/typebox'
 import { ExtensionsSchema } from '@/schemas/v3.1/strict/extensions'
 import { compose } from '@/schemas/compose'
+import { ReferenceObjectSchema } from '@/schemas/v3.1/strict/reference'
 
 export const callbackObjectSchemaBuilder = <P extends TSchema>(pathItem: P) =>
   compose(
     Type.Record(
       Type.String(),
       /** A Path Item Object used to define a callback request and expected responses. A complete example is available. */
-      pathItem,
+      Type.Union([pathItem, ReferenceObjectSchema]),
     ),
     ExtensionsSchema,
   )

--- a/packages/workspace-store/src/schemas/workspace.ts
+++ b/packages/workspace-store/src/schemas/workspace.ts
@@ -6,6 +6,7 @@ import { xScalarClientConfigEnvironmentsSchema } from '@/schemas/v3.1/strict/cli
 import { xScalarClientConfigCookiesSchema } from '@/schemas/v3.1/strict/client-config-extensions/x-scalar-client-config-cookies'
 import { ServerObjectSchema } from '@/schemas/v3.1/strict/server'
 import { SecuritySchemeObjectSchema } from '@/schemas/v3.1/strict/security-scheme'
+import { AVAILABLE_CLIENTS } from '@scalar/types/snippetz'
 
 const WorkspaceDocumentMetaSchema = Type.Partial(
   Type.Object({
@@ -23,7 +24,7 @@ export type WorkspaceDocument = Static<typeof WorkspaceDocumentSchema>
 export const WorkspaceMetaSchema = Type.Partial(
   Type.Object({
     [extensions.workspace.darkMode]: Type.Boolean(),
-    [extensions.workspace.defaultClient]: Type.String(),
+    [extensions.workspace.defaultClient]: Type.Union(AVAILABLE_CLIENTS.map((client) => Type.Literal(client))),
     [extensions.workspace.activeDocument]: Type.String(),
     [extensions.workspace.theme]: Type.String(),
   }),

--- a/packages/workspace-store/src/server.test.ts
+++ b/packages/workspace-store/src/server.test.ts
@@ -241,7 +241,7 @@ describe('create-server-store', () => {
         meta: {
           'x-scalar-active-document': 'test',
           'x-scalar-dark-mode': true,
-          'x-scalar-default-client': 'node',
+          'x-scalar-default-client': 'node/fetch',
           'x-scalar-theme': 'default',
         },
       })
@@ -324,7 +324,7 @@ describe('create-server-store', () => {
         },
         'x-scalar-active-document': 'test',
         'x-scalar-dark-mode': true,
-        'x-scalar-default-client': 'node',
+        'x-scalar-default-client': 'node/fetch',
         'x-scalar-theme': 'default',
       })
 


### PR DESCRIPTION
This is just to break up https://github.com/scalar/scalar/pull/6218 into two PR's. This one lays the groundwork and actually shouldn't change anything as its mostly touching files/components that aren't being used. So its safe to merge and it brings the cognitive load down on reviewing the other one!

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
