### PR TITLE
fix(api-client): authentication description breaks container

### DIFF
--- a/.changeset/silly-zebras-hug.md
+++ b/.changeset/silly-zebras-hug.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: adds request auth tab label clamp display

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -172,9 +172,12 @@ const dataTableInputProps = {
         'request-example-references-header': layout === 'reference',
       }">
       <DataTableCell
-        class="text-c-2 flex items-center pl-3"
+        class="group/cell text-c-2 flex items-center whitespace-nowrap hover:whitespace-normal"
         :class="layout === 'reference' && 'border-b'">
-        {{ generateLabel(scheme!) }}
+        <span
+          class="bg-b-1 z-context top-0 line-clamp-1 px-3 py-1.5 text-ellipsis group-hover/cell:absolute group-hover/cell:line-clamp-none group-hover/cell:border-b">
+          {{ generateLabel(scheme!) }}
+        </span>
       </DataTableCell>
     </DataTableRow>
 


### PR DESCRIPTION
**Changes**

this pr sets clamp display to the request auth label to better handle long content display as seen below.

| state | preview |
| -------|------|
| before | <img width="612" height="281" alt="image" src="https://github.com/user-attachments/assets/cc9ebb8d-6c58-4c6d-8d0d-5b3fb14bcf92" /> |
| after | <img width="612" height="281" alt="image" src="https://github.com/user-attachments/assets/59650b9c-59ea-413e-b35a-b2b6c954bf0d" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
