### PR TITLE
feat(examples/web): add more sources to the deployed example

### DIFF
--- a/examples/web/examples/openapi.json
+++ b/examples/web/examples/openapi.json
@@ -1,0 +1,20 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Relative URL Example",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/hello-world": {
+      "get": {
+        "summary": "Hello World",
+        "description": "Returns a simple hello world message",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/web/src/pages/ApiReferencePage.vue
+++ b/examples/web/src/pages/ApiReferencePage.vue
@@ -5,7 +5,7 @@ import {
 } from '@scalar/api-reference'
 import { useColorMode } from '@scalar/use-hooks/useColorMode'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
-import { computed, reactive, ref, toRaw, watch } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 
 import DevReferencesOptions from '../components/DevReferencesOptions.vue'
 import DevToolbar from '../components/DevToolbar.vue'

--- a/examples/web/src/pages/StandaloneApiReferencePage.vue
+++ b/examples/web/src/pages/StandaloneApiReferencePage.vue
@@ -16,6 +16,11 @@ const configuration: AnyApiReferenceConfiguration = {
       layout: 'classic',
     },
     {
+      title: 'Scalar Galaxy (Path Routing)',
+      url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+      pathRouting: { basePath: '/path-routing' },
+    },
+    {
       title: 'Relative URL Example',
       slug: 'relative-url',
       url: 'examples/openapi.json',

--- a/examples/web/src/pages/StandaloneApiReferencePage.vue
+++ b/examples/web/src/pages/StandaloneApiReferencePage.vue
@@ -1,27 +1,101 @@
 <script setup lang="ts">
 import { ApiReference } from '@scalar/api-reference'
-import content from '@scalar/galaxy/latest.yaml?raw'
-import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
-import { reactive } from 'vue'
+import type { AnyApiReferenceConfiguration } from '@scalar/types/api-reference'
 
-import SlotPlaceholder from '../components/SlotPlaceholder.vue'
-
-const configuration = reactive(
-  apiReferenceConfigurationSchema.parse({
-    proxyUrl: import.meta.env.VITE_REQUEST_PROXY_URL,
-    isEditable: false,
-    // Add path routing option
-    ...(window.location.pathname.startsWith('/path-routing')
-      ? {
-          pathRouting: { basePath: '/path-routing' },
-        }
-      : {}),
-    content,
-  }),
-)
+const configuration: AnyApiReferenceConfiguration = {
+  sources: [
+    {
+      title: 'Scalar Galaxy',
+      slug: 'scalar-galaxy',
+      url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+    },
+    {
+      title: 'Scalar Galaxy (Classic Layout)',
+      url: 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json',
+      // @ts-expect-error TODO: types are wrong here
+      layout: 'classic',
+    },
+    {
+      title: 'Relative URL Example',
+      slug: 'relative-url',
+      url: 'examples/openapi.json',
+    },
+    {
+      title: 'Swagger Petstore 2.0',
+      url: 'https://petstore.swagger.io/v2/swagger.json',
+    },
+    {
+      title: 'Swagger Petstore 3.0',
+      url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+    },
+    {
+      title: 'Swagger Petstore 3.1',
+      url: 'https://petstore31.swagger.io/api/v31/openapi.json',
+    },
+    {
+      title: 'Hello World (string)',
+      content: JSON.stringify({
+        openapi: '3.0.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {
+          '/hello': {
+            get: {
+              summary: 'Hello World',
+              description: 'Hello World',
+              responses: {
+                200: {
+                  description: 'Hello World',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    },
+    {
+      title: 'Valtown',
+      url: 'https://docs.val.town/openapi.documented.json',
+    },
+    {
+      title: 'Zoom',
+      url: 'https://developers.zoom.us/api-hub/meetings/methods/endpoints.json',
+    },
+    {
+      title: 'Cloudinary',
+      url: 'https://cloudinary.com/documentation/schemas/analysis-api/public-schema.yml',
+    },
+    {
+      title: 'Tailscale',
+      url: 'https://api.tailscale.com/api/v2?outputOpenapiSchema=true',
+    },
+    {
+      title: 'Maersk',
+      url: 'https://edpmediastorage.blob.core.windows.net/media/air_booking_v1-0_26092023_scalar_spec.yaml',
+    },
+    {
+      title: 'Bolt',
+      url: 'https://assets.bolt.com/external-api-references/bolt.yml',
+    },
+    {
+      title: 'OpenStatus',
+      url: 'https://api.openstatus.dev/v1/openapi',
+    },
+  ],
+  persistAuth: true,
+  // Avoid CORS issues
+  proxyUrl: import.meta.env.VITE_REQUEST_PROXY_URL,
+}
 </script>
 <template>
-  <ApiReference :configuration="configuration">
-    <template #footer><SlotPlaceholder>footer</SlotPlaceholder></template>
-  </ApiReference>
+  <ApiReference :configuration="configuration" />
 </template>


### PR DESCRIPTION
Hey, I’ve got tons of ideas how to improve our manual and automatic testing setup, but here is a quick (and intermediate one):

It adds a few more sources to the deploy example, so you can quickly check popular OpenAPI files in the deploy example.