### PR TITLE
chore(ci): pin actions/cache/restore to v4 tag

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -23,7 +23,7 @@ runs:
       shell: bash
       run: pnpm install
     - name: Restore Turborepo cache
-      uses: actions/cache/restore@640a1c2554105b57832a23eea0b4672fc7a790d5
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4
       with:
         path: .turbo
         key: turbo-${{ runner.os }}-node-${{ inputs.node-version }}-${{ github.sha }}


### PR DESCRIPTION
**Problem**

I was blind and never tagged the actions/cache/restore GitHub action to a tag.

**Solution**

Now it's tagged to the same version as all actions/cache GitHub actions.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
