### PR TITLE
fix(java): paths ending with a slash break the JS URL

### DIFF
--- a/.changeset/selfish-pets-float.md
+++ b/.changeset/selfish-pets-float.md
@@ -1,0 +1,5 @@
+---
+'@scalar/webjar': patch
+---
+
+fix: paths ending with a slash break the JS URL

--- a/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarController.java
+++ b/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarController.java
@@ -111,6 +111,11 @@ public class ScalarController {
             basePath = DEFAULT_PATH;
         }
 
+        // Remove trailing slash to avoid double slashes when concatenating
+        if (basePath.endsWith("/")) {
+            basePath = basePath.substring(0, basePath.length() - 1);
+        }
+
         return basePath + "/" + JS_FILENAME;
     }
 

--- a/integrations/java/webjar/src/test/java/com/scalar/maven/webjar/ScalarControllerTest.java
+++ b/integrations/java/webjar/src/test/java/com/scalar/maven/webjar/ScalarControllerTest.java
@@ -509,6 +509,22 @@ class ScalarControllerTest {
                     .doesNotContain("__CONFIGURATION__")
                     .contains("url: \"https://example.com/api.json\"");
         }
+
+        @Test
+        @DisplayName("should use correct scalar.js URL when path is set to root")
+        void shouldUseCorrectScalarJsUrlWhenPathIsSetToRoot() throws Exception {
+            // Given
+            when(properties.getPath()).thenReturn("/");
+
+            // When
+            ResponseEntity<String> response = controller.getDocs();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("<script src=\"/scalar.js\"></script>");
+        }
     }
 
     @Nested


### PR DESCRIPTION
**Problem**

When using a path with a trailing slash (e.g. just `/`), it breaks the JS URL (`//scalar.js`).

**Solution**

This PR removes the trailing slash of the path for the JS URL, if there’s one.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
