### PR TITLE
feat(Scalar.Aspire): support HTTPS

### DIFF
--- a/.changeset/soft-chairs-change.md
+++ b/.changeset/soft-chairs-change.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspire': minor
+---
+
+feat: support HTTPS

--- a/documentation/integrations/aspire.md
+++ b/documentation/integrations/aspire.md
@@ -10,13 +10,11 @@ Scalar for Aspire provides:
 - **Simplified Service Discovery**: Automatically discover and configure API endpoints from your Aspire services
 - **Multiple Document Support**: Each service can expose multiple OpenAPI specifications
 - **CORS Issue Elimination**: Built-in proxy (enabled by default) handles API requests without requiring CORS configuration
-- **Full HTTPS Support**: Complete support for both HTTP and HTTPS endpoints with automatic handling
+- **HTTPS Support**: Complete support for both HTTP and HTTPS endpoints with automatic handling
 
 ## Prerequisites
 
-:::scalar-callout{ type=info }
 The Scalar Aspire integration requires a container solution such as **Docker** or **Podman** to be installed on your machine.
-:::
 
 ### Service Requirements
 
@@ -24,7 +22,6 @@ Each service you want to include in the API Reference must:
 
 - Expose OpenAPI documents over HTTP or HTTPS endpoints
 - Implement the `IResourceWithServiceDiscovery` interface
-- Define an endpoint named **"http"** or **"https"**
 
 ## Quick Start
 
@@ -36,7 +33,7 @@ dotnet add package Scalar.Aspire
 
 ### 2. Basic Configuration
 
-Add the integration to your AppHost `Program.cs`:
+Add the integration to your AppHost:
 
 ```csharp
 using Scalar.Aspire;
@@ -44,10 +41,7 @@ using Scalar.Aspire;
 var builder = DistributedApplication.CreateBuilder(args);
 
 // Add your services
-var userService = builder
-    .AddNpmApp("user-service", "../MyUserService")
-    .WithHttpEndpoint(env: "PORT");
-
+var userService = builder.AddNpmApp("user-service", "../MyUserService");
 var bookService = builder.AddProject<Projects.BookService>("book-service");
 
 // Add Scalar API Reference
@@ -76,21 +70,17 @@ var scalar = builder.AddScalarApiReference(options =>
 });
 ```
 
-### Service Registration
+### Service Configuration
 
-Register each service individually to include it in the API Reference:
+Register services with custom configuration options:
 
 ```csharp
-// Basic registration with default settings
-scalar.WithApiReference(weatherService);
-
-// Custom configuration for specific services
 scalar.WithApiReference(bookService, options =>
 {
     options
         .AddDocument("v1", "Book Management API")
         .WithOpenApiRoutePattern("/api-documentation/{documentName}.json")
-        .WithTheme(ScalarTheme.Purple);
+        .WithTheme(ScalarTheme.Mars);
 });
 ```
 
@@ -126,7 +116,7 @@ var scalar = builder.AddScalarApiReference(options =>
 {
     options
         .PreferHttps() // Use HTTPS endpoints when available
-        .AllowSelfSignedCertificates(); // For development environments
+        .AllowSelfSignedCertificates(); // Trust self-signed certificates
 });
 ```
 
@@ -134,9 +124,10 @@ var scalar = builder.AddScalarApiReference(options =>
 The `AllowSelfSignedCertificates()` method should only be used in development environments, never in production.
 :::
 
-### How HTTPS Works
+### How HTTPS Support Works
 
 - **Protocol Selection**: HTTP is used by default. Use `PreferHttps()` to prioritize HTTPS when available
+- **Automatic Configuration**: When HTTPS is preferred, both OpenAPI document routes and server URLs are automatically configured to use HTTPS endpoints
 - **Automatic Redirects**: HTTP to HTTPS redirects are handled automatically with proper header rewriting (localhost only)
 - **Certificate Validation**: Self-signed certificates can be trusted in development using `AllowSelfSignedCertificates()`
 - **Fallback Behavior**: If HTTPS is preferred but unavailable, HTTP endpoints are used as fallback
@@ -151,7 +142,7 @@ Scalar for Aspire includes a built-in proxy that is **enabled by default** to pr
 
 ### How the Proxy Works
 
-When the proxy is enabled (default behavior):
+When the proxy is enabled:
 
 - **Eliminates CORS Issues**: All API requests are routed through the Scalar proxy, avoiding CORS restrictions
 - **Service Discovery Integration**: OpenAPI servers and document routes are configured to use service discovery endpoints through the proxy
@@ -198,6 +189,10 @@ var scalar = builder.AddScalarApiReference(options =>
         });
 });
 ```
+
+:::scalar-callout{ type=info }
+When the proxy is enabled, OAuth token requests are automatically proxied through the Scalar proxy to avoid CORS issues. However, interactive authorization requests are not proxied since they occur directly in the browser, so authorization URLs must be correctly configured and accessible. See the [Aspire playground on GitHub](https://github.com/scalar/scalar/blob/4d509fb6a074b7c779fad9ed17148a9c52db3eb9/integrations/aspire/playground/Scalar.Aspire.BookService/Program.cs#L15-L21).
+:::
 
 ### Service-Specific Authentication
 
@@ -249,4 +244,4 @@ scalar.WithApiReference(bookService, async (options, cancellationToken) =>
 
 ## Additional Resources
 
-For more advanced configuration options and detailed API reference, see the [.NET ASP.NET Core documentation](https://guides.scalar.com/scalar/scalar-api-references/integrations/net-aspnet-core#configuration-options). Most configuration options are shared between `Scalar.AspNetCore` and `Scalar.Aspire` integrations.
+For more advanced configuration options see the [.NET ASP.NET Core documentation](https://guides.scalar.com/scalar/scalar-api-references/integrations/net-aspnet-core#configuration-options). Many configuration options are similar between `Scalar.AspNetCore` and `Scalar.Aspire` integrations.

--- a/documentation/integrations/aspire.md
+++ b/documentation/integrations/aspire.md
@@ -1,17 +1,16 @@
 # Scalar API Reference for .NET Aspire
 
-The `Scalar.Aspire` package seamlessly integrates Scalar API Reference into your .NET Aspire applications, providing a unified documentation interface for all your microservices.
+The `Scalar.Aspire` package seamlessly integrates Scalar API Reference into your .NET Aspire applications, providing a unified documentation interface for all your services.
 
 ## Overview
 
-With Scalar for Aspire, you can:
+Scalar for Aspire provides:
 
-- **Unify API Documentation**: View documentation for all microservices in a single, cohesive interface
-- **Simplify Service Discovery**: Automatically discover and configure API endpoints from your Aspire services
-- **Support Multiple Documents**: Each service can expose multiple OpenAPI specifications
-- **Eliminate CORS Issues**: Built-in proxy (enabled by default) handles API requests without requiring CORS configuration
-- **Automatic Endpoint Configuration**: OpenAPI documents and servers are automatically configured to work with service discovery
-- **Work with HTTPS**: Full support for both HTTP and HTTPS endpoints with automatic handling
+- **Unified API Documentation**: View documentation for all services in a single, cohesive interface
+- **Simplified Service Discovery**: Automatically discover and configure API endpoints from your Aspire services
+- **Multiple Document Support**: Each service can expose multiple OpenAPI specifications
+- **CORS Issue Elimination**: Built-in proxy (enabled by default) handles API requests without requiring CORS configuration
+- **Full HTTPS Support**: Complete support for both HTTP and HTTPS endpoints with automatic handling
 
 ## Prerequisites
 

--- a/documentation/integrations/aspire.md
+++ b/documentation/integrations/aspire.md
@@ -115,7 +115,7 @@ Scalar supports HTTPS endpoints.
 var scalar = builder.AddScalarApiReference(options =>
 {
     options
-        .PreferHttps() // Use HTTPS endpoints when available
+        .PreferHttpsEndpoint() // Use HTTPS endpoints when available
         .AllowSelfSignedCertificates(); // Trust self-signed certificates
 });
 ```
@@ -126,7 +126,7 @@ The `AllowSelfSignedCertificates()` method should only be used in development en
 
 ### How HTTPS Support Works
 
-- **Protocol Selection**: HTTP is used by default. Use `PreferHttps()` to prioritize HTTPS when available
+- **Protocol Selection**: HTTP is used by default. Use `PreferHttpsEndpoint()` to prioritize HTTPS when available
 - **Automatic Configuration**: When HTTPS is preferred, both OpenAPI document routes and server URLs are automatically configured to use HTTPS endpoints
 - **Automatic Redirects**: HTTP to HTTPS redirects are handled automatically with proper header rewriting (localhost only)
 - **Certificate Validation**: Self-signed certificates can be trusted in development using `AllowSelfSignedCertificates()`

--- a/documentation/integrations/aspire.md
+++ b/documentation/integrations/aspire.md
@@ -130,7 +130,7 @@ The `AllowSelfSignedCertificates()` method should only be used in development en
 - **Automatic Configuration**: When HTTPS is preferred, both OpenAPI document routes and server URLs are automatically configured to use HTTPS endpoints
 - **Automatic Redirects**: HTTP to HTTPS redirects are handled automatically with proper header rewriting (localhost only)
 - **Certificate Validation**: Self-signed certificates can be trusted in development using `AllowSelfSignedCertificates()`
-- **Fallback Behavior**: If HTTPS is preferred but unavailable, HTTP endpoints are used as fallback
+- **Fallback Behavior**: If HTTPS is preferred but unavailable, HTTP endpoints are used as fallback. Conversely, if no HTTP endpoint is available, HTTPS endpoints are automatically used
 
 :::scalar-callout{ type=info }
 Currently, the Scalar API Reference interface is hosted over HTTP, even when communicating with HTTPS services. Support for hosting the Scalar interface under HTTPS will be added in a future release.

--- a/integrations/aspire/playground/Scalar.Aspire.AppHost/Program.cs
+++ b/integrations/aspire/playground/Scalar.Aspire.AppHost/Program.cs
@@ -22,9 +22,10 @@ var keycloak = builder
 var scalar = builder
     .AddScalarApiReference(options =>
     {
-        options.WithCdnUrl("https://cdn.jsdelivr.net/npm/@scalar/api-reference");
-        options.AllowSelfSignedCertificate = true;
-        options.PreferHttps = true;
+        options
+            .WithCdnUrl("https://cdn.jsdelivr.net/npm/@scalar/api-reference")
+            .PreferHttps()
+            .AllowSelfSignedCertificates();
     })
     .WithReference(keycloak)
     .WithExternalHttpEndpoints();

--- a/integrations/aspire/playground/Scalar.Aspire.AppHost/Program.cs
+++ b/integrations/aspire/playground/Scalar.Aspire.AppHost/Program.cs
@@ -24,7 +24,7 @@ var scalar = builder
     {
         options
             .WithCdnUrl("https://cdn.jsdelivr.net/npm/@scalar/api-reference")
-            .PreferHttps()
+            .PreferHttpsEndpoint()
             .AllowSelfSignedCertificates();
     })
     .WithReference(keycloak)

--- a/integrations/aspire/playground/Scalar.Aspire.AppHost/Program.cs
+++ b/integrations/aspire/playground/Scalar.Aspire.AppHost/Program.cs
@@ -24,6 +24,7 @@ var scalar = builder
     {
         options.WithCdnUrl("https://cdn.jsdelivr.net/npm/@scalar/api-reference");
         options.AllowSelfSignedCertificate = true;
+        options.PreferHttps = true;
     })
     .WithReference(keycloak)
     .WithExternalHttpEndpoints();
@@ -41,7 +42,12 @@ scalar
             {
                 flow.WithClientId("admin-cli");
             });
-        // options.UseHttps = true;
+    })
+    .WithApiReference(userService, options =>
+    {
+        options.WithTheme(ScalarTheme.Mars);
+        options.WithDefaultHttpClient(ScalarTarget.JavaScript, ScalarClient.Fetch);
+        options.AddDocument("external");
     });
 
 

--- a/integrations/aspire/playground/Scalar.Aspire.AppHost/Program.cs
+++ b/integrations/aspire/playground/Scalar.Aspire.AppHost/Program.cs
@@ -20,18 +20,16 @@ var keycloak = builder
     .WithEnvironment("KC_BOOTSTRAP_ADMIN_PASSWORD", "admin");
 
 var scalar = builder
-    .AddScalarApiReference(options => options.WithCdnUrl("https://cdn.jsdelivr.net/npm/@scalar/api-reference"))
+    .AddScalarApiReference(options =>
+    {
+        options.WithCdnUrl("https://cdn.jsdelivr.net/npm/@scalar/api-reference");
+        options.AllowSelfSignedCertificate = true;
+    })
     .WithReference(keycloak)
     .WithExternalHttpEndpoints();
 
 
 scalar
-    .WithApiReference(userService, options =>
-    {
-        options.WithTheme(ScalarTheme.Mars);
-        options.WithDefaultHttpClient(ScalarTarget.JavaScript, ScalarClient.Fetch);
-        options.AddDocument("external");
-    })
     .WithApiReference(bookService, options =>
     {
         options
@@ -43,6 +41,7 @@ scalar
             {
                 flow.WithClientId("admin-cli");
             });
+        // options.UseHttps = true;
     });
 
 

--- a/integrations/aspire/playground/Scalar.Aspire.AppHost/Properties/launchSettings.json
+++ b/integrations/aspire/playground/Scalar.Aspire.AppHost/Properties/launchSettings.json
@@ -12,18 +12,6 @@
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21277",
         "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22072"
       }
-    },
-    "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "http://localhost:15283",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19299",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20232"
-      }
     }
   }
 }

--- a/integrations/aspire/playground/Scalar.Aspire.BookService/Program.cs
+++ b/integrations/aspire/playground/Scalar.Aspire.BookService/Program.cs
@@ -46,6 +46,8 @@ builder.Services.AddAuthorization();
 
 var app = builder.Build();
 
+app.UseHttpsRedirection();
+
 app.MapOpenApi("/swagger/{documentName}.json");
 
 app.UseAuthentication();

--- a/integrations/aspire/playground/Scalar.Aspire.BookService/Properties/launchSettings.json
+++ b/integrations/aspire/playground/Scalar.Aspire.BookService/Properties/launchSettings.json
@@ -1,6 +1,15 @@
 ﻿{
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:5163;http://localhost:5162",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,

--- a/integrations/aspire/playground/Scalar.Aspire.BookService/Properties/launchSettings.json
+++ b/integrations/aspire/playground/Scalar.Aspire.BookService/Properties/launchSettings.json
@@ -9,15 +9,6 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
-    },
-    "http": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "http://localhost:5162",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
     }
   }
 }

--- a/integrations/aspire/src/Scalar.Aspire.Service/Dockerfile
+++ b/integrations/aspire/src/Scalar.Aspire.Service/Dockerfile
@@ -13,5 +13,6 @@ COPY --from=publish /app/publish .
 # use non-root user
 USER $APP_UID
 EXPOSE 8080
+EXPOSE 8443
 
 ENTRYPOINT ["dotnet", "Scalar.Aspire.Service.dll"]

--- a/integrations/aspire/src/Scalar.Aspire.Service/Dockerfile
+++ b/integrations/aspire/src/Scalar.Aspire.Service/Dockerfile
@@ -13,6 +13,5 @@ COPY --from=publish /app/publish .
 # use non-root user
 USER $APP_UID
 EXPOSE 8080
-EXPOSE 8443
 
 ENTRYPOINT ["dotnet", "Scalar.Aspire.Service.dll"]

--- a/integrations/aspire/src/Scalar.Aspire.Service/Endpoints/ProxyEndpoint.cs
+++ b/integrations/aspire/src/Scalar.Aspire.Service/Endpoints/ProxyEndpoint.cs
@@ -44,6 +44,51 @@ internal static class ProxyEndpoint
         {
             context.Response.StatusCode = StatusCodes.Status500InternalServerError;
             await context.Response.WriteAsync($"Proxy error: {error}", context.RequestAborted);
+            return;
         }
+
+        // Check if we got a redirect response and rewrite localhost URLs
+        if (IsRedirectStatusCode(context.Response.StatusCode))
+        {
+            var locationHeader = context.Response.Headers.Location.FirstOrDefault();
+            if (!string.IsNullOrEmpty(locationHeader) && Uri.TryCreate(locationHeader, UriKind.Absolute, out var redirectUri))
+            {
+                // Check if redirect is to localhost - rewrite it back to proxy
+                if (IsLocalhostRedirect(redirectUri))
+                {
+                    var rewrittenLocation = RewriteLocalhostToProxy(context.Request, redirectUri, targetUrl);
+                    context.Response.Headers.Location = rewrittenLocation;
+                }
+            }
+        }
+    }
+
+    private static bool IsRedirectStatusCode(int statusCode) => statusCode is >= 300 and <= 399;
+
+    private static bool IsLocalhostRedirect(Uri redirectUri) =>
+        redirectUri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
+        redirectUri.Host.Equals("127.0.0.1", StringComparison.OrdinalIgnoreCase);
+
+    private static string RewriteLocalhostToProxy(HttpRequest request, Uri localhostUri, string originalTargetUrl)
+    {
+        // Extract the original service name from the target URL
+        if (!Uri.TryCreate(originalTargetUrl, UriKind.Absolute, out var originalUri))
+        {
+            return localhostUri.ToString();
+        }
+
+        var serviceName = originalUri.Host;
+
+        // Build new URL: https://service-name/path?query
+        var rewrittenUri = new UriBuilder(localhostUri)
+        {
+            Host = serviceName,
+            Port = -1 // Remove port
+        };
+
+        // Create proxy URL that points back to this proxy
+        var proxyUrl = $"{request.Scheme}://{request.Host}{request.Path}?scalar_url={Uri.EscapeDataString(rewrittenUri.Uri.ToString())}";
+
+        return proxyUrl;
     }
 }

--- a/integrations/aspire/src/Scalar.Aspire.Service/Endpoints/ProxyEndpoint.cs
+++ b/integrations/aspire/src/Scalar.Aspire.Service/Endpoints/ProxyEndpoint.cs
@@ -10,8 +10,16 @@ internal static class ProxyEndpoint
 
     internal static void MapScalarProxy(this IEndpointRouteBuilder endpoints)
     {
+        var configuration = endpoints.ServiceProvider.GetRequiredService<IConfiguration>();
+        var shouldAllowAllCertificates = configuration.GetValue<bool>(AllowSelfSignedCertificate);
         var factory = endpoints.ServiceProvider.GetRequiredService<IForwarderHttpClientFactory>();
-        _client = factory.CreateClient(new ForwarderHttpClientContext { NewConfig = HttpClientConfig.Empty });
+        _client = factory.CreateClient(new ForwarderHttpClientContext
+        {
+            NewConfig = new HttpClientConfig
+            {
+                DangerousAcceptAnyServerCertificate = shouldAllowAllCertificates
+            }
+        });
         endpoints.Map(RouteDefaults.ProxyEndpoint, HandleProxy);
     }
 

--- a/integrations/aspire/src/Scalar.Aspire.Service/Endpoints/ProxyEndpoint.cs
+++ b/integrations/aspire/src/Scalar.Aspire.Service/Endpoints/ProxyEndpoint.cs
@@ -11,7 +11,7 @@ internal static class ProxyEndpoint
     internal static void MapScalarProxy(this IEndpointRouteBuilder endpoints)
     {
         var configuration = endpoints.ServiceProvider.GetRequiredService<IConfiguration>();
-        var shouldAllowAllCertificates = configuration.GetValue<bool>(AllowSelfSignedCertificate);
+        var shouldAllowAllCertificates = configuration.GetValue<bool>(AllowSelfSignedCertificates);
         var factory = endpoints.ServiceProvider.GetRequiredService<IForwarderHttpClientFactory>();
         _client = factory.CreateClient(new ForwarderHttpClientContext
         {

--- a/integrations/aspire/src/Scalar.Aspire.Service/EnvironmentVariables.cs
+++ b/integrations/aspire/src/Scalar.Aspire.Service/EnvironmentVariables.cs
@@ -7,4 +7,6 @@ internal static class EnvironmentVariables
     public const string CdnUrl = "CDN_URL";
 
     public const string DefaultProxy = "DEFAULT_PROXY";
+
+    public const string AllowSelfSignedCertificate = "ALLOW_SELF_SIGNED_CERTIFICATE";
 }

--- a/integrations/aspire/src/Scalar.Aspire.Service/EnvironmentVariables.cs
+++ b/integrations/aspire/src/Scalar.Aspire.Service/EnvironmentVariables.cs
@@ -8,5 +8,5 @@ internal static class EnvironmentVariables
 
     public const string DefaultProxy = "DEFAULT_PROXY";
 
-    public const string AllowSelfSignedCertificate = "ALLOW_SELF_SIGNED_CERTIFICATE";
+    public const string AllowSelfSignedCertificates = "ALLOW_SELF_SIGNED_CERTIFICATES";
 }

--- a/integrations/aspire/src/Scalar.Aspire.Service/Extensions/ServiceCollectionExtensions.cs
+++ b/integrations/aspire/src/Scalar.Aspire.Service/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,9 @@
+namespace Scalar.Aspire.Service.Extensions;
+
+internal static class ServiceCollectionExtensions
+{
+    internal static void AddScalarLogger(this IServiceCollection services)
+    {
+        services.AddSingleton<ILogger>(provider => provider.GetRequiredService<ILoggerFactory>().CreateLogger("Scalar.Aspire.Service"));
+    }
+}

--- a/integrations/aspire/src/Scalar.Aspire.Service/LoggerMessages.cs
+++ b/integrations/aspire/src/Scalar.Aspire.Service/LoggerMessages.cs
@@ -1,0 +1,39 @@
+using Yarp.ReverseProxy.Forwarder;
+
+namespace Scalar.Aspire.Service;
+
+internal static partial class LoggerMessages
+{
+    [LoggerMessage(LogLevel.Information, "Proxy request received for target URL: {TargetUrl}")]
+    internal static partial void LogProxyRequestReceived(this ILogger logger, string targetUrl);
+
+    [LoggerMessage(LogLevel.Warning, "Invalid target URL provided: {TargetUrl}")]
+    internal static partial void LogInvalidTargetUrl(this ILogger logger, string targetUrl);
+
+    [LoggerMessage(LogLevel.Debug, "Forwarding request to target host: {TargetHost}, URI: {TargetUri}")]
+    internal static partial void LogForwardingRequest(this ILogger logger, string targetHost, Uri targetUri);
+
+    [LoggerMessage(LogLevel.Error, "Proxy error occurred: {Error} for target URL: {TargetUrl}")]
+    internal static partial void LogProxyError(this ILogger logger, ForwarderError error, string targetUrl);
+
+    [LoggerMessage(LogLevel.Debug, "Proxy response received with status code: {StatusCode}")]
+    internal static partial void LogProxyResponse(this ILogger logger, int statusCode);
+
+    [LoggerMessage(LogLevel.Debug, "Redirect response detected with location: {Location}")]
+    internal static partial void LogRedirectDetected(this ILogger logger, string? location);
+
+    [LoggerMessage(LogLevel.Information, "Rewriting localhost redirect from {OriginalLocation} to {RewrittenLocation}")]
+    internal static partial void LogLocalhostRedirectRewrite(this ILogger logger, string originalLocation, string rewrittenLocation);
+
+    [LoggerMessage(LogLevel.Debug, "Redirect to non-localhost URL, keeping original location: {Location}")]
+    internal static partial void LogNonLocalhostRedirect(this ILogger logger, string location);
+
+    [LoggerMessage(LogLevel.Warning, "Invalid or missing location header in redirect response: {Location}")]
+    internal static partial void LogInvalidRedirectLocation(this ILogger logger, string? location);
+
+    [LoggerMessage(LogLevel.Information, "Proxy request completed successfully for target URL: {TargetUrl}")]
+    internal static partial void LogProxyRequestCompleted(this ILogger logger, string targetUrl);
+
+    [LoggerMessage(LogLevel.Error, "Unexpected error occurred while proxying request to {TargetUrl}")]
+    internal static partial void LogUnexpectedProxyError(this ILogger logger, Exception exception, string targetUrl);
+}

--- a/integrations/aspire/src/Scalar.Aspire.Service/Program.cs
+++ b/integrations/aspire/src/Scalar.Aspire.Service/Program.cs
@@ -1,10 +1,12 @@
 using Scalar.Aspire.Service.Endpoints;
+using Scalar.Aspire.Service.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddHealthChecks();
 builder.Services.AddHttpForwarderWithServiceDiscovery();
 builder.Services.AddServiceDiscovery();
+builder.Services.AddScalarLogger();
 
 var app = builder.Build();
 

--- a/integrations/aspire/src/Scalar.Aspire.Service/Program.cs
+++ b/integrations/aspire/src/Scalar.Aspire.Service/Program.cs
@@ -1,8 +1,6 @@
 using Scalar.Aspire.Service.Endpoints;
 
-var builder = WebApplication.CreateSlimBuilder(args);
-// Required for .MapStaticAssets
-builder.WebHost.UseStaticWebAssets();
+var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddHealthChecks();
 builder.Services.AddHttpForwarderWithServiceDiscovery();
@@ -15,7 +13,7 @@ app.MapHealthChecks(HealthCheckEndpoint);
 app.MapApiReference();
 app.MapStaticAssets();
 
-if (!string.IsNullOrEmpty(app.Configuration.GetValue<string>(DefaultProxy)))
+if (app.Configuration.GetValue<bool>(DefaultProxy))
 {
     app.MapScalarProxy();
 }

--- a/integrations/aspire/src/Scalar.Aspire.Service/appsettings.Development.json
+++ b/integrations/aspire/src/Scalar.Aspire.Service/appsettings.Development.json
@@ -1,7 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information"
+      "Default": "Information",
+      "Scalar.Aspire.Service": "Debug"
     }
   }
 }

--- a/integrations/aspire/src/Scalar.Aspire.Service/appsettings.Development.json
+++ b/integrations/aspire/src/Scalar.Aspire.Service/appsettings.Development.json
@@ -1,8 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Scalar.Aspire.Service": "Debug"
-    }
-  }
-}

--- a/integrations/aspire/src/Scalar.Aspire.Service/appsettings.Production.json
+++ b/integrations/aspire/src/Scalar.Aspire.Service/appsettings.Production.json
@@ -1,7 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Warning"
-    }
-  }
-}

--- a/integrations/aspire/src/Scalar.Aspire.Service/appsettings.json
+++ b/integrations/aspire/src/Scalar.Aspire.Service/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Scalar.Aspire.Service": "Information"
+    }
+  }
+}

--- a/integrations/aspire/src/Scalar.Aspire.Service/appsettings.json
+++ b/integrations/aspire/src/Scalar.Aspire.Service/appsettings.json
@@ -2,7 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Warning",
-      "Scalar.Aspire.Service": "Information"
+      "Scalar.Aspire.Service": "Debug"
     }
   }
 }

--- a/integrations/aspire/src/Scalar.Aspire/EnvironmentVariables.cs
+++ b/integrations/aspire/src/Scalar.Aspire/EnvironmentVariables.cs
@@ -7,4 +7,6 @@ internal static class EnvironmentVariables
     public const string CdnUrl = "CDN_URL";
 
     public const string DefaultProxy = "DEFAULT_PROXY";
+
+    public const string AllowSelfSignedCertificate = "ALLOW_SELF_SIGNED_CERTIFICATE";
 }

--- a/integrations/aspire/src/Scalar.Aspire/EnvironmentVariables.cs
+++ b/integrations/aspire/src/Scalar.Aspire/EnvironmentVariables.cs
@@ -8,5 +8,5 @@ internal static class EnvironmentVariables
 
     public const string DefaultProxy = "DEFAULT_PROXY";
 
-    public const string AllowSelfSignedCertificate = "ALLOW_SELF_SIGNED_CERTIFICATE";
+    public const string AllowSelfSignedCertificates = "ALLOW_SELF_SIGNED_CERTIFICATES";
 }

--- a/integrations/aspire/src/Scalar.Aspire/Extensions/ScalarAspireOptionsExtensions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Extensions/ScalarAspireOptionsExtensions.cs
@@ -18,7 +18,7 @@ public static class ScalarAspireOptionsExtensions
     }
 
     /// <summary>
-    /// Disables the default proxy configuration.
+    /// Disables the default proxy.
     /// By default, all requests will be proxied to prevent CORS issues.
     /// </summary>
     /// <param name="options">The <see cref="ScalarAspireOptions" /> to configure.</param>
@@ -28,4 +28,20 @@ public static class ScalarAspireOptionsExtensions
         options.DefaultProxy = false;
         return options;
     }
+
+    /// <summary>
+    /// Allows self-signed certificates for HTTPS connections.
+    /// </summary>
+    /// <param name="options">The <see cref="ScalarAspireOptions" /> to configure.</param>
+    /// <returns>The <see cref="ScalarAspireOptions" /> so that additional calls can be chained.</returns>
+    /// <remarks>
+    /// When enabled, the scalar proxy will accept self-signed certificates.
+    /// This should only be used in development environments and never in production.
+    /// </remarks>
+    public static ScalarAspireOptions AllowSelfSignedCertificates(this ScalarAspireOptions options)
+    {
+        options.AllowSelfSignedCertificates = true;
+        return options;
+    }
+    
 }

--- a/integrations/aspire/src/Scalar.Aspire/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Extensions/ScalarOptionsExtensions.cs
@@ -595,7 +595,7 @@ public static class ScalarOptionsExtensions
     /// </summary>
     /// <param name="options">The <see cref="ScalarAspireOptions" /> to configure.</param>
     /// <returns>The <see cref="ScalarAspireOptions" /> so that additional calls can be chained.</returns>
-    public static TOptions PreferHttps<TOptions>(this TOptions options) where TOptions : ScalarOptions
+    public static TOptions PreferHttpsEndpoint<TOptions>(this TOptions options) where TOptions : ScalarOptions
     {
         options.PreferHttps = true;
         return options;

--- a/integrations/aspire/src/Scalar.Aspire/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Extensions/ScalarOptionsExtensions.cs
@@ -597,7 +597,7 @@ public static class ScalarOptionsExtensions
     /// <returns>The <see cref="ScalarAspireOptions" /> so that additional calls can be chained.</returns>
     public static TOptions PreferHttpsEndpoint<TOptions>(this TOptions options) where TOptions : ScalarOptions
     {
-        options.PreferHttps = true;
+        options.PreferHttpsEndpoint = true;
         return options;
     }
 }

--- a/integrations/aspire/src/Scalar.Aspire/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Extensions/ScalarOptionsExtensions.cs
@@ -589,4 +589,15 @@ public static class ScalarOptionsExtensions
         options.DocumentDownloadType = documentDownloadType;
         return options;
     }
+
+    /// <summary>
+    /// Sets whether HTTPS should be preferred over HTTP when both are available.
+    /// </summary>
+    /// <param name="options">The <see cref="ScalarAspireOptions" /> to configure.</param>
+    /// <returns>The <see cref="ScalarAspireOptions" /> so that additional calls can be chained.</returns>
+    public static TOptions PreferHttps<TOptions>(this TOptions options) where TOptions : ScalarOptions
+    {
+        options.PreferHttps = true;
+        return options;
+    }
 }

--- a/integrations/aspire/src/Scalar.Aspire/Options/ScalarAspireOptions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Options/ScalarAspireOptions.cs
@@ -24,4 +24,14 @@ public sealed class ScalarAspireOptions : ScalarOptions
     /// Can be customized to use a different CDN or local assets.
     /// </remarks>
     public string CdnUrl { get; set; } = "standalone.js";
+
+    /// <summary>
+    /// Gets or sets whether to allow self-signed certificates for HTTPS connections.
+    /// </summary>
+    /// <value>The default value is <c>false</c>.</value>
+    /// <remarks>
+    /// When enabled, the application will accept self-signed certificates.
+    /// This should only be used in development environments and never in production.
+    /// </remarks>
+    public bool AllowSelfSignedCertificate { get; set; }
 }

--- a/integrations/aspire/src/Scalar.Aspire/Options/ScalarAspireOptions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Options/ScalarAspireOptions.cs
@@ -30,8 +30,8 @@ public sealed class ScalarAspireOptions : ScalarOptions
     /// </summary>
     /// <value>The default value is <c>false</c>.</value>
     /// <remarks>
-    /// When enabled, the application will accept self-signed certificates.
+    /// When enabled, the scalar proxy will accept self-signed certificates.
     /// This should only be used in development environments and never in production.
     /// </remarks>
-    public bool AllowSelfSignedCertificate { get; set; }
+    public bool AllowSelfSignedCertificates { get; set; }
 }

--- a/integrations/aspire/src/Scalar.Aspire/Options/ScalarOptions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Options/ScalarOptions.cs
@@ -196,4 +196,6 @@ public abstract class ScalarOptions
     /// </summary>
     /// <value>The default value is <c>null</c>.</value>
     public DocumentDownloadType? DocumentDownloadType { get; set; }
+
+    public bool UseHttps { get; set; }
 }

--- a/integrations/aspire/src/Scalar.Aspire/Options/ScalarOptions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Options/ScalarOptions.cs
@@ -202,7 +202,7 @@ public abstract class ScalarOptions
     /// </summary>
     /// <value>The default value is <c>false</c>.</value>
     /// <remarks>
-    /// When set to <c>true</c>, HTTPS URLs will be prioritized when multiple server URLs are available.
+    /// When set to <c>true</c>, HTTPS URLs will be prioritized when multiple endpoints are available.
     /// </remarks>
-    public bool PreferHttps { get; set; }
+    public bool PreferHttpsEndpoint { get; set; }
 }

--- a/integrations/aspire/src/Scalar.Aspire/Options/ScalarOptions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Options/ScalarOptions.cs
@@ -197,5 +197,12 @@ public abstract class ScalarOptions
     /// <value>The default value is <c>null</c>.</value>
     public DocumentDownloadType? DocumentDownloadType { get; set; }
 
-    public bool UseHttps { get; set; }
+    /// <summary>
+    /// Gets or sets whether HTTPS should be preferred over HTTP when both are available.
+    /// </summary>
+    /// <value>The default value is <c>false</c>.</value>
+    /// <remarks>
+    /// When set to <c>true</c>, HTTPS URLs will be prioritized when multiple server URLs are available.
+    /// </remarks>
+    public bool PreferHttps { get; set; }
 }

--- a/integrations/aspire/src/Scalar.Aspire/ScalarResourceConfigurator.cs
+++ b/integrations/aspire/src/Scalar.Aspire/ScalarResourceConfigurator.cs
@@ -23,7 +23,7 @@ internal static class ScalarResourceConfigurator
         var serviceProvider = context.ExecutionContext.ServiceProvider;
         var cancellationToken = context.CancellationToken;
         var scalarAnnotations = resource.Annotations.OfType<ScalarAnnotation>();
-        var scalarConfigurations = CreateConfigurationsAsync(serviceProvider, scalarAnnotations, cancellationToken);
+        var scalarConfigurations = CreateConfigurationsAsync(resource.Name, serviceProvider, scalarAnnotations, cancellationToken);
 
         var configurations = await scalarConfigurations.ToScalarConfigurationsAsync(cancellationToken).SerializeToJsonAsync(JsonSerializerOptions, cancellationToken);
 
@@ -42,14 +42,14 @@ internal static class ScalarResourceConfigurator
         environmentVariables.Add(DefaultProxy, scalarAspireOptions.DefaultProxy);
     }
 
-    private static async IAsyncEnumerable<ScalarOptions> CreateConfigurationsAsync(IServiceProvider serviceProvider, IEnumerable<ScalarAnnotation> annotations, [EnumeratorCancellation] CancellationToken cancellationToken)
+    private static async IAsyncEnumerable<ScalarOptions> CreateConfigurationsAsync(string scalarResourceName, IServiceProvider serviceProvider, IEnumerable<ScalarAnnotation> annotations, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         foreach (var scalarAnnotation in annotations)
         {
             var resourceName = scalarAnnotation.Resource.Name;
 
             using var scope = serviceProvider.CreateScope();
-            var scalarAspireOptions = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<ScalarAspireOptions>>().Get(resourceName);
+            var scalarAspireOptions = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<ScalarAspireOptions>>().Get(scalarResourceName);
             if (scalarAnnotation.ConfigureOptions is not null)
             {
                 await scalarAnnotation.ConfigureOptions.Invoke(scalarAspireOptions, cancellationToken);
@@ -60,28 +60,31 @@ internal static class ScalarResourceConfigurator
                 ConfigureProxyUrl(scalarAspireOptions);
             }
 
-            ConfigureOpenApiServers(scalarAspireOptions, resourceName);
-            ConfigureOpenApiRoutePattern(scalarAspireOptions, resourceName);
+            var endpoints = scalarAnnotation.Resource.Annotations.OfType<EndpointAnnotation>();
+            var shouldUseHttps = scalarAspireOptions.PreferHttps && endpoints.Any(endpoint => endpoint.UriScheme == "https");
+
+            var resourceUrl = GetResourceUrl(resourceName, shouldUseHttps);
+
+            ConfigureOpenApiServers(scalarAspireOptions, resourceName, resourceUrl);
+            ConfigureOpenApiRoutePattern(scalarAspireOptions, resourceUrl);
             ConfigureDocuments(scalarAspireOptions, resourceName);
 
             yield return scalarAspireOptions;
         }
     }
 
-    private static void ConfigureOpenApiServers(ScalarOptions scalarOptions, string resourceName)
+    private static void ConfigureOpenApiServers(ScalarOptions scalarOptions, string resourceName, string resourceUrl)
     {
-        var resourceUrl = GetResourceUrl(resourceName, scalarOptions.UseHttps);
         // Only set OpenAPI servers if not already assigned
         var server = new ScalarServer(resourceUrl, resourceName);
         scalarOptions.Servers ??= [server];
     }
 
-    private static void ConfigureOpenApiRoutePattern(ScalarOptions scalarOptions, string resourceName)
+    private static void ConfigureOpenApiRoutePattern(ScalarOptions scalarOptions, string resourceUrl)
     {
         // Only set the full URL if the OpenAPI route pattern is not a full URL
         if (!RegexHelper.HttpUrlPattern().IsMatch(scalarOptions.OpenApiRoutePattern))
         {
-            var resourceUrl = GetResourceUrl(resourceName, scalarOptions.UseHttps);
             scalarOptions.OpenApiRoutePattern = $"{resourceUrl}/{scalarOptions.OpenApiRoutePattern.TrimStart('/')}";
         }
     }
@@ -126,6 +129,5 @@ internal static class ScalarResourceConfigurator
     }
 
     private static string GetResourceUrl(string resourceName, bool useHttps) =>
-        // Let's make the protocol/endpoint name configurable in the future
         $"{(useHttps ? "https" : "http")}://{resourceName}";
 }

--- a/integrations/aspire/src/Scalar.Aspire/ScalarResourceConfigurator.cs
+++ b/integrations/aspire/src/Scalar.Aspire/ScalarResourceConfigurator.cs
@@ -38,10 +38,8 @@ internal static class ScalarResourceConfigurator
         var environmentVariables = context.EnvironmentVariables;
         environmentVariables.Add(ApiReferenceConfig, configurations);
         environmentVariables.Add(CdnUrl, scalarAspireOptions.CdnUrl);
-        if (scalarAspireOptions.DefaultProxy)
-        {
-            environmentVariables.Add(DefaultProxy, "true");
-        }
+        environmentVariables.Add(AllowSelfSignedCertificate, scalarAspireOptions.AllowSelfSignedCertificate);
+        environmentVariables.Add(DefaultProxy, scalarAspireOptions.DefaultProxy);
     }
 
     private static async IAsyncEnumerable<ScalarOptions> CreateConfigurationsAsync(IServiceProvider serviceProvider, IEnumerable<ScalarAnnotation> annotations, [EnumeratorCancellation] CancellationToken cancellationToken)
@@ -72,7 +70,7 @@ internal static class ScalarResourceConfigurator
 
     private static void ConfigureOpenApiServers(ScalarOptions scalarOptions, string resourceName)
     {
-        var resourceUrl = GetResourceUrl(resourceName);
+        var resourceUrl = GetResourceUrl(resourceName, scalarOptions.UseHttps);
         // Only set OpenAPI servers if not already assigned
         var server = new ScalarServer(resourceUrl, resourceName);
         scalarOptions.Servers ??= [server];
@@ -83,7 +81,7 @@ internal static class ScalarResourceConfigurator
         // Only set the full URL if the OpenAPI route pattern is not a full URL
         if (!RegexHelper.HttpUrlPattern().IsMatch(scalarOptions.OpenApiRoutePattern))
         {
-            var resourceUrl = GetResourceUrl(resourceName);
+            var resourceUrl = GetResourceUrl(resourceName, scalarOptions.UseHttps);
             scalarOptions.OpenApiRoutePattern = $"{resourceUrl}/{scalarOptions.OpenApiRoutePattern.TrimStart('/')}";
         }
     }
@@ -127,7 +125,7 @@ internal static class ScalarResourceConfigurator
         }
     }
 
-    private static string GetResourceUrl(string resourceName) =>
+    private static string GetResourceUrl(string resourceName, bool useHttps) =>
         // Let's make the protocol/endpoint name configurable in the future
-        $"http://{resourceName}";
+        $"{(useHttps ? "https" : "http")}://{resourceName}";
 }

--- a/integrations/aspire/src/Scalar.Aspire/ScalarResourceConfigurator.cs
+++ b/integrations/aspire/src/Scalar.Aspire/ScalarResourceConfigurator.cs
@@ -73,7 +73,7 @@ internal static class ScalarResourceConfigurator
                 throw new InvalidOperationException($"No HTTP or HTTPS endpoints found for resource '{resourceName}'. Ensure that the resource has at least one HTTP or HTTPS endpoint.");
             }
 
-            var shouldUseHttps = (!httpAvailable || scalarAspireOptions.PreferHttps) && httpsAvailable;
+            var shouldUseHttps = (!httpAvailable || scalarAspireOptions.PreferHttpsEndpoint) && httpsAvailable;
             var resourceUrl = GetResourceUrl(resourceName, shouldUseHttps, scalarAspireOptions.DefaultProxy, endpoints);
 
             ConfigureOpenApiServers(scalarAspireOptions, resourceName, resourceUrl);

--- a/integrations/aspire/src/Scalar.Aspire/ScalarResourceConfigurator.cs
+++ b/integrations/aspire/src/Scalar.Aspire/ScalarResourceConfigurator.cs
@@ -66,7 +66,14 @@ internal static class ScalarResourceConfigurator
                 throw new InvalidOperationException($"No endpoints found for resource '{resourceName}'. Ensure that the resource has at least one endpoint.");
             }
 
-            var shouldUseHttps = scalarAspireOptions.PreferHttps && endpoints.Any(endpoint => endpoint.UriScheme == "https");
+            var httpAvailable = endpoints.Any(endpoint => endpoint.UriScheme == "http");
+            var httpsAvailable = endpoints.Any(endpoint => endpoint.UriScheme == "https");
+            if (!httpAvailable && !httpsAvailable)
+            {
+                throw new InvalidOperationException($"No HTTP or HTTPS endpoints found for resource '{resourceName}'. Ensure that the resource has at least one HTTP or HTTPS endpoint.");
+            }
+
+            var shouldUseHttps = (!httpAvailable || scalarAspireOptions.PreferHttps) && httpsAvailable;
             var resourceUrl = GetResourceUrl(resourceName, shouldUseHttps, scalarAspireOptions.DefaultProxy, endpoints);
 
             ConfigureOpenApiServers(scalarAspireOptions, resourceName, resourceUrl);


### PR DESCRIPTION
**Problem**

Currently, Scalar only supports HTTP.

**Solution**

This PR adds support for HTTPS endpoints.

```csharp
var scalar = builder.AddScalarApiReference(options =>
{
    options
        .PreferHttpsEndpoint() // Use HTTPS endpoint when available
        .AllowSelfSignedCertificates(); // For development environments
});
```

### How HTTPS Support Works

- **Protocol Selection**: HTTP is used by default. Use `PreferHttpsEndpoint()` to prioritize HTTPS when available
- **Automatic Configuration**: When HTTPS is preferred, both OpenAPI document routes and server URLs are automatically configured to use HTTPS endpoints
- **Automatic Redirects**: HTTP to HTTPS redirects are handled automatically with proper header rewriting (localhost only)
- **Certificate Validation**: Self-signed certificates can be trusted in development using `AllowSelfSignedCertificates()`
- **Fallback Behavior**: If HTTPS is preferred but unavailable, HTTP endpoints are used as fallback. Conversely, if no HTTP endpoint is available, HTTPS endpoints are automatically used

Closes #6524

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
