### PR TITLE
fix(api-reference): empty test request modal

### DIFF
--- a/.changeset/tasty-steaks-jog.md
+++ b/.changeset/tasty-steaks-jog.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: empty test request modal

--- a/packages/api-reference/src/features/api-client-modal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/api-client-modal/ApiClientModal.vue
@@ -59,13 +59,17 @@ onMounted(() => {
 // Ensure we have a document when doing the initial import
 watchDebounced(
   () => dereferencedDocument,
-  (newDocument) => {
+  (newDocument, oldDocument) => {
     if (!newDocument) {
       return
     }
 
+    // Ensure the document is different
+    if (JSON.stringify(newDocument) === JSON.stringify(oldDocument || {})) {
+      return
+    }
+
     // If we already have a collection, remove the store
-    // TODO: add @redis diffing here... or just upgrade to the new store
     if (activeEntities.activeCollection.value) {
       client.value?.resetStore()
     }
@@ -79,7 +83,6 @@ watchDebounced(
       ...configuration,
     })
   },
-  { debounce: 300 },
 )
 
 // Update the config (non document related) on change

--- a/packages/api-reference/src/features/api-client-modal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/api-client-modal/ApiClientModal.vue
@@ -79,6 +79,7 @@ watchDebounced(
       ...configuration,
     })
   },
+  { debounce: 300 },
 )
 
 // Update the config (non document related) on change


### PR DESCRIPTION
**Problem**

closes #6441

Currently, we are double importing the client store.

**Solution**

With this PR we ensure theres actual changes to the content first. This won't be needed once we switch stores so I just put up the bandaid instead of looking for the cause. 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
