### PR TITLE
fix(api-reference): update the hash on scroll for classic layout

### DIFF
--- a/.changeset/stale-squids-glow.md
+++ b/.changeset/stale-squids-glow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: classic layout intersection observer

--- a/packages/api-reference/src/components/Section/SectionAccordion.vue
+++ b/packages/api-reference/src/components/Section/SectionAccordion.vue
@@ -4,7 +4,7 @@ import { ScalarIconCaretRight } from '@scalar/icons'
 import { useElementHover } from '@vueuse/core'
 import { ref } from 'vue'
 
-import { useSidebar } from '@/features/sidebar/hooks/useSidebar'
+import { useSidebar } from '@/features/sidebar'
 import { useNavState } from '@/hooks/useNavState'
 
 import IntersectionObserver from '../IntersectionObserver.vue'

--- a/packages/api-reference/src/components/Section/SectionAccordion.vue
+++ b/packages/api-reference/src/components/Section/SectionAccordion.vue
@@ -4,20 +4,41 @@ import { ScalarIconCaretRight } from '@scalar/icons'
 import { useElementHover } from '@vueuse/core'
 import { ref } from 'vue'
 
+import { useSidebar } from '@/features/sidebar/hooks/useSidebar'
+import { useNavState } from '@/hooks/useNavState'
+
 import IntersectionObserver from '../IntersectionObserver.vue'
 
-defineProps<{
+const { id } = defineProps<{
   id?: string
   transparent?: boolean
 }>()
 
 const button = ref()
 const isHovered = useElementHover(button)
+
+const { getSectionId, isIntersectionEnabled, replaceUrlState } = useNavState()
+const { setCollapsedSidebarItem } = useSidebar()
+
+/** On scroll over this section */
+const handleScroll = () => {
+  if (!id || !isIntersectionEnabled.value) {
+    return
+  }
+
+  replaceUrlState(id)
+
+  // Open models and webhooks on scroll
+  if (id?.startsWith('model') || id?.startsWith('webhook')) {
+    setCollapsedSidebarItem(getSectionId(id), true)
+  }
+}
 </script>
 <template>
   <IntersectionObserver
     :id="id"
-    class="section-wrapper">
+    class="section-wrapper"
+    @intersecting="handleScroll">
     <Disclosure
       v-slot="{ open }"
       as="section"

--- a/packages/object-utils/package.json
+++ b/packages/object-utils/package.json
@@ -75,6 +75,7 @@
   ],
   "module": "dist/index.js",
   "dependencies": {
+    "@scalar/helpers": "workspace:*",
     "flatted": "catalog:*",
     "just-clone": "^6.2.0",
     "ts-deepmerge": "^7.0.1",

--- a/packages/object-utils/src/mutator-record/handlers.ts
+++ b/packages/object-utils/src/mutator-record/handlers.ts
@@ -1,7 +1,7 @@
 import { Mutation } from '../mutator-record/mutations'
 import type { Path, PathValue } from '../nested'
 import { stringify } from 'flatted'
-
+import { safeLocalStorage } from '@scalar/helpers/object/local-storage'
 import { debounce } from './debounce'
 import { LS_CONFIG } from './local-storage'
 
@@ -26,7 +26,7 @@ export function mutationFactory<T extends Record<string, any>>(
 
   /** Triggers on any changes so we can save to localStorage */
   const onChange = localStorageKey
-    ? debounce(() => localStorage.setItem(localStorageKey, stringify(entityMap)), LS_CONFIG.DEBOUNCE_MS, {
+    ? debounce(() => safeLocalStorage().setItem(localStorageKey, stringify(entityMap)), LS_CONFIG.DEBOUNCE_MS, {
         maxWait: LS_CONFIG.MAX_WAIT_MS,
       })
     : () => null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2069,6 +2069,9 @@ importers:
 
   packages/object-utils:
     dependencies:
+      '@scalar/helpers':
+        specifier: workspace:*
+        version: link:../helpers
       flatted:
         specifier: catalog:*
         version: 3.3.3
@@ -20227,8 +20230,8 @@ packages:
   vue-component-type-helpers@2.2.10:
     resolution: {integrity: sha512-iDUO7uQK+Sab2tYuiP9D1oLujCWlhHELHMgV/cB13cuGbG4qwkLHvtfWb6FzvxrIOPDnU0oHsz2MlQjhYDeaHA==}
 
-  vue-component-type-helpers@3.0.3:
-    resolution: {integrity: sha512-koiBu7lO8e6w/UlbZAAIW11qcFQocYIl7Nh/SVwGZ804ej5KrncU32bRxi2zfU2Kyf6HWuk1CeeVP2rhIL+vyQ==}
+  vue-component-type-helpers@3.0.4:
+    resolution: {integrity: sha512-WtR3kPk8vqKYfCK/HGyT47lK/T3FaVyWxaCNuosaHYE8h9/k0lYRZ/PI/+T/z2wP+uuNKmL6z30rOcBboOu/YA==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -28637,7 +28640,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.17(typescript@5.6.2)
-      vue-component-type-helpers: 3.0.3
+      vue-component-type-helpers: 3.0.4
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -43895,7 +43898,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.10: {}
 
-  vue-component-type-helpers@3.0.3: {}
+  vue-component-type-helpers@3.0.4: {}
 
   vue-demi@0.14.10(vue@3.5.17(typescript@5.6.2)):
     dependencies:


### PR DESCRIPTION
**Problem**

Currently, this actually never worked before either.

**Solution**

With this PR we now update the hash on scroll on the classic layout.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
