### PR TITLE
feat(api-reference): use galaxy.scalar.com as the first entry in index.html

### DIFF
--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -21,9 +21,9 @@
       Scalar.createApiReference('#app', {
         sources: [
           {
-            title: 'Scalar Galaxy (CDN)', // optional, would fallback to 'API #1'
-            slug: 'scalar-galaxy-cdn', // optional, would be auto-generated from the title or the index
-            url: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
+            title: 'Scalar Galaxy', // optional, would fallback to 'API #1'
+            slug: 'scalar-galaxy', // optional, would be auto-generated from the title or the index
+            url: 'https://galaxy.scalar.com/openapi.yaml',
           },
           {
             title: 'Scalar Galaxy Registry',

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -21,8 +21,13 @@
       Scalar.createApiReference('#app', {
         sources: [
           {
-            title: 'Scalar Galaxy', // optional, would fallback to 'API #1'
-            slug: 'scalar-galaxy', // optional, would be auto-generated from the title or the index
+            title: 'Scalar Galaxy (CDN)', // optional, would fallback to 'API #1'
+            slug: 'scalar-galaxy-cdn', // optional, would be auto-generated from the title or the index
+            url: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
+          },
+          {
+            title: 'Scalar Galaxy Registry',
+            slug: 'scalar-galaxy-registry',
             url: 'https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json',
           },
           {


### PR DESCRIPTION
**Problem**

Currently, we were pointing the first entry index.html in references to the registry. However galaxy.scalar.com uses another document and we normally compare the two.

**Solution**

With this PR we add the same document that galaxy.scalar.com uses as the first entry and move the registry document to the second entry.

No need for changeset as this only affects dev

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
