### PR TITLE
feat(snippetz): improved rust/reqwest output

### DIFF
--- a/.changeset/eighty-dots-cry.md
+++ b/.changeset/eighty-dots-cry.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+feat: improved rust/reqwest output

--- a/packages/snippetz/src/plugins/rust/reqwest/reqwest.test.ts
+++ b/packages/snippetz/src/plugins/rust/reqwest/reqwest.test.ts
@@ -9,7 +9,9 @@ describe('rustReqwest', () => {
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com");
+
 let response = request.send().await?;`)
   })
 
@@ -20,7 +22,9 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.post("https://example.com");
+
 let response = request.send().await?;`)
   })
 
@@ -36,8 +40,10 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com")
     .header("Content-Type", "application/json");
+
 let response = request.send().await?;`)
   })
 
@@ -48,7 +54,9 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com");
+
 let response = request.send().await?;`)
   })
 
@@ -71,9 +79,11 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.post("https://example.com")
     .header("Content-Type", "application/json")
     .json(&serde_json::json!({"hello":"world"}));
+
 let response = request.send().await?;`)
   })
 
@@ -93,7 +103,9 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com?foo=bar&bar=foo");
+
 let response = request.send().await?;`)
   })
 
@@ -113,8 +125,10 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com")
     .header("Cookie", "foo=bar; bar=foo");
+
 let response = request.send().await?;`)
   })
 
@@ -125,7 +139,9 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com");
+
 let response = request.send().await?;`)
   })
 
@@ -143,8 +159,10 @@ let response = request.send().await?;`)
     )
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com")
     .basic_auth("user", "pass");
+
 let response = request.send().await?;`)
   })
 
@@ -154,7 +172,9 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com");
+
 let response = request.send().await?;`)
   })
 
@@ -172,7 +192,9 @@ let response = request.send().await?;`)
     )
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com");
+
 let response = request.send().await?;`)
   })
 
@@ -190,7 +212,9 @@ let response = request.send().await?;`)
     )
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com");
+
 let response = request.send().await?;`)
   })
 
@@ -208,8 +232,10 @@ let response = request.send().await?;`)
     )
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com")
     .basic_auth("user@example.com", "pass:word!");
+
 let response = request.send().await?;`)
   })
 
@@ -224,7 +250,9 @@ let response = request.send().await?;`)
     )
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com");
+
 let response = request.send().await?;`)
   })
 
@@ -248,6 +276,7 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.post("https://example.com")
     .multipart({
         let mut form = reqwest::multipart::Form::new();
@@ -257,6 +286,7 @@ let request = client.post("https://example.com")
         form = form.text("field", "value");
             form
         });
+
 let response = request.send().await?;`)
   })
 
@@ -276,8 +306,10 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.post("https://example.com")
     .form(&[("special chars!@#", "value")]);
+
 let response = request.send().await?;`)
   })
 
@@ -292,8 +324,10 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.post("https://example.com")
     .body("binary content");
+
 let response = request.send().await?;`)
   })
 
@@ -309,8 +343,10 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com")
     .header("Accept-Encoding", "gzip, deflate");
+
 let response = request.send().await?;`)
   })
 
@@ -320,7 +356,9 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com/path with spaces/[brackets]");
+
 let response = request.send().await?;`)
   })
 
@@ -340,7 +378,9 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com?q=hello%20world%20%26%20more&special=!%40%23%24%25%5E%26*()");
+
 let response = request.send().await?;`)
   })
 
@@ -350,7 +390,9 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("");
+
 let response = request.send().await?;`)
   })
 
@@ -360,7 +402,9 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com/${'a'.repeat(2000)}");
+
 let response = request.send().await?;`)
   })
 
@@ -374,8 +418,10 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com")
     .header("X-Custom", "value2");
+
 let response = request.send().await?;`)
   })
 
@@ -386,7 +432,9 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com");
+
 let response = request.send().await?;`)
   })
 
@@ -406,12 +454,14 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.post("https://example.com")
     .multipart({
         let mut form = reqwest::multipart::Form::new();
         form = form.text("file", "");
             form
         });
+
 let response = request.send().await?;`)
   })
 
@@ -437,9 +487,11 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.post("https://example.com")
     .header("Content-Type", "application/json")
     .json(&serde_json::json!({"key":"\\\"quotes\\\" and \\\\backslashes\\\\","nested":{"array":["item1",null,null]}}));
+
 let response = request.send().await?;`)
   })
 
@@ -455,8 +507,10 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.get("https://example.com")
     .header("Cookie", "special%3Bcookie=value%20with%20spaces");
+
 let response = request.send().await?;`)
   })
 
@@ -483,9 +537,11 @@ let response = request.send().await?;`)
     })
 
     expect(result).toBe(`let client = reqwest::Client::new();
+
 let request = client.post("https://example.com")
     .header("Content-Type", "application/json")
     .json(&serde_json::json!({"nested":{"array":[1,2,3],"object":{"foo":"bar"}},"simple":"value"}));
+
 let response = request.send().await?;`)
   })
 })

--- a/packages/snippetz/src/plugins/rust/reqwest/reqwest.test.ts
+++ b/packages/snippetz/src/plugins/rust/reqwest/reqwest.test.ts
@@ -41,7 +41,8 @@ let response = request.send().await?;`)
 
     expect(result).toBe(`let client = reqwest::Client::new();
 
-let request = client.get("https://example.com")
+let request = client
+    .get("https://example.com")
     .header("Content-Type", "application/json");
 
 let response = request.send().await?;`)
@@ -80,7 +81,8 @@ let response = request.send().await?;`)
 
     expect(result).toBe(`let client = reqwest::Client::new();
 
-let request = client.post("https://example.com")
+let request = client
+    .post("https://example.com")
     .header("Content-Type", "application/json")
     .json(&serde_json::json!({
         "hello": "world"
@@ -128,7 +130,8 @@ let response = request.send().await?;`)
 
     expect(result).toBe(`let client = reqwest::Client::new();
 
-let request = client.get("https://example.com")
+let request = client
+    .get("https://example.com")
     .header("Cookie", "foo=bar; bar=foo");
 
 let response = request.send().await?;`)
@@ -162,7 +165,8 @@ let response = request.send().await?;`)
 
     expect(result).toBe(`let client = reqwest::Client::new();
 
-let request = client.get("https://example.com")
+let request = client
+    .get("https://example.com")
     .basic_auth("user", "pass");
 
 let response = request.send().await?;`)
@@ -235,7 +239,8 @@ let response = request.send().await?;`)
 
     expect(result).toBe(`let client = reqwest::Client::new();
 
-let request = client.get("https://example.com")
+let request = client
+    .get("https://example.com")
     .basic_auth("user@example.com", "pass:word!");
 
 let response = request.send().await?;`)
@@ -279,7 +284,8 @@ let response = request.send().await?;`)
 
     expect(result).toBe(`let client = reqwest::Client::new();
 
-let request = client.post("https://example.com")
+let request = client
+    .post("https://example.com")
     .multipart({
         let mut form = reqwest::multipart::Form::new();
         let part = reqwest::multipart::Part::text("")
@@ -309,7 +315,8 @@ let response = request.send().await?;`)
 
     expect(result).toBe(`let client = reqwest::Client::new();
 
-let request = client.post("https://example.com")
+let request = client
+    .post("https://example.com")
     .form(&[("special chars!@#", "value")]);
 
 let response = request.send().await?;`)
@@ -327,7 +334,8 @@ let response = request.send().await?;`)
 
     expect(result).toBe(`let client = reqwest::Client::new();
 
-let request = client.post("https://example.com")
+let request = client
+    .post("https://example.com")
     .body("binary content");
 
 let response = request.send().await?;`)
@@ -346,7 +354,8 @@ let response = request.send().await?;`)
 
     expect(result).toBe(`let client = reqwest::Client::new();
 
-let request = client.get("https://example.com")
+let request = client
+    .get("https://example.com")
     .header("Accept-Encoding", "gzip, deflate");
 
 let response = request.send().await?;`)
@@ -421,7 +430,8 @@ let response = request.send().await?;`)
 
     expect(result).toBe(`let client = reqwest::Client::new();
 
-let request = client.get("https://example.com")
+let request = client
+    .get("https://example.com")
     .header("X-Custom", "value2");
 
 let response = request.send().await?;`)
@@ -457,7 +467,8 @@ let response = request.send().await?;`)
 
     expect(result).toBe(`let client = reqwest::Client::new();
 
-let request = client.post("https://example.com")
+let request = client
+    .post("https://example.com")
     .multipart({
         let mut form = reqwest::multipart::Form::new();
         form = form.text("file", "");
@@ -490,7 +501,8 @@ let response = request.send().await?;`)
 
     expect(result).toBe(`let client = reqwest::Client::new();
 
-let request = client.post("https://example.com")
+let request = client
+    .post("https://example.com")
     .header("Content-Type", "application/json")
     .json(&serde_json::json!({
         "key": "\\"quotes\\" and \\\\backslashes\\\\",
@@ -519,7 +531,8 @@ let response = request.send().await?;`)
 
     expect(result).toBe(`let client = reqwest::Client::new();
 
-let request = client.get("https://example.com")
+let request = client
+    .get("https://example.com")
     .header("Cookie", "special%3Bcookie=value%20with%20spaces");
 
 let response = request.send().await?;`)
@@ -549,7 +562,8 @@ let response = request.send().await?;`)
 
     expect(result).toBe(`let client = reqwest::Client::new();
 
-let request = client.post("https://example.com")
+let request = client
+    .post("https://example.com")
     .header("Content-Type", "application/json")
     .json(&serde_json::json!({
         "nested": {

--- a/packages/snippetz/src/plugins/rust/reqwest/reqwest.test.ts
+++ b/packages/snippetz/src/plugins/rust/reqwest/reqwest.test.ts
@@ -10,9 +10,7 @@ describe('rustReqwest', () => {
 
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('returns a POST request', () => {
@@ -23,9 +21,7 @@ let body = response.text().await?;
 
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.post("https://example.com");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('has headers', () => {
@@ -42,9 +38,7 @@ let body = response.text().await?;
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com")
     .header("Content-Type", "application/json");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it(`doesn't add empty headers`, () => {
@@ -55,9 +49,7 @@ let body = response.text().await?;
 
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('has JSON body', () => {
@@ -82,9 +74,7 @@ let body = response.text().await?;
 let request = client.post("https://example.com")
     .header("Content-Type", "application/json")
     .json(&serde_json::json!({"hello":"world"}));
-let response = request.send().await?;
-let body = response.json::<serde_json::Value>().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('has query string', () => {
@@ -104,9 +94,7 @@ let body = response.json::<serde_json::Value>().await?;
 
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com?foo=bar&bar=foo");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('has cookies', () => {
@@ -127,9 +115,7 @@ let body = response.text().await?;
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com")
     .header("Cookie", "foo=bar; bar=foo");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it(`doesn't add empty cookies`, () => {
@@ -140,9 +126,7 @@ let body = response.text().await?;
 
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('adds basic auth credentials', () => {
@@ -161,9 +145,7 @@ let body = response.text().await?;
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com")
     .basic_auth("user", "pass");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('omits auth when not provided', () => {
@@ -173,9 +155,7 @@ let body = response.text().await?;
 
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('omits auth when username is missing', () => {
@@ -193,9 +173,7 @@ let body = response.text().await?;
 
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('omits auth when password is missing', () => {
@@ -213,9 +191,7 @@ let body = response.text().await?;
 
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles special characters in auth credentials', () => {
@@ -234,9 +210,7 @@ let body = response.text().await?;
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com")
     .basic_auth("user@example.com", "pass:word!");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles undefined auth object', () => {
@@ -251,9 +225,7 @@ let body = response.text().await?;
 
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles multipart form data with files', () => {
@@ -285,9 +257,7 @@ let request = client.post("https://example.com")
         form = form.text("field", "value");
             form
         });
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles url-encoded form data with special characters', () => {
@@ -308,9 +278,7 @@ let body = response.text().await?;
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.post("https://example.com")
     .form(&[("special chars!@#", "value")]);
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles binary data flag', () => {
@@ -326,9 +294,7 @@ let body = response.text().await?;
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.post("https://example.com")
     .body("binary content");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles compressed response', () => {
@@ -345,9 +311,7 @@ let body = response.text().await?;
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com")
     .header("Accept-Encoding", "gzip, deflate");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles special characters in URL', () => {
@@ -357,9 +321,7 @@ let body = response.text().await?;
 
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com/path with spaces/[brackets]");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles special characters in query parameters', () => {
@@ -379,9 +341,7 @@ let body = response.text().await?;
 
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com?q=hello%20world%20%26%20more&special=!%40%23%24%25%5E%26*()");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles empty URL', () => {
@@ -391,9 +351,7 @@ let body = response.text().await?;
 
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles extremely long URLs', () => {
@@ -403,9 +361,7 @@ let body = response.text().await?;
 
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com/${'a'.repeat(2000)}");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles multiple headers with same name', () => {
@@ -420,9 +376,7 @@ let body = response.text().await?;
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com")
     .header("X-Custom", "value2");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles headers with empty values', () => {
@@ -433,9 +387,7 @@ let body = response.text().await?;
 
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles multipart form data with empty file names', () => {
@@ -460,9 +412,7 @@ let request = client.post("https://example.com")
         form = form.text("file", "");
             form
         });
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles JSON body with special characters', () => {
@@ -490,9 +440,7 @@ let body = response.text().await?;
 let request = client.post("https://example.com")
     .header("Content-Type", "application/json")
     .json(&serde_json::json!({"key":"\\\"quotes\\\" and \\\\backslashes\\\\","nested":{"array":["item1",null,null]}}));
-let response = request.send().await?;
-let body = response.json::<serde_json::Value>().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('handles cookies with special characters', () => {
@@ -509,9 +457,7 @@ let body = response.json::<serde_json::Value>().await?;
     expect(result).toBe(`let client = reqwest::Client::new();
 let request = client.get("https://example.com")
     .header("Cookie", "special%3Bcookie=value%20with%20spaces");
-let response = request.send().await?;
-let body = response.text().await?;
-`)
+let response = request.send().await?;`)
   })
 
   it('prettifies JSON body', () => {
@@ -540,8 +486,6 @@ let body = response.text().await?;
 let request = client.post("https://example.com")
     .header("Content-Type", "application/json")
     .json(&serde_json::json!({"nested":{"array":[1,2,3],"object":{"foo":"bar"}},"simple":"value"}));
-let response = request.send().await?;
-let body = response.json::<serde_json::Value>().await?;
-`)
+let response = request.send().await?;`)
   })
 })

--- a/packages/snippetz/src/plugins/rust/reqwest/reqwest.test.ts
+++ b/packages/snippetz/src/plugins/rust/reqwest/reqwest.test.ts
@@ -82,7 +82,9 @@ let response = request.send().await?;`)
 
 let request = client.post("https://example.com")
     .header("Content-Type", "application/json")
-    .json(&serde_json::json!({"hello":"world"}));
+    .json(&serde_json::json!({
+        "hello": "world"
+    }));
 
 let response = request.send().await?;`)
   })
@@ -490,7 +492,16 @@ let response = request.send().await?;`)
 
 let request = client.post("https://example.com")
     .header("Content-Type", "application/json")
-    .json(&serde_json::json!({"key":"\\\"quotes\\\" and \\\\backslashes\\\\","nested":{"array":["item1",null,null]}}));
+    .json(&serde_json::json!({
+        "key": "\\"quotes\\" and \\\\backslashes\\\\",
+        "nested": {
+            "array": [
+                "item1",
+                null,
+                null
+            ]
+        }
+    }));
 
 let response = request.send().await?;`)
   })
@@ -540,7 +551,19 @@ let response = request.send().await?;`)
 
 let request = client.post("https://example.com")
     .header("Content-Type", "application/json")
-    .json(&serde_json::json!({"nested":{"array":[1,2,3],"object":{"foo":"bar"}},"simple":"value"}));
+    .json(&serde_json::json!({
+        "nested": {
+            "array": [
+                1,
+                2,
+                3
+            ],
+            "object": {
+                "foo": "bar"
+            }
+        },
+        "simple": "value"
+    }));
 
 let response = request.send().await?;`)
   })

--- a/packages/snippetz/src/plugins/rust/reqwest/reqwest.ts
+++ b/packages/snippetz/src/plugins/rust/reqwest/reqwest.ts
@@ -191,6 +191,7 @@ const createBodyCall = (postData: any): string | null => {
 const buildRustCode = (url: string, method: string, chainedCalls: string[]): string => {
   const code = [
     'let client = reqwest::Client::new();',
+    '',
     `let request = client.${method.toLowerCase()}(${toRustString(url)})`,
   ]
 
@@ -202,6 +203,7 @@ const buildRustCode = (url: string, method: string, chainedCalls: string[]): str
   code[code.length - 1] = lastPart + ';'
 
   // Add response handling
+  code.push('')
   code.push('let response = request.send().await?;')
 
   return code.join('\n')

--- a/packages/snippetz/src/plugins/rust/reqwest/reqwest.ts
+++ b/packages/snippetz/src/plugins/rust/reqwest/reqwest.ts
@@ -221,14 +221,18 @@ const createBodyCall = (postData: any): string | null => {
  * Builds the complete Rust code by assembling all code
  */
 const buildRustCode = (url: string, method: string, chainedCalls: string[]): string => {
-  const code = [
-    'let client = reqwest::Client::new();',
-    '',
-    `let request = client.${method.toLowerCase()}(${toRustString(url)})`,
-  ]
+  const code = ['let client = reqwest::Client::new();', '']
 
-  // Add all chained calls
-  code.push(...chainedCalls)
+  // Add chained calls with proper formatting
+  if (chainedCalls.length > 0) {
+    code.push('let request = client')
+    code.push(indent(1, `.${method.toLowerCase()}(${toRustString(url)})`))
+
+    // Add a newline before the first chained call
+    code.push(...chainedCalls)
+  } else {
+    code.push(`let request = client.${method.toLowerCase()}(${toRustString(url)})`)
+  }
 
   // Add semicolon to the last chained call
   const lastPart = code[code.length - 1]

--- a/packages/snippetz/src/plugins/rust/reqwest/reqwest.ts
+++ b/packages/snippetz/src/plugins/rust/reqwest/reqwest.ts
@@ -1,5 +1,5 @@
-import type { Plugin } from '@scalar/types/snippetz'
 import { toRustString } from '@/plugins/rust/rustString'
+import type { Plugin } from '@scalar/types/snippetz'
 
 /**
  * rust/reqwest
@@ -19,7 +19,7 @@ export const rustReqwest: Plugin = {
     normalizedRequest.method = normalizedRequest.method.toUpperCase()
 
     // Start building the Rust code
-    let code = `let client = reqwest::Client::new();\n`
+    let code = 'let client = reqwest::Client::new();\n'
 
     // Handle query string
     const queryString = normalizedRequest.queryString?.length
@@ -68,10 +68,8 @@ export const rustReqwest: Plugin = {
     }
 
     // Handle body
-    let isJsonRequest = false
     if (normalizedRequest.postData) {
       if (normalizedRequest.postData.mimeType === 'application/json') {
-        isJsonRequest = true
         code += `\n    .json(&serde_json::json!(${normalizedRequest.postData.text}))`
       } else if (normalizedRequest.postData.mimeType === 'application/x-www-form-urlencoded') {
         const formData =
@@ -86,9 +84,9 @@ export const rustReqwest: Plugin = {
             ?.map((param) => {
               if (param.fileName) {
                 return `\n        let part = reqwest::multipart::Part::text(${toRustString(param.value || '')})\n            .file_name(${toRustString(param.fileName)});\n        form = form.part(${toRustString(param.name)}, part);`
-              } else {
-                return `\n        form = form.text(${toRustString(param.name)}, ${toRustString(param.value || '')});`
               }
+
+              return `\n        form = form.text(${toRustString(param.name)}, ${toRustString(param.value || '')});`
             })
             .join('') || ''
         code += `\n        let mut form = reqwest::multipart::Form::new();${formParts}\n            form\n        })`
@@ -98,13 +96,7 @@ export const rustReqwest: Plugin = {
     }
 
     code += ';\n'
-    code += `let response = request.send().await?;\n`
-
-    if (isJsonRequest) {
-      code += `let body = response.json::<serde_json::Value>().await?;\n`
-    } else {
-      code += `let body = response.text().await?;\n`
-    }
+    code += 'let response = request.send().await?;'
 
     return code
   },


### PR DESCRIPTION
**Problem**

We’ve added support for rust/reqwest code examples just recently, but it has two issues:

* Even for JSON endpoints, it’s expecting a plain text body.
* The code looks super crammed.

**Solution**

This PR:

* removes the response body handling (other generators don’t have that either)
* adds some whitespace
* pretty prints JSON
* refactors the generator for clarity and readability
* updates the tests

Fixes #6232

**Before**

<img width="543" height="314" alt="Screenshot 2025-07-14 at 14 21 27" src="https://github.com/user-attachments/assets/a8e6b8e6-0f04-4bad-9d6b-9ed852d270b8" />

**After**

<img width="538" height="356" alt="Screenshot 2025-07-14 at 14 25 29" src="https://github.com/user-attachments/assets/0c3d4045-7fde-4bdf-be8d-95d0bece5522" />

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
