### PR TITLE
feat(api-reference): parameter linking

### DIFF
--- a/.changeset/clean-hounds-pump.md
+++ b/.changeset/clean-hounds-pump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: link to parameters

--- a/packages/api-reference/src/components/Anchor/WithBreadcrumb.vue
+++ b/packages/api-reference/src/components/Anchor/WithBreadcrumb.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { scrollToId } from '@scalar/helpers/dom/scroll-to-id'
+import { sleep } from '@scalar/helpers/testing/sleep'
+import { ScalarIconLink } from '@scalar/icons'
+import { useClipboard } from '@scalar/use-hooks/useClipboard'
+import { computed } from 'vue'
+
+import { useNavState } from '@/hooks/useNavState'
+
+const { breadcrumb } = defineProps<{
+  breadcrumb?: string[]
+}>()
+
+const { copyToClipboard } = useClipboard()
+const { getHashedUrl, isIntersectionEnabled, replaceUrlState } = useNavState()
+
+const id = computed(() => breadcrumb?.join('.'))
+
+/**
+ * Copy the URL and scroll to the anchor
+ */
+const handleButtonClick = async () => {
+  if (!id.value) {
+    return
+  }
+
+  // Copy
+  copyToClipboard(getHashedUrl(id.value))
+
+  // Disable intersection observer before we scroll
+  isIntersectionEnabled.value = false
+
+  replaceUrlState(id.value)
+  scrollToId(id.value, true)
+
+  await sleep(100)
+
+  // Re-enable intersection observer
+  isIntersectionEnabled.value = true
+}
+</script>
+
+<template>
+  <template v-if="breadcrumb">
+    <!-- Invisble container for the anchor -->
+    <span
+      :id="id"
+      class="pointer-events-none invisible absolute top-[-25px]">
+    </span>
+    <div class="group">
+      <div class="flex">
+        <!-- Content -->
+        <slot></slot>
+        <!-- Copy button -->
+        <ScalarIconLink
+          class="text-c-3 hover:text-c-1 left-0 ml-1 size-4 cursor-pointer"
+          weight="bold"
+          @click="handleButtonClick" />
+      </div>
+    </div>
+  </template>
+  <template v-else>
+    <slot />
+  </template>
+</template>

--- a/packages/api-reference/src/components/Anchor/WithBreadcrumb.vue
+++ b/packages/api-reference/src/components/Anchor/WithBreadcrumb.vue
@@ -42,20 +42,22 @@ const handleButtonClick = async () => {
 
 <template>
   <template v-if="breadcrumb">
-    <!-- Invisble container for the anchor -->
+    <!-- Invisble container for the anchor, adds an offset to the top of the page -->
     <span
       :id="id"
       class="pointer-events-none invisible absolute top-[-25px]">
     </span>
     <div class="group">
-      <div class="flex">
+      <div
+        class="flex"
+        role="button"
+        @click="handleButtonClick">
         <!-- Content -->
         <slot></slot>
         <!-- Copy button -->
         <ScalarIconLink
           class="text-c-3 hover:text-c-1 left-0 ml-1 size-4 cursor-pointer"
-          weight="bold"
-          @click="handleButtonClick" />
+          weight="bold" />
       </div>
     </div>
   </template>

--- a/packages/api-reference/src/components/Anchor/index.ts
+++ b/packages/api-reference/src/components/Anchor/index.ts
@@ -1,1 +1,2 @@
 export { default as Anchor } from './Anchor.vue'
+export { default as WithBreadcrumb } from './WithBreadcrumb.vue'

--- a/packages/api-reference/src/components/Content/Models/ModernLayout.vue
+++ b/packages/api-reference/src/components/Content/Models/ModernLayout.vue
@@ -75,6 +75,7 @@ const models = computed(() => {
           <ScalarErrorBoundary>
             <Schema
               noncollapsible
+              :breadcrumb="[id]"
               :hideHeading="true"
               :hideModelNames="true"
               :schemas="schemas"

--- a/packages/api-reference/src/components/Content/Models/ModernLayout.vue
+++ b/packages/api-reference/src/components/Content/Models/ModernLayout.vue
@@ -75,7 +75,6 @@ const models = computed(() => {
           <ScalarErrorBoundary>
             <Schema
               noncollapsible
-              :breadcrumb="[id]"
               :hideHeading="true"
               :hideModelNames="true"
               :schemas="schemas"

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -46,6 +46,8 @@ const props = withDefaults(
     discriminatorPropertyName?: string
     /** Whether the schema has a discriminator */
     hasDiscriminator?: boolean
+    /** Breadcrumb for the schema */
+    breadcrumb?: string[]
   }>(),
   { level: 0, noncollapsible: false, hideModelNames: false },
 )
@@ -237,6 +239,7 @@ const handleDiscriminatorChange = (type: string) => {
           <!-- Object properties -->
           <SchemaObjectProperties
             v-if="isTypeObject(schema)"
+            :breadcrumb="breadcrumb"
             :schema="schema"
             :compact="compact"
             :hideHeading="hideHeading"
@@ -253,6 +256,7 @@ const handleDiscriminatorChange = (type: string) => {
           <template v-else>
             <SchemaProperty
               v-if="schema"
+              :breadcrumb="breadcrumb"
               :compact="compact"
               :hideHeading="hideHeading"
               :hideModelNames="hideModelNames"

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -22,6 +22,7 @@ const { schemas, value, composition } = defineProps<{
   level: number
   compact?: boolean
   hideHeading?: boolean
+  breadcrumb?: string[]
 }>()
 
 const selectedIndex = ref(0)
@@ -177,6 +178,7 @@ const shouldRenderSchema = computed(() => {
           (s: any) => !s.oneOf && !s.anyOf,
         )"
         :key="index"
+        :breadcrumb="breadcrumb"
         :compact="compact"
         :level="level"
         :name="name"
@@ -204,6 +206,7 @@ const shouldRenderSchema = computed(() => {
       <div class="composition-panel">
         <Schema
           v-if="shouldRenderSchema"
+          :breadcrumb="breadcrumb"
           :compact="compact"
           :level="level + 1"
           :hideHeading="hideHeading"
@@ -222,6 +225,7 @@ const shouldRenderSchema = computed(() => {
         <!-- Nested tabs -->
         <template v-if="compositionSchema?.oneOf || compositionSchema?.anyOf">
           <SchemaComposition
+            :breadcrumb="breadcrumb"
             :compact="compact"
             :composition="compositionType"
             :hideHeading="hideHeading"
@@ -237,6 +241,7 @@ const shouldRenderSchema = computed(() => {
     </template>
     <template v-else>
       <Schema
+        :breadcrumb="breadcrumb"
         :compact="compact"
         :level="level"
         :name="name"

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
@@ -16,6 +16,7 @@ const { level = 0, hideModelNames = false } = defineProps<{
   discriminatorMapping?: Record<string, string>
   discriminatorPropertyName?: string
   hasDiscriminator?: boolean
+  breadcrumb?: string[]
 }>()
 
 const emit = defineEmits<{
@@ -75,12 +76,12 @@ const getAdditionalPropertiesValue = (
 </script>
 
 <template>
-  <!-- <pre><code>{{ schema }}</code></pre> -->
   <!-- Properties -->
   <template v-if="schema.properties">
     <SchemaProperty
       v-for="property in Object.keys(schema.properties)"
       :key="property"
+      :breadcrumb="breadcrumb"
       :compact="compact"
       :hideHeading="hideHeading"
       :level="level"
@@ -116,6 +117,7 @@ const getAdditionalPropertiesValue = (
   <!-- patternProperties -->
   <template v-if="schema.patternProperties">
     <SchemaProperty
+      :breadcrumb="breadcrumb"
       v-for="property in Object.keys(schema.patternProperties)"
       :key="property"
       variant="patternProperties"
@@ -139,6 +141,7 @@ const getAdditionalPropertiesValue = (
   <!-- additionalProperties -->
   <template v-if="schema.additionalProperties">
     <SchemaProperty
+      :breadcrumb="breadcrumb"
       variant="additionalProperties"
       :compact="compact"
       :hideHeading="hideHeading"

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -290,6 +290,7 @@ const shouldRenderObjectProperties = computed(() => {
       class="children">
       <Schema
         :compact="compact"
+        :breadcrumb="breadcrumb"
         :level="level + 1"
         :name="name"
         :noncollapsible="noncollapsible"

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -2,6 +2,7 @@
 import { ScalarMarkdown } from '@scalar/components'
 import { computed, inject, type Component } from 'vue'
 
+import { WithBreadcrumb } from '@/components/Anchor'
 import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
 import type { Schemas } from '@/features/Operation/types/schemas'
 import { SpecificationExtension } from '@/features/specification-extension'
@@ -42,6 +43,7 @@ const props = withDefaults(
     discriminatorPropertyName?: string
     isDiscriminator?: boolean
     variant?: 'additionalProperties' | 'patternProperties'
+    breadcrumb?: string[]
   }>(),
   {
     level: 0,
@@ -243,19 +245,22 @@ const shouldRenderObjectProperties = computed(() => {
       <template
         v-if="name"
         #name>
-        <template v-if="variant === 'patternProperties'">
-          <span class="property-name-pattern-properties">
+        <WithBreadcrumb
+          :breadcrumb="breadcrumb ? [...breadcrumb, name] : undefined">
+          <template v-if="variant === 'patternProperties'">
+            <span class="property-name-pattern-properties">
+              {{ name }}
+            </span>
+          </template>
+          <template v-else-if="variant === 'additionalProperties'">
+            <span class="property-name-additional-properties">
+              {{ name }}
+            </span>
+          </template>
+          <template v-else>
             {{ name }}
-          </span>
-        </template>
-        <template v-else-if="variant === 'additionalProperties'">
-          <span class="property-name-additional-properties">
-            {{ name }}
-          </span>
-        </template>
-        <template v-else>
-          {{ name }}
-        </template>
+          </template>
+        </WithBreadcrumb>
       </template>
       <template
         v-if="optimizedValue?.example"
@@ -338,6 +343,7 @@ const shouldRenderObjectProperties = computed(() => {
           )
         ">
         <SchemaComposition
+          :breadcrumb="breadcrumb"
           :compact="compact"
           :composition="composition"
           :hideHeading="hideHeading"
@@ -353,6 +359,7 @@ const shouldRenderObjectProperties = computed(() => {
         v-else-if="shouldRenderArrayItemComposition(composition)"
         :key="composition">
         <SchemaComposition
+          :breadcrumb="breadcrumb"
           :compact="compact"
           :composition="composition"
           :hideHeading="hideHeading"

--- a/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
+++ b/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
@@ -1,23 +1,23 @@
 <script setup lang="ts">
 import { cva, ScalarButton, ScalarListbox } from '@scalar/components'
 import { ScalarIconCaretDown } from '@scalar/icons'
-import type { ContentType, RequestBody } from '@scalar/types/legacy'
+import type { RequestBody } from '@scalar/types/legacy'
 import { computed, ref } from 'vue'
 
 import ScreenReader from '@/components/ScreenReader.vue'
 
 const prop = defineProps<{
   requestBody?: RequestBody
-  defaultValue?: ContentType
+  defaultValue?: string
 }>()
 
 const emit = defineEmits<{
-  (e: 'selectContentType', payload: { contentType: ContentType }): void
+  (e: 'selectContentType', payload: { contentType: string }): void
 }>()
 
 const handleSelectContentType = (option: any) => {
   if (option?.id) {
-    emit('selectContentType', { contentType: option.id as ContentType })
+    emit('selectContentType', { contentType: option.id })
   }
 }
 
@@ -28,8 +28,8 @@ const contentTypes = computed(() => {
   return []
 })
 
-const selectedContentType = ref<ContentType>(
-  prop.defaultValue || (contentTypes.value[0] as ContentType),
+const selectedContentType = ref<string>(
+  prop.defaultValue || contentTypes.value[0],
 )
 
 const selectedOption = computed({
@@ -37,7 +37,7 @@ const selectedOption = computed({
     options.value.find((option) => option.id === selectedContentType.value),
   set: (option) => {
     if (option) {
-      selectedContentType.value = option.id as ContentType
+      selectedContentType.value = option.id
     }
   },
 })

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.vue
@@ -11,6 +11,7 @@ const {
   requestBody,
   schemas,
 } = defineProps<{
+  breadcrumb?: string[]
   parameters?: OpenAPIV3_1.ParameterObject[]
   requestBody?: OpenAPIV3_1.RequestBodyObject | undefined
   schemas?: Schemas
@@ -30,6 +31,7 @@ const filterParameters = (where: 'path' | 'query' | 'header' | 'cookie') =>
 <template>
   <!-- Path parameters-->
   <ParameterList
+    :breadcrumb="breadcrumb ? [...breadcrumb, 'path'] : undefined"
     :parameters="filterParameters('path')"
     :schemas="schemas">
     <template #title>Path Parameters</template>
@@ -37,6 +39,7 @@ const filterParameters = (where: 'path' | 'query' | 'header' | 'cookie') =>
 
   <!-- Query parameters -->
   <ParameterList
+    :breadcrumb="breadcrumb ? [...breadcrumb, 'query'] : undefined"
     :parameters="filterParameters('query')"
     :schemas="schemas">
     <template #title>Query Parameters</template>
@@ -44,6 +47,7 @@ const filterParameters = (where: 'path' | 'query' | 'header' | 'cookie') =>
 
   <!-- Headers -->
   <ParameterList
+    :breadcrumb="breadcrumb ? [...breadcrumb, 'headers'] : undefined"
     :parameters="filterParameters('header')"
     :schemas="schemas">
     <template #title>Headers</template>
@@ -51,6 +55,7 @@ const filterParameters = (where: 'path' | 'query' | 'header' | 'cookie') =>
 
   <!-- Cookies -->
   <ParameterList
+    :breadcrumb="breadcrumb ? [...breadcrumb, 'cookies'] : undefined"
     :parameters="filterParameters('cookie')"
     :schemas="schemas">
     <template #title>Cookies</template>
@@ -59,6 +64,7 @@ const filterParameters = (where: 'path' | 'query' | 'header' | 'cookie') =>
   <!-- Request body -->
   <RequestBody
     v-if="requestBody"
+    :breadcrumb="breadcrumb ? [...breadcrumb, 'body'] : undefined"
     :requestBody="requestBody"
     :schemas="schemas"
     @update:modelValue="handleDiscriminatorChange">

--- a/packages/api-reference/src/features/Operation/components/OperationResponses.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationResponses.vue
@@ -9,6 +9,7 @@ const props = withDefaults(
     responses: OpenAPIV3_1.ResponseObject | undefined
     collapsableItems?: boolean
     schemas?: Record<string, OpenAPIV3_1.SchemaObject> | unknown
+    breadcrumb?: string[]
   }>(),
   {
     collapsableItems: true,
@@ -19,6 +20,7 @@ const { responses } = useResponses(props.responses)
 </script>
 <template>
   <ParameterList
+    :breadcrumb="breadcrumb ? [...breadcrumb, 'responses'] : undefined"
     :collapsableItems="collapsableItems"
     :parameters="responses"
     :schemas="schemas"

--- a/packages/api-reference/src/features/Operation/components/OperationResponses.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationResponses.vue
@@ -20,7 +20,6 @@ const { responses } = useResponses(props.responses)
 </script>
 <template>
   <ParameterList
-    :breadcrumb="breadcrumb ? [...breadcrumb, 'responses'] : undefined"
     :collapsableItems="collapsableItems"
     :parameters="responses"
     :schemas="schemas"

--- a/packages/api-reference/src/features/Operation/components/ParameterHeaders.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterHeaders.vue
@@ -7,6 +7,7 @@ import SchemaProperty from '@/components/Content/Schema/SchemaProperty.vue'
 
 defineProps<{
   headers: { [key: string]: OpenAPIV3_1.HeaderObject }
+  breadcrumb?: string[]
 }>()
 
 function hasSchema(
@@ -38,6 +39,7 @@ function hasSchema(
         </DisclosureButton>
         <DisclosurePanel>
           <SchemaProperty
+            :breadcrumb="breadcrumb ? [...breadcrumb, 'headers'] : undefined"
             v-for="(header, key) in headers"
             :key="key"
             :description="header.description"

--- a/packages/api-reference/src/features/Operation/components/ParameterList.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterList.vue
@@ -11,6 +11,7 @@ withDefaults(
     collapsableItems?: boolean
     withExamples?: boolean
     schemas?: Record<string, OpenAPIV3_1.SchemaObject> | unknown
+    breadcrumb?: string[]
   }>(),
   {
     showChildren: false,
@@ -30,6 +31,7 @@ withDefaults(
       <ParameterListItem
         v-for="item in parameters"
         :key="item.name"
+        :breadcrumb="breadcrumb"
         :collapsableItems="collapsableItems"
         :parameter="item"
         :schemas="schemas"

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -94,6 +94,7 @@ const shouldShowParameter = computed(() => {
         :static="!shouldCollapse">
         <ParameterHeaders
           v-if="parameter.headers"
+          :breadcrumb="breadcrumb"
           :headers="parameter.headers" />
         <SchemaProperty
           is="div"

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -22,6 +22,7 @@ const props = withDefaults(
     collapsableItems?: boolean
     withExamples?: boolean
     schemas?: Record<string, OpenAPIV3_1.SchemaObject> | unknown
+    breadcrumb?: string[]
   }>(),
   {
     showChildren: false,
@@ -97,6 +98,7 @@ const shouldShowParameter = computed(() => {
         <SchemaProperty
           is="div"
           compact
+          :breadcrumb="breadcrumb"
           :description="shouldCollapse ? '' : parameter.description"
           :name="shouldCollapse ? '' : parameter.name"
           :noncollapsible="true"

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -5,7 +5,6 @@ import { ScalarIconCaretRight } from '@scalar/icons'
 import type { Request as RequestEntity } from '@scalar/oas-utils/entities/spec'
 import { isDefined } from '@scalar/oas-utils/helpers'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
-import type { ContentType } from '@scalar/types/legacy'
 import { computed, ref } from 'vue'
 
 import { SchemaProperty } from '@/components/Content/Schema'
@@ -37,9 +36,7 @@ const contentTypes = computed(() => {
   }
   return []
 })
-const selectedContentType = ref<ContentType>(
-  contentTypes.value[0] as ContentType,
-)
+const selectedContentType = ref<string>(contentTypes.value[0])
 if (props.parameter.content) {
   if ('application/json' in props.parameter.content) {
     selectedContentType.value = 'application/json'

--- a/packages/api-reference/src/features/Operation/components/callbacks/Callback.vue
+++ b/packages/api-reference/src/features/Operation/components/callbacks/Callback.vue
@@ -17,6 +17,7 @@ const { method, name, schemas, url } = defineProps<{
   name: string
   schemas?: Schemas
   url: string
+  breadcrumb?: string[]
 }>()
 </script>
 

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -109,12 +109,14 @@ const handleDiscriminatorChange = (type: string) => {
               transformType="heading"
               :anchorPrefix="id" />
             <OperationParameters
+              :breadcrumb="[id]"
               :parameters
               :requestBody="oldOperation.requestBody"
               :schemas
               @update:modelValue="handleDiscriminatorChange">
             </OperationParameters>
             <OperationResponses
+              :breadcrumb="[id]"
               :responses="oldOperation.responses"
               :schemas="schemas" />
 

--- a/packages/api-reference/test/features/parameter-linking.e2e.ts
+++ b/packages/api-reference/test/features/parameter-linking.e2e.ts
@@ -1,0 +1,98 @@
+import { expect, test } from '@playwright/test'
+import { serveExample } from '@test/utils/serve-example'
+
+// TODO:
+// - pathRouting
+// - all parameters
+// - requestBody
+
+test.describe('parameter linking', () => {
+  test.use({
+    permissions: ['clipboard-write', 'clipboard-read'],
+  })
+
+  test('requestBody parameters have anchor links', async ({ page }) => {
+    const example = await serveExample({
+      // If it works with pathRouting, it probably works without it too.
+      pathRouting: {
+        basePath: '/custom-base-path',
+      },
+      content: {
+        openapi: '3.1.1',
+        info: {
+          title: 'Test API',
+          version: '1.0.0',
+        },
+        paths: {
+          '/users': {
+            get: {
+              summary: 'Get all users',
+              tags: ['user-tag'],
+              parameters: [
+                {
+                  name: 'myCustomQueryParameter',
+                  in: 'query',
+                  required: true,
+                },
+                {
+                  name: 'myCustomHeaderParameter',
+                  in: 'header',
+                  required: true,
+                },
+                {
+                  name: 'myCustomPathParameter',
+                  in: 'path',
+                  required: true,
+                },
+                {
+                  name: 'myCustomCookieParameter',
+                  in: 'cookie',
+                  required: true,
+                },
+              ],
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        myCustomBodyParameter: { type: 'string' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    // Set viewport to a small height to test that the button is not in the viewport
+    await page.setViewportSize({ width: 1024, height: 200 })
+
+    await page.goto(example)
+
+    // Before
+    await expect(page.getByRole('button', { name: 'myCustomQueryParameter', exact: true })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'myCustomHeaderParameter', exact: true })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'myCustomPathParameter', exact: true })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'myCustomCookieParameter', exact: true })).toBeVisible()
+
+    const button = page.getByRole('button', { name: 'myCustomBodyParameter', exact: true })
+    await expect(button).toBeVisible()
+    await expect(button).not.toBeInViewport()
+
+    // Click
+    await page.getByRole('button', { name: 'myCustomBodyParameter' }).click()
+
+    // After
+    await expect(button).toBeInViewport()
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText())
+    expect(clipboard).toContain('myCustomBodyParameter')
+
+    await page.reload()
+
+    await expect(button).toBeInViewport()
+  })
+})


### PR DESCRIPTION
**Problem**

If you’d like to redirect a user to a specific operation parameter (e.g. in support), you’ve got no way to do this.

**Solution**

This PR adds an ID to all the parameters (operation.requestBody && operation.parameters), that you can copy as an URL share as an URL with others.

**Preview**

<img width="602" height="712" alt="Screenshot 2025-08-01 at 11 31 37" src="https://github.com/user-attachments/assets/2758f620-9606-4c3f-b00b-71f9c84e8397" />

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
