### PR TITLE
fix(api-reference): set the default client lib to shell/curl

### DIFF
--- a/.changeset/old-fishes-relax.md
+++ b/.changeset/old-fishes-relax.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: select shell/curl as default client lib

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.test.ts
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { DEFAULT_CLIENT } from '@/v2/blocks/scalar-request-example-block/helpers/find-client'
+import type { ClientOptionGroup } from '@/v2/blocks/scalar-request-example-block/types'
+import type { WorkspaceDocument } from '@scalar/workspace-store/schemas/schemas/workspace'
+
+import ClientLibraries from './ClientLibraries.vue'
+
+describe('ClientLibraries', () => {
+  // Mock data setup
+  const mockDocument: WorkspaceDocument = {
+    info: {
+      title: 'Test API',
+      version: '1.0.0',
+    },
+    paths: {},
+    openapi: '3.0.0',
+  }
+
+  const mockClientOptions: ClientOptionGroup[] = [
+    {
+      label: 'Shell',
+      options: [
+        {
+          id: 'shell/curl',
+          label: 'cURL',
+          lang: 'curl',
+          title: 'Shell cURL',
+          targetKey: 'shell',
+          targetTitle: 'Shell',
+          clientKey: 'curl',
+        },
+        {
+          id: 'shell/httpie',
+          label: 'HTTPie',
+          lang: 'shell',
+          title: 'Shell HTTPie',
+          targetKey: 'shell',
+          targetTitle: 'Shell',
+          clientKey: 'httpie',
+        },
+      ],
+    },
+    {
+      label: 'Node.js',
+      options: [
+        {
+          id: 'node/undici',
+          label: 'Undici',
+          lang: 'node',
+          title: 'Node.js Undici',
+          targetKey: 'node',
+          targetTitle: 'Node.js',
+          clientKey: 'undici',
+        },
+      ],
+    },
+  ]
+
+  describe('default client selection', () => {
+    it('uses DEFAULT_CLIENT when no selectedClient is provided', () => {
+      const wrapper = mount(ClientLibraries, {
+        props: {
+          document: mockDocument,
+          clientOptions: mockClientOptions,
+          // selectedClient is not provided, should default to DEFAULT_CLIENT
+        },
+        global: {
+          stubs: {
+            'ScalarCodeBlock': true,
+            'ScalarMarkdown': true,
+            'ClientSelector': true,
+          },
+        },
+      })
+
+      // The component should render with the default client
+      expect(wrapper.exists()).toBe(true)
+
+      // The selectedClientOption computed property should resolve to the default client
+      const vm = wrapper.vm as any
+      expect(vm.selectedClientOption?.id).toBe(DEFAULT_CLIENT)
+    })
+
+    it('uses provided selectedClient when available', () => {
+      const customClient = 'node/undici'
+
+      const wrapper = mount(ClientLibraries, {
+        props: {
+          document: mockDocument,
+          clientOptions: mockClientOptions,
+          selectedClient: customClient,
+        },
+        global: {
+          stubs: {
+            'ScalarCodeBlock': true,
+            'ScalarMarkdown': true,
+            'ClientSelector': true,
+          },
+        },
+      })
+
+      // The component should render with the custom client
+      expect(wrapper.exists()).toBe(true)
+
+      // The selectedClientOption computed property should resolve to the custom client
+      const vm = wrapper.vm as any
+      expect(vm.selectedClientOption?.id).toBe(customClient)
+    })
+
+    it('handles undefined selectedClient gracefully', () => {
+      const wrapper = mount(ClientLibraries, {
+        props: {
+          document: mockDocument,
+          clientOptions: mockClientOptions,
+          selectedClient: undefined,
+        },
+        global: {
+          stubs: {
+            'ScalarCodeBlock': true,
+            'ScalarMarkdown': true,
+            'ClientSelector': true,
+          },
+        },
+      })
+
+      // The component should render without errors
+      expect(wrapper.exists()).toBe(true)
+
+      // The selectedClientOption computed property should resolve to the default client
+      const vm = wrapper.vm as any
+      expect(vm.selectedClientOption?.id).toBe(DEFAULT_CLIENT)
+    })
+  })
+})

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
@@ -5,13 +5,18 @@ import type { AvailableClients } from '@scalar/snippetz'
 import type { WorkspaceDocument } from '@scalar/workspace-store/schemas/schemas/workspace'
 import { computed, useId, useTemplateRef } from 'vue'
 
+import { DEFAULT_CLIENT } from '@/v2/blocks/scalar-request-example-block/helpers/find-client'
 import type { ClientOptionGroup } from '@/v2/blocks/scalar-request-example-block/types'
 import { emitCustomEvent } from '@/v2/events/definitions'
 
 import ClientSelector from './ClientSelector.vue'
 import { getFeaturedClients, isFeaturedClient } from './featured-clients'
 
-const { clientOptions, document, selectedClient } = defineProps<{
+const {
+  clientOptions,
+  document,
+  selectedClient = DEFAULT_CLIENT,
+} = defineProps<{
   /** Current document from the store */
   document: WorkspaceDocument
   /** Computed list of all available Http Client options */

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/RequestExample.vue
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/RequestExample.vue
@@ -7,7 +7,7 @@ export type RequestExampleProps = {
   /**
    * Pre-selected client, this will determine which client is initially selected in the dropdown
    *
-   * @defaults to js/fetch or a custom sample if one is available
+   * @defaults to shell/curl or a custom sample if one is available
    */
   selectedClient?: AvailableClients[number]
   /**

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/helpers/find-client.ts
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/helpers/find-client.ts
@@ -1,7 +1,7 @@
 import type { ClientOption, ClientOptionGroup } from '@/v2/blocks/scalar-request-example-block/types'
 import { AVAILABLE_CLIENTS, type AvailableClients } from '@scalar/snippetz'
 
-const DEFAULT_CLIENT = 'shell/curl'
+export const DEFAULT_CLIENT = 'shell/curl'
 
 /** Type guard to check if a string is a valid client id */
 export const isClient = (id: any): id is AvailableClients[number] => AVAILABLE_CLIENTS.includes(id)


### PR DESCRIPTION
**Problem**

Currently, we had the default set in the request example blocks but not the top.

**Solution**

With this PR we set the default at the top as well. It must be done this way because in the "unset" state we show the custom examples in the operations.

| Before | After | 
|--------|--------|
| <img width="616" height="487" alt="image" src="https://github.com/user-attachments/assets/f3b42d5f-27df-418e-a189-c8f45c20afff" /> | <img width="637" height="464" alt="image" src="https://github.com/user-attachments/assets/1f6ad3c1-84a3-4e27-af63-e96db05de693" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
