### PR TITLE
docs: update API Client section

### DIFF
--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -149,41 +149,40 @@ They are open source. So I can get in on free features and stay with Scalar no m
   </div>
   <div class="product">
     <div class="product-copy">
-      <span class="font-bold text-orange">API Client</span>
+      <span class="font-bold text-orange">Scalar API Client</span>
       <h2 class="c">
-        An offline first API Client built for the OpenAPI™ standard.
+        The Postman Alternative Your Team Is Dreaming Of
       </h2>
       <p>
-        Minimal, powerful, fully open-source API Client built on open standards
-        by us + our community
+        Fully open-source API Client built on the OpenAPI standard
       </p>
       <div class="flex flex-wrap text-orange gap-y-2">
         <b class="flex items-center icon-text gap-3 font-medium w-1/2 min-h-8">
-          <scalar-icon src="phosphor/bold/users"></scalar-icon>
-          Collaborate
-        </b>
-        <b class="flex items-center icon-text gap-3 font-medium w-1/2 min-h-8">
           <scalar-icon src="phosphor/bold/wifi-slash"></scalar-icon>
-          Offline First
+          Offline-first
         </b>
         <b class="flex items-center icon-text gap-3 font-medium w-1/2 min-h-8">
           <scalar-icon src="phosphor/bold/globe"></scalar-icon>
-          Sync Local API's
+          Sync your local API
         </b>
         <b class="flex items-center icon-text gap-3 font-medium w-1/2 min-h-8">
           <scalar-icon src="phosphor/bold/graph"></scalar-icon>
-          OpenAPI Support
+          OpenAPI by Heart
+        </b>
+        <b class="flex items-center icon-text gap-3 font-medium w-1/2 min-h-8">
+          <scalar-icon src="phosphor/bold/users"></scalar-icon>
+          Collaborate with Others
         </b>
         <b class="flex items-center icon-text gap-3 font-medium w-1/2 min-h-8">
           <scalar-icon src="phosphor/bold/lock-simple-open"></scalar-icon>
-          No Vendor Lock In
+          No Vendor Lock-In
         </b>
         <b class="flex items-center icon-text gap-3 font-medium w-1/2 min-h-8">
           <scalar-icon src="phosphor/bold/desktop-tower"></scalar-icon>
-          Multi-platform
+          Linux, Windows, macOS
         </b>
       </div>
-      <a class="mt-3 t-editor__anchor" href="https://client.scalar.com/">Try It Out For Free →</a>
+      <a class="mt-3 t-editor__anchor" href="https://client.scalar.com/">Try It in the Browser →</a>
     </div>
     <div class="product-image">
       <div class="product-image-transform">


### PR DESCRIPTION
* tweaked the copy
* API Client -> Scalar API Client (becomes a "product" when reading)
* remind people of the tool they are using now and might want to get rid of
* removed "powerful" (doesn’t mean much if you say this about your own tools)
* made the CTA less generic

**Before**

<img width="1155" height="655" alt="Screenshot 2025-09-10 at 12 21 04" src="https://github.com/user-attachments/assets/34b11bb1-64ab-451e-bc6a-24a553670077" />

**After**

<img width="1152" height="623" alt="Screenshot 2025-09-10 at 10 31 49" src="https://github.com/user-attachments/assets/d7f26a3c-eba5-443c-bfe7-aff0b6eea2c8" />
