### PR TITLE
fix(fastify): does not work with `@fastify/swagger` `decorator` option

### DIFF
--- a/.changeset/ten-seahorses-explain.md
+++ b/.changeset/ten-seahorses-explain.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix: does not work with @fastify/swagger decorator option

--- a/examples/fastify/src/index.ts
+++ b/examples/fastify/src/index.ts
@@ -3,7 +3,7 @@ import Fastify from 'fastify'
 
 // Init Fastify
 const fastify = Fastify({
-  logger: false,
+  logger: true,
   // ignoreTrailingSlash: true,
 })
 

--- a/integrations/fastify/src/fastifyApiReference.ts
+++ b/integrations/fastify/src/fastifyApiReference.ts
@@ -91,13 +91,14 @@ const fastifyApiReference = fp<
         }
       }
 
-      if (fastify.hasPlugin('@fastify/swagger')) {
+      // Even if @fastify/swagger is loaded, when the `decorator` option is set, the `swagger` function is not available.
+      if (fastify.hasPlugin('@fastify/swagger') && typeof fastify.swagger === 'function') {
         return {
           type: 'swagger' as const,
-          // @ts-ignore We know that @fastify/swagger is loaded.
-          get: () => fastify.swagger() as OpenAPI.Document,
+          get: () => fastify.swagger(),
         }
       }
+
       return void 0
     })()
 


### PR DESCRIPTION
**Problem**

Currently, when using the `decorator` option, the OpenAPI document isn’t available under `fastify.swagger()` and our integration breaks.

**Solution**

This PR checks whether the `fastify.swagger()` function is available, otherwise you have to explicitly pass the document(s) you want to render.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
