### PR TITLE
fix(api-reference): long security scheme descriptions break the layout

### DIFF
--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -183,7 +183,7 @@ const dataTableInputProps = {
         :aria-label="scheme.description"
         class="text-c-2 auth-description-container relative outline-none">
         <ScalarMarkdown
-          class="auth-description bg-b-1 text-c-2 outline-b-3 top-0 right-0 left-0 z-1 line-clamp-1 h-auto w-full border border-transparent px-3 py-1.25 text-ellipsis hover:absolute hover:z-10 hover:line-clamp-none hover:rounded-b-lg hover:shadow-lg"
+          class="auth-description bg-b-1 text-c-2 top-0 right-0 left-0 z-1 line-clamp-1 h-auto w-full px-3 py-1 text-ellipsis hover:absolute hover:line-clamp-none"
           :value="scheme.description" />
       </DataTableCell>
     </DataTableRow>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -181,9 +181,9 @@ const dataTableInputProps = {
     <DataTableRow v-if="scheme?.description && security.length <= 1">
       <DataTableCell
         :aria-label="scheme.description"
-        class="text-c-2 group/auth auth-description-container flex items-center whitespace-nowrap outline-none hover:whitespace-normal">
+        class="text-c-2 auth-description-container relative outline-none">
         <ScalarMarkdown
-          class="auth-description bg-b-1 text-c-2 outline-b-3 top-0 z-1 h-full w-full px-3 py-1.25 group-hover/auth:absolute group-hover/auth:h-auto group-hover/auth:border-b *:first:line-clamp-1 *:first:text-ellipsis group-hover/auth:*:first:line-clamp-none"
+          class="auth-description bg-b-1 text-c-2 outline-b-3 top-0 right-0 left-0 z-1 line-clamp-1 h-auto w-full border border-transparent px-3 py-1.25 text-ellipsis hover:absolute hover:z-10 hover:line-clamp-none hover:rounded-b-lg hover:shadow-lg"
           :value="scheme.description" />
       </DataTableCell>
     </DataTableRow>


### PR DESCRIPTION
**Problem**

See #6521

<img width="1388" height="452" alt="image" src="https://github.com/user-attachments/assets/fbd85934-f449-47e2-8bb8-6980cd5980a6" />

**Solution**

* With this PR it doesn’t break the layout anymore.
* The hover state could need a border, but then even short descriptions would get a border on hover. 🤔 
* I think I need @cameronrohani’s help here.

Fixes #6521

https://github.com/user-attachments/assets/48e2bd74-5bc2-4b7a-9fa1-c11220a1f4aa

**Example Document**

```js
{
  openapi: '3.1.1',
  info: {
    title: 'Hello World',
    version: '1.0.0',
  },
  paths: {},
  security: [
    {
      Bearer: [],
    },
  ],
  components: {
    securitySchemes: {
      Bearer: {
        type: 'http',
        scheme: 'bearer',
        // description: 'Short description',
        description:
          'This is a **longer** *Markdown* description that should be displayed in the auth section.\n\n1. This is a list item\n2. This is a list item\n3. This is a list item\n4. This is a list item\n5. This is a list item',
      },
    },
  },
}
```

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
