### PR TITLE
feat(galaxy): circular reference planet ↔ satellite

### DIFF
--- a/.changeset/nice-mangos-cheat.md
+++ b/.changeset/nice-mangos-cheat.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+feat: circular reference between planet ↔ satellite

--- a/packages/galaxy/src/documents/3.1.yaml
+++ b/packages/galaxy/src/documents/3.1.yaml
@@ -1044,12 +1044,8 @@ components:
         orbit:
           type: object
           properties:
-            planetId:
-              type: integer
-              format: int64
-              description: The ID of the planet this satellite orbits
-              examples:
-                - 1
+            planet:
+              $ref: '#/components/schemas/Planet'
             orbitalPeriod:
               type: number
               format: float


### PR DESCRIPTION
**Problem**

Our wonderful `@scalar/galaxy` example doesn’t have a circular reference yet. 🫨 

**Solution**

This PR adds one between planets and their satellites.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
