### PR TITLE
fix(themes): added line height in themes reset breaking alignment

### DIFF
--- a/.changeset/tall-trainers-think.md
+++ b/.changeset/tall-trainers-think.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+fix: removes a level line height from reset

--- a/packages/themes/src/base/reset.css
+++ b/packages/themes/src/base/reset.css
@@ -126,7 +126,6 @@
     --font-color: var(--scalar-link-color, var(--scalar-color-accent));
     --font-visited: var(--scalar-link-color-visited, var(--scalar-color-2));
 
-    line-height: 1.625;
     text-decoration: var(--scalar-text-decoration);
     color: var(--font-color);
     font-weight: var(--scalar-link-font-weight, var(--scalar-semibold));


### PR DESCRIPTION
**Changes**

this pr removes a line-height added at the reset.css level in themes package to prevent misalignment within reference. this will be handle better in #6286

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
