### PR TITLE
docs: add Flask OpenAPI3

### DIFF
--- a/documentation/integrations/flask.md
+++ b/documentation/integrations/flask.md
@@ -1,0 +1,13 @@
+# Scalar API Reference for Flask
+
+Flask OpenAPI3 is a web API framework based on Flask. It uses Pydantic to verify data and automatic generation of interaction documentation.
+
+Flask OpenAPI3 has a Scalar UI template, that you can install:
+
+```bash
+pip install -U flask-openapi3
+pip install -U flask-openapi3-scalar
+```
+
+[Read more about flask_openapi3](https://luolingchun.github.io/flask-openapi3/latest/Usage/UI_Templates/)
+

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "dev:reference:react": "turbo playground --filter @scalar/api-reference-react",
     "dev:void-server": "pnpm --filter @scalar/void-server dev",
     "dev:web": "turbo dev --filter @scalar-examples/web",
+    "dev:documentation": "npx @scalar/cli project preview",
     "format:check": "pnpm prettier --check . && biome format",
     "format": "prettier --write . && biome format --write",
     "lint:check": "biome lint --diagnostic-level=error",

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -300,6 +300,12 @@
                   "type": "page"
                 },
                 {
+                  "name": "Flask",
+                  "slug": "flask",
+                  "path": "documentation/integrations/flask.md",
+                  "type": "page"
+                },
+                {
                   "name": "Go",
                   "slug": "go",
                   "path": "documentation/integrations/go.md",


### PR DESCRIPTION
This PR adds this OpenAPI package for Flask to our list of integrations.

I've also added a pnpm script to quickly preview the documentation.