### PR TITLE
chore(Scalar.Aspire): update Aspire to version 9.4.0

### DIFF
--- a/.changeset/few-masks-pay.md
+++ b/.changeset/few-masks-pay.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspire': minor
+---
+
+chore: support aspire 9.4.0

--- a/integrations/aspire/playground/Scalar.Aspire.AppHost/Scalar.Aspire.AppHost.csproj
+++ b/integrations/aspire/playground/Scalar.Aspire.AppHost/Scalar.Aspire.AppHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.1" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.4.0" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.1" />
-    <PackageReference Include="Aspire.Hosting.Keycloak" Version="9.3.1-preview.1.25305.6" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.4.0" />
+    <PackageReference Include="Aspire.Hosting.Keycloak" Version="9.4.0-preview.1.25378.8" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.NodeJS.Extensions" Version="9.6.0" />
   </ItemGroup>
 

--- a/integrations/aspire/src/Scalar.Aspire.Service/Scalar.Aspire.Service.csproj
+++ b/integrations/aspire/src/Scalar.Aspire.Service/Scalar.Aspire.Service.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="9.3.1" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="9.4.0" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>
 

--- a/integrations/aspire/src/Scalar.Aspire/Scalar.Aspire.csproj
+++ b/integrations/aspire/src/Scalar.Aspire/Scalar.Aspire.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="9.3.0" />
+    <PackageReference Include="Aspire.Hosting" Version="9.4.0" />
     <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta14" PrivateAssets="all" ExcludeAssets="runtime" NoWarn="NU5104" />
   </ItemGroup>
 


### PR DESCRIPTION
This release bumps the Aspire packages to version 9.4.0 🎉 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
