### PR TITLE
docs(java): better docs

### DIFF
--- a/documentation/integrations/spring-boot.md
+++ b/documentation/integrations/spring-boot.md
@@ -2,7 +2,15 @@
 
 The Scalar WebJar provides automatic integration with Spring Boot applications. It includes auto-configuration that automatically sets up the API reference endpoint.
 
+## Requirements
+
+- **Spring Boot**: 2.7.0 or higher (3.x recommended)
+- **Java**: 11 or higher (17 recommended)
+- **Maven**: 3.6+ or **Gradle**: 7.0+
+
 ## Usage
+
+### Maven
 
 Add the [WebJar dependency](https://central.sonatype.com/artifact/com.scalar.maven/scalar) to your `pom.xml`:
 
@@ -14,10 +22,34 @@ Add the [WebJar dependency](https://central.sonatype.com/artifact/com.scalar.mav
 </dependency>
 ```
 
+### Gradle
+
+Add the dependency to your `build.gradle`:
+
+```gradle
+dependencies {
+    implementation 'com.scalar.maven:scalar:0.1.0'
+}
+```
+
+Or if using Kotlin DSL (`build.gradle.kts`):
+
+```kotlin
+dependencies {
+    implementation("com.scalar.maven:scalar:0.1.0")
+}
+```
+
+### Spring Boot Parent POM
+
+If you're using Spring Boot's parent POM, the dependency management will be handled automatically. If not, you may need to specify the version explicitly.
+
+## Configuration
+
 Configure the OpenAPI document URL in your `application.properties`:
 
 ```properties
-# The URL of your OpenAPI specification
+# The URL of your OpenAPI document
 scalar.url=https://example.com/openapi.json
 
 # Optional: Custom path (default: /scalar)
@@ -27,9 +59,51 @@ scalar.path=/docs
 scalar.enabled=true
 ```
 
+Or in `application.yml`:
+
+```yaml
+scalar:
+  url: https://example.com/openapi.json
+  path: /docs
+  enabled: true
+```
+
 Access your API reference at `http://localhost:8080/scalar` (or your custom path)
 
-### Configuration Properties
+## Auto-Configuration
+
+The Scalar integration automatically configures:
+
+- **ScalarController**: Serves the API reference interface
+- **ScalarProperties**: Configuration properties binding
+- **Static Resources**: JavaScript bundles and HTML templates
+
+### Conditional Configuration
+
+The auto-configuration is conditional on:
+
+- `scalar.enabled=true` (default)
+- Spring Boot web starter being present
+- No existing `ScalarController` bean
+
+### Excluding Auto-Configuration
+
+To exclude the auto-configuration:
+
+```java
+@SpringBootApplication(exclude = ScalarAutoConfiguration.class)
+public class MyApplication {
+    // ...
+}
+```
+
+Or in `application.properties`:
+
+```properties
+spring.autoconfigure.exclude=com.scalar.maven.webjar.ScalarAutoConfiguration
+```
+
+## Configuration Properties
 
 | Property                       | Default                                                        | Description                                                                                                                                                      |
 | ------------------------------ | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -47,9 +121,33 @@ Access your API reference at `http://localhost:8080/scalar` (or your custom path
 | `scalar.hideSearch`            | `false`                                                        | Whether to show the sidebar search bar                                                                                                                           |
 | `scalar.documentDownloadType`  | `both`                                                         | Sets the file type of the document to download. Can be "json", "yaml", "both", or "none"                                                                         |
 
-### Example Configuration
+## Security Configuration
 
-Here's a complete example showing all available configuration options:
+### Basic Security
+
+By default, the Scalar endpoint is publicly accessible. To secure it with Spring Security:
+
+```java
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(authz -> authz
+                .requestMatchers("/scalar/**").authenticated()
+                .anyRequest().permitAll()
+            )
+            .formLogin(form -> form.permitAll());
+        return http.build();
+    }
+}
+```
+
+## Example Configuration
+
+Here's an example showing all available configuration options:
 
 ```properties
 # Basic configuration
@@ -76,7 +174,7 @@ scalar.documentDownloadType=both
 scalar.customCss=body { font-family: 'Arial', sans-serif; }
 ```
 
-### Available Themes
+## Available Themes
 
 The `scalar.theme` property supports the following values:
 
@@ -93,19 +191,18 @@ The `scalar.theme` property supports the following values:
 - `laserwave` - Laserwave theme
 - `none` - No theme (custom styling only)
 
-### Layout Options
+## Layout Options
 
 The `scalar.layout` property supports:
 
 - `modern` - Modern layout style (default)
 - `classic` - Classic layout style
 
-### Document Download Types
+## Document Download Types
 
 The `scalar.documentDownloadType` property supports:
 
+- `both` - Show both JSON and YAML download buttons (default)
 - `json` - Show only JSON download button
 - `yaml` - Show only YAML download button
-- `both` - Show both JSON and YAML download buttons (default)
 - `none` - Hide download buttons completely
-


### PR DESCRIPTION
**Problem**

The docs for the Java/Spring Boot integration aren’t good.

**Solution**

This PR updates them and makes them awesome:

* fixes semantic issues (broken `<ol>`, h1, h2, h3 instead of h1 + h3)
* shows all properties
* replaces "specification" with "document"
* adds gradle example
* and so much more

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
