### PR TITLE
fix(api-reference): models with `x-scalar-ignore` show up again

### DIFF
--- a/.changeset/kind-buckets-vanish.md
+++ b/.changeset/kind-buckets-vanish.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: x-scalar-ignore models schema displayed

--- a/packages/api-reference/src/components/Content/Models/Models.test.ts
+++ b/packages/api-reference/src/components/Content/Models/Models.test.ts
@@ -137,6 +137,38 @@ describe('Models', () => {
     })
   })
 
+  it('excludes schemas with x-scalar-ignore', () => {
+    const documentWithIgnoredSchema: OpenAPIV3_1.Document = {
+      ...mockDocument,
+      components: {
+        schemas: {
+          User: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              name: { type: 'string' },
+            },
+          },
+          ImageUploadedMessage: {
+            'x-scalar-ignore': true,
+            description: 'Message about an image upload',
+            type: 'object',
+          },
+        },
+      },
+    }
+
+    const wrapper = mount(Models, {
+      props: {
+        document: documentWithIgnoredSchema,
+        config: mockConfigModern,
+      },
+    })
+
+    expect(wrapper.text()).toContain('User')
+    expect(wrapper.text()).not.toContain('ImageUploadedMessage')
+  })
+
   describe('edge cases', () => {
     it('renders nothing if document.components.schemas is undefined', () => {
       const wrapper = mount(Models, {

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -1,30 +1,35 @@
 <script setup lang="ts">
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { ApiReferenceConfiguration } from '@scalar/types'
+import { computed } from 'vue'
 
 import { Lazy } from '@/components/Lazy'
 import { useNavState } from '@/hooks/useNavState'
+import { getModels } from '@/libs/openapi'
 
 import ClassicLayout from './ClassicLayout.vue'
 import ModernLayout from './ModernLayout.vue'
 
-defineProps<{
+const { document } = defineProps<{
   document: OpenAPIV3_1.Document
   config: ApiReferenceConfiguration
 }>()
 
 const { hash } = useNavState()
+
+/** Returns the model schemas from the document */
+const schemas = computed(() => getModels(document))
 </script>
 <template>
   <Lazy
     id="models"
-    v-if="document?.components?.schemas"
+    v-if="schemas && Object.keys(schemas).length > 0"
     :isLazy="Boolean(hash) && !hash.startsWith('model')">
     <ClassicLayout
       v-if="config?.layout === 'classic'"
-      :schemas="document.components.schemas" />
+      :schemas="schemas" />
     <ModernLayout
       v-else
-      :schemas="document.components.schemas" />
+      :schemas="schemas" />
   </Lazy>
 </template>


### PR DESCRIPTION
**Changes**

this pr updates the models component in order to use the getModels function to render schema models.

| state | preview |
| -------|------|
| before | <img width="640" height="460" alt="image" src="https://github.com/user-attachments/assets/ed5d9abb-253d-4aaa-b3a1-9a1b86a71472" /> |
| after | <img width="640" height="460" alt="image" src="https://github.com/user-attachments/assets/0fef99db-8609-41fd-9ea3-5c5c3c22d5a7" /> | 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
