### PR TITLE
feat(workspace-store): move measurements to workspace store

### DIFF
--- a/packages/api-reference/src/features/document-source/hooks/useDocumentSource.ts
+++ b/packages/api-reference/src/features/document-source/hooks/useDocumentSource.ts
@@ -1,5 +1,5 @@
 import { createActiveEntitiesStore, createWorkspaceStore } from '@scalar/api-client/store'
-import { measureAsync, measureSync } from '@scalar/helpers/testing/measure'
+import { measureAsync } from '@scalar/helpers/testing/measure'
 import { dereference, normalize, upgrade } from '@scalar/openapi-parser'
 import type { OpenAPI, OpenAPIV3_1 } from '@scalar/openapi-types'
 import { type ApiReferenceConfiguration, apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
@@ -86,11 +86,7 @@ export function useDocumentSource({
 
       const upgraded = outdatedVersion
         ? // Upgrade needed
-          measureSync('upgrade', () => {
-            const { specification } = upgrade(content)
-
-            return specification
-          })
+          upgrade(content).specification
         : // Skip the upgrade
           content
 

--- a/packages/api-reference/src/features/sidebar/helpers/create-sidebar.ts
+++ b/packages/api-reference/src/features/sidebar/helpers/create-sidebar.ts
@@ -6,7 +6,6 @@ import { type Ref, computed, reactive, ref } from 'vue'
 import type { TraverseSpecOptions } from '@/features/traverse-schema'
 import { traverseDocument } from '@/features/traverse-schema'
 import { scrollToId } from '@scalar/helpers/dom/scroll-to-id'
-import { measureSync } from '@scalar/helpers/testing/measure'
 
 /** Track which sidebar items are opened */
 type CollapsedSidebarItems = Record<string, boolean>
@@ -56,7 +55,7 @@ export const createSidebar = (dereferencedDocument: Ref<OpenAPIV3_1.Document>, o
 
   /** Sidebar items */
   const items = computed(() => {
-    const result = measureSync('traverse-document', () => traverseDocument(dereferencedDocument.value, options))
+    const result = traverseDocument(dereferencedDocument.value, options)
 
     // Open all tags
     if (options.config.value.defaultOpenAllTags) {

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -27,7 +27,7 @@ import { externalValueResolver, loadingStatus, refsEverywhere, restoreOriginalRe
 import type { Record } from '@sinclair/typebox'
 import { Value } from '@sinclair/typebox/value'
 import { deepClone } from '@/helpers/deep-clone'
-import { measureAsync } from '@scalar/helpers/testing/measure'
+import { measureAsync, measureSync } from '@scalar/helpers/testing/measure'
 
 type DocumentConfiguration = Config &
   PartialDeep<{
@@ -505,40 +505,47 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
   // Add a document to the store synchronously from an in-memory OpenAPI document
   async function addInMemoryDocument(input: ObjectDoc & { initialize?: boolean; origin?: string }) {
     const { name, meta } = input
-    const inputDocument = upgrade(deepClone(input.document)).specification
+    const cloned = measureSync('deepClone', () => deepClone(input.document))
+    const inputDocument = measureSync('upgrade', () => upgrade(cloned).specification)
 
-    if (input.initialize !== false) {
-      // Store the original document in the originalDocuments map
-      // This is used to track the original state of the document as it was loaded into the workspace
-      originalDocuments[name] = deepClone({ ...inputDocument })
+    measureSync('initialize', () => {
+      if (input.initialize !== false) {
+        // Store the original document in the originalDocuments map
+        // This is used to track the original state of the document as it was loaded into the workspace
+        originalDocuments[name] = deepClone({ ...inputDocument })
 
-      // Store the intermediate document state for local edits
-      // This is used to track the last saved state of the document
-      // It allows us to differentiate between the original document and the latest saved version
-      // This is important for local edits that are not yet synced with the remote registry
-      // The intermediate document is used to store the latest saved state of the document
-      // This allows us to track changes and revert to the last saved state if needed
-      intermediateDocuments[name] = deepClone({ ...inputDocument })
-      // Add the document config to the documentConfigs map
-      documentConfigs[name] = input.config ?? {}
-      // Store the overrides for this document, or an empty object if none are provided
-      overrides[name] = input.overrides ?? {}
-      // Store the document metadata for this document, setting the origin if provided
-      documentMeta[name] = { origin: input.origin }
-    }
+        // Store the intermediate document state for local edits
+        // This is used to track the last saved state of the document
+        // It allows us to differentiate between the original document and the latest saved version
+        // This is important for local edits that are not yet synced with the remote registry
+        // The intermediate document is used to store the latest saved state of the document
+        // This allows us to track changes and revert to the last saved state if needed
+        intermediateDocuments[name] = deepClone({ ...inputDocument })
+        // Add the document config to the documentConfigs map
+        documentConfigs[name] = input.config ?? {}
+        // Store the overrides for this document, or an empty object if none are provided
+        overrides[name] = input.overrides ?? {}
+        // Store the document metadata for this document, setting the origin if provided
+        documentMeta[name] = { origin: input.origin }
+      }
+    })
 
-    const strictDocument: UnknownObject = createMagicProxy({ ...inputDocument, ...meta })
+    const strictDocument: UnknownObject = measureSync('createMagicProxy', () =>
+      createMagicProxy({ ...inputDocument, ...meta }),
+    )
 
     if (strictDocument[extensions.document.navigation] === undefined) {
       // If the document navigation is not already present, bundle the entire document to resolve all references.
       // This typically applies when the document is not preprocessed by the server and needs local reference resolution.
       // We need to bundle document first before we validate, so we can also validate the external references
-      await bundle(getRaw(strictDocument), {
-        treeShake: false,
-        plugins: [fetchUrls(), externalValueResolver(), refsEverywhere()],
-        urlMap: true,
-        origin: documentMeta[name]?.origin, // use the document origin (if provided) as the base URL for resolution
-      })
+      await measureAsync('bundle', () =>
+        bundle(getRaw(strictDocument), {
+          treeShake: false,
+          plugins: [fetchUrls(), externalValueResolver(), refsEverywhere()],
+          urlMap: true,
+          origin: documentMeta[name]?.origin, // use the document origin (if provided) as the base URL for resolution
+        }),
+      )
 
       // We coerce the values only when the document is not preprocessed by the server-side-store
       mergeObjects(strictDocument, coerceValue(OpenAPIDocumentSchemaStrict, deepClone(strictDocument)))
@@ -561,7 +568,9 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     }
 
     // Create a proxied document with magic proxy and apply any overrides, then store it in the workspace documents map
-    workspace.documents[name] = createOverridesProxy(strictDocument, input.overrides)
+    workspace.documents[name] = measureSync('createOverridesProxy', () =>
+      createOverridesProxy(strictDocument, input.overrides),
+    )
   }
 
   // Asynchronously adds a new document to the workspace by loading and validating the input.

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -530,9 +530,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       }
     })
 
-    const strictDocument: UnknownObject = measureSync('createMagicProxy', () =>
-      createMagicProxy({ ...inputDocument, ...meta }),
-    )
+    const strictDocument: UnknownObject = createMagicProxy({ ...inputDocument, ...meta })
 
     if (strictDocument[extensions.document.navigation] === undefined) {
       // If the document navigation is not already present, bundle the entire document to resolve all references.
@@ -548,7 +546,10 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       )
 
       // We coerce the values only when the document is not preprocessed by the server-side-store
-      mergeObjects(strictDocument, coerceValue(OpenAPIDocumentSchemaStrict, deepClone(strictDocument)))
+      const coerced = measureSync('coerceValue', () =>
+        coerceValue(OpenAPIDocumentSchemaStrict, deepClone(strictDocument)),
+      )
+      measureSync('mergeObjects', () => mergeObjects(strictDocument, coerced))
     }
 
     const isValid = Value.Check(OpenAPIDocumentSchemaStrict, strictDocument)
@@ -568,9 +569,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     }
 
     // Create a proxied document with magic proxy and apply any overrides, then store it in the workspace documents map
-    workspace.documents[name] = measureSync('createOverridesProxy', () =>
-      createOverridesProxy(strictDocument, input.overrides),
-    )
+    workspace.documents[name] = createOverridesProxy(strictDocument, input.overrides)
   }
 
   // Asynchronously adds a new document to the workspace by loading and validating the input.


### PR DESCRIPTION
**Problem**

Currently, our measurements are done on the references.

**Solution**

With this PR we move them to the workspace store so we can track what is taking a long time. This doesn't move all of them but some. Once we are in a good place we can remove the breakdown and just keep the addDocument time.

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
