### PR TITLE
fix(workspace-store): never write overrides back to the intermediate state

### DIFF
--- a/.changeset/smart-avocados-hammer.md
+++ b/.changeset/smart-avocados-hammer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix(workspace-store): never write overrides back to the intermediate state

--- a/packages/workspace-store/README.md
+++ b/packages/workspace-store/README.md
@@ -276,7 +276,7 @@ store.addDocumentSync({
 })
 ```
 
-To get the active document configuration you can use config getter\
+To get the active document configuration you can use config getter
 
 ```ts
 // Get the configuration for the active document
@@ -416,15 +416,55 @@ Create the workspace from a specification object
 
 ```ts
 await store.importWorkspaceFromSpecification({
-  workspace: 'v1',
+  workspace: 'draft',
   info: { title: 'My Workspace' },
   documents: {
     api: { $ref: '/examples/api.yaml' },
-    petstore: { $ref: '/examples/petstore.yaml' }
+    petstore: { $ref: '/examples/petstore.yaml' },
   },
   overrides: {
-    api: { config: { features: { showModels: true } } }
+    api: {
+      servers: [
+        {
+          url: 'http://localhost:9090',
+        },
+      ],
+    },
   },
-  "x-scalar-dark-mode": true
+  'x-scalar-dark-mode': true,
 })
 ```
+
+### Override specific fields from the document and it's metadata
+
+This feature is helpful when you want to override specific fields in a document without altering the original source. Overrides allow you to customize certain values in-memory, ensuring the original document remains unchanged.
+
+```ts
+const store = createWorkspaceStore()
+await store.addDocument({
+  name: 'default',
+  document: {
+    openapi: '3.1.0',
+    info: {
+      title: 'Document Title',
+      version: '1.0.0',
+    },
+    paths: {},
+    components: {
+      schemas: {},
+    },
+    servers: [],
+  },
+  // Override the servers field
+  overrides: {
+    servers: [
+      {
+        url: 'http://localhost:8080',
+        description: 'Default dev server'
+      }
+    ]
+  }
+})
+```
+
+When you override specific fields, those changes are applied only in-memory and will never be written back to the original document. The original source remains unchanged, and any modifications made through overrides are isolated to the current session.

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -958,6 +958,7 @@ describe('create-workspace-store', () => {
               'paths': { '/users': { 'get': { 'description': 'Get all users' } } },
             },
           },
+          overrides: { default: {}, 'pet-store': {} },
         }),
       )
     })
@@ -1124,7 +1125,7 @@ describe('create-workspace-store', () => {
       expect(defaultDocument.openapi).toBe('3.1.1')
     })
 
-    it('writes back the overrides to the intermediate object', async () => {
+    it('does not write back the overrides to the intermediate object', async () => {
       const store = createWorkspaceStore({
         documents: [
           {
@@ -1155,7 +1156,7 @@ describe('create-workspace-store', () => {
 
       store.saveDocument('default')
       expect(store.exportDocument('default', 'json')).toBe(
-        '{"openapi":"3.1.1","info":{"title":"Edited title","version":"2.0.0"}}',
+        '{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"}}',
       )
     })
 
@@ -1200,6 +1201,7 @@ describe('create-workspace-store', () => {
       expect(newStore.workspace.documents['default']?.openapi).toBe('3.1.1')
     })
 
+    // TODO: check how we can revert changes made to the overrides
     it('should revert the changes made to the overrides', async () => {
       const store = createWorkspaceStore({
         documents: [
@@ -1273,7 +1275,7 @@ describe('create-workspace-store', () => {
       })
 
       expect(store.exportWorkspace()).toBe(
-        '{"documents":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}},"x-scalar-navigation":[{"id":"Get all users","title":"Get all users","path":"/users","method":"get","ref":"#/paths/~1users/get","type":"operation"},{"id":"","title":"Models","children":[{"id":"User","title":"User","name":"User","ref":"#/content/components/schemas/User","type":"model"}],"type":"text"}]}},"meta":{},"documentConfigs":{"default":{}},"originalDocuments":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}}}},"intermediateDocuments":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}}}}}',
+        '{"documents":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}},"x-scalar-navigation":[{"id":"Get all users","title":"Get all users","path":"/users","method":"get","ref":"#/paths/~1users/get","type":"operation"},{"id":"","title":"Models","children":[{"id":"User","title":"User","name":"User","ref":"#/content/components/schemas/User","type":"model"}],"type":"text"}]}},"meta":{},"documentConfigs":{"default":{}},"originalDocuments":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}}}},"intermediateDocuments":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}}}},"overrides":{"default":{}}}',
       )
     })
 

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -286,9 +286,6 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
 
     // Create a proxied document with magic proxy and apply any overrides, then store it in the workspace documents map
     workspace.documents[name] = createOverridesProxy(createMagicProxy({ ...document, ...meta }), input.overrides)
-
-    // Write overrides to the intermediate document
-    saveDocument(name)
   }
 
   // Asynchronously adds a new document to the workspace by loading and validating the input.

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -246,8 +246,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     }
 
     // Obtain the raw state of the current document to ensure accurate diffing
-    // Remove the magic proxy while preserving the overrides proxy to ensure accurate updates
-    const updatedDocument = createOverridesProxy(getRaw(workspaceDocument), overrides[documentName])
+    const updatedDocument = getRaw(workspaceDocument)
 
     // If either the intermediate or updated document is missing, do nothing
     if (!intermediateDocument || !updatedDocument) {
@@ -588,9 +587,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
 
       const intermediateDocument = intermediateDocuments[documentName]
       // Get the raw state of the current document to avoid diffing resolved references.
-      // This ensures we update the actual data, not the references.
-      // Note: We keep the Vue proxy for reactivity by updating the object in place.
-      const updatedDocument = createOverridesProxy(getRaw(workspaceDocument), overrides[documentName])
+      const updatedDocument = getRaw(workspaceDocument)
 
       if (!intermediateDocument || !updatedDocument) {
         return
@@ -639,6 +636,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
         documentConfigs,
         originalDocuments,
         intermediateDocuments,
+        overrides,
       } as InMemoryWorkspace)
     },
     /**
@@ -662,6 +660,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       safeAssign(originalDocuments, result.originalDocuments)
       safeAssign(intermediateDocuments, result.intermediateDocuments)
       safeAssign(documentConfigs, result.documentConfigs)
+      safeAssign(overrides, result.overrides)
       safeAssign(workspace, result.meta)
     },
     /**

--- a/packages/workspace-store/src/schemas/inmemory-workspace.ts
+++ b/packages/workspace-store/src/schemas/inmemory-workspace.ts
@@ -1,3 +1,4 @@
+import { PartialDeep } from '@/schemas/typebox-types'
 import { WorkspaceDocumentSchema, WorkspaceMetaSchema } from '@/schemas/workspace'
 import { ConfigSchema } from '@/schemas/workspace-specification/config'
 import { Type, type Static } from '@sinclair/typebox'
@@ -8,6 +9,7 @@ export const InMemoryWorkspaceSchema = Type.Object({
   documents: Type.Record(Type.String(), WorkspaceDocumentSchema),
   originalDocuments: Type.Record(Type.String(), WorkspaceDocumentSchema),
   intermediateDocuments: Type.Record(Type.String(), WorkspaceDocumentSchema),
+  overrides: Type.Record(Type.String(), PartialDeep(WorkspaceDocumentSchema)),
 })
 
 export type InMemoryWorkspace = Static<typeof InMemoryWorkspaceSchema>

--- a/packages/workspace-store/src/schemas/typebox-types.ts
+++ b/packages/workspace-store/src/schemas/typebox-types.ts
@@ -1,0 +1,60 @@
+/**
+ * See: https://github.com/sinclairzx81/typebox/discussions/835
+ */
+
+import {
+  TypeGuard,
+  Type,
+  type TSchema,
+  type TIntersect,
+  type TUnion,
+  type TObject,
+  type TPartial,
+  type TProperties,
+  type Evaluate,
+} from '@sinclair/typebox'
+
+// -------------------------------------------------------------------------------------
+// TPartialDeepProperties
+// -------------------------------------------------------------------------------------
+export type TPartialDeepProperties<T extends TProperties> = {
+  [K in keyof T]: TPartialDeep<T[K]>
+}
+function PartialDeepProperties<T extends TProperties>(properties: T): TPartialDeepProperties<T> {
+  return Object.getOwnPropertyNames(properties).reduce((acc, key) => {
+    return { ...acc, [key]: PartialDeep(properties[key] as any) }
+  }, {}) as never
+}
+// -------------------------------------------------------------------------------------
+// TPartialDeepRest
+// -------------------------------------------------------------------------------------
+export type TPartialDeepRest<T extends TSchema[], Acc extends TSchema[] = []> = T extends [
+  infer L extends TSchema,
+  ...infer R extends TSchema[],
+]
+  ? TPartialDeepRest<R, [...Acc, TPartialDeep<L>]>
+  : Acc
+function PartialDeepRest<T extends TSchema[]>(rest: [...T]): TPartialDeepRest<T> {
+  return rest.map((schema) => PartialDeep(schema)) as never
+}
+// -------------------------------------------------------------------------------------
+// TPartialDeep
+// -------------------------------------------------------------------------------------
+export type TPartialDeep<T extends TSchema> = T extends TIntersect<infer S>
+  ? TIntersect<TPartialDeepRest<S>>
+  : T extends TUnion<infer S>
+    ? TUnion<TPartialDeepRest<S>>
+    : T extends TObject<infer S>
+      ? TPartial<TObject<Evaluate<TPartialDeepProperties<S>>>>
+      : T
+export function PartialDeep<T extends TSchema>(schema: T): TPartialDeep<T> {
+  return (
+    TypeGuard.IsIntersect(schema)
+      ? Type.Intersect(PartialDeepRest(schema.allOf))
+      : TypeGuard.IsUnion(schema)
+        ? Type.Union(PartialDeepRest(schema.anyOf))
+        : TypeGuard.IsObject(schema)
+          ? Type.Partial(Type.Object(PartialDeepProperties(schema.properties)))
+          : schema
+  ) as never
+}


### PR DESCRIPTION
**Problem**

Currently, overrides are being written back to the intermediate state, which is incorrect. The purpose of overrides is to provide a temporary, in-memory layer of changes without modifying the underlying document state.

**Solution**

This PR ensures that **overrides—and any changes made to them—are kept entirely in-memory** and are no longer propagated back to the intermediate state. This preserves the integrity of the original document while still allowing temporary modifications through the override mechanism.



**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
