### PR TITLE
fix(code-highlight): cursor not visible in codeblock when first added

### DIFF
--- a/.changeset/grumpy-taxis-switch.md
+++ b/.changeset/grumpy-taxis-switch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+fix: removes inline block display to keep caret in empty code input usage

--- a/packages/code-highlight/src/css/code.css
+++ b/packages/code-highlight/src/css/code.css
@@ -15,7 +15,6 @@
     font-size: inherit;
     color: var(--scalar-color-2);
     font-family: var(--scalar-font-code);
-    display: inline-block;
     counter-reset: linenumber;
   }
   .hljs {


### PR DESCRIPTION
**Changes**

this pr removes the inline block display utility set to `hljs` to prevent the caret from being hiddent when using codeblock input.

| state | preview |
| -------|------|
| before | <img width="640" height="83" alt="image" src="https://github.com/user-attachments/assets/6b3d0399-f603-48d4-9f72-a2a6a1102120" /> |
| after | <img width="640" height="83" alt="image" src="https://github.com/user-attachments/assets/6f33c4aa-08bd-400b-bbec-826b79c83d0a" /> | 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
