### PR TITLE
fix(workspace-store):  port over fixes from sidebar traversal

### DIFF
--- a/.changeset/orange-rabbits-design.md
+++ b/.changeset/orange-rabbits-design.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: update workspace traversal with fixes from sidebar

--- a/packages/workspace-store/src/navigation/helpers/traverse-paths.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-paths.test.ts
@@ -223,4 +223,24 @@ describe('traversePaths', () => {
 
     expect(titlesMap.get('GET-/test')).toBe('Test endpoint')
   })
+
+  it('should use the path when the summary is empty', () => {
+    const spec = createBasicSpec()
+    spec.paths = {
+      '/test': {
+        get: {
+          tags: ['Test'],
+          summary: '',
+          operationId: 'testEndpoint',
+        },
+      },
+    }
+
+    const tagsMap: TagsMap = new Map([['Test', { tag: { name: 'Test' }, entries: [] }]])
+    const titlesMap = new Map<string, string>()
+
+    traversePaths(spec, tagsMap, titlesMap, mockGetOperationId)
+
+    expect(titlesMap.get('GET-/test')).toBe('/test')
+  })
 })

--- a/packages/workspace-store/src/navigation/helpers/traverse-paths.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-paths.ts
@@ -30,13 +30,15 @@ const createOperationEntry = (
   getOperationId: TraverseSpecOptions['getOperationId'],
 ): TraversedOperation => {
   const id = getOperationId({ ...operation, method, path }, tag)
-  titlesMap.set(id, operation.summary ?? path)
+  const title = operation.summary?.trim() ? operation.summary : path
+
+  titlesMap.set(id, title)
 
   return {
     id,
-    title: operation.summary ?? path,
+    title,
     path,
-    method: method,
+    method,
     ref,
     type: 'operation',
   }

--- a/packages/workspace-store/src/navigation/helpers/traverse-schemas.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-schemas.test.ts
@@ -266,6 +266,46 @@ describe('traverseSchemas', () => {
     expect(result[0].title).toBe('ValidSchema')
   })
 
+  it('uses the title attribute of the schema', () => {
+    const content: OpenApiDocument = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      components: {
+        schemas: {
+          ValidSchema: {
+            title: 'Foobar',
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+          InternalSchema: {
+            'x-internal': true,
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+          IgnoredSchema: {
+            'x-scalar-ignore': true,
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+        },
+      },
+    }
+
+    const result = traverseSchemas(content, mockTagsMap, mockTitlesMap, mockGetModelId)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('Foobar')
+  })
+
   describe('x-tags', () => {
     it('should handle schemas with x-tags', () => {
       const content: OpenApiDocument = {

--- a/packages/workspace-store/src/navigation/helpers/traverse-schemas.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-schemas.ts
@@ -2,6 +2,7 @@ import { getTag } from '@/navigation/helpers/get-tag'
 import type { TagsMap, TraverseSpecOptions } from '@/navigation/types'
 import type { TraversedSchema } from '@/schemas/navigation'
 import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
+import type { SchemaObject } from '@/schemas/v3.1/strict/schema'
 import type { TagObject } from '@/schemas/v3.1/strict/tag'
 
 /** Creates a traversed schema entry from an OpenAPI schema object.
@@ -12,19 +13,25 @@ import type { TagObject } from '@/schemas/v3.1/strict/tag'
  * @param getModelId - Function to generate unique IDs for schemas
  * @returns A traversed schema entry with ID, title, name and reference
  */
-const createModelEntry = (
+const createSchemaEntry = (
   ref: string,
   name = 'Unknown',
   titlesMap: Map<string, string>,
   getModelId: TraverseSpecOptions['getModelId'],
   tag?: TagObject,
+  schema?: SchemaObject,
 ): TraversedSchema => {
   const id = getModelId({ name }, tag)
-  titlesMap.set(id, name)
+
+  // Use schema.title if available, otherwise fall back to name
+  // @see https://json-schema.org/draft/2020-12/json-schema-core#section-4.3.5
+  const title = (schema?.title as string) || name
+
+  titlesMap.set(id, title)
 
   return {
     id,
-    title: name,
+    title,
     name,
     ref,
     type: 'model',
@@ -65,12 +72,12 @@ export const traverseSchemas = (
     if (schemas[name]['x-tags']) {
       schemas[name]['x-tags'].forEach((tagName: string) => {
         const { tag } = getTag(tagsMap, tagName)
-        tagsMap.get(tagName)?.entries.push(createModelEntry(ref, name, titlesMap, getModelId, tag))
+        tagsMap.get(tagName)?.entries.push(createSchemaEntry(ref, name, titlesMap, getModelId, tag))
       })
     }
     // Add to untagged
     else {
-      untagged.push(createModelEntry(ref, name, titlesMap, getModelId))
+      untagged.push(createSchemaEntry(ref, name, titlesMap, getModelId, undefined, schemas[name]))
     }
   }
 

--- a/packages/workspace-store/src/navigation/helpers/traverse-tags.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-tags.test.ts
@@ -162,6 +162,30 @@ describe('traverseTags', () => {
     expect((result[1] as TraversedOperation).method).toBe('post')
   })
 
+  it.only('should handle custom operationSorter using [deprecated] httpVerb', () => {
+    const document = createMockDocument()
+    const tagsMap = new Map([
+      [
+        'default',
+        {
+          tag: createMockTag('default'),
+          entries: [createMockEntry('POST Operation', 'post'), createMockEntry('GET Operation', 'get')],
+        },
+      ],
+    ])
+    const titlesMap = new Map<string, string>()
+    const options = {
+      getTagId: (tag: TagObject) => tag.name ?? '',
+      tagsSorter: 'alpha',
+      operationsSorter: (a: { httpVerb: string }, b: { httpVerb: string }) =>
+        (a.httpVerb || '').localeCompare(b.httpVerb || ''),
+    } as const
+
+    const result = traverseTags(document, tagsMap, titlesMap, options)
+    expect((result[0] as TraversedOperation).method).toBe('get')
+    expect((result[1] as TraversedOperation).method).toBe('post')
+  })
+
   it('should handle custom tag sorter', () => {
     const document = createMockDocument()
     const tagsMap = new Map([

--- a/packages/workspace-store/src/navigation/helpers/traverse-tags.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-tags.ts
@@ -117,8 +117,8 @@ const getSortedTagEntries = (
         const pathB = b.type === 'operation' ? b.path : b.name
 
         return operationsSorter(
-          { method: a.method, path: pathA, ref: a.ref },
-          { method: b.method, path: pathB, ref: b.ref },
+          { method: a.method, path: pathA, ref: a.ref, httpVerb: a.method },
+          { method: b.method, path: pathB, ref: b.ref, httpVerb: b.method },
         )
       })
     }

--- a/packages/workspace-store/src/navigation/types.ts
+++ b/packages/workspace-store/src/navigation/types.ts
@@ -5,7 +5,13 @@ import type { TagObject } from '@/schemas/v3.1/strict/tag'
 /** Map of tagNames and their entries */
 export type TagsMap = Map<string, { tag: TagObject; entries: TraversedEntry[] }>
 
-type OperationSortValue = { method: string; path: string; ref: string }
+type OperationSortValue = {
+  method: string
+  path: string
+  ref: string
+  /** @deprecated use method instead */
+  httpVerb: string
+}
 
 /** Configuration options for traversing an OpenAPI specification document.
  *


### PR DESCRIPTION
**Problem**

Currently, we made some changes to the sidebar traverse functions.

**Solution**

With this PR we copy those fixes and tests to the workspace traversal functions. 

To avoid having to maintain this duplicated code we should move over to the workspace store ASAP!

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
