### PR TITLE
feat(Scalar.AspNetCore): support OrderRequiredPropertiesFirst and OrderSchemaPropertiesBy

### DIFF
--- a/.changeset/sweet-chefs-work.md
+++ b/.changeset/sweet-chefs-work.md
@@ -1,0 +1,6 @@
+---
+'@scalar/aspnetcore': patch
+'@scalar/aspire': patch
+---
+
+feat: add SchemaPropertyOrder and OrderRequiredPropertiesFirst configuration support

--- a/integrations/aspire/src/Scalar.Aspire/Contract/ScalarConfiguration.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Contract/ScalarConfiguration.cs
@@ -67,4 +67,8 @@ internal sealed class ScalarConfiguration
     public required bool PersistAuth { get; set; }
 
     public required string? DocumentDownloadType { get; init; }
+
+    public required bool OrderRequiredPropertiesFirst { get; init; }
+
+    public required string? OrderSchemaPropertiesBy { get; init; }
 }

--- a/integrations/aspire/src/Scalar.Aspire/Enums/PropertyOrder.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Enums/PropertyOrder.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel;
+using NetEscapades.EnumGenerators;
+
+namespace Scalar.Aspire;
+
+/// <summary>
+/// Specifies the ordering options for schema properties in the Scalar API reference.
+/// </summary>
+[EnumExtensions]
+public enum PropertyOrder
+{
+    /// <summary>
+    /// Preserve the original order of schema properties.
+    /// </summary>
+    [Description("preserve")]
+    Preserve,
+
+    /// <summary>
+    /// Sort schema properties alphabetically.
+    /// </summary>
+    [Description("alpha")]
+    Alpha
+}

--- a/integrations/aspire/src/Scalar.Aspire/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Extensions/ScalarOptionsExtensions.cs
@@ -613,4 +613,28 @@ public static class ScalarOptionsExtensions
         options.PreferHttpsEndpoint = true;
         return options;
     }
+
+    /// <summary>
+    /// Sets whether required properties should be ordered first in schema properties.
+    /// </summary>
+    /// <param name="options">The <see cref="ScalarOptions" /> to configure.</param>
+    /// <param name="orderRequiredFirst">Whether to order required properties first.</param>
+    /// <returns>The <see cref="ScalarOptions" /> so that additional calls can be chained.</returns>
+    public static TOptions WithOrderRequiredPropertiesFirst<TOptions>(this TOptions options, bool orderRequiredFirst = true) where TOptions : ScalarOptions
+    {
+        options.OrderRequiredPropertiesFirst = orderRequiredFirst;
+        return options;
+    }
+
+    /// <summary>
+    /// Sets the ordering method for schema properties.
+    /// </summary>
+    /// <param name="options">The <see cref="ScalarOptions" /> to configure.</param>
+    /// <param name="orderBy">The ordering method to use for schema properties.</param>
+    /// <returns>The <see cref="ScalarOptions" /> so that additional calls can be chained.</returns>
+    public static TOptions WithSchemaPropertyOrder<TOptions>(this TOptions options, PropertyOrder? orderBy) where TOptions : ScalarOptions
+    {
+        options.SchemaPropertyOrder = orderBy;
+        return options;
+    }
 }

--- a/integrations/aspire/src/Scalar.Aspire/Mapper/ScalarOptionsMapper.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Mapper/ScalarOptionsMapper.cs
@@ -72,7 +72,9 @@ internal static class ScalarOptionsMapper
             Sources = sources,
             BaseServerUrl = options.BaseServerUrl,
             PersistAuth = options.PersistentAuthentication,
-            DocumentDownloadType = options.DocumentDownloadType?.ToStringFast(true)
+            DocumentDownloadType = options.DocumentDownloadType?.ToStringFast(true),
+            OrderRequiredPropertiesFirst = options.OrderRequiredPropertiesFirst,
+            OrderSchemaPropertiesBy = options.SchemaPropertyOrder?.ToStringFast(true)
         };
     }
 

--- a/integrations/aspire/src/Scalar.Aspire/Options/ScalarOptions.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Options/ScalarOptions.cs
@@ -211,4 +211,16 @@ public abstract class ScalarOptions
     /// When set to <c>true</c>, HTTPS URLs will be prioritized when multiple endpoints are available.
     /// </remarks>
     public bool PreferHttpsEndpoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether required properties should be ordered first in schema properties.
+    /// </summary>
+    /// <value>The default value is <c>false</c>.</value>
+    public bool OrderRequiredPropertiesFirst { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ordering method for schema properties.
+    /// </summary>
+    /// <value>The default value is <c>null</c>.</value>
+    public PropertyOrder? SchemaPropertyOrder { get; set; }
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Contract/ScalarConfiguration.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Contract/ScalarConfiguration.cs
@@ -70,6 +70,10 @@ internal sealed class ScalarConfiguration
     public required bool PersistAuth { get; init; }
 
     public required DocumentDownloadType? DocumentDownloadType { get; init; }
+
+    public required bool OrderRequiredPropertiesFirst { get; init; }
+
+    public required PropertyOrder? OrderSchemaPropertiesBy { get; init; }
 }
 
 [JsonSerializable(typeof(ScalarConfiguration))]

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Converters/PropertyOrderJsonConverter.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Converters/PropertyOrderJsonConverter.cs
@@ -1,0 +1,16 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Scalar.AspNetCore;
+
+internal sealed class PropertyOrderJsonConverter : JsonConverter<PropertyOrder>
+{
+    public override PropertyOrder Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        // We don't have to implement this method because we don't need to deserialize the PropertyOrder enum.
+        default;
+
+    public override void Write(Utf8JsonWriter writer, PropertyOrder value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToStringFast(true));
+    }
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/PropertyOrder.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/PropertyOrder.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using NetEscapades.EnumGenerators;
+
+namespace Scalar.AspNetCore;
+
+/// <summary>
+/// Specifies the ordering options for schema properties in the Scalar API reference.
+/// </summary>
+[EnumExtensions]
+[JsonConverter(typeof(PropertyOrderJsonConverter))]
+public enum PropertyOrder
+{
+    /// <summary>
+    /// Preserve the original order of schema properties.
+    /// </summary>
+    [Description("preserve")]
+    Preserve,
+
+    /// <summary>
+    /// Sort schema properties alphabetically.
+    /// </summary>
+    [Description("alpha")]
+    Alpha
+}

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -935,9 +935,9 @@ public static class ScalarOptionsExtensions
     /// <param name="options">The <see cref="ScalarOptions" /> to configure.</param>
     /// <param name="orderBy">The ordering method to use for schema properties.</param>
     /// <returns>The <see cref="ScalarOptions" /> so that additional calls can be chained.</returns>
-    public static ScalarOptions WithOrderSchemaPropertiesBy(this ScalarOptions options, PropertyOrder? orderBy)
+    public static ScalarOptions WithSchemaPropertyOrder(this ScalarOptions options, PropertyOrder? orderBy)
     {
-        options.OrderSchemaPropertiesBy = orderBy;
+        options.SchemaPropertyOrder = orderBy;
         return options;
     }
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -916,4 +916,28 @@ public static class ScalarOptionsExtensions
         options.PersistentAuthentication = persistAuth;
         return options;
     }
+
+    /// <summary>
+    /// Sets whether required properties should be ordered first in schema properties.
+    /// </summary>
+    /// <param name="options">The <see cref="ScalarOptions" /> to configure.</param>
+    /// <param name="orderRequiredFirst">Whether to order required properties first.</param>
+    /// <returns>The <see cref="ScalarOptions" /> so that additional calls can be chained.</returns>
+    public static ScalarOptions WithOrderRequiredPropertiesFirst(this ScalarOptions options, bool orderRequiredFirst = true)
+    {
+        options.OrderRequiredPropertiesFirst = orderRequiredFirst;
+        return options;
+    }
+
+    /// <summary>
+    /// Sets the ordering method for schema properties.
+    /// </summary>
+    /// <param name="options">The <see cref="ScalarOptions" /> to configure.</param>
+    /// <param name="orderBy">The ordering method to use for schema properties.</param>
+    /// <returns>The <see cref="ScalarOptions" /> so that additional calls can be chained.</returns>
+    public static ScalarOptions WithOrderSchemaPropertiesBy(this ScalarOptions options, PropertyOrder? orderBy)
+    {
+        options.OrderSchemaPropertiesBy = orderBy;
+        return options;
+    }
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -47,8 +47,10 @@ internal static partial class ScalarOptionsMapper
             BaseServerUrl = options.BaseServerUrl,
             PersistAuth = options.PersistentAuthentication,
 #pragma warning disable CS0618 // Type or member is obsolete
-            DocumentDownloadType = options.HideDownloadButton ? DocumentDownloadType.None : options.DocumentDownloadType
+            DocumentDownloadType = options.HideDownloadButton ? DocumentDownloadType.None : options.DocumentDownloadType,
 #pragma warning restore CS0618 // Type or member is obsolete
+            OrderRequiredPropertiesFirst = options.OrderRequiredPropertiesFirst,
+            OrderSchemaPropertiesBy = options.OrderSchemaPropertiesBy
         };
     }
 

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.cs
@@ -50,7 +50,7 @@ internal static partial class ScalarOptionsMapper
             DocumentDownloadType = options.HideDownloadButton ? DocumentDownloadType.None : options.DocumentDownloadType,
 #pragma warning restore CS0618 // Type or member is obsolete
             OrderRequiredPropertiesFirst = options.OrderRequiredPropertiesFirst,
-            OrderSchemaPropertiesBy = options.OrderSchemaPropertiesBy
+            OrderSchemaPropertiesBy = options.SchemaPropertyOrder
         };
     }
 

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -304,5 +304,5 @@ public sealed class ScalarOptions
     /// Gets or sets the ordering method for schema properties.
     /// </summary>
     /// <value>The default value is <c>null</c>.</value>
-    public PropertyOrder? OrderSchemaPropertiesBy { get; set; }
+    public PropertyOrder? SchemaPropertyOrder { get; set; }
 }

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -293,4 +293,16 @@ public sealed class ScalarOptions
     /// </summary>
     /// <value>The default value is <c>null</c>.</value>
     public DocumentDownloadType? DocumentDownloadType { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether required properties should be ordered first in schema properties.
+    /// </summary>
+    /// <value>The default value is <c>false</c>.</value>
+    public bool OrderRequiredPropertiesFirst { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ordering method for schema properties.
+    /// </summary>
+    /// <value>The default value is <c>null</c>.</value>
+    public PropertyOrder? OrderSchemaPropertiesBy { get; set; }
 }

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Converters/PropertyOrderJsonConverterTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Converters/PropertyOrderJsonConverterTests.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+
+namespace Scalar.AspNetCore.Tests;
+
+public class PropertyOrderJsonConverterTests
+{
+    [Fact]
+    public void Converter_ShouldSerializeToStringFast()
+    {
+        // Arrange
+        const PropertyOrder orderBy = PropertyOrder.Alpha;
+
+        // Act
+        var json = JsonSerializer.Serialize(orderBy);
+
+        // Assert
+        json.Should().Be("\"alpha\"");
+    }
+}

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Extensions/ScalarOptionsExtensionsTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Extensions/ScalarOptionsExtensionsTests.cs
@@ -65,7 +65,7 @@ public class ScalarOptionsExtensionsTests
             .WithJavaScriptConfiguration("/scalar/config.js")
             .WithPersistentAuthentication()
             .WithOrderRequiredPropertiesFirst()
-            .WithOrderSchemaPropertiesBy(PropertyOrder.Alpha);
+            .WithSchemaPropertyOrder(PropertyOrder.Alpha);
 
         // Assert
         options.Title.Should().Be("My title");
@@ -115,7 +115,7 @@ public class ScalarOptionsExtensionsTests
         options.JavaScriptConfiguration.Should().Be("/scalar/config.js");
         options.PersistentAuthentication.Should().BeTrue();
         options.OrderRequiredPropertiesFirst.Should().BeTrue();
-        options.OrderSchemaPropertiesBy.Should().Be(PropertyOrder.Alpha);
+        options.SchemaPropertyOrder.Should().Be(PropertyOrder.Alpha);
 
 #pragma warning restore CS0618 // Type or member is obsolete
     }
@@ -509,10 +509,10 @@ public class ScalarOptionsExtensionsTests
         var options = new ScalarOptions();
 
         // Act
-        options.WithOrderSchemaPropertiesBy(PropertyOrder.Alpha);
+        options.WithSchemaPropertyOrder(PropertyOrder.Alpha);
 
         // Assert
-        options.OrderSchemaPropertiesBy.Should().Be(PropertyOrder.Alpha);
+        options.SchemaPropertyOrder.Should().Be(PropertyOrder.Alpha);
     }
 
     [Fact]
@@ -522,10 +522,10 @@ public class ScalarOptionsExtensionsTests
         var options = new ScalarOptions();
 
         // Act
-        options.WithOrderSchemaPropertiesBy(PropertyOrder.Preserve);
+        options.WithSchemaPropertyOrder(PropertyOrder.Preserve);
 
         // Assert
-        options.OrderSchemaPropertiesBy.Should().Be(PropertyOrder.Preserve);
+        options.SchemaPropertyOrder.Should().Be(PropertyOrder.Preserve);
     }
 
     [Fact]
@@ -535,9 +535,9 @@ public class ScalarOptionsExtensionsTests
         var options = new ScalarOptions();
 
         // Act
-        options.WithOrderSchemaPropertiesBy(null);
+        options.WithSchemaPropertyOrder(null);
 
         // Assert
-        options.OrderSchemaPropertiesBy.Should().BeNull();
+        options.SchemaPropertyOrder.Should().BeNull();
     }
 }

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Extensions/ScalarOptionsExtensionsTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/Extensions/ScalarOptionsExtensionsTests.cs
@@ -63,7 +63,9 @@ public class ScalarOptionsExtensionsTests
             .WithBaseServerUrl("https://example.com")
             .WithDynamicBaseServerUrl()
             .WithJavaScriptConfiguration("/scalar/config.js")
-            .WithPersistentAuthentication();
+            .WithPersistentAuthentication()
+            .WithOrderRequiredPropertiesFirst()
+            .WithOrderSchemaPropertiesBy(PropertyOrder.Alpha);
 
         // Assert
         options.Title.Should().Be("My title");
@@ -112,6 +114,8 @@ public class ScalarOptionsExtensionsTests
         options.DynamicBaseServerUrl.Should().BeTrue();
         options.JavaScriptConfiguration.Should().Be("/scalar/config.js");
         options.PersistentAuthentication.Should().BeTrue();
+        options.OrderRequiredPropertiesFirst.Should().BeTrue();
+        options.OrderSchemaPropertiesBy.Should().Be(PropertyOrder.Alpha);
 
 #pragma warning restore CS0618 // Type or member is obsolete
     }
@@ -470,5 +474,70 @@ public class ScalarOptionsExtensionsTests
         authorizationCodeFlow!.ClientId.Should().Be("clientId");
         authorizationCodeFlow.AuthorizationUrl.Should().Be("https://example.com/authorize");
         oauth2Scheme.DefaultScopes.Should().BeEquivalentTo("scope1", "scope2");
+    }
+
+    [Fact]
+    public void WithOrderRequiredPropertiesFirst_ShouldSetProperty()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.WithOrderRequiredPropertiesFirst();
+
+        // Assert
+        options.OrderRequiredPropertiesFirst.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WithOrderRequiredPropertiesFirst_ShouldSetDefaultValue()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.WithOrderRequiredPropertiesFirst();
+
+        // Assert
+        options.OrderRequiredPropertiesFirst.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WithOrderSchemaPropertiesBy_ShouldSetProperty()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.WithOrderSchemaPropertiesBy(PropertyOrder.Alpha);
+
+        // Assert
+        options.OrderSchemaPropertiesBy.Should().Be(PropertyOrder.Alpha);
+    }
+
+    [Fact]
+    public void WithOrderSchemaPropertiesBy_ShouldSetPreserveProperty()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.WithOrderSchemaPropertiesBy(PropertyOrder.Preserve);
+
+        // Assert
+        options.OrderSchemaPropertiesBy.Should().Be(PropertyOrder.Preserve);
+    }
+
+    [Fact]
+    public void WithOrderSchemaPropertiesBy_ShouldSetNullProperty()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.WithOrderSchemaPropertiesBy(null);
+
+        // Assert
+        options.OrderSchemaPropertiesBy.Should().BeNull();
     }
 }

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -82,7 +82,7 @@ public class ScalarOptionsMapperTests
             HideClientButton = true,
             PersistentAuthentication = true,
             OrderRequiredPropertiesFirst = true,
-            OrderSchemaPropertiesBy = PropertyOrder.Alpha
+            SchemaPropertyOrder = PropertyOrder.Alpha
         };
         options.AddDocument("v2");
 

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -37,6 +37,8 @@ public class ScalarOptionsMapperTests
         configuration.Integration.Should().Be("dotnet");
         configuration.Sources.Should().BeEmpty();
         configuration.PersistAuth.Should().BeFalse();
+        configuration.OrderRequiredPropertiesFirst.Should().BeFalse();
+        configuration.OrderSchemaPropertiesBy.Should().BeNull();
     }
 
     [Fact]
@@ -78,7 +80,9 @@ public class ScalarOptionsMapperTests
             OperationSorter = OperationSorter.Method,
             DotNetFlag = false,
             HideClientButton = true,
-            PersistentAuthentication = true
+            PersistentAuthentication = true,
+            OrderRequiredPropertiesFirst = true,
+            OrderSchemaPropertiesBy = PropertyOrder.Alpha
         };
         options.AddDocument("v2");
 
@@ -117,6 +121,8 @@ public class ScalarOptionsMapperTests
         configuration.HideClientButton.Should().BeTrue();
         configuration.Sources.Should().ContainSingle().Which.Url.Should().Be("openapi/v2.json");
         configuration.PersistAuth.Should().BeTrue();
+        configuration.OrderRequiredPropertiesFirst.Should().BeTrue();
+        configuration.OrderSchemaPropertiesBy.Should().Be(PropertyOrder.Alpha);
     }
 
     [Fact]


### PR DESCRIPTION
This PR adds support for the `orderRequiredPropertiesFirst` and `orderSchemaPropertiesBy` configurations to the Aspire and AspNetCore integration.
**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
