### PR TITLE
feat(openapi-parser): add application and accessCode to Swagger 2.0 upgrade

### DIFF
--- a/.changeset/stupid-years-sparkle.md
+++ b/.changeset/stupid-years-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+feat: add application and accessCode to swagger 2 upgrader

--- a/packages/openapi-parser/src/utils/upgrade-from-two-to-three.test.ts
+++ b/packages/openapi-parser/src/utils/upgrade-from-two-to-three.test.ts
@@ -418,6 +418,25 @@ describe('upgradeFromTwoToThree', () => {
             'write:pets': 'modify pets in your account',
           },
         },
+        petstore_application: {
+          type: 'oauth2',
+          flow: 'application',
+          tokenUrl: 'https://petstore.swagger.io/oauth/token',
+          scopes: {
+            'read:pets': 'read your pets',
+            'write:pets': 'modify pets in your account',
+          },
+        },
+        petstore_access_code: {
+          type: 'oauth2',
+          flow: 'accessCode',
+          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize',
+          tokenUrl: 'https://petstore.swagger.io/oauth/token',
+          scopes: {
+            'read:pets': 'read your pets',
+            'write:pets': 'modify pets in your account',
+          },
+        },
       },
       paths: {
         '/pets': {
@@ -447,6 +466,31 @@ describe('upgradeFromTwoToThree', () => {
         flows: {
           implicit: {
             authorizationUrl: 'https://petstore.swagger.io/oauth/authorize',
+            scopes: {
+              'read:pets': 'read your pets',
+              'write:pets': 'modify pets in your account',
+            },
+          },
+        },
+      },
+      petstore_application: {
+        type: 'oauth2',
+        flows: {
+          clientCredentials: {
+            tokenUrl: 'https://petstore.swagger.io/oauth/token',
+            scopes: {
+              'read:pets': 'read your pets',
+              'write:pets': 'modify pets in your account',
+            },
+          },
+        },
+      },
+      petstore_access_code: {
+        type: 'oauth2',
+        flows: {
+          authorizationCode: {
+            authorizationUrl: 'https://petstore.swagger.io/oauth/authorize',
+            tokenUrl: 'https://petstore.swagger.io/oauth/token',
             scopes: {
               'read:pets': 'read your pets',
               'write:pets': 'modify pets in your account',

--- a/packages/openapi-parser/src/utils/upgrade-from-two-to-three.ts
+++ b/packages/openapi-parser/src/utils/upgrade-from-two-to-three.ts
@@ -3,6 +3,20 @@ import type { UnknownObject } from '@scalar/types/utils'
 
 import { traverse } from './traverse'
 
+/** Update the flow names to OpenAPI 3.1.0 format */
+const upgradeFlow = (
+  flow: 'implicit' | 'password' | 'application' | 'accessCode',
+): 'implicit' | 'password' | 'clientCredentials' | 'authorizationCode' => {
+  switch (flow) {
+    case 'application':
+      return 'clientCredentials'
+    case 'accessCode':
+      return 'authorizationCode'
+    default:
+      return flow
+  }
+}
+
 /**
  * Upgrade Swagger 2.0 to OpenAPI 3.0
  *
@@ -237,12 +251,14 @@ export function upgradeFromTwoToThree(originalSpecification: UnknownObject) {
             scopes?: Record<string, string>
           }
 
+          // Convert flow values to OpenAPI 3.1.0 format
+
           // Assert that securitySchemes is of type OpenAPIV3.SecuritySchemeObject
           Object.assign((specification.components as OpenAPIV3.ComponentsObject).securitySchemes, {
             [key]: {
               type: 'oauth2',
               flows: {
-                [flow as string]: Object.assign(
+                [upgradeFlow(flow)]: Object.assign(
                   {},
                   authorizationUrl && { authorizationUrl },
                   tokenUrl && { tokenUrl },

--- a/packages/openapi-parser/src/utils/upgrade-from-two-to-three.ts
+++ b/packages/openapi-parser/src/utils/upgrade-from-two-to-three.ts
@@ -4,16 +4,18 @@ import type { UnknownObject } from '@scalar/types/utils'
 import { traverse } from './traverse'
 
 /** Update the flow names to OpenAPI 3.1.0 format */
-const upgradeFlow = (
-  flow: 'implicit' | 'password' | 'application' | 'accessCode',
-): 'implicit' | 'password' | 'clientCredentials' | 'authorizationCode' => {
+const upgradeFlow = (flow: string): 'implicit' | 'password' | 'clientCredentials' | 'authorizationCode' => {
   switch (flow) {
     case 'application':
       return 'clientCredentials'
     case 'accessCode':
       return 'authorizationCode'
+    case 'implicit':
+      return 'implicit'
+    case 'password':
+      return 'password'
     default:
-      return flow
+      return flow as never
   }
 }
 


### PR DESCRIPTION
**Problem**

closes #6262 

Currently, we ignore application and access code auth types in swagger 2

**Solution**

With this PR we add them to the upgrader.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
