### PR TITLE
feat(api-reference): better schema `minLength`/`maxLength` labels

### DIFF
--- a/.changeset/fifty-toys-remember.md
+++ b/.changeset/fifty-toys-remember.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+feat: Make the min & max descriptions more descriptive for strings

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -593,7 +593,7 @@ describe('SchemaPropertyHeading', () => {
       })
 
       const detailsElement = wrapper.find('.property-heading')
-      expect(detailsElement.text()).toContain('min:')
+      expect(detailsElement.text()).toContain('min length:')
       expect(detailsElement.text()).toContain('5')
     })
 
@@ -608,7 +608,7 @@ describe('SchemaPropertyHeading', () => {
       })
 
       const detailsElement = wrapper.find('.property-heading')
-      expect(detailsElement.text()).toContain('max:')
+      expect(detailsElement.text()).toContain('max length:')
       expect(detailsElement.text()).toContain('100')
     })
 
@@ -624,9 +624,9 @@ describe('SchemaPropertyHeading', () => {
       })
 
       const detailsElement = wrapper.find('.property-heading')
-      expect(detailsElement.text()).toContain('min:')
+      expect(detailsElement.text()).toContain('min length:')
       expect(detailsElement.text()).toContain('5')
-      expect(detailsElement.text()).toContain('max:')
+      expect(detailsElement.text()).toContain('max length:')
       expect(detailsElement.text()).toContain('100')
     })
   })

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -110,11 +110,11 @@ const modelName = computed(() => {
         {{ value.minItems }}&hellip;{{ value.maxItems }}
       </SchemaPropertyDetail>
       <SchemaPropertyDetail v-if="value.minLength">
-        <template #prefix>min: </template>
+        <template #prefix>min length: </template>
         {{ value.minLength }}
       </SchemaPropertyDetail>
       <SchemaPropertyDetail v-if="value.maxLength">
-        <template #prefix>max: </template>
+        <template #prefix>max length: </template>
         {{ value.maxLength }}
       </SchemaPropertyDetail>
       <SchemaPropertyDetail v-if="value.uniqueItems">


### PR DESCRIPTION
**Problem**
The `min` and `max` field for `minLength` and `maxLength` can be misleading in two ways:
* When the field is a number that is formatted as a string (ex: `"2"`) the user may think that it's indicating a maximum value for the number, when it's actually indicating the maximum string length.
* Additionally, if both `maximum` and `maxLength` or both `minimum` and `minLength` are specified, the UI will show `min` twice and `max` twice, making it impossible for the user to know what each property is referring to without inspecting the actual OpenAPI spec.

Currently, …
This property definition
```
"message": {
    "type": "string",
    "minLength": 2,
    "minimum": 3,
    "example": "Hello, world!",
    "maximum": 8,
    "maxLength":10
}
```

results in this being displayed

<img width="1128" height="208" alt="image" src="https://github.com/user-attachments/assets/8e0278c3-d1da-4eea-bbfb-5345de5109ed" />


**Solution**
<img width="1142" height="302" alt="image" src="https://github.com/user-attachments/assets/c5fd0bb4-9410-43ea-b34e-4b8d018bd504" />

With this PR …

I updated `maxLength` to be labeled with `max length` and `minLength` be labeled with `min length`

**Checklist**

I've gone through the following:

- [X] I've added an explanation _why_ this change is needed.
- [X] I've added a changeset (`pnpm changeset`).
- [X] I've added tests for the regression or new feature.
- [X] I've updated the documentation (I didn't see any docs to update)

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
