### PR TITLE
feat(api-reference): order object properties required > alphabetical

### DIFF
--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -258,4 +258,47 @@ describe('Schema', () => {
       })
     })
   })
+
+  describe('object property order', () => {
+    it('should render properties by required alphabetical order', () => {
+      const wrapper = mount(Schema, {
+        props: {
+          value: {
+            type: 'object',
+            properties: {
+              gOptional: { type: 'string' },
+              bOptional: { type: 'string' },
+              dRequired: { type: 'string' },
+              aOptional: { type: 'string' },
+              bRequired: { type: 'string' },
+              aRequired: { type: 'string' },
+              cRequired: { type: 'string' },
+            },
+            required: ['aRequired', 'bRequired', 'cRequired', 'dRequired'],
+          },
+        },
+      })
+
+      // Get all SchemaProperty components
+      const schemaProperties = wrapper.findAllComponents({ name: 'SchemaProperty' })
+
+      // Extract property names in the order they appear
+      const propertyNames = schemaProperties.map((prop) => prop.props('name'))
+
+      // Expected order: required properties first (alphabetical), then optional properties (alphabetical)
+      const expectedOrder = [
+        // Required properties
+        'aRequired',
+        'bRequired',
+        'cRequired',
+        'dRequired',
+        // Optional properties
+        'aOptional',
+        'bOptional',
+        'gOptional',
+      ]
+
+      expect(propertyNames).toEqual(expectedOrder)
+    })
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.test.ts
@@ -156,4 +156,51 @@ describe('SchemaObjectProperties', () => {
 
     expect(wrapper.findAll('.schema-property')).toHaveLength(0)
   })
+
+  it('sorts properties alphabetically when all have same required status', () => {
+    const schema: OpenAPIV3_1.SchemaObject = {
+      type: 'object',
+      properties: {
+        zebra: { type: 'string' },
+        alpha: { type: 'number' },
+        beta: { type: 'boolean' },
+      },
+    }
+
+    const wrapper = mount(SchemaObjectProperties, {
+      props: { schema },
+    })
+
+    const props = wrapper.findAll('.schema-property')
+    expect(props).toHaveLength(3)
+    expect(props[0].attributes('data-name')).toBe('alpha')
+    expect(props[1].attributes('data-name')).toBe('beta')
+    expect(props[2].attributes('data-name')).toBe('zebra')
+  })
+
+  it('sorts required properties first, then alphabetically', () => {
+    const schema: OpenAPIV3_1.SchemaObject = {
+      type: 'object',
+      properties: {
+        zebra: { type: 'string' },
+        alpha: { type: 'number' },
+        beta: { type: 'boolean' },
+        gamma: { type: 'object' },
+      },
+      required: ['zebra', 'gamma'],
+    }
+
+    const wrapper = mount(SchemaObjectProperties, {
+      props: { schema },
+    })
+
+    const props = wrapper.findAll('.schema-property')
+    expect(props).toHaveLength(4)
+    // Required properties should come first, sorted alphabetically
+    expect(props[0].attributes('data-name')).toBe('gamma')
+    expect(props[1].attributes('data-name')).toBe('zebra')
+    // Optional properties should come after, sorted alphabetically
+    expect(props[2].attributes('data-name')).toBe('alpha')
+    expect(props[3].attributes('data-name')).toBe('beta')
+  })
 })


### PR DESCRIPTION
**Problem**

Currently, we don't order properties.

**Solution**

With this PR we order them by required then alphabetical

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
