### PR TITLE
Feat/disable scalar by default

### DIFF
--- a/.changeset/chilled-mangos-heal.md
+++ b/.changeset/chilled-mangos-heal.md
@@ -1,0 +1,5 @@
+---
+'@scalar/webjar': minor
+---
+
+feat!: disable Scalar by default (use scalar.enabled = true)

--- a/documentation/integrations/spring-boot.md
+++ b/documentation/integrations/spring-boot.md
@@ -49,14 +49,14 @@ If you're using Spring Boot's parent POM, the dependency management will be hand
 Configure the OpenAPI document URL in your `application.properties`:
 
 ```properties
+# Enable/disable the Scalar API reference (default: false)
+scalar.enabled=true
+
 # The URL of your OpenAPI document
 scalar.url=https://example.com/openapi.json
 
 # Optional: Custom path (default: /scalar)
 scalar.path=/docs
-
-# Optional: Enable/disable (default: true)
-scalar.enabled=true
 ```
 
 Or in `application.yml`:

--- a/integrations/java/spring-boot/src/main/resources/application.properties
+++ b/integrations/java/spring-boot/src/main/resources/application.properties
@@ -3,7 +3,7 @@
 # Server configuration
 server.port=8080
 
-# Enable/disable the Scalar API reference (default: true)
+# Enable/disable the Scalar API reference (default: false)
 scalar.enabled=true
 
 # The path where the API reference will be available (default: /scalar)

--- a/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarProperties.java
+++ b/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarProperties.java
@@ -40,9 +40,9 @@ public class ScalarProperties {
 
     /**
      * Whether the Scalar API Reference is enabled.
-     * Defaults to true.
+     * Defaults to false.
      */
-    private boolean enabled = true;
+    private boolean enabled = false;
 
     /**
      * The path where the API reference will be available.

--- a/integrations/java/webjar/src/test/java/com/scalar/maven/webjar/ScalarPropertiesTest.java
+++ b/integrations/java/webjar/src/test/java/com/scalar/maven/webjar/ScalarPropertiesTest.java
@@ -33,9 +33,9 @@ class ScalarPropertiesTest {
         }
 
         @Test
-        @DisplayName("should be enabled by default")
-        void shouldBeEnabledByDefault() {
-            assertThat(properties.isEnabled()).isTrue();
+        @DisplayName("should be disabled by default")
+        void shouldBeDisabledByDefault() {
+            assertThat(properties.isEnabled()).isFalse();
         }
 
         @Test


### PR DESCRIPTION
**Problem**

We got this message:

> I would like to suggest making the following settings disabled (false) by default:
> - scalar.enabled
> 
> When `scalar.enabled` is enabled by default, it can be misleading, especially when using Scalar via the springdoc-openapi-starter-webmvc-scalar Java dependency.
> 
> Also, in 2024, the CVE board updated the CNA rules, including the following:
> 
> 4.1.4 Insecure default configuration settings SHOULD be determined to be vulnerabilities
> So, what do you think? Is this an insecure default configuration or not?

And I think we should make this change.

**Solution**

This PR sets `scalar.enabled = false` by default.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
