### PR TITLE
fix(api-reference): search does not match when the query has a single character word

### DIFF
--- a/.changeset/old-rings-relate.md
+++ b/.changeset/old-rings-relate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: search does not match when the query has a single character word

--- a/packages/api-reference/src/features/Search/helpers/create-fuse-instance.ts
+++ b/packages/api-reference/src/features/Search/helpers/create-fuse-instance.ts
@@ -40,10 +40,6 @@ export function createFuseInstance(): Fuse<FuseData> {
     // Include detailed match information showing which parts of the text matched
     includeMatches: true,
 
-    // Minimum number of characters that must match to be considered a result
-    // Prevents single-character matches that are usually noise
-    minMatchCharLength: 2,
-
     // Don't require matches to be at the beginning of strings
     // Makes search more flexible and user-friendly
     ignoreLocation: true,

--- a/packages/api-reference/src/features/Search/helpers/create-search-index.ts
+++ b/packages/api-reference/src/features/Search/helpers/create-search-index.ts
@@ -55,7 +55,7 @@ function addEntryToIndex(entry: TraversedEntry, index: FuseData[]): void {
   if ('webhook' in entry) {
     index.push({
       type: 'webhook',
-      title: entry.title,
+      title: entry.name,
       href: `#${entry.id}`,
       description: 'Webhook',
       method: entry.method,

--- a/packages/api-reference/src/features/Search/search-quality.test.ts
+++ b/packages/api-reference/src/features/Search/search-quality.test.ts
@@ -19,6 +19,7 @@ function search(query: string, document: Partial<OpenAPIV3_1.Document>) {
   })
 
   const fuse = createFuseInstance()
+
   fuse.setCollection(createSearchIndex(entries))
 
   return fuse.search(query)
@@ -28,7 +29,7 @@ describe('search quality', () => {
   it('looks up operations by summary', () => {
     const query = 'Get a token'
 
-    const document = {
+    const document: Partial<OpenAPIV3_1.Document> = {
       paths: {
         '/auth/token': {
           post: {
@@ -45,5 +46,502 @@ describe('search quality', () => {
 
     expect(result[0]?.item?.title).toEqual('Get a token')
     expect(result.length).toEqual(1)
+  })
+
+  it('finds operations by partial title match', () => {
+    const query = 'token'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      paths: {
+        '/auth/token': {
+          post: {
+            tags: ['Authentication'],
+            summary: 'Get a token',
+            description: 'Authentication endpoint',
+            operationId: 'getToken',
+          },
+        },
+        '/auth/refresh': {
+          post: {
+            tags: ['Authentication'],
+            summary: 'Refresh token',
+            description: 'Refresh authentication token',
+            operationId: 'refreshToken',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]?.item?.title).toContain('token')
+    expect(result[1]?.item?.title).toContain('token')
+  })
+
+  it('finds operations by operationId', () => {
+    const query = 'getToken'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      paths: {
+        '/auth/token': {
+          post: {
+            tags: ['Authentication'],
+            summary: 'Get a token',
+            description: 'Authentication endpoint',
+            operationId: 'getToken',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result[0]?.item?.id).toEqual('getToken')
+    expect(result[0]?.item?.title).toEqual('Get a token')
+  })
+
+  it('finds operations by HTTP method', () => {
+    const query = 'POST'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      paths: {
+        '/auth/token': {
+          post: {
+            tags: ['Authentication'],
+            summary: 'Get a token',
+            description: 'Authentication endpoint',
+            operationId: 'getToken',
+          },
+        },
+        '/users': {
+          post: {
+            tags: ['Users'],
+            summary: 'Create user',
+            description: 'Create a new user',
+            operationId: 'createUser',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]?.item?.method).toEqual('post')
+    expect(result[1]?.item?.method).toEqual('post')
+  })
+
+  it('finds operations by path', () => {
+    const query = '/auth'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      paths: {
+        '/auth/token': {
+          post: {
+            summary: 'Get a token',
+            description: 'Authentication endpoint',
+            operationId: 'getToken',
+          },
+        },
+        '/auth/logout': {
+          post: {
+            summary: 'Logout user',
+            description: 'Logout endpoint',
+            operationId: 'logoutUser',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]?.item?.path).toContain('/auth')
+    expect(result[1]?.item?.path).toContain('/auth')
+  })
+
+  it.todo('finds operations by tag', () => {
+    const query = 'Foobar'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      paths: {
+        '/auth/token': {
+          post: {
+            tags: ['Foobar'],
+            summary: 'Get a token',
+            description: 'Authentication endpoint',
+            operationId: 'getToken',
+          },
+        },
+        '/auth/logout': {
+          post: {
+            tags: ['Foobar'],
+            summary: 'Logout user',
+            description: 'Logout endpoint',
+            operationId: 'logoutUser',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result[0]?.item?.type).toEqual('operation')
+    expect(result[1]?.item?.type).toEqual('operation')
+    expect(result).toHaveLength(3)
+  })
+
+  it('finds operations by description content', () => {
+    const query = 'boring security'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      paths: {
+        '/auth/token': {
+          post: {
+            tags: ['Authentication'],
+            summary: 'Get a token',
+            description: 'Yeah, this is the boring security stuff. Just get your super secret token and move on.',
+            operationId: 'getToken',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result[0]?.item?.title).toEqual('Get a token')
+    expect(result[0]?.item?.description).toContain('boring security')
+  })
+
+  it('finds models by title', () => {
+    const query = 'User'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      components: {
+        schemas: {
+          User: {
+            type: 'object',
+            title: 'User',
+            description: 'A user in the system',
+            properties: {
+              id: { type: 'string' },
+              name: { type: 'string' },
+            },
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result[0]?.item?.type).toEqual('model')
+    expect(result[0]?.item?.title).toEqual('User')
+  })
+
+  it('finds models by description', () => {
+    const query = 'user in the system'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      components: {
+        schemas: {
+          User: {
+            type: 'object',
+            title: 'User',
+            description: 'A user in the system',
+            properties: {
+              id: { type: 'string' },
+              name: { type: 'string' },
+            },
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result[0]?.item?.type).toEqual('model')
+    expect(result[0]?.item?.title).toEqual('User')
+  })
+
+  it('finds webhooks by title', () => {
+    const query = 'user.created'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      webhooks: {
+        'user.created': {
+          post: {
+            summary: 'User created webhook',
+            description: 'Fired when a user is created',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result[0]?.item?.type).toEqual('webhook')
+    expect(result[0]?.item?.title).toEqual('user.created')
+  })
+
+  it('finds webhooks by description', () => {
+    const query = 'fired when'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      webhooks: {
+        'user.created': {
+          post: {
+            summary: 'User created webhook',
+            description: 'Fired when a user is created',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result[0]?.item?.type).toEqual('webhook')
+    expect(result[0]?.item?.title).toEqual('user.created')
+  })
+
+  it('finds tags by name', () => {
+    const query = 'Users'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      tags: [
+        {
+          name: 'Users',
+          description: 'User management operations',
+        },
+      ],
+      paths: {
+        '/users': {
+          get: {
+            tags: ['Users'],
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result[0]?.item?.type).toEqual('tag')
+    expect(result[0]?.item?.title).toEqual('Users')
+  })
+
+  it('finds tags by description', () => {
+    const query = 'user management'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      tags: [
+        {
+          name: 'Users',
+          description: 'User management operations',
+        },
+      ],
+      paths: {
+        '/users': {
+          get: {
+            tags: ['Users'],
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result[0]?.item?.type).toEqual('tag')
+    expect(result[0]?.item?.title).toEqual('Users')
+  })
+
+  it('finds headings by title', () => {
+    const query = 'Models'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      info: {
+        title: 'API Reference',
+        description: 'This is a test API',
+      },
+      components: {
+        schemas: {
+          User: {
+            type: 'string',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result[0]?.item?.type).toEqual('heading')
+    expect(result[0]?.item?.title).toEqual('Models')
+  })
+
+  it('handles case-insensitive search', () => {
+    const query = 'user'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      paths: {
+        '/users': {
+          get: {
+            summary: 'Get users',
+            description: 'Retrieve all users',
+            operationId: 'getUsers',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.item?.title).toEqual('Get users')
+  })
+
+  it('handles fuzzy matching with typos', () => {
+    const query = 'get a tken' // typo for "token"
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      paths: {
+        '/auth/token': {
+          post: {
+            summary: 'Get a token',
+            description: 'Authentication endpoint',
+            operationId: 'getToken',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.item?.title).toEqual('Get a token')
+  })
+
+  it('prioritizes title matches over description matches', () => {
+    const query = 'token'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      paths: {
+        '/auth/token': {
+          post: {
+            tags: ['Authentication'],
+            summary: 'Get a token',
+            description: 'Authentication endpoint for getting tokens',
+            operationId: 'getToken',
+          },
+        },
+        '/users': {
+          get: {
+            tags: ['Users'],
+            summary: 'Get users',
+            description: 'This endpoint returns user tokens',
+            operationId: 'getUsers',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    // The operation with "token" in the title should score higher
+    expect(result[0]?.item?.title).toEqual('Get a token')
+    expect(result[0]?.score).toBeLessThan(result[1]?.score || 1)
+  })
+
+  it('returns empty results for non-matching queries', () => {
+    const query = 'nonexistent'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      paths: {
+        '/auth/token': {
+          post: {
+            tags: ['Authentication'],
+            summary: 'Get a token',
+            description: 'Authentication endpoint',
+            operationId: 'getToken',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('handles empty document gracefully', () => {
+    const query = 'test'
+
+    const document: Partial<OpenAPIV3_1.Document> = {}
+
+    const result = search(query, document)
+
+    expect(result).toHaveLength(0)
+  })
+
+  it.todo('handles complex nested schemas', () => {
+    const query = 'address'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      components: {
+        schemas: {
+          User: {
+            type: 'object',
+            title: 'User',
+            properties: {
+              address: {
+                type: 'object',
+                properties: {
+                  street: { type: 'string' },
+                  city: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.item?.type).toEqual('model')
+  })
+
+  it('finds operations with request body parameters', () => {
+    const query = 'email'
+
+    const document: Partial<OpenAPIV3_1.Document> = {
+      paths: {
+        '/auth/register': {
+          post: {
+            tags: ['Authentication'],
+            summary: 'Register user',
+            description: 'Create a new user account',
+            operationId: 'registerUser',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      email: { type: 'string' },
+                      password: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.item?.title).toEqual('Register user')
   })
 })

--- a/packages/api-reference/src/features/Search/search-quality.test.ts
+++ b/packages/api-reference/src/features/Search/search-quality.test.ts
@@ -7,7 +7,7 @@ import { ref } from 'vue'
 import { createFuseInstance } from './helpers/create-fuse-instance'
 import { createSearchIndex } from './helpers/create-search-index'
 
-function createSearchFoobar(query: string, document: Partial<OpenAPIV3_1.Document>) {
+function search(query: string, document: Partial<OpenAPIV3_1.Document>) {
   const { entries } = traverseDocument(document, {
     config: ref(apiReferenceConfigurationSchema.parse({ hideModels: false })),
     getHeadingId: () => '',
@@ -24,7 +24,7 @@ function createSearchFoobar(query: string, document: Partial<OpenAPIV3_1.Documen
   return fuse.search(query)
 }
 
-describe('search', () => {
+describe('search quality', () => {
   it('looks up operations by summary', () => {
     const query = 'Get a token'
 
@@ -41,7 +41,7 @@ describe('search', () => {
       },
     }
 
-    const result = createSearchFoobar(query, document)
+    const result = search(query, document)
 
     expect(result[0]?.item?.title).toEqual('Get a token')
     expect(result.length).toEqual(1)

--- a/packages/api-reference/src/features/Search/search.test.ts
+++ b/packages/api-reference/src/features/Search/search.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { traverseDocument } from '@/features/traverse-schema'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { apiReferenceConfigurationSchema } from '@scalar/types'
+import { ref } from 'vue'
+import { createFuseInstance } from './helpers/create-fuse-instance'
+import { createSearchIndex } from './helpers/create-search-index'
+
+function createSearchFoobar(query: string, document: Partial<OpenAPIV3_1.Document>) {
+  const { entries } = traverseDocument(document, {
+    config: ref(apiReferenceConfigurationSchema.parse({ hideModels: false })),
+    getHeadingId: () => '',
+    getOperationId: () => '',
+    getWebhookId: () => '',
+    getModelId: () => '',
+    getTagId: () => '',
+    getSectionId: () => '',
+  })
+
+  const fuse = createFuseInstance()
+  fuse.setCollection(createSearchIndex(entries))
+
+  return fuse.search(query)
+}
+
+describe('search', () => {
+  it('looks up operations by summary', () => {
+    const query = 'Get a token'
+
+    const document = {
+      paths: {
+        '/auth/token': {
+          post: {
+            tags: ['Authentication'],
+            summary: 'Get a token',
+            description: 'Yeah, this is the boring security stuff. Just get your super secret token and move on.',
+            operationId: 'getToken',
+          },
+        },
+      },
+    }
+
+    const result = createSearchFoobar(query, document)
+
+    expect(result[0]?.item?.title).toEqual('Get a token')
+    expect(result.length).toEqual(1)
+  })
+})


### PR DESCRIPTION
**Problem**

I’ve configured the search to not match when a word has 2 or less characters. That seemed resonable to me, but made fuse not match an entry when the query has a 1- or 2-charactrer word, example:

* ❌ "Get **a** token" didn’t match "Get a token"
* ✅ "Get token" did match "Get a token"

<img width="1173" height="667" alt="image" src="https://github.com/user-attachments/assets/918c1641-aa8f-419a-ac3c-a778ed4333e5" />

**Solution**

This PR fixes two things:

* you can use 1- or 2-character in a search query now
* webhooks are indexed with their name

And I’ve added tests just to check the search quality.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
