### PR TITLE
chore: add back types check raw

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "test:e2e:nuxt": "pnpm --filter playwright test:e2e nuxt",
     "test:e2e:electron": "pnpm --filter scalar-app test:e2e electron",
     "types:check": "turbo types:check",
+    "types:check:raw": "pnpm run -r --parallel types:check",
     "types:build": "turbo types:build",
     "markdown:check": "remark --frail .",
     "script": "pnpm --filter @scalar-internal/build-scripts start"


### PR DESCRIPTION
**Problem**

Currently, someone removed the old types check.

**Solution**

With this PR we add it back in under :raw. The raw pnpm call is almost twice as fast on faster CPU's than a full turbo call. Now we can choose which one to use. Its helpful when fixing type errors. 

```zsh
pnpm types:check:raw  266.00s user 11.75s system 1593% cpu 17.435 total

Tasks:  92 successful, 92 total
Cached: 92 cached, 92 total
Time:   30.482s >>> FULL TURBO


```

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
