### PR TITLE
feat(api-reference): export workspace store hooks

### DIFF
--- a/.changeset/great-wombats-fail.md
+++ b/.changeset/great-wombats-fail.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat(api-reference): export workspace store hooks

--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -9,6 +9,9 @@ export { createApiReference } from '@/standalone/lib/html-api'
 
 export { useSidebar, Sidebar } from '@/features/sidebar'
 
+// TODO: Remove this export. Needed during store migration
+export { useWorkspaceStoreEvents } from '@/v2/hooks/use-workspace-store-events'
+
 // TODO: Ideally, we'd remove those exports or at least not export them through the root index.
 export { createEmptySpecification } from '@/libs/openapi'
 export { useNavState } from '@/hooks/useNavState'


### PR DESCRIPTION
**Changes**

Need these workspace store hooks over in org separately for now as we have custom reference layouts. 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.
<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->