### PR TITLE
fix(void-server): duplicate XML declaration

### DIFF
--- a/.changeset/spicy-actors-build.md
+++ b/.changeset/spicy-actors-build.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+fix: duplicate xml definition

--- a/packages/void-server/src/utils/createXmlResponse.ts
+++ b/packages/void-server/src/utils/createXmlResponse.ts
@@ -7,12 +7,7 @@ import type { Context } from 'hono'
 export function createXmlResponse(c: Context, data: Record<string, any>) {
   c.header('Content-Type', 'application/xml')
 
-  const obj = {
-    '?xml version="1.0" encoding="UTF-8"?': null,
-    ...data,
-  }
-
-  return c.text(json2xml(obj), 200, {
+  return c.text(json2xml(data), 200, {
     'Content-Type': 'application/xml; charset=UTF-8',
   })
 }


### PR DESCRIPTION
With the recent XML update, I broke the @scalar/void-server XML responses.

They have the XML declaration twice:

<img width="448" height="244" alt="Screenshot 2025-09-15 at 14 44 46" src="https://github.com/user-attachments/assets/66029ae2-d93f-4200-93af-e03dacebeca1" />
