### PR TITLE
fix(fastify): check for the new fastify `routerOptions.ignoreTrailingSlash`

### DIFF
--- a/.changeset/angry-baboons-juggle.md
+++ b/.changeset/angry-baboons-juggle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix: does not check for the new routerOptions.ignoreTrailingSlash

--- a/integrations/fastify/src/fastifyApiReference.ts
+++ b/integrations/fastify/src/fastifyApiReference.ts
@@ -174,11 +174,11 @@ const fastifyApiReference = fp<
     // Redirect route without a trailing slash to force a trailing slash:
     // We need this so the request to the JS file is relative.
 
-    // With ignoreTrailingSlash, fastify responds to both routes anyway.
+    // With ignoreTrailingSlash: true, fastify responds to both routes anyway.
     const ignoreTrailingSlash =
       // @ts-expect-error We're still on Fastify 4, this is introduced in Fastify 5
-      fastify.initialConfig?.routerOptions?.ignoreTrailingSlash !== true &&
-      fastify.initialConfig.ignoreTrailingSlash !== true
+      fastify.initialConfig?.routerOptions?.ignoreTrailingSlash === true ||
+      fastify.initialConfig?.ignoreTrailingSlash === true
 
     if (!ignoreTrailingSlash && getRoutePrefix(options.routePrefix)) {
       fastify.route({

--- a/integrations/fastify/src/fastifyApiReference.ts
+++ b/integrations/fastify/src/fastifyApiReference.ts
@@ -1,14 +1,12 @@
+import { getHtmlDocument } from '@scalar/core/libs/html-rendering'
+import { normalize, toJson, toYaml } from '@scalar/openapi-parser'
 import type { OpenAPI } from '@scalar/openapi-types'
 import type { FastifyBaseLogger, FastifyTypeProviderDefault, RawServerDefault } from 'fastify'
 import fp from 'fastify-plugin'
 import { slug } from 'github-slugger'
 
-import type { FastifyApiReferenceHooksOptions, FastifyApiReferenceOptions } from './types'
+import type { ApiReferenceConfiguration, FastifyApiReferenceHooksOptions, FastifyApiReferenceOptions } from './types'
 import { getJavaScriptFile } from './utils/getJavaScriptFile'
-
-import { getHtmlDocument } from '@scalar/core/libs/html-rendering'
-import { normalize, toJson, toYaml } from '@scalar/openapi-parser'
-import type { ApiReferenceConfiguration } from './types'
 
 /**
  * Path to the bundled Scalar JavaScript file
@@ -176,10 +174,13 @@ const fastifyApiReference = fp<
     // Redirect route without a trailing slash to force a trailing slash:
     // We need this so the request to the JS file is relative.
 
-    // With ignoreTrailingSlash, fastify registeres both routes anyway.
-    const doesNotIgnoreTrailingSlash = fastify.initialConfig?.routerOptions?.ignoreTrailingSlash !== true && fastify.initialConfig.ignoreTrailingSlash !== true
+    // With ignoreTrailingSlash, fastify responds to both routes anyway.
+    const ignoreTrailingSlash =
+      // @ts-expect-error We're still on Fastify 4, this is introduced in Fastify 5
+      fastify.initialConfig?.routerOptions?.ignoreTrailingSlash !== true &&
+      fastify.initialConfig.ignoreTrailingSlash !== true
 
-    if (doesNotIgnoreTrailingSlash && getRoutePrefix(options.routePrefix)) {
+    if (!ignoreTrailingSlash && getRoutePrefix(options.routePrefix)) {
       fastify.route({
         method: 'GET',
         url: getRoutePrefix(options.routePrefix),

--- a/integrations/fastify/src/fastifyApiReference.ts
+++ b/integrations/fastify/src/fastifyApiReference.ts
@@ -177,7 +177,7 @@ const fastifyApiReference = fp<
     // We need this so the request to the JS file is relative.
 
     // With ignoreTrailingSlash, fastify registeres both routes anyway.
-    const doesNotIgnoreTrailingSlash = fastify.initialConfig.ignoreTrailingSlash !== true
+    const doesNotIgnoreTrailingSlash = fastify.initialConfig?.routerOptions?.ignoreTrailingSlash !== true && fastify.initialConfig.ignoreTrailingSlash !== true
 
     if (doesNotIgnoreTrailingSlash && getRoutePrefix(options.routePrefix)) {
       fastify.route({


### PR DESCRIPTION
**Problem**

Fastify is moving the ignoreTrailingSlash to routerOptions and this is generating route conflicts with the scalar plugin.

**Solution**

We should check https://github.com/scalar/scalar/blob/main/integrations/fastify/src/fastifyApiReference.ts#L180
and add second verification for the routerOptions.ignoreTrailingSlash

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
