### PR TITLE
fix(api-reference): add another cache to magic proxy

### DIFF
--- a/packages/api-reference/test/data/sources.ts
+++ b/packages/api-reference/test/data/sources.ts
@@ -4,7 +4,7 @@ export default [
   {
     title: 'Scalar Galaxy', // optional, would fallback to 'API #1'
     slug: 'scalar-galaxy', // optional, would be auto-generated from the title or the index
-    url: 'https://galaxy.scalar.com/openapi.yaml',
+    url: 'https://gist.githubusercontent.com/amritk/27a446170403395375a0c559531a6426/raw/95f969da4f34ba228f738b6b36f1f0789fec5c75/http',
   },
   {
     title: 'Scalar Galaxy Registry',


### PR DESCRIPTION
**Problem**

Currently, we were over proxying, vue was not getting the changes.

**Solution**

With this PR we add another cache to the proxy which prevents over proxying

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
