### PR TITLE
feat(documentation): add changelog generation

### DIFF
--- a/documentation/.env.example
+++ b/documentation/.env.example
@@ -1,0 +1,1 @@
+GH_TOKEN="123acb"

--- a/documentation/changelog-generation/index.ts
+++ b/documentation/changelog-generation/index.ts
@@ -1,0 +1,272 @@
+import { readFileSync, writeFileSync } from 'fs'
+
+type change = {
+  commitType:
+    | 'feat'
+    | 'fix'
+    | 'chore'
+    | 'refactor'
+    | 'docs'
+    | 'style'
+    | 'test'
+    | 'perf'
+    | 'build'
+    | 'ci'
+    | 'revert'
+    | 'other'
+    | null
+  commitHash: string
+  commitMessage: string
+  commitUrl: string
+  pullRequestUrl: string
+  pullRequestDescription: string
+  pullRequestDiffContent?: string
+  pullRequestSummary?: string
+}
+
+type dependency = {
+  packageName: string
+  version: string
+}
+
+type packageChangelog = {
+  version: string | null
+  changeType: 'patch' | 'minor' | 'major' | null
+  changes: change[]
+  dependencies: dependency[]
+}
+
+type changelog = {
+  timestamp: string
+  packageChangelogs: { [packageName: string]: packageChangelog }
+}
+
+type GitHubConfig = {
+  token: string
+  owner: string
+  repo: string
+}
+
+/**
+ * Formats the current date and time as "Month Day Hour:MinuteAM/PM"
+ * Example: "January 15 2:30PM"
+ */
+function formatTimestamp(): string {
+  const now = new Date()
+
+  const months = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ]
+
+  const month = months[now.getMonth()]
+  const day = now.getDate()
+  let hours = now.getHours()
+  const minutes = now.getMinutes().toString().padStart(2, '0')
+  const ampm = hours >= 12 ? 'PM' : 'AM'
+
+  // Convert to 12-hour format
+  hours = hours % 12
+  hours = hours ? hours : 12 // 0 should be 12
+
+  return `${month} ${day} ${hours}:${minutes}${ampm}`
+}
+
+/**
+ * Fetches the pull request URL, description, diff URL, and files changed for a given commit hash using GitHub API.
+ * Uses hardcoded API key and repository details.
+ */
+async function getPullRequestInfo(
+  commitHash: string,
+  config: GitHubConfig,
+): Promise<{
+  url: string
+  description: string
+  diffUrl: string
+  diffContent?: string
+}> {
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${config.owner}/${config.repo}/commits/${commitHash}/pulls`,
+      {
+        headers: {
+          'Accept': 'application/vnd.github+json',
+          'Authorization': `Bearer ${config.token}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    )
+
+    if (!response.ok) {
+      return { url: '', description: '', diffUrl: '' }
+    }
+
+    const pulls = await response.json()
+    if (pulls.length > 0) {
+      const pr = pulls[0]
+
+      // Get detailed PR info including files changed
+      const prResponse = await fetch(`https://api.github.com/repos/${config.owner}/${config.repo}/pulls/${pr.number}`, {
+        headers: {
+          'Accept': 'application/vnd.github+json',
+          'Authorization': `Bearer ${config.token}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      })
+
+      let diffContent: string | undefined
+
+      if (prResponse.ok) {
+        const prDetails = await prResponse.json()
+        // Optionally get the actual diff content
+        if (pr.diff_url) {
+          const diffResponse = await fetch(pr.diff_url, {
+            headers: {
+              'Accept': 'application/vnd.github.diff',
+              'Authorization': `Bearer ${config.token}`,
+            },
+          })
+
+          if (diffResponse.ok) {
+            diffContent = await diffResponse.text()
+          }
+        }
+      }
+
+      return {
+        url: pr.html_url,
+        description: pr.body || '',
+        diffUrl: pr.diff_url || '',
+        diffContent,
+      }
+    }
+
+    return { url: '', description: '', diffUrl: '' }
+  } catch (error) {
+    return { url: '', description: '', diffUrl: '' }
+  }
+}
+
+/**
+ * Extracts the commit type from a commit message.
+ * Looks for conventional commit format: type(scope): description
+ */
+function extractCommitType(
+  commitMessage: string,
+):
+  | 'feat'
+  | 'fix'
+  | 'chore'
+  | 'refactor'
+  | 'docs'
+  | 'style'
+  | 'test'
+  | 'perf'
+  | 'build'
+  | 'ci'
+  | 'revert'
+  | 'other'
+  | null {
+  // Match conventional commit format: type(scope): description
+  const conventionalMatch = commitMessage.match(/^(\w+)(?:\([^)]+\))?:\s*(.+)/)
+  if (conventionalMatch) {
+    return conventionalMatch[1].toLowerCase() as any
+  }
+
+  return null
+}
+
+export async function parseChangelog(input: string, config: GitHubConfig): Promise<changelog> {
+  const changelog: changelog = {
+    timestamp: formatTimestamp(),
+    packageChangelogs: {},
+  }
+  const lines = input.split(/\r?\n/)
+
+  let currentPackageName: string | null = null
+
+  for (const line of lines) {
+    if (line.startsWith('## @')) {
+      const packageSectionLine = line
+      console.log(packageSectionLine)
+      if (packageSectionLine) {
+        const parts = packageSectionLine.split('@')
+        const packageName = parts[1]
+        const version = parts[2].split(' ')[0]
+        currentPackageName = packageName
+        changelog.packageChangelogs[packageName] = {
+          version: version,
+          changeType: null,
+          changes: [],
+          dependencies: [],
+        }
+      }
+    }
+    if (line.startsWith('###') && currentPackageName) {
+      const versionType = line.split('###')[1].trim().toLowerCase()
+      if (versionType) {
+        changelog.packageChangelogs[currentPackageName].changeType = versionType as 'patch' | 'minor' | 'major' | null
+      }
+    }
+    if (line.startsWith('-   ') && currentPackageName) {
+      // Parse commit entries like: -   44aecdd: feat: set default \_integration to svelte
+      const match = line.match(/^\s*-\s+([a-f0-9]{7}): (.+)/)
+      if (match) {
+        const [, commitHash, commitMessage] = match
+        const commitUrl = `https://github.com/${config.owner}/${config.repo}/commit/${commitHash}`
+        const commitType = extractCommitType(commitMessage)
+        const {
+          url: pullRequestUrl,
+          description: pullRequestDescription,
+          diffContent: pullRequestDiffContent,
+        } = await getPullRequestInfo(commitHash, config)
+
+        changelog.packageChangelogs[currentPackageName].changes.push({
+          commitType,
+          commitHash,
+          commitMessage,
+          commitUrl,
+          pullRequestUrl,
+          pullRequestDescription,
+          pullRequestDiffContent,
+        })
+      }
+    }
+    if (line.startsWith('    -   ') && currentPackageName) {
+      const parts = line.split('@')
+      const packageName = parts[1]
+      const version = parts[2].split(' ')[0]
+      changelog.packageChangelogs[currentPackageName].dependencies.push({
+        packageName,
+        version,
+      })
+    }
+  }
+  return changelog
+}
+const content = readFileSync('input-2.md', 'utf-8')
+
+// Parse changelog asynchronously
+parseChangelog(content, {
+  token: process.env.GITHUB_TOKEN || '',
+  owner: 'scalar',
+  repo: 'scalar',
+})
+  .then((jsonChangelog) => {
+    // Write the parsed changelog to a JSON file
+    writeFileSync('../changelog.json', JSON.stringify(jsonChangelog, null, 2), 'utf-8')
+    console.log('Changelog JSON has been written to changelog.json')
+  })
+  .catch((error) => {
+    console.error('Error parsing changelog:', error)
+  })

--- a/documentation/changelog-generation/input.md
+++ b/documentation/changelog-generation/input.md
@@ -1,0 +1,362 @@
+
+# Releases
+## @scalar/docusaurus@0.7.9
+
+### Patch Changes
+
+-   Updated dependencies [591562f]
+    -   @scalar/types@0.2.9
+
+## @scalar/express-api-reference@0.8.11
+
+### Patch Changes
+
+-   @scalar/core@0.3.9
+
+## @scalar/fastify-api-reference@1.32.8
+
+### Patch Changes
+
+-   Updated dependencies [591562f]
+    -   @scalar/openapi-types@0.3.6
+    -   @scalar/openapi-parser@0.18.1
+    -   @scalar/core@0.3.9
+
+## @scalar/hono-api-reference@0.9.11
+
+### Patch Changes
+
+-   @scalar/core@0.3.9
+
+## @scalar/nestjs-api-reference@0.5.10
+
+### Patch Changes
+
+-   Updated dependencies [591562f]
+    -   @scalar/types@0.2.9
+
+## @scalar/nextjs-api-reference@0.8.12
+
+### Patch Changes
+
+-   @scalar/core@0.3.9
+
+## @scalar/nuxt@0.4.32
+
+### Patch Changes
+
+-   Updated dependencies [a04cc15]
+-   Updated dependencies [591562f]
+-   Updated dependencies [b5bcce7]
+-   Updated dependencies [97721b5]
+-   Updated dependencies [9978a16]
+-   Updated dependencies [8a67f4f]
+    -   @scalar/api-reference@1.32.8
+    -   @scalar/api-client@2.5.18
+    -   @scalar/types@0.2.9
+
+## @scalar/sveltekit@0.1.15
+
+### Patch Changes
+
+-   44aecdd: feat: set default \_integration to svelte
+    -   @scalar/core@0.3.9
+
+## @scalar/api-client@2.5.18
+
+### Patch Changes
+
+-   591562f: feat: add support for x-scalar-security-body extension
+-   Updated dependencies [a04cc15]
+-   Updated dependencies [591562f]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [fbb7daa]
+-   Updated dependencies [fbaaa12]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [97721b5]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [8a67f4f]
+    -   @scalar/components@0.14.19
+    -   @scalar/openapi-types@0.3.6
+    -   @scalar/types@0.2.9
+    -   @scalar/snippetz@0.4.2
+    -   @scalar/themes@0.13.10
+    -   @scalar/use-codemirror@0.12.20
+    -   @scalar/oas-utils@0.4.14
+    -   @scalar/openapi-parser@0.18.1
+    -   @scalar/postman-to-openapi@0.3.17
+
+## @scalar/api-client-react@1.3.23
+
+### Patch Changes
+
+-   Updated dependencies [591562f]
+    -   @scalar/api-client@2.5.18
+    -   @scalar/types@0.2.9
+
+## @scalar/api-reference@1.32.8
+
+### Patch Changes
+
+-   a04cc15: feat(components): create scalar card component
+-   b5bcce7: feat: implement new request example openapi block in references
+-   97721b5: fix: prevents navigation on enter in search modal if no result
+-   9978a16: fix: example response has an additional value key
+-   8a67f4f: fix(api-reference): classic layout improvements
+-   Updated dependencies [a04cc15]
+-   Updated dependencies [591562f]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [fbb7daa]
+-   Updated dependencies [3f2ea8a]
+-   Updated dependencies [fbaaa12]
+-   Updated dependencies [828c894]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [97721b5]
+-   Updated dependencies [b5bcce7]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [8a67f4f]
+    -   @scalar/components@0.14.19
+    -   @scalar/openapi-types@0.3.6
+    -   @scalar/api-client@2.5.18
+    -   @scalar/types@0.2.9
+    -   @scalar/snippetz@0.4.2
+    -   @scalar/workspace-store@0.10.1
+    -   @scalar/code-highlight@0.1.8
+    -   @scalar/themes@0.13.10
+    -   @scalar/oas-utils@0.4.14
+    -   @scalar/openapi-parser@0.18.1
+
+## @scalar/api-reference-react@0.7.32
+
+### Patch Changes
+
+-   Updated dependencies [a04cc15]
+-   Updated dependencies [591562f]
+-   Updated dependencies [b5bcce7]
+-   Updated dependencies [97721b5]
+-   Updated dependencies [9978a16]
+-   Updated dependencies [8a67f4f]
+    -   @scalar/api-reference@1.32.8
+    -   @scalar/types@0.2.9
+
+## @scalar/code-highlight@0.1.8
+
+### Patch Changes
+
+-   85ee2ce: feat: updates markdown alert component style
+-   85ee2ce: feat: moves markdown style from code-highlight to components package
+
+## @scalar/components@0.14.19
+
+### Patch Changes
+
+-   a04cc15: feat(components): create scalar card component
+-   85ee2ce: feat: updates markdown ordered list style
+-   fbaaa12: fix(components): update add scalar classes to always watch for the headless root
+-   85ee2ce: feat: updates markdown alert component style
+-   97721b5: feat: updates scalar search input style
+-   85ee2ce: feat: moves markdown style from code-highlight to components package
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [8a67f4f]
+    -   @scalar/code-highlight@0.1.8
+    -   @scalar/themes@0.13.10
+    -   @scalar/oas-utils@0.4.14
+
+## @scalar/core@0.3.9
+
+### Patch Changes
+
+-   Updated dependencies [591562f]
+    -   @scalar/types@0.2.9
+
+## @scalar/galaxy@0.5.4
+
+### Patch Changes
+
+-   926de55: fix: broken internal link
+
+## @scalar/mock-server@0.5.17
+
+### Patch Changes
+
+-   Updated dependencies [591562f]
+    -   @scalar/openapi-types@0.3.6
+    -   @scalar/oas-utils@0.4.14
+    -   @scalar/openapi-parser@0.18.1
+
+## @scalar/nextjs-openapi@0.2.12
+
+### Patch Changes
+
+-   Updated dependencies [591562f]
+    -   @scalar/types@0.2.9
+    -   @scalar/nextjs-api-reference@0.8.12
+
+## @scalar/oas-utils@0.4.14
+
+### Patch Changes
+
+-   Updated dependencies [591562f]
+-   Updated dependencies [3f2ea8a]
+-   Updated dependencies [828c894]
+-   Updated dependencies [b5bcce7]
+-   Updated dependencies [8a67f4f]
+    -   @scalar/openapi-types@0.3.6
+    -   @scalar/types@0.2.9
+    -   @scalar/workspace-store@0.10.1
+    -   @scalar/themes@0.13.10
+
+## @scalar/openapi-to-markdown@0.2.22
+
+### Patch Changes
+
+-   Updated dependencies [a04cc15]
+-   Updated dependencies [591562f]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [fbb7daa]
+-   Updated dependencies [fbaaa12]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [97721b5]
+-   Updated dependencies [85ee2ce]
+    -   @scalar/components@0.14.19
+    -   @scalar/openapi-types@0.3.6
+    -   @scalar/types@0.2.9
+    -   @scalar/snippetz@0.4.2
+    -   @scalar/oas-utils@0.4.14
+    -   @scalar/openapi-parser@0.18.1
+
+## @scalar/openapi-types@0.3.6
+
+### Patch Changes
+
+-   591562f: feat: add support for x-scalar-security-body extension
+
+## @scalar/postman-to-openapi@0.3.17
+
+### Patch Changes
+
+-   Updated dependencies [591562f]
+    -   @scalar/openapi-types@0.3.6
+    -   @scalar/oas-utils@0.4.14
+
+## @scalar/snippetz@0.4.2
+
+### Patch Changes
+
+-   fbb7daa: feat: improved rust/reqwest output
+-   Updated dependencies [591562f]
+    -   @scalar/types@0.2.9
+
+## @scalar/themes@0.13.10
+
+### Patch Changes
+
+-   8a67f4f: fix(api-reference): classic layout improvements
+-   Updated dependencies [591562f]
+    -   @scalar/types@0.2.9
+
+## @scalar/types@0.2.9
+
+### Patch Changes
+
+-   591562f: feat: add support for x-scalar-security-body extension
+-   Updated dependencies [591562f]
+    -   @scalar/openapi-types@0.3.6
+
+## @scalar/use-codemirror@0.12.20
+
+### Patch Changes
+
+-   Updated dependencies [a04cc15]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [fbaaa12]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [97721b5]
+-   Updated dependencies [85ee2ce]
+    -   @scalar/components@0.14.19
+
+## @scalar/workspace-store@0.10.1
+
+### Patch Changes
+
+-   3f2ea8a: fix: shows different console errors whether the request wasn't successful or the data isn't a valid object
+-   828c894: fix: update workspace traversal with fixes from sidebar
+-   b5bcce7: feat: implement new request example openapi block in references
+-   Updated dependencies [591562f]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [85ee2ce]
+    -   @scalar/openapi-types@0.3.6
+    -   @scalar/types@0.2.9
+    -   @scalar/code-highlight@0.1.8
+    -   @scalar/openapi-parser@0.18.1
+
+## @scalar/aspire@0.1.9
+
+### Patch Changes
+
+-   591562f: feat: add support for x-scalar-security-body extension
+-   Updated dependencies [a04cc15]
+-   Updated dependencies [b5bcce7]
+-   Updated dependencies [97721b5]
+-   Updated dependencies [9978a16]
+-   Updated dependencies [8a67f4f]
+    -   @scalar/api-reference@1.32.8
+
+## @scalar/aspnetcore@2.6.2
+
+### Patch Changes
+
+-   591562f: feat: add support for x-scalar-security-body extension
+-   Updated dependencies [a04cc15]
+-   Updated dependencies [b5bcce7]
+-   Updated dependencies [97721b5]
+-   Updated dependencies [9978a16]
+-   Updated dependencies [8a67f4f]
+    -   @scalar/api-reference@1.32.8
+
+## @scalarapi/docker-api-reference@0.2.15
+
+### Patch Changes
+
+-   Updated dependencies [a04cc15]
+-   Updated dependencies [b5bcce7]
+-   Updated dependencies [97721b5]
+-   Updated dependencies [9978a16]
+-   Updated dependencies [8a67f4f]
+    -   @scalar/api-reference@1.32.8
+
+## scalar-fastapi@1.2.2
+
+### Patch Changes
+
+-   926de55: feat: add theme option
+
+## @scalar/scripts@0.0.20
+
+### Patch Changes
+
+-   Updated dependencies [a04cc15]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [fbaaa12]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [97721b5]
+-   Updated dependencies [85ee2ce]
+    -   @scalar/components@0.14.19
+    -   @scalar/oas-utils@0.4.14
+
+## scalar-app@0.1.216
+
+### Patch Changes
+
+-   Updated dependencies [a04cc15]
+-   Updated dependencies [591562f]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [fbaaa12]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [97721b5]
+-   Updated dependencies [85ee2ce]
+-   Updated dependencies [8a67f4f]
+    -   @scalar/components@0.14.19
+    -   @scalar/api-client@2.5.18
+    -   @scalar/themes@0.13.10

--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -1,11 +1,11 @@
+import { useState } from 'react'
 import changelogData from '../documentation/changelog.json'
 
-## Enhanced Changelog Display
-
-Here's a comprehensive component to display all the changelog data with enhanced features:
+# Changelog
+*Last updated: {changelogData.timestamp}*
 
 export const EnhancedChangelog = ({ data }) => {
-  const packages = Object.entries(data.packageChangelogs)
+  const [selectedPackage, setSelectedPackage] = useState('all')
   
   // Priority packages to show at the top
   const priorityPackages = [
@@ -14,82 +14,56 @@ export const EnhancedChangelog = ({ data }) => {
     'scalar/api-client'
   ]
   
-  // Collect and deduplicate all dependencies
-  const allDependencies = new Map()
-  packages.forEach(([packageName, pkg]) => {
-    if (pkg.dependencies) {
-      pkg.dependencies.forEach(dep => {
-        // Use the dependency package name as key, keep the latest version encountered
-        if (!allDependencies.has(dep.packageName) || 
-            allDependencies.get(dep.packageName).version < dep.version) {
-          allDependencies.set(dep.packageName, {
-            ...dep,
-            updatedIn: packageName // Track which package this dependency was updated in
-          })
+  // Process and filter packages
+  const processedPackages = Object.entries(data.packageChangelogs)
+    .filter(([, pkg]) => pkg.changes?.length > 0)
+    .map(([name, pkg]) => {
+      // Deduplicate changes by commit hash, preferring non-dependency versions
+      const uniqueChanges = new Map()
+      
+      pkg.changes.forEach(change => {
+        const key = change.commitHash
+        const existing = uniqueChanges.get(key)
+        
+        if (!existing || (!change.isDep && existing.isDep)) {
+          uniqueChanges.set(key, change)
         }
       })
-    }
-  })
+      
+      return [name, { ...pkg, changes: Array.from(uniqueChanges.values()) }]
+    })
+    .sort(([nameA, pkgA], [nameB, pkgB]) => {
+      const priorityIndexA = priorityPackages.indexOf(nameA)
+      const priorityIndexB = priorityPackages.indexOf(nameB)
+      
+      // Priority packages first, sorted by priority order
+      if (priorityIndexA !== -1 && priorityIndexB !== -1) {
+        return priorityIndexA - priorityIndexB
+      }
+      if (priorityIndexA !== -1) return -1
+      if (priorityIndexB !== -1) return 1
+      
+      // Then by changes count (descending)
+      return (pkgB.changes?.length || 0) - (pkgA.changes?.length || 0)
+    })
   
-  // Convert dependencies to changes format
-  const dependencyChanges = Array.from(allDependencies.values()).map(dep => ({
-    commitType: 'chore',
-    commitMessage: `update ${dep.packageName} to v${dep.version}`,
-    commitHash: 'deps',
-    commitUrl: '#',
-    pullRequestSummary: `Dependency update: ${dep.packageName} has been updated to version ${dep.version}`,
-    isDependencyUpdate: true,
-    originalDependency: dep
-  }))
-  
-  // Filter out empty packages (no changes and no dependencies)
-  const filteredPackages = packages.filter(([name, pkg]) => 
-    (pkg.changes && pkg.changes.length > 0) || (pkg.dependencies && pkg.dependencies.length > 0)
-  )
-  
-  // Sort packages: priority first, then by changes count (desc), then dependencies only
-  const sortedPackages = filteredPackages.sort(([nameA, pkgA], [nameB, pkgB]) => {
-    const priorityIndexA = priorityPackages.indexOf(nameA)
-    const priorityIndexB = priorityPackages.indexOf(nameB)
-    
-    // If both are priority packages, sort by priority order
-    if (priorityIndexA !== -1 && priorityIndexB !== -1) {
-      return priorityIndexA - priorityIndexB
-    }
-    
-    // Priority packages always come first
-    if (priorityIndexA !== -1) return -1
-    if (priorityIndexB !== -1) return 1
-    
-    // For non-priority packages, sort by changes count (packages with changes first)
-    const changesA = pkgA.changes?.length || 0
-    const changesB = pkgB.changes?.length || 0
-    
-    // If one has changes and other doesn't, prioritize the one with changes
-    if (changesA > 0 && changesB === 0) return -1
-    if (changesB > 0 && changesA === 0) return 1
-    
-    // If both have changes, sort by count descending
-    if (changesA > 0 && changesB > 0) {
-      return changesB - changesA
-    }
-    
-    // If neither has changes (dependencies only), sort alphabetically
-    return nameA.localeCompare(nameB)
-  })
+  // Filter based on selection
+  const displayedPackages = selectedPackage === 'all' 
+    ? processedPackages 
+    : processedPackages.filter(([name]) => name === selectedPackage)
   
   const getCommitTypeBadge = (type) => {
     const badgeClasses = {
       feat: 'bg-green-100 text-green-700',
-      fix: 'bg-red-100 text-red-700',
+      fix: 'bg-blue-100 text-blue-700',
       chore: 'bg-gray-100 text-gray-700',
       refactor: 'bg-yellow-100 text-yellow-700',
-      docs: 'bg-blue-100 text-blue-700',
+      docs: 'bg-slate-100 text-slate-700',
       style: 'bg-purple-100 text-purple-700',
       test: 'bg-cyan-100 text-cyan-700',
       perf: 'bg-orange-100 text-orange-700',
       build: 'bg-lime-100 text-lime-700',
-      ci: 'bg-slate-100 text-slate-700',
+      ci: 'bg-gray-100 text-gray-700',
       revert: 'bg-pink-100 text-pink-700',
       other: 'bg-gray-100 text-gray-700'
     }
@@ -115,155 +89,180 @@ export const EnhancedChangelog = ({ data }) => {
     )
   }
   
-  const isPriorityPackage = (name) => priorityPackages.includes(name)
-  const hasChanges = (pkg) => pkg.changes && pkg.changes.length > 0
+  // Find base package for dependency updates
+  const findBasePackageForDependency = (commitHash) => {
+    for (const [packageName, pkg] of processedPackages) {
+      const baseChange = pkg.changes.find(change => 
+        change.commitHash === commitHash && !change.isDep
+      )
+      if (baseChange) return packageName
+    }
+    return null
+  }
   
   return (
     <div className="scalar-app font-sans text-c-1 bg-b-1">
-      <div className="space-y-6">
-        {sortedPackages.map(([name, pkgData]) => (
+      {/* Package Filter */}
+      <div className="mb-4 p-4 bg-b-2 rounded-lg border border-solid border-border">
+        <div className="flex items-center gap-4 flex-wrap">
+          <label htmlFor="package-filter" className="text-sm font-medium text-c-1 whitespace-nowrap">
+            Filter packages:
+          </label>
+          <select
+            id="package-filter"
+            value={selectedPackage}
+            onChange={(e) => setSelectedPackage(e.target.value)}
+            className="flex-1 min-w-64 px-3 py-2 bg-white border border-solid border-border rounded-md text-sm text-c-1 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          >
+            <option value="all">All packages ({processedPackages.length})</option>
+            {processedPackages.map(([packageName]) => (
+              <option key={packageName} value={packageName}>
+                {packageName}
+              </option>
+            ))}
+          </select>
+          {selectedPackage !== 'all' && (
+            <button
+              onClick={() => setSelectedPackage('all')}
+              className="px-3 py-2 text-sm font-medium text-blue-600 hover:text-blue-800 bg-blue-50 hover:bg-blue-100 rounded-md transition-colors"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+      
+      {/* Package List */}
+      <div className="space-y-2">
+        {displayedPackages.map(([name, pkgData]) => (
           <div 
             key={name} 
             id={name.replace(/\//g, '-')} 
             className={`bg-b-2 rounded-lg shadow-sm transition-all duration-200 ${
-              isPriorityPackage(name) 
+              priorityPackages.includes(name) 
                 ? 'bg-blue-50/30' 
-                : hasChanges(pkgData) 
-                  ? 'hover:shadow-md' 
-                  : 'opacity-90'
+                : 'hover:shadow-md'
             }`}
           >
-          <div className="p-6">
-            {/* Package Header */}
-            <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
-              <div className="flex items-center gap-3">
-                <h3 className="text-lg font-semibold text-c-1 m-0">
-                  {name}
-                </h3>
-                {isPriorityPackage(name) && (
-                  <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200">
-                    Core Package
-                  </span>
-                )}
+            <div className="p-4">
+              {/* Package Header */}
+              <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
+                <div className="flex items-center gap-3">
+                  <h3 className="text-lg font-semibold text-c-1 m-0">
+                    {name}
+                  </h3>
+                  {priorityPackages.includes(name) && (
+                    <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200">
+                      Core Package
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <code className="px-2.5 py-1 bg-b-3 text-c-2 rounded text-sm font-mono">
+                    v{pkgData.version}
+                  </code>
+                  {pkgData.changeType && getChangeTypeBadge(pkgData.changeType)}
+                </div>
               </div>
-              <div className="flex items-center gap-2">
-                <code className="px-2.5 py-1 bg-b-3 text-c-2 rounded text-sm font-mono">
-                  v{pkgData.version}
-                </code>
-                {pkgData.changeType && getChangeTypeBadge(pkgData.changeType)}
-              </div>
-            </div>
 
-            {/* Changes Section */}
-            {pkgData.changes && pkgData.changes.length > 0 && (
-              <div className="mb-8">
-                <h4 className="text-base font-semibold text-c-1 mb-4 flex items-center gap-2">
-                  <span>Changes</span>
-                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-b-3 text-c-2">
-                    {pkgData.changes.length}
-                  </span>
-                </h4>
-                <div className="space-y-4">
-                  {pkgData.changes.map((change, index) => (
-                    <div 
-                      key={index} 
-                      className="p-4 bg-b-1 rounded-lg border border-solid border-border hover:bg-b-1.5 transition-colors"
-                    >
-                      {/* Change metadata */}
-                      <div className="flex items-center gap-2 mb-3 flex-wrap">
-                        {change.commitType && getCommitTypeBadge(change.commitType)}
-                        <a 
-                          href={change.commitUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center px-2 py-1 bg-b-3 text-c-3 rounded text-xs font-mono hover:text-c-1 transition-colors"
-                        >
-                          {change.commitHash}
-                        </a>
-                        {change.pullRequestUrl && (
+              {/* Changes Section */}
+              {pkgData.changes?.length > 0 && (
+                <div>
+                  <h4 className="text-base font-semibold text-c-1 mb-3 flex items-center gap-2">
+                    <span>Changes</span>
+                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-b-3 text-c-2">
+                      {pkgData.changes.length}
+                    </span>
+                  </h4>
+                  <div className="space-y-3">
+                    {pkgData.changes.map((change, index) => (
+                      <div 
+                        key={index} 
+                        className="p-3 bg-b-1 rounded-lg border border-solid border-border hover:bg-b-1.5 transition-colors"
+                      >
+                        {/* Change metadata */}
+                        <div className="flex items-center gap-2 mb-2 flex-wrap">
+                          {change.commitType && getCommitTypeBadge(change.commitType)}
                           <a 
-                            href={change.pullRequestUrl}
+                            href={change.commitUrl}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="inline-flex items-center px-2 py-1 bg-blue-50 text-blue-600 rounded text-xs font-medium hover:bg-blue-100 transition-colors"
+                            className="inline-flex items-center px-2 py-1 bg-b-3 text-c-3 rounded text-xs font-mono hover:text-c-1 transition-colors"
                           >
-                            PR #{change.pullRequestUrl.split('/').pop()}
+                            {change.commitHash}
                           </a>
+                          {change.pullRequestUrl && (
+                            <a 
+                              href={change.pullRequestUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inline-flex items-center px-2 py-1 bg-blue-50 text-blue-600 rounded text-xs font-medium hover:bg-blue-100 transition-colors"
+                            >
+                              PR #{change.pullRequestUrl.split('/').pop()}
+                            </a>
+                          )}
+                          {change.isDep && (
+                            (() => {
+                              const basePackage = findBasePackageForDependency(change.commitHash)
+                              return basePackage ? (
+                                <a
+                                  href={`#${basePackage.replace(/\//g, '-')}`}
+                                  className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-700 hover:bg-orange-200 transition-colors cursor-pointer"
+                                  title={`View original change in ${basePackage}`}
+                                >
+                                  Dependency Update → {basePackage}
+                                </a>
+                              ) : (
+                                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-b-3 text-c-2">
+                                  Dependency Update
+                                </span>
+                              )
+                            })()
+                          )}
+                        </div>
+                        
+                        {/* Commit message */}
+                        <div className="text-sm text-c-1 leading-relaxed mb-2 font-medium">
+                          {change.commitMessage}
+                        </div>
+
+                        {/* AI Summary */}
+                        {change.pullRequestSummary && (
+                          <details className="group mb-2">
+                            <summary className="cursor-pointer text-xs font-medium text-blue-700 hover:text-blue-900 transition-colors list-none select-none">
+                              <span className="inline-flex items-center gap-1">
+                                <span className="transform transition-transform group-open:rotate-90">▶</span>
+                                AI Summary
+                              </span>
+                            </summary>
+                            <div className="mt-2 p-2 bg-blue-50/50 border border-blue-200/50 rounded-md text-sm text-blue-800 leading-relaxed max-h-48 overflow-auto">
+                              {change.pullRequestSummary}
+                            </div>
+                          </details>
+                        )}
+
+                        {/* PR Description */}
+                        {change.pullRequestDescription && (
+                          <details className="group">
+                            <summary className="cursor-pointer text-xs font-medium text-c-3 hover:text-c-1 transition-colors list-none select-none">
+                              <span className="inline-flex items-center gap-1">
+                                <span className="transform transition-transform group-open:rotate-90">▶</span>
+                                View Pull Request Description
+                              </span>
+                            </summary>
+                            <div className="mt-2 p-2 bg-b-2 border border-solid border-border rounded text-xs text-c-2 leading-relaxed max-h-48 overflow-auto whitespace-pre-wrap">
+                              {change.pullRequestDescription}
+                            </div>
+                          </details>
                         )}
                       </div>
-                      
-                      {/* Commit message */}
-                      <div className="text-sm text-c-1 leading-relaxed mb-3 font-medium">
-                        {change.commitMessage}
-                      </div>
-
-                      {/* AI Summary (collapsible) */}
-                      {change.pullRequestSummary && (
-                        <details className="group mb-3">
-                          <summary className="cursor-pointer text-xs font-medium text-blue-700 hover:text-blue-900 transition-colors list-none select-none">
-                            <span className="inline-flex items-center gap-1">
-                              <span className="transform transition-transform group-open:rotate-90">▶</span>
-                              AI Summary
-                            </span>
-                          </summary>
-                          <div className="mt-2 p-3 bg-blue-50/50 border border-blue-200/50 rounded-md text-sm text-blue-800 leading-relaxed max-h-48 overflow-auto">
-                            {change.pullRequestSummary}
-                          </div>
-                        </details>
-                      )}
-
-                      {/* PR Description (collapsible) */}
-                      {change.pullRequestDescription && (
-                        <details className="group">
-                          <summary className="cursor-pointer text-xs font-medium text-c-3 hover:text-c-1 transition-colors list-none select-none">
-                            <span className="inline-flex items-center gap-1">
-                              <span className="transform transition-transform group-open:rotate-90">▶</span>
-                              View Pull Request Description
-                            </span>
-                          </summary>
-                          <div className="mt-2 p-3 bg-b-2 border border-solid border-border rounded text-xs text-c-2 leading-relaxed max-h-48 overflow-auto whitespace-pre-wrap">
-                            {change.pullRequestDescription}
-                          </div>
-                        </details>
-                      )}
-                    </div>
-                  ))}
+                    ))}
+                  </div>
                 </div>
-              </div>
-            )}
-
-                      {/* Dependencies Section */}
-            {pkgData.dependencies && pkgData.dependencies.length > 0 && (
-              <div>
-                <h4 className="text-base font-semibold text-c-1 mb-4 flex items-center gap-2">
-                  <span>Updated Dependencies</span>
-                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-b-3 text-c-2">
-                    {pkgData.dependencies.length}
-                  </span>
-                </h4>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                  {pkgData.dependencies.map((dep, index) => (
-                    <div
-                      key={index}
-                      className="p-3 bg-b-1 border border-solid border-border rounded-lg hover:bg-b-1.5 transition-colors"
-                    >
-                      <a 
-                        href={`#${dep.packageName.replace(/\//g, '-')}`}
-                        className="font-medium text-c-1 hover:text-blue-600 transition-colors no-underline"
-                      >
-                        {dep.packageName}
-                      </a>
-                      <div className="text-xs text-c-3 mt-1 font-mono">
-                        v{dep.version}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
+              )}
+            </div>
           </div>
-        </div>
-      ))}
+        ))}
       </div>
     </div>
   )
@@ -272,19 +271,30 @@ export const EnhancedChangelog = ({ data }) => {
 ## Quick Stats
 
 export const ChangelogStats = ({ data }) => {
-  const packages = Object.entries(data.packageChangelogs)
-  const totalPackages = packages.length
-  const totalChanges = packages.reduce((sum, [, pkg]) => sum + (pkg.changes?.length || 0), 0)
-  const totalDependencies = packages.reduce((sum, [, pkg]) => sum + (pkg.dependencies?.length || 0), 0)
+  // Process packages the same way as main component
+  const processedPackages = Object.entries(data.packageChangelogs)
+    .filter(([, pkg]) => pkg.changes?.length > 0)
+    .map(([name, pkg]) => {
+      const uniqueChanges = new Map()
+      
+      pkg.changes.forEach(change => {
+        const key = change.commitHash
+        const existing = uniqueChanges.get(key)
+        
+        if (!existing || (!change.isDep && existing.isDep)) {
+          uniqueChanges.set(key, change)
+        }
+      })
+      
+      return [name, { ...pkg, changes: Array.from(uniqueChanges.values()) }]
+    })
   
-  const changeTypeStats = packages.reduce((stats, [, pkg]) => {
-    if (pkg.changeType) {
-      stats[pkg.changeType] = (stats[pkg.changeType] || 0) + 1
-    }
-    return stats
-  }, {})
-
-  const commitTypeStats = packages.reduce((stats, [, pkg]) => {
+  const totalPackages = processedPackages.length
+  const totalChanges = processedPackages.reduce((sum, [, pkg]) => sum + (pkg.changes?.length || 0), 0)
+  const dependencyChanges = processedPackages.reduce((sum, [, pkg]) => 
+    sum + (pkg.changes?.filter(change => change.isDep)?.length || 0), 0)
+  
+  const commitTypeStats = processedPackages.reduce((stats, [, pkg]) => {
     pkg.changes?.forEach(change => {
       if (change.commitType) {
         stats[change.commitType] = (stats[change.commitType] || 0) + 1
@@ -316,10 +326,10 @@ export const ChangelogStats = ({ data }) => {
         
         <div className="p-4 bg-yellow-50 rounded-lg text-center border border-yellow-200">
           <div className="text-2xl font-bold text-yellow-700">
-            {totalDependencies}
+            {dependencyChanges}
           </div>
           <div className="text-sm text-yellow-600 font-medium">
-            Dependencies Updated
+            Dependency Changes
           </div>
         </div>
         

--- a/documentation/changelog.mdx
+++ b/documentation/changelog.mdx
@@ -1,0 +1,340 @@
+import changelogData from '../documentation/changelog.json'
+
+## Enhanced Changelog Display
+
+Here's a comprehensive component to display all the changelog data with enhanced features:
+
+export const EnhancedChangelog = ({ data }) => {
+  const packages = Object.entries(data.packageChangelogs)
+  
+  // Priority packages to show at the top
+  const priorityPackages = [
+    'scalar/api-reference',
+    'scalar/api-reference-react', 
+    'scalar/api-client'
+  ]
+  
+  // Collect and deduplicate all dependencies
+  const allDependencies = new Map()
+  packages.forEach(([packageName, pkg]) => {
+    if (pkg.dependencies) {
+      pkg.dependencies.forEach(dep => {
+        // Use the dependency package name as key, keep the latest version encountered
+        if (!allDependencies.has(dep.packageName) || 
+            allDependencies.get(dep.packageName).version < dep.version) {
+          allDependencies.set(dep.packageName, {
+            ...dep,
+            updatedIn: packageName // Track which package this dependency was updated in
+          })
+        }
+      })
+    }
+  })
+  
+  // Convert dependencies to changes format
+  const dependencyChanges = Array.from(allDependencies.values()).map(dep => ({
+    commitType: 'chore',
+    commitMessage: `update ${dep.packageName} to v${dep.version}`,
+    commitHash: 'deps',
+    commitUrl: '#',
+    pullRequestSummary: `Dependency update: ${dep.packageName} has been updated to version ${dep.version}`,
+    isDependencyUpdate: true,
+    originalDependency: dep
+  }))
+  
+  // Filter out empty packages (no changes and no dependencies)
+  const filteredPackages = packages.filter(([name, pkg]) => 
+    (pkg.changes && pkg.changes.length > 0) || (pkg.dependencies && pkg.dependencies.length > 0)
+  )
+  
+  // Sort packages: priority first, then by changes count (desc), then dependencies only
+  const sortedPackages = filteredPackages.sort(([nameA, pkgA], [nameB, pkgB]) => {
+    const priorityIndexA = priorityPackages.indexOf(nameA)
+    const priorityIndexB = priorityPackages.indexOf(nameB)
+    
+    // If both are priority packages, sort by priority order
+    if (priorityIndexA !== -1 && priorityIndexB !== -1) {
+      return priorityIndexA - priorityIndexB
+    }
+    
+    // Priority packages always come first
+    if (priorityIndexA !== -1) return -1
+    if (priorityIndexB !== -1) return 1
+    
+    // For non-priority packages, sort by changes count (packages with changes first)
+    const changesA = pkgA.changes?.length || 0
+    const changesB = pkgB.changes?.length || 0
+    
+    // If one has changes and other doesn't, prioritize the one with changes
+    if (changesA > 0 && changesB === 0) return -1
+    if (changesB > 0 && changesA === 0) return 1
+    
+    // If both have changes, sort by count descending
+    if (changesA > 0 && changesB > 0) {
+      return changesB - changesA
+    }
+    
+    // If neither has changes (dependencies only), sort alphabetically
+    return nameA.localeCompare(nameB)
+  })
+  
+  const getCommitTypeBadge = (type) => {
+    const badgeClasses = {
+      feat: 'bg-green-100 text-green-700',
+      fix: 'bg-red-100 text-red-700',
+      chore: 'bg-gray-100 text-gray-700',
+      refactor: 'bg-yellow-100 text-yellow-700',
+      docs: 'bg-blue-100 text-blue-700',
+      style: 'bg-purple-100 text-purple-700',
+      test: 'bg-cyan-100 text-cyan-700',
+      perf: 'bg-orange-100 text-orange-700',
+      build: 'bg-lime-100 text-lime-700',
+      ci: 'bg-slate-100 text-slate-700',
+      revert: 'bg-pink-100 text-pink-700',
+      other: 'bg-gray-100 text-gray-700'
+    }
+    
+    return (
+      <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium uppercase tracking-wide ${badgeClasses[type] || badgeClasses.other}`}>
+        {type || 'other'}
+      </span>
+    )
+  }
+
+  const getChangeTypeBadge = (changeType) => {
+    const badgeClasses = {
+      'patch changes': 'bg-green-100 text-green-800 border-green-200',
+      'minor changes': 'bg-yellow-100 text-yellow-800 border-yellow-200', 
+      'major changes': 'bg-red-100 text-red-800 border-red-200'
+    }
+    
+    return (
+      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold border ${badgeClasses[changeType] || 'bg-gray-100 text-gray-800 border-gray-200'}`}>
+        {changeType || 'unknown'}
+      </span>
+    )
+  }
+  
+  const isPriorityPackage = (name) => priorityPackages.includes(name)
+  const hasChanges = (pkg) => pkg.changes && pkg.changes.length > 0
+  
+  return (
+    <div className="scalar-app font-sans text-c-1 bg-b-1">
+      <div className="space-y-6">
+        {sortedPackages.map(([name, pkgData]) => (
+          <div 
+            key={name} 
+            id={name.replace(/\//g, '-')} 
+            className={`bg-b-2 rounded-lg shadow-sm transition-all duration-200 ${
+              isPriorityPackage(name) 
+                ? 'bg-blue-50/30' 
+                : hasChanges(pkgData) 
+                  ? 'hover:shadow-md' 
+                  : 'opacity-90'
+            }`}
+          >
+          <div className="p-6">
+            {/* Package Header */}
+            <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
+              <div className="flex items-center gap-3">
+                <h3 className="text-lg font-semibold text-c-1 m-0">
+                  {name}
+                </h3>
+                {isPriorityPackage(name) && (
+                  <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200">
+                    Core Package
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <code className="px-2.5 py-1 bg-b-3 text-c-2 rounded text-sm font-mono">
+                  v{pkgData.version}
+                </code>
+                {pkgData.changeType && getChangeTypeBadge(pkgData.changeType)}
+              </div>
+            </div>
+
+            {/* Changes Section */}
+            {pkgData.changes && pkgData.changes.length > 0 && (
+              <div className="mb-8">
+                <h4 className="text-base font-semibold text-c-1 mb-4 flex items-center gap-2">
+                  <span>Changes</span>
+                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-b-3 text-c-2">
+                    {pkgData.changes.length}
+                  </span>
+                </h4>
+                <div className="space-y-4">
+                  {pkgData.changes.map((change, index) => (
+                    <div 
+                      key={index} 
+                      className="p-4 bg-b-1 rounded-lg border border-solid border-border hover:bg-b-1.5 transition-colors"
+                    >
+                      {/* Change metadata */}
+                      <div className="flex items-center gap-2 mb-3 flex-wrap">
+                        {change.commitType && getCommitTypeBadge(change.commitType)}
+                        <a 
+                          href={change.commitUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center px-2 py-1 bg-b-3 text-c-3 rounded text-xs font-mono hover:text-c-1 transition-colors"
+                        >
+                          {change.commitHash}
+                        </a>
+                        {change.pullRequestUrl && (
+                          <a 
+                            href={change.pullRequestUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center px-2 py-1 bg-blue-50 text-blue-600 rounded text-xs font-medium hover:bg-blue-100 transition-colors"
+                          >
+                            PR #{change.pullRequestUrl.split('/').pop()}
+                          </a>
+                        )}
+                      </div>
+                      
+                      {/* Commit message */}
+                      <div className="text-sm text-c-1 leading-relaxed mb-3 font-medium">
+                        {change.commitMessage}
+                      </div>
+
+                      {/* AI Summary (collapsible) */}
+                      {change.pullRequestSummary && (
+                        <details className="group mb-3">
+                          <summary className="cursor-pointer text-xs font-medium text-blue-700 hover:text-blue-900 transition-colors list-none select-none">
+                            <span className="inline-flex items-center gap-1">
+                              <span className="transform transition-transform group-open:rotate-90">▶</span>
+                              AI Summary
+                            </span>
+                          </summary>
+                          <div className="mt-2 p-3 bg-blue-50/50 border border-blue-200/50 rounded-md text-sm text-blue-800 leading-relaxed max-h-48 overflow-auto">
+                            {change.pullRequestSummary}
+                          </div>
+                        </details>
+                      )}
+
+                      {/* PR Description (collapsible) */}
+                      {change.pullRequestDescription && (
+                        <details className="group">
+                          <summary className="cursor-pointer text-xs font-medium text-c-3 hover:text-c-1 transition-colors list-none select-none">
+                            <span className="inline-flex items-center gap-1">
+                              <span className="transform transition-transform group-open:rotate-90">▶</span>
+                              View Pull Request Description
+                            </span>
+                          </summary>
+                          <div className="mt-2 p-3 bg-b-2 border border-solid border-border rounded text-xs text-c-2 leading-relaxed max-h-48 overflow-auto whitespace-pre-wrap">
+                            {change.pullRequestDescription}
+                          </div>
+                        </details>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+                      {/* Dependencies Section */}
+            {pkgData.dependencies && pkgData.dependencies.length > 0 && (
+              <div>
+                <h4 className="text-base font-semibold text-c-1 mb-4 flex items-center gap-2">
+                  <span>Updated Dependencies</span>
+                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-b-3 text-c-2">
+                    {pkgData.dependencies.length}
+                  </span>
+                </h4>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                  {pkgData.dependencies.map((dep, index) => (
+                    <div
+                      key={index}
+                      className="p-3 bg-b-1 border border-solid border-border rounded-lg hover:bg-b-1.5 transition-colors"
+                    >
+                      <a 
+                        href={`#${dep.packageName.replace(/\//g, '-')}`}
+                        className="font-medium text-c-1 hover:text-blue-600 transition-colors no-underline"
+                      >
+                        {dep.packageName}
+                      </a>
+                      <div className="text-xs text-c-3 mt-1 font-mono">
+                        v{dep.version}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
+      </div>
+    </div>
+  )
+}
+
+## Quick Stats
+
+export const ChangelogStats = ({ data }) => {
+  const packages = Object.entries(data.packageChangelogs)
+  const totalPackages = packages.length
+  const totalChanges = packages.reduce((sum, [, pkg]) => sum + (pkg.changes?.length || 0), 0)
+  const totalDependencies = packages.reduce((sum, [, pkg]) => sum + (pkg.dependencies?.length || 0), 0)
+  
+  const changeTypeStats = packages.reduce((stats, [, pkg]) => {
+    if (pkg.changeType) {
+      stats[pkg.changeType] = (stats[pkg.changeType] || 0) + 1
+    }
+    return stats
+  }, {})
+
+  const commitTypeStats = packages.reduce((stats, [, pkg]) => {
+    pkg.changes?.forEach(change => {
+      if (change.commitType) {
+        stats[change.commitType] = (stats[change.commitType] || 0) + 1
+      }
+    })
+    return stats
+  }, {})
+
+  return (
+    <div className="scalar-app mb-8">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="p-4 bg-blue-50 rounded-lg text-center border border-blue-200">
+          <div className="text-2xl font-bold text-blue-700">
+            {totalPackages}
+          </div>
+          <div className="text-sm text-blue-600 font-medium">
+            Packages Updated
+          </div>
+        </div>
+        
+        <div className="p-4 bg-green-50 rounded-lg text-center border border-green-200">
+          <div className="text-2xl font-bold text-green-700">
+            {totalChanges}
+          </div>
+          <div className="text-sm text-green-600 font-medium">
+            Total Changes
+          </div>
+        </div>
+        
+        <div className="p-4 bg-yellow-50 rounded-lg text-center border border-yellow-200">
+          <div className="text-2xl font-bold text-yellow-700">
+            {totalDependencies}
+          </div>
+          <div className="text-sm text-yellow-600 font-medium">
+            Dependencies Updated
+          </div>
+        </div>
+        
+        <div className="p-4 bg-purple-50 rounded-lg text-center border border-purple-200">
+          <div className="text-2xl font-bold text-purple-700">
+            {Object.keys(commitTypeStats).length}
+          </div>
+          <div className="text-sm text-purple-600 font-medium">
+            Commit Types
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+<ChangelogStats data={changelogData} />
+<EnhancedChangelog data={changelogData} /> 

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -20,6 +20,11 @@
           "type": "page"
         },
         {
+          "name": "Changelog",
+          "path": "documentation/changelog.mdx",
+          "type": "page"
+        },
+        {
           "name": "Scalar Docs",
           "type": "folder",
           "defaultOpen": false,


### PR DESCRIPTION
**Problem**

Currently, it's really frustrating for our users to grok through our changeset release summaries as changes are duplicated, not summarized nor grouped nor filterable

Solution

This PR parses the markdown changelog into a structured JSON format and renders it as a readable, filterable MDX component on our docs site. This makes it easier for users to quickly digest release changes and dependency updates.

<img width="505" height="800" alt="image" src="https://github.com/user-attachments/assets/560b6761-c66f-452b-b659-7903a130a7d6" />


**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
