### PR TITLE
chore: make Biome ignore the JS in the webjar

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -32,7 +32,8 @@
       "**/obj/**",
       "**/bin/**",
       "packages/openapi-parser/src/schemas/**/*.ts",
-      ".github/renovate.json"
+      ".github/renovate.json",
+      "**/webjars/**/*.js"
     ]
   },
   "organizeImports": {


### PR DESCRIPTION
**Problem**

I’m probably the only one with a webjar build, but it contains the bundled JS and Biome fails to check the file, because it’s too big.

**Solution**

Let’s ignore the bundle.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
