### PR TITLE
feat(Scalar.Aspire): support async configuration

### DIFF
--- a/.changeset/honest-ladybugs-roll.md
+++ b/.changeset/honest-ladybugs-roll.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspire': patch
+---
+
+feat: support async configuration

--- a/documentation/integrations/aspire.md
+++ b/documentation/integrations/aspire.md
@@ -117,7 +117,7 @@ scalar.WithApiReference(bookService, async (options, cancellationToken) =>
 
     options
         .AddPreferredSecuritySchemes("BookApiKey")
-        .AddApiKeyAuthentication("ApiKey", apiKey => apiKey.WithValue(apiKey));
+        .AddApiKeyAuthentication("ApiKey", schema => schema.WithValue(apiKey));
 });
 ```
 

--- a/documentation/integrations/aspire.md
+++ b/documentation/integrations/aspire.md
@@ -101,6 +101,26 @@ scalar
     });
 ```
 
+#### Async Service-Specific Configuration
+
+Use the async overload of `WithApiReference` when you need to perform asynchronous work (for example, fetching secrets or remote configuration):
+
+```csharp
+scalar.WithApiReference(bookService, async (options, cancellationToken) =>
+{
+    options
+        .AddDocument("v1", "Book Management API")
+        .WithOpenApiRoutePattern("/swagger/{documentName}.json");
+
+    // Example: load a dev API key asynchronously
+    var apiKey = await secretProvider.GetValueAsync("BOOKS_API_KEY", cancellationToken);
+
+    options
+        .AddPreferredSecuritySchemes("BookApiKey")
+        .AddApiKeyAuthentication("ApiKey", apiKey => apiKey.WithValue(apiKey));
+});
+```
+
 ### Multiple OpenAPI Documents per Service
 
 Each service can expose multiple OpenAPI documents:

--- a/integrations/aspire/playground/Scalar.Aspire.AppHost/Program.cs
+++ b/integrations/aspire/playground/Scalar.Aspire.AppHost/Program.cs
@@ -22,8 +22,9 @@ var scalar = builder
 
 
 scalar
-    .WithApiReference(userService, options =>
+    .WithApiReference(userService, async (options, ctx) =>
     {
+        await Task.Delay(2000, ctx);
         options.WithTheme(ScalarTheme.Mars);
         options.WithDefaultHttpClient(ScalarTarget.JavaScript, ScalarClient.Fetch);
         options.AddDocument("external");

--- a/integrations/aspire/playground/Scalar.Aspire.AppHost/Program.cs
+++ b/integrations/aspire/playground/Scalar.Aspire.AppHost/Program.cs
@@ -22,9 +22,8 @@ var scalar = builder
 
 
 scalar
-    .WithApiReference(userService, async (options, ctx) =>
+    .WithApiReference(userService, options =>
     {
-        await Task.Delay(2000, ctx);
         options.WithTheme(ScalarTheme.Mars);
         options.WithDefaultHttpClient(ScalarTarget.JavaScript, ScalarClient.Fetch);
         options.AddDocument("external");

--- a/integrations/aspire/src/Scalar.Aspire/Extensions/AsyncEnumerableExtensions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Extensions/AsyncEnumerableExtensions.cs
@@ -1,0 +1,30 @@
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+
+namespace Scalar.Aspire;
+
+internal static class AsyncEnumerableExtensions
+{
+    internal static async Task<string> SerializeToJsonAsync<T>(
+        this IAsyncEnumerable<T> source,
+        JsonSerializerOptions? options,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        await using var writer = new Utf8JsonWriter(buffer);
+
+        writer.WriteStartArray();
+
+        await foreach (var item in source.WithCancellation(cancellationToken))
+        {
+            JsonSerializer.Serialize(writer, item, options);
+        }
+
+        writer.WriteEndArray();
+        await writer.FlushAsync(cancellationToken);
+
+
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+}

--- a/integrations/aspire/src/Scalar.Aspire/Extensions/ResourceBuilderExtensions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Extensions/ResourceBuilderExtensions.cs
@@ -26,8 +26,8 @@ public static class ResourceBuilderExtensions
                 configureOptions?.Invoke(options);
                 return Task.CompletedTask;
             }));
-    
-    
+
+
     /// <summary>
     /// Adds an OpenAPI reference to the Scalar resource from another resource with service discovery.
     /// </summary>

--- a/integrations/aspire/src/Scalar.Aspire/Extensions/ResourceBuilderExtensions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Extensions/ResourceBuilderExtensions.cs
@@ -27,6 +27,14 @@ public static class ResourceBuilderExtensions
                 return Task.CompletedTask;
             }));
     
+    
+    /// <summary>
+    /// Adds an OpenAPI reference to the Scalar resource from another resource with service discovery.
+    /// </summary>
+    /// <param name="builder">The Scalar resource builder.</param>
+    /// <param name="resourceBuilder">The resource builder that provides the OpenAPI document.</param>
+    /// <param name="configureOptions">Action to configure <see cref="ScalarOptions"/> for this service asynchronously.</param>
+    /// <returns>The resource builder for the <see cref="ScalarResource"/>.</returns>
     public static IResourceBuilder<ScalarResource> WithApiReference(
         this IResourceBuilder<ScalarResource> builder,
         IResourceBuilder<IResourceWithServiceDiscovery> resourceBuilder,

--- a/integrations/aspire/src/Scalar.Aspire/Extensions/ResourceBuilderExtensions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Extensions/ResourceBuilderExtensions.cs
@@ -21,5 +21,17 @@ public static class ResourceBuilderExtensions
         Action<ScalarOptions>? configureOptions = null) =>
         builder
             .WithReference(resourceBuilder)
+            .WithAnnotation(new ScalarAnnotation(resourceBuilder.Resource, (options, _) =>
+            {
+                configureOptions?.Invoke(options);
+                return Task.CompletedTask;
+            }));
+    
+    public static IResourceBuilder<ScalarResource> WithApiReference(
+        this IResourceBuilder<ScalarResource> builder,
+        IResourceBuilder<IResourceWithServiceDiscovery> resourceBuilder,
+        Func<ScalarOptions, CancellationToken, Task> configureOptions) =>
+        builder
+            .WithReference(resourceBuilder)
             .WithAnnotation(new ScalarAnnotation(resourceBuilder.Resource, configureOptions));
 }

--- a/integrations/aspire/src/Scalar.Aspire/Mapper/ScalarOptionsMapper.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Mapper/ScalarOptionsMapper.cs
@@ -30,8 +30,6 @@ internal static class ScalarOptionsMapper
         { ScalarTarget.Rust, [ScalarClient.Reqwest] }
     };
 
-    internal static IEnumerable<ScalarConfiguration> ToScalarConfigurations(this IEnumerable<ScalarOptions> options) => options.Select(option => option.ToScalarConfiguration());
-
     internal static async IAsyncEnumerable<ScalarConfiguration> ToScalarConfigurationsAsync(this IAsyncEnumerable<ScalarOptions> options, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         await foreach (var option in options.WithCancellation(cancellationToken))

--- a/integrations/aspire/src/Scalar.Aspire/Mapper/ScalarOptionsMapper.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Mapper/ScalarOptionsMapper.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace Scalar.Aspire;
 
 internal static class ScalarOptionsMapper
@@ -29,6 +31,14 @@ internal static class ScalarOptionsMapper
     };
 
     internal static IEnumerable<ScalarConfiguration> ToScalarConfigurations(this IEnumerable<ScalarOptions> options) => options.Select(option => option.ToScalarConfiguration());
+
+    internal static async IAsyncEnumerable<ScalarConfiguration> ToScalarConfigurationsAsync(this IAsyncEnumerable<ScalarOptions> options, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await foreach (var option in options.WithCancellation(cancellationToken))
+        {
+            yield return option.ToScalarConfiguration();
+        }
+    }
 
     internal static ScalarConfiguration ToScalarConfiguration(this ScalarOptions options)
     {

--- a/integrations/aspire/src/Scalar.Aspire/ScalarAnnotation.cs
+++ b/integrations/aspire/src/Scalar.Aspire/ScalarAnnotation.cs
@@ -2,4 +2,4 @@
 
 namespace Scalar.Aspire;
 
-internal sealed record ScalarAnnotation(IResource Resource, Action<ScalarOptions>? ConfigureOptions) : IResourceAnnotation;
+internal sealed record ScalarAnnotation(IResource Resource, Func<ScalarOptions, CancellationToken, Task>? ConfigureOptions) : IResourceAnnotation;

--- a/integrations/aspire/src/Scalar.Aspire/ScalarHook.cs
+++ b/integrations/aspire/src/Scalar.Aspire/ScalarHook.cs
@@ -45,7 +45,7 @@ internal sealed class ScalarHook(IServiceProvider provider) : IDistributedApplic
         scalarResource.Annotations.Add(callback);
     }
 
-    
+
     private static async IAsyncEnumerable<ScalarAspireOptions> CreateConfigurationsAsync(IServiceProvider serviceProvider, IEnumerable<ScalarAnnotation> annotations, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         foreach (var scalarAnnotation in annotations)
@@ -59,6 +59,7 @@ internal sealed class ScalarHook(IServiceProvider provider) : IDistributedApplic
             {
                 await scalarAnnotation.ConfigureOptions.Invoke(scalarAspireOptions, cancellationToken);
             }
+
             if (scalarAspireOptions.DefaultProxy)
             {
                 ConfigureProxyUrl(scalarAspireOptions);

--- a/integrations/aspire/src/Scalar.Aspire/ScalarHook.cs
+++ b/integrations/aspire/src/Scalar.Aspire/ScalarHook.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
@@ -30,8 +31,6 @@ internal sealed class ScalarHook(IServiceProvider provider) : IDistributedApplic
 
         var serializedConfigurations = await scalarConfigurations.ToScalarConfigurationsAsync(cancellationToken).SerializeToJsonAsync(JsonSerializerOptions, cancellationToken);
 
-        // var serializedConfigurations = JsonSerializer.Serialize(configurations, JsonSerializerOptions);
-
         var scalarAspireOptions = provider.GetRequiredService<IOptions<ScalarAspireOptions>>().Value;
         var callback = new EnvironmentCallbackAnnotation(context =>
         {
@@ -46,7 +45,8 @@ internal sealed class ScalarHook(IServiceProvider provider) : IDistributedApplic
         scalarResource.Annotations.Add(callback);
     }
 
-    private static async IAsyncEnumerable<ScalarAspireOptions> CreateConfigurationsAsync(IServiceProvider serviceProvider, IEnumerable<ScalarAnnotation> annotations, CancellationToken cancellationToken)
+    
+    private static async IAsyncEnumerable<ScalarAspireOptions> CreateConfigurationsAsync(IServiceProvider serviceProvider, IEnumerable<ScalarAnnotation> annotations, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         foreach (var scalarAnnotation in annotations)
         {

--- a/integrations/aspire/src/Scalar.Aspire/ScalarHook.cs
+++ b/integrations/aspire/src/Scalar.Aspire/ScalarHook.cs
@@ -46,7 +46,7 @@ internal sealed class ScalarHook(IServiceProvider provider) : IDistributedApplic
     }
 
 
-    private static async IAsyncEnumerable<ScalarAspireOptions> CreateConfigurationsAsync(IServiceProvider serviceProvider, IEnumerable<ScalarAnnotation> annotations, [EnumeratorCancellation] CancellationToken cancellationToken)
+    private static async IAsyncEnumerable<ScalarOptions> CreateConfigurationsAsync(IServiceProvider serviceProvider, IEnumerable<ScalarAnnotation> annotations, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         foreach (var scalarAnnotation in annotations)
         {

--- a/integrations/aspire/tests/Scalar.Aspire.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/aspire/tests/Scalar.Aspire.Tests/ScalarOptionsMapperTests.cs
@@ -203,9 +203,10 @@ public class ScalarOptionsMapperTests
 
 file static class ScalarTestOptionsExtensions
 {
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
     public static async IAsyncEnumerable<T> AsAsyncEnumerable<T>(this IEnumerable<T> enumerable, [EnumeratorCancellation] CancellationToken cancellationToken)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
     {
-        await Task.CompletedTask;
         foreach (var value in enumerable)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/integrations/aspire/tests/Scalar.Aspire.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/aspire/tests/Scalar.Aspire.Tests/ScalarOptionsMapperTests.cs
@@ -1,7 +1,16 @@
+using System.Runtime.CompilerServices;
+
 namespace Scalar.Aspire.Tests;
 
 public class ScalarOptionsMapperTests
 {
+    private static IEnumerable<ScalarConfiguration> GetConfigurations(IEnumerable<ScalarTestOptions> options)
+    {
+        var finalOptions = options.AsAsyncEnumerable(TestContext.Current.CancellationToken);
+        var configurations = finalOptions.ToScalarConfigurationsAsync(TestContext.Current.CancellationToken).ToBlockingEnumerable(TestContext.Current.CancellationToken);
+        return configurations;
+    }
+    
     [Fact]
     public void ToScalarConfigurations_ShouldReturnCorrectDefaultConfiguration()
     {
@@ -9,7 +18,7 @@ public class ScalarOptionsMapperTests
         ScalarTestOptions[] options = [new()];
 
         // Act
-        var configurations = options.ToScalarConfigurations();
+        var configurations = GetConfigurations(options);
 
         // Assert
         var configuration = configurations.First();
@@ -189,5 +198,18 @@ public class ScalarOptionsMapperTests
                 first => first.Url.Should().Be("openapi/default.json"),
                 second => second.Url.Should().Be("external/custom.json")
             );
+    }
+}
+
+file static class ScalarTestOptionsExtensions
+{
+    public static async IAsyncEnumerable<T> AsAsyncEnumerable<T>(this IEnumerable<T> enumerable, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await Task.CompletedTask;
+        foreach (var value in enumerable)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return value;
+        }
     }
 }


### PR DESCRIPTION
**Problem**

Currently, it is not possible to do some async tasks inside the `WithApiReference` method.

**Solution**

With this PR, we add an async overload to the method.

Usage:

```csharp
scalar.WithApiReference(bookService, async (options, cancellationToken) =>
{
    options
        .AddDocument("v1", "Book Management API")
        .WithOpenApiRoutePattern("/swagger/{documentName}.json");

    // Example: load a dev API key asynchronously
    var apiKey = await secretProvider.GetValueAsync("BOOKS_API_KEY", cancellationToken);

    options
        .AddPreferredSecuritySchemes("BookApiKey")
        .AddApiKeyAuthentication("ApiKey", schema => schema.WithValue(apiKey));
});
```


**Checklist**

Closes #6422 

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
