### PR TITLE
docs(CONTRIBUTING): add section for GitHub Codespaces and devcontainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,15 @@ These scripts use [`turbo`](https://turbo.build/) to build all the dependencies 
 
 \* Hot module replacement and file watching only works for the main package being worked on, e.g. changes to `@scalar/api-client` if you're running `pnpm dev:client:app` or `@scalar/api-reference` if you're running `pnpm dev:reference`
 
+## GitHub Codespaces & Devcontainers
+
+We support development using [GitHub Codespaces](https://github.com/features/codespaces) and [devcontainers](https://containers.dev/). This allows you to get started quickly in a cloud-based or local containerized environment without the need to install dependencies locally.
+
+**Note:** Codespaces may incur costs depending on your usage and GitHub plan.  
+**Current limitation:** Only the Node.js stack is supported in our devcontainer setup.
+
+For more details, see the `.devcontainer` folder in the repository.
+
 ## Tests
 
 Most packages have a bunch of tests, mostly for all the helper functions we use.


### PR DESCRIPTION
This PR adds a section for Codespaces and devcontainers to our contributing documentation.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
