### PR TITLE
fix(api-reference): show schema description from allOf properties

### DIFF
--- a/.changeset/curly-waves-think.md
+++ b/.changeset/curly-waves-think.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: show description when merging allOf properties

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -8,6 +8,7 @@ describe('Schema', () => {
     it('shows the first description with allOf composition', () => {
       const wrapper = mount(Schema, {
         props: {
+          name: 'Request Body',
           value: {
             type: 'object',
             allOf: [
@@ -34,6 +35,7 @@ describe('Schema', () => {
     it('shows the first description with allOf composition if there is only one', () => {
       const wrapper = mount(Schema, {
         props: {
+          name: 'Request Body',
           value: {
             type: 'object',
             allOf: [
@@ -53,6 +55,30 @@ describe('Schema', () => {
 
       const text = wrapper.text()
       expect(text).toContain('This description should be shown')
+    })
+
+    it('does not show the allOf description if we are not in the Request Body', () => {
+      const wrapper = mount(Schema, {
+        props: {
+          value: {
+            type: 'object',
+            allOf: [
+              {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+              {
+                type: 'object',
+                description: 'This description should not be shown',
+                properties: { email: { type: 'string' } },
+              },
+            ],
+          },
+        },
+      })
+
+      const text = wrapper.text()
+      expect(text).not.toContain('This description should not be shown')
     })
   })
 

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -4,6 +4,58 @@ import { describe, expect, it } from 'vitest'
 import Schema from './Schema.vue'
 
 describe('Schema', () => {
+  describe('shouldShowDescription computed property', () => {
+    it('shows the first description with allOf composition', () => {
+      const wrapper = mount(Schema, {
+        props: {
+          value: {
+            type: 'object',
+            allOf: [
+              {
+                type: 'object',
+                description: 'This description should be shown',
+                properties: { name: { type: 'string' } },
+              },
+              {
+                type: 'object',
+                description: 'This description should not be shown',
+                properties: { email: { type: 'string' } },
+              },
+            ],
+          },
+        },
+      })
+
+      const text = wrapper.text()
+      expect(text).toContain('This description should be shown')
+      expect(text).not.toContain('This description should not be shown')
+    })
+
+    it('shows the first description with allOf composition if there is only one', () => {
+      const wrapper = mount(Schema, {
+        props: {
+          value: {
+            type: 'object',
+            allOf: [
+              {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+              {
+                type: 'object',
+                description: 'This description should be shown',
+                properties: { email: { type: 'string' } },
+              },
+            ],
+          },
+        },
+      })
+
+      const text = wrapper.text()
+      expect(text).toContain('This description should be shown')
+    })
+  })
+
   describe('additionalProperties Vue prop', () => {
     it('shows special toggle button when additionalProperties is true', () => {
       const wrapper = mount(Schema, {

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -5,6 +5,34 @@ import Schema from './Schema.vue'
 
 describe('Schema', () => {
   describe('shouldShowDescription computed property', () => {
+    it('shows the base description with allOf composition', () => {
+      const wrapper = mount(Schema, {
+        props: {
+          name: 'Request Body',
+          value: {
+            type: 'object',
+            description: 'This description should be shown',
+            allOf: [
+              {
+                type: 'object',
+                description: 'This description should not be shown',
+                properties: { name: { type: 'string' } },
+              },
+              {
+                type: 'object',
+                description: 'This description should not be shown',
+                properties: { email: { type: 'string' } },
+              },
+            ],
+          },
+        },
+      })
+
+      const text = wrapper.text()
+      expect(text).toContain('This description should be shown')
+      expect(text).not.toContain('This description should not be shown')
+    })
+
     it('shows the first description with allOf composition', () => {
       const wrapper = mount(Schema, {
         props: {

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -340,7 +340,6 @@ button.schema-card-title:hover {
 }
 .schema-card-description {
   color: var(--scalar-color-2);
-  margin-top: 8px;
 }
 .schema-card-description + .schema-properties {
   width: fit-content;

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -123,8 +123,12 @@ const schemaDescription = computed(() => {
 
 /** Determines whether to show the schema description */
 const shouldShowDescription = computed(() => {
-  // For allOf compositions, find the first schema with a description
-  if (schema.value?.allOf && Array.isArray(schema.value.allOf)) {
+  // For allOf compositions, find the first schema with a description, only for the request body (for now)
+  if (
+    schema.value?.allOf &&
+    Array.isArray(schema.value.allOf) &&
+    props.name === 'Request Body'
+  ) {
     const firstSchemaWithDescription = schema.value.allOf.find(
       (item) => item.description && typeof item.description === 'string',
     )

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -105,8 +105,34 @@ const shouldShowToggle = computed(() => {
   return true
 })
 
+/** Gets the description to show for the schema */
+const schemaDescription = computed(() => {
+  // For allOf compositions, find the first schema with a description
+  if (schema.value?.allOf && Array.isArray(schema.value.allOf)) {
+    const firstSchemaWithDescription = schema.value.allOf.find(
+      (item) => item.description && typeof item.description === 'string',
+    )
+    if (firstSchemaWithDescription?.description) {
+      return firstSchemaWithDescription.description
+    }
+  }
+
+  // Return the schema's own description
+  return schema.value?.description
+})
+
 /** Determines whether to show the schema description */
 const shouldShowDescription = computed(() => {
+  // For allOf compositions, find the first schema with a description
+  if (schema.value?.allOf && Array.isArray(schema.value.allOf)) {
+    const firstSchemaWithDescription = schema.value.allOf.find(
+      (item) => item.description && typeof item.description === 'string',
+    )
+    if (firstSchemaWithDescription?.description) {
+      return true
+    }
+  }
+
   // Don't show description if there's no description or it's not a string
   if (
     !schema.value?.description ||
@@ -115,9 +141,9 @@ const shouldShowDescription = computed(() => {
     return false
   }
 
-  // Don't show description if the schema has composition keywords
+  // Don't show description if the schema has other composition keywords
   // This prevents duplicate descriptions when individual schemas are part of compositions
-  if (schema.value.allOf || schema.value.oneOf || schema.value.anyOf) {
+  if (schema.value.oneOf || schema.value.anyOf) {
     return false
   }
 
@@ -169,7 +195,7 @@ const handleDiscriminatorChange = (type: string) => {
         v-if="shouldShowDescription"
         class="schema-card-description">
         <template v-if="!schema?.enum">
-          <ScalarMarkdown :value="schema?.description" />
+          <ScalarMarkdown :value="schemaDescription" />
         </template>
       </div>
       <div
@@ -314,6 +340,7 @@ button.schema-card-title:hover {
 }
 .schema-card-description {
   color: var(--scalar-color-2);
+  margin-top: 8px;
 }
 .schema-card-description + .schema-properties {
   width: fit-content;

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -158,8 +158,10 @@ const handleDiscriminatorChange = (type: string) => {
 }
 
 .request-body-header
-  + .request-body-schema:has(> .schema-card > .schema-card-description) {
-  /** Add a bit of space between the heading border and the schema description */
+  + .request-body-schema:has(> .schema-card > .schema-card-description),
+.request-body-header
+  + .request-body-schema:has(> .schema-card > .schema-properties) {
+  /** Add a bit of space between the heading border and the schema description or properties */
   padding-top: 8px;
 }
 .request-body-description :deep(.markdown) * {

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -156,6 +156,12 @@ const handleDiscriminatorChange = (type: string) => {
   font-size: var(--scalar-small);
   width: 100%;
 }
+
+.request-body-header
+  + .request-body-schema:has(> .schema-card > .schema-card-description) {
+  /** Add a bit of space between the heading border and the schema description */
+  padding-top: 8px;
+}
 .request-body-description :deep(.markdown) * {
   color: var(--scalar-color-2) !important;
 }

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -160,7 +160,9 @@ const handleDiscriminatorChange = (type: string) => {
 .request-body-header
   + .request-body-schema:has(> .schema-card > .schema-card-description),
 .request-body-header
-  + .request-body-schema:has(> .schema-card > .schema-properties) {
+  + .request-body-schema:has(
+    > .schema-card > .schema-properties > * > .property--level-0
+  ) {
   /** Add a bit of space between the heading border and the schema description or properties */
   padding-top: 8px;
 }


### PR DESCRIPTION
**Problem**

Currently, we don't show the description from level 0 in schema.

**Solution**

With this PR we take the first description from allOf properties. A specific fix that we can later make more generic

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
