### PR TITLE
fix(api-client): highlight scrolling within response bodies not working

### DIFF
--- a/.changeset/loud-dancers-greet.md
+++ b/.changeset/loud-dancers-greet.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: enables highlight scroll along mouse scroll for response body

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyDownload.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyDownload.vue
@@ -18,7 +18,7 @@ const filenameExtension = computed(() => {
 </script>
 <template>
   <a
-    class="text-c-3 text-xxs hover:bg-b-3 no-underlin flex items-center gap-1 rounded px-1.5 py-0.5"
+    class="text-c-3 text-xxs hover:bg-b-3 flex items-center gap-1 rounded px-1.5 py-0.5 no-underline"
     :download="`${filenameExtension}`"
     :href="href"
     @click.stop>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyRaw.vue
@@ -45,7 +45,7 @@ const getCurrentContent = () => {
       </button>
     </div>
     <div
-      class="body-raw-scroller custom-scroll relative overflow-x-auto overscroll-contain"
+      class="body-raw-scroller relative overflow-auto overscroll-contain"
       tabindex="0">
       <!-- CodeMirror container -->
       <div ref="codeMirrorRef" />
@@ -64,8 +64,8 @@ const getCurrentContent = () => {
 }
 
 .body-raw :deep(.cm-scroller) {
-  overflow: visible;
-  width: fit-content;
+  overflow: auto;
+  min-width: 100%;
 }
 
 /* Copy Button Styles */


### PR DESCRIPTION
**Changes**

this pr updates the response body styling to bring back highlight scrolling that was not effective along utility typo fix. fixes #6283 

**QA**

- go to api client / api reference
- send request 
- highlight and scroll within the reponse body

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
