### PR TITLE
fix(api-reference): show empty query params and fill in path params in request example

### DIFF
--- a/.changeset/warm-pugs-switch.md
+++ b/.changeset/warm-pugs-switch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: show path parameter values in request exammples

--- a/.changeset/warm-pugs-switch.md
+++ b/.changeset/warm-pugs-switch.md
@@ -2,4 +2,4 @@
 '@scalar/oas-utils': patch
 ---
 
-fix: show path parameter values in request exammples
+fix: show path parameter values in request examples

--- a/packages/oas-utils/src/helpers/operation-to-har/operation-to-har.ts
+++ b/packages/oas-utils/src/helpers/operation-to-har/operation-to-har.ts
@@ -97,12 +97,22 @@ export const operationToHar = ({
     harRequest.postData = postData
     harRequest.bodySize = postData.text?.length ?? -1
 
-    // Add Content-Type header if not already present
-    if (postData.mimeType && !harRequest.headers.some((header) => header.name.toLowerCase() === 'content-type')) {
-      harRequest.headers.push({
-        name: 'Content-Type',
-        value: postData.mimeType,
-      })
+    // Add or update Content-Type header
+    if (postData.mimeType) {
+      const existingContentTypeHeader = harRequest.headers.find(
+        (header) => header.name.toLowerCase() === 'content-type',
+      )
+      // Update existing header if it has an empty value
+      if (existingContentTypeHeader && !existingContentTypeHeader.value) {
+        existingContentTypeHeader.value = postData.mimeType
+      }
+      // Add new header if none exists
+      else {
+        harRequest.headers.push({
+          name: 'Content-Type',
+          value: postData.mimeType,
+        })
+      }
     }
   }
 

--- a/packages/oas-utils/src/helpers/operation-to-har/process-parameters.test.ts
+++ b/packages/oas-utils/src/helpers/operation-to-har/process-parameters.test.ts
@@ -1783,7 +1783,7 @@ describe('parameter styles', () => {
       const operation: Dereference<OperationObject> = {
         parameters: [
           {
-            name: 'userEmail',
+            name: 'email',
             in: 'query',
             schema: {
               type: 'string',
@@ -1797,7 +1797,100 @@ describe('parameter styles', () => {
       const harRequest = createHarRequest('/api/users')
       const result = processParameters(harRequest, deReferenceParams(operation.parameters))
 
-      expect(result.queryString).toEqual([{ name: 'userEmail', value: '' }])
+      expect(result.queryString).toEqual([{ name: 'email', value: '' }])
+    })
+  })
+
+  describe('path parameters', () => {
+    it('should add variable name if no value or example is provided', () => {
+      const operation: Dereference<OperationObject> = {
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+        responses: {
+          '200': { description: 'OK' },
+        },
+      }
+      const harRequest = createHarRequest('/api/users/{username}')
+      const result = processParameters(harRequest, deReferenceParams(operation.parameters))
+
+      expect(result.url).toEqual('/api/users/{username}')
+    })
+
+    it('should replace the variable with the example value', () => {
+      const operation: Dereference<OperationObject> = {
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            schema: {
+              type: 'string',
+              example: 'scalarUser',
+            },
+          },
+        ],
+        responses: {
+          '200': { description: 'OK' },
+        },
+      }
+      const harRequest = createHarRequest('/api/users/{username}')
+      const result = processParameters(harRequest, deReferenceParams(operation.parameters))
+
+      expect(result.url).toEqual('/api/users/scalarUser')
+    })
+
+    it('should replace the variable with the upper example value', () => {
+      const operation: Dereference<OperationObject> = {
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            example: 'scalarUser',
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+        responses: {
+          '200': { description: 'OK' },
+        },
+      }
+      const harRequest = createHarRequest('/api/users/{username}')
+      const result = processParameters(harRequest, deReferenceParams(operation.parameters))
+
+      expect(result.url).toEqual('/api/users/scalarUser')
+    })
+
+    it('should replace the variable with the example value from examples', () => {
+      const operation: Dereference<OperationObject> = {
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            schema: {
+              type: 'string',
+            },
+            examples: {
+              'example1': {
+                value: 'scalarUser',
+              },
+            },
+          },
+        ],
+        responses: {
+          '200': { description: 'OK' },
+        },
+      }
+      const harRequest = createHarRequest('/api/users/{username}')
+      const result = processParameters(harRequest, deReferenceParams(operation.parameters))
+
+      expect(result.url).toEqual('/api/users/scalarUser')
     })
   })
 })

--- a/packages/oas-utils/src/helpers/operation-to-har/process-parameters.test.ts
+++ b/packages/oas-utils/src/helpers/operation-to-har/process-parameters.test.ts
@@ -1476,7 +1476,12 @@ describe('parameter styles', () => {
       })
 
       expect(result.url).toBe('/api/users')
-      expect(result.cookies).toEqual([])
+      expect(result.cookies).toEqual([
+        {
+          name: 'sessionId',
+          value: '',
+        },
+      ])
     })
 
     it('should handle cookie parameter with empty string value', () => {
@@ -1770,6 +1775,29 @@ describe('parameter styles', () => {
         { name: 'existingCookie', value: 'existingValue' },
         { name: 'newCookie', value: 'newValue' },
       ])
+    })
+  })
+
+  describe('query parameters', () => {
+    it('should add empty query string if no parameters are present', () => {
+      const operation: Dereference<OperationObject> = {
+        parameters: [
+          {
+            name: 'userEmail',
+            in: 'query',
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+        responses: {
+          '200': { description: 'OK' },
+        },
+      }
+      const harRequest = createHarRequest('/api/users')
+      const result = processParameters(harRequest, deReferenceParams(operation.parameters))
+
+      expect(result.queryString).toEqual([{ name: 'userEmail', value: '' }])
     })
   })
 })

--- a/packages/oas-utils/src/helpers/operation-to-har/process-parameters.ts
+++ b/packages/oas-utils/src/helpers/operation-to-har/process-parameters.ts
@@ -1,4 +1,5 @@
 import { getExampleFromSchema } from '@/spec-getters/get-example-from-schema'
+import type { ExampleObject } from '@scalar/workspace-store/schemas/v3.1/strict/example'
 import type { ParameterObject } from '@scalar/workspace-store/schemas/v3.1/strict/parameter'
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/path-operations'
 import type { ReferenceObject } from '@scalar/workspace-store/schemas/v3.1/strict/reference'
@@ -66,9 +67,21 @@ const getParameterValue = (param: ParameterObject, example?: unknown): unknown =
     }
   }
 
+  // Check if the parameter itself has an example
+  if ('example' in param && param.example) {
+    return param.example
+  }
+
+  // Or multiple examples
+  if ('examples' in param && param.examples) {
+    const examples = param.examples as Record<string, unknown>
+    return examples[param.name] || (Object.values(examples)[0] as ExampleObject | undefined)?.value
+  }
+
   // Fall back to schema example if available
   if ('schema' in param && param.schema) {
-    return getExampleFromSchema(param.schema)
+    const options = param.in === 'path' ? { emptyString: `{${param.name}}` } : {}
+    return getExampleFromSchema(param.schema, options)
   }
 
   return undefined


### PR DESCRIPTION
**Problem**

Currently, we omit query params with no value, we also show the path variable in the request example.

**Solution**

With this PR
- we show empty query params
- we replace the param variable with any example values

|  | Screenshot |
|--------|--------|
| Before | <img width="488" height="132" alt="image" src="https://github.com/user-attachments/assets/7342b36c-effb-462e-bcd9-8dd366800e86" /> | 
| After | <img width="506" height="130" alt="image" src="https://github.com/user-attachments/assets/683bacb9-d5fd-4577-bb5b-9babaa64041f" /> | 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
