### PR TITLE
feat(api-client): ignore query params on findRequestByPathMethod

### DIFF
--- a/.changeset/smooth-boats-kneel.md
+++ b/.changeset/smooth-boats-kneel.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: allow query params on findRequestByPathMethod method

--- a/packages/api-client/src/libs/find-request.test.ts
+++ b/packages/api-client/src/libs/find-request.test.ts
@@ -1,6 +1,7 @@
-import { parseCurlCommand } from '@/libs/parse-curl'
 import { operationSchema } from '@scalar/oas-utils/entities/spec'
 import { describe, expect, it } from 'vitest'
+
+import { parseCurlCommand } from '@/libs/parse-curl'
 
 import { findRequestByPathMethod, pathToRegex } from './find-request'
 
@@ -38,6 +39,13 @@ describe('pathToRegex', () => {
     expect(regex.test('/api/v1.0/data/123')).toBe(true)
     expect(regex.test('/api/v1.0/data/abc')).toBe(true)
     expect(regex.test('/api/v1.0/data/')).toBe(false)
+  })
+
+  it('should ignore query parameters', () => {
+    const regex = pathToRegex('/planets')
+
+    expect(regex.test('/planets?name=earth&age=100')).toBe(true)
+    expect(regex.test('/planets?age=100')).toBe(true)
   })
 })
 

--- a/packages/api-client/src/libs/find-request.ts
+++ b/packages/api-client/src/libs/find-request.ts
@@ -7,14 +7,14 @@ export const pathToRegex = (path: string) => {
     path
       .replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // escape special regex chars
       .replace(/\\\{([^}]+)\\\}/g, '([^/]+)') + // replace {param} with capture group
-    '$' // end anchor
+    '(\\?.*)?$' // optional query parameters at the end
 
   return new RegExp(regxStr)
 }
 
 /**
  * Takes a path and method and returns the request that matches the path and method while taking
- * path params into account by converting to a regex. Will also return the path params if they exist
+ * path params into account by converting to a regex. Will also return the path params if they exist.
  *
  * @example path can be /planets/{planetId} OR /planets/1
  */


### PR DESCRIPTION
**Problem**

Currently, the `findRequestByPathMethod` would not match if you have query params

**Solution**

With this PR we ignore the query params to find a suitable match. If we needed, we could extract the query params later like we do with the path.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
