### PR TITLE
fix(openapi-parser): ensure upgrader doesn't lose schema properties

### DIFF
--- a/.changeset/friendly-donuts-serve.md
+++ b/.changeset/friendly-donuts-serve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix: ensure upgrader doesn't lose schema properties

--- a/packages/openapi-parser/src/utils/upgrade-from-three-to-three-one.test.ts
+++ b/packages/openapi-parser/src/utils/upgrade-from-three-to-three-one.test.ts
@@ -398,6 +398,7 @@ describe('upgradeFromThreeToThreeOne', () => {
                         },
                         fileName: {
                           type: 'string',
+                          description: 'The file name',
                           format: 'binary',
                         },
                       },
@@ -419,6 +420,7 @@ describe('upgradeFromThreeToThreeOne', () => {
             },
             fileName: {
               type: 'string',
+              description: 'The file name',
               contentMediaType: 'application/octet-stream',
             },
           },

--- a/packages/openapi-parser/src/utils/upgrade-from-three-to-three-one.ts
+++ b/packages/openapi-parser/src/utils/upgrade-from-three-to-three-one.ts
@@ -121,9 +121,13 @@ const applyChangesToDocument = (schema: UnknownObject, path: string[]) => {
     return {}
   }
 
+  // 6. Handle older formats
+  const { format: _, ...rest } = schema
+
   if (schema.type === 'string') {
     if (schema.format === 'binary') {
       return {
+        ...rest,
         type: 'string',
         contentMediaType: 'application/octet-stream',
       }
@@ -131,6 +135,7 @@ const applyChangesToDocument = (schema: UnknownObject, path: string[]) => {
 
     if (schema.format === 'base64') {
       return {
+        ...rest,
         type: 'string',
         contentEncoding: 'base64',
       }
@@ -140,6 +145,7 @@ const applyChangesToDocument = (schema: UnknownObject, path: string[]) => {
       const parentPath = path.slice(0, -1)
       const contentMediaType = parentPath.find((_, index) => path[index - 1] === 'content')
       return {
+        ...rest,
         type: 'string',
         contentEncoding: 'base64',
         contentMediaType,
@@ -147,7 +153,7 @@ const applyChangesToDocument = (schema: UnknownObject, path: string[]) => {
     }
   }
 
-  // 6. Handle x-webhooks
+  // 7. Handle x-webhooks
   if (schema['x-webhooks'] !== undefined) {
     schema.webhooks = schema['x-webhooks']
     delete schema['x-webhooks']


### PR DESCRIPTION
**Problem**

closes #6537

Currently, the upgrader will remove all of the old schema properties.

**Solution**

With this PR we only remove format and keep the rest.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
