### PR TITLE
fix: markdown support headings in table of contents

### DIFF
--- a/documentation/guides/docs/components/markdown-support.md
+++ b/documentation/guides/docs/components/markdown-support.md
@@ -2,7 +2,7 @@
 
 We support all standard markdown features:
 
-### Headings
+## Headings
 
 ```markdown
 # Heading 1
@@ -13,7 +13,7 @@ We support all standard markdown features:
 ###### Heading 6
 ```
 
-### Text Formatting
+## Text Formatting
 
 **Bold text**
 *Italic text*
@@ -28,7 +28,7 @@ We support all standard markdown features:
 `Inline code`
 ```
 
-### Lists
+## Lists
 
 - Unordered list item
 - Another item
@@ -54,14 +54,14 @@ We support all standard markdown features:
    2. Another nested item
 ```
 
-### Links and Images
+## Links and Images
 
 ```markdown
 [Link text](https://example.com)
 ![Alt text](https://example.com/image.png)
 ```
 
-### Code Blocks
+## Code Blocks
 
 ````markdown
 ```javascript
@@ -71,7 +71,7 @@ function example() {
 ```
 ````
 
-### Blockquotes
+## Blockquotes
 
 > This is a blockquote
 > 
@@ -83,7 +83,7 @@ function example() {
 > It can span multiple lines
 ```
 
-### Tables
+## Tables
 | Header 1 | Header 2 | Header 3 |
 |----------|----------|----------|
 | Cell 1   | Cell 2   | Cell 3   |
@@ -96,7 +96,7 @@ function example() {
 | Cell 4   | Cell 5   | Cell 6   |
 ```
 
-### Task Lists
+## Task Lists
 
 ```markdown
 - [x] Completed task


### PR DESCRIPTION
**Problem**

before:
<img width="3024" height="1710" alt="image" src="https://github.com/user-attachments/assets/9110d615-9e0e-49bd-93a9-9506d487da12" />

after:
<img width="1512" height="853" alt="image" src="https://github.com/user-attachments/assets/8888b7b3-c49a-47dc-aa2e-d3543270f8f9" />


**Solution**

With this PR we render headings in the ToC

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
