### PR TITLE
fix(examples/web): Basic API Reference example does not load

### DIFF
--- a/examples/web/src/pages/ApiReferencePage.vue
+++ b/examples/web/src/pages/ApiReferencePage.vue
@@ -5,12 +5,15 @@ import {
 } from '@scalar/api-reference'
 import { useColorMode } from '@scalar/use-hooks/useColorMode'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
-import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 
 import DevReferencesOptions from '../components/DevReferencesOptions.vue'
 import DevToolbar from '../components/DevToolbar.vue'
 import MonacoEditor from '../components/MonacoEditor.vue'
 import SlotPlaceholder from '../components/SlotPlaceholder.vue'
+
+// TODO: Editing does not work, make it work again.
+// Requires: https://github.com/scalar/scalar/pull/6319
 
 const content = ref('')
 
@@ -20,31 +23,8 @@ const configuration = reactive<Partial<ApiReferenceConfiguration>>({
   isEditable: false,
   showSidebar: true,
   layout: 'modern',
-  content,
-  // authentication: {
-  //   // The OpenAPI file has keys for all security schemes:
-  //   // Which one should be used by default?
-  //   preferredSecurityScheme: 'my_custom_security_scheme',
-  //   // The `my_custom_security_scheme` security scheme is of type `apiKey`, so prefill the token:
-  //   apiKey: {
-  //     token: 'super-secret-token',
-  //   },
-  // },
+  url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
 })
-
-onMounted(() => {
-  content.value = window.localStorage?.getItem('api-reference-content') ?? ''
-})
-
-watch(
-  content,
-  () => {
-    window.localStorage?.setItem('api-reference-content', content.value)
-
-    // TODO: Update the document in the store?
-  },
-  { deep: true },
-)
 
 const configProxy = computed({
   get: () => configuration,
@@ -64,13 +44,11 @@ watch(
   },
 )
 
-const store = createWorkspaceStore({
-  documents: [
-    {
-      name: 'default',
-      document: JSON.parse(content.value) as Record<string, unknown>,
-    },
-  ],
+const store = createWorkspaceStore()
+
+store.addDocument({
+  name: 'default',
+  url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
 })
 </script>
 <template>


### PR DESCRIPTION
**Problem**

This examples uses the new store and the `configuration` to provide content, but it’s not actually wired up and the example doesn’t even load:

<img width="3024" height="1820" alt="image" src="https://github.com/user-attachments/assets/b42a4c0f-e571-4ef3-a306-3ebb5e6999a0" />

**Solution**

This PR just loads Scalar Galaxy from an URL (through the configuration and through the store).

Editing doesn’t work yet, it requires #6319. 😬 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
