### PR TITLE
feat(workspace-store): make `required: null` an empty array

### DIFF
--- a/.changeset/cuddly-snakes-think.md
+++ b/.changeset/cuddly-snakes-think.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+feat: make required: null an empty array

--- a/packages/workspace-store/src/plugins.test.ts
+++ b/packages/workspace-store/src/plugins.test.ts
@@ -1021,5 +1021,29 @@ describe('plugins', () => {
       expect((input.components.schemas.EscapedPattern as any).type).toBe('string')
       expect((input.components.schemas.UnicodePattern as any).type).toBe('string')
     })
+
+    it('converts required: null to required: [] for object schemas', async () => {
+      const input = {
+        components: {
+          schemas: {
+            User: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                email: { type: 'string' },
+              },
+              required: null,
+            },
+          },
+        },
+      }
+
+      await bundle(input, {
+        treeShake: false,
+        plugins: [cleanUp()],
+      })
+
+      expect(input.components.schemas.User.required).toEqual([])
+    })
   })
 })

--- a/packages/workspace-store/src/plugins.ts
+++ b/packages/workspace-store/src/plugins.ts
@@ -226,6 +226,11 @@ export const cleanUp = (): LifecyclePlugin => {
       if ('pattern' in node && !('type' in node)) {
         node['type'] = 'string'
       }
+
+      // Convert required: null to required: [] for object schemas
+      if ('required' in node && node.required === null && 'properties' in node) {
+        node.required = []
+      }
     },
   }
 }


### PR DESCRIPTION
**Problem**

Documents that have `required: null` don’t pass the validation, which makes the whole rendering fail.

**Solution**

This PR adds a bit of code to the `cleanUp` plugin, to replace `required: null` with `required: []`.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
