### PR TITLE
fix(workspace-store): can’t load relative URLs

### DIFF
--- a/.changeset/seven-onions-compete.md
+++ b/.changeset/seven-onions-compete.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+fix: broken internal link

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -26,9 +26,14 @@
             url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
           },
           {
-            title: 'Scalar Galaxy Classic',
+            title: 'Scalar Galaxy (Classic Layout)',
             url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
             layout: 'classic',
+          },
+          {
+            title: 'Relative URL Example',
+            slug: 'relative-url',
+            url: 'examples/openapi.json',
           },
           {
             title: 'Swagger Petstore 2.0',

--- a/packages/openapi-parser/src/utils/bundle/plugins/fetch-urls/index.ts
+++ b/packages/openapi-parser/src/utils/bundle/plugins/fetch-urls/index.ts
@@ -5,10 +5,6 @@ import { createLimiter } from '@/utils/bundle/create-limiter'
 type FetchConfig = Partial<{
   headers: { headers: HeadersInit; domains: string[] }[]
   fetch: (input: string | URL | globalThis.Request, init?: RequestInit) => Promise<Response>
-  /**
-   * Used to validate the URL, defaults to checking for remote URLs
-   */
-  validate?: (url: string) => boolean
 }>
 
 /**
@@ -91,7 +87,7 @@ export function fetchUrls(config?: FetchConfig & Partial<{ limit: number | null 
   const limiter = config?.limit ? createLimiter(config.limit) : <T>(fn: () => Promise<T>) => fn()
 
   return {
-    validate: config?.validate ?? isRemoteUrl,
+    validate: isRemoteUrl,
     exec: (value) => fetchUrl(value, limiter, config),
   }
 }

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -1125,7 +1125,7 @@ describe('create-workspace-store', () => {
     it('allows relative urls', async () => {
       const store = createWorkspaceStore()
 
-      // Mock fetch to return a successful response but with non-object data
+      // We dont' care about the response, we just want to make sure the fetch is called
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
       })

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -1122,6 +1122,23 @@ describe('create-workspace-store', () => {
       expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
     })
 
+    it('allows relative urls', async () => {
+      const store = createWorkspaceStore()
+
+      // Mock fetch to return a successful response but with non-object data
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+      })
+
+      await store.addDocument({
+        name: 'relative-doc',
+        url: 'examples/openapi.json',
+        fetch: mockFetch,
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith('examples/openapi.json', { headers: undefined })
+    })
+
     it('logs different errors for different failure conditions', async () => {
       const store = createWorkspaceStore()
 

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -83,7 +83,7 @@ const defaultConfig: DeepTransform<Config, 'NonNullable'> = {
  */
 async function loadDocument(workspaceDocument: WorkspaceDocumentInput) {
   if ('url' in workspaceDocument) {
-    // validate normally checks for local files, but we want to fetch them anyway ex: examples/openapi.json
+    // validate normally checks for relative files, but we want to fetch them anyway ex: examples/openapi.json
     return fetchUrls({ fetch: workspaceDocument.fetch, validate: () => true }).exec(workspaceDocument.url)
   }
 

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -84,7 +84,7 @@ const defaultConfig: DeepTransform<Config, 'NonNullable'> = {
 async function loadDocument(workspaceDocument: WorkspaceDocumentInput) {
   if ('url' in workspaceDocument) {
     // validate normally checks for relative files, but we want to fetch them anyway ex: examples/openapi.json
-    return fetchUrls({ fetch: workspaceDocument.fetch, validate: () => true }).exec(workspaceDocument.url)
+    return fetchUrls({ fetch: workspaceDocument.fetch }).exec(workspaceDocument.url)
   }
 
   return {

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -83,7 +83,8 @@ const defaultConfig: DeepTransform<Config, 'NonNullable'> = {
  */
 async function loadDocument(workspaceDocument: WorkspaceDocumentInput) {
   if ('url' in workspaceDocument) {
-    return fetchUrls({ fetch: workspaceDocument.fetch }).exec(workspaceDocument.url)
+    // validate normally checks for local files, but we want to fetch them anyway ex: examples/openapi.json
+    return fetchUrls({ fetch: workspaceDocument.fetch, validate: () => true }).exec(workspaceDocument.url)
   }
 
   return {

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -83,7 +83,6 @@ const defaultConfig: DeepTransform<Config, 'NonNullable'> = {
  */
 async function loadDocument(workspaceDocument: WorkspaceDocumentInput) {
   if ('url' in workspaceDocument) {
-    // validate normally checks for relative files, but we want to fetch them anyway ex: examples/openapi.json
     return fetchUrls({ fetch: workspaceDocument.fetch }).exec(workspaceDocument.url)
   }
 


### PR DESCRIPTION
**Problem**

Currently, the workspace store doesn’t load relative URLs. I think it’s because `isRemoteUrl` returns `false` for relative URLs.

**Solution**

This PR adds a relative URL example (`pnpm dev:reference`) to show the error.

⚠️ It doesn’t fix the issue yet.

<img width="367" height="52" alt="Screenshot 2025-07-15 at 14 32 59" src="https://github.com/user-attachments/assets/33752704-0aad-47ed-9f85-434d01bfb038" />

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
