### PR TITLE
fix(api-reference): grab first tag from sidebar if not defined

### DIFF
--- a/.changeset/poor-steaks-watch.md
+++ b/.changeset/poor-steaks-watch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: open first tag when not defined in document

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -211,15 +211,23 @@ watch(dereferencedDocument, (newDoc) => {
       setCollapsedSidebarItem(hashSectionId, true)
     }
   }
-  // Open the first tag
-  else {
+  // Open the first tag if there are tags defined
+  else if (newDoc.tags?.length) {
     const firstTag = newDoc.tags?.[0]
 
     if (firstTag) {
       setCollapsedSidebarItem(getTagId(firstTag), true)
     }
   }
+  // If there's no tags defined on the document, grab the first tag entry
+  else {
+    const firstTag = items.value.entries.find((item) => 'tag' in item)
+    if (firstTag) {
+      setCollapsedSidebarItem(firstTag.id, true)
+    }
+  }
 
+  // Open the sidebar
   sidebarOpened.value = true
 })
 

--- a/packages/api-reference/test/configuration/layout.e2e.ts
+++ b/packages/api-reference/test/configuration/layout.e2e.ts
@@ -23,11 +23,8 @@ test.describe('layout', () => {
 
     await page.goto(example)
 
-    await expect(page.getByRole('region', { name: 'user-tag (Collapsed)', exact: true })).toBeVisible()
-    await expect(page.getByRole('region', { name: 'user-tag (Collapsed)', exact: true })).toHaveAttribute(
-      'layout',
-      'modern',
-    )
+    await expect(page.getByRole('region', { name: 'user-tag', exact: true })).toBeVisible()
+    await expect(page.getByRole('region', { name: 'user-tag', exact: true })).toHaveAttribute('layout', 'modern')
   })
 
   test('renders classic layout when set to classic', async ({ page }) => {


### PR DESCRIPTION
**Problem**

Currently, we try to grab the first tag from the document to open it. But if there's no tags defined on the document this doesn't work.

**Solution**

With this PR we use the side bar entries to grab a tag.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
