### PR TITLE
fix(api-reference): add failsafe types for schema

### DIFF
--- a/packages/api-reference/src/components/Content/Schema/SchemaHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaHeading.vue
@@ -1,14 +1,37 @@
 <script lang="ts" setup>
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { computed } from 'vue'
 
-defineProps<{
+const { value } = defineProps<{
   value:
     | OpenAPIV3_1.SchemaObject
     | OpenAPIV3_1.ArraySchemaObject
     | OpenAPIV3_1.NonArraySchemaObject
   name?: string
 }>()
+
+/** Generate a failsafe type from the properties when we don't have one */
+const failsafeType = computed(() => {
+  if (value.type) {
+    return value.type
+  }
+
+  if ('items' in value && value.items === 'object') {
+    return 'array'
+  }
+
+  if (value.properties || value.additionalProperties) {
+    return 'object'
+  }
+
+  if (value.enum) {
+    return 'enum'
+  }
+
+  return 'unknown'
+})
 </script>
+
 <template>
   <span
     v-if="typeof value === 'object'"
@@ -30,7 +53,7 @@ defineProps<{
       {{ name }}
     </template>
     <template v-else>
-      {{ value.type }}
+      {{ failsafeType }}
     </template>
   </span>
 </template>

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -424,6 +424,38 @@ describe('SchemaProperty', () => {
       })
     })
 
+    describe('object compositions', () => {
+      it('renders object compositions with allOf', async () => {
+        const wrapper = mount(SchemaProperty, {
+          props: {
+            value: {
+              allOf: [
+                {
+                  properties: {
+                    testStr: { type: 'string', description: 'This is a test string' },
+                    testBool: { type: 'boolean', description: 'This is a test boolean' },
+                  },
+                  required: ['testStr'],
+                },
+              ],
+            },
+          },
+        })
+
+        // For allOf compositions, properties should be displayed directly without expansion
+        const html = wrapper.html()
+
+        // Check that both properties are rendered with their descriptions
+        expect(html).toContain('testStr')
+        expect(html).toContain('This is a test string')
+        expect(html).toContain('testBool')
+        expect(html).toContain('This is a test boolean')
+
+        // Check that the required property is marked as required
+        expect(html).toContain('required')
+      })
+    })
+
     describe('nested compositions', () => {
       it('renders nested composition selectors with correct titles', async () => {
         const wrapper = mount(SchemaProperty, {

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
@@ -85,7 +85,8 @@ export function optimizeValueForDisplay(value: UnknownObject | undefined): Recor
 
   // If there's only one schema, overwrite the original value with the schema
   // Skip it for arrays for now, need to handle that specifically.
-  if (newSchemas.length === 1 && newValue?.[composition]) {
+  // For allOf, we want to preserve the composition structure so it can be rendered properly
+  if (newSchemas.length === 1 && newValue?.[composition] && composition !== 'allOf') {
     newValue = { ...newValue, ...newSchemas[0] }
 
     // Delete the original composition keyword


### PR DESCRIPTION
**Problem**

Currently, we aren't showing anything in certain cases of an `allOf` schema.

**Solution**

With this PR we show the object expand button button and have it labeled as object.

As a follow up we should auto expand this object as its the only one.

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
