### PR TITLE
chore(agent): Change `WORKSPACE_SYMBOL` to string for portability

### DIFF
--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -14,7 +14,7 @@ import { useModal } from '@scalar/components'
 import type { RequestEvent, SecurityScheme } from '@scalar/oas-utils/entities/spec'
 import type { Path, PathValue } from '@scalar/object-utils/nested'
 import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
-import { type InjectionKey, inject, reactive, ref, toRaw } from 'vue'
+import { inject, reactive, ref, toRaw } from 'vue'
 
 export type UpdateScheme = <P extends Path<SecurityScheme>>(
   path: P,
@@ -233,7 +233,8 @@ export const createWorkspaceStore = ({
 }
 
 export type WorkspaceStore = ReturnType<typeof createWorkspaceStore>
-export const WORKSPACE_SYMBOL = Symbol() as InjectionKey<WorkspaceStore>
+/** Set as a string so that different instances of api-client can reference inject the same store */
+export const WORKSPACE_SYMBOL = 'WORKSPACE_SYMBOL' as const
 
 /**
  * Global hook which contains the store for the whole app
@@ -242,7 +243,7 @@ export const WORKSPACE_SYMBOL = Symbol() as InjectionKey<WorkspaceStore>
  * ex: add examples when adding a request
  */
 export const useWorkspace = (): WorkspaceStore => {
-  const store = inject(WORKSPACE_SYMBOL)
+  const store = inject<WorkspaceStore>(WORKSPACE_SYMBOL)
   if (!store) {
     throw new Error('Workspace store not provided')
   }


### PR DESCRIPTION
**Problem**

Currently,`WORKSPACE_SYMBOL` is a Symbol, this is causing a few issues when different instances of the symbol are instantiated.

**Solution**

With this PR `WORKSPACE_SYMBOL` is now a string.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
