### PR TITLE
feat(Scalar.AspNetCore): add download type direct

### DIFF
--- a/.changeset/nine-bottles-greet.md
+++ b/.changeset/nine-bottles-greet.md
@@ -1,0 +1,6 @@
+---
+'@scalar/aspnetcore': patch
+'@scalar/aspire': patch
+---
+
+feat: add direct download type

--- a/integrations/aspire/src/Scalar.Aspire/Enums/DocumentDownloadType.cs
+++ b/integrations/aspire/src/Scalar.Aspire/Enums/DocumentDownloadType.cs
@@ -28,6 +28,12 @@ public enum DocumentDownloadType
     Both,
 
     /// <summary>
+    /// Show the regular link to the OpenAPI document.
+    /// </summary>
+    [Description("direct")]
+    Direct,
+
+    /// <summary>
     /// Do not allow documentation downloads.
     /// </summary>
     [Description("none")]

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/DocumentDownloadType.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/DocumentDownloadType.cs
@@ -30,6 +30,12 @@ public enum DocumentDownloadType
     Both,
 
     /// <summary>
+    /// Show the regular link to the OpenAPI document.
+    /// </summary>
+    [Description("direct")]
+    Direct,
+
+    /// <summary>
     /// Do not allow documentation downloads.
     /// </summary>
     [Description("none")]


### PR DESCRIPTION
Follow-up of https://github.com/scalar/scalar/pull/6854. This PR adds the `direct` download type to the .NET integrations.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
