### PR TITLE
feat(api-reference): updates client libraries card

### DIFF
--- a/.changeset/tough-needles-film.md
+++ b/.changeset/tough-needles-film.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+feat: adds scalar combobox to client libraries card

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
@@ -174,6 +174,7 @@ const installationInstructions = computed(() => {
   border-bottom-right-radius: var(--scalar-radius-lg);
   min-height: fit-content;
 }
+
 .client-libraries-heading {
   font-size: var(--scalar-small);
   font-weight: var(--scalar-font-medium);
@@ -187,6 +188,7 @@ const installationInstructions = computed(() => {
   border-top-left-radius: var(--scalar-radius-lg);
   border-top-right-radius: var(--scalar-radius-lg);
 }
+
 :deep(.scalar-codeblock-pre .hljs) {
   margin-top: 8px;
 }

--- a/packages/api-reference/src/features/example-responses/ExampleResponseTab.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponseTab.vue
@@ -32,19 +32,20 @@ import { Tab } from '@headlessui/vue'
   position: relative;
   line-height: 22px;
 }
-.tab:before {
+.tab::before {
   content: '';
   position: absolute;
   z-index: 0;
-  left: -6px;
-  top: -6px;
-  width: calc(100% + 12px);
-  height: calc(100% + 12px);
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: calc(100% + 18px);
+  height: calc(100% + 8px);
   border-radius: var(--scalar-radius);
   background: var(--scalar-background-3);
   opacity: 0;
 }
-.tab:hover:before,
+.tab:not(.tab-selected):hover:before,
 .tab:focus-visible:before {
   opacity: 1;
 }

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.vue
@@ -270,7 +270,7 @@ const showSchema = ref(false)
   width: fit-content;
   white-space: nowrap;
   gap: 6px;
-  padding: 7px 6px;
+  padding: 7px;
 }
 .scalar-card-checkbox:has(.scalar-card-checkbox-input:focus-visible)
   .scalar-card-checkbox-checkmark {
@@ -320,8 +320,8 @@ const showSchema = ref(false)
 }
 
 .scalar-card-checkbox .scalar-card-checkbox-checkmark:after {
-  right: 6px;
-  top: 36.5%;
+  right: 12.5px;
+  top: 12px;
   width: 5px;
   height: 9px;
   border: solid 1px var(--scalar-button-1-color);


### PR DESCRIPTION
**Changes**

this pr adds the scalar combobox to the client libraries card and some style fixtures.

`client libraries`
| state | preview |
| -------|------|
| before | <img width="640" height="445" alt="image" src="https://github.com/user-attachments/assets/8b47451f-0b6f-4835-bd0c-77e4790b5603" /> |
| after | <img width="640" height="445" alt="image" src="https://github.com/user-attachments/assets/c2c56cc8-493a-4c8d-98c5-a5dae132a33f" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
