### PR TITLE
ci: replace pinned action job with repository setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,6 @@ env:
   NODE_OPTIONS: '--max_old_space_size=8192'
   TURBO_CACHE_DIR: '${{ github.ref_name }}/.turbo'
 jobs:
-  harden_security:
-    name: Check used GitHub Actions
-    runs-on: blacksmith-2vcpu-ubuntu-2204
-    timeout-minutes: 10
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - name: Ensure all Actions are pinned to a Commit SHA
-        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@fc87bb5b5a97953d987372e74478de634726b3e5
-
   # Initial build.
   # We only build the packages and integrations as everything else depends on them
   # turbo is cached to sticky disk and pnpm is cached in the standard actions cache
@@ -587,8 +577,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    needs:
-      [harden_security, build, format, types, test-packages, test-integrations]
+    needs: [build, format, types, test-packages, test-integrations]
     strategy:
       matrix:
         node-version: [22]
@@ -969,7 +958,6 @@ jobs:
       cancel-in-progress: false
     needs:
       [
-        harden_security,
         build,
         format,
         types,
@@ -1053,7 +1041,6 @@ jobs:
       cancel-in-progress: false
     needs:
       [
-        harden_security,
         build,
         format,
         types,
@@ -1192,7 +1179,6 @@ jobs:
       cancel-in-progress: false
     needs:
       [
-        harden_security,
         build,
         format,
         types,


### PR DESCRIPTION
**Problem**

We use an action to make sure we only use actions pinned to a commit (for security reasons).

**Solution**

[GitHub introduced that as a checkbox](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/), so we can just use that now.

<img width="440" height="110" alt="Screenshot 2025-09-04 at 12 26 36" src="https://github.com/user-attachments/assets/1b85c300-59f2-4355-a050-d8936f9258a2" />

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
