### PR TITLE
fix(components): scalar tooltip style inconsistency

### DIFF
--- a/.changeset/eighty-days-greet.md
+++ b/.changeset/eighty-days-greet.md
@@ -1,0 +1,6 @@
+---
+'@scalar/components': patch
+'@scalar/themes': patch
+---
+
+fix: scalar tooltip style inconsistency

--- a/packages/components/src/components/ScalarTooltip/ScalarTooltip.vue
+++ b/packages/components/src/components/ScalarTooltip/ScalarTooltip.vue
@@ -58,14 +58,11 @@ useTooltip({
 
   padding: calc(var(--scalar-tooltip-padding) + var(--scalar-tooltip-offset));
 
-  @apply z-tooltip text-c-tooltip text-xs font-medium break-words max-w-xs leading-5;
+  @apply z-tooltip text-c-tooltip text-xs break-words max-w-xs leading-5;
 }
-:where(body) > .scalar-tooltip:before {
+:where(body) > .scalar-tooltip::before {
   content: '';
   inset: var(--scalar-tooltip-offset);
-  @apply absolute rounded bg-b-tooltip -z-1 backdrop-blur;
-}
-:where(body.dark-mode) > .scalar-tooltip:before {
-  @apply shadow-border;
+  @apply absolute rounded shadow-lg bg-b-tooltip brightness-lifted -z-1;
 }
 </style>

--- a/packages/themes/src/presets/default.css
+++ b/packages/themes/src/presets/default.css
@@ -68,8 +68,8 @@
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
   --scalar-button-1-color: rgba(255, 255, 255, 0.9);
 
-  --scalar-tooltip-background: color-mix(in srgb, #1a1a1a, transparent 10%);
-  --scalar-tooltip-color: color-mix(in srgb, #fff, transparent 15%);
+  --scalar-tooltip-background: var(--scalar-background-1);
+  --scalar-tooltip-color: var(--scalar-color-1);
 
   --scalar-color-alert: color-mix(in srgb, var(--scalar-color-orange), var(--scalar-color-1) 20%);
   --scalar-color-danger: color-mix(in srgb, var(--scalar-color-red), var(--scalar-color-1) 20%);
@@ -92,8 +92,8 @@
   --scalar-button-1-hover: rgba(255, 255, 255, 0.9);
   --scalar-button-1-color: black;
 
-  --scalar-tooltip-background: color-mix(in srgb, var(--scalar-background-1), #fff 10%);
-  --scalar-tooltip-color: color-mix(in srgb, #fff, transparent 5%);
+  --scalar-tooltip-background: var(--scalar-background-1);
+  --scalar-tooltip-color: var(--scalar-color-1);
 
   --scalar-color-danger: color-mix(in srgb, var(--scalar-color-red), var(--scalar-background-1) 20%);
 


### PR DESCRIPTION
**Changes**

this pr updates the scalar tooltip style to be consistent with other tooltip like element usage.

| state | preview |
| -------|------|
| before | <img width="343" height="211" alt="image" src="https://github.com/user-attachments/assets/1f4c40e3-4afc-4979-a63d-dcf78428224c" /> <img width="343" height="211" alt="image" src="https://github.com/user-attachments/assets/6b684a36-1c70-40a9-a496-14b1ee3a5dfc" /> |
| after | <img width="343" height="211" alt="image" src="https://github.com/user-attachments/assets/e41ce549-9294-4b16-9108-354709971463" /> <img width="343" height="211" alt="image" src="https://github.com/user-attachments/assets/7178bb0f-e6ce-448a-a1ce-e7be975aa4f2" /> | 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
