### PR TITLE
fix(api-client): don't apply block layout on desktop

### DIFF
--- a/.changeset/weak-countries-occur.md
+++ b/.changeset/weak-countries-occur.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): don't apply block layout on desktop

--- a/packages/api-client/src/components/Sidebar/SidebarButton.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarButton.vue
@@ -23,7 +23,7 @@ const handleClick = () => {
     <slot name="title" />
     <ScalarHotkey
       v-if="hotkey && layout === 'desktop'"
-      class="text-c-2 add-item-hotkey absolute right-2 hidden group-hover:opacity-80 md:block"
+      class="text-c-2 add-item-hotkey absolute right-2 hidden group-hover:opacity-80 md:flex"
       :hotkey="hotkey" />
   </ScalarButton>
 </template>


### PR DESCRIPTION
We changed up the hotkey so it uses a flex layout now (but this was overriding it with `block`).

Before:

<img width="674" height="420" alt="CleanShot 2025-09-08 at 21 39 38@2x" src="https://github.com/user-attachments/assets/d0eb8430-a652-4990-9816-20d508f3464b" />

After:

<img width="674" height="420" alt="CleanShot 2025-09-08 at 21 38 46@2x" src="https://github.com/user-attachments/assets/48e398af-2677-464e-9f5e-96c486918c05" />


**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
