### PR TITLE
feat(api-reference): updates heading anchor style

### DIFF
--- a/.changeset/itchy-dancers-prove.md
+++ b/.changeset/itchy-dancers-prove.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: updates heading anchor style to use latest icons

--- a/packages/api-reference/src/components/Anchor/Anchor.vue
+++ b/packages/api-reference/src/components/Anchor/Anchor.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { ScalarButton } from '@scalar/components'
+import { ScalarIconHash } from '@scalar/icons'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { useId } from 'vue'
 
@@ -21,60 +23,25 @@ const handleCopy = () => {
 }
 </script>
 <template>
-  <span class="label">
+  <span class="group/heading word-break-all relative inline-block">
     <span
       :id="labelId"
       class="contents">
       <slot />
     </span>
-    <span class="anchor">
+    <span class="relative">
       <!-- Position anchor to align the copy button to the last line of text  -->
       <span>&ZeroWidthSpace;</span>
-      <button
+      <ScalarButton
         :aria-describedby="labelId"
-        class="anchor-copy"
-        type="button"
+        class="absolute left-0 mt-1.75 inline-block h-fit px-2 py-1 opacity-0 group-hover/heading:opacity-100 group-has-focus-visible/heading:opacity-100"
+        variant="ghost"
         @click.stop="handleCopy">
-        <span aria-hidden="true">#</span>
+        <ScalarIconHash
+          aria-hidden="true"
+          class="size-4" />
         <ScreenReader>Copy link</ScreenReader>
-      </button>
+      </ScalarButton>
     </span>
   </span>
 </template>
-<style scoped>
-.label {
-  position: relative;
-  display: inline-block;
-  word-break: break-all;
-}
-.anchor {
-  position: relative;
-  display: inline-block;
-  opacity: 0;
-}
-
-.anchor-copy {
-  position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translateY(-50%);
-
-  cursor: pointer;
-
-  padding: 0 6px;
-
-  color: var(--scalar-color-3);
-  font-weight: var(--scalar-semibold);
-  font-size: 0.8em;
-}
-
-.anchor-copy:hover,
-.anchor-copy:focus-visible {
-  color: var(--scalar-color-2);
-}
-
-.label:hover .anchor,
-.label:has(:focus-visible) .anchor {
-  opacity: 1;
-}
-</style>

--- a/packages/api-reference/src/components/Section/SectionHeaderTag.vue
+++ b/packages/api-reference/src/components/Section/SectionHeaderTag.vue
@@ -10,6 +10,6 @@ const { level = 1 } = defineProps<{ level?: 1 | 2 | 3 | 4 | 5 | 6 }>()
 </template>
 <style scoped>
 .section-header-label {
-  display: inline;
+  display: inline-block;
 }
 </style>


### PR DESCRIPTION
**Changes**

this pr updates the api reference heading anchor to use latest icons.

| state | preview |
| -------|------|
| before | <img width="538" height="182" alt="image" src="https://github.com/user-attachments/assets/7854d1dc-d305-4bf4-8e20-f336f46cca0a" /> |
| after | <img width="538" height="182" alt="image" src="https://github.com/user-attachments/assets/6bc2b1ca-18ad-47dc-86ec-c271ce0ffe35" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
