### PR TITLE
fix(workspace-store): correctly propagate documents from one state to the other

### DIFF
--- a/.changeset/tender-roses-reply.md
+++ b/.changeset/tender-roses-reply.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': minor
+'@scalar/json-magic': minor
+---
+
+fix(workspace-store): correctly propagate documents from one state to the other

--- a/packages/json-magic/src/bundle/bundle.test.ts
+++ b/packages/json-magic/src/bundle/bundle.test.ts
@@ -2032,6 +2032,11 @@ describe('bundle', () => {
         path: [],
         resolutionCache: new Map(),
         parentNode: null,
+        rootNode: {
+          prop: {
+            innerProp: 'string',
+          },
+        },
       })
       expect(onBeforeNodeProcessCallback.mock.calls[1][0]).toEqual({
         innerProp: 'string',
@@ -2040,6 +2045,11 @@ describe('bundle', () => {
         path: ['prop'],
         resolutionCache: new Map(),
         parentNode: {
+          prop: {
+            innerProp: 'string',
+          },
+        },
+        rootNode: {
           prop: {
             innerProp: 'string',
           },
@@ -2057,6 +2067,11 @@ describe('bundle', () => {
             innerProp: 'string',
           },
         },
+        rootNode: {
+          prop: {
+            innerProp: 'string',
+          },
+        },
       })
       expect(onAfterNodeProcessCallback.mock.calls[1][0]).toEqual({
         prop: {
@@ -2067,6 +2082,11 @@ describe('bundle', () => {
         path: [],
         resolutionCache: new Map(),
         parentNode: null,
+        rootNode: {
+          prop: {
+            innerProp: 'string',
+          },
+        },
       })
     })
 

--- a/packages/json-magic/src/bundle/bundle.test.ts
+++ b/packages/json-magic/src/bundle/bundle.test.ts
@@ -2037,6 +2037,7 @@ describe('bundle', () => {
             innerProp: 'string',
           },
         },
+        loaders: [],
       })
       expect(onBeforeNodeProcessCallback.mock.calls[1][0]).toEqual({
         innerProp: 'string',
@@ -2054,6 +2055,7 @@ describe('bundle', () => {
             innerProp: 'string',
           },
         },
+        loaders: [],
       })
       expect(onAfterNodeProcessCallback).toHaveBeenCalledTimes(2)
       expect(onAfterNodeProcessCallback.mock.calls[0][0]).toEqual({
@@ -2072,6 +2074,7 @@ describe('bundle', () => {
             innerProp: 'string',
           },
         },
+        loaders: [],
       })
       expect(onAfterNodeProcessCallback.mock.calls[1][0]).toEqual({
         prop: {
@@ -2087,6 +2090,7 @@ describe('bundle', () => {
             innerProp: 'string',
           },
         },
+        loaders: [],
       })
     })
 

--- a/packages/json-magic/src/bundle/bundle.ts
+++ b/packages/json-magic/src/bundle/bundle.ts
@@ -397,6 +397,7 @@ type NodeProcessContext = {
   path: readonly string[]
   resolutionCache: Map<string, Promise<Readonly<ResolveResult>>>
   parentNode: UnknownObject | null
+  rootNode: UnknownObject
 }
 
 /**
@@ -699,10 +700,16 @@ export async function bundle(input: UnknownObject | string, config: Config) {
       path,
       resolutionCache: cache,
       parentNode: parent,
+      rootNode: documentRoot as UnknownObject,
     })
     // Invoke onBeforeNodeProcess hooks from all registered lifecycle plugins
     for (const plugin of lifecyclePlugin) {
-      await plugin.onBeforeNodeProcess?.(root as UnknownObject, { path, resolutionCache: cache, parentNode: parent })
+      await plugin.onBeforeNodeProcess?.(root as UnknownObject, {
+        path,
+        resolutionCache: cache,
+        parentNode: parent,
+        rootNode: documentRoot as UnknownObject,
+      })
     }
 
     if (typeof root === 'object' && '$ref' in root && typeof root['$ref'] === 'string') {
@@ -842,12 +849,18 @@ export async function bundle(input: UnknownObject | string, config: Config) {
       path,
       resolutionCache: cache,
       parentNode: parent,
+      rootNode: documentRoot as UnknownObject,
     })
 
     // Iterate through all lifecycle plugins and invoke their onAfterNodeProcess hooks, if defined.
     // This enables plugins to perform additional post-processing or cleanup after the node is processed.
     for (const plugin of lifecyclePlugin) {
-      await plugin.onAfterNodeProcess?.(root as UnknownObject, { path, resolutionCache: cache, parentNode: parent })
+      await plugin.onAfterNodeProcess?.(root as UnknownObject, {
+        path,
+        resolutionCache: cache,
+        parentNode: parent,
+        rootNode: documentRoot as UnknownObject,
+      })
     }
   }
 

--- a/packages/json-magic/src/bundle/bundle.ts
+++ b/packages/json-magic/src/bundle/bundle.ts
@@ -398,6 +398,7 @@ type NodeProcessContext = {
   resolutionCache: Map<string, Promise<Readonly<ResolveResult>>>
   parentNode: UnknownObject | null
   rootNode: UnknownObject
+  loaders: LoaderPlugin[]
 }
 
 /**
@@ -701,6 +702,7 @@ export async function bundle(input: UnknownObject | string, config: Config) {
       resolutionCache: cache,
       parentNode: parent,
       rootNode: documentRoot as UnknownObject,
+      loaders: loaderPlugins,
     })
     // Invoke onBeforeNodeProcess hooks from all registered lifecycle plugins
     for (const plugin of lifecyclePlugin) {
@@ -709,6 +711,7 @@ export async function bundle(input: UnknownObject | string, config: Config) {
         resolutionCache: cache,
         parentNode: parent,
         rootNode: documentRoot as UnknownObject,
+        loaders: loaderPlugins,
       })
     }
 
@@ -850,6 +853,7 @@ export async function bundle(input: UnknownObject | string, config: Config) {
       resolutionCache: cache,
       parentNode: parent,
       rootNode: documentRoot as UnknownObject,
+      loaders: loaderPlugins,
     })
 
     // Iterate through all lifecycle plugins and invoke their onAfterNodeProcess hooks, if defined.
@@ -860,6 +864,7 @@ export async function bundle(input: UnknownObject | string, config: Config) {
         resolutionCache: cache,
         parentNode: parent,
         rootNode: documentRoot as UnknownObject,
+        loaders: loaderPlugins,
       })
     }
   }

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -1049,7 +1049,7 @@ describe('create-workspace-store', () => {
       })
 
       expect(store.exportWorkspace()).toEqual(
-        '{"documents":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}},"/external":{"get":{"$ref":"#/x-ext/29442af"}}},"x-scalar-navigation":[{"id":"Get all users","title":"Get all users","path":"/users","method":"get","ref":"#/paths/~1users/get","type":"operation"},{"id":"","title":"Models","children":[{"id":"User","title":"User","name":"User","ref":"#/content/components/schemas/User","type":"model"}],"type":"text"}],"x-ext-urls":{"29442af":"http://localhost:9988/some-other-path"},"x-ext":{"29442af":{"description":"New content"}}}},"meta":{},"documentConfigs":{"default":{}},"originalDocuments":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}},"/external":{"get":{"$ref":"http://localhost:9988/some-other-path"}}}}},"intermediateDocuments":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}},"/external":{"get":{"$ref":"http://localhost:9988/some-other-path"}}}}},"overrides":{"default":{}}}',
+        '{"documents":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}},"/external":{"get":{"$ref":"#/x-ext/29442af"}}},"x-scalar-navigation":[{"id":"Get all users","title":"Get all users","path":"/users","method":"get","ref":"#/paths/~1users/get","type":"operation"},{"id":"","title":"Models","children":[{"id":"User","title":"User","name":"User","ref":"#/content/components/schemas/User","type":"model"}],"type":"text"}],"x-ext-urls":{"29442af":"http://localhost:9988/some-other-path"},"x-ext":{"29442af":{"description":"New content"}}}},"meta":{},"documentConfigs":{"default":{}},"originalDocuments":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}},"/external":{"get":{"$ref":"http://localhost:9988"}}}}},"intermediateDocuments":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}},"/external":{"get":{"$ref":"http://localhost:9988"}}}}},"overrides":{"default":{}}}',
       )
     })
   })
@@ -1083,7 +1083,7 @@ describe('create-workspace-store', () => {
       expect(store.workspace?.documents['api-3']?.info?.title).toBe('Updated API')
 
       // Revert the changes
-      store.revertDocumentChanges('api-3')
+      await store.revertDocumentChanges('api-3')
 
       // Should return the original document without any modifications
       expect(store.exportDocument('api-1', 'json')).toBe(
@@ -1471,11 +1471,65 @@ describe('create-workspace-store', () => {
       expect(defaultDocument.openapi).toBe('3.1.1')
 
       // Revert the changes
-      store.revertDocumentChanges('default')
+      await store.revertDocumentChanges('default')
 
       expect(defaultDocument.info.title).toBe('Edited title')
       expect(defaultDocument.info.version).toBe('2.0.0')
       expect(defaultDocument.openapi).toBe('3.1.1')
+    })
+
+    it('correctly reverts back the document while preserving external references', async () => {
+      server.get('/', () => ({
+        description: 'some description',
+      }))
+      server.get('/a', () => ({
+        description: 'updated',
+      }))
+      await server.listen({ port })
+
+      const store = createWorkspaceStore()
+
+      await store.addDocument({
+        name: 'default',
+        document: {
+          openapi: '3.1.1',
+          paths: {
+            '/': {
+              get: {
+                requestBody: {
+                  $ref: url,
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(store.exportWorkspace()).toBe(
+        '{"documents":{"default":{"openapi":"3.1.1","info":{"title":"","version":""},"paths":{"/":{"get":{"requestBody":{"$ref":"#/x-ext/c766ed8"}}}},"x-scalar-navigation":[{"id":"","title":"/","path":"/","method":"get","ref":"#/paths/~1/get","type":"operation"}],"x-ext-urls":{"c766ed8":"http://localhost:9988"},"x-ext":{"c766ed8":{"description":"some description"}}}},"meta":{},"documentConfigs":{"default":{}},"originalDocuments":{"default":{"openapi":"3.1.1","info":{"title":"","version":""},"paths":{"/":{"get":{"requestBody":{"$ref":"http://localhost:9988"}}}}}},"intermediateDocuments":{"default":{"openapi":"3.1.1","info":{"title":"","version":""},"paths":{"/":{"get":{"requestBody":{"$ref":"http://localhost:9988"}}}}}},"overrides":{"default":{}}}',
+      )
+
+      await store.replaceDocument('default', {
+        openapi: '3.1.1',
+        paths: {
+          '/': {
+            get: {
+              requestBody: {
+                $ref: `${url}/a`,
+              },
+            },
+          },
+        },
+      })
+      expect(store.exportWorkspace()).toBe(
+        '{"documents":{"default":{"openapi":"3.1.1","info":{"title":"","version":""},"paths":{"/":{"get":{"requestBody":{"$ref":"#/x-ext/8fad302"}}}},"x-scalar-navigation":[{"id":"","title":"/","path":"/","method":"get","ref":"#/paths/~1/get","type":"operation"}],"x-ext-urls":{"8fad302":"http://localhost:9988/a"},"x-ext":{"8fad302":{"description":"updated"}}}},"meta":{},"documentConfigs":{"default":{}},"originalDocuments":{"default":{"openapi":"3.1.1","info":{"title":"","version":""},"paths":{"/":{"get":{"requestBody":{"$ref":"http://localhost:9988"}}}}}},"intermediateDocuments":{"default":{"openapi":"3.1.1","info":{"title":"","version":""},"paths":{"/":{"get":{"requestBody":{"$ref":"http://localhost:9988"}}}}}},"overrides":{"default":{}}}',
+      )
+
+      await store.revertDocumentChanges('default')
+
+      expect(store.exportWorkspace()).toBe(
+        '{"documents":{"default":{"openapi":"3.1.1","info":{"title":"","version":""},"paths":{"/":{"get":{"requestBody":{"$ref":"#/x-ext/c766ed8"}}}},"x-scalar-navigation":[{"id":"","title":"/","path":"/","method":"get","ref":"#/paths/~1/get","type":"operation"}],"x-ext-urls":{"c766ed8":"http://localhost:9988"},"x-ext":{"c766ed8":{"description":"some description"}}}},"meta":{},"documentConfigs":{"default":{}},"originalDocuments":{"default":{"openapi":"3.1.1","info":{"title":"","version":""},"paths":{"/":{"get":{"requestBody":{"$ref":"http://localhost:9988"}}}}}},"intermediateDocuments":{"default":{"openapi":"3.1.1","info":{"title":"","version":""},"paths":{"/":{"get":{"requestBody":{"$ref":"http://localhost:9988"}}}}}},"overrides":{"default":{}}}',
+      )
     })
   })
 

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -1738,14 +1738,14 @@ describe('create-workspace-store', () => {
         ],
       })
 
-      store.replaceDocument('default', {
+      await store.replaceDocument('default', {
         openapi: '3.0.0',
         info: {
           title: 'Updated API',
           version: '1.0.0',
         },
         paths: {
-          '/users': {
+          '/users-v2': {
             get: {
               summary: 'Get all users',
               responses: {
@@ -1810,7 +1810,7 @@ describe('create-workspace-store', () => {
         },
         openapi: '3.1.1',
         paths: {
-          '/users': {
+          '/users-v2': {
             get: {
               responses: {
                 '200': {
@@ -1853,8 +1853,8 @@ describe('create-workspace-store', () => {
           {
             id: 'Get all users',
             method: 'get',
-            path: '/users',
-            ref: '#/paths/~1users/get',
+            path: '/users-v2',
+            ref: '#/paths/~1users-v2/get',
             title: 'Get all users',
             type: 'operation',
           },

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -161,6 +161,7 @@ describe('create-workspace-store', () => {
       'x-scalar-active-auth': 'Bearer',
       'x-scalar-active-server': 'server-1',
       'x-scalar-navigation': [],
+      'x-ext-urls': {},
     })
   })
 
@@ -183,6 +184,7 @@ describe('create-workspace-store', () => {
       },
       openapi: '3.1.1',
       'x-scalar-navigation': [],
+      'x-ext-urls': {},
     })
   })
 
@@ -548,6 +550,7 @@ describe('create-workspace-store', () => {
           type: 'text',
         },
       ],
+      'x-ext-urls': {},
     })
   })
 
@@ -702,6 +705,9 @@ describe('create-workspace-store', () => {
           },
         },
       },
+      'x-ext-urls': {
+        'c766ed8': 'http://localhost:9988',
+      },
       'x-scalar-navigation': [],
     })
   })
@@ -844,6 +850,7 @@ describe('create-workspace-store', () => {
           type: 'text',
         },
       ],
+      'x-ext-urls': {},
     })
   })
 
@@ -940,7 +947,7 @@ describe('create-workspace-store', () => {
       }
 
       // Write the changes back to the original document
-      store.saveDocument('api-3')
+      await store.saveDocument('api-3')
 
       // Should return the original document without any modifications
       expect(store.exportDocument('api-1', 'json')).toBe(
@@ -987,7 +994,7 @@ describe('create-workspace-store', () => {
       }
 
       // Write the changes back to the original document
-      store.saveDocument('default')
+      await store.saveDocument('default')
 
       // Should return the updated document without any extensions
       expect(store.exportDocument('default', 'json')).toEqual(
@@ -1100,6 +1107,7 @@ describe('create-workspace-store', () => {
               openapi: '3.1.1',
               info: { title: 'My API', version: '1.0.0' },
               'x-scalar-navigation': [],
+              'x-ext-urls': {},
               'x-scalar-active-server': 'server-1',
             },
             'pet-store': {
@@ -1116,6 +1124,7 @@ describe('create-workspace-store', () => {
                   type: 'operation',
                 },
               ],
+              'x-ext-urls': {},
             },
           },
           meta: {
@@ -1340,7 +1349,7 @@ describe('create-workspace-store', () => {
       expect(defaultDocument.info.version).toBe('2.0.0')
       expect(defaultDocument.openapi).toBe('3.1.1')
 
-      store.saveDocument('default')
+      await store.saveDocument('default')
       expect(store.exportDocument('default', 'json')).toBe(
         '{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"}}',
       )
@@ -1372,7 +1381,7 @@ describe('create-workspace-store', () => {
       expect(defaultDocument.info.version).toBe('2.0.0')
       expect(defaultDocument.openapi).toBe('3.1.1')
 
-      store.saveDocument('default')
+      await store.saveDocument('default')
       const exported = store.exportWorkspace()
 
       // Create a new store and load the exported workspace
@@ -1454,7 +1463,7 @@ describe('create-workspace-store', () => {
       })
 
       expect(store.exportWorkspace()).toBe(
-        '{"documents":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}},"x-scalar-navigation":[{"id":"Get all users","title":"Get all users","path":"/users","method":"get","ref":"#/paths/~1users/get","type":"operation"},{"id":"","title":"Models","children":[{"id":"User","title":"User","name":"User","ref":"#/content/components/schemas/User","type":"model"}],"type":"text"}]}},"meta":{},"documentConfigs":{"default":{}},"originalDocuments":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}}}},"intermediateDocuments":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}}}},"overrides":{"default":{}}}',
+        '{"documents":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}},"x-scalar-navigation":[{"id":"Get all users","title":"Get all users","path":"/users","method":"get","ref":"#/paths/~1users/get","type":"operation"},{"id":"","title":"Models","children":[{"id":"User","title":"User","name":"User","ref":"#/content/components/schemas/User","type":"model"}],"type":"text"}],"x-ext-urls":{}}},"meta":{},"documentConfigs":{"default":{}},"originalDocuments":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}}}},"intermediateDocuments":{"default":{"openapi":"3.1.1","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}}}},"overrides":{"default":{}}}',
       )
     })
 
@@ -1712,6 +1721,7 @@ describe('create-workspace-store', () => {
             },
           },
         },
+        'x-ext-urls': {},
         'x-scalar-navigation': [
           {
             id: 'Get all users',
@@ -1849,6 +1859,7 @@ describe('create-workspace-store', () => {
             },
           },
         },
+        'x-ext-urls': {},
         'x-scalar-navigation': [
           {
             id: 'Get all users',
@@ -1903,7 +1914,7 @@ describe('create-workspace-store', () => {
       })
 
       store.workspace.activeDocument!.info.title = 'new title'
-      store.saveDocument(documentName)
+      await store.saveDocument(documentName)
 
       const result = store.rebaseDocument(documentName, {
         ...getDocument(),
@@ -1939,7 +1950,7 @@ describe('create-workspace-store', () => {
       })
 
       store.workspace.activeDocument!.info.title = 'new title'
-      store.saveDocument(documentName)
+      await store.saveDocument(documentName)
 
       const newDocument = {
         ...getDocument(),
@@ -1997,7 +2008,7 @@ describe('create-workspace-store', () => {
       })
 
       store.workspace.activeDocument!.info.title = 'new title'
-      store.saveDocument(documentName)
+      await store.saveDocument(documentName)
 
       store.workspace.activeDocument!.info.version = '2.0'
 

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -682,7 +682,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
               name,
               // Extract the raw document data for export, removing any Vue reactivity wrappers.
               // When importing, the document can be wrapped again in a magic proxy.
-              createOverridesProxy(getRaw(doc), overrides[name]),
+              getRaw(doc),
             ]),
           ),
         },
@@ -699,7 +699,12 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       // Assign the magic proxy to the documents
       safeAssign(
         workspace.documents,
-        Object.fromEntries(Object.entries(result.documents).map(([name, doc]) => [name, createMagicProxy(doc)])),
+        Object.fromEntries(
+          Object.entries(result.documents).map(([name, doc]) => [
+            name,
+            createOverridesProxy(createMagicProxy(doc), result.overrides[name]),
+          ]),
+        ),
       )
 
       safeAssign(originalDocuments, result.originalDocuments)

--- a/packages/workspace-store/src/helpers/apply-selective-updates.test.ts
+++ b/packages/workspace-store/src/helpers/apply-selective-updates.test.ts
@@ -85,56 +85,6 @@ describe('applySelectiveUpdates', () => {
     ])
   })
 
-  it('should not update refs', () => {
-    const [result, excludedDiffs] = applySelectiveUpdates(
-      {
-        a: 1,
-        b: {
-          c: 2,
-          d: 3,
-          e: {
-            $ref: 'http://example.com/some-ref',
-          },
-        },
-      },
-      {
-        a: 0,
-        b: {
-          c: 2,
-          d: 5,
-          e: {
-            $ref: '#/definitions/internal-ref',
-            $status: 'loading',
-          },
-        },
-      },
-    )
-
-    expect(result).toEqual({
-      a: 0,
-      b: {
-        c: 2,
-        d: 5,
-        e: {
-          $ref: 'http://example.com/some-ref',
-        },
-      },
-    })
-
-    expect(excludedDiffs).toEqual([
-      {
-        changes: '#/definitions/internal-ref',
-        path: ['b', 'e', '$ref'],
-        type: 'update',
-      },
-      {
-        changes: 'loading',
-        path: ['b', 'e', '$status'],
-        type: 'add',
-      },
-    ])
-  })
-
   it('should skip navigation properties', () => {
     const [result, excludedDiffs] = applySelectiveUpdates(
       {

--- a/packages/workspace-store/src/helpers/apply-selective-updates.ts
+++ b/packages/workspace-store/src/helpers/apply-selective-updates.ts
@@ -3,7 +3,7 @@ import { apply, diff, type Difference } from '@scalar/json-magic/diff'
 
 // Keys to exclude from the diff - these are metadata fields that should not be persisted
 // when applying updates to the original document
-const excludeKeys = new Set(['x-scalar-navigation', 'x-ext', 'x-ext-urls', '$ref', '$status'])
+const excludeKeys = new Set(['x-scalar-navigation', 'x-ext', 'x-ext-urls', '$status'])
 
 /**
  * Applies updates from an updated document to an original document, while excluding changes to certain metadata keys.

--- a/packages/workspace-store/src/plugins.test.ts
+++ b/packages/workspace-store/src/plugins.test.ts
@@ -146,7 +146,7 @@ describe('plugins', () => {
 
       await bundle(input, {
         treeShake: false,
-        plugins: [externalValueResolver()],
+        plugins: [externalValueResolver(), fetchUrls()],
       })
 
       expect(input).toEqual({
@@ -189,7 +189,7 @@ describe('plugins', () => {
 
       const result = await bundle(input, {
         treeShake: false,
-        plugins: [refsEverywhere()],
+        plugins: [refsEverywhere(), fetchUrls()],
       })
 
       expect(result).toEqual({


### PR DESCRIPTION
**Problem**

There were several bugs related to how we handle replacing documents and reverting changes, which caused the document state to fall out of sync.

**Solution**

This PR fixes those issues by ensuring the document state remains consistent.
Additionally, it introduces a new bundler plugin that restores the original references, which is useful when saving the working document to an intermediate state.
We’ve also enhanced the plugin hooks with additional context, making them more flexible and adaptable for different use cases.

⚠️ **Breaking changes**
- `store.replaceDocument` now returns a `Promise`
- `saveDocument` now returns a `Promise`
- `revertDocumentChanges` now returns a `Promise`



**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
