### PR TITLE
docs(api-reference): `pathRouting` example does not work as intended

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -793,7 +793,7 @@ Configuration for path-based routing instead of hash-based routing. Your server 
 ```js
 {
   pathRouting: {
-    basePath: '/standalone-api-reference/:custom(.*)?'
+    basePath: '/standalone-api-reference'
   }
 }
 ```


### PR DESCRIPTION
The current example for the `pathRouting` setting does not really work as I’d expect it to work. It looks like a routing regex pattern, but it’s actually just a string.

Found out when I wrote a e2e test for it.

I don’t know what the initial intention was, but a regular string does what it should do.