### PR TITLE
docs(rust): update link to the documentation

### DIFF
--- a/.changeset/gentle-apricots-kneel.md
+++ b/.changeset/gentle-apricots-kneel.md
@@ -1,0 +1,5 @@
+---
+'scalar_api_reference': patch
+---
+
+docs: update link to documentation

--- a/integrations/rust/README.md
+++ b/integrations/rust/README.md
@@ -9,7 +9,7 @@ A Rust crate for embedding Scalar API documentation in web applications.
 
 ## Documentation
 
-[Read the documentation here](https://guides.scalar.com/scalar/scalar_api_references/integrations/rust)
+[Read the documentation here](https://guides.scalar.com/scalar/scalar-api-references/integrations/rust)
 
 ## Community
 


### PR DESCRIPTION
a happy search and replace accident,
let’s fix it swiftly

so all is good again
and people can read our documentation