### PR TITLE
docs(docker): fix syntax error in `API_REFERENCE_CONFIG` sample

### DIFF
--- a/documentation/integrations/docker.md
+++ b/documentation/integrations/docker.md
@@ -27,7 +27,7 @@ services:
             {
               "url": "https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json"
             }
-          ]
+          ],
           "theme": "purple"
         }
 ```


### PR DESCRIPTION
**Problem**

A syntax error in the sample JSON in `API_REFERENCE_CONFIG` causing crash on startup (in browser).

**Solution**

Fixed

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
