### PR TITLE
fix(api-reference): render proper slots

### DIFF
--- a/.changeset/tidy-flies-roll.md
+++ b/.changeset/tidy-flies-roll.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): render proper slots

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -14,10 +14,11 @@ defineProps<{
 
 /** These slots render in their respective slots in the underlying ApiReferenceWorkspace component */
 defineSlots<{
-  footer?(): unknown
+  'content-start'?(): unknown
   'content-end'?(): unknown
   'sidebar-start'?(): unknown
   'sidebar-end'?(): unknown
+  footer?(): unknown
 }>()
 
 /**
@@ -37,17 +38,11 @@ if (typeof window !== 'undefined') {
   <ApiReferenceWorkspace
     :configuration="configuration"
     :store="workspaceStore">
-    <template #footer>
-      <slot name="footer" />
-    </template>
-    <template #content-end>
-      <slot name="content-end" />
-    </template>
-    <template #sidebar-start>
-      <slot name="sidebar-start" />
-    </template>
-    <template #sidebar-end>
-      <slot name="sidebar-end" />
-    </template>
+    <!-- Pass through content, sidebar and footer slots -->
+    <template #content-start><slot name="content-start" /></template>
+    <template #content-end><slot name="content-end" /></template>
+    <template #sidebar-start><slot name="sidebar-start" /></template>
+    <template #sidebar-end><slot name="sidebar-end" /></template>
+    <template #footer><slot name="footer" /></template>
   </ApiReferenceWorkspace>
 </template>

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -401,29 +401,28 @@ useLegacyStoreEvents(store, workspaceStore, activeEntitiesStore, documentEl)
           <template #start>
             <slot
               v-bind="referenceSlotProps"
-              name="content-start">
-              <ClassicHeader v-if="configuration.layout === 'classic'">
-                <div
-                  v-if="$slots['document-selector']"
-                  class="w-64 *:!p-0 empty:hidden">
-                  <slot name="document-selector" />
-                </div>
-                <SearchButton
-                  v-if="!configuration.hideSearch"
-                  class="t-doc__sidebar max-w-64"
-                  :hideModels="configuration?.hideModels"
-                  :searchHotKey="configuration.searchHotKey" />
-                <template #dark-mode-toggle>
-                  <ScalarColorModeToggleIcon
-                    v-if="!configuration.hideDarkModeToggle"
-                    class="text-c-2 hover:text-c-1"
-                    :mode="isDark ? 'dark' : 'light'"
-                    style="transform: scale(1.4)"
-                    variant="icon"
-                    @click="$emit('toggleDarkMode')" />
-                </template>
-              </ClassicHeader>
-            </slot>
+              name="content-start" />
+            <ClassicHeader v-if="configuration.layout === 'classic'">
+              <div
+                v-if="$slots['document-selector']"
+                class="w-64 *:!p-0 empty:hidden">
+                <slot name="document-selector" />
+              </div>
+              <SearchButton
+                v-if="!configuration.hideSearch"
+                class="t-doc__sidebar max-w-64"
+                :hideModels="configuration?.hideModels"
+                :searchHotKey="configuration.searchHotKey" />
+              <template #dark-mode-toggle>
+                <ScalarColorModeToggleIcon
+                  v-if="!configuration.hideDarkModeToggle"
+                  class="text-c-2 hover:text-c-1"
+                  :mode="isDark ? 'dark' : 'light'"
+                  style="transform: scale(1.4)"
+                  variant="icon"
+                  @click="$emit('toggleDarkMode')" />
+              </template>
+            </ClassicHeader>
           </template>
           <template
             v-if="configuration?.isEditable"

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
@@ -270,24 +270,17 @@ useFavicon(favicon)
       :store="store"
       @toggleDarkMode="() => toggleColorMode()"
       @updateContent="$emit('updateContent', $event)">
-      <template #footer>
-        <slot name="footer" />
-      </template>
-      <!-- Expose the content end slot as a slot for the footer -->
-      <template #content-end>
-        <slot name="footer" />
-      </template>
       <template #document-selector>
         <DocumentSelector
           v-model="selectedDocumentIndex"
           :options="availableDocuments" />
       </template>
-      <template #sidebar-start>
-        <slot name="sidebar-start" />
-      </template>
-      <template #sidebar-end>
-        <slot name="sidebar-end" />
-      </template>
+      <!-- Pass through content, sidebar and footer slots -->
+      <template #content-start><slot name="content-start" /></template>
+      <template #content-end><slot name="content-end" /></template>
+      <template #sidebar-start><slot name="sidebar-start" /></template>
+      <template #sidebar-end><slot name="sidebar-end" /></template>
+      <template #footer><slot name="footer" /></template>
     </ApiReferenceLayout>
   </div>
 </template>


### PR DESCRIPTION
Paves the way for the dev toolbar (which will use the `content-start` slot) and fixes a double footer issue.

Before:

<img width="2940" height="1958" alt="CleanShot 2025-09-09 at 15 45 05@2x" src="https://github.com/user-attachments/assets/63ee9912-4e2f-45a0-8eee-662c854a3c71" />
<img width="2940" height="1958" alt="CleanShot 2025-09-09 at 15 44 53@2x" src="https://github.com/user-attachments/assets/d053f003-d4a7-41fe-94cb-251dedb55cca" />
<img width="2940" height="1958" alt="CleanShot 2025-09-09 at 15 45 13@2x" src="https://github.com/user-attachments/assets/496c175b-63fe-428f-bd72-bb18b7316480" />
<img width="2940" height="1958" alt="CleanShot 2025-09-09 at 15 45 18@2x" src="https://github.com/user-attachments/assets/c4031541-74eb-478c-9bf7-8963b3c5325f" />

 After:
<img width="2940" height="1958" alt="CleanShot 2025-09-09 at 15 47 03@2x" src="https://github.com/user-attachments/assets/376a1eaf-7188-4f5e-b93a-78e9667e36ab" />
<img width="2940" height="1958" alt="CleanShot 2025-09-09 at 15 47 07@2x" src="https://github.com/user-attachments/assets/6773141c-9f90-42a1-a7c0-bfd6d534b744" />
<img width="2940" height="1958" alt="CleanShot 2025-09-09 at 15 47 13@2x" src="https://github.com/user-attachments/assets/28585050-37f2-4f17-8eee-d25924762709" />
<img width="2940" height="1958" alt="CleanShot 2025-09-09 at 15 47 17@2x" src="https://github.com/user-attachments/assets/87602796-db0d-43c1-a488-a835aec9bab9" />


**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
