### PR TITLE
fix(api-reference): allow server variables dropdown to close on selection

### DIFF
--- a/packages/api-client/src/components/Server/ServerVariablesForm.vue
+++ b/packages/api-client/src/components/Server/ServerVariablesForm.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useId } from 'vue'
+
 import ServerVariablesSelect from '@/components/Server/ServerVariablesSelect.vue'
 import ServerVariablesTextbox from '@/components/Server/ServerVariablesTextbox.vue'
 import type {
@@ -23,6 +25,8 @@ const emit = defineEmits<{
   (e: 'update:variable', name: string, value: string): void
 }>()
 
+const id = useId()
+
 function setVariable(name: string, value: string) {
   emit('update:variable', name, value)
 }
@@ -36,31 +40,33 @@ const getVariable = (name: string) => {
     <template
       v-for="name in Object.keys(variables)"
       :key="name">
-      <label
+      <div
         class="group/label flex w-full"
         :class="
           layout === 'reference' &&
           'items-center border-x border-b last:rounded-b-lg'
         ">
-        <span
+        <label
+          :for="`${id}-${name}`"
           class="flex items-center py-1.5 pl-3 group-has-[input]/label:mr-0 after:content-[':']">
           {{ name }}
-        </span>
+        </label>
         <template v-if="variables?.[name]?.enum?.length">
           <ServerVariablesSelect
+            :id="`${id}-${name}`"
             :controls="controls"
             :enum="variables[name]?.enum?.map((v) => `${v}`) ?? []"
-            :label="name"
             :value="getVariable(name)"
             @change="(s) => setVariable(name, s)" />
         </template>
         <template v-else>
           <ServerVariablesTextbox
+            :id="`${id}-${name}`"
             :controls="controls"
             :value="getVariable(name)"
             @change="(s) => setVariable(name, s)" />
         </template>
-      </label>
+      </div>
     </template>
   </template>
 </template>


### PR DESCRIPTION
So because the ScalarListbox was wrapped in a `<label>` weird click events were getting passed into the listbox and the listbox wasn't closing. 

This updates it so the `<label>` is adjacent to the form inputs and connected with an `id`.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
