### PR TITLE
fix(api-client): request auth not displayed when wrapping

### DIFF
--- a/.changeset/silver-hornets-exercise.md
+++ b/.changeset/silver-hornets-exercise.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: request auth tab not displayed when overflowing

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
@@ -76,7 +76,7 @@ watch(
   <form @submit.prevent>
     <div
       v-if="selectedSchemeOptions.length > 1"
-      class="box-content flex h-8 flex-wrap gap-x-2.5 overflow-hidden border border-b-0 px-3"
+      class="box-content flex flex-wrap gap-x-2.5 overflow-hidden border border-b-0 px-3"
       :class="layout === 'client' && 'border-x-0'">
       <div
         v-for="(option, index) in selectedSchemeOptions"


### PR DESCRIPTION
**Changes**

this pr removes a fixed height set in request auth in order to keep auth tab getting displayed when wrapping - a lot are selected.

| state | preview |
| -------|------|
| before | <img width="612" height="211" alt="image" src="https://github.com/user-attachments/assets/47a3963d-5630-439c-a6ac-8e4e69baa2c0" /> |
| after | <img width="612" height="211" alt="image" src="https://github.com/user-attachments/assets/c1764893-cfe7-4071-ab0d-7929d3990ccc" /> | 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
