### PR TITLE
fix(components): apply tooltip shadow without tailwind variant

### DIFF
--- a/.changeset/eighty-pets-dress.md
+++ b/.changeset/eighty-pets-dress.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): apply tooltip shadow without tailwind variant

--- a/packages/components/src/components/ScalarTooltip/ScalarTooltip.vue
+++ b/packages/components/src/components/ScalarTooltip/ScalarTooltip.vue
@@ -63,6 +63,9 @@ useTooltip({
 :where(body) > .scalar-tooltip:before {
   content: '';
   inset: var(--scalar-tooltip-offset);
-  @apply absolute rounded bg-b-tooltip -z-1 backdrop-blur dark:shadow-border;
+  @apply absolute rounded bg-b-tooltip -z-1 backdrop-blur;
+}
+:where(body.dark-mode) > .scalar-tooltip:before {
+  @apply shadow-border;
 }
 </style>


### PR DESCRIPTION
Turns out we we're getting weird css generated by using our `dark:` Tailwind variant in an `@apply` and it was creating a warning from our minifiers.

This cleans it up while doing the same thing :)

<img width="2044" height="1258" alt="Hyper-2025-07-25-16-17-26@2x" src="https://github.com/user-attachments/assets/1730ec47-0105-4c28-a677-747fb52b3fda" />

<img width="2044" height="1258" alt="Hyper-2025-07-25-16-17-50@2x" src="https://github.com/user-attachments/assets/ddf1b1b6-252f-41af-822e-ef81c8bea373" />


**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
