### PR TITLE
fix(api-reference): server dropdown stacking issue

### DIFF
--- a/.changeset/spicy-humans-travel.md
+++ b/.changeset/spicy-humans-travel.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: prevents introduction card dropdown stacking issue

--- a/.changeset/young-singers-unite.md
+++ b/.changeset/young-singers-unite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: increases server variables label input font size

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -99,7 +99,7 @@ const introCardsSlot = computed(() =>
             :class="{ 'introduction-card-row': layout === 'classic' }">
             <div
               v-if="activeCollection?.servers?.length"
-              class="scalar-reference-intro-server scalar-client introduction-card-item text-sm leading-normal [--scalar-address-bar-height:0px]">
+              class="scalar-reference-intro-server scalar-client introduction-card-item text-base leading-normal [--scalar-address-bar-height:0px]">
               <BaseUrl
                 :collection="activeCollection"
                 :server="activeServer" />

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -53,7 +53,7 @@ onMounted(() => config.value.onLoaded?.())
   <SectionContainer>
     <!-- If the #after slot is used, we need to add a gap to the section. -->
     <Section
-      class="introduction-section gap-12"
+      class="introduction-section z-1 gap-12"
       :id="
         getHeadingId({
           slug: DEFAULT_INTRODUCTION_SLUG,

--- a/packages/api-reference/src/features/base-url/BaseUrl.vue
+++ b/packages/api-reference/src/features/base-url/BaseUrl.vue
@@ -37,7 +37,7 @@ const updateServer = (newServer: string) => {
 </script>
 <template>
   <label
-    class="bg-b-2 flex h-8 items-center rounded-t-lg border border-b-0 px-3 py-2.5 text-base font-medium">
+    class="bg-b-2 flex h-8 items-center rounded-t-lg border border-b-0 px-3 py-2.5 font-medium">
     Server
   </label>
   <div


### PR DESCRIPTION
**Problem**

currently when the server dropdown overflow the next section, a stacking issue appears preventing from selection the last servers + server variables label/input font size is not consistent with the other introduction forms.

**Solution**

this pr fixes the stacking issue + font size inconsistency. fixes #6259 

| state | preview |
| -------|------|
| before | <img width="644" height="363" alt="image" src="https://github.com/user-attachments/assets/62e24418-eef0-4b63-940e-ee3c9d57243d" /> |
| after | <img width="644" height="363" alt="image" src="https://github.com/user-attachments/assets/528b1b7d-beeb-4c85-b6f5-b7fd82cf456a" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
