### PR TITLE
fix(components): make paragraph line height variable

### DIFF
--- a/.changeset/fresh-planes-grab.md
+++ b/.changeset/fresh-planes-grab.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): make paragraph line height variable

--- a/packages/components/src/components/ScalarMarkdown/ScalarMarkdown.stories.ts
+++ b/packages/components/src/components/ScalarMarkdown/ScalarMarkdown.stories.ts
@@ -8,6 +8,9 @@ import markdownContent from './test.md?raw'
  */
 const meta = {
   component: ScalarMarkdown,
+  argTypes: {
+    class: { control: 'text' },
+  },
   tags: ['autodocs'],
   render: (args) => ({
     components: { ScalarMarkdown },

--- a/packages/components/src/components/ScalarMarkdown/ScalarMarkdown.vue
+++ b/packages/components/src/components/ScalarMarkdown/ScalarMarkdown.vue
@@ -135,8 +135,8 @@ const html = computed(() => {
 
   .markdown p {
     color: inherit;
-    line-height: 22px;
     display: block;
+    line-height: var(--markdown-line-height);
   }
 
   /* Images */


### PR DESCRIPTION
Updates the markdown `<p>` line height to match the figma (more or less). We use a 16px font size for most of refs and we were hard coding the line height to 22px (supposed to be `26px`).

This just puts it back to using `1.625` which means at 16px font size we get `26px` line-height, however at `14px` is `22.75px` which isn't technically right (supposed to be 22px) but I think let's clean it up and figure out a more cohesive markdown line height approach once we get OSS released.

It's worth note since the font size is variable for markdown (and technically the rest of our app since it's themed?) we might need to move away from using pixel based line heights all together.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
