### PR TITLE
feat(galaxy): publish in Scalar Registry

### DIFF
--- a/.changeset/silly-experts-decide.md
+++ b/.changeset/silly-experts-decide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+feat: publish @scalar/galaxy in the Scalar Registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,7 +584,7 @@ jobs:
         run: npx @scalar/cli auth login --token ${{ secrets.SCALAR_API_KEY }}
       - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
         name: Push to Scalar Registry
-        run: npx @scalar/cli registry publish --force true --namespace scalar --slug galaxy --version ${{ env.VERSION }} packages/galaxy/dist/latest.yaml
+        run: npx @scalar/cli registry publish --namespace scalar --slug galaxy --version ${{ env.VERSION }} packages/galaxy/dist/latest.yaml
 
   deploy-examples:
     # Main Branch or PR from the same repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,7 +587,7 @@ jobs:
         run: npx @scalar/cli auth login --token ${{ secrets.SCALAR_API_KEY }}
       # - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
       - name: Push to Scalar Registry
-        run: npx @scalar/cli registry publish --force true --namespace scalar --slug galaxy --version ${{ env.VERSION }} dist/latest.yaml
+        run: npx @scalar/cli registry publish --force true --namespace scalar --slug galaxy --version ${{ env.VERSION }} packages/galaxy/dist/latest.yaml
 
   deploy-examples:
     # Main Branch or PR from the same repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,6 +549,46 @@ jobs:
           # 2) Create a token with the following permissions:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
+  push-to-scalar-registry:
+    # TODO: Uncomment this when we tested the workflow
+    # if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    timeout-minutes: 10
+    needs: [build]
+    # TODO: Uncomment this when we tested the workflow
+    # needs: [build, test-packages]
+    strategy:
+      matrix:
+        node-version: [22]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f
+      - name: Build @scalar/galaxy
+        uses: ./.github/actions/build-blacksmith
+        with:
+          node-version: ${{ matrix.node-version }}
+          packages: '@scalar/galaxy...'
+      - name: Check whether there's a new version of @scalar/galaxy
+        id: changed-files
+        uses: step-security/changed-files@95b56dadb92a30ca9036f16423fd3c088a71ee94
+        with:
+          files_yaml: |
+            galaxy:
+              - packages/galaxy/**
+      - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
+        name: Extract version from package.json
+        working-directory: packages/galaxy
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
+        name: Login to Scalar Registry
+        run: npx @scalar/cli auth login --token ${{ secrets.SCALAR_API_KEY }}
+      - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
+        name: Push to Scalar Registry
+        run: npx @scalar/cli registry publish --force true --namespace scalar --slug galaxy --version ${{ env.VERSION }} dist/latest.yaml
+
   deploy-examples:
     # Main Branch or PR from the same repository
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,17 +576,17 @@ jobs:
           files_yaml: |
             galaxy:
               - packages/galaxy/**
-      - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
-        name: Extract version from package.json
+      #- if: steps.changed-files.outputs.galaxy_any_changed == 'true'
+      - name: Extract version from package.json
         working-directory: packages/galaxy
         run: |
           VERSION=$(node -p "require('./package.json').version")
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-      - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
-        name: Login to Scalar Registry
+      #- if: steps.changed-files.outputs.galaxy_any_changed == 'true'
+      - name: Login to Scalar Registry
         run: npx @scalar/cli auth login --token ${{ secrets.SCALAR_API_KEY }}
-      - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
-        name: Push to Scalar Registry
+      # - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
+      - name: Push to Scalar Registry
         run: npx @scalar/cli registry publish --force true --namespace scalar --slug galaxy --version ${{ env.VERSION }} dist/latest.yaml
 
   deploy-examples:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,13 +550,10 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
   push-to-scalar-registry:
-    # TODO: Uncomment this when we tested the workflow
-    # if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
+    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
     runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 10
-    needs: [build]
-    # TODO: Uncomment this when we tested the workflow
-    # needs: [build, test-packages]
+    needs: [build, test-packages]
     strategy:
       matrix:
         node-version: [22]
@@ -576,17 +573,17 @@ jobs:
           files_yaml: |
             galaxy:
               - packages/galaxy/**
-      #- if: steps.changed-files.outputs.galaxy_any_changed == 'true'
-      - name: Extract version from package.json
+      - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
+        name: Extract version from package.json
         working-directory: packages/galaxy
         run: |
           VERSION=$(node -p "require('./package.json').version")
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-      #- if: steps.changed-files.outputs.galaxy_any_changed == 'true'
-      - name: Login to Scalar Registry
+      - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
+        name: Login to Scalar Registry
         run: npx @scalar/cli auth login --token ${{ secrets.SCALAR_API_KEY }}
-      # - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
-      - name: Push to Scalar Registry
+      - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
+        name: Push to Scalar Registry
         run: npx @scalar/cli registry publish --force true --namespace scalar --slug galaxy --version ${{ env.VERSION }} packages/galaxy/dist/latest.yaml
 
   deploy-examples:

--- a/packages/galaxy/README.md
+++ b/packages/galaxy/README.md
@@ -15,6 +15,13 @@ npm install @scalar/galaxy
 
 ## Usage
 
+### Scalar Registry
+
+| Version | Format | URL                                                                |
+| ------- | ------ | ------------------------------------------------------------------ |
+| Latest  | JSON   | https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json |
+| Latest  | YAML   | https://registry.scalar.com/@scalar/apis/galaxy/latest?format=yaml |
+
 ### CDN
 
 | Version     | Format | URL                                                          |

--- a/packages/galaxy/README.md
+++ b/packages/galaxy/README.md
@@ -17,10 +17,11 @@ npm install @scalar/galaxy
 
 ### Scalar Registry
 
-| Version | Format | URL                                                                |
-| ------- | ------ | ------------------------------------------------------------------ |
-| Latest  | JSON   | https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json |
-| Latest  | YAML   | https://registry.scalar.com/@scalar/apis/galaxy/latest?format=yaml |
+| Version | Format  | URL                                                                |
+| ------- | ------- | ------------------------------------------------------------------ |
+| Latest  | Preview | https://registry.scalar.com/@scalar/apis/galaxy                    |
+| Latest  | JSON    | https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json |
+| Latest  | YAML    | https://registry.scalar.com/@scalar/apis/galaxy/latest?format=yaml |
 
 ### CDN
 


### PR DESCRIPTION
**Problem**

Currently, we’re publishing @scalar/galaxy on NPM and promote the jsdelivr URLs, but don’t have it in the Scalar Registry™.

**Solution**

With this PR the OpenAPI document is pushed to the Scalar Registry on release. It’s using the version from the package.json (which is also in the document).

The resulting URLs:

* https://registry.scalar.com/@scalar/apis/galaxy
* https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json
* https://registry.scalar.com/@scalar/apis/galaxy/latest?format=yaml

I’ll replace the jsdelivr URLs in a different PR.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->