### PR TITLE
chore(CODEOWNERS): add xC0dex as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,12 +2,11 @@
 * @hanspagel @amritk @geoffgscott @marclave
 
 # Root level code owners
-/.github @hanspagel @geoffgscott
-/.github/renovate.json @hanspagel @xC0dex
+/.github @hanspagel @geoffgscott @xC0dex
 /*.md @hanspagel @marclave
 
 # Documentation
-/documentation/* @hanspagel @marclave
+/documentation/* @hanspagel @marclave @xC0dex
 
 # Changesets
 /.changeset/*
@@ -37,6 +36,7 @@
 /integrations/nestjs @marclave
 /integrations/aspire @marclave @hanspagel @xC0dex
 /integrations/aspnetcore @marclave @hanspagel @xC0dex
+/integrations/docker @marclave @hanspagel @xC0dex
 /packages/use-hooks @hwkr @hanspagel @marclave
 # /packages/use-toasts
 /packages/api-client-react @amritk @marclave


### PR DESCRIPTION
**Problem**

Currently, I don’t have permission to merge PRs for:

- Docker integration
- Documentation
- GitHub workflows

I would appreciate it if we could change this 🙂
**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
