### PR TITLE
feat(build-tooling): Improve vite return type

### DIFF
--- a/.changeset/fifty-teachers-laugh.md
+++ b/.changeset/fifty-teachers-laugh.md
@@ -1,0 +1,5 @@
+---
+'@scalar/build-tooling': patch
+---
+
+Improve return types for vite options

--- a/packages/build-tooling/src/esbuild/build.ts
+++ b/packages/build-tooling/src/esbuild/build.ts
@@ -136,10 +136,13 @@ export async function build({
 
   console.log(as.blue('[esbuild]: Running initial build'))
   await esbuildCtx.rebuild()
+  console.log(as.blue('[esbuild]: Initial build complete'))
+
+  const start = performance.now()
   runCommand('tsc       -p tsconfig.build.json --watch', 'tsc')
   runCommand('tsc-alias -p tsconfig.build.json --watch', 'tsc-alias')
-
-  console.log(as.blue('[esbuild]: Initial build complete'))
+  const end = performance.now()
+  console.log(as.blue(`[esbuild]: Types build completed in ${(end - start).toFixed(0)}ms`))
 
   const srcDir = path.join(process.cwd(), 'src')
   const watcher = chokidar.watch([srcDir, 'package.json', 'tsconfig.json', 'tsconfig.build.json'], {

--- a/packages/build-tooling/src/vite/options.ts
+++ b/packages/build-tooling/src/vite/options.ts
@@ -15,11 +15,13 @@ import { type StrictPluginOptions, createRollupConfig } from '../rollup'
  * - Builds only ESM output
  * - Preserves modules
  */
-export function createViteBuildOptions(props: {
+export function createViteBuildOptions<
+  T extends Partial<BuildOptions & { rollupOptions: StrictPluginOptions }>,
+>(props: {
   entry: LibraryOptions['entry']
   pkgFile?: Record<string, any>
-  options?: BuildOptions & { rollupOptions?: StrictPluginOptions }
-}): BuildOptions {
+  options?: T
+}): T & Pick<BuildOptions, 'rollupOptions' | 'lib' | 'outDir'> {
   return {
     outDir: './dist',
     ...props.options,
@@ -38,7 +40,7 @@ export function createViteBuildOptions(props: {
       options: props.options?.rollupOptions,
       emptyOutDir: false,
     }),
-  }
+  } as Pick<BuildOptions, 'rollupOptions' | 'lib' | 'outDir'> & T
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Limits the type return of vite options to help with version mismatch compat. 