### PR TITLE
ci: remove minimumReleaseAge (wip)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,9 +9,6 @@ packages:
   - '!**/dist/**'
   - '!**/.output/**'
 
-# To reduce the risk of installing compromised packages, we delay the installation of newly published versions.
-minimumReleaseAge: 10080 # 1 week
-
 catalogs:
   '*':
     '@electron-toolkit/preload': ^3.0.0


### PR DESCRIPTION
just testing if this causes CI to hang

**Problem**

Currently, …

**Solution**

With this PR …

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
