### PR TITLE
chore: update vscode tailwind config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,10 +72,17 @@
   "git.pullTags": false,
   "vue.complete.casing.props": "camel",
   "vue.complete.casing.tags": "pascal",
-  "tailwindCSS.experimental.classRegex": [
-    ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
-    ["cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
+  "tailwindCSS.classAttributes": [
+    "class",
+    "className",
+    "enterFromClass",
+    "enterToClass",
+    "enterActiveClass",
+    "leaveFromClass",
+    "leaveToClass",
+    "leaveActiveClass"
   ],
+  "tailwindCSS.classFunctions": ["tw", "clsx", "cx"],
   "tailwindCSS.experimental.configFile": {
     "packages/api-client/src/style.css": "packages/api-client/**",
     "packages/api-reference/src/style.css": "packages/api-reference/**",


### PR DESCRIPTION
Updates the vs code config so we get tailwind support in functions and Vue `<transition>` classes.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
