### PR TITLE
feat(workspace-store): error message tells the reason `loadDocument` fails

### DIFF
--- a/.changeset/empty-garlics-yell.md
+++ b/.changeset/empty-garlics-yell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: shows different console errors whether the request wasn't successful or the data isn't a valid object

--- a/.changeset/seven-onions-compete.md
+++ b/.changeset/seven-onions-compete.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+fix: broken internal link

--- a/packages/api-reference/examples/openapi.json
+++ b/packages/api-reference/examples/openapi.json
@@ -1,0 +1,20 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Relative URL Example",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/hello-world": {
+      "get": {
+        "summary": "Hello World",
+        "description": "Returns a simple hello world message",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -1072,7 +1072,7 @@ describe('create-workspace-store', () => {
     })
   })
 
-  describe.only('addDocument error handling', () => {
+  describe('addDocument error handling', () => {
     beforeEach(() => {
       resetConsoleSpies()
     })

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -1,9 +1,10 @@
-import { createServerWorkspaceStore } from '@/server'
-import { createWorkspaceStore } from '@/client'
-import { beforeEach, afterEach, describe, expect, it } from 'vitest'
-import fastify, { type FastifyInstance } from 'fastify'
-import { defaultReferenceConfig } from '@/schemas/reference-config'
 import { setTimeout } from 'node:timers/promises'
+import { createWorkspaceStore } from '@/client'
+import { defaultReferenceConfig } from '@/schemas/reference-config'
+import { createServerWorkspaceStore } from '@/server'
+import { consoleErrorSpy, resetConsoleSpies } from '@scalar/helpers/testing/console-spies'
+import fastify, { type FastifyInstance } from 'fastify'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test document
 const getDocument = (version?: string) => ({
@@ -1068,6 +1069,97 @@ describe('create-workspace-store', () => {
       expect(store.workspace['x-scalar-dark-mode']).toBe(true)
       expect(store.workspace['x-scalar-active-document']).toBe('default')
       expect(store.workspace['x-scalar-default-client']).toBe('c/libcurl')
+    })
+  })
+
+  describe.only('addDocument error handling', () => {
+    beforeEach(() => {
+      resetConsoleSpies()
+    })
+
+    afterEach(() => {
+      resetConsoleSpies()
+    })
+
+    it('logs specific error when resolve.ok is false', async () => {
+      const store = createWorkspaceStore()
+
+      // Mock fetch to return a failed response
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      })
+
+      await store.addDocument({
+        name: 'failed-doc',
+        url: 'https://example.com/api.json',
+        fetch: mockFetch,
+      })
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to fetch document 'failed-doc': request was not successful")
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('logs specific error when resolve.data is not an object', async () => {
+      const store = createWorkspaceStore()
+
+      // Mock fetch to return a successful response but with non-object data
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('not an object'),
+      })
+
+      await store.addDocument({
+        name: 'invalid-doc',
+        url: 'https://example.com/api.json',
+        fetch: mockFetch,
+      })
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Failed to load document 'invalid-doc': response data is not a valid object",
+      )
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('logs different errors for different failure conditions', async () => {
+      const store = createWorkspaceStore()
+
+      // Test first condition: resolve.ok is false
+      const mockFetch1 = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      })
+
+      await store.addDocument({
+        name: 'server-error-doc',
+        url: 'https://example.com/api.json',
+        fetch: mockFetch1,
+      })
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Failed to fetch document 'server-error-doc': request was not successful",
+      )
+
+      // Reset the spy
+      resetConsoleSpies()
+
+      // Test second condition: resolve.data is not an object
+      const mockFetch2 = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(null),
+      })
+
+      await store.addDocument({
+        name: 'null-data-doc',
+        url: 'https://example.com/api2.json',
+        fetch: mockFetch2,
+      })
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Failed to load document 'null-data-doc': response data is not a valid object",
+      )
     })
   })
 })

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -1,22 +1,22 @@
-import YAML from 'yaml'
-import { reactive, toRaw } from 'vue'
 import { bundle, upgrade } from '@scalar/openapi-parser'
 import { fetchUrls } from '@scalar/openapi-parser/plugins-browser'
+import { reactive, toRaw } from 'vue'
+import YAML from 'yaml'
 
-import { createNavigation, type createNavigationOptions } from '@/navigation'
-import type { DeepTransform } from '@/types'
-import { createMagicProxy, getRaw } from '@/helpers/proxy'
-import { deepClone, isObject, safeAssign } from '@/helpers/general'
-import { mergeObjects } from '@/helpers/merge-object'
 import { applySelectiveUpdates } from '@/helpers/apply-selective-updates'
+import { deepClone, isObject, safeAssign } from '@/helpers/general'
 import { getValueByPath } from '@/helpers/json-path-utils'
-import type { WorkspaceMeta, WorkspaceDocumentMeta, Workspace } from '@/schemas/workspace'
+import { mergeObjects } from '@/helpers/merge-object'
+import { createMagicProxy, getRaw } from '@/helpers/proxy'
+import { createNavigation, type createNavigationOptions } from '@/navigation'
 import { extensions } from '@/schemas/extensions'
+import { type InMemoryWorkspace, InMemoryWorkspaceSchema } from '@/schemas/inmemory-workspace'
+import { defaultReferenceConfig } from '@/schemas/reference-config'
 import { coerceValue } from '@/schemas/typebox-coerce'
 import { OpenAPIDocumentSchema } from '@/schemas/v3.1/strict/openapi-document'
-import { defaultReferenceConfig } from '@/schemas/reference-config'
+import type { Workspace, WorkspaceDocumentMeta, WorkspaceMeta } from '@/schemas/workspace'
 import type { Config } from '@/schemas/workspace-specification/config'
-import { InMemoryWorkspaceSchema, type InMemoryWorkspace } from '@/schemas/inmemory-workspace'
+import type { DeepTransform } from '@/types'
 
 /**
  * Input type for workspace document metadata and configuration.
@@ -361,16 +361,33 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
 
       const resolve = await loadDocument(input)
 
-      if (!resolve.ok || !isObject(resolve.data)) {
-        console.error(`Can not load the document '${name}'`)
+      if (!resolve.ok) {
+        console.error(`Failed to fetch document '${name}': request was not successful`)
+
         workspace.documents[name] = {
           ...meta,
+          openapi: '3.1.0',
           info: {
             title: `Document '${name}' could not be loaded`,
             version: 'unknown',
           },
-          openapi: '3.1.0',
         }
+
+        return
+      }
+
+      if (!isObject(resolve.data)) {
+        console.error(`Failed to load document '${name}': response data is not a valid object`)
+
+        workspace.documents[name] = {
+          ...meta,
+          openapi: '3.1.0',
+          info: {
+            title: `Document '${name}' could not be loaded`,
+            version: 'unknown',
+          },
+        }
+
         return
       }
 


### PR DESCRIPTION
**Problem**

Currently, when the request fails OR the data is not a valid object, it’s the same console message.

**Solution**

With this PR, we’re making a difference here. :) Easier to debug errors.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
