### PR TITLE
chore(galaxy): add live serving of galaxy for some convenience

### DIFF
--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -105,6 +105,10 @@
             title: 'OpenStatus',
             url: 'https://api.openstatus.dev/v1/openapi',
           },
+          {
+            title: 'Galaxy Live',
+            url: 'http://localhost:8080/3.1.yaml',
+          },
         ],
         persistAuth: true,
         // Avoid CORS issues

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "scalar-build-esbuild",
     "dev": "npx @scalar/cli document serve ./src/documents/3.1.yaml --watch",
-    "live": "cd src/documents && pnpx http-server --cors",
+    "dev:live": "cd src/documents && pnpx http-server --cors",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
     "test": "vitest",

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "scalar-build-esbuild",
     "dev": "npx @scalar/cli document serve ./src/documents/3.1.yaml --watch",
+    "live": "cd src/documents && pnpx http-server --cors",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
     "test": "vitest",


### PR DESCRIPTION
No deps, all convenience

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
