### PR TITLE
feat(api-reference): make all chevrons look the same

### DIFF
--- a/.changeset/tiny-flowers-yell.md
+++ b/.changeset/tiny-flowers-yell.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'@scalar/components': patch
+---
+
+feat: increases caret icon usage and style concistency amongst reference and client

--- a/packages/api-client/src/components/Server/ServerSelector.vue
+++ b/packages/api-client/src/components/Server/ServerSelector.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
+import { ScalarButton, ScalarListbox } from '@scalar/components'
+import { ScalarIconCaretDown } from '@scalar/icons'
 import type { Collection, Server } from '@scalar/oas-utils/entities/spec'
 import { computed, watch } from 'vue'
 
@@ -87,16 +88,16 @@ const serverUrlWithoutTrailingSlash = computed(() => {
     placement="bottom-start"
     resize
     :target="target"
-    :teleport="`#${target}`">
+    :teleport="`#${target}`"
+    class="group">
     <ScalarButton
-      class="bg-b-1 text-c-1 h-auto w-full justify-start gap-0.75 overflow-x-auto rounded-t-none rounded-b-lg px-3 py-1.5 text-base font-normal whitespace-nowrap -outline-offset-1"
+      class="bg-b-1 text-c-1 h-auto w-full justify-start gap-1.5 overflow-x-auto rounded-t-none rounded-b-lg px-3 py-1.5 text-base font-normal whitespace-nowrap -outline-offset-1"
       variant="ghost">
       <span class="sr-only">Server:</span>
       <span class="overflow-x-auto">{{ serverUrlWithoutTrailingSlash }}</span>
-      <ScalarIcon
-        class="text-c-2"
-        icon="ChevronDown"
-        size="sm" />
+      <ScalarIconCaretDown
+        weight="bold"
+        class="text-c-2 ui-open:rotate-180 mt-0.25 size-3 transition-transform duration-100" />
     </ScalarButton>
   </ScalarListbox>
   <div

--- a/packages/api-client/src/components/Server/ServerVariablesForm.vue
+++ b/packages/api-client/src/components/Server/ServerVariablesForm.vue
@@ -38,9 +38,11 @@ const getVariable = (name: string) => {
       :key="name">
       <label
         class="group/label flex w-full"
-        :class="layout === 'reference' && 'rounded-b-lg border-x border-b'">
+        :class="
+          layout === 'reference' && 'border-x border-b last:rounded-b-lg'
+        ">
         <span
-          class="mr-1.5 flex items-center py-1.5 pl-3 group-has-[input]/label:mr-0 after:content-[':']">
+          class="flex items-center py-1.5 pl-3 group-has-[input]/label:mr-0 after:content-[':']">
           {{ name }}
         </span>
         <template v-if="variables?.[name]?.enum?.length">

--- a/packages/api-client/src/components/Server/ServerVariablesSelect.vue
+++ b/packages/api-client/src/components/Server/ServerVariablesSelect.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import {
   ScalarButton,
-  ScalarIcon,
   ScalarListbox,
   type ScalarListboxOption,
 } from '@scalar/components'
+import { ScalarIconCaretDown } from '@scalar/icons'
 import { computed } from 'vue'
 
 const props = defineProps<{
@@ -32,7 +32,7 @@ const selected = computed<ScalarListboxOption | undefined>({
     :options="options">
     <ScalarButton
       :aria-controls="controls"
-      class="h-8 p-1.5 font-normal"
+      class="h-8 gap-1.5 p-1.5 text-base font-normal"
       variant="ghost">
       <span :class="{ 'text-c-1': value }">
         <span
@@ -42,10 +42,9 @@ const selected = computed<ScalarListboxOption | undefined>({
         </span>
         {{ value || 'Select value' }}
       </span>
-      <ScalarIcon
-        class="ml-1"
-        icon="ChevronDown"
-        size="sm" />
+      <ScalarIconCaretDown
+        weight="bold"
+        class="ui-open:rotate-180 mt-0.25 size-3 transition-transform duration-100" />
     </ScalarButton>
   </ScalarListbox>
 </template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -2,7 +2,6 @@
 import {
   ScalarButton,
   ScalarComboboxMultiselect,
-  ScalarIcon,
   useModal,
   type Icon,
   type ScalarButton as ScalarButtonType,
@@ -11,6 +10,7 @@ import {
   CLIENT_LS_KEYS,
   safeLocalStorage,
 } from '@scalar/helpers/object/local-storage'
+import { ScalarIconCaretDown } from '@scalar/icons'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type { SelectedSecuritySchemeUids } from '@scalar/oas-utils/entities/shared'
 import type {
@@ -269,27 +269,24 @@ const openAuthCombobox = (event: Event) => {
           <ScalarButton
             ref="comboboxButtonRef"
             :aria-describedby="titleId"
-            class="hover:bg-b-3 text-c-1 hover:text-c-1 h-fit px-1.5 py-0.25 font-normal"
+            class="group/combobox-button hover:text-c-1 text-c-2 flex h-fit items-center gap-1 px-1.5 py-0.25 text-base font-normal transition-transform"
             fullWidth
             variant="ghost">
-            <div class="text-c-1">
-              <template v-if="selectedSchemeOptions.length === 0">
-                <span class="sr-only">Select</span>
-                Auth Type
-              </template>
-              <template v-else-if="selectedSchemeOptions.length === 1">
-                <span class="sr-only">Selected Auth Type:</span>
-                {{ selectedSchemeOptions[0]?.label }}
-              </template>
-              <template v-else>
-                Multiple
-                <span class="sr-only">Auth Types Selected</span>
-              </template>
-            </div>
-            <ScalarIcon
-              class="ml-1 shrink-0"
-              icon="ChevronDown"
-              size="sm" />
+            <template v-if="selectedSchemeOptions.length === 0">
+              <span class="sr-only">Select</span>
+              Auth Type
+            </template>
+            <template v-else-if="selectedSchemeOptions.length === 1">
+              <span class="sr-only">Selected Auth Type:</span>
+              {{ selectedSchemeOptions[0]?.label }}
+            </template>
+            <template v-else>
+              Multiple
+              <span class="sr-only">Auth Types Selected</span>
+            </template>
+            <ScalarIconCaretDown
+              weight="bold"
+              class="size-3 shrink-0 transition-transform duration-100 group-aria-expanded/combobox-button:rotate-180" />
           </ScalarButton>
         </ScalarComboboxMultiselect>
       </div>

--- a/packages/api-reference/src/components/Content/Introduction/Introduction.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Introduction.vue
@@ -78,7 +78,7 @@ const { hash } = useNavState()
             :class="{ 'introduction-card-row': config?.layout === 'classic' }">
             <div
               v-if="activeCollection?.servers?.length"
-              class="scalar-reference-intro-server scalar-client introduction-card-item text-sm leading-normal [--scalar-address-bar-height:0px]">
+              class="scalar-reference-intro-server scalar-client introduction-card-item text-base leading-normal [--scalar-address-bar-height:0px]">
               <BaseUrl
                 :collection="activeCollection"
                 :server="activeServer" />

--- a/packages/api-reference/src/components/Section/CompactSection.vue
+++ b/packages/api-reference/src/components/Section/CompactSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
 import { scrollToId } from '@scalar/helpers/dom/scroll-to-id'
+import { ScalarIconCaretRight } from '@scalar/icons'
 import { nextTick, ref, useId, watch } from 'vue'
 
 import Anchor from '@/components/Anchor/Anchor.vue'
@@ -39,10 +39,10 @@ watch(
       :class="{ 'collapsible-section-trigger-open': open }"
       type="button"
       @click="open = !open">
-      <ScalarIcon
-        :icon="open ? 'ChevronDown' : 'ChevronRight'"
-        size="md"
-        thickness="1.5" />
+      <ScalarIconCaretRight
+        weight="bold"
+        class="size-3 transition-transform duration-100"
+        :class="{ 'rotate-90': open }" />
       <Anchor
         :id="id"
         class="collapsible-section-header">

--- a/packages/api-reference/src/components/ShowMoreButton.vue
+++ b/packages/api-reference/src/components/ShowMoreButton.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconCaretDown } from '@scalar/icons'
 
 import { useSidebar } from '@/features/sidebar'
 import { useConfig } from '@/hooks/useConfig'
@@ -23,9 +23,9 @@ const handleClick = () => {
     type="button"
     @click="handleClick">
     Show More
-    <ScalarIcon
-      class="show-more-icon"
-      icon="ChevronDown" />
+    <ScalarIconCaretDown
+      weight="bold"
+      class="text-c-2 mt-0.25 size-3" />
   </button>
 </template>
 
@@ -44,21 +44,19 @@ const handleClick = () => {
   align-items: center;
   justify-content: center;
   position: relative;
+  gap: 6px;
   top: -48px;
 }
+
 .show-more:hover {
   background: var(--scalar-background-2);
   cursor: pointer;
 }
-.show-more-icon {
-  /* todo remove but its for docusaurus */
-  width: 16px !important;
-  height: 16px !important;
-  margin-left: 3px;
-}
+
 .show-more:active {
   box-shadow: 0 0 0 1px var(--scalar-border-color);
 }
+
 @container narrow-references-container (max-width: 900px) {
   .show-more {
     top: -24px;

--- a/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
+++ b/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
-import {
-  cva,
-  ScalarButton,
-  ScalarIcon,
-  ScalarListbox,
-} from '@scalar/components'
+import { cva, ScalarButton, ScalarListbox } from '@scalar/components'
+import { ScalarIconCaretDown } from '@scalar/icons'
 import type { ContentType, RequestBody } from '@scalar/types/legacy'
 import { computed, ref } from 'vue'
 
@@ -55,7 +51,7 @@ const options = computed(() => {
 
 // Content type select style variant based on dropdown availability
 const contentTypeSelect = cva({
-  base: 'font-normal text-c-2 bg-b-2 py-0.75 flex cursor-pointer items-center gap-1 rounded-full text-xs',
+  base: 'font-normal text-c-2 bg-b-2 py-0.75 flex cursor-pointer items-center gap-1 rounded-full text-sm',
   variants: {
     dropdown: {
       true: 'border hover:text-c-1 pl-2 pr-1.5',
@@ -68,7 +64,6 @@ const contentTypeSelect = cva({
   <ScalarListbox
     v-if="prop?.requestBody && contentTypes.length > 1"
     v-model="selectedOption"
-    class="font-normal"
     :options="options"
     placement="bottom-end"
     @update:modelValue="handleSelectContentType">
@@ -78,11 +73,9 @@ const contentTypeSelect = cva({
       variant="ghost">
       <ScreenReader>Selected Content Type:</ScreenReader>
       <span>{{ selectedContentType }}</span>
-      <ScalarIcon
-        class="ui-open:rotate-180 ml-auto"
-        icon="ChevronDown"
-        size="sm"
-        thickness="2" />
+      <ScalarIconCaretDown
+        weight="bold"
+        class="ui-open:rotate-180 size-2.75 transition-transform duration-100" />
     </ScalarButton>
   </ScalarListbox>
   <div

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components'
+import { ScalarIconCaretRight } from '@scalar/icons'
 import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
 import { isDefined } from '@scalar/oas-utils/helpers'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
@@ -71,12 +72,12 @@ const shouldShowParameter = computed(() => {
     <Disclosure v-slot="{ open }">
       <DisclosureButton
         v-if="shouldCollapse"
-        class="parameter-item-trigger flex"
+        class="parameter-item-trigger"
         :class="{ 'parameter-item-trigger-open': open }">
-        <ScalarIcon
-          class="parameter-item-icon size-4.5"
-          :icon="open ? 'ChevronDown' : 'ChevronRight'"
-          thickness="1.5" />
+        <ScalarIconCaretRight
+          weight="bold"
+          class="parameter-item-icon size-3 transition-transform duration-100"
+          :class="{ 'rotate-90': open }" />
         <span class="parameter-item-name">
           {{ parameter.name }}
         </span>
@@ -137,9 +138,11 @@ const shouldShowParameter = computed(() => {
   flex-direction: column;
   border-top: var(--scalar-border-width) solid var(--scalar-border-color);
 }
+
 .parameter-item:last-of-type .parameter-schema {
   padding-bottom: 0;
 }
+
 .parameter-item-container {
   padding: 0;
 }
@@ -155,6 +158,7 @@ const shouldShowParameter = computed(() => {
   font-family: var(--scalar-font-code);
   color: var(--scalar-color-1);
 }
+
 .parameter-item-type {
   font-size: var(--scalar-mini);
   color: var(--scalar-color-2);
@@ -165,15 +169,18 @@ const shouldShowParameter = computed(() => {
   width: 100%;
   overflow: hidden;
 }
+
 .parameter-item-trigger-open .parameter-item-type {
   white-space: normal;
 }
+
 /* Match font size of markdown for property-detail-value since first child within accordian is displayed as if it were in the markdown section */
 .parameter-item-trigger
   + .parameter-item-container
   :deep(.property--level-0 > .property-heading .property-detail-value) {
   font-size: var(--scalar-micro);
 }
+
 .parameter-item-required-optional {
   color: var(--scalar-color-2);
   font-weight: var(--scalar-semibold);
@@ -206,18 +213,21 @@ const shouldShowParameter = computed(() => {
   padding-bottom: 9px;
   margin-top: 3px;
 }
+
 .parameter-item-trigger {
+  display: flex;
+  align-items: center;
   padding: 12px 0;
   cursor: pointer;
   outline: none;
   text-align: left;
   position: relative;
-  align-items: baseline;
 }
 
 .parameter-item-trigger-open {
   padding-bottom: 0;
 }
+
 .parameter-item-trigger:after {
   content: '';
   position: absolute;
@@ -225,16 +235,18 @@ const shouldShowParameter = computed(() => {
   width: 100%;
   bottom: 0;
 }
+
 .parameter-item-icon {
   color: var(--scalar-color-3);
   left: -19px;
   position: absolute;
-  top: 11px;
 }
+
 .parameter-item-trigger:hover .parameter-item-icon,
 .parameter-item-trigger:focus-visible .parameter-item-icon {
   color: var(--scalar-color-1);
 }
+
 .parameter-item-trigger:focus-visible .parameter-item-icon {
   outline: 1px solid var(--scalar-color-accent);
   outline-offset: 2px;

--- a/packages/api-reference/src/features/Operation/components/callbacks/Callback.vue
+++ b/packages/api-reference/src/features/Operation/components/callbacks/Callback.vue
@@ -60,17 +60,18 @@ const { method, name, schemas, url, path, operationMethod } = defineProps<{
   top: var(--refs-header-height, 0px);
   z-index: 100;
 }
+.callback-operation-container :deep(.request-body),
+.callback-operation-container :deep(.request-body-description),
+.callback-operation-container :deep(.request-body-header) {
+  margin-top: 0;
+}
 .callback-operation-container :deep(.request-body-header) {
   --scalar-font-size-2: var(--scalar-font-size-4);
-  margin-top: 0;
   padding: 8px;
   border-bottom: none;
   border: 0.5px solid var(--scalar-border-color);
   border-radius: var(--scalar-radius-lg) var(--scalar-radius-lg) 0 0;
   background: color-mix(in srgb, var(--scalar-background-2) 50%, transparent);
-}
-.callback-operation-container :deep(.request-body-description) {
-  margin-top: 0;
 }
 .callback-operation-container :deep(ul li.property.property--level-1) {
   padding: 8px;

--- a/packages/api-reference/src/features/Operation/components/callbacks/Callback.vue
+++ b/packages/api-reference/src/features/Operation/components/callbacks/Callback.vue
@@ -24,12 +24,12 @@ const { method, name, schemas, url, path, operationMethod } = defineProps<{
   <details class="group callback-list-item">
     <!-- Title -->
     <summary
-      class="font-code bg-b-1 callback-sticky-offset callback-list-item-title sticky flex cursor-pointer flex-row items-center gap-2 border-t py-3 text-sm group-open:flex-wrap">
+      class="font-code bg-b-1 callback-sticky-offset callback-list-item-title sticky flex cursor-pointer flex-row items-start gap-2 border-t py-3 text-sm group-open:flex-wrap">
       <ScalarIconCaretRight
-        class="callback-list-item-icon text-c-3 group-hover:text-c-1 absolute -left-5 size-4 transition-transform group-open:rotate-90" />
+        class="callback-list-item-icon text-c-3 group-hover:text-c-1 absolute top-3.5 -left-5 size-4 transition-transform duration-100 group-open:rotate-90" />
       <HttpMethod
         as="span"
-        class="request-method"
+        class="request-method py-0.75"
         :method="method" />
       <div
         class="text-c-1 min-w-0 flex-1 truncate leading-3 group-open:whitespace-normal">

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/ExamplePicker.vue
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/ExamplePicker.vue
@@ -44,7 +44,9 @@ defineExpose({
       fullWidth
       variant="ghost">
       <span>{{ getLabel(selectedExampleKey) }}</span>
-      <ScalarIconCaretDown />
+      <ScalarIconCaretDown
+        weight="bold"
+        class="ui-open:rotate-180 mt-0.25 size-3 transition-transform duration-100" />
     </ScalarButton>
     <template #items>
       <ScalarDropdownItem

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/RequestExample.vue
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/RequestExample.vue
@@ -262,7 +262,7 @@ const id = useId()
     class="request-card dark-mode"
     ref="elem">
     <!-- Header -->
-    <ScalarCardHeader class="pr-0.5">
+    <ScalarCardHeader class="pr-2.5">
       <span class="sr-only">Request Example for</span>
       <HttpMethod
         as="span"
@@ -287,11 +287,15 @@ const id = useId()
           @update:modelValue="selectClient($event as ClientOption)">
           <ScalarButton
             data-testid="client-picker"
-            class="text-c-2 hover:text-c-1 flex h-full w-fit gap-2 px-1"
+            class="text-c-2 hover:text-c-1 flex h-full w-fit gap-1.5 px-0"
             fullWidth
             variant="ghost">
-            <span class="text-base">{{ localSelectedClient?.title }}</span>
-            <ScalarIconCaretDown class="size-3.5" />
+            <span class="text-base font-normal">{{
+              localSelectedClient.title
+            }}</span>
+            <ScalarIconCaretDown
+              weight="bold"
+              class="ui-open:rotate-180 mt-0.25 size-3 transition-transform duration-100" />
           </ScalarButton>
         </ScalarCombobox>
       </template>

--- a/packages/components/src/components/ScalarCard/ScalarCardHeader.vue
+++ b/packages/components/src/components/ScalarCard/ScalarCardHeader.vue
@@ -35,7 +35,7 @@ useCardHeading(id)
   <ScalarCardSection
     v-bind="
       cx(
-        'scalar-card-header leading-[22px] font-medium py-[6.75px] px-3 shrink-0',
+        'scalar-card-header leading-[22px] font-medium py-[6.75px] pl-3 pr-1.5 shrink-0',
       )
     ">
     <div

--- a/packages/components/src/components/ScalarCard/ScalarCardHeader.vue
+++ b/packages/components/src/components/ScalarCard/ScalarCardHeader.vue
@@ -35,7 +35,7 @@ useCardHeading(id)
   <ScalarCardSection
     v-bind="
       cx(
-        'scalar-card-header leading-[22px] font-medium py-[6.75px] pl-3 pr-1.5 shrink-0',
+        'scalar-card-header leading-[22px] font-medium py-[6.75px] px-3 shrink-0',
       )
     ">
     <div

--- a/packages/components/src/components/ScalarMarkdown/ScalarMarkdown.vue
+++ b/packages/components/src/components/ScalarMarkdown/ScalarMarkdown.vue
@@ -341,7 +341,7 @@ const html = computed(() => {
     border-radius: 2.5px;
     display: flex;
     align-items: flex-start;
-    gap: 10px;
+    gap: 8px;
     min-height: 40px;
     padding: 7px 14px;
     position: relative;
@@ -382,6 +382,7 @@ const html = computed(() => {
 
   .markdown details[open] > summary::before {
     transform: rotate(90deg);
+    transition: transform 0.1s ease-in-out;
   }
 
   .markdown details:has(+ details) {


### PR DESCRIPTION
**Changes**

this pr increases caret icon usage and style consistency amongst reference / client.

| state | preview |
| -------|------|
| before | <img width="583" height="291" alt="image" src="https://github.com/user-attachments/assets/d860bc4b-2b33-4741-97d5-5148cb967d21" /> |
| after | <img width="583" height="291" alt="image" src="https://github.com/user-attachments/assets/1a1df402-3212-422c-842c-edf809c595f2" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
