### PR TITLE
fix(api-reference): config.hiddenClients not affecting the request example code blocks

### DIFF
--- a/.changeset/spicy-bugs-trade.md
+++ b/.changeset/spicy-bugs-trade.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: hiddenClients config option

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -178,6 +178,7 @@ const handleDiscriminatorChange = (type: string) => {
             :selectedServer="server"
             :selectedClient="store.workspace['x-scalar-default-client']"
             :securitySchemes="securitySchemes"
+            :hideClientSelector="config.hiddenClients === true"
             :path="path"
             fallback
             :operation="operation"

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -139,6 +139,7 @@ const handleDiscriminatorChange = (type: string) => {
                 :selectedServer="server"
                 :securitySchemes="securitySchemes"
                 :selectedClient="store.workspace['x-scalar-default-client']"
+                :hideClientSelector="config.hiddenClients === true"
                 :path="path"
                 fallback
                 :operation="operation"


### PR DESCRIPTION
**Problem**

Currently, `hiddenClients` does not affect the request example code blocks

**Solution**

With this PR we add this functionality back.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
