### PR TITLE
Feat/spring add sources support

### DIFF
--- a/.changeset/popular-beers-rush.md
+++ b/.changeset/popular-beers-rush.md
@@ -1,0 +1,5 @@
+---
+'@scalar/webjar': minor
+---
+
+Added support for the "sources" field

--- a/integrations/java/spring-boot/src/main/resources/application.properties
+++ b/integrations/java/spring-boot/src/main/resources/application.properties
@@ -12,4 +12,11 @@ scalar.path=/scalar
 # The URL of your OpenAPI document
 scalar.url=https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json
 
+# The sources of your OpenAPI document (replaces scalar.url)
+scalar.sources[0].url=https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json
+scalar.sources[1].url=https://api.apis.guru/v2/specs/1forge.com/0.0.1/swagger.json
+scalar.sources[1].title=Scalar Galaxy
+scalar.sources[1].slug=scalar-galaxy
+scalar.sources[1].default=true
+
 scalar.theme=purple

--- a/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarController.java
+++ b/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarController.java
@@ -189,8 +189,6 @@ public class ScalarController {
             config.append(",\n  sources: ").append(buildSourcesJsonArray(properties.getSources()));
         }
 
-        // Add specification reference sources
-
         // Add showSidebar
         if (!properties.isShowSidebar()) {
             config.append(",\n  showSidebar: false");

--- a/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarProperties.java
+++ b/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarProperties.java
@@ -2,6 +2,8 @@ package com.scalar.maven.webjar;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.List;
+
 /**
  * Configuration properties for the Scalar API Reference integration.
  *
@@ -30,6 +32,11 @@ public class ScalarProperties {
      * Defaults to a sample specification from the Scalar Galaxy CDN.
      */
     private String url = "https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json";
+
+    /**
+     * List of OpenAPI reference sources, allowing to set multiple OpenAPI references (replaces {@link #url})
+     */
+    private List<ScalarSource> sources;
 
     /**
      * Whether the Scalar API Reference is enabled.
@@ -105,6 +112,24 @@ public class ScalarProperties {
      * Defaults to "both".
      */
     private String documentDownloadType = "both";
+
+    /**
+     * Gets the list of OpenAPI specification sources
+     *
+     * @return list of OpenAPI specification sources
+     */
+    public List<ScalarSource> getSources() {
+        return sources;
+    }
+
+    /**
+     * Sets the list of OpenAPI specification sources
+     *
+     * @param sources list of OpenAPI specification sources
+     */
+    public void setSources(List<ScalarSource> sources) {
+        this.sources = sources;
+    }
 
     /**
      * Gets the URL of the OpenAPI specification.
@@ -338,5 +363,128 @@ public class ScalarProperties {
      */
     public void setDocumentDownloadType(String documentDownloadType) {
         this.documentDownloadType = documentDownloadType;
+    }
+
+    /**
+     * Defines an OpenAPI reference source
+     */
+    public static class ScalarSource {
+
+        /**
+         * The URL of the OpenAPI specification to display in the API reference.
+         */
+        private String url;
+
+        /**
+         * The display title of the OpenAPI specification
+         * optional
+         */
+        private String title;
+
+        /**
+         * The url slug of the OpenAPI specification
+         * optional, would be auto-generated from the title or the index
+         */
+        private String slug;
+
+        /**
+         * Whether this is the default source
+         * optional
+         */
+        private Boolean isDefault;
+
+        /**
+         * Creates an OpenAPI reference source
+         * {@link #url} must be set
+         */
+        public ScalarSource() {
+        }
+
+        /**
+         * Creates an OpenAPI reference source
+         *
+         * @param url the url of the OpenAPI specification
+         * @param title the display title of the OpenAPI specification
+         * @param slug the url slug of the OpenAPI specification
+         * @param isDefault whether this is the default source
+         */
+        public ScalarSource(String url, String title, String slug, Boolean isDefault) {
+            this.url = url;
+            this.title = title;
+            this.slug = slug;
+            this.isDefault = isDefault;
+        }
+
+        /**
+         * Gets the URL of the OpenAPI specification
+         *
+         * @return the url
+         */
+        public String getUrl() {
+            return url;
+        }
+
+        /**
+         * Sets the URL of the OpenAPI specification
+         *
+         * @param url the url
+         */
+        public void setUrl(String url) {
+            this.url = url;
+        }
+
+        /**
+         * Gets the display title of the OpenAPI specification
+         *
+         * @return the display title or null
+         */
+        public String getTitle() {
+            return title;
+        }
+
+        /**
+         * Sets the display title of the OpenAPI specification
+         *
+         * @param title the display title
+         */
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        /**
+         * Gets the url slug of the OpenAPI specification
+         *
+         * @return the url slug or null
+         */
+        public String getSlug() {
+            return slug;
+        }
+
+        /**
+         * Sets the url slug of the OpenAPI specification
+         *
+         * @param slug the url slug
+         */
+        public void setSlug(String slug) {
+            this.slug = slug;
+        }
+
+        /**
+         * Gets whether this is the default source
+         *
+         * @return whether this is the default source or null
+         */
+        public Boolean isDefault() {
+            return isDefault;
+        }
+
+        /**
+         * Sets whether this is the default source
+         *
+         * @param isDefault whether this is the default source
+         */
+        public void setDefault(Boolean isDefault) {
+            this.isDefault = isDefault;
+        }
     }
 }

--- a/integrations/java/webjar/src/test/java/com/scalar/maven/webjar/ScalarPropertiesTest.java
+++ b/integrations/java/webjar/src/test/java/com/scalar/maven/webjar/ScalarPropertiesTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("ScalarProperties")
@@ -27,7 +29,7 @@ class ScalarPropertiesTest {
         @DisplayName("should have correct default URL")
         void shouldHaveCorrectDefaultUrl() {
             assertThat(properties.getUrl())
-                .isEqualTo("https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json");
+                    .isEqualTo("https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json");
         }
 
         @Test
@@ -138,6 +140,39 @@ class ScalarPropertiesTest {
 
             // Then
             assertThat(properties.isEnabled()).isEqualTo(enabled);
+        }
+    }
+
+    @Nested
+    @DisplayName("Sources property")
+    class SourcesProperty {
+
+        @Test
+        @DisplayName("should set and get custom sources")
+        void shouldSetAndGetCustomSources() {
+            // Given
+            final List<ScalarProperties.ScalarSource> sources = List.of(
+                    new ScalarProperties.ScalarSource(
+                            "url", "title", "slug", true
+                    ),
+                    new ScalarProperties.ScalarSource()
+            );
+
+            // When
+            properties.setSources(sources);
+
+            // Then
+            assertThat(properties.getSources()).isEqualTo(sources);
+        }
+
+        @Test
+        @DisplayName("should handle null sources")
+        void shouldHandleNullSources() {
+            // When
+            properties.setSources(null);
+
+            // Then
+            assertThat(properties.getSources()).isNull();
         }
     }
 
@@ -486,8 +521,13 @@ class ScalarPropertiesTest {
         @Test
         @DisplayName("should maintain property independence")
         void shouldMaintainPropertyIndependence() {
+            final ScalarProperties.ScalarSource source = new ScalarProperties.ScalarSource();
+            source.setUrl("https://example.com/openapi.json");
+            final List<ScalarProperties.ScalarSource> sources = List.of(source);
+
             // Given - set initial values
             properties.setUrl("https://initial.com");
+            properties.setSources(sources);
             properties.setEnabled(false);
             properties.setPath("/initial");
             properties.setShowSidebar(false);
@@ -500,6 +540,7 @@ class ScalarPropertiesTest {
 
             // Then - only URL should change, others should remain
             assertThat(properties.getUrl()).isEqualTo("https://changed.com");
+            assertThat(properties.getSources()).isEqualTo(sources);
             assertThat(properties.isEnabled()).isFalse();
             assertThat(properties.getPath()).isEqualTo("/initial");
             assertThat(properties.isShowSidebar()).isFalse();


### PR DESCRIPTION
**Problem**

Currently, the Spring client doesn't support the "sources" field, which allows to add multiple OpenAPI documents.

**Solution**

With this PR, I added support the the "sources" field.

**Checklist**

I've gone through the following:

- [ X ] I've added an explanation _why_ this change is needed.
- [ X ] I've added a changeset (`pnpm changeset`).
- [ X ] I've added tests for the regression or new feature.
- [ X ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
