### PR TITLE
ci: test against Node 22 only (remove Node 20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
 
     steps:
       - name: Checkout repository
@@ -218,7 +218,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5


### PR DESCRIPTION
**Problem**

We never had issues with Node 20 (but with Node 18 and the lack of the native `File` type), and we never had failing *tests* in Node 20. If we had Node issues, it was in the build stage.

Though, we’re running the tests against Node 20 and 22.

**Solution**

This PR removes Node 20 from the test matrix. This won’t make CI pass faster, because those tests are running parallel anyway, but it’ll save some trees and maybe a few dollar notes.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CI matrices to drop Node 20 and run jobs on Node 22 only.
> 
> - **CI**:
>   - Update GitHub Actions matrix in `.github/workflows/ci.yml` to `node-version: [22]` for:
>     - `build`
>     - `test-packages`
>     - `test-integrations`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51409a6e15f8b7f098b4ef8ab95b26291280cda5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->