### PR TITLE
fix(api-reference): horizontal scrollbars in a VS Code WebView

### DIFF
--- a/.changeset/orange-ties-relax.md
+++ b/.changeset/orange-ties-relax.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: horizontal scrollbars in a VS Code webview

--- a/packages/api-reference/src/components/MobileHeader.vue
+++ b/packages/api-reference/src/components/MobileHeader.vue
@@ -27,7 +27,8 @@ defineProps<{
   display: none;
   align-items: center;
   height: 100%;
-  width: 100dvw;
+  width: 100%;
+  max-width: 100dvw;
   padding: 0 8px;
   background: var(--scalar-background-1);
   border-bottom: 1px solid var(--scalar-border-color);


### PR DESCRIPTION
**Problem**

Currently, the API reference has horizontal scrollbars in a VS Code WebView.

<img width="609" height="820" alt="Screenshot 2025-08-11 at 17 30 00" src="https://github.com/user-attachments/assets/109a155d-cf85-4b3d-bfc6-2b7935366595" />

**Solution**

The changes in this PR make them go away.

I’ve patched the VS Code integration already, so there’s no rush to get this in here. But I thought we might want to have the fix upstream.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
