### PR TITLE
chore: ignore a few super popular dependencies with `minimumReleaseAgeExclude`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,13 @@ packages:
 # To reduce the risk of installing compromised packages, we delay the installation of newly published versions.
 minimumReleaseAge: 10080 # 1 week
 
+minimumReleaseAgeExclude:
+  - rollup
+  - vite
+  - vue
+  - vite-node
+  - vitest
+
 catalogs:
   '*':
     '@electron-toolkit/preload': ^3.0.0


### PR DESCRIPTION
**Problem**

Currently, the Docker build is failing, because we’re using a 4 days old version of rollup (we require it to be published 7 days ago at least).

**Solution**

This is annoying already. So let’s ignore a few of the suuuper popular dependencies.

We might even remove this again, but this will fix the build in main _now_.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
