### PR TITLE
fix(api-reference): webhook request example display

### DIFF
--- a/.changeset/gentle-buttons-flash.md
+++ b/.changeset/gentle-buttons-flash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): webhook request example display

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -186,6 +186,7 @@ const { copyToClipboard } = useClipboard()
             :method="method"
             :operation="operation"
             :path="path"
+            :isWebhook="isWebhook"
             :securitySchemes="securitySchemes"
             :selectedClient="store.workspace['x-scalar-default-client']"
             :selectedServer="server" />

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -153,6 +153,7 @@ const labelId = useId()
                 :method="method"
                 :operation="operation"
                 :path="path"
+                :isWebhook="isWebhook"
                 :securitySchemes="securitySchemes"
                 :selectedClient="store.workspace['x-scalar-default-client']"
                 :selectedServer="server">


### PR DESCRIPTION
**Problem**

Currently, the display of webhook request examples has regressed and shows the same as normal operations.

**Solution**

With this PR webhook request examples are displayed correctly.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
