### PR TITLE
chore(renovate): add minimumReleaseAge rule for npm packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,12 @@
   },
   "recreateWhen": "never",
   "packageRules": [
+    // Keep this in sync with package.json minimumReleaseAge
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "7 days"
+    },
+
     // Group major dependencies
     {
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
Follow up for https://github.com/scalar/scalar/pull/6879


**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
