### PR TITLE
docs: Corrected typo - `returned from` not `returned form`

### DIFF
--- a/packages/api-reference/src/features/traverse-schema/types.ts
+++ b/packages/api-reference/src/features/traverse-schema/types.ts
@@ -11,14 +11,14 @@ import type { Ref } from 'vue'
 /** Map of tagNames and their entries */
 export type TagsMap = Map<string, { tag: Dereference<TagObject>; entries: TraversedEntry[] }>
 
-/** Description entry returned form traversing the document */
+/** Description entry returned from traversing the document */
 export type TraversedDescription = {
   id: string
   title: string
   children?: TraversedDescription[]
 }
 
-/** Operation entry returned form traversing the document */
+/** Operation entry returned from traversing the document */
 export type TraversedOperation = {
   id: string
   title: string
@@ -27,7 +27,7 @@ export type TraversedOperation = {
   operation: Dereference<OperationObject>
 }
 
-/** Model entry returned form traversing the document */
+/** Model entry returned from traversing the document */
 export type TraversedSchema = {
   id: string
   title: string
@@ -35,7 +35,7 @@ export type TraversedSchema = {
   schema: Dereference<SchemaObject>
 }
 
-/** Tag entry returned form traversing the document, includes tagGroups */
+/** Tag entry returned from traversing the document, includes tagGroups */
 export type TraversedTag = {
   id: string
   title: string
@@ -45,7 +45,7 @@ export type TraversedTag = {
   isWebhooks?: boolean
 }
 
-/** Webhook entry returned form traversing the document, basically the same as an operaation but with name instead of path */
+/** Webhook entry returned from traversing the document, basically the same as an operaation but with name instead of path */
 export type TraversedWebhook = {
   id: string
   title: string
@@ -54,7 +54,7 @@ export type TraversedWebhook = {
   webhook: Dereference<OperationObject>
 }
 
-/** Entries returned form traversing the document */
+/** Entries returned from traversing the document */
 export type TraversedEntry =
   | TraversedDescription
   | TraversedOperation


### PR DESCRIPTION
**Problem**

Currently, the comments are saying "returned form" when in fact they mean "returned from".

**Solution**

With this PR the typos are fixed.

**Checklist**

This is a one-word change (in multiple places) and the checklist items below do not apply:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

