### PR TITLE
ci: use API Reference artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           packages: './{packages,integrations}/**'
+      - if: matrix.node-version == 22
+        name: Upload standalone.js artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: standalone-js
+          path: packages/api-reference/dist/browser/standalone.js
+          retention-days: 3
 
   docker:
     name: Build and Tag Docker Image
@@ -857,19 +864,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
-      - name: Build @scalar/api-reference
-        uses: ./.github/actions/build-blacksmith
+      - name: Download standalone.js artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
-          node-version: 22
-          packages: '@scalar/api-reference...'
+          name: standalone-js
+          path: integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets
 
-      - name: Copy JavaScript asset from @scalar/api-reference
-        working-directory: integrations/aspnetcore
-        run: pnpm copy:standalone
+      - name: Rename standalone.js to scalar.js
+        working-directory: integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets
+        run: mv standalone.js scalar.js
 
       - name: Compress static assets
-        working-directory: integrations/aspnetcore
-        run: pnpm compress
+        working-directory: integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets
+        run: gzip --keep --verbose --force scalar.js scalar.aspnetcore.js
 
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -870,7 +870,7 @@ jobs:
           name: standalone-js
           path: integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets
 
-      - name: Rename standalone.js to scalar.js
+      - name: Rename standalone.js to scalar.js # Lets get rid of this
         working-directory: integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets
         run: mv standalone.js scalar.js
 
@@ -980,21 +980,21 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - if: steps.changed-files.outputs.aspnetcore_package_any_changed == 'true'
-        name: Build @scalar/api-reference
-        uses: ./.github/actions/build-blacksmith
+        name: Download standalone.js artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
-          node-version: 22
-          packages: '@scalar/api-reference...'
+          name: standalone-js
+          path: integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets
 
       - if: steps.changed-files.outputs.aspnetcore_package_any_changed == 'true'
-        name: Copy JavaScript asset from @scalar/api-reference
-        working-directory: integrations/aspnetcore
-        run: pnpm copy:standalone
+        name: Rename standalone.js to scalar.js # Lets get rid of this
+        working-directory: integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets
+        run: mv standalone.js scalar.js
 
       - if: steps.changed-files.outputs.aspnetcore_package_any_changed == 'true'
         name: Compress static assets
-        working-directory: integrations/aspnetcore
-        run: pnpm compress
+        working-directory: integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets
+        run: gzip --keep --verbose --force scalar.js scalar.aspnetcore.js
 
       - if: steps.changed-files.outputs.aspnetcore_package_any_changed == 'true'
         name: Setup .NET

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -906,15 +906,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
-      - name: Build @scalar/api-reference
-        uses: ./.github/actions/build-blacksmith
+      - name: Download standalone.js artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
-          node-version: 22
-          packages: '@scalar/api-reference...'
-
-      - name: Copy JavaScript asset from @scalar/api-reference
-        working-directory: integrations/aspire
-        run: pnpm copy:standalone
+          name: standalone-js
+          path: integrations/aspire/src/Scalar.Aspire.Service/wwwroot
 
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
@@ -1064,16 +1060,11 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - if: steps.changed-files.outputs.aspire_package_any_changed == 'true'
-        name: Build @scalar/api-reference
-        uses: ./.github/actions/build-blacksmith
+        name: Download standalone.js artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
-          node-version: 22
-          packages: '@scalar/api-reference...'
-
-      - if: steps.changed-files.outputs.aspire_package_any_changed == 'true'
-        name: Copy JavaScript asset from @scalar/api-reference
-        working-directory: integrations/aspire
-        run: pnpm copy:standalone
+          name: standalone-js
+          path: integrations/aspire/src/Scalar.Aspire.Service/wwwroot
 
       - if: steps.changed-files.outputs.aspire_package_any_changed == 'true'
         name: Log in to DockerHub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
     name: Build and Tag Docker Image
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
+    needs: [build]
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -75,21 +76,16 @@ jobs:
         run: echo "VERSION=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
-        name: Build @scalar/api-reference
-        uses: ./.github/actions/build-blacksmith
+        name: Download standalone.js artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
-          node-version: 22
-          packages: '@scalar/api-reference...'
-
-      - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
-        name: Copy JavaScript asset from @scalar/api-reference
-        working-directory: integrations/docker
-        run: pnpm copy:standalone
+          name: standalone-js
+          path: integrations/docker/assets
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Compress static assets
-        working-directory: integrations/docker
-        run: pnpm compress
+        working-directory: integrations/docker/assets
+        run: gzip --keep --verbose --force standalone.js
 
       - if: steps.changed-files.outputs.api_reference_docker_any_changed == 'true'
         name: Setup Docker Builder


### PR DESCRIPTION
With this PR we reuse the already built `standalone.js` (artifact of the API Reference package) instead of building it multiple times. This is faster and more efficient.

Thoughts?

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
