### PR TITLE
feat(api-reference): convert link list to icons when it scrolls

### DIFF
--- a/.changeset/plenty-garlics-destroy.md
+++ b/.changeset/plenty-garlics-destroy.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: convert links list to icons only if it needs to scroll

--- a/packages/api-reference/src/components/LinkList/LinkList.test.ts
+++ b/packages/api-reference/src/components/LinkList/LinkList.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import LinkList from './LinkList.vue'
+
+// Mock MutationObserver
+const mockMutationObserver = vi.fn()
+const mockDisconnect = vi.fn()
+const mockObserve = vi.fn()
+let capturedCallback: (() => void) | null = null
+
+beforeEach(() => {
+  // Reset mocks
+  vi.clearAllMocks()
+  capturedCallback = null
+
+  // Mock MutationObserver
+  global.MutationObserver = mockMutationObserver
+  mockMutationObserver.mockImplementation((callback: () => void) => {
+    capturedCallback = callback
+    return {
+      observe: mockObserve,
+      disconnect: mockDisconnect,
+    }
+  })
+
+  // Mock window resize event
+  global.window = {
+    ...global.window,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as any
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('LinkList', () => {
+  it('renders with default slot content', () => {
+    const wrapper = mount(LinkList, {
+      slots: {
+        default: '<span>Test Link</span>',
+      },
+    })
+
+    expect(wrapper.text()).toContain('Test Link')
+    expect(wrapper.classes()).toContain('custom-scroll')
+  })
+
+  it('does not apply icons-only class when scroll is not needed', async () => {
+    const wrapper = mount(LinkList, {
+      slots: {
+        default: '<span>Short content</span>',
+      },
+    })
+
+    // Mock scrollWidth to be less than clientWidth (no scroll needed)
+    Object.defineProperty(wrapper.element, 'scrollWidth', {
+      value: 100,
+      writable: true,
+    })
+    Object.defineProperty(wrapper.element, 'clientWidth', {
+      value: 200,
+      writable: true,
+    })
+
+    await nextTick()
+
+    expect(wrapper.classes()).not.toContain('icons-only')
+  })
+
+  it('applies icons-only class when scroll is needed', async () => {
+    const wrapper = mount(LinkList, {
+      slots: {
+        default: '<span>Very long content that will cause scrolling</span>',
+      },
+    })
+
+    // Mock scrollWidth to be greater than clientWidth (scroll needed)
+    Object.defineProperty(wrapper.element, 'scrollWidth', {
+      value: 300,
+      writable: true,
+    })
+    Object.defineProperty(wrapper.element, 'clientWidth', {
+      value: 200,
+      writable: true,
+    })
+
+    // Trigger the checkScrollability function manually by calling the captured callback
+    capturedCallback?.()
+
+    await nextTick()
+
+    expect(wrapper.classes()).toContain('icons-only')
+  })
+
+  it('sets up MutationObserver on mount', () => {
+    mount(LinkList, {
+      slots: {
+        default: '<span>Test</span>',
+      },
+    })
+
+    expect(mockMutationObserver).toHaveBeenCalled()
+    expect(mockObserve).toHaveBeenCalledWith(expect.any(HTMLElement), {
+      childList: true,
+      subtree: true,
+    })
+  })
+
+  it('adds window resize event listener on mount', () => {
+    mount(LinkList, {
+      slots: {
+        default: '<span>Test</span>',
+      },
+    })
+
+    expect(global.window.addEventListener).toHaveBeenCalledWith('resize', expect.any(Function))
+  })
+
+  it('removes window resize event listener on unmount', () => {
+    const wrapper = mount(LinkList, {
+      slots: {
+        default: '<span>Test</span>',
+      },
+    })
+
+    wrapper.unmount()
+
+    expect(global.window.removeEventListener).toHaveBeenCalledWith('resize', expect.any(Function))
+  })
+
+  it('disconnects MutationObserver on unmount', () => {
+    const wrapper = mount(LinkList, {
+      slots: {
+        default: '<span>Test</span>',
+      },
+    })
+
+    wrapper.unmount()
+
+    expect(mockDisconnect).toHaveBeenCalled()
+  })
+
+  it('handles MutationObserver callback correctly', async () => {
+    const wrapper = mount(LinkList, {
+      slots: {
+        default: '<span>Test</span>',
+      },
+    })
+
+    // Mock that scroll is needed
+    Object.defineProperty(wrapper.element, 'scrollWidth', {
+      value: 300,
+      writable: true,
+    })
+    Object.defineProperty(wrapper.element, 'clientWidth', {
+      value: 200,
+      writable: true,
+    })
+
+    // Call the captured MutationObserver callback
+    capturedCallback?.()
+    await nextTick()
+
+    expect(wrapper.classes()).toContain('icons-only')
+  })
+
+  it('handles window resize event correctly', async () => {
+    const wrapper = mount(LinkList, {
+      slots: {
+        default: '<span>Test</span>',
+      },
+    })
+
+    // Get the resize event listener
+    const resizeHandler = (global.window.addEventListener as any).mock.calls[0][1]
+
+    // Mock that scroll is needed after resize
+    Object.defineProperty(wrapper.element, 'scrollWidth', {
+      value: 300,
+      writable: true,
+    })
+    Object.defineProperty(wrapper.element, 'clientWidth', {
+      value: 200,
+      writable: true,
+    })
+
+    // Call the resize handler
+    resizeHandler()
+    await nextTick()
+
+    expect(wrapper.classes()).toContain('icons-only')
+  })
+
+  it('handles missing container ref gracefully', async () => {
+    const wrapper = mount(LinkList, {
+      slots: {
+        default: '<span>Test</span>',
+      },
+    })
+
+    // Temporarily set containerRef to null
+    const originalRef = wrapper.vm.$refs.containerRef
+    wrapper.vm.$refs.containerRef = null
+
+    // This should not throw an error
+    await nextTick()
+
+    // Restore the ref
+    wrapper.vm.$refs.containerRef = originalRef
+  })
+
+  it('applies icons-only CSS when scroll is needed', async () => {
+    const wrapper = mount(LinkList, {
+      slots: {
+        default: '<span>Long content</span>',
+      },
+    })
+
+    // Mock scroll needed
+    Object.defineProperty(wrapper.element, 'scrollWidth', {
+      value: 300,
+      writable: true,
+    })
+    Object.defineProperty(wrapper.element, 'clientWidth', {
+      value: 200,
+      writable: true,
+    })
+
+    // Trigger the checkScrollability function manually by calling the captured callback
+    capturedCallback?.()
+    await nextTick()
+
+    // Check that the component has the icons-only class
+    expect(wrapper.classes()).toContain('icons-only')
+
+    // Verify the scoped style is applied
+    expect(wrapper.attributes('class')).toContain('icons-only')
+  })
+
+  it('updates scroll state when content changes dynamically', async () => {
+    const wrapper = mount(LinkList, {
+      slots: {
+        default: '<span>Initial content</span>',
+      },
+    })
+
+    // Initially no scroll needed
+    Object.defineProperty(wrapper.element, 'scrollWidth', {
+      value: 100,
+      writable: true,
+    })
+    Object.defineProperty(wrapper.element, 'clientWidth', {
+      value: 200,
+      writable: true,
+    })
+
+    await nextTick()
+    expect(wrapper.classes()).not.toContain('icons-only')
+
+    // Simulate content change that requires scroll
+    Object.defineProperty(wrapper.element, 'scrollWidth', {
+      value: 300,
+      writable: true,
+    })
+
+    // Call the captured MutationObserver callback
+    capturedCallback?.()
+
+    await nextTick()
+    expect(wrapper.classes()).toContain('icons-only')
+  })
+})

--- a/packages/api-reference/src/components/LinkList/LinkList.test.ts
+++ b/packages/api-reference/src/components/LinkList/LinkList.test.ts
@@ -10,11 +10,9 @@ const mockObserve = vi.fn()
 let capturedCallback: (() => void) | null = null
 
 beforeEach(() => {
-  // Reset mocks
   vi.clearAllMocks()
   capturedCallback = null
 
-  // Mock MutationObserver
   global.MutationObserver = mockMutationObserver
   mockMutationObserver.mockImplementation((callback: () => void) => {
     capturedCallback = callback
@@ -24,7 +22,6 @@ beforeEach(() => {
     }
   })
 
-  // Mock window resize event
   global.window = {
     ...global.window,
     addEventListener: vi.fn(),
@@ -46,6 +43,30 @@ describe('LinkList', () => {
 
     expect(wrapper.text()).toContain('Test Link')
     expect(wrapper.classes()).toContain('custom-scroll')
+  })
+
+  it('applies icons-only class when scroll is needed', async () => {
+    const wrapper = mount(LinkList, {
+      slots: {
+        default: '<span>Very long content that will cause scrolling</span>',
+      },
+    })
+
+    // Mock scrollWidth to be greater than clientWidth (scroll needed)
+    Object.defineProperty(wrapper.element, 'scrollWidth', {
+      value: 300,
+      writable: true,
+    })
+    Object.defineProperty(wrapper.element, 'clientWidth', {
+      value: 200,
+      writable: true,
+    })
+
+    // Trigger the checkScrollability function manually
+    capturedCallback?.()
+    await nextTick()
+
+    expect(wrapper.classes()).toContain('icons-only')
   })
 
   it('does not apply icons-only class when scroll is not needed', async () => {
@@ -70,32 +91,7 @@ describe('LinkList', () => {
     expect(wrapper.classes()).not.toContain('icons-only')
   })
 
-  it('applies icons-only class when scroll is needed', async () => {
-    const wrapper = mount(LinkList, {
-      slots: {
-        default: '<span>Very long content that will cause scrolling</span>',
-      },
-    })
-
-    // Mock scrollWidth to be greater than clientWidth (scroll needed)
-    Object.defineProperty(wrapper.element, 'scrollWidth', {
-      value: 300,
-      writable: true,
-    })
-    Object.defineProperty(wrapper.element, 'clientWidth', {
-      value: 200,
-      writable: true,
-    })
-
-    // Trigger the checkScrollability function manually by calling the captured callback
-    capturedCallback?.()
-
-    await nextTick()
-
-    expect(wrapper.classes()).toContain('icons-only')
-  })
-
-  it('sets up MutationObserver on mount', () => {
+  it('sets up MutationObserver and window event listeners on mount', () => {
     mount(LinkList, {
       slots: {
         default: '<span>Test</span>',
@@ -107,31 +103,10 @@ describe('LinkList', () => {
       childList: true,
       subtree: true,
     })
-  })
-
-  it('adds window resize event listener on mount', () => {
-    mount(LinkList, {
-      slots: {
-        default: '<span>Test</span>',
-      },
-    })
-
     expect(global.window.addEventListener).toHaveBeenCalledWith('resize', expect.any(Function))
   })
 
-  it('removes window resize event listener on unmount', () => {
-    const wrapper = mount(LinkList, {
-      slots: {
-        default: '<span>Test</span>',
-      },
-    })
-
-    wrapper.unmount()
-
-    expect(global.window.removeEventListener).toHaveBeenCalledWith('resize', expect.any(Function))
-  })
-
-  it('disconnects MutationObserver on unmount', () => {
+  it('cleans up MutationObserver and window event listeners on unmount', () => {
     const wrapper = mount(LinkList, {
       slots: {
         default: '<span>Test</span>',
@@ -141,117 +116,6 @@ describe('LinkList', () => {
     wrapper.unmount()
 
     expect(mockDisconnect).toHaveBeenCalled()
-  })
-
-  it('handles MutationObserver callback correctly', async () => {
-    const wrapper = mount(LinkList, {
-      slots: {
-        default: '<span>Test</span>',
-      },
-    })
-
-    // Mock that scroll is needed
-    Object.defineProperty(wrapper.element, 'scrollWidth', {
-      value: 300,
-      writable: true,
-    })
-    Object.defineProperty(wrapper.element, 'clientWidth', {
-      value: 200,
-      writable: true,
-    })
-
-    // Call the captured MutationObserver callback
-    capturedCallback?.()
-    await nextTick()
-
-    expect(wrapper.classes()).toContain('icons-only')
-  })
-
-  it('handles window resize event correctly', async () => {
-    const wrapper = mount(LinkList, {
-      slots: {
-        default: '<span>Test</span>',
-      },
-    })
-
-    // Get the resize event listener
-    const resizeHandler = (global.window.addEventListener as any).mock.calls[0][1]
-
-    // Mock that scroll is needed after resize
-    Object.defineProperty(wrapper.element, 'scrollWidth', {
-      value: 300,
-      writable: true,
-    })
-    Object.defineProperty(wrapper.element, 'clientWidth', {
-      value: 200,
-      writable: true,
-    })
-
-    // Call the resize handler
-    resizeHandler()
-    await nextTick()
-
-    expect(wrapper.classes()).toContain('icons-only')
-  })
-
-  it('applies icons-only CSS when scroll is needed', async () => {
-    const wrapper = mount(LinkList, {
-      slots: {
-        default: '<span>Long content</span>',
-      },
-    })
-
-    // Mock scroll needed
-    Object.defineProperty(wrapper.element, 'scrollWidth', {
-      value: 300,
-      writable: true,
-    })
-    Object.defineProperty(wrapper.element, 'clientWidth', {
-      value: 200,
-      writable: true,
-    })
-
-    // Trigger the checkScrollability function manually by calling the captured callback
-    capturedCallback?.()
-    await nextTick()
-
-    // Check that the component has the icons-only class
-    expect(wrapper.classes()).toContain('icons-only')
-
-    // Verify the scoped style is applied
-    expect(wrapper.attributes('class')).toContain('icons-only')
-  })
-
-  it('updates scroll state when content changes dynamically', async () => {
-    const wrapper = mount(LinkList, {
-      slots: {
-        default: '<span>Initial content</span>',
-      },
-    })
-
-    // Initially no scroll needed
-    Object.defineProperty(wrapper.element, 'scrollWidth', {
-      value: 100,
-      writable: true,
-    })
-    Object.defineProperty(wrapper.element, 'clientWidth', {
-      value: 200,
-      writable: true,
-    })
-
-    await nextTick()
-    expect(wrapper.classes()).not.toContain('icons-only')
-
-    // Simulate content change that requires scroll
-    Object.defineProperty(wrapper.element, 'scrollWidth', {
-      value: 300,
-      writable: true,
-    })
-
-    // Call the captured MutationObserver callback
-    capturedCallback?.()
-
-    await nextTick()
-    expect(wrapper.classes()).toContain('icons-only')
+    expect(global.window.removeEventListener).toHaveBeenCalledWith('resize', expect.any(Function))
   })
 })

--- a/packages/api-reference/src/components/LinkList/LinkList.test.ts
+++ b/packages/api-reference/src/components/LinkList/LinkList.test.ts
@@ -194,24 +194,6 @@ describe('LinkList', () => {
     expect(wrapper.classes()).toContain('icons-only')
   })
 
-  it('handles missing container ref gracefully', async () => {
-    const wrapper = mount(LinkList, {
-      slots: {
-        default: '<span>Test</span>',
-      },
-    })
-
-    // Temporarily set containerRef to null
-    const originalRef = wrapper.vm.$refs.containerRef
-    wrapper.vm.$refs.containerRef = null
-
-    // This should not throw an error
-    await nextTick()
-
-    // Restore the ref
-    wrapper.vm.$refs.containerRef = originalRef
-  })
-
   it('applies icons-only CSS when scroll is needed', async () => {
     const wrapper = mount(LinkList, {
       slots: {

--- a/packages/api-reference/src/components/LinkList/LinkList.vue
+++ b/packages/api-reference/src/components/LinkList/LinkList.vue
@@ -1,6 +1,69 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+
+const containerRef = ref<HTMLDivElement>()
+
+/** Whether the container needs to scroll */
+const needsScroll = ref(false)
+
+/** Check if the container can scroll in either direction */
+const checkScrollability = () => {
+  if (!containerRef.value) {
+    return
+  }
+
+  const { scrollWidth, clientWidth } = containerRef.value
+  needsScroll.value = scrollWidth > clientWidth
+}
+
+/** MutationObserver to watch for changes in child elements */
+let mutationObserver: MutationObserver | null = null
+
+/**
+ * We use the mutation observer to watch for changes and check if we need to scroll,
+ * if we do need to scroll we apply the icons-only class to the container
+ */
+onMounted(() => {
+  checkScrollability()
+
+  // Re-check on window resize
+  window.addEventListener('resize', checkScrollability)
+
+  // Watch for changes in child elements
+  if (containerRef.value) {
+    mutationObserver = new MutationObserver(() => {
+      checkScrollability()
+    })
+
+    mutationObserver.observe(containerRef.value, {
+      childList: true,
+      subtree: true,
+    })
+  }
+})
+
+onUnmounted(() => {
+  // Clean up event listeners and observer
+  window.removeEventListener('resize', checkScrollability)
+
+  if (mutationObserver) {
+    mutationObserver.disconnect()
+    mutationObserver = null
+  }
+})
+</script>
+
 <template>
   <div
-    class="mb-3 flex h-auto min-h-8 max-w-full items-center gap-2 overflow-auto text-xs whitespace-nowrap xl:mb-1.5">
+    ref="containerRef"
+    :class="{ 'icons-only': needsScroll }"
+    class="custom-scroll mb-3 flex h-auto min-h-8 max-w-full items-center gap-2 overflow-x-auto text-xs whitespace-nowrap xl:mb-1.5">
     <slot />
   </div>
 </template>
+
+<style scoped>
+.icons-only :deep(span) {
+  display: none;
+}
+</style>

--- a/packages/api-reference/src/features/info-object/License.vue
+++ b/packages/api-reference/src/features/info-object/License.vue
@@ -24,6 +24,9 @@ defineProps<{
       }}</span>
     </a>
     <template v-else>
+      <ScalarIconGavel
+        weight="bold"
+        class="size-3 text-current" />
       <span class="ml-1 empty:hidden">{{ value?.name }}</span>
     </template>
   </div>


### PR DESCRIPTION
**Problem**

Currently, the link list may need to scroll

**Solution**

With this PR we reduce it to icons only if scroll is needed.
| | Preview |
|--------|--------|
| Before | <img width="563" height="450" alt="image" src="https://github.com/user-attachments/assets/4e9170fd-aa4d-4268-a502-279b9a98cc5c" /> |
| After | <img width="578" height="463" alt="image" src="https://github.com/user-attachments/assets/c9e14208-e376-457a-b068-ff17db771a89" /> | 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
