### PR TITLE
docs: group integrations by language

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -266,102 +266,55 @@
                   "type": "page"
                 },
                 {
-                  "name": ".NET Aspire",
-                  "slug": "aspire",
-                  "path": "documentation/integrations/aspire.md",
-                  "type": "page"
-                },
-                {
-                  "name": ".NET ASP.NET Core",
-                  "type": "folder",
-                  "defaultOpen": false,
-                  "children": [
-                    {
-                      "name": "Integration",
-                      "path": "documentation/integrations/aspnetcore/integration.md",
-                      "type": "page"
-                    },
-                    {
-                      "name": "Build-Time Generation",
-                      "path": "documentation/integrations/aspnetcore/build-time-generation.md",
-                      "type": "page"
-                    },
-                    {
-                      "name": "OpenAPI Extensions",
-                      "path": "documentation/integrations/aspnetcore/openapi-extensions.md",
-                      "type": "page"
-                    },
-                    {
-                      "name": "Legacy Integration",
-                      "path": "documentation/integrations/aspnetcore/legacy-integration.md",
-                      "type": "page"
-                    }
-                  ]
-                },
-                {
-                  "name": "AdonisJS",
-                  "slug": "adonisjs",
-                  "path": "documentation/integrations/adonisjs.md",
-                  "type": "page"
-                },
-                {
-                  "name": "Django",
-                  "slug": "django",
-                  "path": "documentation/integrations/django.md",
-                  "type": "page"
-                },
-                {
-                  "name": "Django Ninja",
-                  "slug": "django-ninja",
-                  "path": "documentation/integrations/django-ninja.md",
-                  "type": "page"
-                },
-                {
                   "name": "Docker",
                   "slug": "docker",
                   "path": "documentation/integrations/docker.md",
                   "type": "page"
                 },
                 {
-                  "name": "Docusaurus",
-                  "slug": "docusaurus",
-                  "path": "documentation/integrations/docusaurus.md",
-                  "type": "page"
+                  "name": ".NET",
+                  "type": "folder",
+                  "defaultOpen": false,
+                  "children": [
+                    {
+                      "name": "ASP.NET Core",
+                      "type": "folder",
+                      "defaultOpen": false,
+                      "children": [
+                        {
+                          "name": "Integration",
+                          "path": "documentation/integrations/aspnetcore/integration.md",
+                          "type": "page"
+                        },
+                        {
+                          "name": "Build-Time Generation",
+                          "path": "documentation/integrations/aspnetcore/build-time-generation.md",
+                          "type": "page"
+                        },
+                        {
+                          "name": "OpenAPI Extensions",
+                          "path": "documentation/integrations/aspnetcore/openapi-extensions.md",
+                          "type": "page"
+                        },
+                        {
+                          "name": "Legacy Integration",
+                          "path": "documentation/integrations/aspnetcore/legacy-integration.md",
+                          "type": "page"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Aspire",
+                      "slug": "aspire",
+                      "path": "documentation/integrations/aspire.md",
+                      "type": "page"
+                    }
+                  ]
                 },
                 {
                   "name": "Elixir",
                   "slug": "elixir",
                   "path": "documentation/integrations/elixir.md",
-                  "type": "page"
-                },
-                {
-                  "name": "ElysiaJS",
-                  "slug": "elysiajs",
-                  "path": "documentation/integrations/elysiajs.md",
-                  "type": "page"
-                },
-                {
-                  "name": "Express",
-                  "slug": "express",
-                  "path": "documentation/integrations/express.md",
-                  "type": "page"
-                },
-                {
-                  "name": "FastAPI",
-                  "slug": "fastapi",
-                  "path": "documentation/integrations/fastapi.md",
-                  "type": "page"
-                },
-                {
-                  "name": "Fastify",
-                  "slug": "fastify",
-                  "path": "documentation/integrations/fastify.md",
-                  "type": "page"
-                },
-                {
-                  "name": "Flask",
-                  "slug": "flask",
-                  "path": "documentation/integrations/flask.md",
                   "type": "page"
                 },
                 {
@@ -371,111 +324,207 @@
                   "type": "page"
                 },
                 {
-                  "name": "Hapi",
-                  "slug": "hapi",
-                  "path": "documentation/integrations/hapi.md",
-                  "type": "page"
+                  "name": "JavaScript/TypeScript",
+                  "type": "folder",
+                  "defaultOpen": false,
+                  "children": [
+                    {
+                      "name": "Docusaurus",
+                      "slug": "docusaurus",
+                      "path": "documentation/integrations/docusaurus.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Next.js",
+                      "slug": "nextjs",
+                      "path": "documentation/integrations/nextjs.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Nuxt",
+                      "slug": "nuxt",
+                      "path": "documentation/integrations/nuxt.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "React",
+                      "slug": "react",
+                      "path": "documentation/integrations/react.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "SvelteKit",
+                      "slug": "sveltekit",
+                      "path": "documentation/integrations/sveltekit.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Vue.js",
+                      "slug": "vue",
+                      "path": "documentation/integrations/vue.md",
+                      "type": "page"
+                    }
+                  ]
                 },
                 {
-                  "name": "Hono",
-                  "slug": "hono",
-                  "path": "documentation/integrations/hono.md",
-                  "type": "page"
+                  "name": "Java",
+                  "type": "folder",
+                  "defaultOpen": false,
+                  "children": [
+                    {
+                      "name": "Micronaut",
+                      "slug": "micronaut",
+                      "path": "documentation/integrations/micronaut.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Spring Boot",
+                      "slug": "spring-boot",
+                      "path": "documentation/integrations/spring-boot.md",
+                      "type": "page"
+                    }
+                  ]
                 },
                 {
-                  "name": "Laravel",
-                  "slug": "laravel",
-                  "path": "documentation/integrations/laravel.md",
-                  "type": "page"
+                  "name": "Node.js/TypeScript",
+                  "type": "folder",
+                  "defaultOpen": false,
+                  "children": [
+                    {
+                      "name": "AdonisJS",
+                      "slug": "adonisjs",
+                      "path": "documentation/integrations/adonisjs.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "ElysiaJS",
+                      "slug": "elysiajs",
+                      "path": "documentation/integrations/elysiajs.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Express",
+                      "slug": "express",
+                      "path": "documentation/integrations/express.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Fastify",
+                      "slug": "fastify",
+                      "path": "documentation/integrations/fastify.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Hapi",
+                      "slug": "hapi",
+                      "path": "documentation/integrations/hapi.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Hono",
+                      "slug": "hono",
+                      "path": "documentation/integrations/hono.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "NestJS",
+                      "slug": "nestjs",
+                      "path": "documentation/integrations/nestjs.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Nitro",
+                      "slug": "nitro",
+                      "path": "documentation/integrations/nitro.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Platformatic",
+                      "slug": "platformatic",
+                      "path": "documentation/integrations/platformatic.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Ts.ED",
+                      "slug": "tsed",
+                      "path": "documentation/integrations/tsed.md",
+                      "type": "page"
+                    }
+                  ]
                 },
                 {
-                  "name": "Laravel Scribe",
-                  "slug": "laravel-scribe",
-                  "path": "documentation/integrations/laravel-scribe.md",
-                  "type": "page"
-                },
-                {
-                  "name": "Micronaut",
-                  "slug": "micronaut",
-                  "path": "documentation/integrations/micronaut.md",
-                  "type": "page"
-                },
-                {
-                  "name": "Next.js",
-                  "slug": "nextjs",
-                  "path": "documentation/integrations/nextjs.md",
-                  "type": "page"
-                },
-                {
-                  "name": "NestJS",
-                  "slug": "nestjs",
-                  "path": "documentation/integrations/nestjs.md",
-                  "type": "page"
-                },
-                {
-                  "name": "Nitro",
-                  "slug": "nitro",
-                  "path": "documentation/integrations/nitro.md",
-                  "type": "page"
-                },
-                {
-                  "name": "Nuxt",
-                  "slug": "nuxt",
-                  "path": "documentation/integrations/nuxt.md",
-                  "type": "page"
-                },
-                {
-                  "name": "Platformatic",
-                  "slug": "platformatic",
-                  "path": "documentation/integrations/platformatic.md",
-                  "type": "page"
+                  "name": "PHP",
+                  "type": "folder",
+                  "defaultOpen": false,
+                  "children": [
+                    {
+                      "name": "Laravel",
+                      "slug": "laravel",
+                      "path": "documentation/integrations/laravel.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Laravel Scribe",
+                      "slug": "laravel-scribe",
+                      "path": "documentation/integrations/laravel-scribe.md",
+                      "type": "page"
+                    }
+                  ]
                 },
                 {
                   "name": "Python",
-                  "slug": "python",
-                  "path": "documentation/integrations/python.md",
-                  "type": "page"
+                  "type": "folder",
+                  "defaultOpen": false,
+                  "children": [
+                    {
+                      "name": "Python",
+                      "slug": "python",
+                      "path": "documentation/integrations/python.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Django",
+                      "slug": "django",
+                      "path": "documentation/integrations/django.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Django Ninja",
+                      "slug": "django-ninja",
+                      "path": "documentation/integrations/django-ninja.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "FastAPI",
+                      "slug": "fastapi",
+                      "path": "documentation/integrations/fastapi.md",
+                      "type": "page"
+                    },
+                    {
+                      "name": "Flask",
+                      "slug": "flask",
+                      "path": "documentation/integrations/flask.md",
+                      "type": "page"
+                    }
+                  ]
                 },
                 {
-                  "name": "React",
-                  "slug": "react",
-                  "path": "documentation/integrations/react.md",
-                  "type": "page"
-                },
-                {
-                  "name": "Ruby on Rails",
-                  "slug": "ruby-on-rails",
-                  "path": "documentation/integrations/ruby-on-rails.md",
-                  "type": "page"
+                  "name": "Ruby",
+                  "type": "folder",
+                  "defaultOpen": false,
+                  "children": [
+                    {
+                      "name": "Ruby on Rails",
+                      "slug": "ruby-on-rails",
+                      "path": "documentation/integrations/ruby-on-rails.md",
+                      "type": "page"
+                    }
+                  ]
                 },
                 {
                   "name": "Rust",
                   "slug": "rust",
                   "path": "documentation/integrations/rust.md",
-                  "type": "page"
-                },
-                {
-                  "name": "Spring Boot",
-                  "slug": "spring-boot",
-                  "path": "documentation/integrations/spring-boot.md",
-                  "type": "page"
-                },
-                {
-                  "name": "SvelteKit",
-                  "slug": "sveltekit",
-                  "path": "documentation/integrations/sveltekit.md",
-                  "type": "page"
-                },
-                {
-                  "name": "Ts.ED",
-                  "slug": "tsed",
-                  "path": "documentation/integrations/tsed.md",
-                  "type": "page"
-                },
-                {
-                  "name": "Vue.js",
-                  "slug": "vue",
-                  "path": "documentation/integrations/vue.md",
                   "type": "page"
                 }
               ]
@@ -507,12 +556,12 @@
     {
       "type": "version-selector"
     },
-    { 
+    {
       "title": "Log in",
       "type": "link",
       "link": "https://dashboard.scalar.com/login"
     },
-    { 
+    {
       "title": "Register",
       "type": "link",
       "isButton": true,


### PR DESCRIPTION
Not sure whether I prefer it, but - as discussed - this PR groups the integrations by language:

<img width="308" height="656" alt="Screenshot 2025-09-02 at 14 37 35" src="https://github.com/user-attachments/assets/399bcec9-d0ca-4551-9499-b3caf05b25d7" />
