### PR TITLE
fix(api-reference): remove asterisk on additionalProperties

### DIFF
--- a/.changeset/nine-wasps-dance.md
+++ b/.changeset/nine-wasps-dance.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: remove asterisk from additionalProperties

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.test.ts
@@ -98,7 +98,7 @@ describe('SchemaObjectProperties', () => {
 
     const prop = wrapper.find('.schema-property')
     expect(prop.exists()).toBe(true)
-    expect(prop.attributes('data-name')).toBe('propertyName*')
+    expect(prop.attributes('data-name')).toBe('propertyName')
   })
 
   it('renders additionalProperties with x-additionalPropertiesName', () => {
@@ -116,7 +116,7 @@ describe('SchemaObjectProperties', () => {
 
     const prop = wrapper.find('.schema-property')
     expect(prop.exists()).toBe(true)
-    expect(prop.attributes('data-name')).toBe('customName*')
+    expect(prop.attributes('data-name')).toBe('customName')
   })
 
   it('handles additionalProperties as boolean true correctly', () => {
@@ -131,7 +131,7 @@ describe('SchemaObjectProperties', () => {
 
     const prop = wrapper.find('.schema-property')
     expect(prop.exists()).toBe(true)
-    expect(prop.attributes('data-name')).toBe('propertyName*')
+    expect(prop.attributes('data-name')).toBe('propertyName')
   })
 
   it('handles additionalProperties as empty object correctly', () => {
@@ -146,7 +146,7 @@ describe('SchemaObjectProperties', () => {
 
     const prop = wrapper.find('.schema-property')
     expect(prop.exists()).toBe(true)
-    expect(prop.attributes('data-name')).toBe('propertyName*')
+    expect(prop.attributes('data-name')).toBe('propertyName')
   })
 
   it('does not render anything if schema has no properties, patternProperties, or additionalProperties', () => {

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
@@ -117,10 +117,10 @@ const getAdditionalPropertiesName = (
     typeof additionalProperties['x-additionalPropertiesName'] === 'string' &&
     additionalProperties['x-additionalPropertiesName'].trim().length > 0
   ) {
-    return `${additionalProperties['x-additionalPropertiesName'].trim()}*`
+    return `${additionalProperties['x-additionalPropertiesName'].trim()}`
   }
 
-  return 'propertyName*'
+  return 'propertyName'
 }
 
 /**


### PR DESCRIPTION
**Problem**

Currently, we add an asterisk on additional properties. This actually breaks the snippet as it becomes invalid JS

**Solution**

With this PR we remove the asterisk

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
