### PR TITLE
docs: callouts don’t render

### DIFF
--- a/documentation/integrations/react.md
+++ b/documentation/integrations/react.md
@@ -12,7 +12,7 @@ npm install @scalar/api-reference-react
 
 The API Reference package is written in Vue. That shouldn't stop you from using it in React, though. We have created a client side wrapper in React:
 
-> [!WARNING]\
+> [!WARNING]
 > This is untested on SSR/SSG!
 
 ```ts

--- a/documentation/themes.md
+++ b/documentation/themes.md
@@ -8,7 +8,7 @@ You don't like the color scheme? We've prepared some themes for you:
 <ApiReference :configuration="{ theme: 'moon' }" />
 ```
 
-> [!NOTE]\
+> [!NOTE]
 > The `default` theme is … the default theme.
 > If you want to make sure **no** theme is applied, pass `none`.
 
@@ -37,7 +37,7 @@ To get started, overwrite our CSS variables. We won't judge.
 </style>
 ```
 
-> [!NOTE]\
+> [!NOTE]
 > By default, we're using Inter and JetBrains Mono, served by our in-house CDN.
 
 If you want use a different font or want to use Google Fonts, pass `withDefaultFonts: false` to the configuration and overwrite the `--scalar-font` and `--scalar-font-code` CSS variables. You will also need to provide the source of your new font which can be local or served over the network.


### PR DESCRIPTION
Oh we have those additional slashes in the callout, those don’t work in the deployed version. 🤔 

Let’s remove them, this should fix the callouts.

<img width="634" height="133" alt="Screenshot 2025-09-02 at 16 00 47" src="https://github.com/user-attachments/assets/0cc8800f-0ce2-47f3-a6f8-0cf4ac2d9df8" />

<img width="1610" height="372" alt="image" src="https://github.com/user-attachments/assets/6c5b28cc-324e-4eec-963e-211565e3901e" />
