### PR TITLE
feat(analytics): Add `analytics-client` package

### DIFF
--- a/packages/analytics-client/esbuild.ts
+++ b/packages/analytics-client/esbuild.ts
@@ -1,0 +1,6 @@
+import { build } from '@scalar/build-tooling/esbuild'
+
+await build({
+  platform: 'shared',
+  entries: ['./src/index.ts'],
+})

--- a/packages/analytics-client/package.json
+++ b/packages/analytics-client/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@scalar/analytics-client",
+  "description": "Event and metric tracking across Scalar",
+  "license": "MIT",
+  "author": "Scalar (https://github.com/scalar)",
+  "homepage": "https://github.com/scalar/scalar",
+  "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/scalar/scalar.git",
+    "directory": "packages/analytics-client"
+  },
+  "keywords": [],
+  "version": "1.0.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "scalar-build-esbuild",
+    "lint:check": "biome lint --diagnostic-level=error",
+    "lint:fix": "biome lint --write",
+    "types:build": "scalar-types-build",
+    "types:check": "scalar-types-check"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "module": "dist/index.js",
+  "dependencies": {
+    "zod": "catalog:*"
+  },
+  "devDependencies": {
+    "@scalar/build-tooling": "workspace:*",
+    "@types/node": "catalog:*",
+    "vite": "catalog:*"
+  }
+}

--- a/packages/analytics-client/src/events.ts
+++ b/packages/analytics-client/src/events.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const analyticsEventData = {
+  'page-view': z.object({
+    path: z.string(),
+  }),
+} as const
+
+export type Events = keyof typeof analyticsEventData
+
+// For backward compatibility or if you need the array form
+export const analyticsEvents = Object.keys(analyticsEventData) as Events[]
+
+// Create a Zod enum from the object keys with strong typing
+export const analyticsEventEnum = z.enum(analyticsEvents as [Events, ...Events[]])

--- a/packages/analytics-client/src/index.ts
+++ b/packages/analytics-client/src/index.ts
@@ -1,0 +1,50 @@
+import { analyticsEvents, type analyticsEventData, type Events, analyticsEventEnum } from '@/events'
+import type { z } from 'zod'
+
+export const analyticsFactory = (
+  /**
+   * Base URL for the API. For Scalar services all services live
+   * at a root path of the baseUrl
+   *
+   * ex. https://services.scalar.com/core/<endpointName>
+   *     or
+   *     http://localhost:9999/core/<endpointName>
+   */
+  baseUrl: string,
+  /**
+   * Getter function to retrieve the active auth token
+   * This will be run on each request
+   */
+  getAuthToken: () => string | null,
+) => {
+  async function capture<E extends Events>(
+    event: E,
+    ...[data]: z.input<(typeof analyticsEventData)[E]> extends undefined
+      ? []
+      : [z.input<(typeof analyticsEventData)[E]>]
+  ) {
+    if (!analyticsEvents.includes(event)) {
+      throw new Error('[Analytics]: Invalid event submission')
+    }
+
+    const authToken = getAuthToken()
+
+    await fetch(`${baseUrl}/analytics/send`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(authToken ? { 'authorization': `Bearer ${authToken}` } : {}),
+      },
+      body: JSON.stringify({
+        event,
+        data,
+      }),
+    })
+  }
+
+  return {
+    capture,
+  }
+}
+
+export { analyticsEventEnum }

--- a/packages/analytics-client/tsconfig.build.json
+++ b/packages/analytics-client/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": ["dist", "vite.config.ts"],
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/"
+  }
+}

--- a/packages/analytics-client/tsconfig.json
+++ b/packages/analytics-client/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["vite/client", "node"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1121,6 +1121,22 @@ importers:
         specifier: ^4.0.0
         version: 4.1.5(picomatch@4.0.3)(svelte@5.25.10)(typescript@5.8.3)
 
+  packages/analytics-client:
+    dependencies:
+      zod:
+        specifier: catalog:*
+        version: 3.24.1
+    devDependencies:
+      '@scalar/build-tooling':
+        specifier: workspace:*
+        version: link:../build-tooling
+      '@types/node':
+        specifier: catalog:*
+        version: 22.15.3
+      vite:
+        specifier: catalog:*
+        version: 6.1.6(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
+
   packages/api-client:
     dependencies:
       '@headlessui/tailwindcss':


### PR DESCRIPTION
**Problem**

Currently, there is no analytics client.

**Solution**

With this PR we can send analytic events using the new `analytics-client` package.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
