### PR TITLE
chore(ci): bump useblacksmith/build-push-action action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Setup Docker Builder
         uses: useblacksmith/setup-docker-builder@0b434dfbb431f4e3a2bcee7a773a56bd363184c5 # v1
+        with:
+          platforms: |
+            linux/amd64
+            linux/arm64
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Build Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
         with:
           context: integrations/docker
           file: integrations/docker/Dockerfile
+          platforms: |
+            linux/amd64
+            linux/arm64
           load: true
           tags: |
             scalarapi/api-reference:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ jobs:
         run: pnpm compress
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
+        name: Setup Docker Builder
+        uses: useblacksmith/setup-docker-builder@0b434dfbb431f4e3a2bcee7a773a56bd363184c5 # v1
+
+      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Build Docker image
         uses: useblacksmith/build-push-action@4af38cd11563732a1d67e9e9e01299346c955825 # v2
         with:
@@ -114,6 +118,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           # https://app.docker.com/settings/personal-access-tokens
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - if: startsWith(github.event.head_commit.message, 'RELEASING:') && steps.changed-files.outputs.api_reference_docker_version_any_changed == 'true'
+        name: Setup Docker Builder
+        uses: useblacksmith/setup-docker-builder@0b434dfbb431f4e3a2bcee7a773a56bd363184c5 # v1
 
       - if: startsWith(github.event.head_commit.message, 'RELEASING:') && steps.changed-files.outputs.api_reference_docker_version_any_changed == 'true'
         name: Build and Push Docker image
@@ -1071,6 +1079,10 @@ jobs:
       - if: steps.changed-files.outputs.aspire_package_any_changed == 'true'
         name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
+
+      - if: steps.changed-files.outputs.aspire_package_any_changed == 'true'
+        name: Setup Docker Builder
+        uses: useblacksmith/setup-docker-builder@0b434dfbb431f4e3a2bcee7a773a56bd363184c5 # v1
 
       - if: steps.changed-files.outputs.aspire_package_any_changed == 'true'
         name: Build and push Aspire Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,10 @@ jobs:
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Setup Docker Builder
         uses: useblacksmith/setup-docker-builder@0b434dfbb431f4e3a2bcee7a773a56bd363184c5 # v1
+        with:
+          platforms: |
+            linux/amd64
+            linux/arm64
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Build Docker image
@@ -116,14 +120,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           # https://app.docker.com/settings/personal-access-tokens
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - if: startsWith(github.event.head_commit.message, 'RELEASING:') && steps.changed-files.outputs.api_reference_docker_version_any_changed == 'true'
-        name: Setup Docker Builder
-        uses: useblacksmith/setup-docker-builder@0b434dfbb431f4e3a2bcee7a773a56bd363184c5 # v1
-        with:
-          platforms: |
-            linux/amd64
-            linux/arm64
 
       - if: startsWith(github.event.head_commit.message, 'RELEASING:') && steps.changed-files.outputs.api_reference_docker_version_any_changed == 'true'
         name: Build and Push Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ jobs:
         run: pnpm compress
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
+
+      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Setup Docker Builder
         uses: useblacksmith/setup-docker-builder@0b434dfbb431f4e3a2bcee7a773a56bd363184c5 # v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Build Docker image
-        uses: useblacksmith/build-push-action@574eb0ee0b59c6a687ace24192f0727dfb65d6d7 # v1
+        uses: useblacksmith/build-push-action@4af38cd11563732a1d67e9e9e01299346c955825 # v2
         with:
           context: integrations/docker
           file: integrations/docker/Dockerfile
@@ -117,7 +117,7 @@ jobs:
 
       - if: startsWith(github.event.head_commit.message, 'RELEASING:') && steps.changed-files.outputs.api_reference_docker_version_any_changed == 'true'
         name: Build and Push Docker image
-        uses: useblacksmith/build-push-action@574eb0ee0b59c6a687ace24192f0727dfb65d6d7 # v1
+        uses: useblacksmith/build-push-action@4af38cd11563732a1d67e9e9e01299346c955825 # v2
         with:
           context: integrations/docker
           file: integrations/docker/Dockerfile
@@ -1074,7 +1074,7 @@ jobs:
 
       - if: steps.changed-files.outputs.aspire_package_any_changed == 'true'
         name: Build and push Aspire Docker image
-        uses: useblacksmith/build-push-action@574eb0ee0b59c6a687ace24192f0727dfb65d6d7 # v1
+        uses: useblacksmith/build-push-action@4af38cd11563732a1d67e9e9e01299346c955825 # v2
         with:
           context: integrations/aspire
           file: integrations/aspire/src/Scalar.Aspire.Service/Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,9 @@ jobs:
         working-directory: integrations/docker
         run: pnpm compress
 
-      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
+      # - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
+      #   name: Set up QEMU
+      #   uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Setup Docker Builder
@@ -97,7 +97,7 @@ jobs:
             linux/arm64
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
-        name: Build Docker image
+        name: Build Docker image (tmp)
         uses: useblacksmith/build-push-action@4af38cd11563732a1d67e9e9e01299346c955825 # v2
         with:
           context: integrations/docker
@@ -105,6 +105,16 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64
+          tags: |
+            scalarapi/api-reference:latest
+            scalarapi/api-reference:${{ steps.package-version.outputs.VERSION }}
+
+      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
+        name: Build Docker image
+        uses: useblacksmith/build-push-action@4af38cd11563732a1d67e9e9e01299346c955825 # v2
+        with:
+          context: integrations/docker
+          file: integrations/docker/Dockerfile
           load: true
           tags: |
             scalarapi/api-reference:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,30 +84,9 @@ jobs:
         working-directory: integrations/docker
         run: pnpm compress
 
-      # - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
-      #   name: Set up QEMU
-      #   uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
-
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Setup Docker Builder
         uses: useblacksmith/setup-docker-builder@0b434dfbb431f4e3a2bcee7a773a56bd363184c5 # v1
-        with:
-          platforms: |
-            linux/amd64
-            linux/arm64
-
-      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
-        name: Build Docker image (tmp)
-        uses: useblacksmith/build-push-action@4af38cd11563732a1d67e9e9e01299346c955825 # v2
-        with:
-          context: integrations/docker
-          file: integrations/docker/Dockerfile
-          platforms: |
-            linux/amd64
-            linux/arm64
-          tags: |
-            scalarapi/api-reference:latest
-            scalarapi/api-reference:${{ steps.package-version.outputs.VERSION }}
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Build Docker image
@@ -116,9 +95,7 @@ jobs:
           context: integrations/docker
           file: integrations/docker/Dockerfile
           load: true
-          tags: |
-            scalarapi/api-reference:latest
-            scalarapi/api-reference:${{ steps.package-version.outputs.VERSION }}
+          tags: scalarapi/api-reference:latest
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Scan for vulnerabilities
@@ -143,6 +120,10 @@ jobs:
       - if: startsWith(github.event.head_commit.message, 'RELEASING:') && steps.changed-files.outputs.api_reference_docker_version_any_changed == 'true'
         name: Setup Docker Builder
         uses: useblacksmith/setup-docker-builder@0b434dfbb431f4e3a2bcee7a773a56bd363184c5 # v1
+        with:
+          platforms: |
+            linux/amd64
+            linux/arm64
 
       - if: startsWith(github.event.head_commit.message, 'RELEASING:') && steps.changed-files.outputs.api_reference_docker_version_any_changed == 'true'
         name: Build and Push Docker image
@@ -151,7 +132,6 @@ jobs:
           context: integrations/docker
           file: integrations/docker/Dockerfile
           push: true
-          # With ARM
           platforms: |
             linux/amd64
             linux/arm64
@@ -1104,6 +1084,10 @@ jobs:
       - if: steps.changed-files.outputs.aspire_package_any_changed == 'true'
         name: Setup Docker Builder
         uses: useblacksmith/setup-docker-builder@0b434dfbb431f4e3a2bcee7a773a56bd363184c5 # v1
+        with:
+          platforms: |
+            linux/amd64
+            linux/arm64
 
       - if: steps.changed-files.outputs.aspire_package_any_changed == 'true'
         name: Build and push Aspire Docker image
@@ -1112,7 +1096,6 @@ jobs:
           context: integrations/aspire
           file: integrations/aspire/src/Scalar.Aspire.Service/Dockerfile
           push: true
-          # With ARM
           platforms: |
             linux/amd64
             linux/arm64

--- a/integrations/docker/README.md
+++ b/integrations/docker/README.md
@@ -16,4 +16,3 @@ We are API nerds. You too? Let's chat on Discord: <https://discord.gg/scalar>
 ## License
 
 The source code in this repository is licensed under [MIT](https://github.com/scalar/scalar/blob/main/LICENSE).
-

--- a/integrations/docker/README.md
+++ b/integrations/docker/README.md
@@ -16,3 +16,4 @@ We are API nerds. You too? Let's chat on Discord: <https://discord.gg/scalar>
 ## License
 
 The source code in this repository is licensed under [MIT](https://github.com/scalar/scalar/blob/main/LICENSE).
+


### PR DESCRIPTION
This PR updates the `useblacksmith/build-push-action` GitHub action to version 2 and fixes the breaking changes by configuring `useblacksmith/setup-docker-builder` before each action.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
