### PR TITLE
chore(pnpm): use catalog in more places

### DIFF
--- a/integrations/aspire/package.json
+++ b/integrations/aspire/package.json
@@ -27,7 +27,6 @@
     "@scalar/api-reference": "workspace:*"
   },
   "devDependencies": {
-    "@scalar/build-tooling": "workspace:*",
-    "shx": "^0.4.0"
+    "@scalar/build-tooling": "workspace:*"
   }
 }

--- a/integrations/aspnetcore/package.json
+++ b/integrations/aspnetcore/package.json
@@ -27,7 +27,6 @@
     "@scalar/api-reference": "workspace:*"
   },
   "devDependencies": {
-    "@scalar/build-tooling": "workspace:*",
-    "shx": "^0.4.0"
+    "@scalar/build-tooling": "workspace:*"
   }
 }

--- a/integrations/docker/package.json
+++ b/integrations/docker/package.json
@@ -27,7 +27,6 @@
     "@scalar/api-reference": "workspace:*"
   },
   "devDependencies": {
-    "@scalar/build-tooling": "workspace:*",
-    "shx": "^0.4.0"
+    "@scalar/build-tooling": "workspace:*"
   }
 }

--- a/integrations/docusaurus/package.json
+++ b/integrations/docusaurus/package.json
@@ -48,8 +48,7 @@
     "postcss": "catalog:*",
     "postcss-cli": "^11.0.0",
     "postcss-nesting": "^12.1.5",
-    "react": "catalog:*",
-    "shx": "^0.4.0"
+    "react": "catalog:*"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0"

--- a/integrations/fastify/package.json
+++ b/integrations/fastify/package.json
@@ -66,7 +66,6 @@
     "@scalar/build-tooling": "workspace:*",
     "fastify": "^4.26.2",
     "rollup-plugin-node-externals": "^7.1.2",
-    "shx": "^0.4.0",
     "terser": "^5.30.0",
     "vite": "catalog:*",
     "vite-plugin-static-copy": "^2.3.2",

--- a/integrations/java/webjar/package.json
+++ b/integrations/java/webjar/package.json
@@ -26,7 +26,6 @@
     "@scalar/api-reference": "workspace:*"
   },
   "devDependencies": {
-    "@scalar/build-tooling": "workspace:*",
-    "shx": "^0.4.0"
+    "@scalar/build-tooling": "workspace:*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "remark-lint-no-dead-urls": "^1.1.0",
     "remark-validate-links": "^13.0.2",
     "rollup": "catalog:*",
-    "shx": "^0.4.0",
+    "shx": "catalog:*",
     "start-server-and-test": "^2.0.9",
     "syncpack": "^12.4.0",
     "tailwindcss": "catalog:*",
@@ -38,7 +38,7 @@
     "turbo": "^2.4.4",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.15.0",
-    "vite-node": "^2.1.1",
+    "vite-node": "catalog:*",
     "vitest": "catalog:*",
     "vue-eslint-parser": "^9.4.3",
     "vue-tsc": "catalog:*"

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -100,7 +100,6 @@
   },
   "devDependencies": {
     "@types/node": "catalog:*",
-    "@types/picomatch": "^2.3.3",
-    "vite-node": "^2.1.1"
+    "@types/picomatch": "^2.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ catalogs:
     semver:
       specifier: 7.7.2
       version: 7.7.2
+    shx:
+      specifier: ^0.4.0
+      version: 0.4.0
     stdout-update:
       specifier: 4.0.1
       version: 4.0.1
@@ -222,7 +225,7 @@ importers:
         specifier: catalog:*
         version: 4.45.1
       shx:
-        specifier: ^0.4.0
+        specifier: catalog:*
         version: 0.4.0
       start-server-and-test:
         specifier: ^2.0.9
@@ -249,8 +252,8 @@ importers:
         specifier: ^8.15.0
         version: 8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.8.3)
       vite-node:
-        specifier: ^2.1.1
-        version: 2.1.5(@types/node@22.15.3)(lightningcss@1.30.1)(terser@5.31.2)
+        specifier: catalog:*
+        version: 3.2.4(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
       vitest:
         specifier: catalog:*
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.4.2)(jsdom@25.0.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
@@ -747,9 +750,6 @@ importers:
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../../packages/build-tooling
-      shx:
-        specifier: ^0.4.0
-        version: 0.4.0
 
   integrations/aspire/playground/Scalar.Aspire.UserService: {}
 
@@ -762,9 +762,6 @@ importers:
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../../packages/build-tooling
-      shx:
-        specifier: ^0.4.0
-        version: 0.4.0
 
   integrations/docker:
     dependencies:
@@ -775,9 +772,6 @@ importers:
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../../packages/build-tooling
-      shx:
-        specifier: ^0.4.0
-        version: 0.4.0
 
   integrations/docusaurus:
     dependencies:
@@ -809,9 +803,6 @@ importers:
       react:
         specifier: catalog:*
         version: 19.1.0
-      shx:
-        specifier: ^0.4.0
-        version: 0.4.0
 
   integrations/express:
     dependencies:
@@ -888,9 +879,6 @@ importers:
       rollup-plugin-node-externals:
         specifier: ^7.1.2
         version: 7.1.2(rollup@4.45.1)
-      shx:
-        specifier: ^0.4.0
-        version: 0.4.0
       terser:
         specifier: ^5.30.0
         version: 5.31.2
@@ -944,9 +932,6 @@ importers:
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../../../packages/build-tooling
-      shx:
-        specifier: ^0.4.0
-        version: 0.4.0
 
   integrations/nestjs:
     dependencies:
@@ -1612,9 +1597,6 @@ importers:
       '@types/picomatch':
         specifier: ^2.3.3
         version: 2.3.3
-      vite-node:
-        specifier: ^2.1.1
-        version: 2.1.5(@types/node@22.15.3)(lightningcss@1.30.1)(terser@5.31.2)
 
   packages/code-highlight:
     dependencies:
@@ -2816,9 +2798,6 @@ importers:
       stdout-update:
         specifier: catalog:*
         version: 4.0.1
-      vite-node:
-        specifier: catalog:*
-        version: 3.2.4(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
       yaml:
         specifier: catalog:*
         version: 2.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,6 +60,7 @@ catalogs:
     react: ^19.1.0
     rollup: 4.45.1
     semver: 7.7.2
+    shx: ^0.4.0
     stdout-update: 4.0.1
     tailwindcss: ^4.1.7
     type-fest: 4.41.0

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -20,7 +20,6 @@
     "picomatch": "catalog:*",
     "prettier": "catalog:*",
     "semver": "catalog:*",
-    "vite-node": "catalog:*",
     "yaml": "catalog:*",
     "zod": "catalog:*",
     "concurrently": "catalog:*"


### PR DESCRIPTION
**Problem**

Currently, we have some inconsistencies across our dependencies.

**Solution**

With this PR, we:

- Use `vite-node` only from the catalog.
- Use `shx` in our root `package.json`, so it's available across all packages.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
