### PR TITLE
feat(Scalar.Aspire): support multiple scalar resources

### DIFF
--- a/.changeset/honest-flies-burn.md
+++ b/.changeset/honest-flies-burn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspire': patch
+---
+
+feat: support multiple scalar resources

--- a/integrations/aspire/src/Scalar.Aspire/Extensions/DistributedApplicationBuilderExtensions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Extensions/DistributedApplicationBuilderExtensions.cs
@@ -29,7 +29,7 @@ public static class DistributedApplicationBuilderExtensions
     public static IResourceBuilder<ScalarResource> AddScalarApiReference(
         this IDistributedApplicationBuilder builder,
         [ResourceName] string name,
-        Action<ScalarOptions> configureOptions) => builder.AddScalarApiReference(name, null, configureOptions);
+        Action<ScalarAspireOptions> configureOptions) => builder.AddScalarApiReference(name, null, configureOptions);
 
     /// <summary>
     /// Adds a Scalar API reference resource to the distributed application with detailed configuration.

--- a/integrations/aspire/src/Scalar.Aspire/Extensions/DistributedApplicationBuilderExtensions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Extensions/DistributedApplicationBuilderExtensions.cs
@@ -47,7 +47,7 @@ public static class DistributedApplicationBuilderExtensions
     {
         if (configureOptions is not null)
         {
-            builder.Services.Configure(configureOptions);
+            builder.Services.Configure(name, configureOptions);
         }
 
         builder.Services.TryAddLifecycleHook<ScalarHook>();

--- a/integrations/aspire/src/Scalar.Aspire/ScalarHook.cs
+++ b/integrations/aspire/src/Scalar.Aspire/ScalarHook.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
@@ -22,13 +23,11 @@ internal sealed class ScalarHook(IServiceProvider provider) : IDistributedApplic
 
         foreach (var scalarResource in scalarResources)
         {
-            ConfigureScalarResource(scalarResource);
+            await ConfigureScalarResourceAsync(scalarResource, cancellationToken);
         }
-
-        return Task.CompletedTask;
     }
 
-    private void ConfigureScalarResource(ScalarResource scalarResource)
+    private async Task ConfigureScalarResourceAsync(ScalarResource scalarResource, CancellationToken cancellationToken)
     {
         var scalarAnnotations = scalarResource.Annotations.OfType<ScalarAnnotation>();
         var scalarConfigurations = CreateConfigurationsAsync(provider, scalarAnnotations, cancellationToken);
@@ -48,7 +47,6 @@ internal sealed class ScalarHook(IServiceProvider provider) : IDistributedApplic
         });
         scalarResource.Annotations.Add(callback);
     }
-
 
     private static async IAsyncEnumerable<ScalarOptions> CreateConfigurationsAsync(IServiceProvider serviceProvider, IEnumerable<ScalarAnnotation> annotations, [EnumeratorCancellation] CancellationToken cancellationToken)
     {

--- a/integrations/aspire/src/Scalar.Aspire/ScalarHook.cs
+++ b/integrations/aspire/src/Scalar.Aspire/ScalarHook.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
@@ -19,13 +18,18 @@ internal sealed class ScalarHook(IServiceProvider provider) : IDistributedApplic
 
     public async Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
     {
-        var scalarResource = appModel.Resources.OfType<ScalarResource>().FirstOrDefault();
+        var scalarResources = appModel.Resources.OfType<ScalarResource>();
 
-        if (scalarResource is null)
+        foreach (var scalarResource in scalarResources)
         {
-            return;
+            ConfigureScalarResource(scalarResource);
         }
 
+        return Task.CompletedTask;
+    }
+
+    private void ConfigureScalarResource(ScalarResource scalarResource)
+    {
         var scalarAnnotations = scalarResource.Annotations.OfType<ScalarAnnotation>();
         var scalarConfigurations = CreateConfigurationsAsync(provider, scalarAnnotations, cancellationToken);
 

--- a/integrations/aspire/src/Scalar.Aspire/ScalarHook.cs
+++ b/integrations/aspire/src/Scalar.Aspire/ScalarHook.cs
@@ -34,7 +34,7 @@ internal sealed class ScalarHook(IServiceProvider provider) : IDistributedApplic
 
         var serializedConfigurations = await scalarConfigurations.ToScalarConfigurationsAsync(cancellationToken).SerializeToJsonAsync(JsonSerializerOptions, cancellationToken);
 
-        var scalarAspireOptions = provider.GetRequiredService<IOptions<ScalarAspireOptions>>().Value;
+        var scalarAspireOptions = provider.GetRequiredService<IOptionsMonitor<ScalarAspireOptions>>().Get(scalarResource.Name);
         var callback = new EnvironmentCallbackAnnotation(context =>
         {
             var environmentVariables = context.EnvironmentVariables;
@@ -56,7 +56,7 @@ internal sealed class ScalarHook(IServiceProvider provider) : IDistributedApplic
 
 
             using var scope = serviceProvider.CreateScope();
-            var scalarAspireOptions = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<ScalarAspireOptions>>().Value;
+            var scalarAspireOptions = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<ScalarAspireOptions>>().Get(resourceName);
             if (scalarAnnotation.ConfigureOptions is not null)
             {
                 await scalarAnnotation.ConfigureOptions.Invoke(scalarAspireOptions, cancellationToken);


### PR DESCRIPTION
**Problem**

Currently, it's not possible to run multiple scalar instances in .NET Aspire.

**Solution**

Now every resource will be configured, not only the first one.

Closes #6424 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
