### PR TITLE
fix(themes): don't style `<a>` in reset only in markdown

### DIFF
--- a/.changeset/pink-peas-taste.md
+++ b/.changeset/pink-peas-taste.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+fix(themes): don't style <a> in reset only in markdown

--- a/packages/themes/src/base/reset.css
+++ b/packages/themes/src/base/reset.css
@@ -41,6 +41,7 @@
     font-size: inherit;
     font-weight: inherit;
     font-style: inherit;
+    text-decoration: inherit;
     line-height: inherit;
     color: inherit;
     margin: unset;
@@ -120,25 +121,6 @@
   button,
   [role="button"] {
     cursor: pointer;
-  }
-
-  a {
-    --font-color: var(--scalar-link-color, var(--scalar-color-accent));
-    --font-visited: var(--scalar-link-color-visited, var(--scalar-color-2));
-
-    text-decoration: var(--scalar-text-decoration);
-    color: var(--font-color);
-    font-weight: var(--scalar-link-font-weight, var(--scalar-semibold));
-    text-underline-offset: 0.25rem;
-    text-decoration-thickness: 1px;
-    text-decoration-color: color-mix(in srgb, var(--font-color) 30%, transparent);
-  }
-
-  a:hover {
-    text-decoration-color: var(currentColor, var(--scalar-color-1));
-    color: var(--scalar-link-color-hover, var(--scalar-color-accent));
-    -webkit-text-decoration: var(--scalar-text-decoration-hover);
-    text-decoration: var(--scalar-text-decoration-hover);
   }
 
   /** Make sure disabled buttons don't get the pointer cursor. */


### PR DESCRIPTION
Somehow I missed this in the original PR it was in but we really just want the reset to strip away the base styles not apply style (we use `<a>`'s for all kinds of buttons and stuff).

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
