### PR TITLE
test(api-reference): retry flaky React tests 3 times

### DIFF
--- a/packages/react-renderer/src/components/ReactRenderer.test.tsx
+++ b/packages/react-renderer/src/components/ReactRenderer.test.tsx
@@ -5,7 +5,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ReactConnector } from './ReactConnector'
 import ReactRenderer from './ReactRenderer.vue'
 
-describe('ReactRenderer', () => {
+/**
+ * Those tests are a bit flaky, so we're retrying them 3 times.
+ */
+
+describe('ReactRenderer', { retry: 3 }, () => {
   let TestComponent: FC<{ message?: string }>
   let wrapper: ReturnType<typeof mount>
 
@@ -100,7 +104,7 @@ describe('ReactRenderer', () => {
   })
 })
 
-describe('ReactConnector', () => {
+describe('ReactConnector', { retry: 3 }, () => {
   let container: HTMLDivElement
   let connectors: ReactConnector[] = []
 
@@ -117,8 +121,7 @@ describe('ReactConnector', () => {
     document.body.removeChild(container)
   })
 
-  // This test is too flaky
-  it.skip('creates a root and renders a React component', async () => {
+  it('creates a root and renders a React component', async () => {
     const TestComponent: FC<{ message: string }> = ({ message }) => <div data-testid="test">{message}</div>
     const connector = new ReactConnector(container, TestComponent)
     connectors.push(connector)


### PR DESCRIPTION
**Problem**

The React tests fail every now and then, it seems to be a timing issue.

**Solution**

This PR allows Vitest to retry the tests 3 times, maybe that helps already.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
