### PR TITLE
feat(json-magic): support node lifecycle hooks in bundler plugins

### DIFF
--- a/packages/json-magic/package.json
+++ b/packages/json-magic/package.json
@@ -55,7 +55,8 @@
   },
   "dependencies": {
     "vue": "catalog:*",
-    "yaml": "catalog:*"
+    "yaml": "catalog:*",
+    "@scalar/helpers": "workspace:*"
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",

--- a/packages/json-magic/src/bundle/index.ts
+++ b/packages/json-magic/src/bundle/index.ts
@@ -1,2 +1,3 @@
 // biome-ignore lint/performance/noBarrelFile: <explanation>
-export { bundle, type Plugin, type ResolveResult } from './bundle'
+export { bundle } from './bundle'
+export type { Plugin, LoaderPlugin, LifecyclePlugin, ResolveResult } from './bundle'

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/index.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/index.ts
@@ -1,6 +1,6 @@
 import { normalize } from '@/utils/normalize'
 import { createLimiter } from '@/bundle/create-limiter'
-import type { Plugin, ResolveResult } from '@/bundle'
+import type { LoaderPlugin, ResolveResult } from '@/bundle'
 import { isRemoteUrl } from '@/bundle/bundle'
 
 type FetchConfig = Partial<{
@@ -83,11 +83,12 @@ export async function fetchUrl(
  *   const result = await urlPlugin.exec('https://example.com/schema.json')
  * }
  */
-export function fetchUrls(config?: FetchConfig & Partial<{ limit: number | null }>): Plugin {
+export function fetchUrls(config?: FetchConfig & Partial<{ limit: number | null }>): LoaderPlugin {
   // If there is a limit specified we limit the number of concurrent calls
   const limiter = config?.limit ? createLimiter(config.limit) : <T>(fn: () => Promise<T>) => fn()
 
   return {
+    type: 'loader',
     validate: isRemoteUrl,
     exec: (value) => fetchUrl(value, limiter, config),
   }

--- a/packages/json-magic/src/bundle/plugins/parse-json/index.ts
+++ b/packages/json-magic/src/bundle/plugins/parse-json/index.ts
@@ -1,5 +1,5 @@
 import { isJsonObject } from '@/utils/is-json-object'
-import type { Plugin, ResolveResult } from '@/bundle'
+import type { LoaderPlugin, ResolveResult } from '@/bundle'
 
 /**
  * Creates a plugin that parses JSON strings into JavaScript objects.
@@ -11,8 +11,9 @@ import type { Plugin, ResolveResult } from '@/bundle'
  * // result = { name: 'John', age: 30 }
  * ```
  */
-export function parseJson(): Plugin {
+export function parseJson(): LoaderPlugin {
   return {
+    type: 'loader',
     validate: isJsonObject,
     exec: async (value): Promise<ResolveResult> => {
       try {

--- a/packages/json-magic/src/bundle/plugins/parse-yaml/index.ts
+++ b/packages/json-magic/src/bundle/plugins/parse-yaml/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin, ResolveResult } from '@/bundle/bundle'
+import type { LoaderPlugin, ResolveResult } from '@/bundle'
 import { isYaml } from '@/utils/is-yaml'
 import YAML from 'yaml'
 
@@ -12,8 +12,9 @@ import YAML from 'yaml'
  * // result = { name: 'John', age: 30 }
  * ```
  */
-export function parseYaml(): Plugin {
+export function parseYaml(): LoaderPlugin {
   return {
+    type: 'loader',
     validate: isYaml,
     exec: async (value): Promise<ResolveResult> => {
       try {

--- a/packages/json-magic/src/bundle/plugins/read-files/index.ts
+++ b/packages/json-magic/src/bundle/plugins/read-files/index.ts
@@ -1,5 +1,6 @@
 import { normalize } from '@/utils/normalize'
-import { isFilePath, type Plugin, type ResolveResult } from '@/bundle/bundle'
+import type { LoaderPlugin, ResolveResult } from '@/bundle'
+import { isFilePath } from '@/bundle/bundle'
 
 /**
  * Reads and normalizes data from a local file
@@ -47,8 +48,9 @@ export async function readFile(path: string): Promise<ResolveResult> {
  *   const result = await filePlugin.exec('./local-schema.json')
  * }
  */
-export function readFiles(): Plugin {
+export function readFiles(): LoaderPlugin {
   return {
+    type: 'loader',
     validate: isFilePath,
     exec: readFile,
   }

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -4,7 +4,7 @@ import { upgrade } from '@scalar/openapi-parser'
 import { createMagicProxy, getRaw } from '@scalar/json-magic/magic-proxy'
 
 import { applySelectiveUpdates } from '@/helpers/apply-selective-updates'
-import { deepClone, isObject, safeAssign, type UnknownObject } from '@/helpers/general'
+import { deepClone, isObject, safeAssign } from '@/helpers/general'
 import { getValueByPath } from '@/helpers/json-path-utils'
 import { mergeObjects } from '@/helpers/merge-object'
 import { createNavigation } from '@/navigation'
@@ -22,6 +22,7 @@ import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
 import { apply, diff, merge, type Difference } from '@scalar/json-magic/diff'
 import type { TraverseSpecOptions } from '@/navigation/types'
 import type { PartialDeep, RequiredDeep } from 'type-fest'
+import { externalValueResolver, loadingStatus, refsEverywhere } from '@/plugins'
 
 type DocumentConfiguration = Config &
   PartialDeep<{
@@ -467,26 +468,6 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     return excludedDiffs
   }
 
-  /**
-   * Hook function to be called after processing a node during document bundling.
-   * If the node contains an 'externalValue' property (as a string), this function
-   * fetches the external value (e.g., from a URL or file) and assigns the result to the node's 'value' property.
-   * This is used to resolve and embed external content referenced in the OpenAPI document.
-   *
-   * @param node - The node being processed, potentially containing an 'externalValue' property.
-   */
-  async function onAfterNodeProcess(node: UnknownObject) {
-    if (typeof node['externalValue'] !== 'string') {
-      return
-    }
-
-    const result = await fetchUrls().exec(node['externalValue'])
-
-    if (result.ok) {
-      node['value'] = result.data
-    }
-  }
-
   // Add a document to the store synchronously from an in-memory OpenAPI document
   async function addInMemoryDocument(input: ObjectDoc) {
     const { name, meta } = input
@@ -523,10 +504,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       // This typically applies when the document is not preprocessed by the server and needs local reference resolution.
       await bundle(document, {
         treeShake: false,
-        plugins: [fetchUrls()],
-        hooks: {
-          onAfterNodeProcess,
-        },
+        plugins: [fetchUrls(), externalValueResolver(), refsEverywhere()],
       })
     }
 
@@ -632,17 +610,8 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       return bundle(target, {
         root: activeDocument,
         treeShake: false,
-        plugins: [fetchUrls()],
+        plugins: [fetchUrls(), loadingStatus(), externalValueResolver()],
         urlMap: false,
-        hooks: {
-          onResolveStart: (node) => {
-            node['$status'] = 'loading'
-          },
-          onResolveError: (node) => {
-            node['$status'] = 'error'
-          },
-          onAfterNodeProcess,
-        },
         visitedNodes: visitedNodesCache,
       })
     },

--- a/packages/workspace-store/src/plugins.test.ts
+++ b/packages/workspace-store/src/plugins.test.ts
@@ -1,0 +1,236 @@
+import { externalValueResolver, loadingStatus, refsEverywhere } from '@/plugins'
+import { bundle } from '@scalar/json-magic/bundle'
+import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
+import { fastify, type FastifyInstance } from 'fastify'
+import { setTimeout } from 'node:timers/promises'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: any) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('plugins', () => {
+  describe('loadingStatus', () => {
+    it('sets the loading status to the correct value during ref resolution', async () => {
+      const onResolveStart = vi.fn()
+      const onResolveError = vi.fn()
+      const onResolveSuccess = vi.fn()
+
+      const resolveStarted = deferred<null>()
+      const resolveSucceeded = deferred<null>()
+
+      const input = {
+        a: {
+          b: 'hello',
+        },
+        c: {
+          $ref: 'some-ref',
+        },
+      } as any
+
+      bundle(input, {
+        plugins: [
+          {
+            type: 'loader',
+            validate: (value: string) => value === 'some-ref',
+            exec: async () => {
+              return {
+                ok: true,
+                data: { resolved: true },
+              }
+            },
+          },
+          {
+            type: 'lifecycle',
+            onResolveStart: (...args) => {
+              onResolveStart(args)
+              resolveStarted.resolve(null)
+            },
+            onResolveError,
+            onResolveSuccess: (...args) => {
+              onResolveSuccess(args)
+              resolveSucceeded.resolve(null)
+            },
+          },
+          loadingStatus(),
+        ],
+        treeShake: false,
+      })
+
+      await resolveStarted.promise
+
+      // Verify that the loading status was set during resolution
+      expect(onResolveStart).toHaveBeenCalled()
+      expect(input.c['$status']).toBe('loading')
+
+      await resolveSucceeded.promise
+
+      // Verify that the loading status was set during resolution
+      expect(onResolveSuccess).toHaveBeenCalled()
+      expect(input.c['$status']).toBeUndefined() // Should be removed after successful resolution
+    })
+
+    it('sets error status when ref resolution fails', async () => {
+      const input = {
+        c: {
+          $ref: 'invalid-ref',
+        },
+      } as any
+
+      const resolveErrored = deferred<null>()
+
+      bundle(input, {
+        plugins: [
+          {
+            type: 'loader',
+            validate: (value: string) => value === 'invalid-ref',
+            exec: async () => {
+              return {
+                ok: false,
+                error: 'Failed to resolve reference',
+              }
+            },
+          },
+          {
+            type: 'lifecycle',
+            onResolveError: () => {
+              resolveErrored.resolve(null)
+            },
+          },
+          loadingStatus(),
+        ],
+        treeShake: false,
+      })
+
+      await resolveErrored.promise
+
+      // Verify that the error status was set
+      expect(input.c.$status).toBe('error')
+    })
+  })
+
+  describe('externalValueResolver', () => {
+    let server: FastifyInstance
+    const port = 9988
+    const url = `http://localhost:${port}`
+
+    beforeEach(() => {
+      server = fastify({ logger: false })
+    })
+
+    afterEach(async () => {
+      await server.close()
+      await setTimeout(100)
+    })
+
+    it('resolves external values', async () => {
+      server.get('/', () => {
+        return { a: 'a' }
+      })
+
+      await server.listen({ port })
+
+      const input = {
+        hello: 'world',
+        a: {
+          externalValue: url,
+        },
+      }
+
+      await bundle(input, {
+        treeShake: false,
+        plugins: [externalValueResolver()],
+      })
+
+      expect(input).toEqual({
+        hello: 'world',
+        a: {
+          externalValue: url,
+          value: { a: 'a' },
+        },
+      })
+    })
+  })
+
+  describe('refsEverywhere', () => {
+    let server: FastifyInstance
+    const port = 9988
+    const url = `http://localhost:${port}`
+
+    beforeEach(() => {
+      server = fastify({ logger: false })
+    })
+
+    afterEach(async () => {
+      await server.close()
+      await setTimeout(100)
+    })
+
+    it('inline refs on the info object', async () => {
+      server.get('/', () => {
+        return {
+          description: 'Some description',
+        }
+      })
+      await server.listen({ port })
+
+      const input = {
+        info: {
+          $ref: url,
+        },
+      }
+
+      const result = await bundle(input, {
+        treeShake: false,
+        plugins: [refsEverywhere()],
+      })
+
+      expect(result).toEqual({
+        info: {
+          description: 'Some description',
+        },
+      })
+    })
+
+    it('does not inline refs if the info object is not top level', async () => {
+      server.get('/', () => {
+        return {
+          description: 'Some description',
+        }
+      })
+      await server.listen({ port })
+
+      const input = {
+        someProp: {
+          info: {
+            $ref: url,
+          },
+        },
+      }
+
+      const result = await bundle(input, {
+        treeShake: false,
+        plugins: [fetchUrls(), refsEverywhere()],
+      })
+
+      expect(result).toEqual({
+        someProp: {
+          info: {
+            '$ref': '#/x-ext/c766ed8',
+          },
+        },
+        'x-ext': {
+          'c766ed8': {
+            description: 'Some description',
+          },
+        },
+      })
+    })
+  })
+})

--- a/packages/workspace-store/src/plugins.ts
+++ b/packages/workspace-store/src/plugins.ts
@@ -1,0 +1,106 @@
+/**
+ * This file contains a collection of plugins used for the bundler.
+ * Plugins defined here can extend or modify the behavior of the bundling process,
+ * such as adding lifecycle hooks or custom processing logic.
+ */
+import type { LifecyclePlugin } from '@scalar/json-magic/bundle'
+import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
+
+/**
+ * A lifecycle plugin that adds a `$status` property to nodes during resolution.
+ * - Sets `$status` to 'loading' when resolution starts.
+ * - Sets `$status` to 'error' if resolution fails.
+ * - Removes `$status` when resolution succeeds.
+ */
+export const loadingStatus = (): LifecyclePlugin => {
+  return {
+    type: 'lifecycle',
+    onResolveStart: (node) => {
+      node['$status'] = 'loading'
+    },
+    onResolveError: (node) => {
+      node['$status'] = 'error'
+    },
+    onResolveSuccess: (node) => {
+      delete node['$status']
+    },
+  }
+}
+
+/**
+ * Lifecycle plugin to resolve and embed external content referenced by an 'externalValue' property in a node.
+ *
+ * When a node contains an 'externalValue' property (as a string), this plugin will:
+ *   - Fetch the external resource (such as a URL or file) using the fetchUrls plugin.
+ *   - If the fetch is successful, assign the fetched data to the node's 'value' property.
+ *
+ * This is useful for inlining external content (like examples or schemas) into the OpenAPI document during bundling.
+ *
+ * @param node - The node being processed, which may contain an 'externalValue' property.
+ */
+export const externalValueResolver = (): LifecyclePlugin => {
+  return {
+    type: 'lifecycle',
+    onAfterNodeProcess: async (node, context) => {
+      const externalValue = node['externalValue']
+      const cache = context.resolutionCache
+
+      // Only process if 'externalValue' is a string
+      if (typeof externalValue !== 'string') {
+        return
+      }
+
+      if (!cache.has(externalValue)) {
+        cache.set(externalValue, fetchUrls().exec(externalValue))
+      }
+
+      const result = await cache.get(externalValue)
+
+      // If fetch is successful, assign the data to the node's 'value' property
+      if (result?.ok) {
+        node['value'] = result.data
+      }
+    },
+  }
+}
+
+/**
+ * Lifecycle plugin to resolve $ref on any object, including non-standard locations like the info object.
+ * 
+ * This plugin will:
+ *   - Detect if a node contains a $ref property (as a string).
+ *   - If the node is under the 'info' path, attempt to resolve the reference using fetchUrls.
+ *   - Replace the node's properties with the resolved data if successful.
+ * 
+ * Note: This currently only supports refs on the 'info' object and does not handle primitive types.
+ */
+export const refsEverywhere = (): LifecyclePlugin => {
+  return {
+    type: 'lifecycle',
+    onBeforeNodeProcess: async (node, context) => {
+      // Only process nodes that have a $ref property as a string
+      if (!('$ref' in node) || typeof node['$ref'] !== 'string') {
+        return
+      }
+
+      const ref = node['$ref']
+      const { path, resolutionCache } = context
+
+      // Support resolving $ref on the info object
+      if (path[0] === 'info') {
+        // Use the cache to avoid duplicate fetches
+        if (!resolutionCache.has(ref)) {
+          resolutionCache.set(ref, fetchUrls().exec(ref))
+        }
+
+        const result = await resolutionCache.get(ref)
+
+        if (result?.ok) {
+          delete node['$ref']
+          // TODO: handle primitive types (going to need access to the parent node)
+          Object.assign(node, result.data)
+        }
+      }
+    },
+  }
+}

--- a/packages/workspace-store/src/plugins.ts
+++ b/packages/workspace-store/src/plugins.ts
@@ -66,12 +66,12 @@ export const externalValueResolver = (): LifecyclePlugin => {
 
 /**
  * Lifecycle plugin to resolve $ref on any object, including non-standard locations like the info object.
- * 
+ *
  * This plugin will:
  *   - Detect if a node contains a $ref property (as a string).
  *   - If the node is under the 'info' path, attempt to resolve the reference using fetchUrls.
  *   - Replace the node's properties with the resolved data if successful.
- * 
+ *
  * Note: This currently only supports refs on the 'info' object and does not handle primitive types.
  */
 export const refsEverywhere = (): LifecyclePlugin => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1925,6 +1925,9 @@ importers:
 
   packages/json-magic:
     dependencies:
+      '@scalar/helpers':
+        specifier: workspace:*
+        version: link:../helpers
       vue:
         specifier: catalog:*
         version: 3.5.17(typescript@5.8.3)


### PR DESCRIPTION
**Problem**

Plugins currently only support resolving external documents (e.g. from URLs or files) and do not have access to the node processing lifecycle. This limits their ability to interact with or modify nodes during the bundling process.

Additionally, $ref values in non-standard locations—such as under the info object—are not currently supported, which can cause issues for non compliant documents.

**Solution**

This PR introduces a new plugin type that can hook into the node lifecycle during bundling. These lifecycle-aware plugins can inspect, transform, or clean up nodes as they are processed.

We also include a new built-in plugin that detects $refs in non-standard locations (e.g. info) and replaces them with their resolved content. This ensures that such $refs are removed before further processing, allowing the rest of the pipeline to work as expected.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
