### PR TITLE
chore(renovate): remove labels and disable aspire playground node updates 

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,10 +44,6 @@
 
     // Packages
     {
-      "matchFileNames": ["packages/**"],
-      "labels": ["package"]
-    },
-    {
       "matchFileNames": ["packages/api-client/**"],
       "additionalBranchPrefix": "api-client"
     },
@@ -198,10 +194,6 @@
 
     // Integrations
     {
-      "matchFileNames": ["integrations/**"],
-      "labels": ["integration"]
-    },
-    {
       "matchFileNames": ["integrations/aspire/**"],
       "additionalBranchPrefix": "aspire"
     },
@@ -328,6 +320,13 @@
       "matchFileNames": ["**/Scalar.Aspire.csproj"],
       "matchPackageNames": ["Aspire.Hosting"],
       "matchUpdateTypes": ["patch"],
+      "enabled": false
+    },
+
+    // Disable node updates for Aspire playground image
+    {
+      "matchFileNames": ["**/aspire/playground/**"],
+      "matchDatasources": ["docker"],
       "enabled": false
     },
 


### PR DESCRIPTION
This PR removes the `integration` and `package` labels. I also disabled updates for the node Dockerfiles inside the Aspire playground.


**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
