### PR TITLE
fix(api-reference): classic layout improvements

### DIFF
--- a/.changeset/wise-roses-divide.md
+++ b/.changeset/wise-roses-divide.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/themes': patch
+---
+
+fix(api-reference): classic layout improvements

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -24,6 +24,7 @@
             title: 'Scalar Galaxy', // optional, would fallback to 'API #1'
             slug: 'scalar-galaxy', // optional, would be auto-generated from the title or the index
             url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+            layout: 'classic',
           },
           {
             title: 'Swagger Petstore 2.0',

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -24,7 +24,6 @@
             title: 'Scalar Galaxy', // optional, would fallback to 'API #1'
             slug: 'scalar-galaxy', // optional, would be auto-generated from the title or the index
             url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-            layout: 'classic',
           },
           {
             title: 'Swagger Petstore 2.0',

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -593,7 +593,6 @@ watch(hash, (newHash, oldHash) => {
 }
 .scalar-api-reference.references-classic,
 .references-classic .references-rendered {
-  --full-height: fit-content !important;
   height: initial !important;
   max-height: initial !important;
 }

--- a/packages/api-reference/src/components/Section/SectionAccordion.vue
+++ b/packages/api-reference/src/components/Section/SectionAccordion.vue
@@ -70,7 +70,7 @@ const isHovered = useElementHover(button)
 
 .section-accordion-transparent {
   background: transparent;
-  border: 1px solid var(--scalar-border-color);
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
 }
 
 .section-accordion-button {
@@ -104,7 +104,7 @@ const isHovered = useElementHover(button)
   color: var(--scalar-color-1);
 }
 .section-accordion-content {
-  border-top: 1px solid var(--scalar-border-color);
+  border-top: var(--scalar-border-width) solid var(--scalar-border-color);
   display: flex;
   flex-direction: column;
 }

--- a/packages/api-reference/src/components/Section/SectionAccordion.vue
+++ b/packages/api-reference/src/components/Section/SectionAccordion.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
 import { ScalarIcon } from '@scalar/components'
+import {
+  ScalarIconCaretDown,
+  ScalarIconCaretLeft,
+  ScalarIconCaretRight,
+} from '@scalar/icons'
 import { useElementHover } from '@vueuse/core'
 import { ref } from 'vue'
 
@@ -36,9 +41,9 @@ const isHovered = useElementHover(button)
             :active="isHovered || open"
             name="actions" />
         </div>
-        <ScalarIcon
-          class="section-accordion-chevron size-5"
-          :icon="open ? 'ChevronDown' : 'ChevronRight'" />
+        <ScalarIconCaretRight
+          class="section-accordion-chevron size-4.5 transition-transform"
+          :class="{ 'rotate-90': open }" />
       </DisclosureButton>
       <DisclosurePanel class="section-accordion-content">
         <div

--- a/packages/api-reference/src/components/Section/SectionContainerAccordion.vue
+++ b/packages/api-reference/src/components/Section/SectionContainerAccordion.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
 import { ScalarIcon } from '@scalar/components'
+import { ScalarIconCaretRight } from '@scalar/icons'
 </script>
 <template>
   <div class="section-accordion-wrapper">
@@ -10,9 +11,9 @@ import { ScalarIcon } from '@scalar/components'
       class="section-accordion"
       defaultOpen>
       <DisclosureButton class="section-accordion-button">
-        <ScalarIcon
-          class="section-accordion-chevron size-6"
-          :icon="open ? 'ChevronDown' : 'ChevronRight'" />
+        <ScalarIconCaretRight
+          class="section-accordion-chevron size-5 transition-transform"
+          :class="{ 'rotate-90': open }" />
         <div class="section-accordion-title">
           <slot name="title" />
         </div>
@@ -52,8 +53,8 @@ import { ScalarIcon } from '@scalar/components'
 }
 .section-accordion-chevron {
   position: absolute;
-  left: -24px;
-  top: 10px;
+  left: -22px;
+  top: 12px;
   color: var(--scalar-color-3);
 }
 

--- a/packages/api-reference/src/features/Operation/components/callbacks/Callback.vue
+++ b/packages/api-reference/src/features/Operation/components/callbacks/Callback.vue
@@ -28,17 +28,18 @@ const operation = computed(() =>
 <template>
   <details
     v-if="collection && operation"
-    class="group">
+    class="group callback-list-item">
     <!-- Title -->
     <summary
-      class="font-code bg-b-1 callback-sticky-offset sticky flex cursor-pointer flex-row items-center gap-2 border-t py-3 text-sm group-open:flex-wrap">
+      class="font-code bg-b-1 callback-sticky-offset callback-list-item-title sticky flex cursor-pointer flex-row items-center gap-2 border-t py-3 text-sm group-open:flex-wrap">
       <ScalarIconCaretRight
-        class="text-c-3 group-hover:text-c-1 absolute -left-5 size-4 transition-transform group-open:rotate-90" />
+        class="callback-list-item-icon text-c-3 group-hover:text-c-1 absolute -left-5 size-4 transition-transform group-open:rotate-90" />
       <HttpMethod
         as="span"
         class="request-method"
         :method="method" />
-      <div class="text-c-1 truncate leading-3 group-open:whitespace-normal">
+      <div
+        class="text-c-1 min-w-0 flex-1 truncate leading-3 group-open:whitespace-normal">
         {{ name }}
         <span class="text-c-2">
           {{ url }}

--- a/packages/api-reference/src/features/Operation/components/callbacks/Callbacks.vue
+++ b/packages/api-reference/src/features/Operation/components/callbacks/Callbacks.vue
@@ -13,8 +13,10 @@ const { callbacks, collection, schemas } = defineProps<{
 </script>
 
 <template>
-  <div class="mt-6 gap-3">
-    <div class="text-c-1 my-3 text-lg font-medium">Callbacks</div>
+  <div class="callbacks-list gap-3">
+    <div class="callbacks-title text-c-1 my-3 text-lg font-medium">
+      Callbacks
+    </div>
 
     <!-- Loop over names -->
     <template

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -202,7 +202,7 @@ const handleDiscriminatorChange = (type: string) => {
   background: currentColor;
   opacity: 0.15;
 
-  border-radius: var(--scalar-radius-lg);
+  border-radius: var(--scalar-radius);
 }
 
 .endpoint-anchor {
@@ -291,7 +291,7 @@ const handleDiscriminatorChange = (type: string) => {
   gap: 12px;
 }
 .operation-details-card-item :deep(.parameter-list) {
-  border: 1px solid var(--scalar-border-color);
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
   border-radius: var(--scalar-radius-lg);
   margin-top: 0;
 }
@@ -333,13 +333,13 @@ const handleDiscriminatorChange = (type: string) => {
 .operation-details-card :deep(.request-body-description) {
   margin-top: 0;
   padding: 9px 9px 0 9px;
-  border-top: 1px solid var(--scalar-border-color);
+  border-top: var(--scalar-border-width) solid var(--scalar-border-color);
 }
 
 .operation-details-card :deep(.request-body) {
   margin-top: 0;
   border-radius: var(--scalar-radius-lg);
-  border: 1px solid var(--scalar-border-color);
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
 }
 
 .operation-details-card :deep(.request-body-header) {
@@ -353,7 +353,7 @@ const handleDiscriminatorChange = (type: string) => {
 
 .operation-details-card :deep(.request-body-schema > .schema-card) {
   border-radius: var(--scalar-radius-lg);
-  border: 1px solid var(--scalar-border-color);
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
   margin: 9px;
 }
 

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -146,8 +146,11 @@ const handleDiscriminatorChange = (type: string) => {
             :schemas="schemas" />
         </div>
       </div>
-      <ExampleResponses :responses="operation.responses" />
+      <ExampleResponses
+        class="operation-example-card"
+        :responses="operation.responses" />
       <ExampleRequest
+        class="operation-example-card"
         :request="request"
         :method="method"
         :collection="collection"
@@ -363,5 +366,11 @@ const handleDiscriminatorChange = (type: string) => {
 
 .operation-details-card :deep(.selected-content-type) {
   margin-right: 9px;
+}
+
+.operation-example-card {
+  position: sticky;
+  top: calc(var(--refs-header-height) + 24px);
+  max-height: calc(((var(--full-height) - var(--refs-header-height)) - 48px));
 }
 </style>

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -375,4 +375,11 @@ const handleDiscriminatorChange = (type: string) => {
   top: calc(var(--refs-header-height) + 24px);
   max-height: calc(((var(--full-height) - var(--refs-header-height)) - 48px));
 }
+
+@media (max-width: 600px) {
+  .operation-example-card {
+    max-height: unset;
+    position: static;
+  }
+}
 </style>

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -325,7 +325,7 @@ const handleDiscriminatorChange = (type: string) => {
 }
 .operation-details-card :deep(.parameter-item) {
   margin: 0;
-  padding: 0 9px;
+  padding: 0;
 }
 .operation-details-card :deep(.property) {
   padding: 9px;
@@ -390,12 +390,11 @@ const handleDiscriminatorChange = (type: string) => {
   margin-right: 9px;
 }
 
-.operation-details-card :deep(.request-body-schema > .schema-card) {
-  border-radius: var(--scalar-radius-lg);
-  border: var(--scalar-border-width) solid var(--scalar-border-color);
-  margin: 9px;
+.operation-details-card
+  :deep(.schema-card--open + .schema-card:not(.schema-card--open)) {
+  margin-inline: 9px;
+  margin-bottom: 9px;
 }
-
 .operation-details-card :deep(.request-body-schema .property--level-0) {
   padding: 0;
 }

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -4,7 +4,11 @@ import {
   ScalarIconButton,
   ScalarMarkdown,
 } from '@scalar/components'
-import { ScalarIconWebhooksLogo } from '@scalar/icons'
+import {
+  ScalarIconCopy,
+  ScalarIconPlay,
+  ScalarIconWebhooksLogo,
+} from '@scalar/icons'
 import type {
   Collection,
   Request,
@@ -107,14 +111,12 @@ const handleDiscriminatorChange = (type: string) => {
       <TestRequestButton
         v-if="active && request"
         :operation="request" />
-      <ScalarIcon
+      <ScalarIconPlay
         v-else-if="!config?.hideTestRequestButton"
-        class="endpoint-try-hint size-6"
-        icon="Play"
-        thickness="1.75px" />
+        class="endpoint-try-hint size-4.5" />
       <ScalarIconButton
         class="endpoint-copy p-0.5"
-        icon="Clipboard"
+        :icon="ScalarIconCopy"
         label="Copy endpoint URL"
         size="xs"
         variant="ghost"

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -30,6 +30,7 @@ import OperationPath from '@/components/OperationPath.vue'
 import { SectionAccordion } from '@/components/Section'
 import { ExampleRequest } from '@/features/example-request'
 import { ExampleResponses } from '@/features/example-responses'
+import Callbacks from '@/features/Operation/components/callbacks/Callbacks.vue'
 import type { Schemas } from '@/features/Operation/types/schemas'
 import { TestRequestButton } from '@/features/test-request-button'
 import { useConfig } from '@/hooks/useConfig'
@@ -146,6 +147,14 @@ const handleDiscriminatorChange = (type: string) => {
             :collapsableItems="false"
             :responses="operation.responses"
             :schemas="schemas" />
+        </div>
+        <div
+          v-if="operation?.callbacks"
+          class="operation-details-card-item">
+          <Callbacks
+            :callbacks="operation.callbacks"
+            :schemas="schemas"
+            :collection="collection" />
         </div>
       </div>
       <ExampleResponses
@@ -286,16 +295,14 @@ const handleDiscriminatorChange = (type: string) => {
   }
 }
 
-.endpoint-content > * {
-  max-height: unset;
-}
-
 .operation-details-card {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  min-width: 0;
 }
-.operation-details-card-item :deep(.parameter-list) {
+.operation-details-card-item :deep(.parameter-list),
+.operation-details-card-item :deep(.callbacks-list) {
   border: var(--scalar-border-width) solid var(--scalar-border-color);
   border-radius: var(--scalar-radius-lg);
   margin-top: 0;
@@ -325,7 +332,8 @@ const handleDiscriminatorChange = (type: string) => {
   margin: 0;
 }
 .operation-details-card :deep(.parameter-list-title),
-.operation-details-card :deep(.request-body-title) {
+.operation-details-card :deep(.request-body-title),
+.operation-details-card :deep(.callbacks-title) {
   text-transform: uppercase;
   font-weight: var(--scalar-bold);
   font-size: var(--scalar-mini);
@@ -333,6 +341,32 @@ const handleDiscriminatorChange = (type: string) => {
   line-height: 1.33;
   padding: 9px;
   margin: 0;
+}
+
+.operation-details-card :deep(.callback-list-item-title) {
+  padding-left: 28px;
+  padding-right: 12px;
+}
+
+.operation-details-card :deep(.callback-list-item-icon) {
+  left: 6px;
+}
+
+.operation-details-card :deep(.callback-operation-container) {
+  padding-inline: 9px;
+  padding-bottom: 9px;
+}
+
+.operation-details-card :deep(.callback-operation-container > .request-body),
+.operation-details-card :deep(.callback-operation-container > .parameter-list) {
+  border: none;
+}
+
+.operation-details-card
+  :deep(.callback-operation-container > .request-body > .request-body-header) {
+  padding: 0;
+  padding-bottom: 9px;
+  border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
 }
 
 .operation-details-card :deep(.request-body-description) {

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -119,6 +119,7 @@ const handleDiscriminatorChange = (type: string) => {
             <ScalarErrorBoundary>
               <Callbacks
                 v-if="operation?.callbacks"
+                class="mt-6"
                 :callbacks="operation?.callbacks"
                 :collection="collection"
                 :schemas="schemas" />

--- a/packages/api-reference/src/features/example-request/ExampleRequest.vue
+++ b/packages/api-reference/src/features/example-request/ExampleRequest.vue
@@ -471,7 +471,7 @@ watch(discriminator, (newValue) => {
         :id="`${id}-example`"
         class="code-snippet">
         <ScalarCodeBlock
-          class="bg-b-2 -outline-offset-2"
+          class="bg-b-2 !min-h-full -outline-offset-2"
           :content="generatedCode"
           :hideCredentials="secretCredentials"
           :lang="language"

--- a/packages/api-reference/src/features/test-request-button/TestRequestButton.test.ts
+++ b/packages/api-reference/src/features/test-request-button/TestRequestButton.test.ts
@@ -53,7 +53,7 @@ describe('TestRequestButton', () => {
     })
 
     expect(wrapper.find('button').exists()).toBe(true)
-    expect(wrapper.find('.scalar-icon').exists()).toBe(true)
+    expect(wrapper.find('svg').exists()).toBe(true)
     expect(wrapper.text()).toContain('Test Request')
     expect(wrapper.text()).toContain('(get /test)')
   })

--- a/packages/api-reference/src/features/test-request-button/TestRequestButton.vue
+++ b/packages/api-reference/src/features/test-request-button/TestRequestButton.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ScalarIcon } from '@scalar/components'
+import { ScalarIconPlay } from '@scalar/icons'
 import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
 import { computed } from 'vue'
 
@@ -34,9 +35,9 @@ const handleClick = () => {
     :method="operation.method"
     type="button"
     @click.stop="handleClick">
-    <ScalarIcon
-      icon="Play"
-      size="sm" />
+    <ScalarIconPlay
+      class="size-3"
+      weight="fill" />
     <span>Test Request</span>
     <ScreenReader>({{ operation.method }} {{ operation.path }})</ScreenReader>
   </button>

--- a/packages/themes/src/base/reset.css
+++ b/packages/themes/src/base/reset.css
@@ -40,6 +40,7 @@
     font-variation-settings: inherit;
     font-size: inherit;
     font-weight: inherit;
+    font-style: inherit;
     line-height: inherit;
     color: inherit;
     margin: unset;


### PR DESCRIPTION
A bunch of cleanup on the classic layout:

* Update border to use default border width (0.5px)
* Fix issue with italics in operation path
* Matched operation HTTP method border radius to external card
* Restricted the height of the examples and made them sticky
* Update icons to phosphor and clean up transitions
* Add callback support in classic layout
* Fixed some double border issues

@cameronrohani we can tweak things however you like :)

# Before / Afters

## HTTP Method Border Radius

<img width="49%" alt="Google Chrome-2025-07-11-21-18-34@2x" src="https://github.com/user-attachments/assets/3e91a93b-8c76-4f65-8e18-b5bf234d1ff2" />
<img width="49%" alt="Google Chrome-2025-07-11-21-18-28@2x" src="https://github.com/user-attachments/assets/4abd40e8-326b-4c1d-a784-5105b57a0a73" />

## Operations List
<img width="2374" height="908" alt="Google Chrome-2025-07-11-22-46-31@2x" src="https://github.com/user-attachments/assets/9b3c854a-c59c-4212-a9af-cb39fdccaa7c" />
<img width="2374" height="908" alt="Google Chrome-2025-07-11-22-45-55@2x" src="https://github.com/user-attachments/assets/a3e7e205-79d4-4d32-a79d-74df4e5bc20b" />

## Operation Card
<img width="2318" height="1486" alt="Google Chrome-2025-07-11-22-51-51@2x" src="https://github.com/user-attachments/assets/cb7706ad-8fd2-421b-bf87-b0c1f0ea7aba" />
<img width="2318" height="1486" alt="Google Chrome-2025-07-11-22-51-34@2x" src="https://github.com/user-attachments/assets/14f76fba-d669-42a1-a586-13538c9a33a9" />

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
