### PR TITLE
fix(api-reference): use operation/path servers for code examples

### DIFF
--- a/.changeset/nervous-rings-shake.md
+++ b/.changeset/nervous-rings-shake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+Fix server selection for examples/snippets in Operation: prefer operation-level servers, then path-level servers, then provided server prop.

--- a/packages/api-reference/src/features/Operation/Operation.vue
+++ b/packages/api-reference/src/features/Operation/Operation.vue
@@ -16,6 +16,7 @@ import { combineParams } from '@/features/Operation/helpers/combine-params'
 import { convertSecurityScheme } from '@/helpers/convert-security-scheme'
 import type { ClientOptionGroup } from '@/v2/blocks/scalar-request-example-block/types'
 
+import { getFirstServer } from './helpers/get-first-server'
 import ClassicLayout from './layouts/ClassicLayout.vue'
 import ModernLayout from './layouts/ModernLayout.vue'
 
@@ -75,27 +76,18 @@ const selectedSecuritySchemes = computed(() =>
 )
 
 /**
- * Determine the effective server for examples/snippets.
- * Preference order: operation.servers -> pathItem.servers -> provided server prop
+ * Determine the effective server for the code examples.
  */
-const effectiveServer = computed<ServerObject | undefined>(() => {
-  const opServer =
-    operation.value?.servers && operation.value.servers[0]
-      ? (getResolvedRef(operation.value.servers[0]) as ServerObject)
-      : undefined
-
-  if (opServer?.url) return opServer
-
-  const pathServer =
-    pathItem.value?.servers && pathItem.value.servers[0]
-      ? (getResolvedRef(pathItem.value.servers[0]) as ServerObject)
-      : undefined
-
-  if (pathServer?.url) return pathServer
-
-  // Fallback to the server coming from the active collection selection
-  return server as unknown as ServerObject | undefined
-})
+const selectedServer = computed<ServerObject | undefined>(() =>
+  getFirstServer(
+    // 1) Operation
+    operation.value?.servers,
+    // 2) Path Item
+    pathItem.value?.servers,
+    // 3) Document
+    server,
+  ),
+)
 </script>
 
 <template>
@@ -110,7 +102,7 @@ const effectiveServer = computed<ServerObject | undefined>(() => {
         :operation="operation"
         :path="path"
         :securitySchemes="selectedSecuritySchemes"
-        :server="effectiveServer"
+        :server="selectedServer"
         :store="store" />
     </template>
     <template v-else>
@@ -123,7 +115,7 @@ const effectiveServer = computed<ServerObject | undefined>(() => {
         :operation="operation"
         :path="path"
         :securitySchemes="selectedSecuritySchemes"
-        :server="effectiveServer"
+        :server="selectedServer"
         :store="store" />
     </template>
   </template>

--- a/packages/api-reference/src/features/Operation/helpers/get-first-server.test.ts
+++ b/packages/api-reference/src/features/Operation/helpers/get-first-server.test.ts
@@ -1,0 +1,161 @@
+import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { describe, expect, it } from 'vitest'
+
+import { getFirstServer } from './get-first-server'
+
+describe('get-first-server', () => {
+  describe('getFirstServer', () => {
+    it('returns the first server with a URL from a single server object', () => {
+      const server: ServerObject = {
+        url: 'https://api.example.com',
+        description: 'Production server',
+      }
+
+      const result = getFirstServer(server)
+
+      expect(result).toEqual(server)
+    })
+
+    it('returns the first server with a URL from an array of servers', () => {
+      const servers: ServerObject[] = [
+        { url: 'https://api.example.com', description: 'Production' },
+        { url: 'https://staging.example.com', description: 'Staging' },
+        { url: 'https://dev.example.com', description: 'Development' },
+      ]
+
+      const result = getFirstServer(servers)
+
+      expect(result).toEqual(servers[0])
+    })
+
+    it('skips servers without URLs and returns the first valid one', () => {
+      const servers: ServerObject[] = [
+        // @ts-expect-error - Testing an invalid server object
+        { description: 'No URL server' },
+        { url: 'https://api.example.com', description: 'Valid server' },
+        { url: 'https://staging.example.com', description: 'Another valid server' },
+      ]
+
+      const result = getFirstServer(servers)
+
+      expect(result).toEqual(servers[1])
+    })
+
+    it('returns the first server from the first non-empty source', () => {
+      const operationServers: ServerObject[] = [
+        { url: 'https://operation.example.com', description: 'Operation server' },
+      ]
+      const pathItemServers: ServerObject[] = [{ url: 'https://path.example.com', description: 'Path server' }]
+      const documentServer: ServerObject = {
+        url: 'https://document.example.com',
+        description: 'Document server',
+      }
+
+      const result = getFirstServer(operationServers, pathItemServers, documentServer)
+
+      expect(result).toEqual(operationServers[0])
+    })
+
+    it('falls back to the next source when the first source has no valid servers', () => {
+      // @ts-expect-error - Testing an invalid server object
+      const operationServers: ServerObject[] = [{ description: 'No URL' }]
+      const pathItemServers: ServerObject[] = [{ url: 'https://path.example.com', description: 'Path server' }]
+      const documentServer: ServerObject = {
+        url: 'https://document.example.com',
+        description: 'Document server',
+      }
+
+      const result = getFirstServer(operationServers, pathItemServers, documentServer)
+
+      expect(result).toEqual(pathItemServers[0])
+    })
+
+    it('handles undefined sources gracefully', () => {
+      const validServer: ServerObject = {
+        url: 'https://api.example.com',
+        description: 'Valid server',
+      }
+
+      const result = getFirstServer(undefined, null, validServer)
+
+      expect(result).toEqual(validServer)
+    })
+
+    it('returns undefined when no servers have URLs', () => {
+      // @ts-expect-error - Testing an invalid server object
+      const servers: ServerObject[] = [{ description: 'No URL 1' }, { description: 'No URL 2' }]
+
+      const result = getFirstServer(servers)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('returns undefined when all sources are empty or undefined', () => {
+      // @ts-expect-error - Testing an invalid server object
+      const result = getFirstServer(undefined, [], null)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('handles empty arrays', () => {
+      const result = getFirstServer([])
+
+      expect(result).toBeUndefined()
+    })
+
+    it('prioritizes operation servers over path item servers over document servers', () => {
+      const operationServer: ServerObject = {
+        url: 'https://operation.example.com',
+        description: 'Operation server',
+      }
+      const pathItemServer: ServerObject = {
+        url: 'https://path.example.com',
+        description: 'Path server',
+      }
+      const documentServer: ServerObject = {
+        url: 'https://document.example.com',
+        description: 'Document server',
+      }
+
+      // Test operation server priority
+      let result = getFirstServer(operationServer, pathItemServer, documentServer)
+      expect(result).toEqual(operationServer)
+
+      // Test path item server priority when operation server is undefined
+      result = getFirstServer(undefined, pathItemServer, documentServer)
+      expect(result).toEqual(pathItemServer)
+
+      // Test document server as fallback
+      result = getFirstServer(undefined, undefined, documentServer)
+      expect(result).toEqual(documentServer)
+    })
+
+    it('handles mixed server types in the same call', () => {
+      const singleServer: ServerObject = {
+        url: 'https://single.example.com',
+        description: 'Single server',
+      }
+      const serverArray: ServerObject[] = [{ url: 'https://array.example.com', description: 'Array server' }]
+
+      const result = getFirstServer(singleServer, serverArray)
+
+      expect(result).toEqual(singleServer)
+    })
+
+    it('works with the exact usage pattern from Operation.vue', () => {
+      // Simulate the exact usage from Operation.vue lines 82-90
+      const operationServers: ServerObject[] = [
+        { url: 'https://operation.example.com', description: 'Operation server' },
+      ]
+      const pathItemServers: ServerObject[] = [{ url: 'https://path.example.com', description: 'Path server' }]
+      const documentServer: ServerObject = {
+        url: 'https://document.example.com',
+        description: 'Document server',
+      }
+
+      const result = getFirstServer(operationServers, pathItemServers, documentServer)
+
+      expect(result).toEqual(operationServers[0])
+    })
+  })
+})

--- a/packages/api-reference/src/features/Operation/helpers/get-first-server.test.ts
+++ b/packages/api-reference/src/features/Operation/helpers/get-first-server.test.ts
@@ -76,6 +76,7 @@ describe('get-first-server', () => {
         description: 'Valid server',
       }
 
+      // @ts-expect-error - Testing an invalid server object
       const result = getFirstServer(undefined, null, validServer)
 
       expect(result).toEqual(validServer)

--- a/packages/api-reference/src/features/Operation/helpers/get-first-server.ts
+++ b/packages/api-reference/src/features/Operation/helpers/get-first-server.ts
@@ -1,0 +1,37 @@
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+
+/**
+ * Iterate through all available servers and pick the first one
+ *
+ * @example
+ * getFirstServer([operation.servers, pathItem.servers, server])
+ */
+export function getFirstServer(
+  ...availableServers: (ServerObject[] | ServerObject | undefined)[]
+): ServerObject | undefined {
+  for (const serverSource of availableServers) {
+    if (!serverSource) {
+      continue
+    }
+
+    // Handle single server object
+    if (!Array.isArray(serverSource)) {
+      const resolvedServer = getResolvedRef(serverSource) as ServerObject
+      if (resolvedServer?.url) {
+        return resolvedServer
+      }
+      continue
+    }
+
+    // Handle array of servers, pick the first one with a URL
+    for (const server of serverSource) {
+      const resolvedServer = getResolvedRef(server) as ServerObject
+      if (resolvedServer?.url) {
+        return resolvedServer
+      }
+    }
+  }
+
+  return undefined
+}


### PR DESCRIPTION
**Problem**

When using multiple servers (root servers and operation-level servers), the “Examples” code samples ignore the operation/path server selection and always use the first server from the root of the OpenAPI document. The “Test Request” button already respects operation-level (and path-level) servers, so Examples and Test Request can disagree.

Steps to reproduce:
1. Define root servers: `[https://root.example.com, …]`
2. For an operation, define servers: `[{ url: 'https://op.example.com' }]`
3. “Test Request” sends to https://op.example.com, but “Examples” shows code using https://root.example.com

**Solution**

With this PR, Examples now use the same precedence as Test Request:
1. Prefer `operation.servers[0]`
2. Else `pathItem.servers[0]`
3. Else fall back to the provided/active collection server

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
