### PR TITLE
docs: reorder sidebar

### DIFF
--- a/documentation/openapi.md
+++ b/documentation/openapi.md
@@ -1,12 +1,8 @@
-# OpenAPI Specification
+# OpenAPI Extensions
 
 We're expecting the passed OpenAPI document to adhere to [the Swagger 2.0, OpenAPI 3.0 or OpenAPI 3.1 specification](https://github.com/OAI/OpenAPI-Specification).
 
 On top of that, we've added a few things for your convenience:
-
-## Custom Specification Extensions
-
-You can add custom specification extensions (starting with a `x-`) through [our plugin API](configuration.md).
 
 ## x-scalar-environments
 
@@ -306,3 +302,7 @@ info:
     source: |-
       npm install @your-awesome-company/sdk
 ```
+
+## Custom Specification Extensions
+
+You can add custom specification extensions (starting with a `x-`) through [our plugin API](https://guides.scalar.com/scalar/scalar-api-references/configuration).

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -14,10 +14,35 @@
       "sidebar": [
         {
           "name": "Introduction",
-          "description": "Introduction to Scalar",
           "icon": "phosphor/regular/house",
           "path": "documentation/guides/introduction.md",
           "type": "page"
+        },
+        {
+          "name": "Scalar Registry",
+          "type": "folder",
+          "defaultOpen": false,
+          "icon": "phosphor/regular/seal-check",
+          "children": [
+            {
+              "path": "documentation/guides/registry/getting-started.md",
+              "type": "page"
+            },
+            {
+              "path": "documentation/guides/registry/upload.md",
+              "type": "page",
+              "name": "Upload"
+            },
+            {
+              "path": "documentation/guides/registry/cli.md",
+              "type": "page"
+            },
+            {
+              "path": "documentation/guides/registry/github-actions.md",
+              "type": "page",
+              "name": "GitHub Actions"
+            }
+          ]
         },
         {
           "name": "Scalar Docs",
@@ -157,38 +182,6 @@
           ]
         },
         {
-          "name": "Scalar Registry",
-          "type": "folder",
-          "defaultOpen": false,
-          "icon": "phosphor/regular/seal-check",
-          "children": [
-            {
-              "path": "documentation/guides/registry/getting-started.md",
-              "type": "page"
-            },
-            {
-              "path": "documentation/guides/registry/upload.md",
-              "type": "page",
-              "name": "Upload"
-            },
-            {
-              "path": "documentation/guides/registry/cli.md",
-              "type": "page"
-            },
-            {
-              "path": "documentation/guides/registry/github-actions.md",
-              "type": "page",
-              "name": "GitHub Actions"
-            }
-          ]
-        },
-        {
-          "name": "Access",
-          "icon": "phosphor/regular/lock-simple",
-          "path": "documentation/guides/access.md",
-          "type": "page"
-        },
-        {
           "name": "Scalar CLI",
           "type": "folder",
           "defaultOpen": false,
@@ -203,6 +196,12 @@
               "type": "page"
             }
           ]
+        },
+        {
+          "name": "Access",
+          "icon": "phosphor/regular/lock-simple",
+          "path": "documentation/guides/access.md",
+          "type": "page"
         },
         {
           "name": "Scalar API References",
@@ -221,23 +220,23 @@
               "type": "page"
             },
             {
-              "name": "Themes",
-              "path": "documentation/themes.md",
-              "type": "page"
-            },
-            {
-              "name": "Plugins",
-              "path": "documentation/plugins.md",
-              "type": "page"
-            },
-            {
               "name": "OpenAPI",
               "path": "documentation/openapi.md",
               "type": "page"
             },
             {
+              "name": "Themes",
+              "path": "documentation/themes.md",
+              "type": "page"
+            },
+            {
               "name": "Markdown",
               "path": "documentation/markdown.md",
+              "type": "page"
+            },
+            {
+              "name": "Plugins",
+              "path": "documentation/plugins.md",
               "type": "page"
             },
             {
@@ -442,12 +441,6 @@
           ]
         }
       ]
-    }
-  ],
-  "references": [
-    {
-      "liveLink": "https://registry.scalar.com/@scalar/apis/access-service/latest",
-      "name": "Scalar API"
     }
   ],
   "siteConfig": {


### PR DESCRIPTION
This PR is a proposal to reorder the sidebar of the deployed docs:

<img width="307" height="546" alt="Screenshot 2025-08-14 at 14 27 22" src="https://github.com/user-attachments/assets/26ddc367-2c6f-4bb6-b0bb-f4a2497ceb7d" />

- First, an introduction,
- then the Registry (where everything should start)
- then Scalar Docs (most popular product I guess)
- then SDKs
- then the CLI for a deeper integration
- then Access for advanced use cases
- and then the Scalar API Reference

And inside the API Reference:

* Getting Started
* Configure it
* OpenAPI extensions (moved the plugins for specification extensions to the bottom, as something more advanced)
* Customize it (themes)
* Markdown support
* And if that’s not enough: Plugins

⚠️ And I removed the Scalar Access API Reference. Or did we have that on purpose? It seemed a bit confusing to me.