### PR TITLE
fix(examples/web): add scalar-app class

### DIFF
--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -16,7 +16,7 @@
     <title>Scalar API Reference</title>
   </head>
 
-  <body class="light-mode">
+  <body class="light-mode scalar-app">
     <div id="app"></div>
     <script
       type="module"


### PR DESCRIPTION
Need this now that we're using the card component from `@scalar/components`.

Before / after:

<img width="2912" height="1968" alt="Google Chrome-2025-07-22-20-40-16@2x" src="https://github.com/user-attachments/assets/71199920-64c0-4a9b-a79c-d78a3d9d0fc4" />

<img width="2912" height="1968" alt="Google Chrome-2025-07-22-20-39-27@2x" src="https://github.com/user-attachments/assets/e4dce1f3-bf97-4021-9b48-c9e9ed5e1f01" />

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
