### PR TITLE
fix(api-client): server variables dropdown always open

### DIFF
--- a/.changeset/poor-rocks-worry.md
+++ b/.changeset/poor-rocks-worry.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: server variables dropdown caret alway open

--- a/packages/api-client/src/components/Server/ServerVariablesForm.vue
+++ b/packages/api-client/src/components/Server/ServerVariablesForm.vue
@@ -39,7 +39,8 @@ const getVariable = (name: string) => {
       <label
         class="group/label flex w-full"
         :class="
-          layout === 'reference' && 'border-x border-b last:rounded-b-lg'
+          layout === 'reference' &&
+          'items-center border-x border-b last:rounded-b-lg'
         ">
         <span
           class="flex items-center py-1.5 pl-3 group-has-[input]/label:mr-0 after:content-[':']">

--- a/packages/api-client/src/components/Server/ServerVariablesSelect.vue
+++ b/packages/api-client/src/components/Server/ServerVariablesSelect.vue
@@ -32,7 +32,7 @@ const selected = computed<ScalarListboxOption | undefined>({
     :options="options">
     <ScalarButton
       :aria-controls="controls"
-      class="h-8 gap-1.5 p-1.5 text-base font-normal"
+      class="group/button h-8 gap-1.5 p-1.5 text-base font-normal"
       variant="ghost">
       <span :class="{ 'text-c-1': value }">
         <span
@@ -44,7 +44,7 @@ const selected = computed<ScalarListboxOption | undefined>({
       </span>
       <ScalarIconCaretDown
         weight="bold"
-        class="ui-open:rotate-180 mt-0.25 size-3 transition-transform duration-100" />
+        class="mt-0.25 size-3 transition-transform duration-100 group-aria-expanded/button:rotate-180" />
     </ScalarButton>
   </ScalarListbox>
 </template>


### PR DESCRIPTION
**Changes**

this pr updates the server variables dropdown utility used to rotate the icon that is always set on open due to conflicted state in the api client as being nested within another dropdown.

| state | preview |
| -------|------|
| before | <img width="525" height="298" alt="image" src="https://github.com/user-attachments/assets/c3c3153b-1c30-4aca-b682-537db65cd5c0" /> |
| after | <img width="525" height="298" alt="image" src="https://github.com/user-attachments/assets/650c1f82-8040-4ea5-955f-fcb9e911182a" /> | 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
