### PR TITLE
fix(api-reference): block quote font size

### DIFF
--- a/packages/components/src/components/ScalarMarkdown/ScalarMarkdown.vue
+++ b/packages/components/src/components/ScalarMarkdown/ScalarMarkdown.vue
@@ -492,7 +492,7 @@ const html = computed(() => {
     margin: 0;
     display: block;
     font-weight: var(--scalar-bold);
-    font-size: var(--scalar-heading-2);
+    font-size: var(--scalar-font-size-2);
   }
 
   /* Markdown Checklist */


### PR DESCRIPTION
**Problem**

Currently, the block quotes were too big

**Solution**

With this PR we drop em to 16px aka font-size-2

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
