### PR TITLE
fix(api-reference): wrong paragraph line height within markdown

### DIFF
--- a/.changeset/forty-doors-lay.md
+++ b/.changeset/forty-doors-lay.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/components': patch
+---
+
+feat: favors tailwind utility for text styling

--- a/.changeset/neat-poems-hide.md
+++ b/.changeset/neat-poems-hide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+feat: sets line height to theme text styling variables

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientLibraries.vue
@@ -160,9 +160,12 @@ const installationInstructions = computed(() => {
   </div>
 </template>
 <style scoped>
+@reference "tailwindcss";
+
 .selected-client {
+  @apply text-sm leading-none;
+
   color: var(--scalar-color-1);
-  font-size: var(--scalar-small);
   font-family: var(--scalar-font-code);
   padding: 9px 12px;
   border-top: none;

--- a/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
+++ b/packages/api-reference/src/components/Content/ClientLibraries/ClientSelector.vue
@@ -132,6 +132,8 @@ const selectedTargetKey = computed(
   </div>
 </template>
 <style scoped>
+@reference "tailwindcss";
+
 .client-libraries-content {
   container: client-libraries-content / inline-size;
   display: flex;
@@ -228,7 +230,8 @@ const selectedTargetKey = computed(
   }
 }
 .client-libraries .client-libraries-text {
-  font-size: var(--scalar-small);
+  @apply text-sm leading-none;
+
   position: relative;
   display: flex;
   align-items: center;

--- a/packages/api-reference/src/components/Content/Introduction/Description.vue
+++ b/packages/api-reference/src/components/Content/Introduction/Description.vue
@@ -103,11 +103,15 @@ const transformHeading = (node: Record<string, any>) => {
 </template>
 
 <style scoped>
+@reference "tailwindcss";
+
 .introduction-description-heading {
   scroll-margin-top: 64px;
 }
 
 .introduction-description {
+  @apply text-lg;
+
   display: flex;
   flex-direction: column;
   margin-top: 24px;

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -374,12 +374,15 @@ const shouldRenderObjectProperties = computed(() => {
 </template>
 
 <style scoped>
+@reference "tailwindcss";
+
 .property {
+  @apply text-base;
+
   color: var(--scalar-color-1);
   display: flex;
   flex-direction: column;
   padding: 8px;
-  font-size: var(--scalar-small);
   position: relative;
 }
 
@@ -431,9 +434,9 @@ const shouldRenderObjectProperties = computed(() => {
 }
 
 .property-description {
+  @apply text-sm;
+
   margin-top: 6px;
-  line-height: 1.4;
-  font-size: var(--scalar-small);
 }
 
 .property-description:has(+ .property-rule) {

--- a/packages/api-reference/src/components/Section/SectionColumn.vue
+++ b/packages/api-reference/src/components/Section/SectionColumn.vue
@@ -3,7 +3,11 @@
 </template>
 
 <style scoped>
+@reference "tailwindcss";
+
 .section-column {
+  @apply text-lg;
+
   flex: 1;
   min-width: 0;
 }

--- a/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
+++ b/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
@@ -51,7 +51,7 @@ const options = computed(() => {
 
 // Content type select style variant based on dropdown availability
 const contentTypeSelect = cva({
-  base: 'font-normal text-c-2 bg-b-2 py-0.75 flex cursor-pointer items-center gap-1 rounded-full text-xs',
+  base: 'font-normal text-c-2 bg-b-2 py-0.75 flex cursor-pointer items-center gap-1 rounded-full text-xs leading-none',
   variants: {
     dropdown: {
       true: 'border hover:text-c-1 pl-2 pr-1.5',

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -133,6 +133,8 @@ const shouldShowParameter = computed(() => {
 </template>
 
 <style scoped>
+@reference "tailwindcss";
+
 .parameter-item {
   display: flex;
   flex-direction: column;
@@ -152,9 +154,10 @@ const shouldShowParameter = computed(() => {
 }
 
 .parameter-item-name {
+  @apply text-sm;
+
   margin-right: 6px;
   font-weight: var(--scalar-semibold);
-  font-size: var(--scalar-font-size-3);
   font-family: var(--scalar-font-code);
   color: var(--scalar-color-1);
 }

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -127,6 +127,8 @@ const handleDiscriminatorChange = (type: string) => {
 </template>
 
 <style scoped>
+@reference "tailwindcss";
+
 .request-body {
   margin-top: 24px;
 }
@@ -152,8 +154,9 @@ const handleDiscriminatorChange = (type: string) => {
   font-weight: normal;
 }
 .request-body-description {
+  @apply text-sm;
+
   margin-top: 6px;
-  font-size: var(--scalar-small);
   width: 100%;
 }
 .request-body-description :deep(.markdown) * {

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.vue
@@ -191,8 +191,10 @@ const showSchema = ref(false)
 </template>
 
 <style scoped>
+@reference "tailwindcss";
+
 .response-card {
-  font-size: var(--scalar-font-size-3);
+  @apply text-sm;
 }
 
 .markdown :deep(*) {

--- a/packages/api-reference/src/features/test-request-button/TestRequestButton.vue
+++ b/packages/api-reference/src/features/test-request-button/TestRequestButton.vue
@@ -45,6 +45,7 @@ const handleClick = () => {
 </template>
 <style scoped>
 .show-api-client-button {
+  align-self: center;
   appearance: none;
   border: none;
   padding: 1px 6px;
@@ -53,6 +54,7 @@ const handleClick = () => {
   display: flex;
   justify-content: center;
   align-items: center;
+  height: fit-content;
   font-weight: var(--scalar-semibold);
   font-size: var(--scalar-small);
   line-height: 22px;

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/RequestExample.vue
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/RequestExample.vue
@@ -353,10 +353,13 @@ const id = useId()
   </ScalarCard>
 </template>
 <style scoped>
+@reference "tailwindcss";
+
 .request-card {
-  font-size: var(--scalar-font-size-3);
+  @apply text-sm;
 }
 .request-method {
+  display: inline-block;
   font-family: var(--scalar-font-code);
   text-transform: uppercase;
   margin-right: 6px;
@@ -364,7 +367,7 @@ const id = useId()
 .request-card-footer {
   display: flex;
   justify-content: flex-end;
-  padding: 6px;
+  padding: 4px 6px;
   flex-shrink: 0;
 }
 .request-card-footer-addon {

--- a/packages/components/src/components/ScalarCard/ScalarCardHeader.vue
+++ b/packages/components/src/components/ScalarCard/ScalarCardHeader.vue
@@ -33,11 +33,7 @@ useCardHeading(id)
 </script>
 <template>
   <ScalarCardSection
-    v-bind="
-      cx(
-        'scalar-card-header leading-[22px] font-medium py-[6.75px] px-3 shrink-0',
-      )
-    ">
+    v-bind="cx('scalar-card-header font-medium py-[6.75px] px-3 shrink-0')">
     <div
       :id="id"
       class="scalar-card-header-title min-w-0 flex-1 truncate">

--- a/packages/components/src/components/ScalarMarkdown/ScalarMarkdown.vue
+++ b/packages/components/src/components/ScalarMarkdown/ScalarMarkdown.vue
@@ -72,6 +72,7 @@ const html = computed(() => {
 </template>
 <style>
 @import '@scalar/code-highlight/css/code.css';
+@reference "tailwindcss";
 
 .scalar-app {
   /* Base container and variables */
@@ -110,7 +111,7 @@ const html = computed(() => {
   .markdown h4,
   .markdown h5,
   .markdown h6 {
-    --font-size: 1rem;
+    @apply text-lg;
   }
 
   .markdown h1,

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
@@ -26,7 +26,7 @@ const { cx } = useBindCx()
     <!-- Icon -->
     <div
       v-if="icon"
-      class="flex h-fit items-center text-sm font-medium text-c-3 group-hover:text-c-1">
+      class="flex h-fit items-center text-base font-medium text-c-3 group-hover:text-c-1">
       <slot name="icon">
         <ScalarIconLegacyAdapter
           v-if="icon"

--- a/packages/themes/src/base/reset.css
+++ b/packages/themes/src/base/reset.css
@@ -16,7 +16,7 @@
 :where(.scalar-app) {
   /* Apply styles that are normally applied to `html`. */
   font-family: var(--scalar-font);
-  line-height: 1.15;
+  line-height: 1;
   color: var(--scalar-color-1);
 
   -webkit-text-size-adjust: 100%;

--- a/packages/themes/src/base/variables.css
+++ b/packages/themes/src/base/variables.css
@@ -40,10 +40,10 @@
   --scalar-font-size-7: 10px;
 
   --scalar-line-height-1: 32px;
-  --scalar-line-height-2: 24px;
-  --scalar-line-height-3: 20px;
-  --scalar-line-height-4: 18px;
-  --scalar-line-height-5: 16px;
+  --scalar-line-height-2: 26px;
+  --scalar-line-height-3: 22px;
+  --scalar-line-height-4: 20px;
+  --scalar-line-height-5: 18px;
 
   --scalar-font-normal: 400;
   --scalar-font-medium: 500;

--- a/packages/themes/src/tailwind/theme.css
+++ b/packages/themes/src/tailwind/theme.css
@@ -27,13 +27,27 @@
 
   /* Font Sizes */
   --text-\*: initial;
-  --text-3xs: var(--scalar-font-size-7);
-  --text-xxs: var(--scalar-font-size-6);
-  --text-xs: var(--scalar-font-size-5);
-  --text-sm: var(--scalar-font-size-4);
-  --text-base: var(--scalar-font-size-3);
-  --text-lg: var(--scalar-font-size-2);
-  --text-xl: var(--scalar-font-size-1);
+
+  --text-3xs: var(--scalar-font-size-7); /* 10px */
+  --text-3xs-line-height: var(--scalar-line-height-5); /* 18px */
+
+  --text-xxs: var(--scalar-font-size-6); /* 12px */
+  --text-xxs-line-height: var(--scalar-line-height-5); /* 18px */
+
+  --text-xs: var(--scalar-font-size-5); /* 12px */
+  --text-xs-line-height: var(--scalar-line-height-5); /* 18px */
+
+  --text-sm: var(--scalar-font-size-4); /* 13px */
+  --text-sm-line-height: var(--scalar-line-height-4); /* 20px */
+
+  --text-base: var(--scalar-font-size-3); /* 14px */
+  --text-base-line-height: var(--scalar-line-height-3); /* 22px */
+
+  --text-lg: var(--scalar-font-size-2); /* 16px */
+  --text-lg-line-height: var(--scalar-line-height-2); /* 26px */
+
+  --text-xl: var(--scalar-font-size-1); /* 21px */
+  --text-xl-line-height: var(--scalar-line-height-1); /* 32px */
 
   /* Font Weights */
   --font-weight-\*: initial;

--- a/packages/themes/src/tailwind/theme.css
+++ b/packages/themes/src/tailwind/theme.css
@@ -29,25 +29,25 @@
   --text-\*: initial;
 
   --text-3xs: var(--scalar-font-size-7); /* 10px */
-  --text-3xs-line-height: var(--scalar-line-height-5); /* 18px */
+  --text-3xs--line-height: var(--scalar-line-height-5); /* 18px */
 
   --text-xxs: var(--scalar-font-size-6); /* 12px */
-  --text-xxs-line-height: var(--scalar-line-height-5); /* 18px */
+  --text-xxs--line-height: var(--scalar-line-height-5); /* 18px */
 
   --text-xs: var(--scalar-font-size-5); /* 12px */
-  --text-xs-line-height: var(--scalar-line-height-5); /* 18px */
+  --text-xs--line-height: var(--scalar-line-height-5); /* 18px */
 
   --text-sm: var(--scalar-font-size-4); /* 13px */
-  --text-sm-line-height: var(--scalar-line-height-4); /* 20px */
+  --text-sm--line-height: var(--scalar-line-height-4); /* 20px */
 
   --text-base: var(--scalar-font-size-3); /* 14px */
-  --text-base-line-height: var(--scalar-line-height-3); /* 22px */
+  --text-base--line-height: var(--scalar-line-height-3); /* 22px */
 
   --text-lg: var(--scalar-font-size-2); /* 16px */
-  --text-lg-line-height: var(--scalar-line-height-2); /* 26px */
+  --text-lg--line-height: var(--scalar-line-height-2); /* 26px */
 
   --text-xl: var(--scalar-font-size-1); /* 21px */
-  --text-xl-line-height: var(--scalar-line-height-1); /* 32px */
+  --text-xl--line-height: var(--scalar-line-height-1); /* 32px */
 
   /* Font Weights */
   --font-weight-\*: initial;


### PR DESCRIPTION
**Changes**

this pr brings back #6286 and updates adds tw utility usage within reference for text stytling. this pr fixes line height within markdown usage + overhaul text - some changes might apply vs previous state which should match latest figma updates.

| state | preview |
| -------|------|
| before | <img width="558" height="184" alt="image" src="https://github.com/user-attachments/assets/374a7850-4b17-43d6-a979-36ad12644333" /> |
| after | <img width="558" height="184" alt="image" src="https://github.com/user-attachments/assets/82811713-5e5c-4a36-b308-62e85c355e8b" /> | 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
