### PR TITLE
fix(rust): changeset has outdated crate name

### DIFF
--- a/.changeset/chatty-jars-glow.md
+++ b/.changeset/chatty-jars-glow.md
@@ -1,5 +1,5 @@
 ---
-'scalar-api-reference': minor
+'scalar_api_reference': minor
 ---
 
 hello world :)


### PR DESCRIPTION
I’ve updated the name to use underscore and the changeset still has the dashes, this breaks CI in main.