### PR TITLE
feat(api-reference): update the workspace store when the document changes

### DIFF
--- a/.changeset/modern-pants-help.md
+++ b/.changeset/modern-pants-help.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-reference': patch
+---
+
+feat: make content reactive and update workspace store

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -18,98 +18,47 @@
 
     <!-- Initialize the Scalar API Reference -->
     <script type="module">
-      Scalar.createApiReference('#app', {
+      const scal = Scalar.createApiReference('#app', {
         sources: [
           {
             title: 'Scalar Galaxy', // optional, would fallback to 'API #1'
             slug: 'scalar-galaxy', // optional, would be auto-generated from the title or the index
-            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-          },
-          {
-            title: 'Scalar Galaxy (Classic Layout)',
-            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
-            layout: 'classic',
-          },
-          {
-            title: 'Relative URL Example',
-            slug: 'relative-url',
-            url: 'examples/openapi.json',
-          },
-          {
-            title: 'Swagger Petstore 2.0',
-            url: 'https://petstore.swagger.io/v2/swagger.json',
-          },
-          {
-            title: 'Swagger Petstore 3.0',
-            url: 'https://petstore3.swagger.io/api/v3/openapi.json',
-          },
-          {
-            title: 'Swagger Petstore 3.1',
-            url: 'https://petstore31.swagger.io/api/v31/openapi.json',
-          },
-          {
-            title: 'Hello World (string)',
-            content: JSON.stringify({
-              openapi: '3.0.0',
-              info: {
-                title: 'Hello World',
-                version: '1.0.0',
-              },
+            content: {
+              openapi: '3.1.0',
+              info: { title: 'Updated API', version: '1.0.0' },
               paths: {
-                '/hello': {
+                '/test': {
                   get: {
-                    summary: 'Hello World',
-                    description: 'Hello World',
-                    responses: {
-                      200: {
-                        description: 'Hello World',
-                        content: {
-                          'application/json': {
-                            schema: {
-                              type: 'string',
-                            },
-                          },
-                        },
-                      },
-                    },
+                    tags: ['Test'],
+                    summary: 'New Operation',
                   },
                 },
               },
-            }),
-          },
-          {
-            title: 'Valtown',
-            url: 'https://docs.val.town/openapi.documented.json',
-          },
-          {
-            title: 'Zoom',
-            url: 'https://developers.zoom.us/api-hub/meetings/methods/endpoints.json',
-          },
-          {
-            title: 'Cloudinary',
-            url: 'https://cloudinary.com/documentation/schemas/analysis-api/public-schema.yml',
-          },
-          {
-            title: 'Tailscale',
-            url: 'https://api.tailscale.com/api/v2?outputOpenapiSchema=true',
-          },
-          {
-            title: 'Maersk',
-            url: 'https://edpmediastorage.blob.core.windows.net/media/air_booking_v1-0_26092023_scalar_spec.yaml',
-          },
-          {
-            title: 'Bolt',
-            url: 'https://assets.bolt.com/external-api-references/bolt.yml',
-          },
-          {
-            title: 'OpenStatus',
-            url: 'https://api.openstatus.dev/v1/openapi',
+            },
           },
         ],
         persistAuth: true,
         // Avoid CORS issues
         proxyUrl: 'https://proxy.scalar.com',
       })
+
+      // setTimeout(() => {
+      //   console.log('updating configuration')
+      //   scal.updateConfiguration({
+      //     content: {
+      //       openapi: '3.1.0',
+      //       info: { title: 'Updated API', version: '1.0.0' },
+      //       paths: {
+      //         '/test': {
+      //           post: {
+      //             tags: ['Test'],
+      //             summary: 'New Operation',
+      //           },
+      //         },
+      //       },
+      //     },
+      //   })
+      // }, 5000)
     </script>
   </body>
 </html>

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -18,47 +18,98 @@
 
     <!-- Initialize the Scalar API Reference -->
     <script type="module">
-      const scal = Scalar.createApiReference('#app', {
+      Scalar.createApiReference('#app', {
         sources: [
           {
             title: 'Scalar Galaxy', // optional, would fallback to 'API #1'
             slug: 'scalar-galaxy', // optional, would be auto-generated from the title or the index
-            content: {
-              openapi: '3.1.0',
-              info: { title: 'Updated API', version: '1.0.0' },
+            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+          },
+          {
+            title: 'Scalar Galaxy (Classic Layout)',
+            url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+            layout: 'classic',
+          },
+          {
+            title: 'Relative URL Example',
+            slug: 'relative-url',
+            url: 'examples/openapi.json',
+          },
+          {
+            title: 'Swagger Petstore 2.0',
+            url: 'https://petstore.swagger.io/v2/swagger.json',
+          },
+          {
+            title: 'Swagger Petstore 3.0',
+            url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+          },
+          {
+            title: 'Swagger Petstore 3.1',
+            url: 'https://petstore31.swagger.io/api/v31/openapi.json',
+          },
+          {
+            title: 'Hello World (string)',
+            content: JSON.stringify({
+              openapi: '3.0.0',
+              info: {
+                title: 'Hello World',
+                version: '1.0.0',
+              },
               paths: {
-                '/test': {
+                '/hello': {
                   get: {
-                    tags: ['Test'],
-                    summary: 'New Operation',
+                    summary: 'Hello World',
+                    description: 'Hello World',
+                    responses: {
+                      200: {
+                        description: 'Hello World',
+                        content: {
+                          'application/json': {
+                            schema: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                      },
+                    },
                   },
                 },
               },
-            },
+            }),
+          },
+          {
+            title: 'Valtown',
+            url: 'https://docs.val.town/openapi.documented.json',
+          },
+          {
+            title: 'Zoom',
+            url: 'https://developers.zoom.us/api-hub/meetings/methods/endpoints.json',
+          },
+          {
+            title: 'Cloudinary',
+            url: 'https://cloudinary.com/documentation/schemas/analysis-api/public-schema.yml',
+          },
+          {
+            title: 'Tailscale',
+            url: 'https://api.tailscale.com/api/v2?outputOpenapiSchema=true',
+          },
+          {
+            title: 'Maersk',
+            url: 'https://edpmediastorage.blob.core.windows.net/media/air_booking_v1-0_26092023_scalar_spec.yaml',
+          },
+          {
+            title: 'Bolt',
+            url: 'https://assets.bolt.com/external-api-references/bolt.yml',
+          },
+          {
+            title: 'OpenStatus',
+            url: 'https://api.openstatus.dev/v1/openapi',
           },
         ],
         persistAuth: true,
         // Avoid CORS issues
         proxyUrl: 'https://proxy.scalar.com',
       })
-
-      // setTimeout(() => {
-      //   console.log('updating configuration')
-      //   scal.updateConfiguration({
-      //     content: {
-      //       openapi: '3.1.0',
-      //       info: { title: 'Updated API', version: '1.0.0' },
-      //       paths: {
-      //         '/test': {
-      //           post: {
-      //             tags: ['Test'],
-      //             summary: 'New Operation',
-      //           },
-      //         },
-      //       },
-      //     },
-      //   })
-      // }, 5000)
     </script>
   </body>
 </html>

--- a/packages/api-reference/src/helpers/test-utils.ts
+++ b/packages/api-reference/src/helpers/test-utils.ts
@@ -79,3 +79,12 @@ export const createMockStore = (activeDocument: WorkspaceDocument): WorkspaceSto
   importWorkspaceFromSpecification: vi.fn(),
   replaceDocument: vi.fn(),
 })
+
+export const createMockLocalStorage = () => ({
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+  key: vi.fn(),
+  length: 0,
+})

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -164,6 +164,8 @@ describe('html-api', () => {
         }),
       })
 
+      await flushPromises()
+
       expect(document.getElementById('tag/test/post/test')).not.toBeNull()
       expect(document.getElementById('tag/test/post/test')?.innerHTML).toContain('Even newer operation')
 

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -145,8 +145,30 @@ describe('html-api', () => {
       // Assert the configuration was updated
       await flushPromises()
 
-      expect(document.getElementById('tag/default/get/test')).not.toBeNull()
-      expect(document.getElementById('tag/default/get/test')?.innerHTML).toContain('New Operation')
+      expect(document.getElementById('tag/test/get/test')).not.toBeNull()
+      expect(document.getElementById('tag/test/get/test')?.innerHTML).toContain('New Operation')
+
+      // Update configuration
+      app.updateConfiguration({
+        content: JSON.stringify({
+          'openapi': '3.1.0',
+          'info': { 'title': 'Updated API', 'version': '1.0.0' },
+          'paths': {
+            '/test': {
+              'post': {
+                'tags': ['Test'],
+                'summary': 'Even newer operation',
+              },
+            },
+          },
+        }),
+      })
+
+      expect(document.getElementById('tag/test/post/test')).not.toBeNull()
+      expect(document.getElementById('tag/test/post/test')?.innerHTML).toContain('Even newer operation')
+
+      // Assert the configuration was updated
+      await flushPromises()
     })
   })
 

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -121,6 +121,33 @@ describe('html-api', () => {
       await flushPromises()
       expect(document.getElementById('mount-point')?.innerHTML).toContain('Updated API')
     })
+
+    it('updates the operations when the configuration changes', async () => {
+      const config = { _integration: 'html' }
+      const app = createApiReference('#mount-point', apiReferenceConfigurationSchema.parse(config))
+
+      // Update configuration
+      app.updateConfiguration({
+        content: JSON.stringify({
+          'openapi': '3.1.0',
+          'info': { 'title': 'Updated API', 'version': '1.0.0' },
+          'paths': {
+            '/test': {
+              'get': {
+                'tags': ['Test'],
+                'summary': 'New Operation',
+              },
+            },
+          },
+        }),
+      })
+
+      // Assert the configuration was updated
+      await flushPromises()
+
+      expect(document.getElementById('tag/default/get/test')).not.toBeNull()
+      expect(document.getElementById('tag/default/get/test')?.innerHTML).toContain('New Operation')
+    })
   })
 
   describe('findDataAttributes (legacy)', () => {

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.test.ts
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.test.ts
@@ -1,0 +1,505 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import ApiReferenceWorkspace from './ApiReferenceWorkspace.vue'
+import type { WorkspaceStore } from '@scalar/workspace-store/client'
+import { createMockLocalStorage, createMockStore } from '@/helpers/test-utils'
+import { REFERENCE_LS_KEYS } from '@scalar/helpers/object/local-storage'
+
+// vi.mock('@scalar/oas-utils/helpers', async () => ({
+//   redirectToProxy: vi.fn((proxyUrl, url) => `${proxyUrl}?url=${encodeURIComponent(url)}`),
+// }))
+
+vi.mock('@unhead/vue', () => ({
+  useSeoMeta: vi.fn(),
+}))
+
+vi.mock('@/v2/events')
+
+vi.mock('@vueuse/core', async () => ({
+  ...(await import('@vueuse/core')),
+  useFavicon: vi.fn(),
+}))
+
+vi.mock('@/hooks/useNavState', async () => ({
+  ...(await import('@/hooks/useNavState')),
+  NAV_STATE_SYMBOL: Symbol('nav-state'),
+}))
+
+describe('ApiReferenceWorkspace', () => {
+  let wrapper: VueWrapper
+  let mockStore: WorkspaceStore
+  let mockConfiguration: any
+
+  beforeEach(async () => {
+    // Reset all mocks
+    vi.clearAllMocks()
+
+    // Clear localStorage before each test
+    localStorage.clear()
+
+    // Create mock configuration
+    mockConfiguration = {
+      title: 'Test API',
+      content: {
+        openapi: '3.0.0',
+        info: {
+          title: 'Test API',
+          version: '1.0.0',
+        },
+        paths: {},
+      },
+    }
+
+    // Create mock store
+    mockStore = createMockStore(mockConfiguration.content)
+  })
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount()
+    }
+  })
+
+  describe('component rendering', () => {
+    it('renders the component with basic props', async () => {
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: mockConfiguration,
+          store: mockStore,
+        },
+      })
+
+      await flushPromises()
+
+      expect(wrapper.exists()).toBe(true)
+      expect(wrapper.findComponent({ name: 'ApiReferenceLayout' }).exists()).toBe(true)
+      expect(wrapper.text()).toContain('Test API')
+    })
+
+    it('renders custom CSS when provided', () => {
+      const configWithCss = {
+        ...mockConfiguration,
+        customCss: '.custom-style { color: red; }',
+      }
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: configWithCss,
+          store: mockStore,
+        },
+      })
+
+      const styleElement = wrapper.find('style')
+      expect(styleElement.exists()).toBe(true)
+      expect(styleElement.text()).toContain('.custom-style { color: red; }')
+    })
+
+    it('does render style tag when no custom CSS, for the base theme', () => {
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: mockConfiguration,
+          store: mockStore,
+        },
+      })
+
+      const styleElement = wrapper.find('style')
+      expect(styleElement.exists()).toBe(true)
+    })
+  })
+
+  describe('document management', () => {
+    it('adds document to store when content is provided', async () => {
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: mockConfiguration,
+          store: mockStore,
+        },
+      })
+
+      await nextTick()
+
+      expect(mockStore.addDocumentSync).toHaveBeenCalledWith({
+        name: 'test-api',
+        document: mockConfiguration.content,
+      })
+    })
+
+    it('adds document to store when URL is provided', async () => {
+      const configWithUrl = {
+        ...mockConfiguration,
+        url: 'https://example.com/api/spec.json',
+        content: undefined,
+      }
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: configWithUrl,
+          store: mockStore,
+        },
+      })
+
+      await nextTick()
+
+      expect(mockStore.addDocument).toHaveBeenCalledWith({
+        name: 'test-api',
+        url: 'https://example.com/api/spec.json',
+        fetch: expect.any(Function),
+      })
+    })
+
+    it('replaces existing document when name already exists', async () => {
+      // Mock that document already exists
+      mockStore.workspace.documents = {
+        'existing-document': {} as any,
+      }
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: {
+            slug: 'existing-document',
+            content: mockConfiguration.content,
+          },
+          store: mockStore,
+        },
+      })
+
+      await nextTick()
+
+      expect(mockStore.replaceDocument).toHaveBeenCalledWith('existing-document', mockConfiguration.content)
+      expect(mockStore.update).toHaveBeenCalledWith('x-scalar-active-document', 'existing-document')
+    })
+  })
+
+  describe('dark mode handling', () => {
+    it('updates dark mode state when configuration changes', async () => {
+      const configWithDarkMode = {
+        ...mockConfiguration,
+        darkMode: true,
+      }
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: configWithDarkMode,
+          store: mockStore,
+        },
+      })
+
+      await nextTick()
+
+      expect(mockStore.update).toHaveBeenCalledWith('x-scalar-dark-mode', true)
+    })
+
+    it('handles dark mode toggle event', async () => {
+      const { onCustomEvent } = await import('@/v2/events')
+      const mockOnCustomEvent = vi.mocked(onCustomEvent)
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: mockConfiguration,
+          store: mockStore,
+        },
+      })
+
+      await nextTick()
+
+      // Simulate the event handler being called
+      const eventHandler = mockOnCustomEvent.mock.calls.find((call) => call[1] === 'scalar-update-dark-mode')?.[2]
+
+      if (eventHandler) {
+        eventHandler({ detail: { value: true } })
+        expect(mockStore.update).toHaveBeenCalledWith('x-scalar-dark-mode', true)
+      }
+    })
+  })
+
+  describe('client selection', () => {
+    let localStorageSpy: any
+
+    beforeEach(() => {
+      // Create a spy for localStorage
+      localStorageSpy = createMockLocalStorage()
+      // Mock global localStorage
+      Object.defineProperty(window, 'localStorage', {
+        value: localStorageSpy,
+        writable: true,
+      })
+    })
+
+    afterEach(() => {
+      // Clear all mocks
+      vi.clearAllMocks()
+    })
+
+    it('loads stored client on mount', async () => {
+      localStorageSpy.getItem.mockReturnValue('node/fetch')
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: mockConfiguration,
+          store: mockStore,
+        },
+      })
+
+      expect(mockStore.update).toHaveBeenCalledWith('x-scalar-default-client', 'node/fetch')
+    })
+
+    it('handles client selection event', async () => {
+      const { onCustomEvent } = await import('@/v2/events')
+      const mockOnCustomEvent = vi.mocked(onCustomEvent)
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: mockConfiguration,
+          store: mockStore,
+        },
+      })
+
+      await nextTick()
+
+      // Simulate the event handler being called
+      const eventHandler = mockOnCustomEvent.mock.calls.find((call) => call[1] === 'scalar-update-selected-client')?.[2]
+
+      if (eventHandler) {
+        eventHandler({ detail: 'new-client' })
+        expect(mockStore.update).toHaveBeenCalledWith('x-scalar-default-client', 'new-client')
+        expect(localStorage.setItem).toHaveBeenCalledWith(REFERENCE_LS_KEYS.SELECTED_CLIENT, 'new-client')
+      }
+    })
+  })
+
+  describe('document selection', () => {
+    it('handles active document update event', async () => {
+      const { onCustomEvent } = await import('@/v2/events')
+      const mockOnCustomEvent = vi.mocked(onCustomEvent)
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: mockConfiguration,
+          store: mockStore,
+        },
+      })
+
+      await nextTick()
+
+      // Simulate the event handler being called
+      const eventHandler = mockOnCustomEvent.mock.calls.find((call) => call[1] === 'scalar-update-active-document')?.[2]
+
+      if (eventHandler) {
+        eventHandler({ detail: { value: 'new-document' } })
+        expect(mockStore.update).toHaveBeenCalledWith('x-scalar-active-document', 'new-document')
+      }
+    })
+  })
+
+  describe('default HTTP client configuration', () => {
+    it('updates default client when configuration changes', async () => {
+      const { isClient } = await import('@/v2/blocks/scalar-request-example-block/helpers/find-client')
+      const configWithDefaultClient = {
+        ...mockConfiguration,
+        defaultHttpClient: {
+          targetKey: 'js',
+          clientKey: 'fetch',
+        },
+      }
+
+      vi.mocked(isClient).mockReturnValue(true)
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: configWithDefaultClient,
+          store: mockStore,
+        },
+      })
+
+      await nextTick()
+
+      expect(mockStore.update).toHaveBeenCalledWith('x-scalar-default-client', 'js/fetch')
+    })
+
+    it('does not update default client when isClient returns false', async () => {
+      const { isClient } = await import('@/v2/blocks/scalar-request-example-block/helpers/find-client')
+      const configWithDefaultClient = {
+        ...mockConfiguration,
+        defaultHttpClient: {
+          targetKey: 'js',
+          clientKey: 'fetch',
+        },
+      }
+
+      vi.mocked(isClient).mockReturnValue(false)
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: configWithDefaultClient,
+          store: mockStore,
+        },
+      })
+
+      await nextTick()
+
+      expect(mockStore.update).not.toHaveBeenCalledWith('x-scalar-default-client', expect.any(String))
+    })
+  })
+
+  describe('SEO and favicon', () => {
+    it('sets SEO meta when metadata is provided', async () => {
+      const { useSeoMeta } = await import('@unhead/vue')
+      const configWithMeta = {
+        ...mockConfiguration,
+        metaData: {
+          title: 'Test API',
+          description: 'Test API description',
+        },
+      }
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: configWithMeta,
+          store: mockStore,
+        },
+      })
+
+      await nextTick()
+
+      expect(useSeoMeta).toHaveBeenCalledWith(configWithMeta.metaData)
+    })
+
+    it('sets favicon when provided', async () => {
+      const { useFavicon } = await import('@vueuse/core')
+      const configWithFavicon = {
+        ...mockConfiguration,
+        favicon: '/favicon.ico',
+      }
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: configWithFavicon,
+          store: mockStore,
+        },
+      })
+
+      await nextTick()
+
+      expect(useFavicon).toHaveBeenCalledWith(expect.any(Object))
+    })
+  })
+
+  describe('proxy functionality', () => {
+    it('creates proxy function for external requests', async () => {
+      const { redirectToProxy } = await import('@scalar/oas-utils/helpers')
+      const configWithProxy = {
+        ...mockConfiguration,
+        proxyUrl: 'https://proxy.example.com',
+      }
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: configWithProxy,
+          store: mockStore,
+        },
+      })
+
+      await nextTick()
+
+      // The proxy function should be created and used in addDocument
+      expect(redirectToProxy).toHaveBeenCalled()
+    })
+  })
+
+  describe('slot rendering', () => {
+    it('renders footer slot', () => {
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: mockConfiguration,
+          store: mockStore,
+        },
+        slots: {
+          footer: '<div>Footer content</div>',
+        },
+      })
+
+      expect(wrapper.html()).toContain('Footer content')
+    })
+
+    it('renders sidebar-start slot', () => {
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: mockConfiguration,
+          store: mockStore,
+        },
+        slots: {
+          'sidebar-start': '<div>Sidebar content</div>',
+        },
+      })
+
+      expect(wrapper.html()).toContain('Sidebar content')
+    })
+  })
+
+  describe('event emission', () => {
+    it('emits updateContent event', async () => {
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: mockConfiguration,
+          store: mockStore,
+        },
+      })
+
+      const layoutComponent = wrapper.findComponent({ name: 'ApiReferenceLayout' })
+      await layoutComponent.vm.$emit('updateContent', { some: 'content' })
+
+      expect(wrapper.emitted('updateContent')).toBeTruthy()
+      expect(wrapper.emitted('updateContent')?.[0]).toEqual([{ some: 'content' }])
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles empty configuration gracefully', () => {
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: undefined,
+          store: mockStore,
+        },
+      })
+
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    it('handles configuration without content or URL', () => {
+      const emptyConfig = {
+        title: 'Empty API',
+      }
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: emptyConfig,
+          store: mockStore,
+        },
+      })
+
+      expect(wrapper.exists()).toBe(true)
+      expect(mockStore.addDocumentSync).not.toHaveBeenCalled()
+      expect(mockStore.addDocument).not.toHaveBeenCalled()
+    })
+
+    it('handles store without workspace documents', () => {
+      const emptyStore = {
+        ...mockStore,
+        workspace: {
+          ...mockStore.workspace,
+          documents: {},
+        },
+      }
+
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: mockConfiguration,
+          store: emptyStore,
+        },
+      })
+
+      expect(wrapper.exists()).toBe(true)
+    })
+  })
+})

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.test.ts
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.test.ts
@@ -119,7 +119,7 @@ describe('ApiReferenceWorkspace', () => {
 
       await nextTick()
 
-      expect(mockStore.addDocumentSync).toHaveBeenCalledWith({
+      expect(mockStore.addDocument).toHaveBeenCalledWith({
         name: 'test-api',
         document: mockConfiguration.content,
       })
@@ -493,7 +493,6 @@ describe('ApiReferenceWorkspace', () => {
       })
 
       expect(wrapper.exists()).toBe(true)
-      expect(mockStore.addDocumentSync).not.toHaveBeenCalled()
       expect(mockStore.addDocument).not.toHaveBeenCalled()
     })
 

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
@@ -131,6 +131,9 @@ const addDocument = (config: Partial<ApiReferenceConfigurationWithSources>) => {
   // If the document is already in the store, we may want to update it
   if (store.workspace.documents[name]) {
     if (document) {
+      // Disable intersection observer to prevent url changing
+      isIntersectionEnabled.value = false
+
       /**
        * We need to clone the object as it gets mutated by the upgrader causing a stack overflow
        * todo: we can remove the deepClone once the upgrader becomes functional
@@ -140,6 +143,11 @@ const addDocument = (config: Partial<ApiReferenceConfigurationWithSources>) => {
 
       // Lets set it to active as well just in case the name changed
       store.update('x-scalar-active-document', name)
+
+      // Re-enable intersection observer
+      setTimeout(() => {
+        isIntersectionEnabled.value = true
+      }, 300)
     }
 
     return

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
@@ -131,9 +131,6 @@ const addDocument = (config: Partial<ApiReferenceConfigurationWithSources>) => {
   // If the document is already in the store, we may want to update it
   if (store.workspace.documents[name]) {
     if (document) {
-      // Disable intersection observer to prevent url changing
-      isIntersectionEnabled.value = false
-
       /**
        * We need to clone the object as it gets mutated by the upgrader causing a stack overflow
        * todo: we can remove the deepClone once the upgrader becomes functional
@@ -143,11 +140,6 @@ const addDocument = (config: Partial<ApiReferenceConfigurationWithSources>) => {
 
       // Lets set it to active as well just in case the name changed
       store.update('x-scalar-active-document', name)
-
-      // Re-enable intersection observer
-      setTimeout(() => {
-        isIntersectionEnabled.value = true
-      }, 300)
     }
 
     return

--- a/packages/api-reference/src/v2/helpers/get-document-name.test.ts
+++ b/packages/api-reference/src/v2/helpers/get-document-name.test.ts
@@ -25,10 +25,10 @@ describe('getDocumentName', () => {
 
     it('should base the unknown name on the number of documents', () => {
       const result = getDocumentName({}, {
-        'OpenAPI Document #1': {},
-        'OpenAPI Document #2': {},
-        'OpenAPI Document #3': {},
-        'OpenAPI Document #5': {},
+        'API #1': {},
+        'API #2': {},
+        'API #3': {},
+        'API #5': {},
       } as any)
       expect(result).toBe('OpenAPI Document #4')
     })

--- a/packages/api-reference/src/v2/helpers/get-document-name.test.ts
+++ b/packages/api-reference/src/v2/helpers/get-document-name.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { getDocumentName } from './get-document-name'
+
+describe('getDocumentName', () => {
+  describe('URL-based documents', () => {
+    it('should return name when one is provided', () => {
+      const result = getDocumentName({ name: 'Test name', url: 'https://api.example.com' }, {})
+      expect(result).toBe('Test name')
+    })
+
+    it('should return URL when no explicit name is provided', () => {
+      const result = getDocumentName({ url: 'https://api.example.com' }, {})
+      expect(result).toBe('https://api.example.com')
+    })
+
+    it('should return the title if it exists and there is no name or url', () => {
+      const result = getDocumentName(
+        {
+          document: { info: { title: 'Test title' } },
+        },
+        {},
+      )
+      expect(result).toBe('Test title')
+    })
+
+    it('should base the unknown name on the number of documents', () => {
+      const result = getDocumentName({}, {
+        'OpenAPI Document #1': {},
+        'OpenAPI Document #2': {},
+        'OpenAPI Document #3': {},
+        'OpenAPI Document #5': {},
+      } as any)
+      expect(result).toBe('OpenAPI Document #4')
+    })
+  })
+})

--- a/packages/api-reference/src/v2/helpers/get-document-name.test.ts
+++ b/packages/api-reference/src/v2/helpers/get-document-name.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { getDocumentName } from './get-document-name'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
 describe('getDocumentName', () => {
   describe('URL-based documents', () => {
@@ -27,10 +28,10 @@ describe('getDocumentName', () => {
       const result = getDocumentName(
         {},
         {
-          'API #1': {},
-          'API #2': {},
-          'API #3': {},
-          'API #5': {},
+          'API #1': {} as OpenApiDocument,
+          'API #2': {} as OpenApiDocument,
+          'API #3': {} as OpenApiDocument,
+          'API #5': {} as OpenApiDocument,
         },
       )
       expect(result).toBe('API #4')

--- a/packages/api-reference/src/v2/helpers/get-document-name.test.ts
+++ b/packages/api-reference/src/v2/helpers/get-document-name.test.ts
@@ -24,13 +24,16 @@ describe('getDocumentName', () => {
     })
 
     it('should base the unknown name on the number of documents', () => {
-      const result = getDocumentName({}, {
-        'API #1': {},
-        'API #2': {},
-        'API #3': {},
-        'API #5': {},
-      } as any)
-      expect(result).toBe('OpenAPI Document #4')
+      const result = getDocumentName(
+        {},
+        {
+          'API #1': {},
+          'API #2': {},
+          'API #3': {},
+          'API #5': {},
+        },
+      )
+      expect(result).toBe('API #4')
     })
   })
 })

--- a/packages/api-reference/src/v2/helpers/get-document-name.ts
+++ b/packages/api-reference/src/v2/helpers/get-document-name.ts
@@ -37,7 +37,7 @@ export const getDocumentName = (
   // If we cannot resolve a name, we iterate over the documens in case of a conflict
   if (documents) {
     const names = Object.keys(documents)
-    return iterateTitle('OpenAPI Document #1', (t) => names.some((name) => name === t))
+    return iterateTitle('API #1', (t) => names.some((name) => name === t))
   }
 
   // Otherwise we just default

--- a/packages/api-reference/src/v2/helpers/get-document-name.ts
+++ b/packages/api-reference/src/v2/helpers/get-document-name.ts
@@ -1,0 +1,45 @@
+import { iterateTitle } from '@scalar/helpers/string/iterate-title'
+import type { ObjectDoc, UrlDoc } from '@scalar/workspace-store/client'
+import type { InfoObject } from '@scalar/workspace-store/schemas/v3.1/strict/info'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+
+/**
+ * Calculate a default name for the document to make the workspace store name parameter optional
+ *
+ * @param params.name - If we have a name already, like config.slug
+ * @param params.url - URL of the document
+ * @param params.document - The document object
+ * @param documents - Optional documents record which will automatically iterate the title if we have a duplicate
+ * @returns The name of the document
+ */
+export const getDocumentName = (
+  { name, url, document }: Partial<UrlDoc> & Partial<ObjectDoc> = {},
+  documents?: Record<string, OpenApiDocument>,
+): string => {
+  // Check for explicit name first (highest priority)
+  if (name) {
+    return name
+  }
+
+  // Check for URL-based document
+  if (url) {
+    return url
+  }
+
+  // Check for OpenAPI info title
+  if (document?.info) {
+    const info = document.info as InfoObject
+    if (info.title) {
+      return info.title
+    }
+  }
+
+  // If we cannot resolve a name, we iterate over the documens in case of a conflict
+  if (documents) {
+    const names = Object.keys(documents)
+    return iterateTitle('OpenAPI Document #1', (t) => names.some((name) => name === t))
+  }
+
+  // Otherwise we just default
+  return 'default'
+}

--- a/packages/api-reference/src/v2/helpers/normalize-content.test.ts
+++ b/packages/api-reference/src/v2/helpers/normalize-content.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeContent } from './normalize-content'
+
+describe('normalizeContent', () => {
+  describe('function input', () => {
+    it('should handle function that returns a string', () => {
+      const content = () => '{"name": "test", "version": "1.0.0"}'
+      const result = normalizeContent(content)
+
+      expect(result).toEqual({
+        name: 'test',
+        version: '1.0.0',
+      })
+    })
+
+    it('should handle function that returns an object', () => {
+      const content = () => ({ name: 'test', version: '1.0.0' })
+      const result = normalizeContent(content)
+
+      expect(result).toEqual({
+        name: 'test',
+        version: '1.0.0',
+      })
+    })
+
+    it('should handle nested function calls', () => {
+      const innerContent = () => '{"nested": true}'
+      const content = () => innerContent()
+      const result = normalizeContent(content)
+
+      expect(result).toEqual({
+        nested: true,
+      })
+    })
+
+    it('should handle function that returns undefined', () => {
+      const content = () => undefined as any
+      const result = normalizeContent(content)
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('string input', () => {
+    it('should parse valid JSON string', () => {
+      const content = '{"openapi": "3.0.0", "info": {"title": "Test API"}}'
+      const result = normalizeContent(content)
+
+      expect(result).toEqual({
+        openapi: '3.0.0',
+        info: {
+          title: 'Test API',
+        },
+      })
+    })
+
+    it('should parse valid YAML string', () => {
+      const content = `
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+`
+      const result = normalizeContent(content)
+
+      expect(result).toEqual({
+        openapi: '3.0.0',
+        info: {
+          title: 'Test API',
+          version: '1.0.0',
+        },
+      })
+    })
+
+    it('should throw error for invalid JSON/YAML string', () => {
+      const content = 'invalid json or yaml content'
+
+      expect(() => normalizeContent(content)).toThrow()
+    })
+
+    it('should throw error for malformed JSON', () => {
+      const content = '{"name": "test", "version": "1.0.0"'
+
+      expect(() => normalizeContent(content)).toThrow()
+    })
+
+    it('should throw error for malformed YAML', () => {
+      const content = `
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+  description: "This is a test
+`
+
+      expect(() => normalizeContent(content)).toThrow()
+    })
+  })
+
+  describe('object input', () => {
+    it('should return object as-is', () => {
+      const content = { name: 'test', version: '1.0.0' }
+      const result = normalizeContent(content)
+
+      expect(result).toBe(content)
+      expect(result).toEqual({
+        name: 'test',
+        version: '1.0.0',
+      })
+    })
+
+    it('should handle complex nested objects', () => {
+      const content = {
+        openapi: '3.0.0',
+        info: {
+          title: 'Test API',
+          version: '1.0.0',
+          description: 'A test API',
+        },
+        paths: {
+          '/test': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'OK',
+                },
+              },
+            },
+          },
+        },
+      }
+      const result = normalizeContent(content)
+
+      expect(result).toBe(content)
+      expect(result).toEqual(content)
+    })
+
+    it('should handle empty object', () => {
+      const content = {}
+      const result = normalizeContent(content)
+
+      expect(result).toBe(content)
+      expect(result).toEqual({})
+    })
+  })
+
+  describe('undefined input', () => {
+    it('should return undefined', () => {
+      const result = normalizeContent(undefined)
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty string', () => {
+      const content = ''
+
+      expect(normalizeContent(content)).toBeUndefined()
+    })
+
+    it('should handle function that throws an error', () => {
+      const content = () => {
+        throw new Error('Function error')
+      }
+
+      expect(() => normalizeContent(content)).toThrow('Function error')
+    })
+
+    it('should handle function that returns null', () => {
+      const content = () => null as any
+      const result = normalizeContent(content)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should handle function that returns primitive values', () => {
+      const stringContent = () => '{"test": true}'
+      const numberContent = () => 42 as any
+      const booleanContent = () => true as any
+
+      expect(normalizeContent(stringContent)).toEqual({ test: true })
+      expect(normalizeContent(numberContent)).toBe(42)
+      expect(normalizeContent(booleanContent)).toBe(true)
+    })
+  })
+
+  describe('recursive function calls', () => {
+    it('should handle deeply nested function calls', () => {
+      const level3 = () => '{"deep": "value"}'
+      const level2 = () => level3 as any
+      const level1 = () => level2 as any
+      const content = () => level1 as any
+
+      const result = normalizeContent(content)
+
+      expect(result).toEqual({
+        deep: 'value',
+      })
+    })
+
+    it('should handle function that returns another function', () => {
+      const innerFn = () => '{"inner": "data"}'
+      const content = () => innerFn as any
+
+      const result = normalizeContent(content)
+
+      expect(result).toEqual({
+        inner: 'data',
+      })
+    })
+  })
+})

--- a/packages/api-reference/src/v2/helpers/normalize-content.ts
+++ b/packages/api-reference/src/v2/helpers/normalize-content.ts
@@ -1,0 +1,20 @@
+import { parseJsonOrYaml } from '@scalar/oas-utils/helpers'
+
+/** Normalize content into a JS object or return null if it is falsey */
+export const normalizeContent = (
+  content: string | Record<string, unknown> | (() => string | Record<string, unknown>) | undefined | null,
+): Record<string, unknown> | undefined => {
+  if (!content) {
+    return undefined
+  }
+
+  if (typeof content === 'function') {
+    return normalizeContent(content())
+  }
+
+  if (typeof content === 'string') {
+    return parseJsonOrYaml(content)
+  }
+
+  return content || undefined
+}

--- a/packages/workspace-store/esbuild.ts
+++ b/packages/workspace-store/esbuild.ts
@@ -1,6 +1,7 @@
 import { build } from '@scalar/build-tooling/esbuild'
 
 const entries = [
+  './src/helpers/*.ts',
   './src/schemas.ts',
   './src/client.ts',
   './src/server.ts',

--- a/packages/workspace-store/package.json
+++ b/packages/workspace-store/package.json
@@ -49,6 +49,11 @@
       "types": "./dist/schemas/workspace.d.ts",
       "default": "./dist/schemas/workspace.js"
     },
+    "./helpers/*": {
+      "import": "./dist/helpers/*.js",
+      "types": "./dist/helpers/*.d.ts",
+      "default": "./dist/helpers/*.js"
+    },
     "./schemas/v3.1/*": {
       "import": "./dist/schemas/v3.1/*.js",
       "types": "./dist/schemas/v3.1/*.d.ts",


### PR DESCRIPTION
I only added the failing test, the actual PR is authored by @amritk. 🤝 

**Problem**

When using the `'scalar:update-references-config'` event, or the `app.updateConfiguration` API, or updating the `configuration` prop of `<ApiReference />`, the new store doesn’t listen to changes to `content` or `url` anymore.

### Alright this is getting there, we can decide if we want the content property to be reactive and update automatically OR we want to only update when we explicitly call `app.updateConfiguration`


**Solution**

- [x] We listen to configuration changes and update the document in the store.
- [ ] Disable intersection observer before updating spec, maybe even freeze element as well

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
