### PR TITLE
feat(api-reference): updates content type select style

### DIFF
--- a/.changeset/famous-trainers-add.md
+++ b/.changeset/famous-trainers-add.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: updates content type select style and position

--- a/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
+++ b/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
@@ -51,7 +51,7 @@ const options = computed(() => {
 
 // Content type select style variant based on dropdown availability
 const contentTypeSelect = cva({
-  base: 'font-normal text-c-2 bg-b-2 py-0.75 flex cursor-pointer items-center gap-1 rounded-full text-sm',
+  base: 'font-normal text-c-2 bg-b-2 py-0.75 flex cursor-pointer items-center gap-1 rounded-full text-xs',
   variants: {
     dropdown: {
       true: 'border hover:text-c-1 pl-2 pr-1.5',

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -119,7 +119,7 @@ const shouldShowParameter = computed(() => {
       </DisclosurePanel>
     </Disclosure>
     <div
-      class="absolute top-2.5 right-0 opacity-0 group-focus-within/parameter-item:opacity-100 group-hover/parameter-item:opacity-100">
+      class="absolute top-3 right-0 opacity-0 group-focus-within/parameter-item:opacity-100 group-hover/parameter-item:opacity-100">
       <ContentTypeSelect
         v-if="shouldCollapse && props.parameter.content"
         class="parameter-item-content-type"


### PR DESCRIPTION
**Changes**

this pr decreases content type select font size back + fixes its position in parameter list item.

| state | preview |
| -------|------|
| before | <img width="553" height="261" alt="image" src="https://github.com/user-attachments/assets/3c49c360-f6c5-491e-81da-ce93e805c13a" />  <img width="378" height="147" alt="image" src="https://github.com/user-attachments/assets/2ddc0523-c0cd-4785-adde-cf61d22d1c3d" /> |
| after | <img width="553" height="261" alt="image" src="https://github.com/user-attachments/assets/971a1fc1-90f1-442c-bbc7-3f3cd274d537" /> <img width="378" height="147" alt="image" src="https://github.com/user-attachments/assets/884887d6-49d3-4142-8376-ca3f92117b39" /> | 

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
