### PR TITLE
fix(api-reference): does not load document when the `url`/`content` stays the same

### DIFF
--- a/.changeset/stupid-moose-tickle.md
+++ b/.changeset/stupid-moose-tickle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: does not load document when the url/content stays the same

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
@@ -170,12 +170,25 @@ const addOrUpdateDocument = async (
   return
 }
 
-/** Watch for slug changes to add or update the document */
+/** Watch for changes to the slug to add or update the document */
 watch(
   () => selectedConfiguration.value.slug,
-  () =>
-    (selectedConfiguration.value.url || selectedConfiguration.value.content) &&
-    addOrUpdateDocument(selectedConfiguration.value),
+  (newSlug) => newSlug && addOrUpdateDocument(selectedConfiguration.value),
+  { immediate: true },
+)
+
+/** Watch for changes to the URL to add or update the document */
+watch(
+  () => selectedConfiguration.value.url,
+  (newUrl) => newUrl && addOrUpdateDocument(selectedConfiguration.value),
+  { immediate: true },
+)
+
+/** Watch for changes to the content to add or update the document */
+watch(
+  () => selectedConfiguration.value.content,
+  (newContent) =>
+    newContent && addOrUpdateDocument(selectedConfiguration.value),
   { immediate: true },
 )
 

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
@@ -170,19 +170,13 @@ const addOrUpdateDocument = async (
   return
 }
 
-/** Watch for URL changes */
+/** Watch for slug changes to add or update the document */
 watch(
-  () => selectedConfiguration.value.url,
-  (newUrl) => newUrl && addOrUpdateDocument(selectedConfiguration.value),
+  () => selectedConfiguration.value.slug,
+  () =>
+    (selectedConfiguration.value.url || selectedConfiguration.value.content) &&
+    addOrUpdateDocument(selectedConfiguration.value),
   { immediate: true },
-)
-
-/** Watch for content changes */
-watch(
-  () => selectedConfiguration.value.content,
-  (newContent) =>
-    newContent && addOrUpdateDocument(selectedConfiguration.value),
-  { immediate: true, deep: true },
 )
 
 // onCustomEvent(root, 'scalar-update-sidebar', (event) => {


### PR DESCRIPTION
**Problem**

**TL;DR** We don’t load the document, if you switch between two configurations with the same `url` or `content`.

Details: #6528

**Solution**

* This PR adds a watcher for `slug` changes, as an addition to the `content` and `url` watcher.
* The slug is generated even if you only have a single document or didn’t define a slug yourself.
* This will be removed once we fully use the store.

Fixes #6528

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
