### PR TITLE
feat(workspace-store): use the configuration fetcher to bundle the document

### DIFF
--- a/.changeset/modern-balloons-lick.md
+++ b/.changeset/modern-balloons-lick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': minor
+---
+
+feat(workspace-store): use the configuration fetcher to bundle the document

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -603,7 +603,10 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
   async function addDocument(input: WorkspaceDocumentInput) {
     const { name, meta } = input
 
-    const resolve = await measureAsync('loadDocument', async () => await loadDocument(input))
+    const resolve = await measureAsync(
+      'loadDocument',
+      async () => await loadDocument({ ...input, fetch: input.fetch ?? workspaceProps?.fetch }),
+    )
 
     // Log the time taken to add a document
     await measureAsync('addDocument', async () => {


### PR DESCRIPTION
**Problem**

At the moment, the fetcher is only applied to the top-level document. As a result, when external references are bundled, they are fetched without the configured fetcher, which can lead to CORS errors and inconsistent behavior.

**Solution**

This PR ensures that the same document configuration and fetcher are consistently applied not just to the top-level document but also to all external references during bundling. This makes reference resolution more reliable and prevents CORS issues.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
