### PR TITLE
fix(api-client): environment variable tooltip not displayed

### DIFF
--- a/.changeset/wicked-foxes-applaud.md
+++ b/.changeset/wicked-foxes-applaud.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: environment variable pill not displayed

--- a/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
+++ b/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
@@ -1,6 +1,6 @@
 import { parseEnvVariables } from '@/libs'
 import { type EnvVariables, getEnvColor } from '@/libs/env-helpers'
-import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
+import { ScalarIcon, ScalarTooltip } from '@scalar/components'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { REGEX } from '@scalar/oas-utils/helpers'
@@ -57,70 +57,51 @@ class PillWidget extends WidgetType {
 
         // Set the pill color based on the environment source or fallback to default color
         const isGlobal = val?.source === 'global'
-        const pillColor = isGlobal ? '#FFFFFF' : val && this.environment ? getEnvColor(this.environment) : '#FFFFFF'
+        const pillColor = isGlobal
+          ? 'var(--scalar-color-1)'
+          : val && this.environment && this.environment.name !== 'No Environment'
+            ? getEnvColor(this.environment)
+            : 'var(--scalar-color-1)'
 
         span.style.setProperty('--tw-bg-base', pillColor)
 
         // Set opacity based on the existence of a value
         span.style.opacity = val?.value ? '1' : '0.5'
 
-        // Tooltip trigger element
-        const tooltipTrigger = h('div', { class: 'flex items-center gap-1 whitespace-nowrap' }, [
-          (isGlobal || (this.environment?.name === 'No Environment' && val?.value)) &&
-            h(ScalarIcon, { class: 'size-2.5 -ml-1', icon: 'Globe' }),
-          h('span', this.variableName),
-        ])
+        // Tooltip content as string
+        const tooltipContent = val?.value || 'No value'
 
-        const tooltipContent = val?.value
-          ? h('div', { class: 'p-2' }, val.value)
-          : h('div', { class: 'divide-y divide-1/2 grid' }, [
-              h('span', { class: 'p-2 opacity-25' }, 'No value'),
-              !this.isReadOnly &&
-                h('div', { class: 'p-1' }, [
-                  h(
-                    ScalarButton,
-                    {
-                      class:
-                        'gap-1.5 justify-start font-normal px-1 py-1.5 h-auto transition-colors rounded no-underline text-xxs w-full hover:bg-b-2',
-                      variant: 'ghost',
-                      onClick: () => {
-                        // TODO: Use named route instead
-                        window.location.href = `/workspace/${this.workspace?.uid}/environment`
-                      },
-                    },
-                    {
-                      default: () => [
-                        h(ScalarIcon, {
-                          class: 'w-2',
-                          icon: 'Add',
-                          size: 'xs',
-                        }),
-                        'Add variable',
-                      ],
-                    },
-                  ),
-                ]),
-            ])
+        // Tooltip trigger element
+        const tooltipTrigger = h(
+          'div',
+          {
+            class: 'flex items-center gap-1 whitespace-nowrap',
+            onClick:
+              !val?.value && !this.isReadOnly
+                ? () => {
+                    // TODO: Use named route instead
+                    window.location.href = `/workspace/${this.workspace?.uid}/environment`
+                  }
+                : undefined,
+            style: !val?.value && !this.isReadOnly ? 'cursor: pointer;' : undefined,
+          },
+          [
+            (isGlobal || (this.environment?.name === 'No Environment' && val?.value)) &&
+              h(ScalarIcon, { class: 'size-2.5 -ml-1', icon: 'Globe' }),
+            h('span', this.variableName),
+          ],
+        )
 
         return h(
           ScalarTooltip,
           {
-            align: 'center',
-            class: 'w-full',
+            content: tooltipContent,
             delay: 0,
-            side: 'bottom',
-            sideOffset: 6,
+            placement: 'bottom',
+            offset: 6,
           },
           {
-            trigger: () => tooltipTrigger,
-            content: () =>
-              h(
-                'div',
-                {
-                  class: ['border w-content rounded bg-b-1 brightness-lifted text-xxs leading-5 text-c-1'],
-                },
-                tooltipContent,
-              ),
+            default: () => tooltipTrigger,
           },
         )
       },

--- a/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
+++ b/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
@@ -1,6 +1,7 @@
 import { parseEnvVariables } from '@/libs'
 import { type EnvVariables, getEnvColor } from '@/libs/env-helpers'
-import { ScalarIcon, ScalarTooltip } from '@scalar/components'
+import { ScalarTooltip } from '@scalar/components'
+import { ScalarIconGlobe } from '@scalar/icons'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { REGEX } from '@scalar/oas-utils/helpers'
@@ -87,7 +88,7 @@ class PillWidget extends WidgetType {
           },
           [
             (isGlobal || (this.environment?.name === 'No Environment' && val?.value)) &&
-              h(ScalarIcon, { class: 'size-2.5 -ml-1', icon: 'Globe' }),
+              h(ScalarIconGlobe, { class: 'size-3 -ml-1', icon: 'Globe' }),
             h('span', this.variableName),
           ],
         )

--- a/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
+++ b/packages/api-client/src/components/CodeInput/codeVariableWidget.ts
@@ -73,25 +73,11 @@ class PillWidget extends WidgetType {
         const tooltipContent = val?.value || 'No value'
 
         // Tooltip trigger element
-        const tooltipTrigger = h(
-          'div',
-          {
-            class: 'flex items-center gap-1 whitespace-nowrap',
-            onClick:
-              !val?.value && !this.isReadOnly
-                ? () => {
-                    // TODO: Use named route instead
-                    window.location.href = `/workspace/${this.workspace?.uid}/environment`
-                  }
-                : undefined,
-            style: !val?.value && !this.isReadOnly ? 'cursor: pointer;' : undefined,
-          },
-          [
-            (isGlobal || (this.environment?.name === 'No Environment' && val?.value)) &&
-              h(ScalarIconGlobe, { class: 'size-3 -ml-1', icon: 'Globe' }),
-            h('span', this.variableName),
-          ],
-        )
+        const tooltipTrigger = h('div', { class: 'flex items-center gap-1 whitespace-nowrap' }, [
+          (isGlobal || (this.environment?.name === 'No Environment' && val?.value)) &&
+            h(ScalarIconGlobe, { class: 'size-3 -ml-1', icon: 'Globe' }),
+          h('span', this.variableName),
+        ])
 
         return h(
           ScalarTooltip,

--- a/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
@@ -8,6 +8,8 @@ import { useRouter } from 'vue-router'
 
 import { parseEnvVariables } from '@/libs'
 import { getEnvColor, type EnvVariables } from '@/libs/env-helpers'
+import { PathId } from '@/routes'
+import { useActiveEntities } from '@/store'
 
 const props = defineProps<{
   query: string
@@ -25,20 +27,35 @@ const isOpen = ref(true)
 const dropdownRef = ref<HTMLElement | null>(null)
 const selectedVariableIndex = ref(0)
 const router = useRouter()
+const { activeCollection } = useActiveEntities()
 
 const redirectToEnvironment = () => {
   if (!router) {
     return
   }
   const { currentRoute, push } = router
-
   const workspaceId = currentRoute.value.params.workspace
-  push({
-    name: 'environment.default',
-    params: {
-      workspace: workspaceId,
-    },
-  })
+
+  // Global environment page for draft collection
+  if (
+    !activeCollection.value ||
+    activeCollection.value.info?.title === 'Drafts'
+  ) {
+    push({
+      name: 'environment.default',
+      params: {
+        [PathId.Workspace]: workspaceId,
+      },
+    })
+  } else {
+    // Collection environment page for collections
+    push({
+      name: 'collection.environment',
+      params: {
+        [PathId.Collection]: activeCollection.value.uid,
+      },
+    })
+  }
   isOpen.value = false
 }
 
@@ -159,7 +176,7 @@ onClickOutside(
       </ul>
       <ScalarButton
         v-else-if="router"
-        class="font-code text-xxs hover:bg-b-2 flex h-8 w-full justify-start gap-2 px-1.5 transition-colors duration-150"
+        class="font-code text-xxs bg-b-inherit hover:bg-b-2 flex h-8 w-full justify-start gap-2 px-1.5 transition-colors duration-150"
         variant="outlined"
         @click="redirectToEnvironment">
         <ScalarIcon

--- a/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentVariableDropdown.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarIcon, ScalarTeleport } from '@scalar/components'
+import { ScalarButton, ScalarTeleport } from '@scalar/components'
+import { ScalarIconGlobe, ScalarIconPlus } from '@scalar/icons'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import { onClickOutside } from '@vueuse/core'
 import Fuse from 'fuse.js'
@@ -156,14 +157,17 @@ onClickOutside(
             @click="selectVariable(item.key)">
             <div class="flex items-center gap-2 whitespace-nowrap">
               <span
-                v-if="item.source === 'collection'"
+                v-if="
+                  item.source === 'collection' &&
+                  environment.name !== 'No Environment'
+                "
                 class="h-2.25 w-2.25 min-w-2.25 rounded-full"
                 :style="{
                   backgroundColor: getEnvColor(environment),
                 }"></span>
-              <ScalarIcon
+              <ScalarIconGlobe
                 v-else
-                class="-ml-1/2 h-2.5 w-2.5"
+                class="-ml-0.25 size-2.5"
                 icon="Globe" />
               {{ item.key }}
             </div>
@@ -179,9 +183,7 @@ onClickOutside(
         class="font-code text-xxs bg-b-inherit hover:bg-b-2 flex h-8 w-full justify-start gap-2 px-1.5 transition-colors duration-150"
         variant="outlined"
         @click="redirectToEnvironment">
-        <ScalarIcon
-          icon="Add"
-          size="sm" />
+        <ScalarIconPlus class="size-3" />
         Add Variable
       </ScalarButton>
       <!-- Backdrop for the dropdown -->


### PR DESCRIPTION
**Changes**

this pr:
- updates the code variable widget according to recent tooltip component changes
- fixes color mode support
- update scalar icon usages
- enhances navigation logic

| state | preview |
| -------|------|
| before | <img width="603" height="110" alt="image" src="https://github.com/user-attachments/assets/ec8e6419-cbfc-45dd-b936-d6b8f748eab3" /> |
| after | <img width="603" height="110" alt="image" src="https://github.com/user-attachments/assets/36d7ad0c-e191-46e9-a557-c9466c72469a" /> | 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
