### PR TITLE
feat(Scalar.AspNetCore): content-based ETag generation

### DIFF
--- a/.changeset/unlucky-toys-hug.md
+++ b/.changeset/unlucky-toys-hug.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+feat: improve etag header generation


### PR DESCRIPTION
This PR improves the way the `etag` header for our static assets is generated.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
