### PR TITLE
Fix fastapi theme

### DIFF
--- a/.changeset/shaggy-chicken-refuse.md
+++ b/.changeset/shaggy-chicken-refuse.md
@@ -1,0 +1,5 @@
+---
+'scalar-fastapi': patch
+---
+
+Remove the hardcoded scalar_theme

--- a/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
+++ b/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
@@ -55,103 +55,6 @@ class Theme(Enum):
     NONE = "none"
 
 
-scalar_theme = """
-/* basic theme */
-.light-mode {
-  --scalar-color-1: #2a2f45;
-  --scalar-color-2: #757575;
-  --scalar-color-3: #8e8e8e;
-  --scalar-color-accent: #009485;
-
-  --scalar-background-1: #fff;
-  --scalar-background-2: #fcfcfc;
-  --scalar-background-3: #f8f8f8;
-  --scalar-background-accent: #ecf8f6;
-
-  --scalar-border-color: rgba(0, 0, 0, 0.1);
-}
-.dark-mode {
-  --scalar-color-1: rgba(255, 255, 255, 0.9);
-  --scalar-color-2: rgba(255, 255, 255, 0.62);
-  --scalar-color-3: rgba(255, 255, 255, 0.44);
-  --scalar-color-accent: #00ccb8;
-
-  --scalar-background-1: #1f2129;
-  --scalar-background-2: #282a35;
-  --scalar-background-3: #30323d;
-  --scalar-background-accent: #223136;
-
-  --scalar-border-color: rgba(255, 255, 255, 0.1);
-}
-/* Document Sidebar */
-.light-mode .t-doc__sidebar {
-  --scalar-sidebar-background-1: var(--scalar-background-1);
-  --scalar-sidebar-item-hover-color: currentColor;
-  --scalar-sidebar-item-hover-background: var(--scalar-background-2);
-  --scalar-sidebar-item-active-background: var(--scalar-background-accent);
-  --scalar-sidebar-border-color: var(--scalar-border-color);
-  --scalar-sidebar-color-1: var(--scalar-color-1);
-  --scalar-sidebar-color-2: var(--scalar-color-2);
-  --scalar-sidebar-color-active: var(--scalar-color-accent);
-  --scalar-sidebar-search-background: transparent;
-  --scalar-sidebar-search-border-color: var(--scalar-border-color);
-  --scalar-sidebar-search--color: var(--scalar-color-3);
-}
-
-.dark-mode .sidebar {
-  --scalar-sidebar-background-1: var(--scalar-background-1);
-  --scalar-sidebar-item-hover-color: currentColor;
-  --scalar-sidebar-item-hover-background: var(--scalar-background-2);
-  --scalar-sidebar-item-active-background: var(--scalar-background-accent);
-  --scalar-sidebar-border-color: var(--scalar-border-color);
-  --scalar-sidebar-color-1: var(--scalar-color-1);
-  --scalar-sidebar-color-2: var(--scalar-color-2);
-  --scalar-sidebar-color-active: var(--scalar-color-accent);
-  --scalar-sidebar-search-background: transparent;
-  --scalar-sidebar-search-border-color: var(--scalar-border-color);
-  --scalar-sidebar-search--color: var(--scalar-color-3);
-}
-
-/* advanced */
-.light-mode {
-  --scalar-button-1: rgb(49 53 56);
-  --scalar-button-1-color: #fff;
-  --scalar-button-1-hover: rgb(28 31 33);
-
-  --scalar-color-green: #009485;
-  --scalar-color-red: #d52b2a;
-  --scalar-color-yellow: #ffaa01;
-  --scalar-color-blue: #0a52af;
-  --scalar-color-orange: #953800;
-  --scalar-color-purple: #8251df;
-
-  --scalar-scrollbar-color: rgba(0, 0, 0, 0.18);
-  --scalar-scrollbar-color-active: rgba(0, 0, 0, 0.36);
-}
-.dark-mode {
-  --scalar-button-1: #f6f6f6;
-  --scalar-button-1-color: #000;
-  --scalar-button-1-hover: #e7e7e7;
-
-  --scalar-color-green: #00ccb8;
-  --scalar-color-red: #e5695b;
-  --scalar-color-yellow: #ffaa01;
-  --scalar-color-blue: #78bffd;
-  --scalar-color-orange: #ffa656;
-  --scalar-color-purple: #d2a8ff;
-
-  --scalar-scrollbar-color: rgba(255, 255, 255, 0.24);
-  --scalar-scrollbar-color-active: rgba(255, 255, 255, 0.48);
-}
-:root {
-  --scalar-radius: 3px;
-  --scalar-radius-lg: 6px;
-  --scalar-radius-xl: 8px;
-}
-.scalar-card:nth-of-type(3) {
-  display: none;
-}"""
-
 def get_scalar_api_reference(
     *,
     openapi_url: Annotated[
@@ -205,7 +108,7 @@ def get_scalar_api_reference(
             Custom CSS theme for Scalar.
             """
         ),
-    ] = scalar_theme,
+    ] = "",
     layout: Annotated[
         Layout,
         Doc(


### PR DESCRIPTION
**Problem**

After #6256, we don't have to use hardcoded theme styles anymore. Also, if we set the `theme` but not the `scalar_theme`, the hardcoded style will take priority and make the theme ineffective.

**Solution**

With this PR …

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
