### PR TITLE
feat(api-reference): updates heading anchor style

### DIFF
--- a/.changeset/itchy-dancers-prove.md
+++ b/.changeset/itchy-dancers-prove.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: updates heading anchor style to use latest icons

--- a/packages/api-reference/src/components/Anchor/Anchor.vue
+++ b/packages/api-reference/src/components/Anchor/Anchor.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { ScalarButton, useBindCx } from '@scalar/components'
+import { ScalarIconHash } from '@scalar/icons'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { useId } from 'vue'
 
@@ -12,6 +14,8 @@ const { id } = defineProps<{
 
 const labelId = useId()
 
+const { cx } = useBindCx()
+
 const { copyToClipboard } = useClipboard()
 const { getHashedUrl } = useNavState()
 
@@ -21,60 +25,25 @@ const handleCopy = () => {
 }
 </script>
 <template>
-  <span class="label">
+  <span v-bind="cx('group/heading word-break-all relative')">
     <span
       :id="labelId"
       class="contents">
       <slot />
     </span>
-    <span class="anchor">
+    <span class="relative">
       <!-- Position anchor to align the copy button to the last line of text  -->
       <span>&ZeroWidthSpace;</span>
-      <button
+      <ScalarButton
         :aria-describedby="labelId"
-        class="anchor-copy"
-        type="button"
+        class="absolute top-1 left-0 inline-block h-fit px-1.5 py-1 opacity-0 group-hover/heading:opacity-100 group-has-focus-visible/heading:opacity-100"
+        variant="ghost"
         @click.stop="handleCopy">
-        <span aria-hidden="true">#</span>
+        <ScalarIconHash
+          aria-hidden="true"
+          class="size-4.5" />
         <ScreenReader>Copy link</ScreenReader>
-      </button>
+      </ScalarButton>
     </span>
   </span>
 </template>
-<style scoped>
-.label {
-  position: relative;
-  display: inline-block;
-  word-break: break-all;
-}
-.anchor {
-  position: relative;
-  display: inline-block;
-  opacity: 0;
-}
-
-.anchor-copy {
-  position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translateY(-50%);
-
-  cursor: pointer;
-
-  padding: 0 6px;
-
-  color: var(--scalar-color-3);
-  font-weight: var(--scalar-semibold);
-  font-size: 0.8em;
-}
-
-.anchor-copy:hover,
-.anchor-copy:focus-visible {
-  color: var(--scalar-color-2);
-}
-
-.label:hover .anchor,
-.label:has(:focus-visible) .anchor {
-  opacity: 1;
-}
-</style>

--- a/packages/api-reference/src/components/Content/Models/ClassicLayout.vue
+++ b/packages/api-reference/src/components/Content/Models/ClassicLayout.vue
@@ -86,6 +86,7 @@ const { getModelId } = useNavState()
   color: var(--scalar-color-1);
 }
 .reference-models-label {
+  display: block;
   font-size: var(--scalar-mini);
 }
 

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -210,6 +210,13 @@ const handleDiscriminatorChange = (type: string) => {
   min-width: 0;
   flex-shrink: 1;
 }
+.operation-details :deep(.endpoint-anchor .scalar-button) {
+  top: 0;
+}
+.operation-details :deep(.endpoint-anchor .scalar-button svg) {
+  width: 16px;
+  height: 16px;
+}
 .endpoint-type {
   display: flex;
   align-items: center;


### PR DESCRIPTION
New attempt, see #6292

PR is actually by @antlio 

**Changes**

this pr updates the api reference heading anchor to use latest icons.

`modern`
| state | preview |
| -------|------|
| before | <img width="583" height="322" alt="image" src="https://github.com/user-attachments/assets/856f4883-ddd4-4981-8a7e-737b642cf56f" /> |
| after | <img width="583" height="291" alt="image" src="https://github.com/user-attachments/assets/62077ed5-0fb3-4c16-ba4a-b1f2f5320fca" /> |

`classic`
| state | preview |
| -------|------|
| before | <img width="583" height="291" alt="image" src="https://github.com/user-attachments/assets/3796dcd4-ea1f-4b51-851b-ced46eb79a5d" /> |
| after | <img width="583" height="291" alt="image" src="https://github.com/user-attachments/assets/f294e857-07f7-4cd6-8e90-7a911132f461" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->