### PR TITLE
feat(api-reference): `x-badges`

### DIFF
--- a/.changeset/sixty-spiders-compare.md
+++ b/.changeset/sixty-spiders-compare.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: x-badges

--- a/documentation/openapi.md
+++ b/documentation/openapi.md
@@ -203,6 +203,34 @@ paths:
 +      x-scalar-stability: 'experimental'
 ```
 
+## x-badges
+
+You can add badges to operations to use as indicators in documentation. Each operation can have multiple badges, and the displayed color is also configurable. The following example sets badges on the GET `/hello-world` operation:
+
+```diff
+openapi: 3.1.0
+info:
+  title: x-badges
+  version: 1.0.0
+paths:
+  /hello-world:
+    get:
+      summary: Hello World
++      x-badges:
++        - name: 'Alpha'
++        - name: 'Beta'
++          position: before
++        - name: 'Gamma'
++          position: after
++          color: '#ffcc00'
+```
+
+| Option   | Type   | Description                                                                                                                 |
+| -------- | ------ | --------------------------------------------------------------------------------------------------------------------------- |
+| name     | string | **REQUIRED**. The text that displays in the badge.                                                                          |
+| position | string | The position of the badge in relation to the header. Possible values: `before`, `after`. The default value is `after`.      |
+| color    | string | The color of the badge. It can be defined in various formats such as color keywords, RGB, RGBA, HSL, HSLA, and Hexadecimal. |
+
 ## x-enum-descriptions
 
 You can add a descriptions to `enum` values with `x-enum-descriptions`:
@@ -272,9 +300,9 @@ openapi: 3.1.0
 info:
   title: Example
   version: 1.0
-+  x-scalar-sdk-installation:
-+  - lang: Node
-+    description: Install our **Custom SDK** for Node.js from npm:
-+    source: |-
-+      npm install @your-awesome-company/sdk
+  x-scalar-sdk-installation:
+  - lang: Node
+    description: Install our **Custom SDK** for Node.js from npm:
+    source: |-
+      npm install @your-awesome-company/sdk
 ```

--- a/packages/api-reference/src/components/Badge/Badge.vue
+++ b/packages/api-reference/src/components/Badge/Badge.vue
@@ -1,15 +1,35 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const { color } = defineProps<{
+  color?: string
+}>()
+
+const badgeStyle = computed(() =>
+  color
+    ? {
+        '--badge-background-color': color,
+        '--badge-text-color': `color-mix(in srgb, ${color}, black 40%)`,
+      }
+    : {},
+)
+</script>
+
 <template>
-  <div class="badge">
+  <div
+    class="badge"
+    :style="badgeStyle">
     <slot />
   </div>
 </template>
 
 <style scoped>
 .badge {
-  color: var(--scalar-color-2);
+  color: var(--badge-text-color, var(--scalar-color-2));
   font-size: var(--scalar-mini);
-  background: var(--scalar-background-2);
-  border: var(--scalar-border-width) solid var(--scalar-border-color);
+  background: var(--badge-background-color, var(--scalar-background-2));
+  border: var(--scalar-border-width) solid
+    var(--badge-border-color, var(--scalar-border-color));
   padding: 2px 6px;
   border-radius: 12px;
   display: inline-block;

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -37,6 +37,7 @@ import OperationParameters from '@/features/Operation/components/OperationParame
 import OperationResponses from '@/features/Operation/components/OperationResponses.vue'
 import type { Schemas } from '@/features/Operation/types/schemas'
 import { TestRequestButton } from '@/features/test-request-button'
+import { XBadges } from '@/features/x-badges'
 import { useConfig } from '@/hooks/useConfig'
 import { RequestExample } from '@/v2/blocks/scalar-request-example-block'
 import type { ClientOptionGroup } from '@/v2/blocks/scalar-request-example-block/types'
@@ -93,23 +94,35 @@ const handleDiscriminatorChange = (type: string) => {
               <div class="endpoint-label-name">
                 {{ operationTitle }}
               </div>
+              <!-- Stability badge -->
               <Badge
+                class="capitalize"
                 v-if="getOperationStability(operation)"
                 :class="getOperationStabilityColor(operation)">
                 {{ getOperationStability(operation) }}
               </Badge>
 
+              <!-- Webhook badge -->
               <Badge
                 v-if="isWebhook"
                 class="font-code text-green flex w-fit items-center justify-center gap-1">
                 <ScalarIconWebhooksLogo weight="bold" />Webhook
               </Badge>
+
+              <!-- x-badges before -->
+              <XBadges
+                :badges="operation['x-badges']"
+                position="before" />
             </h3>
           </Anchor>
         </div>
       </div>
     </template>
     <template #actions="{ active }">
+      <!-- x-badges after -->
+      <XBadges
+        :badges="operation['x-badges']"
+        position="after" />
       <TestRequestButton
         v-if="active && !isWebhook"
         :method="method"

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -34,6 +34,7 @@ import OperationParameters from '@/features/Operation/components/OperationParame
 import OperationResponses from '@/features/Operation/components/OperationResponses.vue'
 import type { Schemas } from '@/features/Operation/types/schemas'
 import { TestRequestButton } from '@/features/test-request-button'
+import { XBadges } from '@/features/x-badges'
 import { useConfig } from '@/hooks/useConfig'
 import { RequestExample } from '@/v2/blocks/scalar-request-example-block'
 import type { ClientOptionGroup } from '@/v2/blocks/scalar-request-example-block/types'
@@ -74,18 +75,35 @@ const handleDiscriminatorChange = (type: string) => {
     :label="operationTitle"
     tabindex="-1">
     <SectionContent :loading="config.isLoading">
-      <Badge
-        class="capitalize"
-        v-if="getOperationStability(operation)"
-        :class="getOperationStabilityColor(operation)">
-        {{ getOperationStability(operation) }}
-      </Badge>
-
-      <Badge
-        v-if="isWebhook"
-        class="font-code text-green flex w-fit items-center justify-center gap-1">
-        <ScalarIconWebhooksLogo weight="bold" />Webhook
-      </Badge>
+      <div class="flex flex-row justify-between gap-1">
+        <!-- Left -->
+        <div class="flex gap-1">
+          <!-- Stability badge -->
+          <Badge
+            class="capitalize"
+            v-if="getOperationStability(operation)"
+            :class="getOperationStabilityColor(operation)">
+            {{ getOperationStability(operation) }}
+          </Badge>
+          <!-- Webhook badge -->
+          <Badge
+            v-if="isWebhook"
+            class="font-code text-green flex w-fit items-center justify-center gap-1">
+            <ScalarIconWebhooksLogo weight="bold" />Webhook
+          </Badge>
+          <!-- x-badges before -->
+          <XBadges
+            :badges="operation['x-badges']"
+            position="before" />
+        </div>
+        <!-- Right -->
+        <div class="flex gap-1">
+          <!-- x-badges after -->
+          <XBadges
+            :badges="operation['x-badges']"
+            position="after" />
+        </div>
+      </div>
       <div :class="isOperationDeprecated(operation) ? 'deprecated' : ''">
         <SectionHeader>
           <Anchor :id="id">

--- a/packages/api-reference/src/features/x-badges/XBadges.test.ts
+++ b/packages/api-reference/src/features/x-badges/XBadges.test.ts
@@ -1,0 +1,211 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import XBadges from './XBadges.vue'
+
+describe('XBadges', () => {
+  const createBadge = (name: string, position: 'before' | 'after' | undefined, color: string) => ({
+    name,
+    position,
+    color,
+  })
+
+  describe('badge filtering', () => {
+    it('filters badges by before position', () => {
+      const badges = [
+        createBadge('Badge 1', 'before', 'red'),
+        createBadge('Badge 2', 'after', 'blue'),
+        createBadge('Badge 3', 'before', 'green'),
+      ]
+
+      const wrapper = mount(XBadges, {
+        props: { position: 'before', badges },
+      })
+
+      const renderedBadges = wrapper.findAll('.badge')
+      expect(renderedBadges).toHaveLength(2)
+      expect(renderedBadges[0].text()).toBe('Badge 1')
+      expect(renderedBadges[1].text()).toBe('Badge 3')
+    })
+
+    it('filters badges by after position', () => {
+      const badges = [
+        createBadge('Badge 1', 'before', 'red'),
+        createBadge('Badge 2', 'after', 'blue'),
+        createBadge('Badge 3', undefined, 'green'),
+      ]
+
+      const wrapper = mount(XBadges, {
+        props: { position: 'after', badges },
+      })
+
+      const renderedBadges = wrapper.findAll('.badge')
+      expect(renderedBadges).toHaveLength(2)
+      expect(renderedBadges[0].text()).toBe('Badge 2')
+      expect(renderedBadges[1].text()).toBe('Badge 3')
+    })
+
+    it('includes badges without position when filtering for after', () => {
+      const badges = [
+        createBadge('Badge 1', undefined, 'red'),
+        createBadge('Badge 2', 'after', 'blue'),
+        createBadge('Badge 3', 'before', 'green'),
+      ]
+
+      const wrapper = mount(XBadges, {
+        props: { position: 'after', badges },
+      })
+
+      const renderedBadges = wrapper.findAll('.badge')
+      expect(renderedBadges).toHaveLength(2)
+      expect(renderedBadges[0].text()).toBe('Badge 1')
+      expect(renderedBadges[1].text()).toBe('Badge 2')
+    })
+
+    it('excludes badges without position when filtering for before', () => {
+      const badges = [
+        createBadge('Badge 1', 'before', 'red'),
+        createBadge('Badge 2', undefined, 'blue'),
+        createBadge('Badge 3', 'before', 'green'),
+      ]
+
+      const wrapper = mount(XBadges, {
+        props: { position: 'before', badges },
+      })
+
+      const renderedBadges = wrapper.findAll('.badge')
+      expect(renderedBadges).toHaveLength(2)
+      expect(renderedBadges[0].text()).toBe('Badge 1')
+      expect(renderedBadges[1].text()).toBe('Badge 3')
+    })
+  })
+
+  describe('edge cases and error handling', () => {
+    it('handles empty badges array', () => {
+      const wrapper = mount(XBadges, {
+        props: { position: 'before', badges: [] },
+      })
+
+      const renderedBadges = wrapper.findAll('.badge')
+      expect(renderedBadges).toHaveLength(0)
+    })
+
+    it('handles null badges', () => {
+      const wrapper = mount(XBadges, {
+        props: { position: 'before', badges: null },
+      })
+
+      const renderedBadges = wrapper.findAll('.badge')
+      expect(renderedBadges).toHaveLength(0)
+    })
+
+    it('handles undefined badges', () => {
+      const wrapper = mount(XBadges, {
+        props: { position: 'before', badges: undefined },
+      })
+
+      const renderedBadges = wrapper.findAll('.badge')
+      expect(renderedBadges).toHaveLength(0)
+    })
+
+    it('handles non-array badges gracefully', () => {
+      const wrapper = mount(XBadges, {
+        props: { position: 'before', badges: 'not-an-array' },
+      })
+
+      const renderedBadges = wrapper.findAll('.badge')
+      expect(renderedBadges).toHaveLength(0)
+    })
+
+    it('handles mixed valid and invalid badge data', () => {
+      const badges = [
+        createBadge('Valid Badge', 'before', 'red'),
+        { invalid: 'badge' },
+        createBadge('Another Valid', 'before', 'blue'),
+      ]
+
+      const wrapper = mount(XBadges, {
+        props: { position: 'before', badges },
+      })
+
+      const renderedBadges = wrapper.findAll('.badge')
+      expect(renderedBadges).toHaveLength(2)
+      expect(renderedBadges[0].text()).toBe('Valid Badge')
+      expect(renderedBadges[1].text()).toBe('Another Valid')
+    })
+  })
+
+  describe('badge rendering', () => {
+    it('renders badges with correct color props', () => {
+      const badges = [createBadge('Red Badge', 'before', 'red'), createBadge('Blue Badge', 'before', 'blue')]
+
+      const wrapper = mount(XBadges, {
+        props: { position: 'before', badges },
+      })
+
+      const renderedBadges = wrapper.findAll('.badge')
+      expect(renderedBadges[0].attributes('style')).toContain('color: red')
+      expect(renderedBadges[1].attributes('style')).toContain('color: blue')
+    })
+
+    it('renders badge names as text content', () => {
+      const badges = [createBadge('Test Badge', 'before', 'red')]
+
+      const wrapper = mount(XBadges, {
+        props: { position: 'before', badges },
+      })
+
+      const badge = wrapper.find('.badge')
+      expect(badge.text()).toBe('Test Badge')
+    })
+
+    it('renders badges in correct order', () => {
+      const badges = [createBadge('Badge 1', 'before', 'red'), createBadge('Badge 2', 'before', 'blue')]
+
+      const wrapper = mount(XBadges, {
+        props: { position: 'before', badges },
+      })
+
+      const renderedBadges = wrapper.findAll('.badge')
+      expect(renderedBadges).toHaveLength(2)
+
+      // Verify that badges are rendered in the correct order
+      expect(renderedBadges[0].text()).toBe('Badge 1')
+      expect(renderedBadges[1].text()).toBe('Badge 2')
+    })
+
+    describe('position-specific behavior', () => {
+      it('only shows badges for before position when position is before', () => {
+        const badges = [
+          createBadge('Before Badge', 'before', 'red'),
+          createBadge('After Badge', 'after', 'blue'),
+          createBadge('No Position Badge', undefined, 'green'),
+        ]
+
+        const wrapper = mount(XBadges, {
+          props: { position: 'before', badges },
+        })
+
+        const renderedBadges = wrapper.findAll('.badge')
+        expect(renderedBadges).toHaveLength(1)
+        expect(renderedBadges[0].text()).toBe('Before Badge')
+      })
+
+      it('shows after badges and no-position badges when position is after', () => {
+        const badges = [
+          createBadge('Before Badge', 'before', 'red'),
+          createBadge('After Badge', 'after', 'blue'),
+          createBadge('No Position Badge', undefined, 'green'),
+        ]
+
+        const wrapper = mount(XBadges, {
+          props: { position: 'after', badges },
+        })
+
+        const renderedBadges = wrapper.findAll('.badge')
+        expect(renderedBadges).toHaveLength(2)
+        expect(renderedBadges[0].text()).toBe('After Badge')
+        expect(renderedBadges[1].text()).toBe('No Position Badge')
+      })
+    })
+  })
+})

--- a/packages/api-reference/src/features/x-badges/XBadges.vue
+++ b/packages/api-reference/src/features/x-badges/XBadges.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { Badge } from '@/components/Badge'
+
+type XBadge = {
+  name: string
+  position: 'before' | 'after'
+  color: string
+}
+
+const { position, badges } = defineProps<{
+  position: 'before' | 'after'
+  badges: XBadge[] | unknown
+}>()
+
+const filteredBadges = computed<XBadge[]>(() => {
+  if (Array.isArray(badges)) {
+    return badges.filter(
+      (badge) =>
+        badge.position === position ||
+        (position === 'after' && !badge.position),
+    )
+  }
+
+  return []
+})
+</script>
+
+<template>
+  <template
+    v-if="filteredBadges.length"
+    v-for="badge in filteredBadges"
+    :key="badge.name">
+    <Badge :color="badge.color">
+      {{ badge.name }}
+    </Badge>
+  </template>
+</template>

--- a/packages/api-reference/src/features/x-badges/index.ts
+++ b/packages/api-reference/src/features/x-badges/index.ts
@@ -1,0 +1,1 @@
+export { default as XBadges } from './XBadges.vue'


### PR DESCRIPTION
**Problem**

We have a few badges for operations already, for webhooks, `x-scalar-stability` and `deprecated`. But we don’t support [`x-badges`](https://redocly.com/docs/realm/content/api-docs/openapi-extensions/x-badges) yet.

**Solution**

This PR adds support for `x-badges`, including docs and tests.

Fixes #6545

**Example**

```yaml
openapi: 3.1.0
info:
  title: x-badges example
  version: 1.0.0
paths:
  /hello-world:
    get:
      summary: Hello World
      deprecated: true
      x-badges:
        - name: 'Alpha'
        - name: 'Beta'
          position: before
        - name: 'Gamma'
          position: after
          color: '#ffcc00'
```

**Preview**

<img width="889" height="568" alt="Screenshot 2025-08-13 at 16 20 04" src="https://github.com/user-attachments/assets/d18be491-531f-45d4-a5e3-57fa6dce501e" />

<img width="1159" height="319" alt="Screenshot 2025-08-13 at 16 15 37" src="https://github.com/user-attachments/assets/236b4db5-037f-4afd-8290-69ec32f5dc42" />

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
