### PR TITLE
feat: initial support for dev containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
     }
   },
   "hostRequirements": {
-    "memory": "4gb",
+    "memory": "6gb",
     "cpus": 4
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
     }
   },
   "hostRequirements": {
-    "memory": "6gb",
+    "memory": "8gb",
     "cpus": 4
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,30 +3,40 @@
 {
   "name": "Node.js & TypeScript",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
   "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22",
+      "pnpmVersion": "10.5.2"
+    },
     "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "latest"
+      "version": "9.0"
     },
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "latest"
-    },
-    "ghcr.io/devcontainers-extra/features/pnpm:2": {
-      "version": "latest"
+      "version": "1.24.5"
     }
   },
 
-  // Features to add to the dev container. More info: https://containers.dev/features.
-  // "features": {},
-
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  // "forwardPorts": [],
+  "forwardPorts": [5173],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "pnpm install"
+  // "postCreateCommand": "pnpm install",
 
   // Configure tool-specific properties.
-  // "customizations": {},
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vue.volar",
+        "cpylua.language-postcss",
+        "streetsidesoftware.code-spell-checker",
+        "biomejs.biome",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        "vitest.explorer"
+      ]
+    }
+  }
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,18 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
 {
-  "name": "Node.js & TypeScript",
+  "name": "Scalar Node",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+  "image": "mcr.microsoft.com/devcontainers/base:debian",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "22",
       "pnpmVersion": "10.5.2"
     },
-    "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "9.0"
-    },
     "ghcr.io/devcontainers/features/go:1": {
       "version": "1.24.5"
     }
   },
-
-  // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  "forwardPorts": [5173],
-
-  // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": "pnpm install",
 
   // Configure tool-specific properties.
   "customizations": {
@@ -36,6 +27,10 @@
         "vitest.explorer"
       ]
     }
+  },
+  "hostRequirements": {
+    "memory": "4gb",
+    "cpus": 4
   }
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+  "name": "Node.js & TypeScript",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers-extra/features/pnpm:2": {
+      "version": "latest"
+    }
+  },
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "pnpm install"
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,20 +1,13 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+// For details, see https://aka.ms/devcontainer.json.
 {
   "name": "Scalar Node",
-  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
   "image": "mcr.microsoft.com/devcontainers/base:debian",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "22",
       "pnpmVersion": "10.5.2"
-    },
-    "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.24.5"
     }
   },
-
-  // Configure tool-specific properties.
   "customizations": {
     "vscode": {
       "extensions": [
@@ -32,7 +25,4 @@
     "memory": "4gb",
     "cpus": 4
   }
-
-  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-  // "remoteUser": "root"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ rollup.config-*.mjs
 
 # Svelte
 .svelte-kit
+
+.pnpm-store/

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -12,7 +12,9 @@ export default defineConfig({
     'process.env.SCALAR_API_REFERENCE_VERSION': `"${version}"`,
   },
   server: {
-    host: true,
+    // Enable host binding in dev containers for proper port forwarding
+    // See: https://vite.dev/guide/troubleshooting.html#dev-containers-vs-code-port-forwarding
+    ...(process.env.REMOTE_CONTAINERS && { host: '127.0.0.1' }),
   },
   resolve: {
     alias: {

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
     'process.env.NODE_ENV': '"production"',
     'process.env.SCALAR_API_REFERENCE_VERSION': `"${version}"`,
   },
+  server: {
+    host: true,
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["GOCACHE", "LOCALAPPDATA"],
+  "globalEnv": ["GOCACHE", "LOCALAPPDATA", "REMOTE_CONTAINERS"],
   "ui": "tui",
   "tasks": {
     "lint:fix": {},


### PR DESCRIPTION
This PR introduces the initial `.devcontainer/devcontainer.json`, enabling:

- the usage of dev containers in VS Code
- the usage of GitHub Codespaces

Currently, the container only supports Node, which means that packages like the proxy (Go) or `Scalar.Aspire` (.NET) won't work. We can consider adding them later to this config or add dedicated dev containers for them.


Tested with the `pnpm dev:reference` command 👍 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
