### PR TITLE
fix(api-reference): add custom-scrollbar style to external docs

### DIFF
--- a/packages/api-reference/src/components/LinkList/LinkList.vue
+++ b/packages/api-reference/src/components/LinkList/LinkList.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="mb-3 flex h-auto min-h-8 max-w-full items-center gap-2 overflow-auto text-xs whitespace-nowrap xl:mb-1.5">
+    class="custom-scroll mb-3 flex h-auto min-h-8 max-w-full items-center gap-2 overflow-x-auto text-xs whitespace-nowrap xl:mb-1.5">
     <slot />
   </div>
 </template>


### PR DESCRIPTION
**Problem**

Currently, we forgot to add the `.custom-scroll` class

**Solution**

With this PR we add the class.

| Before| After |
|--------|--------|
| <img width="602" height="456" alt="image" src="https://github.com/user-attachments/assets/2894990d-8b2e-40e9-8565-1a5eb54200e5" /> | <img width="611" height="509" alt="image" src="https://github.com/user-attachments/assets/4cb2b3fc-8e17-4a86-91a2-f1809dcdc263" /> |

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
