### PR TITLE
fix(workspace-store): schema does not allow custom formats

### DIFF
--- a/.changeset/large-pigs-sin.md
+++ b/.changeset/large-pigs-sin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: schema format does not allow custom formats

--- a/packages/workspace-store/src/schemas/v3.1/strict/schema.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/schema.ts
@@ -130,6 +130,8 @@ const StringValidationProperties = Type.Object({
       Type.Literal('sf-token'),
       Type.Literal('sf-binary'),
       Type.Literal('sf-boolean'),
+      // Allow any arbitrary string
+      Type.String(),
     ]),
   ),
   /** Maximum string length. */


### PR DESCRIPTION
**Problem**

For `format: 'custom-format'` we render `date` as the format. That’s because our schema is too strict. 

> It should be noted that format is not limited to a specific set of valid values or types. 

Source: https://json-schema.org/understanding-json-schema/reference/type

**Solution**

This PR allows any string to be passed.

**Before**

<img width="589" height="119" alt="Screenshot 2025-09-21 at 17 35 14" src="https://github.com/user-attachments/assets/85dc6324-5054-4d88-89f1-daac77b4c071" />

**After**

<img width="266" height="87" alt="Screenshot 2025-09-21 at 17 34 23" src="https://github.com/user-attachments/assets/1e892c5f-4dee-4d57-b39f-2d2e32b587c9" />

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
