### PR TITLE
feat(api-client): add de-selectall button for scopes

### DIFF
--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuthScopesInput.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuthScopesInput.vue
@@ -44,11 +44,19 @@ function setScope(id: string, checked: boolean) {
   }
 }
 
-function selectAllScopes() {
+const allScopesSelected = computed(() => {
+  return flow?.selectedScopes?.length === Object.keys(flow?.scopes ?? {}).length
+})
+
+const selectAllScopes = () => {
   updateScheme(
     `flows.${flow.type}.selectedScopes`,
     Object.keys(flow?.scopes ?? {}),
   )
+}
+
+const deselectAllScopes = () => {
+  updateScheme(`flows.${flow.type}.selectedScopes`, [])
 }
 </script>
 
@@ -72,12 +80,14 @@ function selectAllScopes() {
           </div>
           <div class="flex items-center gap-1.75">
             <ScalarButton
-              v-if="
-                flow?.selectedScopes?.length > 4 &&
-                open &&
-                flow?.selectedScopes?.length <
-                  Object.keys(flow?.scopes ?? {}).length
-              "
+              v-if="allScopesSelected"
+              class="text-c-3 hover:bg-b-2 hover:text-c-1 rounded px-1.5"
+              size="sm"
+              @click.stop="deselectAllScopes">
+              Deselect All
+            </ScalarButton>
+            <ScalarButton
+              v-if="!allScopesSelected"
               class="text-c-3 hover:bg-b-2 hover:text-c-1 rounded px-1.5"
               size="sm"
               @click.stop="selectAllScopes">

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -106,6 +106,10 @@
             url: 'https://api.openstatus.dev/v1/openapi',
           },
           {
+            title: 'Spotify',
+            url: 'https://developer.spotify.com/reference/web-api/open-api-schema.yaml',
+          },
+          {
             title: 'Galaxy Live',
             url: 'http://localhost:8080/3.1.yaml',
           },


### PR DESCRIPTION
**Problem**

Currently, we only show the select all button when over a certain amount of scopes.

**Solution**

With this PR we always show select all, then when all are selected, we show de-select all.

Also added spotify for testing

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
