### PR TITLE
feat(docs): Update `scalar.enabled` default in spring-boot.md

### DIFF
--- a/documentation/integrations/spring-boot.md
+++ b/documentation/integrations/spring-boot.md
@@ -82,7 +82,7 @@ The Scalar integration automatically configures:
 
 The auto-configuration is conditional on:
 
-- `scalar.enabled=true` (default)
+- `scalar.enabled=true`
 - Spring Boot web starter being present
 - No existing `ScalarController` bean
 
@@ -107,7 +107,7 @@ spring.autoconfigure.exclude=com.scalar.maven.webjar.ScalarAutoConfiguration
 
 | Property                       | Default                                                              | Description                                                                                                                                                      |
 | ------------------------------ | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scalar.enabled`               | `true`                                                               | Enable or disable the Scalar API reference                                                                                                                       |
+| `scalar.enabled`               | `false`                                                               | Enable or disable the Scalar API reference                                                                                                                       |
 | `scalar.path`                  | `/scalar`                                                            | Path where the API reference will be available                                                                                                                   |
 | `scalar.url`                   | `https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json` | URL of your OpenAPI document                                                                                                                                     |
 | `scalar.showSidebar`           | `true`                                                               | Whether the sidebar should be shown                                                                                                                              |


### PR DESCRIPTION
Update documentation to reflect the change in default value for `scalar.enabled`, which is now false by default in java module via #6781 