### PR TITLE
chore(renovate): add java integration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -242,6 +242,10 @@
       "additionalBranchPrefix": "hono"
     },
     {
+      "matchFileNames": ["integrations/java/**"],
+      "additionalBranchPrefix": "java"
+    },
+    {
       "matchFileNames": ["integrations/nestjs/**", "examples/nestjs/**"],
       "additionalBranchPrefix": "nestjs"
     },


### PR DESCRIPTION
We recently introduced the Java integration. Let`s add the integration to renovate.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
