### PR TITLE
docs: correct ElysiaJS plugin references and update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,11 @@ And there's an ever-growing list of plugins and integrations:
 
 The following frameworks have chosen Scalar API Reference as their default OpenAPI documentation UI, recognizing its developer-friendly features and modern design:
 
-- [ElysiaJS](documentation/integrations/elysiajs.md)
+- [ElysiaJS](https://guides.scalar.com/scalar/scalar-api-references/integrations/elysiajs)
 - [HappyX](https://github.com/HapticX/happyx)
 - [Litestar](https://docs.litestar.dev/latest/usage/openapi/ui_plugins.html)
-- [Nitro](documentation/integrations/nitro.md)
-- [Platformatic](documentation/integrations/platformatic.md)
+- [Nitro](https://guides.scalar.com/scalar/scalar-api-references/integrations/nitro)
+- [Platformatic](https://guides.scalar.com/scalar/scalar-api-references/integrations/platformatic)
 - [oRPC](https://orpc.unnoq.com/docs/openapi/plugins/openapi-reference)
 
 <br>

--- a/documentation/integrations/elysiajs.md
+++ b/documentation/integrations/elysiajs.md
@@ -1,18 +1,18 @@
 # Scalar API Reference for ElysiaJS
 
-The `@elysiajs/swagger` plugin uses our API reference by default:
+The `@elysiajs/openapi` plugin uses our API Reference by default:
 
 ```ts
-import { swagger } from '@elysiajs/swagger'
 import { Elysia } from 'elysia'
+import { openapi } from '@elysiajs/openapi'
 
 new Elysia()
-  .use(swagger())
-  .get('/', () => 'hi')
-  .post('/hello', () => 'world')
-  .listen(8080)
+    .use(openapi())
+    .get('/', () => 'hello')
+    .post('/hello', () => 'OpenAPI')
+    .listen(3000)
 
-// open http://localhost:8080/swagger
+// open http://localhost:3000/openapi
 ```
 
-[Read more about @elysiajs/swagger](https://elysiajs.com/plugins/swagger.html)
+[Read more about @elysiajs/openapi](https://elysiajs.com/plugins/openapi)


### PR DESCRIPTION
This PR updates the README links to direct users to the guides on our website. It also refreshes the ElysiaJS documentation by removing references to a deprecated plugin.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
