### PR TITLE
fix(api-client): missing request auth border and empty state

### DIFF
--- a/.changeset/clean-paws-grab.md
+++ b/.changeset/clean-paws-grab.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: enhances empty state handling for request auth

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -272,17 +272,17 @@ const openAuthCombobox = (event: Event) => {
             class="group/combobox-button hover:text-c-1 text-c-2 flex h-fit items-center gap-1 px-1.5 py-0.25 text-base font-normal transition-transform"
             fullWidth
             variant="ghost">
-            <template v-if="selectedSchemeOptions.length === 0">
-              <span class="sr-only">Select</span>
-              Auth Type
-            </template>
-            <template v-else-if="selectedSchemeOptions.length === 1">
+            <template v-if="selectedSchemeOptions.length === 1">
               <span class="sr-only">Selected Auth Type:</span>
               {{ selectedSchemeOptions[0]?.label }}
             </template>
-            <template v-else>
+            <template v-else-if="selectedSchemeOptions.length > 1">
               Multiple
               <span class="sr-only">Auth Types Selected</span>
+            </template>
+            <template v-else>
+              <span class="sr-only">Select</span>
+              Auth Type
             </template>
             <ScalarIconCaretDown
               weight="bold"

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
@@ -45,18 +45,28 @@ const activeAuthIndex = ref(0)
 
 /** Return currently selected schemes including complex auth */
 const activeScheme = computed(() => {
+  if (!selectedSchemeOptions || selectedSchemeOptions.length === 0) {
+    return []
+  }
+
   const option = selectedSchemeOptions[activeAuthIndex.value]
   if (!option) {
     return []
   }
-  const keys = option?.id.split(',')
+
+  const keys = option.id.split(',').filter(Boolean)
   return keys.length > 1 ? keys : [option.id]
+})
+
+/** Return true if there are any active schemes */
+const hasActiveSchemes = computed(() => {
+  return activeScheme.value.length > 0
 })
 
 watch(
   () => selectedSchemeOptions,
   (newOptions) => {
-    if (!newOptions[activeAuthIndex.value]) {
+    if (!newOptions || !newOptions[activeAuthIndex.value]) {
       activeAuthIndex.value = Math.max(0, activeAuthIndex.value - 1)
     }
   },
@@ -88,7 +98,7 @@ watch(
     </div>
 
     <DataTable
-      v-if="activeScheme.length"
+      v-if="hasActiveSchemes"
       class="flex-1"
       :class="layout === 'reference' && 'bg-b-1 rounded-b-lg border border-t-0'"
       :columns="['']"

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -165,30 +165,17 @@ const dataTableInputProps = {
   <template
     v-for="{ scheme } in security"
     :key="scheme?.uid">
-    <!-- Header -->
+    <!-- Header/Description -->
     <DataTableRow
-      v-if="security.length > 1"
-      :class="{
-        'request-example-references-header': layout === 'reference',
-      }">
+      v-if="
+        security.length > 1 || (scheme?.description && security.length <= 1)
+      ">
       <DataTableCell
-        class="group/cell text-c-2 flex items-center whitespace-nowrap hover:whitespace-normal"
-        :class="layout === 'reference' && 'border-b'">
-        <span
-          class="bg-b-1 z-context top-0 line-clamp-1 px-3 py-1.5 text-ellipsis group-hover/cell:absolute group-hover/cell:line-clamp-none group-hover/cell:border-b">
-          {{ generateLabel(scheme!) }}
-        </span>
-      </DataTableCell>
-    </DataTableRow>
-
-    <!-- Description -->
-    <DataTableRow v-if="scheme?.description && security.length <= 1">
-      <DataTableCell
-        :aria-label="scheme.description"
-        class="text-c-2 auth-description-container group/auth flex items-center whitespace-nowrap outline-none hover:whitespace-normal">
+        :aria-label="generateLabel(scheme!) || scheme?.description"
+        class="text-c-2 group/auth auth-description-container flex items-center whitespace-nowrap outline-none hover:whitespace-normal">
         <ScalarMarkdown
-          class="auth-description bg-b-1 text-c-2 outline-b-3 top-0 z-1 h-full w-full px-3 py-1.25 *:first:line-clamp-1 *:first:text-ellipsis group-hover/auth:*:first:line-clamp-none"
-          :value="scheme.description" />
+          class="auth-description bg-b-1 text-c-2 outline-b-3 top-0 z-1 h-full w-full px-3 py-1.25 group-hover/auth:absolute group-hover/auth:h-auto group-hover/auth:border-b *:first:line-clamp-1 *:first:text-ellipsis group-hover/auth:*:first:line-clamp-none"
+          :value="generateLabel(scheme!) || scheme?.description || ''" />
       </DataTableCell>
     </DataTableRow>
 
@@ -318,20 +305,5 @@ const dataTableInputProps = {
   background: var(--scalar-background-2);
   --tw-bg-base: var(--scalar-background-2);
   --tw-shadow: -8px 0 4px var(--scalar-background-2);
-}
-
-.request-example-references-header :deep(+ tr > td) {
-  border-top: 0;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
-
-.scalar-data-table .auth-description-container .auth-description {
-  outline: 0.5px solid var(--scalar-border-color);
-}
-
-.scalar-data-table .auth-description-container:hover .auth-description {
-  position: absolute;
-  height: auto;
 }
 </style>


### PR DESCRIPTION
**Changes**

this pr handles in a better way unselected request auth in order to rely on the empty state + refactors style for header/description to fix missing borders, following up of #6346 

| state | preview |
| -------|------|
| before | <img width="543" height="246" alt="image" src="https://github.com/user-attachments/assets/80686346-bee6-4ee2-8edb-4d11b44158af" /> |
| before | <img width="543" height="246" alt="image" src="https://github.com/user-attachments/assets/06c3cfd9-58dd-4fd1-bf48-c34fa42e743e" /> |
| after | <img width="543" height="246" alt="image" src="https://github.com/user-attachments/assets/b70addc3-ff56-4ae2-b836-572d3cd17f8d" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
