### PR TITLE
feat(docs): subpages redesign for getting started docs/sdks/registry

### DIFF
--- a/documentation/assets/api-docs-static-zoom-dark.svg
+++ b/documentation/assets/api-docs-static-zoom-dark.svg
@@ -1,5 +1,327 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1360" height="765" viewBox="0 0 0 1360 765"><foreignObject width="1360" height="765" class="fo"><div xmlns="http://www.w3.org/1999/xhtml" class="transform-rr"><div class="h-animation-ref dark-mode rr"><div class="h-animation-ref-safari size"><div class="dotted-top"></div><div class="h-animation-ref-safari-left"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="16" fill="currentColor" viewBox="0 0 20 16"><path fill-rule="evenodd" d="M19.4 15.4a2 2 0 0 1-1.4.6H2a2 2 0 0 1-1.4-.6A2 2 0 0 1 0 14V2C0 1.4.2 1 .6.6A2 2 0 0 1 2 0h16c.6 0 1 .2 1.4.6.4.4.6.8.6 1.4v12c0 .6-.2 1-.6 1.4ZM2 14h5V2H2v12Zm7 0h9V2H9v12ZM3.3 3c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3Zm0 2c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3ZM3 7.4c0-.1.1-.2.3-.2h2.5c.1 0 .2 0 .2.2v1c0 .2-.1.3-.2.3H3.3a.3.3 0 0 1-.3-.3v-1Z" clip-rule="evenodd"/></svg><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M16 22 6 12 16 2l1.8 1.8L9.5 12l8.3 8.2L16 22Z"/></svg><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="m8 22 10-10L8 2 6.2 3.8l8.3 8.2-8.3 8.2L8 22Z"/></svg></div><div class="h-animation-ref-safari-nav"><div class="h-animation-ref-safari-nav-url"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M7 10h8V6c0-.83-.3-1.54-.88-2.13A2.9 2.9 0 0 0 12 3c-.83 0-1.54.3-2.13.88A2.9 2.9 0 0 0 9 6v4H7V6c0-1.38.49-2.56 1.46-3.54A4.82 4.82 0 0 1 12 1c1.38 0 2.56.49 3.54 1.46A4.82 4.82 0 0 1 17 6v4c.55 0 1.02.2 1.41.59.4.39.59.86.59 1.41v8c0 .55-.2 1.02-.59 1.41-.39.4-.86.59-1.41.59H7c-.55 0-1.02-.2-1.41-.59-.4-.39-.59-.86-.59-1.41v-8c0-.55.2-1.02.59-1.41.39-.4.86-.59 1.41-.59Z"/></svg>developers.zoom.us/docs/api/meetings/#tag/archiving<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M12 22a8.7 8.7 0 0 0 6.4-2.6A9.1 9.1 0 0 0 21 13h-2c0 2-.7 3.6-2 5-1.4 1.3-3 2-5 2s-3.6-.7-5-2c-1.3-1.4-2-3-2-5s.7-3.6 2-5c1.4-1.3 3-2 5-2h.2l-1.6 1.5L12 9l4-4-4-4-1.4 1.5L12.2 4H12a8.7 8.7 0 0 0-6.4 2.6A9.1 9.1 0 0 0 3 13a8.7 8.7 0 0 0 2.6 6.4A9.1 9.1 0 0 0 12 22Z"/></svg></div></div><div class="h-animation-ref-safari-right"></div></div><div class="h-animation-doc-header"><svg xmlns="http://www.w3.org/2000/svg" width="180" height="25" fill="none" viewBox="0 0 203 25"><path fill="#00031F" d="M97 8.85c0 6.84-4.16 8.87-9.78 8.87h-4.84V0h4.84C92.84 0 97 2.03 97 8.85ZM85.17 2.3v13.13h1.93c3.54 0 7.01-.74 7.01-6.58 0-5.82-3.47-6.55-7.01-6.55h-1.93Zm25.45 11.56c-.6 2.18-2.56 4.18-5.91 4.18-4.25 0-6.55-3.1-6.55-6.92 0-4.08 2.73-6.8 6.47-6.8 4.06 0 6.43 3.33 6.17 7.6h-10.03c.25 2.43 1.79 3.94 3.84 3.94 1.83 0 2.9-.75 3.45-2h2.56Zm-2.47-3.94c-.07-1.95-1.44-3.52-3.54-3.52-1.98 0-3.45 1.03-3.79 3.52h7.33Zm12.34-5.35h2.64l-4.87 13.15h-2.32l-4.89-13.15h2.81l3.33 9.75 3.3-9.75Zm15 9.29c-.6 2.18-2.56 4.18-5.91 4.18-4.25 0-6.55-3.1-6.55-6.92 0-4.08 2.74-6.8 6.48-6.8 4.05 0 6.42 3.33 6.16 7.6h-10.03c.25 2.43 1.79 3.94 3.84 3.94 1.83 0 2.91-.75 3.45-2h2.57Zm-2.46-3.94c-.08-1.95-1.45-3.52-3.55-3.52-1.98 0-3.45 1.03-3.79 3.52h7.34Zm4.27 7.8V0h2.54v17.72h-2.54Zm10.5.32c-3.1 0-6.38-2.1-6.38-6.84 0-4.77 3.28-6.87 6.38-6.87 3.13 0 6.4 2.1 6.4 6.87 0 4.74-3.27 6.84-6.4 6.84Zm3.72-6.84c0-3.28-1.78-4.72-3.72-4.72-1.9 0-3.69 1.4-3.69 4.72 0 3.25 1.79 4.69 3.7 4.69 1.93 0 3.71-1.5 3.71-4.7Zm6.94-4.7a4.5 4.5 0 0 1 4.1-2.17c3.06 0 5.68 2.56 5.68 6.84 0 4.3-2.62 6.87-5.67 6.87a4.5 4.5 0 0 1-4.1-2.18V22h-2.55V4.57h2.54V6.5Zm7.07 4.67c0-2.96-1.45-4.72-3.55-4.72-1.95 0-3.62 1.47-3.62 4.72s1.67 4.74 3.62 4.74c2.1 0 3.55-1.78 3.55-4.74Zm16.6 2.7c-.62 2.17-2.57 4.17-5.92 4.17-4.26 0-6.55-3.1-6.55-6.92 0-4.08 2.73-6.8 6.48-6.8 4.05 0 6.42 3.33 6.15 7.6h-10.02c.25 2.43 1.79 3.94 3.84 3.94 1.83 0 2.9-.75 3.45-2h2.56Zm-2.47-3.95c-.08-1.95-1.45-3.52-3.55-3.52-1.98 0-3.45 1.03-3.79 3.52h7.34Zm9.8-2.8c-1.95 0-2.98.95-2.98 3.7v6.9h-2.54V4.57h2.49v2.32c.68-1.49 2-2.34 3.64-2.37.22 0 .5 0 .71.03v2.64a12.76 12.76 0 0 0-1.32-.08Zm7.43-.76c-1.25 0-2.59.5-2.59 1.58 0 .98.64 1.4 1.83 1.64l1.89.37c2.49.49 4.66 1.34 4.66 3.91 0 2.67-2.49 4.18-5.52 4.18-3.32 0-5.35-1.93-5.67-4.4h2.59c.34 1.49 1.32 2.37 3.15 2.37 1.64 0 2.91-.68 2.91-1.86 0-1.22-1.15-1.7-2.52-1.98l-1.98-.39c-1.98-.39-3.83-1.27-3.83-3.74 0-2.32 2.44-3.74 5.33-3.74 2.64 0 4.76 1.4 5.25 3.94h-2.52c-.36-1.35-1.49-1.88-2.98-1.88Z"/><path fill="#0B5CFF" d="M15.56 17.72H2.29c-.93 0-1.76-.55-2.11-1.41a2.29 2.29 0 0 1 .5-2.5l9.18-9.19H3.28A3.27 3.27 0 0 1 0 1.34h12.23a2.29 2.29 0 0 1 1.62 3.92l-9.18 9.19h7.61a3.28 3.28 0 0 1 3.28 3.27ZM74.19 7.5a6.4 6.4 0 0 0-6.39-6.4c-1.88 0-3.58.83-4.75 2.13A6.37 6.37 0 0 0 58.3 1.1a6.4 6.4 0 0 0-6.38 6.39v10.23a3.27 3.27 0 0 0 3.27-3.27V7.49a3.12 3.12 0 0 1 3.11-3.11 3.12 3.12 0 0 1 3.12 3.1v6.97a3.28 3.28 0 0 0 3.27 3.27V7.5a3.12 3.12 0 0 1 3.11-3.12 3.12 3.12 0 0 1 3.12 3.12v6.96a3.28 3.28 0 0 0 3.27 3.27V7.5ZM50.28 9.53a8.43 8.43 0 1 1-16.87 0 8.43 8.43 0 0 1 16.87 0Zm-3.28 0a5.16 5.16 0 1 0-10.31 0 5.16 5.16 0 0 0 10.31 0Zm-14.9 0a8.43 8.43 0 1 1-16.87 0 8.43 8.43 0 0 1 16.87 0Zm-3.27 0a5.16 5.16 0 1 0-10.32 0 5.16 5.16 0 0 0 10.32 0Z"/></svg></div><div class="h-animation-sidebar"><div class="h-animation-sidebar-search"><svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16m10 2-4.35-4.35"/></svg>Search<div class="h-animation-sidebar-search-hotkey">⌘K</div></div><div class="h-animation-sidebar__animate"><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M224 48H32a16 16 0 0 0-16 16v24a16 16 0 0 0 16 16v88a16 16 0 0 0 16 16h160a16 16 0 0 0 16-16v-88a16 16 0 0 0 16-16V64a16 16 0 0 0-16-16Zm-16 144H48v-88h160Zm16-104H32V64h192v24ZM96 136a8 8 0 0 1 8-8h48a8 8 0 0 1 0 16h-48a8 8 0 0 1-8-8Z"/></svg>Archiving</div><div class="h-animation-sidebar-endpoint beforeme beforeme__alt"><em>Delete a meeting's archived files</em><span class="h-red">DEL</span></div><div class="h-animation-sidebar-endpoint">Get a meeting's archived files<span class="h-blue">GET</span></div><div class="h-animation-sidebar-endpoint">Get archived file statistics<span class="h-blue">GET</span></div><div class="h-animation-sidebar-endpoint">List archived files<span class="h-blue">GET</span></div><div class="h-animation-sidebar-endpoint">Update an archived file's auto-delete status<span class="h-orange">PATCH</span></div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M160 40a88.09 88.09 0 0 0-78.71 48.67A64 64 0 1 0 72 216h88a88 88 0 0 0 0-176Zm0 160H72a48 48 0 0 1 0-96c1.1 0 2.2 0 3.29.11A88 88 0 0 0 72 128a8 8 0 0 0 16 0 72 72 0 1 1 72 72Z"/></svg>Cloud Recording</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M224 72h-16v-8a24 24 0 0 0-24-24H40a24 24 0 0 0-24 24v96a24 24 0 0 0 24 24h112v8a24 24 0 0 0 24 24h48a24 24 0 0 0 24-24V96a24 24 0 0 0-24-24ZM40 168a8 8 0 0 1-8-8V64a8 8 0 0 1 8-8h144a8 8 0 0 1 8 8v8h-16a24 24 0 0 0-24 24v72Zm192 24a8 8 0 0 1-8 8h-48a8 8 0 0 1-8-8V96a8 8 0 0 1 8-8h48a8 8 0 0 1 8 8Zm-96 16a8 8 0 0 1-8 8H88a8 8 0 0 1 0-16h40a8 8 0 0 1 8 8Zm80-96a8 8 0 0 1-8 8h-16a8 8 0 0 1 0-16h16a8 8 0 0 1 8 8Z"/></svg>Devices</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M128 24a104 104 0 1 0 104 104A104.12 104.12 0 0 0 128 24Zm88 104a87.61 87.61 0 0 1-3.33 24h-38.51a157.44 157.44 0 0 0 0-48h38.51a87.61 87.61 0 0 1 3.33 24Zm-114 40h52a115.11 115.11 0 0 1-26 45 115.27 115.27 0 0 1-26-45Zm-3.9-16a140.84 140.84 0 0 1 0-48h59.88a140.84 140.84 0 0 1 0 48ZM40 128a87.61 87.61 0 0 1 3.33-24h38.51a157.44 157.44 0 0 0 0 48H43.33A87.61 87.61 0 0 1 40 128Zm114-40h-52a115.11 115.11 0 0 1 26-45 115.27 115.27 0 0 1 26 45Zm52.33 0h-35.62a135.28 135.28 0 0 0-22.3-45.6A88.29 88.29 0 0 1 206.37 88Zm-98.74-45.6A135.28 135.28 0 0 0 85.29 88H49.63a88.29 88.29 0 0 1 57.96-45.6ZM49.63 168h35.66a135.28 135.28 0 0 0 22.3 45.6A88.29 88.29 0 0 1 49.63 168Zm98.78 45.6a135.28 135.28 0 0 0 22.3-45.6h35.66a88.29 88.29 0 0 1-57.96 45.6Z"/></svg>H323 Devices</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M216 40H40a16 16 0 0 0-16 16v144a16 16 0 0 0 16 16h176a16 16 0 0 0 16-16V56a16 16 0 0 0-16-16Zm0 80h-48V56h48ZM40 56h112v144H40Zm176 144h-48v-64h48v64ZM180 88a12 12 0 1 1 12 12 12 12 0 0 1-12-12Zm24 80a12 12 0 1 1-12-12 12 12 0 0 1 12 12Zm-68.25-2a39.76 39.76 0 0 0-17.19-23.34 32 32 0 1 0-45.12 0A39.84 39.84 0 0 0 56.25 166a8 8 0 0 0 15.5 4c2.64-10.25 13.06-18 24.25-18s21.62 7.73 24.25 18a8 8 0 1 0 15.5-4ZM80 120a16 16 0 1 1 16 16 16 16 0 0 1-16-16Z"/></svg>Meetings</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M184 112a8 8 0 0 1-8 8h-64a8 8 0 0 1 0-16h64a8 8 0 0 1 8 8Zm-8 24h-64a8 8 0 0 0 0 16h64a8 8 0 0 0 0-16Zm48-88v160a16 16 0 0 1-16 16H48a16 16 0 0 1-16-16V48a16 16 0 0 1 16-16h160a16 16 0 0 1 16 16ZM48 208h24V48H48Zm160 0V48H88v160h120Z"/></svg>PAC</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M88 96a8 8 0 0 1 8-8h64a8 8 0 0 1 0 16H96a8 8 0 0 1-8-8Zm8 40h64a8 8 0 0 0 0-16H96a8 8 0 0 0 0 16Zm32 16H96a8 8 0 0 0 0 16h32a8 8 0 0 0 0-16Zm96-104v108.69a15.86 15.86 0 0 1-4.69 11.31L168 219.31a15.86 15.86 0 0 1-11.31 4.69H48a16 16 0 0 1-16-16V48a16 16 0 0 1 16-16h160a16 16 0 0 1 16 16ZM48 208h104v-48a8 8 0 0 1 8-8h48V48H48Zm120-40v28.7l28.69-28.7Z"/></svg>Reports</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M231.59 90.13C175.44 34 80.56 34 24.41 90.13c-20 20-21.92 49.49-4.69 71.71A16 16 0 0 0 32.35 168a15.8 15.8 0 0 0 5.75-1.08l49-17.37.29-.11a16 16 0 0 0 9.75-11.73l5.9-29.52a76.52 76.52 0 0 1 49.68-.11l6.21 29.75a16 16 0 0 0 9.72 11.59l.29.11 49 17.39a16 16 0 0 0 18.38-5.06c17.19-22.24 15.26-51.73-4.73-71.73ZM223.67 152l-.3-.12-48.82-17.33-6.21-29.74A16 16 0 0 0 158 93a92.56 92.56 0 0 0-60.34.13 16 16 0 0 0-10.32 12l-5.9 29.51-48.81 17.22c-.1 0-.17.13-.27.17-12.33-15.91-11-36.23 3.36-50.58 25-25 58.65-37.53 92.28-37.53s67.27 12.51 92.28 37.53c14.33 14.35 15.72 34.67 3.39 50.55Zm.32 48a8 8 0 0 1-8 8H40a8 8 0 0 1 0-16h176a8 8 0 0 1 8 8Z"/></svg>SIP Phone</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M232 112h-96V88h8a16 16 0 0 0 16-16V40a16 16 0 0 0-16-16h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h8v24H24a8 8 0 0 0 0 16h32v32h-8a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-8v-32h112v32h-8a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-8v-32h32a8 8 0 0 0 0-16ZM112 40h32v32h-32ZM80 208H48v-32h32Zm128 0h-32v-32h32Z"/></svg>Tracking Field</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M168 104a40 40 0 1 0-40 40 40 40 0 0 0 40-40Zm-64 0a24 24 0 1 1 24 24 24 24 0 0 1-24-24Zm120 96h-88v-16.4a80 80 0 1 0-16 0V200H32a8 8 0 0 0 0 16h192a8 8 0 0 0 0-16ZM64 104a64 64 0 1 1 64 64 64.07 64.07 0 0 1-64-64Z"/></svg>Webinars</div></div></div><div class="h-animation-content"><div class="h-animation-tag"><div class="h-animation-endpoint"><div class="h-animation-endpoint-markdown"><div class="h-animation-header">Delete a meeting's archived files</div><div class="h-markdown"><p>Delete all of a meeting's archived files.</p><div class="h-markdown-list"><div class="h-markdown-heading"><span class="h-black">Path Parameters</span></div><div class="h-markdown-item"><span class="h-black">meetingUUID</span><span class="h-grey">string</span><span class="h-orange">Required</span><div class="h-markdown-item-description"><span class="h-grey">The meeting's universally unique identifier (UUID). Each meeting instance generates a UUID. For example, after a meeting ends, a new UUID is generated for the next meeting instance.<br /><br />If the meeting UUID begins with a / character or contains a // character, you must double-encode the meeting UUID when using the meeting UUID for other API calls.</span></div></div><div class="h-markdown-list"><div class="h-markdown-heading"><span class="h-black">Responses</span></div><div class="h-markdown-item"><svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5"/></svg><span class="h-black">204</span><span class="h-grey">Meeting archived file deleted.</span></div><div class="h-markdown-item"><svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5"/></svg><span class="h-black">400</span><span class="h-grey">Bad Request</span></div><div class="h-markdown-item"><svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5"/></svg><span class="h-black">401</span><span class="h-grey">Not Found</span></div><div class="h-markdown-item"><svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5"/></svg><span class="h-black">429</span><span class="h-grey">Too Many Requests.</span></div></div></div></div></div></div></div></div></div></div><style><![CDATA[@keyframes scrollupdown{0%,10%,80%,to{transform:translate3d(0,0,0)}18%,72%{transform:translate3d(0,-380px,0)}}@keyframes fadein{0%,40%,70%,to{opacity:0}45%,68.5%{opacity:1}}@keyframes popupcontent{0%,43%,68%,to{opacity:0;transform:scale(.99) translate3d(0,10px,0)}47%,66%{opacity:1;transform:scale(1)]]><![CDATA[ translate3d(0,0,0)}}*{padding:0;box-sizing:border-box;margin:0;-webkit-font-smoothing:antialiased}:root{--app-header-height:48px;--scalar-border-width:1px;--scalar-radius:3px;--scalar-radius-lg:6px;--scalar-radius-xl:8px;--scalar-header-height:50px;--scalar-sidebar-width:280px;--scalar-toc-width:28]]><![CDATA[0px;--scalar-card-icon-width:40px;--scalar-card-icon-height:40px;--scalar-card-icon-diameter:20px;--scalar-card-padding:16px;--scalar-card-inter-element-gap:4px;--scalar-row-gap:16px;--system-fonts:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;--scalar-font:"Inter", var(--system-fonts);--scalar-font-code:Monaco, Menlo, monospace;--scalar-heading-1:24px;--scalar-page-description:16px;--scalar-heading-2:20px;--scalar-heading-3:20px;--scalar-heading-4:16px;--scalar-heading-5:16px;--scalar-heading-6:16px;--scalar-paragraph:16px;--scalar-small:14px;--scalar-mini:13px;--scalar-micro:12px;--scalar-extra-bold:700;--scalar-bold:600;--scalar-semibold:500;--scalar-regular:400;--scalar-font-size-1:24px;--scalar-font-size-2:16px;--scalar-font-size-3:14px;--scalar-font-size-4:13px;--scalar-font-size-5:12px;--scalar-line-height-1:32px;--scalar-line-height-2:24px;--scalar-line-height-3:20px;--scalar-line-height-4:18px;--scalar-line-height-5:16px;--scalar-heading-spacing:44px;--scalar-block-spacing:12px}.light-mode{--scalar-sidebar-width:280px;--scalar-color-1:#000;--scalar-color-2:#666666;--scalar-color-3:#8e8e8e;--scalar-color-disabled:#b4b1b1;--scalar-color-ghost:#a7a7a7;--scalar-color-accent:#0099ff;--scalar-background-1:#fff;--scalar-background-2:#f6f6f6;--scalar-background-3:#e7e7e7;--scalar-background-4:rgba(0, 0, 0, 0.06);--scalar-background-accent:#8ab4f81f;--scalar-border-color:rgba(0, 0, 0, 0.05);--scalar-scrollbar-color:rgba(0, 0, 0, 0.18);--scalar-scrollbar-color-active:rgba(0, 0, 0, 0.36);--scalar-lifted-brightness:1;--scalar-backdrop-brightness:1;--scalar-shadow-1:0 1px 3px 0 rgba(0, 0, 0, 0.11);--scalar-shadow-2:rgba(0, 0, 0, 0.08) 0px 13px 20px 0px,
-          rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 1px;--scalar-button-1:rgb(49 53 56);--scalar-button-1-color:#fff;--scalar-button-1-hover:rgb(28 31 33);--scalar-color-green:#00a67d;--scalar-color-red:#ef0006;--scalar-color-yellow:#f9c514;--scalar-color-blue:#579dfb;--scalar-color-orange:#fc8528;--scalar-color-purple:#5203d1;font-family:var(--scalar-font);color:var(--scalar-color-1)}.dotted-top{position:absolute;top:17px;left:12px;background-color:var(--scalar-background-3);border-radius:50%;width:10px;box-shadow:14px 0 0 var(--scalar-background-3),29px 0 0 var(--scalar-background-3);height:9px}.h-animation-ref-safari{height:40px;background-color:var(--scalar-background-2);z-index:1;position:absolute;top:0;width:100%;display:flex;justify-content:space-between}.h-animation-ref-safari-left{width:150px;display:flex;align-items:center;gap:10px;padding-left:68px;color:var(--scalar-color-3)}.h-animation-ref-safari-nav{width:600px;padding:6px 0}.h-animation-ref-safari-right{width:150px;display:flex;align-items:center;justify-content:flex-end;gap:10px;color:var(--scalar-color-3);padding-right:12px}.h-animation-ref-safari-right svg{width:17px;height:17px}.h-animation-ref-safari-left svg{width:16px;height:16px}.h-animation-ref-safari-left svg:last-of-type{opacity:.5}.h-animation-ref-safari-nav-url{width:100%;border-radius:7px;height:100%;text-align:center;display:flex;align-items:center;justify-content:center;font-size:13px;position:relative;border:1px solid var(--scalar-border-color)}.h-animation-ref-safari-nav-url svg{width:13px;height:13px;color:var(--scalar-color-3);margin-right:3px}.h-animation-ref-safari-nav-url svg:last-of-type{position:absolute;right:4px}.h-animation-ref{-webkit-user-select:none;-moz-user-select:none;user-select:none;background:var(--scalar-background-1);min-width:1280px;min-height:720px;display:flex;padding-top:90px}.h-animation-sidebar{padding:12px;max-width:var(--scalar-sidebar-width);border-right:1px solid var(--scalar-border-color);flex:1}.h-animation-sidebar-search{display:flex;align-items:center;position:relative;padding:0 3px 0 6px;width:100%;background:var(--scalar-sidebar-search-background, var(--scalar-background-1));color:var(--scalar-sidebar-color-2, var(--scalar-color-2));border-radius:var(--scalar-radius);box-shadow:0 0 0 1px var(--scalar-sidebar-search-border-color, var(--scalar-border-color));height:31px;font-size:13px;margin-bottom:12px;gap:6px}.h-animation-sidebar-endpoint{position:relative}.h-animation-sidebar-endpoint span{margin-left:auto;font-family:var(--scalar-font-code);font-weight:700;font-size:10px;margin-top:10px;line-height:0}.beforeme,.beforeme em{color:var(--scalar-color-1)}.beforeme{font-weight:var(--scalar-semibold)}.beforeme em{font-style:normal}.beforeme,.beforeme em,.beforeme span{position:relative}.beforeme:after,.beforeme:before{content:"";position:absolute;height:100%}.beforeme:before{background:var(--scalar-background-2);width:256px;z-index:0;right:0;top:0;border-radius:var(--scalar-radius)}.beforeme:after{background:var(--scalar-border-color);width:1px;left:-1px;box-shadow:-12.5px 0 0 0 var(--scalar-border-color)}.beforeme__alt:after{box-shadow:none}.h-animation-sidebar-endpoint,.h-animation-sidebar-folder{font-size:14px;min-height:32px;display:flex;padding:8px 9px;color:var(--scalar-color-2);border-radius:var(--scalar-radius)}.h-animation-sidebar-folder svg{margin-right:6px}.h-animation-sidebar-folder{padding-left:6px}.h-animation-sidebar-endpoint{padding-left:12px;border-radius:0;margin-left:12px;border-left:1px solid var(--scalar-border-color)}.h-animation-sidebar-folder:first-of-type{color:var(--scalar-color-1);font-weight:500}.h-animation-sidebar-folder:first-of-type svg{fill:var(--scalar-color-1)}.h-animation-sidebar-search-hotkey{background-color:var(--scalar-background-2);color:var(--scalar-color-3);margin-left:auto;padding:3px 5px;border-radius:var(--scalar-radius)}.h-animation-content{flex:1}.h-animation-tag{border-bottom:1px solid var(--scalar-border-color);width:100%;display:flex}.h-animation-endpoint{gap:48px}.h-animation-tag{border-bottom:none;flex-flow:wrap;gap:0;padding:0 60px}.h-animation-header{font-size:var(--font-size, var(--scalar-heading-2));font-weight:var(--font-weight, var(--scalar-bold));color:var(--scalar-color-1);word-wrap:break-word;line-height:1.45}.h-animation-endpoint-markdown{width:50%}.h-markdown{margin-top:18px;display:flex;flex-direction:column;gap:18px;line-height:1.5;color:var(--scalar-color-1)}.h-blue{color:var(--scalar-color-blue)}.h-orange{color:var(--scalar-color-orange)}.h-red{color:var(--scalar-color-red)}.h-grey{color:var(--scalar-color-3)}.h-animation-endpoint,.h-markdown-item{border-top:1px solid var(--scalar-border-color);display:flex}.h-animation-endpoint{width:100%;padding:90px 0}.h-markdown-item{position:relative;padding:10px 0;flex-flow:wrap;gap:9px;font-family:var(--scalar-font);font-size:12px}.h-markdown-heading{display:flex;align-items:center;gap:6px;font-size:14px;padding-bottom:10px}.h-markdown-item div{width:100%;font-family:var(--scalar-font)}@supports (color:color(display-p3 1 1 1)){.light-mode{--scalar-color-accent:var(--scalar-color-1);--scalar-color-green:color(display-p3 0.023529 0.564706 0.380392 / 1);--scalar-color-red:color(display-p3 0.937255 0 0.023529 / 1);--scalar-color-yellow:color(display-p3 0.929412 0.745098 0.12549 / 1);--scalar-color-blue:color(display-p3 0 0.509804 0.815686 / 1);--scalar-color-orange:color(display-p3 0.984314 0.537255 0.172549 / 1);--scalar-color-purple:color(display-p3 0.321569 0.011765 0.819608 / 1)}}.h-markdown-item-description{font-size:14px;margin-top:-6px}.h-markdown-item .h-animation-14{position:absolute;left:-18px;margin-top:2px;transform:rotate(-90deg);color:var(--scalar-color-3)}.h-animation-doc-header{font-weight:800;width:100%;position:absolute;top:40px;left:0;height:50px;padding:12px;display:flex;align-items:center;font-size:16px;border-bottom:1px solid var(--scalar-border-color);background-color:var(--scalar-background-1);z-index:1;gap:4px}.h-animation-doc-header svg{width:auto;height:22px;margin-top:8px}.h-animation-14{width:16px;height:16px;stroke-width:2}svg{vertical-align:middle;display:block}.h-black{color:var(--scalar-color-1)}@supports (color:color(display-p3 1 1 1)){.light-mode{--scalar-color-accent:var(--scalar-color-1);--scalar-color-green:color(display-p3 0.023529 0.564706 0.380392 / 1);--scalar-color-red:color(display-p3 0.937255 0 0.023529 / 1);--scalar-color-yellow:color(display-p3 0.929412 0.745098 0.12549 / 1);--scalar-color-blue:color(display-p3 0 0.509804 0.815686 / 1);--scalar-color-orange:color(display-p3 0.984314 0.537255 0.172549 / 1);--scalar-color-purple:color(display-p3 0.321569 0.011765 0.819608 / 1)}}.h-animation-ref{position:fixed;top:0;left:0;width:100%;height:765px;border:1px solid rgba(55,55,55,1);border-radius:8px;overflow:hidden}.h-markdown-item>span:first-of-type{font-size:13px;font-family:var(--scalar-font-code);font-weight:500}@supports (hanging-punctuation:first) and (font:-apple-system-body) and (-webkit-appearance:none){.transform-rr{--var:1;--varcalcx:calc(var(--var) * 1360px);--xcalc:calc((100dvw - var(--varcalcx))/2);--varcalcy:calc(var(--var) * 765px);--ycalc:calc((100dvh - var(--varcalcy))/2);transform:translate3d(var(--xcalc),var(--ycalc),0)}*{animation:none!important}.h-animation-endpoint{border-top:none}.h-animation-sidebar-endpoint span{font-weight:500}@media only screen and (max-width:1360px){.transform-rr{--var:0.95}.rr{transform:scale(var(--var));transform-origin:top left;position:relative;overflow:hidden}}@media only screen and (max-width:1292px){.transform-rr{--var:0.9}}@media only screen and (max-width:1224px){.transform-rr{--var:0.85}}@media only screen and (max-width:1156px){.transform-rr{--var:0.8}}@media only screen and (max-width:1088px){.transform-rr{--var:0.75}}@media only screen and (max-width:1020px){.transform-rr{--var:0.7}}@media only screen and (max-width:952px){.transform-rr{--var:0.65}}@media only screen and (max-width:884px){.transform-rr{--var:0.6}}@media only screen and (max-width:816px){.transform-rr{--var:0.55}}@media only screen and (max-width:748px){.transform-rr{--var:0.5}}@media only screen and (max-width:680px){.transform-rr{--var:0.45}}@media only screen and (max-width:612px){.transform-rr{--var:0.4}}@media only screen and (max-width:544px){.transform-rr{--var:0.35}}@media only screen and (max-width:476px){.transform-rr{--var:0.3}}@media only screen and (max-width:408px){.transform-rr{--var:0.25}}@media only screen and (max-width:340px){.transform-rr{--var:0.2}}@media only screen and (max-width:272px){.transform-rr{--var:0.15}}}.h-markdown-heading>span:first-of-type{font-weight:var(--scalar-semibold);font-size:16px}]]>.dark-mode {
+<svg xmlns="http://www.w3.org/2000/svg" width="1360" height="765" viewBox="0 0 0 1360 765">
+    <foreignObject width="1360" height="765" class="fo">
+        <div xmlns="http://www.w3.org/1999/xhtml" class="transform-rr">
+            <div class="h-animation-ref dark-mode rr">
+                <div class="h-animation-ref-safari size">
+                    <div class="dotted-top"></div>
+                    <div class="h-animation-ref-safari-left">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="16" fill="currentColor" viewBox="0 0 20 16">
+                            <path
+                                fill-rule="evenodd"
+                                d="M19.4 15.4a2 2 0 0 1-1.4.6H2a2 2 0 0 1-1.4-.6A2 2 0 0 1 0 14V2C0 1.4.2 1 .6.6A2 2 0 0 1 2 0h16c.6 0 1 .2 1.4.6.4.4.6.8.6 1.4v12c0 .6-.2 1-.6 1.4ZM2 14h5V2H2v12Zm7 0h9V2H9v12ZM3.3 3c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3Zm0 2c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3ZM3 7.4c0-.1.1-.2.3-.2h2.5c.1 0 .2 0 .2.2v1c0 .2-.1.3-.2.3H3.3a.3.3 0 0 1-.3-.3v-1Z"
+                                clip-rule="evenodd"
+                            />
+                        </svg>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M16 22 6 12 16 2l1.8 1.8L9.5 12l8.3 8.2L16 22Z" /></svg>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="m8 22 10-10L8 2 6.2 3.8l8.3 8.2-8.3 8.2L8 22Z" /></svg>
+                    </div>
+                    <div class="h-animation-ref-safari-nav">
+                        <div class="h-animation-ref-safari-nav-url">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+                                <path
+                                    d="M7 10h8V6c0-.83-.3-1.54-.88-2.13A2.9 2.9 0 0 0 12 3c-.83 0-1.54.3-2.13.88A2.9 2.9 0 0 0 9 6v4H7V6c0-1.38.49-2.56 1.46-3.54A4.82 4.82 0 0 1 12 1c1.38 0 2.56.49 3.54 1.46A4.82 4.82 0 0 1 17 6v4c.55 0 1.02.2 1.41.59.4.39.59.86.59 1.41v8c0 .55-.2 1.02-.59 1.41-.39.4-.86.59-1.41.59H7c-.55 0-1.02-.2-1.41-.59-.4-.39-.59-.86-.59-1.41v-8c0-.55.2-1.02.59-1.41.39-.4.86-.59 1.41-.59Z"
+                                />
+                            </svg>
+                            developers.zoom.us/docs/api/meetings/#tag/archiving
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+                                <path
+                                    d="M12 22a8.7 8.7 0 0 0 6.4-2.6A9.1 9.1 0 0 0 21 13h-2c0 2-.7 3.6-2 5-1.4 1.3-3 2-5 2s-3.6-.7-5-2c-1.3-1.4-2-3-2-5s.7-3.6 2-5c1.4-1.3 3-2 5-2h.2l-1.6 1.5L12 9l4-4-4-4-1.4 1.5L12.2 4H12a8.7 8.7 0 0 0-6.4 2.6A9.1 9.1 0 0 0 3 13a8.7 8.7 0 0 0 2.6 6.4A9.1 9.1 0 0 0 12 22Z"
+                                />
+                            </svg>
+                        </div>
+                    </div>
+                    <div xmlns="http://www.w3.org/1999/xhtml" class="h-animation-ref-safari-right">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+              <path d="M6 23a2 2 0 0 1-1.4-.6A2 2 0 0 1 4 21V10c0-.6.2-1 .6-1.4A2 2 0 0 1 6 8h3v2H6v11h12V10h-3V8h3c.6 0 1 .2 1.4.6.4.4.6.8.6 1.4v11c0 .6-.2 1-.6 1.4a2 2 0 0 1-1.4.6H6Zm5-7V4.8L9.4 6.4 8 5l4-4 4 4-1.4 1.4L13 4.8V16h-2Z"/></svg><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+              <path d="M11 13H5v-2h6V5h2v6h6v2h-6v6h-2v-6Z"/></svg><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+              <path d="M8 22a2 2 0 0 1-1.4-.6A2 2 0 0 1 6 20v-2H4a2 2 0 0 1-1.4-.6A2 2 0 0 1 2 16V6h2v10h2V8c0-.5.2-1 .6-1.4A2 2 0 0 1 8 6h8V4H6V2h10c.6 0 1 .2 1.4.6.4.4.6.9.6 1.4v2h2c.6 0 1 .2 1.4.6.4.4.6.9.6 1.4v12c0 .6-.2 1-.6 1.4a2 2 0 0 1-1.4.6H8Zm0-2h12V8H8v12ZM2 6V4c0-.5.2-1 .6-1.4A2 2 0 0 1 4 2h2v2H4v2H2Z"/>
+            </svg>
+          </div>
+                </div>
+                <div class="h-animation-doc-header">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="180" height="25" fill="none" viewBox="0 0 203 25">
+                        <path
+                            fill="#00031F"
+                            d="M97 8.85c0 6.84-4.16 8.87-9.78 8.87h-4.84V0h4.84C92.84 0 97 2.03 97 8.85ZM85.17 2.3v13.13h1.93c3.54 0 7.01-.74 7.01-6.58 0-5.82-3.47-6.55-7.01-6.55h-1.93Zm25.45 11.56c-.6 2.18-2.56 4.18-5.91 4.18-4.25 0-6.55-3.1-6.55-6.92 0-4.08 2.73-6.8 6.47-6.8 4.06 0 6.43 3.33 6.17 7.6h-10.03c.25 2.43 1.79 3.94 3.84 3.94 1.83 0 2.9-.75 3.45-2h2.56Zm-2.47-3.94c-.07-1.95-1.44-3.52-3.54-3.52-1.98 0-3.45 1.03-3.79 3.52h7.33Zm12.34-5.35h2.64l-4.87 13.15h-2.32l-4.89-13.15h2.81l3.33 9.75 3.3-9.75Zm15 9.29c-.6 2.18-2.56 4.18-5.91 4.18-4.25 0-6.55-3.1-6.55-6.92 0-4.08 2.74-6.8 6.48-6.8 4.05 0 6.42 3.33 6.16 7.6h-10.03c.25 2.43 1.79 3.94 3.84 3.94 1.83 0 2.91-.75 3.45-2h2.57Zm-2.46-3.94c-.08-1.95-1.45-3.52-3.55-3.52-1.98 0-3.45 1.03-3.79 3.52h7.34Zm4.27 7.8V0h2.54v17.72h-2.54Zm10.5.32c-3.1 0-6.38-2.1-6.38-6.84 0-4.77 3.28-6.87 6.38-6.87 3.13 0 6.4 2.1 6.4 6.87 0 4.74-3.27 6.84-6.4 6.84Zm3.72-6.84c0-3.28-1.78-4.72-3.72-4.72-1.9 0-3.69 1.4-3.69 4.72 0 3.25 1.79 4.69 3.7 4.69 1.93 0 3.71-1.5 3.71-4.7Zm6.94-4.7a4.5 4.5 0 0 1 4.1-2.17c3.06 0 5.68 2.56 5.68 6.84 0 4.3-2.62 6.87-5.67 6.87a4.5 4.5 0 0 1-4.1-2.18V22h-2.55V4.57h2.54V6.5Zm7.07 4.67c0-2.96-1.45-4.72-3.55-4.72-1.95 0-3.62 1.47-3.62 4.72s1.67 4.74 3.62 4.74c2.1 0 3.55-1.78 3.55-4.74Zm16.6 2.7c-.62 2.17-2.57 4.17-5.92 4.17-4.26 0-6.55-3.1-6.55-6.92 0-4.08 2.73-6.8 6.48-6.8 4.05 0 6.42 3.33 6.15 7.6h-10.02c.25 2.43 1.79 3.94 3.84 3.94 1.83 0 2.9-.75 3.45-2h2.56Zm-2.47-3.95c-.08-1.95-1.45-3.52-3.55-3.52-1.98 0-3.45 1.03-3.79 3.52h7.34Zm9.8-2.8c-1.95 0-2.98.95-2.98 3.7v6.9h-2.54V4.57h2.49v2.32c.68-1.49 2-2.34 3.64-2.37.22 0 .5 0 .71.03v2.64a12.76 12.76 0 0 0-1.32-.08Zm7.43-.76c-1.25 0-2.59.5-2.59 1.58 0 .98.64 1.4 1.83 1.64l1.89.37c2.49.49 4.66 1.34 4.66 3.91 0 2.67-2.49 4.18-5.52 4.18-3.32 0-5.35-1.93-5.67-4.4h2.59c.34 1.49 1.32 2.37 3.15 2.37 1.64 0 2.91-.68 2.91-1.86 0-1.22-1.15-1.7-2.52-1.98l-1.98-.39c-1.98-.39-3.83-1.27-3.83-3.74 0-2.32 2.44-3.74 5.33-3.74 2.64 0 4.76 1.4 5.25 3.94h-2.52c-.36-1.35-1.49-1.88-2.98-1.88Z"
+                        />
+                        <path
+                            fill="#0B5CFF"
+                            d="M15.56 17.72H2.29c-.93 0-1.76-.55-2.11-1.41a2.29 2.29 0 0 1 .5-2.5l9.18-9.19H3.28A3.27 3.27 0 0 1 0 1.34h12.23a2.29 2.29 0 0 1 1.62 3.92l-9.18 9.19h7.61a3.28 3.28 0 0 1 3.28 3.27ZM74.19 7.5a6.4 6.4 0 0 0-6.39-6.4c-1.88 0-3.58.83-4.75 2.13A6.37 6.37 0 0 0 58.3 1.1a6.4 6.4 0 0 0-6.38 6.39v10.23a3.27 3.27 0 0 0 3.27-3.27V7.49a3.12 3.12 0 0 1 3.11-3.11 3.12 3.12 0 0 1 3.12 3.1v6.97a3.28 3.28 0 0 0 3.27 3.27V7.5a3.12 3.12 0 0 1 3.11-3.12 3.12 3.12 0 0 1 3.12 3.12v6.96a3.28 3.28 0 0 0 3.27 3.27V7.5ZM50.28 9.53a8.43 8.43 0 1 1-16.87 0 8.43 8.43 0 0 1 16.87 0Zm-3.28 0a5.16 5.16 0 1 0-10.31 0 5.16 5.16 0 0 0 10.31 0Zm-14.9 0a8.43 8.43 0 1 1-16.87 0 8.43 8.43 0 0 1 16.87 0Zm-3.27 0a5.16 5.16 0 1 0-10.32 0 5.16 5.16 0 0 0 10.32 0Z"
+                        />
+                    </svg>
+                </div>
+                <div class="h-animation-sidebar">
+                    <div class="h-animation-sidebar-search">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16m10 2-4.35-4.35" />
+                        </svg>
+                        Search
+                        <div class="h-animation-sidebar-search-hotkey">⌘K</div>
+                    </div>
+                    <div class="h-animation-sidebar__animate">
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M224 48H32a16 16 0 0 0-16 16v24a16 16 0 0 0 16 16v88a16 16 0 0 0 16 16h160a16 16 0 0 0 16-16v-88a16 16 0 0 0 16-16V64a16 16 0 0 0-16-16Zm-16 144H48v-88h160Zm16-104H32V64h192v24ZM96 136a8 8 0 0 1 8-8h48a8 8 0 0 1 0 16h-48a8 8 0 0 1-8-8Z"
+                                />
+                            </svg>
+                            Archiving
+                        </div>
+                        <div class="h-animation-sidebar-endpoint beforeme beforeme__alt"><em>Delete a meeting's archived files</em><span class="h-red">DEL</span></div>
+                        <div class="h-animation-sidebar-endpoint">Get a meeting's archived files<span class="h-blue">GET</span></div>
+                        <div class="h-animation-sidebar-endpoint">Get archived file statistics<span class="h-blue">GET</span></div>
+                        <div class="h-animation-sidebar-endpoint">List archived files<span class="h-blue">GET</span></div>
+                        <div class="h-animation-sidebar-endpoint">Update an archived file's auto-delete status<span class="h-orange">PATCH</span></div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path d="M160 40a88.09 88.09 0 0 0-78.71 48.67A64 64 0 1 0 72 216h88a88 88 0 0 0 0-176Zm0 160H72a48 48 0 0 1 0-96c1.1 0 2.2 0 3.29.11A88 88 0 0 0 72 128a8 8 0 0 0 16 0 72 72 0 1 1 72 72Z" />
+                            </svg>
+                            Cloud Recording
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M224 72h-16v-8a24 24 0 0 0-24-24H40a24 24 0 0 0-24 24v96a24 24 0 0 0 24 24h112v8a24 24 0 0 0 24 24h48a24 24 0 0 0 24-24V96a24 24 0 0 0-24-24ZM40 168a8 8 0 0 1-8-8V64a8 8 0 0 1 8-8h144a8 8 0 0 1 8 8v8h-16a24 24 0 0 0-24 24v72Zm192 24a8 8 0 0 1-8 8h-48a8 8 0 0 1-8-8V96a8 8 0 0 1 8-8h48a8 8 0 0 1 8 8Zm-96 16a8 8 0 0 1-8 8H88a8 8 0 0 1 0-16h40a8 8 0 0 1 8 8Zm80-96a8 8 0 0 1-8 8h-16a8 8 0 0 1 0-16h16a8 8 0 0 1 8 8Z"
+                                />
+                            </svg>
+                            Devices
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M128 24a104 104 0 1 0 104 104A104.12 104.12 0 0 0 128 24Zm88 104a87.61 87.61 0 0 1-3.33 24h-38.51a157.44 157.44 0 0 0 0-48h38.51a87.61 87.61 0 0 1 3.33 24Zm-114 40h52a115.11 115.11 0 0 1-26 45 115.27 115.27 0 0 1-26-45Zm-3.9-16a140.84 140.84 0 0 1 0-48h59.88a140.84 140.84 0 0 1 0 48ZM40 128a87.61 87.61 0 0 1 3.33-24h38.51a157.44 157.44 0 0 0 0 48H43.33A87.61 87.61 0 0 1 40 128Zm114-40h-52a115.11 115.11 0 0 1 26-45 115.27 115.27 0 0 1 26 45Zm52.33 0h-35.62a135.28 135.28 0 0 0-22.3-45.6A88.29 88.29 0 0 1 206.37 88Zm-98.74-45.6A135.28 135.28 0 0 0 85.29 88H49.63a88.29 88.29 0 0 1 57.96-45.6ZM49.63 168h35.66a135.28 135.28 0 0 0 22.3 45.6A88.29 88.29 0 0 1 49.63 168Zm98.78 45.6a135.28 135.28 0 0 0 22.3-45.6h35.66a88.29 88.29 0 0 1-57.96 45.6Z"
+                                />
+                            </svg>
+                            H323 Devices
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M216 40H40a16 16 0 0 0-16 16v144a16 16 0 0 0 16 16h176a16 16 0 0 0 16-16V56a16 16 0 0 0-16-16Zm0 80h-48V56h48ZM40 56h112v144H40Zm176 144h-48v-64h48v64ZM180 88a12 12 0 1 1 12 12 12 12 0 0 1-12-12Zm24 80a12 12 0 1 1-12-12 12 12 0 0 1 12 12Zm-68.25-2a39.76 39.76 0 0 0-17.19-23.34 32 32 0 1 0-45.12 0A39.84 39.84 0 0 0 56.25 166a8 8 0 0 0 15.5 4c2.64-10.25 13.06-18 24.25-18s21.62 7.73 24.25 18a8 8 0 1 0 15.5-4ZM80 120a16 16 0 1 1 16 16 16 16 0 0 1-16-16Z"
+                                />
+                            </svg>
+                            Meetings
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M184 112a8 8 0 0 1-8 8h-64a8 8 0 0 1 0-16h64a8 8 0 0 1 8 8Zm-8 24h-64a8 8 0 0 0 0 16h64a8 8 0 0 0 0-16Zm48-88v160a16 16 0 0 1-16 16H48a16 16 0 0 1-16-16V48a16 16 0 0 1 16-16h160a16 16 0 0 1 16 16ZM48 208h24V48H48Zm160 0V48H88v160h120Z"
+                                />
+                            </svg>
+                            PAC
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M88 96a8 8 0 0 1 8-8h64a8 8 0 0 1 0 16H96a8 8 0 0 1-8-8Zm8 40h64a8 8 0 0 0 0-16H96a8 8 0 0 0 0 16Zm32 16H96a8 8 0 0 0 0 16h32a8 8 0 0 0 0-16Zm96-104v108.69a15.86 15.86 0 0 1-4.69 11.31L168 219.31a15.86 15.86 0 0 1-11.31 4.69H48a16 16 0 0 1-16-16V48a16 16 0 0 1 16-16h160a16 16 0 0 1 16 16ZM48 208h104v-48a8 8 0 0 1 8-8h48V48H48Zm120-40v28.7l28.69-28.7Z"
+                                />
+                            </svg>
+                            Reports
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M231.59 90.13C175.44 34 80.56 34 24.41 90.13c-20 20-21.92 49.49-4.69 71.71A16 16 0 0 0 32.35 168a15.8 15.8 0 0 0 5.75-1.08l49-17.37.29-.11a16 16 0 0 0 9.75-11.73l5.9-29.52a76.52 76.52 0 0 1 49.68-.11l6.21 29.75a16 16 0 0 0 9.72 11.59l.29.11 49 17.39a16 16 0 0 0 18.38-5.06c17.19-22.24 15.26-51.73-4.73-71.73ZM223.67 152l-.3-.12-48.82-17.33-6.21-29.74A16 16 0 0 0 158 93a92.56 92.56 0 0 0-60.34.13 16 16 0 0 0-10.32 12l-5.9 29.51-48.81 17.22c-.1 0-.17.13-.27.17-12.33-15.91-11-36.23 3.36-50.58 25-25 58.65-37.53 92.28-37.53s67.27 12.51 92.28 37.53c14.33 14.35 15.72 34.67 3.39 50.55Zm.32 48a8 8 0 0 1-8 8H40a8 8 0 0 1 0-16h176a8 8 0 0 1 8 8Z"
+                                />
+                            </svg>
+                            SIP Phone
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M232 112h-96V88h8a16 16 0 0 0 16-16V40a16 16 0 0 0-16-16h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h8v24H24a8 8 0 0 0 0 16h32v32h-8a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-8v-32h112v32h-8a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-8v-32h32a8 8 0 0 0 0-16ZM112 40h32v32h-32ZM80 208H48v-32h32Zm128 0h-32v-32h32Z"
+                                />
+                            </svg>
+                            Tracking Field
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M168 104a40 40 0 1 0-40 40 40 40 0 0 0 40-40Zm-64 0a24 24 0 1 1 24 24 24 24 0 0 1-24-24Zm120 96h-88v-16.4a80 80 0 1 0-16 0V200H32a8 8 0 0 0 0 16h192a8 8 0 0 0 0-16ZM64 104a64 64 0 1 1 64 64 64.07 64.07 0 0 1-64-64Z"
+                                />
+                            </svg>
+                            Webinars
+                        </div>
+                    </div>
+                </div>
+                <div class="h-animation-content">
+                    <div class="h-animation-tag">
+                        <div class="h-animation-endpoint">
+                            <div class="h-animation-endpoint-markdown">
+                                <div class="h-animation-header">Delete a meeting's archived files</div>
+                                <div class="h-markdown">
+                                    <p>Delete all of a meeting's archived files.</p>
+                                    <div class="h-markdown-list">
+                                        <div class="h-markdown-heading"><span class="h-black">Path Parameters</span></div>
+                                        <div class="h-markdown-item">
+                                            <span class="h-black">meetingUUID</span><span class="h-grey">string</span><span class="h-orange">Required</span>
+                                            <div class="h-markdown-item-description">
+                                                <span class="h-grey">
+                                                    The meeting's universally unique identifier (UUID). Each meeting instance generates a UUID. For example, after a meeting ends, a new UUID is generated for the next meeting instance.<br />
+                                                    <br />If the meeting UUID begins with a / character or contains a // character, you must double-encode the meeting UUID when using the meeting UUID for other API calls.
+                                                </span>
+                                            </div>
+                                        </div>
+                                        <div class="h-markdown-list">
+                                            <div class="h-markdown-heading"><span class="h-black">Responses</span></div>
+                                            <div class="h-markdown-item">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24">
+                                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5" />
+                                                </svg>
+                                                <span class="h-black">204</span><span class="h-grey">Meeting archived file deleted.</span>
+                                            </div>
+                                            <div class="h-markdown-item">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24">
+                                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5" />
+                                                </svg>
+                                                <span class="h-black">400</span><span class="h-grey">Bad Request</span>
+                                            </div>
+                                            <div class="h-markdown-item">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24">
+                                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5" />
+                                                </svg>
+                                                <span class="h-black">401</span><span class="h-grey">Not Found</span>
+                                            </div>
+                                            <div class="h-markdown-item">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24">
+                                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5" />
+                                                </svg>
+                                                <span class="h-black">429</span><span class="h-grey">Too Many Requests.</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div xmlns="http://www.w3.org/1999/xhtml" class="h-animation-endpoint-meta">
+                <div class="ello"></div>
+                <div class="h-animation-endpoint-code">
+                  <div class="h-animation-endpoint-code-header">
+                    <span class="h-red">DELETE</span><span class="h-grey">/past_meetings/{meetingUUID}/arc...</span>
+                    <span class="h-grey ml-auto">Shell Curl</span>
+                  </div>
+                  <div class="h-animation-endpoint-code-body">
+                    <div>
+                      <span>1</span><span class="h-purple">curl</span><span class="h-black">https://api.zoom.us/v2/past_meetings/4444AAAiAA</span><span class="h-grey">\</span>
+                    </div>
+                    <div class="body-second">
+                      <span>2</span><span class="h-black">--request</span><span class="h-grey">
+                        DELETE \
+                      </span>
+                    </div>
+                    <div class="body-second">
+                      <span>3</span><span class="h-black">--header</span><span class="h-black">'Authorization:Bearer YOUR_SECRET_TOKEN'</span>
+                    </div>
+                  </div>
+                  <div class="h-animation-endpoint-code-footer">
+                    <span class="button-press"><svg xmlns="http://www.w3.org/2000/svg" class="h-animation-14" fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+                        <path d="M6 6.663c0-1.582 1.75-2.538 3.082-1.682l8.301 5.337a2 2 0 0 1 0 3.364L9.082 19.02C7.75 19.875 6 18.919 6 17.337z"/>
+                      </svg>
+                      Test Request
+                    </span>
+                  </div>
+                </div>
+                <div class="h-animation-endpoint-code h-animation-endpoint-code-tabs">
+                  <div class="h-animation-endpoint-code-header">
+                    <span class="h-black">204</span><span class="h-grey">400</span><span class="h-grey">404</span><span class="h-grey">429</span>
+                  </div>
+                  <div class="h-animation-endpoint-code-body">
+                    <div class="no-body">No Body</div>
+                  </div>
+                </div>
+              </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <style>
+      * {
+        padding: 0;
+        box-sizing: border-box;
+        margin: 0;
+        -webkit-font-smoothing: antialiased
+      }
+      :root {
+        
+    --app-header-height: 48px;
+    --scalar-border-width: 1px;
+    --scalar-radius: 3px;
+    --scalar-radius-lg: 6px;
+    --scalar-radius-xl: 8px;
+    --scalar-header-height: 50px;
+    --scalar-sidebar-width: 280px;
+    --scalar-toc-width: 280px;
+    --scalar-card-icon-width: 40px;
+    --scalar-card-icon-height: 40px;
+    --scalar-card-icon-diameter: 20px;
+    --scalar-card-padding: 16px;
+    --scalar-card-inter-element-gap: 4px;
+    --scalar-row-gap: 16px;
+    --system-fonts: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    --scalar-font: "Inter", var(--system-fonts);
+    --scalar-font-code: Monaco, Menlo, monospace;
+    --scalar-heading-1: 24px;
+    --scalar-page-description: 16px;
+    --scalar-heading-2: 20px;
+    --scalar-heading-3: 20px;
+    --scalar-heading-4: 16px;
+    --scalar-heading-5: 16px;
+    --scalar-heading-6: 16px;
+    --scalar-paragraph: 16px;
+    --scalar-small: 14px;
+    --scalar-mini: 13px;
+    --scalar-micro: 12px;
+    --scalar-extra-bold: 700;
+    --scalar-bold: 600;
+    --scalar-semibold: 500;
+    --scalar-regular: 400;
+    --scalar-font-size-1: 24px;
+    --scalar-font-size-2: 16px;
+    --scalar-font-size-3: 14px;
+    --scalar-font-size-4: 13px;
+    --scalar-font-size-5: 12px;
+    --scalar-line-height-1: 32px;
+    --scalar-line-height-2: 24px;
+    --scalar-line-height-3: 20px;
+    --scalar-line-height-4: 18px;
+    --scalar-line-height-5: 16px;
+    --scalar-heading-spacing: 44px;
+    --scalar-block-spacing: 12px;
+      }
+      .light-mode {
+        --scalar-sidebar-width: 280px;
+        --scalar-color-1: #000;
+        --scalar-color-2: #666666;
+        --scalar-color-3: #8e8e8e;
+        --scalar-color-disabled: #b4b1b1;
+        --scalar-color-ghost: #a7a7a7;
+        --scalar-color-accent: #0099ff;
+        --scalar-background-1: #fff;
+        --scalar-background-2: #f6f6f6;
+        --scalar-background-3: #e7e7e7;
+        --scalar-background-4: rgba(0, 0, 0, 0.06);
+        --scalar-background-accent: #8ab4f81f;
+        --scalar-border-color: rgba(0, 0, 0, 0.05);
+        --scalar-scrollbar-color: rgba(0, 0, 0, 0.18);
+        --scalar-scrollbar-color-active: rgba(0, 0, 0, 0.36);
+        --scalar-lifted-brightness: 1;
+        --scalar-backdrop-brightness: 1;
+        --scalar-shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.11);
+        --scalar-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px,
+          rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 1px;
+        --scalar-button-1: rgb(49 53 56);
+        --scalar-button-1-color: #fff;
+        --scalar-button-1-hover: rgb(28 31 33);
+        --scalar-color-green: #00a67d;
+        --scalar-color-red: #ef0006;
+        --scalar-color-yellow: #f9c514;
+        --scalar-color-blue: #579dfb;
+        --scalar-color-orange: #fc8528;
+        --scalar-color-purple: #5203d1;
+        font-family: var(--scalar-font);
+        color: var(--scalar-color-1);
+      }
+      .dark-mode {
         font-family: var(--scalar-font);
         color-scheme: dark;
   --scalar-color-1: rgba(255, 255, 255, 0.9);
@@ -38,4 +360,1018 @@
 
   /* Misc Scalar Branding */
   --scalar-brand: #8b7256;
-      }</style></foreignObject></svg>
+      }
+      .dotted-top {
+        position: absolute;
+        top: 17px;
+        left: 12px;
+        background-color: var(--scalar-background-3);
+        border-radius: 50%;
+        width: 10px;
+        box-shadow: 14px 0 0 var(--scalar-background-3),
+          29px 0 0 var(--scalar-background-3);
+        height: 9px;
+      }
+      .h-animation-ref-safari {
+        height: 40px;
+        background-color: var(--scalar-background-2);
+        z-index: 1;
+        position: absolute;
+        top: 0;
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+      }
+
+      .h-animation-ref-safari-left {
+        width: 150px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding-left: 68px;
+        color: var(--scalar-color-3);
+      }
+
+      .h-animation-ref-safari-nav {
+        width: 600px;
+        padding: 6px 0;
+      }
+
+      .h-animation-ref-safari-right {
+        width: 150px;
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 10px;
+        color: var(--scalar-color-3);
+        padding-right: 12px;
+      }
+
+      .h-animation-ref-safari-right svg {
+        width: 17px;
+        height: 17px;
+      }
+
+      .h-animation-ref-safari-left svg {
+        width: 16px;
+        height: 16px;
+      }
+
+      .h-animation-ref-safari-left svg:last-of-type {
+        opacity: 0.5;
+      }
+
+      .h-animation-ref-safari-nav-url {
+        width: 100%;
+        border-radius: 7px;
+        height: 100%;
+        text-align: center;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 13px;
+        position: relative;
+        border: 1px solid var(--scalar-border-color);
+      }
+
+      .h-animation-ref-safari-nav-url svg {
+        width: 13px;
+        height: 13px;
+        color: var(--scalar-color-3);
+        margin-right: 3px;
+      }
+
+
+      .h-animation-ref-safari-nav-url svg:last-of-type {
+        position: absolute;
+        right: 4px;
+      }
+
+      .h-animation-ref {
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        user-select: none;
+        background: var(--scalar-background-1);
+        min-width: 1280px;
+        min-height: 720px;
+      }
+
+      .h-animation-ref {
+        display: flex;
+        padding-top: 90px;
+      }
+
+      .h-animation-sidebar {
+        padding: 12px;
+        max-width: var(--scalar-sidebar-width);
+        border-right: 1px solid var(--scalar-border-color);
+        flex: 1;
+      }
+
+      .h-animation-sidebar-search {
+        display: flex;
+        align-items: center;
+        position: relative;
+        padding: 0 3px 0 6px;
+        width: 100%;
+        background: var(
+          --scalar-sidebar-search-background,
+          var(--scalar-background-1)
+        );
+        color: var(--scalar-sidebar-color-2, var(--scalar-color-2));
+        border-radius: var(--scalar-radius);
+        box-shadow: 0 0 0 1px
+          var(--scalar-sidebar-search-border-color, var(--scalar-border-color));
+        height: 31px;
+        font-size: 13px;
+        margin-bottom: 12px;
+        gap: 6px;
+      }
+
+      .h-animation-sidebar-endpoint span {
+            margin-left: auto;
+    font-family: var(--scalar-font-code);
+    font-weight: 700;
+    font-size: 10px;
+    margin-top: 10px;
+    line-height: 0;
+      }
+
+.beforeme {
+    color: var(--scalar-color-1);
+    position: relative;
+    font-weight: var(--scalar-semibold);
+}
+.beforeme em {
+    font-style: normal;
+    color: var(--scalar-color-1);
+}
+.beforeme em,.beforeme span {
+    position: relative;
+}
+
+.beforeme:before {
+    content: "";
+    position: absolute;
+    background: var(--scalar-background-2);
+    width: 256px;
+    z-index: 0;
+    right: 0;
+    top: 0;
+    height: 100%;
+    border-radius: var(--scalar-radius)
+}
+
+.beforeme:after {
+    content: "";
+    position: absolute;
+    background: var(--scalar-border-color);
+    width: 1px;
+    left: -1px;
+    height: 100%;
+    box-shadow: -12.5px 0 0 0 var(--scalar-border-color)
+}
+
+.beforeme__alt:after {
+    box-shadow: none
+}
+      .h-animation-sidebar-folder,
+      .h-animation-sidebar-endpoint,
+      .h-animation-sidebar-item {
+        font-size: 14px;
+        display: flex;
+        padding: 8px 9px;
+        color: var(--scalar-color-2);
+        border-radius: var(--scalar-radius);
+      }
+
+      .h-animation-sidebar-folder svg {
+        margin-right: 6px;
+      }
+
+      .h-animation-sidebar-folder {
+        padding-left: 6px;
+      }
+
+      .h-animation-sidebar-endpoint {
+        padding-left: 12px;
+      }
+.h-animation-sidebar-endpoint {
+    border-radius: 0;
+    margin-left: 12px;
+    border-left: 1px solid var(--scalar-border-color);
+}
+      .h-animation-sidebar-folder:first-of-type {
+        color: var(--scalar-color-1);
+        font-weight: 500
+      }
+      .h-animation-sidebar-folder:first-of-type svg {
+        fill: var(--scalar-color-1);
+
+      }
+
+      .h-animation-sidebar-search-hotkey {
+        background-color: var(--scalar-background-2);
+        color: var(--scalar-color-3);
+        margin-left: auto;
+        padding: 3px 5px;
+        border-radius: var(--scalar-radius);
+      }
+
+      .h-animation-content {
+        flex: 1;
+      }
+
+      .h-animation-tag {
+        padding: 90px 60px;
+        border-bottom: 1px solid var(--scalar-border-color);
+        width: 100%;
+        display: flex;
+        gap: 48px;
+      }
+
+      .h-animation-endpoint {
+        gap: 48px;
+      }
+
+      .h-animation-tag {
+        border-bottom: none;
+        flex-flow: wrap;
+        gap: 0;
+        padding: 0 60px;
+      }
+
+      .h-animation-tag-wrap {
+        display: flex;
+        gap: 48px;
+        padding: 90px 0;
+      }
+
+      .h-animation-header {
+        font-size: var(--font-size, var(--scalar-heading-2));
+        font-weight: var(--font-weight, var(--scalar-bold));
+        color: var(--scalar-color-1);
+        word-wrap: break-word;
+        line-height: 1.45;
+      }
+
+      .h-animation-endpoint-markdown,
+      .h-animation-endpoint-meta,
+      .h-animation-tag-markdown,
+      .h-animation-tag-meta {
+        width: 50%;
+      }
+
+      .h-animation-endpoint-meta,
+      .h-animation-tag-meta {
+        margin-top: 48px;
+      }
+
+      .h-markdown {
+        margin-top: 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+        line-height: 1.5;
+        color: var(--scalar-color-1);
+      }
+
+      .h-green {
+        color: var(--scalar-color-green);
+      }
+
+      .h-blue {
+        color: var(--scalar-color-blue);
+      }
+
+      .h-orange {
+        color: var(--scalar-color-orange);
+      }
+      .h-purple {
+        color: var(--scalar-color-purple);
+      }
+
+      .h-red {
+        color: var(--scalar-color-red);
+      }
+
+      .h-black {
+        color: var(--scalar-color-1);
+      }
+
+      .h-animation-endpoint-code-body span:first-of-type {
+        color: var(--scalar-color-3);
+        margin-right: 4px;
+      }
+
+      .body-second span:first-of-type {
+        margin-right: 28px;
+      }
+
+      .h-grey {
+        color: var(--scalar-color-3);
+      }
+      .dark-mode .h-grey {
+        color: var(--scalar-color-2);
+      }
+      .h-animation-code {
+        background: var(--scalar-background-2);
+        border: 1px solid var(--scalar-border-color);
+        border-radius: var(--scalar-radius-lg);
+      }
+
+      .h-animation-code-header {
+        padding: 9px 12px;
+        border-bottom: 1px solid var(--scalar-border-color);
+        display: flex;
+        gap: 6px;
+      }
+
+      .h-animation-code-header span {
+        color: var(--scalar-color-1);
+        font-weight: var(--scalar-semibold);
+        font-size: var(--scalar-font-size-3);
+      }
+
+      .h-animation-endpoint-code-header,
+      .h-animation-endpoint-code-body,
+      .h-animation-code-body {
+        padding: 10px 12px;
+        font-family: var(--scalar-font-code);
+        font-size: 14px;
+        line-height: 1.5;
+      }
+
+      .h-animation-endpoint-code-header {
+        border-bottom: 1px solid var(--scalar-border-color);
+        padding: 9px 12px;
+        height: 34px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .h-animation-code-body em {
+        min-width: 62px;
+        text-align: right;
+        display: inline-block;
+        margin-right: 12px;
+        font-style: initial;
+      }
+
+      .h-animation-endpoint {
+        width: 100%;
+        display: flex;
+        padding: 90px 0;
+      }
+
+      .h-animation-14 {
+        width: 14px;
+        height: 14px;
+        stroke-width: 2;
+      }
+
+      .h-animation-endpoint-code-body div {
+        display: flex;
+        gap: 4.5px;
+      }
+
+      .h-animation-endpoint-code {
+        background: var(--scalar-background-2);
+        font-family: var(--scalar-font-code);
+        border: 1px solid var(--scalar-border-color);
+        border-radius: var(--scalar-radius-lg);
+      }
+
+      .h-animation-endpoint-code-footer {
+        padding: 6px;
+        display: flex;
+        justify-content: flex-end;
+        background: var(--scalar-background-3);
+        border-radius: 0 0 var(--scalar-radius-lg) var(--scalar-radius-lg);
+      }
+
+      .h-animation-endpoint-code-footer span {
+        background-color: var(--scalar-button-1);
+        padding: 4px 6px;
+        white-space: nowrap;
+        border-radius: var(--scalar-radius);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-weight: var(--scalar-semibold);
+        font-size: var(--scalar-mini);
+        color: var(--scalar-background-2);
+        font-family: var(--scalar-font);
+        width: -moz-fit-content;
+        width: fit-content;
+        box-shadow: inset 0 0 0 1px #0000001a;
+      }
+
+      .h-animation-endpoint-code-tabs {
+        background: var(--scalar-background-2);
+        margin-top: 12px;
+      }
+
+      .h-animation-endpoint-code-tabs .h-animation-endpoint-code-header {
+        gap: 12px;
+        font-family: var(--scalar-font);
+      }
+
+      .h-animation-endpoint-code-tabs
+        .h-animation-endpoint-code-header
+        span:first-of-type {
+        text-decoration: underline;
+        text-underline-offset: 10px;
+      }
+
+      .h-markdown-item {
+        position: relative;
+        border-top: 1px solid var(--scalar-border-color);
+        padding: 10px 0;
+        display: flex;
+        flex-flow: wrap;
+        gap: 9px;
+        font-family: var(--scalar-font);
+        font-size: 12px;
+      }
+
+      .h-markdown-item &gt; span:first-of-type {
+        font-size: 13px;
+        font-family: var(--scalar-font-code);
+        font-weight: 500
+      }
+
+      .h-markdown-heading {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 14px;
+        padding-bottom: 10px;
+      }
+
+      .h-markdown-heading &gt; span:first-of-type {
+        font-weight: var(--scalar-semibold);
+        font-size: 16px;
+      }
+
+      .h-markdown-item div {
+        width: 100%;
+        font-family: var(--scalar-font);
+      } 
+      @supports (color: color(display-p3 1 1 1)) {
+  .light-mode {
+    --scalar-color-accent: var(--scalar-color-1);
+    --scalar-color-green: color(display-p3 0.023529 0.564706 0.380392 / 1.0);
+    --scalar-color-red: color(display-p3 0.937255 0.0 0.023529 / 1.0);
+    --scalar-color-yellow: color(display-p3 0.929412 0.745098 0.12549 / 1.0);
+    --scalar-color-blue: color(display-p3 0.0 0.509804 0.815686 / 1.0);
+    --scalar-color-orange: color(display-p3 0.984314 0.537255 0.172549 / 1.0);
+    --scalar-color-purple: color(display-p3 0.321569 0.011765 0.819608 / 1.0);
+  }
+  .dark-mode {
+    --scalar-color-accent: var(--scalar-color-1);
+    --scalar-color-green: color(display-p3 0.0 0.713725 0.282353 / 1.0);
+    --scalar-color-red: color(display-p3 0.862745 0.105882 0.098039 / 1.0);
+    --scalar-color-yellow: color(display-p3 1.0 0.788235 0.05098 / 1.0);
+    --scalar-color-blue: color(display-p3 0.305882 0.701961 0.92549 / 1.0);
+    --scalar-color-orange: color(display-p3 1.0 0.552941 0.301961 / 1.0);
+    --scalar-color-purple: color(display-p3 0.694118 0.568627 0.976471 / 1.0);
+  }
+}
+.examples {
+  text-decoration: dotted underline;
+  text-underline-offset: 3px;
+}
+.h-markdown-item-description {
+  font-size: 14px;
+  margin-top: -6px;
+}
+.h-markdown-item .h-animation-14  {
+  position: absolute;
+  left: -18px;
+  margin-top: 2px;
+  transform: rotate(-90deg);
+  color: var(--scalar-color-3);
+}
+.ml-auto {
+  margin-left: auto;
+  font-family: var(--scalar-font);
+  color: var(--scalar-color-3);
+}
+.h-animation-doc-header {
+  font-weight: 800;
+  width: 100%;
+  position: absolute;
+  top: 40px;
+  left: 0;
+  height: 50px;
+  padding: 12px;
+  display: flex;
+  align-items: center;
+  font-size: 16px;
+  border-bottom: 1px solid var(--scalar-border-color);
+  background-color: var(--scalar-background-1);
+  z-index: 1;
+  gap: 4px;
+}
+.h-animation-doc-header svg {
+  width: auto;
+  height: 22px;
+  margin-top: 8px;
+}
+.h-animation-popup-fade {
+  position: fixed;
+  left: 0;
+  width: 100%;
+  height: calc(100% - 40px);
+  background-color: rgba(0, 0, 0, 0.06);
+  z-index: 1;
+  top: 40px;
+  border-radius: 0 0 8px 8px;
+  animation: fadein 10s ease-in-out infinite;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.dark-mode .h-animation-popup-fade {
+  background-color: rgba(0,0,0,0.5);
+}
+@keyframes fadein {
+  0%, 40%, 70%, 100% {
+    opacity: 0;
+  }
+  45%, 68.5% {
+    opacity: 1;
+  }
+}
+.h-animation-popup-content {
+  position: relative;
+  width: 80%;
+  height: 80%;
+  z-index: 1;
+  top: -30px;
+  background: var(--scalar-background-1);
+  border-radius: var(--scalar-radius-lg);
+  border: 1px solid var(--scalar-border-color);
+  animation: popupcontent 10s ease-in-out infinite;
+}
+@keyframes popupcontent {
+  0%, 43%, 68%, 100% {
+    opacity: 0;
+    transform: scale(0.99) translate3d(0,10px,0);
+  }
+  47%, 66% {
+    opacity: 1;
+    transform: scale(1) translate3d(0,0,0);
+  }
+}
+.h-animation-doc-header-cta-container {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.h-animation-doc-header-github {
+  font-weight: 500;
+  font-size: 12px;
+  padding: 8px 12px;
+  border-radius: var(--scalar-radius-lg);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.h-animation-doc-header-github svg {
+  width: 16px;
+  height: 16px;
+}
+.h-animation-doc-header-cta {
+  font-weight: 500;
+  font-size: 12px;
+  padding: 8px 12px;
+  border-radius: var(--scalar-radius-lg);
+  background-color: var(--scalar-color-1);
+  color: var(--scalar-background-1);
+}
+.flex {
+    display: flex;
+}
+.font-medium {
+    --tw-font-weight: var(--scalar-semibold);
+    font-weight: var(--scalar-semibold);
+}
+.gap-1 {
+    gap: 4px;
+}
+.gap-15 {
+    gap: 6px;
+}
+.justify-center {
+    justify-content: center;
+}
+.items-center {
+    align-items: center;
+}
+.w-full {
+    width: 100%;
+}
+.flex-1 {
+    flex: 1;
+}
+.size-3 {
+    width: 12px;
+    height: 12px;
+}
+.h-animation-14 {
+    width: 16px;
+    height: 16px;
+    stroke-width: 2;
+}
+.min-h-0 {
+    min-height: 0;
+}
+.text-c-2 {
+    color: var(--scalar-color-2);
+}
+.text-c-3 {
+    color: var(--scalar-color-2);
+}
+.py-2 {
+    padding-block: 8px;
+}
+.py-15 {
+    padding-block: 7.5px;
+}
+.px-2 {
+    padding-inline: 8px;
+}
+.flex-col {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    flex-direction: column;
+}
+.w-15 {
+    width: 60px;
+}
+.relative {
+    position: relative;
+}
+.p-11 {
+    padding: 11px;
+}
+.p-9 {
+    padding: 9px;
+}
+.text-c-1 {
+    color: var(--scalar-color-1);
+}
+.rounded {
+    border-radius: var(--scalar-radius);
+}
+.bg-b-3 {
+    background-color: var(--scalar-background-3);
+}
+.bg-b-2 {
+    background-color: var(--scalar-background-2);
+}
+.bg-b-1 {
+    background-color: var(--scalar-background-1);
+}
+.min-w-37 {
+    min-width: 37px;
+}
+svg {
+    vertical-align: middle;
+    display: block;
+}
+.size-full {
+    width: 100%;
+    height: 100%;
+}
+.p-3 {
+    padding: 0 12px 12px 12px;
+}
+.text-\[13px\] {
+    font-size: 14px;
+}
+.h-10 {
+    height: 40px;
+}
+.rounded-popup {
+    border-radius: var(--scalar-radius);
+    max-height: 713px;
+    overflow: hidden;
+}
+.popup-container {
+    width: 100%;
+}
+.w-780 {
+    width: 580px;
+    font-size: 14px;
+    border: 1px solid var(--scalar-border-color);
+}
+.w-780 .font-code {
+    font-size: 14px;
+}
+.min-h-32,
+.min-h-8 {
+    min-height: 32px;
+}
+.min-h-44 {
+    min-height: 44px;
+}
+.font-code {
+    font-family: var(--scalar-font-code);
+}
+.size-35 {
+    width: 14px;
+    height: 14px;
+}
+.background-button {
+    color: var(--scalar-button-1-color);
+    background: var(--scalar-button-1);
+    height: 26px;
+    margin-right: 2px;
+    padding: 0 8px;
+}
+.fill-current {
+    fill: currentColor;
+}
+.shrink-0 {
+    flex-shrink: 0;
+}
+.px-25 {
+    padding-inline: 10px;
+}
+.mr-2 {
+    margin-right: 8px;
+}
+.ml-2 {
+    margin-left: 8px;
+}
+.p-1 {
+    padding: 4px;
+}
+.border-b {
+    border-bottom: 1px solid var(--scalar-border-color);
+}
+.border-r {
+    border-right: 1px solid var(--scalar-border-color);
+}
+.border {
+    border: 1px solid var(--scalar-border-color);
+}
+.min-h-\[50px\] {
+    min-height: 50px;
+}
+.px-3 {
+    padding-inline: 12px;
+}
+.font-bold {
+    font-weight: 600;
+}
+.px-6 {
+    padding-inline: 24px;
+}
+.h-full {
+    height: 100%;
+}
+.h-animation-code-body,
+.h-animation-endpoint-code-body,
+.h-animation-endpoint-code-header {
+    font-family: var(--scalar-font-code);
+    font-size: 14px;
+    line-height: 1.5;
+    padding: 10px 12px;
+}
+.h-animation-endpoint-code-body span:first-of-type {
+    color: var(--scalar-color-3);
+    margin-right: 4px;
+}
+.h-black {
+    color: var(--scalar-color-1);
+}
+.body-second span:first-of-type {
+    margin-right: 28px;
+}
+@supports (color: color(display-p3 1 1 1)) {
+    .light-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0.023529 0.564706 0.380392 / 1);
+        --scalar-color-red: color(display-p3 0.937255 0 0.023529 / 1);
+        --scalar-color-yellow: color(display-p3 0.929412 0.745098 0.12549 / 1);
+        --scalar-color-blue: color(display-p3 0 0.509804 0.815686 / 1);
+        --scalar-color-orange: color(display-p3 0.984314 0.537255 0.172549 / 1);
+        --scalar-color-purple: color(display-p3 0.321569 0.011765 0.819608 / 1);
+    }
+    .dark-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0 0.713725 0.282353 / 1);
+        --scalar-color-red: color(display-p3 0.862745 0.105882 0.098039 / 1);
+        --scalar-color-yellow: color(display-p3 1 0.788235 0.05098 / 1);
+        --scalar-color-blue: color(display-p3 0.305882 0.701961 0.92549 / 1);
+        --scalar-color-orange: color(display-p3 1 0.552941 0.301961 / 1);
+        --scalar-color-purple: color(display-p3 0.694118 0.568627 0.976471 / 1);
+    }
+}
+.rotate-90 {
+    transform: rotate(90deg);
+}
+.gridy {
+    border-bottom: 1px solid var(--scalar-border-color);
+    display: flex;
+    align-items: center;
+}
+.gridy-item {
+    width: calc(50% - 16px);
+    height: 32px;
+    padding-left: 12px;
+    display: flex;
+    align-items: center;
+}
+.gridy-item:last-of-type {
+    border-left: 1px solid var(--scalar-border-color);
+}
+.gridy-check {
+    height: 32px;
+    width: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    stroke-width: 2.25;
+    border-right: 1px solid var(--scalar-border-color);
+}
+.gridy-inactive {
+    color: var(--scalar-color-3);
+}
+.http-bg-gradient {
+    background: linear-gradient(rgba(255,255,255,0.1), rgba(0,0,0,0.05));
+    font-size: 10px !important;
+    height: 24px;
+    border-radius: 2px;
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    box-shadow: 0 0 0 1px var(--scalar-border-color);
+    margin-right: 4px;
+    margin-left: 4px;
+    font-weight: 500;
+}
+.http-domain {
+    padding-inline: 8px;
+    height: 24px;
+    border-radius: 2px;
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    box-shadow: 0 0 0 1px var(--scalar-border-color);
+    margin-right: 8px;
+}
+.filters {
+    margin-left: auto;
+    font-size: 14px;
+}
+.translate-popup {
+  background: color-mix(in srgb, var(--scalar-background-1) 50%, var(--scalar-background-2));
+}
+.h-animation-ref {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 765px;
+  border: 1px solid rgb(55, 55, 55);
+  border-radius: 8px;
+  overflow: hidden;
+}
+@supports (hanging-punctuation: first) and (font: -apple-system-body) and
+  (-webkit-appearance: none) {
+    .transform-rr {
+      --var: 1;
+      --varcalcx: calc(var(--var) * 1360px);
+      --xcalc: calc((100dvw - var(--varcalcx))/2);
+      --varcalcy: calc(var(--var) * 765px);
+      --ycalc: calc((100dvh - var(--varcalcy))/2);
+      transform: translate3d(var(--xcalc), var(--ycalc), 0);
+    }
+    * {
+      animation: none !important;
+    }
+    .h-animation-tag-wrap {
+      display: none;
+    }
+    .h-animation-endpoint {
+      border-top: none;
+    }
+    .h-animation-sidebar-endpoint span {
+      font-weight: 500;
+    }
+    .h-animation-popup {
+      display: none;
+    }
+  @media only screen and (max-width: 1360px) {
+    .transform-rr {
+      --var: 0.95;
+    }
+    .rr {
+      transform: scale(var(--var));
+      transform-origin: top left;
+      position: relative;
+      overflow: hidden
+    }
+  }
+  @media only screen and (max-width: 1292px) {
+    .transform-rr {
+      --var: 0.9
+    }
+  }
+  @media only screen and (max-width: 1224px) {
+    .transform-rr {
+      --var: 0.85
+    }
+  }
+  @media only screen and (max-width: 1156px) {
+    .transform-rr {
+      --var: 0.8
+    }
+  }
+  @media only screen and (max-width: 1088px) {
+    .transform-rr {
+      --var: 0.75
+    }
+  }
+  @media only screen and (max-width: 1020px) {
+    .transform-rr {
+      --var: 0.7
+    }
+  }
+  @media only screen and (max-width: 952px) {
+    .transform-rr {
+      --var: 0.65
+    }
+  }
+  @media only screen and (max-width: 884px) {
+    .transform-rr {
+      --var: 0.6
+    }
+  }
+  @media only screen and (max-width: 816px) {
+    .transform-rr {
+      --var: 0.55
+    }
+  }
+  @media only screen and (max-width: 748px) {
+    .transform-rr {
+      --var: 0.5
+    }
+  }
+  @media only screen and (max-width: 680px) {
+    .transform-rr {
+      --var: 0.45
+    }
+  }
+  @media only screen and (max-width: 612px) {
+    .transform-rr {
+      --var: 0.4
+    }
+  }
+  @media only screen and (max-width: 544px) {
+    .transform-rr {
+      --var: 0.35
+    }
+  }
+  @media only screen and (max-width: 476px) {
+    .transform-rr {
+      --var: 0.3
+    }
+  }
+  @media only screen and (max-width: 408px) {
+    .transform-rr {
+      --var: 0.25
+    }
+  }
+  @media only screen and (max-width: 340px) {
+    .transform-rr {
+      --var: 0.2
+    }
+  }
+  @media only screen and (max-width: 272px) {
+    .transform-rr {
+      --var: 0.15
+    }
+  }
+}
+.no-body {
+  min-height: 80px;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  color: var(--scalar-color-3);
+}  
+  
+</style>
+    </foreignObject>
+</svg>

--- a/documentation/assets/api-docs-static-zoom.svg
+++ b/documentation/assets/api-docs-static-zoom.svg
@@ -1,2 +1,1377 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1360" height="765" viewBox="0 0 0 1360 765"><foreignObject width="1360" height="765" class="fo"><div xmlns="http://www.w3.org/1999/xhtml" class="transform-rr"><div class="h-animation-ref light-mode rr"><div class="h-animation-ref-safari size"><div class="dotted-top"></div><div class="h-animation-ref-safari-left"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="16" fill="currentColor" viewBox="0 0 20 16"><path fill-rule="evenodd" d="M19.4 15.4a2 2 0 0 1-1.4.6H2a2 2 0 0 1-1.4-.6A2 2 0 0 1 0 14V2C0 1.4.2 1 .6.6A2 2 0 0 1 2 0h16c.6 0 1 .2 1.4.6.4.4.6.8.6 1.4v12c0 .6-.2 1-.6 1.4ZM2 14h5V2H2v12Zm7 0h9V2H9v12ZM3.3 3c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3Zm0 2c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3ZM3 7.4c0-.1.1-.2.3-.2h2.5c.1 0 .2 0 .2.2v1c0 .2-.1.3-.2.3H3.3a.3.3 0 0 1-.3-.3v-1Z" clip-rule="evenodd"/></svg><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M16 22 6 12 16 2l1.8 1.8L9.5 12l8.3 8.2L16 22Z"/></svg><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="m8 22 10-10L8 2 6.2 3.8l8.3 8.2-8.3 8.2L8 22Z"/></svg></div><div class="h-animation-ref-safari-nav"><div class="h-animation-ref-safari-nav-url"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M7 10h8V6c0-.83-.3-1.54-.88-2.13A2.9 2.9 0 0 0 12 3c-.83 0-1.54.3-2.13.88A2.9 2.9 0 0 0 9 6v4H7V6c0-1.38.49-2.56 1.46-3.54A4.82 4.82 0 0 1 12 1c1.38 0 2.56.49 3.54 1.46A4.82 4.82 0 0 1 17 6v4c.55 0 1.02.2 1.41.59.4.39.59.86.59 1.41v8c0 .55-.2 1.02-.59 1.41-.39.4-.86.59-1.41.59H7c-.55 0-1.02-.2-1.41-.59-.4-.39-.59-.86-.59-1.41v-8c0-.55.2-1.02.59-1.41.39-.4.86-.59 1.41-.59Z"/></svg>developers.zoom.us/docs/api/meetings/#tag/archiving<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M12 22a8.7 8.7 0 0 0 6.4-2.6A9.1 9.1 0 0 0 21 13h-2c0 2-.7 3.6-2 5-1.4 1.3-3 2-5 2s-3.6-.7-5-2c-1.3-1.4-2-3-2-5s.7-3.6 2-5c1.4-1.3 3-2 5-2h.2l-1.6 1.5L12 9l4-4-4-4-1.4 1.5L12.2 4H12a8.7 8.7 0 0 0-6.4 2.6A9.1 9.1 0 0 0 3 13a8.7 8.7 0 0 0 2.6 6.4A9.1 9.1 0 0 0 12 22Z"/></svg></div></div><div class="h-animation-ref-safari-right"></div></div><div class="h-animation-doc-header"><svg xmlns="http://www.w3.org/2000/svg" width="180" height="25" fill="none" viewBox="0 0 203 25"><path fill="#00031F" d="M97 8.85c0 6.84-4.16 8.87-9.78 8.87h-4.84V0h4.84C92.84 0 97 2.03 97 8.85ZM85.17 2.3v13.13h1.93c3.54 0 7.01-.74 7.01-6.58 0-5.82-3.47-6.55-7.01-6.55h-1.93Zm25.45 11.56c-.6 2.18-2.56 4.18-5.91 4.18-4.25 0-6.55-3.1-6.55-6.92 0-4.08 2.73-6.8 6.47-6.8 4.06 0 6.43 3.33 6.17 7.6h-10.03c.25 2.43 1.79 3.94 3.84 3.94 1.83 0 2.9-.75 3.45-2h2.56Zm-2.47-3.94c-.07-1.95-1.44-3.52-3.54-3.52-1.98 0-3.45 1.03-3.79 3.52h7.33Zm12.34-5.35h2.64l-4.87 13.15h-2.32l-4.89-13.15h2.81l3.33 9.75 3.3-9.75Zm15 9.29c-.6 2.18-2.56 4.18-5.91 4.18-4.25 0-6.55-3.1-6.55-6.92 0-4.08 2.74-6.8 6.48-6.8 4.05 0 6.42 3.33 6.16 7.6h-10.03c.25 2.43 1.79 3.94 3.84 3.94 1.83 0 2.91-.75 3.45-2h2.57Zm-2.46-3.94c-.08-1.95-1.45-3.52-3.55-3.52-1.98 0-3.45 1.03-3.79 3.52h7.34Zm4.27 7.8V0h2.54v17.72h-2.54Zm10.5.32c-3.1 0-6.38-2.1-6.38-6.84 0-4.77 3.28-6.87 6.38-6.87 3.13 0 6.4 2.1 6.4 6.87 0 4.74-3.27 6.84-6.4 6.84Zm3.72-6.84c0-3.28-1.78-4.72-3.72-4.72-1.9 0-3.69 1.4-3.69 4.72 0 3.25 1.79 4.69 3.7 4.69 1.93 0 3.71-1.5 3.71-4.7Zm6.94-4.7a4.5 4.5 0 0 1 4.1-2.17c3.06 0 5.68 2.56 5.68 6.84 0 4.3-2.62 6.87-5.67 6.87a4.5 4.5 0 0 1-4.1-2.18V22h-2.55V4.57h2.54V6.5Zm7.07 4.67c0-2.96-1.45-4.72-3.55-4.72-1.95 0-3.62 1.47-3.62 4.72s1.67 4.74 3.62 4.74c2.1 0 3.55-1.78 3.55-4.74Zm16.6 2.7c-.62 2.17-2.57 4.17-5.92 4.17-4.26 0-6.55-3.1-6.55-6.92 0-4.08 2.73-6.8 6.48-6.8 4.05 0 6.42 3.33 6.15 7.6h-10.02c.25 2.43 1.79 3.94 3.84 3.94 1.83 0 2.9-.75 3.45-2h2.56Zm-2.47-3.95c-.08-1.95-1.45-3.52-3.55-3.52-1.98 0-3.45 1.03-3.79 3.52h7.34Zm9.8-2.8c-1.95 0-2.98.95-2.98 3.7v6.9h-2.54V4.57h2.49v2.32c.68-1.49 2-2.34 3.64-2.37.22 0 .5 0 .71.03v2.64a12.76 12.76 0 0 0-1.32-.08Zm7.43-.76c-1.25 0-2.59.5-2.59 1.58 0 .98.64 1.4 1.83 1.64l1.89.37c2.49.49 4.66 1.34 4.66 3.91 0 2.67-2.49 4.18-5.52 4.18-3.32 0-5.35-1.93-5.67-4.4h2.59c.34 1.49 1.32 2.37 3.15 2.37 1.64 0 2.91-.68 2.91-1.86 0-1.22-1.15-1.7-2.52-1.98l-1.98-.39c-1.98-.39-3.83-1.27-3.83-3.74 0-2.32 2.44-3.74 5.33-3.74 2.64 0 4.76 1.4 5.25 3.94h-2.52c-.36-1.35-1.49-1.88-2.98-1.88Z"/><path fill="#0B5CFF" d="M15.56 17.72H2.29c-.93 0-1.76-.55-2.11-1.41a2.29 2.29 0 0 1 .5-2.5l9.18-9.19H3.28A3.27 3.27 0 0 1 0 1.34h12.23a2.29 2.29 0 0 1 1.62 3.92l-9.18 9.19h7.61a3.28 3.28 0 0 1 3.28 3.27ZM74.19 7.5a6.4 6.4 0 0 0-6.39-6.4c-1.88 0-3.58.83-4.75 2.13A6.37 6.37 0 0 0 58.3 1.1a6.4 6.4 0 0 0-6.38 6.39v10.23a3.27 3.27 0 0 0 3.27-3.27V7.49a3.12 3.12 0 0 1 3.11-3.11 3.12 3.12 0 0 1 3.12 3.1v6.97a3.28 3.28 0 0 0 3.27 3.27V7.5a3.12 3.12 0 0 1 3.11-3.12 3.12 3.12 0 0 1 3.12 3.12v6.96a3.28 3.28 0 0 0 3.27 3.27V7.5ZM50.28 9.53a8.43 8.43 0 1 1-16.87 0 8.43 8.43 0 0 1 16.87 0Zm-3.28 0a5.16 5.16 0 1 0-10.31 0 5.16 5.16 0 0 0 10.31 0Zm-14.9 0a8.43 8.43 0 1 1-16.87 0 8.43 8.43 0 0 1 16.87 0Zm-3.27 0a5.16 5.16 0 1 0-10.32 0 5.16 5.16 0 0 0 10.32 0Z"/></svg></div><div class="h-animation-sidebar"><div class="h-animation-sidebar-search"><svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16m10 2-4.35-4.35"/></svg>Search<div class="h-animation-sidebar-search-hotkey">⌘K</div></div><div class="h-animation-sidebar__animate"><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M224 48H32a16 16 0 0 0-16 16v24a16 16 0 0 0 16 16v88a16 16 0 0 0 16 16h160a16 16 0 0 0 16-16v-88a16 16 0 0 0 16-16V64a16 16 0 0 0-16-16Zm-16 144H48v-88h160Zm16-104H32V64h192v24ZM96 136a8 8 0 0 1 8-8h48a8 8 0 0 1 0 16h-48a8 8 0 0 1-8-8Z"/></svg>Archiving</div><div class="h-animation-sidebar-endpoint beforeme beforeme__alt"><em>Delete a meeting's archived files</em><span class="h-red">DEL</span></div><div class="h-animation-sidebar-endpoint">Get a meeting's archived files<span class="h-blue">GET</span></div><div class="h-animation-sidebar-endpoint">Get archived file statistics<span class="h-blue">GET</span></div><div class="h-animation-sidebar-endpoint">List archived files<span class="h-blue">GET</span></div><div class="h-animation-sidebar-endpoint">Update an archived file's auto-delete status<span class="h-orange">PATCH</span></div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M160 40a88.09 88.09 0 0 0-78.71 48.67A64 64 0 1 0 72 216h88a88 88 0 0 0 0-176Zm0 160H72a48 48 0 0 1 0-96c1.1 0 2.2 0 3.29.11A88 88 0 0 0 72 128a8 8 0 0 0 16 0 72 72 0 1 1 72 72Z"/></svg>Cloud Recording</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M224 72h-16v-8a24 24 0 0 0-24-24H40a24 24 0 0 0-24 24v96a24 24 0 0 0 24 24h112v8a24 24 0 0 0 24 24h48a24 24 0 0 0 24-24V96a24 24 0 0 0-24-24ZM40 168a8 8 0 0 1-8-8V64a8 8 0 0 1 8-8h144a8 8 0 0 1 8 8v8h-16a24 24 0 0 0-24 24v72Zm192 24a8 8 0 0 1-8 8h-48a8 8 0 0 1-8-8V96a8 8 0 0 1 8-8h48a8 8 0 0 1 8 8Zm-96 16a8 8 0 0 1-8 8H88a8 8 0 0 1 0-16h40a8 8 0 0 1 8 8Zm80-96a8 8 0 0 1-8 8h-16a8 8 0 0 1 0-16h16a8 8 0 0 1 8 8Z"/></svg>Devices</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M128 24a104 104 0 1 0 104 104A104.12 104.12 0 0 0 128 24Zm88 104a87.61 87.61 0 0 1-3.33 24h-38.51a157.44 157.44 0 0 0 0-48h38.51a87.61 87.61 0 0 1 3.33 24Zm-114 40h52a115.11 115.11 0 0 1-26 45 115.27 115.27 0 0 1-26-45Zm-3.9-16a140.84 140.84 0 0 1 0-48h59.88a140.84 140.84 0 0 1 0 48ZM40 128a87.61 87.61 0 0 1 3.33-24h38.51a157.44 157.44 0 0 0 0 48H43.33A87.61 87.61 0 0 1 40 128Zm114-40h-52a115.11 115.11 0 0 1 26-45 115.27 115.27 0 0 1 26 45Zm52.33 0h-35.62a135.28 135.28 0 0 0-22.3-45.6A88.29 88.29 0 0 1 206.37 88Zm-98.74-45.6A135.28 135.28 0 0 0 85.29 88H49.63a88.29 88.29 0 0 1 57.96-45.6ZM49.63 168h35.66a135.28 135.28 0 0 0 22.3 45.6A88.29 88.29 0 0 1 49.63 168Zm98.78 45.6a135.28 135.28 0 0 0 22.3-45.6h35.66a88.29 88.29 0 0 1-57.96 45.6Z"/></svg>H323 Devices</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M216 40H40a16 16 0 0 0-16 16v144a16 16 0 0 0 16 16h176a16 16 0 0 0 16-16V56a16 16 0 0 0-16-16Zm0 80h-48V56h48ZM40 56h112v144H40Zm176 144h-48v-64h48v64ZM180 88a12 12 0 1 1 12 12 12 12 0 0 1-12-12Zm24 80a12 12 0 1 1-12-12 12 12 0 0 1 12 12Zm-68.25-2a39.76 39.76 0 0 0-17.19-23.34 32 32 0 1 0-45.12 0A39.84 39.84 0 0 0 56.25 166a8 8 0 0 0 15.5 4c2.64-10.25 13.06-18 24.25-18s21.62 7.73 24.25 18a8 8 0 1 0 15.5-4ZM80 120a16 16 0 1 1 16 16 16 16 0 0 1-16-16Z"/></svg>Meetings</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M184 112a8 8 0 0 1-8 8h-64a8 8 0 0 1 0-16h64a8 8 0 0 1 8 8Zm-8 24h-64a8 8 0 0 0 0 16h64a8 8 0 0 0 0-16Zm48-88v160a16 16 0 0 1-16 16H48a16 16 0 0 1-16-16V48a16 16 0 0 1 16-16h160a16 16 0 0 1 16 16ZM48 208h24V48H48Zm160 0V48H88v160h120Z"/></svg>PAC</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M88 96a8 8 0 0 1 8-8h64a8 8 0 0 1 0 16H96a8 8 0 0 1-8-8Zm8 40h64a8 8 0 0 0 0-16H96a8 8 0 0 0 0 16Zm32 16H96a8 8 0 0 0 0 16h32a8 8 0 0 0 0-16Zm96-104v108.69a15.86 15.86 0 0 1-4.69 11.31L168 219.31a15.86 15.86 0 0 1-11.31 4.69H48a16 16 0 0 1-16-16V48a16 16 0 0 1 16-16h160a16 16 0 0 1 16 16ZM48 208h104v-48a8 8 0 0 1 8-8h48V48H48Zm120-40v28.7l28.69-28.7Z"/></svg>Reports</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M231.59 90.13C175.44 34 80.56 34 24.41 90.13c-20 20-21.92 49.49-4.69 71.71A16 16 0 0 0 32.35 168a15.8 15.8 0 0 0 5.75-1.08l49-17.37.29-.11a16 16 0 0 0 9.75-11.73l5.9-29.52a76.52 76.52 0 0 1 49.68-.11l6.21 29.75a16 16 0 0 0 9.72 11.59l.29.11 49 17.39a16 16 0 0 0 18.38-5.06c17.19-22.24 15.26-51.73-4.73-71.73ZM223.67 152l-.3-.12-48.82-17.33-6.21-29.74A16 16 0 0 0 158 93a92.56 92.56 0 0 0-60.34.13 16 16 0 0 0-10.32 12l-5.9 29.51-48.81 17.22c-.1 0-.17.13-.27.17-12.33-15.91-11-36.23 3.36-50.58 25-25 58.65-37.53 92.28-37.53s67.27 12.51 92.28 37.53c14.33 14.35 15.72 34.67 3.39 50.55Zm.32 48a8 8 0 0 1-8 8H40a8 8 0 0 1 0-16h176a8 8 0 0 1 8 8Z"/></svg>SIP Phone</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M232 112h-96V88h8a16 16 0 0 0 16-16V40a16 16 0 0 0-16-16h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h8v24H24a8 8 0 0 0 0 16h32v32h-8a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-8v-32h112v32h-8a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-8v-32h32a8 8 0 0 0 0-16ZM112 40h32v32h-32ZM80 208H48v-32h32Zm128 0h-32v-32h32Z"/></svg>Tracking Field</div><div class="h-animation-sidebar-folder"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M168 104a40 40 0 1 0-40 40 40 40 0 0 0 40-40Zm-64 0a24 24 0 1 1 24 24 24 24 0 0 1-24-24Zm120 96h-88v-16.4a80 80 0 1 0-16 0V200H32a8 8 0 0 0 0 16h192a8 8 0 0 0 0-16ZM64 104a64 64 0 1 1 64 64 64.07 64.07 0 0 1-64-64Z"/></svg>Webinars</div></div></div><div class="h-animation-content"><div class="h-animation-tag"><div class="h-animation-endpoint"><div class="h-animation-endpoint-markdown"><div class="h-animation-header">Delete a meeting's archived files</div><div class="h-markdown"><p>Delete all of a meeting's archived files.</p><div class="h-markdown-list"><div class="h-markdown-heading"><span class="h-black">Path Parameters</span></div><div class="h-markdown-item"><span class="h-black">meetingUUID</span><span class="h-grey">string</span><span class="h-orange">Required</span><div class="h-markdown-item-description"><span class="h-grey">The meeting's universally unique identifier (UUID). Each meeting instance generates a UUID. For example, after a meeting ends, a new UUID is generated for the next meeting instance.<br /><br />If the meeting UUID begins with a / character or contains a // character, you must double-encode the meeting UUID when using the meeting UUID for other API calls.</span></div></div><div class="h-markdown-list"><div class="h-markdown-heading"><span class="h-black">Responses</span></div><div class="h-markdown-item"><svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5"/></svg><span class="h-black">204</span><span class="h-grey">Meeting archived file deleted.</span></div><div class="h-markdown-item"><svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5"/></svg><span class="h-black">400</span><span class="h-grey">Bad Request</span></div><div class="h-markdown-item"><svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5"/></svg><span class="h-black">401</span><span class="h-grey">Not Found</span></div><div class="h-markdown-item"><svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5"/></svg><span class="h-black">429</span><span class="h-grey">Too Many Requests.</span></div></div></div></div></div></div></div></div></div></div><style><![CDATA[@keyframes scrollupdown{0%,10%,80%,to{transform:translate3d(0,0,0)}18%,72%{transform:translate3d(0,-380px,0)}}@keyframes fadein{0%,40%,70%,to{opacity:0}45%,68.5%{opacity:1}}@keyframes popupcontent{0%,43%,68%,to{opacity:0;transform:scale(.99) translate3d(0,10px,0)}47%,66%{opacity:1;transform:scale(1)]]><![CDATA[ translate3d(0,0,0)}}*{padding:0;box-sizing:border-box;margin:0;-webkit-font-smoothing:antialiased}:root{--app-header-height:48px;--scalar-border-width:1px;--scalar-radius:3px;--scalar-radius-lg:6px;--scalar-radius-xl:8px;--scalar-header-height:50px;--scalar-sidebar-width:280px;--scalar-toc-width:28]]><![CDATA[0px;--scalar-card-icon-width:40px;--scalar-card-icon-height:40px;--scalar-card-icon-diameter:20px;--scalar-card-padding:16px;--scalar-card-inter-element-gap:4px;--scalar-row-gap:16px;--system-fonts:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;--scalar-font:"Inter", var(--system-fonts);--scalar-font-code:Monaco, Menlo, monospace;--scalar-heading-1:24px;--scalar-page-description:16px;--scalar-heading-2:20px;--scalar-heading-3:20px;--scalar-heading-4:16px;--scalar-heading-5:16px;--scalar-heading-6:16px;--scalar-paragraph:16px;--scalar-small:14px;--scalar-mini:13px;--scalar-micro:12px;--scalar-extra-bold:700;--scalar-bold:600;--scalar-semibold:500;--scalar-regular:400;--scalar-font-size-1:24px;--scalar-font-size-2:16px;--scalar-font-size-3:14px;--scalar-font-size-4:13px;--scalar-font-size-5:12px;--scalar-line-height-1:32px;--scalar-line-height-2:24px;--scalar-line-height-3:20px;--scalar-line-height-4:18px;--scalar-line-height-5:16px;--scalar-heading-spacing:44px;--scalar-block-spacing:12px}.light-mode{--scalar-sidebar-width:280px;--scalar-color-1:#000;--scalar-color-2:#666666;--scalar-color-3:#8e8e8e;--scalar-color-disabled:#b4b1b1;--scalar-color-ghost:#a7a7a7;--scalar-color-accent:#0099ff;--scalar-background-1:#fff;--scalar-background-2:#f6f6f6;--scalar-background-3:#e7e7e7;--scalar-background-4:rgba(0, 0, 0, 0.06);--scalar-background-accent:#8ab4f81f;--scalar-border-color:rgba(0, 0, 0, 0.05);--scalar-scrollbar-color:rgba(0, 0, 0, 0.18);--scalar-scrollbar-color-active:rgba(0, 0, 0, 0.36);--scalar-lifted-brightness:1;--scalar-backdrop-brightness:1;--scalar-shadow-1:0 1px 3px 0 rgba(0, 0, 0, 0.11);--scalar-shadow-2:rgba(0, 0, 0, 0.08) 0px 13px 20px 0px,
-          rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 1px;--scalar-button-1:rgb(49 53 56);--scalar-button-1-color:#fff;--scalar-button-1-hover:rgb(28 31 33);--scalar-color-green:#00a67d;--scalar-color-red:#ef0006;--scalar-color-yellow:#f9c514;--scalar-color-blue:#579dfb;--scalar-color-orange:#fc8528;--scalar-color-purple:#5203d1;font-family:var(--scalar-font);color:var(--scalar-color-1)}.dotted-top{position:absolute;top:17px;left:12px;background-color:var(--scalar-background-3);border-radius:50%;width:10px;box-shadow:14px 0 0 var(--scalar-background-3),29px 0 0 var(--scalar-background-3);height:9px}.h-animation-ref-safari{height:40px;background-color:var(--scalar-background-2);z-index:1;position:absolute;top:0;width:100%;display:flex;justify-content:space-between}.h-animation-ref-safari-left{width:150px;display:flex;align-items:center;gap:10px;padding-left:68px;color:var(--scalar-color-3)}.h-animation-ref-safari-nav{width:600px;padding:6px 0}.h-animation-ref-safari-right{width:150px;display:flex;align-items:center;justify-content:flex-end;gap:10px;color:var(--scalar-color-3);padding-right:12px}.h-animation-ref-safari-right svg{width:17px;height:17px}.h-animation-ref-safari-left svg{width:16px;height:16px}.h-animation-ref-safari-left svg:last-of-type{opacity:.5}.h-animation-ref-safari-nav-url{width:100%;border-radius:7px;height:100%;text-align:center;display:flex;align-items:center;justify-content:center;font-size:13px;position:relative;border:1px solid var(--scalar-border-color)}.h-animation-ref-safari-nav-url svg{width:13px;height:13px;color:var(--scalar-color-3);margin-right:3px}.h-animation-ref-safari-nav-url svg:last-of-type{position:absolute;right:4px}.h-animation-ref{-webkit-user-select:none;-moz-user-select:none;user-select:none;background:var(--scalar-background-1);min-width:1280px;min-height:720px;display:flex;padding-top:90px}.h-animation-sidebar{padding:12px;max-width:var(--scalar-sidebar-width);border-right:1px solid var(--scalar-border-color);flex:1}.h-animation-sidebar-search{display:flex;align-items:center;position:relative;padding:0 3px 0 6px;width:100%;background:var(--scalar-sidebar-search-background, var(--scalar-background-1));color:var(--scalar-sidebar-color-2, var(--scalar-color-2));border-radius:var(--scalar-radius);box-shadow:0 0 0 1px var(--scalar-sidebar-search-border-color, var(--scalar-border-color));height:31px;font-size:13px;margin-bottom:12px;gap:6px}.h-animation-sidebar-endpoint{position:relative}.h-animation-sidebar-endpoint span{margin-left:auto;font-family:var(--scalar-font-code);font-weight:700;font-size:10px;margin-top:10px;line-height:0}.beforeme,.beforeme em{color:var(--scalar-color-1)}.beforeme{font-weight:var(--scalar-semibold)}.beforeme em{font-style:normal}.beforeme,.beforeme em,.beforeme span{position:relative}.beforeme:after,.beforeme:before{content:"";position:absolute;height:100%}.beforeme:before{background:var(--scalar-background-2);width:256px;z-index:0;right:0;top:0;border-radius:var(--scalar-radius)}.beforeme:after{background:var(--scalar-border-color);width:1px;left:-1px;box-shadow:-12.5px 0 0 0 var(--scalar-border-color)}.beforeme__alt:after{box-shadow:none}.h-animation-sidebar-endpoint,.h-animation-sidebar-folder{font-size:14px;min-height:32px;display:flex;padding:8px 9px;color:var(--scalar-color-2);border-radius:var(--scalar-radius)}.h-animation-sidebar-folder svg{margin-right:6px}.h-animation-sidebar-folder{padding-left:6px}.h-animation-sidebar-endpoint{padding-left:12px;border-radius:0;margin-left:12px;border-left:1px solid var(--scalar-border-color)}.h-animation-sidebar-folder:first-of-type{color:var(--scalar-color-1);font-weight:500}.h-animation-sidebar-folder:first-of-type svg{fill:var(--scalar-color-1)}.h-animation-sidebar-search-hotkey{background-color:var(--scalar-background-2);color:var(--scalar-color-3);margin-left:auto;padding:3px 5px;border-radius:var(--scalar-radius)}.h-animation-content{flex:1}.h-animation-tag{border-bottom:1px solid var(--scalar-border-color);width:100%;display:flex}.h-animation-endpoint{gap:48px}.h-animation-tag{border-bottom:none;flex-flow:wrap;gap:0;padding:0 60px}.h-animation-header{font-size:var(--font-size, var(--scalar-heading-2));font-weight:var(--font-weight, var(--scalar-bold));color:var(--scalar-color-1);word-wrap:break-word;line-height:1.45}.h-animation-endpoint-markdown{width:50%}.h-markdown{margin-top:18px;display:flex;flex-direction:column;gap:18px;line-height:1.5;color:var(--scalar-color-1)}.h-blue{color:var(--scalar-color-blue)}.h-orange{color:var(--scalar-color-orange)}.h-red{color:var(--scalar-color-red)}.h-grey{color:var(--scalar-color-3)}.h-animation-endpoint,.h-markdown-item{border-top:1px solid var(--scalar-border-color);display:flex}.h-animation-endpoint{width:100%;padding:90px 0}.h-markdown-item{position:relative;padding:10px 0;flex-flow:wrap;gap:9px;font-family:var(--scalar-font);font-size:12px}.h-markdown-heading{display:flex;align-items:center;gap:6px;font-size:14px;padding-bottom:10px}.h-markdown-item div{width:100%;font-family:var(--scalar-font)}@supports (color:color(display-p3 1 1 1)){.light-mode{--scalar-color-accent:var(--scalar-color-1);--scalar-color-green:color(display-p3 0.023529 0.564706 0.380392 / 1);--scalar-color-red:color(display-p3 0.937255 0 0.023529 / 1);--scalar-color-yellow:color(display-p3 0.929412 0.745098 0.12549 / 1);--scalar-color-blue:color(display-p3 0 0.509804 0.815686 / 1);--scalar-color-orange:color(display-p3 0.984314 0.537255 0.172549 / 1);--scalar-color-purple:color(display-p3 0.321569 0.011765 0.819608 / 1)}}.h-markdown-item-description{font-size:14px;margin-top:-6px}.h-markdown-item .h-animation-14{position:absolute;left:-18px;margin-top:2px;transform:rotate(-90deg);color:var(--scalar-color-3)}.h-animation-doc-header{font-weight:800;width:100%;position:absolute;top:40px;left:0;height:50px;padding:12px;display:flex;align-items:center;font-size:16px;border-bottom:1px solid var(--scalar-border-color);background-color:var(--scalar-background-1);z-index:1;gap:4px}.h-animation-doc-header svg{width:auto;height:22px;margin-top:8px}.h-animation-14{width:16px;height:16px;stroke-width:2}svg{vertical-align:middle;display:block}.h-black{color:var(--scalar-color-1)}@supports (color:color(display-p3 1 1 1)){.light-mode{--scalar-color-accent:var(--scalar-color-1);--scalar-color-green:color(display-p3 0.023529 0.564706 0.380392 / 1);--scalar-color-red:color(display-p3 0.937255 0 0.023529 / 1);--scalar-color-yellow:color(display-p3 0.929412 0.745098 0.12549 / 1);--scalar-color-blue:color(display-p3 0 0.509804 0.815686 / 1);--scalar-color-orange:color(display-p3 0.984314 0.537255 0.172549 / 1);--scalar-color-purple:color(display-p3 0.321569 0.011765 0.819608 / 1)}}.h-animation-ref{position:fixed;top:0;left:0;width:100%;height:765px;border:1px solid #dbdbdb;border-radius:8px;overflow:hidden}.h-markdown-item>span:first-of-type{font-size:13px;font-family:var(--scalar-font-code);font-weight:500}@supports (hanging-punctuation:first) and (font:-apple-system-body) and (-webkit-appearance:none){.transform-rr{--var:1;--varcalcx:calc(var(--var) * 1360px);--xcalc:calc((100dvw - var(--varcalcx))/2);--varcalcy:calc(var(--var) * 765px);--ycalc:calc((100dvh - var(--varcalcy))/2);transform:translate3d(var(--xcalc),var(--ycalc),0)}*{animation:none!important}.h-animation-endpoint{border-top:none}.h-animation-sidebar-endpoint span{font-weight:500}@media only screen and (max-width:1360px){.transform-rr{--var:0.95}.rr{transform:scale(var(--var));transform-origin:top left;position:relative;overflow:hidden}}@media only screen and (max-width:1292px){.transform-rr{--var:0.9}}@media only screen and (max-width:1224px){.transform-rr{--var:0.85}}@media only screen and (max-width:1156px){.transform-rr{--var:0.8}}@media only screen and (max-width:1088px){.transform-rr{--var:0.75}}@media only screen and (max-width:1020px){.transform-rr{--var:0.7}}@media only screen and (max-width:952px){.transform-rr{--var:0.65}}@media only screen and (max-width:884px){.transform-rr{--var:0.6}}@media only screen and (max-width:816px){.transform-rr{--var:0.55}}@media only screen and (max-width:748px){.transform-rr{--var:0.5}}@media only screen and (max-width:680px){.transform-rr{--var:0.45}}@media only screen and (max-width:612px){.transform-rr{--var:0.4}}@media only screen and (max-width:544px){.transform-rr{--var:0.35}}@media only screen and (max-width:476px){.transform-rr{--var:0.3}}@media only screen and (max-width:408px){.transform-rr{--var:0.25}}@media only screen and (max-width:340px){.transform-rr{--var:0.2}}@media only screen and (max-width:272px){.transform-rr{--var:0.15}}}.h-markdown-heading>span:first-of-type{font-weight:var(--scalar-semibold);font-size:16px}]]></style></foreignObject></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="1360" height="765" viewBox="0 0 0 1360 765">
+    <foreignObject width="1360" height="765" class="fo">
+        <div xmlns="http://www.w3.org/1999/xhtml" class="transform-rr">
+            <div class="h-animation-ref light-mode rr">
+                <div class="h-animation-ref-safari size">
+                    <div class="dotted-top"></div>
+                    <div class="h-animation-ref-safari-left">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="16" fill="currentColor" viewBox="0 0 20 16">
+                            <path
+                                fill-rule="evenodd"
+                                d="M19.4 15.4a2 2 0 0 1-1.4.6H2a2 2 0 0 1-1.4-.6A2 2 0 0 1 0 14V2C0 1.4.2 1 .6.6A2 2 0 0 1 2 0h16c.6 0 1 .2 1.4.6.4.4.6.8.6 1.4v12c0 .6-.2 1-.6 1.4ZM2 14h5V2H2v12Zm7 0h9V2H9v12ZM3.3 3c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3Zm0 2c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3ZM3 7.4c0-.1.1-.2.3-.2h2.5c.1 0 .2 0 .2.2v1c0 .2-.1.3-.2.3H3.3a.3.3 0 0 1-.3-.3v-1Z"
+                                clip-rule="evenodd"
+                            />
+                        </svg>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="M16 22 6 12 16 2l1.8 1.8L9.5 12l8.3 8.2L16 22Z" /></svg>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path d="m8 22 10-10L8 2 6.2 3.8l8.3 8.2-8.3 8.2L8 22Z" /></svg>
+                    </div>
+                    <div class="h-animation-ref-safari-nav">
+                        <div class="h-animation-ref-safari-nav-url">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+                                <path
+                                    d="M7 10h8V6c0-.83-.3-1.54-.88-2.13A2.9 2.9 0 0 0 12 3c-.83 0-1.54.3-2.13.88A2.9 2.9 0 0 0 9 6v4H7V6c0-1.38.49-2.56 1.46-3.54A4.82 4.82 0 0 1 12 1c1.38 0 2.56.49 3.54 1.46A4.82 4.82 0 0 1 17 6v4c.55 0 1.02.2 1.41.59.4.39.59.86.59 1.41v8c0 .55-.2 1.02-.59 1.41-.39.4-.86.59-1.41.59H7c-.55 0-1.02-.2-1.41-.59-.4-.39-.59-.86-.59-1.41v-8c0-.55.2-1.02.59-1.41.39-.4.86-.59 1.41-.59Z"
+                                />
+                            </svg>
+                            developers.zoom.us/docs/api/meetings/#tag/archiving
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+                                <path
+                                    d="M12 22a8.7 8.7 0 0 0 6.4-2.6A9.1 9.1 0 0 0 21 13h-2c0 2-.7 3.6-2 5-1.4 1.3-3 2-5 2s-3.6-.7-5-2c-1.3-1.4-2-3-2-5s.7-3.6 2-5c1.4-1.3 3-2 5-2h.2l-1.6 1.5L12 9l4-4-4-4-1.4 1.5L12.2 4H12a8.7 8.7 0 0 0-6.4 2.6A9.1 9.1 0 0 0 3 13a8.7 8.7 0 0 0 2.6 6.4A9.1 9.1 0 0 0 12 22Z"
+                                />
+                            </svg>
+                        </div>
+                    </div>
+                    <div xmlns="http://www.w3.org/1999/xhtml" class="h-animation-ref-safari-right">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+              <path d="M6 23a2 2 0 0 1-1.4-.6A2 2 0 0 1 4 21V10c0-.6.2-1 .6-1.4A2 2 0 0 1 6 8h3v2H6v11h12V10h-3V8h3c.6 0 1 .2 1.4.6.4.4.6.8.6 1.4v11c0 .6-.2 1-.6 1.4a2 2 0 0 1-1.4.6H6Zm5-7V4.8L9.4 6.4 8 5l4-4 4 4-1.4 1.4L13 4.8V16h-2Z"/></svg><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+              <path d="M11 13H5v-2h6V5h2v6h6v2h-6v6h-2v-6Z"/></svg><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+              <path d="M8 22a2 2 0 0 1-1.4-.6A2 2 0 0 1 6 20v-2H4a2 2 0 0 1-1.4-.6A2 2 0 0 1 2 16V6h2v10h2V8c0-.5.2-1 .6-1.4A2 2 0 0 1 8 6h8V4H6V2h10c.6 0 1 .2 1.4.6.4.4.6.9.6 1.4v2h2c.6 0 1 .2 1.4.6.4.4.6.9.6 1.4v12c0 .6-.2 1-.6 1.4a2 2 0 0 1-1.4.6H8Zm0-2h12V8H8v12ZM2 6V4c0-.5.2-1 .6-1.4A2 2 0 0 1 4 2h2v2H4v2H2Z"/>
+            </svg>
+          </div>
+                </div>
+                <div class="h-animation-doc-header">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="180" height="25" fill="none" viewBox="0 0 203 25">
+                        <path
+                            fill="#00031F"
+                            d="M97 8.85c0 6.84-4.16 8.87-9.78 8.87h-4.84V0h4.84C92.84 0 97 2.03 97 8.85ZM85.17 2.3v13.13h1.93c3.54 0 7.01-.74 7.01-6.58 0-5.82-3.47-6.55-7.01-6.55h-1.93Zm25.45 11.56c-.6 2.18-2.56 4.18-5.91 4.18-4.25 0-6.55-3.1-6.55-6.92 0-4.08 2.73-6.8 6.47-6.8 4.06 0 6.43 3.33 6.17 7.6h-10.03c.25 2.43 1.79 3.94 3.84 3.94 1.83 0 2.9-.75 3.45-2h2.56Zm-2.47-3.94c-.07-1.95-1.44-3.52-3.54-3.52-1.98 0-3.45 1.03-3.79 3.52h7.33Zm12.34-5.35h2.64l-4.87 13.15h-2.32l-4.89-13.15h2.81l3.33 9.75 3.3-9.75Zm15 9.29c-.6 2.18-2.56 4.18-5.91 4.18-4.25 0-6.55-3.1-6.55-6.92 0-4.08 2.74-6.8 6.48-6.8 4.05 0 6.42 3.33 6.16 7.6h-10.03c.25 2.43 1.79 3.94 3.84 3.94 1.83 0 2.91-.75 3.45-2h2.57Zm-2.46-3.94c-.08-1.95-1.45-3.52-3.55-3.52-1.98 0-3.45 1.03-3.79 3.52h7.34Zm4.27 7.8V0h2.54v17.72h-2.54Zm10.5.32c-3.1 0-6.38-2.1-6.38-6.84 0-4.77 3.28-6.87 6.38-6.87 3.13 0 6.4 2.1 6.4 6.87 0 4.74-3.27 6.84-6.4 6.84Zm3.72-6.84c0-3.28-1.78-4.72-3.72-4.72-1.9 0-3.69 1.4-3.69 4.72 0 3.25 1.79 4.69 3.7 4.69 1.93 0 3.71-1.5 3.71-4.7Zm6.94-4.7a4.5 4.5 0 0 1 4.1-2.17c3.06 0 5.68 2.56 5.68 6.84 0 4.3-2.62 6.87-5.67 6.87a4.5 4.5 0 0 1-4.1-2.18V22h-2.55V4.57h2.54V6.5Zm7.07 4.67c0-2.96-1.45-4.72-3.55-4.72-1.95 0-3.62 1.47-3.62 4.72s1.67 4.74 3.62 4.74c2.1 0 3.55-1.78 3.55-4.74Zm16.6 2.7c-.62 2.17-2.57 4.17-5.92 4.17-4.26 0-6.55-3.1-6.55-6.92 0-4.08 2.73-6.8 6.48-6.8 4.05 0 6.42 3.33 6.15 7.6h-10.02c.25 2.43 1.79 3.94 3.84 3.94 1.83 0 2.9-.75 3.45-2h2.56Zm-2.47-3.95c-.08-1.95-1.45-3.52-3.55-3.52-1.98 0-3.45 1.03-3.79 3.52h7.34Zm9.8-2.8c-1.95 0-2.98.95-2.98 3.7v6.9h-2.54V4.57h2.49v2.32c.68-1.49 2-2.34 3.64-2.37.22 0 .5 0 .71.03v2.64a12.76 12.76 0 0 0-1.32-.08Zm7.43-.76c-1.25 0-2.59.5-2.59 1.58 0 .98.64 1.4 1.83 1.64l1.89.37c2.49.49 4.66 1.34 4.66 3.91 0 2.67-2.49 4.18-5.52 4.18-3.32 0-5.35-1.93-5.67-4.4h2.59c.34 1.49 1.32 2.37 3.15 2.37 1.64 0 2.91-.68 2.91-1.86 0-1.22-1.15-1.7-2.52-1.98l-1.98-.39c-1.98-.39-3.83-1.27-3.83-3.74 0-2.32 2.44-3.74 5.33-3.74 2.64 0 4.76 1.4 5.25 3.94h-2.52c-.36-1.35-1.49-1.88-2.98-1.88Z"
+                        />
+                        <path
+                            fill="#0B5CFF"
+                            d="M15.56 17.72H2.29c-.93 0-1.76-.55-2.11-1.41a2.29 2.29 0 0 1 .5-2.5l9.18-9.19H3.28A3.27 3.27 0 0 1 0 1.34h12.23a2.29 2.29 0 0 1 1.62 3.92l-9.18 9.19h7.61a3.28 3.28 0 0 1 3.28 3.27ZM74.19 7.5a6.4 6.4 0 0 0-6.39-6.4c-1.88 0-3.58.83-4.75 2.13A6.37 6.37 0 0 0 58.3 1.1a6.4 6.4 0 0 0-6.38 6.39v10.23a3.27 3.27 0 0 0 3.27-3.27V7.49a3.12 3.12 0 0 1 3.11-3.11 3.12 3.12 0 0 1 3.12 3.1v6.97a3.28 3.28 0 0 0 3.27 3.27V7.5a3.12 3.12 0 0 1 3.11-3.12 3.12 3.12 0 0 1 3.12 3.12v6.96a3.28 3.28 0 0 0 3.27 3.27V7.5ZM50.28 9.53a8.43 8.43 0 1 1-16.87 0 8.43 8.43 0 0 1 16.87 0Zm-3.28 0a5.16 5.16 0 1 0-10.31 0 5.16 5.16 0 0 0 10.31 0Zm-14.9 0a8.43 8.43 0 1 1-16.87 0 8.43 8.43 0 0 1 16.87 0Zm-3.27 0a5.16 5.16 0 1 0-10.32 0 5.16 5.16 0 0 0 10.32 0Z"
+                        />
+                    </svg>
+                </div>
+                <div class="h-animation-sidebar">
+                    <div class="h-animation-sidebar-search">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16m10 2-4.35-4.35" />
+                        </svg>
+                        Search
+                        <div class="h-animation-sidebar-search-hotkey">⌘K</div>
+                    </div>
+                    <div class="h-animation-sidebar__animate">
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M224 48H32a16 16 0 0 0-16 16v24a16 16 0 0 0 16 16v88a16 16 0 0 0 16 16h160a16 16 0 0 0 16-16v-88a16 16 0 0 0 16-16V64a16 16 0 0 0-16-16Zm-16 144H48v-88h160Zm16-104H32V64h192v24ZM96 136a8 8 0 0 1 8-8h48a8 8 0 0 1 0 16h-48a8 8 0 0 1-8-8Z"
+                                />
+                            </svg>
+                            Archiving
+                        </div>
+                        <div class="h-animation-sidebar-endpoint beforeme beforeme__alt"><em>Delete a meeting's archived files</em><span class="h-red">DEL</span></div>
+                        <div class="h-animation-sidebar-endpoint">Get a meeting's archived files<span class="h-blue">GET</span></div>
+                        <div class="h-animation-sidebar-endpoint">Get archived file statistics<span class="h-blue">GET</span></div>
+                        <div class="h-animation-sidebar-endpoint">List archived files<span class="h-blue">GET</span></div>
+                        <div class="h-animation-sidebar-endpoint">Update an archived file's auto-delete status<span class="h-orange">PATCH</span></div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path d="M160 40a88.09 88.09 0 0 0-78.71 48.67A64 64 0 1 0 72 216h88a88 88 0 0 0 0-176Zm0 160H72a48 48 0 0 1 0-96c1.1 0 2.2 0 3.29.11A88 88 0 0 0 72 128a8 8 0 0 0 16 0 72 72 0 1 1 72 72Z" />
+                            </svg>
+                            Cloud Recording
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M224 72h-16v-8a24 24 0 0 0-24-24H40a24 24 0 0 0-24 24v96a24 24 0 0 0 24 24h112v8a24 24 0 0 0 24 24h48a24 24 0 0 0 24-24V96a24 24 0 0 0-24-24ZM40 168a8 8 0 0 1-8-8V64a8 8 0 0 1 8-8h144a8 8 0 0 1 8 8v8h-16a24 24 0 0 0-24 24v72Zm192 24a8 8 0 0 1-8 8h-48a8 8 0 0 1-8-8V96a8 8 0 0 1 8-8h48a8 8 0 0 1 8 8Zm-96 16a8 8 0 0 1-8 8H88a8 8 0 0 1 0-16h40a8 8 0 0 1 8 8Zm80-96a8 8 0 0 1-8 8h-16a8 8 0 0 1 0-16h16a8 8 0 0 1 8 8Z"
+                                />
+                            </svg>
+                            Devices
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M128 24a104 104 0 1 0 104 104A104.12 104.12 0 0 0 128 24Zm88 104a87.61 87.61 0 0 1-3.33 24h-38.51a157.44 157.44 0 0 0 0-48h38.51a87.61 87.61 0 0 1 3.33 24Zm-114 40h52a115.11 115.11 0 0 1-26 45 115.27 115.27 0 0 1-26-45Zm-3.9-16a140.84 140.84 0 0 1 0-48h59.88a140.84 140.84 0 0 1 0 48ZM40 128a87.61 87.61 0 0 1 3.33-24h38.51a157.44 157.44 0 0 0 0 48H43.33A87.61 87.61 0 0 1 40 128Zm114-40h-52a115.11 115.11 0 0 1 26-45 115.27 115.27 0 0 1 26 45Zm52.33 0h-35.62a135.28 135.28 0 0 0-22.3-45.6A88.29 88.29 0 0 1 206.37 88Zm-98.74-45.6A135.28 135.28 0 0 0 85.29 88H49.63a88.29 88.29 0 0 1 57.96-45.6ZM49.63 168h35.66a135.28 135.28 0 0 0 22.3 45.6A88.29 88.29 0 0 1 49.63 168Zm98.78 45.6a135.28 135.28 0 0 0 22.3-45.6h35.66a88.29 88.29 0 0 1-57.96 45.6Z"
+                                />
+                            </svg>
+                            H323 Devices
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M216 40H40a16 16 0 0 0-16 16v144a16 16 0 0 0 16 16h176a16 16 0 0 0 16-16V56a16 16 0 0 0-16-16Zm0 80h-48V56h48ZM40 56h112v144H40Zm176 144h-48v-64h48v64ZM180 88a12 12 0 1 1 12 12 12 12 0 0 1-12-12Zm24 80a12 12 0 1 1-12-12 12 12 0 0 1 12 12Zm-68.25-2a39.76 39.76 0 0 0-17.19-23.34 32 32 0 1 0-45.12 0A39.84 39.84 0 0 0 56.25 166a8 8 0 0 0 15.5 4c2.64-10.25 13.06-18 24.25-18s21.62 7.73 24.25 18a8 8 0 1 0 15.5-4ZM80 120a16 16 0 1 1 16 16 16 16 0 0 1-16-16Z"
+                                />
+                            </svg>
+                            Meetings
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M184 112a8 8 0 0 1-8 8h-64a8 8 0 0 1 0-16h64a8 8 0 0 1 8 8Zm-8 24h-64a8 8 0 0 0 0 16h64a8 8 0 0 0 0-16Zm48-88v160a16 16 0 0 1-16 16H48a16 16 0 0 1-16-16V48a16 16 0 0 1 16-16h160a16 16 0 0 1 16 16ZM48 208h24V48H48Zm160 0V48H88v160h120Z"
+                                />
+                            </svg>
+                            PAC
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M88 96a8 8 0 0 1 8-8h64a8 8 0 0 1 0 16H96a8 8 0 0 1-8-8Zm8 40h64a8 8 0 0 0 0-16H96a8 8 0 0 0 0 16Zm32 16H96a8 8 0 0 0 0 16h32a8 8 0 0 0 0-16Zm96-104v108.69a15.86 15.86 0 0 1-4.69 11.31L168 219.31a15.86 15.86 0 0 1-11.31 4.69H48a16 16 0 0 1-16-16V48a16 16 0 0 1 16-16h160a16 16 0 0 1 16 16ZM48 208h104v-48a8 8 0 0 1 8-8h48V48H48Zm120-40v28.7l28.69-28.7Z"
+                                />
+                            </svg>
+                            Reports
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M231.59 90.13C175.44 34 80.56 34 24.41 90.13c-20 20-21.92 49.49-4.69 71.71A16 16 0 0 0 32.35 168a15.8 15.8 0 0 0 5.75-1.08l49-17.37.29-.11a16 16 0 0 0 9.75-11.73l5.9-29.52a76.52 76.52 0 0 1 49.68-.11l6.21 29.75a16 16 0 0 0 9.72 11.59l.29.11 49 17.39a16 16 0 0 0 18.38-5.06c17.19-22.24 15.26-51.73-4.73-71.73ZM223.67 152l-.3-.12-48.82-17.33-6.21-29.74A16 16 0 0 0 158 93a92.56 92.56 0 0 0-60.34.13 16 16 0 0 0-10.32 12l-5.9 29.51-48.81 17.22c-.1 0-.17.13-.27.17-12.33-15.91-11-36.23 3.36-50.58 25-25 58.65-37.53 92.28-37.53s67.27 12.51 92.28 37.53c14.33 14.35 15.72 34.67 3.39 50.55Zm.32 48a8 8 0 0 1-8 8H40a8 8 0 0 1 0-16h176a8 8 0 0 1 8 8Z"
+                                />
+                            </svg>
+                            SIP Phone
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M232 112h-96V88h8a16 16 0 0 0 16-16V40a16 16 0 0 0-16-16h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h8v24H24a8 8 0 0 0 0 16h32v32h-8a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-8v-32h112v32h-8a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-8v-32h32a8 8 0 0 0 0-16ZM112 40h32v32h-32ZM80 208H48v-32h32Zm128 0h-32v-32h32Z"
+                                />
+                            </svg>
+                            Tracking Field
+                        </div>
+                        <div class="h-animation-sidebar-folder">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256">
+                                <path
+                                    d="M168 104a40 40 0 1 0-40 40 40 40 0 0 0 40-40Zm-64 0a24 24 0 1 1 24 24 24 24 0 0 1-24-24Zm120 96h-88v-16.4a80 80 0 1 0-16 0V200H32a8 8 0 0 0 0 16h192a8 8 0 0 0 0-16ZM64 104a64 64 0 1 1 64 64 64.07 64.07 0 0 1-64-64Z"
+                                />
+                            </svg>
+                            Webinars
+                        </div>
+                    </div>
+                </div>
+                <div class="h-animation-content">
+                    <div class="h-animation-tag">
+                        <div class="h-animation-endpoint">
+                            <div class="h-animation-endpoint-markdown">
+                                <div class="h-animation-header">Delete a meeting's archived files</div>
+                                <div class="h-markdown">
+                                    <p>Delete all of a meeting's archived files.</p>
+                                    <div class="h-markdown-list">
+                                        <div class="h-markdown-heading"><span class="h-black">Path Parameters</span></div>
+                                        <div class="h-markdown-item">
+                                            <span class="h-black">meetingUUID</span><span class="h-grey">string</span><span class="h-orange">Required</span>
+                                            <div class="h-markdown-item-description">
+                                                <span class="h-grey">
+                                                    The meeting's universally unique identifier (UUID). Each meeting instance generates a UUID. For example, after a meeting ends, a new UUID is generated for the next meeting instance.<br />
+                                                    <br />If the meeting UUID begins with a / character or contains a // character, you must double-encode the meeting UUID when using the meeting UUID for other API calls.
+                                                </span>
+                                            </div>
+                                        </div>
+                                        <div class="h-markdown-list">
+                                            <div class="h-markdown-heading"><span class="h-black">Responses</span></div>
+                                            <div class="h-markdown-item">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24">
+                                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5" />
+                                                </svg>
+                                                <span class="h-black">204</span><span class="h-grey">Meeting archived file deleted.</span>
+                                            </div>
+                                            <div class="h-markdown-item">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24">
+                                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5" />
+                                                </svg>
+                                                <span class="h-black">400</span><span class="h-grey">Bad Request</span>
+                                            </div>
+                                            <div class="h-markdown-item">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24">
+                                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5" />
+                                                </svg>
+                                                <span class="h-black">401</span><span class="h-grey">Not Found</span>
+                                            </div>
+                                            <div class="h-markdown-item">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" class="h-animation-14" viewBox="0 0 24 24">
+                                                    <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="m4.5 8.25 7.5 7.5 7.5-7.5" />
+                                                </svg>
+                                                <span class="h-black">429</span><span class="h-grey">Too Many Requests.</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div xmlns="http://www.w3.org/1999/xhtml" class="h-animation-endpoint-meta">
+                <div class="ello"></div>
+                <div class="h-animation-endpoint-code">
+                  <div class="h-animation-endpoint-code-header">
+                    <span class="h-red">DELETE</span><span class="h-grey">/past_meetings/{meetingUUID}/arc...</span>
+                    <span class="h-grey ml-auto">Shell Curl</span>
+                  </div>
+                  <div class="h-animation-endpoint-code-body">
+                    <div>
+                      <span>1</span><span class="h-purple">curl</span><span class="h-black">https://api.zoom.us/v2/past_meetings/4444AAAiAA</span><span class="h-grey">\</span>
+                    </div>
+                    <div class="body-second">
+                      <span>2</span><span class="h-black">--request</span><span class="h-grey">
+                        DELETE \
+                      </span>
+                    </div>
+                    <div class="body-second">
+                      <span>3</span><span class="h-black">--header</span><span class="h-black">'Authorization:Bearer YOUR_SECRET_TOKEN'</span>
+                    </div>
+                  </div>
+                  <div class="h-animation-endpoint-code-footer">
+                    <span class="button-press"><svg xmlns="http://www.w3.org/2000/svg" class="h-animation-14" fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+                        <path d="M6 6.663c0-1.582 1.75-2.538 3.082-1.682l8.301 5.337a2 2 0 0 1 0 3.364L9.082 19.02C7.75 19.875 6 18.919 6 17.337z"/>
+                      </svg>
+                      Test Request
+                    </span>
+                  </div>
+                </div>
+                <div class="h-animation-endpoint-code h-animation-endpoint-code-tabs">
+                  <div class="h-animation-endpoint-code-header">
+                    <span class="h-black">204</span><span class="h-grey">400</span><span class="h-grey">404</span><span class="h-grey">429</span>
+                  </div>
+                  <div class="h-animation-endpoint-code-body">
+                    <div class="no-body">No Body</div>
+                  </div>
+                </div>
+              </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <style>
+      * {
+        padding: 0;
+        box-sizing: border-box;
+        margin: 0;
+        -webkit-font-smoothing: antialiased
+      }
+      :root {
+        
+    --app-header-height: 48px;
+    --scalar-border-width: 1px;
+    --scalar-radius: 3px;
+    --scalar-radius-lg: 6px;
+    --scalar-radius-xl: 8px;
+    --scalar-header-height: 50px;
+    --scalar-sidebar-width: 280px;
+    --scalar-toc-width: 280px;
+    --scalar-card-icon-width: 40px;
+    --scalar-card-icon-height: 40px;
+    --scalar-card-icon-diameter: 20px;
+    --scalar-card-padding: 16px;
+    --scalar-card-inter-element-gap: 4px;
+    --scalar-row-gap: 16px;
+    --system-fonts: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    --scalar-font: "Inter", var(--system-fonts);
+    --scalar-font-code: Monaco, Menlo, monospace;
+    --scalar-heading-1: 24px;
+    --scalar-page-description: 16px;
+    --scalar-heading-2: 20px;
+    --scalar-heading-3: 20px;
+    --scalar-heading-4: 16px;
+    --scalar-heading-5: 16px;
+    --scalar-heading-6: 16px;
+    --scalar-paragraph: 16px;
+    --scalar-small: 14px;
+    --scalar-mini: 13px;
+    --scalar-micro: 12px;
+    --scalar-extra-bold: 700;
+    --scalar-bold: 600;
+    --scalar-semibold: 500;
+    --scalar-regular: 400;
+    --scalar-font-size-1: 24px;
+    --scalar-font-size-2: 16px;
+    --scalar-font-size-3: 14px;
+    --scalar-font-size-4: 13px;
+    --scalar-font-size-5: 12px;
+    --scalar-line-height-1: 32px;
+    --scalar-line-height-2: 24px;
+    --scalar-line-height-3: 20px;
+    --scalar-line-height-4: 18px;
+    --scalar-line-height-5: 16px;
+    --scalar-heading-spacing: 44px;
+    --scalar-block-spacing: 12px;
+      }
+      .light-mode {
+        --scalar-sidebar-width: 280px;
+        --scalar-color-1: #000;
+        --scalar-color-2: #666666;
+        --scalar-color-3: #8e8e8e;
+        --scalar-color-disabled: #b4b1b1;
+        --scalar-color-ghost: #a7a7a7;
+        --scalar-color-accent: #0099ff;
+        --scalar-background-1: #fff;
+        --scalar-background-2: #f6f6f6;
+        --scalar-background-3: #e7e7e7;
+        --scalar-background-4: rgba(0, 0, 0, 0.06);
+        --scalar-background-accent: #8ab4f81f;
+        --scalar-border-color: rgba(0, 0, 0, 0.05);
+        --scalar-scrollbar-color: rgba(0, 0, 0, 0.18);
+        --scalar-scrollbar-color-active: rgba(0, 0, 0, 0.36);
+        --scalar-lifted-brightness: 1;
+        --scalar-backdrop-brightness: 1;
+        --scalar-shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.11);
+        --scalar-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px,
+          rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 1px;
+        --scalar-button-1: rgb(49 53 56);
+        --scalar-button-1-color: #fff;
+        --scalar-button-1-hover: rgb(28 31 33);
+        --scalar-color-green: #00a67d;
+        --scalar-color-red: #ef0006;
+        --scalar-color-yellow: #f9c514;
+        --scalar-color-blue: #579dfb;
+        --scalar-color-orange: #fc8528;
+        --scalar-color-purple: #5203d1;
+        font-family: var(--scalar-font);
+        color: var(--scalar-color-1);
+      }
+      .dark-mode {
+        font-family: var(--scalar-font);
+        color-scheme: dark;
+  --scalar-color-1: rgba(255, 255, 255, 0.9);
+  --scalar-color-2: rgba(255, 255, 255, 0.62);
+  --scalar-color-3: rgba(255, 255, 255, 0.44);
+  --scalar-color-disabled: rgba(255, 255, 255, 0.34);
+  --scalar-color-ghost: rgba(255, 255, 255, 0.26);
+  --scalar-color-accent: #8ab4f8;
+  --scalar-background-1: #0f0f0f;
+  --scalar-background-2: #1a1a1a;
+  --scalar-background-3: #272727;
+  --scalar-background-4: rgba(255, 255, 255, 0.06);
+  --scalar-background-accent: #8ab4f81f;
+
+  --scalar-border-color: rgba(255, 255, 255, 0.1);
+  --scalar-scrollbar-color: rgba(255, 255, 255, 0.24);
+  --scalar-scrollbar-color-active: rgba(255, 255, 255, 0.48);
+  --scalar-lifted-brightness: 1.45;
+  --scalar-backdrop-brightness: 0.5;
+
+  --scalar-shadow-1: 0 1px 3px 0 rgb(0, 0, 0, 0.1);
+  --scalar-shadow-2: rgba(15, 15, 15, 0.2) 0px 3px 6px, rgba(15, 15, 15, 0.4)
+    0px 9px 24px, 0 0 0 1px rgba(255, 255, 255, 0.1);
+
+  --scalar-button-1: #f6f6f6;
+  --scalar-button-1-color: #000;
+  --scalar-button-1-hover: #e7e7e7;
+
+  --scalar-color-green: #00b848;
+  --scalar-color-red: #fe1d2c;
+  --scalar-color-yellow: #fbca25;
+  --scalar-color-blue: #76aedf;
+  --scalar-color-orange: #dd922f;
+  --scalar-color-purple: #b090f8;
+  color: var(--scalar-color-1);
+
+  /* Misc Scalar Branding */
+  --scalar-brand: #8b7256;
+      }
+      .dotted-top {
+        position: absolute;
+        top: 17px;
+        left: 12px;
+        background-color: var(--scalar-background-3);
+        border-radius: 50%;
+        width: 10px;
+        box-shadow: 14px 0 0 var(--scalar-background-3),
+          29px 0 0 var(--scalar-background-3);
+        height: 9px;
+      }
+      .h-animation-ref-safari {
+        height: 40px;
+        background-color: var(--scalar-background-2);
+        z-index: 1;
+        position: absolute;
+        top: 0;
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+      }
+
+      .h-animation-ref-safari-left {
+        width: 150px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding-left: 68px;
+        color: var(--scalar-color-3);
+      }
+
+      .h-animation-ref-safari-nav {
+        width: 600px;
+        padding: 6px 0;
+      }
+
+      .h-animation-ref-safari-right {
+        width: 150px;
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 10px;
+        color: var(--scalar-color-3);
+        padding-right: 12px;
+      }
+
+      .h-animation-ref-safari-right svg {
+        width: 17px;
+        height: 17px;
+      }
+
+      .h-animation-ref-safari-left svg {
+        width: 16px;
+        height: 16px;
+      }
+
+      .h-animation-ref-safari-left svg:last-of-type {
+        opacity: 0.5;
+      }
+
+      .h-animation-ref-safari-nav-url {
+        width: 100%;
+        border-radius: 7px;
+        height: 100%;
+        text-align: center;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 13px;
+        position: relative;
+        border: 1px solid var(--scalar-border-color);
+      }
+
+      .h-animation-ref-safari-nav-url svg {
+        width: 13px;
+        height: 13px;
+        color: var(--scalar-color-3);
+        margin-right: 3px;
+      }
+
+
+      .h-animation-ref-safari-nav-url svg:last-of-type {
+        position: absolute;
+        right: 4px;
+      }
+
+      .h-animation-ref {
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        user-select: none;
+        background: var(--scalar-background-1);
+        min-width: 1280px;
+        min-height: 720px;
+      }
+
+      .h-animation-ref {
+        display: flex;
+        padding-top: 90px;
+      }
+
+      .h-animation-sidebar {
+        padding: 12px;
+        max-width: var(--scalar-sidebar-width);
+        border-right: 1px solid var(--scalar-border-color);
+        flex: 1;
+      }
+
+      .h-animation-sidebar-search {
+        display: flex;
+        align-items: center;
+        position: relative;
+        padding: 0 3px 0 6px;
+        width: 100%;
+        background: var(
+          --scalar-sidebar-search-background,
+          var(--scalar-background-1)
+        );
+        color: var(--scalar-sidebar-color-2, var(--scalar-color-2));
+        border-radius: var(--scalar-radius);
+        box-shadow: 0 0 0 1px
+          var(--scalar-sidebar-search-border-color, var(--scalar-border-color));
+        height: 31px;
+        font-size: 13px;
+        margin-bottom: 12px;
+        gap: 6px;
+      }
+
+      .h-animation-sidebar-endpoint span {
+            margin-left: auto;
+    font-family: var(--scalar-font-code);
+    font-weight: 700;
+    font-size: 10px;
+    margin-top: 10px;
+    line-height: 0;
+      }
+
+.beforeme {
+    color: var(--scalar-color-1);
+    position: relative;
+    font-weight: var(--scalar-semibold);
+}
+.beforeme em {
+    font-style: normal;
+    color: var(--scalar-color-1);
+}
+.beforeme em,.beforeme span {
+    position: relative;
+}
+
+.beforeme:before {
+    content: "";
+    position: absolute;
+    background: var(--scalar-background-2);
+    width: 256px;
+    z-index: 0;
+    right: 0;
+    top: 0;
+    height: 100%;
+    border-radius: var(--scalar-radius)
+}
+
+.beforeme:after {
+    content: "";
+    position: absolute;
+    background: var(--scalar-border-color);
+    width: 1px;
+    left: -1px;
+    height: 100%;
+    box-shadow: -12.5px 0 0 0 var(--scalar-border-color)
+}
+
+.beforeme__alt:after {
+    box-shadow: none
+}
+      .h-animation-sidebar-folder,
+      .h-animation-sidebar-endpoint,
+      .h-animation-sidebar-item {
+        font-size: 14px;
+        display: flex;
+        padding: 8px 9px;
+        color: var(--scalar-color-2);
+        border-radius: var(--scalar-radius);
+      }
+
+      .h-animation-sidebar-folder svg {
+        margin-right: 6px;
+      }
+
+      .h-animation-sidebar-folder {
+        padding-left: 6px;
+      }
+
+      .h-animation-sidebar-endpoint {
+        padding-left: 12px;
+      }
+.h-animation-sidebar-endpoint {
+    border-radius: 0;
+    margin-left: 12px;
+    border-left: 1px solid var(--scalar-border-color);
+}
+      .h-animation-sidebar-folder:first-of-type {
+        color: var(--scalar-color-1);
+        font-weight: 500
+      }
+      .h-animation-sidebar-folder:first-of-type svg {
+        fill: var(--scalar-color-1);
+
+      }
+
+      .h-animation-sidebar-search-hotkey {
+        background-color: var(--scalar-background-2);
+        color: var(--scalar-color-3);
+        margin-left: auto;
+        padding: 3px 5px;
+        border-radius: var(--scalar-radius);
+      }
+
+      .h-animation-content {
+        flex: 1;
+      }
+
+      .h-animation-tag {
+        padding: 90px 60px;
+        border-bottom: 1px solid var(--scalar-border-color);
+        width: 100%;
+        display: flex;
+        gap: 48px;
+      }
+
+      .h-animation-endpoint {
+        gap: 48px;
+      }
+
+      .h-animation-tag {
+        border-bottom: none;
+        flex-flow: wrap;
+        gap: 0;
+        padding: 0 60px;
+      }
+
+      .h-animation-tag-wrap {
+        display: flex;
+        gap: 48px;
+        padding: 90px 0;
+      }
+
+      .h-animation-header {
+        font-size: var(--font-size, var(--scalar-heading-2));
+        font-weight: var(--font-weight, var(--scalar-bold));
+        color: var(--scalar-color-1);
+        word-wrap: break-word;
+        line-height: 1.45;
+      }
+
+      .h-animation-endpoint-markdown,
+      .h-animation-endpoint-meta,
+      .h-animation-tag-markdown,
+      .h-animation-tag-meta {
+        width: 50%;
+      }
+
+      .h-animation-endpoint-meta,
+      .h-animation-tag-meta {
+        margin-top: 48px;
+      }
+
+      .h-markdown {
+        margin-top: 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+        line-height: 1.5;
+        color: var(--scalar-color-1);
+      }
+
+      .h-green {
+        color: var(--scalar-color-green);
+      }
+
+      .h-blue {
+        color: var(--scalar-color-blue);
+      }
+
+      .h-orange {
+        color: var(--scalar-color-orange);
+      }
+      .h-purple {
+        color: var(--scalar-color-purple);
+      }
+
+      .h-red {
+        color: var(--scalar-color-red);
+      }
+
+      .h-black {
+        color: var(--scalar-color-1);
+      }
+
+      .h-animation-endpoint-code-body span:first-of-type {
+        color: var(--scalar-color-3);
+        margin-right: 4px;
+      }
+
+      .body-second span:first-of-type {
+        margin-right: 28px;
+      }
+
+      .h-grey {
+        color: var(--scalar-color-3);
+      }
+      .dark-mode .h-grey {
+        color: var(--scalar-color-2);
+      }
+      .h-animation-code {
+        background: var(--scalar-background-2);
+        border: 1px solid var(--scalar-border-color);
+        border-radius: var(--scalar-radius-lg);
+      }
+
+      .h-animation-code-header {
+        padding: 9px 12px;
+        border-bottom: 1px solid var(--scalar-border-color);
+        display: flex;
+        gap: 6px;
+      }
+
+      .h-animation-code-header span {
+        color: var(--scalar-color-1);
+        font-weight: var(--scalar-semibold);
+        font-size: var(--scalar-font-size-3);
+      }
+
+      .h-animation-endpoint-code-header,
+      .h-animation-endpoint-code-body,
+      .h-animation-code-body {
+        padding: 10px 12px;
+        font-family: var(--scalar-font-code);
+        font-size: 14px;
+        line-height: 1.5;
+      }
+
+      .h-animation-endpoint-code-header {
+        border-bottom: 1px solid var(--scalar-border-color);
+        padding: 9px 12px;
+        height: 34px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .h-animation-code-body em {
+        min-width: 62px;
+        text-align: right;
+        display: inline-block;
+        margin-right: 12px;
+        font-style: initial;
+      }
+
+      .h-animation-endpoint {
+        width: 100%;
+        display: flex;
+        padding: 90px 0;
+      }
+
+      .h-animation-14 {
+        width: 14px;
+        height: 14px;
+        stroke-width: 2;
+      }
+
+      .h-animation-endpoint-code-body div {
+        display: flex;
+        gap: 4.5px;
+      }
+
+      .h-animation-endpoint-code {
+        background: var(--scalar-background-2);
+        font-family: var(--scalar-font-code);
+        border: 1px solid var(--scalar-border-color);
+        border-radius: var(--scalar-radius-lg);
+      }
+
+      .h-animation-endpoint-code-footer {
+        padding: 6px;
+        display: flex;
+        justify-content: flex-end;
+        background: var(--scalar-background-3);
+        border-radius: 0 0 var(--scalar-radius-lg) var(--scalar-radius-lg);
+      }
+
+      .h-animation-endpoint-code-footer span {
+        background-color: var(--scalar-button-1);
+        padding: 4px 6px;
+        white-space: nowrap;
+        border-radius: var(--scalar-radius);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-weight: var(--scalar-semibold);
+        font-size: var(--scalar-mini);
+        color: var(--scalar-background-2);
+        font-family: var(--scalar-font);
+        width: -moz-fit-content;
+        width: fit-content;
+        box-shadow: inset 0 0 0 1px #0000001a;
+      }
+
+      .h-animation-endpoint-code-tabs {
+        background: var(--scalar-background-2);
+        margin-top: 12px;
+      }
+
+      .h-animation-endpoint-code-tabs .h-animation-endpoint-code-header {
+        gap: 12px;
+        font-family: var(--scalar-font);
+      }
+
+      .h-animation-endpoint-code-tabs
+        .h-animation-endpoint-code-header
+        span:first-of-type {
+        text-decoration: underline;
+        text-underline-offset: 10px;
+      }
+
+      .h-markdown-item {
+        position: relative;
+        border-top: 1px solid var(--scalar-border-color);
+        padding: 10px 0;
+        display: flex;
+        flex-flow: wrap;
+        gap: 9px;
+        font-family: var(--scalar-font);
+        font-size: 12px;
+      }
+
+      .h-markdown-item &gt; span:first-of-type {
+        font-size: 13px;
+        font-family: var(--scalar-font-code);
+        font-weight: 500
+      }
+
+      .h-markdown-heading {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 14px;
+        padding-bottom: 10px;
+      }
+
+      .h-markdown-heading &gt; span:first-of-type {
+        font-weight: var(--scalar-semibold);
+        font-size: 16px;
+      }
+
+      .h-markdown-item div {
+        width: 100%;
+        font-family: var(--scalar-font);
+      } 
+      @supports (color: color(display-p3 1 1 1)) {
+  .light-mode {
+    --scalar-color-accent: var(--scalar-color-1);
+    --scalar-color-green: color(display-p3 0.023529 0.564706 0.380392 / 1.0);
+    --scalar-color-red: color(display-p3 0.937255 0.0 0.023529 / 1.0);
+    --scalar-color-yellow: color(display-p3 0.929412 0.745098 0.12549 / 1.0);
+    --scalar-color-blue: color(display-p3 0.0 0.509804 0.815686 / 1.0);
+    --scalar-color-orange: color(display-p3 0.984314 0.537255 0.172549 / 1.0);
+    --scalar-color-purple: color(display-p3 0.321569 0.011765 0.819608 / 1.0);
+  }
+  .dark-mode {
+    --scalar-color-accent: var(--scalar-color-1);
+    --scalar-color-green: color(display-p3 0.0 0.713725 0.282353 / 1.0);
+    --scalar-color-red: color(display-p3 0.862745 0.105882 0.098039 / 1.0);
+    --scalar-color-yellow: color(display-p3 1.0 0.788235 0.05098 / 1.0);
+    --scalar-color-blue: color(display-p3 0.305882 0.701961 0.92549 / 1.0);
+    --scalar-color-orange: color(display-p3 1.0 0.552941 0.301961 / 1.0);
+    --scalar-color-purple: color(display-p3 0.694118 0.568627 0.976471 / 1.0);
+  }
+}
+.examples {
+  text-decoration: dotted underline;
+  text-underline-offset: 3px;
+}
+.h-markdown-item-description {
+  font-size: 14px;
+  margin-top: -6px;
+}
+.h-markdown-item .h-animation-14  {
+  position: absolute;
+  left: -18px;
+  margin-top: 2px;
+  transform: rotate(-90deg);
+  color: var(--scalar-color-3);
+}
+.ml-auto {
+  margin-left: auto;
+  font-family: var(--scalar-font);
+  color: var(--scalar-color-3);
+}
+.h-animation-doc-header {
+  font-weight: 800;
+  width: 100%;
+  position: absolute;
+  top: 40px;
+  left: 0;
+  height: 50px;
+  padding: 12px;
+  display: flex;
+  align-items: center;
+  font-size: 16px;
+  border-bottom: 1px solid var(--scalar-border-color);
+  background-color: var(--scalar-background-1);
+  z-index: 1;
+  gap: 4px;
+}
+.h-animation-doc-header svg {
+  width: auto;
+  height: 22px;
+  margin-top: 8px;
+}
+.h-animation-popup-fade {
+  position: fixed;
+  left: 0;
+  width: 100%;
+  height: calc(100% - 40px);
+  background-color: rgba(0, 0, 0, 0.06);
+  z-index: 1;
+  top: 40px;
+  border-radius: 0 0 8px 8px;
+  animation: fadein 10s ease-in-out infinite;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.dark-mode .h-animation-popup-fade {
+  background-color: rgba(0,0,0,0.5);
+}
+@keyframes fadein {
+  0%, 40%, 70%, 100% {
+    opacity: 0;
+  }
+  45%, 68.5% {
+    opacity: 1;
+  }
+}
+.h-animation-popup-content {
+  position: relative;
+  width: 80%;
+  height: 80%;
+  z-index: 1;
+  top: -30px;
+  background: var(--scalar-background-1);
+  border-radius: var(--scalar-radius-lg);
+  border: 1px solid var(--scalar-border-color);
+  animation: popupcontent 10s ease-in-out infinite;
+}
+@keyframes popupcontent {
+  0%, 43%, 68%, 100% {
+    opacity: 0;
+    transform: scale(0.99) translate3d(0,10px,0);
+  }
+  47%, 66% {
+    opacity: 1;
+    transform: scale(1) translate3d(0,0,0);
+  }
+}
+.h-animation-doc-header-cta-container {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.h-animation-doc-header-github {
+  font-weight: 500;
+  font-size: 12px;
+  padding: 8px 12px;
+  border-radius: var(--scalar-radius-lg);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.h-animation-doc-header-github svg {
+  width: 16px;
+  height: 16px;
+}
+.h-animation-doc-header-cta {
+  font-weight: 500;
+  font-size: 12px;
+  padding: 8px 12px;
+  border-radius: var(--scalar-radius-lg);
+  background-color: var(--scalar-color-1);
+  color: var(--scalar-background-1);
+}
+.flex {
+    display: flex;
+}
+.font-medium {
+    --tw-font-weight: var(--scalar-semibold);
+    font-weight: var(--scalar-semibold);
+}
+.gap-1 {
+    gap: 4px;
+}
+.gap-15 {
+    gap: 6px;
+}
+.justify-center {
+    justify-content: center;
+}
+.items-center {
+    align-items: center;
+}
+.w-full {
+    width: 100%;
+}
+.flex-1 {
+    flex: 1;
+}
+.size-3 {
+    width: 12px;
+    height: 12px;
+}
+.h-animation-14 {
+    width: 16px;
+    height: 16px;
+    stroke-width: 2;
+}
+.min-h-0 {
+    min-height: 0;
+}
+.text-c-2 {
+    color: var(--scalar-color-2);
+}
+.text-c-3 {
+    color: var(--scalar-color-2);
+}
+.py-2 {
+    padding-block: 8px;
+}
+.py-15 {
+    padding-block: 7.5px;
+}
+.px-2 {
+    padding-inline: 8px;
+}
+.flex-col {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    flex-direction: column;
+}
+.w-15 {
+    width: 60px;
+}
+.relative {
+    position: relative;
+}
+.p-11 {
+    padding: 11px;
+}
+.p-9 {
+    padding: 9px;
+}
+.text-c-1 {
+    color: var(--scalar-color-1);
+}
+.rounded {
+    border-radius: var(--scalar-radius);
+}
+.bg-b-3 {
+    background-color: var(--scalar-background-3);
+}
+.bg-b-2 {
+    background-color: var(--scalar-background-2);
+}
+.bg-b-1 {
+    background-color: var(--scalar-background-1);
+}
+.min-w-37 {
+    min-width: 37px;
+}
+svg {
+    vertical-align: middle;
+    display: block;
+}
+.size-full {
+    width: 100%;
+    height: 100%;
+}
+.p-3 {
+    padding: 0 12px 12px 12px;
+}
+.text-\[13px\] {
+    font-size: 14px;
+}
+.h-10 {
+    height: 40px;
+}
+.rounded-popup {
+    border-radius: var(--scalar-radius);
+    max-height: 713px;
+    overflow: hidden;
+}
+.popup-container {
+    width: 100%;
+}
+.w-780 {
+    width: 580px;
+    font-size: 14px;
+    border: 1px solid var(--scalar-border-color);
+}
+.w-780 .font-code {
+    font-size: 14px;
+}
+.min-h-32,
+.min-h-8 {
+    min-height: 32px;
+}
+.min-h-44 {
+    min-height: 44px;
+}
+.font-code {
+    font-family: var(--scalar-font-code);
+}
+.size-35 {
+    width: 14px;
+    height: 14px;
+}
+.background-button {
+    color: var(--scalar-button-1-color);
+    background: var(--scalar-button-1);
+    height: 26px;
+    margin-right: 2px;
+    padding: 0 8px;
+}
+.fill-current {
+    fill: currentColor;
+}
+.shrink-0 {
+    flex-shrink: 0;
+}
+.px-25 {
+    padding-inline: 10px;
+}
+.mr-2 {
+    margin-right: 8px;
+}
+.ml-2 {
+    margin-left: 8px;
+}
+.p-1 {
+    padding: 4px;
+}
+.border-b {
+    border-bottom: 1px solid var(--scalar-border-color);
+}
+.border-r {
+    border-right: 1px solid var(--scalar-border-color);
+}
+.border {
+    border: 1px solid var(--scalar-border-color);
+}
+.min-h-\[50px\] {
+    min-height: 50px;
+}
+.px-3 {
+    padding-inline: 12px;
+}
+.font-bold {
+    font-weight: 600;
+}
+.px-6 {
+    padding-inline: 24px;
+}
+.h-full {
+    height: 100%;
+}
+.h-animation-code-body,
+.h-animation-endpoint-code-body,
+.h-animation-endpoint-code-header {
+    font-family: var(--scalar-font-code);
+    font-size: 14px;
+    line-height: 1.5;
+    padding: 10px 12px;
+}
+.h-animation-endpoint-code-body span:first-of-type {
+    color: var(--scalar-color-3);
+    margin-right: 4px;
+}
+.h-black {
+    color: var(--scalar-color-1);
+}
+.body-second span:first-of-type {
+    margin-right: 28px;
+}
+@supports (color: color(display-p3 1 1 1)) {
+    .light-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0.023529 0.564706 0.380392 / 1);
+        --scalar-color-red: color(display-p3 0.937255 0 0.023529 / 1);
+        --scalar-color-yellow: color(display-p3 0.929412 0.745098 0.12549 / 1);
+        --scalar-color-blue: color(display-p3 0 0.509804 0.815686 / 1);
+        --scalar-color-orange: color(display-p3 0.984314 0.537255 0.172549 / 1);
+        --scalar-color-purple: color(display-p3 0.321569 0.011765 0.819608 / 1);
+    }
+    .dark-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0 0.713725 0.282353 / 1);
+        --scalar-color-red: color(display-p3 0.862745 0.105882 0.098039 / 1);
+        --scalar-color-yellow: color(display-p3 1 0.788235 0.05098 / 1);
+        --scalar-color-blue: color(display-p3 0.305882 0.701961 0.92549 / 1);
+        --scalar-color-orange: color(display-p3 1 0.552941 0.301961 / 1);
+        --scalar-color-purple: color(display-p3 0.694118 0.568627 0.976471 / 1);
+    }
+}
+.rotate-90 {
+    transform: rotate(90deg);
+}
+.gridy {
+    border-bottom: 1px solid var(--scalar-border-color);
+    display: flex;
+    align-items: center;
+}
+.gridy-item {
+    width: calc(50% - 16px);
+    height: 32px;
+    padding-left: 12px;
+    display: flex;
+    align-items: center;
+}
+.gridy-item:last-of-type {
+    border-left: 1px solid var(--scalar-border-color);
+}
+.gridy-check {
+    height: 32px;
+    width: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    stroke-width: 2.25;
+    border-right: 1px solid var(--scalar-border-color);
+}
+.gridy-inactive {
+    color: var(--scalar-color-3);
+}
+.http-bg-gradient {
+    background: linear-gradient(rgba(255,255,255,0.1), rgba(0,0,0,0.05));
+    font-size: 10px !important;
+    height: 24px;
+    border-radius: 2px;
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    box-shadow: 0 0 0 1px var(--scalar-border-color);
+    margin-right: 4px;
+    margin-left: 4px;
+    font-weight: 500;
+}
+.http-domain {
+    padding-inline: 8px;
+    height: 24px;
+    border-radius: 2px;
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    box-shadow: 0 0 0 1px var(--scalar-border-color);
+    margin-right: 8px;
+}
+.filters {
+    margin-left: auto;
+    font-size: 14px;
+}
+.translate-popup {
+  background: color-mix(in srgb, var(--scalar-background-1) 50%, var(--scalar-background-2));
+}
+.h-animation-ref {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 765px;
+  border: 1px solid #dbdbdb;
+  border-radius: 8px;
+  overflow: hidden;
+}
+@supports (hanging-punctuation: first) and (font: -apple-system-body) and
+  (-webkit-appearance: none) {
+    .transform-rr {
+      --var: 1;
+      --varcalcx: calc(var(--var) * 1360px);
+      --xcalc: calc((100dvw - var(--varcalcx))/2);
+      --varcalcy: calc(var(--var) * 765px);
+      --ycalc: calc((100dvh - var(--varcalcy))/2);
+      transform: translate3d(var(--xcalc), var(--ycalc), 0);
+    }
+    * {
+      animation: none !important;
+    }
+    .h-animation-tag-wrap {
+      display: none;
+    }
+    .h-animation-endpoint {
+      border-top: none;
+    }
+    .h-animation-sidebar-endpoint span {
+      font-weight: 500;
+    }
+    .h-animation-popup {
+      display: none;
+    }
+  @media only screen and (max-width: 1360px) {
+    .transform-rr {
+      --var: 0.95;
+    }
+    .rr {
+      transform: scale(var(--var));
+      transform-origin: top left;
+      position: relative;
+      overflow: hidden
+    }
+  }
+  @media only screen and (max-width: 1292px) {
+    .transform-rr {
+      --var: 0.9
+    }
+  }
+  @media only screen and (max-width: 1224px) {
+    .transform-rr {
+      --var: 0.85
+    }
+  }
+  @media only screen and (max-width: 1156px) {
+    .transform-rr {
+      --var: 0.8
+    }
+  }
+  @media only screen and (max-width: 1088px) {
+    .transform-rr {
+      --var: 0.75
+    }
+  }
+  @media only screen and (max-width: 1020px) {
+    .transform-rr {
+      --var: 0.7
+    }
+  }
+  @media only screen and (max-width: 952px) {
+    .transform-rr {
+      --var: 0.65
+    }
+  }
+  @media only screen and (max-width: 884px) {
+    .transform-rr {
+      --var: 0.6
+    }
+  }
+  @media only screen and (max-width: 816px) {
+    .transform-rr {
+      --var: 0.55
+    }
+  }
+  @media only screen and (max-width: 748px) {
+    .transform-rr {
+      --var: 0.5
+    }
+  }
+  @media only screen and (max-width: 680px) {
+    .transform-rr {
+      --var: 0.45
+    }
+  }
+  @media only screen and (max-width: 612px) {
+    .transform-rr {
+      --var: 0.4
+    }
+  }
+  @media only screen and (max-width: 544px) {
+    .transform-rr {
+      --var: 0.35
+    }
+  }
+  @media only screen and (max-width: 476px) {
+    .transform-rr {
+      --var: 0.3
+    }
+  }
+  @media only screen and (max-width: 408px) {
+    .transform-rr {
+      --var: 0.25
+    }
+  }
+  @media only screen and (max-width: 340px) {
+    .transform-rr {
+      --var: 0.2
+    }
+  }
+  @media only screen and (max-width: 272px) {
+    .transform-rr {
+      --var: 0.15
+    }
+  }
+}
+.no-body {
+  min-height: 80px;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  color: var(--scalar-color-3);
+}  
+  
+</style>
+    </foreignObject>
+</svg>

--- a/documentation/assets/scalar-dashboard-dark.svg
+++ b/documentation/assets/scalar-dashboard-dark.svg
@@ -1,0 +1,871 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 1360 765" width="1360" height="765" preserveAspectRatio="xMidYMid meet">
+  <foreignObject width="1360" height="765" class="fo">
+    <div xmlns="http://www.w3.org/1999/xhtml" class="transform-rr">
+      <div class="h-animation-ref dark-mode rr">
+        <div class="h-animation-ref-safari size">
+          <div class="dotted-top"></div>
+          <div class="h-animation-ref-safari-left">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="16" viewBox="0 0 20 16" width="20">
+              <path clip-rule="evenodd" d="M19.4 15.4a2 2 0 0 1-1.4.6H2a2 2 0 0 1-1.4-.6A2 2 0 0 1 0 14V2C0 1.4.2 1 .6.6A2 2 0 0 1 2 0h16c.6 0 1 .2 1.4.6.4.4.6.8.6 1.4v12c0 .6-.2 1-.6 1.4ZM2 14h5V2H2v12Zm7 0h9V2H9v12ZM3.3 3c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3Zm0 2c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3ZM3 7.4c0-.1.1-.2.3-.2h2.5c.1 0 .2 0 .2.2v1c0 .2-.1.3-.2.3H3.3a.3.3 0 0 1-.3-.3v-1Z" fill-rule="evenodd"/></svg><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+              <path d="M16 22 6 12 16 2l1.8 1.8L9.5 12l8.3 8.2L16 22Z"/></svg><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+              <path d="m8 22 10-10L8 2 6.2 3.8l8.3 8.2-8.3 8.2L8 22Z"/>
+            </svg>
+          </div>
+          <div class="h-animation-ref-safari-nav">
+            <div class="h-animation-ref-safari-nav-url">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+                <path d="M7 10H15V6C15 5.16667 14.7083 4.45833 14.125 3.875C13.5417 3.29167 12.8333 3 12 3C11.1667 3 10.4583 3.29167 9.875 3.875C9.29167 4.45833 9 5.16667 9 6V10H7V6C7 4.61667 7.4875 3.4375 8.4625 2.4625C9.4375 1.4875 10.6167 1 12 1C13.3833 1 14.5625 1.4875 15.5375 2.4625C16.5125 3.4375 17 4.61667 17 6V10C17.55 10 18.0208 10.1958 18.4125 10.5875C18.8042 10.9792 19 11.45 19 12V20C19 20.55 18.8042 21.0208 18.4125 21.4125C18.0208 21.8042 17.55 22 17 22H7C6.45 22 5.97917 21.8042 5.5875 21.4125C5.19583 21.0208 5 20.55 5 20V12C5 11.45 5.19583 10.9792 5.5875 10.5875C5.97917 10.1958 6.45 10 7 10Z"/>
+              </svg>
+              dashboard.scalar.com
+              <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+                <path d="M12 22a8.7 8.7 0 0 0 6.4-2.6A9.1 9.1 0 0 0 21 13h-2c0 2-.7 3.6-2 5-1.4 1.3-3 2-5 2s-3.6-.7-5-2c-1.3-1.4-2-3-2-5s.7-3.6 2-5c1.4-1.3 3-2 5-2h.2l-1.6 1.5L12 9l4-4-4-4-1.4 1.5L12.2 4H12a8.7 8.7 0 0 0-6.4 2.6A9.1 9.1 0 0 0 3 13a8.7 8.7 0 0 0 2.6 6.4A9.1 9.1 0 0 0 12 22Z"/>
+              </svg>
+            </div>
+          </div>
+          <div class="h-animation-ref-safari-right">
+            
+          </div>
+        </div>
+        <div class="h-animation-doc-header">
+        <svg xmlns="http://www.w3.org/2000/svg" width="129" height="39" viewBox="0 0 129 39" fill="none">
+            <g clip-path="url(#a)">
+              <path fill="currentColor" fill-rule="evenodd" d="M22.2 0c.4 0 .8.3.8.8v8.8l6-6.2c.3-.4.9-.4 1.1 0L34.7 8c.3.3.4.8 0 1v.1l-6 6.2h8.5c.5 0 .8.3.8.8v6.6c0 .5-.3.8-.8.8h-8.6l6.1 6.2c.3.3.4.8 0 1.1l-4.6 4.7c-.2.3-.8.4-1 0l-6-6.2v8.8c0 .5-.4.8-.9.8h-6.4c-.5 0-.8-.3-.8-.8v-4.6c0-1.4.6-2.8 1.5-3.9l8.4-8.5c.9-1 .9-2.5 0-3.4l-8.3-8.5c-1-1-1.6-2.4-1.6-3.8V.8c0-.5.3-.8.8-.8h6.4ZM8.8 3.4H9l14 14.4c1 1 1 2.5 0 3.4L9 35.6c-.2.4-.8.4-1 0L3.2 31c-.3-.3-.4-.7 0-1l6-6.4H.9c-.5 0-.8-.3-.8-.8v-6.6c0-.5.3-.8.8-.8h8.6L3.3 9.2a1 1 0 0 1 0-1.1l4.5-4.7c.3-.3.8-.3 1 0Z" clip-rule="evenodd"/>
+            </g>
+            <path fill="currentColor" d="M61 15.3c0-.9-.4-1.6-1.1-2-.7-.5-1.6-.8-2.7-.8a5 5 0 0 0-2 .4 3 3 0 0 0-1.2 1 2.3 2.3 0 0 0-.2 2.4l.8.8 1.1.5 1.3.4 1.9.4 2.2.8 2 1.1a5 5 0 0 1 1.8 4 5.5 5.5 0 0 1-3.6 5.3c-1.1.5-2.5.7-4.1.7-1.6 0-3-.2-4.2-.7-1.1-.5-2-1.2-2.7-2.2-.6-1-1-2-1-3.4h3.6c0 .7.3 1.3.6 1.8.4.4 1 .8 1.5 1a6 6 0 0 0 2.1.4c.8 0 1.5-.2 2.1-.4.6-.2 1.1-.6 1.5-1 .3-.4.5-1 .5-1.5 0-.6-.2-1-.5-1.3-.3-.4-.7-.7-1.3-1-.5-.2-1.1-.4-1.9-.5l-2.3-.6c-1.7-.5-3-1.1-4-2-1-.9-1.4-2-1.4-3.5 0-1.2.3-2.2 1-3.1.6-1 1.5-1.6 2.6-2.1 1.2-.5 2.4-.8 3.9-.8a9 9 0 0 1 3.7.8c1.1.5 2 1.2 2.6 2 .6 1 1 2 1 3H61Zm12.8 15a6.7 6.7 0 0 1-6.4-3.8 9.1 9.1 0 0 1-1-4c0-1.6.4-3 1-4.2a6.7 6.7 0 0 1 2.5-2.7c1-.7 2.4-1 3.9-1 1.2 0 2.3.2 3.2.7a5.6 5.6 0 0 1 3.3 4.7H77c-.2-.7-.5-1.3-1-1.8s-1.2-.7-2-.7-1.5.2-2 .6c-.6.4-1 1-1.3 1.6-.3.8-.5 1.7-.5 2.7 0 1 .2 2 .5 2.7a4 4 0 0 0 1.3 1.7c.5.4 1.2.6 2 .6.4 0 1-.1 1.3-.3.5-.2.8-.5 1-1 .4-.3.6-.8.7-1.3h3.4c0 1-.4 2-1 2.9-.5.8-1.2 1.4-2.2 1.9-1 .5-2 .7-3.3.7Zm13 0c-1 0-1.8-.2-2.6-.5-.8-.4-1.4-.9-1.8-1.6-.5-.6-.7-1.5-.7-2.5 0-.8.2-1.5.5-2.1.3-.6.7-1 1.3-1.4l1.8-.7a85.1 85.1 0 0 0 5.5-1c.3-.2.5-.4.5-.8 0-.8-.3-1.4-.7-1.8-.5-.4-1-.6-2-.6-.8 0-1.5.2-2 .6-.5.4-.9.8-1 1.4l-3.4-.5a5.4 5.4 0 0 1 3.5-3.8c1-.3 1.9-.4 3-.4.7 0 1.4 0 2.1.2.8.2 1.4.5 2 .9.6.4 1.1.9 1.5 1.6.4.7.5 1.5.5 2.5V30h-3.4v-2h-.1a4.4 4.4 0 0 1-2.4 2 6 6 0 0 1-2.1.3Zm1-2.6c.7 0 1.3-.2 1.8-.5.5-.2 1-.6 1.2-1.1.3-.5.5-1 .5-1.6v-1.8l-.6.3-1 .2a27.5 27.5 0 0 1-1.7.3c-.6 0-1 .2-1.5.3l-1 .7c-.2.3-.3.7-.3 1.2 0 .6.2 1.1.7 1.5.5.3 1 .5 1.8.5Zm13.4-18V30h-3.6V9.7h3.6Zm7.2 20.6c-1 0-1.8-.2-2.6-.5-.7-.4-1.3-.9-1.8-1.6-.4-.6-.7-1.5-.7-2.5 0-.8.2-1.5.5-2.1.3-.6.8-1 1.3-1.4l1.9-.7 2.1-.4a85.8 85.8 0 0 0 3.4-.6c.3-.2.4-.4.4-.8 0-.8-.2-1.4-.7-1.8-.4-.4-1-.6-1.9-.6-.9 0-1.6.2-2 .6-.6.4-1 .8-1.1 1.4l-3.4-.5a5.4 5.4 0 0 1 3.6-3.8c.9-.3 1.8-.4 2.9-.4.7 0 1.5 0 2.2.2.7.2 1.4.5 2 .9.6.4 1 .9 1.4 1.6.4.7.6 1.5.6 2.5V30H113v-2a4.4 4.4 0 0 1-2.5 2 6 6 0 0 1-2 .3Zm1-2.6c.7 0 1.3-.2 1.8-.5.6-.2 1-.6 1.3-1.1.3-.5.4-1 .4-1.6v-1.8l-.6.3-.9.2a27.3 27.3 0 0 1-1.8.3c-.5 0-1 .2-1.4.3-.5.2-.8.4-1 .7-.3.3-.4.7-.4 1.2 0 .6.2 1.1.7 1.5.5.3 1.1.5 1.9.5Zm9.8 2.3V14.8h3.5v2.5h.2a3.8 3.8 0 0 1 3.7-2.7 8.3 8.3 0 0 1 1.3 0V18l-.7-.2h-1c-.6 0-1.2 0-1.7.4a3.1 3.1 0 0 0-1.7 2.8v9h-3.5Z"/>
+            <defs>
+              <clipPath id="a">
+                <path fill="#fff" d="M0 0h38v39H0z"/>
+              </clipPath>
+            </defs>
+          </svg>
+        </div>
+        <div class="h-animation-sidebar">
+          <div class="h-animation-sidebar__animate">
+            <div class="h-animation-sidebar-title">Products</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M219.31,108.68l-80-80a16,16,0,0,0-22.62,0l-80,80A15.87,15.87,0,0,0,32,120v96a8,8,0,0,0,8,8h64a8,8,0,0,0,8-8V160h32v56a8,8,0,0,0,8,8h64a8,8,0,0,0,8-8V120A15.87,15.87,0,0,0,219.31,108.68ZM208,208H160V152a8,8,0,0,0-8-8H104a8,8,0,0,0-8,8v56H48V120l80-80,80,80Z"/></svg>
+              Home
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M208,24H72A32,32,0,0,0,40,56V224a8,8,0,0,0,8,8H192a8,8,0,0,0,0-16H56a16,16,0,0,1,16-16H208a8,8,0,0,0,8-8V32A8,8,0,0,0,208,24Zm-8,160H72a31.82,31.82,0,0,0-16,4.29V56A16,16,0,0,1,72,40H200Z"/></svg>
+              Docs
+              <span class="h-animation-sidebar-number">2</span>
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"/></svg>
+              SDKs
+              <span class="h-animation-sidebar-number">5</span>
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M43.18,128a29.78,29.78,0,0,1,8,10.26c4.8,9.9,4.8,22,4.8,33.74,0,24.31,1,36,24,36a8,8,0,0,1,0,16c-17.48,0-29.32-6.14-35.2-18.26-4.8-9.9-4.8-22-4.8-33.74,0-24.31-1-36-24-36a8,8,0,0,1,0-16c23,0,24-11.69,24-36,0-11.72,0-23.84,4.8-33.74C50.68,38.14,62.52,32,80,32a8,8,0,0,1,0,16C57,48,56,59.69,56,84c0,11.72,0,23.84-4.8,33.74A29.78,29.78,0,0,1,43.18,128ZM240,120c-23,0-24-11.69-24-36,0-11.72,0-23.84-4.8-33.74C205.32,38.14,193.48,32,176,32a8,8,0,0,0,0,16c23,0,24,11.69,24,36,0,11.72,0,23.84,4.8,33.74a29.78,29.78,0,0,0,8,10.26,29.78,29.78,0,0,0-8,10.26c-4.8,9.9-4.8,22-4.8,33.74,0,24.31-1,36-24,36a8,8,0,0,0,0,16c17.48,0,29.32-6.14,35.2-18.26,4.8-9.9,4.8-22,4.8-33.74,0-24.31,1-36,24-36a8,8,0,0,0,0-16Z"/></svg>
+              Registry
+              <span class="h-animation-sidebar-number">1</span>
+            </div>
+            <div class="h-animation-sidebar-title">Access</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M208,80H176V56a48,48,0,0,0-96,0V80H48A16,16,0,0,0,32,96V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V96A16,16,0,0,0,208,80ZM96,56a32,32,0,0,1,64,0V80H96ZM208,208H48V96H208V208Z"/></svg>
+              Access Groups
+              <span class="h-animation-sidebar-number">4</span>
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M128,24h0A104,104,0,1,0,232,128,104.12,104.12,0,0,0,128,24Zm88,104a87.61,87.61,0,0,1-3.33,24H174.16a157.44,157.44,0,0,0,0-48h38.51A87.61,87.61,0,0,1,216,128ZM102,168H154a115.11,115.11,0,0,1-26,45A115.27,115.27,0,0,1,102,168Zm-3.9-16a140.84,140.84,0,0,1,0-48h59.88a140.84,140.84,0,0,1,0,48ZM40,128a87.61,87.61,0,0,1,3.33-24H81.84a157.44,157.44,0,0,0,0,48H43.33A87.61,87.61,0,0,1,40,128ZM154,88H102a115.11,115.11,0,0,1,26-45A115.27,115.27,0,0,1,154,88Zm52.33,0H170.71a135.28,135.28,0,0,0-22.3-45.6A88.29,88.29,0,0,1,206.37,88ZM107.59,42.4A135.28,135.28,0,0,0,85.29,88H49.63A88.29,88.29,0,0,1,107.59,42.4ZM49.63,168H85.29a135.28,135.28,0,0,0,22.3,45.6A88.29,88.29,0,0,1,49.63,168Zm98.78,45.6a135.28,135.28,0,0,0,22.3-45.6h35.66A88.29,88.29,0,0,1,148.41,213.6Z"/></svg>
+              Login Portals
+            </div>
+            <div class="h-animation-sidebar-title">User</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M230.92,212c-15.23-26.33-38.7-45.21-66.09-54.16a72,72,0,1,0-73.66,0C63.78,166.78,40.31,185.66,25.08,212a8,8,0,1,0,13.85,8c18.84-32.56,52.14-52,89.07-52s70.23,19.44,89.07,52a8,8,0,1,0,13.85-8ZM72,96a56,56,0,1,1,56,56A56.06,56.06,0,0,1,72,96Z"/></svg>
+              Profile
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M216.57,39.43A80,80,0,0,0,83.91,120.78L28.69,176A15.86,15.86,0,0,0,24,187.31V216a16,16,0,0,0,16,16H72a8,8,0,0,0,8-8V208H96a8,8,0,0,0,8-8V184h16a8,8,0,0,0,5.66-2.34l9.56-9.57A79.73,79.73,0,0,0,160,176h.1A80,80,0,0,0,216.57,39.43ZM224,98.1c-1.09,34.09-29.75,61.86-63.89,61.9H160a63.7,63.7,0,0,1-23.65-4.51,8,8,0,0,0-8.84,1.68L116.69,168H96a8,8,0,0,0-8,8v16H72a8,8,0,0,0-8,8v16H40V187.31l58.83-58.82a8,8,0,0,0,1.68-8.84A63.72,63.72,0,0,1,96,95.92c0-34.14,27.81-62.8,61.9-63.89A64,64,0,0,1,224,98.1ZM192,76a12,12,0,1,1-12-12A12,12,0,0,1,192,76Z"/></svg>
+              API Keys
+            </div>
+            <div class="h-animation-sidebar-title">Team</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M216,64H56a8,8,0,0,1,0-16H192a8,8,0,0,0,0-16H56A24,24,0,0,0,32,56V184a24,24,0,0,0,24,24H216a16,16,0,0,0,16-16V80A16,16,0,0,0,216,64Zm0,128H56a8,8,0,0,1-8-8V78.63A23.84,23.84,0,0,0,56,80H216Zm-48-60a12,12,0,1,1,12,12A12,12,0,0,1,168,132Z"/></svg>
+              Billing
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M117.25,157.92a60,60,0,1,0-66.5,0A95.83,95.83,0,0,0,3.53,195.63a8,8,0,1,0,13.4,8.74,80,80,0,0,1,134.14,0,8,8,0,0,0,13.4-8.74A95.83,95.83,0,0,0,117.25,157.92ZM40,108a44,44,0,1,1,44,44A44.05,44.05,0,0,1,40,108Zm210.14,98.7a8,8,0,0,1-11.07-2.33A79.83,79.83,0,0,0,172,168a8,8,0,0,1,0-16,44,44,0,1,0-16.34-84.87,8,8,0,1,1-5.94-14.85,60,60,0,0,1,55.53,105.64,95.83,95.83,0,0,1,47.22,37.71A8,8,0,0,1,250.14,206.7Z"/></svg>
+              Members
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Zm88-29.84q.06-2.16,0-4.32l14.92-18.64a8,8,0,0,0,1.48-7.06,107.21,107.21,0,0,0-10.88-26.25,8,8,0,0,0-6-3.93l-23.72-2.64q-1.48-1.56-3-3L186,40.54a8,8,0,0,0-3.94-6,107.71,107.71,0,0,0-26.25-10.87,8,8,0,0,0-7.06,1.49L130.16,40Q128,40,125.84,40L107.2,25.11a8,8,0,0,0-7.06-1.48A107.6,107.6,0,0,0,73.89,34.51a8,8,0,0,0-3.93,6L67.32,64.27q-1.56,1.49-3,3L40.54,70a8,8,0,0,0-6,3.94,107.71,107.71,0,0,0-10.87,26.25,8,8,0,0,0,1.49,7.06L40,125.84Q40,128,40,130.16L25.11,148.8a8,8,0,0,0-1.48,7.06,107.21,107.21,0,0,0,10.88,26.25,8,8,0,0,0,6,3.93l23.72,2.64q1.49,1.56,3,3L70,215.46a8,8,0,0,0,3.94,6,107.71,107.71,0,0,0,26.25,10.87,8,8,0,0,0,7.06-1.49L125.84,216q2.16.06,4.32,0l18.64,14.92a8,8,0,0,0,7.06,1.48,107.21,107.21,0,0,0,26.25-10.88,8,8,0,0,0,3.93-6l2.64-23.72q1.56-1.48,3-3L215.46,186a8,8,0,0,0,6-3.94,107.71,107.71,0,0,0,10.87-26.25,8,8,0,0,0-1.49-7.06Zm-16.1-6.5a73.93,73.93,0,0,1,0,8.68,8,8,0,0,0,1.74,5.48l14.19,17.73a91.57,91.57,0,0,1-6.23,15L187,173.11a8,8,0,0,0-5.1,2.64,74.11,74.11,0,0,1-6.14,6.14,8,8,0,0,0-2.64,5.1l-2.51,22.58a91.32,91.32,0,0,1-15,6.23l-17.74-14.19a8,8,0,0,0-5-1.75h-.48a73.93,73.93,0,0,1-8.68,0,8,8,0,0,0-5.48,1.74L100.45,215.8a91.57,91.57,0,0,1-15-6.23L82.89,187a8,8,0,0,0-2.64-5.1,74.11,74.11,0,0,1-6.14-6.14,8,8,0,0,0-5.1-2.64L46.43,170.6a91.32,91.32,0,0,1-6.23-15l14.19-17.74a8,8,0,0,0,1.74-5.48,73.93,73.93,0,0,1,0-8.68,8,8,0,0,0-1.74-5.48L40.2,100.45a91.57,91.57,0,0,1,6.23-15L69,82.89a8,8,0,0,0,5.1-2.64,74.11,74.11,0,0,1,6.14-6.14A8,8,0,0,0,82.89,69L85.4,46.43a91.32,91.32,0,0,1,15-6.23l17.74,14.19a8,8,0,0,0,5.48,1.74,73.93,73.93,0,0,1,8.68,0,8,8,0,0,0,5.48-1.74L155.55,40.2a91.57,91.57,0,0,1,15,6.23L173.11,69a8,8,0,0,0,2.64,5.1,74.11,74.11,0,0,1,6.14,6.14,8,8,0,0,0,5.1,2.64l22.58,2.51a91.32,91.32,0,0,1,6.23,15l-14.19,17.74A8,8,0,0,0,199.87,123.66Z"/></svg>
+              Settings
+            </div>
+          </div>
+        </div>
+        <div class="h-animation-content">
+          <div class="h-animation-tag">
+            
+            <div class="h-animation-endpoint">
+              <div class="h-animation-endpoint-markdown">
+                <div class="h-animation-header">Overview</div>
+                <div class="product">
+                <div class="productthing">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="h-green size-6"><g><path d="M43.18,128a29.78,29.78,0,0,1,8,10.26c4.8,9.9,4.8,22,4.8,33.74,0,24.31,1,36,24,36a8,8,0,0,1,0,16c-17.48,0-29.32-6.14-35.2-18.26-4.8-9.9-4.8-22-4.8-33.74,0-24.31-1-36-24-36a8,8,0,0,1,0-16c23,0,24-11.69,24-36,0-11.72,0-23.84,4.8-33.74C50.68,38.14,62.52,32,80,32a8,8,0,0,1,0,16C57,48,56,59.69,56,84c0,11.72,0,23.84-4.8,33.74A29.78,29.78,0,0,1,43.18,128ZM240,120c-23,0-24-11.69-24-36,0-11.72,0-23.84-4.8-33.74C205.32,38.14,193.48,32,176,32a8,8,0,0,0,0,16c23,0,24,11.69,24,36,0,11.72,0,23.84,4.8,33.74a29.78,29.78,0,0,0,8,10.26,29.78,29.78,0,0,0-8,10.26c-4.8,9.9-4.8,22-4.8,33.74,0,24.31-1,36-24,36a8,8,0,0,0,0,16c17.48,0,29.32-6.14,35.2-18.26,4.8-9.9,4.8-22,4.8-33.74,0-24.31,1-36,24-36a8,8,0,0,0,0-16Z"/></g></svg>
+                    <b>Upload API</b>
+                    <p>User Guide / API Reference</p>
+                  </div>
+                  <div class="productthing">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="h-blue size-6"><g><path d="M208,24H72A32,32,0,0,0,40,56V224a8,8,0,0,0,8,8H192a8,8,0,0,0,0-16H56a16,16,0,0,1,16-16H208a8,8,0,0,0,8-8V32A8,8,0,0,0,208,24Zm-8,160H72a31.82,31.82,0,0,0-16,4.29V56A16,16,0,0,1,72,40H200Z"/></g></svg>
+                    <b>Create Documentation</b>
+                    <p>User Guide / API Reference</p>
+                  </div>
+                  <div class="productthing">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="h-purple size-6"><g><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"/></g></svg>
+                    <b>Create SDK</b>
+                    <p>User Guide / API Reference</p>
+                  </div>
+                </div>
+                <div class="product-list-title bg-green"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="h-green"><g><path d="M43.18,128a29.78,29.78,0,0,1,8,10.26c4.8,9.9,4.8,22,4.8,33.74,0,24.31,1,36,24,36a8,8,0,0,1,0,16c-17.48,0-29.32-6.14-35.2-18.26-4.8-9.9-4.8-22-4.8-33.74,0-24.31-1-36-24-36a8,8,0,0,1,0-16c23,0,24-11.69,24-36,0-11.72,0-23.84,4.8-33.74C50.68,38.14,62.52,32,80,32a8,8,0,0,1,0,16C57,48,56,59.69,56,84c0,11.72,0,23.84-4.8,33.74A29.78,29.78,0,0,1,43.18,128ZM240,120c-23,0-24-11.69-24-36,0-11.72,0-23.84-4.8-33.74C205.32,38.14,193.48,32,176,32a8,8,0,0,0,0,16c23,0,24,11.69,24,36,0,11.72,0,23.84,4.8,33.74a29.78,29.78,0,0,0,8,10.26,29.78,29.78,0,0,0-8,10.26c-4.8,9.9-4.8,22-4.8,33.74,0,24.31-1,36-24,36a8,8,0,0,0,0,16c17.48,0,29.32-6.14,35.2-18.26,4.8-9.9,4.8-22,4.8-33.74,0-24.31,1-36,24-36a8,8,0,0,0,0-16Z"/></g></svg> Registry</div>
+                <div class="product-list-item"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation"><g><path d="M43.18,128a29.78,29.78,0,0,1,8,10.26c4.8,9.9,4.8,22,4.8,33.74,0,24.31,1,36,24,36a8,8,0,0,1,0,16c-17.48,0-29.32-6.14-35.2-18.26-4.8-9.9-4.8-22-4.8-33.74,0-24.31-1-36-24-36a8,8,0,0,1,0-16c23,0,24-11.69,24-36,0-11.72,0-23.84,4.8-33.74C50.68,38.14,62.52,32,80,32a8,8,0,0,1,0,16C57,48,56,59.69,56,84c0,11.72,0,23.84-4.8,33.74A29.78,29.78,0,0,1,43.18,128ZM240,120c-23,0-24-11.69-24-36,0-11.72,0-23.84-4.8-33.74C205.32,38.14,193.48,32,176,32a8,8,0,0,0,0,16c23,0,24,11.69,24,36,0,11.72,0,23.84,4.8,33.74a29.78,29.78,0,0,0,8,10.26,29.78,29.78,0,0,0-8,10.26c-4.8,9.9-4.8,22-4.8,33.74,0,24.31-1,36-24,36a8,8,0,0,0,0,16c17.48,0,29.32-6.14,35.2-18.26,4.8-9.9,4.8-22,4.8-33.74,0-24.31,1-36,24-36a8,8,0,0,0,0-16Z"/></g></svg>@scalar/scalar-galaxy</div>
+                <div class="product-list-title bg-blue"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="h-blue"><g><path d="M208,24H72A32,32,0,0,0,40,56V224a8,8,0,0,0,8,8H192a8,8,0,0,0,0-16H56a16,16,0,0,1,16-16H208a8,8,0,0,0,8-8V32A8,8,0,0,0,208,24Zm-8,160H72a31.82,31.82,0,0,0-16,4.29V56A16,16,0,0,1,72,40H200Z"/></g></svg> Documentation</div>
+                <div class="product-list-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" viewBox="0 0 256 256"><path d="M208.31,75.68A59.78,59.78,0,0,0,202.93,28,8,8,0,0,0,196,24a59.75,59.75,0,0,0-48,24H124A59.75,59.75,0,0,0,76,24a8,8,0,0,0-6.93,4,59.78,59.78,0,0,0-5.38,47.68A58.14,58.14,0,0,0,56,104v8a56.06,56.06,0,0,0,48.44,55.47A39.8,39.8,0,0,0,96,192v8H72a24,24,0,0,1-24-24A40,40,0,0,0,8,136a8,8,0,0,0,0,16,24,24,0,0,1,24,24,40,40,0,0,0,40,40H96v16a8,8,0,0,0,16,0V192a24,24,0,0,1,48,0v40a8,8,0,0,0,16,0V192a39.8,39.8,0,0,0-8.44-24.53A56.06,56.06,0,0,0,216,112v-8A58.14,58.14,0,0,0,208.31,75.68ZM200,112a40,40,0,0,1-40,40H112a40,40,0,0,1-40-40v-8a41.74,41.74,0,0,1,6.9-22.48A8,8,0,0,0,80,73.83a43.81,43.81,0,0,1,.79-33.58,43.88,43.88,0,0,1,32.32,20.06A8,8,0,0,0,119.82,64h32.35a8,8,0,0,0,6.74-3.69,43.87,43.87,0,0,1,32.32-20.06A43.81,43.81,0,0,1,192,73.83a8.09,8.09,0,0,0,1,7.65A41.72,41.72,0,0,1,200,104Z"/></svg>
+                Scalar/docs <span class="ml-auto text-c-3">Published</span></div>
+                <div class="product-list-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" viewBox="0 0 256 256"><path d="M208.31,75.68A59.78,59.78,0,0,0,202.93,28,8,8,0,0,0,196,24a59.75,59.75,0,0,0-48,24H124A59.75,59.75,0,0,0,76,24a8,8,0,0,0-6.93,4,59.78,59.78,0,0,0-5.38,47.68A58.14,58.14,0,0,0,56,104v8a56.06,56.06,0,0,0,48.44,55.47A39.8,39.8,0,0,0,96,192v8H72a24,24,0,0,1-24-24A40,40,0,0,0,8,136a8,8,0,0,0,0,16,24,24,0,0,1,24,24,40,40,0,0,0,40,40H96v16a8,8,0,0,0,16,0V192a24,24,0,0,1,48,0v40a8,8,0,0,0,16,0V192a39.8,39.8,0,0,0-8.44-24.53A56.06,56.06,0,0,0,216,112v-8A58.14,58.14,0,0,0,208.31,75.68ZM200,112a40,40,0,0,1-40,40H112a40,40,0,0,1-40-40v-8a41.74,41.74,0,0,1,6.9-22.48A8,8,0,0,0,80,73.83a43.81,43.81,0,0,1,.79-33.58,43.88,43.88,0,0,1,32.32,20.06A8,8,0,0,0,119.82,64h32.35a8,8,0,0,0,6.74-3.69,43.87,43.87,0,0,1,32.32-20.06A43.81,43.81,0,0,1,192,73.83a8.09,8.09,0,0,0,1,7.65A41.72,41.72,0,0,1,200,104Z"/></svg>
+                Scalar/internal-apis <span class="ml-auto text-c-3">Private</span></div>
+                <div class="product-list-title bg-purple"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="h-purple"><g><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"/></g></svg> SDKs</div>
+                <div class="product-list-item"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation"><g><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"/></g></svg>Typescript - Scalar Galaxy</div>
+                <div class="product-list-item"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation"><g><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"/></g></svg>Python - Scalar Galaxy</div>
+                <div class="product-list-item"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation"><g><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"/></g></svg>C# - Scalar Galaxy</div>
+                <div class="product-list-item"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation"><g><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"/></g></svg>Go - Scalar Galaxy</div>
+            </div>
+          </div>
+          <div class="h-animation-endpoint-copy">
+            <div class="h-animation-header">Guides</div>
+            <p>Reading this guide helps you to get started with Scalar Docs, literally in minutes. </p>
+            <div class="h-animation-endpoint-copy-product">
+              <div class="h-animation-header-2">SDK's</div>
+              <p>This guide will help you get started with generating world-class SDKs on scalar.com in several languages: TypeScript, Python, Golang and more powered by Speakeasy.</p>
+              <b>Learn More</b>
+            </div>
+            <div class="h-animation-endpoint-copy-product">
+              <div class="h-animation-header-2">Registry</div>
+              <p>This guide will help you get started with generating world-class SDKs on scalar.com in several languages: TypeScript, Python, Golang and more powered by Speakeasy.</p>
+              <b>Learn More</b>
+            </div>
+        </div>
+        </div>  
+      </div>
+      </div>
+    </div>
+    <style>
+      * {
+        padding: 0;
+        box-sizing: border-box;
+        margin: 0;
+        -webkit-font-smoothing: antialiased
+      }
+      :root {
+        
+    --app-header-height: 48px;
+    --scalar-border-width: 1px;
+    --scalar-radius: 3px;
+    --scalar-radius-lg: 6px;
+    --scalar-radius-xl: 8px;
+    --scalar-header-height: 50px;
+    --scalar-sidebar-width: 280px;
+    --scalar-toc-width: 280px;
+    --scalar-card-icon-width: 40px;
+    --scalar-card-icon-height: 40px;
+    --scalar-card-icon-diameter: 20px;
+    --scalar-card-padding: 16px;
+    --scalar-card-inter-element-gap: 4px;
+    --scalar-row-gap: 16px;
+    --system-fonts: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    --scalar-font: "Inter", var(--system-fonts);
+    --scalar-font-code: Monaco, Menlo, monospace;
+    --scalar-heading-1: 24px;
+    --scalar-page-description: 16px;
+    --scalar-heading-2: 20px;
+    --scalar-heading-3: 20px;
+    --scalar-heading-4: 16px;
+    --scalar-heading-5: 16px;
+    --scalar-heading-6: 16px;
+    --scalar-paragraph: 16px;
+    --scalar-small: 14px;
+    --scalar-mini: 13px;
+    --scalar-micro: 12px;
+    --scalar-extra-bold: 700;
+    --scalar-bold: 600;
+    --scalar-semibold: 500;
+    --scalar-regular: 400;
+    --scalar-font-size-1: 24px;
+    --scalar-font-size-2: 16px;
+    --scalar-font-size-3: 14px;
+    --scalar-font-size-4: 13px;
+    --scalar-font-size-5: 12px;
+    --scalar-line-height-1: 32px;
+    --scalar-line-height-2: 24px;
+    --scalar-line-height-3: 20px;
+    --scalar-line-height-4: 18px;
+    --scalar-line-height-5: 16px;
+    --scalar-heading-spacing: 44px;
+    --scalar-block-spacing: 12px;
+      }
+      .light-mode {
+        --scalar-sidebar-width: 280px;
+        --scalar-color-1: #000;
+        --scalar-color-2: #666666;
+        --scalar-color-3: #8e8e8e;
+        --scalar-color-disabled: #b4b1b1;
+        --scalar-color-ghost: #a7a7a7;
+        --scalar-color-accent: #0099ff;
+        --scalar-background-1: #fff;
+        --scalar-background-2: #f6f6f6;
+        --scalar-background-3: #e7e7e7;
+        --scalar-background-4: rgba(0, 0, 0, 0.06);
+        --scalar-background-accent: #8ab4f81f;
+        --scalar-border-color: rgba(0, 0, 0, 0.05);
+        --scalar-scrollbar-color: rgba(0, 0, 0, 0.18);
+        --scalar-scrollbar-color-active: rgba(0, 0, 0, 0.36);
+        --scalar-lifted-brightness: 1;
+        --scalar-backdrop-brightness: 1;
+        --scalar-shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.11);
+        --scalar-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px,
+          rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 1px;
+        --scalar-button-1: rgb(49 53 56);
+        --scalar-button-1-color: #fff;
+        --scalar-button-1-hover: rgb(28 31 33);
+        --scalar-color-green: #00a67d;
+        --scalar-color-red: #ef0006;
+        --scalar-color-yellow: #f9c514;
+        --scalar-color-blue: #579dfb;
+        --scalar-color-orange: #fc8528;
+        --scalar-color-purple: #5203d1;
+        font-family: var(--scalar-font);
+        color: var(--scalar-color-1);
+      }
+      .dark-mode {
+        font-family: var(--scalar-font);
+        color-scheme: dark;
+  --scalar-color-1: rgba(255, 255, 255, 0.9);
+  --scalar-color-2: rgba(255, 255, 255, 0.62);
+  --scalar-color-3: rgba(255, 255, 255, 0.44);
+  --scalar-color-disabled: rgba(255, 255, 255, 0.34);
+  --scalar-color-ghost: rgba(255, 255, 255, 0.26);
+  --scalar-color-accent: #8ab4f8;
+  --scalar-background-1: #0f0f0f;
+  --scalar-background-2: #1a1a1a;
+  --scalar-background-3: #272727;
+  --scalar-background-4: rgba(255, 255, 255, 0.06);
+  --scalar-background-accent: #8ab4f81f;
+
+  --scalar-border-color: rgba(255, 255, 255, 0.1);
+  --scalar-scrollbar-color: rgba(255, 255, 255, 0.24);
+  --scalar-scrollbar-color-active: rgba(255, 255, 255, 0.48);
+  --scalar-lifted-brightness: 1.45;
+  --scalar-backdrop-brightness: 0.5;
+
+  --scalar-shadow-1: 0 1px 3px 0 rgb(0, 0, 0, 0.1);
+  --scalar-shadow-2: rgba(15, 15, 15, 0.2) 0px 3px 6px, rgba(15, 15, 15, 0.4)
+    0px 9px 24px, 0 0 0 1px rgba(255, 255, 255, 0.1);
+
+  --scalar-button-1: #f6f6f6;
+  --scalar-button-1-color: #000;
+  --scalar-button-1-hover: #e7e7e7;
+
+  --scalar-color-green: #00b848;
+  --scalar-color-red: #fe1d2c;
+  --scalar-color-yellow: #fbca25;
+  --scalar-color-blue: #76aedf;
+  --scalar-color-orange: #dd922f;
+  --scalar-color-purple: #b090f8;
+  color: var(--scalar-color-1);
+
+  /* Misc Scalar Branding */
+  --scalar-brand: #8b7256;
+      }
+      .dotted-top {
+    position: absolute;
+    top: 17px;
+    left: 12px;
+    background-color: var(--scalar-background-3);
+    border-radius: 50%;
+    width: 10px;
+    box-shadow: 14px 0 0 var(--scalar-background-3), 29px 0 0 var(--scalar-background-3);
+    height: 9px;
+}
+.h-animation-ref-safari {
+    height: 40px;
+    background-color: var(--scalar-background-2);
+    z-index: 1;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+}
+.h-animation-ref-safari-left {
+    width: 150px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding-left: 68px;
+    color: var(--scalar-color-3);
+}
+.h-animation-ref-safari-nav {
+    width: 600px;
+    padding: 6px 0;
+}
+.h-animation-ref-safari-right {
+    width: 150px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+    color: var(--scalar-color-3);
+    padding-right: 12px;
+}
+.h-animation-ref-safari-right svg {
+    width: 17px;
+    height: 17px;
+}
+.h-animation-ref-safari-left svg {
+    width: 16px;
+    height: 16px;
+}
+.h-animation-ref-safari-left svg:last-of-type {
+    opacity: 0.5;
+}
+.h-animation-ref-safari-nav-url {
+    width: 100%;
+    border-radius: 7px;
+    height: 100%;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    position: relative;
+    border: 1px solid var(--scalar-border-color);
+}
+.h-animation-ref-safari-nav-url svg {
+    width: 13px;
+    height: 13px;
+    color: var(--scalar-color-3);
+    margin-right: 3px;
+}
+.h-animation-ref-safari-nav-url svg:last-of-type {
+    position: absolute;
+    right: 4px;
+}
+.h-animation-ref {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+    background: var(--scalar-background-1);
+    min-width: 1280px;
+    min-height: 720px;
+}
+.h-animation-ref {
+    display: flex;
+    padding-top: 90px;
+}
+.h-animation-sidebar {
+    padding: 12px;
+    max-width: var(--scalar-sidebar-width);
+    border-right: 1px solid var(--scalar-border-color);
+    flex: 1;
+}
+.h-animation-sidebar-endpoint {
+    position: relative;
+}
+.h-animation-sidebar-number {
+    margin-left: auto;
+    font-family: var(--scalar-font-code);
+    font-weight: 700;
+    font-size: 10px;
+    margin-top: 10px;
+    line-height: 0;
+}
+.h-animation-sidebar-endpoint,
+.h-animation-sidebar-folder,
+.h-animation-sidebar-item {
+    font-size: 14px;
+    min-height: 32px;
+    display: flex;
+    padding: 8px 9px;
+    color: var(--scalar-color-2);
+    border-radius: var(--scalar-radius);
+}
+.h-animation-sidebar-folder svg {
+    margin-right: 6px;
+}
+.h-animation-sidebar-folder {
+    padding-left: 6px;
+}
+.h-animation-sidebar-endpoint {
+    padding-left: 12px;
+}
+.h-animation-sidebar-endpoint {
+    border-radius: 0;
+    margin-left: 12px;
+    border-left: 1px solid var(--scalar-border-color);
+}
+.h-animation-sidebar-title {
+    color: var(--scalar-color-3);
+    padding: 8px;
+    font-size: 14px;
+    font-weight: 600;
+}
+.h-animation-sidebar-title:not(:first-of-type) {
+    margin-top: 18px;
+}
+.h-animation-sidebar-folder:nth-of-type(2) {
+    color: var(--scalar-color-1);
+    font-weight: 500;
+    background-color: var(--scalar-background-2);
+}
+.h-animation-sidebar-folder:nth-of-type(2) svg {
+    fill: var(--scalar-color-1);
+}
+.h-animation-content {
+    flex: 1;
+}
+@keyframes scrollupdown {
+    0%,
+    10%,
+    100%,
+    80% {
+        transform: translate3d(0, 0, 0);
+    }
+    18%,
+    72% {
+        transform: translate3d(0, -380px, 0);
+    }
+}
+.h-animation-tag {
+    border-bottom: 1px solid var(--scalar-border-color);
+    width: 100%;
+    display: flex;
+    gap: 48px;
+}
+.h-animation-tag {
+    border-bottom: none;
+    flex-flow: wrap;
+    gap: 0;
+    padding: 0 0 0 36px;
+}
+.h-animation-header {
+    font-size: var(--font-size, var(--scalar-heading-2));
+    font-weight: var(--font-weight, var(--scalar-bold));
+    color: var(--scalar-color-1);
+    word-wrap: break-word;
+    line-height: 1.45;
+}
+.h-animation-endpoint-markdown,
+.h-animation-tag-markdown {
+    width: 100%;
+}
+.h-markdown {
+    margin-top: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    line-height: 1.5;
+    color: var(--scalar-color-1);
+}
+.h-green {
+    color: var(--scalar-color-green);
+}
+.h-purple {
+    color: var(--scalar-color-purple);
+}
+.h-blue {
+    color: var(--scalar-color-blue);
+}
+.h-animation-endpoint {
+    width: 65%;
+    display: flex;
+    padding: 24px 0;
+}
+.h-animation-14 {
+    width: 12px;
+    height: 12px;
+    stroke-width: 2;
+}
+.h-markdown-item {
+    position: relative;
+    border-top: 1px solid var(--scalar-border-color);
+    padding: 10px 0;
+    display: flex;
+    flex-flow: wrap;
+    gap: 9px;
+    font-family: var(--scalar-font);
+    font-size: 12px;
+}
+.h-markdown-item div {
+    width: 100%;
+    font-family: var(--scalar-font);
+}
+@supports (color: color(display-p3 1 1 1)) {
+    .light-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0.023529 0.564706 0.380392 / 1);
+        --scalar-color-red: color(display-p3 0.937255 0 0.023529 / 1);
+        --scalar-color-yellow: color(display-p3 0.929412 0.745098 0.12549 / 1);
+        --scalar-color-blue: color(display-p3 0 0.509804 0.815686 / 1);
+        --scalar-color-orange: color(display-p3 0.984314 0.537255 0.172549 / 1);
+        --scalar-color-purple: color(display-p3 0.321569 0.011765 0.819608 / 1);
+    }
+    .dark-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0 0.713725 0.282353 / 1);
+        --scalar-color-red: color(display-p3 0.862745 0.105882 0.098039 / 1);
+        --scalar-color-yellow: color(display-p3 1 0.788235 0.05098 / 1);
+        --scalar-color-blue: color(display-p3 0.305882 0.701961 0.92549 / 1);
+        --scalar-color-orange: color(display-p3 1 0.552941 0.301961 / 1);
+        --scalar-color-purple: color(display-p3 0.694118 0.568627 0.976471 / 1);
+    }
+}
+.h-markdown-item .h-animation-14 {
+    position: absolute;
+    left: -18px;
+    margin-top: 2px;
+    transform: rotate(-90deg);
+    color: var(--scalar-color-3);
+}
+.h-animation-doc-header {
+    font-weight: 800;
+    width: 100%;
+    position: absolute;
+    top: 40px;
+    left: 0;
+    height: 50px;
+    padding: 12px;
+    display: flex;
+    align-items: center;
+    font-size: 16px;
+    border-bottom: 1px solid var(--scalar-border-color);
+    background-color: var(--scalar-background-1);
+    z-index: 1;
+    gap: 4px;
+}
+.h-animation-doc-header svg {
+    width: auto;
+    height: 22px;
+}
+@keyframes fadein {
+    0%,
+    100%,
+    40%,
+    70% {
+        opacity: 0;
+    }
+    45%,
+    68.5% {
+        opacity: 1;
+    }
+}
+@keyframes popupcontent {
+    0%,
+    100%,
+    43%,
+    68% {
+        opacity: 0;
+        transform: scale(0.99) translate3d(0, 10px, 0);
+    }
+    47%,
+    66% {
+        opacity: 1;
+        transform: scale(1) translate3d(0, 0, 0);
+    }
+}
+.size-3 {
+    width: 12px;
+    height: 12px;
+}
+.h-animation-14 {
+    width: 16px;
+    height: 16px;
+}
+.w-15 {
+    width: 60px;
+}
+.p-11 {
+    padding: 11px;
+}
+.p-9 {
+    padding: 9px;
+}
+svg {
+    vertical-align: middle;
+    display: block;
+}
+.p-3 {
+    padding: 0 12px 12px 12px;
+}
+.h-10 {
+    height: 40px;
+}
+.w-780 {
+    width: 580px;
+    font-size: 14px;
+    border: 1px solid var(--scalar-border-color);
+}
+.size-35 {
+    width: 14px;
+    height: 14px;
+}
+.p-1 {
+    padding: 4px;
+}
+@supports (color: color(display-p3 1 1 1)) {
+    .light-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0.023529 0.564706 0.380392 / 1);
+        --scalar-color-red: color(display-p3 0.937255 0 0.023529 / 1);
+        --scalar-color-yellow: color(display-p3 0.929412 0.745098 0.12549 / 1);
+        --scalar-color-blue: color(display-p3 0 0.509804 0.815686 / 1);
+        --scalar-color-orange: color(display-p3 0.984314 0.537255 0.172549 / 1);
+        --scalar-color-purple: color(display-p3 0.321569 0.011765 0.819608 / 1);
+    }
+    .dark-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0 0.713725 0.282353 / 1);
+        --scalar-color-red: color(display-p3 0.862745 0.105882 0.098039 / 1);
+        --scalar-color-yellow: color(display-p3 1 0.788235 0.05098 / 1);
+        --scalar-color-blue: color(display-p3 0.305882 0.701961 0.92549 / 1);
+        --scalar-color-orange: color(display-p3 1 0.552941 0.301961 / 1);
+        --scalar-color-purple: color(display-p3 0.694118 0.568627 0.976471 / 1);
+    }
+}
+.h-animation-ref {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 765px;
+    border: 1px solid rgb(55,55,55);
+    border-radius: 8px;
+    overflow: hidden;
+}
+.h-markdown-item &gt; span:first-of-type {
+    font-size: 13px;
+    font-family: var(--scalar-font-code);
+    font-weight: 500;
+}
+@supports (hanging-punctuation: first) and (font: -apple-system-body) and (-webkit-appearance: none) {
+    .transform-rr {
+        --var: 1;
+        --varcalcx: calc(var(--var) * 1360px);
+        --xcalc: calc((100dvw - var(--varcalcx)) / 2);
+        --varcalcy: calc(var(--var) * 765px);
+        --ycalc: calc((100dvh - var(--varcalcy)) / 2);
+        transform: translate3d(var(--xcalc), var(--ycalc), 0);
+    }
+    * {
+        animation: none !important;
+    }
+    .h-animation-tag-wrap {
+        display: none;
+    }
+    .h-animation-endpoint {
+        border-top: none;
+    }
+    .h-animation-sidebar-endpoint span {
+        font-weight: 500;
+    }
+    .h-animation-popup {
+        display: none;
+    }
+    @media only screen and (max-width: 1360px) {
+        .transform-rr {
+            --var: 0.95;
+        }
+        .rr {
+            transform: scale(var(--var));
+            transform-origin: top left;
+            position: relative;
+            overflow: hidden;
+        }
+    }
+    @media only screen and (max-width: 1292px) {
+        .transform-rr {
+            --var: 0.9;
+        }
+    }
+    @media only screen and (max-width: 1224px) {
+        .transform-rr {
+            --var: 0.85;
+        }
+    }
+    @media only screen and (max-width: 1156px) {
+        .transform-rr {
+            --var: 0.8;
+        }
+    }
+    @media only screen and (max-width: 1088px) {
+        .transform-rr {
+            --var: 0.75;
+        }
+    }
+    @media only screen and (max-width: 1020px) {
+        .transform-rr {
+            --var: 0.7;
+        }
+    }
+    @media only screen and (max-width: 952px) {
+        .transform-rr {
+            --var: 0.65;
+        }
+    }
+    @media only screen and (max-width: 884px) {
+        .transform-rr {
+            --var: 0.6;
+        }
+    }
+    @media only screen and (max-width: 816px) {
+        .transform-rr {
+            --var: 0.55;
+        }
+    }
+    @media only screen and (max-width: 748px) {
+        .transform-rr {
+            --var: 0.5;
+        }
+    }
+    @media only screen and (max-width: 680px) {
+        .transform-rr {
+            --var: 0.45;
+        }
+    }
+    @media only screen and (max-width: 612px) {
+        .transform-rr {
+            --var: 0.4;
+        }
+    }
+    @media only screen and (max-width: 544px) {
+        .transform-rr {
+            --var: 0.35;
+        }
+    }
+    @media only screen and (max-width: 476px) {
+        .transform-rr {
+            --var: 0.3;
+        }
+    }
+    @media only screen and (max-width: 408px) {
+        .transform-rr {
+            --var: 0.25;
+        }
+    }
+    @media only screen and (max-width: 340px) {
+        .transform-rr {
+            --var: 0.2;
+        }
+    }
+    @media only screen and (max-width: 272px) {
+        .transform-rr {
+            --var: 0.15;
+        }
+    }
+}
+.productthing {
+    padding: 12px;
+    border: 1px solid var(--scalar-border-color);
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 14px;
+    margin-top: 12px;
+    width: 100%;
+}
+.productthing b {
+    font-weight: 600;
+}
+.size-6 {
+    width: 24px;
+    height: 24px;
+    margin-bottom: 12px;
+}
+.product {
+    display: flex;
+    gap: 12px;
+    width: 100%;
+}
+.product-list-title {
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-weight: 500;
+    color: var(--scalar-color-1);
+    padding: 10px 8px;
+    border-radius: 3px;
+    margin-top: 40px;
+    margin-bottom: 6px;
+}
+.bg-blue {
+    background-color: color-mix(in srgb, var(--scalar-color-blue) 4%, transparent);
+}
+.bg-green {
+    background-color: color-mix(in srgb, var(--scalar-color-green) 4%, transparent);
+}
+.bg-purple {
+    background-color: color-mix(in srgb, var(--scalar-color-purple) 4%, transparent);
+}
+.product-list-item svg,
+.product-list-title svg {
+    width: 16px;
+    height: 16px;
+}
+.product-list-item {
+    padding: 10px 8px;
+    border-top: 1px solid var(--scalar-border-color);
+    color: var(--scalar-color-1);
+    font-size: 14px;
+    display: flex;
+    gap: 4px;
+}
+.product-list-item:has(+ .product-list-title) {
+    border-bottom: 1px solid var(--scalar-border-color);
+}
+.ml-auto {
+    margin-left: auto;
+}
+.text-c-3 {
+    color: var(--scalar-color-3);
+}
+.h-animation-endpoint-copy {
+    border-left: 1px solid var(--scalar-border-color);
+    margin-left: 36px;
+    padding: 24px;
+    width: 31%;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    font-size: 14px;
+}
+.h-animation-endpoint-copy p {
+    color: var(--scalar-color-3);
+    line-height: 1.45;
+}
+.h-animation-endpoint-copy-product {
+    margin-top: 40px;
+}
+.h-animation-header-2 {
+    font-size: 14px;
+    color: var(--scalar-color-1);
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+.h-animation-endpoint-copy b {
+    color: var(--scalar-color-1);
+    border: 1px solid var(--scalar-border-color);
+    border-radius: 3px;
+    text-align: center;
+    font-weight: 500;
+    margin-top: 12px;
+    display: block;
+    font-size: 14px;
+    padding: 8px;
+}
+</style>
+</foreignObject>
+</svg>

--- a/documentation/assets/scalar-dashboard.svg
+++ b/documentation/assets/scalar-dashboard.svg
@@ -1,0 +1,871 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 1360 765" width="1360" height="765" preserveAspectRatio="xMidYMid meet">
+  <foreignObject width="1360" height="765" class="fo">
+    <div xmlns="http://www.w3.org/1999/xhtml" class="transform-rr">
+      <div class="h-animation-ref light-mode rr">
+        <div class="h-animation-ref-safari size">
+          <div class="dotted-top"></div>
+          <div class="h-animation-ref-safari-left">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="16" viewBox="0 0 20 16" width="20">
+              <path clip-rule="evenodd" d="M19.4 15.4a2 2 0 0 1-1.4.6H2a2 2 0 0 1-1.4-.6A2 2 0 0 1 0 14V2C0 1.4.2 1 .6.6A2 2 0 0 1 2 0h16c.6 0 1 .2 1.4.6.4.4.6.8.6 1.4v12c0 .6-.2 1-.6 1.4ZM2 14h5V2H2v12Zm7 0h9V2H9v12ZM3.3 3c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3Zm0 2c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3ZM3 7.4c0-.1.1-.2.3-.2h2.5c.1 0 .2 0 .2.2v1c0 .2-.1.3-.2.3H3.3a.3.3 0 0 1-.3-.3v-1Z" fill-rule="evenodd"/></svg><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+              <path d="M16 22 6 12 16 2l1.8 1.8L9.5 12l8.3 8.2L16 22Z"/></svg><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+              <path d="m8 22 10-10L8 2 6.2 3.8l8.3 8.2-8.3 8.2L8 22Z"/>
+            </svg>
+          </div>
+          <div class="h-animation-ref-safari-nav">
+            <div class="h-animation-ref-safari-nav-url">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+                <path d="M7 10H15V6C15 5.16667 14.7083 4.45833 14.125 3.875C13.5417 3.29167 12.8333 3 12 3C11.1667 3 10.4583 3.29167 9.875 3.875C9.29167 4.45833 9 5.16667 9 6V10H7V6C7 4.61667 7.4875 3.4375 8.4625 2.4625C9.4375 1.4875 10.6167 1 12 1C13.3833 1 14.5625 1.4875 15.5375 2.4625C16.5125 3.4375 17 4.61667 17 6V10C17.55 10 18.0208 10.1958 18.4125 10.5875C18.8042 10.9792 19 11.45 19 12V20C19 20.55 18.8042 21.0208 18.4125 21.4125C18.0208 21.8042 17.55 22 17 22H7C6.45 22 5.97917 21.8042 5.5875 21.4125C5.19583 21.0208 5 20.55 5 20V12C5 11.45 5.19583 10.9792 5.5875 10.5875C5.97917 10.1958 6.45 10 7 10Z"/>
+              </svg>
+              dashboard.scalar.com
+              <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+                <path d="M12 22a8.7 8.7 0 0 0 6.4-2.6A9.1 9.1 0 0 0 21 13h-2c0 2-.7 3.6-2 5-1.4 1.3-3 2-5 2s-3.6-.7-5-2c-1.3-1.4-2-3-2-5s.7-3.6 2-5c1.4-1.3 3-2 5-2h.2l-1.6 1.5L12 9l4-4-4-4-1.4 1.5L12.2 4H12a8.7 8.7 0 0 0-6.4 2.6A9.1 9.1 0 0 0 3 13a8.7 8.7 0 0 0 2.6 6.4A9.1 9.1 0 0 0 12 22Z"/>
+              </svg>
+            </div>
+          </div>
+          <div class="h-animation-ref-safari-right">
+            
+          </div>
+        </div>
+        <div class="h-animation-doc-header">
+        <svg xmlns="http://www.w3.org/2000/svg" width="129" height="39" viewBox="0 0 129 39" fill="none">
+            <g clip-path="url(#a)">
+              <path fill="currentColor" fill-rule="evenodd" d="M22.2 0c.4 0 .8.3.8.8v8.8l6-6.2c.3-.4.9-.4 1.1 0L34.7 8c.3.3.4.8 0 1v.1l-6 6.2h8.5c.5 0 .8.3.8.8v6.6c0 .5-.3.8-.8.8h-8.6l6.1 6.2c.3.3.4.8 0 1.1l-4.6 4.7c-.2.3-.8.4-1 0l-6-6.2v8.8c0 .5-.4.8-.9.8h-6.4c-.5 0-.8-.3-.8-.8v-4.6c0-1.4.6-2.8 1.5-3.9l8.4-8.5c.9-1 .9-2.5 0-3.4l-8.3-8.5c-1-1-1.6-2.4-1.6-3.8V.8c0-.5.3-.8.8-.8h6.4ZM8.8 3.4H9l14 14.4c1 1 1 2.5 0 3.4L9 35.6c-.2.4-.8.4-1 0L3.2 31c-.3-.3-.4-.7 0-1l6-6.4H.9c-.5 0-.8-.3-.8-.8v-6.6c0-.5.3-.8.8-.8h8.6L3.3 9.2a1 1 0 0 1 0-1.1l4.5-4.7c.3-.3.8-.3 1 0Z" clip-rule="evenodd"/>
+            </g>
+            <path fill="currentColor" d="M61 15.3c0-.9-.4-1.6-1.1-2-.7-.5-1.6-.8-2.7-.8a5 5 0 0 0-2 .4 3 3 0 0 0-1.2 1 2.3 2.3 0 0 0-.2 2.4l.8.8 1.1.5 1.3.4 1.9.4 2.2.8 2 1.1a5 5 0 0 1 1.8 4 5.5 5.5 0 0 1-3.6 5.3c-1.1.5-2.5.7-4.1.7-1.6 0-3-.2-4.2-.7-1.1-.5-2-1.2-2.7-2.2-.6-1-1-2-1-3.4h3.6c0 .7.3 1.3.6 1.8.4.4 1 .8 1.5 1a6 6 0 0 0 2.1.4c.8 0 1.5-.2 2.1-.4.6-.2 1.1-.6 1.5-1 .3-.4.5-1 .5-1.5 0-.6-.2-1-.5-1.3-.3-.4-.7-.7-1.3-1-.5-.2-1.1-.4-1.9-.5l-2.3-.6c-1.7-.5-3-1.1-4-2-1-.9-1.4-2-1.4-3.5 0-1.2.3-2.2 1-3.1.6-1 1.5-1.6 2.6-2.1 1.2-.5 2.4-.8 3.9-.8a9 9 0 0 1 3.7.8c1.1.5 2 1.2 2.6 2 .6 1 1 2 1 3H61Zm12.8 15a6.7 6.7 0 0 1-6.4-3.8 9.1 9.1 0 0 1-1-4c0-1.6.4-3 1-4.2a6.7 6.7 0 0 1 2.5-2.7c1-.7 2.4-1 3.9-1 1.2 0 2.3.2 3.2.7a5.6 5.6 0 0 1 3.3 4.7H77c-.2-.7-.5-1.3-1-1.8s-1.2-.7-2-.7-1.5.2-2 .6c-.6.4-1 1-1.3 1.6-.3.8-.5 1.7-.5 2.7 0 1 .2 2 .5 2.7a4 4 0 0 0 1.3 1.7c.5.4 1.2.6 2 .6.4 0 1-.1 1.3-.3.5-.2.8-.5 1-1 .4-.3.6-.8.7-1.3h3.4c0 1-.4 2-1 2.9-.5.8-1.2 1.4-2.2 1.9-1 .5-2 .7-3.3.7Zm13 0c-1 0-1.8-.2-2.6-.5-.8-.4-1.4-.9-1.8-1.6-.5-.6-.7-1.5-.7-2.5 0-.8.2-1.5.5-2.1.3-.6.7-1 1.3-1.4l1.8-.7a85.1 85.1 0 0 0 5.5-1c.3-.2.5-.4.5-.8 0-.8-.3-1.4-.7-1.8-.5-.4-1-.6-2-.6-.8 0-1.5.2-2 .6-.5.4-.9.8-1 1.4l-3.4-.5a5.4 5.4 0 0 1 3.5-3.8c1-.3 1.9-.4 3-.4.7 0 1.4 0 2.1.2.8.2 1.4.5 2 .9.6.4 1.1.9 1.5 1.6.4.7.5 1.5.5 2.5V30h-3.4v-2h-.1a4.4 4.4 0 0 1-2.4 2 6 6 0 0 1-2.1.3Zm1-2.6c.7 0 1.3-.2 1.8-.5.5-.2 1-.6 1.2-1.1.3-.5.5-1 .5-1.6v-1.8l-.6.3-1 .2a27.5 27.5 0 0 1-1.7.3c-.6 0-1 .2-1.5.3l-1 .7c-.2.3-.3.7-.3 1.2 0 .6.2 1.1.7 1.5.5.3 1 .5 1.8.5Zm13.4-18V30h-3.6V9.7h3.6Zm7.2 20.6c-1 0-1.8-.2-2.6-.5-.7-.4-1.3-.9-1.8-1.6-.4-.6-.7-1.5-.7-2.5 0-.8.2-1.5.5-2.1.3-.6.8-1 1.3-1.4l1.9-.7 2.1-.4a85.8 85.8 0 0 0 3.4-.6c.3-.2.4-.4.4-.8 0-.8-.2-1.4-.7-1.8-.4-.4-1-.6-1.9-.6-.9 0-1.6.2-2 .6-.6.4-1 .8-1.1 1.4l-3.4-.5a5.4 5.4 0 0 1 3.6-3.8c.9-.3 1.8-.4 2.9-.4.7 0 1.5 0 2.2.2.7.2 1.4.5 2 .9.6.4 1 .9 1.4 1.6.4.7.6 1.5.6 2.5V30H113v-2a4.4 4.4 0 0 1-2.5 2 6 6 0 0 1-2 .3Zm1-2.6c.7 0 1.3-.2 1.8-.5.6-.2 1-.6 1.3-1.1.3-.5.4-1 .4-1.6v-1.8l-.6.3-.9.2a27.3 27.3 0 0 1-1.8.3c-.5 0-1 .2-1.4.3-.5.2-.8.4-1 .7-.3.3-.4.7-.4 1.2 0 .6.2 1.1.7 1.5.5.3 1.1.5 1.9.5Zm9.8 2.3V14.8h3.5v2.5h.2a3.8 3.8 0 0 1 3.7-2.7 8.3 8.3 0 0 1 1.3 0V18l-.7-.2h-1c-.6 0-1.2 0-1.7.4a3.1 3.1 0 0 0-1.7 2.8v9h-3.5Z"/>
+            <defs>
+              <clipPath id="a">
+                <path fill="#fff" d="M0 0h38v39H0z"/>
+              </clipPath>
+            </defs>
+          </svg>
+        </div>
+        <div class="h-animation-sidebar">
+          <div class="h-animation-sidebar__animate">
+            <div class="h-animation-sidebar-title">Products</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M219.31,108.68l-80-80a16,16,0,0,0-22.62,0l-80,80A15.87,15.87,0,0,0,32,120v96a8,8,0,0,0,8,8h64a8,8,0,0,0,8-8V160h32v56a8,8,0,0,0,8,8h64a8,8,0,0,0,8-8V120A15.87,15.87,0,0,0,219.31,108.68ZM208,208H160V152a8,8,0,0,0-8-8H104a8,8,0,0,0-8,8v56H48V120l80-80,80,80Z"/></svg>
+              Home
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M208,24H72A32,32,0,0,0,40,56V224a8,8,0,0,0,8,8H192a8,8,0,0,0,0-16H56a16,16,0,0,1,16-16H208a8,8,0,0,0,8-8V32A8,8,0,0,0,208,24Zm-8,160H72a31.82,31.82,0,0,0-16,4.29V56A16,16,0,0,1,72,40H200Z"/></svg>
+              Docs
+              <span class="h-animation-sidebar-number">2</span>
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"/></svg>
+              SDKs
+              <span class="h-animation-sidebar-number">5</span>
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M43.18,128a29.78,29.78,0,0,1,8,10.26c4.8,9.9,4.8,22,4.8,33.74,0,24.31,1,36,24,36a8,8,0,0,1,0,16c-17.48,0-29.32-6.14-35.2-18.26-4.8-9.9-4.8-22-4.8-33.74,0-24.31-1-36-24-36a8,8,0,0,1,0-16c23,0,24-11.69,24-36,0-11.72,0-23.84,4.8-33.74C50.68,38.14,62.52,32,80,32a8,8,0,0,1,0,16C57,48,56,59.69,56,84c0,11.72,0,23.84-4.8,33.74A29.78,29.78,0,0,1,43.18,128ZM240,120c-23,0-24-11.69-24-36,0-11.72,0-23.84-4.8-33.74C205.32,38.14,193.48,32,176,32a8,8,0,0,0,0,16c23,0,24,11.69,24,36,0,11.72,0,23.84,4.8,33.74a29.78,29.78,0,0,0,8,10.26,29.78,29.78,0,0,0-8,10.26c-4.8,9.9-4.8,22-4.8,33.74,0,24.31-1,36-24,36a8,8,0,0,0,0,16c17.48,0,29.32-6.14,35.2-18.26,4.8-9.9,4.8-22,4.8-33.74,0-24.31,1-36,24-36a8,8,0,0,0,0-16Z"/></svg>
+              Registry
+              <span class="h-animation-sidebar-number">1</span>
+            </div>
+            <div class="h-animation-sidebar-title">Access</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M208,80H176V56a48,48,0,0,0-96,0V80H48A16,16,0,0,0,32,96V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V96A16,16,0,0,0,208,80ZM96,56a32,32,0,0,1,64,0V80H96ZM208,208H48V96H208V208Z"/></svg>
+              Access Groups
+              <span class="h-animation-sidebar-number">4</span>
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M128,24h0A104,104,0,1,0,232,128,104.12,104.12,0,0,0,128,24Zm88,104a87.61,87.61,0,0,1-3.33,24H174.16a157.44,157.44,0,0,0,0-48h38.51A87.61,87.61,0,0,1,216,128ZM102,168H154a115.11,115.11,0,0,1-26,45A115.27,115.27,0,0,1,102,168Zm-3.9-16a140.84,140.84,0,0,1,0-48h59.88a140.84,140.84,0,0,1,0,48ZM40,128a87.61,87.61,0,0,1,3.33-24H81.84a157.44,157.44,0,0,0,0,48H43.33A87.61,87.61,0,0,1,40,128ZM154,88H102a115.11,115.11,0,0,1,26-45A115.27,115.27,0,0,1,154,88Zm52.33,0H170.71a135.28,135.28,0,0,0-22.3-45.6A88.29,88.29,0,0,1,206.37,88ZM107.59,42.4A135.28,135.28,0,0,0,85.29,88H49.63A88.29,88.29,0,0,1,107.59,42.4ZM49.63,168H85.29a135.28,135.28,0,0,0,22.3,45.6A88.29,88.29,0,0,1,49.63,168Zm98.78,45.6a135.28,135.28,0,0,0,22.3-45.6h35.66A88.29,88.29,0,0,1,148.41,213.6Z"/></svg>
+              Login Portals
+            </div>
+            <div class="h-animation-sidebar-title">User</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M230.92,212c-15.23-26.33-38.7-45.21-66.09-54.16a72,72,0,1,0-73.66,0C63.78,166.78,40.31,185.66,25.08,212a8,8,0,1,0,13.85,8c18.84-32.56,52.14-52,89.07-52s70.23,19.44,89.07,52a8,8,0,1,0,13.85-8ZM72,96a56,56,0,1,1,56,56A56.06,56.06,0,0,1,72,96Z"/></svg>
+              Profile
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M216.57,39.43A80,80,0,0,0,83.91,120.78L28.69,176A15.86,15.86,0,0,0,24,187.31V216a16,16,0,0,0,16,16H72a8,8,0,0,0,8-8V208H96a8,8,0,0,0,8-8V184h16a8,8,0,0,0,5.66-2.34l9.56-9.57A79.73,79.73,0,0,0,160,176h.1A80,80,0,0,0,216.57,39.43ZM224,98.1c-1.09,34.09-29.75,61.86-63.89,61.9H160a63.7,63.7,0,0,1-23.65-4.51,8,8,0,0,0-8.84,1.68L116.69,168H96a8,8,0,0,0-8,8v16H72a8,8,0,0,0-8,8v16H40V187.31l58.83-58.82a8,8,0,0,0,1.68-8.84A63.72,63.72,0,0,1,96,95.92c0-34.14,27.81-62.8,61.9-63.89A64,64,0,0,1,224,98.1ZM192,76a12,12,0,1,1-12-12A12,12,0,0,1,192,76Z"/></svg>
+              API Keys
+            </div>
+            <div class="h-animation-sidebar-title">Team</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M216,64H56a8,8,0,0,1,0-16H192a8,8,0,0,0,0-16H56A24,24,0,0,0,32,56V184a24,24,0,0,0,24,24H216a16,16,0,0,0,16-16V80A16,16,0,0,0,216,64Zm0,128H56a8,8,0,0,1-8-8V78.63A23.84,23.84,0,0,0,56,80H216Zm-48-60a12,12,0,1,1,12,12A12,12,0,0,1,168,132Z"/></svg>
+              Billing
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M117.25,157.92a60,60,0,1,0-66.5,0A95.83,95.83,0,0,0,3.53,195.63a8,8,0,1,0,13.4,8.74,80,80,0,0,1,134.14,0,8,8,0,0,0,13.4-8.74A95.83,95.83,0,0,0,117.25,157.92ZM40,108a44,44,0,1,1,44,44A44.05,44.05,0,0,1,40,108Zm210.14,98.7a8,8,0,0,1-11.07-2.33A79.83,79.83,0,0,0,172,168a8,8,0,0,1,0-16,44,44,0,1,0-16.34-84.87,8,8,0,1,1-5.94-14.85,60,60,0,0,1,55.53,105.64,95.83,95.83,0,0,1,47.22,37.71A8,8,0,0,1,250.14,206.7Z"/></svg>
+              Members
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Zm88-29.84q.06-2.16,0-4.32l14.92-18.64a8,8,0,0,0,1.48-7.06,107.21,107.21,0,0,0-10.88-26.25,8,8,0,0,0-6-3.93l-23.72-2.64q-1.48-1.56-3-3L186,40.54a8,8,0,0,0-3.94-6,107.71,107.71,0,0,0-26.25-10.87,8,8,0,0,0-7.06,1.49L130.16,40Q128,40,125.84,40L107.2,25.11a8,8,0,0,0-7.06-1.48A107.6,107.6,0,0,0,73.89,34.51a8,8,0,0,0-3.93,6L67.32,64.27q-1.56,1.49-3,3L40.54,70a8,8,0,0,0-6,3.94,107.71,107.71,0,0,0-10.87,26.25,8,8,0,0,0,1.49,7.06L40,125.84Q40,128,40,130.16L25.11,148.8a8,8,0,0,0-1.48,7.06,107.21,107.21,0,0,0,10.88,26.25,8,8,0,0,0,6,3.93l23.72,2.64q1.49,1.56,3,3L70,215.46a8,8,0,0,0,3.94,6,107.71,107.71,0,0,0,26.25,10.87,8,8,0,0,0,7.06-1.49L125.84,216q2.16.06,4.32,0l18.64,14.92a8,8,0,0,0,7.06,1.48,107.21,107.21,0,0,0,26.25-10.88,8,8,0,0,0,3.93-6l2.64-23.72q1.56-1.48,3-3L215.46,186a8,8,0,0,0,6-3.94,107.71,107.71,0,0,0,10.87-26.25,8,8,0,0,0-1.49-7.06Zm-16.1-6.5a73.93,73.93,0,0,1,0,8.68,8,8,0,0,0,1.74,5.48l14.19,17.73a91.57,91.57,0,0,1-6.23,15L187,173.11a8,8,0,0,0-5.1,2.64,74.11,74.11,0,0,1-6.14,6.14,8,8,0,0,0-2.64,5.1l-2.51,22.58a91.32,91.32,0,0,1-15,6.23l-17.74-14.19a8,8,0,0,0-5-1.75h-.48a73.93,73.93,0,0,1-8.68,0,8,8,0,0,0-5.48,1.74L100.45,215.8a91.57,91.57,0,0,1-15-6.23L82.89,187a8,8,0,0,0-2.64-5.1,74.11,74.11,0,0,1-6.14-6.14,8,8,0,0,0-5.1-2.64L46.43,170.6a91.32,91.32,0,0,1-6.23-15l14.19-17.74a8,8,0,0,0,1.74-5.48,73.93,73.93,0,0,1,0-8.68,8,8,0,0,0-1.74-5.48L40.2,100.45a91.57,91.57,0,0,1,6.23-15L69,82.89a8,8,0,0,0,5.1-2.64,74.11,74.11,0,0,1,6.14-6.14A8,8,0,0,0,82.89,69L85.4,46.43a91.32,91.32,0,0,1,15-6.23l17.74,14.19a8,8,0,0,0,5.48,1.74,73.93,73.93,0,0,1,8.68,0,8,8,0,0,0,5.48-1.74L155.55,40.2a91.57,91.57,0,0,1,15,6.23L173.11,69a8,8,0,0,0,2.64,5.1,74.11,74.11,0,0,1,6.14,6.14,8,8,0,0,0,5.1,2.64l22.58,2.51a91.32,91.32,0,0,1,6.23,15l-14.19,17.74A8,8,0,0,0,199.87,123.66Z"/></svg>
+              Settings
+            </div>
+          </div>
+        </div>
+        <div class="h-animation-content">
+          <div class="h-animation-tag">
+            
+            <div class="h-animation-endpoint">
+              <div class="h-animation-endpoint-markdown">
+                <div class="h-animation-header">Overview</div>
+                <div class="product">
+                <div class="productthing">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="h-green size-6"><g><path d="M43.18,128a29.78,29.78,0,0,1,8,10.26c4.8,9.9,4.8,22,4.8,33.74,0,24.31,1,36,24,36a8,8,0,0,1,0,16c-17.48,0-29.32-6.14-35.2-18.26-4.8-9.9-4.8-22-4.8-33.74,0-24.31-1-36-24-36a8,8,0,0,1,0-16c23,0,24-11.69,24-36,0-11.72,0-23.84,4.8-33.74C50.68,38.14,62.52,32,80,32a8,8,0,0,1,0,16C57,48,56,59.69,56,84c0,11.72,0,23.84-4.8,33.74A29.78,29.78,0,0,1,43.18,128ZM240,120c-23,0-24-11.69-24-36,0-11.72,0-23.84-4.8-33.74C205.32,38.14,193.48,32,176,32a8,8,0,0,0,0,16c23,0,24,11.69,24,36,0,11.72,0,23.84,4.8,33.74a29.78,29.78,0,0,0,8,10.26,29.78,29.78,0,0,0-8,10.26c-4.8,9.9-4.8,22-4.8,33.74,0,24.31-1,36-24,36a8,8,0,0,0,0,16c17.48,0,29.32-6.14,35.2-18.26,4.8-9.9,4.8-22,4.8-33.74,0-24.31,1-36,24-36a8,8,0,0,0,0-16Z"/></g></svg>
+                    <b>Upload API</b>
+                    <p>User Guide / API Reference</p>
+                  </div>
+                  <div class="productthing">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="h-blue size-6"><g><path d="M208,24H72A32,32,0,0,0,40,56V224a8,8,0,0,0,8,8H192a8,8,0,0,0,0-16H56a16,16,0,0,1,16-16H208a8,8,0,0,0,8-8V32A8,8,0,0,0,208,24Zm-8,160H72a31.82,31.82,0,0,0-16,4.29V56A16,16,0,0,1,72,40H200Z"/></g></svg>
+                    <b>Create Documentation</b>
+                    <p>User Guide / API Reference</p>
+                  </div>
+                  <div class="productthing">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="h-purple size-6"><g><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"/></g></svg>
+                    <b>Create SDK</b>
+                    <p>User Guide / API Reference</p>
+                  </div>
+                </div>
+                <div class="product-list-title bg-green"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="h-green"><g><path d="M43.18,128a29.78,29.78,0,0,1,8,10.26c4.8,9.9,4.8,22,4.8,33.74,0,24.31,1,36,24,36a8,8,0,0,1,0,16c-17.48,0-29.32-6.14-35.2-18.26-4.8-9.9-4.8-22-4.8-33.74,0-24.31-1-36-24-36a8,8,0,0,1,0-16c23,0,24-11.69,24-36,0-11.72,0-23.84,4.8-33.74C50.68,38.14,62.52,32,80,32a8,8,0,0,1,0,16C57,48,56,59.69,56,84c0,11.72,0,23.84-4.8,33.74A29.78,29.78,0,0,1,43.18,128ZM240,120c-23,0-24-11.69-24-36,0-11.72,0-23.84-4.8-33.74C205.32,38.14,193.48,32,176,32a8,8,0,0,0,0,16c23,0,24,11.69,24,36,0,11.72,0,23.84,4.8,33.74a29.78,29.78,0,0,0,8,10.26,29.78,29.78,0,0,0-8,10.26c-4.8,9.9-4.8,22-4.8,33.74,0,24.31-1,36-24,36a8,8,0,0,0,0,16c17.48,0,29.32-6.14,35.2-18.26,4.8-9.9,4.8-22,4.8-33.74,0-24.31,1-36,24-36a8,8,0,0,0,0-16Z"/></g></svg> Registry</div>
+                <div class="product-list-item"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation"><g><path d="M43.18,128a29.78,29.78,0,0,1,8,10.26c4.8,9.9,4.8,22,4.8,33.74,0,24.31,1,36,24,36a8,8,0,0,1,0,16c-17.48,0-29.32-6.14-35.2-18.26-4.8-9.9-4.8-22-4.8-33.74,0-24.31-1-36-24-36a8,8,0,0,1,0-16c23,0,24-11.69,24-36,0-11.72,0-23.84,4.8-33.74C50.68,38.14,62.52,32,80,32a8,8,0,0,1,0,16C57,48,56,59.69,56,84c0,11.72,0,23.84-4.8,33.74A29.78,29.78,0,0,1,43.18,128ZM240,120c-23,0-24-11.69-24-36,0-11.72,0-23.84-4.8-33.74C205.32,38.14,193.48,32,176,32a8,8,0,0,0,0,16c23,0,24,11.69,24,36,0,11.72,0,23.84,4.8,33.74a29.78,29.78,0,0,0,8,10.26,29.78,29.78,0,0,0-8,10.26c-4.8,9.9-4.8,22-4.8,33.74,0,24.31-1,36-24,36a8,8,0,0,0,0,16c17.48,0,29.32-6.14,35.2-18.26,4.8-9.9,4.8-22,4.8-33.74,0-24.31,1-36,24-36a8,8,0,0,0,0-16Z"/></g></svg>@scalar/scalar-galaxy</div>
+                <div class="product-list-title bg-blue"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="h-blue"><g><path d="M208,24H72A32,32,0,0,0,40,56V224a8,8,0,0,0,8,8H192a8,8,0,0,0,0-16H56a16,16,0,0,1,16-16H208a8,8,0,0,0,8-8V32A8,8,0,0,0,208,24Zm-8,160H72a31.82,31.82,0,0,0-16,4.29V56A16,16,0,0,1,72,40H200Z"/></g></svg> Documentation</div>
+                <div class="product-list-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" viewBox="0 0 256 256"><path d="M208.31,75.68A59.78,59.78,0,0,0,202.93,28,8,8,0,0,0,196,24a59.75,59.75,0,0,0-48,24H124A59.75,59.75,0,0,0,76,24a8,8,0,0,0-6.93,4,59.78,59.78,0,0,0-5.38,47.68A58.14,58.14,0,0,0,56,104v8a56.06,56.06,0,0,0,48.44,55.47A39.8,39.8,0,0,0,96,192v8H72a24,24,0,0,1-24-24A40,40,0,0,0,8,136a8,8,0,0,0,0,16,24,24,0,0,1,24,24,40,40,0,0,0,40,40H96v16a8,8,0,0,0,16,0V192a24,24,0,0,1,48,0v40a8,8,0,0,0,16,0V192a39.8,39.8,0,0,0-8.44-24.53A56.06,56.06,0,0,0,216,112v-8A58.14,58.14,0,0,0,208.31,75.68ZM200,112a40,40,0,0,1-40,40H112a40,40,0,0,1-40-40v-8a41.74,41.74,0,0,1,6.9-22.48A8,8,0,0,0,80,73.83a43.81,43.81,0,0,1,.79-33.58,43.88,43.88,0,0,1,32.32,20.06A8,8,0,0,0,119.82,64h32.35a8,8,0,0,0,6.74-3.69,43.87,43.87,0,0,1,32.32-20.06A43.81,43.81,0,0,1,192,73.83a8.09,8.09,0,0,0,1,7.65A41.72,41.72,0,0,1,200,104Z"/></svg>
+                Scalar/docs <span class="ml-auto text-c-3">Published</span></div>
+                <div class="product-list-item">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" viewBox="0 0 256 256"><path d="M208.31,75.68A59.78,59.78,0,0,0,202.93,28,8,8,0,0,0,196,24a59.75,59.75,0,0,0-48,24H124A59.75,59.75,0,0,0,76,24a8,8,0,0,0-6.93,4,59.78,59.78,0,0,0-5.38,47.68A58.14,58.14,0,0,0,56,104v8a56.06,56.06,0,0,0,48.44,55.47A39.8,39.8,0,0,0,96,192v8H72a24,24,0,0,1-24-24A40,40,0,0,0,8,136a8,8,0,0,0,0,16,24,24,0,0,1,24,24,40,40,0,0,0,40,40H96v16a8,8,0,0,0,16,0V192a24,24,0,0,1,48,0v40a8,8,0,0,0,16,0V192a39.8,39.8,0,0,0-8.44-24.53A56.06,56.06,0,0,0,216,112v-8A58.14,58.14,0,0,0,208.31,75.68ZM200,112a40,40,0,0,1-40,40H112a40,40,0,0,1-40-40v-8a41.74,41.74,0,0,1,6.9-22.48A8,8,0,0,0,80,73.83a43.81,43.81,0,0,1,.79-33.58,43.88,43.88,0,0,1,32.32,20.06A8,8,0,0,0,119.82,64h32.35a8,8,0,0,0,6.74-3.69,43.87,43.87,0,0,1,32.32-20.06A43.81,43.81,0,0,1,192,73.83a8.09,8.09,0,0,0,1,7.65A41.72,41.72,0,0,1,200,104Z"/></svg>
+                Scalar/internal-apis <span class="ml-auto text-c-3">Private</span></div>
+                <div class="product-list-title bg-purple"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation" class="h-purple"><g><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"/></g></svg> SDKs</div>
+                <div class="product-list-item"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation"><g><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"/></g></svg>Typescript - Scalar Galaxy</div>
+                <div class="product-list-item"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation"><g><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"/></g></svg>Python - Scalar Galaxy</div>
+                <div class="product-list-item"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation"><g><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"/></g></svg>C# - Scalar Galaxy</div>
+                <div class="product-list-item"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="1em" height="1em" aria-hidden="true" role="presentation"><g><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"/></g></svg>Go - Scalar Galaxy</div>
+            </div>
+          </div>
+          <div class="h-animation-endpoint-copy">
+            <div class="h-animation-header">Guides</div>
+            <p>Reading this guide helps you to get started with Scalar Docs, literally in minutes. </p>
+            <div class="h-animation-endpoint-copy-product">
+              <div class="h-animation-header-2">SDK's</div>
+              <p>This guide will help you get started with generating world-class SDKs on scalar.com in several languages: TypeScript, Python, Golang and more powered by Speakeasy.</p>
+              <b>Learn More</b>
+            </div>
+            <div class="h-animation-endpoint-copy-product">
+              <div class="h-animation-header-2">Registry</div>
+              <p>This guide will help you get started with generating world-class SDKs on scalar.com in several languages: TypeScript, Python, Golang and more powered by Speakeasy.</p>
+              <b>Learn More</b>
+            </div>
+        </div>
+        </div>  
+      </div>
+      </div>
+    </div>
+    <style>
+      * {
+        padding: 0;
+        box-sizing: border-box;
+        margin: 0;
+        -webkit-font-smoothing: antialiased
+      }
+      :root {
+        
+    --app-header-height: 48px;
+    --scalar-border-width: 1px;
+    --scalar-radius: 3px;
+    --scalar-radius-lg: 6px;
+    --scalar-radius-xl: 8px;
+    --scalar-header-height: 50px;
+    --scalar-sidebar-width: 280px;
+    --scalar-toc-width: 280px;
+    --scalar-card-icon-width: 40px;
+    --scalar-card-icon-height: 40px;
+    --scalar-card-icon-diameter: 20px;
+    --scalar-card-padding: 16px;
+    --scalar-card-inter-element-gap: 4px;
+    --scalar-row-gap: 16px;
+    --system-fonts: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    --scalar-font: "Inter", var(--system-fonts);
+    --scalar-font-code: Monaco, Menlo, monospace;
+    --scalar-heading-1: 24px;
+    --scalar-page-description: 16px;
+    --scalar-heading-2: 20px;
+    --scalar-heading-3: 20px;
+    --scalar-heading-4: 16px;
+    --scalar-heading-5: 16px;
+    --scalar-heading-6: 16px;
+    --scalar-paragraph: 16px;
+    --scalar-small: 14px;
+    --scalar-mini: 13px;
+    --scalar-micro: 12px;
+    --scalar-extra-bold: 700;
+    --scalar-bold: 600;
+    --scalar-semibold: 500;
+    --scalar-regular: 400;
+    --scalar-font-size-1: 24px;
+    --scalar-font-size-2: 16px;
+    --scalar-font-size-3: 14px;
+    --scalar-font-size-4: 13px;
+    --scalar-font-size-5: 12px;
+    --scalar-line-height-1: 32px;
+    --scalar-line-height-2: 24px;
+    --scalar-line-height-3: 20px;
+    --scalar-line-height-4: 18px;
+    --scalar-line-height-5: 16px;
+    --scalar-heading-spacing: 44px;
+    --scalar-block-spacing: 12px;
+      }
+      .light-mode {
+        --scalar-sidebar-width: 280px;
+        --scalar-color-1: #000;
+        --scalar-color-2: #666666;
+        --scalar-color-3: #8e8e8e;
+        --scalar-color-disabled: #b4b1b1;
+        --scalar-color-ghost: #a7a7a7;
+        --scalar-color-accent: #0099ff;
+        --scalar-background-1: #fff;
+        --scalar-background-2: #f6f6f6;
+        --scalar-background-3: #e7e7e7;
+        --scalar-background-4: rgba(0, 0, 0, 0.06);
+        --scalar-background-accent: #8ab4f81f;
+        --scalar-border-color: rgba(0, 0, 0, 0.05);
+        --scalar-scrollbar-color: rgba(0, 0, 0, 0.18);
+        --scalar-scrollbar-color-active: rgba(0, 0, 0, 0.36);
+        --scalar-lifted-brightness: 1;
+        --scalar-backdrop-brightness: 1;
+        --scalar-shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.11);
+        --scalar-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px,
+          rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 1px;
+        --scalar-button-1: rgb(49 53 56);
+        --scalar-button-1-color: #fff;
+        --scalar-button-1-hover: rgb(28 31 33);
+        --scalar-color-green: #00a67d;
+        --scalar-color-red: #ef0006;
+        --scalar-color-yellow: #f9c514;
+        --scalar-color-blue: #579dfb;
+        --scalar-color-orange: #fc8528;
+        --scalar-color-purple: #5203d1;
+        font-family: var(--scalar-font);
+        color: var(--scalar-color-1);
+      }
+      .dark-mode {
+        font-family: var(--scalar-font);
+        color-scheme: dark;
+  --scalar-color-1: rgba(255, 255, 255, 0.9);
+  --scalar-color-2: rgba(255, 255, 255, 0.62);
+  --scalar-color-3: rgba(255, 255, 255, 0.44);
+  --scalar-color-disabled: rgba(255, 255, 255, 0.34);
+  --scalar-color-ghost: rgba(255, 255, 255, 0.26);
+  --scalar-color-accent: #8ab4f8;
+  --scalar-background-1: #0f0f0f;
+  --scalar-background-2: #1a1a1a;
+  --scalar-background-3: #272727;
+  --scalar-background-4: rgba(255, 255, 255, 0.06);
+  --scalar-background-accent: #8ab4f81f;
+
+  --scalar-border-color: rgba(255, 255, 255, 0.1);
+  --scalar-scrollbar-color: rgba(255, 255, 255, 0.24);
+  --scalar-scrollbar-color-active: rgba(255, 255, 255, 0.48);
+  --scalar-lifted-brightness: 1.45;
+  --scalar-backdrop-brightness: 0.5;
+
+  --scalar-shadow-1: 0 1px 3px 0 rgb(0, 0, 0, 0.1);
+  --scalar-shadow-2: rgba(15, 15, 15, 0.2) 0px 3px 6px, rgba(15, 15, 15, 0.4)
+    0px 9px 24px, 0 0 0 1px rgba(255, 255, 255, 0.1);
+
+  --scalar-button-1: #f6f6f6;
+  --scalar-button-1-color: #000;
+  --scalar-button-1-hover: #e7e7e7;
+
+  --scalar-color-green: #00b848;
+  --scalar-color-red: #fe1d2c;
+  --scalar-color-yellow: #fbca25;
+  --scalar-color-blue: #76aedf;
+  --scalar-color-orange: #dd922f;
+  --scalar-color-purple: #b090f8;
+  color: var(--scalar-color-1);
+
+  /* Misc Scalar Branding */
+  --scalar-brand: #8b7256;
+      }
+      .dotted-top {
+    position: absolute;
+    top: 17px;
+    left: 12px;
+    background-color: var(--scalar-background-3);
+    border-radius: 50%;
+    width: 10px;
+    box-shadow: 14px 0 0 var(--scalar-background-3), 29px 0 0 var(--scalar-background-3);
+    height: 9px;
+}
+.h-animation-ref-safari {
+    height: 40px;
+    background-color: var(--scalar-background-2);
+    z-index: 1;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+}
+.h-animation-ref-safari-left {
+    width: 150px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding-left: 68px;
+    color: var(--scalar-color-3);
+}
+.h-animation-ref-safari-nav {
+    width: 600px;
+    padding: 6px 0;
+}
+.h-animation-ref-safari-right {
+    width: 150px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+    color: var(--scalar-color-3);
+    padding-right: 12px;
+}
+.h-animation-ref-safari-right svg {
+    width: 17px;
+    height: 17px;
+}
+.h-animation-ref-safari-left svg {
+    width: 16px;
+    height: 16px;
+}
+.h-animation-ref-safari-left svg:last-of-type {
+    opacity: 0.5;
+}
+.h-animation-ref-safari-nav-url {
+    width: 100%;
+    border-radius: 7px;
+    height: 100%;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    position: relative;
+    border: 1px solid var(--scalar-border-color);
+}
+.h-animation-ref-safari-nav-url svg {
+    width: 13px;
+    height: 13px;
+    color: var(--scalar-color-3);
+    margin-right: 3px;
+}
+.h-animation-ref-safari-nav-url svg:last-of-type {
+    position: absolute;
+    right: 4px;
+}
+.h-animation-ref {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+    background: var(--scalar-background-1);
+    min-width: 1280px;
+    min-height: 720px;
+}
+.h-animation-ref {
+    display: flex;
+    padding-top: 90px;
+}
+.h-animation-sidebar {
+    padding: 12px;
+    max-width: var(--scalar-sidebar-width);
+    border-right: 1px solid var(--scalar-border-color);
+    flex: 1;
+}
+.h-animation-sidebar-endpoint {
+    position: relative;
+}
+.h-animation-sidebar-number {
+    margin-left: auto;
+    font-family: var(--scalar-font-code);
+    font-weight: 700;
+    font-size: 10px;
+    margin-top: 10px;
+    line-height: 0;
+}
+.h-animation-sidebar-endpoint,
+.h-animation-sidebar-folder,
+.h-animation-sidebar-item {
+    font-size: 14px;
+    min-height: 32px;
+    display: flex;
+    padding: 8px 9px;
+    color: var(--scalar-color-2);
+    border-radius: var(--scalar-radius);
+}
+.h-animation-sidebar-folder svg {
+    margin-right: 6px;
+}
+.h-animation-sidebar-folder {
+    padding-left: 6px;
+}
+.h-animation-sidebar-endpoint {
+    padding-left: 12px;
+}
+.h-animation-sidebar-endpoint {
+    border-radius: 0;
+    margin-left: 12px;
+    border-left: 1px solid var(--scalar-border-color);
+}
+.h-animation-sidebar-title {
+    color: var(--scalar-color-3);
+    padding: 8px;
+    font-size: 14px;
+    font-weight: 600;
+}
+.h-animation-sidebar-title:not(:first-of-type) {
+    margin-top: 18px;
+}
+.h-animation-sidebar-folder:nth-of-type(2) {
+    color: var(--scalar-color-1);
+    font-weight: 500;
+    background-color: var(--scalar-background-2);
+}
+.h-animation-sidebar-folder:nth-of-type(2) svg {
+    fill: var(--scalar-color-1);
+}
+.h-animation-content {
+    flex: 1;
+}
+@keyframes scrollupdown {
+    0%,
+    10%,
+    100%,
+    80% {
+        transform: translate3d(0, 0, 0);
+    }
+    18%,
+    72% {
+        transform: translate3d(0, -380px, 0);
+    }
+}
+.h-animation-tag {
+    border-bottom: 1px solid var(--scalar-border-color);
+    width: 100%;
+    display: flex;
+    gap: 48px;
+}
+.h-animation-tag {
+    border-bottom: none;
+    flex-flow: wrap;
+    gap: 0;
+    padding: 0 0 0 36px;
+}
+.h-animation-header {
+    font-size: var(--font-size, var(--scalar-heading-2));
+    font-weight: var(--font-weight, var(--scalar-bold));
+    color: var(--scalar-color-1);
+    word-wrap: break-word;
+    line-height: 1.45;
+}
+.h-animation-endpoint-markdown,
+.h-animation-tag-markdown {
+    width: 100%;
+}
+.h-markdown {
+    margin-top: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    line-height: 1.5;
+    color: var(--scalar-color-1);
+}
+.h-green {
+    color: var(--scalar-color-green);
+}
+.h-purple {
+    color: var(--scalar-color-purple);
+}
+.h-blue {
+    color: var(--scalar-color-blue);
+}
+.h-animation-endpoint {
+    width: 65%;
+    display: flex;
+    padding: 24px 0;
+}
+.h-animation-14 {
+    width: 12px;
+    height: 12px;
+    stroke-width: 2;
+}
+.h-markdown-item {
+    position: relative;
+    border-top: 1px solid var(--scalar-border-color);
+    padding: 10px 0;
+    display: flex;
+    flex-flow: wrap;
+    gap: 9px;
+    font-family: var(--scalar-font);
+    font-size: 12px;
+}
+.h-markdown-item div {
+    width: 100%;
+    font-family: var(--scalar-font);
+}
+@supports (color: color(display-p3 1 1 1)) {
+    .light-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0.023529 0.564706 0.380392 / 1);
+        --scalar-color-red: color(display-p3 0.937255 0 0.023529 / 1);
+        --scalar-color-yellow: color(display-p3 0.929412 0.745098 0.12549 / 1);
+        --scalar-color-blue: color(display-p3 0 0.509804 0.815686 / 1);
+        --scalar-color-orange: color(display-p3 0.984314 0.537255 0.172549 / 1);
+        --scalar-color-purple: color(display-p3 0.321569 0.011765 0.819608 / 1);
+    }
+    .dark-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0 0.713725 0.282353 / 1);
+        --scalar-color-red: color(display-p3 0.862745 0.105882 0.098039 / 1);
+        --scalar-color-yellow: color(display-p3 1 0.788235 0.05098 / 1);
+        --scalar-color-blue: color(display-p3 0.305882 0.701961 0.92549 / 1);
+        --scalar-color-orange: color(display-p3 1 0.552941 0.301961 / 1);
+        --scalar-color-purple: color(display-p3 0.694118 0.568627 0.976471 / 1);
+    }
+}
+.h-markdown-item .h-animation-14 {
+    position: absolute;
+    left: -18px;
+    margin-top: 2px;
+    transform: rotate(-90deg);
+    color: var(--scalar-color-3);
+}
+.h-animation-doc-header {
+    font-weight: 800;
+    width: 100%;
+    position: absolute;
+    top: 40px;
+    left: 0;
+    height: 50px;
+    padding: 12px;
+    display: flex;
+    align-items: center;
+    font-size: 16px;
+    border-bottom: 1px solid var(--scalar-border-color);
+    background-color: var(--scalar-background-1);
+    z-index: 1;
+    gap: 4px;
+}
+.h-animation-doc-header svg {
+    width: auto;
+    height: 22px;
+}
+@keyframes fadein {
+    0%,
+    100%,
+    40%,
+    70% {
+        opacity: 0;
+    }
+    45%,
+    68.5% {
+        opacity: 1;
+    }
+}
+@keyframes popupcontent {
+    0%,
+    100%,
+    43%,
+    68% {
+        opacity: 0;
+        transform: scale(0.99) translate3d(0, 10px, 0);
+    }
+    47%,
+    66% {
+        opacity: 1;
+        transform: scale(1) translate3d(0, 0, 0);
+    }
+}
+.size-3 {
+    width: 12px;
+    height: 12px;
+}
+.h-animation-14 {
+    width: 16px;
+    height: 16px;
+}
+.w-15 {
+    width: 60px;
+}
+.p-11 {
+    padding: 11px;
+}
+.p-9 {
+    padding: 9px;
+}
+svg {
+    vertical-align: middle;
+    display: block;
+}
+.p-3 {
+    padding: 0 12px 12px 12px;
+}
+.h-10 {
+    height: 40px;
+}
+.w-780 {
+    width: 580px;
+    font-size: 14px;
+    border: 1px solid var(--scalar-border-color);
+}
+.size-35 {
+    width: 14px;
+    height: 14px;
+}
+.p-1 {
+    padding: 4px;
+}
+@supports (color: color(display-p3 1 1 1)) {
+    .light-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0.023529 0.564706 0.380392 / 1);
+        --scalar-color-red: color(display-p3 0.937255 0 0.023529 / 1);
+        --scalar-color-yellow: color(display-p3 0.929412 0.745098 0.12549 / 1);
+        --scalar-color-blue: color(display-p3 0 0.509804 0.815686 / 1);
+        --scalar-color-orange: color(display-p3 0.984314 0.537255 0.172549 / 1);
+        --scalar-color-purple: color(display-p3 0.321569 0.011765 0.819608 / 1);
+    }
+    .dark-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0 0.713725 0.282353 / 1);
+        --scalar-color-red: color(display-p3 0.862745 0.105882 0.098039 / 1);
+        --scalar-color-yellow: color(display-p3 1 0.788235 0.05098 / 1);
+        --scalar-color-blue: color(display-p3 0.305882 0.701961 0.92549 / 1);
+        --scalar-color-orange: color(display-p3 1 0.552941 0.301961 / 1);
+        --scalar-color-purple: color(display-p3 0.694118 0.568627 0.976471 / 1);
+    }
+}
+.h-animation-ref {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 765px;
+    border: 1px solid #dbdbdb;
+    border-radius: 8px;
+    overflow: hidden;
+}
+.h-markdown-item &gt; span:first-of-type {
+    font-size: 13px;
+    font-family: var(--scalar-font-code);
+    font-weight: 500;
+}
+@supports (hanging-punctuation: first) and (font: -apple-system-body) and (-webkit-appearance: none) {
+    .transform-rr {
+        --var: 1;
+        --varcalcx: calc(var(--var) * 1360px);
+        --xcalc: calc((100dvw - var(--varcalcx)) / 2);
+        --varcalcy: calc(var(--var) * 765px);
+        --ycalc: calc((100dvh - var(--varcalcy)) / 2);
+        transform: translate3d(var(--xcalc), var(--ycalc), 0);
+    }
+    * {
+        animation: none !important;
+    }
+    .h-animation-tag-wrap {
+        display: none;
+    }
+    .h-animation-endpoint {
+        border-top: none;
+    }
+    .h-animation-sidebar-endpoint span {
+        font-weight: 500;
+    }
+    .h-animation-popup {
+        display: none;
+    }
+    @media only screen and (max-width: 1360px) {
+        .transform-rr {
+            --var: 0.95;
+        }
+        .rr {
+            transform: scale(var(--var));
+            transform-origin: top left;
+            position: relative;
+            overflow: hidden;
+        }
+    }
+    @media only screen and (max-width: 1292px) {
+        .transform-rr {
+            --var: 0.9;
+        }
+    }
+    @media only screen and (max-width: 1224px) {
+        .transform-rr {
+            --var: 0.85;
+        }
+    }
+    @media only screen and (max-width: 1156px) {
+        .transform-rr {
+            --var: 0.8;
+        }
+    }
+    @media only screen and (max-width: 1088px) {
+        .transform-rr {
+            --var: 0.75;
+        }
+    }
+    @media only screen and (max-width: 1020px) {
+        .transform-rr {
+            --var: 0.7;
+        }
+    }
+    @media only screen and (max-width: 952px) {
+        .transform-rr {
+            --var: 0.65;
+        }
+    }
+    @media only screen and (max-width: 884px) {
+        .transform-rr {
+            --var: 0.6;
+        }
+    }
+    @media only screen and (max-width: 816px) {
+        .transform-rr {
+            --var: 0.55;
+        }
+    }
+    @media only screen and (max-width: 748px) {
+        .transform-rr {
+            --var: 0.5;
+        }
+    }
+    @media only screen and (max-width: 680px) {
+        .transform-rr {
+            --var: 0.45;
+        }
+    }
+    @media only screen and (max-width: 612px) {
+        .transform-rr {
+            --var: 0.4;
+        }
+    }
+    @media only screen and (max-width: 544px) {
+        .transform-rr {
+            --var: 0.35;
+        }
+    }
+    @media only screen and (max-width: 476px) {
+        .transform-rr {
+            --var: 0.3;
+        }
+    }
+    @media only screen and (max-width: 408px) {
+        .transform-rr {
+            --var: 0.25;
+        }
+    }
+    @media only screen and (max-width: 340px) {
+        .transform-rr {
+            --var: 0.2;
+        }
+    }
+    @media only screen and (max-width: 272px) {
+        .transform-rr {
+            --var: 0.15;
+        }
+    }
+}
+.productthing {
+    padding: 12px;
+    border: 1px solid var(--scalar-border-color);
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 14px;
+    margin-top: 12px;
+    width: 100%;
+}
+.productthing b {
+    font-weight: 600;
+}
+.size-6 {
+    width: 24px;
+    height: 24px;
+    margin-bottom: 12px;
+}
+.product {
+    display: flex;
+    gap: 12px;
+    width: 100%;
+}
+.product-list-title {
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-weight: 500;
+    color: var(--scalar-color-1);
+    padding: 10px 8px;
+    border-radius: 3px;
+    margin-top: 40px;
+    margin-bottom: 6px;
+}
+.bg-blue {
+    background-color: color-mix(in srgb, var(--scalar-color-blue) 4%, transparent);
+}
+.bg-green {
+    background-color: color-mix(in srgb, var(--scalar-color-green) 4%, transparent);
+}
+.bg-purple {
+    background-color: color-mix(in srgb, var(--scalar-color-purple) 4%, transparent);
+}
+.product-list-item svg,
+.product-list-title svg {
+    width: 16px;
+    height: 16px;
+}
+.product-list-item {
+    padding: 10px 8px;
+    border-top: 1px solid var(--scalar-border-color);
+    color: var(--scalar-color-1);
+    font-size: 14px;
+    display: flex;
+    gap: 4px;
+}
+.product-list-item:has(+ .product-list-title) {
+    border-bottom: 1px solid var(--scalar-border-color);
+}
+.ml-auto {
+    margin-left: auto;
+}
+.text-c-3 {
+    color: var(--scalar-color-3);
+}
+.h-animation-endpoint-copy {
+    border-left: 1px solid var(--scalar-border-color);
+    margin-left: 36px;
+    padding: 24px;
+    width: 31%;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    font-size: 14px;
+}
+.h-animation-endpoint-copy p {
+    color: var(--scalar-color-3);
+    line-height: 1.45;
+}
+.h-animation-endpoint-copy-product {
+    margin-top: 40px;
+}
+.h-animation-header-2 {
+    font-size: 14px;
+    color: var(--scalar-color-1);
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+.h-animation-endpoint-copy b {
+    color: var(--scalar-color-1);
+    border: 1px solid var(--scalar-border-color);
+    border-radius: 3px;
+    text-align: center;
+    font-weight: 500;
+    margin-top: 12px;
+    display: block;
+    font-size: 14px;
+    padding: 8px;
+}
+</style>
+</foreignObject>
+</svg>

--- a/documentation/assets/sdk-dashboard-static-dark.svg
+++ b/documentation/assets/sdk-dashboard-static-dark.svg
@@ -1,0 +1,1103 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 1360 765" width="1360" height="765" preserveAspectRatio="xMidYMid meet">
+  <foreignObject width="1360" height="765" class="fo">
+    <div xmlns="http://www.w3.org/1999/xhtml" class="transform-rr">
+      <div class="h-animation-ref dark-mode rr">
+        <div class="h-animation-ref-safari size">
+          <div class="dotted-top"></div>
+          <div class="h-animation-ref-safari-left">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="16" viewBox="0 0 20 16" width="20">
+              <path clip-rule="evenodd" d="M19.4 15.4a2 2 0 0 1-1.4.6H2a2 2 0 0 1-1.4-.6A2 2 0 0 1 0 14V2C0 1.4.2 1 .6.6A2 2 0 0 1 2 0h16c.6 0 1 .2 1.4.6.4.4.6.8.6 1.4v12c0 .6-.2 1-.6 1.4ZM2 14h5V2H2v12Zm7 0h9V2H9v12ZM3.3 3c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3Zm0 2c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3ZM3 7.4c0-.1.1-.2.3-.2h2.5c.1 0 .2 0 .2.2v1c0 .2-.1.3-.2.3H3.3a.3.3 0 0 1-.3-.3v-1Z" fill-rule="evenodd"/></svg><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+              <path d="M16 22 6 12 16 2l1.8 1.8L9.5 12l8.3 8.2L16 22Z"/></svg><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+              <path d="m8 22 10-10L8 2 6.2 3.8l8.3 8.2-8.3 8.2L8 22Z"/>
+            </svg>
+          </div>
+          <div class="h-animation-ref-safari-nav">
+            <div class="h-animation-ref-safari-nav-url">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+                <path d="M7 10H15V6C15 5.16667 14.7083 4.45833 14.125 3.875C13.5417 3.29167 12.8333 3 12 3C11.1667 3 10.4583 3.29167 9.875 3.875C9.29167 4.45833 9 5.16667 9 6V10H7V6C7 4.61667 7.4875 3.4375 8.4625 2.4625C9.4375 1.4875 10.6167 1 12 1C13.3833 1 14.5625 1.4875 15.5375 2.4625C16.5125 3.4375 17 4.61667 17 6V10C17.55 10 18.0208 10.1958 18.4125 10.5875C18.8042 10.9792 19 11.45 19 12V20C19 20.55 18.8042 21.0208 18.4125 21.4125C18.0208 21.8042 17.55 22 17 22H7C6.45 22 5.97917 21.8042 5.5875 21.4125C5.19583 21.0208 5 20.55 5 20V12C5 11.45 5.19583 10.9792 5.5875 10.5875C5.97917 10.1958 6.45 10 7 10Z"/>
+              </svg>
+              dashboard.scalar.com/registry/Cpf7C2tXIN2wDrnflCa-o
+              <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+                <path d="M12 22a8.7 8.7 0 0 0 6.4-2.6A9.1 9.1 0 0 0 21 13h-2c0 2-.7 3.6-2 5-1.4 1.3-3 2-5 2s-3.6-.7-5-2c-1.3-1.4-2-3-2-5s.7-3.6 2-5c1.4-1.3 3-2 5-2h.2l-1.6 1.5L12 9l4-4-4-4-1.4 1.5L12.2 4H12a8.7 8.7 0 0 0-6.4 2.6A9.1 9.1 0 0 0 3 13a8.7 8.7 0 0 0 2.6 6.4A9.1 9.1 0 0 0 12 22Z"/>
+              </svg>
+            </div>
+          </div>
+          <div class="h-animation-ref-safari-right">
+            
+          </div>
+        </div>
+        <div class="h-animation-doc-header">
+        <svg xmlns="http://www.w3.org/2000/svg" width="129" height="39" viewBox="0 0 129 39" fill="none">
+            <g clip-path="url(#a)">
+              <path fill="currentColor" fill-rule="evenodd" d="M22.2 0c.4 0 .8.3.8.8v8.8l6-6.2c.3-.4.9-.4 1.1 0L34.7 8c.3.3.4.8 0 1v.1l-6 6.2h8.5c.5 0 .8.3.8.8v6.6c0 .5-.3.8-.8.8h-8.6l6.1 6.2c.3.3.4.8 0 1.1l-4.6 4.7c-.2.3-.8.4-1 0l-6-6.2v8.8c0 .5-.4.8-.9.8h-6.4c-.5 0-.8-.3-.8-.8v-4.6c0-1.4.6-2.8 1.5-3.9l8.4-8.5c.9-1 .9-2.5 0-3.4l-8.3-8.5c-1-1-1.6-2.4-1.6-3.8V.8c0-.5.3-.8.8-.8h6.4ZM8.8 3.4H9l14 14.4c1 1 1 2.5 0 3.4L9 35.6c-.2.4-.8.4-1 0L3.2 31c-.3-.3-.4-.7 0-1l6-6.4H.9c-.5 0-.8-.3-.8-.8v-6.6c0-.5.3-.8.8-.8h8.6L3.3 9.2a1 1 0 0 1 0-1.1l4.5-4.7c.3-.3.8-.3 1 0Z" clip-rule="evenodd"></path>
+            </g>
+            <path fill="currentColor" d="M61 15.3c0-.9-.4-1.6-1.1-2-.7-.5-1.6-.8-2.7-.8a5 5 0 0 0-2 .4 3 3 0 0 0-1.2 1 2.3 2.3 0 0 0-.2 2.4l.8.8 1.1.5 1.3.4 1.9.4 2.2.8 2 1.1a5 5 0 0 1 1.8 4 5.5 5.5 0 0 1-3.6 5.3c-1.1.5-2.5.7-4.1.7-1.6 0-3-.2-4.2-.7-1.1-.5-2-1.2-2.7-2.2-.6-1-1-2-1-3.4h3.6c0 .7.3 1.3.6 1.8.4.4 1 .8 1.5 1a6 6 0 0 0 2.1.4c.8 0 1.5-.2 2.1-.4.6-.2 1.1-.6 1.5-1 .3-.4.5-1 .5-1.5 0-.6-.2-1-.5-1.3-.3-.4-.7-.7-1.3-1-.5-.2-1.1-.4-1.9-.5l-2.3-.6c-1.7-.5-3-1.1-4-2-1-.9-1.4-2-1.4-3.5 0-1.2.3-2.2 1-3.1.6-1 1.5-1.6 2.6-2.1 1.2-.5 2.4-.8 3.9-.8a9 9 0 0 1 3.7.8c1.1.5 2 1.2 2.6 2 .6 1 1 2 1 3H61Zm12.8 15a6.7 6.7 0 0 1-6.4-3.8 9.1 9.1 0 0 1-1-4c0-1.6.4-3 1-4.2a6.7 6.7 0 0 1 2.5-2.7c1-.7 2.4-1 3.9-1 1.2 0 2.3.2 3.2.7a5.6 5.6 0 0 1 3.3 4.7H77c-.2-.7-.5-1.3-1-1.8s-1.2-.7-2-.7-1.5.2-2 .6c-.6.4-1 1-1.3 1.6-.3.8-.5 1.7-.5 2.7 0 1 .2 2 .5 2.7a4 4 0 0 0 1.3 1.7c.5.4 1.2.6 2 .6.4 0 1-.1 1.3-.3.5-.2.8-.5 1-1 .4-.3.6-.8.7-1.3h3.4c0 1-.4 2-1 2.9-.5.8-1.2 1.4-2.2 1.9-1 .5-2 .7-3.3.7Zm13 0c-1 0-1.8-.2-2.6-.5-.8-.4-1.4-.9-1.8-1.6-.5-.6-.7-1.5-.7-2.5 0-.8.2-1.5.5-2.1.3-.6.7-1 1.3-1.4l1.8-.7a85.1 85.1 0 0 0 5.5-1c.3-.2.5-.4.5-.8 0-.8-.3-1.4-.7-1.8-.5-.4-1-.6-2-.6-.8 0-1.5.2-2 .6-.5.4-.9.8-1 1.4l-3.4-.5a5.4 5.4 0 0 1 3.5-3.8c1-.3 1.9-.4 3-.4.7 0 1.4 0 2.1.2.8.2 1.4.5 2 .9.6.4 1.1.9 1.5 1.6.4.7.5 1.5.5 2.5V30h-3.4v-2h-.1a4.4 4.4 0 0 1-2.4 2 6 6 0 0 1-2.1.3Zm1-2.6c.7 0 1.3-.2 1.8-.5.5-.2 1-.6 1.2-1.1.3-.5.5-1 .5-1.6v-1.8l-.6.3-1 .2a27.5 27.5 0 0 1-1.7.3c-.6 0-1 .2-1.5.3l-1 .7c-.2.3-.3.7-.3 1.2 0 .6.2 1.1.7 1.5.5.3 1 .5 1.8.5Zm13.4-18V30h-3.6V9.7h3.6Zm7.2 20.6c-1 0-1.8-.2-2.6-.5-.7-.4-1.3-.9-1.8-1.6-.4-.6-.7-1.5-.7-2.5 0-.8.2-1.5.5-2.1.3-.6.8-1 1.3-1.4l1.9-.7 2.1-.4a85.8 85.8 0 0 0 3.4-.6c.3-.2.4-.4.4-.8 0-.8-.2-1.4-.7-1.8-.4-.4-1-.6-1.9-.6-.9 0-1.6.2-2 .6-.6.4-1 .8-1.1 1.4l-3.4-.5a5.4 5.4 0 0 1 3.6-3.8c.9-.3 1.8-.4 2.9-.4.7 0 1.5 0 2.2.2.7.2 1.4.5 2 .9.6.4 1 .9 1.4 1.6.4.7.6 1.5.6 2.5V30H113v-2a4.4 4.4 0 0 1-2.5 2 6 6 0 0 1-2 .3Zm1-2.6c.7 0 1.3-.2 1.8-.5.6-.2 1-.6 1.3-1.1.3-.5.4-1 .4-1.6v-1.8l-.6.3-.9.2a27.3 27.3 0 0 1-1.8.3c-.5 0-1 .2-1.4.3-.5.2-.8.4-1 .7-.3.3-.4.7-.4 1.2 0 .6.2 1.1.7 1.5.5.3 1.1.5 1.9.5Zm9.8 2.3V14.8h3.5v2.5h.2a3.8 3.8 0 0 1 3.7-2.7 8.3 8.3 0 0 1 1.3 0V18l-.7-.2h-1c-.6 0-1.2 0-1.7.4a3.1 3.1 0 0 0-1.7 2.8v9h-3.5Z"></path>
+            <defs>
+              <clipPath id="a">
+                <path fill="#fff" d="M0 0h38v39H0z"></path>
+              </clipPath>
+            </defs>
+          </svg>
+        </div>
+        <div class="h-animation-sidebar">
+          <div class="h-animation-sidebar__animate">
+            <div class="h-animation-sidebar-title">Products</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M219.31,108.68l-80-80a16,16,0,0,0-22.62,0l-80,80A15.87,15.87,0,0,0,32,120v96a8,8,0,0,0,8,8h64a8,8,0,0,0,8-8V160h32v56a8,8,0,0,0,8,8h64a8,8,0,0,0,8-8V120A15.87,15.87,0,0,0,219.31,108.68ZM208,208H160V152a8,8,0,0,0-8-8H104a8,8,0,0,0-8,8v56H48V120l80-80,80,80Z"></path></svg>
+              Home
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M43.18,128a29.78,29.78,0,0,1,8,10.26c4.8,9.9,4.8,22,4.8,33.74,0,24.31,1,36,24,36a8,8,0,0,1,0,16c-17.48,0-29.32-6.14-35.2-18.26-4.8-9.9-4.8-22-4.8-33.74,0-24.31-1-36-24-36a8,8,0,0,1,0-16c23,0,24-11.69,24-36,0-11.72,0-23.84,4.8-33.74C50.68,38.14,62.52,32,80,32a8,8,0,0,1,0,16C57,48,56,59.69,56,84c0,11.72,0,23.84-4.8,33.74A29.78,29.78,0,0,1,43.18,128ZM240,120c-23,0-24-11.69-24-36,0-11.72,0-23.84-4.8-33.74C205.32,38.14,193.48,32,176,32a8,8,0,0,0,0,16c23,0,24,11.69,24,36,0,11.72,0,23.84,4.8,33.74a29.78,29.78,0,0,0,8,10.26,29.78,29.78,0,0,0-8,10.26c-4.8,9.9-4.8,22-4.8,33.74,0,24.31-1,36-24,36a8,8,0,0,0,0,16c17.48,0,29.32-6.14,35.2-18.26,4.8-9.9,4.8-22,4.8-33.74,0-24.31,1-36,24-36a8,8,0,0,0,0-16Z"></path></svg>
+              Registry
+              <span class="h-animation-sidebar-number">1</span>
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M208,24H72A32,32,0,0,0,40,56V224a8,8,0,0,0,8,8H192a8,8,0,0,0,0-16H56a16,16,0,0,1,16-16H208a8,8,0,0,0,8-8V32A8,8,0,0,0,208,24Zm-8,160H72a31.82,31.82,0,0,0-16,4.29V56A16,16,0,0,1,72,40H200Z"></path></svg>
+              Docs
+              <span class="h-animation-sidebar-number">2</span>
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"></path></svg>
+              SDKs
+              <span class="h-animation-sidebar-number">5</span>
+            </div>
+            <div class="h-animation-sidebar-title">Access</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M208,80H176V56a48,48,0,0,0-96,0V80H48A16,16,0,0,0,32,96V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V96A16,16,0,0,0,208,80ZM96,56a32,32,0,0,1,64,0V80H96ZM208,208H48V96H208V208Z"></path></svg>
+              Access Groups
+              <span class="h-animation-sidebar-number">4</span>
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M128,24h0A104,104,0,1,0,232,128,104.12,104.12,0,0,0,128,24Zm88,104a87.61,87.61,0,0,1-3.33,24H174.16a157.44,157.44,0,0,0,0-48h38.51A87.61,87.61,0,0,1,216,128ZM102,168H154a115.11,115.11,0,0,1-26,45A115.27,115.27,0,0,1,102,168Zm-3.9-16a140.84,140.84,0,0,1,0-48h59.88a140.84,140.84,0,0,1,0,48ZM40,128a87.61,87.61,0,0,1,3.33-24H81.84a157.44,157.44,0,0,0,0,48H43.33A87.61,87.61,0,0,1,40,128ZM154,88H102a115.11,115.11,0,0,1,26-45A115.27,115.27,0,0,1,154,88Zm52.33,0H170.71a135.28,135.28,0,0,0-22.3-45.6A88.29,88.29,0,0,1,206.37,88ZM107.59,42.4A135.28,135.28,0,0,0,85.29,88H49.63A88.29,88.29,0,0,1,107.59,42.4ZM49.63,168H85.29a135.28,135.28,0,0,0,22.3,45.6A88.29,88.29,0,0,1,49.63,168Zm98.78,45.6a135.28,135.28,0,0,0,22.3-45.6h35.66A88.29,88.29,0,0,1,148.41,213.6Z"></path></svg>
+              Login Portals
+            </div>
+            <div class="h-animation-sidebar-title">User</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M230.92,212c-15.23-26.33-38.7-45.21-66.09-54.16a72,72,0,1,0-73.66,0C63.78,166.78,40.31,185.66,25.08,212a8,8,0,1,0,13.85,8c18.84-32.56,52.14-52,89.07-52s70.23,19.44,89.07,52a8,8,0,1,0,13.85-8ZM72,96a56,56,0,1,1,56,56A56.06,56.06,0,0,1,72,96Z"></path></svg>
+              Profile
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M216.57,39.43A80,80,0,0,0,83.91,120.78L28.69,176A15.86,15.86,0,0,0,24,187.31V216a16,16,0,0,0,16,16H72a8,8,0,0,0,8-8V208H96a8,8,0,0,0,8-8V184h16a8,8,0,0,0,5.66-2.34l9.56-9.57A79.73,79.73,0,0,0,160,176h.1A80,80,0,0,0,216.57,39.43ZM224,98.1c-1.09,34.09-29.75,61.86-63.89,61.9H160a63.7,63.7,0,0,1-23.65-4.51,8,8,0,0,0-8.84,1.68L116.69,168H96a8,8,0,0,0-8,8v16H72a8,8,0,0,0-8,8v16H40V187.31l58.83-58.82a8,8,0,0,0,1.68-8.84A63.72,63.72,0,0,1,96,95.92c0-34.14,27.81-62.8,61.9-63.89A64,64,0,0,1,224,98.1ZM192,76a12,12,0,1,1-12-12A12,12,0,0,1,192,76Z"></path></svg>
+              API Keys
+            </div>
+            <div class="h-animation-sidebar-title">Team</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M216,64H56a8,8,0,0,1,0-16H192a8,8,0,0,0,0-16H56A24,24,0,0,0,32,56V184a24,24,0,0,0,24,24H216a16,16,0,0,0,16-16V80A16,16,0,0,0,216,64Zm0,128H56a8,8,0,0,1-8-8V78.63A23.84,23.84,0,0,0,56,80H216Zm-48-60a12,12,0,1,1,12,12A12,12,0,0,1,168,132Z"></path></svg>
+              Billing
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M117.25,157.92a60,60,0,1,0-66.5,0A95.83,95.83,0,0,0,3.53,195.63a8,8,0,1,0,13.4,8.74,80,80,0,0,1,134.14,0,8,8,0,0,0,13.4-8.74A95.83,95.83,0,0,0,117.25,157.92ZM40,108a44,44,0,1,1,44,44A44.05,44.05,0,0,1,40,108Zm210.14,98.7a8,8,0,0,1-11.07-2.33A79.83,79.83,0,0,0,172,168a8,8,0,0,1,0-16,44,44,0,1,0-16.34-84.87,8,8,0,1,1-5.94-14.85,60,60,0,0,1,55.53,105.64,95.83,95.83,0,0,1,47.22,37.71A8,8,0,0,1,250.14,206.7Z"></path></svg>
+              Members
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Zm88-29.84q.06-2.16,0-4.32l14.92-18.64a8,8,0,0,0,1.48-7.06,107.21,107.21,0,0,0-10.88-26.25,8,8,0,0,0-6-3.93l-23.72-2.64q-1.48-1.56-3-3L186,40.54a8,8,0,0,0-3.94-6,107.71,107.71,0,0,0-26.25-10.87,8,8,0,0,0-7.06,1.49L130.16,40Q128,40,125.84,40L107.2,25.11a8,8,0,0,0-7.06-1.48A107.6,107.6,0,0,0,73.89,34.51a8,8,0,0,0-3.93,6L67.32,64.27q-1.56,1.49-3,3L40.54,70a8,8,0,0,0-6,3.94,107.71,107.71,0,0,0-10.87,26.25,8,8,0,0,0,1.49,7.06L40,125.84Q40,128,40,130.16L25.11,148.8a8,8,0,0,0-1.48,7.06,107.21,107.21,0,0,0,10.88,26.25,8,8,0,0,0,6,3.93l23.72,2.64q1.49,1.56,3,3L70,215.46a8,8,0,0,0,3.94,6,107.71,107.71,0,0,0,26.25,10.87,8,8,0,0,0,7.06-1.49L125.84,216q2.16.06,4.32,0l18.64,14.92a8,8,0,0,0,7.06,1.48,107.21,107.21,0,0,0,26.25-10.88,8,8,0,0,0,3.93-6l2.64-23.72q1.56-1.48,3-3L215.46,186a8,8,0,0,0,6-3.94,107.71,107.71,0,0,0,10.87-26.25,8,8,0,0,0-1.49-7.06Zm-16.1-6.5a73.93,73.93,0,0,1,0,8.68,8,8,0,0,0,1.74,5.48l14.19,17.73a91.57,91.57,0,0,1-6.23,15L187,173.11a8,8,0,0,0-5.1,2.64,74.11,74.11,0,0,1-6.14,6.14,8,8,0,0,0-2.64,5.1l-2.51,22.58a91.32,91.32,0,0,1-15,6.23l-17.74-14.19a8,8,0,0,0-5-1.75h-.48a73.93,73.93,0,0,1-8.68,0,8,8,0,0,0-5.48,1.74L100.45,215.8a91.57,91.57,0,0,1-15-6.23L82.89,187a8,8,0,0,0-2.64-5.1,74.11,74.11,0,0,1-6.14-6.14,8,8,0,0,0-5.1-2.64L46.43,170.6a91.32,91.32,0,0,1-6.23-15l14.19-17.74a8,8,0,0,0,1.74-5.48,73.93,73.93,0,0,1,0-8.68,8,8,0,0,0-1.74-5.48L40.2,100.45a91.57,91.57,0,0,1,6.23-15L69,82.89a8,8,0,0,0,5.1-2.64,74.11,74.11,0,0,1,6.14-6.14A8,8,0,0,0,82.89,69L85.4,46.43a91.32,91.32,0,0,1,15-6.23l17.74,14.19a8,8,0,0,0,5.48,1.74,73.93,73.93,0,0,1,8.68,0,8,8,0,0,0,5.48-1.74L155.55,40.2a91.57,91.57,0,0,1,15,6.23L173.11,69a8,8,0,0,0,2.64,5.1,74.11,74.11,0,0,1,6.14,6.14,8,8,0,0,0,5.1,2.64l22.58,2.51a91.32,91.32,0,0,1,6.23,15l-14.19,17.74A8,8,0,0,0,199.87,123.66Z"></path></svg>
+              Settings
+            </div>
+          </div>
+        </div>
+        <div class="h-animation-content">
+          <div class="h-animation-tag">
+            
+            <div class="h-animation-endpoint">
+              <div class="h-animation-endpoint-markdown">
+                <div class="h-animation-header">
+                <span><svg xmlns="http://www.w3.org/2000/svg" fill="none" height="512" viewBox="0 0 512 512" width="512"><rect fill="#3178c6" height="512" rx="50" width="512"/><rect fill="#3178c6" height="512" rx="50" width="512"/><path clip-rule="evenodd" d="m316.939 407.424v50.061c8.138 4.172 17.763 7.3 28.875 9.386s22.823 3.129 35.135 3.129c11.999 0 23.397-1.147 34.196-3.442 10.799-2.294 20.268-6.075 28.406-11.342 8.138-5.266 14.581-12.15 19.328-20.65s7.121-19.007 7.121-31.522c0-9.074-1.356-17.026-4.069-23.857s-6.625-12.906-11.738-18.225c-5.112-5.319-11.242-10.091-18.389-14.315s-15.207-8.213-24.18-11.967c-6.573-2.712-12.468-5.345-17.685-7.9-5.217-2.556-9.651-5.163-13.303-7.822-3.652-2.66-6.469-5.476-8.451-8.448-1.982-2.973-2.974-6.336-2.974-10.091 0-3.441.887-6.544 2.661-9.308s4.278-5.136 7.512-7.118c3.235-1.981 7.199-3.52 11.894-4.615 4.696-1.095 9.912-1.642 15.651-1.642 4.173 0 8.581.313 13.224.938 4.643.626 9.312 1.591 14.008 2.894 4.695 1.304 9.259 2.947 13.694 4.928 4.434 1.982 8.529 4.276 12.285 6.884v-46.776c-7.616-2.92-15.937-5.084-24.962-6.492s-19.381-2.112-31.066-2.112c-11.895 0-23.163 1.278-33.805 3.833s-20.006 6.544-28.093 11.967c-8.086 5.424-14.476 12.333-19.171 20.729-4.695 8.395-7.043 18.433-7.043 30.114 0 14.914 4.304 27.638 12.912 38.172 8.607 10.533 21.675 19.45 39.204 26.751 6.886 2.816 13.303 5.579 19.25 8.291s11.086 5.528 15.415 8.448c4.33 2.92 7.747 6.101 10.252 9.543 2.504 3.441 3.756 7.352 3.756 11.733 0 3.233-.783 6.231-2.348 8.995s-3.939 5.162-7.121 7.196-7.147 3.624-11.894 4.771c-4.748 1.148-10.303 1.721-16.668 1.721-10.851 0-21.597-1.903-32.24-5.71-10.642-3.806-20.502-9.516-29.579-17.13zm-84.159-123.342h64.22v-41.082h-179v41.082h63.906v182.918h50.874z" fill="#fff" fill-rule="evenodd"/></svg>Scalar Galaxy Typescript</span>
+                <div class="h-animation-header-buttons">
+                  <b>Download</b>
+                  <b>Link Github</b>
+                  <b>Build</b>
+                </div>
+                </div>
+                <div class="tabs">
+                  <div class="tab-item">
+                    Overview
+                  </div>
+                  <div class="tab-item">
+                    Metadata
+                  </div>
+                  <div class="tab-item">
+                    Configuration
+                  </div>
+                </div>
+                <div class="tab-stuff-1">
+                  <div class="tab-label">Name</div>
+                  <div class="tab-input">https://registry.scalar.com/@scalar/apis/<b>scalar-galaxy</b>@0.3.2<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" viewBox="0 0 256 256"><path d="M216,28H88A12,12,0,0,0,76,40V76H40A12,12,0,0,0,28,88V216a12,12,0,0,0,12,12H168a12,12,0,0,0,12-12V180h36a12,12,0,0,0,12-12V40A12,12,0,0,0,216,28ZM156,204H52V100H156Zm48-48H180V88a12,12,0,0,0-12-12H100V52H204Z"></path></svg></div>
+                  <div class="tab-label">Description</div>
+                  <div class="tab-input">
+                  The Scalar Galaxy is an example OpenAPI specification to test OpenAPI tools and libraries. It's a fictional universe with fictional planets and fictional data. Get all the data for [all planets](#tag/planets/GET/planets).
+                  <br />
+                  <br />
+                  ## Resources
+                  <br /><br />
+                  * https://github.com/scalar/scalar
+                  <br />
+                  * https://github.com/OAI/OpenAPI-Specification
+                  <br />
+                  * https://scalar.com
+                  </div>
+                  <div class="tab-label">Namespace</div>
+                  <div class="tab-input"><b>@scalar</b><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" viewBox="0 0 256 256"><path d="M216.49,104.49l-80,80a12,12,0,0,1-17,0l-80-80a12,12,0,0,1,17-17L128,159l71.51-71.52a12,12,0,0,1,17,17Z"></path></svg></div>
+                  <div class="tab-label">Active Version</div>
+                  <div class="tab-input"><b>@0.3.2</b><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" viewBox="0 0 256 256"><path d="M216.49,104.49l-80,80a12,12,0,0,1-17,0l-80-80a12,12,0,0,1,17-17L128,159l71.51-71.52a12,12,0,0,1,17,17Z"></path></svg></div>
+                </div>
+            </div>
+          </div>
+          <div class="h-animation-endpoint-copy">
+            <div class="h-animation-header">
+            <span>Versions</span>
+            </div>
+            <div class="version-list">
+              <div class="version-list-item"><b>v0.3.2</b> Active <span class="ml-auto">Pending</span></div>
+              <div class="version-list-item"><b>v0.3.1</b></div>
+              <div class="version-list-item"><b>v0.3.0</b></div>
+            </div>
+            <div class="h-animation-header">
+            <span>Build History</span>
+            </div>
+            <div class="version-list">
+              <div class="version-list-item"><b>Building</b> v0.3.2</div>
+            </div>
+          </div>
+        </div>  
+      </div>
+      </div>
+    </div>
+    <style>
+      * {
+        padding: 0;
+        box-sizing: border-box;
+        margin: 0;
+        -webkit-font-smoothing: antialiased
+      }
+      :root {
+        
+    --app-header-height: 48px;
+    --scalar-border-width: 1px;
+    --scalar-radius: 3px;
+    --scalar-radius-lg: 6px;
+    --scalar-radius-xl: 8px;
+    --scalar-header-height: 50px;
+    --scalar-sidebar-width: 280px;
+    --scalar-toc-width: 280px;
+    --scalar-card-icon-width: 40px;
+    --scalar-card-icon-height: 40px;
+    --scalar-card-icon-diameter: 20px;
+    --scalar-card-padding: 16px;
+    --scalar-card-inter-element-gap: 4px;
+    --scalar-row-gap: 16px;
+    --system-fonts: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    --scalar-font: "Inter", var(--system-fonts);
+    --scalar-font-code: Monaco, Menlo, monospace;
+    --scalar-heading-1: 24px;
+    --scalar-page-description: 16px;
+    --scalar-heading-2: 20px;
+    --scalar-heading-3: 20px;
+    --scalar-heading-4: 16px;
+    --scalar-heading-5: 16px;
+    --scalar-heading-6: 16px;
+    --scalar-paragraph: 16px;
+    --scalar-small: 14px;
+    --scalar-mini: 13px;
+    --scalar-micro: 12px;
+    --scalar-extra-bold: 700;
+    --scalar-bold: 600;
+    --scalar-semibold: 500;
+    --scalar-regular: 400;
+    --scalar-font-size-1: 24px;
+    --scalar-font-size-2: 16px;
+    --scalar-font-size-3: 14px;
+    --scalar-font-size-4: 13px;
+    --scalar-font-size-5: 12px;
+    --scalar-line-height-1: 32px;
+    --scalar-line-height-2: 24px;
+    --scalar-line-height-3: 20px;
+    --scalar-line-height-4: 18px;
+    --scalar-line-height-5: 16px;
+    --scalar-heading-spacing: 44px;
+    --scalar-block-spacing: 12px;
+      }
+      .light-mode {
+        --scalar-sidebar-width: 280px;
+        --scalar-color-1: #000;
+        --scalar-color-2: #666666;
+        --scalar-color-3: #8e8e8e;
+        --scalar-color-disabled: #b4b1b1;
+        --scalar-color-ghost: #a7a7a7;
+        --scalar-color-accent: #0099ff;
+        --scalar-background-1: #fff;
+        --scalar-background-2: #f6f6f6;
+        --scalar-background-3: #e7e7e7;
+        --scalar-background-4: rgba(0, 0, 0, 0.06);
+        --scalar-background-accent: #8ab4f81f;
+        --scalar-border-color: rgba(0, 0, 0, 0.05);
+        --scalar-scrollbar-color: rgba(0, 0, 0, 0.18);
+        --scalar-scrollbar-color-active: rgba(0, 0, 0, 0.36);
+        --scalar-lifted-brightness: 1;
+        --scalar-backdrop-brightness: 1;
+        --scalar-shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.11);
+        --scalar-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px,
+          rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 1px;
+        --scalar-button-1: rgb(49 53 56);
+        --scalar-button-1-color: #fff;
+        --scalar-button-1-hover: rgb(28 31 33);
+        --scalar-color-green: #00a67d;
+        --scalar-color-red: #ef0006;
+        --scalar-color-yellow: #f9c514;
+        --scalar-color-blue: #579dfb;
+        --scalar-color-orange: #fc8528;
+        --scalar-color-purple: #5203d1;
+        font-family: var(--scalar-font);
+        color: var(--scalar-color-1);
+      }
+      .dark-mode {
+        font-family: var(--scalar-font);
+        color-scheme: dark;
+  --scalar-color-1: rgba(255, 255, 255, 0.9);
+  --scalar-color-2: rgba(255, 255, 255, 0.62);
+  --scalar-color-3: rgba(255, 255, 255, 0.44);
+  --scalar-color-disabled: rgba(255, 255, 255, 0.34);
+  --scalar-color-ghost: rgba(255, 255, 255, 0.26);
+  --scalar-color-accent: #8ab4f8;
+  --scalar-background-1: #0f0f0f;
+  --scalar-background-2: #1a1a1a;
+  --scalar-background-3: #272727;
+  --scalar-background-4: rgba(255, 255, 255, 0.06);
+  --scalar-background-accent: #8ab4f81f;
+
+  --scalar-border-color: rgba(255, 255, 255, 0.1);
+  --scalar-scrollbar-color: rgba(255, 255, 255, 0.24);
+  --scalar-scrollbar-color-active: rgba(255, 255, 255, 0.48);
+  --scalar-lifted-brightness: 1.45;
+  --scalar-backdrop-brightness: 0.5;
+
+  --scalar-shadow-1: 0 1px 3px 0 rgb(0, 0, 0, 0.1);
+  --scalar-shadow-2: rgba(15, 15, 15, 0.2) 0px 3px 6px, rgba(15, 15, 15, 0.4)
+    0px 9px 24px, 0 0 0 1px rgba(255, 255, 255, 0.1);
+
+  --scalar-button-1: #f6f6f6;
+  --scalar-button-1-color: #000;
+  --scalar-button-1-hover: #e7e7e7;
+
+  --scalar-color-green: #00b848;
+  --scalar-color-red: #fe1d2c;
+  --scalar-color-yellow: #fbca25;
+  --scalar-color-blue: #76aedf;
+  --scalar-color-orange: #dd922f;
+  --scalar-color-purple: #b090f8;
+  color: var(--scalar-color-1);
+
+  /* Misc Scalar Branding */
+  --scalar-brand: #8b7256;
+      }
+      .dotted-top {
+    position: absolute;
+    top: 17px;
+    left: 12px;
+    background-color: var(--scalar-background-3);
+    border-radius: 50%;
+    width: 10px;
+    box-shadow: 14px 0 0 var(--scalar-background-3), 29px 0 0 var(--scalar-background-3);
+    height: 9px;
+}
+.h-animation-ref-safari {
+    height: 40px;
+    background-color: var(--scalar-background-2);
+    z-index: 1;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+}
+.h-animation-ref-safari-left {
+    width: 150px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding-left: 68px;
+    color: var(--scalar-color-3);
+}
+.h-animation-ref-safari-nav {
+    width: 600px;
+    padding: 6px 0;
+}
+.h-animation-ref-safari-right {
+    width: 150px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+    color: var(--scalar-color-3);
+    padding-right: 12px;
+}
+.h-animation-ref-safari-right svg {
+    width: 17px;
+    height: 17px;
+}
+.h-animation-ref-safari-left svg {
+    width: 16px;
+    height: 16px;
+}
+.h-animation-ref-safari-left svg:last-of-type {
+    opacity: 0.5;
+}
+.h-animation-ref-safari-nav-url {
+    width: 100%;
+    border-radius: 7px;
+    height: 100%;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    position: relative;
+    border: 1px solid var(--scalar-border-color);
+}
+.h-animation-ref-safari-nav-url svg {
+    width: 13px;
+    height: 13px;
+    color: var(--scalar-color-3);
+    margin-right: 3px;
+}
+.h-animation-ref-safari-nav-url svg:last-of-type {
+    position: absolute;
+    right: 4px;
+}
+.h-animation-ref {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+    background: var(--scalar-background-1);
+    min-width: 1280px;
+    min-height: 720px;
+}
+.h-animation-ref {
+    display: flex;
+    padding-top: 90px;
+}
+.h-animation-sidebar {
+    padding: 12px;
+    max-width: var(--scalar-sidebar-width);
+    border-right: 1px solid var(--scalar-border-color);
+    flex: 1;
+}
+.h-animation-sidebar-endpoint {
+    position: relative;
+}
+.h-animation-sidebar-number {
+    margin-left: auto;
+    font-family: var(--scalar-font-code);
+    font-weight: 700;
+    font-size: 10px;
+    margin-top: 10px;
+    line-height: 0;
+}
+.h-animation-sidebar-endpoint,
+.h-animation-sidebar-folder {
+    font-size: 14px;
+    min-height: 32px;
+    display: flex;
+    padding: 8px 9px;
+    color: var(--scalar-color-2);
+    border-radius: var(--scalar-radius);
+}
+.h-animation-sidebar-folder svg {
+    margin-right: 6px;
+}
+.h-animation-sidebar-folder {
+    padding-left: 6px;
+}
+.h-animation-sidebar-endpoint {
+    padding-left: 12px;
+}
+.h-animation-sidebar-endpoint {
+    border-radius: 0;
+    margin-left: 12px;
+    border-left: 1px solid var(--scalar-border-color);
+}
+.h-animation-sidebar-title {
+    color: var(--scalar-color-3);
+    padding: 8px;
+    font-size: 14px;
+    font-weight: 600;
+}
+.h-animation-sidebar-title:not(:first-of-type) {
+    margin-top: 18px;
+}
+.h-animation-sidebar-folder:nth-of-type(5) {
+    color: var(--scalar-color-1);
+    font-weight: 500;
+    background-color: var(--scalar-background-2);
+}
+.h-animation-sidebar-folder:nth-of-type(5) svg {
+    fill: var(--scalar-color-purple);
+}
+.h-animation-content {
+    flex: 1;
+}
+.h-animation-tag {
+    border-bottom: 1px solid var(--scalar-border-color);
+    width: 100%;
+    display: flex;
+    gap: 48px;
+}
+.h-animation-tag {
+    border-bottom: none;
+    flex-flow: wrap;
+    gap: 0;
+    padding: 0 0 0 36px;
+}
+.h-animation-header {
+    font-size: var(--font-size, var(--scalar-heading-2));
+    font-weight: var(--font-weight, var(--scalar-bold));
+    color: var(--scalar-color-1);
+    word-wrap: break-word;
+    line-height: 1.45;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+.h-animation-header span {
+    display: flex;
+    align-items: center; justify-content: center;
+}
+.h-animation-header span svg {
+    width: 18px;
+    height: 18px;
+    margin-right: 6px;
+}
+.h-animation-header:nth-of-type(n + 3) {
+    font-size: 16px;
+    margin-top: 24px
+}
+.h-animation-header-buttons {
+  display: flex;
+}
+.h-animation-header-buttons b {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid var(--scalar-border-color);
+  border-radius: 4px;
+  padding: 4px 8px;
+  margin-left: 12px;
+}
+.h-animation-header-buttons b:nth-of-type(1) {
+    background: var(--scalar-background-2);
+}
+.h-animation-header-buttons b:nth-of-type(3) {
+  background: var(--scalar-color-1);
+  color: var(--scalar-background-1);
+}
+.h-animation-endpoint-markdown,
+.h-animation-tag-markdown {
+    width: 100%;
+}
+.h-markdown {
+    margin-top: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    line-height: 1.5;
+    color: var(--scalar-color-1);
+}
+.h-animation-endpoint {
+    width: 65%;
+    display: flex;
+    padding: 24px 0;
+    min-height: 674px;
+}
+.h-animation-14 {
+    width: 12px;
+    height: 12px;
+    stroke-width: 2;
+}
+@supports (color: color(display-p3 1 1 1)) {
+    .light-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0.023529 0.564706 0.380392 / 1);
+        --scalar-color-red: color(display-p3 0.937255 0 0.023529 / 1);
+        --scalar-color-yellow: color(display-p3 0.929412 0.745098 0.12549 / 1);
+        --scalar-color-blue: color(display-p3 0 0.509804 0.815686 / 1);
+        --scalar-color-orange: color(display-p3 0.984314 0.537255 0.172549 / 1);
+        --scalar-color-purple: color(display-p3 0.321569 0.011765 0.819608 / 1);
+    }
+    .dark-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0 0.713725 0.282353 / 1);
+        --scalar-color-red: color(display-p3 0.862745 0.105882 0.098039 / 1);
+        --scalar-color-yellow: color(display-p3 1 0.788235 0.05098 / 1);
+        --scalar-color-blue: color(display-p3 0.305882 0.701961 0.92549 / 1);
+        --scalar-color-orange: color(display-p3 1 0.552941 0.301961 / 1);
+        --scalar-color-purple: color(display-p3 0.694118 0.568627 0.976471 / 1);
+    }
+}
+.h-animation-doc-header {
+    font-weight: 800;
+    width: 100%;
+    position: absolute;
+    top: 40px;
+    left: 0;
+    height: 50px;
+    padding: 12px;
+    display: flex;
+    align-items: center;
+    font-size: 16px;
+    border-bottom: 1px solid var(--scalar-border-color);
+    background-color: var(--scalar-background-1);
+    z-index: 1;
+    gap: 4px;
+}
+.h-animation-doc-header svg {
+    width: auto;
+    height: 22px;
+}
+.size-3 {
+    width: 12px;
+    height: 12px;
+}
+.h-animation-14 {
+    width: 16px;
+    height: 16px;
+}
+.w-15 {
+    width: 60px;
+}
+.p-11 {
+    padding: 11px;
+}
+.p-9 {
+    padding: 9px;
+}
+svg {
+    vertical-align: middle;
+    display: block;
+}
+.p-3 {
+    padding: 0 12px 12px 12px;
+}
+.h-10 {
+    height: 40px;
+}
+.w-780 {
+    width: 580px;
+    font-size: 14px;
+    border: 1px solid var(--scalar-border-color);
+}
+.size-35 {
+    width: 14px;
+    height: 14px;
+}
+.p-1 {
+    padding: 4px;
+}
+@supports (color: color(display-p3 1 1 1)) {
+    .light-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0.023529 0.564706 0.380392 / 1);
+        --scalar-color-red: color(display-p3 0.937255 0 0.023529 / 1);
+        --scalar-color-yellow: color(display-p3 0.929412 0.745098 0.12549 / 1);
+        --scalar-color-blue: color(display-p3 0 0.509804 0.815686 / 1);
+        --scalar-color-orange: color(display-p3 0.984314 0.537255 0.172549 / 1);
+        --scalar-color-purple: color(display-p3 0.321569 0.011765 0.819608 / 1);
+    }
+    .dark-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0 0.713725 0.282353 / 1);
+        --scalar-color-red: color(display-p3 0.862745 0.105882 0.098039 / 1);
+        --scalar-color-yellow: color(display-p3 1 0.788235 0.05098 / 1);
+        --scalar-color-blue: color(display-p3 0.305882 0.701961 0.92549 / 1);
+        --scalar-color-orange: color(display-p3 1 0.552941 0.301961 / 1);
+        --scalar-color-purple: color(display-p3 0.694118 0.568627 0.976471 / 1);
+    }
+}
+.h-animation-ref {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 765px;
+    border: 1px solid rgb(55,55,55);
+    border-radius: 8px;
+    overflow: hidden;
+}
+@supports (hanging-punctuation: first) and (font: -apple-system-body) and (-webkit-appearance: none) {
+    .transform-rr {
+        --var: 1;
+        --varcalcx: calc(var(--var) * 1360px);
+        --xcalc: calc((100dvw - var(--varcalcx)) / 2);
+        --varcalcy: calc(var(--var) * 765px);
+        --ycalc: calc((100dvh - var(--varcalcy)) / 2);
+        transform: translate3d(var(--xcalc), var(--ycalc), 0);
+    }
+    .tab-stuff-3,
+    .tab-stuff-2 {
+        display: none;
+    }
+    * {
+        animation: none !important;
+    }
+    .tab-item:nth-of-type(1) {
+        font-weight: 500;
+        color: var(--scalar-color-1);
+        border-bottom: 1px solid var(--scalar-color-1);
+    }
+    .h-animation-tag-wrap {
+        display: none;
+    }
+    .h-animation-endpoint {
+        border-top: none;
+    }
+    .h-animation-sidebar-endpoint span {
+        font-weight: 500;
+    }
+    .h-animation-popup {
+        display: none;
+    }
+    @media only screen and (max-width: 1360px) {
+        .transform-rr {
+            --var: 0.95;
+        }
+        .rr {
+            transform: scale(var(--var));
+            transform-origin: top left;
+            position: relative;
+            overflow: hidden;
+        }
+    }
+    @media only screen and (max-width: 1292px) {
+        .transform-rr {
+            --var: 0.9;
+        }
+    }
+    @media only screen and (max-width: 1224px) {
+        .transform-rr {
+            --var: 0.85;
+        }
+    }
+    @media only screen and (max-width: 1156px) {
+        .transform-rr {
+            --var: 0.8;
+        }
+    }
+    @media only screen and (max-width: 1088px) {
+        .transform-rr {
+            --var: 0.75;
+        }
+    }
+    @media only screen and (max-width: 1020px) {
+        .transform-rr {
+            --var: 0.7;
+        }
+    }
+    @media only screen and (max-width: 952px) {
+        .transform-rr {
+            --var: 0.65;
+        }
+    }
+    @media only screen and (max-width: 884px) {
+        .transform-rr {
+            --var: 0.6;
+        }
+    }
+    @media only screen and (max-width: 816px) {
+        .transform-rr {
+            --var: 0.55;
+        }
+    }
+    @media only screen and (max-width: 748px) {
+        .transform-rr {
+            --var: 0.5;
+        }
+    }
+    @media only screen and (max-width: 680px) {
+        .transform-rr {
+            --var: 0.45;
+        }
+    }
+    @media only screen and (max-width: 612px) {
+        .transform-rr {
+            --var: 0.4;
+        }
+    }
+    @media only screen and (max-width: 544px) {
+        .transform-rr {
+            --var: 0.35;
+        }
+    }
+    @media only screen and (max-width: 476px) {
+        .transform-rr {
+            --var: 0.3;
+        }
+    }
+    @media only screen and (max-width: 408px) {
+        .transform-rr {
+            --var: 0.25;
+        }
+    }
+    @media only screen and (max-width: 340px) {
+        .transform-rr {
+            --var: 0.2;
+        }
+    }
+    @media only screen and (max-width: 272px) {
+        .transform-rr {
+            --var: 0.15;
+        }
+    }
+}
+.size-6 {
+    width: 24px;
+    height: 24px;
+    margin-bottom: 12px;
+}
+.product {
+    display: flex;
+    gap: 12px;
+    width: 100%;
+}
+.h-animation-endpoint-copy {
+    border-left: 1px solid var(--scalar-border-color);
+    margin-left: 36px;
+    padding: 24px;
+    width: 31%;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    font-size: 14px;
+    min-height: 674px;
+}
+.h-animation-endpoint-copy p {
+    color: var(--scalar-color-3);
+    line-height: 1.45;
+}
+.h-animation-endpoint-copy-product {
+    margin-top: 40px;
+}
+.h-animation-header-2 {
+    font-size: 14px;
+    color: var(--scalar-color-1);
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+
+.h-animation-endpoint-copy {
+  height: 100%;
+}
+.version-list {
+  border: 1px solid var(--scalar-border-color);
+  border-radius: 4px;
+}
+.version-list-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--scalar-color-3);
+  padding: 8px;
+  border-bottom: 1px solid var(--scalar-border-color);
+}
+.version-list-item:last-child {
+  border-bottom: none;
+}
+.version-list-item b {
+  color: var(--scalar-color-1);
+  font-weight: 500;
+}
+.tabs {
+  border-bottom: 1px solid var(--scalar-border-color);
+  display: flex;
+  gap: 24px;
+  margin-top: 20px;
+}
+.tab-item {
+  color: var(--scalar-color-3);
+  font-size: 14px;
+  padding: 8px 0;
+  border-bottom: 1px solid transparent;
+}
+.tab-item:nth-of-type(1) {
+  font-weight: 500;
+  color: var(--scalar-color-1);
+  border-bottom: 1px solid var(--scalar-color-1);
+}
+
+.tab-label {
+  color: var(--scalar-color-1);
+  font-size: 14px;
+  font-weight: 500;
+  margin-top: 20px;
+  margin-bottom: 8px;
+}
+.tab-input {
+  padding: 8px 10px;
+  background:  color-mix(in srgb, var(--scalar-background-1), var(--scalar-background-2));
+  border: 1px solid var(--scalar-border-color);
+  border-radius: 4px;
+  color: var(--scalar-color-3);
+  font-size: 14px;
+  max-height: 200px;
+  overflow: hidden;
+  line-height: 1.45;
+  display: flex;
+  align-items: center;
+}
+.bigone {
+  max-height: 800px;
+}
+.tab-input b {
+  color: var(--scalar-color-1);
+  font-weight: 500;
+}
+.tab-input svg {
+  width: 14px;
+  height: 14px;
+  margin-left: auto;
+}
+
+      .h-green {
+        color: var(--scalar-color-green);
+      }
+
+      .h-blue {
+        color: var(--scalar-color-blue);
+      }
+
+      .h-orange {
+        color: var(--scalar-color-orange);
+      }
+      .h-purple {
+        color: var(--scalar-color-purple);
+      }
+
+      .h-red {
+        color: var(--scalar-color-red);
+      }
+
+      .h-black {
+        color: var(--scalar-color-1);
+      }
+      .h-animation-endpoint-code-body {
+        font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace;
+        font-size: 13px;
+        line-height: 1.6;
+      }
+      .h-animation-endpoint-code-body span:first-of-type {
+        color: var(--scalar-color-3);
+        margin-right: 4px;
+        width: 18px;
+        display: inline-block;
+      }
+
+      .body-second span:first-of-type {
+        margin-right: 28px;
+      }
+      .body-third span:first-of-type {
+        margin-right: 54px;
+      }
+      .body-fourth span:first-of-type {
+        margin-right: 80px;
+      }
+      .body-fifth span:first-of-type {
+        margin-right: 106px;
+      }
+
+      
+      .h-grey {
+        color: var(--scalar-color-3);
+      }
+      .dark-mode .h-grey {
+        color: var(--scalar-color-2);
+      }
+      .h-animation-code {
+        background: var(--scalar-background-2);
+        border: 1px solid var(--scalar-border-color);
+        border-radius: var(--scalar-radius-lg);
+        font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace;
+      }
+
+      /* Replace the Tailwind classes with these regular CSS classes */
+
+      .flex {
+        display: flex;
+      }
+
+      .flex-col {
+        flex-direction: column;
+      }
+
+      .divide-y > * + * {
+        border-top: 1px solid var(--scalar-border-color);
+      }
+
+      .overflow-hidden {
+        overflow: hidden;
+      }
+
+      .rounded-lg {
+        border-radius: 8px;
+      }
+
+      .border {
+        border: 1px solid var(--scalar-border-color);
+      }
+
+      .text-c-2 {
+        color: var(--scalar-color-2);
+      }
+
+      .items-center {
+        align-items: center;
+      }
+
+      .gap-3 {
+        gap: 12px;
+      }
+
+      .hover\:cursor-pointer:hover {
+        cursor: pointer;
+      }
+
+      .size-4 {
+        width: 16px;
+        height: 16px;
+      }
+
+      .justify-center {
+        justify-content: center;
+      }
+
+      .p-0\.75 {
+        padding: 3px;
+      }
+
+      .text-transparent {
+        color: transparent;
+      }
+
+      .shadow-border {
+        box-shadow: 0 0 0 1px var(--scalar-border-color);
+      }
+
+      .rounded-full {
+        border-radius: 9999px;
+      }
+
+      .bg-b-2 {
+        background-color: var(--scalar-background-2);
+      }
+
+      .gap-1\.5 {
+        gap: 6px;
+      }
+
+      .text-c-1 {
+        color: var(--scalar-color-1);
+      }
+
+      .font-medium {
+        font-weight: 500;
+      }
+
+      .w-10 {
+        width: 40px;
+      }
+
+      .bg-b-1\.5 {
+        background-color: color-mix(in srgb, var(--scalar-background-1), var(--scalar-background-2));
+      }
+
+      .bg-c-accent {
+        background-color: var(--scalar-color-accent);
+      }
+
+      .text-b-1 {
+        color: var(--scalar-background-1);
+      }
+
+      .size-3 {
+        width: 12px;
+        height: 12px;
+      }
+      .registy-privacy {
+        font-size: 14px;
+        padding: 10px;
+      }
+      .tab-item-active {
+        padding: 8px 0;
+        font-size: 14px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .tab-item-active svg {
+        color: var(--scalar-color-green);
+      }
+      .tab-item-active + .tab-item-active {
+        border-top: 1px solid var(--scalar-border-color);
+      }
+
+      .scalar-verify-badge {
+    position: relative;
+    width: 36px;
+    height: 36px;
+}
+
+.scalar-verify-badge-inner {
+    position: absolute;
+    width: 36px;
+    height: 36px;
+}
+
+
+.scalar-verify-badge-inner-layer {
+    position: absolute;
+    width: 36px;
+    height: 36px;
+    clip-path: path("M36 18c0 1.7-1.2 3-2.3 4-.5.7-1.2 1.3-1.4 2-.2.4-.3 1.3-.3 2.2 0 1.5 0 3.3-1.3 4.5-1.3 1.3-3 1.3-4.5 1.3-.9 0-1.8 0-2.3.3-.6.2-1.2.8-1.8 1.5-1.1 1-2.4 2.2-4.1 2.2-1.7 0-3-1.2-4-2.3-.7-.5-1.3-1.2-2-1.4-.4-.2-1.3-.3-2.2-.3-1.5 0-3.3 0-4.5-1.3C4 29.4 4 27.7 4 26.2c0-.9 0-1.8-.3-2.3-.2-.6-.8-1.2-1.5-1.8C1.3 21 0 19.7 0 18c0-1.7 1.2-3 2.3-4 .5-.7 1.2-1.3 1.4-2 .2-.4.3-1.3.3-2.2 0-1.5 0-3.3 1.3-4.5C6.6 4 8.3 4 9.8 4c.9 0 1.8 0 2.3-.3.6-.2 1.2-.8 1.8-1.5C15 1.3 16.3 0 18 0c1.7 0 3 1.2 4 2.3.7.5 1.3 1.2 2 1.4.4.2 1.3.3 2.2.3 1.5 0 3.3 0 4.5 1.3C32 6.6 32 8.3 32 9.8c0 .9 0 1.8.3 2.3.2.6.8 1.2 1.5 1.8 1 1.1 2.2 2.4 2.2 4.1Z")
+}
+ .check {
+  display: flex;
+  align-items: center;
+  justify-content: center;  
+  z-index: 1;
+}
+.check svg {
+  width: 24px;
+  height: 24px;
+  margin: auto;
+  color: white;
+}
+
+.lines {
+    background: var(--scalar-color-blue)
+}
+.verify {
+  background: linear-gradient(color-mix(in srgb,var(--scalar-color-blue),transparent 90%),color-mix(in srgb,var(--scalar-color-blue),transparent 100%));
+  padding: 24px;
+  height: 200px;
+  border-radius: 3px;
+  gap: 12px;
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  text-align: center;
+  font-size: 14px;
+  box-shadow: 0 0 0 1px var(--scalar-border-color);
+}
+.verify p {
+  color: var(--scalar-color-2);
+}
+.verify a {
+  color: var(--scalar-color-blue);
+  font-weight: 500;
+}
+.ml-auto {
+    margin-left: auto;
+}
+</style>
+</foreignObject>
+</svg>

--- a/documentation/assets/sdk-dashboard-static.svg
+++ b/documentation/assets/sdk-dashboard-static.svg
@@ -1,0 +1,1103 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 1360 765" width="1360" height="765" preserveAspectRatio="xMidYMid meet">
+  <foreignObject width="1360" height="765" class="fo">
+    <div xmlns="http://www.w3.org/1999/xhtml" class="transform-rr">
+      <div class="h-animation-ref light-mode rr">
+        <div class="h-animation-ref-safari size">
+          <div class="dotted-top"></div>
+          <div class="h-animation-ref-safari-left">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="16" viewBox="0 0 20 16" width="20">
+              <path clip-rule="evenodd" d="M19.4 15.4a2 2 0 0 1-1.4.6H2a2 2 0 0 1-1.4-.6A2 2 0 0 1 0 14V2C0 1.4.2 1 .6.6A2 2 0 0 1 2 0h16c.6 0 1 .2 1.4.6.4.4.6.8.6 1.4v12c0 .6-.2 1-.6 1.4ZM2 14h5V2H2v12Zm7 0h9V2H9v12ZM3.3 3c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3Zm0 2c-.2 0-.3.2-.3.3v1c0 .2.1.3.3.3h2.5c.1 0 .2-.1.2-.3v-1l-.2-.2H3.3ZM3 7.4c0-.1.1-.2.3-.2h2.5c.1 0 .2 0 .2.2v1c0 .2-.1.3-.2.3H3.3a.3.3 0 0 1-.3-.3v-1Z" fill-rule="evenodd"/></svg><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+              <path d="M16 22 6 12 16 2l1.8 1.8L9.5 12l8.3 8.2L16 22Z"/></svg><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+              <path d="m8 22 10-10L8 2 6.2 3.8l8.3 8.2-8.3 8.2L8 22Z"/>
+            </svg>
+          </div>
+          <div class="h-animation-ref-safari-nav">
+            <div class="h-animation-ref-safari-nav-url">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+                <path d="M7 10H15V6C15 5.16667 14.7083 4.45833 14.125 3.875C13.5417 3.29167 12.8333 3 12 3C11.1667 3 10.4583 3.29167 9.875 3.875C9.29167 4.45833 9 5.16667 9 6V10H7V6C7 4.61667 7.4875 3.4375 8.4625 2.4625C9.4375 1.4875 10.6167 1 12 1C13.3833 1 14.5625 1.4875 15.5375 2.4625C16.5125 3.4375 17 4.61667 17 6V10C17.55 10 18.0208 10.1958 18.4125 10.5875C18.8042 10.9792 19 11.45 19 12V20C19 20.55 18.8042 21.0208 18.4125 21.4125C18.0208 21.8042 17.55 22 17 22H7C6.45 22 5.97917 21.8042 5.5875 21.4125C5.19583 21.0208 5 20.55 5 20V12C5 11.45 5.19583 10.9792 5.5875 10.5875C5.97917 10.1958 6.45 10 7 10Z"/>
+              </svg>
+              dashboard.scalar.com/registry/Cpf7C2tXIN2wDrnflCa-o
+              <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="24" viewBox="0 0 24 24" width="24">
+                <path d="M12 22a8.7 8.7 0 0 0 6.4-2.6A9.1 9.1 0 0 0 21 13h-2c0 2-.7 3.6-2 5-1.4 1.3-3 2-5 2s-3.6-.7-5-2c-1.3-1.4-2-3-2-5s.7-3.6 2-5c1.4-1.3 3-2 5-2h.2l-1.6 1.5L12 9l4-4-4-4-1.4 1.5L12.2 4H12a8.7 8.7 0 0 0-6.4 2.6A9.1 9.1 0 0 0 3 13a8.7 8.7 0 0 0 2.6 6.4A9.1 9.1 0 0 0 12 22Z"/>
+              </svg>
+            </div>
+          </div>
+          <div class="h-animation-ref-safari-right">
+            
+          </div>
+        </div>
+        <div class="h-animation-doc-header">
+        <svg xmlns="http://www.w3.org/2000/svg" width="129" height="39" viewBox="0 0 129 39" fill="none">
+            <g clip-path="url(#a)">
+              <path fill="currentColor" fill-rule="evenodd" d="M22.2 0c.4 0 .8.3.8.8v8.8l6-6.2c.3-.4.9-.4 1.1 0L34.7 8c.3.3.4.8 0 1v.1l-6 6.2h8.5c.5 0 .8.3.8.8v6.6c0 .5-.3.8-.8.8h-8.6l6.1 6.2c.3.3.4.8 0 1.1l-4.6 4.7c-.2.3-.8.4-1 0l-6-6.2v8.8c0 .5-.4.8-.9.8h-6.4c-.5 0-.8-.3-.8-.8v-4.6c0-1.4.6-2.8 1.5-3.9l8.4-8.5c.9-1 .9-2.5 0-3.4l-8.3-8.5c-1-1-1.6-2.4-1.6-3.8V.8c0-.5.3-.8.8-.8h6.4ZM8.8 3.4H9l14 14.4c1 1 1 2.5 0 3.4L9 35.6c-.2.4-.8.4-1 0L3.2 31c-.3-.3-.4-.7 0-1l6-6.4H.9c-.5 0-.8-.3-.8-.8v-6.6c0-.5.3-.8.8-.8h8.6L3.3 9.2a1 1 0 0 1 0-1.1l4.5-4.7c.3-.3.8-.3 1 0Z" clip-rule="evenodd"></path>
+            </g>
+            <path fill="currentColor" d="M61 15.3c0-.9-.4-1.6-1.1-2-.7-.5-1.6-.8-2.7-.8a5 5 0 0 0-2 .4 3 3 0 0 0-1.2 1 2.3 2.3 0 0 0-.2 2.4l.8.8 1.1.5 1.3.4 1.9.4 2.2.8 2 1.1a5 5 0 0 1 1.8 4 5.5 5.5 0 0 1-3.6 5.3c-1.1.5-2.5.7-4.1.7-1.6 0-3-.2-4.2-.7-1.1-.5-2-1.2-2.7-2.2-.6-1-1-2-1-3.4h3.6c0 .7.3 1.3.6 1.8.4.4 1 .8 1.5 1a6 6 0 0 0 2.1.4c.8 0 1.5-.2 2.1-.4.6-.2 1.1-.6 1.5-1 .3-.4.5-1 .5-1.5 0-.6-.2-1-.5-1.3-.3-.4-.7-.7-1.3-1-.5-.2-1.1-.4-1.9-.5l-2.3-.6c-1.7-.5-3-1.1-4-2-1-.9-1.4-2-1.4-3.5 0-1.2.3-2.2 1-3.1.6-1 1.5-1.6 2.6-2.1 1.2-.5 2.4-.8 3.9-.8a9 9 0 0 1 3.7.8c1.1.5 2 1.2 2.6 2 .6 1 1 2 1 3H61Zm12.8 15a6.7 6.7 0 0 1-6.4-3.8 9.1 9.1 0 0 1-1-4c0-1.6.4-3 1-4.2a6.7 6.7 0 0 1 2.5-2.7c1-.7 2.4-1 3.9-1 1.2 0 2.3.2 3.2.7a5.6 5.6 0 0 1 3.3 4.7H77c-.2-.7-.5-1.3-1-1.8s-1.2-.7-2-.7-1.5.2-2 .6c-.6.4-1 1-1.3 1.6-.3.8-.5 1.7-.5 2.7 0 1 .2 2 .5 2.7a4 4 0 0 0 1.3 1.7c.5.4 1.2.6 2 .6.4 0 1-.1 1.3-.3.5-.2.8-.5 1-1 .4-.3.6-.8.7-1.3h3.4c0 1-.4 2-1 2.9-.5.8-1.2 1.4-2.2 1.9-1 .5-2 .7-3.3.7Zm13 0c-1 0-1.8-.2-2.6-.5-.8-.4-1.4-.9-1.8-1.6-.5-.6-.7-1.5-.7-2.5 0-.8.2-1.5.5-2.1.3-.6.7-1 1.3-1.4l1.8-.7a85.1 85.1 0 0 0 5.5-1c.3-.2.5-.4.5-.8 0-.8-.3-1.4-.7-1.8-.5-.4-1-.6-2-.6-.8 0-1.5.2-2 .6-.5.4-.9.8-1 1.4l-3.4-.5a5.4 5.4 0 0 1 3.5-3.8c1-.3 1.9-.4 3-.4.7 0 1.4 0 2.1.2.8.2 1.4.5 2 .9.6.4 1.1.9 1.5 1.6.4.7.5 1.5.5 2.5V30h-3.4v-2h-.1a4.4 4.4 0 0 1-2.4 2 6 6 0 0 1-2.1.3Zm1-2.6c.7 0 1.3-.2 1.8-.5.5-.2 1-.6 1.2-1.1.3-.5.5-1 .5-1.6v-1.8l-.6.3-1 .2a27.5 27.5 0 0 1-1.7.3c-.6 0-1 .2-1.5.3l-1 .7c-.2.3-.3.7-.3 1.2 0 .6.2 1.1.7 1.5.5.3 1 .5 1.8.5Zm13.4-18V30h-3.6V9.7h3.6Zm7.2 20.6c-1 0-1.8-.2-2.6-.5-.7-.4-1.3-.9-1.8-1.6-.4-.6-.7-1.5-.7-2.5 0-.8.2-1.5.5-2.1.3-.6.8-1 1.3-1.4l1.9-.7 2.1-.4a85.8 85.8 0 0 0 3.4-.6c.3-.2.4-.4.4-.8 0-.8-.2-1.4-.7-1.8-.4-.4-1-.6-1.9-.6-.9 0-1.6.2-2 .6-.6.4-1 .8-1.1 1.4l-3.4-.5a5.4 5.4 0 0 1 3.6-3.8c.9-.3 1.8-.4 2.9-.4.7 0 1.5 0 2.2.2.7.2 1.4.5 2 .9.6.4 1 .9 1.4 1.6.4.7.6 1.5.6 2.5V30H113v-2a4.4 4.4 0 0 1-2.5 2 6 6 0 0 1-2 .3Zm1-2.6c.7 0 1.3-.2 1.8-.5.6-.2 1-.6 1.3-1.1.3-.5.4-1 .4-1.6v-1.8l-.6.3-.9.2a27.3 27.3 0 0 1-1.8.3c-.5 0-1 .2-1.4.3-.5.2-.8.4-1 .7-.3.3-.4.7-.4 1.2 0 .6.2 1.1.7 1.5.5.3 1.1.5 1.9.5Zm9.8 2.3V14.8h3.5v2.5h.2a3.8 3.8 0 0 1 3.7-2.7 8.3 8.3 0 0 1 1.3 0V18l-.7-.2h-1c-.6 0-1.2 0-1.7.4a3.1 3.1 0 0 0-1.7 2.8v9h-3.5Z"></path>
+            <defs>
+              <clipPath id="a">
+                <path fill="#fff" d="M0 0h38v39H0z"></path>
+              </clipPath>
+            </defs>
+          </svg>
+        </div>
+        <div class="h-animation-sidebar">
+          <div class="h-animation-sidebar__animate">
+            <div class="h-animation-sidebar-title">Products</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M219.31,108.68l-80-80a16,16,0,0,0-22.62,0l-80,80A15.87,15.87,0,0,0,32,120v96a8,8,0,0,0,8,8h64a8,8,0,0,0,8-8V160h32v56a8,8,0,0,0,8,8h64a8,8,0,0,0,8-8V120A15.87,15.87,0,0,0,219.31,108.68ZM208,208H160V152a8,8,0,0,0-8-8H104a8,8,0,0,0-8,8v56H48V120l80-80,80,80Z"></path></svg>
+              Home
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M43.18,128a29.78,29.78,0,0,1,8,10.26c4.8,9.9,4.8,22,4.8,33.74,0,24.31,1,36,24,36a8,8,0,0,1,0,16c-17.48,0-29.32-6.14-35.2-18.26-4.8-9.9-4.8-22-4.8-33.74,0-24.31-1-36-24-36a8,8,0,0,1,0-16c23,0,24-11.69,24-36,0-11.72,0-23.84,4.8-33.74C50.68,38.14,62.52,32,80,32a8,8,0,0,1,0,16C57,48,56,59.69,56,84c0,11.72,0,23.84-4.8,33.74A29.78,29.78,0,0,1,43.18,128ZM240,120c-23,0-24-11.69-24-36,0-11.72,0-23.84-4.8-33.74C205.32,38.14,193.48,32,176,32a8,8,0,0,0,0,16c23,0,24,11.69,24,36,0,11.72,0,23.84,4.8,33.74a29.78,29.78,0,0,0,8,10.26,29.78,29.78,0,0,0-8,10.26c-4.8,9.9-4.8,22-4.8,33.74,0,24.31-1,36-24,36a8,8,0,0,0,0,16c17.48,0,29.32-6.14,35.2-18.26,4.8-9.9,4.8-22,4.8-33.74,0-24.31,1-36,24-36a8,8,0,0,0,0-16Z"></path></svg>
+              Registry
+              <span class="h-animation-sidebar-number">1</span>
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M208,24H72A32,32,0,0,0,40,56V224a8,8,0,0,0,8,8H192a8,8,0,0,0,0-16H56a16,16,0,0,1,16-16H208a8,8,0,0,0,8-8V32A8,8,0,0,0,208,24Zm-8,160H72a31.82,31.82,0,0,0-16,4.29V56A16,16,0,0,1,72,40H200Z"></path></svg>
+              Docs
+              <span class="h-animation-sidebar-number">2</span>
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M223.68,66.15,135.68,18a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32l80.34,44-29.77,16.3-80.35-44ZM128,120,47.66,76l33.9-18.56,80.34,44ZM40,90l80,43.78v85.79L40,175.82Zm176,85.78h0l-80,43.79V133.82l32-17.51V152a8,8,0,0,0,16,0V107.55L216,90v85.77Z"></path></svg>
+              SDKs
+              <span class="h-animation-sidebar-number">5</span>
+            </div>
+            <div class="h-animation-sidebar-title">Access</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M208,80H176V56a48,48,0,0,0-96,0V80H48A16,16,0,0,0,32,96V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V96A16,16,0,0,0,208,80ZM96,56a32,32,0,0,1,64,0V80H96ZM208,208H48V96H208V208Z"></path></svg>
+              Access Groups
+              <span class="h-animation-sidebar-number">4</span>
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M128,24h0A104,104,0,1,0,232,128,104.12,104.12,0,0,0,128,24Zm88,104a87.61,87.61,0,0,1-3.33,24H174.16a157.44,157.44,0,0,0,0-48h38.51A87.61,87.61,0,0,1,216,128ZM102,168H154a115.11,115.11,0,0,1-26,45A115.27,115.27,0,0,1,102,168Zm-3.9-16a140.84,140.84,0,0,1,0-48h59.88a140.84,140.84,0,0,1,0,48ZM40,128a87.61,87.61,0,0,1,3.33-24H81.84a157.44,157.44,0,0,0,0,48H43.33A87.61,87.61,0,0,1,40,128ZM154,88H102a115.11,115.11,0,0,1,26-45A115.27,115.27,0,0,1,154,88Zm52.33,0H170.71a135.28,135.28,0,0,0-22.3-45.6A88.29,88.29,0,0,1,206.37,88ZM107.59,42.4A135.28,135.28,0,0,0,85.29,88H49.63A88.29,88.29,0,0,1,107.59,42.4ZM49.63,168H85.29a135.28,135.28,0,0,0,22.3,45.6A88.29,88.29,0,0,1,49.63,168Zm98.78,45.6a135.28,135.28,0,0,0,22.3-45.6h35.66A88.29,88.29,0,0,1,148.41,213.6Z"></path></svg>
+              Login Portals
+            </div>
+            <div class="h-animation-sidebar-title">User</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M230.92,212c-15.23-26.33-38.7-45.21-66.09-54.16a72,72,0,1,0-73.66,0C63.78,166.78,40.31,185.66,25.08,212a8,8,0,1,0,13.85,8c18.84-32.56,52.14-52,89.07-52s70.23,19.44,89.07,52a8,8,0,1,0,13.85-8ZM72,96a56,56,0,1,1,56,56A56.06,56.06,0,0,1,72,96Z"></path></svg>
+              Profile
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M216.57,39.43A80,80,0,0,0,83.91,120.78L28.69,176A15.86,15.86,0,0,0,24,187.31V216a16,16,0,0,0,16,16H72a8,8,0,0,0,8-8V208H96a8,8,0,0,0,8-8V184h16a8,8,0,0,0,5.66-2.34l9.56-9.57A79.73,79.73,0,0,0,160,176h.1A80,80,0,0,0,216.57,39.43ZM224,98.1c-1.09,34.09-29.75,61.86-63.89,61.9H160a63.7,63.7,0,0,1-23.65-4.51,8,8,0,0,0-8.84,1.68L116.69,168H96a8,8,0,0,0-8,8v16H72a8,8,0,0,0-8,8v16H40V187.31l58.83-58.82a8,8,0,0,0,1.68-8.84A63.72,63.72,0,0,1,96,95.92c0-34.14,27.81-62.8,61.9-63.89A64,64,0,0,1,224,98.1ZM192,76a12,12,0,1,1-12-12A12,12,0,0,1,192,76Z"></path></svg>
+              API Keys
+            </div>
+            <div class="h-animation-sidebar-title">Team</div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M216,64H56a8,8,0,0,1,0-16H192a8,8,0,0,0,0-16H56A24,24,0,0,0,32,56V184a24,24,0,0,0,24,24H216a16,16,0,0,0,16-16V80A16,16,0,0,0,216,64Zm0,128H56a8,8,0,0,1-8-8V78.63A23.84,23.84,0,0,0,56,80H216Zm-48-60a12,12,0,1,1,12,12A12,12,0,0,1,168,132Z"></path></svg>
+              Billing
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M117.25,157.92a60,60,0,1,0-66.5,0A95.83,95.83,0,0,0,3.53,195.63a8,8,0,1,0,13.4,8.74,80,80,0,0,1,134.14,0,8,8,0,0,0,13.4-8.74A95.83,95.83,0,0,0,117.25,157.92ZM40,108a44,44,0,1,1,44,44A44.05,44.05,0,0,1,40,108Zm210.14,98.7a8,8,0,0,1-11.07-2.33A79.83,79.83,0,0,0,172,168a8,8,0,0,1,0-16,44,44,0,1,0-16.34-84.87,8,8,0,1,1-5.94-14.85,60,60,0,0,1,55.53,105.64,95.83,95.83,0,0,1,47.22,37.71A8,8,0,0,1,250.14,206.7Z"></path></svg>
+              Members
+            </div>
+            <div class="h-animation-sidebar-folder">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="h-animation-14" viewBox="0 0 256 256"><path d="M128,80a48,48,0,1,0,48,48A48.05,48.05,0,0,0,128,80Zm0,80a32,32,0,1,1,32-32A32,32,0,0,1,128,160Zm88-29.84q.06-2.16,0-4.32l14.92-18.64a8,8,0,0,0,1.48-7.06,107.21,107.21,0,0,0-10.88-26.25,8,8,0,0,0-6-3.93l-23.72-2.64q-1.48-1.56-3-3L186,40.54a8,8,0,0,0-3.94-6,107.71,107.71,0,0,0-26.25-10.87,8,8,0,0,0-7.06,1.49L130.16,40Q128,40,125.84,40L107.2,25.11a8,8,0,0,0-7.06-1.48A107.6,107.6,0,0,0,73.89,34.51a8,8,0,0,0-3.93,6L67.32,64.27q-1.56,1.49-3,3L40.54,70a8,8,0,0,0-6,3.94,107.71,107.71,0,0,0-10.87,26.25,8,8,0,0,0,1.49,7.06L40,125.84Q40,128,40,130.16L25.11,148.8a8,8,0,0,0-1.48,7.06,107.21,107.21,0,0,0,10.88,26.25,8,8,0,0,0,6,3.93l23.72,2.64q1.49,1.56,3,3L70,215.46a8,8,0,0,0,3.94,6,107.71,107.71,0,0,0,26.25,10.87,8,8,0,0,0,7.06-1.49L125.84,216q2.16.06,4.32,0l18.64,14.92a8,8,0,0,0,7.06,1.48,107.21,107.21,0,0,0,26.25-10.88,8,8,0,0,0,3.93-6l2.64-23.72q1.56-1.48,3-3L215.46,186a8,8,0,0,0,6-3.94,107.71,107.71,0,0,0,10.87-26.25,8,8,0,0,0-1.49-7.06Zm-16.1-6.5a73.93,73.93,0,0,1,0,8.68,8,8,0,0,0,1.74,5.48l14.19,17.73a91.57,91.57,0,0,1-6.23,15L187,173.11a8,8,0,0,0-5.1,2.64,74.11,74.11,0,0,1-6.14,6.14,8,8,0,0,0-2.64,5.1l-2.51,22.58a91.32,91.32,0,0,1-15,6.23l-17.74-14.19a8,8,0,0,0-5-1.75h-.48a73.93,73.93,0,0,1-8.68,0,8,8,0,0,0-5.48,1.74L100.45,215.8a91.57,91.57,0,0,1-15-6.23L82.89,187a8,8,0,0,0-2.64-5.1,74.11,74.11,0,0,1-6.14-6.14,8,8,0,0,0-5.1-2.64L46.43,170.6a91.32,91.32,0,0,1-6.23-15l14.19-17.74a8,8,0,0,0,1.74-5.48,73.93,73.93,0,0,1,0-8.68,8,8,0,0,0-1.74-5.48L40.2,100.45a91.57,91.57,0,0,1,6.23-15L69,82.89a8,8,0,0,0,5.1-2.64,74.11,74.11,0,0,1,6.14-6.14A8,8,0,0,0,82.89,69L85.4,46.43a91.32,91.32,0,0,1,15-6.23l17.74,14.19a8,8,0,0,0,5.48,1.74,73.93,73.93,0,0,1,8.68,0,8,8,0,0,0,5.48-1.74L155.55,40.2a91.57,91.57,0,0,1,15,6.23L173.11,69a8,8,0,0,0,2.64,5.1,74.11,74.11,0,0,1,6.14,6.14,8,8,0,0,0,5.1,2.64l22.58,2.51a91.32,91.32,0,0,1,6.23,15l-14.19,17.74A8,8,0,0,0,199.87,123.66Z"></path></svg>
+              Settings
+            </div>
+          </div>
+        </div>
+        <div class="h-animation-content">
+          <div class="h-animation-tag">
+            
+            <div class="h-animation-endpoint">
+              <div class="h-animation-endpoint-markdown">
+                <div class="h-animation-header">
+                <span><svg xmlns="http://www.w3.org/2000/svg" fill="none" height="512" viewBox="0 0 512 512" width="512"><rect fill="#3178c6" height="512" rx="50" width="512"/><rect fill="#3178c6" height="512" rx="50" width="512"/><path clip-rule="evenodd" d="m316.939 407.424v50.061c8.138 4.172 17.763 7.3 28.875 9.386s22.823 3.129 35.135 3.129c11.999 0 23.397-1.147 34.196-3.442 10.799-2.294 20.268-6.075 28.406-11.342 8.138-5.266 14.581-12.15 19.328-20.65s7.121-19.007 7.121-31.522c0-9.074-1.356-17.026-4.069-23.857s-6.625-12.906-11.738-18.225c-5.112-5.319-11.242-10.091-18.389-14.315s-15.207-8.213-24.18-11.967c-6.573-2.712-12.468-5.345-17.685-7.9-5.217-2.556-9.651-5.163-13.303-7.822-3.652-2.66-6.469-5.476-8.451-8.448-1.982-2.973-2.974-6.336-2.974-10.091 0-3.441.887-6.544 2.661-9.308s4.278-5.136 7.512-7.118c3.235-1.981 7.199-3.52 11.894-4.615 4.696-1.095 9.912-1.642 15.651-1.642 4.173 0 8.581.313 13.224.938 4.643.626 9.312 1.591 14.008 2.894 4.695 1.304 9.259 2.947 13.694 4.928 4.434 1.982 8.529 4.276 12.285 6.884v-46.776c-7.616-2.92-15.937-5.084-24.962-6.492s-19.381-2.112-31.066-2.112c-11.895 0-23.163 1.278-33.805 3.833s-20.006 6.544-28.093 11.967c-8.086 5.424-14.476 12.333-19.171 20.729-4.695 8.395-7.043 18.433-7.043 30.114 0 14.914 4.304 27.638 12.912 38.172 8.607 10.533 21.675 19.45 39.204 26.751 6.886 2.816 13.303 5.579 19.25 8.291s11.086 5.528 15.415 8.448c4.33 2.92 7.747 6.101 10.252 9.543 2.504 3.441 3.756 7.352 3.756 11.733 0 3.233-.783 6.231-2.348 8.995s-3.939 5.162-7.121 7.196-7.147 3.624-11.894 4.771c-4.748 1.148-10.303 1.721-16.668 1.721-10.851 0-21.597-1.903-32.24-5.71-10.642-3.806-20.502-9.516-29.579-17.13zm-84.159-123.342h64.22v-41.082h-179v41.082h63.906v182.918h50.874z" fill="#fff" fill-rule="evenodd"/></svg>Scalar Galaxy Typescript</span>
+                <div class="h-animation-header-buttons">
+                  <b>Download</b>
+                  <b>Link Github</b>
+                  <b>Build</b>
+                </div>
+                </div>
+                <div class="tabs">
+                  <div class="tab-item">
+                    Overview
+                  </div>
+                  <div class="tab-item">
+                    Metadata
+                  </div>
+                  <div class="tab-item">
+                    Configuration
+                  </div>
+                </div>
+                <div class="tab-stuff-1">
+                  <div class="tab-label">Name</div>
+                  <div class="tab-input">https://registry.scalar.com/@scalar/apis/<b>scalar-galaxy</b>@0.3.2<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" viewBox="0 0 256 256"><path d="M216,28H88A12,12,0,0,0,76,40V76H40A12,12,0,0,0,28,88V216a12,12,0,0,0,12,12H168a12,12,0,0,0,12-12V180h36a12,12,0,0,0,12-12V40A12,12,0,0,0,216,28ZM156,204H52V100H156Zm48-48H180V88a12,12,0,0,0-12-12H100V52H204Z"></path></svg></div>
+                  <div class="tab-label">Description</div>
+                  <div class="tab-input">
+                  The Scalar Galaxy is an example OpenAPI specification to test OpenAPI tools and libraries. It's a fictional universe with fictional planets and fictional data. Get all the data for [all planets](#tag/planets/GET/planets).
+                  <br />
+                  <br />
+                  ## Resources
+                  <br /><br />
+                  * https://github.com/scalar/scalar
+                  <br />
+                  * https://github.com/OAI/OpenAPI-Specification
+                  <br />
+                  * https://scalar.com
+                  </div>
+                  <div class="tab-label">Namespace</div>
+                  <div class="tab-input"><b>@scalar</b><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" viewBox="0 0 256 256"><path d="M216.49,104.49l-80,80a12,12,0,0,1-17,0l-80-80a12,12,0,0,1,17-17L128,159l71.51-71.52a12,12,0,0,1,17,17Z"></path></svg></div>
+                  <div class="tab-label">Active Version</div>
+                  <div class="tab-input"><b>@0.3.2</b><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" viewBox="0 0 256 256"><path d="M216.49,104.49l-80,80a12,12,0,0,1-17,0l-80-80a12,12,0,0,1,17-17L128,159l71.51-71.52a12,12,0,0,1,17,17Z"></path></svg></div>
+                </div>
+            </div>
+          </div>
+          <div class="h-animation-endpoint-copy">
+            <div class="h-animation-header">
+            <span>Versions</span>
+            </div>
+            <div class="version-list">
+              <div class="version-list-item"><b>v0.3.2</b> Active <span class="ml-auto">Pending</span></div>
+              <div class="version-list-item"><b>v0.3.1</b></div>
+              <div class="version-list-item"><b>v0.3.0</b></div>
+            </div>
+            <div class="h-animation-header">
+            <span>Build History</span>
+            </div>
+            <div class="version-list">
+              <div class="version-list-item"><b>Building</b> v0.3.2</div>
+            </div>
+          </div>
+        </div>  
+      </div>
+      </div>
+    </div>
+    <style>
+      * {
+        padding: 0;
+        box-sizing: border-box;
+        margin: 0;
+        -webkit-font-smoothing: antialiased
+      }
+      :root {
+        
+    --app-header-height: 48px;
+    --scalar-border-width: 1px;
+    --scalar-radius: 3px;
+    --scalar-radius-lg: 6px;
+    --scalar-radius-xl: 8px;
+    --scalar-header-height: 50px;
+    --scalar-sidebar-width: 280px;
+    --scalar-toc-width: 280px;
+    --scalar-card-icon-width: 40px;
+    --scalar-card-icon-height: 40px;
+    --scalar-card-icon-diameter: 20px;
+    --scalar-card-padding: 16px;
+    --scalar-card-inter-element-gap: 4px;
+    --scalar-row-gap: 16px;
+    --system-fonts: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    --scalar-font: "Inter", var(--system-fonts);
+    --scalar-font-code: Monaco, Menlo, monospace;
+    --scalar-heading-1: 24px;
+    --scalar-page-description: 16px;
+    --scalar-heading-2: 20px;
+    --scalar-heading-3: 20px;
+    --scalar-heading-4: 16px;
+    --scalar-heading-5: 16px;
+    --scalar-heading-6: 16px;
+    --scalar-paragraph: 16px;
+    --scalar-small: 14px;
+    --scalar-mini: 13px;
+    --scalar-micro: 12px;
+    --scalar-extra-bold: 700;
+    --scalar-bold: 600;
+    --scalar-semibold: 500;
+    --scalar-regular: 400;
+    --scalar-font-size-1: 24px;
+    --scalar-font-size-2: 16px;
+    --scalar-font-size-3: 14px;
+    --scalar-font-size-4: 13px;
+    --scalar-font-size-5: 12px;
+    --scalar-line-height-1: 32px;
+    --scalar-line-height-2: 24px;
+    --scalar-line-height-3: 20px;
+    --scalar-line-height-4: 18px;
+    --scalar-line-height-5: 16px;
+    --scalar-heading-spacing: 44px;
+    --scalar-block-spacing: 12px;
+      }
+      .light-mode {
+        --scalar-sidebar-width: 280px;
+        --scalar-color-1: #000;
+        --scalar-color-2: #666666;
+        --scalar-color-3: #8e8e8e;
+        --scalar-color-disabled: #b4b1b1;
+        --scalar-color-ghost: #a7a7a7;
+        --scalar-color-accent: #0099ff;
+        --scalar-background-1: #fff;
+        --scalar-background-2: #f6f6f6;
+        --scalar-background-3: #e7e7e7;
+        --scalar-background-4: rgba(0, 0, 0, 0.06);
+        --scalar-background-accent: #8ab4f81f;
+        --scalar-border-color: rgba(0, 0, 0, 0.05);
+        --scalar-scrollbar-color: rgba(0, 0, 0, 0.18);
+        --scalar-scrollbar-color-active: rgba(0, 0, 0, 0.36);
+        --scalar-lifted-brightness: 1;
+        --scalar-backdrop-brightness: 1;
+        --scalar-shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.11);
+        --scalar-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px,
+          rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 1px;
+        --scalar-button-1: rgb(49 53 56);
+        --scalar-button-1-color: #fff;
+        --scalar-button-1-hover: rgb(28 31 33);
+        --scalar-color-green: #00a67d;
+        --scalar-color-red: #ef0006;
+        --scalar-color-yellow: #f9c514;
+        --scalar-color-blue: #579dfb;
+        --scalar-color-orange: #fc8528;
+        --scalar-color-purple: #5203d1;
+        font-family: var(--scalar-font);
+        color: var(--scalar-color-1);
+      }
+      .dark-mode {
+        font-family: var(--scalar-font);
+        color-scheme: dark;
+  --scalar-color-1: rgba(255, 255, 255, 0.9);
+  --scalar-color-2: rgba(255, 255, 255, 0.62);
+  --scalar-color-3: rgba(255, 255, 255, 0.44);
+  --scalar-color-disabled: rgba(255, 255, 255, 0.34);
+  --scalar-color-ghost: rgba(255, 255, 255, 0.26);
+  --scalar-color-accent: #8ab4f8;
+  --scalar-background-1: #0f0f0f;
+  --scalar-background-2: #1a1a1a;
+  --scalar-background-3: #272727;
+  --scalar-background-4: rgba(255, 255, 255, 0.06);
+  --scalar-background-accent: #8ab4f81f;
+
+  --scalar-border-color: rgba(255, 255, 255, 0.1);
+  --scalar-scrollbar-color: rgba(255, 255, 255, 0.24);
+  --scalar-scrollbar-color-active: rgba(255, 255, 255, 0.48);
+  --scalar-lifted-brightness: 1.45;
+  --scalar-backdrop-brightness: 0.5;
+
+  --scalar-shadow-1: 0 1px 3px 0 rgb(0, 0, 0, 0.1);
+  --scalar-shadow-2: rgba(15, 15, 15, 0.2) 0px 3px 6px, rgba(15, 15, 15, 0.4)
+    0px 9px 24px, 0 0 0 1px rgba(255, 255, 255, 0.1);
+
+  --scalar-button-1: #f6f6f6;
+  --scalar-button-1-color: #000;
+  --scalar-button-1-hover: #e7e7e7;
+
+  --scalar-color-green: #00b848;
+  --scalar-color-red: #fe1d2c;
+  --scalar-color-yellow: #fbca25;
+  --scalar-color-blue: #76aedf;
+  --scalar-color-orange: #dd922f;
+  --scalar-color-purple: #b090f8;
+  color: var(--scalar-color-1);
+
+  /* Misc Scalar Branding */
+  --scalar-brand: #8b7256;
+      }
+      .dotted-top {
+    position: absolute;
+    top: 17px;
+    left: 12px;
+    background-color: var(--scalar-background-3);
+    border-radius: 50%;
+    width: 10px;
+    box-shadow: 14px 0 0 var(--scalar-background-3), 29px 0 0 var(--scalar-background-3);
+    height: 9px;
+}
+.h-animation-ref-safari {
+    height: 40px;
+    background-color: var(--scalar-background-2);
+    z-index: 1;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+}
+.h-animation-ref-safari-left {
+    width: 150px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding-left: 68px;
+    color: var(--scalar-color-3);
+}
+.h-animation-ref-safari-nav {
+    width: 600px;
+    padding: 6px 0;
+}
+.h-animation-ref-safari-right {
+    width: 150px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+    color: var(--scalar-color-3);
+    padding-right: 12px;
+}
+.h-animation-ref-safari-right svg {
+    width: 17px;
+    height: 17px;
+}
+.h-animation-ref-safari-left svg {
+    width: 16px;
+    height: 16px;
+}
+.h-animation-ref-safari-left svg:last-of-type {
+    opacity: 0.5;
+}
+.h-animation-ref-safari-nav-url {
+    width: 100%;
+    border-radius: 7px;
+    height: 100%;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    position: relative;
+    border: 1px solid var(--scalar-border-color);
+}
+.h-animation-ref-safari-nav-url svg {
+    width: 13px;
+    height: 13px;
+    color: var(--scalar-color-3);
+    margin-right: 3px;
+}
+.h-animation-ref-safari-nav-url svg:last-of-type {
+    position: absolute;
+    right: 4px;
+}
+.h-animation-ref {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+    background: var(--scalar-background-1);
+    min-width: 1280px;
+    min-height: 720px;
+}
+.h-animation-ref {
+    display: flex;
+    padding-top: 90px;
+}
+.h-animation-sidebar {
+    padding: 12px;
+    max-width: var(--scalar-sidebar-width);
+    border-right: 1px solid var(--scalar-border-color);
+    flex: 1;
+}
+.h-animation-sidebar-endpoint {
+    position: relative;
+}
+.h-animation-sidebar-number {
+    margin-left: auto;
+    font-family: var(--scalar-font-code);
+    font-weight: 700;
+    font-size: 10px;
+    margin-top: 10px;
+    line-height: 0;
+}
+.h-animation-sidebar-endpoint,
+.h-animation-sidebar-folder {
+    font-size: 14px;
+    min-height: 32px;
+    display: flex;
+    padding: 8px 9px;
+    color: var(--scalar-color-2);
+    border-radius: var(--scalar-radius);
+}
+.h-animation-sidebar-folder svg {
+    margin-right: 6px;
+}
+.h-animation-sidebar-folder {
+    padding-left: 6px;
+}
+.h-animation-sidebar-endpoint {
+    padding-left: 12px;
+}
+.h-animation-sidebar-endpoint {
+    border-radius: 0;
+    margin-left: 12px;
+    border-left: 1px solid var(--scalar-border-color);
+}
+.h-animation-sidebar-title {
+    color: var(--scalar-color-3);
+    padding: 8px;
+    font-size: 14px;
+    font-weight: 600;
+}
+.h-animation-sidebar-title:not(:first-of-type) {
+    margin-top: 18px;
+}
+.h-animation-sidebar-folder:nth-of-type(5) {
+    color: var(--scalar-color-1);
+    font-weight: 500;
+    background-color: var(--scalar-background-2);
+}
+.h-animation-sidebar-folder:nth-of-type(5) svg {
+    fill: var(--scalar-color-purple);
+}
+.h-animation-content {
+    flex: 1;
+}
+.h-animation-tag {
+    border-bottom: 1px solid var(--scalar-border-color);
+    width: 100%;
+    display: flex;
+    gap: 48px;
+}
+.h-animation-tag {
+    border-bottom: none;
+    flex-flow: wrap;
+    gap: 0;
+    padding: 0 0 0 36px;
+}
+.h-animation-header {
+    font-size: var(--font-size, var(--scalar-heading-2));
+    font-weight: var(--font-weight, var(--scalar-bold));
+    color: var(--scalar-color-1);
+    word-wrap: break-word;
+    line-height: 1.45;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+.h-animation-header span {
+    display: flex;
+    align-items: center; justify-content: center;
+}
+.h-animation-header span svg {
+    width: 18px;
+    height: 18px;
+    margin-right: 6px;
+}
+.h-animation-header:nth-of-type(n + 3) {
+    font-size: 16px;
+    margin-top: 24px
+}
+.h-animation-header-buttons {
+  display: flex;
+}
+.h-animation-header-buttons b {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid var(--scalar-border-color);
+  border-radius: 4px;
+  padding: 4px 8px;
+  margin-left: 12px;
+}
+.h-animation-header-buttons b:nth-of-type(1) {
+    background: var(--scalar-background-2);
+}
+.h-animation-header-buttons b:nth-of-type(3) {
+  background: var(--scalar-color-1);
+  color: var(--scalar-background-1);
+}
+.h-animation-endpoint-markdown,
+.h-animation-tag-markdown {
+    width: 100%;
+}
+.h-markdown {
+    margin-top: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    line-height: 1.5;
+    color: var(--scalar-color-1);
+}
+.h-animation-endpoint {
+    width: 65%;
+    display: flex;
+    padding: 24px 0;
+    min-height: 674px;
+}
+.h-animation-14 {
+    width: 12px;
+    height: 12px;
+    stroke-width: 2;
+}
+@supports (color: color(display-p3 1 1 1)) {
+    .light-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0.023529 0.564706 0.380392 / 1);
+        --scalar-color-red: color(display-p3 0.937255 0 0.023529 / 1);
+        --scalar-color-yellow: color(display-p3 0.929412 0.745098 0.12549 / 1);
+        --scalar-color-blue: color(display-p3 0 0.509804 0.815686 / 1);
+        --scalar-color-orange: color(display-p3 0.984314 0.537255 0.172549 / 1);
+        --scalar-color-purple: color(display-p3 0.321569 0.011765 0.819608 / 1);
+    }
+    .dark-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0 0.713725 0.282353 / 1);
+        --scalar-color-red: color(display-p3 0.862745 0.105882 0.098039 / 1);
+        --scalar-color-yellow: color(display-p3 1 0.788235 0.05098 / 1);
+        --scalar-color-blue: color(display-p3 0.305882 0.701961 0.92549 / 1);
+        --scalar-color-orange: color(display-p3 1 0.552941 0.301961 / 1);
+        --scalar-color-purple: color(display-p3 0.694118 0.568627 0.976471 / 1);
+    }
+}
+.h-animation-doc-header {
+    font-weight: 800;
+    width: 100%;
+    position: absolute;
+    top: 40px;
+    left: 0;
+    height: 50px;
+    padding: 12px;
+    display: flex;
+    align-items: center;
+    font-size: 16px;
+    border-bottom: 1px solid var(--scalar-border-color);
+    background-color: var(--scalar-background-1);
+    z-index: 1;
+    gap: 4px;
+}
+.h-animation-doc-header svg {
+    width: auto;
+    height: 22px;
+}
+.size-3 {
+    width: 12px;
+    height: 12px;
+}
+.h-animation-14 {
+    width: 16px;
+    height: 16px;
+}
+.w-15 {
+    width: 60px;
+}
+.p-11 {
+    padding: 11px;
+}
+.p-9 {
+    padding: 9px;
+}
+svg {
+    vertical-align: middle;
+    display: block;
+}
+.p-3 {
+    padding: 0 12px 12px 12px;
+}
+.h-10 {
+    height: 40px;
+}
+.w-780 {
+    width: 580px;
+    font-size: 14px;
+    border: 1px solid var(--scalar-border-color);
+}
+.size-35 {
+    width: 14px;
+    height: 14px;
+}
+.p-1 {
+    padding: 4px;
+}
+@supports (color: color(display-p3 1 1 1)) {
+    .light-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0.023529 0.564706 0.380392 / 1);
+        --scalar-color-red: color(display-p3 0.937255 0 0.023529 / 1);
+        --scalar-color-yellow: color(display-p3 0.929412 0.745098 0.12549 / 1);
+        --scalar-color-blue: color(display-p3 0 0.509804 0.815686 / 1);
+        --scalar-color-orange: color(display-p3 0.984314 0.537255 0.172549 / 1);
+        --scalar-color-purple: color(display-p3 0.321569 0.011765 0.819608 / 1);
+    }
+    .dark-mode {
+        --scalar-color-accent: var(--scalar-color-1);
+        --scalar-color-green: color(display-p3 0 0.713725 0.282353 / 1);
+        --scalar-color-red: color(display-p3 0.862745 0.105882 0.098039 / 1);
+        --scalar-color-yellow: color(display-p3 1 0.788235 0.05098 / 1);
+        --scalar-color-blue: color(display-p3 0.305882 0.701961 0.92549 / 1);
+        --scalar-color-orange: color(display-p3 1 0.552941 0.301961 / 1);
+        --scalar-color-purple: color(display-p3 0.694118 0.568627 0.976471 / 1);
+    }
+}
+.h-animation-ref {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 765px;
+    border: 1px solid #dbdbdb;
+    border-radius: 8px;
+    overflow: hidden;
+}
+@supports (hanging-punctuation: first) and (font: -apple-system-body) and (-webkit-appearance: none) {
+    .transform-rr {
+        --var: 1;
+        --varcalcx: calc(var(--var) * 1360px);
+        --xcalc: calc((100dvw - var(--varcalcx)) / 2);
+        --varcalcy: calc(var(--var) * 765px);
+        --ycalc: calc((100dvh - var(--varcalcy)) / 2);
+        transform: translate3d(var(--xcalc), var(--ycalc), 0);
+    }
+    .tab-stuff-3,
+    .tab-stuff-2 {
+        display: none;
+    }
+    * {
+        animation: none !important;
+    }
+    .tab-item:nth-of-type(1) {
+        font-weight: 500;
+        color: var(--scalar-color-1);
+        border-bottom: 1px solid var(--scalar-color-1);
+    }
+    .h-animation-tag-wrap {
+        display: none;
+    }
+    .h-animation-endpoint {
+        border-top: none;
+    }
+    .h-animation-sidebar-endpoint span {
+        font-weight: 500;
+    }
+    .h-animation-popup {
+        display: none;
+    }
+    @media only screen and (max-width: 1360px) {
+        .transform-rr {
+            --var: 0.95;
+        }
+        .rr {
+            transform: scale(var(--var));
+            transform-origin: top left;
+            position: relative;
+            overflow: hidden;
+        }
+    }
+    @media only screen and (max-width: 1292px) {
+        .transform-rr {
+            --var: 0.9;
+        }
+    }
+    @media only screen and (max-width: 1224px) {
+        .transform-rr {
+            --var: 0.85;
+        }
+    }
+    @media only screen and (max-width: 1156px) {
+        .transform-rr {
+            --var: 0.8;
+        }
+    }
+    @media only screen and (max-width: 1088px) {
+        .transform-rr {
+            --var: 0.75;
+        }
+    }
+    @media only screen and (max-width: 1020px) {
+        .transform-rr {
+            --var: 0.7;
+        }
+    }
+    @media only screen and (max-width: 952px) {
+        .transform-rr {
+            --var: 0.65;
+        }
+    }
+    @media only screen and (max-width: 884px) {
+        .transform-rr {
+            --var: 0.6;
+        }
+    }
+    @media only screen and (max-width: 816px) {
+        .transform-rr {
+            --var: 0.55;
+        }
+    }
+    @media only screen and (max-width: 748px) {
+        .transform-rr {
+            --var: 0.5;
+        }
+    }
+    @media only screen and (max-width: 680px) {
+        .transform-rr {
+            --var: 0.45;
+        }
+    }
+    @media only screen and (max-width: 612px) {
+        .transform-rr {
+            --var: 0.4;
+        }
+    }
+    @media only screen and (max-width: 544px) {
+        .transform-rr {
+            --var: 0.35;
+        }
+    }
+    @media only screen and (max-width: 476px) {
+        .transform-rr {
+            --var: 0.3;
+        }
+    }
+    @media only screen and (max-width: 408px) {
+        .transform-rr {
+            --var: 0.25;
+        }
+    }
+    @media only screen and (max-width: 340px) {
+        .transform-rr {
+            --var: 0.2;
+        }
+    }
+    @media only screen and (max-width: 272px) {
+        .transform-rr {
+            --var: 0.15;
+        }
+    }
+}
+.size-6 {
+    width: 24px;
+    height: 24px;
+    margin-bottom: 12px;
+}
+.product {
+    display: flex;
+    gap: 12px;
+    width: 100%;
+}
+.h-animation-endpoint-copy {
+    border-left: 1px solid var(--scalar-border-color);
+    margin-left: 36px;
+    padding: 24px;
+    width: 31%;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    font-size: 14px;
+    min-height: 674px;
+}
+.h-animation-endpoint-copy p {
+    color: var(--scalar-color-3);
+    line-height: 1.45;
+}
+.h-animation-endpoint-copy-product {
+    margin-top: 40px;
+}
+.h-animation-header-2 {
+    font-size: 14px;
+    color: var(--scalar-color-1);
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+
+.h-animation-endpoint-copy {
+  height: 100%;
+}
+.version-list {
+  border: 1px solid var(--scalar-border-color);
+  border-radius: 4px;
+}
+.version-list-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--scalar-color-3);
+  padding: 8px;
+  border-bottom: 1px solid var(--scalar-border-color);
+}
+.version-list-item:last-child {
+  border-bottom: none;
+}
+.version-list-item b {
+  color: var(--scalar-color-1);
+  font-weight: 500;
+}
+.tabs {
+  border-bottom: 1px solid var(--scalar-border-color);
+  display: flex;
+  gap: 24px;
+  margin-top: 20px;
+}
+.tab-item {
+  color: var(--scalar-color-3);
+  font-size: 14px;
+  padding: 8px 0;
+  border-bottom: 1px solid transparent;
+}
+.tab-item:nth-of-type(1) {
+  font-weight: 500;
+  color: var(--scalar-color-1);
+  border-bottom: 1px solid var(--scalar-color-1);
+}
+
+.tab-label {
+  color: var(--scalar-color-1);
+  font-size: 14px;
+  font-weight: 500;
+  margin-top: 20px;
+  margin-bottom: 8px;
+}
+.tab-input {
+  padding: 8px 10px;
+  background:  color-mix(in srgb, var(--scalar-background-1), var(--scalar-background-2));
+  border: 1px solid var(--scalar-border-color);
+  border-radius: 4px;
+  color: var(--scalar-color-3);
+  font-size: 14px;
+  max-height: 200px;
+  overflow: hidden;
+  line-height: 1.45;
+  display: flex;
+  align-items: center;
+}
+.bigone {
+  max-height: 800px;
+}
+.tab-input b {
+  color: var(--scalar-color-1);
+  font-weight: 500;
+}
+.tab-input svg {
+  width: 14px;
+  height: 14px;
+  margin-left: auto;
+}
+
+      .h-green {
+        color: var(--scalar-color-green);
+      }
+
+      .h-blue {
+        color: var(--scalar-color-blue);
+      }
+
+      .h-orange {
+        color: var(--scalar-color-orange);
+      }
+      .h-purple {
+        color: var(--scalar-color-purple);
+      }
+
+      .h-red {
+        color: var(--scalar-color-red);
+      }
+
+      .h-black {
+        color: var(--scalar-color-1);
+      }
+      .h-animation-endpoint-code-body {
+        font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace;
+        font-size: 13px;
+        line-height: 1.6;
+      }
+      .h-animation-endpoint-code-body span:first-of-type {
+        color: var(--scalar-color-3);
+        margin-right: 4px;
+        width: 18px;
+        display: inline-block;
+      }
+
+      .body-second span:first-of-type {
+        margin-right: 28px;
+      }
+      .body-third span:first-of-type {
+        margin-right: 54px;
+      }
+      .body-fourth span:first-of-type {
+        margin-right: 80px;
+      }
+      .body-fifth span:first-of-type {
+        margin-right: 106px;
+      }
+
+      
+      .h-grey {
+        color: var(--scalar-color-3);
+      }
+      .dark-mode .h-grey {
+        color: var(--scalar-color-2);
+      }
+      .h-animation-code {
+        background: var(--scalar-background-2);
+        border: 1px solid var(--scalar-border-color);
+        border-radius: var(--scalar-radius-lg);
+        font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace;
+      }
+
+      /* Replace the Tailwind classes with these regular CSS classes */
+
+      .flex {
+        display: flex;
+      }
+
+      .flex-col {
+        flex-direction: column;
+      }
+
+      .divide-y > * + * {
+        border-top: 1px solid var(--scalar-border-color);
+      }
+
+      .overflow-hidden {
+        overflow: hidden;
+      }
+
+      .rounded-lg {
+        border-radius: 8px;
+      }
+
+      .border {
+        border: 1px solid var(--scalar-border-color);
+      }
+
+      .text-c-2 {
+        color: var(--scalar-color-2);
+      }
+
+      .items-center {
+        align-items: center;
+      }
+
+      .gap-3 {
+        gap: 12px;
+      }
+
+      .hover\:cursor-pointer:hover {
+        cursor: pointer;
+      }
+
+      .size-4 {
+        width: 16px;
+        height: 16px;
+      }
+
+      .justify-center {
+        justify-content: center;
+      }
+
+      .p-0\.75 {
+        padding: 3px;
+      }
+
+      .text-transparent {
+        color: transparent;
+      }
+
+      .shadow-border {
+        box-shadow: 0 0 0 1px var(--scalar-border-color);
+      }
+
+      .rounded-full {
+        border-radius: 9999px;
+      }
+
+      .bg-b-2 {
+        background-color: var(--scalar-background-2);
+      }
+
+      .gap-1\.5 {
+        gap: 6px;
+      }
+
+      .text-c-1 {
+        color: var(--scalar-color-1);
+      }
+
+      .font-medium {
+        font-weight: 500;
+      }
+
+      .w-10 {
+        width: 40px;
+      }
+
+      .bg-b-1\.5 {
+        background-color: color-mix(in srgb, var(--scalar-background-1), var(--scalar-background-2));
+      }
+
+      .bg-c-accent {
+        background-color: var(--scalar-color-accent);
+      }
+
+      .text-b-1 {
+        color: var(--scalar-background-1);
+      }
+
+      .size-3 {
+        width: 12px;
+        height: 12px;
+      }
+      .registy-privacy {
+        font-size: 14px;
+        padding: 10px;
+      }
+      .tab-item-active {
+        padding: 8px 0;
+        font-size: 14px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .tab-item-active svg {
+        color: var(--scalar-color-green);
+      }
+      .tab-item-active + .tab-item-active {
+        border-top: 1px solid var(--scalar-border-color);
+      }
+
+      .scalar-verify-badge {
+    position: relative;
+    width: 36px;
+    height: 36px;
+}
+
+.scalar-verify-badge-inner {
+    position: absolute;
+    width: 36px;
+    height: 36px;
+}
+
+
+.scalar-verify-badge-inner-layer {
+    position: absolute;
+    width: 36px;
+    height: 36px;
+    clip-path: path("M36 18c0 1.7-1.2 3-2.3 4-.5.7-1.2 1.3-1.4 2-.2.4-.3 1.3-.3 2.2 0 1.5 0 3.3-1.3 4.5-1.3 1.3-3 1.3-4.5 1.3-.9 0-1.8 0-2.3.3-.6.2-1.2.8-1.8 1.5-1.1 1-2.4 2.2-4.1 2.2-1.7 0-3-1.2-4-2.3-.7-.5-1.3-1.2-2-1.4-.4-.2-1.3-.3-2.2-.3-1.5 0-3.3 0-4.5-1.3C4 29.4 4 27.7 4 26.2c0-.9 0-1.8-.3-2.3-.2-.6-.8-1.2-1.5-1.8C1.3 21 0 19.7 0 18c0-1.7 1.2-3 2.3-4 .5-.7 1.2-1.3 1.4-2 .2-.4.3-1.3.3-2.2 0-1.5 0-3.3 1.3-4.5C6.6 4 8.3 4 9.8 4c.9 0 1.8 0 2.3-.3.6-.2 1.2-.8 1.8-1.5C15 1.3 16.3 0 18 0c1.7 0 3 1.2 4 2.3.7.5 1.3 1.2 2 1.4.4.2 1.3.3 2.2.3 1.5 0 3.3 0 4.5 1.3C32 6.6 32 8.3 32 9.8c0 .9 0 1.8.3 2.3.2.6.8 1.2 1.5 1.8 1 1.1 2.2 2.4 2.2 4.1Z")
+}
+ .check {
+  display: flex;
+  align-items: center;
+  justify-content: center;  
+  z-index: 1;
+}
+.check svg {
+  width: 24px;
+  height: 24px;
+  margin: auto;
+  color: white;
+}
+
+.lines {
+    background: var(--scalar-color-blue)
+}
+.verify {
+  background: linear-gradient(color-mix(in srgb,var(--scalar-color-blue),transparent 90%),color-mix(in srgb,var(--scalar-color-blue),transparent 100%));
+  padding: 24px;
+  height: 200px;
+  border-radius: 3px;
+  gap: 12px;
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  text-align: center;
+  font-size: 14px;
+  box-shadow: 0 0 0 1px var(--scalar-border-color);
+}
+.verify p {
+  color: var(--scalar-color-2);
+}
+.verify a {
+  color: var(--scalar-color-blue);
+  font-weight: 500;
+}
+.ml-auto {
+    margin-left: auto;
+}
+</style>
+</foreignObject>
+</svg>

--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -1,44 +1,668 @@
-# Getting Started
+<h1>Getting Started</h1>
+<div class="hero-animation container-full">
+  <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/v1Pu6_BCmly6VhPAuotVZ.svg"></scalar-icon>
+</div>
+<div class="flex flex-col gap-3 hero small-test">
+  <h2 class="text-balance">
+    Developer Docs.
+  </h2>
+  <p>
+    Get started with Scalar Docs, literally in minutes. You don't need anything to get started, not even an account if you just want to play around.
+  </p>
+</div>
+<div class="logowall">
+  <div class="logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-tr.svg"></scalar-icon>
+  </div>
+  <div class="logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-maersk.svg"></scalar-icon>
+  </div>
+  <div class="logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-tailscale.svg"></scalar-icon>
+  </div>
+  <div class="logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-supabase.svg"></scalar-icon>
+  </div>
+  <div class="logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-flyio.svg"></scalar-icon>
+  </div>
+  <div class="logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-sfcompute.svg"></scalar-icon>
+  </div>
+</div>
+<img class="light-image mt-10" src="/api-docs-static-zoom.svg"/>
+<img class="dark-image mt-10" src="/api-docs-static-zoom-dark.svg"/>
 
-Reading this guide helps you to get started with Scalar Docs, literally in minutes. You don't need anything to get started, not even an account if you just want to play around.
+<div class="flex">
+  <div class="full-container-constrained">
 
-## Guides
+  ## Getting Started
 
-:::scalar-callout{ type=info }
-Guides are part of our Scalar Pro plan (read below, or [visit our pricing page for more info](https://scalar.com/#pricing)).
-:::
+  :::scalar-callout{ type=info }
+  Guides are part of our Scalar Pro plan (read below, or [visit our pricing page for more info](https://scalar.com/#pricing)).
+  :::
+  In the top left corner of <https://docs.scalar.com>, you'll see a “Guide” tab. This is where you land by default.
 
-In the top left corner of <https://docs.scalar.com>, you'll see a “Guide” tab. This is where you land by default.
+  Guides are basically a blank sheet of paper. These pages are where you will publish your non-reference content (API reference pages are [discussed below](#api-references)). You can start writing your documentation, your guidelines, your knowledge base — whatever you want to write — using our editor. You can alternatively manage your guides using a Git repository, covered in the [GitHub Sync](https://guides.scalar.com/scalar/scalar-docs/github-sync) guide.
 
-Guides are basically a blank sheet of paper. These pages are where you will publish your non-reference content (API reference pages are [discussed below](#api-references)). You can start writing your documentation, your guidelines, your knowledge base — whatever you want to write — using our editor. You can alternatively manage your guides using a Git repository, covered in the [GitHub Sync](https://guides.scalar.com/scalar/scalar-docs/github-sync) guide.
+  If you're serious about this, you can [create an account here](https://docs.scalar.com/register) to make sure your changes are saved.
 
-If you're serious about this, you can [create an account here](https://docs.scalar.com/register) to make sure your changes are saved.
+  ## API References
 
-## API References
+  :::scalar-callout{ type=neutral }
+  This is a free feature. You'll even get a nice `${whatever-you-like}.apidocumentation.com` subdomain.
+  :::
 
-> This is a free feature. You'll even get a nice `${whatever-you-like}.apidocumentation.com` subdomain.
+  Every project can have one, or even multiple API references: In the top left corner, you'll see a “Reference” tab. Try to click on it to switch to our OpenAPI editor.
 
-Every project can have one, or even multiple API references: In the top left corner, you'll see a “Reference” tab. Try to click on it to switch to our OpenAPI editor.
+  OpenAPI is the most popular standard to describe your API in a machine readable format. No matter which languages, libraries or frameworks you're using to build your API, it's very, very likely there's a tool, plugin or package to generate an OpenAPI document for you. If you don't find something which says “OpenAPI”, look for “Swagger”. It's what it used be called a few years ago, before it was an open standard.
 
-OpenAPI is the most popular standard to describe your API in a machine readable format. No matter which languages, libraries or frameworks you're using to build your API, it's very, very likely there's a tool, plugin or package to generate an OpenAPI document for you. If you don't find something which says “OpenAPI”, look for “Swagger”. It's what it used be called a few years ago, before it was an open standard.
+  Those OpenAPI documents are what we base all our tools on. So once you've got one, it should be straight-forward to use our tools.
 
-Those OpenAPI documents are what we base all our tools on. So once you've got one, it should be straight-forward to use our tools.
+  Scalar Docs offers multiple ways to connect your OpenAPI document. Pick whatever fits your workflow:
 
-Scalar Docs offers multiple ways to connect your OpenAPI document. Pick whatever fits your workflow:
+  - Paste your OpenAPI document in the editor
+  - Upload an OpenAPI document to the editor
+  - Import an URL (you can even create a “Live Link”, which means it'll fetch updates from the URL vs. just fetching it once)
+  - [Sync your OpenAPI document from GitHub](https://guides.scalar.com/scalar/scalar-docs/github-sync#advanced-configuration__add-an-openapi-reference)
 
-- Paste your OpenAPI document in the editor
-- Upload an OpenAPI document to the editor
-- Import an URL (you can even create a “Live Link”, which means it'll fetch updates from the URL vs. just fetching it once)
-- [Sync your OpenAPI document from GitHub](https://guides.scalar.com/scalar/scalar-docs/github-sync#advanced-configuration__add-an-openapi-reference)
+  ## Scalar Pro
 
-## Scalar Pro
+  Most of our stuff is actually freely available. Upgrading to Scalar Pro unlocks a set of additional features, including:
 
-Most of our stuff is actually freely available. Upgrading to Scalar Pro unlocks a set of additional features, including:
+  * Custom domains,
+  * [GitHub sync](https://guides.scalar.com/scalar/scalar-docs/github-sync),
+  * Guides (and versioning of your guides),
+  * TypeSense search and
+  * priority support (including a private Discord channel or a dedicated Slack connect channel if you like).
 
-* Custom domains,
-* [GitHub sync](https://guides.scalar.com/scalar/scalar-docs/github-sync),
-* Guides (and versioning of your guides),
-* TypeSense search and
-* priority support (including a private Discord channel or a dedicated Slack connect channel if you like).
+  [Pricing information can be found here](https://scalar.com#pricing).
 
-[Pricing information can be found here](https://scalar.com#pricing).
+<div class="feature">
+  <h2>Features</h2>
+  <div class="flex flex-wrap feature-container">
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
+        <scalar-icon src="phosphor/bold/brackets-angle"></scalar-icon>
+        Markdown & MDX
+      </b>
+      <p>
+        "After years of helping enterprises implemeain points I watched customers struggle with daily. This is the modern API platform developers deserve."
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
+        <scalar-icon src="phosphor/bold/brackets-curly"></scalar-icon>
+        Custom HTML/CSS/JS
+      </b>
+      <p>
+        "One of my most recent favorites is a in-browser ad hoc testing UI called Scalar.
+One of the things that I really love about Scalar, it's got this modern UI experience, and it
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
+        <scalar-icon src="phosphor/bold/arrow-up-right"></scalar-icon>
+        OpenAPI Documents
+      </b>
+      <p>
+with offerings at every price point.
+They are open source. So I can get in on free features and stay with Scalar no matter how big my API needs blow up."
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
+        <scalar-icon src="phosphor/bold/github-logo"></scalar-icon>
+        Github Sync
+      </b>
+      <p>
+        "After years of helping enterprises implemeain points I watched customers struggle with daily. This is the modern API platform developers deserve."
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
+        <scalar-icon src="phosphor/bold/palette"></scalar-icon>
+        Customize Everything
+      </b>
+      <p>
+        "One of my most recent favorites is a in-browser ad hoc testing UI called Scalar.
+One of the things that I really love about Scalar, it's got this modern UI experience, and it
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
+        <scalar-icon src="phosphor/bold/users"></scalar-icon>
+        Gine-grained Access
+      </b>
+      <p>
+with offerings at every price point.
+They are open source. So I can get in on free features and stay with Scalar no matter how big my API needs blow up."
+      </p>
+    </div>
+  </div>
+  <div class="cta flex flex-col gap-3 small-test">
+  <h2 class="text-balance">What are you waiting for?</h2>
+  <p>
+    We're committed to enabling developers and companies to practice the highest
+    of API industry standards.
+  </p>
+  <div class="flex gap-2 mb-11">
+    <a class="t-editor__button" href="https://dashboard.scalar.com/register">Get Started</a>
+    <a class="t-editor__button" href="https://cal.com/scalar/30min" target="_blank">Book a Demo</a>
+  </div>
+  <a class="expander-hover-link" href="https://discord.gg/scalar" target="_blank">Community →</a>
+  <a class="expander-hover-link" href="https://github.com/scalar/scalar" target="_blank">GitHub →</a>
+  <a class="expander-hover-link" href="mailto:support@scalar.com" target="_blank">Contact Us →</a>
+</div>
+</div>
+</div>
+  <div class="resources-cta sticky">
+    <div class="resources-cta-container">
+      <p class="mt-3 mb-1 pl-2">
+        <b class="font-medium">Additioanl Reading</b>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/scalar-docs/github-sync"><scalar-icon src="phosphor/bold/git-branch"></scalar-icon> Github Sync</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/scalar-docs/components/markdown-support"><scalar-icon src="phosphor/bold/file-md"></scalar-icon> Markdown Support</a>
+      </p>
+      <p class="mt-3 mb-1 pl-2">
+        <b class="font-medium">Community</b>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="https://discord.gg/scalar" target="_blank"><scalar-icon src="phosphor/bold/discord-logo"></scalar-icon> Discord</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="https://twitter.com/scalar" target="_blank"><scalar-icon src="phosphor/bold/twitter-logo"></scalar-icon> Twitter</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="https://github.com/scalar/scalar" target="_blank"><scalar-icon src="phosphor/bold/github-logo"></scalar-icon> Github</a>
+      </p>
+    </div>
+  </div>
+</div>
+
+<div class="expander-container">
+  <div class="expander-hover">
+    <div class="expander-hover-preview">
+      <img class="light-image" src="/api-client-static.svg" />
+      <img class="dark-image" src="/api-client-static-dark.svg" />
+    </div>
+    <div class="relative">
+      <div class="expander-hover-sticker">
+        <object class="sticker-clip-client" width="156" height="110"
+          data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/JXS6tZ4EbKIkeGpjP6QKc.svg"></object>
+      </div>
+      <div class="expander-hover-title">API Client</div>
+      <div class="expander">
+        <div class="expander-content">
+          Minimal, powerful, fully open-source API Client built on open standards by us + our community.
+        </div>
+      </div>
+      <a class="expander-hover-link" href="https://client.scalar.com/" target="_blank">Learn More</a>
+    </div>
+  </div>
+  <div class="expander-hover">
+    <div class="expander-hover-preview">
+      <img class="light-image" src="/sdks-static.svg" />
+      <img class="dark-image" src="/sdks-static-dark.svg" />
+    </div>
+    <div class="relative">
+      <div class="expander-hover-sticker">
+        <object class="sticker-clip-sdk" width="145" height="145"
+          data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/gM-mqYTBYMkqpnexTIr-r.svg"></object>
+      </div>
+      <div class="expander-hover-title">SDKs</div>
+      <div class="expander">
+        <div class="expander-content">
+          Bring your OpenAPI document and get type-safe client libraries for TypeScript, Python and more.
+        </div>
+      </div>
+      <a class="expander-hover-link" href="/scalar/scalar-sdks/getting-started">Learn More</a>
+    </div>
+  </div>
+  <div class="expander-hover">
+    <div class="expander-hover-preview">
+      <img class="light-image" src="/registry-static.svg" />
+      <img class="dark-image" src="/registry-static-dark.svg" />
+    </div>
+    <div class="relative">
+      <div class="expander-hover-sticker">
+      <object class="sticker-clip-registry" width="136" height="186"
+          data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/jgGF_IKsu-T_irS-6MMOy.svg"></object>
+      </div>
+      <div class="expander-hover-title">API Registry</div>
+      <div class="expander">
+        <div class="expander-content">
+          Managing & versioning OpenAPI Documents with a deep Git integration.
+        </div>
+      </div>
+      <a class="expander-hover-link" href="/scalar/scalar-registry/getting-started">Learn More</a>
+    </div>
+  </div>
+  <div class="expander-hover">
+    <div class="expander-hover-preview">
+      <img class="light-image" src="/api-docs-static-zoom.svg" />
+      <img class="dark-image" src="/api-docs-static-zoom-dark.svg" />
+    </div>
+    <div class="relative">
+      <div class="expander-hover-sticker">
+        <object class="sticker-clip-docs" width="113" height="143" data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/HLhbFqJ4vSzo4UDEZX2dq.svg"></object>
+      </div>
+      <div class="expander-hover-title">API Docs</div>
+      <div class="expander">
+        <div class="expander-content">
+          Write beautiful documentation with Markdown + MDX + Git Sync.
+        </div>
+      </div>
+      <a class="expander-hover-link" href="/scalar/scalar-docs/getting-started">Learn More</a>
+    </div>
+  </div>
+</div>
+<div class="footer container-full">
+  <div class="footer-content">
+      <div>
+        <span class="text-c-1">
+          <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
+        </span>
+        <p class="mt-10 text-c-3 text-sm text-balance">The Open API company.</p>
+        <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
+      </div>
+      <div class="flex text-sm">
+        <div class="w-1/3 flex flex-col gap-2">
+          <b>Products</b>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://guides.scalar.com/scalar/scalar-api-references/getting-started" target="_blank">API References</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://client.scalar.com/" target="_blank">API Client</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://docs.scalar.com/" target="_blank">API Docs</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://editor.scalar.com/" target="_blank">Swagger Editor</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://agent.scalar.com/" target="_blank">Agent Scalar</a>
+        </div>
+        <div class="w-1/3 flex flex-col gap-2">
+          <b>Company</b>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="mailto:support@scalar.com" target="_blank">Support</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/changelog" target="_blank">Changelog</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/terms-and-conditions" target="_blank">Terms of Service</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/privacy-policy" target="_blank">Privacy Policy</a>
+        </div>
+        <div class="w-1/3 flex flex-col gap-2">
+          <b>Socials</b>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://twitter.com/scalar" target="_blank">x (formerly twitter)</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://github.com/scalar/scalar" target="_blank">Github</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://discord.gg/scalar" target="_blank">Discord</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://www.linkedin.com/company/scalar-org" target="_blank">Linkedin</a>
+        </div>
+      </div>
+  </div>
+  <!-- footer animation -->
+  <div class="footer-animation">
+    <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/v1Pu6_BCmly6VhPAuotVZ.svg"></scalar-icon>
+  </div>
+</div>
+<style>
+    .resources-cta-container {
+      border-radius: var(--scalar-radius-lg);
+      border: var(--scalar-border-width) solid var(--scalar-border-color);
+      width: 100%;
+      padding: 12px 8px;
+    }
+  .resources-cta {
+    max-height: fit-content;
+    width: 100%;
+    top: 12px;
+    padding-top: 50px;
+    padding-bottom: 200px;
+  }
+  .full-container-constrained {
+    max-width: 720px;
+    padding-right: 40px;
+  }
+  .full-container-constrained > .t-editor__heading {
+    margin-top: 44px;
+  }
+  .full-container-constrained > .t-editor__paragraph {
+    margin-top: 12px;
+  }
+  .hero-animation  {
+    position: absolute;
+    top: -88px;
+    transform: scaleY(-1);
+    margin-top: 0 !important;
+  }
+  .hero-animation .fa {
+    --fa-orange: rgba(49, 215, 250, .25);
+    --fa-yellow: #0189fc;
+    --fa-red: rgba(54, 114, 255,0);
+    --scalar-background-2: var(--scalar-background-1)
+  }
+  @supports (color: color(display-p3 1 1 1)) {
+    .hero-animation .fa {
+      --fa-orange: color(display-p3 0.19 0.57 0.98 / 0.25);
+      --fa-yellow: color(display-p3 0 0.67 0.99);
+      --fa-red: color(display-p3 0.21 0.43 1 / 0);
+    }
+  }
+  .t-editor__page-title,
+  .layout-aside-right,
+  .t-editor__page-nav,
+  .notify-container,
+  .subheading {
+    display: none;
+  }
+  .t-doc .layout-header {
+    z-index: 10000;
+  }
+  .t-editor__button {
+    min-width: 160px;
+    justify-content: center;
+  }
+  .t-editor .editor-content,
+  .t-editor {
+    padding-bottom: 0;
+  }
+  h3.t-editor__heading,
+  h2.t-editor__heading {
+    --font-size: var(--scalar-heading-1);
+      margin-top: 0;
+  }
+  :root {
+    --scalar-container-width: 960px;
+    --scalar-toc-width: 0;
+  }
+  .hero.hero {
+    margin-top: 88px;
+  }
+  .small-test {
+    max-width: 680px;
+    text-wrap: balance;
+    margin-top: 88px;
+    position: relative;
+  }
+  .t-editor .editor-static .page-node {
+    max-width: var(--scalar-container-width);
+    padding-bottom: 0;
+    margin-bottom: 0;
+  }
+  .container {
+    width: var(--scalar-container-width);
+    margin: auto;
+    position: relative;
+  }
+  .container-full {
+    --scalar-container-sidebar-gap: calc(
+      (
+        (100dvw - var(--scalar-container-width) - var(--scalar-sidebar-width)) /
+          2
+      )
+    );
+    width: calc(100dvw - var(--scalar-sidebar-width));
+    margin-left: min(-1 * var(--scalar-container-sidebar-gap), -50px);
+  }
+  .container {
+    width: 900px;
+    margin: auto;
+    position: relative;
+  }
+  /* logos */
+  .logowall.logowall {
+    margin-top: 48px;
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    align-items: center;
+    gap: 40px;
+  }
+  .logowall-item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .logowall-item svg {
+    width: 100%;
+    height: auto;
+    max-height: 24px;
+  }
+  .ign-logo__fill {
+    fill: var(--scalar-color-1);
+  }
+  .fill-current-bg {
+    fill: var(--scalar-background-1);
+  }
+  /* feature */
+  .feature {
+    padding: 60px 0 !important;
+  }
+  .feature-container {
+    gap: 44px;
+    margin-top: 32px;
+  }
+  .feature-item {
+    flex: 0 0 calc(50% - 44px);
+  }
+  /* new stuff  */
+  .expander {
+    display: grid;
+    grid-template-rows: 0fr;
+    overflow: hidden;
+    opacity: 0;
+    transition: grid-template-rows 0.25s, opacity 0.25s ease-in-out;
+  }
+  .expander-content {
+    min-height: 0;
+    margin-bottom: 12px;
+    margin-top: 6px;
+    line-height: 1.45;
+    font-size: 14px;
+  }
+  .expander-hover {
+    height: 370px;
+    position: relative;
+  }
+  .expander-hover:hover .expander {
+    grid-template-rows: 1fr;
+    opacity: 1;
+    transition: grid-template-rows 0.5s, opacity 0.5s ease-in-out;
+  }
+  .expander.expanded .expander-content {
+    visibility: visible;
+  }
+  .expander-hover-title {
+    font-size: 20px;
+    font-weight: var(--scalar-semibold);
+    margin-top: 24px;
+  }
+  .expander-hover-link {
+    --font-color: var(--scalar-color-2);
+    --font-visited: var(--scalar-color-2);
+    color: var(--font-color, var(--scalar-color-1));
+    font-weight: var(--scalar-semibold);
+    text-underline-offset: 0.25rem;
+    text-decoration-thickness: 1px;
+    text-decoration: underline;
+    text-decoration-color: color-mix(
+      in srgb,
+      var(--font-color, var(--scalar-color-1)) 30%,
+      transparent
+    );
+    margin-top: 6px;
+  }
+  .expander-hover:hover .expander-hover-link {
+    --font-color: var(--scalar-color-1);
+  }
+  .expander-hover-preview {
+    position: absolute;
+    left: -120px;
+    top: -220px;
+    width: 1100px;
+    mask-image: radial-gradient(circle at top left, black 25%, transparent 40%);
+    pointer-events: none;
+    opacity: 0;
+    transition: all 0.3s ease-in-out;
+    transform: rotate(1deg) translate3d(-10px, -10px, 0);
+    max-height: 500px;
+    overflow: hidden;
+  }
+  .expander-hover .relative {
+    z-index: 1;
+  }
+  .expander-hover:hover .expander-hover-preview {
+    opacity: 1;
+    transform: rotate(2deg) translate3d(0, 0, 0);
+    transition: all 0.3s ease-in-out 0.2s;
+  }
+  .expander-hover-preview img {
+    margin-left: 0;
+    mask-image: linear-gradient(black, transparent);
+    width: 100%;
+  }
+  .expander-hover-sticker {
+    height: 143px;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    position: relative;
+    margin-left: -12px;
+    transition: transform 0.3s ease-in-out;
+    justify-content: flex-start;
+  }
+  .expander-hover-sticker object {
+    pointer-events: none;
+  }
+  .expander-hover-sticker img {
+    max-height: initial;
+    margin-left: initial;
+  }
+  .expander-hover:hover .expander-hover-sticker {
+    transform: rotate(-3deg);
+  }
+  .expander-container {
+    display: flex;
+    gap: 44px;
+  }
+  .cta {
+    padding: 140px 0;
+    margin-top: 0 !important;
+  }
+  .mb-11 {
+    margin-bottom: 44px;
+  }
+  /* footer */
+  .footer {
+    position: relative;
+    overflow: hidden;
+    background: var(--scalar-background-2);
+    padding-inline: 20px;
+    padding-bottom: 200px;
+    margin-top: 100px;
+  }
+  .footer-animation {
+    margin-inline: -30px;
+  }
+  .footer-animation svg {
+    position: absolute;
+    bottom: 0;
+  }
+  .footer-content {
+    display: flex;
+    gap: 48px;
+    max-width: var(--scalar-container-width);
+    width: 100%;
+    margin: auto;
+    padding-top: 92px;
+  }
+  .footer-content > * {
+    flex: 1;
+  }
+  .footer-content span,
+  .footer-content p,
+  .footer-content a {
+    position: relative;
+    z-index: 1;
+  }
+  .w-1\/3 {
+    width: 33.33%
+  }
+  .light-mode .dark-image {
+    display: none;
+  }
+  .dark-mode .light-image {
+    display: none;
+  }
+  .sticker-clip-client {
+    clip-path: path("M158 91.9102C158 95.8908 154.773 99.1172 150.792 99.1172L147.269 99.1172L147.269 105.78C147.268 107.948 145.511 109.705 143.343 109.705L86.2051 109.705C84.0373 109.705 82.2795 107.948 82.2793 105.78L82.2793 99.1172L7.208 99.1172C3.22741 99.1172 1.10673e-05 95.8908 -4.01752e-06 91.9101L-3.50643e-06 80.2178C-3.47119e-06 79.4117 0.135571 78.6109 0.400387 77.8496L25.7949 4.83984C26.8028 1.94219 29.5346 -5.6154e-06 32.6025 -5.4813e-06L150.792 -3.15072e-07C154.773 -1.41078e-07 158 3.22654 158 7.20703L158 91.9102Z")
+  }
+  .sticker-clip-sdk {
+    clip-path: path("M60.0562 8.61129C65.9233 -1.83053 81.0294 -1.61478 86.5955 8.99068L142.416 115.353C144.543 119.406 141.567 124.259 136.991 124.201L114.679 123.918L114.138 135.797C113.962 139.654 110.761 142.678 106.9 142.634L32.9393 141.782C29.1212 141.738 26.0084 138.707 25.864 134.891L25.406 122.787L6.28841 122.544C1.70363 122.486 -1.1476 117.543 1.09835 113.545L60.0562 8.61129Z")
+  }
+  .sticker-clip-registry {
+    clip-path: path("M71.0986 1.13334C75.8537 -0.596969 81.1116 1.85514 82.8428 6.6099L90.3037 27.1079H98.5059C104.199 27.108 108.814 31.7235 108.814 37.4165V77.9663L121.32 112.329C119.703 112.128 118.003 112.298 116.351 112.899C110.96 114.861 108.12 120.659 110.009 125.848C111.898 131.038 117.8 133.654 123.191 131.692C124.844 131.091 126.254 130.127 127.364 128.933L134.608 148.835C136.339 153.591 133.887 158.849 129.132 160.58L73.3945 180.866C68.6393 182.596 63.3816 180.145 61.6504 175.39L58.958 167.994H2.29102C1.02582 167.994 0 166.968 0 165.703V29.398C0.000538247 28.1333 1.02616 27.1079 2.29102 27.1079H9.8125C10.6721 24.5603 12.6383 22.4116 15.3613 21.4204L71.0986 1.13334Z")
+  }
+  .sticker-clip-docs {
+    overflow: hidden;
+    border-radius: 20px;
+  }
+  @media screen and (max-width: 1280px) {
+      .resources-cta {
+        display: none;
+      }
+      .full-container-constrained {
+        padding-right: 0px;
+        max-width: 100%;
+      }
+    }
+  @media screen and (max-width: 1000px) {
+    .t-doc {
+      --scalar-sidebar-width: 0px;
+    }
+    .hero.hero {
+      margin-top: 188px;
+    }
+    .container-full {
+      --scalar-container-sidebar-gap: 30px;
+      padding-inline: 30px;
+      margin-inline: -30px;
+    }
+    .hero-animation {
+      margin-top: -100px !important;
+      padding-inline: 0;
+      margin-inline: 0;
+    }
+    .logowall.logowall {
+      grid-template-columns: repeat(3, 1fr);
+      column-gap: 20px;
+      row-gap: 40px;
+    }
+    .logowall-item {
+      justify-content: start;
+    }
+    .logowall-item svg {
+      width: auto;
+      max-width: 100%;
+      height: 100%;
+      max-height: 20px;
+    }
+    .feature-item {
+      flex: 0 0 calc(100% - 22px);
+    }
+    .expander-container {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      row-gap: 0;
+    }
+    .expander-hover {
+      width: auto;
+    }
+    .expander-hover .expander {
+      grid-template-rows: 1fr;
+      opacity: 1;
+    }
+    .expander .expander-content {
+      visibility: visible;
+    }
+    .footer-content {
+      flex-direction: column;
+    }
+    .footer-content > * {
+      flex: initial;
+    }
+  }
+</style>

--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -159,7 +159,7 @@ They are open source. So I can get in on free features and stay with Scalar no m
   <div class="resources-cta sticky">
     <div class="resources-cta-container">
       <p class="mt-3 mb-1 pl-2">
-        <b class="font-medium">Additioanl Reading</b>
+        <b class="font-medium">Additional Reading</b>
       </p>
       <p>
         <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/scalar-docs/github-sync"><scalar-icon src="phosphor/bold/git-branch"></scalar-icon> Github Sync</a>

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -495,7 +495,7 @@ They are open source. So I can get in on free features and stay with Scalar no m
     --scalar-toc-width: 0;
   }
   .hero.hero {
-    margin-top: 80px;
+    margin-top: 88px;
   }
   .small-test {
     max-width: 440px;
@@ -541,7 +541,7 @@ They are open source. So I can get in on free features and stay with Scalar no m
     overflow: scroll;
     scroll-snap-type: both mandatory;
     scrollbar-width: none;
-    padding-left: max(var(--scalar-container-sidebar-gap) - 70px, 50px);
+    padding-left: max(var(--scalar-container-sidebar-gap) - 70px, 50px) !important;
     position: relative;
     margin-top: 32px;
   }

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -825,7 +825,7 @@ h4.t-editor__heading {
     --scalar-toc-width: 0;
   }
   .hero.hero {
-    margin-top: 80px;
+    margin-top: 88px;
   }
   .small-test {
     max-width: 440px;

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -1,15 +1,34 @@
-# Getting Started
+<h1>Getting Started</h1>
+<div class="hero-animation container-full">
+  <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/v1Pu6_BCmly6VhPAuotVZ.svg"></scalar-icon>
+</div>
+<div class="flex flex-col gap-3 hero small-test">
+  <h2 class="text-balance">
+    Scalar Registry
+  </h2>
+  <p>
+    Get started with Scalar Docs, literally in minutes. You don't need anything to get started, not even an account if you just want to play around.
+  </p>
+</div>
+<img class="light-image mt-10" src="/registry-animated.svg"/>
+<img class="dark-image mt-10" src="/registry-animated-dark.svg"/>
+
+<div class="flex">
+  <div class="full-container-constrained">
+
+## Getting Started
 Reading this guide helps you to get started with Scalar Registry for managing & versioning OpenAPI Documents, JSON Schema, Spectral Rules as your source of truth with a deep Git integration.
 
 ## Create your Scalar Account
 To first access the Scalar Registry you need to [create an account](https://dashboard.scalar.com/register) or [sign in](https://dashboard.scalar.com/login).
 
-![Scalar Dashboard](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/t8MUp4KrYwCT9WKYuVnUu.png "Scalar Dashboard")
-
 Once authenticated you will see your dashboard, you have two options to interface with the Scalar Registry:
 - The Scalar [dashboard](https://guides.scalar.com/scalar/scalar-registry/dashboard)
 - The Scalar [CLI](https://guides.scalar.com/scalar/scalar-registry/cli)
 - Our [GitHub Workflows](https://guides.scalar.com/scalar/scalar-registry/github-workflows)
+
+<img class="light-image mt-6" src="/scalar-dashboard.svg"/>
+<img class="dark-image mt-6" src="/scalar-dashboard-dark.svg"/>
 
 ## So... Why a Registry?
 Managing OpenAPI can be difficult; is the source-of-truth: design, implementation, Git, cloud? How do you manage versions and access, also how do downstream consumers of your API interact with it? Does it need to be private?
@@ -20,12 +39,609 @@ Scalar handles all this and makes it incredibly easy to get to the exciting stuf
 
 ### Create Docs
 World Class API Docs with just a few clicks, all managed by Scalars registry automagically from your OpenAPI document changes.
-![Scalar Docs](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/5m7ze7mOrL8sfCsiscwBv.png "Scalar Docs")
+
+<img class="light-image mt-6" src="/api-docs-static-zoom.svg" />
+<img class="dark-image mt-6" src="/api-docs-static-zoom-dark.svg" />
 
 ### Create SDKs
 World Class SDKs with just a few clicks, all managed by Scalars registry automagically from your OpenAPI document changes.
-![Scalar SDKs](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/IFjPvoh6_GLT0oVZfLQvl.png "Scalar SDKs")
 
 and so much more!
 
 All of this with just a couple clicks or a few API requests! You handle making your API great, and we will handle the rest of the tooling. OpenAPI first.
+
+<img class="light-image mt-6" src="/sdk-dashboard-static.svg" />
+<img class="dark-image mt-6" src="/sdk-dashboard-static-dark.svg" />
+
+<div class="feature">
+  <h2>Features</h2>
+  <div class="flex flex-wrap feature-container">
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-green">
+        <scalar-icon src="phosphor/bold/git-branch"></scalar-icon>
+        Single Source of Truth
+      </b>
+      <p>
+        "After years of helping enterprises implemeain points I watched customers struggle with daily. This is the modern API platform developers deserve."
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-green">
+        <scalar-icon src="phosphor/bold/arrows-clockwise"></scalar-icon>
+          Bi-directional Git Sync
+      </b>
+      <p>
+        "One of my most recent favorites is a in-browser ad hoc testing UI called Scalar.
+One of the things that I really love about Scalar, it's got this modern UI experience, and it
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-green">
+        <scalar-icon src="phosphor/bold/arrow-up-right"></scalar-icon>
+          OpenAPI Documents
+      </b>
+      <p>
+with offerings at every price point.
+They are open source. So I can get in on free features and stay with Scalar no matter how big my API needs blow up."
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-green">
+        <scalar-icon src="phosphor/bold/brackets-curly"></scalar-icon>
+        JSON Schema  Support
+      </b>
+      <p>
+        "After years of helping enterprises implemeain points I watched customers struggle with daily. This is the modern API platform developers deserve."
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-green">
+        <scalar-icon src="phosphor/bold/warning-octagon"></scalar-icon>
+          Spectral Rules
+      </b>
+      <p>
+        "One of my most recent favorites is a in-browser ad hoc testing UI called Scalar.
+One of the things that I really love about Scalar, it's got this modern UI experience, and it
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-green">
+        <scalar-icon src="phosphor/bold/lock-simple"></scalar-icon>
+          Private or Public
+      </b>
+      <p>
+with offerings at every price point.
+They are open source. So I can get in on free features and stay with Scalar no matter how big my API needs blow up."
+      </p>
+    </div>
+  </div>
+  <div class="cta flex flex-col gap-3 small-test">
+  <h2 class="text-balance">What are you waiting for?</h2>
+  <p>
+    We're committed to enabling developers and companies to practice the highest
+    of API industry standards.
+  </p>
+  <div class="flex gap-2 mb-11">
+    <a class="t-editor__button" href="https://dashboard.scalar.com/register">Get Started</a>
+    <a class="t-editor__button" href="https://cal.com/scalar/30min" target="_blank">Book a Demo</a>
+  </div>
+  <a class="expander-hover-link" href="https://discord.gg/scalar" target="_blank">Community →</a>
+  <a class="expander-hover-link" href="https://github.com/scalar/scalar" target="_blank">GitHub →</a>
+  <a class="expander-hover-link" href="mailto:support@scalar.com" target="_blank">Contact Us →</a>
+</div>
+</div>
+</div>
+  <div class="resources-cta sticky">
+    <div class="resources-cta-container">
+      <p class="mt-3 mb-1 pl-2">
+        <b class="font-medium">Additioanl Reading</b>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/scalar-registry/cli"><scalar-icon src="phosphor/bold/brackets-square"></scalar-icon> CLI</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/scalar-regsitry/upload"><scalar-icon src="phosphor/bold/upload"></scalar-icon> Upload API</a>
+      </p>
+      <p class="mt-3 mb-1 pl-2">
+        <b class="font-medium">Community</b>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="https://discord.gg/scalar" target="_blank"><scalar-icon src="phosphor/bold/discord-logo"></scalar-icon> Discord</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="https://twitter.com/scalar" target="_blank"><scalar-icon src="phosphor/bold/twitter-logo"></scalar-icon> Twitter</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="https://github.com/scalar/scalar" target="_blank"><scalar-icon src="phosphor/bold/github-logo"></scalar-icon> Github</a>
+      </p>
+    </div>
+  </div>
+</div>
+
+<div class="expander-container">
+  <div class="expander-hover">
+    <div class="expander-hover-preview">
+      <img class="light-image" src="/api-client-static.svg" />
+      <img class="dark-image" src="/api-client-static-dark.svg" />
+    </div>
+    <div class="relative">
+      <div class="expander-hover-sticker">
+        <object class="sticker-clip-client" width="156" height="110"
+          data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/JXS6tZ4EbKIkeGpjP6QKc.svg"></object>
+      </div>
+      <div class="expander-hover-title">API Client</div>
+      <div class="expander">
+        <div class="expander-content">
+          Minimal, powerful, fully open-source API Client built on open standards by us + our community.
+        </div>
+      </div>
+      <a class="expander-hover-link" href="https://client.scalar.com/" target="_blank">Learn More</a>
+    </div>
+  </div>
+  <div class="expander-hover">
+    <div class="expander-hover-preview">
+      <img class="light-image" src="/sdks-static.svg" />
+      <img class="dark-image" src="/sdks-static-dark.svg" />
+    </div>
+    <div class="relative">
+      <div class="expander-hover-sticker">
+        <object class="sticker-clip-sdk" width="145" height="145"
+          data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/gM-mqYTBYMkqpnexTIr-r.svg"></object>
+      </div>
+      <div class="expander-hover-title">SDKs</div>
+      <div class="expander">
+        <div class="expander-content">
+          Bring your OpenAPI document and get type-safe client libraries for TypeScript, Python and more.
+        </div>
+      </div>
+      <a class="expander-hover-link" href="/scalar/scalar-sdks/getting-started">Learn More</a>
+    </div>
+  </div>
+  <div class="expander-hover">
+    <div class="expander-hover-preview">
+      <img class="light-image" src="/registry-static.svg" />
+      <img class="dark-image" src="/registry-static-dark.svg" />
+    </div>
+    <div class="relative">
+      <div class="expander-hover-sticker">
+      <object class="sticker-clip-registry" width="136" height="186"
+          data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/jgGF_IKsu-T_irS-6MMOy.svg"></object>
+      </div>
+      <div class="expander-hover-title">API Registry</div>
+      <div class="expander">
+        <div class="expander-content">
+          Managing & versioning OpenAPI Documents with a deep Git integration.
+        </div>
+      </div>
+      <a class="expander-hover-link" href="/scalar/scalar-registry/getting-started">Learn More</a>
+    </div>
+  </div>
+  <div class="expander-hover">
+    <div class="expander-hover-preview">
+      <img class="light-image" src="/api-docs-static-zoom.svg" />
+      <img class="dark-image" src="/api-docs-static-zoom-dark.svg" />
+    </div>
+    <div class="relative">
+      <div class="expander-hover-sticker">
+        <object class="sticker-clip-docs" width="113" height="143" data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/HLhbFqJ4vSzo4UDEZX2dq.svg"></object>
+      </div>
+      <div class="expander-hover-title">API Docs</div>
+      <div class="expander">
+        <div class="expander-content">
+          Write beautiful documentation with Markdown + MDX + Git Sync.
+        </div>
+      </div>
+      <a class="expander-hover-link" href="/scalar/scalar-docs/getting-started">Learn More</a>
+    </div>
+  </div>
+</div>
+<div class="footer container-full">
+  <div class="footer-content">
+      <div>
+        <span class="text-c-1">
+          <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
+        </span>
+        <p class="mt-10 text-c-3 text-sm text-balance">The Open API company.</p>
+        <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
+      </div>
+      <div class="flex text-sm">
+        <div class="w-1/3 flex flex-col gap-2">
+          <b>Products</b>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://guides.scalar.com/scalar/scalar-api-references/getting-started" target="_blank">API References</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://client.scalar.com/" target="_blank">API Client</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://docs.scalar.com/" target="_blank">API Docs</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://editor.scalar.com/" target="_blank">Swagger Editor</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://agent.scalar.com/" target="_blank">Agent Scalar</a>
+        </div>
+        <div class="w-1/3 flex flex-col gap-2">
+          <b>Company</b>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="mailto:support@scalar.com" target="_blank">Support</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/changelog" target="_blank">Changelog</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/terms-and-conditions" target="_blank">Terms of Service</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/privacy-policy" target="_blank">Privacy Policy</a>
+        </div>
+        <div class="w-1/3 flex flex-col gap-2">
+          <b>Socials</b>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://twitter.com/scalar" target="_blank">x (formerly twitter)</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://github.com/scalar/scalar" target="_blank">Github</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://discord.gg/scalar" target="_blank">Discord</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://www.linkedin.com/company/scalar-org" target="_blank">Linkedin</a>
+        </div>
+      </div>
+  </div>
+  <!-- footer animation -->
+  <div class="footer-animation">
+    <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/v1Pu6_BCmly6VhPAuotVZ.svg"></scalar-icon>
+  </div>
+</div>
+<style>
+    .resources-cta-container {
+      border-radius: var(--scalar-radius-lg);
+      border: var(--scalar-border-width) solid var(--scalar-border-color);
+      width: 100%;
+      padding: 12px 8px;
+    }
+  .resources-cta {
+    max-height: fit-content;
+    width: 100%;
+    top: 12px;
+    padding-top: 50px;
+    padding-bottom: 200px;
+  }
+  .full-container-constrained {
+    max-width: 720px;
+    padding-right: 40px;
+  }
+  .full-container-constrained > .t-editor__heading {
+    margin-top: 44px;
+  }
+  .full-container-constrained > .t-editor__paragraph {
+    margin-top: 12px;
+  }
+  .full-container-constrained > .t-editor__steps {
+    margin-top: 24px;
+    margin-bottom: 24px;
+  }
+  .hero-animation  {
+    position: absolute;
+    top: -88px;
+    transform: scaleY(-1);
+    margin-top: 0 !important;
+  }
+  .hero-animation .fa {
+    --fa-orange: rgb(128 248 0 / 38%);
+    --fa-yellow: rgb(0 158 85);
+    --fa-red: rgb(115 0 255 / 0%);
+    --scalar-background-2: var(--scalar-background-1)
+  }
+  @supports (color: color(display-p3 1 1 1)) {
+    .hero-animation .fa {
+        --fa-orange: color(display-p3 0.62 0.96 0.17 / 0.38);
+        --fa-yellow: color(display-p3 0.19 0.61 0.36);
+        --fa-red: color(display-p3 0.41 0 0.99 / 0);
+    }
+  }
+  .t-editor__page-title,
+  .layout-aside-right,
+  .t-editor__page-nav,
+  .notify-container,
+  .subheading {
+    display: none;
+  }
+  .t-doc .layout-header {
+    z-index: 10000;
+  }
+  .t-editor__button {
+    min-width: 160px;
+    justify-content: center;
+  }
+  .t-editor .editor-content,
+  .t-editor {
+    padding-bottom: 0;
+  }
+  h3.t-editor__heading,
+  h2.t-editor__heading {
+    --font-size: var(--scalar-heading-1);
+      margin-top: 0;
+  }
+  :root {
+    --scalar-container-width: 960px;
+    --scalar-toc-width: 0;
+  }
+  .hero.hero {
+    margin-top: 88px;
+  }
+  .small-test {
+    max-width: 680px;
+    text-wrap: balance;
+    margin-top: 88px;
+    position: relative;
+  }
+  .t-editor .editor-static .page-node {
+    max-width: var(--scalar-container-width);
+    padding-bottom: 0;
+    margin-bottom: 0;
+  }
+  .container {
+    width: var(--scalar-container-width);
+    margin: auto;
+    position: relative;
+  }
+  .container-full {
+    --scalar-container-sidebar-gap: calc(
+      (
+        (100dvw - var(--scalar-container-width) - var(--scalar-sidebar-width)) /
+          2
+      )
+    );
+    width: calc(100dvw - var(--scalar-sidebar-width));
+    margin-left: min(-1 * var(--scalar-container-sidebar-gap), -50px);
+  }
+  .container {
+    width: 900px;
+    margin: auto;
+    position: relative;
+  }
+  /* logos */
+  .logowall.logowall {
+    margin-top: 48px;
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    align-items: center;
+    gap: 40px;
+  }
+  .logowall-item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .logowall-item svg {
+    width: 100%;
+    height: auto;
+    max-height: 24px;
+  }
+  .ign-logo__fill {
+    fill: var(--scalar-color-1);
+  }
+  .fill-current-bg {
+    fill: var(--scalar-background-1);
+  }
+  /* feature */
+  .feature {
+    padding: 60px 0 !important;
+  }
+  .feature-container {
+    gap: 44px;
+    margin-top: 32px;
+  }
+  .feature-item {
+    flex: 0 0 calc(50% - 44px);
+  }
+  /* new stuff  */
+  .expander {
+    display: grid;
+    grid-template-rows: 0fr;
+    overflow: hidden;
+    opacity: 0;
+    transition: grid-template-rows 0.25s, opacity 0.25s ease-in-out;
+  }
+  .expander-content {
+    min-height: 0;
+    margin-bottom: 12px;
+    margin-top: 6px;
+    line-height: 1.45;
+    font-size: 14px;
+  }
+  .expander-hover {
+    height: 370px;
+    position: relative;
+  }
+  .expander-hover:hover .expander {
+    grid-template-rows: 1fr;
+    opacity: 1;
+    transition: grid-template-rows 0.5s, opacity 0.5s ease-in-out;
+  }
+  .expander.expanded .expander-content {
+    visibility: visible;
+  }
+  .expander-hover-title {
+    font-size: 20px;
+    font-weight: var(--scalar-semibold);
+    margin-top: 24px;
+  }
+  .expander-hover-link {
+    --font-color: var(--scalar-color-2);
+    --font-visited: var(--scalar-color-2);
+    color: var(--font-color, var(--scalar-color-1));
+    font-weight: var(--scalar-semibold);
+    text-underline-offset: 0.25rem;
+    text-decoration-thickness: 1px;
+    text-decoration: underline;
+    text-decoration-color: color-mix(
+      in srgb,
+      var(--font-color, var(--scalar-color-1)) 30%,
+      transparent
+    );
+    margin-top: 6px;
+  }
+  .expander-hover:hover .expander-hover-link {
+    --font-color: var(--scalar-color-1);
+  }
+  .expander-hover-preview {
+    position: absolute;
+    left: -120px;
+    top: -220px;
+    width: 1100px;
+    mask-image: radial-gradient(circle at top left, black 25%, transparent 40%);
+    pointer-events: none;
+    opacity: 0;
+    transition: all 0.3s ease-in-out;
+    transform: rotate(1deg) translate3d(-10px, -10px, 0);
+    max-height: 500px;
+    overflow: hidden;
+  }
+  .expander-hover .relative {
+    z-index: 1;
+  }
+  .expander-hover:hover .expander-hover-preview {
+    opacity: 1;
+    transform: rotate(2deg) translate3d(0, 0, 0);
+    transition: all 0.3s ease-in-out 0.2s;
+  }
+  .expander-hover-preview img {
+    margin-left: 0;
+    mask-image: linear-gradient(black, transparent);
+    width: 100%;
+  }
+  .expander-hover-sticker {
+    height: 143px;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    position: relative;
+    margin-left: -12px;
+    transition: transform 0.3s ease-in-out;
+    justify-content: flex-start;
+  }
+  .expander-hover-sticker object {
+    pointer-events: none;
+  }
+  .expander-hover-sticker img {
+    max-height: initial;
+    margin-left: initial;
+  }
+  .expander-hover:hover .expander-hover-sticker {
+    transform: rotate(-3deg);
+  }
+  .expander-container {
+    display: flex;
+    gap: 44px;
+  }
+  .cta {
+    padding: 140px 0;
+    margin-top: 0 !important;
+  }
+  .mb-11 {
+    margin-bottom: 44px;
+  }
+  /* footer */
+  .footer {
+    position: relative;
+    overflow: hidden;
+    background: var(--scalar-background-2);
+    padding-inline: 20px;
+    padding-bottom: 200px;
+    margin-top: 100px;
+  }
+  .footer-animation {
+    margin-inline: -30px;
+  }
+  .footer-animation svg {
+    position: absolute;
+    bottom: 0;
+  }
+  .footer-content {
+    display: flex;
+    gap: 48px;
+    max-width: var(--scalar-container-width);
+    width: 100%;
+    margin: auto;
+    padding-top: 92px;
+  }
+  .footer-content > * {
+    flex: 1;
+  }
+  .footer-content span,
+  .footer-content p,
+  .footer-content a {
+    position: relative;
+    z-index: 1;
+  }
+  .w-1\/3 {
+    width: 33.33%
+  }
+  .light-mode .dark-image {
+    display: none;
+  }
+  .dark-mode .light-image {
+    display: none;
+  }
+  .sticker-clip-client {
+    clip-path: path("M158 91.9102C158 95.8908 154.773 99.1172 150.792 99.1172L147.269 99.1172L147.269 105.78C147.268 107.948 145.511 109.705 143.343 109.705L86.2051 109.705C84.0373 109.705 82.2795 107.948 82.2793 105.78L82.2793 99.1172L7.208 99.1172C3.22741 99.1172 1.10673e-05 95.8908 -4.01752e-06 91.9101L-3.50643e-06 80.2178C-3.47119e-06 79.4117 0.135571 78.6109 0.400387 77.8496L25.7949 4.83984C26.8028 1.94219 29.5346 -5.6154e-06 32.6025 -5.4813e-06L150.792 -3.15072e-07C154.773 -1.41078e-07 158 3.22654 158 7.20703L158 91.9102Z")
+  }
+  .sticker-clip-sdk {
+    clip-path: path("M60.0562 8.61129C65.9233 -1.83053 81.0294 -1.61478 86.5955 8.99068L142.416 115.353C144.543 119.406 141.567 124.259 136.991 124.201L114.679 123.918L114.138 135.797C113.962 139.654 110.761 142.678 106.9 142.634L32.9393 141.782C29.1212 141.738 26.0084 138.707 25.864 134.891L25.406 122.787L6.28841 122.544C1.70363 122.486 -1.1476 117.543 1.09835 113.545L60.0562 8.61129Z")
+  }
+  .sticker-clip-registry {
+    clip-path: path("M71.0986 1.13334C75.8537 -0.596969 81.1116 1.85514 82.8428 6.6099L90.3037 27.1079H98.5059C104.199 27.108 108.814 31.7235 108.814 37.4165V77.9663L121.32 112.329C119.703 112.128 118.003 112.298 116.351 112.899C110.96 114.861 108.12 120.659 110.009 125.848C111.898 131.038 117.8 133.654 123.191 131.692C124.844 131.091 126.254 130.127 127.364 128.933L134.608 148.835C136.339 153.591 133.887 158.849 129.132 160.58L73.3945 180.866C68.6393 182.596 63.3816 180.145 61.6504 175.39L58.958 167.994H2.29102C1.02582 167.994 0 166.968 0 165.703V29.398C0.000538247 28.1333 1.02616 27.1079 2.29102 27.1079H9.8125C10.6721 24.5603 12.6383 22.4116 15.3613 21.4204L71.0986 1.13334Z")
+  }
+  .sticker-clip-docs {
+    overflow: hidden;
+    border-radius: 20px;
+  }
+  @media screen and (max-width: 1280px) {
+      .resources-cta {
+        display: none;
+      }
+      .full-container-constrained {
+        padding-right: 0px;
+        max-width: 100%;
+      }
+    }
+  @media screen and (max-width: 1000px) {
+    .t-doc {
+      --scalar-sidebar-width: 0px;
+    }
+    .hero.hero {
+      margin-top: 188px;
+    }
+    .container-full {
+      --scalar-container-sidebar-gap: 30px;
+      padding-inline: 30px;
+      margin-inline: -30px;
+    }
+    .hero-animation {
+      margin-top: -100px !important;
+      padding-inline: 0;
+      margin-inline: 0;
+    }
+    .logowall.logowall {
+      grid-template-columns: repeat(3, 1fr);
+      column-gap: 20px;
+      row-gap: 40px;
+    }
+    .logowall-item {
+      justify-content: start;
+    }
+    .logowall-item svg {
+      width: auto;
+      max-width: 100%;
+      height: 100%;
+      max-height: 20px;
+    }
+    .feature-item {
+      flex: 0 0 calc(100% - 22px);
+    }
+    .expander-container {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      row-gap: 0;
+    }
+    .expander-hover {
+      width: auto;
+    }
+    .expander-hover .expander {
+      grid-template-rows: 1fr;
+      opacity: 1;
+    }
+    .expander .expander-content {
+      visibility: visible;
+    }
+    .footer-content {
+      flex-direction: column;
+    }
+    .footer-content > * {
+      flex: initial;
+    }
+  }
+</style>

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -7,7 +7,7 @@
     Scalar Registry
   </h2>
   <p>
-    Get started with Scalar Docs, literally in minutes. You don't need anything to get started, not even an account if you just want to play around.
+    Get started with Scalar Registry for managing & versioning OpenAPI Documents, JSON Schema, Spectral Rules as your source of truth with a deep Git integration.
   </p>
 </div>
 <img class="light-image mt-10" src="/registry-animated.svg"/>
@@ -15,9 +15,6 @@
 
 <div class="flex">
   <div class="full-container-constrained">
-
-## Getting Started
-Reading this guide helps you to get started with Scalar Registry for managing & versioning OpenAPI Documents, JSON Schema, Spectral Rules as your source of truth with a deep Git integration.
 
 ## Create your Scalar Account
 To first access the Scalar Registry you need to [create an account](https://dashboard.scalar.com/register) or [sign in](https://dashboard.scalar.com/login).
@@ -134,13 +131,13 @@ They are open source. So I can get in on free features and stay with Scalar no m
   <div class="resources-cta sticky">
     <div class="resources-cta-container">
       <p class="mt-3 mb-1 pl-2">
-        <b class="font-medium">Additioanl Reading</b>
+        <b class="font-medium">Additional Reading</b>
       </p>
       <p>
         <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/scalar-registry/cli"><scalar-icon src="phosphor/bold/brackets-square"></scalar-icon> CLI</a>
       </p>
       <p>
-        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/scalar-regsitry/upload"><scalar-icon src="phosphor/bold/upload"></scalar-icon> Upload API</a>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/scalar-registry/upload"><scalar-icon src="phosphor/bold/upload"></scalar-icon> Upload API</a>
       </p>
       <p class="mt-3 mb-1 pl-2">
         <b class="font-medium">Community</b>

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -1,4 +1,22 @@
-# Getting Started
+<h1>Getting Started</h1>
+<div class="hero-animation container-full">
+  <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/v1Pu6_BCmly6VhPAuotVZ.svg"></scalar-icon>
+</div>
+<div class="flex flex-col gap-3 hero small-test">
+  <h2 class="text-balance">
+    Scalar SDKs.
+  </h2>
+  <p>
+    Get started with Scalar Docs, literally in minutes. You don't need anything to get started, not even an account if you just want to play around.
+  </p>
+</div>
+<img class="light-image mt-10" src="/sdks-animated.svg"/>
+<img class="dark-image mt-10" src="/sdks-animated-dark.svg"/>
+
+<div class="flex">
+  <div class="full-container-constrained">
+
+## Getting Started
 This guide will help you get started with generating world-class SDKs on scalar.com in several languages: TypeScript, Python, Golang & more powered by [Speakeasy](https://speakeasy.com).
 
 :::scalar-callout{ type=info }
@@ -8,26 +26,623 @@ SDK generation is part of our paid plans and costs $100 per month per language. 
 Make sure you have created a Scalar Account & are logged in ([see create account guide](https://guides.scalar.com/scalar/scalar-registry/getting-started#create-your-scalar-account))
 
 ## Generating your first SDK
-From the [dashboard](https://dashboard.scalar.com) left-most sidebar under Products > SDKs, then click Create new SDK.
 
-![Create new SDK Page](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/_-IfCKbkQuZevciAtViRX.png "Create new SDK Page")
+<scalar-steps>
+  <scalar-step id="step-1" title="Upload OpenAPI Document">
 
-#### Import OpenAPI Document (Optional) 
+From the [dashboard](https://dashboard.scalar.com) click "Create new SDK".
+<br>
+<br>
 If you don't already have an OpenAPI document on our registry, you can import it right in the modal.
 
-![Import OpenAPI Document (Optional)](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/WnMVG8hrR_f-6t-lOtDYb.png "Import OpenAPI Document (Optional)")
-
+  </scalar-step>
+  
+  <scalar-step id="step-2" title="Select Desired Languages">
 Select as many SDKs as you would like, or just one language to start. Once you click "Continue" we will begin generating your SDKs.
 
-![Create TypeScript SDK](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/lH3Grvx1nPikw7-0sTE4Y.png "Create TypeScript SDK")
-
-
+  </scalar-step>
+  
+  <scalar-step id="step-3" title="Manage your new SDKs">
 Once created, you will get redirected to the SDK Overview page where you can:
 - Configure your SDK settings
 - Add our GitHub Integration
 - Downlad the SDK Client
 
-![SDK Overview Page](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/1TbvZqmSD170GGOw9O_iP.png "SDK Overview Page")
+  </scalar-step>
+</scalar-steps>
 
-## Link with GitHub
+<img class="light-image" src="/sdk-dashboard-static.svg" />
+<img class="dark-image" src="/sdk-dashboard-static-dark.svg" />
 
+<div class="feature">
+  <h2>Features</h2>
+  <div class="flex flex-wrap feature-container">
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/arrow-up-right"></scalar-icon>
+          OpenAPI-First
+      </b>
+      <p>
+        "After years of helping enterprises implemeain points I watched customers struggle with daily. This is the modern API platform developers deserve."
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/brackets-square"></scalar-icon>
+          Custom-code
+      </b>
+      <p>
+        "One of my most recent favorites is a in-browser ad hoc testing UI called Scalar.
+One of the things that I really love about Scalar, it's got this modern UI experience, and it
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/code"></scalar-icon>
+          Code Samples
+      </b>
+      <p>
+with offerings at every price point.
+They are open source. So I can get in on free features and stay with Scalar no matter how big my API needs blow up."
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/fingerprint"></scalar-icon>
+          OpenAPI Authentication
+      </b>
+      <p>
+        "After years of helping enterprises implemeain points I watched customers struggle with daily. This is the modern API platform developers deserve."
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/cloud-check"></scalar-icon>
+          Syncs with Docs
+      </b>
+      <p>
+        "One of my most recent favorites is a in-browser ad hoc testing UI called Scalar.
+One of the things that I really love about Scalar, it's got this modern UI experience, and it
+      </p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/file-cloud"></scalar-icon>
+          File Streaming Support
+      </b>
+      <p>
+with offerings at every price point.
+They are open source. So I can get in on free features and stay with Scalar no matter how big my API needs blow up."
+      </p>
+    </div>
+  </div>
+  <div class="cta flex flex-col gap-3 small-test">
+  <h2 class="text-balance">What are you waiting for?</h2>
+  <p>
+    We're committed to enabling developers and companies to practice the highest
+    of API industry standards.
+  </p>
+  <div class="flex gap-2 mb-11">
+    <a class="t-editor__button" href="https://dashboard.scalar.com/register">Get Started</a>
+    <a class="t-editor__button" href="https://cal.com/scalar/30min" target="_blank">Book a Demo</a>
+  </div>
+  <a class="expander-hover-link" href="https://discord.gg/scalar" target="_blank">Community →</a>
+  <a class="expander-hover-link" href="https://github.com/scalar/scalar" target="_blank">GitHub →</a>
+  <a class="expander-hover-link" href="mailto:support@scalar.com" target="_blank">Contact Us →</a>
+</div>
+</div>
+</div>
+  <div class="resources-cta sticky">
+    <div class="resources-cta-container">
+      <p class="mt-3 mb-1 pl-2">
+        <b class="font-medium">Additioanl Reading</b>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/scalar-sdks/configuration/typescript"><scalar-icon src="phosphor/bold/file-ts"></scalar-icon> Typescript SDKs</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/scalar-regsitry/getting-started"><scalar-icon src="phosphor/bold/seal-check"></scalar-icon> Scalar Registry</a>
+      </p>
+      <p class="mt-3 mb-1 pl-2">
+        <b class="font-medium">Community</b>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="https://discord.gg/scalar" target="_blank"><scalar-icon src="phosphor/bold/discord-logo"></scalar-icon> Discord</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="https://twitter.com/scalar" target="_blank"><scalar-icon src="phosphor/bold/twitter-logo"></scalar-icon> Twitter</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="https://github.com/scalar/scalar" target="_blank"><scalar-icon src="phosphor/bold/github-logo"></scalar-icon> Github</a>
+      </p>
+    </div>
+  </div>
+</div>
+
+<div class="expander-container">
+  <div class="expander-hover">
+    <div class="expander-hover-preview">
+      <img class="light-image" src="/api-client-static.svg" />
+      <img class="dark-image" src="/api-client-static-dark.svg" />
+    </div>
+    <div class="relative">
+      <div class="expander-hover-sticker">
+        <object class="sticker-clip-client" width="156" height="110"
+          data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/JXS6tZ4EbKIkeGpjP6QKc.svg"></object>
+      </div>
+      <div class="expander-hover-title">API Client</div>
+      <div class="expander">
+        <div class="expander-content">
+          Minimal, powerful, fully open-source API Client built on open standards by us + our community.
+        </div>
+      </div>
+      <a class="expander-hover-link" href="https://client.scalar.com/" target="_blank">Learn More</a>
+    </div>
+  </div>
+  <div class="expander-hover">
+    <div class="expander-hover-preview">
+      <img class="light-image" src="/sdks-static.svg" />
+      <img class="dark-image" src="/sdks-static-dark.svg" />
+    </div>
+    <div class="relative">
+      <div class="expander-hover-sticker">
+        <object class="sticker-clip-sdk" width="145" height="145"
+          data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/gM-mqYTBYMkqpnexTIr-r.svg"></object>
+      </div>
+      <div class="expander-hover-title">SDKs</div>
+      <div class="expander">
+        <div class="expander-content">
+          Bring your OpenAPI document and get type-safe client libraries for TypeScript, Python and more.
+        </div>
+      </div>
+      <a class="expander-hover-link" href="/scalar/scalar-sdks/getting-started">Learn More</a>
+    </div>
+  </div>
+  <div class="expander-hover">
+    <div class="expander-hover-preview">
+      <img class="light-image" src="/registry-static.svg" />
+      <img class="dark-image" src="/registry-static-dark.svg" />
+    </div>
+    <div class="relative">
+      <div class="expander-hover-sticker">
+      <object class="sticker-clip-registry" width="136" height="186"
+          data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/jgGF_IKsu-T_irS-6MMOy.svg"></object>
+      </div>
+      <div class="expander-hover-title">API Registry</div>
+      <div class="expander">
+        <div class="expander-content">
+          Managing & versioning OpenAPI Documents with a deep Git integration.
+        </div>
+      </div>
+      <a class="expander-hover-link" href="/scalar/scalar-registry/getting-started">Learn More</a>
+    </div>
+  </div>
+  <div class="expander-hover">
+    <div class="expander-hover-preview">
+      <img class="light-image" src="/api-docs-static-zoom.svg" />
+      <img class="dark-image" src="/api-docs-static-zoom-dark.svg" />
+    </div>
+    <div class="relative">
+      <div class="expander-hover-sticker">
+        <object class="sticker-clip-docs" width="113" height="143" data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/HLhbFqJ4vSzo4UDEZX2dq.svg"></object>
+      </div>
+      <div class="expander-hover-title">API Docs</div>
+      <div class="expander">
+        <div class="expander-content">
+          Write beautiful documentation with Markdown + MDX + Git Sync.
+        </div>
+      </div>
+      <a class="expander-hover-link" href="/scalar/scalar-docs/getting-started">Learn More</a>
+    </div>
+  </div>
+</div>
+<div class="footer container-full">
+  <div class="footer-content">
+      <div>
+        <span class="text-c-1">
+          <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
+        </span>
+        <p class="mt-10 text-c-3 text-sm text-balance">The Open API company.</p>
+        <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
+      </div>
+      <div class="flex text-sm">
+        <div class="w-1/3 flex flex-col gap-2">
+          <b>Products</b>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://guides.scalar.com/scalar/scalar-api-references/getting-started" target="_blank">API References</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://client.scalar.com/" target="_blank">API Client</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://docs.scalar.com/" target="_blank">API Docs</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://editor.scalar.com/" target="_blank">Swagger Editor</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://agent.scalar.com/" target="_blank">Agent Scalar</a>
+        </div>
+        <div class="w-1/3 flex flex-col gap-2">
+          <b>Company</b>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="mailto:support@scalar.com" target="_blank">Support</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/changelog" target="_blank">Changelog</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/terms-and-conditions" target="_blank">Terms of Service</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/privacy-policy" target="_blank">Privacy Policy</a>
+        </div>
+        <div class="w-1/3 flex flex-col gap-2">
+          <b>Socials</b>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://twitter.com/scalar" target="_blank">x (formerly twitter)</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://github.com/scalar/scalar" target="_blank">Github</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://discord.gg/scalar" target="_blank">Discord</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://www.linkedin.com/company/scalar-org" target="_blank">Linkedin</a>
+        </div>
+      </div>
+  </div>
+  <!-- footer animation -->
+  <div class="footer-animation">
+    <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/v1Pu6_BCmly6VhPAuotVZ.svg"></scalar-icon>
+  </div>
+</div>
+<style>
+    .resources-cta-container {
+      border-radius: var(--scalar-radius-lg);
+      border: var(--scalar-border-width) solid var(--scalar-border-color);
+      width: 100%;
+      padding: 12px 8px;
+    }
+  .resources-cta {
+    max-height: fit-content;
+    width: 100%;
+    top: 12px;
+    padding-top: 50px;
+    padding-bottom: 200px;
+  }
+  .full-container-constrained {
+    max-width: 720px;
+    padding-right: 40px;
+  }
+  .full-container-constrained > .t-editor__heading {
+    margin-top: 44px;
+  }
+  .full-container-constrained > .t-editor__paragraph {
+    margin-top: 12px;
+  }
+  .full-container-constrained > .t-editor__steps {
+    margin-top: 24px;
+    margin-bottom: 24px;
+  }
+  .hero-animation  {
+    position: absolute;
+    top: -88px;
+    transform: scaleY(-1);
+    margin-top: 0 !important;
+  }
+  .hero-animation .fa {
+    --fa-orange: rgba(49, 215, 250, .25);
+    --fa-yellow: #0189fc;
+    --fa-red: rgba(54, 114, 255,0);
+    --scalar-background-2: var(--scalar-background-1)
+  }
+  @supports (color: color(display-p3 1 1 1)) {
+    .hero-animation .fa {
+        --fa-orange: rgb(141 49 250 / 25%);
+        --fa-yellow: color(display-p3 0.41 0 0.99);
+        --fa-red: rgb(255 54 223 / 0%);
+    }
+  }
+  .t-editor__page-title,
+  .layout-aside-right,
+  .t-editor__page-nav,
+  .notify-container,
+  .subheading {
+    display: none;
+  }
+  .t-doc .layout-header {
+    z-index: 10000;
+  }
+  .t-editor__button {
+    min-width: 160px;
+    justify-content: center;
+  }
+  .t-editor .editor-content,
+  .t-editor {
+    padding-bottom: 0;
+  }
+  h3.t-editor__heading,
+  h2.t-editor__heading {
+    --font-size: var(--scalar-heading-1);
+      margin-top: 0;
+  }
+  :root {
+    --scalar-container-width: 960px;
+    --scalar-toc-width: 0;
+  }
+  .hero.hero {
+    margin-top: 88px;
+  }
+  .small-test {
+    max-width: 680px;
+    text-wrap: balance;
+    margin-top: 88px;
+    position: relative;
+  }
+  .t-editor .editor-static .page-node {
+    max-width: var(--scalar-container-width);
+    padding-bottom: 0;
+    margin-bottom: 0;
+  }
+  .container {
+    width: var(--scalar-container-width);
+    margin: auto;
+    position: relative;
+  }
+  .container-full {
+    --scalar-container-sidebar-gap: calc(
+      (
+        (100dvw - var(--scalar-container-width) - var(--scalar-sidebar-width)) /
+          2
+      )
+    );
+    width: calc(100dvw - var(--scalar-sidebar-width));
+    margin-left: min(-1 * var(--scalar-container-sidebar-gap), -50px);
+  }
+  .container {
+    width: 900px;
+    margin: auto;
+    position: relative;
+  }
+  /* logos */
+  .logowall.logowall {
+    margin-top: 48px;
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    align-items: center;
+    gap: 40px;
+  }
+  .logowall-item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .logowall-item svg {
+    width: 100%;
+    height: auto;
+    max-height: 24px;
+  }
+  .ign-logo__fill {
+    fill: var(--scalar-color-1);
+  }
+  .fill-current-bg {
+    fill: var(--scalar-background-1);
+  }
+  /* feature */
+  .feature {
+    padding: 60px 0 !important;
+  }
+  .feature-container {
+    gap: 44px;
+    margin-top: 32px;
+  }
+  .feature-item {
+    flex: 0 0 calc(50% - 44px);
+  }
+  /* new stuff  */
+  .expander {
+    display: grid;
+    grid-template-rows: 0fr;
+    overflow: hidden;
+    opacity: 0;
+    transition: grid-template-rows 0.25s, opacity 0.25s ease-in-out;
+  }
+  .expander-content {
+    min-height: 0;
+    margin-bottom: 12px;
+    margin-top: 6px;
+    line-height: 1.45;
+    font-size: 14px;
+  }
+  .expander-hover {
+    height: 370px;
+    position: relative;
+  }
+  .expander-hover:hover .expander {
+    grid-template-rows: 1fr;
+    opacity: 1;
+    transition: grid-template-rows 0.5s, opacity 0.5s ease-in-out;
+  }
+  .expander.expanded .expander-content {
+    visibility: visible;
+  }
+  .expander-hover-title {
+    font-size: 20px;
+    font-weight: var(--scalar-semibold);
+    margin-top: 24px;
+  }
+  .expander-hover-link {
+    --font-color: var(--scalar-color-2);
+    --font-visited: var(--scalar-color-2);
+    color: var(--font-color, var(--scalar-color-1));
+    font-weight: var(--scalar-semibold);
+    text-underline-offset: 0.25rem;
+    text-decoration-thickness: 1px;
+    text-decoration: underline;
+    text-decoration-color: color-mix(
+      in srgb,
+      var(--font-color, var(--scalar-color-1)) 30%,
+      transparent
+    );
+    margin-top: 6px;
+  }
+  .expander-hover:hover .expander-hover-link {
+    --font-color: var(--scalar-color-1);
+  }
+  .expander-hover-preview {
+    position: absolute;
+    left: -120px;
+    top: -220px;
+    width: 1100px;
+    mask-image: radial-gradient(circle at top left, black 25%, transparent 40%);
+    pointer-events: none;
+    opacity: 0;
+    transition: all 0.3s ease-in-out;
+    transform: rotate(1deg) translate3d(-10px, -10px, 0);
+    max-height: 500px;
+    overflow: hidden;
+  }
+  .expander-hover .relative {
+    z-index: 1;
+  }
+  .expander-hover:hover .expander-hover-preview {
+    opacity: 1;
+    transform: rotate(2deg) translate3d(0, 0, 0);
+    transition: all 0.3s ease-in-out 0.2s;
+  }
+  .expander-hover-preview img {
+    margin-left: 0;
+    mask-image: linear-gradient(black, transparent);
+    width: 100%;
+  }
+  .expander-hover-sticker {
+    height: 143px;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    position: relative;
+    margin-left: -12px;
+    transition: transform 0.3s ease-in-out;
+    justify-content: flex-start;
+  }
+  .expander-hover-sticker object {
+    pointer-events: none;
+  }
+  .expander-hover-sticker img {
+    max-height: initial;
+    margin-left: initial;
+  }
+  .expander-hover:hover .expander-hover-sticker {
+    transform: rotate(-3deg);
+  }
+  .expander-container {
+    display: flex;
+    gap: 44px;
+  }
+  .cta {
+    padding: 140px 0;
+    margin-top: 0 !important;
+  }
+  .mb-11 {
+    margin-bottom: 44px;
+  }
+  /* footer */
+  .footer {
+    position: relative;
+    overflow: hidden;
+    background: var(--scalar-background-2);
+    padding-inline: 20px;
+    padding-bottom: 200px;
+    margin-top: 100px;
+  }
+  .footer-animation {
+    margin-inline: -30px;
+  }
+  .footer-animation svg {
+    position: absolute;
+    bottom: 0;
+  }
+  .footer-content {
+    display: flex;
+    gap: 48px;
+    max-width: var(--scalar-container-width);
+    width: 100%;
+    margin: auto;
+    padding-top: 92px;
+  }
+  .footer-content > * {
+    flex: 1;
+  }
+  .footer-content span,
+  .footer-content p,
+  .footer-content a {
+    position: relative;
+    z-index: 1;
+  }
+  .w-1\/3 {
+    width: 33.33%
+  }
+  .light-mode .dark-image {
+    display: none;
+  }
+  .dark-mode .light-image {
+    display: none;
+  }
+  .sticker-clip-client {
+    clip-path: path("M158 91.9102C158 95.8908 154.773 99.1172 150.792 99.1172L147.269 99.1172L147.269 105.78C147.268 107.948 145.511 109.705 143.343 109.705L86.2051 109.705C84.0373 109.705 82.2795 107.948 82.2793 105.78L82.2793 99.1172L7.208 99.1172C3.22741 99.1172 1.10673e-05 95.8908 -4.01752e-06 91.9101L-3.50643e-06 80.2178C-3.47119e-06 79.4117 0.135571 78.6109 0.400387 77.8496L25.7949 4.83984C26.8028 1.94219 29.5346 -5.6154e-06 32.6025 -5.4813e-06L150.792 -3.15072e-07C154.773 -1.41078e-07 158 3.22654 158 7.20703L158 91.9102Z")
+  }
+  .sticker-clip-sdk {
+    clip-path: path("M60.0562 8.61129C65.9233 -1.83053 81.0294 -1.61478 86.5955 8.99068L142.416 115.353C144.543 119.406 141.567 124.259 136.991 124.201L114.679 123.918L114.138 135.797C113.962 139.654 110.761 142.678 106.9 142.634L32.9393 141.782C29.1212 141.738 26.0084 138.707 25.864 134.891L25.406 122.787L6.28841 122.544C1.70363 122.486 -1.1476 117.543 1.09835 113.545L60.0562 8.61129Z")
+  }
+  .sticker-clip-registry {
+    clip-path: path("M71.0986 1.13334C75.8537 -0.596969 81.1116 1.85514 82.8428 6.6099L90.3037 27.1079H98.5059C104.199 27.108 108.814 31.7235 108.814 37.4165V77.9663L121.32 112.329C119.703 112.128 118.003 112.298 116.351 112.899C110.96 114.861 108.12 120.659 110.009 125.848C111.898 131.038 117.8 133.654 123.191 131.692C124.844 131.091 126.254 130.127 127.364 128.933L134.608 148.835C136.339 153.591 133.887 158.849 129.132 160.58L73.3945 180.866C68.6393 182.596 63.3816 180.145 61.6504 175.39L58.958 167.994H2.29102C1.02582 167.994 0 166.968 0 165.703V29.398C0.000538247 28.1333 1.02616 27.1079 2.29102 27.1079H9.8125C10.6721 24.5603 12.6383 22.4116 15.3613 21.4204L71.0986 1.13334Z")
+  }
+  .sticker-clip-docs {
+    overflow: hidden;
+    border-radius: 20px;
+  }
+  @media screen and (max-width: 1280px) {
+      .resources-cta {
+        display: none;
+      }
+      .full-container-constrained {
+        padding-right: 0px;
+        max-width: 100%;
+      }
+    }
+  @media screen and (max-width: 1000px) {
+    .t-doc {
+      --scalar-sidebar-width: 0px;
+    }
+    .hero.hero {
+      margin-top: 188px;
+    }
+    .container-full {
+      --scalar-container-sidebar-gap: 30px;
+      padding-inline: 30px;
+      margin-inline: -30px;
+    }
+    .hero-animation {
+      margin-top: -100px !important;
+      padding-inline: 0;
+      margin-inline: 0;
+    }
+    .logowall.logowall {
+      grid-template-columns: repeat(3, 1fr);
+      column-gap: 20px;
+      row-gap: 40px;
+    }
+    .logowall-item {
+      justify-content: start;
+    }
+    .logowall-item svg {
+      width: auto;
+      max-width: 100%;
+      height: 100%;
+      max-height: 20px;
+    }
+    .feature-item {
+      flex: 0 0 calc(100% - 22px);
+    }
+    .expander-container {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      row-gap: 0;
+    }
+    .expander-hover {
+      width: auto;
+    }
+    .expander-hover .expander {
+      grid-template-rows: 1fr;
+      opacity: 1;
+    }
+    .expander .expander-content {
+      visibility: visible;
+    }
+    .footer-content {
+      flex-direction: column;
+    }
+    .footer-content > * {
+      flex: initial;
+    }
+  }
+</style>

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -4,10 +4,10 @@
 </div>
 <div class="flex flex-col gap-3 hero small-test">
   <h2 class="text-balance">
-    Scalar SDKs.
+    Scalar SDKs
   </h2>
   <p>
-    Get started with Scalar Docs, literally in minutes. You don't need anything to get started, not even an account if you just want to play around.
+    Get started with generating world-class SDKs in minutes on scalar.com in several languages: TypeScript, Python, Golang & more.
   </p>
 </div>
 <img class="light-image mt-10" src="/sdks-animated.svg"/>
@@ -17,7 +17,6 @@
   <div class="full-container-constrained">
 
 ## Getting Started
-This guide will help you get started with generating world-class SDKs on scalar.com in several languages: TypeScript, Python, Golang & more powered by [Speakeasy](https://speakeasy.com).
 
 :::scalar-callout{ type=info }
 SDK generation is part of our paid plans and costs $100 per month per language. Keep this in mind when selecting which languages you'd like to generate SDKs for.
@@ -135,7 +134,7 @@ They are open source. So I can get in on free features and stay with Scalar no m
   <div class="resources-cta sticky">
     <div class="resources-cta-container">
       <p class="mt-3 mb-1 pl-2">
-        <b class="font-medium">Additioanl Reading</b>
+        <b class="font-medium">Additional Reading</b>
       </p>
       <p>
         <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/scalar-sdks/configuration/typescript"><scalar-icon src="phosphor/bold/file-ts"></scalar-icon> Typescript SDKs</a>


### PR DESCRIPTION
redesign subpages for scalar-docs/getting-started, scalar-sdks/getting-started, scalar-registry/getting-started

<img width="1512" height="866" alt="image" src="https://github.com/user-attachments/assets/6931aa7d-ab64-4379-a93d-0e4e6de1d2e6" />

missing some copy which @marclave will add 