### PR TITLE
chore: upgrade Hono to 4.9.7

### DIFF
--- a/integrations/hono/package.json
+++ b/integrations/hono/package.json
@@ -49,7 +49,7 @@
     "@hono/zod-openapi": "^0.8.6",
     "@scalar/build-tooling": "workspace:*",
     "@scalar/openapi-to-markdown": "workspace:*",
-    "hono": "^4.6.5",
+    "hono": "catalog:*",
     "vite": "catalog:*",
     "vitest": "catalog:*"
   },

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -109,7 +109,7 @@
     "@vitejs/plugin-vue": "catalog:*",
     "@vue/server-renderer": "^3.5.17",
     "@vue/test-utils": "^2.4.1",
-    "hono": "^4.6.5",
+    "hono": "catalog:*",
     "react": "catalog:*",
     "react-dom": "catalog:*",
     "rollup-plugin-webpack-stats": "^0.2.5",

--- a/packages/api-reference/playground/ssr/package.json
+++ b/packages/api-reference/playground/ssr/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@scalar/api-reference": "workspace:*",
     "compression": "^1.8.0",
-    "hono": "^4.6.5",
+    "hono": "catalog:*",
     "@hono/node-server": "^1.11.0",
     "sirv": "^3.0.1",
     "vue": "catalog:*"

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -50,7 +50,7 @@
     "@scalar/oas-utils": "workspace:*",
     "@scalar/openapi-parser": "workspace:*",
     "@scalar/openapi-types": "workspace:*",
-    "hono": "^4.6.5"
+    "hono": "catalog:*"
   },
   "devDependencies": {
     "@hono/node-server": "^1.11.0",

--- a/packages/openapi-to-markdown/package.json
+++ b/packages/openapi-to-markdown/package.json
@@ -78,7 +78,7 @@
     "@types/html-minifier-terser": "^7.0.2",
     "@vitejs/plugin-vue": "catalog:*",
     "@vue/test-utils": "^2.4.1",
-    "hono": "^4.6.5",
+    "hono": "catalog:*",
     "vite": "catalog:*",
     "vue": "catalog:*"
   }

--- a/packages/void-server/package.json
+++ b/packages/void-server/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@hono/node-server": "^1.11.0",
     "@scalar/helpers": "workspace:*",
-    "hono": "^4.6.5",
+    "hono": "catalog:*",
     "js-base64": "catalog:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ catalogs:
     fuse.js:
       specifier: ^7.1.0
       version: 7.1.0
+    hono:
+      specifier: 4.9.7
+      version: 4.9.7
     js-base64:
       specifier: ^3.7.8
       version: 3.7.8
@@ -930,7 +933,7 @@ importers:
         version: 1.11.3
       '@hono/zod-openapi':
         specifier: ^0.8.6
-        version: 0.8.6(hono@4.6.5)(zod@3.24.1)
+        version: 0.8.6(hono@4.9.7)(zod@3.24.1)
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../../packages/build-tooling
@@ -938,8 +941,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/openapi-to-markdown
       hono:
-        specifier: ^4.6.5
-        version: 4.6.5
+        specifier: catalog:*
+        version: 4.9.7
       vite:
         specifier: catalog:*
         version: 7.1.5(@types/node@22.15.3)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
@@ -1454,8 +1457,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.6
       hono:
-        specifier: ^4.6.5
-        version: 4.6.5
+        specifier: catalog:*
+        version: 4.9.7
       react:
         specifier: catalog:*
         version: 19.1.0
@@ -1542,8 +1545,8 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
       hono:
-        specifier: ^4.6.5
-        version: 4.6.5
+        specifier: catalog:*
+        version: 4.9.7
       sirv:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1980,8 +1983,8 @@ importers:
         specifier: workspace:*
         version: link:../openapi-types
       hono:
-        specifier: ^4.6.5
-        version: 4.6.5
+        specifier: catalog:*
+        version: 4.9.7
     devDependencies:
       '@hono/node-server':
         specifier: ^1.11.0
@@ -2280,8 +2283,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.6
       hono:
-        specifier: ^4.6.5
-        version: 4.6.5
+        specifier: catalog:*
+        version: 4.9.7
       vite:
         specifier: catalog:*
         version: 7.1.5(@types/node@22.15.3)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
@@ -2615,8 +2618,8 @@ importers:
         specifier: workspace:*
         version: link:../helpers
       hono:
-        specifier: ^4.6.5
-        version: 4.6.5
+        specifier: catalog:*
+        version: 4.9.7
       js-base64:
         specifier: catalog:*
         version: 3.7.8
@@ -13056,8 +13059,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.6.5:
-    resolution: {integrity: sha512-qsmN3V5fgtwdKARGLgwwHvcdLKursMd+YOt69eGpl1dUCJb8mCd7hZfyZnBYjxCegBG7qkJRQRUy2oO25yHcyQ==}
+  hono@4.9.7:
+    resolution: {integrity: sha512-t4Te6ERzIaC48W3x4hJmBwgNlLhmiEdEE5ViYb02ffw4ignHNHa5IBtPjmbKstmtKa8X6C35iWwK4HaqvrzG9w==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
@@ -24062,16 +24065,16 @@ snapshots:
 
   '@hono/node-server@1.11.3': {}
 
-  '@hono/zod-openapi@0.8.6(hono@4.6.5)(zod@3.24.1)':
+  '@hono/zod-openapi@0.8.6(hono@4.9.7)(zod@3.24.1)':
     dependencies:
       '@asteasolutions/zod-to-openapi': 5.5.0(zod@3.24.1)
-      '@hono/zod-validator': 0.1.11(hono@4.6.5)(zod@3.24.1)
-      hono: 4.6.5
+      '@hono/zod-validator': 0.1.11(hono@4.9.7)(zod@3.24.1)
+      hono: 4.9.7
       zod: 3.24.1
 
-  '@hono/zod-validator@0.1.11(hono@4.6.5)(zod@3.24.1)':
+  '@hono/zod-validator@0.1.11(hono@4.9.7)(zod@3.24.1)':
     dependencies:
-      hono: 4.6.5
+      hono: 4.9.7
       zod: 3.24.1
 
   '@humanfs/core@0.19.1': {}
@@ -33923,7 +33926,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.6.5: {}
+  hono@4.9.7: {}
 
   hookable@5.5.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,7 @@ catalogs:
     fathom-client: ^3.7.2
     flatted: ^3.3.3
     fuse.js: ^7.1.0
+    hono: 4.9.7
     js-base64: ^3.7.8
     microdiff: ^1.5.0
     nanoid: 5.1.5


### PR DESCRIPTION
Moves Hono to the catalog, upgrades to 4.9.7 (security). :)