### PR TITLE
chore: make a specific changeset a patch instead of minor

### DIFF
--- a/.changeset/fifty-toys-remember.md
+++ b/.changeset/fifty-toys-remember.md
@@ -1,5 +1,5 @@
 ---
-'@scalar/api-reference': minor
+'@scalar/api-reference': patch
 ---
 
 feat: Make the min & max descriptions more descriptive for strings


### PR DESCRIPTION
I mean, the next release will be a minor release anyway, but I just saw that another minor changeset slipped through, so let’s fix this and make it a patch.

Again: The release will still be a minor release. :)