### PR TITLE
ci: update CLI command documentation automatically

### DIFF
--- a/.github/workflows/update-scalar-cli-documentation.yml
+++ b/.github/workflows/update-scalar-cli-documentation.yml
@@ -4,9 +4,6 @@ on:
   # Run every day at 15:00 UTC
   schedule:
     - cron: '0 15 * * *'
-  # Run in PRs
-  # TODO: Remove before merging
-  pull_request:
   # Allow manual triggering
   workflow_dispatch:
 


### PR DESCRIPTION
**Problem**

Currently, the CLI command documenation is outdated: https://github.com/scalar/scalar/blob/main/documentation/guides/cli/commands.md

**Solution**

With this PR we’ll update the docs on a schedule.

Example PR: #6550

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
