### PR TITLE
fix(api-reference): can not render operation without responses

### DIFF
--- a/.changeset/light-turkeys-rush.md
+++ b/.changeset/light-turkeys-rush.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: can not render operation without responses

--- a/packages/api-reference/src/features/example-responses/ExampleResponse.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponse.vue
@@ -1,18 +1,20 @@
 <script lang="ts" setup>
 import { ScalarCodeBlock } from '@scalar/components'
 import { getExampleFromSchema } from '@scalar/oas-utils/spec-getters'
-import type { OpenAPI } from '@scalar/openapi-types'
+import type { ExampleObject } from '@scalar/workspace-store/schemas/v3.1/strict/example'
+import type { MediaTypeObject } from '@scalar/workspace-store/schemas/v3.1/strict/media-header-encoding'
 
 defineProps<{
-  response: OpenAPI.ResponseObject
+  response: MediaTypeObject | undefined
+  example: ExampleObject
 }>()
 </script>
 <template>
   <!-- Example -->
   <ScalarCodeBlock
-    v-if="response?.example !== undefined"
+    v-if="example !== undefined"
     class="bg-b-2 -outline-offset-2"
-    :content="response?.example"
+    :content="example?.value"
     lang="json" />
 
   <!-- Schema -->

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.test.ts
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.test.ts
@@ -68,7 +68,7 @@ describe('ExampleResponses', () => {
     expect(wrapper.text()).toContain('Example 2')
   })
 
-  it('handles xml example response', () => {
+  it.only('handles xml example response', () => {
     const wrapper = mount(ExampleResponses, {
       props: {
         responses: {
@@ -76,7 +76,9 @@ describe('ExampleResponses', () => {
             description: 'XML response',
             content: {
               'application/xml': {
-                example: '<user><name>John</name><age>30</age></user>',
+                examples: {
+                  example1: { value: '<user><name>John</name><age>30</age></user>' },
+                },
               },
             },
           },
@@ -104,7 +106,9 @@ describe('ExampleResponses', () => {
             description: 'Plain text response',
             content: {
               'text/plain': {
-                example: 'Hello world',
+                examples: {
+                  example1: { value: 'Hello world' },
+                },
               },
             },
           },
@@ -132,7 +136,9 @@ describe('ExampleResponses', () => {
             description: 'HTML response',
             content: {
               'text/html': {
-                example: '<div>Hello <strong>world</strong></div>',
+                examples: {
+                  example1: { value: '<div>Hello <strong>world</strong></div>' },
+                },
               },
             },
           },
@@ -160,7 +166,9 @@ describe('ExampleResponses', () => {
             description: 'Success response',
             content: {
               'application/json': {
-                example: { status: 'success' },
+                examples: {
+                  example1: { value: { status: 'success' } },
+                },
               },
             },
           },
@@ -168,7 +176,9 @@ describe('ExampleResponses', () => {
             description: 'Error response',
             content: {
               'application/json': {
-                example: { error: 'Bad request' },
+                examples: {
+                  example1: { value: { error: 'Bad request' } },
+                },
               },
             },
           },
@@ -176,7 +186,9 @@ describe('ExampleResponses', () => {
             description: 'Server error',
             content: {
               'application/json': {
-                example: { error: 'Internal server error' },
+                examples: {
+                  example1: { value: { error: 'Internal server error' } },
+                },
               },
             },
           },
@@ -207,7 +219,9 @@ describe('ExampleResponses', () => {
             description: 'Success response',
             content: {
               'application/json': {
-                example: { status: 'success' },
+                examples: {
+                  example1: { value: { status: 'success' } },
+                },
               },
             },
           },
@@ -215,7 +229,9 @@ describe('ExampleResponses', () => {
             description: 'Default error response',
             content: {
               'application/json': {
-                example: { error: 'Unexpected error' },
+                examples: {
+                  example1: { value: { error: 'Unexpected error' } },
+                },
               },
             },
           },
@@ -223,7 +239,9 @@ describe('ExampleResponses', () => {
             description: 'Not found error',
             content: {
               'application/json': {
-                example: { error: 'Resource not found' },
+                examples: {
+                  example1: { value: { error: 'Resource not found' } },
+                },
               },
             },
           },
@@ -254,7 +272,9 @@ describe('ExampleResponses', () => {
             description: 'Not found error',
             content: {
               'application/json': {
-                example: { error: 'Resource not found' },
+                examples: {
+                  example1: { value: { error: 'Resource not found' } },
+                },
               },
             },
           },
@@ -262,7 +282,9 @@ describe('ExampleResponses', () => {
             description: 'Server error',
             content: {
               'application/json': {
-                example: { error: 'Internal server error' },
+                examples: {
+                  example1: { value: { error: 'Internal server error' } },
+                },
               },
             },
           },
@@ -270,7 +292,9 @@ describe('ExampleResponses', () => {
             description: 'Forbidden error',
             content: {
               'application/json': {
-                example: { error: 'Access denied' },
+                examples: {
+                  example1: { value: { error: 'Access denied' } },
+                },
               },
             },
           },
@@ -301,7 +325,9 @@ describe('ExampleResponses', () => {
             description: 'OK',
             content: {
               'application/json': {
-                example: { foo: 'bar' },
+                examples: {
+                  example1: { value: { foo: 'bar' } },
+                },
               },
             },
           },
@@ -377,7 +403,9 @@ describe('ExampleResponses', () => {
             description: 'OK',
             content: {
               '*/*': {
-                example: { message: 'Wildcard mimetype' },
+                examples: {
+                  example1: { value: { message: 'Wildcard mimetype' } },
+                },
               },
             },
           },

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.test.ts
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.test.ts
@@ -12,7 +12,9 @@ describe('ExampleResponses', () => {
             description: 'Successful response',
             content: {
               'application/json': {
-                example: { message: 'Success' },
+                examples: {
+                  example1: { value: { message: 'Success' } },
+                },
               },
             },
           },
@@ -28,6 +30,7 @@ describe('ExampleResponses', () => {
     expect(tabs[0].text()).toContain('200')
     expect(codeBlock.length).toBe(1)
     expect(wrapper.text()).toContain('Success')
+    expect(wrapper.text()).not.toContain('value')
     expect(examplePicker.exists()).toBe(false)
   })
 
@@ -68,7 +71,7 @@ describe('ExampleResponses', () => {
     expect(wrapper.text()).toContain('Example 2')
   })
 
-  it.only('handles xml example response', () => {
+  it('handles xml example response', () => {
     const wrapper = mount(ExampleResponses, {
       props: {
         responses: {
@@ -91,7 +94,7 @@ describe('ExampleResponses', () => {
     const examplePicker = wrapper.findComponent({ name: 'ExamplePicker' })
 
     expect(tabs.length).toBe(1)
-    expect(tabs[0].text()).toContain('200')
+    expect(tabs[0].text()).toContain('Status: 200')
     expect(codeBlock.length).toBe(1)
     expect(wrapper.text()).toContain('XML response')
     expect(wrapper.text()).toContain('<user><name>John</name><age>30</age></user>')
@@ -335,7 +338,7 @@ describe('ExampleResponses', () => {
       },
     })
 
-    const copyButton = wrapper.find('.code-copy')
+    const copyButton = wrapper.find('.copy-button')
     expect(copyButton.exists()).toBe(true)
 
     await copyButton.trigger('click')

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.vue
@@ -13,8 +13,9 @@ import {
 } from '@scalar/oas-utils/helpers'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import type { MediaTypeObject } from '@scalar/workspace-store/schemas/v3.1/strict/media-header-encoding'
+import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/path-operations'
 import type { ResponseObject } from '@scalar/workspace-store/schemas/v3.1/strict/response'
-import type { ResponsesObject } from '@scalar/workspace-store/schemas/v3.1/strict/responses'
+import type { Dereference } from '@scalar/workspace-store/schemas/v3.1/type-guard'
 import { computed, ref, toValue, useId } from 'vue'
 
 import ScreenReader from '@/components/ScreenReader.vue'
@@ -29,7 +30,7 @@ import ExampleResponseTabList from './ExampleResponseTabList.vue'
  */
 
 const { responses } = defineProps<{
-  responses: ResponsesObject
+  responses: Dereference<OperationObject>['responses']
 }>()
 
 const id = useId()

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.vue
@@ -87,22 +87,19 @@ const selectedExampleKey = ref<string>(
  * Gets the first example response if there are multiple example responses
  * or the only example if there is only one example response.
  */
-const getFirstExampleResponse = () => {
-  const jsonResponse = toValue(currentResponseContent)
+const getFirstResponseExample = () => {
+  const response = toValue(currentResponseContent)
 
-  if (!jsonResponse) {
+  if (!response) {
     return undefined
   }
 
-  if (!hasMultipleExamples.value) {
-    return jsonResponse.example
-  }
-  if (Array.isArray(jsonResponse.examples)) {
-    return jsonResponse.examples[0]
+  if (Array.isArray(response.examples)) {
+    return response.examples[0]
   }
 
-  const firstProperty = Object.keys(jsonResponse.examples ?? {})[0]
-  const firstExample = jsonResponse.examples?.[firstProperty]
+  const firstExampleKey = Object.keys(response.examples ?? {})[0]
+  const firstExample = response.examples?.[firstExampleKey]
 
   return firstExample
 }
@@ -110,7 +107,7 @@ const getFirstExampleResponse = () => {
 const currentExample = computed(() => {
   return hasMultipleExamples.value && selectedExampleKey.value
     ? currentResponseContent.value?.examples?.[selectedExampleKey.value]
-    : getFirstExampleResponse()
+    : getFirstResponseExample()
 })
 
 const changeTab = (index: number) => {
@@ -159,20 +156,15 @@ const showSchema = ref(false)
       </template>
     </ExampleResponseTabList>
     <ScalarCardSection class="grid flex-1">
-      <template v-if="currentResponseContent?.schema">
-        <ScalarCodeBlock
-          v-if="showSchema && currentResponseContent"
-          :id="id"
-          class="-outline-offset-2"
-          :content="currentResponseContent.schema"
-          lang="json" />
-        <ExampleResponse
-          v-else
-          :id="id"
-          :response="currentResponseContent"
-          :example="currentExample" />
-      </template>
-      <!-- Without Schema: Don't show tabs -->
+      <!-- Schema -->
+      <ScalarCodeBlock
+        v-if="showSchema && currentResponseContent?.schema"
+        :id="id"
+        class="-outline-offset-2"
+        :content="currentResponseContent.schema"
+        lang="json" />
+
+      <!-- Example -->
       <ExampleResponse
         v-else
         :id="id"

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/ExamplePicker.vue
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/ExamplePicker.vue
@@ -17,7 +17,7 @@ const selectedExampleKey = defineModel<string>({
 })
 
 /** Generate label for an example */
-const getLabel = (key: string) => {
+const getLabel = (key: string | null) => {
   if (!key) {
     return 'Select an example'
   }

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/ExamplePicker.vue
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/ExamplePicker.vue
@@ -6,22 +6,29 @@ import {
   ScalarIcon,
 } from '@scalar/components'
 import { ScalarIconCaretDown } from '@scalar/icons'
-import type { ExampleObject } from '@scalar/workspace-store/schemas/v3.1/strict/example'
+import type { MediaTypeObject } from '@scalar/workspace-store/schemas/v3.1/strict/media-header-encoding'
 
-const props = defineProps<{
-  examples: Record<string, ExampleObject>
+const { examples } = defineProps<{
+  examples: MediaTypeObject['examples']
 }>()
 
-const selectedExampleKey = defineModel<string>({ required: true })
+const selectedExampleKey = defineModel<string>({
+  required: true,
+})
 
 /** Generate label for an example */
-const getLabel = (key: string | null) => {
+const getLabel = (key: string) => {
   if (!key) {
     return 'Select an example'
   }
 
-  const example = props.examples[key]
-  return example?.summary ?? key
+  const example = examples?.[key]
+
+  if (!example) {
+    return key
+  }
+
+  return example?.summary
 }
 
 /** Handle example selection */

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/ExamplePicker.vue
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/ExamplePicker.vue
@@ -22,13 +22,8 @@ const getLabel = (key: string | null) => {
     return 'Select an example'
   }
 
-  const example = examples?.[key]
-
-  if (!example) {
-    return key
-  }
-
-  return example?.summary
+  // Use the summary, if available, fallback to the key
+  return examples?.[key]?.summary ?? key
 }
 
 /** Handle example selection */

--- a/packages/oas-utils/src/helpers/normalize-mime-type-object.ts
+++ b/packages/oas-utils/src/helpers/normalize-mime-type-object.ts
@@ -1,5 +1,6 @@
 import type { ContentType } from '@scalar/types/legacy'
 
+import type { ResponseObject } from '@scalar/workspace-store/schemas/v3.1/strict/response'
 import { normalizeMimeType } from './normalize-mime-type'
 
 /**
@@ -7,7 +8,7 @@ import { normalizeMimeType } from './normalize-mime-type'
  *
  * Example: `application/json; charset=utf-8` -> `application/json`
  */
-export function normalizeMimeTypeObject(content?: Record<ContentType, any>) {
+export function normalizeMimeTypeObject(content?: ResponseObject['content']): ResponseObject['content'] {
   if (!content) {
     return content
   }

--- a/packages/oas-utils/src/spec-getters/get-request-body-from-operation.ts
+++ b/packages/oas-utils/src/spec-getters/get-request-body-from-operation.ts
@@ -81,7 +81,7 @@ export function getRequestBodyFromOperation(
   if (selectedExample) {
     return {
       mimeType,
-      text: prettyPrintJson(selectedExample?.value),
+      text: prettyPrintJson('value' in selectedExample ? selectedExample.value : selectedExample),
     }
   }
 


### PR DESCRIPTION
EDIT: Tests are failing, need to look into that

**Problem**

```js
{
  openapi: '3.0.0',
  info: {
    title: 'Example',
    version: '1.0.0',
  },
  paths: {
    '/hello': {
      get: {
        summary: 'Hello World',
        description: 'Hello World',
        // Operation *without* responses
        // responses: {
        //   200: {
        //     description: 'Hello World',
        //   },
        // },
      },
    },
  },
}
```

<img width="547" height="273" alt="Screenshot 2025-07-22 at 16 52 09" src="https://github.com/user-attachments/assets/e21e005a-98fc-4181-be42-e7a167b2ea64" />

**Solution**

This PR deals with undefined responses.

And I’ve switched to the new workspace OpenAPI types. 👍 

We work with an upgraded document now, so we can remove all the code to support Swagger 2.0 or the old single `example` syntax from OpenAPI pre-3.1.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
