### PR TITLE
fix(components): default scalar menu links to be <a> tags

### DIFF
--- a/packages/components/src/components/ScalarMenu/ScalarMenuLink.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuLink.vue
@@ -19,7 +19,8 @@ defineOptions({ inheritAttrs: false })
 <template>
   <ScalarDropdownButton
     v-bind="cx('flex items-center')"
-    :is="is">
+    :is="is"
+    as="a">
     <ScalarIconLegacyAdapter
       v-if="icon"
       :class="[


### PR DESCRIPTION
**Problem**

Currently, …

**Solution**

With this PR …

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
