### PR TITLE
fix(openapi-upgrader): missing changeset

### DIFF
--- a/.changeset/beige-ants-sniff.md
+++ b/.changeset/beige-ants-sniff.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-upgrader': minor
+---
+
+hello world :)


### PR DESCRIPTION
There’s no changeset for the new @scalar/openapi-upgrader to trigger an initial 0.1.0 release. 😳