### PR TITLE
feat(api-reference): show `operationId`

### DIFF
--- a/.changeset/big-cobras-punch.md
+++ b/.changeset/big-cobras-punch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: show operationId

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -534,7 +534,9 @@ Whether to show the dark mode toggle.
 }
 ```
 
-### showOperationId?: boolean
+### showOperationId
+
+**Type:** `boolean`
 
 Every operation can have a `operationId`, a unique string used to identify the operation, but it's optional.
 

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -534,6 +534,20 @@ Whether to show the dark mode toggle.
 }
 ```
 
+### showOperationId?: boolean
+
+Every operation can have a `operationId`, a unique string used to identify the operation, but it's optional.
+
+By default we don't render it in the UI. If it's helpful to show it to your users, enable it like this:
+
+`@default false`
+
+```js
+{
+  showOperationId: true
+}
+```
+
 #### hideModels
 
 **Type:** `boolean`

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -119,7 +119,7 @@ const { copyToClipboard } = useClipboard()
         :method="method"
         :path="path" />
       <span
-        v-if="operation.operationId"
+        v-if="config.showOperationId && operation.operationId"
         class="font-code text-sm">
         {{ operation.operationId }}
       </span>
@@ -188,10 +188,10 @@ const { copyToClipboard } = useClipboard()
             class="operation-example-card"
             :clientOptions="clientOptions"
             fallback
+            :isWebhook="isWebhook"
             :method="method"
             :operation="operation"
             :path="path"
-            :isWebhook="isWebhook"
             :securitySchemes="securitySchemes"
             :selectedClient="store.workspace['x-scalar-default-client']"
             :selectedServer="server" />

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -114,18 +114,20 @@ const { copyToClipboard } = useClipboard()
       <XBadges
         :badges="operation['x-badges']"
         position="after" />
-      <TestRequestButton
-        v-if="active && !isWebhook"
-        :method="method"
-        :path="path" />
+      <template v-if="!config?.hideTestRequestButton">
+        <TestRequestButton
+          v-if="active && !isWebhook"
+          :method="method"
+          :path="path" />
+        <ScalarIconPlay
+          v-else
+          class="endpoint-try-hint size-4.5" />
+      </template>
       <span
         v-if="config.showOperationId && operation.operationId"
         class="font-code text-sm">
         {{ operation.operationId }}
       </span>
-      <ScalarIconPlay
-        v-else-if="!config?.hideTestRequestButton"
-        class="endpoint-try-hint size-4.5" />
       <ScalarIconButton
         class="endpoint-copy p-0.5"
         :icon="ScalarIconCopy"

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -118,6 +118,11 @@ const { copyToClipboard } = useClipboard()
         v-if="active && !isWebhook"
         :method="method"
         :path="path" />
+      <span
+        v-if="operation.operationId"
+        class="font-code text-sm">
+        {{ operation.operationId }}
+      </span>
       <ScalarIconPlay
         v-else-if="!config?.hideTestRequestButton"
         class="endpoint-try-hint size-4.5" />

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -69,6 +69,10 @@ const labelId = useId()
       <div class="flex flex-row justify-between gap-1">
         <!-- Left -->
         <div class="flex gap-1">
+          <!-- Operation ID -->
+          <Badge v-if="operation.operationId">
+            {{ operation.operationId }}
+          </Badge>
           <!-- Stability badge -->
           <Badge
             v-if="getOperationStability(operation)"

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -70,7 +70,7 @@ const labelId = useId()
         <!-- Left -->
         <div class="flex gap-1">
           <!-- Operation ID -->
-          <Badge v-if="operation.operationId">
+          <Badge v-if="config.showOperationId && operation.operationId">
             {{ operation.operationId }}
           </Badge>
           <!-- Stability badge -->
@@ -154,10 +154,10 @@ const labelId = useId()
               <RequestExample
                 :clientOptions="clientOptions"
                 fallback
+                :isWebhook="isWebhook"
                 :method="method"
                 :operation="operation"
                 :path="path"
-                :isWebhook="isWebhook"
                 :securitySchemes="securitySchemes"
                 :selectedClient="store.workspace['x-scalar-default-client']"
                 :selectedServer="server">

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -301,6 +301,12 @@ const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
      * @default false
      */
     hideSearch: z.boolean().optional().default(false).catch(false),
+    /**
+     * Whether to show the operationId
+     *
+     * @default false
+     */
+    showOperationId: z.boolean().optional().default(false).catch(false),
     /** Whether dark mode is on or off initially (light mode) */
     darkMode: z.boolean().optional(),
     /** forceDarkModeState makes it always this state no matter what */


### PR DESCRIPTION
**Problem**

Currently, the `operationId` doesn’t appear anywhere.

**Solution**

This PR adds `showOperationId` (`@default false`) to the configuration. If enabled, it shows the `operationId` in the classic and the modern layout.

Fixes #1274

**Classic Layout**

on the right side:

<img width="943" height="794" alt="Screenshot 2025-09-01 at 14 32 19" src="https://github.com/user-attachments/assets/77f32e2b-1a3e-42ff-8b0e-52f8034e8f08" />

**Modern Layout**

adds another badge:

<img width="697" height="459" alt="Screenshot 2025-09-01 at 14 33 56" src="https://github.com/user-attachments/assets/d0d812b7-da41-4dae-bfb0-1ea7cf2ca68f" />

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `showOperationId` config (default false) to optionally display `operationId` in modern and classic layouts, with tests and docs updates.
> 
> - **UI (api-reference)**:
>   - `ModernLayout`: show `operation.operationId` as a badge when `config.showOperationId` is true.
>   - `ClassicLayout`: render `operationId` next to actions when enabled; streamline Test Request button visibility logic (behavior unchanged).
> - **Configuration**:
>   - Add `showOperationId: boolean` (default `false`) to `apiReferenceConfigurationSchema`.
>   - Document `showOperationId` in `documentation/configuration.md`.
> - **Tests**:
>   - Add tests verifying `operationId` visibility in both layouts and default-hidden behavior.
> - **Changeset**:
>   - Patch release for `@scalar/api-reference`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 136d3da6ad747bd24b6f0152283ac91ce8c3c9b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->