### PR TITLE
feat(fastapi): new theme option

### DIFF
--- a/.changeset/eight-hotels-care.md
+++ b/.changeset/eight-hotels-care.md
@@ -1,0 +1,5 @@
+---
+'scalar-fastapi': patch
+---
+
+feat: add theme option

--- a/.changeset/seven-onions-compete.md
+++ b/.changeset/seven-onions-compete.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+fix: broken internal link

--- a/integrations/fastapi/package.json
+++ b/integrations/fastapi/package.json
@@ -16,7 +16,8 @@
     "node": ">=20"
   },
   "scripts": {
-    "test": "python3 run_tests.py"
+    "test": "python3 run_tests.py",
+    "dev": "cd playground && uvicorn main:app --reload"
   },
   "dependencies": {},
   "devDependencies": {}

--- a/integrations/fastapi/playground/main.py
+++ b/integrations/fastapi/playground/main.py
@@ -1,6 +1,6 @@
 from typing import Union
 from fastapi import FastAPI
-from scalar_fastapi import get_scalar_api_reference
+from scalar_fastapi import get_scalar_api_reference, Theme
 
 app = FastAPI()
 
@@ -13,6 +13,7 @@ async def scalar_html():
     return get_scalar_api_reference(
         openapi_url=app.openapi_url,
         title=app.title + " - Scalar",
+        theme=Theme.KEPLER,
     )
 
 

--- a/integrations/fastapi/playground/main.py
+++ b/integrations/fastapi/playground/main.py
@@ -1,5 +1,11 @@
 from typing import Union
 from fastapi import FastAPI
+import sys
+import os
+
+# Use the local scalar_fastapi package
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
 from scalar_fastapi import get_scalar_api_reference, Theme
 
 app = FastAPI()

--- a/integrations/fastapi/scalar_fastapi/__init__.py
+++ b/integrations/fastapi/scalar_fastapi/__init__.py
@@ -1,1 +1,1 @@
-from .scalar_fastapi import get_scalar_api_reference, Layout, SearchHotKey
+from .scalar_fastapi import get_scalar_api_reference, Layout, SearchHotKey, Theme

--- a/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
+++ b/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
@@ -40,6 +40,21 @@ class SearchHotKey(Enum):
     Z = "z"
 
 
+class Theme(Enum):
+    ALTERNATE = "alternate"
+    DEFAULT = "default"
+    MOON = "moon"
+    PURPLE = "purple"
+    SOLARIZED = "solarized"
+    BLUE_PLANET = "bluePlanet"
+    SATURN = "saturn"
+    KEPLER = "kepler"
+    MARS = "mars"
+    DEEP_SPACE = "deepSpace"
+    LASERWAVE = "laserwave"
+    NONE = "none"
+
+
 scalar_theme = """
 /* basic theme */
 .light-mode {
@@ -301,6 +316,15 @@ def get_scalar_api_reference(
             """
         ),
     ] = 'fastapi',
+    theme: Annotated[
+        Theme,
+        Doc(
+            """
+            The theme to use for Scalar.
+            Default is "default".
+            """
+        ),
+    ] = Theme.DEFAULT,
 ) -> HTMLResponse:
     html = f"""
     <!DOCTYPE html>
@@ -343,6 +367,7 @@ def get_scalar_api_reference(
         authentication: {json.dumps(authentication)},
         hideClientButton: {json.dumps(hide_client_button)},
         _integration: {json.dumps(integration)},
+        theme: "{theme.value}",
       }}
 
       document.getElementById('api-reference').dataset.configuration =

--- a/integrations/fastapi/tests/test_imports.py
+++ b/integrations/fastapi/tests/test_imports.py
@@ -8,18 +8,32 @@ import pytest
 
 def test_scalar_fastapi_imports():
     """Test that all scalar_fastapi imports work correctly"""
-    
+
     # Test main function import
     from scalar_fastapi import get_scalar_api_reference
     assert callable(get_scalar_api_reference)
-    
+
     # Test enum imports
-    from scalar_fastapi import Layout, SearchHotKey
+    from scalar_fastapi import Layout, SearchHotKey, Theme
     assert Layout.MODERN.value == "modern"
     assert Layout.CLASSIC.value == "classic"
     assert SearchHotKey.K.value == "k"
     assert SearchHotKey.A.value == "a"
     assert SearchHotKey.Z.value == "z"
+
+    # Test Theme enum values
+    assert Theme.DEFAULT.value == "default"
+    assert Theme.ALTERNATE.value == "alternate"
+    assert Theme.MOON.value == "moon"
+    assert Theme.PURPLE.value == "purple"
+    assert Theme.SOLARIZED.value == "solarized"
+    assert Theme.BLUE_PLANET.value == "bluePlanet"
+    assert Theme.SATURN.value == "saturn"
+    assert Theme.KEPLER.value == "kepler"
+    assert Theme.MARS.value == "mars"
+    assert Theme.DEEP_SPACE.value == "deepSpace"
+    assert Theme.LASERWAVE.value == "laserwave"
+    assert Theme.NONE.value == "none"
 
 
 def test_fastapi_imports():
@@ -27,11 +41,11 @@ def test_fastapi_imports():
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
     from fastapi.responses import HTMLResponse
-    
+
     # Verify we can create a FastAPI app
     app = FastAPI()
     assert app is not None
-    
+
     # Verify we can create a test client
     client = TestClient(app)
     assert client is not None
@@ -40,7 +54,7 @@ def test_fastapi_imports():
 def test_pytest_imports():
     """Test that pytest imports work correctly"""
     import pytest
-    
+
     # Verify pytest is available
     assert pytest is not None
 
@@ -48,7 +62,36 @@ def test_pytest_imports():
 def test_typing_imports():
     """Test that typing imports work correctly"""
     from typing_extensions import Annotated, Doc
-    
+
     # Verify typing extensions are available
     assert Annotated is not None
-    assert Doc is not None 
+    assert Doc is not None
+
+
+def test_theme_enum_completeness():
+    """Test that all expected theme values are available"""
+    from scalar_fastapi import Theme
+
+    # Check that all expected themes are present
+    expected_themes = [
+        "default", "alternate", "moon", "purple", "solarized",
+        "bluePlanet", "saturn", "kepler", "mars", "deepSpace",
+        "laserwave", "none"
+    ]
+
+    actual_themes = [theme.value for theme in Theme]
+
+    for expected_theme in expected_themes:
+        assert expected_theme in actual_themes, f"Theme '{expected_theme}' not found in Theme enum"
+
+    assert len(actual_themes) == len(expected_themes), "Number of themes doesn't match expected count"
+
+
+def test_theme_enum_uniqueness():
+    """Test that all theme values are unique"""
+    from scalar_fastapi import Theme
+
+    theme_values = [theme.value for theme in Theme]
+    unique_values = set(theme_values)
+
+    assert len(theme_values) == len(unique_values), "Theme enum contains duplicate values"

--- a/integrations/fastapi/tests/test_integration.py
+++ b/integrations/fastapi/tests/test_integration.py
@@ -3,33 +3,33 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from typing import Union
 
-from scalar_fastapi import get_scalar_api_reference, Layout, SearchHotKey
+from scalar_fastapi import get_scalar_api_reference, Layout, SearchHotKey, Theme
 
 
 @pytest.fixture
 def app():
     """Create a test FastAPI application"""
     app = FastAPI(title="Test API")
-    
+
     @app.get("/")
     def read_root():
         return {"Hello": "World"}
-    
+
     @app.get("/items/{item_id}")
     def read_item(item_id: int, q: Union[str, None] = None):
         return {"item_id": item_id, "q": q}
-    
+
     @app.post("/items/")
     def create_item(item: dict):
         return {"item": item, "created": True}
-    
+
     @app.get("/scalar", include_in_schema=False)
     async def scalar_html():
         return get_scalar_api_reference(
             openapi_url=app.openapi_url,
             title=app.title + " - Scalar",
         )
-    
+
     @app.get("/scalar-custom", include_in_schema=False)
     async def scalar_custom_html():
         return get_scalar_api_reference(
@@ -41,6 +41,7 @@ def app():
             hide_models=True,
             show_sidebar=False,
             search_hot_key=SearchHotKey.S,
+            theme=Theme.MOON,  # Add theme parameter
             servers=[
                 {"name": "Production", "url": "https://api.example.com"},
                 {"name": "Development", "url": "http://localhost:8000"}
@@ -53,7 +54,15 @@ def app():
                 }
             }
         )
-    
+
+    @app.get("/scalar-theme-test", include_in_schema=False)
+    async def scalar_theme_test_html():
+        return get_scalar_api_reference(
+            openapi_url=app.openapi_url,
+            title=app.title + " - Theme Test",
+            theme=Theme.PURPLE,
+        )
+
     return app
 
 
@@ -65,17 +74,17 @@ def client(app):
 
 class TestFastAPIIntegration:
     """Integration tests for FastAPI with Scalar"""
-    
+
     def test_basic_endpoints_work(self, client):
         """Test that basic API endpoints work"""
         response = client.get("/")
         assert response.status_code == 200
         assert response.json() == {"Hello": "World"}
-        
+
         response = client.get("/items/123?q=test")
         assert response.status_code == 200
         assert response.json() == {"item_id": 123, "q": "test"}
-        
+
         response = client.post("/items/", json={"name": "test item"})
         assert response.status_code == 200
         assert response.json() == {"item": {"name": "test item"}, "created": True}
@@ -83,39 +92,40 @@ class TestFastAPIIntegration:
     def test_scalar_endpoint_returns_html(self, client, app):
         """Test that the scalar endpoint returns proper HTML"""
         response = client.get("/scalar")
-        
+
         assert response.status_code == 200
         assert "text/html" in response.headers["content-type"]
-        
+
         html_content = response.text
-        
+
         # Check basic HTML structure
         assert "<!DOCTYPE html>" in html_content
         assert "<html>" in html_content
         assert "<head>" in html_content
         assert "<body>" in html_content
-        
+
         # Check title
         assert f"<title>{app.title} - Scalar</title>" in html_content
-        
+
         # Check OpenAPI URL
         assert f'data-url="{app.openapi_url}"' in html_content
-        
+
         # Check default configuration
         assert 'layout: "modern"' in html_content
         assert 'showSidebar: true' in html_content
         assert 'darkMode: true' in html_content
         assert '_integration: "fastapi"' in html_content
+        assert 'theme: "default"' in html_content  # Add theme check
 
     def test_scalar_custom_endpoint(self, client, app):
         """Test scalar endpoint with custom configuration"""
         response = client.get("/scalar-custom")
-        
+
         assert response.status_code == 200
         assert "text/html" in response.headers["content-type"]
-        
+
         html_content = response.text
-        
+
         # Check custom configuration
         assert 'layout: "classic"' in html_content
         assert 'darkMode: false' in html_content
@@ -123,46 +133,66 @@ class TestFastAPIIntegration:
         assert 'hideModels: true' in html_content
         assert 'showSidebar: false' in html_content
         assert 'searchHotKey: "s"' in html_content
-        
+        assert 'theme: "moon"' in html_content  # Add theme check
+
         # Check servers configuration
         assert '"name": "Production"' in html_content
         assert '"url": "https://api.example.com"' in html_content
         assert '"name": "Development"' in html_content
         assert '"url": "http://localhost:8000"' in html_content
-        
+
         # Check authentication configuration
         assert '"type": "apiKey"' in html_content
         assert '"in": "header"' in html_content
         assert '"name": "X-API-Key"' in html_content
 
+    def test_scalar_theme_endpoint(self, client, app):
+        """Test scalar endpoint with theme configuration"""
+        response = client.get("/scalar-theme-test")
+
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+        html_content = response.text
+
+        # Check theme configuration
+        assert 'theme: "purple"' in html_content
+        assert f"<title>{app.title} - Theme Test</title>" in html_content
+
+        # Check that other defaults are still present
+        assert 'layout: "modern"' in html_content
+        assert 'showSidebar: true' in html_content
+        assert 'darkMode: true' in html_content
+
     def test_openapi_schema_endpoint(self, client):
         """Test that the OpenAPI schema endpoint works"""
         response = client.get("/openapi.json")
-        
+
         assert response.status_code == 200
         assert "application/json" in response.headers["content-type"]
-        
+
         schema = response.json()
-        
+
         # Check basic OpenAPI structure
         assert "openapi" in schema
         assert "info" in schema
         assert "paths" in schema
-        
+
         # Check that our endpoints are in the schema
         assert "/" in schema["paths"]
         assert "/items/{item_id}" in schema["paths"]
         assert "/items/" in schema["paths"]
-        
+
         # Check that scalar endpoint is NOT in the schema (include_in_schema=False)
         assert "/scalar" not in schema["paths"]
         assert "/scalar-custom" not in schema["paths"]
+        assert "/scalar-theme-test" not in schema["paths"]
 
     def test_scalar_uses_correct_openapi_url(self, client, app):
         """Test that scalar uses the correct OpenAPI URL"""
         response = client.get("/scalar")
         html_content = response.text
-        
+
         # The scalar endpoint should reference the app's openapi_url
         expected_url = app.openapi_url or "/openapi.json"
         assert f'data-url="{expected_url}"' in html_content
@@ -171,7 +201,7 @@ class TestFastAPIIntegration:
         """Test that the default theme CSS is included"""
         response = client.get("/scalar")
         html_content = response.text
-        
+
         # Check that theme CSS is included
         assert "--scalar-color-1: #2a2f45;" in html_content
         assert "--scalar-color-accent: #009485;" in html_content
@@ -181,7 +211,7 @@ class TestFastAPIIntegration:
         """Test that the Scalar JavaScript is included"""
         response = client.get("/scalar")
         html_content = response.text
-        
+
         # Check that the Scalar script is included
         assert 'src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"' in html_content
 
@@ -189,7 +219,7 @@ class TestFastAPIIntegration:
         """Test that the configuration script is properly generated"""
         response = client.get("/scalar")
         html_content = response.text
-        
+
         # Check configuration script structure
         assert 'var configuration = {' in html_content
         assert 'document.getElementById(\'api-reference\').dataset.configuration =' in html_content
@@ -199,7 +229,7 @@ class TestFastAPIIntegration:
         """Test that noscript message is included"""
         response = client.get("/scalar")
         html_content = response.text
-        
+
         assert "<noscript>" in html_content
         assert "Scalar requires Javascript to function" in html_content
 
@@ -207,63 +237,89 @@ class TestFastAPIIntegration:
         """Test that favicon is included"""
         response = client.get("/scalar")
         html_content = response.text
-        
+
         assert 'href="https://fastapi.tiangolo.com/img/favicon.png"' in html_content
 
     def test_scalar_meta_tags(self, client):
         """Test that proper meta tags are included"""
         response = client.get("/scalar")
         html_content = response.text
-        
+
         assert '<meta charset="utf-8"/>' in html_content
         assert '<meta name="viewport" content="width=device-width, initial-scale=1">' in html_content
 
     def test_multiple_scalar_endpoints(self, client):
         """Test that multiple scalar endpoints can coexist"""
-        # Test both scalar endpoints
+        # Test all scalar endpoints
         response1 = client.get("/scalar")
         response2 = client.get("/scalar-custom")
-        
+        response3 = client.get("/scalar-theme-test")
+
         assert response1.status_code == 200
         assert response2.status_code == 200
-        
+        assert response3.status_code == 200
+
         # They should have different titles
         assert "Test API - Scalar" in response1.text
         assert "Test API - Custom Scalar" in response2.text
-        
+        assert "Test API - Theme Test" in response3.text
+
         # They should have different configurations
         assert 'layout: "modern"' in response1.text
         assert 'layout: "classic"' in response2.text
+        assert 'layout: "modern"' in response3.text  # Default layout
+
+        # They should have different themes
+        assert 'theme: "default"' in response1.text
+        assert 'theme: "moon"' in response2.text
+        assert 'theme: "purple"' in response3.text
 
 
 class TestScalarConfiguration:
     """Test various Scalar configuration options"""
-    
+
     def test_layout_configuration(self, client):
         """Test different layout configurations"""
         # Test modern layout (default)
         response = client.get("/scalar")
         assert 'layout: "modern"' in response.text
-        
+
         # Test classic layout
         response = client.get("/scalar-custom")
         assert 'layout: "classic"' in response.text
 
     def test_theme_configuration(self, client):
         """Test theme configuration"""
+        # Test default theme
+        response = client.get("/scalar")
+        assert 'theme: "default"' in response.text
+
+        # Test custom theme
+        response = client.get("/scalar-custom")
+        assert 'theme: "moon"' in response.text
+
+        # Test theme-only endpoint
+        response = client.get("/scalar-theme-test")
+        assert 'theme: "purple"' in response.text
+
+    def test_theme_and_css_theme_relationship(self, client):
+        """Test that theme parameter and scalar_theme CSS work together"""
         response = client.get("/scalar")
         html_content = response.text
-        
+
         # Check that default theme is applied
         assert "--scalar-color-1: #2a2f45;" in html_content
         assert "--scalar-color-accent: #009485;" in html_content
+
+        # Check that theme parameter is set
+        assert 'theme: "default"' in html_content
 
     def test_sidebar_configuration(self, client):
         """Test sidebar configuration"""
         # Default should show sidebar
         response = client.get("/scalar")
         assert 'showSidebar: true' in response.text
-        
+
         # Custom should hide sidebar
         response = client.get("/scalar-custom")
         assert 'showSidebar: false' in response.text
@@ -273,7 +329,7 @@ class TestScalarConfiguration:
         # Default should be dark mode
         response = client.get("/scalar")
         assert 'darkMode: true' in response.text
-        
+
         # Custom should be light mode
         response = client.get("/scalar-custom")
         assert 'darkMode: false' in response.text
@@ -283,7 +339,73 @@ class TestScalarConfiguration:
         # Default should be 'k'
         response = client.get("/scalar")
         assert 'searchHotKey: "k"' in response.text
-        
+
         # Custom should be 's'
         response = client.get("/scalar-custom")
-        assert 'searchHotKey: "s"' in response.text 
+        assert 'searchHotKey: "s"' in response.text
+
+
+class TestThemeIntegration:
+    """Test theme integration specifically"""
+
+    def test_all_theme_values_work(self, client):
+        """Test that all theme values can be used in FastAPI integration"""
+        app = FastAPI(title="Theme Test API")
+
+        # Create endpoints for each theme
+        for theme in Theme:
+            @app.get(f"/scalar-{theme.value}", include_in_schema=False)
+            async def scalar_theme_html(theme=theme):
+                return get_scalar_api_reference(
+                    openapi_url=app.openapi_url,
+                    title=f"Test API - {theme.value}",
+                    theme=theme
+                )
+
+        test_client = TestClient(app)
+
+        # Test each theme endpoint
+        for theme in Theme:
+            response = test_client.get(f"/scalar-{theme.value}")
+            assert response.status_code == 200
+            assert f'theme: "{theme.value}"' in response.text
+            assert f"<title>Test API - {theme.value}</title>" in response.text
+
+    def test_theme_with_complex_configuration(self, client):
+        """Test theme with complex configuration"""
+        app = FastAPI(title="Complex Theme API")
+
+        @app.get("/scalar-complex", include_in_schema=False)
+        async def scalar_complex_html():
+            return get_scalar_api_reference(
+                openapi_url=app.openapi_url,
+                title="Complex Theme Test",
+                theme=Theme.DEEP_SPACE,
+                layout=Layout.CLASSIC,
+                dark_mode=False,
+                show_sidebar=False,
+                hide_download_button=True,
+                hide_models=True,
+                search_hot_key=SearchHotKey.A,
+                servers=[{"name": "Test", "url": "https://test.com"}],
+                authentication={"bearer": {"type": "http", "scheme": "bearer"}},
+                hide_client_button=True,
+                default_open_all_tags=True
+            )
+
+        test_client = TestClient(app)
+        response = test_client.get("/scalar-complex")
+
+        assert response.status_code == 200
+        html_content = response.text
+
+        # Check all configuration values including theme
+        assert 'theme: "deepSpace"' in html_content
+        assert 'layout: "classic"' in html_content
+        assert 'darkMode: false' in html_content
+        assert 'showSidebar: false' in html_content
+        assert 'hideDownloadButton: true' in html_content
+        assert 'hideModels: true' in html_content
+        assert 'searchHotKey: "a"' in html_content
+        assert 'hideClientButton: true' in html_content
+        assert 'defaultOpenAllTags: true' in html_content

--- a/integrations/fastapi/tests/test_scalar_fastapi.py
+++ b/integrations/fastapi/tests/test_scalar_fastapi.py
@@ -8,6 +8,7 @@ from scalar_fastapi import (
     get_scalar_api_reference,
     Layout,
     SearchHotKey,
+    Theme,  # Add Theme to imports
 )
 
 
@@ -26,6 +27,36 @@ class TestSearchHotKey:
         assert SearchHotKey.Z.value == "z"
 
 
+class TestTheme:
+    """Test the Theme enum functionality"""
+
+    def test_theme_enum_values(self):
+        """Test that Theme enum has correct values"""
+        assert Theme.DEFAULT.value == "default"
+        assert Theme.ALTERNATE.value == "alternate"
+        assert Theme.MOON.value == "moon"
+        assert Theme.PURPLE.value == "purple"
+        assert Theme.SOLARIZED.value == "solarized"
+        assert Theme.BLUE_PLANET.value == "bluePlanet"
+        assert Theme.SATURN.value == "saturn"
+        assert Theme.KEPLER.value == "kepler"
+        assert Theme.MARS.value == "mars"
+        assert Theme.DEEP_SPACE.value == "deepSpace"
+        assert Theme.LASERWAVE.value == "laserwave"
+        assert Theme.NONE.value == "none"
+
+    def test_theme_enum_all_values(self):
+        """Test that all theme values are unique and valid"""
+        theme_values = [theme.value for theme in Theme]
+        assert len(theme_values) == len(set(theme_values))  # All values are unique
+        assert len(theme_values) == 12  # Total number of themes
+
+        # Check that all values are strings
+        for value in theme_values:
+            assert isinstance(value, str)
+            assert len(value) > 0
+
+
 class TestGetScalarApiReference:
     def test_basic_functionality(self):
         """Test basic functionality with minimal parameters"""
@@ -33,11 +64,11 @@ class TestGetScalarApiReference:
             openapi_url="/openapi.json",
             title="Test API"
         )
-        
+
         assert isinstance(response, HTMLResponse)
         assert response.status_code == 200
         assert "text/html" in response.headers["content-type"]
-        
+
         html_content = response.body.decode()
         assert "<!DOCTYPE html>" in html_content
         assert "<title>Test API</title>" in html_content
@@ -49,9 +80,9 @@ class TestGetScalarApiReference:
             openapi_url="/openapi.json",
             title="Test API"
         )
-        
+
         html_content = response.body.decode()
-        
+
         # Check default values
         assert 'data-proxy-url=""' in html_content
         assert 'href="https://fastapi.tiangolo.com/img/favicon.png"' in html_content
@@ -68,6 +99,7 @@ class TestGetScalarApiReference:
         assert 'authentication: {}' in html_content
         assert 'hideClientButton: false' in html_content
         assert '_integration: "fastapi"' in html_content
+        assert 'theme: "default"' in html_content  # Add theme default check
 
     def test_custom_parameters(self):
         """Test custom parameter values"""
@@ -88,11 +120,12 @@ class TestGetScalarApiReference:
             default_open_all_tags=True,
             authentication={"apiKey": "test-key"},
             hide_client_button=True,
-            integration="custom"
+            integration="custom",
+            theme=Theme.MOON  # Add theme parameter
         )
-        
+
         html_content = response.body.decode()
-        
+
         # Check custom values
         assert 'data-url="/custom/openapi.json"' in html_content
         assert "<title>Custom API</title>" in html_content
@@ -111,6 +144,75 @@ class TestGetScalarApiReference:
         assert 'authentication: {"apiKey": "test-key"}' in html_content
         assert 'hideClientButton: true' in html_content
         assert '_integration: "custom"' in html_content
+        assert 'theme: "moon"' in html_content  # Check theme value
+
+    def test_theme_parameter_all_values(self):
+        """Test all theme enum values work correctly"""
+        for theme in Theme:
+            response = get_scalar_api_reference(
+                openapi_url="/openapi.json",
+                title=f"Test API - {theme.value}",
+                theme=theme
+            )
+
+            html_content = response.body.decode()
+            assert f'theme: "{theme.value}"' in html_content
+            assert f"<title>Test API - {theme.value}</title>" in html_content
+
+    def test_theme_with_other_parameters(self):
+        """Test theme parameter works correctly with other parameters"""
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API",
+            theme=Theme.PURPLE,
+            layout=Layout.CLASSIC,
+            dark_mode=False,
+            show_sidebar=False
+        )
+
+        html_content = response.body.decode()
+
+        # Check that theme is included with other parameters
+        assert 'theme: "purple"' in html_content
+        assert 'layout: "classic"' in html_content
+        assert 'darkMode: false' in html_content
+        assert 'showSidebar: false' in html_content
+
+    def test_theme_default_value(self):
+        """Test that the default theme is 'default'"""
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API",
+        )
+
+        html_content = response.body.decode()
+        assert 'theme: "default"' in html_content
+
+    def test_theme_none_value(self):
+        """Test the 'none' theme value"""
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API",
+            theme=Theme.NONE
+        )
+
+        html_content = response.body.decode()
+        assert 'theme: "none"' in html_content
+
+    def test_theme_in_configuration_object(self):
+        """Test that theme is properly included in the configuration object"""
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API",
+            theme=Theme.SOLARIZED
+        )
+
+        html_content = response.body.decode()
+
+        # Check that theme is in the configuration object
+        assert 'var configuration = {' in html_content
+        assert 'theme: "solarized"' in html_content
+        assert 'document.getElementById(\'api-reference\').dataset.configuration =' in html_content
 
     def test_hidden_clients_dict_format(self):
         """Test hidden_clients parameter with dictionary format"""
@@ -119,13 +221,13 @@ class TestGetScalarApiReference:
             "target2": ["client1", "client2"],
             "target3": False
         }
-        
+
         response = get_scalar_api_reference(
             openapi_url="/openapi.json",
             title="Test API",
             hidden_clients=hidden_clients
         )
-        
+
         html_content = response.body.decode()
         expected_json = json.dumps(hidden_clients)
         assert f'hiddenClients: {expected_json}' in html_content
@@ -137,13 +239,13 @@ class TestGetScalarApiReference:
             {"name": "Staging", "url": "https://staging-api.example.com"},
             {"name": "Development", "url": "http://localhost:8000"}
         ]
-        
+
         response = get_scalar_api_reference(
             openapi_url="/openapi.json",
             title="Test API",
             servers=servers
         )
-        
+
         html_content = response.body.decode()
         expected_json = json.dumps(servers)
         assert f'servers: {expected_json}' in html_content
@@ -161,13 +263,13 @@ class TestGetScalarApiReference:
                 "scheme": "bearer"
             }
         }
-        
+
         response = get_scalar_api_reference(
             openapi_url="/openapi.json",
             title="Test API",
             authentication=auth_config
         )
-        
+
         html_content = response.body.decode()
         expected_json = json.dumps(auth_config)
         assert f'authentication: {expected_json}' in html_content
@@ -180,13 +282,13 @@ class TestGetScalarApiReference:
             --scalar-color-accent: #00ff00;
         }
         """
-        
+
         response = get_scalar_api_reference(
             openapi_url="/openapi.json",
             title="Test API",
             scalar_theme=custom_theme
         )
-        
+
         html_content = response.body.decode()
         assert custom_theme in html_content
 
@@ -197,7 +299,7 @@ class TestGetScalarApiReference:
             title="Test API",
             integration=None
         )
-        
+
         html_content = response.body.decode()
         assert '_integration: null' in html_content
 
@@ -207,24 +309,24 @@ class TestGetScalarApiReference:
             openapi_url="/openapi.json",
             title="Test API"
         )
-        
+
         html_content = response.body.decode()
-        
+
         # Check essential HTML elements
         assert "<!DOCTYPE html>" in html_content
         assert "<html>" in html_content
         assert "<head>" in html_content
         assert "<body>" in html_content
         assert "</html>" in html_content
-        
+
         # Check meta tags
         assert '<meta charset="utf-8"/>' in html_content
         assert '<meta name="viewport" content="width=device-width, initial-scale=1">' in html_content
-        
+
         # Check script tags
         assert 'id="api-reference"' in html_content
         assert '<script src=' in html_content
-        
+
         # Check noscript tag
         assert "<noscript>" in html_content
         assert "Scalar requires Javascript to function" in html_content
@@ -235,9 +337,9 @@ class TestGetScalarApiReference:
             openapi_url="/openapi.json",
             title="Test API"
         )
-        
+
         html_content = response.body.decode()
-        
+
         # Check that configuration script exists
         assert 'var configuration = {' in html_content
         assert 'document.getElementById(\'api-reference\').dataset.configuration =' in html_content
@@ -246,29 +348,29 @@ class TestGetScalarApiReference:
 
 class TestFastAPIIntegration:
     """Test the integration with FastAPI"""
-    
+
     def test_fastapi_integration(self):
         """Test that the function works with FastAPI"""
         app = FastAPI()
-        
+
         @app.get("/scalar", include_in_schema=False)
         async def scalar_html():
             return get_scalar_api_reference(
                 openapi_url=app.openapi_url,
                 title=app.title + " - Scalar",
             )
-        
+
         @app.get("/")
         def read_root():
             return {"Hello": "World"}
-        
+
         client = TestClient(app)
-        
+
         # Test the scalar endpoint
         response = client.get("/scalar")
         assert response.status_code == 200
         assert "text/html" in response.headers["content-type"]
-        
+
         html_content = response.text
         assert "<!DOCTYPE html>" in html_content
         assert f"<title>{app.title} - Scalar</title>" in html_content
@@ -277,7 +379,7 @@ class TestFastAPIIntegration:
     def test_fastapi_with_custom_config(self):
         """Test FastAPI integration with custom configuration"""
         app = FastAPI(title="Custom API")
-        
+
         @app.get("/scalar", include_in_schema=False)
         async def scalar_html():
             return get_scalar_api_reference(
@@ -287,12 +389,12 @@ class TestFastAPIIntegration:
                 dark_mode=False,
                 hide_download_button=True
             )
-        
+
         client = TestClient(app)
-        
+
         response = client.get("/scalar")
         assert response.status_code == 200
-        
+
         html_content = response.text
         assert 'layout: "classic"' in html_content
         assert 'darkMode: false' in html_content
@@ -301,7 +403,7 @@ class TestFastAPIIntegration:
 
 class TestEdgeCases:
     """Test edge cases and error conditions"""
-    
+
     def test_empty_strings(self):
         """Test with empty string parameters"""
         response = get_scalar_api_reference(
@@ -311,7 +413,7 @@ class TestEdgeCases:
             scalar_proxy_url="",
             scalar_favicon_url=""
         )
-        
+
         assert isinstance(response, HTMLResponse)
         html_content = response.body.decode()
         assert 'data-url=""' in html_content
@@ -324,7 +426,7 @@ class TestEdgeCases:
             openapi_url="/openapi.json",
             title=title_with_special_chars
         )
-        
+
         html_content = response.body.decode()
         # The title should be properly escaped in the HTML
         assert title_with_special_chars in html_content
@@ -346,14 +448,14 @@ class TestEdgeCases:
                 }
             }
         }
-        
+
         response = get_scalar_api_reference(
             openapi_url="/openapi.json",
             title="Test API",
             authentication=complex_auth
         )
-        
+
         html_content = response.body.decode()
         # The complex JSON should be properly serialized
         assert "oauth2" in html_content
-        assert "authorizationCode" in html_content 
+        assert "authorizationCode" in html_content


### PR DESCRIPTION
**Problem**

Currently, we don’t support themes in the FastAPI integration.

**Solution**

This PR adds support for themes, including a whole bunch of tests.

Fixes #4157

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
