### PR TITLE
fix(oas-utils): use const value as example

### DIFF
--- a/.changeset/moody-avocados-rule.md
+++ b/.changeset/moody-avocados-rule.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix(oas-utils): use const value as example

--- a/packages/oas-utils/src/spec-getters/get-example-from-schema.test.ts
+++ b/packages/oas-utils/src/spec-getters/get-example-from-schema.test.ts
@@ -606,6 +606,15 @@ describe('getExampleFromSchema', () => {
     expect(getExampleFromSchema(schema)).toBe('BAD_REQUEST_EXCEPTION')
   })
 
+  it('uses the const value', () => {
+    const schema = coerceValue(SchemaObjectSchema, {
+      type: 'string',
+      const: 'BAD_REQUEST_EXCEPTION',
+    })
+
+    expect(getExampleFromSchema(schema)).toBe('BAD_REQUEST_EXCEPTION')
+  })
+
   it('uses 1 as the default for a number', () => {
     expect(
       getExampleFromSchema(

--- a/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
+++ b/packages/oas-utils/src/spec-getters/get-example-from-schema.ts
@@ -162,6 +162,11 @@ export const getExampleFromSchema = (
     return cache(schema, schema.default)
   }
 
+  // Use a const value, if there's one
+  if (schema.const !== undefined) {
+    return cache(schema, schema.const)
+  }
+
   // enum: [ 'available', 'pending', 'sold' ]
   if (Array.isArray(schema.enum) && schema.enum.length > 0) {
     return cache(schema, schema.enum[0])


### PR DESCRIPTION
**Problem**

Const values are not considered for schema examples.

**Solution**

With this PR, const values are one of the sources of possible schema examples.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
