### PR TITLE
chore(Scalar.AspNetCore): downgrade package for better compatibility

### DIFF
--- a/.changeset/tender-clouds-think.md
+++ b/.changeset/tender-clouds-think.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+chore(Scalar.AspNetCore): downgrade package for better compatibility

--- a/integrations/aspnetcore/src/Scalar.AspNetCore.Microsoft/Scalar.AspNetCore.Microsoft.csproj
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore.Microsoft/Scalar.AspNetCore.Microsoft.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">


### PR DESCRIPTION
**Problem**

With the latest .NET 10 PR, I accidentally bumped the version of `Microsoft.AspNetCore.OpenApi` to the latest version.

**Solution**

This PR downgrades the version back to `9.0.0` for better compatibility.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
