### PR TITLE
fix(openapi-parser): depend on @scalar/openapi-types

### DIFF
--- a/.changeset/many-phones-hunt.md
+++ b/.changeset/many-phones-hunt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix: added dependency on @scalar/openapi-types

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -68,6 +68,7 @@
   "module": "./dist/index.js",
   "sideEffects": false,
   "dependencies": {
+    "@scalar/openapi-types": "workspace:*",
     "ajv": "^8.17.1",
     "ajv-draft-04": "^1.0.0",
     "ajv-formats": "^3.0.1",
@@ -78,7 +79,6 @@
   "devDependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
     "@scalar/build-tooling": "workspace:*",
-    "@scalar/openapi-types": "workspace:*",
     "@scalar/types": "workspace:*",
     "@types/node": "catalog:*",
     "fastify": "catalog:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2097,6 +2097,9 @@ importers:
 
   packages/openapi-parser:
     dependencies:
+      '@scalar/openapi-types':
+        specifier: workspace:*
+        version: link:../openapi-types
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -2122,9 +2125,6 @@ importers:
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../build-tooling
-      '@scalar/openapi-types':
-        specifier: workspace:*
-        version: link:../openapi-types
       '@scalar/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
E.g. validate and dereference from the parser return the OpenAPI.Document type from @scalar/openapi-types. Without the dependency if you install the parser and call one of these functions TypeScript will infer the type of their returned schema to be any.