### PR TITLE
fix(api-reference): the order of the client libraries was reversed

### DIFF
--- a/.changeset/cuddly-buses-speak.md
+++ b/.changeset/cuddly-buses-speak.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: the order of the client libraries

--- a/packages/api-reference/src/components/Content/ClientLibraries/featured-clients.ts
+++ b/packages/api-reference/src/components/Content/ClientLibraries/featured-clients.ts
@@ -16,9 +16,28 @@ export const isFeaturedClient = (
   featuredClients: AvailableClients[number][] = FEATURED_CLIENTS,
 ) => Boolean(clientId && featuredClients.includes(clientId as (typeof featuredClients)[number]))
 
-/** Client option arry that matches the featured list */
+/**
+ * Maps featured client IDs to their corresponding ClientOption objects.
+ * Returns an array of ClientOption objects that match the featured clients list,
+ * maintaining the order of the featured clients.
+ */
 export const getFeaturedClients = (
   clientOptions: ClientOptionGroup[],
   featuredClients: AvailableClients[number][] = FEATURED_CLIENTS,
-): ClientOption[] =>
-  clientOptions.flatMap((option) => option.options.filter((option) => isFeaturedClient(option.id, featuredClients)))
+): ClientOption[] => {
+  // Create a map of all available client options for quick lookup
+  const clientMap = new Map<string, ClientOption>()
+
+  // Using the map means we only have to loop through once
+  for (const group of clientOptions) {
+    for (const option of group.options) {
+      clientMap.set(option.id, option)
+    }
+  }
+
+  // Map featured clients to their corresponding options, maintaining order
+  return featuredClients.flatMap((clientId) => {
+    const client = clientMap.get(clientId)
+    return client ?? []
+  })
+}


### PR DESCRIPTION
**Problem**

Currently, the order of the client libraries got reversed as I was taking the options and filtering by featured. 

**Solution**

With this PR instead I am using a map of the clients then mapping the filtered clients from it.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
