### PR TITLE
feat(helpers): don’t use proxy for reserved tlds

### DIFF
--- a/.changeset/light-humans-compare.md
+++ b/.changeset/light-humans-compare.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': patch
+---
+
+feat: don’t use proxy for reserved tlds

--- a/packages/helpers/src/url/is-local-url.test.ts
+++ b/packages/helpers/src/url/is-local-url.test.ts
@@ -23,6 +23,31 @@ describe('isLocalUrl ', () => {
     expect(isLocalUrl('https://0.0.0.0')).toBe(true)
   })
 
+  /**
+   * @see https://en.wikipedia.org/wiki/.test
+   */
+  describe('reserved tlds', () => {
+    it('returns true for reserved test tld', () => {
+      expect(isLocalUrl('http://foobar.test')).toBe(true)
+      expect(isLocalUrl('https://foobar.test')).toBe(true)
+    })
+
+    it('returns true for reserved example tld', () => {
+      expect(isLocalUrl('http://foobar.example')).toBe(true)
+      expect(isLocalUrl('https://foobar.example')).toBe(true)
+    })
+
+    it('returns true for reserved invalid tld', () => {
+      expect(isLocalUrl('http://foobar.invalid')).toBe(true)
+      expect(isLocalUrl('https://foobar.invalid')).toBe(true)
+    })
+
+    it('returns true for reserved local tld', () => {
+      expect(isLocalUrl('http://foobar.localhost')).toBe(true)
+      expect(isLocalUrl('https://foobar.localhost')).toBe(true)
+    })
+  })
+
   it('returns false for non-local URLs', () => {
     expect(isLocalUrl('http://example.com')).toBe(false)
     expect(isLocalUrl('https://google.com')).toBe(false)

--- a/packages/helpers/src/url/is-local-url.ts
+++ b/packages/helpers/src/url/is-local-url.ts
@@ -1,14 +1,28 @@
 /** Obviously local hostnames */
 const LOCAL_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]', '0.0.0.0']
 
+/** Reserved TLDs that are guaranteed to never be assigned */
+const RESERVED_TLDS = ['test', 'example', 'invalid', 'localhost']
+
 /**
- * Detect requests to localhost
+ * Detect requests to localhost or reserved TLDs
  */
 export function isLocalUrl(url: string) {
   try {
     const { hostname } = new URL(url)
 
-    return LOCAL_HOSTNAMES.includes(hostname)
+    // Check if hostname is in the local hostnames list
+    if (LOCAL_HOSTNAMES.includes(hostname)) {
+      return true
+    }
+
+    // Check if hostname ends with a reserved TLD
+    const tld = hostname.split('.').pop()
+    if (tld && RESERVED_TLDS.includes(tld)) {
+      return true
+    }
+
+    return false
   } catch {
     // If it's not a valid URL, we can't use the proxy anyway,
     // but it also covers cases like relative URLs (e.g. `openapi.json`).


### PR DESCRIPTION
**Problem**

Currently, when sending a request to `http://something.localhost`, we’ll try to use the proxy. But it’s a reserved tld, that’s never gonna be registered, so it'll point to localhost or something that’s not reachable from the outside.

**Solution**

With this PR the proxy is skipped for those reserved TLDs. :)

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
