### PR TITLE
feat(api-reference): custom fetcher to load opeanpi documents

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -280,6 +280,18 @@ You can use our hosted proxy:
 
 If you like to run your own, check out our [example proxy written in Go](https://github.com/scalar/scalar/tree/main/projects/proxy-scalar-com).
 
+### fetch?: fetch(input: string | URL | globalThis.Request, init?: RequestInit): Promise<Response>
+
+Custom [fetch function](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to fetch documents with a custom logic. Can be used to add custom headers, handle auth, etc.
+
+```ts
+{
+  fetch: (input: string | URL | globalThis.Request, init?: RequestInit) => {
+    return window.fetch(input, init)
+  }
+}
+```
+
 ### plugins?: ApiReferencePlugin[]
 
 Pass an array of custom plugins that you want. [Read more about plugins here.](https://guides.scalar.com/scalar/scalar-api-references/plugins)

--- a/packages/api-client/src/views/Request/hooks/useOpenApiWatcher.ts
+++ b/packages/api-client/src/views/Request/hooks/useOpenApiWatcher.ts
@@ -89,7 +89,7 @@ export const useOpenApiWatcher = () => {
 
     try {
       // Grab the new spec
-      const spec = await fetchDocument(url, activeWorkspace.value?.proxyUrl, false)
+      const spec = await fetchDocument(url, activeWorkspace.value?.proxyUrl, undefined, false)
       const hash = createHash(spec)
 
       collectionMutators.edit(activeCollection.value.uid, 'watchModeStatus', 'WATCHING')

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.test.ts
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.test.ts
@@ -436,7 +436,7 @@ describe('ApiReferenceWorkspace', () => {
     })
   })
 
-  describe.only('custom fetch functionality', async () => {
+  describe('custom fetch functionality', async () => {
     it('use the provided fetch function to fetch the documents', async () => {
       const fn = vi.fn()
       wrapper = mount(ApiReferenceWorkspace, {

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.test.ts
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.test.ts
@@ -436,6 +436,39 @@ describe('ApiReferenceWorkspace', () => {
     })
   })
 
+  describe.only('custom fetch functionality', async () => {
+    it('use the provided fetch function to fetch the documents', async () => {
+      const fn = vi.fn()
+      wrapper = mount(ApiReferenceWorkspace, {
+        props: {
+          configuration: {
+            title: 'Test API',
+            url: 'https://example.com/api/spec.json',
+            fetch: async (...args) => {
+              fn(...args)
+              // Simple mock fetch function that returns a fixed response
+              return new Response(JSON.stringify({ openapi: '3.0.0', info: { title: 'Test API' }, paths: {} }), {
+                headers: { 'Content-Type': 'application/json' },
+                status: 200,
+              })
+            },
+          },
+          store: mockStore,
+        },
+      })
+
+      await flushPromises()
+
+      expect(wrapper.exists()).toBe(true)
+      expect(wrapper.findComponent({ name: 'ApiReferenceLayout' }).exists()).toBe(true)
+      expect(wrapper.text()).toContain('Test API')
+
+      // Expect the custom fetch function to have been called
+      expect(fn).toHaveBeenCalledOnce()
+      expect(fn).toHaveBeenCalledWith('https://example.com/api/spec.json', undefined)
+    })
+  })
+
   describe('slot rendering', () => {
     it('renders footer slot', () => {
       wrapper = mount(ApiReferenceWorkspace, {

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
@@ -85,6 +85,7 @@ const {
  */
 const proxy = (
   input: string | URL | globalThis.Request,
+  // eslint-disable-next-line no-undef
   init?: RequestInit,
 ) => {
   return fetch(
@@ -165,7 +166,7 @@ const addOrUpdateDocument = async (
       url: makeUrlAbsolute(config.url, {
         basePath: selectedConfiguration.value.pathRouting?.basePath,
       }),
-      fetch: proxy,
+      fetch: config.fetch ?? proxy,
       config: mapConfiguration(config),
     })
   }

--- a/packages/oas-utils/src/helpers/fetch-document.test.ts
+++ b/packages/oas-utils/src/helpers/fetch-document.test.ts
@@ -80,4 +80,19 @@ describe('fetchDocument', () => {
   it('throws error when fetch fails', async () => {
     await expect(fetchDocument('https://does-not-exist.scalar.com/spec.yaml')).rejects.toThrow('fetch failed')
   })
+
+  it('uses custom fetch implementation', async () => {
+    const fn = vi.fn()
+
+    const fetcher = async (...args: any) => {
+      fn(...args)
+      return new Response('custom-fetch', { status: 200 })
+    }
+
+    const spec = await fetchDocument('https://example.com/spec.yaml', undefined, fetcher)
+
+    expect(fn).toHaveBeenCalled()
+    expect(fn).toHaveBeenCalledWith('https://example.com/spec.yaml', undefined)
+    expect(spec).toEqual('custom-fetch')
+  })
 })

--- a/packages/oas-utils/src/helpers/fetch-document.ts
+++ b/packages/oas-utils/src/helpers/fetch-document.ts
@@ -11,14 +11,19 @@ const NEW_PROXY_URL = 'https://proxy.scalar.com'
  *
  * @throws an error if the fetch fails
  */
-export async function fetchDocument(url: string, proxyUrl?: string, prettyPrint = true): Promise<string> {
+export async function fetchDocument(
+  url: string,
+  proxyUrl?: string,
+  fetcher?: (input: string | URL | globalThis.Request, init?: RequestInit) => Promise<Response>,
+  prettyPrint = true,
+): Promise<string> {
   // This replaces the OLD_PROXY_URL with the NEW_PROXY_URL on the fly.
   if (proxyUrl === OLD_PROXY_URL) {
     // biome-ignore lint/style/noParameterAssign: It's ok, let's make an exception here.
     proxyUrl = NEW_PROXY_URL
   }
 
-  const response = await fetch(redirectToProxy(proxyUrl, url))
+  const response = await (fetcher ? fetcher(url, undefined) : fetch(redirectToProxy(proxyUrl, url)))
 
   // Looks like the request failed
   if (response.status !== 200) {

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -229,6 +229,12 @@ export const apiClientConfigurationSchema = z.object({
 
 export type ApiClientConfiguration = z.infer<typeof apiClientConfigurationSchema>
 
+export const FetchLike = z
+  .function()
+  .args(z.union([z.string(), z.instanceof(URL), z.instanceof(Request)]), z.any().optional())
+  .returns(z.promise(z.instanceof(Response)))
+  .optional()
+
 /** Configuration for the Api Client without the transform since it cannot be merged */
 const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
   z.object({
@@ -242,6 +248,12 @@ const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
      * @deprecated Use proxyUrl instead
      */
     proxy: z.string().optional(),
+    /**
+     * Custom fetch function for custom logic
+     *
+     * Can be used to add custom headers, handle auth, etc.
+     */
+    fetch: FetchLike,
     /**
      * Plugins for the API reference
      */


### PR DESCRIPTION
**Problem**

When the API document is behind an authentication wall, it can only be loaded if it’s prefetched. Additionally, there’s currently no way to use a custom proxy implementation, which limits flexibility for different environments and authentication flows.

**Solution**

This PR introduces support for providing a custom fetcher function. When supplied, this function will be used to fetch the API document with user-defined logic (e.g., handling auth or proxies). This makes the integration more flexible and adaptable to different setups.

Closes #2824

📝 **Notes**

In a future major release, once we fully migrate to the new store and configuration shape, we can discuss about supporting passing custom headers directly. This will provide an even simpler and more configurable way to handle authenticated documents.


**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
