### PR TITLE
feat(java): actuator endpoint

### DIFF
--- a/.changeset/itchy-hotels-juggle.md
+++ b/.changeset/itchy-hotels-juggle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/webjar': patch
+---
+
+feat: actuator endpoint

--- a/documentation/integrations/spring-boot.md
+++ b/documentation/integrations/spring-boot.md
@@ -80,7 +80,7 @@ To enable actuator support, add the following configuration:
 
 ```properties
 # Enable actuator support
-scalar.actuator-enabled=true
+scalar.actuatorEnabled=true
 
 # Expose the scalar endpoint
 management.endpoints.web.exposure.include=scalar
@@ -90,7 +90,7 @@ Or in `application.yml`:
 
 ```yaml
 scalar:
-  actuator-enabled: true
+  actuatorEnabled: true
 
 management:
   endpoints:
@@ -190,7 +190,7 @@ spring.autoconfigure.exclude=com.scalar.maven.webjar.ScalarAutoConfiguration
 | `scalar.layout`                | `modern`                                                             | The layout style to use for the API reference. Can be "modern" or "classic"                                                                                      |
 | `scalar.hideSearch`            | `false`                                                              | Whether to show the sidebar search bar                                                                                                                           |
 | `scalar.documentDownloadType`  | `both`                                                               | Sets the file type of the document to download. Can be "json", "yaml", "both", or "none"                                                                         |
-| `scalar.actuator-enabled`      | `false`                                                              | Whether to expose the Scalar UI as an actuator endpoint at /actuator/scalar                                                                                      |
+| `scalar.actuatorEnabled`       | `false`                                                              | Whether to expose the Scalar UI as an actuator endpoint at /actuator/scalar                                                                                      |
 
 ## Security Configuration
 
@@ -242,7 +242,7 @@ scalar.layout=modern
 scalar.documentDownloadType=both
 
 # Actuator support
-scalar.actuator-enabled=false
+scalar.actuatorEnabled=false
 
 # Custom styling
 scalar.customCss=body { font-family: 'Arial', sans-serif; }

--- a/documentation/integrations/spring-boot.md
+++ b/documentation/integrations/spring-boot.md
@@ -70,6 +70,76 @@ scalar:
 
 Access your API reference at `http://localhost:8080/scalar` (or your custom path)
 
+## Actuator Support
+
+The Scalar integration supports exposing the API reference interface through Spring Boot Actuator endpoints. This is useful when you want to integrate the Scalar UI with your application's monitoring and management infrastructure.
+
+### Enabling Actuator Support
+
+To enable actuator support, add the following configuration:
+
+```properties
+# Enable actuator support
+scalar.actuator-enabled=true
+
+# Expose the scalar endpoint
+management.endpoints.web.exposure.include=scalar
+```
+
+Or in `application.yml`:
+
+```yaml
+scalar:
+  actuator-enabled: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: scalar
+```
+
+### Accessing the Actuator Endpoint
+
+Once enabled, the Scalar UI will be available at:
+
+```
+http://localhost:8080/actuator/scalar
+```
+
+### Actuator Security
+
+When using actuator endpoints, it's recommended to secure them, especially in production:
+
+```properties
+# Enable actuator security
+management.security.enabled=true
+
+# Or with Spring Security
+management.endpoints.web.base-path=/actuator
+```
+
+With Spring Security:
+
+```java
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(authz -> authz
+                .requestMatchers("/actuator/scalar").authenticated()
+                .requestMatchers("/actuator/health").permitAll()
+                .anyRequest().permitAll()
+            )
+            .formLogin(form -> form.permitAll());
+        return http.build();
+    }
+}
+```
+
 ## Auto-Configuration
 
 The Scalar integration automatically configures:
@@ -120,6 +190,7 @@ spring.autoconfigure.exclude=com.scalar.maven.webjar.ScalarAutoConfiguration
 | `scalar.layout`                | `modern`                                                             | The layout style to use for the API reference. Can be "modern" or "classic"                                                                                      |
 | `scalar.hideSearch`            | `false`                                                              | Whether to show the sidebar search bar                                                                                                                           |
 | `scalar.documentDownloadType`  | `both`                                                               | Sets the file type of the document to download. Can be "json", "yaml", "both", or "none"                                                                         |
+| `scalar.actuator-enabled`      | `false`                                                              | Whether to expose the Scalar UI as an actuator endpoint at /actuator/scalar                                                                                      |
 
 ## Security Configuration
 
@@ -169,6 +240,9 @@ scalar.layout=modern
 
 # Document options
 scalar.documentDownloadType=both
+
+# Actuator support
+scalar.actuator-enabled=false
 
 # Custom styling
 scalar.customCss=body { font-family: 'Arial', sans-serif; }

--- a/integrations/java/spring-boot/src/main/resources/application.properties
+++ b/integrations/java/spring-boot/src/main/resources/application.properties
@@ -21,3 +21,7 @@ scalar.url=https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json
 
 # The theme of the API reference (optional)
 # scalar.theme=purple
+
+# Actuator support (optional)
+# scalar.actuator-enabled=true
+# management.endpoints.web.exposure.include=scalar

--- a/integrations/java/spring-boot/src/main/resources/application.properties
+++ b/integrations/java/spring-boot/src/main/resources/application.properties
@@ -23,5 +23,5 @@ scalar.url=https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json
 # scalar.theme=purple
 
 # Actuator support (optional)
-# scalar.actuator-enabled=true
+# scalar.actuatorEnabled=true
 # management.endpoints.web.exposure.include=scalar

--- a/integrations/java/webjar/pom.xml
+++ b/integrations/java/webjar/pom.xml
@@ -82,6 +82,14 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Spring Boot Actuator - for actuator endpoint support -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>${spring-boot.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarActuatorEndpoint.java
+++ b/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarActuatorEndpoint.java
@@ -17,7 +17,7 @@ import java.nio.charset.StandardCharsets;
  * Spring Boot Actuator endpoints. It serves the same HTML content as the
  * regular ScalarController but is accessible at the actuator path.</p>
  *
- * <p>The endpoint is only enabled when {@code scalar.actuator-enabled=true} is set
+ * <p>The endpoint is only enabled when {@code scalar.actuatorEnabled=true} is set
  * in the configuration properties.</p>
  *
  * <p>Access the endpoint at: {@code /actuator/scalar}</p>

--- a/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarActuatorEndpoint.java
+++ b/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarActuatorEndpoint.java
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets;
  * @since 0.1.0
  */
 @Endpoint(id = "scalar")
-@WebEndpoint
+@WebEndpoint(id = "scalar")
 public class ScalarActuatorEndpoint {
 
     private final ScalarProperties properties;

--- a/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarActuatorEndpoint.java
+++ b/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarActuatorEndpoint.java
@@ -1,0 +1,242 @@
+package com.scalar.maven.webjar;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Actuator endpoint for serving the Scalar API Reference interface.
+ *
+ * <p>This endpoint provides access to the Scalar API Reference interface through
+ * Spring Boot Actuator endpoints. It serves the same HTML content as the
+ * regular ScalarController but is accessible at the actuator path.</p>
+ *
+ * <p>The endpoint is only enabled when {@code scalar.actuator-enabled=true} is set
+ * in the configuration properties.</p>
+ *
+ * <p>Access the endpoint at: {@code /actuator/scalar}</p>
+ *
+ * @since 0.1.0
+ */
+@Endpoint(id = "scalar")
+@WebEndpoint
+public class ScalarActuatorEndpoint {
+
+    private final ScalarProperties properties;
+
+    /**
+     * Creates a new ScalarActuatorEndpoint with the specified properties.
+     *
+     * @param properties the configuration properties for the Scalar integration
+     */
+    public ScalarActuatorEndpoint(ScalarProperties properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * Serves the Scalar API Reference interface as an actuator endpoint.
+     *
+     * <p>This method returns the same HTML content as the regular ScalarController
+     * but is accessible through the actuator endpoint system.</p>
+     *
+     * @return a ResponseEntity containing the HTML content for the API reference interface
+     * @throws IOException if the HTML template cannot be loaded
+     */
+    @ReadOperation(produces = MediaType.TEXT_HTML_VALUE)
+    public ResponseEntity<String> scalarUi() throws IOException {
+        // Load the template HTML
+        InputStream inputStream = getClass().getResourceAsStream("/META-INF/resources/webjars/scalar/index.html");
+        if (inputStream == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        String html = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+
+        // Replace the placeholders with actual values
+        String cdnUrl = buildJsBundleUrl();
+        String injectedHtml = html
+                .replace("__JS_BUNDLE_URL__", cdnUrl)
+                .replace("__CONFIGURATION__", buildConfigurationJson());
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.TEXT_HTML)
+                .body(injectedHtml);
+    }
+
+    /**
+     * Builds the CDN URL for the Scalar JavaScript file.
+     * Uses the configured path if available, otherwise defaults to the actuator path.
+     *
+     * @return the complete URL for the JavaScript bundle
+     */
+    private String buildJsBundleUrl() {
+        String basePath = properties.getPath();
+
+        if (basePath == null || basePath.isEmpty()) {
+            basePath = "/scalar";
+        }
+
+        return basePath + "/scalar.js";
+    }
+
+    /**
+     * Builds the configuration JSON for the Scalar API Reference.
+     *
+     * @return the configuration JSON as a string
+     */
+    private String buildConfigurationJson() {
+        StringBuilder config = new StringBuilder();
+        config.append("{");
+
+        // Add URL
+        config.append("\n  url: \"").append(escapeJson(properties.getUrl())).append("\"");
+
+        // Add sources
+        if (properties.getSources() != null && !properties.getSources().isEmpty()) {
+            config.append(",\n  sources: ").append(buildSourcesJsonArray(properties.getSources()));
+        }
+
+        // Add showSidebar
+        if (!properties.isShowSidebar()) {
+            config.append(",\n  showSidebar: false");
+        }
+
+        // Add hideModels
+        if (properties.isHideModels()) {
+            config.append(",\n  hideModels: true");
+        }
+
+        // Add hideTestRequestButton
+        if (properties.isHideTestRequestButton()) {
+            config.append(",\n  hideTestRequestButton: true");
+        }
+
+        // Add darkMode
+        if (properties.isDarkMode()) {
+            config.append(",\n  darkMode: true");
+        }
+
+        // Add hideDarkModeToggle
+        if (properties.isHideDarkModeToggle()) {
+            config.append(",\n  hideDarkModeToggle: true");
+        }
+
+        // Add customCss
+        if (properties.getCustomCss() != null && !properties.getCustomCss().trim().isEmpty()) {
+            config.append(",\n  customCss: \"").append(escapeJson(properties.getCustomCss())).append("\"");
+        }
+
+        // Add theme
+        if (properties.getTheme() != null && !"default".equals(properties.getTheme())) {
+            config.append(",\n  theme: \"").append(escapeJson(properties.getTheme())).append("\"");
+        }
+
+        // Add layout
+        if (properties.getLayout() != null && !"modern".equals(properties.getLayout())) {
+            config.append(",\n  layout: \"").append(escapeJson(properties.getLayout())).append("\"");
+        }
+
+        // Add hideSearch
+        if (properties.isHideSearch()) {
+            config.append(",\n  hideSearch: true");
+        }
+
+        // Add documentDownloadType
+        if (properties.getDocumentDownloadType() != null && !"both".equals(properties.getDocumentDownloadType())) {
+            config.append(",\n  documentDownloadType: \"").append(escapeJson(properties.getDocumentDownloadType())).append("\"");
+        }
+
+        config.append("\n}");
+        return config.toString();
+    }
+
+    /**
+     * Builds the JSON for the OpenAPI reference sources
+     *
+     * @param sources list of OpenAPI reference sources
+     * @return the sources as a JSON string
+     */
+    private String buildSourcesJsonArray(java.util.List<ScalarProperties.ScalarSource> sources) {
+        final StringBuilder builder = new StringBuilder("[");
+
+        // Filter out sources with invalid urls
+        final java.util.List<ScalarProperties.ScalarSource> filteredSources = sources.stream()
+                .filter(source -> isNotNullOrBlank(source.getUrl()))
+                .collect(java.util.stream.Collectors.toList());
+
+        // Append each source to json array
+        for (int i = 0; i < filteredSources.size(); i++) {
+            final ScalarProperties.ScalarSource source = filteredSources.get(i);
+
+            final String sourceJson = buildSourceJson(source);
+            builder.append("\n").append(sourceJson);
+
+            if (i != filteredSources.size() - 1) {
+                builder.append(",");
+            }
+        }
+
+        builder.append("\n]");
+        return builder.toString();
+    }
+
+    /**
+     * Builds the JSON for an OpenAPI reference source
+     *
+     * @param source the OpenAPI reference source
+     * @return the source as a JSON string
+     */
+    private String buildSourceJson(ScalarProperties.ScalarSource source) {
+        final StringBuilder builder = new StringBuilder("{");
+
+        builder.append("\n  url: \"").append(escapeJson(source.getUrl())).append("\"");
+
+        if (isNotNullOrBlank(source.getTitle())) {
+            builder.append(",\n  title: \"").append(escapeJson(source.getTitle())).append("\"");
+        }
+
+        if (isNotNullOrBlank(source.getSlug())) {
+            builder.append(",\n  slug: \"").append(escapeJson(source.getSlug())).append("\"");
+        }
+
+        if (source.isDefault() != null) {
+            builder.append(",\n  default: ").append(source.isDefault());
+        }
+
+        builder.append("\n}");
+        return builder.toString();
+    }
+
+    /**
+     * Escapes a string for JSON output.
+     *
+     * @param input the input string
+     * @return the escaped string
+     */
+    private String escapeJson(String input) {
+        if (input == null) {
+            return "";
+        }
+        return input.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+
+    /**
+     * Returns whether a String is not null or blank
+     *
+     * @param input the string
+     * @return whether the string is not null or blank
+     */
+    private boolean isNotNullOrBlank(String input) {
+        return input != null && !input.isBlank();
+    }
+}

--- a/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarAutoConfiguration.java
+++ b/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarAutoConfiguration.java
@@ -49,7 +49,7 @@ public class ScalarAutoConfiguration {
      * @return a configured ScalarActuatorEndpoint instance
      */
     @Bean
-    @ConditionalOnProperty(prefix = "scalar", name = "actuator-enabled", havingValue = "true")
+    @ConditionalOnProperty(prefix = "scalar", name = "actuatorEnabled", havingValue = "true")
     @ConditionalOnClass(name = "org.springframework.boot.actuate.endpoint.annotation.Endpoint")
     @ConditionalOnAvailableEndpoint(endpoint = ScalarActuatorEndpoint.class)
     public ScalarActuatorEndpoint scalarActuatorEndpoint(ScalarProperties properties) {

--- a/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarAutoConfiguration.java
+++ b/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarAutoConfiguration.java
@@ -1,5 +1,7 @@
 package com.scalar.maven.webjar;
 
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -37,5 +39,20 @@ public class ScalarAutoConfiguration {
     @Bean
     public ScalarController scalarController(ScalarProperties properties) {
         return new ScalarController(properties);
+    }
+
+    /**
+     * Creates a ScalarActuatorEndpoint bean when actuator support is enabled.
+     * This endpoint exposes the Scalar UI at /actuator/scalar.
+     *
+     * @param properties the configuration properties for the Scalar integration
+     * @return a configured ScalarActuatorEndpoint instance
+     */
+    @Bean
+    @ConditionalOnProperty(prefix = "scalar", name = "actuator-enabled", havingValue = "true")
+    @ConditionalOnClass(name = "org.springframework.boot.actuate.endpoint.annotation.Endpoint")
+    @ConditionalOnAvailableEndpoint(endpoint = ScalarActuatorEndpoint.class)
+    public ScalarActuatorEndpoint scalarActuatorEndpoint(ScalarProperties properties) {
+        return new ScalarActuatorEndpoint(properties);
     }
 }

--- a/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarProperties.java
+++ b/integrations/java/webjar/src/main/java/com/scalar/maven/webjar/ScalarProperties.java
@@ -114,6 +114,13 @@ public class ScalarProperties {
     private String documentDownloadType = "both";
 
     /**
+     * Whether to expose the Scalar UI as an actuator endpoint.
+     * When enabled, the Scalar UI will be available at /actuator/scalar.
+     * Defaults to false.
+     */
+    private boolean actuatorEnabled = false;
+
+    /**
      * Gets the list of OpenAPI specification sources
      *
      * @return list of OpenAPI specification sources
@@ -363,6 +370,24 @@ public class ScalarProperties {
      */
     public void setDocumentDownloadType(String documentDownloadType) {
         this.documentDownloadType = documentDownloadType;
+    }
+
+    /**
+     * Checks if the actuator endpoint is enabled.
+     *
+     * @return true if actuator endpoint is enabled, false otherwise
+     */
+    public boolean isActuatorEnabled() {
+        return actuatorEnabled;
+    }
+
+    /**
+     * Sets whether the actuator endpoint is enabled.
+     *
+     * @param actuatorEnabled true to enable actuator endpoint, false to disable
+     */
+    public void setActuatorEnabled(boolean actuatorEnabled) {
+        this.actuatorEnabled = actuatorEnabled;
     }
 
     /**

--- a/integrations/java/webjar/src/test/java/com/scalar/maven/webjar/ScalarActuatorEndpointTest.java
+++ b/integrations/java/webjar/src/test/java/com/scalar/maven/webjar/ScalarActuatorEndpointTest.java
@@ -1,0 +1,457 @@
+package com.scalar.maven.webjar;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ScalarActuatorEndpoint")
+class ScalarActuatorEndpointTest {
+
+    @Mock
+    private ScalarProperties properties;
+
+    private ScalarActuatorEndpoint endpoint;
+
+    @BeforeEach
+    void setUp() {
+        endpoint = new ScalarActuatorEndpoint(properties);
+    }
+
+    @Nested
+    @DisplayName("scalarUi endpoint")
+    class ScalarUiEndpoint {
+
+        @Test
+        @DisplayName("should return HTML with default configuration when URL is not specified")
+        void shouldReturnHtmlWithDefaultConfiguration() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn("https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json");
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            assertThat(response)
+                    .isNotNull()
+                    .satisfies(resp -> {
+                        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+                        assertThat(resp.getHeaders().getContentType()).isEqualTo(MediaType.TEXT_HTML);
+                    });
+
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("<!doctype html>")
+                    .contains("<title>Scalar API Reference</title>")
+                    .contains("Scalar.createApiReference('#app',")
+                    .contains("url: \"https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json\"");
+        }
+
+        @Test
+        @DisplayName("should return HTML with custom URL configuration")
+        void shouldReturnHtmlWithCustomUrl() throws Exception {
+            // Given
+            String customUrl = "https://example.com/api/openapi.json";
+            when(properties.getUrl()).thenReturn(customUrl);
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            assertThat(response)
+                    .isNotNull()
+                    .satisfies(resp -> {
+                        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+                        assertThat(resp.getHeaders().getContentType()).isEqualTo(MediaType.TEXT_HTML);
+                    });
+
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("url: \"https://example.com/api/openapi.json\"");
+        }
+
+        @Test
+        @DisplayName("should handle URLs with special characters correctly")
+        void shouldHandleUrlsWithSpecialCharacters() throws Exception {
+            // Given
+            String urlWithSpecialChars = "https://api.example.com/v1/docs?format=json&version=2.0";
+            when(properties.getUrl()).thenReturn(urlWithSpecialChars);
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            assertThat(response)
+                    .isNotNull()
+                    .satisfies(resp -> assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK));
+
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("url: \"https://api.example.com/v1/docs?format=json&version=2.0\"");
+        }
+
+        @Test
+        @DisplayName("should handle empty URL gracefully")
+        void shouldHandleEmptyUrl() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn("");
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            assertThat(response)
+                    .isNotNull()
+                    .satisfies(resp -> assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK));
+
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("url: \"\"");
+        }
+
+        @Test
+        @DisplayName("should handle null URL by converting to empty string")
+        void shouldHandleNullUrl() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn(null);
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            assertThat(response)
+                    .isNotNull()
+                    .satisfies(resp -> assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK));
+
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("url: \"\"");
+        }
+
+        @Test
+        @DisplayName("should return HTML with custom sources configuration")
+        void shouldReturnHtmlWithCustomSources() throws Exception {
+            // Given
+            final ScalarProperties.ScalarSource source = new ScalarProperties.ScalarSource();
+            source.setUrl("https://example.com/api/openapi.json");
+
+            final List<ScalarProperties.ScalarSource> sources = List.of(
+                    source,
+                    new ScalarProperties.ScalarSource(
+                            "https://anotherexample.com/api.json",
+                            "API 2",
+                            "another-example",
+                            true
+                    )
+            );
+            when(properties.getSources()).thenReturn(sources);
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            assertThat(response)
+                    .isNotNull()
+                    .satisfies(resp -> {
+                        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+                        assertThat(resp.getHeaders().getContentType()).isEqualTo(MediaType.TEXT_HTML);
+                    });
+
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .containsIgnoringWhitespaces("""
+                            sources: [
+                                {
+                                  url: "https://example.com/api/openapi.json"
+                                },
+                                {
+                                  url: "https://anotherexample.com/api.json",
+                                  title: "API 2",
+                                  slug: "another-example",
+                                  default: true
+                                }
+                            ]
+                            """);
+        }
+
+        @Test
+        @DisplayName("should include showSidebar configuration when disabled")
+        void shouldIncludeShowSidebarConfigurationWhenDisabled() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn("https://example.com/api.json");
+            when(properties.isShowSidebar()).thenReturn(false);
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("showSidebar: false");
+        }
+
+        @Test
+        @DisplayName("should include hideModels configuration when enabled")
+        void shouldIncludeHideModelsConfigurationWhenEnabled() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn("https://example.com/api.json");
+            when(properties.isHideModels()).thenReturn(true);
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("hideModels: true");
+        }
+
+        @Test
+        @DisplayName("should include hideTestRequestButton configuration when enabled")
+        void shouldIncludeHideTestRequestButtonConfigurationWhenEnabled() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn("https://example.com/api.json");
+            when(properties.isHideTestRequestButton()).thenReturn(true);
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("hideTestRequestButton: true");
+        }
+
+        @Test
+        @DisplayName("should include darkMode configuration when enabled")
+        void shouldIncludeDarkModeConfigurationWhenEnabled() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn("https://example.com/api.json");
+            when(properties.isDarkMode()).thenReturn(true);
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("darkMode: true");
+        }
+
+        @Test
+        @DisplayName("should include hideDarkModeToggle configuration when enabled")
+        void shouldIncludeHideDarkModeToggleConfigurationWhenEnabled() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn("https://example.com/api.json");
+            when(properties.isHideDarkModeToggle()).thenReturn(true);
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("hideDarkModeToggle: true");
+        }
+
+        @Test
+        @DisplayName("should include customCss configuration when provided")
+        void shouldIncludeCustomCssConfigurationWhenProvided() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn("https://example.com/api.json");
+            when(properties.getCustomCss()).thenReturn("body { background-color: #BADA55; }");
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("customCss: \"body { background-color: #BADA55; }\"");
+        }
+
+        @Test
+        @DisplayName("should include theme configuration when not default")
+        void shouldIncludeThemeConfigurationWhenNotDefault() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn("https://example.com/api.json");
+            when(properties.getTheme()).thenReturn("mars");
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("theme: \"mars\"");
+        }
+
+        @Test
+        @DisplayName("should include layout configuration when not modern")
+        void shouldIncludeLayoutConfigurationWhenNotModern() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn("https://example.com/api.json");
+            when(properties.getLayout()).thenReturn("classic");
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("layout: \"classic\"");
+        }
+
+        @Test
+        @DisplayName("should include hideSearch configuration when enabled")
+        void shouldIncludeHideSearchConfigurationWhenEnabled() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn("https://example.com/api.json");
+            when(properties.isHideSearch()).thenReturn(true);
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("hideSearch: true");
+        }
+
+        @Test
+        @DisplayName("should include documentDownloadType configuration when not both")
+        void shouldIncludeDocumentDownloadTypeConfigurationWhenNotBoth() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn("https://example.com/api.json");
+            when(properties.getDocumentDownloadType()).thenReturn("json");
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("documentDownloadType: \"json\"");
+        }
+
+        @Test
+        @DisplayName("should handle multiple configuration options together")
+        void shouldHandleMultipleConfigurationOptionsTogether() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn("https://example.com/api.json");
+            when(properties.isShowSidebar()).thenReturn(false);
+            when(properties.isHideModels()).thenReturn(true);
+            when(properties.isDarkMode()).thenReturn(true);
+            when(properties.getTheme()).thenReturn("mars");
+            when(properties.getCustomCss()).thenReturn("body { background-color: #BADA55; }");
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("url: \"https://example.com/api.json\"")
+                    .contains("showSidebar: false")
+                    .contains("hideModels: true")
+                    .contains("darkMode: true")
+                    .contains("theme: \"mars\"")
+                    .contains("customCss: \"body { background-color: #BADA55; }\"");
+        }
+
+        @Test
+        @DisplayName("should escape special characters in customCss")
+        void shouldEscapeSpecialCharactersInCustomCss() throws Exception {
+            // Given
+            when(properties.getUrl()).thenReturn("https://example.com/api.json");
+            when(properties.getCustomCss()).thenReturn("body { content: \"quoted text\"; }");
+
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("customCss: \"body { content: \\\"quoted text\\\"; }\"");
+        }
+    }
+
+    @Nested
+    @DisplayName("HTML structure validation")
+    class HtmlStructureValidation {
+
+        @BeforeEach
+        void setUp() {
+            when(properties.getUrl()).thenReturn("https://example.com/api.json");
+        }
+
+        @Test
+        @DisplayName("should generate valid HTML structure with all required elements")
+        void shouldGenerateValidHtmlStructure() throws Exception {
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .contains("<title>Scalar API Reference</title>")
+                    .contains("<div id=\"app\"></div>")
+                    .contains("<script src=\"/scalar/scalar.js\"></script>")
+                    .contains("Scalar.createApiReference('#app',");
+        }
+
+        @Test
+        @DisplayName("should replace configuration placeholder with actual configuration")
+        void shouldReplaceConfigurationPlaceholder() throws Exception {
+            // When
+            ResponseEntity<String> response = endpoint.scalarUi();
+
+            // Then
+            String html = response.getBody();
+            assertThat(html)
+                    .isNotNull()
+                    .doesNotContain("__CONFIGURATION__")
+                    .contains("url: \"https://example.com/api.json\"");
+        }
+    }
+
+    @Nested
+    @DisplayName("Error handling")
+    class ErrorHandling {
+
+        // Note: This test would require mocking the resource loading
+        // which is more complex and might not be necessary for this simple endpoint
+        // The current implementation doesn't have explicit error handling for missing resources
+    }
+}

--- a/integrations/java/webjar/src/test/java/com/scalar/maven/webjar/ScalarPropertiesTest.java
+++ b/integrations/java/webjar/src/test/java/com/scalar/maven/webjar/ScalarPropertiesTest.java
@@ -97,6 +97,12 @@ class ScalarPropertiesTest {
         void shouldHaveCorrectDefaultDocumentDownloadType() {
             assertThat(properties.getDocumentDownloadType()).isEqualTo("both");
         }
+
+        @Test
+        @DisplayName("should have correct default actuatorEnabled")
+        void shouldHaveCorrectDefaultActuatorEnabled() {
+            assertThat(properties.isActuatorEnabled()).isFalse();
+        }
     }
 
     @Nested
@@ -466,6 +472,22 @@ class ScalarPropertiesTest {
     }
 
     @Nested
+    @DisplayName("actuatorEnabled property")
+    class ActuatorEnabledProperty {
+
+        @ParameterizedTest
+        @ValueSource(booleans = {true, false})
+        @DisplayName("should set and get actuatorEnabled state")
+        void shouldSetAndGetActuatorEnabledState(boolean actuatorEnabled) {
+            // When
+            properties.setActuatorEnabled(actuatorEnabled);
+
+            // Then
+            assertThat(properties.isActuatorEnabled()).isEqualTo(actuatorEnabled);
+        }
+    }
+
+    @Nested
     @DisplayName("property combinations")
     class PropertyCombinations {
 
@@ -486,6 +508,7 @@ class ScalarPropertiesTest {
             String customLayout = "classic";
             boolean customHideSearch = true;
             String customDocumentDownloadType = "json";
+            boolean customActuatorEnabled = true;
 
             // When
             properties.setUrl(customUrl);
@@ -501,6 +524,7 @@ class ScalarPropertiesTest {
             properties.setLayout(customLayout);
             properties.setHideSearch(customHideSearch);
             properties.setDocumentDownloadType(customDocumentDownloadType);
+            properties.setActuatorEnabled(customActuatorEnabled);
 
             // Then
             assertThat(properties.getUrl()).isEqualTo(customUrl);
@@ -516,6 +540,7 @@ class ScalarPropertiesTest {
             assertThat(properties.getLayout()).isEqualTo(customLayout);
             assertThat(properties.isHideSearch()).isEqualTo(customHideSearch);
             assertThat(properties.getDocumentDownloadType()).isEqualTo(customDocumentDownloadType);
+            assertThat(properties.isActuatorEnabled()).isEqualTo(customActuatorEnabled);
         }
 
         @Test


### PR DESCRIPTION
**Problem**

> The current webjar does not support exposing the Scalar UI beneath actuator endpoints. 

**Solution**

This PR adds support for it. :)

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
