### PR TITLE
fix(rust): pnpm fails when there is a build

### DIFF
--- a/integrations/rust/Cargo.toml
+++ b/integrations/rust/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 repository = "https://github.com/scalar/scalar"
 keywords = ["api", "documentation", "openapi", "swagger"]
 categories = ["web-programming", "development-tools"]
+exclude = ["package.json", "CHANGELOG.md"]
 
 [dependencies]
 rust-embed = "8"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ packages:
   - '!**/.next/**'
   - '!**/dist/**'
   - '!**/.output/**'
+  - '!**/target/**'
 
 # To reduce the risk of installing compromised packages, we delay the installation of newly published versions.
 minimumReleaseAge: 10080 # 1 week


### PR DESCRIPTION
When there’s a build of the Rust crate, pnpm fails. Cargo copies the package.json and then pnpm complains there are two packages with the same name.

We need to Cargo to please ignore the package.json and not bundle it.

Easy as that.