### PR TITLE
fix(snippetz): use correct query format in ofetch snippet

### DIFF
--- a/.changeset/cool-lions-flash.md
+++ b/.changeset/cool-lions-flash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+fix(snippetz): use correct query format in ofetch snippets

--- a/packages/snippetz/src/plugins/js/ofetch/ofetch.test.ts
+++ b/packages/snippetz/src/plugins/js/ofetch/ofetch.test.ts
@@ -95,16 +95,10 @@ ofetch('https://example.com', {
     expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com', {
-  query: [
-    {
-      name: 'foo',
-      value: 'bar'
-    },
-    {
-      name: 'bar',
-      value: 'foo'
-    }
-  ]
+  query: {
+    foo: 'bar',
+    bar: 'foo'
+  }
 })`)
   })
 

--- a/packages/snippetz/src/plugins/js/ofetch/ofetch.ts
+++ b/packages/snippetz/src/plugins/js/ofetch/ofetch.ts
@@ -24,7 +24,9 @@ export const jsOfetch: Plugin = {
     }
 
     // Query
-    options.query = normalizedRequest.queryString
+    if (normalizedRequest.queryString?.length) {
+      options.query = Object.fromEntries(normalizedRequest.queryString.map((q) => [q.name, q.value]))
+    }
 
     // Headers
     if (normalizedRequest.headers?.length) {

--- a/packages/snippetz/src/plugins/node/ofetch/ofetch.test.ts
+++ b/packages/snippetz/src/plugins/node/ofetch/ofetch.test.ts
@@ -95,16 +95,10 @@ ofetch('https://example.com', {
     expect(result).toBe(`import { ofetch } from 'ofetch'
 
 ofetch('https://example.com', {
-  query: [
-    {
-      name: 'foo',
-      value: 'bar'
-    },
-    {
-      name: 'bar',
-      value: 'foo'
-    }
-  ]
+  query: {
+    foo: 'bar',
+    bar: 'foo'
+  }
 })`)
   })
 

--- a/packages/snippetz/src/plugins/node/ofetch/ofetch.ts
+++ b/packages/snippetz/src/plugins/node/ofetch/ofetch.ts
@@ -24,7 +24,9 @@ export const nodeOfetch: Plugin = {
     }
 
     // Query
-    options.query = normalizedRequest.queryString
+    if (normalizedRequest.queryString?.length) {
+      options.query = Object.fromEntries(normalizedRequest.queryString.map((q) => [q.name, q.value]))
+    }
 
     // Headers
     if (normalizedRequest.headers?.length) {


### PR DESCRIPTION
**Problem**

Currently, ofetch snippet uses an incorrect format for query parameters.

**Solution**

With this PR ofetch now uses the correct format.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
