### PR TITLE
chore(api-client): emit authorized event from RequestAuth component

### DIFF
--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuth2.vue
@@ -40,6 +40,10 @@ const {
   workspace: Workspace
 }>()
 
+const emits = defineEmits<{
+  authorized: []
+}>()
+
 const loadingState = useLoadingState()
 const { toast } = useToasts()
 const storeContext = useWorkspace()
@@ -67,6 +71,7 @@ const handleAuthorize = async () => {
 
   if (accessToken) {
     updateScheme(`flows.${flow.type}.token`, accessToken)
+    emits('authorized')
   } else {
     console.error(error)
     toast(error?.message ?? 'Failed to authorize', 'error')

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.vue
@@ -64,6 +64,10 @@ const {
   workspace: Workspace
 }>()
 
+const emits = defineEmits<{
+  authorized: []
+}>()
+
 const { layout: clientLayout } = useLayout()
 const {
   securitySchemes,
@@ -261,10 +265,10 @@ const openAuthCombobox = (event: Event) => {
         <ScalarComboboxMultiselect
           class="w-72 text-xs"
           :modelValue="selectedSchemeOptions"
-          teleport
           multiple
-          placement="bottom-end"
           :options="schemeOptions"
+          placement="bottom-end"
+          teleport
           @delete="handleDeleteScheme"
           @update:modelValue="updateSelectedAuth">
           <ScalarButton
@@ -286,13 +290,13 @@ const openAuthCombobox = (event: Event) => {
               Auth Type
             </template>
             <ScalarIconCaretDown
-              weight="bold"
-              class="size-3 shrink-0 transition-transform duration-100 group-aria-expanded/combobox-button:rotate-180" />
+              class="size-3 shrink-0 transition-transform duration-100 group-aria-expanded/combobox-button:rotate-180"
+              weight="bold" />
           </ScalarButton>
           <template #option="{ option, selected }">
             <ScalarListboxCheckbox
-              :selected="selected"
-              multiselect />
+              multiselect
+              :selected="selected" />
             <div class="min-w-0 flex-1 truncate">
               {{ option.label }}
             </div>
@@ -301,11 +305,11 @@ const openAuthCombobox = (event: Event) => {
                 option.isDeletable ??
                 (clientLayout !== 'modal' && layout !== 'reference')
               "
-              size="xs"
-              :label="`Delete ${option.label}`"
+              class="-m-0.5 shrink-0 p-0.5 opacity-0 group-hover/item:opacity-100"
               :icon="ScalarIconTrash"
-              @click.stop="handleDeleteScheme(option)"
-              class="-m-0.5 shrink-0 p-0.5 opacity-0 group-hover/item:opacity-100" />
+              :label="`Delete ${option.label}`"
+              size="xs"
+              @click.stop="handleDeleteScheme(option)" />
           </template>
         </ScalarComboboxMultiselect>
       </div>
@@ -318,7 +322,8 @@ const openAuthCombobox = (event: Event) => {
       :persistAuth="persistAuth"
       :selectedSchemeOptions="selectedSchemeOptions"
       :server="server"
-      :workspace="workspace" />
+      :workspace="workspace"
+      @authorized="emits('authorized')" />
     <DeleteRequestAuthModal
       :scheme="selectedScheme"
       :state="deleteSchemeModal"

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthDataTable.vue
@@ -35,6 +35,11 @@ const {
   workspace: Workspace
 }>()
 
+const emits = defineEmits<{
+  /** Emits when the user has authorized with an oauth2 flow */
+  authorized: []
+}>()
+
 const deleteSchemeModal = useModal()
 const selectedScheme = ref<{ id: SecurityScheme['uid']; label: string } | null>(
   null,
@@ -111,7 +116,8 @@ watch(
         :persistAuth="persistAuth"
         :securitySchemeUids="activeScheme"
         :server="server"
-        :workspace="workspace" />
+        :workspace="workspace"
+        @authorized="emits('authorized')" />
     </DataTable>
 
     <div

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuthTab.vue
@@ -47,6 +47,10 @@ const {
   workspace: Workspace
 }>()
 
+const emits = defineEmits<{
+  authorized: []
+}>()
+
 const storeContext = useWorkspace()
 const { collectionMutators, securitySchemes, securitySchemeMutators } =
   storeContext
@@ -180,8 +184,8 @@ const dataTableInputProps = {
     <!-- Description -->
     <DataTableRow v-if="scheme?.description && security.length <= 1">
       <DataTableCell
-        class="max-h-[auto]"
-        :aria-label="scheme.description">
+        :aria-label="scheme.description"
+        class="max-h-[auto]">
         <ScalarMarkdownSummary
           class="auth-description bg-b-1 text-c-2 min-w-0 flex-1 px-3 py-1.25"
           :value="scheme.description" />
@@ -290,7 +294,8 @@ const dataTableInputProps = {
           :persistAuth="persistAuth"
           :scheme="scheme"
           :server="server"
-          :workspace="workspace" />
+          :workspace="workspace"
+          @authorized="emits('authorized')" />
       </template>
     </template>
 


### PR DESCRIPTION
**Problem**

Currently, we don't emit any events, only update the store.

**Solution**

With this PR we emit a vue event when we authorize with oauth2

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
