### PR TITLE
fix(api-reference): does not download updated content

### DIFF
--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -18,14 +18,30 @@
 
     <!-- Initialize the Scalar API Reference -->
     <script type="module">
-      import sources from './test/data/sources.ts'
-
-      Scalar.createApiReference('#app', {
-        sources,
-        persistAuth: true,
-        // Avoid CORS issues
-        proxyUrl: 'https://proxy.scalar.com',
+      // TODO: Restore file before merging
+      const scalar = Scalar.createApiReference('#app', {
+        content: JSON.stringify({
+          openapi: '3.1.0',
+          info: {
+            title: 'Loading…',
+            version: '1.0.0',
+          },
+          paths: {},
+        }),
       })
+
+      setTimeout(() => {
+        scalar.updateConfiguration({
+          content: JSON.stringify({
+            openapi: '3.1.0',
+            info: {
+              title: 'Hello World',
+              version: '1.0.0',
+            },
+            paths: {},
+          }),
+        })
+      }, 1000)
     </script>
   </body>
 </html>


### PR DESCRIPTION
**Problem**

Currently, when updating the content, the download button still downloads the initial version (not the updated) version.

**Solution**

This PR contains a reproduction (that we want to remove before merging):

1. `pnpm dev:reference`
2. http://localhost:5173/
3. click download button
4. downloaded document contains "Loading…" not "Hello World"

Looks like this is an issue in the workspace-store, that seems to export the initial version?

```js
const getOriginalDocument = () => store.exportActiveDocument('json') ?? '{}'
```

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
