### PR TITLE
fix(fastapi): scalar-fastapi installs tests

### DIFF
--- a/.changeset/fluffy-days-smoke.md
+++ b/.changeset/fluffy-days-smoke.md
@@ -1,0 +1,5 @@
+---
+'scalar-fastapi': patch
+---
+
+fix: scalar-fastapi installs tests

--- a/integrations/fastapi/MANIFEST.in
+++ b/integrations/fastapi/MANIFEST.in
@@ -2,4 +2,3 @@ include README.md
 include package.json
 include LICENSE
 recursive-include scalar_fastapi *.py
-recursive-include tests *.py


### PR DESCRIPTION
**Problem**

Currently, we install `tests` with `scalar-fastapi`, which isn't expected.

**Solution**

This PR removes it from the MANIFEST so it won't be installed for our users.

Fixes #6857

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
