### PR TITLE
fix(api-reference): cyclic object error in client store watcher

### DIFF
--- a/.changeset/silver-falcons-suffer.md
+++ b/.changeset/silver-falcons-suffer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: cyclic error in client store watcher

--- a/packages/api-reference/src/features/api-client-modal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/api-client-modal/ApiClientModal.vue
@@ -65,7 +65,8 @@ watchDebounced(
     }
 
     // Ensure the document is different
-    if (JSON.stringify(newDocument) === JSON.stringify(oldDocument || {})) {
+    const diff = microdiff(newDocument, oldDocument || {})
+    if (!diff?.length) {
       return
     }
 


### PR DESCRIPTION
**Problem**

Currently, I forgot that we are de-referenced at this point.

**Solution**

With this PR we skip the stringify and check the diff length.

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
