### PR TITLE
fix(api-reference): test expects just one external request

### DIFF
--- a/packages/api-reference/test/configuration/with-default-fonts.e2e.ts
+++ b/packages/api-reference/test/configuration/with-default-fonts.e2e.ts
@@ -16,7 +16,7 @@ test.describe('withDefaultFonts', () => {
     await page.goto(example)
 
     // Verify that font requests were made to fonts.scalar.com
-    expect(fontRequests).toHaveLength(1)
+    expect(fontRequests.length).toBeGreaterThan(0)
   })
 
   test('does not load default fonts from fonts.scalar.com', async ({ page }) => {


### PR DESCRIPTION
**Problem**

We’ve added e2e tests for the configuration, and one was expecting exact 1 external request to `fonts.scalar.com`. But actually, it’s 2 requests. Whether we see both requests in the test, is a matter of time.

**Solution**

I don’t think we need to wait for both requests to got out, it’s enough to know that at least one request goes out. So I’ve updated the test to just check whether there was any request to `fonts.scalar.com`.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
