### PR TITLE
feat(agent): Add `agent` slot and button to `ApiReferenceLayout`

### DIFF
--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -39,6 +39,7 @@ import { Content } from '@/components/Content'
 import GettingStarted from '@/components/GettingStarted.vue'
 import { hasLazyLoaded } from '@/components/Lazy/lazyBus'
 import MobileHeader from '@/components/MobileHeader.vue'
+import AgentButton from '@/features/agent/AgentButton.vue'
 import { ApiClientModal } from '@/features/api-client-modal'
 import { useDocumentSource } from '@/features/document-source'
 import { SearchButton } from '@/features/Search'
@@ -66,6 +67,7 @@ defineEmits<{
   (e: 'loadSwaggerFile'): void
   (e: 'linkSwaggerFile'): void
   (e: 'toggleDarkMode'): void
+  (e: 'showAgent'): void
 }>()
 
 const configuration = computed(() =>
@@ -312,6 +314,10 @@ useLegacyStoreEvents(store, workspaceStore, activeEntitiesStore, documentEl)
     :style="{
       '--scalar-y-offset': `var(--scalar-custom-header-height, ${yPosition}px)`,
     }">
+    <!-- Agent -->
+    <slot
+      breadcrumb="agent"
+      name="agent" />
     <!-- Header -->
     <div class="references-header">
       <MobileHeader
@@ -358,6 +364,9 @@ useLegacyStoreEvents(store, workspaceStore, activeEntitiesStore, documentEl)
                 v-bind="referenceSlotProps"
                 name="sidebar-end">
                 <ScalarSidebarFooter class="darklight-reference">
+                  <AgentButton
+                    v-if="$slots.agent"
+                    @click="$emit('showAgent')" />
                   <OpenApiClientButton
                     v-if="!configuration.hideClientButton"
                     buttonSource="sidebar"

--- a/packages/api-reference/src/features/agent/AgentButton.vue
+++ b/packages/api-reference/src/features/agent/AgentButton.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { ScalarButton } from '@scalar/components'
+import { ScalarIconChat } from '@scalar/icons'
+
+const emit = defineEmits<{
+  (e: 'click'): void
+}>()
+
+function handleClick() {
+  emit('click')
+}
+</script>
+
+<template>
+  <ScalarButton @click="handleClick">
+    <template #icon><ScalarIconChat class="size-full" /></template>
+    Open Agent
+  </ScalarButton>
+</template>

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -72,6 +72,7 @@ export type ReferenceLayoutSlot =
   | 'content-end'
   | 'sidebar-start'
   | 'sidebar-end'
+  | 'agent'
 
 export type ReferenceLayoutSlots = {
   [x in ReferenceLayoutSlot]: (props: ReferenceSlotProps) => any


### PR DESCRIPTION
**Problem**

Currently, there is no slot for agent in `ApiReferenceLayout`

**Solution**

With this PR a new agent button will render if some content has been provided to the agent slot.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
