### PR TITLE
fix(oas-utils): skip readOnly properties in request examples

### DIFF
--- a/.changeset/moody-coats-exist.md
+++ b/.changeset/moody-coats-exist.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix: skip readOnly properties in request examples

--- a/packages/oas-utils/src/helpers/operation-to-har/process-body.test.ts
+++ b/packages/oas-utils/src/helpers/operation-to-har/process-body.test.ts
@@ -274,6 +274,29 @@ describe('processBody', () => {
     })
   })
 
+  it('skips readOnly properties', () => {
+    const content = {
+      'application/json': {
+        schema: coerceValue(SchemaObjectSchema, {
+          type: 'object',
+          properties: {
+            name: { type: 'string', example: 'Alice' },
+            age: { type: 'number', readOnly: true },
+          },
+        }),
+      },
+    }
+
+    const result = processBody({ content })
+
+    expect(result).toEqual({
+      mimeType: 'application/json',
+      text: JSON.stringify({
+        name: 'Alice',
+      }),
+    })
+  })
+
   it('handles custom content type with schema examples', () => {
     const content = {
       'application/xml': {

--- a/packages/oas-utils/src/helpers/operation-to-har/process-body.ts
+++ b/packages/oas-utils/src/helpers/operation-to-har/process-body.ts
@@ -68,7 +68,7 @@ export const processBody = ({ content, contentType, example }: ProcessBodyProps)
   // Try to extract examples from the schema
   const contentSchema = getResolvedRef(content[_contentType]?.schema)
   if (contentSchema) {
-    const extractedExample = getExampleFromSchema(contentSchema)
+    const extractedExample = getExampleFromSchema(contentSchema, { mode: 'write' })
 
     if (extractedExample !== undefined) {
       if (isFormData && typeof extractedExample === 'object' && extractedExample !== null) {


### PR DESCRIPTION
**Problem**

Request examples should not contain readOnly properties.

**Solution**

Pass mode: write to getExampleFromSchema when generating request examples.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
