### PR TITLE
feat(api-reference): map reference configuration to the new store configuration

### DIFF
--- a/.changeset/famous-doors-hang.md
+++ b/.changeset/famous-doors-hang.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat(api-reference): map reference configuration to the new store configuration

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
@@ -47,6 +47,7 @@ import { NAV_STATE_SYMBOL } from '@/hooks/useNavState'
 import { isClient } from '@/v2/blocks/scalar-request-example-block/helpers/find-client'
 import { onCustomEvent } from '@/v2/events'
 import { getDocumentName } from '@/v2/helpers/get-document-name'
+import { mapConfiguration } from '@/v2/helpers/map-configuration'
 import { normalizeContent } from '@/v2/helpers/normalize-content'
 
 const props = defineProps<{
@@ -154,6 +155,7 @@ const addOrUpdateDocument = async (
     return await store.addDocument({
       name,
       document,
+      config: mapConfiguration(config),
     })
   }
 
@@ -164,6 +166,7 @@ const addOrUpdateDocument = async (
         basePath: selectedConfiguration.value.pathRouting?.basePath,
       }),
       fetch: proxy,
+      config: mapConfiguration(config),
     })
   }
 

--- a/packages/api-reference/src/v2/helpers/map-configuration.ts
+++ b/packages/api-reference/src/v2/helpers/map-configuration.ts
@@ -1,0 +1,56 @@
+import type { ApiReferenceConfigurationWithSources } from '@scalar/types'
+import type { DocumentConfiguration } from '@scalar/workspace-store/client'
+
+/**
+ * Maps a partial ApiReferenceConfigurationWithSources object to a DocumentConfiguration
+ * for use in the API Reference. This function transforms configuration options
+ * into the expected structure for the 'x-scalar-reference-config' property.
+ *
+ * @param config - Partial configuration object for the API Reference
+ * @returns DocumentConfiguration object with mapped settings
+ */
+export const mapConfiguration = (config: Partial<ApiReferenceConfigurationWithSources>) => {
+  return {
+    'x-scalar-reference-config': {
+      title: config.title,
+      slug: config.slug,
+      getOperationId: config.generateOperationSlug,
+      getHeadingId: config.generateHeadingSlug,
+      getTagId: config.generateTagSlug,
+      getModelId: config.generateModelSlug,
+      getWebhookId: config.generateWebhookSlug,
+      tagSort: config.tagsSorter,
+      operationsSorter: config.operationsSorter,
+      features: {
+        // Feature toggles for UI elements and behaviors
+        showModels: !config.hideModels,
+        expandAllTagSections: config.defaultOpenAllTags,
+        persistAuthenticationState: config.persistAuth,
+        showDarkModeToggle: !config.hideDarkModeToggle,
+        showDownload: !config.hideDownloadButton,
+        showSearch: !config.hideSearch,
+        showSidebar: config.showSidebar,
+        showTestRequestButton: !config.hideTestRequestButton,
+      },
+      appearance: {
+        // Appearance-related configuration
+        css: config.customCss,
+        favicon: config.favicon,
+        forceColorMode: config.forceDarkModeState,
+        initialColorMode: config.darkMode ? 'dark' : undefined,
+        layout: config.layout,
+        loadDefaultFonts: config.withDefaultFonts,
+        theme: config.theme,
+      },
+      routing: {
+        // Routing configuration
+        basePath: config.pathRouting?.basePath,
+      },
+      settings: {
+        // Miscellaneous settings
+        proxyUrl: config.proxyUrl,
+        searchKey: config.searchHotKey,
+      },
+    },
+  } satisfies DocumentConfiguration
+}

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -29,7 +29,7 @@ import { Value } from '@sinclair/typebox/value'
 import { deepClone } from '@/helpers/deep-clone'
 import { measureAsync } from '@scalar/helpers/testing/measure'
 
-type DocumentConfiguration = Config &
+export type DocumentConfiguration = Config &
   PartialDeep<{
     'x-scalar-reference-config': {
       tagSort: TraverseSpecOptions['tagsSorter']

--- a/packages/workspace-store/src/navigation/helpers/traverse-document.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-document.ts
@@ -52,7 +52,7 @@ export const traverseDocument = (
   // Add untagged webhooks
   if (untaggedWebhooks.length) {
     entries.push({
-      id: getWebhookId(),
+      id: getWebhookId({ name: '' }),
       title: 'Webhooks',
       children: untaggedWebhooks,
       type: 'text',
@@ -65,7 +65,7 @@ export const traverseDocument = (
 
     if (untaggedModels.length) {
       entries.push({
-        id: getModelId(),
+        id: getModelId({}),
         title: 'Models',
         children: untaggedModels,
         type: 'text',

--- a/packages/workspace-store/src/navigation/types.ts
+++ b/packages/workspace-store/src/navigation/types.ts
@@ -48,7 +48,7 @@ export type TraverseSpecOptions = {
 
   /** Function to generate unique IDs for webhooks */
   getWebhookId: (
-    webhook?: {
+    webhook: {
       name: string
       method?: string
     },
@@ -57,8 +57,8 @@ export type TraverseSpecOptions = {
 
   /** Function to generate unique IDs for models/schemas */
   getModelId: (
-    model?: {
-      name: string
+    model: {
+      name?: string
     },
     parentTag?: TagObject,
   ) => string


### PR DESCRIPTION
**Problem**

The current implementation does not propagate the existing references configuration when creating a new store configuration. As a result, important reference settings are lost, preventing consistent behavior and blocking upcoming migration work.

**Solution**

This PR ensures that the references configuration is properly propagated to the new store configuration. This allows us to maintain consistency across store updates and enables the references to be used effectively during migration tasks.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
