### PR TITLE
feat(api-reference): do not show example picker for one example

### DIFF
--- a/.changeset/fair-knives-greet.md
+++ b/.changeset/fair-knives-greet.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: do not show example picker for one example

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/RequestExample.vue
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/components/RequestExample.vue
@@ -359,18 +359,24 @@ const id = useId()
 
     <!-- Footer -->
     <ScalarCardFooter
-      v-if="Object.keys(operationExamples).length || $slots.footer"
+      v-if="Object.keys(operationExamples).length > 1 || $slots.footer"
       class="request-card-footer bg-b-3">
       <!-- Example picker -->
       <div
-        v-if="Object.keys(operationExamples).length"
+        v-if="Object.keys(operationExamples).length > 1"
         class="request-card-footer-addon">
-        <ExamplePicker
-          v-model="selectedExampleKey"
-          :examples="operationExamples"
-          @update:modelValue="
-            emitCustomEvent(elem?.$el, 'scalar-update-selected-example', $event)
-          " />
+        <template v-if="Object.keys(operationExamples).length">
+          <ExamplePicker
+            v-model="selectedExampleKey"
+            :examples="operationExamples"
+            @update:modelValue="
+              emitCustomEvent(
+                elem?.$el,
+                'scalar-update-selected-example',
+                $event,
+              )
+            " />
+        </template>
       </div>
 
       <!-- Footer -->


### PR DESCRIPTION
**Problem**

Currently, …

**Solution**

With this PR …

<img width="544" height="418" alt="Screenshot 2025-09-18 at 11 51 58" src="https://github.com/user-attachments/assets/e5706210-0955-4654-89d5-0643a485c63c" />

<img width="549" height="450" alt="Screenshot 2025-09-18 at 11 52 13" src="https://github.com/user-attachments/assets/057035dc-3b9f-41ab-9d75-9294db7b7874" />


**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
