### PR TITLE
fix(integration-fastapi): export all from scalar_fastapi

### DIFF
--- a/.changeset/good-ads-rush.md
+++ b/.changeset/good-ads-rush.md
@@ -1,0 +1,5 @@
+---
+'scalar-fastapi': patch
+---
+
+Export objects from scalar_fastapi package root

--- a/integrations/fastapi/scalar_fastapi/__init__.py
+++ b/integrations/fastapi/scalar_fastapi/__init__.py
@@ -1,1 +1,3 @@
 from .scalar_fastapi import get_scalar_api_reference, Layout, SearchHotKey, Theme
+
+__all__ = ["get_scalar_api_reference", "Layout", "SearchHotKey", "Theme"]


### PR DESCRIPTION
**Problem**

Currently, the following snippet fails type-checking with `pyright`:

```py
from scalar_fastapi import get_scalar_api_reference
```

Output from `pyright`:

```text
error: "get_scalar_api_reference" is not exported from module "scalar_fastapi"
    Import from "scalar_fastapi.scalar_fastapi" instead (reportPrivateImportUsage)
```

This arose after the `py.typed` file was added - without that, it seems that `pyright` doesn't report the issue.

**Solution**

This PR adds a `__all__` export for each symbol imported into `__init__.py`, which satisfies the type checker.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
