### PR TITLE
feat(Scalar.Aspire): allow publishing and service discovery

### DIFF
--- a/.changeset/tender-days-sneeze.md
+++ b/.changeset/tender-days-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspire': minor
+---
+
+feat: allow publish and service discovery

--- a/integrations/aspire/src/Scalar.Aspire/Extensions/DistributedApplicationBuilderExtensions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Extensions/DistributedApplicationBuilderExtensions.cs
@@ -63,7 +63,6 @@ public static class DistributedApplicationBuilderExtensions
                 x.DisplayText = "Scalar API Reference";
                 x.Url = ApiReferenceEndpoint;
             })
-            .WithHttpHealthCheck(HealthCheckEndpoint)
-            .ExcludeFromManifest();
+            .WithHttpHealthCheck(HealthCheckEndpoint);
     }
 }

--- a/integrations/aspire/src/Scalar.Aspire/ScalarResource.cs
+++ b/integrations/aspire/src/Scalar.Aspire/ScalarResource.cs
@@ -1,4 +1,5 @@
-﻿using Aspire.Hosting.ApplicationModel;
+﻿using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
 
 namespace Scalar.Aspire;
 
@@ -6,4 +7,4 @@ namespace Scalar.Aspire;
 /// Represents a Scalar container resource.
 /// </summary>
 /// <param name="name">The unique name identifier for the Scalar resource.</param>
-public sealed class ScalarResource(string name) : ContainerResource(name);
+public sealed class ScalarResource(string name) : ContainerResource(name), IResourceWithServiceDiscovery;


### PR DESCRIPTION
**Problem**

Currently, the resource is excluded from publishing.

**Solution**

This PR includes the resource by default. The devs can optionally exclude the resource if they want.

Closes #6366

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
