### PR TITLE
Do not encode placeholder curly braces

### DIFF
--- a/.changeset/blue-dancers-hang.md
+++ b/.changeset/blue-dancers-hang.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+Do not encode placeholder curly brackets in code samples.

--- a/packages/snippetz/src/httpsnippet-lite/esm/targets/python/python3/client.ts
+++ b/packages/snippetz/src/httpsnippet-lite/esm/targets/python/python3/client.ts
@@ -10,6 +10,7 @@
  */
 import { CodeBuilder } from '../../../helpers/code-builder.js'
 import { escapeForDoubleQuotes } from '../../../helpers/escape.js'
+import { getStringPathnameWithRestoredBrackets } from '@/utils/getPathnameWithRestoredBrackets.js'
 
 export const python3 = {
   info: {
@@ -22,6 +23,9 @@ export const python3 = {
     { uriObj: { path, protocol, host }, postData, allHeaders, method },
     options = {},
   ) => {
+
+    const bracketedPath = getStringPathnameWithRestoredBrackets(path)
+
     const { insecureSkipVerify = false } = options
     const { push, blank, join } = new CodeBuilder()
     // Start Request
@@ -74,13 +78,13 @@ export const python3 = {
     }
     // Make Request
     if (payload && headerCount) {
-      push(`conn.request("${method}", "${path}", payload, headers)`)
+      push(`conn.request("${method}", "${bracketedPath}", payload, headers)`)
     } else if (payload && !headerCount) {
-      push(`conn.request("${method}", "${path}", payload)`)
+      push(`conn.request("${method}", "${bracketedPath}", payload)`)
     } else if (!payload && headerCount) {
-      push(`conn.request("${method}", "${path}", headers=headers)`)
+      push(`conn.request("${method}", "${bracketedPath}", headers=headers)`)
     } else {
-      push(`conn.request("${method}", "${path}")`)
+      push(`conn.request("${method}", "${bracketedPath}")`)
     }
     // Get Response
     blank()

--- a/packages/snippetz/src/plugins/c/libcurl/libcurl.test.ts
+++ b/packages/snippetz/src/plugins/c/libcurl/libcurl.test.ts
@@ -152,7 +152,7 @@ CURLcode ret = curl_easy_perform(hnd);`,
     )
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = cLibcurl.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
@@ -162,6 +162,21 @@ CURLcode ret = curl_easy_perform(hnd);`,
 
 curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
 curl_easy_setopt(hnd, CURLOPT_URL, "https://example.com/path%20with%20spaces/[brackets]");
+
+CURLcode ret = curl_easy_perform(hnd);`,
+    )
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = cLibcurl.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(
+      `CURL *hnd = curl_easy_init();
+
+curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
+curl_easy_setopt(hnd, CURLOPT_URL, "https://example.com/path%20with%20spaces/{brackets}");
 
 CURLcode ret = curl_easy_perform(hnd);`,
     )

--- a/packages/snippetz/src/plugins/clojure/clj_http/clj_http.test.ts
+++ b/packages/snippetz/src/plugins/clojure/clj_http/clj_http.test.ts
@@ -113,7 +113,7 @@ describe('clojureCljhttp', () => {
     )
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = clojureCljhttp.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
@@ -122,6 +122,18 @@ describe('clojureCljhttp', () => {
       `(require '[clj-http.client :as client])
 
 (client/get "https://example.com/path%20with%20spaces/[brackets]")`,
+    )
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = clojureCljhttp.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(
+      `(require '[clj-http.client :as client])
+
+(client/get "https://example.com/path%20with%20spaces/{brackets}")`,
     )
   })
 

--- a/packages/snippetz/src/plugins/dart/http/http.test.ts
+++ b/packages/snippetz/src/plugins/dart/http/http.test.ts
@@ -386,7 +386,7 @@ void main() async {
 }`)
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = dartHttp.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
@@ -395,6 +395,19 @@ void main() async {
 
 void main() async {
   final response = await http.get(Uri.parse('https://example.com/path with spaces/[brackets]'));
+  print(response.body);
+}`)
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = dartHttp.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(`import 'package:http/http.dart' as http;
+
+void main() async {
+  final response = await http.get(Uri.parse('https://example.com/path with spaces/{brackets}'));
   print(response.body);
 }`)
   })

--- a/packages/snippetz/src/plugins/go/native/native.test.ts
+++ b/packages/snippetz/src/plugins/go/native/native.test.ts
@@ -250,7 +250,7 @@ func main() {
     )
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = goNative.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
@@ -266,6 +266,37 @@ import (
 
 func main() {
 	url := "https://example.com/path%20with%20spaces/[brackets]"
+
+	req, _ := http.NewRequest("GET", url, nil)
+
+	res, _ := http.DefaultClient.Do(req)
+
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+
+	fmt.Println(res)
+	fmt.Println(string(body))
+
+}`,
+    )
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = goNative.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(
+      `package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func main() {
+	url := "https://example.com/path%20with%20spaces/{brackets}"
 
 	req, _ := http.NewRequest("GET", url, nil)
 

--- a/packages/snippetz/src/plugins/http/http11/http11.test.ts
+++ b/packages/snippetz/src/plugins/http/http11/http11.test.ts
@@ -136,12 +136,20 @@ describe('httpHttp11', () => {
     )
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = httpHttp11.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
 
     expect(result).toBe('GET /path%20with%20spaces/[brackets] HTTP/1.1\r\n' + 'Host: example.com\r\n' + '\r\n')
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = httpHttp11.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe('GET /path%20with%20spaces/{brackets} HTTP/1.1\r\n' + 'Host: example.com\r\n' + '\r\n')
   })
 
   it('handles multiple headers with same name', () => {

--- a/packages/snippetz/src/plugins/http/http11/http11.ts
+++ b/packages/snippetz/src/plugins/http/http11/http11.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from '@scalar/types/snippetz'
+import { getUrlPathnameWithRestoredBrackets } from '@/utils/getPathnameWithRestoredBrackets'
 
 /**
  * http/http1.1
@@ -24,7 +25,8 @@ export const httpHttp11: Plugin = {
     let path
     try {
       url = new URL(normalizedRequest.url || 'http://')
-      path = url.pathname + (url.search || '')
+      const pathname = getUrlPathnameWithRestoredBrackets(url)
+      path = pathname + (url.search || '')
     } catch (_error) {
       // Oops, got an invalid URL, use the provided URL directly.
       path = normalizedRequest.url || '/'

--- a/packages/snippetz/src/plugins/java/okhttp/okhttp.test.ts
+++ b/packages/snippetz/src/plugins/java/okhttp/okhttp.test.ts
@@ -112,7 +112,7 @@ Request request = new Request.Builder()
 Response response = client.newCall(request).execute();`)
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = javaOkhttp.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
@@ -121,6 +121,21 @@ Response response = client.newCall(request).execute();`)
 
 Request request = new Request.Builder()
   .url("https://example.com/path%20with%20spaces/[brackets]")
+  .get()
+  .build();
+
+Response response = client.newCall(request).execute();`)
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = javaOkhttp.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(`OkHttpClient client = new OkHttpClient();
+
+Request request = new Request.Builder()
+  .url("https://example.com/path%20with%20spaces/{brackets}")
   .get()
   .build();
 

--- a/packages/snippetz/src/plugins/kotlin/okhttp/okhttp.test.ts
+++ b/packages/snippetz/src/plugins/kotlin/okhttp/okhttp.test.ts
@@ -112,7 +112,7 @@ val request = Request.Builder()
 val response = client.newCall(request).execute()`)
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = kotlinOkhttp.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
@@ -121,6 +121,21 @@ val response = client.newCall(request).execute()`)
 
 val request = Request.Builder()
   .url("https://example.com/path%20with%20spaces/[brackets]")
+  .get()
+  .build()
+
+val response = client.newCall(request).execute()`)
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = kotlinOkhttp.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(`val client = OkHttpClient()
+
+val request = Request.Builder()
+  .url("https://example.com/path%20with%20spaces/{brackets}")
   .get()
   .build()
 

--- a/packages/snippetz/src/plugins/php/curl/curl.test.ts
+++ b/packages/snippetz/src/plugins/php/curl/curl.test.ts
@@ -395,12 +395,24 @@ curl_exec($ch);
 curl_close($ch);`)
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = phpCurl.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
 
     expect(result).toBe(`$ch = curl_init("https://example.com/path with spaces/[brackets]");
+
+curl_exec($ch);
+
+curl_close($ch);`)
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = phpCurl.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(`$ch = curl_init("https://example.com/path with spaces/{brackets}");
 
 curl_exec($ch);
 

--- a/packages/snippetz/src/plugins/php/guzzle/guzzle.test.ts
+++ b/packages/snippetz/src/plugins/php/guzzle/guzzle.test.ts
@@ -380,7 +380,7 @@ $response = $client->request('GET', 'https://example.com', [
 ]);`)
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = phpGuzzle.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
@@ -388,6 +388,16 @@ $response = $client->request('GET', 'https://example.com', [
     expect(result).toBe(`$client = new GuzzleHttp\\Client();
 
 $response = $client->request('GET', 'https://example.com/path with spaces/[brackets]');`)
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = phpGuzzle.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(`$client = new GuzzleHttp\\Client();
+
+$response = $client->request('GET', 'https://example.com/path with spaces/{brackets}');`)
   })
 
   it('handles special characters in query parameters', () => {

--- a/packages/snippetz/src/plugins/python/httpx/async.test.ts
+++ b/packages/snippetz/src/plugins/python/httpx/async.test.ts
@@ -272,7 +272,7 @@ describe('pythonHttpxAsync', () => {
     )`)
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = pythonHttpxAsync.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
@@ -280,6 +280,17 @@ describe('pythonHttpxAsync', () => {
     expect(result).toBe(`with httpx.AsyncClient() as client:
     await client.get(
         "https://example.com/path with spaces/[brackets]"
+    )`)
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = pythonHttpxAsync.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(`with httpx.AsyncClient() as client:
+    await client.get(
+        "https://example.com/path with spaces/{brackets}"
     )`)
   })
 

--- a/packages/snippetz/src/plugins/python/python3/python3.test.ts
+++ b/packages/snippetz/src/plugins/python/python3/python3.test.ts
@@ -1,26 +1,44 @@
 import { describe, expect, it } from 'vitest'
-import { pythonHttpxSync } from './sync'
+import { pythonPython3 } from './python3'
 
-describe('pythonHttpxSync', () => {
+describe('pythonRequests', () => {
   it('returns a basic request', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
     })
 
-    expect(result).toBe('httpx.get("https://example.com")')
+    expect(result).toBe(`import http.client
+
+conn = http.client.HTTPSConnection("example.com")
+
+conn.request("GET", "/")
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
   })
 
   it('returns a POST request', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       method: 'post',
     })
 
-    expect(result).toBe('httpx.post("https://example.com")')
+    expect(result).toBe(`import http.client
+
+conn = http.client.HTTPSConnection("example.com")
+
+conn.request("POST", "/")
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
   })
 
   it('has headers', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       headers: [
         {
@@ -30,24 +48,40 @@ describe('pythonHttpxSync', () => {
       ],
     })
 
-    expect(result).toBe(`httpx.get("https://example.com",
-    headers={
-      "Content-Type": "application/json"
-    }
-)`)
+    expect(result).toBe(`import http.client
+
+conn = http.client.HTTPSConnection("example.com")
+
+headers = { 'Content-Type': "application/json" }
+
+conn.request("GET", "/", headers=headers)
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
   })
 
   it(`doesn't add empty headers`, () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       headers: [],
     })
 
-    expect(result).toBe('httpx.get("https://example.com")')
+    expect(result).toBe(`import http.client
+
+conn = http.client.HTTPSConnection("example.com")
+
+conn.request("GET", "/")
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
   })
 
   it('has JSON body', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       method: 'POST',
       headers: [
@@ -64,18 +98,25 @@ describe('pythonHttpxSync', () => {
       },
     })
 
-    expect(result).toBe(`httpx.post("https://example.com",
-    headers={
-      "Content-Type": "application/json"
-    },
-    json={
-      "hello": "world"
-    }
-)`)
+    expect(result).toBe(`import http.client
+
+conn = http.client.HTTPSConnection("example.com")
+
+payload = "{\\"hello\\":\\"world\\"}"
+
+headers = { 'Content-Type': "application/json" }
+
+conn.request("POST", "/", payload, headers)
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
   })
 
+  /*
   it('has query string', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       queryString: [
         {
@@ -89,16 +130,13 @@ describe('pythonHttpxSync', () => {
       ],
     })
 
-    expect(result).toBe(`httpx.get("https://example.com",
-    params={
-      "foo": "bar",
-      "bar": "foo"
-    }
-)`)
+    expect(result).toBe(`(awaiting implementation)`)
   })
+  */
 
+  /*
   it('has cookies', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       cookies: [
         {
@@ -112,25 +150,24 @@ describe('pythonHttpxSync', () => {
       ],
     })
 
-    expect(result).toBe(`httpx.get("https://example.com",
-    cookies={
-      "foo": "bar",
-      "bar": "foo"
-    }
-)`)
+    expect(result).toBe(`(awaiting implementation)`)
   })
+  */
 
+  /*
   it(`doesn't add empty cookies`, () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       cookies: [],
     })
 
-    expect(result).toBe('httpx.get("https://example.com")')
+    expect(result).toBe(`(awaiting implementation)`)
   })
+  */
 
+  /*
   it('adds basic auth credentials', () => {
-    const result = pythonHttpxSync.generate(
+    const result = pythonPython3.generate(
       {
         url: 'https://example.com',
       },
@@ -142,13 +179,13 @@ describe('pythonHttpxSync', () => {
       },
     )
 
-    expect(result).toBe(`httpx.get("https://example.com",
-    auth=("user", "pass")
-)`)
+    expect(result).toBe(`(awaiting implementation)`)
   })
+  */
 
+  /*
   it('handles multipart form data with files', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       method: 'POST',
       postData: {
@@ -166,18 +203,13 @@ describe('pythonHttpxSync', () => {
       },
     })
 
-    expect(result).toBe(`httpx.post("https://example.com",
-    files=[
-      ("file", open("test.txt", "rb"))
-    ],
-    data={
-      "field": "value"
-    }
-)`)
+    expect(result).toBe(`(awaiting implementation)`)
   })
+  */
 
+  /*
   it('handles multipart form data with multiple files', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       method: 'POST',
       postData: {
@@ -195,16 +227,13 @@ describe('pythonHttpxSync', () => {
       },
     })
 
-    expect(result).toBe(`httpx.post("https://example.com",
-    files=[
-      ("file", open("test.txt", "rb")),
-      ("file", open("another.txt", "rb"))
-    ]
-)`)
+    expect(result).toBe(`(awaiting implementation)`)
   })
+  */
 
+  /*
   it('handles url-encoded form data', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       method: 'POST',
       postData: {
@@ -218,15 +247,13 @@ describe('pythonHttpxSync', () => {
       },
     })
 
-    expect(result).toBe(`httpx.post("https://example.com",
-    data={
-      "special chars!@#": "value"
-    }
-)`)
+    expect(result).toBe(`(awaiting implementation)`)
   })
+  */
 
+  /*
   it('handles binary data flag', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       method: 'POST',
       postData: {
@@ -235,13 +262,13 @@ describe('pythonHttpxSync', () => {
       },
     })
 
-    expect(result).toBe(`httpx.post("https://example.com",
-    data=b"binary content"
-)`)
+    expect(result).toBe(`(awaiting implementation)`)
   })
+  */
 
+  /*
   it('handles compressed response', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       headers: [
         {
@@ -251,35 +278,47 @@ describe('pythonHttpxSync', () => {
       ],
     })
 
-    expect(result).toBe(`httpx.get("https://example.com",
-    headers={
-      "Accept-Encoding": "gzip, deflate"
-    }
-)`)
+    expect(result).toBe(`(awaiting implementation)`)
   })
+  */
 
   it('handles special characters in URL, square brackets', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
 
-    expect(result).toBe(`httpx.get(
-    "https://example.com/path with spaces/[brackets]"
-)`)
+    expect(result).toBe(`import http.client
+
+conn = http.client.HTTPSConnection("example.com")
+
+conn.request("GET", "/path%20with%20spaces/[brackets]")
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
   })
 
   it('handles special characters in URL, curly brackets', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com/path with spaces/{brackets}',
     })
 
-    expect(result).toBe(`httpx.get(
-    "https://example.com/path with spaces/{brackets}"
-)`)
+    expect(result).toBe(`import http.client
+
+conn = http.client.HTTPSConnection("example.com")
+
+conn.request("GET", "/path%20with%20spaces/{brackets}")
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
   })
 
+  /*
   it('handles special characters in query parameters', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       queryString: [
         {
@@ -293,42 +332,56 @@ describe('pythonHttpxSync', () => {
       ],
     })
 
-    expect(result).toBe(`httpx.get("https://example.com",
-    params={
-      "q": "hello world & more",
-      "special": "!@#$%^&*()"
-    }
-)`)
+    expect(result).toBe(`(awaiting implementation)`)
   })
+  */
 
+  /* Do we need to handle this? Other plugins using convertWithHttpSnippetLite don't.
   it('handles empty URL', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: '',
     })
 
-    expect(result).toBe('httpx.get("")')
+    expect(result).toBe(`awaiting implementation`)
   })
+  */
 
   it(`doesn't add a line break for a short URL`, () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
     })
 
-    expect(result).toBe('httpx.get("https://example.com")')
+    expect(result).toBe(`import http.client
+
+conn = http.client.HTTPSConnection("example.com")
+
+conn.request("GET", "/")
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
   })
 
   it('handles extremely long URLs', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com/' + 'a'.repeat(2000),
     })
 
-    expect(result).toBe(`httpx.get(
-    "https://example.com/${'a'.repeat(2000)}"
-)`)
+    expect(result).toBe(`import http.client
+
+conn = http.client.HTTPSConnection("example.com")
+
+conn.request("GET", "/${'a'.repeat(2000)}")
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
   })
 
   it('handles multiple headers with same name', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       headers: [
         { name: 'X-Custom', value: 'value1' },
@@ -336,28 +389,43 @@ describe('pythonHttpxSync', () => {
       ],
     })
 
-    expect(result).toBe(`httpx.get("https://example.com",
-    headers={
-      "X-Custom": "value1"
-    }
-)`)
+    expect(result).toBe(`import http.client
+
+conn = http.client.HTTPSConnection("example.com")
+
+headers = { 'X-Custom': "value2" }
+
+conn.request("GET", "/", headers=headers)
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
   })
 
   it('handles headers with empty values', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       headers: [{ name: 'X-Empty', value: '' }],
     })
 
-    expect(result).toBe(`httpx.get("https://example.com",
-    headers={
-      "X-Empty": ""
-    }
-)`)
+    expect(result).toBe(`import http.client
+
+conn = http.client.HTTPSConnection("example.com")
+
+headers = { 'X-Empty': "" }
+
+conn.request("GET", "/", headers=headers)
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
   })
 
+  /*
   it('handles multipart form data with empty file names', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       method: 'POST',
       postData: {
@@ -371,15 +439,12 @@ describe('pythonHttpxSync', () => {
       },
     })
 
-    expect(result).toBe(`httpx.post("https://example.com",
-    files=[
-      ("file", open("", "rb"))
-    ]
-)`)
+    expect(result).toBe(`(awaiting implementation)`)
   })
+  */
 
   it('handles JSON body with special characters', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       method: 'POST',
       headers: [
@@ -399,43 +464,41 @@ describe('pythonHttpxSync', () => {
       },
     })
 
-    expect(result).toBe(`httpx.post("https://example.com",
-    headers={
-      "Content-Type": "application/json"
-    },
-    json={
-      "key": "\\"quotes\\" and \\\\backslashes\\\\",
-      "nested": {
-        "array": [
-          "item1",
-          None,
-          None
-        ]
-      }
-    }
-)`)
+    expect(result).toBe(`import http.client
+
+conn = http.client.HTTPSConnection("example.com")
+
+payload = "{\\"key\\":\\"\\\\\\"quotes\\\\\\" and \\\\\\\\backslashes\\\\\\\\\\",\\"nested\\":{\\"array\\":[\\"item1\\",null,null]}}"
+
+headers = { 'Content-Type': "application/json" }
+
+conn.request("POST", "/", payload, headers)
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
   })
 
-  it('handles cookies with special characters', () => {
-    const result = pythonHttpxSync.generate({
-      url: 'https://example.com',
-      cookies: [
-        {
-          name: 'special;cookie',
-          value: 'value with spaces',
-        },
-      ],
+  /*
+    it('handles cookies with special characters', () => {
+      const result = pythonPython3.generate({
+        url: 'https://example.com',
+        cookies: [
+          {
+            name: 'special;cookie',
+            value: 'value with spaces',
+          },
+        ],
+      })
+  
+      expect(result).toBe(`(awaiting implementation)`)
     })
+  */
 
-    expect(result).toBe(`httpx.get("https://example.com",
-    cookies={
-      "special;cookie": "value with spaces"
-    }
-)`)
-  })
-
+  /*
   it('prettifies JSON body', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       method: 'POST',
       headers: [
@@ -456,28 +519,12 @@ describe('pythonHttpxSync', () => {
       },
     })
 
-    expect(result).toBe(`httpx.post("https://example.com",
-    headers={
-      "Content-Type": "application/json"
-    },
-    json={
-      "nested": {
-        "array": [
-          1,
-          2,
-          3
-        ],
-        "object": {
-          "foo": "bar"
-        }
-      },
-      "simple": "value"
-    }
-)`)
+    expect(result).toBe(`awaiting implementation`)
   })
+  */
 
   it('converts true/false/null to Python syntax', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       method: 'POST',
       headers: [
@@ -495,31 +542,29 @@ describe('pythonHttpxSync', () => {
           nested: {
             boolArray: [true, false, null],
           },
+          nullValue2: null,
         }),
       },
     })
 
-    expect(result).toBe(`httpx.post("https://example.com",
-    headers={
-      "Content-Type": "application/json"
-    },
-    json={
-      "boolTrue": True,
-      "boolFalse": False,
-      "nullValue": None,
-      "nested": {
-        "boolArray": [
-          True,
-          False,
-          None
-        ]
-      }
-    }
-)`)
+    expect(result).toBe(`import http.client
+
+conn = http.client.HTTPSConnection("example.com")
+
+payload = "{\\"boolTrue\\":true,\\"boolFalse\\":false,\\"nullValue\\":null,\\"nested\\":{\\"boolArray\\":[true,false,null]},\\"nullValue2\\":null}"
+
+headers = { 'Content-Type': "application/json" }
+
+conn.request("POST", "/", payload, headers)
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
   })
 
   it('does not replace true/false/null in string literals', () => {
-    const result = pythonHttpxSync.generate({
+    const result = pythonPython3.generate({
       url: 'https://example.com',
       method: 'POST',
       headers: [
@@ -538,19 +583,19 @@ describe('pythonHttpxSync', () => {
       },
     })
 
-    expect(result).toBe(`httpx.post("https://example.com",
-    headers={
-      "Content-Type": "application/json"
-    },
-    json={
-      "stringWithTrue": "This string contains true",
-      "stringWithTrue2": "aaa   true,   aa",
-      "array": [
-        "true,",
-        "     true\\n",
-        "true"
-      ]
-    }
-)`)
+    expect(result).toBe(`import http.client
+
+conn = http.client.HTTPSConnection("example.com")
+
+payload = "{\\"stringWithTrue\\":\\"This string contains true\\",\\"stringWithTrue2\\":\\"aaa   true,   aa\\",\\"array\\":[\\"true,\\",\\"     true\\\\n\\",\\"true\\"]}"
+
+headers = { 'Content-Type': "application/json" }
+
+conn.request("POST", "/", payload, headers)
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))`)
   })
 })

--- a/packages/snippetz/src/plugins/python/requests/requests.test.ts
+++ b/packages/snippetz/src/plugins/python/requests/requests.test.ts
@@ -258,13 +258,23 @@ describe('pythonRequests', () => {
 )`)
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = pythonRequests.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
 
     expect(result).toBe(`requests.get(
     "https://example.com/path with spaces/[brackets]"
+)`)
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = pythonRequests.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(`requests.get(
+    "https://example.com/path with spaces/{brackets}"
 )`)
   })
 

--- a/packages/snippetz/src/plugins/ruby/native/native.test.ts
+++ b/packages/snippetz/src/plugins/ruby/native/native.test.ts
@@ -166,7 +166,7 @@ puts response.read_body`,
     )
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = rubyNative.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
@@ -176,6 +176,27 @@ puts response.read_body`,
 require 'net/http'
 
 url = URI("https://example.com/path%20with%20spaces/[brackets]")
+
+http = Net::HTTP.new(url.host, url.port)
+http.use_ssl = true
+
+request = Net::HTTP::Get.new(url)
+
+response = http.request(request)
+puts response.read_body`,
+    )
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = rubyNative.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(
+      `require 'uri'
+require 'net/http'
+
+url = URI("https://example.com/path%20with%20spaces/{brackets}")
 
 http = Net::HTTP.new(url.host, url.port)
 http.use_ssl = true

--- a/packages/snippetz/src/plugins/rust/reqwest/reqwest.test.ts
+++ b/packages/snippetz/src/plugins/rust/reqwest/reqwest.test.ts
@@ -361,7 +361,7 @@ let request = client
 let response = request.send().await?;`)
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = rustReqwest.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
@@ -369,6 +369,18 @@ let response = request.send().await?;`)
     expect(result).toBe(`let client = reqwest::Client::new();
 
 let request = client.get("https://example.com/path with spaces/[brackets]");
+
+let response = request.send().await?;`)
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = rustReqwest.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(`let client = reqwest::Client::new();
+
+let request = client.get("https://example.com/path with spaces/{brackets}");
 
 let response = request.send().await?;`)
   })

--- a/packages/snippetz/src/plugins/shell/curl/curl.test.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.test.ts
@@ -306,12 +306,20 @@ describe('shellCurl', () => {
   --compressed`)
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = shellCurl.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
 
     expect(result).toBe(`curl 'https://example.com/path with spaces/[brackets]'`)
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(`curl 'https://example.com/path with spaces/{brackets}'`)
   })
 
   it('handles special characters in query parameters', () => {

--- a/packages/snippetz/src/plugins/shell/httpie/httpie.test.ts
+++ b/packages/snippetz/src/plugins/shell/httpie/httpie.test.ts
@@ -91,12 +91,20 @@ describe('shellHttpie', () => {
   http POST https://example.com`)
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = shellHttpie.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
 
     expect(result).toBe(`http GET 'https://example.com/path%20with%20spaces/[brackets]'`)
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = shellHttpie.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(`http GET 'https://example.com/path%20with%20spaces/{brackets}'`)
   })
 
   it('handles multiple headers with same name', () => {

--- a/packages/snippetz/src/plugins/shell/wget/wget.test.ts
+++ b/packages/snippetz/src/plugins/shell/wget/wget.test.ts
@@ -109,7 +109,7 @@ describe('shellWget', () => {
   - https://example.com`)
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = shellWget.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
@@ -118,6 +118,17 @@ describe('shellWget', () => {
   --method GET \\
   --output-document \\
   - 'https://example.com/path%20with%20spaces/[brackets]'`)
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = shellWget.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(`wget --quiet \\
+  --method GET \\
+  --output-document \\
+  - 'https://example.com/path%20with%20spaces/{brackets}'`)
   })
 
   it('handles multiple headers with same name', () => {

--- a/packages/snippetz/src/plugins/swift/nsurlsession/nsurlsession.test.ts
+++ b/packages/snippetz/src/plugins/swift/nsurlsession/nsurlsession.test.ts
@@ -242,7 +242,7 @@ dataTask.resume()`,
     )
   })
 
-  it('handles special characters in URL', () => {
+  it('handles special characters in URL, square brackets', () => {
     const result = swiftNsurlsession.generate({
       url: 'https://example.com/path with spaces/[brackets]',
     })
@@ -251,6 +251,33 @@ dataTask.resume()`,
       `import Foundation
 
 let request = NSMutableURLRequest(url: NSURL(string: "https://example.com/path%20with%20spaces/[brackets]")! as URL,
+                                        cachePolicy: .useProtocolCachePolicy,
+                                    timeoutInterval: 10.0)
+request.httpMethod = "GET"
+
+let session = URLSession.shared
+let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
+  if (error != nil) {
+    print(error as Any)
+  } else {
+    let httpResponse = response as? HTTPURLResponse
+    print(httpResponse)
+  }
+})
+
+dataTask.resume()`,
+    )
+  })
+
+  it('handles special characters in URL, curly brackets', () => {
+    const result = swiftNsurlsession.generate({
+      url: 'https://example.com/path with spaces/{brackets}',
+    })
+
+    expect(result).toBe(
+      `import Foundation
+
+let request = NSMutableURLRequest(url: NSURL(string: "https://example.com/path%20with%20spaces/{brackets}")! as URL,
                                         cachePolicy: .useProtocolCachePolicy,
                                     timeoutInterval: 10.0)
 request.httpMethod = "GET"

--- a/packages/snippetz/src/utils/convertWithHttpSnippetLite.ts
+++ b/packages/snippetz/src/utils/convertWithHttpSnippetLite.ts
@@ -1,5 +1,19 @@
 import type { Request } from '@/httpsnippet-lite/types/httpsnippet'
 import type { HarRequest } from '@scalar/types/snippetz'
+import { getUrlPathnameWithRestoredBrackets } from './getPathnameWithRestoredBrackets.js'
+
+/**
+ * Helper function to extract URL as string from URL object
+ */
+function getUrlObjectAsString(urlObject: URL): string {
+  // If it's just the domain, omit the trailing slash
+  if (urlObject.pathname === '/' || urlObject.pathname === '') {
+    return urlObject.origin
+  }
+  // Otherwise, encode the pathname while preserving brackets
+  const encodedPathname = getUrlPathnameWithRestoredBrackets(urlObject)
+  return urlObject.origin + encodedPathname + urlObject.search
+}
 
 /**
  * Takes a httpsnippet-lite client and converts the given request to a code example with it.
@@ -12,9 +26,7 @@ export function convertWithHttpSnippetLite(
   request?: Partial<HarRequest>,
 ): string {
   const urlObject = new URL(request?.url ?? '')
-
-  // If it's just the domain, omit the trailing slash
-  const url = urlObject.pathname === '/' ? urlObject.origin : urlObject.toString()
+  const url = getUrlObjectAsString(urlObject)
 
   const harRequest: HarRequest = {
     method: request?.method ?? 'GET',

--- a/packages/snippetz/src/utils/getPathnameWithRestoredBrackets.test.ts
+++ b/packages/snippetz/src/utils/getPathnameWithRestoredBrackets.test.ts
@@ -1,0 +1,120 @@
+import {
+  getUrlPathnameWithRestoredBrackets,
+  getStringPathnameWithRestoredBrackets,
+} from '@/utils/getPathnameWithRestoredBrackets'
+import { describe, expect, it } from 'vitest'
+
+describe('getPathnameWithRestoredBrackets', () => {
+  it('encodes simple path', () => {
+    const path = 'path_without_spaces'
+    const url = new URL(path, 'https://example.com ')
+    const result = getUrlPathnameWithRestoredBrackets(url)
+    expect(result.toString()).toBe('/path_without_spaces')
+  })
+
+  it('encodes path with spaces', () => {
+    const path = 'path with spaces'
+    const url = new URL(path, 'https://example.com ')
+    const result = getUrlPathnameWithRestoredBrackets(url)
+    expect(result).toBe('/path%20with%20spaces')
+  })
+
+  it('does not encode square brackets surrounding a segment', () => {
+    const path = 'path with spaces/[brackets]'
+    const url = new URL(path, 'https://example.com ')
+    const result = getUrlPathnameWithRestoredBrackets(url)
+    expect(result).toBe('/path%20with%20spaces/[brackets]')
+  })
+
+  it('does not encode curly brackets surrounding a segment', () => {
+    const path = 'path with spaces/{brackets}'
+    const url = new URL(path, 'https://example.com ')
+    const result = getUrlPathnameWithRestoredBrackets(url)
+    expect(result).toBe('/path%20with%20spaces/{brackets}')
+  })
+
+  it('encodes path of source with origin', () => {
+    const path = 'https://example.com/path with spaces/{brackets}'
+    const url = new URL(path)
+    const result = getUrlPathnameWithRestoredBrackets(url)
+    expect(result).toBe('/path%20with%20spaces/{brackets}')
+  })
+
+  it('encodes path of source with query parameters', () => {
+    const path = 'path with spaces?query=param with spaces'
+    const url = new URL(path, 'https://example.com ')
+    const result = getUrlPathnameWithRestoredBrackets(url)
+    expect(result).toBe('/path%20with%20spaces')
+  })
+
+  it('it encodes curly brackets not surrounding a segment, trailing text', () => {
+    const path = 'path with spaces/{brackets}a'
+    const url = new URL(path, 'https://example.com ')
+    const result = getUrlPathnameWithRestoredBrackets(url)
+    expect(result).toBe('/path%20with%20spaces/%7Bbrackets%7Da')
+  })
+
+  it('it encodes curly brackets not surrounding a segment, leading text', () => {
+    const path = 'path with spaces/b{brackets}'
+    const url = new URL(path, 'https://example.com ')
+    const result = getUrlPathnameWithRestoredBrackets(url)
+    expect(result).toBe('/path%20with%20spaces/b%7Bbrackets%7D')
+  })
+
+  it('it encodes curly brackets not surrounding a segment, brackets not in open-and-close positions', () => {
+    const path = 'path with spaces/}brackets{'
+    const url = new URL(path, 'https://example.com ')
+    const result = getUrlPathnameWithRestoredBrackets(url)
+    expect(result).toBe('/path%20with%20spaces/%7Dbrackets%7B')
+  })
+
+  it('it encodes curly brackets within segment', () => {
+    const path = 'path with spaces/{br{ack}ets}'
+    const url = new URL(path, 'https://example.com ')
+    const result = getUrlPathnameWithRestoredBrackets(url)
+    expect(result).toBe('/path%20with%20spaces/{br%7Back%7Dets}')
+  })
+
+  it('it does not encode curly brackets within an intermediate segment', () => {
+    const path = 'path with spaces/{brackets}/more'
+    const url = new URL(path, 'https://example.com ')
+    const result = getUrlPathnameWithRestoredBrackets(url)
+    expect(result).toBe('/path%20with%20spaces/{brackets}/more')
+  })
+
+  it('it decodes segment curly brackets, at end', () => {
+    const url = 'http://example.com/some-path/%7Bbrackets%7D'
+    const result = getStringPathnameWithRestoredBrackets(url)
+    expect(result).toBe('http://example.com/some-path/{brackets}')
+  })
+
+  it('it decodes segment curly brackets, intermediate', () => {
+    const url = 'http://example.com/some-path/%7Bbrackets%7D/more'
+    const result = getStringPathnameWithRestoredBrackets(url)
+    expect(result).toBe('http://example.com/some-path/{brackets}/more')
+  })
+
+  it('it decodes segment curly brackets, lower case', () => {
+    const url = 'http://example.com/some-path/%7bbrackets%7d'
+    const result = getStringPathnameWithRestoredBrackets(url)
+    expect(result).toBe('http://example.com/some-path/{brackets}')
+  })
+
+  it('it decodes segment square brackets, at end', () => {
+    const url = 'http://example.com/some-path/%5Bbrackets%5D'
+    const result = getStringPathnameWithRestoredBrackets(url)
+    expect(result).toBe('http://example.com/some-path/[brackets]')
+  })
+
+  it('it does not decode other values', () => {
+    const url = 'http://example.com/some-path/%6Bbrackets%6D'
+    const result = getStringPathnameWithRestoredBrackets(url)
+    expect(result).toBe('http://example.com/some-path/%6Bbrackets%6D')
+  })
+
+  it('it does not decode without percent', () => {
+    const url = 'http://example.com/some-path/7Bbrackets%7D'
+    const result = getStringPathnameWithRestoredBrackets(url)
+    expect(result).toBe('http://example.com/some-path/7Bbrackets%7D')
+  })
+})

--- a/packages/snippetz/src/utils/getPathnameWithRestoredBrackets.ts
+++ b/packages/snippetz/src/utils/getPathnameWithRestoredBrackets.ts
@@ -1,0 +1,41 @@
+/**
+ * For any URL segments bounded by encoded brackets, turn them into unencoded brackets.
+ */
+export const getUrlPathnameWithRestoredBrackets = (url: URL): string => {
+  if (!url) {
+    return '/'
+  }
+  return getStringPathnameWithRestoredBrackets(url.pathname)
+}
+
+/**
+ * For any URL segments bounded by encoded brackets, turn them into unencoded brackets.
+ */
+export const getStringPathnameWithRestoredBrackets = (pathname: string): string => {
+  if (!pathname) {
+    return '/'
+  }
+  if (pathname === '/' || pathname === '') {
+    return pathname
+  }
+
+  // Looking for a forward slash followed by a escaped opening bracket (curly or square)
+  const hasBrackets = new RegExp('/%[57]B', 'i').test(pathname)
+  if (!hasBrackets) {
+    return pathname
+  }
+
+  const encodedPathWithBracketsReinstated = pathname
+    .split('/')
+    .map((segment) => {
+      if (/^%5B.*%5D$/i.test(segment)) {
+        return '[' + segment.slice(3, -3) + ']'
+      }
+      if (/^%7B.*%7D$/i.test(segment)) {
+        return '{' + segment.slice(3, -3) + '}'
+      }
+      return segment
+    })
+    .join('/')
+  return encodedPathWithBracketsReinstated
+}


### PR DESCRIPTION
**Problem**

This can be demonstrated with the _Galaxy_ example api docs that come with Scalar.  Various of the methods have placeholders in them, e.g. `get/planets/{planetId}`  The curly brackets there are placeholders, saying "you should put your _planetId_ here."  The curly brackets set the parameters off from the method path.  The curly brackets shouldn't be included in your path when you submit it; they are there just to say "this isn't part of the method path - this is where you add your stuff."

It follows then that the curly brackets should not be URL escaped.  

Some of the code samples viewable in the Scalar API explorer get this right.  e.g. for snippets in _Dart Http, JavaScipt Fetch, JavaScript oFetch, Node.js Fetch, Node.js ofetch, Node.js undici, PHP cURL, PHP Guzzle, Python Requests, Python HTTPX, Rust reqwest, Shell Curl,_ you get an example looking something like this (this is _Node.js Fetch_)

```
fetch('https://galaxy.scalar.com/planets/{planetId}')
```

But for other snippets, including _JavaScript Axios, JavaScript jQuery, Python http.client, C#,_ the curly braces end up getting URL-encoded, which obscures their function as marking the placeholder for where your parameter should go. e.g., for _C#_:

```
RequestUri = new Uri("https://galaxy.scalar.com/planets/%7BplanetId%7D"),
```

This is wrong.  It hides that the curly brackets are there to show where your _planetId_ should go.

**Tests**

There are many unit tests that touch this area with names like 'handles special characters in URL', and they check that placeholders using square brackets get through without being URL-encoded.  But most API docs (including Scalar's example _Galaxy_ docs) use curly brackets for denoting placeholders.  So this PR also adds tests for this - where we had a test for 'handles special characters in URL', we now have tests for 'handles special characters in URL, square brackets' and 'handles special characters in URL, curly brackets'.

**Solution**

With this PR, this issue is fixed.  The snippetz code makes extensive use of the JavaScript _URL_ object, and gets the page from the `URL.pathname` which comes out URL-encoded where applicable, including encoding curly brackets.  The new `getPathnameWithRestoredBrackets.ts` file has helper methods to reinstate brackets unencoded when they are doing the work of a placeholder.

**Checklist**

I've gone through the following:

- [✓] I've added an explanation _why_ this change is needed.
- [✓] I've added a changeset (`pnpm changeset`).
- [✓] I've added tests for the regression or new feature.
- [✓] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
