### PR TITLE
fix(api-reference): removes unused prop from request example

### DIFF
--- a/.changeset/pretty-papayas-tell.md
+++ b/.changeset/pretty-papayas-tell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: removes unsused prop in layout for request example

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -173,7 +173,6 @@ const handleDiscriminatorChange = (type: string) => {
           :path="path"
           fallback
           :operation="operation"
-          :schemas="schemas"
           @update:modelValue="handleDiscriminatorChange" />
       </ScalarErrorBoundary>
     </div>

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -135,7 +135,6 @@ const handleDiscriminatorChange = (type: string) => {
                 :path="path"
                 fallback
                 :operation="operation"
-                :schemas="schemas"
                 @update:modelValue="handleDiscriminatorChange">
                 <template #header>
                   <OperationPath


### PR DESCRIPTION
**Changes**

following new request example introduction, this pr removes the schemas prop still passes to it that might not be used anymore.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
