### PR TITLE
chore(documentation): add Brynn and Cam as docs code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,7 @@
 /*.md @hanspagel @marclave
 
 # Documentation
-/documentation/* @hanspagel @marclave
+/documentation/* @hanspagel @marclave @hwkr @cameronrohani
 
 # Changesets
 /.changeset/*


### PR DESCRIPTION
With all the updates to docs add's Cam and I to reviews

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
