### PR TITLE
fix(api-reference): search bug with undefined operation on enter key

### DIFF
--- a/.changeset/serious-rings-dress.md
+++ b/.changeset/serious-rings-dress.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat: updates scalar search input style

--- a/.changeset/slow-cougars-hope.md
+++ b/.changeset/slow-cougars-hope.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: prevents navigation on enter in search modal if no result

--- a/packages/api-reference/src/features/Search/SearchModal.vue
+++ b/packages/api-reference/src/features/Search/SearchModal.vue
@@ -167,6 +167,12 @@ function onSearchResultEnter() {
   }
 
   const results = searchResultsWithPlaceholderResults.value
+
+  // Prevents the user from navigating if there are no results
+  if (results.length === 0) {
+    return
+  }
+
   onSearchResultClick(results[selectedSearchIndex.value])
 }
 </script>

--- a/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.vue
+++ b/packages/components/src/components/ScalarSearchInput/ScalarSearchInput.vue
@@ -44,7 +44,9 @@ const { classCx, otherAttrs } = useBindCx()
 <template>
   <label
     v-bind="
-      classCx('flex items-center text-lg font-medium h-10 p-3 pr-1 h-14 gap-2')
+      classCx(
+        'flex items-center text-lg font-medium h-10 pl-3 pr-1 py-2 gap-2.25',
+      )
     ">
     <ScalarIconMagnifyingGlass class="text-sidebar-c-search size-4" />
     <input


### PR DESCRIPTION
**Problem**

currently hitting enter within api reference search modal in no result presence lead to an error getting displayed and breaking the experience.

**Solution**

this pr prevents navigation on enter in no result presence + updates style to enhance empty state element positioning.

| state | preview |
| -------|------|
| before | <img width="612" height="177" alt="image" src="https://github.com/user-attachments/assets/69d40ea2-23ba-4c91-880d-06d7187b6c16" /> |
| after | <img width="612" height="177" alt="image" src="https://github.com/user-attachments/assets/84dcc650-d3a0-4b4b-a198-c74bad3617d8" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
