### PR TITLE
fix(openapi-upgrader): traversing circular references causes infinite recursion

### DIFF
--- a/.changeset/calm-turkeys-battle.md
+++ b/.changeset/calm-turkeys-battle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-upgrader': patch
+---
+
+fix: traversing circular references causes infinite recursion

--- a/packages/openapi-upgrader/src/helpers/traverse.test.ts
+++ b/packages/openapi-upgrader/src/helpers/traverse.test.ts
@@ -80,4 +80,50 @@ describe('traverse', () => {
 
     expect(result).toEqual({ a: null, b: 2 })
   })
+
+  it('handles circular references', () => {
+    const definition: { a: number; b?: unknown; c: number } = { a: 2, c: 3 }
+    definition.b = definition
+
+    const transform = (schema: any) => {
+      return Object.fromEntries(
+        Object.entries(schema).filter(([, value]) => {
+          if (typeof value !== 'number') {
+            return true
+          }
+
+          return value % 2 === 0
+        }),
+      )
+    }
+
+    const result = traverse(definition, transform)
+
+    expect(result).toMatchObject({ a: 2, b: { a: 2, b: { a: 2 } } })
+  })
+
+  it('handles circular references with arrays', () => {
+    const definition: { a: number; b?: unknown; c: number[] } = { a: 8, c: [4, 1, 8] }
+    definition.b = definition
+
+    const transform = (schema: any) => {
+      return Object.fromEntries(
+        Object.entries(schema).map(([key, value]) => {
+          if (Array.isArray(value)) {
+            return [key, value.sort()]
+          }
+
+          if (typeof value !== 'number') {
+            return [key, value]
+          }
+
+          return [key, value ** 2]
+        }),
+      )
+    }
+
+    const result = traverse(definition, transform)
+
+    expect(result).toMatchObject({ a: 64, c: [1, 4, 8], b: { a: 64, c: [1, 4, 8] } })
+  })
 })

--- a/packages/openapi-upgrader/src/helpers/traverse.ts
+++ b/packages/openapi-upgrader/src/helpers/traverse.ts
@@ -1,38 +1,64 @@
 import type { UnknownObject } from '@scalar/types/utils'
 
+function merge(from: UnknownObject, to: UnknownObject): UnknownObject {
+  if (from !== to && typeof from === 'object' && from !== null) {
+    for (const key of Object.keys(to)) {
+      if (!Object.hasOwn(from, key)) {
+        delete to[key]
+      }
+    }
+
+    for (const [k, v] of Object.entries(from)) {
+      to[k] = v
+    }
+  }
+
+  return to
+}
+
 /**
  * Recursively traverses the content and applies the transform function to each node.
  */
 export function traverse(
   content: UnknownObject,
   transform: (content: UnknownObject, path?: string[]) => UnknownObject,
-  path: string[] = [],
 ) {
-  const result: UnknownObject = {}
+  const cache = new WeakMap<UnknownObject, UnknownObject>()
 
-  for (const [key, value] of Object.entries(content)) {
-    const currentPath = [...path, key]
-
-    if (Array.isArray(value)) {
-      result[key] = value.map((item, index) => {
-        if (typeof item === 'object' && !Array.isArray(item) && item !== null) {
-          return traverse(item, transform, [...currentPath, index.toString()])
-        }
-
-        return item
-      })
-
-      continue
+  function walk(node: UnknownObject, path: string[]): UnknownObject {
+    const cached = cache.get(node)
+    if (cached) {
+      return cached
     }
 
-    if (typeof value === 'object' && value !== null) {
-      result[key] = traverse(value as UnknownObject, transform, currentPath)
+    const result: UnknownObject = {}
+    cache.set(node, result)
 
-      continue
+    for (const [key, value] of Object.entries(node)) {
+      const currentPath = [...path, key]
+
+      if (Array.isArray(value)) {
+        result[key] = value.map((item, index) => {
+          if (typeof item === 'object' && item !== null && !Array.isArray(item)) {
+            return walk(item, [...currentPath, index.toString()])
+          }
+          return item
+        })
+        continue
+      }
+
+      if (typeof value === 'object' && value !== null) {
+        result[key] = walk(value as UnknownObject, currentPath)
+        continue
+      }
+
+      result[key] = value
     }
 
-    result[key] = value
+    const transformed = transform(result, path)
+
+    return merge(transformed, result)
   }
 
-  return transform(result, path)
+  return walk(content, [])
 }


### PR DESCRIPTION
**Problem**

Currently, when calling `traverse` with an object that includes a circular reference, an infinite recursion is caused, resulting in a maximum call size error. I encountered the bug when I wanted to upgrade an OpenAPI document that I had previously dereferenced. However, the problem lies in the traverse function.

**Solution**

With this PR the `traverse` caches all objects. If it traverses an already seen object, it simply returns the cached result.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
