### PR TITLE
feat(json-magic): introduce type-safe `apply` function with tracked target type in `diff` results

### DIFF
--- a/packages/json-magic/src/diff/apply.test.ts
+++ b/packages/json-magic/src/diff/apply.test.ts
@@ -1,4 +1,5 @@
 import { apply, InvalidChangesDetectedError } from '@/diff/apply'
+import { DifferenceResult } from '@/diff/diff'
 import { describe, expect, test } from 'vitest'
 
 const deepClone = <T extends object>(obj: T) => JSON.parse(JSON.stringify(obj)) as T
@@ -14,7 +15,7 @@ describe('apply', () => {
       const docCopy = deepClone(doc)
       const location = { city: 'New York', street: '5th Avenue' }
 
-      expect(apply(doc, [{ path: ['location'], changes: location, type: 'add' }])).toEqual({
+      expect(apply(doc, new DifferenceResult([{ path: ['location'], changes: location, type: 'add' }]))).toEqual({
         ...docCopy,
         location,
       })
@@ -34,13 +35,16 @@ describe('apply', () => {
       const coordinates = { lat: 40.7128, long: 74.006 }
 
       expect(
-        apply(doc, [
-          {
-            path: ['location', 'coordinates'],
-            changes: coordinates,
-            type: 'add',
-          },
-        ]),
+        apply(
+          doc,
+          new DifferenceResult([
+            {
+              path: ['location', 'coordinates'],
+              changes: coordinates,
+              type: 'add',
+            },
+          ]),
+        ),
       ).toEqual({
         ...docCopy,
         location: {
@@ -64,7 +68,7 @@ describe('apply', () => {
       const docCopy = deepClone(doc)
       const updatedAge = 26
 
-      expect(apply(doc, [{ path: ['age'], changes: updatedAge, type: 'update' }])).toEqual({
+      expect(apply(doc, new DifferenceResult([{ path: ['age'], changes: updatedAge, type: 'update' }]))).toEqual({
         ...docCopy,
         age: updatedAge,
       })
@@ -83,7 +87,9 @@ describe('apply', () => {
       const docCopy = deepClone(doc)
       const updatedCity = 'Boston'
 
-      expect(apply(doc, [{ path: ['location', 'city'], changes: updatedCity, type: 'update' }])).toEqual({
+      expect(
+        apply(doc, new DifferenceResult([{ path: ['location', 'city'], changes: updatedCity, type: 'update' }])),
+      ).toEqual({
         ...docCopy,
         location: { ...docCopy.location, city: updatedCity },
       })
@@ -105,7 +111,9 @@ describe('apply', () => {
         },
       }
 
-      expect(apply(doc1, [{ path: ['location'], changes: doc1.location, type: 'delete' }])).toEqual(doc2)
+      expect(
+        apply(doc1, new DifferenceResult([{ path: ['location'], changes: doc1.location, type: 'delete' }])),
+      ).toEqual(doc2)
     })
 
     test('should apply `delete` operation correctly on nested objects', () => {
@@ -126,13 +134,16 @@ describe('apply', () => {
       }
 
       expect(
-        apply(doc1, [
-          {
-            path: ['location', 'street'],
-            changes: doc1.location.street,
-            type: 'delete',
-          },
-        ]),
+        apply(
+          doc1,
+          new DifferenceResult([
+            {
+              path: ['location', 'street'],
+              changes: doc1.location.street,
+              type: 'delete',
+            },
+          ]),
+        ),
       ).toEqual(doc2)
     })
   })
@@ -149,13 +160,16 @@ describe('apply', () => {
       }
 
       expect(() =>
-        apply(doc, [
-          {
-            path: ['location', 'city', 'something'],
-            changes: { test: 1 },
-            type: 'add',
-          },
-        ]),
+        apply(
+          doc,
+          new DifferenceResult([
+            {
+              path: ['location', 'city', 'something'],
+              changes: { test: 1 },
+              type: 'add',
+            },
+          ]),
+        ),
       ).toThrow(InvalidChangesDetectedError)
     })
 
@@ -170,13 +184,16 @@ describe('apply', () => {
       }
 
       expect(() =>
-        apply(doc, [
-          {
-            path: ['location', 'coordinates', 'lang'],
-            changes: 41.25,
-            type: 'add',
-          },
-        ]),
+        apply(
+          doc,
+          new DifferenceResult([
+            {
+              path: ['location', 'coordinates', 'lang'],
+              changes: 41.25,
+              type: 'add',
+            },
+          ]),
+        ),
       ).toThrow(InvalidChangesDetectedError)
     })
   })
@@ -197,13 +214,16 @@ describe('apply', () => {
       const newHobby = 'coding'
 
       expect(
-        apply(doc, [
-          {
-            path: ['hobbies', '1'],
-            changes: newHobby,
-            type: 'add',
-          },
-        ]),
+        apply(
+          doc,
+          new DifferenceResult([
+            {
+              path: ['hobbies', '1'],
+              changes: newHobby,
+              type: 'add',
+            },
+          ]),
+        ),
       ).toEqual({ ...docCopy, hobbies: [...docCopy.hobbies, newHobby] })
     })
   })
@@ -224,13 +244,16 @@ describe('apply', () => {
     docCopy.hobbies[1] = updatedHobby
 
     expect(
-      apply(doc, [
-        {
-          path: ['hobbies', '1'],
-          changes: updatedHobby,
-          type: 'update',
-        },
-      ]),
+      apply(
+        doc,
+        new DifferenceResult([
+          {
+            path: ['hobbies', '1'],
+            changes: updatedHobby,
+            type: 'update',
+          },
+        ]),
+      ),
     ).toEqual(docCopy)
   })
 
@@ -250,13 +273,16 @@ describe('apply', () => {
     docCopy.hobbies.splice(1, 1)
 
     expect(
-      apply(doc, [
-        {
-          path: ['hobbies', '1'],
-          changes: doc.hobbies[1],
-          type: 'delete',
-        },
-      ]),
+      apply(
+        doc,
+        new DifferenceResult([
+          {
+            path: ['hobbies', '1'],
+            changes: doc.hobbies[1],
+            type: 'delete',
+          },
+        ]),
+      ),
     ).toEqual(docCopy)
   })
 })

--- a/packages/json-magic/src/diff/apply.ts
+++ b/packages/json-magic/src/diff/apply.ts
@@ -76,7 +76,7 @@ export const apply = <T>(document: Record<string, unknown>, diff: DifferenceResu
     applyChange(document, d.path, d)
   }
 
-  // Safe to typecast since this function which apply changes to A to turn it into B
-  // where B is the type of the changelog target
+  // It is safe to cast here because this function mutates the input document
+  // to match the target type T as described by the diff changeset.
   return document as T
 }

--- a/packages/json-magic/src/diff/apply.ts
+++ b/packages/json-magic/src/diff/apply.ts
@@ -1,4 +1,4 @@
-import type { Difference } from '@/diff/diff'
+import type { Difference, DifferenceResult } from '@/diff/diff'
 
 export class InvalidChangesDetectedError extends Error {
   constructor(message: string) {
@@ -13,8 +13,8 @@ export class InvalidChangesDetectedError extends Error {
  * and applies the corresponding changes (add, update, or delete) at each location.
  *
  * @param document - The original document to apply changes to
- * @param diff - Array of differences to apply, each containing a path and change type
- * @returns The modified document with all changes applied
+ * @param diff - The DifferenceResult object returned by the diff function, containing a changeset array
+ * @returns The modified document with all changes applied, cast to the target type as determined by the diff function's generic parameter
  *
  * @example
  * const original = {
@@ -25,18 +25,20 @@ export class InvalidChangesDetectedError extends Error {
  *   }
  * }
  *
- * const changes = [
- *   {
- *     path: ['paths', '/users', 'get', 'responses', '200', 'content'],
- *     type: 'add',
- *     changes: { 'application/json': { schema: { type: 'object' } } }
- *   }
- * ]
+ * const changes = {
+ *   changeset: [
+ *     {
+ *       path: ['paths', '/users', 'get', 'responses', '200', 'content'],
+ *       type: 'add',
+ *       changes: { 'application/json': { schema: { type: 'object' } } }
+ *     }
+ *   ]
+ * }
  *
  * const updated = apply(original, changes)
  * // Result: original document with content added to the 200 response
  */
-export const apply = (document: Record<string, unknown>, diff: Difference[]): Record<string, unknown> => {
+export const apply = <T>(document: Record<string, unknown>, diff: DifferenceResult<T>): T => {
   // Traverse the object and apply the change
   const applyChange = (current: any, path: string[], d: Difference, depth = 0) => {
     if (path[depth] === undefined) {
@@ -70,9 +72,11 @@ export const apply = (document: Record<string, unknown>, diff: Difference[]): Re
     applyChange(current[path[depth]], path, d, depth + 1)
   }
 
-  for (const d of diff) {
+  for (const d of diff.changeset) {
     applyChange(document, d.path, d)
   }
 
-  return document
+  // Safe to typecast since this function which apply changes to A to turn it into B
+  // where B is the type of the changelog target
+  return document as T
 }

--- a/packages/json-magic/src/diff/diff.test.ts
+++ b/packages/json-magic/src/diff/diff.test.ts
@@ -17,7 +17,7 @@ describe('diff', () => {
         },
       }
 
-      expect(diff(doc1, doc2)).toEqual([{ path: ['address'], changes: doc2.address, type: 'add' }])
+      expect(diff(doc1, doc2)).toEqual({ changeset: [{ path: ['address'], changes: doc2.address, type: 'add' }] })
     })
 
     test('should correctly get added properties in nested objects between two json objects', () => {
@@ -41,13 +41,15 @@ describe('diff', () => {
         },
       }
 
-      expect(diff(doc1, doc2)).toEqual([
-        {
-          path: ['address', 'coordinates'],
-          changes: doc2.address.coordinates,
-          type: 'add',
-        },
-      ])
+      expect(diff(doc1, doc2)).toEqual({
+        changeset: [
+          {
+            path: ['address', 'coordinates'],
+            changes: doc2.address.coordinates,
+            type: 'add',
+          },
+        ],
+      })
     })
 
     test('should correctly get added properties in deeply nested objects between two json objects', () => {
@@ -74,13 +76,15 @@ describe('diff', () => {
         },
       }
 
-      expect(diff(doc1, doc2)).toEqual([
-        {
-          path: ['address', 'coordinates', 'long'],
-          changes: doc2.address.coordinates.long,
-          type: 'add',
-        },
-      ])
+      expect(diff(doc1, doc2)).toEqual({
+        changeset: [
+          {
+            path: ['address', 'coordinates', 'long'],
+            changes: doc2.address.coordinates.long,
+            type: 'add',
+          },
+        ],
+      })
     })
   })
 
@@ -100,7 +104,7 @@ describe('diff', () => {
         age: 26,
       }
 
-      expect(diff(doc1, doc2)).toEqual([{ path: ['age'], changes: doc2.age, type: 'update' }])
+      expect(diff(doc1, doc2)).toEqual({ changeset: [{ path: ['age'], changes: doc2.age, type: 'update' }] })
     })
 
     test('should correctly get updates on nested objects between two objects', () => {
@@ -121,13 +125,15 @@ describe('diff', () => {
         },
       }
 
-      expect(diff(doc1, doc2)).toEqual([
-        {
-          path: ['address', 'city'],
-          changes: doc2.address.city,
-          type: 'update',
-        },
-      ])
+      expect(diff(doc1, doc2)).toEqual({
+        changeset: [
+          {
+            path: ['address', 'city'],
+            changes: doc2.address.city,
+            type: 'update',
+          },
+        ],
+      })
     })
 
     test('should correctly get updates when the type is different', () => {
@@ -146,7 +152,9 @@ describe('diff', () => {
         isStudent: true,
       }
 
-      expect(diff(doc1, doc2)).toEqual([{ path: ['isStudent'], changes: doc2.isStudent, type: 'update' }])
+      expect(diff(doc1, doc2)).toEqual({
+        changeset: [{ path: ['isStudent'], changes: doc2.isStudent, type: 'update' }],
+      })
     })
   })
 
@@ -165,7 +173,7 @@ describe('diff', () => {
         },
       }
 
-      expect(diff(doc1, doc2)).toEqual([{ path: ['address'], changes: doc1.address, type: 'delete' }])
+      expect(diff(doc1, doc2)).toEqual({ changeset: [{ path: ['address'], changes: doc1.address, type: 'delete' }] })
     })
 
     test('should correctly get removed properties on deeply nested objects', () => {
@@ -189,13 +197,15 @@ describe('diff', () => {
         },
       }
 
-      expect(diff(doc1, doc2)).toEqual([
-        {
-          path: ['address', 'coordinates'],
-          changes: doc1.address.coordinates,
-          type: 'delete',
-        },
-      ])
+      expect(diff(doc1, doc2)).toEqual({
+        changeset: [
+          {
+            path: ['address', 'coordinates'],
+            changes: doc1.address.coordinates,
+            type: 'delete',
+          },
+        ],
+      })
     })
   })
 
@@ -212,7 +222,9 @@ describe('diff', () => {
         hobbies: ['reading', 'running', 'swimming'],
       }
 
-      expect(diff(doc1, doc2)).toEqual([{ path: ['hobbies', '2'], changes: doc2.hobbies[2], type: 'add' }])
+      expect(diff(doc1, doc2)).toEqual({
+        changeset: [{ path: ['hobbies', '2'], changes: doc2.hobbies[2], type: 'add' }],
+      })
     })
 
     test('detect adding elements on arrays of objects', () => {
@@ -230,7 +242,9 @@ describe('diff', () => {
         hobbies: [...doc1.hobbies, { name: 'swimming', duration: 3 }],
       }
 
-      expect(diff(doc1, doc2)).toEqual([{ path: ['hobbies', '2'], changes: doc2.hobbies[2], type: 'add' }])
+      expect(diff(doc1, doc2)).toEqual({
+        changeset: [{ path: ['hobbies', '2'], changes: doc2.hobbies[2], type: 'add' }],
+      })
     })
 
     test('detects updates on objects on array of objects', () => {
@@ -248,18 +262,20 @@ describe('diff', () => {
         hobbies: [doc1.hobbies[0], { name: 'swimming', duration: 3 }],
       }
 
-      expect(diff(doc1, doc2)).toEqual([
-        {
-          path: ['hobbies', '1', 'name'],
-          changes: doc2.hobbies[1]?.name,
-          type: 'update',
-        },
-        {
-          path: ['hobbies', '1', 'duration'],
-          changes: doc2.hobbies[1]?.duration,
-          type: 'update',
-        },
-      ])
+      expect(diff(doc1, doc2)).toEqual({
+        changeset: [
+          {
+            path: ['hobbies', '1', 'name'],
+            changes: doc2.hobbies[1]?.name,
+            type: 'update',
+          },
+          {
+            path: ['hobbies', '1', 'duration'],
+            changes: doc2.hobbies[1]?.duration,
+            type: 'update',
+          },
+        ],
+      })
     })
 
     test('detects delete operations on array of objects', () => {
@@ -277,7 +293,9 @@ describe('diff', () => {
         hobbies: [doc1.hobbies[0]],
       }
 
-      expect(diff(doc1, doc2)).toEqual([{ path: ['hobbies', '1'], changes: doc1.hobbies[1], type: 'delete' }])
+      expect(diff(doc1, doc2)).toEqual({
+        changeset: [{ path: ['hobbies', '1'], changes: doc1.hobbies[1], type: 'delete' }],
+      })
     })
   })
 
@@ -308,21 +326,23 @@ describe('diff', () => {
 
     delete doc2.isStudent
 
-    expect(diff(doc1, doc2)).toEqual([
-      { path: ['age'], changes: doc2.age, type: 'update' },
-      { path: ['address', 'city'], changes: doc2.address.city, type: 'update' },
-      {
-        path: ['hobbies', '1', 'name'],
-        changes: doc2.hobbies[1]?.name,
-        type: 'update',
-      },
-      {
-        path: ['hobbies', '1', 'duration'],
-        changes: doc2.hobbies[1]?.duration,
-        type: 'update',
-      },
-      { path: ['hobbies', '2'], changes: doc2.hobbies[2], type: 'add' },
-      { path: ['isStudent'], changes: doc1.isStudent, type: 'delete' },
-    ])
+    expect(diff(doc1, doc2)).toEqual({
+      changeset: [
+        { path: ['age'], changes: doc2.age, type: 'update' },
+        { path: ['address', 'city'], changes: doc2.address.city, type: 'update' },
+        {
+          path: ['hobbies', '1', 'name'],
+          changes: doc2.hobbies[1]?.name,
+          type: 'update',
+        },
+        {
+          path: ['hobbies', '1', 'duration'],
+          changes: doc2.hobbies[1]?.duration,
+          type: 'update',
+        },
+        { path: ['hobbies', '2'], changes: doc2.hobbies[2], type: 'add' },
+        { path: ['isStudent'], changes: doc1.isStudent, type: 'delete' },
+      ],
+    })
   })
 })

--- a/packages/json-magic/src/diff/diff.ts
+++ b/packages/json-magic/src/diff/diff.ts
@@ -15,21 +15,34 @@ type ChangeType = 'add' | 'update' | 'delete'
 export type Difference = { path: string[]; changes: any; type: ChangeType }
 
 /**
+ * Represents the result of a diff operation.
+ * @template _T - The type of the target object being diffed (for type inference/documentation only).
+ * @property changeset - The list of differences (add/update/delete) found between two objects.
+ *   The changeset is a list of operations that, when applied to the source object, will transform it into the target object.
+ */
+export class DifferenceResult<_T> {
+  /**
+   * @param changeset - List of differences that, when applied to the source, will produce the target.
+   */
+  constructor(public changeset: Difference[]) {}
+}
+
+/**
  * Get the difference between two objects.
  *
  * This function performs a breadth-first comparison between two objects and returns
- * a list of operations needed to transform the first object into the second.
+ * a DifferenceResult containing a list of operations needed to transform the first object into the second.
  *
  * @param doc1 - The source object to compare from
  * @param doc2 - The target object to compare to
- * @returns A list of operations (add/update/delete) with their paths and changes
+ * @returns A DifferenceResult instance containing a list of operations (add/update/delete) with their paths and changes
  *
  * @example
  * // Compare two simple objects
  * const original = { name: 'John', age: 30 }
  * const updated = { name: 'John', age: 31, city: 'New York' }
- * const differences = diff(original, updated)
- * // Returns:
+ * const result = diff(original, updated)
+ * // result.changeset:
  * // [
  * //   { path: ['age'], changes: 31, type: 'update' },
  * //   { path: ['city'], changes: 'New York', type: 'add' }
@@ -43,13 +56,16 @@ export type Difference = { path: string[]; changes: any; type: ChangeType }
  * const updated = {
  *   user: { name: 'John', settings: { theme: 'dark' } }
  * }
- * const differences = diff(original, updated)
- * // Returns:
+ * const result = diff(original, updated)
+ * // result.changeset:
  * // [
  * //   { path: ['user', 'settings', 'theme'], changes: 'dark', type: 'update' }
  * // ]
  */
-export const diff = (doc1: Record<string, unknown>, doc2: Record<string, unknown>): Difference[] => {
+export const diff = <T extends Record<string, unknown>>(
+  doc1: Record<string, unknown>,
+  doc2: T,
+): DifferenceResult<T> => {
   const diff: Difference[] = []
 
   const bfs = (el1: unknown, el2: unknown, prefix = []) => {
@@ -90,5 +106,5 @@ export const diff = (doc1: Record<string, unknown>, doc2: Record<string, unknown
 
   // Run breadth-first search
   bfs(doc1, doc2)
-  return diff
+  return new DifferenceResult(diff)
 }

--- a/packages/json-magic/src/diff/index.ts
+++ b/packages/json-magic/src/diff/index.ts
@@ -1,5 +1,5 @@
-import { diff, type Difference } from '@/diff/diff'
+import { diff, DifferenceResult, type Difference } from '@/diff/diff'
 import { apply } from '@/diff/apply'
 import { merge } from '@/diff/merge'
 
-export { diff, apply, merge, type Difference }
+export { diff, apply, merge, DifferenceResult, type Difference }

--- a/packages/json-magic/src/diff/merge.test.ts
+++ b/packages/json-magic/src/diff/merge.test.ts
@@ -1,5 +1,5 @@
 import { merge } from '@/diff/merge'
-import { diff } from '@/diff/diff'
+import { diff, DifferenceResult } from '@/diff/diff'
 import { describe, expect, test } from 'vitest'
 
 const deepClone = <T extends object>(obj: T) => JSON.parse(JSON.stringify(obj)) as T
@@ -38,7 +38,7 @@ describe('mergeDiff', () => {
     }
 
     expect(merge(diff(baseDoc, doc1), diff(baseDoc, doc2))).toEqual({
-      diffs: [],
+      diffs: new DifferenceResult([]),
       conflicts: [
         [
           [
@@ -54,7 +54,7 @@ describe('mergeDiff', () => {
     })
 
     expect(merge(diff(baseDoc, doc2), diff(baseDoc, doc1))).toEqual({
-      diffs: [],
+      diffs: new DifferenceResult([]),
       conflicts: [
         [
           [{ path: ['info'], changes: deletedInformation, type: 'delete' }],
@@ -183,7 +183,7 @@ describe('mergeDiff', () => {
     }
 
     expect(merge(diff(baseDoc, doc1), diff(baseDoc, doc2))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           path: ['paths', '/users/{id}'],
           changes: doc1.paths['/users/{id}'],
@@ -194,7 +194,7 @@ describe('mergeDiff', () => {
           changes: deletedDescription,
           type: 'delete',
         },
-      ],
+      ]),
       conflicts: [
         [
           [
@@ -216,7 +216,7 @@ describe('mergeDiff', () => {
     })
 
     expect(merge(diff(baseDoc, doc2), diff(baseDoc, doc1))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           path: ['info', 'description'],
           changes: deletedDescription,
@@ -227,7 +227,7 @@ describe('mergeDiff', () => {
           changes: doc1.paths['/users/{id}'],
           type: 'add',
         },
-      ],
+      ]),
       conflicts: [
         [
           [
@@ -305,7 +305,7 @@ describe('mergeDiff', () => {
     }
 
     expect(merge(diff(base, doc1), diff(base, doc2))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           path: ['paths', '/products'],
           changes: doc1.paths['/products'],
@@ -316,12 +316,12 @@ describe('mergeDiff', () => {
           changes: doc2.paths['/orders'],
           type: 'add',
         },
-      ],
+      ]),
       conflicts: [],
     })
 
     expect(merge(diff(base, doc2), diff(base, doc1))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           path: ['paths', '/orders'],
           changes: doc2.paths['/orders'],
@@ -332,7 +332,7 @@ describe('mergeDiff', () => {
           changes: doc1.paths['/products'],
           type: 'add',
         },
-      ],
+      ]),
       conflicts: [],
     })
   })
@@ -393,7 +393,7 @@ describe('mergeDiff', () => {
     }
 
     expect(merge(diff(base, doc1), diff(base, doc2))).toEqual({
-      diffs: [],
+      diffs: new DifferenceResult([]),
       conflicts: [
         [
           [
@@ -415,7 +415,7 @@ describe('mergeDiff', () => {
     })
 
     expect(merge(diff(base, doc2), diff(base, doc1))).toEqual({
-      diffs: [],
+      diffs: new DifferenceResult([]),
       conflicts: [
         [
           [
@@ -481,7 +481,7 @@ describe('mergeDiff', () => {
     }
 
     expect(merge(diff(base, doc1), diff(base, doc2))).toEqual({
-      diffs: [],
+      diffs: new DifferenceResult([]),
       conflicts: [
         [
           [
@@ -503,7 +503,7 @@ describe('mergeDiff', () => {
     })
 
     expect(merge(diff(base, doc2), diff(base, doc1))).toEqual({
-      diffs: [],
+      diffs: new DifferenceResult([]),
       conflicts: [
         [
           [
@@ -554,24 +554,24 @@ describe('mergeDiff', () => {
     delete doc2.paths?.['/users']
 
     expect(merge(diff(base, doc1), diff(base, doc2))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           path: ['paths', '/users'],
           changes: removePaths2,
           type: 'delete',
         },
-      ],
+      ]),
       conflicts: [],
     })
 
     expect(merge(diff(base, doc2), diff(base, doc1))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           path: ['paths', '/users'],
           changes: removePaths2,
           type: 'delete',
         },
-      ],
+      ]),
       conflicts: [],
     })
   })
@@ -604,24 +604,24 @@ describe('mergeDiff', () => {
     delete doc2.paths?.['/users']?.get
 
     expect(merge(diff(base, doc1), diff(base, doc2))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           type: 'delete',
           changes: base.paths['/users'].get,
           path: ['paths', '/users', 'get'],
         },
-      ],
+      ]),
       conflicts: [],
     })
 
     expect(merge(diff(base, doc2), diff(base, doc1))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           type: 'delete',
           changes: base.paths['/users'].get,
           path: ['paths', '/users', 'get'],
         },
-      ],
+      ]),
       conflicts: [],
     })
   })
@@ -652,24 +652,24 @@ describe('mergeDiff', () => {
     }
 
     expect(merge(diff(base, doc1), diff(base, doc2))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           type: 'add',
           changes: doc1.info.description,
           path: ['info', 'description'],
         },
-      ],
+      ]),
       conflicts: [],
     })
 
     expect(merge(diff(base, doc2), diff(base, doc1))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           type: 'add',
           changes: doc1.info.description,
           path: ['info', 'description'],
         },
-      ],
+      ]),
       conflicts: [],
     })
   })
@@ -696,24 +696,24 @@ describe('mergeDiff', () => {
     }
 
     expect(merge(diff(base, doc1), diff(base, doc2))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           type: 'add',
           changes: doc1.info,
           path: ['info'],
         },
-      ],
+      ]),
       conflicts: [],
     })
 
     expect(merge(diff(base, doc2), diff(base, doc1))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           type: 'add',
           changes: doc1.info,
           path: ['info'],
         },
-      ],
+      ]),
       conflicts: [],
     })
   })
@@ -740,7 +740,7 @@ describe('mergeDiff', () => {
     }
 
     expect(merge(diff(base, doc1), diff(base, doc2))).toEqual({
-      diffs: [],
+      diffs: new DifferenceResult([]),
       conflicts: [
         [
           [
@@ -762,7 +762,7 @@ describe('mergeDiff', () => {
     })
 
     expect(merge(diff(base, doc2), diff(base, doc1))).toEqual({
-      diffs: [],
+      diffs: new DifferenceResult([]),
       conflicts: [
         [
           [
@@ -809,24 +809,24 @@ describe('mergeDiff', () => {
     }
 
     expect(merge(diff(base, doc1), diff(base, doc2))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           type: 'add',
           changes: doc1.info.version,
           path: ['info', 'version'],
         },
-      ],
+      ]),
       conflicts: [],
     })
 
     expect(merge(diff(base, doc2), diff(base, doc1))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           type: 'add',
           changes: doc1.info.version,
           path: ['info', 'version'],
         },
-      ],
+      ]),
       conflicts: [],
     })
   })
@@ -913,7 +913,7 @@ describe('mergeDiff', () => {
     }
 
     expect(merge(diff(base, doc1), diff(base, doc2))).toEqual({
-      diffs: [],
+      diffs: new DifferenceResult([]),
       conflicts: [
         [
           [
@@ -971,7 +971,7 @@ describe('mergeDiff', () => {
     })
 
     expect(merge(diff(base, doc2), diff(base, doc1))).toEqual({
-      diffs: [],
+      diffs: new DifferenceResult([]),
       conflicts: [
         [
           [
@@ -1086,7 +1086,7 @@ describe('mergeDiff', () => {
     }
 
     expect(merge(diff(base, doc1), diff(base, doc2))).toEqual({
-      diffs: [
+      diffs: new DifferenceResult([
         {
           type: 'delete',
           changes: deletedUsersChanges,
@@ -1102,7 +1102,7 @@ describe('mergeDiff', () => {
           changes: doc2.paths['/users'].post,
           path: ['paths', '/users', 'post'],
         },
-      ],
+      ]),
       conflicts: [],
     })
   })

--- a/packages/json-magic/src/diff/merge.ts
+++ b/packages/json-magic/src/diff/merge.ts
@@ -1,36 +1,30 @@
-import type { Difference } from '@/diff/diff'
+import { DifferenceResult, type Difference } from '@/diff/diff'
 import { Trie } from '@/diff/trie'
 import { isArrayEqual, isKeyCollisions, mergeObjects } from '@/diff/utils'
 
 /**
- * Merges two sets of differences from the same document and resolves conflicts.
- * This function combines changes from two diff lists while handling potential conflicts
+ * Merges two DifferenceResult objects (as returned by the diff function) and resolves conflicts.
+ * This function combines changes from two DifferenceResult.changeset arrays while handling potential conflicts
  * that arise when both diffs modify the same paths. It uses a trie data structure for
  * efficient path matching and conflict detection.
  *
- * @param diff1 - First list of differences
- * @param diff2 - Second list of differences
+ * @param diff1 - First DifferenceResult (as returned by diff)
+ * @param diff2 - Second DifferenceResult (as returned by diff)
  * @returns Object containing:
- *   - diffs: Combined list of non-conflicting differences
- *   - conflicts: Array of conflicting difference pairs that need manual resolution
+ *   - diffs: DifferenceResult<T> with the combined list of non-conflicting differences
+ *   - conflicts: Array of conflicting difference pairs (each as [Difference[], Difference[]]) that need manual resolution
  *
  * @example
  * // Merge two sets of changes to a user profile
- * const diff1 = [
- *   { path: ['name'], changes: 'John', type: 'update' },
- *   { path: ['age'], changes: 30, type: 'add' }
- * ]
- * const diff2 = [
- *   { path: ['name'], changes: 'Johnny', type: 'update' },
- *   { path: ['address'], changes: { city: 'NY' }, type: 'add' }
- * ]
+ * const diff1 = diff(base, userA); // DifferenceResult
+ * const diff2 = diff(base, userB); // DifferenceResult
  * const { diffs, conflicts } = merge(diff1, diff2)
  * // Returns:
  * // {
- * //   diffs: [
+ * //   diffs: new DifferenceResult([
  * //     { path: ['age'], changes: 30, type: 'add' },
  * //     { path: ['address'], changes: { city: 'NY' }, type: 'add' }
- * //   ],
+ * //   ]),
  * //   conflicts: [
  * //     [
  * //       [{ path: ['name'], changes: 'John', type: 'update' }],
@@ -39,7 +33,7 @@ import { isArrayEqual, isKeyCollisions, mergeObjects } from '@/diff/utils'
  * //   ]
  * // }
  */
-export const merge = (diff1: Difference[], diff2: Difference[]) => {
+export const merge = <T>(diff1: DifferenceResult<T>, diff2: DifferenceResult<T>) => {
   // Here we need to use a trie to optimize searching for a prefix
   // With the naive approach time complexity of the algorithm would be
   //                         O(n * m)
@@ -52,7 +46,7 @@ export const merge = (diff1: Difference[], diff2: Difference[]) => {
   const trie = new Trie<{ index: number; changes: Difference }>()
 
   // Create the trie
-  for (const [index, diff] of diff1.entries()) {
+  for (const [index, diff] of diff1.changeset.entries()) {
     trie.addPath(diff.path, { index, changes: diff })
   }
 
@@ -67,7 +61,7 @@ export const merge = (diff1: Difference[], diff2: Difference[]) => {
   // a delete operation with one to many conflicts
   const conflictsMap2 = new Map<number, [Difference[], Difference[]]>()
 
-  for (const [index, diff] of diff2.entries()) {
+  for (const [index, diff] of diff2.changeset.entries()) {
     trie.findMatch(diff.path, (value) => {
       if (diff.type === 'delete') {
         if (value.changes.type === 'delete') {
@@ -127,10 +121,10 @@ export const merge = (diff1: Difference[], diff2: Difference[]) => {
 
   // Filter all changes that should be skipped because of conflicts
   // or auto conflict resolution
-  const diffs: Difference[] = [
-    ...diff1.filter((_, index) => !skipDiff1.has(index)),
-    ...diff2.filter((_, index) => !skipDiff2.has(index)),
-  ]
+  const diffs: DifferenceResult<T> = new DifferenceResult([
+    ...diff1.changeset.filter((_, index) => !skipDiff1.has(index)),
+    ...diff2.changeset.filter((_, index) => !skipDiff2.has(index)),
+  ])
 
   return { diffs, conflicts }
 }

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -734,10 +734,11 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
         return changesA.conflicts
       }
 
-      const changesetA = changesA.diffs.concat(resolvedConflicts)
+      // Push the list of resolved conflicts to the original changeset
+      changesA.diffs.changeset.push(...resolvedConflicts)
 
       // Apply the changes to the original document to get the new intermediate
-      const newIntermediateDocument = apply(deepClone(originalDocument), changesetA) as typeof originalDocument
+      const newIntermediateDocument = apply(deepClone(originalDocument), changesA.diffs)
       intermediateDocuments[documentName] = newIntermediateDocument
 
       // Update the original document
@@ -751,9 +752,9 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
 
       // Auto-conflict resolution: pick only the changes from the first changeset
       // TODO: In the future, implement smarter conflict resolution if needed
-      const changesetB = changesB.diffs.concat(changesB.conflicts.flatMap((it) => it[0]))
+      changesB.diffs.changeset.push(...changesB.conflicts.flatMap((it) => it[0]))
 
-      const newActiveDocument = apply(deepClone(newIntermediateDocument), changesetB) as typeof newIntermediateDocument
+      const newActiveDocument = apply(deepClone(newIntermediateDocument), changesB.diffs)
 
       // Update the active document to the new value
       workspace.documents[documentName] = createOverridesProxy(


### PR DESCRIPTION
**Problem**

The current apply function returns a generic UnknownObject, since the original target type of the Difference[] list is not retained. This limits type safety and forces consumers to manually cast the result.

**Solution**

This PR introduces a new DifferenceResult object returned by the diff function. This object retains the target type that the differences were generated from. With this context preserved, the apply function can now infer and return the correct type, enabling full type safety when applying diffs.

⚠️ **Note:** The return type of apply is only accurate when the entire changeset is provided, including all resolved conflicts. Partial or unresolved diffs may lead to an incomplete or invalid cast, so full context is required for complete type safety.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
