### PR TITLE
feat(workspace-store): add tests for reactivitiy

### DIFF
--- a/packages/galaxy/src/documents/3.1.yaml
+++ b/packages/galaxy/src/documents/3.1.yaml
@@ -67,6 +67,7 @@ servers:
       protocol:
         enum:
           - https
+          - http
         default: https
       path:
         default: ''


### PR DESCRIPTION
**Problem**

Currently, we had an issue where the proxy was blocking vue reactivity. We fixed that issue but didn't add a proper test.

**Solution**

With this PR we test the reactivity of all proxies. Plus we add another option to the enum in the galaxy variables for testing.`

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
