### PR TITLE
fix(fastapi): `pnpm dev` throws error

### DIFF
--- a/integrations/fastapi/package.json
+++ b/integrations/fastapi/package.json
@@ -16,8 +16,8 @@
     "node": ">=20"
   },
   "scripts": {
-    "dev": "cd playground && uvicorn main:app --reload",
-    "test": "python3 run_tests.py"
+    "dev": "command -v uvicorn >/dev/null 2>&1 && cd playground && uvicorn main:app --reload || echo '⚠️ uvicorn is not available, skipping the dev server.'",
+    "test": "command -v python >/dev/null 2>&1 && python run_tests.py || echo '⚠️ python is not available, skipping the tests.'"
   },
   "dependencies": {},
   "devDependencies": {}

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "clean:nuxt": "shx rm -rf \"**/.nuxt\"",
     "clean:dist": "shx rm -rf \"**/dist\"",
     "clean:turbo": "shx rm -rf \"**/.turbo\"",
-    "dev": "turbo dev --concurrency=100% --filter './examples/*' --filter './integrations/*' --filter=@scalar/nuxt --filter=@scalar/draggable --filter @scalar/components --filter @scalar/api-client --filter @scalar/nextjs-openapi",
+    "dev": "turbo dev --concurrency=20 --filter './examples/*' --filter './integrations/*' --filter=@scalar/nuxt --filter=@scalar/draggable --filter @scalar/components --filter @scalar/api-client --filter @scalar/nextjs-openapi",
     "dev:client": "turbo dev --filter @scalar/api-client",
     "dev:client:desktop": "turbo dev --filter scalar-app",
     "dev:client:app": "turbo playground:app --filter @scalar/api-client",


### PR DESCRIPTION
**Problem**

I’ve recently added a `dev` and `test` script to the fastapi integration. The `dev` script is also executed when you run `pnpm dev` in root and fails if python or uvicorn isn’t available.

**Solution**

This PR checks whether python and uvicorn are available.

I’ve also had to increase the concurrency for `pnpm dev`, because I don’t have enough cores to run that many dev servers in parallel.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
