### PR TITLE
fix(api-reference): prevents discriminator selector display within nested properties

### DIFF
--- a/.changeset/shaggy-wasps-move.md
+++ b/.changeset/shaggy-wasps-move.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: removes discriminator selector presence from nested property name presence

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.test.ts
@@ -156,4 +156,31 @@ describe('SchemaObjectProperties', () => {
 
     expect(wrapper.findAll('.schema-property')).toHaveLength(0)
   })
+
+  it('does not set discriminator within nested property name presence', () => {
+    const nestedSchema: OpenAPIV3_1.SchemaObject = {
+      type: 'object',
+      properties: {
+        type: { type: 'string' },
+        name: { type: 'string' },
+      },
+    }
+
+    const wrapper = mount(SchemaObjectProperties, {
+      props: {
+        schema: nestedSchema,
+        discriminatorPropertyName: 'type',
+        discriminatorMapping: {
+          planet: '#/components/schemas/Planet',
+          satellite: '#/components/schemas/Satellite',
+        },
+      },
+    })
+
+    const schemaProperties = wrapper.findAllComponents({ name: 'SchemaProperty' })
+    expect(schemaProperties).toHaveLength(2)
+
+    const typeProperty = schemaProperties.find((comp) => comp.props('name') === 'type')
+    expect(typeProperty?.props('isDiscriminator')).toBe(false)
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
@@ -106,8 +106,8 @@ const getAdditionalPropertiesValue = (
         schema.discriminator?.propertyName || discriminatorPropertyName
       "
       :isDiscriminator="
-        property ===
-        (schema.discriminator?.propertyName || discriminatorPropertyName)
+        property === schema.discriminator?.propertyName &&
+        !!schema.discriminator
       "
       :modelValue="discriminator"
       @update:modelValue="handleDiscriminatorChange" />


### PR DESCRIPTION
**Problem**

currently if amongst nested properties the targeted property name in discriminator presence is also existing, the discriminator get displayed making when it should only be displayed at the schema level set.

**Solution**

this pr updates the schema object properties component in order to add a null check for discriminator schema and avoid duplicated display.

| state | preview |
| -------|------|
| before | <img width="564" height="591" alt="image" src="https://github.com/user-attachments/assets/d6284613-5963-4ef5-b105-c1f8621b72e9" /> |
| after |  <img width="564" height="591" alt="image" src="https://github.com/user-attachments/assets/635ad809-364e-41ad-a261-1073de178615" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
