### PR TITLE
feat(components)!: add "Add new option" slot to combobox

### DIFF
--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.stories.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.stories.ts
@@ -194,26 +194,31 @@ export const WithAddNew: Story = {
   args: { options: [] },
   render: (args) => ({
     components: {
-      ScalarCombobox: ScalarCombobox as ComponentExposed<typeof ScalarCombobox>,
+      ScalarComboboxMultiselect: ScalarComboboxMultiselect as any,
       ScalarButton,
       ScalarDropdownButton,
       ScalarListboxCheckbox,
     },
     setup() {
-      const selected = ref<Option>()
-      const opts = ref<Option[]>([...options])
+      const selected = ref<Option[]>([])
+      const opts = ref<Option[]>([])
       const counter = ref<number>(1)
-      const add = () =>
-        (opts.value = [...opts.value, { label: `New Option ${counter.value}`, id: `new-option-${counter.value++}` }])
+      function add() {
+        const newOpt = { label: `Option ${counter.value}`, id: `${counter.value++}` }
+        opts.value = [...opts.value, newOpt]
+        selected.value = [...selected.value, newOpt]
+      }
+      add(), add(), add()
+
       return { args, selected, add, opts }
     },
     template: `
 <div class="flex justify-center w-full min-h-96">
-  <ScalarCombobox v-model="selected" v-bind="args" :options="opts" @add="add">
+  <ScalarComboboxMultiselect v-model="selected" v-bind="args" :options="opts" @add="add">
     <ScalarButton class="w-48 px-3" variant="outlined">
       <div class="flex flex-1 items-center min-w-0">
         <span class="inline-block truncate flex-1 min-w-0 text-left">
-          {{ selected?.label ?? 'Select an option' }}
+          {{ selected.length }} of {{ opts.length }} options selected
         </span>
       </div>
     </ScalarButton>

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.stories.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.stories.ts
@@ -239,6 +239,42 @@ export const WithSlots: Story = {
   }),
 }
 
+export const WithAddNewOption: Story = {
+  args: { options: [] },
+  render: (args) => ({
+    components: {
+      ScalarCombobox: ScalarCombobox as ComponentExposed<typeof ScalarCombobox>,
+      ScalarButton,
+      ScalarDropdownButton,
+      ScalarListboxCheckbox,
+    },
+    setup() {
+      const selected = ref<Option>()
+      const opts = ref<Option[]>([...options])
+      const counter = ref<number>(1)
+      const add = () =>
+        (opts.value = [...opts.value, { label: `New Option ${counter.value}`, id: `new-option-${counter.value++}` }])
+      return { args, selected, add, opts }
+    },
+    template: `
+<div class="flex justify-center w-full min-h-96">
+  <ScalarCombobox v-model="selected" v-bind="args" :options="opts" @add="add">
+    <ScalarButton class="w-48 px-3" variant="outlined">
+      <div class="flex flex-1 items-center min-w-0">
+        <span class="inline-block truncate flex-1 min-w-0 text-left">
+          {{ selected?.label ?? 'Select an option' }}
+        </span>
+      </div>
+    </ScalarButton>
+    <template #add>
+      Add a new option
+    </template>
+  </ScalarCombobox>
+</div>
+`,
+  }),
+}
+
 /**
  * Applies a custom class to the combobox popover
  */

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.stories.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.stories.ts
@@ -190,56 +190,7 @@ export const MultiselectGroups: Story = {
   }),
 }
 
-export const WithSlots: Story = {
-  args: { options: groups, resize: true },
-  render: (args) => ({
-    components: {
-      ScalarCombobox: ScalarCombobox as ComponentExposed<typeof ScalarCombobox>,
-      ScalarButton,
-      ScalarDropdownButton,
-      ScalarListboxCheckbox,
-    },
-    setup() {
-      const selected = ref<Option>()
-      return { args, selected }
-    },
-    template: `
-<div class="flex justify-center w-full min-h-96">
-  <ScalarCombobox v-model="selected" placeholder="Select a city..." v-bind="args">
-    <ScalarButton class="w-48 px-3" variant="outlined">
-      <div class="flex flex-1 items-center min-w-0">
-        <span class="inline-block truncate flex-1 min-w-0 text-left">
-          {{ selected?.label ?? 'Select a city' }}
-        </span>
-      </div>
-    </ScalarButton>
-    <template #option="{ option, selected }">
-      <ScalarListboxCheckbox
-        :selected />
-      <div class="flex-1 min-w-0 truncate">
-        {{ option.label }}
-      </div>
-      <div class="text-c-3">
-        GMT{{ option.timezone }}
-      </div>
-    </template>
-    <template #group="{ group }">
-      {{ group.flag }}
-      {{ group.label }}
-    </template>
-    <template #before>
-      <div class="placeholder">Before</div>
-    </template>
-    <template #after>
-      <div class="placeholder">After</div>
-    </template>
-  </ScalarCombobox>
-</div>
-`,
-  }),
-}
-
-export const WithAddNewOption: Story = {
+export const WithAddNew: Story = {
   args: { options: [] },
   render: (args) => ({
     components: {

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.test.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.test.ts
@@ -155,25 +155,6 @@ describe('ScalarCombobox', () => {
   })
 
   describe('slot functionality', () => {
-    it('renders before and after slots', async () => {
-      const wrapper = mount(ScalarCombobox, {
-        props: { options: singleOptions },
-        slots: {
-          default: '<button>Toggle</button>',
-          before: '<div data-test="before-content">Before content</div>',
-          after: '<div data-test="after-content">After content</div>',
-        },
-      })
-
-      await wrapper.find('button').trigger('click')
-      await nextTick()
-
-      expect(wrapper.find('[data-test="before-content"]').exists()).toBe(true)
-      expect(wrapper.find('[data-test="before-content"]').text()).toBe('Before content')
-      expect(wrapper.find('[data-test="after-content"]').exists()).toBe(true)
-      expect(wrapper.find('[data-test="after-content"]').text()).toBe('After content')
-    })
-
     it('renders custom option slot with correct props', async () => {
       const wrapper = mount(ScalarCombobox, {
         props: { options: extendedOptions },
@@ -239,8 +220,6 @@ describe('ScalarCombobox', () => {
         props: { options: extendedGroups },
         slots: {
           default: '<button>Toggle</button>',
-          before: '<div data-test="before">Before content</div>',
-          after: '<div data-test="after">After content</div>',
           option: `
             <template #option="{ option }">
               <div data-test="custom-option">{{ option.label }}</div>
@@ -258,8 +237,6 @@ describe('ScalarCombobox', () => {
       await nextTick()
 
       // All slots should be present
-      expect(wrapper.find('[data-test="before"]').exists()).toBe(true)
-      expect(wrapper.find('[data-test="after"]').exists()).toBe(true)
       expect(wrapper.find('[data-test="custom-option"]').exists()).toBe(true)
       expect(wrapper.find('[data-test="custom-group"]').exists()).toBe(true)
     })
@@ -282,28 +259,6 @@ describe('ScalarCombobox', () => {
       // Should not have custom slot content
       expect(wrapper.find('[data-test="custom-option"]').exists()).toBe(false)
       expect(wrapper.find('[data-test="custom-group"]').exists()).toBe(false)
-    })
-
-    it('shows/hides slots based on content availability', async () => {
-      const wrapper = mount(ScalarCombobox, {
-        props: { options: [] }, // Empty options
-        slots: {
-          default: '<button>Toggle</button>',
-          before: '<div data-test="before-empty">Before empty</div>',
-          after: '<div data-test="after-empty">After empty</div>',
-        },
-      })
-
-      await wrapper.find('button').trigger('click')
-      await nextTick()
-
-      // Before/after slots should still be visible even with empty options
-      expect(wrapper.find('[data-test="before-empty"]').exists()).toBe(true)
-      expect(wrapper.find('[data-test="after-empty"]').exists()).toBe(true)
-
-      // Options list should exist but have no options
-      const optionsList = wrapper.find('ul[role="listbox"]')
-      expect(optionsList.exists()).toBe(true)
     })
   })
 

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.vue
@@ -7,6 +7,7 @@ import type { ScalarFloatingOptions } from '../ScalarFloating'
 import ComboboxOptions from './ScalarComboboxOptions.vue'
 import ComboboxPopover from './ScalarComboboxPopover.vue'
 import type {
+  ComboboxEmits,
   ComboboxSlots,
   Option,
   OptionGroup,
@@ -21,6 +22,8 @@ defineProps<
 >()
 
 const model = defineModel<O>()
+
+const emit = defineEmits<ComboboxEmits>()
 
 defineSlots<ComboboxSlots<O, G>>()
 </script>
@@ -41,7 +44,8 @@ defineSlots<ComboboxSlots<O, G>>()
         :open
         :options
         :placeholder
-        @update:modelValue="(v) => (close(), (model = v[0]))">
+        @update:modelValue="(v) => (close(), (model = v[0]))"
+        @add="() => (close(), emit('add'))">
         <!-- Pass through the combobox slots -->
         <template
           v-if="$slots.before"
@@ -66,6 +70,13 @@ defineSlots<ComboboxSlots<O, G>>()
           v-if="$slots.after"
           #after>
           <slot name="after" />
+        </template>
+        <template
+          v-if="$slots.add"
+          #add="props">
+          <slot
+            name="add"
+            v-bind="props" />
         </template>
       </ComboboxOptions>
     </template>

--- a/packages/components/src/components/ScalarCombobox/ScalarCombobox.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarCombobox.vue
@@ -48,11 +48,6 @@ defineSlots<ComboboxSlots<O, G>>()
         @add="() => (close(), emit('add'))">
         <!-- Pass through the combobox slots -->
         <template
-          v-if="$slots.before"
-          #before>
-          <slot name="before" />
-        </template>
-        <template
           v-if="$slots.option"
           #option="props">
           <slot
@@ -65,11 +60,6 @@ defineSlots<ComboboxSlots<O, G>>()
           <slot
             name="group"
             v-bind="props" />
-        </template>
-        <template
-          v-if="$slots.after"
-          #after>
-          <slot name="after" />
         </template>
         <template
           v-if="$slots.add"

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.test.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.test.ts
@@ -88,23 +88,6 @@ describe('ScalarComboboxMultiselect', () => {
   })
 
   describe('slot functionality', () => {
-    it('renders before and after slots in multiselect mode', async () => {
-      const wrapper = mount(ScalarComboboxMultiselect, {
-        props: { options: singleOptions },
-        slots: {
-          default: '<button>Toggle</button>',
-          before: '<div data-test="before-multiselect">Before multiselect</div>',
-          after: '<div data-test="after-multiselect">After multiselect</div>',
-        },
-      })
-
-      await wrapper.find('button').trigger('click')
-      await nextTick()
-
-      expect(wrapper.find('[data-test="before-multiselect"]').exists()).toBe(true)
-      expect(wrapper.find('[data-test="after-multiselect"]').exists()).toBe(true)
-    })
-
     it('renders custom option slot with selection state in multiselect', async () => {
       const wrapper = mount(ScalarComboboxMultiselect, {
         props: {

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.test.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.test.ts
@@ -115,4 +115,90 @@ describe('ScalarComboboxMultiselect', () => {
       expect(selectedOptions[1]?.text()).toBe('false') // Second option should not be selected
     })
   })
+
+  describe('add slot', () => {
+    it('renders add slot when provided', async () => {
+      const wrapper = mount(ScalarComboboxMultiselect, {
+        props: { options: singleOptions },
+        slots: {
+          default: '<button>Toggle</button>',
+          add: `
+            <template #add>
+              <div data-test="add-slot">Create</div>
+            </template>
+          `,
+        },
+      })
+
+      await wrapper.find('button').trigger('click')
+      await nextTick()
+      expect(wrapper.find('[data-test="add-slot"]').exists()).toBe(true)
+    })
+
+    it('focuses add option when no results and keeps popover open on add', async () => {
+      const wrapper = mount(ScalarComboboxMultiselect, {
+        props: { options: singleOptions, modelValue: [] },
+        slots: {
+          default: '<button>Toggle</button>',
+          add: `
+            <template #add>
+              <div data-test="add-slot">Create</div>
+            </template>
+          `,
+        },
+      })
+
+      await wrapper.find('button').trigger('click')
+      await nextTick()
+
+      const input = wrapper.find('input[type="text"]')
+      await input.setValue('not-present')
+      await nextTick()
+
+      const addEl = wrapper.find('[data-test="add-slot"]').element
+      const addLi = addEl.closest('li') as HTMLLIElement | null
+      const ariaId = input.attributes('aria-activedescendant')
+      expect(addLi).toBeTruthy()
+      expect(ariaId).toBe(addLi?.id)
+
+      // Clicking add should emit add but the popover stays open in multiselect
+      await wrapper.get('[data-test="add-slot"]').trigger('click')
+      expect(wrapper.emitted('add')).toBeTruthy()
+      expect(wrapper.find('ul[role="listbox"]').exists()).toBe(true)
+    })
+
+    it('navigates to add via arrow keys and Enter emits add (open remains)', async () => {
+      const wrapper = mount(ScalarComboboxMultiselect, {
+        props: { options: singleOptions, modelValue: [] },
+        slots: {
+          default: '<button>Toggle</button>',
+          add: `
+            <template #add>
+              <div data-test="add-slot">Create</div>
+            </template>
+          `,
+        },
+      })
+
+      await wrapper.find('button').trigger('click')
+      await nextTick()
+
+      const input = wrapper.find('input[type="text"]')
+      await input.trigger('keydown.down')
+      await input.trigger('keydown.down')
+      await input.trigger('keydown.down')
+      await input.trigger('keydown.down')
+
+      const addEl = wrapper.find('[data-test="add-slot"]').element
+      const addLi = addEl.closest('li') as HTMLLIElement | null
+      const ariaId = input.attributes('aria-activedescendant')
+      expect(addLi).toBeTruthy()
+      expect(ariaId).toBe(addLi?.id)
+
+      await input.trigger('keydown.enter')
+      expect(wrapper.emitted('add')).toBeTruthy()
+      // Multiselect does not close on add
+      expect(wrapper.find('ul[role="listbox"]').exists()).toBe(true)
+    })
+  })
 })

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.vue
@@ -9,6 +9,7 @@ import type { ScalarFloatingOptions } from '../ScalarFloating'
 import ComboboxOptions from './ScalarComboboxOptions.vue'
 import ComboboxPopover from './ScalarComboboxPopover.vue'
 import type {
+  ComboboxEmits,
   ComboboxSlots,
   Option,
   OptionGroup,
@@ -24,7 +25,9 @@ defineProps<
 
 const model = defineModel<O[]>({ default: [] })
 
-defineSlots<ComboboxSlots<O, G>>()
+const emit = defineEmits<ComboboxEmits>()
+
+const slots = defineSlots<ComboboxSlots<O, G>>()
 
 /** Propagate up the popover ref */
 const comboboxPopoverRef = ref<typeof ComboboxPopover | null>(null)
@@ -50,7 +53,8 @@ defineExpose({ comboboxPopoverRef })
         multiselect
         :open
         :options
-        :placeholder>
+        :placeholder
+        @add="emit('add')">
         <!-- Pass through the combobox slots -->
         <template
           v-if="$slots.before"
@@ -75,6 +79,13 @@ defineExpose({ comboboxPopoverRef })
           v-if="$slots.after"
           #after>
           <slot name="after" />
+        </template>
+        <template
+          v-if="$slots.add"
+          #add="props">
+          <slot
+            name="add"
+            v-bind="props" />
         </template>
       </ComboboxOptions>
     </template>

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxMultiselect.vue
@@ -57,11 +57,6 @@ defineExpose({ comboboxPopoverRef })
         @add="emit('add')">
         <!-- Pass through the combobox slots -->
         <template
-          v-if="$slots.before"
-          #before>
-          <slot name="before" />
-        </template>
-        <template
           v-if="$slots.option"
           #option="props">
           <slot
@@ -74,11 +69,6 @@ defineExpose({ comboboxPopoverRef })
           <slot
             name="group"
             v-bind="props" />
-        </template>
-        <template
-          v-if="$slots.after"
-          #after>
-          <slot name="after" />
         </template>
         <template
           v-if="$slots.add"

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.test.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.test.ts
@@ -110,21 +110,6 @@ describe('ScalarComboboxOptions', () => {
   })
 
   describe('slot functionality', () => {
-    it('renders before and after slots', async () => {
-      const wrapper = mount(ScalarComboboxOptions, {
-        props: { options: singleOptions },
-        slots: {
-          before: '<div data-test="options-before">Before options content</div>',
-          after: '<div data-test="options-after">After options content</div>',
-        },
-      })
-
-      expect(wrapper.find('[data-test="options-before"]').exists()).toBe(true)
-      expect(wrapper.find('[data-test="options-before"]').text()).toBe('Before options content')
-      expect(wrapper.find('[data-test="options-after"]').exists()).toBe(true)
-      expect(wrapper.find('[data-test="options-after"]').text()).toBe('After options content')
-    })
-
     it('passes correct props to option slot', async () => {
       const wrapper = mount(ScalarComboboxOptions, {
         props: {
@@ -199,7 +184,6 @@ describe('ScalarComboboxOptions', () => {
       const wrapper = mount(ScalarComboboxOptions, {
         props: { options: extendedGroups },
         slots: {
-          before: '<div data-test="before-filter">Before with filtering</div>',
           option: `
             <template #option="{ option }">
               <div data-test="filtered-option">{{ option.label }}</div>
@@ -210,7 +194,6 @@ describe('ScalarComboboxOptions', () => {
               <div data-test="filtered-group">{{ group.label }}</div>
             </template>
           `,
-          after: '<div data-test="after-filter">After with filtering</div>',
         },
       })
 
@@ -227,10 +210,6 @@ describe('ScalarComboboxOptions', () => {
       const filteredOptions = wrapper.findAll('[data-test="filtered-option"]')
       expect(filteredOptions).toHaveLength(1)
       expect(filteredOptions[0]?.text()).toBe('Apple')
-
-      // Before/after slots should still be visible
-      expect(wrapper.find('[data-test="before-filter"]').exists()).toBe(true)
-      expect(wrapper.find('[data-test="after-filter"]').exists()).toBe(true)
 
       // Only groups with matching options should show their labels
       const visibleGroups = wrapper.findAll('[data-test="filtered-group"]')
@@ -331,38 +310,6 @@ describe('ScalarComboboxOptions', () => {
       const groups = wrapper.findAllComponents(ScalarComboboxOptionGroup)
       expect(groups).toHaveLength(1)
       expect(groups[0]?.props('hidden')).toBe(true)
-    })
-
-    it('handles empty options array with custom slots', async () => {
-      // Test that the component doesn't crash with empty options and renders slots properly
-      const wrapper = mount(ScalarComboboxOptions, {
-        props: {
-          options: singleOptions, // Start with options to avoid the isGroups issue
-          modelValue: [],
-        },
-        slots: {
-          before: '<div data-test="before-content">Before content</div>',
-          after: '<div data-test="after-content">After content</div>',
-        },
-      })
-
-      // Before/after slots should be visible
-      expect(wrapper.find('[data-test="before-content"]').exists()).toBe(true)
-      expect(wrapper.find('[data-test="after-content"]').exists()).toBe(true)
-
-      // Should have options initially
-      expect(wrapper.findAllComponents(ScalarComboboxOption).length).toBeGreaterThan(0)
-
-      // Now update to empty options
-      await wrapper.setProps({ options: [] })
-      await nextTick()
-
-      // Before/after slots should still be visible
-      expect(wrapper.find('[data-test="before-content"]').exists()).toBe(true)
-      expect(wrapper.find('[data-test="after-content"]').exists()).toBe(true)
-
-      // No options should be rendered now
-      expect(wrapper.findAllComponents(ScalarComboboxOption)).toHaveLength(0)
     })
   })
 

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -34,11 +34,9 @@ defineOptions({ inheritAttrs: false })
 
 /** A unique ID for the combobox */
 const id = `scalar-combobox-items-${useId()}`
-/** A unique ID for the "Add a new option" option */
-const addId = `${useId()}-add`
 
 /** A static option entry for the "Add a new option" option */
-const addOption: Option = { id: addId, label: 'Add a new option' }
+const addOption: Option = { id: `${useId()}-add`, label: 'Add a new option' }
 
 /** Generate a unique ID for an option */
 function getOptionId(option: Option) {
@@ -116,7 +114,7 @@ function toggleSelected(option: Option | undefined) {
     return
   }
 
-  if (option.id === addId) {
+  if (option.id === addOption.id) {
     addNew()
     return
   }
@@ -253,8 +251,8 @@ onMounted(() => setTimeout(() => input.value?.focus(), 0))
     </ComboboxOptionGroup>
     <ComboboxOption
       v-if="slots.add"
-      :id="addId"
-      :active="active?.id === addId"
+      :id="getOptionId(addOption)"
+      :active="active?.id === addOption.id"
       @click="addNew"
       @mousedown.prevent
       @mouseenter="active = addOption"

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -3,13 +3,14 @@
   setup
   lang="ts"
   generic="O extends Option = Option, G extends OptionGroup<O> = OptionGroup<O>">
-import { ScalarIconMagnifyingGlass } from '@scalar/icons'
+import { ScalarIconMagnifyingGlass, ScalarIconPlus } from '@scalar/icons'
 import { computed, onMounted, ref, useId, watch } from 'vue'
 
 import { ScalarListboxCheckbox } from '../ScalarListbox'
 import ComboboxOption from './ScalarComboboxOption.vue'
 import ComboboxOptionGroup from './ScalarComboboxOptionGroup.vue'
 import {
+  type ComboboxEmits,
   type ComboboxSlots,
   type Option,
   type OptionGroup,
@@ -25,12 +26,19 @@ const props = defineProps<{
 
 const model = defineModel<O[]>({ default: [] })
 
-defineSlots<Omit<ComboboxSlots<O, G>, 'default'>>()
+const emit = defineEmits<ComboboxEmits>()
+
+const slots = defineSlots<Omit<ComboboxSlots<O, G>, 'default'>>()
 
 defineOptions({ inheritAttrs: false })
 
 /** A unique ID for the combobox */
 const id = `scalar-combobox-items-${useId()}`
+/** A unique ID for the "Add a new option" option */
+const addId = `${useId()}-add`
+
+/** A static option entry for the "Add a new option" option */
+const addOption: Option = { id: addId, label: 'Add a new option' }
 
 /** Generate a unique ID for an option */
 function getOptionId(option: Option) {
@@ -86,9 +94,10 @@ onMounted(async () => {
 // Set the top option as active when searching
 watch(
   () => query.value,
-  () => (active.value = filtered.value[0]),
+  () => (active.value = withAdd.value[0]),
 )
 
+/** The filtered list of options */
 const filtered = computed<O[]>(() =>
   query.value === ''
     ? options.value
@@ -97,8 +106,18 @@ const filtered = computed<O[]>(() =>
       }),
 )
 
+/** The list of filtered options with the "Add a new option" option */
+const withAdd = computed<Option[]>(() =>
+  slots.add ? [...filtered.value, addOption] : filtered.value,
+)
+
 function toggleSelected(option: Option | undefined) {
   if (!option) {
+    return
+  }
+
+  if (option.id === addId) {
+    addNew()
     return
   }
 
@@ -121,13 +140,14 @@ function toggleSelected(option: Option | undefined) {
 }
 
 function moveActive(dir: 1 | -1) {
-  const list = filtered.value
+  const list = withAdd.value
 
   // Find active index
   const activeIdx = list.findIndex((option) => option.id === active.value?.id)
 
   // Calculate next index and exit if it's out of bounds
   const nextIdx = activeIdx + dir
+
   if (nextIdx < 0 || nextIdx > list.length - 1) {
     return
   }
@@ -145,6 +165,11 @@ function moveActive(dir: 1 | -1) {
   })
 }
 
+function addNew() {
+  emit('add')
+  query.value = ''
+}
+
 // Manual autofocus for the input
 const input = ref<HTMLInputElement | null>(null)
 
@@ -154,7 +179,7 @@ onMounted(() => setTimeout(() => input.value?.focus(), 0))
 <template>
   <div class="relative flex">
     <ScalarIconMagnifyingGlass
-      class="pointer-events-none absolute left-2.5 search-icon text-c-3 size-4" />
+      class="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-c-3 size-4" />
     <input
       v-model="query"
       ref="input"
@@ -172,7 +197,7 @@ onMounted(() => setTimeout(() => input.value?.focus(), 0))
       @keydown.up.prevent="moveActive(-1)" />
   </div>
   <ul
-    v-show="filtered.length || $slots.before || $slots.after"
+    v-show="filtered.length || $slots.before || $slots.after || $slots.add"
     :id="id"
     :aria-multiselectable="multiselect"
     class="border-t p-0.75 custom-scroll overscroll-contain flex-1 min-h-0"
@@ -227,12 +252,19 @@ onMounted(() => setTimeout(() => input.value?.focus(), 0))
         </ComboboxOption>
       </template>
     </ComboboxOptionGroup>
+    <ComboboxOption
+      v-if="slots.add"
+      :id="addId"
+      :active="active?.id === addId"
+      @click="addNew"
+      @mousedown.prevent
+      @mouseenter="active = addOption"
+      v-slot="{ active }">
+      <ScalarIconPlus class="size-4 p-px" />
+      <slot
+        name="add"
+        :active />
+    </ComboboxOption>
     <slot name="after" />
   </ul>
 </template>
-<style scoped>
-.search-icon {
-  top: 50%;
-  transform: translateY(-50%);
-}
-</style>

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -197,13 +197,12 @@ onMounted(() => setTimeout(() => input.value?.focus(), 0))
       @keydown.up.prevent="moveActive(-1)" />
   </div>
   <ul
-    v-show="filtered.length || $slots.before || $slots.after || $slots.add"
+    v-show="filtered.length || slots.add"
     :id="id"
     :aria-multiselectable="multiselect"
     class="border-t p-0.75 custom-scroll overscroll-contain flex-1 min-h-0"
     role="listbox"
     tabindex="-1">
-    <slot name="before" />
     <ComboboxOptionGroup
       v-for="(group, i) in groups"
       :id="`${id}-group-${i}`"
@@ -265,6 +264,5 @@ onMounted(() => setTimeout(() => input.value?.focus(), 0))
         name="add"
         :active />
     </ComboboxOption>
-    <slot name="after" />
   </ul>
 </template>

--- a/packages/components/src/components/ScalarCombobox/types.ts
+++ b/packages/components/src/components/ScalarCombobox/types.ts
@@ -39,8 +39,4 @@ export type ComboboxSlots<O extends Option = Option, G extends OptionGroup<O> = 
   group?(props: { group: G }): unknown
   /** Creates an "Add a new option" button after the options list*/
   add?(props: { active: boolean }): unknown
-  /** A slot for contents before the combobox options */
-  before?(): unknown
-  /** A slot for contents after the combobox options */
-  after?(): unknown
 }

--- a/packages/components/src/components/ScalarCombobox/types.ts
+++ b/packages/components/src/components/ScalarCombobox/types.ts
@@ -23,6 +23,12 @@ export function isGroups(options: Option[] | OptionGroup[]): options is OptionGr
   return isGroup(options[0])
 }
 
+/** Available events emitted by the combobox */
+export type ComboboxEmits = {
+  /** Emitted when the "Add a new option" button is clicked */
+  add: []
+}
+
 /** Available slots for the combobox */
 export type ComboboxSlots<O extends Option = Option, G extends OptionGroup<O> = OptionGroup<O>> = {
   /** The reference element / trigger for the combobox */
@@ -31,6 +37,8 @@ export type ComboboxSlots<O extends Option = Option, G extends OptionGroup<O> = 
   option?(props: { option: O; active: boolean; selected: boolean }): unknown
   /** A template to override the group label */
   group?(props: { group: G }): unknown
+  /** Creates an "Add a new option" button after the options list*/
+  add?(props: { active: boolean }): unknown
   /** A slot for contents before the combobox options */
   before?(): unknown
   /** A slot for contents after the combobox options */


### PR DESCRIPTION
Previously we were using the `after` slot in a bunch of places to have an "Add new option" (in fact this is all the `before` and `after` slots were being used for). The problem was buttons added into those slots weren't handled as part of the options list and weren't accessible by keyboard as part of the options list (tl;dr; the UX wasn't very good).

This PR:

* Deprecates (removes) the `before` and `after` slots
* Adds and `add` slot which when filled adds an "Add new option" entry at the bottom of the list
* The "Add new option" entry is
  * Always shown regardless of search query
  * Accessible by keyboard like a normal entry
  * Automatically focused if there aren't any other matching filter results
* Adds and updates the tests 

https://github.com/user-attachments/assets/83692d67-233c-4c9c-9660-b5fdf0ceacf3

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
