### PR TITLE
chore: `minimumReleaseAge` (requires pnpm 10.16)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "22",
-      "pnpmVersion": "10.15.1"
+      "pnpmVersion": "10.16.1"
     }
   },
   "customizations": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "pnpm": "^10.15.1"
+    "pnpm": "^10.16.1"
   },
-  "packageManager": "pnpm@10.15.1",
+  "packageManager": "pnpm@10.16.1",
   "devDependencies": {
     "@biomejs/biome": "^2.2.3",
     "@changesets/cli": "^2.27.10",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,9 @@ packages:
   - '!**/dist/**'
   - '!**/.output/**'
 
+# To reduce the risk of installing compromised packages, we delay the installation of newly published versions.
+minimumReleaseAge: 1.440 # 1 day
+
 catalogs:
   '*':
     '@electron-toolkit/preload': ^3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ packages:
   - '!**/.output/**'
 
 # To reduce the risk of installing compromised packages, we delay the installation of newly published versions.
-minimumReleaseAge: 1.440 # 1 day
+minimumReleaseAge: 10080 # 1 week
 
 catalogs:
   '*':

--- a/projects/scalar-app/todesktop.json
+++ b/projects/scalar-app/todesktop.json
@@ -5,7 +5,7 @@
   "icon": "./build/icon.png",
   "nodeVersion": "20",
   "packageManager": "pnpm",
-  "pnpmVersion": "10.15.1",
+  "pnpmVersion": "10.16.1",
   "packageJson": {
     "extends": "package.json",
     "productName": "Scalar",

--- a/tooling/base-docker-builder/Dockerfile
+++ b/tooling/base-docker-builder/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends dumb-init git c
 # Set Node.js memory limit to 8GB
 ENV NODE_OPTIONS="--max-old-space-size=8192"
 
-RUN npm install pnpm@10.15.1 --global
+RUN npm install pnpm@10.16.1 --global
 RUN pnpm config set store-dir ~/.pnpm-store
 
 WORKDIR /app


### PR DESCRIPTION
**Problem**

Sometimes, npm packages have security issues. They are mostly removed/fixed quickly, but we might install them before they are fixed/removed.

**Solution**

This PR uses pnpm’s `minimumReleaseAge` to wait at least a day until it installs a new version of something.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
