### PR TITLE
feat(analytics): Add `page-view` & `client-send-request` to api-client

### DIFF
--- a/.changeset/violet-doors-unite.md
+++ b/.changeset/violet-doors-unite.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/types': patch
+---
+
+Add analytic events to api-client + add telemetry option

--- a/integrations/express/package.json
+++ b/integrations/express/package.json
@@ -50,11 +50,11 @@
     "@scalar/build-tooling": "workspace:*",
     "@types/express": "catalog:*",
     "@types/supertest": "^2.0.12",
+    "@types/swagger-jsdoc": "^6.0.3",
     "express": "catalog:*",
     "supertest": "^6.3.3",
-    "vite": "catalog:*",
-    "vitest": "catalog:*",
     "swagger-jsdoc": "^6.2.8",
-    "@types/swagger-jsdoc": "^6.0.3"
+    "vite": "catalog:*",
+    "vitest": "catalog:*"
   }
 }

--- a/packages/analytics-client/src/events.ts
+++ b/packages/analytics-client/src/events.ts
@@ -6,6 +6,7 @@ export const analyticsEventData = {
     from: z.string(),
     hostname: z.string(),
   }),
+  'client-send-request': z.undefined(),
 } as const
 
 export type Events = keyof typeof analyticsEventData

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -202,6 +202,7 @@
   "dependencies": {
     "@headlessui/tailwindcss": "catalog:*",
     "@headlessui/vue": "catalog:*",
+    "@scalar/analytics-client": "workspace:*",
     "@scalar/components": "workspace:*",
     "@scalar/draggable": "workspace:*",
     "@scalar/helpers": "workspace:*",

--- a/packages/api-client/src/analytics.ts
+++ b/packages/api-client/src/analytics.ts
@@ -4,18 +4,25 @@ import { type ClientLayout, useLayout } from '@/hooks'
 import { analytics as appAnalytics } from '@/layouts/App'
 import { analytics as webAnalytics } from '@/layouts/Web'
 
+/** Centralized method to control creation of analytics clients.  */
 export function createAnalyticsClient() {
-  return analyticsFactory('https://api.scalar.com', () => '')
+  return analyticsFactory(
+    'https://api.scalar.com',
+    () => null, // There is no auth to return.
+  )
 }
 
-export function useAnalyticsClient() {
+/** Gets the correct analytics client based on the layout. */
+export function useAnalytics() {
   const { layout } = useLayout()
 
-  const AnalyticsClientMapping: Record<ClientLayout, ReturnType<typeof analyticsFactory> | undefined> = {
+  // Create layout -> client mapping
+  const AnalyticsMapping: Record<ClientLayout, ReturnType<typeof analyticsFactory> | undefined> = {
     'desktop': appAnalytics,
     'web': webAnalytics,
-    modal: undefined,
+    modal: undefined, // There are currently no analytics for the modal layout.
   }
 
-  return AnalyticsClientMapping[layout]
+  // Return the correct analytics client
+  return AnalyticsMapping[layout]
 }

--- a/packages/api-client/src/analytics.ts
+++ b/packages/api-client/src/analytics.ts
@@ -1,0 +1,21 @@
+import { analyticsFactory } from '@scalar/analytics-client'
+
+import { type ClientLayout, useLayout } from '@/hooks'
+import { analytics as appAnalytics } from '@/layouts/App'
+import { analytics as webAnalytics } from '@/layouts/Web'
+
+export function createAnalyticsClient() {
+  return analyticsFactory('https://api.scalar.com', () => '')
+}
+
+export function useAnalyticsClient() {
+  const { layout } = useLayout()
+
+  const AnalyticsClientMapping: Record<ClientLayout, ReturnType<typeof analyticsFactory> | undefined> = {
+    'desktop': appAnalytics,
+    'web': webAnalytics,
+    modal: undefined,
+  }
+
+  return AnalyticsClientMapping[layout]
+}

--- a/packages/api-client/src/analytics.ts
+++ b/packages/api-client/src/analytics.ts
@@ -1,6 +1,7 @@
 import { analyticsFactory } from '@scalar/analytics-client'
 
 import { type ClientLayout, useLayout } from '@/hooks'
+import { useClientConfig } from '@/hooks/useClientConfig'
 import { analytics as appAnalytics } from '@/layouts/App'
 import { analytics as webAnalytics } from '@/layouts/Web'
 
@@ -15,6 +16,11 @@ export function createAnalyticsClient() {
 /** Gets the correct analytics client based on the layout. */
 export function useAnalytics() {
   const { layout } = useLayout()
+  const config = useClientConfig()
+
+  if (!config.value.telemetry) {
+    return
+  }
 
   // Create layout -> client mapping
   const AnalyticsMapping: Record<ClientLayout, ReturnType<typeof analyticsFactory> | undefined> = {

--- a/packages/api-client/src/hooks/useClientConfig.ts
+++ b/packages/api-client/src/hooks/useClientConfig.ts
@@ -1,4 +1,4 @@
-import { apiClientConfigurationSchema, type ApiClientConfiguration } from '@scalar/types/api-reference'
+import { type ApiClientConfiguration, apiClientConfigurationSchema } from '@scalar/types/api-reference'
 import { type InjectionKey, type Ref, inject, ref } from 'vue'
 
 export const CLIENT_CONFIGURATION_SYMBOL = Symbol() as InjectionKey<Ref<ApiClientConfiguration>>

--- a/packages/api-client/src/layouts/App/create-api-client-app.ts
+++ b/packages/api-client/src/layouts/App/create-api-client-app.ts
@@ -1,7 +1,12 @@
+import type { ApiClientConfiguration } from '@scalar/types/api-reference'
+
+import { createAnalyticsClient } from '@/analytics'
 import { createApiClient } from '@/libs'
 import { createWebHistoryRouter, saveActiveWorkspace } from '@/router'
-import type { ApiClientConfiguration } from '@scalar/types/api-reference'
+
 import ApiClientApp from './ApiClientApp.vue'
+
+export const analytics = createAnalyticsClient()
 
 /**
  * Mount the full-blown API Client modal to a given element.
@@ -29,7 +34,16 @@ export const createApiClientApp = async (
   })
 
   const { importSpecFile, importSpecFromUrl } = client.store
-  router.afterEach(saveActiveWorkspace)
+
+  router.afterEach((to, from) => {
+    analytics.capture('page-view', {
+      hostname: window.location.hostname,
+      to: to.path, // capture path excluding query params
+      from: from.path,
+    })
+
+    saveActiveWorkspace(to)
+  })
 
   // Import the spec if needed
   if (configuration.url) {

--- a/packages/api-client/src/layouts/Web/create-api-client-web.ts
+++ b/packages/api-client/src/layouts/Web/create-api-client-web.ts
@@ -1,8 +1,12 @@
-import { createApiClient } from '@/libs'
-import { createWebHistoryRouter, saveActiveWorkspace } from '@/router'
 import type { ApiClientConfiguration } from '@scalar/types/api-reference'
 
+import { createAnalyticsClient } from '@/analytics'
+import { createApiClient } from '@/libs'
+import { createWebHistoryRouter, saveActiveWorkspace } from '@/router'
+
 import ApiClientWeb from './ApiClientWeb.vue'
+
+export const analytics = createAnalyticsClient()
 
 /**
  * Mount the API Client to a given element.
@@ -29,7 +33,16 @@ export const createApiClientWeb = async (
   })
 
   const { importSpecFile, importSpecFromUrl } = client.store
-  router.afterEach(saveActiveWorkspace)
+
+  router.afterEach((to, from) => {
+    analytics.capture('page-view', {
+      hostname: window.location.hostname,
+      to: to.path, // capture path excluding query params
+      from: from.path,
+    })
+
+    saveActiveWorkspace(to)
+  })
 
   // Import the spec if needed
   if (configuration.url) {

--- a/packages/api-client/src/views/Request/RequestRoot.vue
+++ b/packages/api-client/src/views/Request/RequestRoot.vue
@@ -5,7 +5,7 @@ import { useToasts } from '@scalar/use-toasts'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { RouterView } from 'vue-router'
 
-import { useAnalyticsClient } from '@/analytics'
+import { useAnalytics } from '@/analytics'
 import SidebarToggle from '@/components/Sidebar/SidebarToggle.vue'
 import { useLayout } from '@/hooks'
 import { useClientConfig } from '@/hooks/useClientConfig'
@@ -27,7 +27,7 @@ const { toast } = useToasts()
 const { layout } = useLayout()
 const config = useClientConfig()
 const { isSidebarOpen } = useSidebar()
-const analytics = useAnalyticsClient()
+const analytics = useAnalytics()
 
 const {
   activeCollection,
@@ -135,6 +135,7 @@ const executeRequest = async () => {
 const cancelRequest = async () =>
   requestAbortController.value?.abort(ERRORS.REQUEST_ABORTED)
 
+/** Subscribed to executeRequest, used for logging / analytics. */
 function logRequest() {
   analytics?.capture('client-send-request')
 }

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -225,6 +225,8 @@ export const apiClientConfigurationSchema = z.object({
   persistAuth: z.boolean().optional().default(false).catch(false),
   /** Plugins for the API client */
   plugins: z.array(ApiClientPluginSchema).optional(),
+  /** Enables / disables telemetry*/
+  telemetry: z.boolean().optional().default(true),
 })
 
 export type ApiClientConfiguration = z.infer<typeof apiClientConfigurationSchema>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1135,6 +1135,9 @@ importers:
       '@headlessui/vue':
         specifier: catalog:*
         version: 1.7.23(vue@3.5.17(typescript@5.8.3))
+      '@scalar/analytics-client':
+        specifier: workspace:*
+        version: link:../analytics-client
       '@scalar/components':
         specifier: workspace:*
         version: link:../components


### PR DESCRIPTION
**Problem**

Currently, there are no scalar analytics set up for api-client

**Solution**

With this PR I've made use of `@scalar/analytics-client` to send 2 events:
- `page-view`
- `client-send-request`

These events are sent by the api-client, but only for: `desktop` and `web` not `modal`.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
