### PR TITLE
ci: do not deploy component test report on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,7 +481,7 @@ jobs:
           done
 
   test-component-snapshots:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]')
     needs: [build]
     runs-on: blacksmith-2vcpu-ubuntu-2204
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,7 +481,7 @@ jobs:
           done
 
   test-component-snapshots:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]')
+    if: github.event_name == 'pull_request'
     needs: [build]
     runs-on: blacksmith-2vcpu-ubuntu-2204
     permissions:
@@ -513,7 +513,8 @@ jobs:
         run: pnpm --filter components build:storybook
       - name: Run e2e tests (@scalar/components)
         run: pnpm --filter components test:e2e:ci
-      - if: ${{ !cancelled() }}
+        # Only when the tests failed and the PR is from the same repository
+      - if: ${{ !cancelled() }} && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]')
         name: Deploy Playwright Report to Netlify
         run: |
           pnpx netlify deploy --dir "./packages/components/playwright-report" \
@@ -522,7 +523,8 @@ jobs:
             --auth ${{ secrets.NETLIFY_AUTH_TOKEN }} \
             --filter @scalar/components \
             --alias=${{env.DEPLOY_ID}}
-      - if: ${{ !cancelled() }}
+        # Only when the tests failed and the PR is from the same repository
+      - if: ${{ !cancelled() }} && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]')
         name: Add Netlify Playwright Report URL to the PR
         uses: daun/playwright-report-summary@93883773b4f4f0951d8bcdb780c6443ca51eaf7b # v3
         with:


### PR DESCRIPTION
**Problem**

We try to deploy the component test reports in CI, but forks and bots don’t have access to the Netlify secrets, so it’ll fail.

**Solution**

With this PR we’ll skip it for bots and forks.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
