### PR TITLE
fix(build-tooling): check dirname exists before accessing

### DIFF
--- a/.changeset/perfect-boats-add.md
+++ b/.changeset/perfect-boats-add.md
@@ -1,0 +1,5 @@
+---
+'@scalar/build-tooling': patch
+---
+
+fix(build-tooling): check dirname exists before accessing

--- a/packages/build-tooling/src/helpers.ts
+++ b/packages/build-tooling/src/helpers.ts
@@ -6,8 +6,8 @@
  */
 import fs from 'node:fs/promises'
 import path from 'node:path'
-
 import { fileURLToPath } from 'node:url'
+
 import { glob } from 'glob'
 
 const cssExports = {
@@ -106,7 +106,7 @@ export async function addPackageFileExports({ allowCss, entries }: { allowCss?: 
   })
 
   // don't touch the package.json in ./dist
-  if (import.meta.dirname.endsWith('dist')) {
+  if (import.meta.dirname?.endsWith('dist')) {
     return
   }
 


### PR DESCRIPTION
I'm not sure why I'm the only one having this issue but sometimes `import.meta.dirname` was undefined for me...

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
