### PR TITLE
ci(renovate): disable major updates for Microsoft.AspNetCore packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,12 @@
       "description": "Disable .NET SDK updates",
       "matchFileNames": ["**/global.json"],
       "enabled": false
+    },
+    {
+      "description": "Disable major updates for Microsoft.AspNetCore packages. We will manually update these after each .NET release.",
+      "matchPackageNames": ["Microsoft.AspNetCore**"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
This PR reduces the noise for the .NET packages. Renovate doesn't need to create PRs for major releases; we'll tackle this manually.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
