### PR TITLE
fix(api-reference): custom reference fixtures

### DIFF
--- a/.changeset/soft-pots-shake.md
+++ b/.changeset/soft-pots-shake.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+fix: sets missing line height contraint and transform reset

--- a/.changeset/wise-trainers-wonder.md
+++ b/.changeset/wise-trainers-wonder.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: updates request auth border radius

--- a/packages/api-client/src/components/SectionFilter.vue
+++ b/packages/api-client/src/components/SectionFilter.vue
@@ -44,7 +44,7 @@ const navigateSection = (direction: 'next' | 'prev') => {
     @keydown.left="navigateSection('prev')"
     @keydown.right="navigateSection('next')">
     <div
-      class="request-section-content request-section-content-filter fade-request-section-content text-c-3 pointer-events-auto relative hidden w-full justify-end gap-[1.5px] rounded py-2 text-xs xl:flex">
+      class="request-section-content request-section-content-filter fade-request-section-content text-c-3 pointer-events-auto relative hidden w-full justify-end gap-[1.5px] rounded py-1.75 text-xs xl:flex">
       <SectionFilterButton
         v-for="filter in filters"
         :key="filter"
@@ -56,7 +56,7 @@ const navigateSection = (direction: 'next' | 'prev') => {
         {{ filter }}
       </SectionFilterButton>
       <div
-        class="context-bar-group-hover:text-c-1 absolute top-1/2 -right-[30px] flex -translate-y-1/2 items-center">
+        class="filter-button context-bar-group-hover:text-c-1 absolute -right-[30px] flex items-center">
         <span class="context-bar-group-hover:hidden mr-1.5">{{ model }}</span>
         <ScalarIcon
           icon="FilterList"
@@ -94,7 +94,7 @@ const navigateSection = (direction: 'next' | 'prev') => {
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
+  height: fit-content;
   background-color: var(--scalar-background-1);
   opacity: 0;
   transition: all 0.3s ease-in-out;
@@ -141,6 +141,10 @@ const navigateSection = (direction: 'next' | 'prev') => {
 .filter-hover:has(:focus-visible):before {
   opacity: 0.9;
   backdrop-filter: blur(10px);
+}
+.filter-button {
+  top: 50%;
+  transform: translateY(-50%);
 }
 .context-bar-group:hover .context-bar-group-hover\:text-c-1,
 .context-bar-group:has(:focus-visible) .context-bar-group-hover\:text-c-1 {

--- a/packages/api-client/src/components/Server/ServerSelector.vue
+++ b/packages/api-client/src/components/Server/ServerSelector.vue
@@ -101,7 +101,7 @@ const serverUrlWithoutTrailingSlash = computed(() => {
   </ScalarListbox>
   <div
     v-else
-    class="text-c-1 flex h-auto w-full items-center gap-0.75 rounded-b-lg px-3 py-1.5 text-base whitespace-nowrap">
+    class="text-c-1 flex h-auto w-full items-center gap-0.75 rounded-b-lg px-3 py-1.5 text-base leading-[20px] whitespace-nowrap">
     <span class="sr-only">Server:</span>
     <span class="overflow-x-auto">{{ serverUrlWithoutTrailingSlash }}</span>
   </div>

--- a/packages/api-client/src/components/Server/ServerVariablesForm.vue
+++ b/packages/api-client/src/components/Server/ServerVariablesForm.vue
@@ -38,7 +38,7 @@ const getVariable = (name: string) => {
       :key="name">
       <label
         class="group/label flex w-full"
-        :class="layout === 'reference' && 'border-x border-b'">
+        :class="layout === 'reference' && 'rounded-b-lg border-x border-b'">
         <span
           class="mr-1.5 flex items-center py-1.5 pl-3 group-has-[input]/label:mr-0 after:content-[':']">
           {{ name }}

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -58,7 +58,8 @@ onMounted(() => {
             ]"
             icon="ChevronRight"
             size="md" />
-          <h2 class="text-c-1 flex flex-1 items-center gap-1.5">
+          <h2
+            class="text-c-1 m-0 flex flex-1 items-center gap-1.5 leading-[20px]">
             <span
               :id="id"
               class="contents">

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -242,7 +242,7 @@ const openAuthCombobox = (event: Event) => {
     <template #title>
       <div
         :id="titleId"
-        class="inline-flex items-center gap-0.5">
+        class="inline-flex items-center gap-0.5 leading-[20px]">
         <span>{{ title }}</span>
         <!-- Authentication indicator -->
         <span

--- a/packages/api-reference/src/features/base-url/BaseUrl.vue
+++ b/packages/api-reference/src/features/base-url/BaseUrl.vue
@@ -44,7 +44,7 @@ const updateServer = (newServer: string) => {
     :id="id"
     class="border"
     :class="{
-      'rounded-b-lg': !server?.description,
+      'rounded-b-lg': !server?.description && !server?.variables,
     }">
     <ServerSelector
       v-if="collection?.servers?.length"

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -138,7 +138,7 @@ onMounted(() => setTimeout(() => input.value?.focus(), 0))
 <template>
   <div class="relative flex">
     <ScalarIconMagnifyingGlass
-      class="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-c-3 size-4" />
+      class="pointer-events-none absolute left-2.5 search-icon text-c-3 size-4" />
     <input
       v-model="query"
       ref="input"
@@ -197,3 +197,9 @@ onMounted(() => setTimeout(() => input.value?.focus(), 0))
     <slot name="after" />
   </ul>
 </template>
+<style scoped>
+.search-icon {
+  top: 50%;
+  transform: translateY(-50%);
+}
+</style>

--- a/packages/scripts/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/scripts/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -43,7 +43,8 @@ const id = useId()
             ]"
             icon="ChevronRight"
             size="md" />
-          <h2 class="text-c-1 flex flex-1 items-center gap-1.5">
+          <h2
+            class="text-c-1 m-0 flex flex-1 items-center gap-1.5 leading-[20px]">
             <span
               :id="id"
               class="contents">


### PR DESCRIPTION
**Problem**

within customized api reference, section title are sometimes lack of line height contraint affects the parent height + custom utility on transform is breaking the alignment of glass icon and filter button. 

**Solution**

this pr sets line height on section title + reset tranform on glass icon and filter button.

<details>
<summary>changes preview</summary>

`request auth`
| state | preview |
| -------|------|
| before | <img width="422" height="128" alt="image" src="https://github.com/user-attachments/assets/4d84d023-9de0-4889-a24b-7b05a2552ea7" /> |
| after | <img width="422" height="128" alt="image" src="https://github.com/user-attachments/assets/13c4d62e-4348-42cf-8808-19b158d5a4ab" /> |

`section title`
| state | preview |
| -------|------|
| before | <img width="422" height="128" alt="image" src="https://github.com/user-attachments/assets/b9d3abe0-e673-4e84-a97b-038e69d2bb09" /> |
| after | <img width="422" height="128" alt="image" src="https://github.com/user-attachments/assets/d0108416-edbd-403a-8532-c33a42659e1d" /> |


`dropdown icon`
| state | preview |
| -------|------|
| before | <img width="422" height="128" alt="image" src="https://github.com/user-attachments/assets/0cf6773e-0fdf-424a-8318-4f726e08aa66" /> |
| after | <img width="422" height="128" alt="image" src="https://github.com/user-attachments/assets/c3055d9d-eabf-4d73-b0c2-8ad258610ef0" /> |

`filter button`
| state | preview |
| -------|------|
| before | <img width="422" height="128" alt="image" src="https://github.com/user-attachments/assets/18d4e90a-c416-4930-b61f-9c4f86f1de5d" /> |
| after | <img width="422" height="128" alt="image" src="https://github.com/user-attachments/assets/019069de-77e9-4091-9215-4fe6cbe2ca62" /> |
</details>

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
