### PR TITLE
fix(api-reference): example responses show additional `value` key

### DIFF
--- a/.changeset/tall-comics-fry.md
+++ b/.changeset/tall-comics-fry.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: example response has an additional value key

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.vue
@@ -85,7 +85,10 @@ const getFirstExampleResponse = () => {
   }
 
   const firstProperty = Object.keys(currentJsonResponse.value.examples)[0]
-  return currentJsonResponse.value.examples[firstProperty]
+  const firstExample = currentJsonResponse.value.examples[firstProperty]
+
+  // Handle the case where the example already has a 'value' property
+  return firstExample?.value ?? firstExample
 }
 
 const currentResponseWithExample = computed(() => ({


### PR DESCRIPTION
**Problem**

In some cases, an additional `value` key shows up in the example responses after switching the tabs.

**Solution**

This PR fixes it. :)

Fixes #5435
Fixes #5064

I struggled to write a test for it, the code is ready to be refactored for sure. I’ll look into this on another day.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
