### PR TITLE
ci: skip stats job for forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,8 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   stats:
+    # Skip for forks and bot PRs
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]')
     needs: [build]
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10


### PR DESCRIPTION
The stats job is failing for forks, because it doesn’t have access to the repository credentials. Let’s skip it for forks.

This seems to have started with a recent update, I think.

<img width="1456" height="928" alt="Screenshot 2025-08-25 at 14 43 44" src="https://github.com/user-attachments/assets/cb468995-186c-4f5b-9c42-1261eeabf8b0" />
