### PR TITLE
feat(workspace-store): don't throw on validation errors, add validation errors to the console

### DIFF
--- a/.changeset/quiet-goats-think.md
+++ b/.changeset/quiet-goats-think.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+feat: output validation errors in the console

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -1,12 +1,12 @@
-import assert from 'node:assert'
 import { setTimeout } from 'node:timers/promises'
 import { createWorkspaceStore } from '@/client'
 import { defaultReferenceConfig } from '@/schemas/reference-config'
 import { createServerWorkspaceStore } from '@/server'
 import { consoleErrorSpy, resetConsoleSpies } from '@scalar/helpers/testing/console-spies'
-import { getRaw } from '@scalar/json-magic/magic-proxy'
 import fastify, { type FastifyInstance } from 'fastify'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import assert from 'node:assert'
+import { getRaw } from '@scalar/json-magic/magic-proxy'
 
 // Test document
 const getDocument = (version?: string) => ({
@@ -182,35 +182,6 @@ describe('create-workspace-store', () => {
       info: {
         title: 'My API',
         version: '',
-      },
-      openapi: '3.1.1',
-      'x-scalar-navigation': [],
-      'x-ext-urls': {},
-    })
-  })
-
-  it.only('omits invalid parts', async () => {
-    const store = createWorkspaceStore()
-
-    await store.addDocument({
-      document: {
-        openapi: '3.0.0',
-        info: {
-          title: 'My API',
-          // Something invalid
-          contact: true,
-        },
-      },
-      name: 'default',
-    })
-
-    store.update('x-scalar-active-document', 'default')
-    expect(store.workspace.activeDocument).toEqual({
-      info: {
-        title: 'My API',
-        version: '',
-        // Becomes an empty object, which is valid
-        contact: {},
       },
       openapi: '3.1.1',
       'x-scalar-navigation': [],

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -614,10 +614,8 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       }))
     }
 
-    // Create a cleaned document that follows the strict schema
-    const strictDocument = isValid
-      ? temporaryDocument
-      : Value.Cast(OpenAPIDocumentSchemaStrict, Value.Default(OpenAPIDocumentSchemaStrict, temporaryDocument))
+    // Type-cast and just try to render, even if the document is (partially) invalid
+    const strictDocument = isValid ? temporaryDocument : (temporaryDocument as WorkspaceDocument)
 
     // Skip navigation generation if the document already has a server-side generated navigation structure
     if (strictDocument[extensions.document.navigation] === undefined) {

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -593,7 +593,20 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     const isValid = Value.Check(OpenAPIDocumentSchemaStrict, strictDocument)
 
     if (!isValid) {
-      throw 'Invalid document provided! Please check your input document. It has some invalid refs.'
+      const errors = Array.from(Value.Errors(OpenAPIDocumentSchemaStrict, strictDocument))
+
+      console.group(`🔴 OpenAPI Document Validation Failed for '${name}'`)
+      errors.forEach((error, index) => {
+        console.error(`Error #${index + 1}:`, {
+          message: error.message,
+          path: error.path,
+          schema: error.schema,
+          value: error.value,
+        })
+      })
+      console.groupEnd()
+
+      throw 'Invalid document provided! Please check your input document.'
     }
 
     // Skip navigation generation if the document already has a server-side generated navigation structure


### PR DESCRIPTION
**Problem**

Currently, when a referenced part of a document is invalid, validation fails completely and says something about invalid refs. This makes the whole rendering fail.

**Solution**

With this PR, we show the exact validation error messages in the console and still add the document so it can be rendered.

Fixes #6644

The actual issue seems to be in the coerce, we’ll try to fix that in another PR.

**Example Document**

```
openapi: 3.1.0
info:
  title: Test API
  version: 1.0.0
paths:
  /test:
    get:
      responses:
        '200':
          content:
            application/json:
              schema:
                # Only happens when we $ref to a schema with invalid properties
                $ref: '#/components/schemas/Foobar'
components:
  schemas:
    Foobar:
      type: object
      # Invalid, makes the validation fail
      required:
      properties:
        storage:
          type: string

```

**Console**

<img width="1153" height="99" alt="Screenshot 2025-08-25 at 18 34 13" src="https://github.com/user-attachments/assets/3c602973-1df7-4f7b-b349-4b791930a2f1" />

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
