### PR TITLE
fix(api-reference): path parameters not showing in request example code

### DIFF
--- a/.changeset/dull-glasses-wave.md
+++ b/.changeset/dull-glasses-wave.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+fix(api-reference): path parameters not showing in request example code

--- a/packages/api-reference/src/features/Operation/Operation.vue
+++ b/packages/api-reference/src/features/Operation/Operation.vue
@@ -92,14 +92,29 @@ const selectedSecuritySchemes = computed(() =>
   ).map(convertSecurityScheme),
 )
 
-/** Dereference path parameters and combine with operation parameters */
+/**
+ * Dereference path parameters and combine with operation parameters
+ *
+ * Ensure that operation parameters take prescedence and there are no duplicates
+ */
 const parameters = computed(() => {
   const pathParams = pathItem.value?.parameters ?? []
   const operationParams = operation.value?.parameters ?? []
 
-  return [...pathParams, ...operationParams].filter(
+  const allParams = [...pathParams, ...operationParams].filter(
     isResolvedRef<ParameterObject>,
   )
+
+  // Use a Map to ensure unique in+name combinations
+  // Operation parameters take precedence over path parameters
+  const uniqueParams = new Map<string, ParameterObject>()
+
+  for (const param of allParams) {
+    const key = `${param.in}:${param.name}`
+    uniqueParams.set(key, param)
+  }
+
+  return Array.from(uniqueParams.values())
 })
 </script>
 

--- a/packages/api-reference/src/features/Operation/helpers/combine-params.test.ts
+++ b/packages/api-reference/src/features/Operation/helpers/combine-params.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { combineParams } from './combine-params'
+import type { ParameterObject } from '@scalar/workspace-store/schemas/v3.1/strict/parameter'
+
+describe('combineParams', () => {
+  it('combines path and operation parameters', () => {
+    const pathParams: ParameterObject[] = [
+      { name: 'id', in: 'path', required: true },
+      { name: 'version', in: 'query', required: false },
+    ]
+
+    const operationParams: ParameterObject[] = [
+      { name: 'limit', in: 'query', required: false },
+      { name: 'offset', in: 'query', required: false },
+    ]
+
+    const result = combineParams(pathParams, operationParams)
+    expect(result).toHaveLength(4)
+    expect(result).toEqual([...pathParams, ...operationParams])
+  })
+
+  it('gives operation parameters precedence over path parameters with same name and location', () => {
+    const pathParams: ParameterObject[] = [{ name: 'id', in: 'path', required: true, description: 'Path parameter' }]
+
+    const operationParams: ParameterObject[] = [
+      { name: 'id', in: 'path', required: false, description: 'Operation parameter' },
+    ]
+
+    const result = combineParams(pathParams, operationParams)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(operationParams[0])
+  })
+
+  it('handles parameters with same name but different locations', () => {
+    const pathParams: ParameterObject[] = [{ name: 'id', in: 'path', required: true }]
+
+    const operationParams: ParameterObject[] = [{ name: 'id', in: 'query', required: false }]
+
+    const result = combineParams(pathParams, operationParams)
+    expect(result).toHaveLength(2)
+    expect(result).toEqual([...pathParams, ...operationParams])
+  })
+
+  it('filters out unresolved references', () => {
+    const pathParams: any[] = [
+      { name: 'id', in: 'path', required: true },
+      { $ref: '#/components/parameters/UnresolvedParam' }, // Unresolved reference
+    ]
+
+    const operationParams: any[] = [
+      { name: 'limit', in: 'query', required: false },
+      { $ref: '#/components/parameters/AnotherUnresolved' }, // Unresolved reference
+    ]
+
+    const result = combineParams(pathParams, operationParams)
+    expect(result).toHaveLength(2)
+    expect(result).toEqual([
+      { name: 'id', in: 'path', required: true },
+      { name: 'limit', in: 'query', required: false },
+    ])
+  })
+
+  it('handles edge case with null values in arrays', () => {
+    const pathParams: any[] = [
+      { name: 'id', in: 'path', required: true },
+      null, // This should be filtered out
+    ]
+
+    const operationParams: any[] = [
+      { name: 'limit', in: 'query', required: false },
+      undefined, // This should be filtered out
+    ]
+
+    const result = combineParams(pathParams, operationParams)
+    expect(result).toHaveLength(2)
+    expect(result).toEqual([
+      { name: 'id', in: 'path', required: true },
+      { name: 'limit', in: 'query', required: false },
+    ])
+  })
+})

--- a/packages/api-reference/src/features/Operation/helpers/combine-params.ts
+++ b/packages/api-reference/src/features/Operation/helpers/combine-params.ts
@@ -1,0 +1,22 @@
+import type { ParameterObject } from '@scalar/workspace-store/schemas/v3.1/strict/parameter'
+import type { OperationObject, PathItemObject } from '@scalar/workspace-store/schemas/v3.1/strict/path-operations'
+import { isResolvedRef, type Dereference } from '@scalar/workspace-store/schemas/v3.1/type-guard'
+
+/** Combine pathItem and operation parameters into a single, dereferenced parameter array */
+export const combineParams = (
+  pathParams: PathItemObject['parameters'] = [],
+  operationParams: Dereference<OperationObject>['parameters'] = [],
+): ParameterObject[] => {
+  const allParams = [...pathParams, ...operationParams].filter(isResolvedRef<ParameterObject>)
+
+  // Use a Map to ensure unique in+name combinations
+  // Operation parameters take precedence over path parameters
+  const uniqueParams = new Map<string, ParameterObject>()
+
+  for (const param of allParams) {
+    const key = `${param.in}:${param.name}`
+    uniqueParams.set(key, param)
+  }
+
+  return Array.from(uniqueParams.values())
+}

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -18,7 +18,6 @@ import {
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
-import type { ParameterObject } from '@scalar/workspace-store/schemas/v3.1/strict/parameter'
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/path-operations'
 import type { SecuritySchemeObject } from '@scalar/workspace-store/schemas/v3.1/strict/security-scheme'
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/server'
@@ -49,7 +48,6 @@ const { operation, path, isWebhook } = defineProps<{
   method: HttpMethodType
   operation: Dereference<OperationObject>
   oldOperation: OpenAPIV3_1.OperationObject
-  parameters: ParameterObject[]
   // pathServers: ServerObject[] | undefined
   isWebhook: boolean
   server: ServerObject | undefined
@@ -142,7 +140,7 @@ const handleDiscriminatorChange = (type: string) => {
         <div class="operation-details-card-item">
           <OperationParameters
             :requestBody="oldOperation.requestBody"
-            :parameters
+            :parameters="operation.parameters"
             :schemas
             @update:modelValue="handleDiscriminatorChange" />
         </div>

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -9,7 +9,6 @@ import {
 } from '@scalar/oas-utils/helpers'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
-import type { ParameterObject } from '@scalar/workspace-store/schemas/v3.1/strict/parameter'
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/path-operations'
 import type { SecuritySchemeObject } from '@scalar/workspace-store/schemas/v3.1/strict/security-scheme'
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/server'
@@ -46,7 +45,6 @@ const { path, operation, method, isWebhook, oldOperation } = defineProps<{
   method: HttpMethodType
   operation: Dereference<OperationObject>
   oldOperation: OpenAPIV3_1.OperationObject
-  parameters: ParameterObject[]
   // pathServers: ServerObject[] | undefined
   isWebhook: boolean
   securitySchemes: SecuritySchemeObject[]
@@ -110,7 +108,7 @@ const handleDiscriminatorChange = (type: string) => {
               :anchorPrefix="id" />
             <OperationParameters
               :breadcrumb="[id]"
-              :parameters
+              :parameters="operation.parameters"
               :requestBody="oldOperation.requestBody"
               :schemas
               @update:modelValue="handleDiscriminatorChange">

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -38,21 +38,20 @@ import { useConfig } from '@/hooks/useConfig'
 import { RequestExample } from '@/v2/blocks/scalar-request-example-block'
 import type { ClientOptionGroup } from '@/v2/blocks/scalar-request-example-block/types'
 
-const { path, operation, method, isWebhook, oldOperation, store } =
-  defineProps<{
-    id: string
-    path: string
-    clientOptions: ClientOptionGroup[]
-    method: HttpMethodType
-    operation: Dereference<OperationObject>
-    oldOperation: OpenAPIV3_1.OperationObject
-    // pathServers: ServerObject[] | undefined
-    isWebhook: boolean
-    securitySchemes: SecuritySchemeObject[]
-    server: ServerObject | undefined
-    schemas?: Schemas
-    store: WorkspaceStore
-  }>()
+const { path, operation, method, isWebhook, oldOperation } = defineProps<{
+  id: string
+  path: string
+  clientOptions: ClientOptionGroup[]
+  method: HttpMethodType
+  operation: Dereference<OperationObject>
+  oldOperation: OpenAPIV3_1.OperationObject
+  // pathServers: ServerObject[] | undefined
+  isWebhook: boolean
+  securitySchemes: SecuritySchemeObject[]
+  server: ServerObject | undefined
+  schemas?: Schemas
+  store: WorkspaceStore
+}>()
 
 const operationTitle = computed(() => operation.summary || path || '')
 

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -38,20 +38,21 @@ import { useConfig } from '@/hooks/useConfig'
 import { RequestExample } from '@/v2/blocks/scalar-request-example-block'
 import type { ClientOptionGroup } from '@/v2/blocks/scalar-request-example-block/types'
 
-const { path, operation, method, isWebhook, oldOperation } = defineProps<{
-  id: string
-  path: string
-  clientOptions: ClientOptionGroup[]
-  method: HttpMethodType
-  operation: Dereference<OperationObject>
-  oldOperation: OpenAPIV3_1.OperationObject
-  // pathServers: ServerObject[] | undefined
-  isWebhook: boolean
-  securitySchemes: SecuritySchemeObject[]
-  server: ServerObject | undefined
-  schemas?: Schemas
-  store: WorkspaceStore
-}>()
+const { path, operation, method, isWebhook, oldOperation, store } =
+  defineProps<{
+    id: string
+    path: string
+    clientOptions: ClientOptionGroup[]
+    method: HttpMethodType
+    operation: Dereference<OperationObject>
+    oldOperation: OpenAPIV3_1.OperationObject
+    // pathServers: ServerObject[] | undefined
+    isWebhook: boolean
+    securitySchemes: SecuritySchemeObject[]
+    server: ServerObject | undefined
+    schemas?: Schemas
+    store: WorkspaceStore
+  }>()
 
 const operationTitle = computed(() => operation.summary || path || '')
 

--- a/packages/api-reference/src/helpers/test-utils.ts
+++ b/packages/api-reference/src/helpers/test-utils.ts
@@ -63,7 +63,6 @@ export const createMockStore = (activeDocument: WorkspaceDocument): WorkspaceSto
   workspace: {
     documents: {},
     activeDocument,
-    'x-scalar-default-client': 'shell/curl',
   },
   update: vi.fn(),
   updateDocument: vi.fn(),

--- a/packages/api-reference/src/helpers/test-utils.ts
+++ b/packages/api-reference/src/helpers/test-utils.ts
@@ -63,6 +63,7 @@ export const createMockStore = (activeDocument: WorkspaceDocument): WorkspaceSto
   workspace: {
     documents: {},
     activeDocument,
+    'x-scalar-default-client': 'shell/curl',
   },
   update: vi.fn(),
   updateDocument: vi.fn(),

--- a/packages/api-reference/src/vitest.setup.ts
+++ b/packages/api-reference/src/vitest.setup.ts
@@ -1,3 +1,4 @@
+import { createPluginManager } from '@/plugins/plugin-manager'
 import {
   consoleErrorSpy,
   consoleWarnSpy,
@@ -8,6 +9,11 @@ import {
   resetConsoleSpies,
 } from '@scalar/helpers/testing/console-spies'
 import { afterEach, expect, vi } from 'vitest'
+
+// Mock usePluginManager
+vi.mock('@/plugins/hooks/usePluginManager', () => ({
+  usePluginManager: vi.fn(() => createPluginManager({})),
+}))
 
 afterEach(() => {
   /**


### PR DESCRIPTION
**Problem**

closes #6472

Currently, we weren't passing the path parameters into the request example code.

**Solution**

With this PR we merge it into the operation. We can keep them separate if we have any reason to. 

|  | Screenshot |
|--------|--------|
| Before | <img width="876" height="728" alt="image" src="https://github.com/user-attachments/assets/1f63e6a6-dbda-4685-bc93-ca2a94a25b7f" /> |
| After |  <img width="1136" height="572" alt="image" src="https://github.com/user-attachments/assets/d4f8b5c6-4ec4-4ff3-9c72-9f2b4586d863" />| 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
