### PR TITLE
feat(api-reference): Expose slots to ApiReference

### DIFF
--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -12,6 +12,14 @@ defineProps<{
   configuration?: AnyApiReferenceConfiguration
 }>()
 
+/** These slots render in their respective slots in the underlying ApiReferenceWorkspace component */
+defineSlots<{
+  footer?(): unknown
+  'content-end'?(): unknown
+  'sidebar-start'?(): unknown
+  'sidebar-end'?(): unknown
+}>()
+
 /**
  * Initializes the new client workspace store.
  *

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -27,6 +27,19 @@ if (typeof window !== 'undefined') {
 
 <template>
   <ApiReferenceWorkspace
-    :store="workspaceStore"
-    :configuration="configuration" />
+    :configuration="configuration"
+    :store="workspaceStore">
+    <template #footer>
+      <slot name="footer" />
+    </template>
+    <template #content-end>
+      <slot name="content-end" />
+    </template>
+    <template #sidebar-start>
+      <slot name="sidebar-start" />
+    </template>
+    <template #sidebar-end>
+      <slot name="sidebar-end" />
+    </template>
+  </ApiReferenceWorkspace>
 </template>

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
@@ -284,6 +284,9 @@ useFavicon(favicon)
       <template #sidebar-start>
         <slot name="sidebar-start" />
       </template>
+      <template #sidebar-end>
+        <slot name="sidebar-end" />
+      </template>
     </ApiReferenceLayout>
   </div>
 </template>


### PR DESCRIPTION
**Problem**

Currently, there are no slots exposed on the `ApiReference` component.

**Solution**

With this PR I'm exposing all the slots that are available in `<ApiReferenceWorkspace />`

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
