### PR TITLE
fix(api-reference): correctly pass down schema options

### DIFF
--- a/.changeset/hot-glasses-own.md
+++ b/.changeset/hot-glasses-own.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: propogate property sorting into schema

--- a/packages/api-reference/src/components/Content/Models/ClassicLayout.vue
+++ b/packages/api-reference/src/components/Content/Models/ClassicLayout.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
@@ -13,6 +14,7 @@ import {
 import { SchemaHeading, SchemaProperty } from '../Schema'
 
 defineProps<{
+  config: ApiReferenceConfiguration
   schemas: { id: string; name: string; schema: SchemaObject }[]
 }>()
 </script>
@@ -48,11 +50,20 @@ defineProps<{
           v-for="[property, value] in Object.entries(schema.properties ?? {})"
           :key="property"
           :name="property"
+          :options="{
+            orderRequiredPropertiesFirst: config.orderRequiredPropertiesFirst,
+            orderSchemaPropertiesBy: config.orderSchemaPropertiesBy,
+          }"
           :required="schema.required?.includes(property)"
-          :value="getResolvedRef(value)" />
+          :schema="getResolvedRef(value)" />
       </div>
       <div v-else>
-        <SchemaProperty :value="schema" />
+        <SchemaProperty
+          :options="{
+            orderRequiredPropertiesFirst: config.orderRequiredPropertiesFirst,
+            orderSchemaPropertiesBy: config.orderSchemaPropertiesBy,
+          }"
+          :schema="schema" />
       </div>
     </SectionAccordion>
   </SectionContainerAccordion>

--- a/packages/api-reference/src/components/Content/Models/Models.vue
+++ b/packages/api-reference/src/components/Content/Models/Models.vue
@@ -49,6 +49,7 @@ const flatSchemas = computed(() => {
     :isLazy="Boolean(hash) && !hash.startsWith('model')">
     <ClassicLayout
       v-if="config?.layout === 'classic'"
+      :config="config"
       :schemas="flatSchemas" />
     <ModernLayout
       v-else

--- a/packages/api-reference/src/components/Content/Models/ModernLayout.vue
+++ b/packages/api-reference/src/components/Content/Models/ModernLayout.vue
@@ -74,10 +74,15 @@ const models = computed(() => {
           </template>
           <ScalarErrorBoundary>
             <Schema
-              :hideHeading="true"
-              :hideModelNames="true"
+              hideHeading
+              hideModelNames
               :level="1"
               noncollapsible
+              :options="{
+                orderRequiredPropertiesFirst:
+                  config.orderRequiredPropertiesFirst,
+                orderSchemaPropertiesBy: config.orderSchemaPropertiesBy,
+              }"
               :schema />
           </ScalarErrorBoundary>
         </CompactSection>

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -10,6 +10,7 @@ describe('Schema', () => {
     it('shows the base description of the first allOf schema', () => {
       const wrapper = mount(Schema, {
         props: {
+          options: {},
           name: 'Request Body',
           schema: coerceValue(SchemaObjectSchema, {
             description: 'This description should be shown',
@@ -51,6 +52,7 @@ describe('Schema', () => {
               },
             ],
           }),
+          options: {},
         },
       })
 
@@ -76,6 +78,7 @@ describe('Schema', () => {
               },
             ],
           },
+          options: {},
         },
       })
 
@@ -95,6 +98,7 @@ describe('Schema', () => {
             },
           }),
           additionalProperties: true,
+          options: {},
         },
       })
 
@@ -113,6 +117,7 @@ describe('Schema', () => {
             },
           }),
           additionalProperties: false,
+          options: {},
         },
       })
 
@@ -131,6 +136,7 @@ describe('Schema', () => {
           }),
           additionalProperties: true,
           name: 'User',
+          options: {},
         },
       })
 
@@ -149,6 +155,7 @@ describe('Schema', () => {
             },
           }),
           additionalProperties: true,
+          options: {},
         },
       })
 
@@ -173,6 +180,7 @@ describe('Schema', () => {
             },
           }),
           additionalProperties: true,
+          options: {},
         },
       })
 
@@ -201,6 +209,7 @@ describe('Schema', () => {
           }),
           additionalProperties: true,
           noncollapsible: true,
+          options: {},
         },
       })
 
@@ -226,6 +235,7 @@ describe('Schema', () => {
           }),
           additionalProperties: true,
           noncollapsible: false,
+          options: {},
         },
       })
 
@@ -250,6 +260,7 @@ describe('Schema', () => {
             additionalProperties: true,
           }),
           additionalProperties: true,
+          options: {},
         },
       })
 
@@ -270,6 +281,7 @@ describe('Schema', () => {
             additionalProperties: true,
           }),
           additionalProperties: true,
+          options: {},
         },
       })
 
@@ -295,6 +307,7 @@ describe('Schema', () => {
             additionalProperties: true,
           }),
           additionalProperties: true,
+          options: {},
         },
       })
 
@@ -306,7 +319,7 @@ describe('Schema', () => {
       const additionalProperty = schemaProperties.find((prop) => prop.props('variant') === 'additionalProperties')
 
       expect(additionalProperty).toBeDefined()
-      expect(additionalProperty?.props('value')).toEqual({
+      expect(additionalProperty?.props('schema')).toEqual({
         type: 'anything',
       })
     })
@@ -322,6 +335,7 @@ describe('Schema', () => {
             additionalProperties: {},
           } as any,
           additionalProperties: true,
+          options: {},
         },
       })
 
@@ -333,7 +347,7 @@ describe('Schema', () => {
       const additionalProperty = schemaProperties.find((prop) => prop.props('variant') === 'additionalProperties')
 
       expect(additionalProperty).toBeDefined()
-      expect(additionalProperty?.props('value')).toEqual({
+      expect(additionalProperty?.props('schema')).toEqual({
         type: 'anything',
       })
     })
@@ -356,6 +370,7 @@ describe('Schema', () => {
             },
             required: ['aRequired', 'bRequired', 'cRequired', 'dRequired'],
           },
+          options: {},
         },
       })
 
@@ -386,7 +401,6 @@ describe('Schema', () => {
     it('does not render readOnly properties when hideReadOnly is true', () => {
       const wrapper = mount(Schema, {
         props: {
-          hideReadOnly: true,
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
             properties: {
@@ -395,6 +409,9 @@ describe('Schema', () => {
               alsoVisible: { type: 'integer', format: 'int32' },
             },
           }),
+          options: {
+            hideReadOnly: true,
+          },
         },
       })
 
@@ -407,7 +424,6 @@ describe('Schema', () => {
     it('applies to nested object properties as well', async () => {
       const wrapper = mount(Schema, {
         props: {
-          hideReadOnly: true,
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
             properties: {
@@ -420,6 +436,9 @@ describe('Schema', () => {
               },
             },
           }),
+          options: {
+            hideReadOnly: true,
+          },
         },
       })
 
@@ -444,7 +463,6 @@ describe('Schema', () => {
     it('does not render writeOnly properties when hideWriteOnly is true', () => {
       const wrapper = mount(Schema, {
         props: {
-          hideWriteOnly: true,
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
             properties: {
@@ -453,6 +471,9 @@ describe('Schema', () => {
               alsoVisible: { type: 'integer', format: 'int32' },
             },
           }),
+          options: {
+            hideWriteOnly: true,
+          },
         },
       })
 
@@ -465,7 +486,6 @@ describe('Schema', () => {
     it('applies to nested object properties as well', async () => {
       const wrapper = mount(Schema, {
         props: {
-          hideWriteOnly: true,
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
             properties: {
@@ -478,6 +498,9 @@ describe('Schema', () => {
               },
             },
           }),
+          options: {
+            hideWriteOnly: true,
+          },
         },
       })
 

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -7,6 +7,7 @@ import type {
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed } from 'vue'
 
+import type { SchemaOptions } from '@/components/Content/Schema/types'
 import ScreenReader from '@/components/ScreenReader.vue'
 
 import { isTypeObject } from './helpers/is-type-object'
@@ -21,12 +22,11 @@ const {
   compact,
   noncollapsible = false,
   hideHeading,
-  hideReadOnly,
-  hideWriteOnly,
   additionalProperties,
-  hideModelNames = false,
   discriminator,
   breadcrumb,
+  hideModelNames = false,
+  options,
 } = defineProps<{
   schema?: SchemaObject
   /** Track how deep we've gone */
@@ -39,10 +39,6 @@ const {
   noncollapsible?: boolean
   /** Hide the heading */
   hideHeading?: boolean
-  /** Hide read-only properties */
-  hideReadOnly?: boolean
-  /** Hide write-only properties */
-  hideWriteOnly?: boolean
   /** Show a special one way toggle for additional properties, also has a top border when open */
   additionalProperties?: boolean
   /** Hide model names in type display */
@@ -51,6 +47,8 @@ const {
   discriminator?: DiscriminatorObject
   /** Breadcrumb for the schema */
   breadcrumb?: string[]
+  /** Move the options into a single prop so they are easy to pass around */
+  options: SchemaOptions
 }>()
 
 /**
@@ -183,15 +181,14 @@ const handleClick = (e: MouseEvent) => noncollapsible && e.stopPropagation()
           <!-- Object properties -->
           <SchemaObjectProperties
             v-if="isTypeObject(schema)"
-            :breadcrumb="breadcrumb"
-            :compact="compact"
+            :breadcrumb
+            :compact
             :discriminator
-            :hideHeading="hideHeading"
-            :hideModelNames="hideModelNames"
-            :hideReadOnly="hideReadOnly"
-            :hideWriteOnly="hideWriteOnly"
+            :hideHeading
+            :hideModelNames
             :level="level + 1"
-            :schema="schema" />
+            :options
+            :schema />
 
           <!-- Not an object -->
           <template v-else>
@@ -201,10 +198,9 @@ const handleClick = (e: MouseEvent) => noncollapsible && e.stopPropagation()
               :compact
               :hideHeading
               :hideModelNames
-              :hideReadOnly="hideReadOnly"
-              :hideWriteOnly="hideWriteOnly"
               :level
-              :value="schema" />
+              :options
+              :schema />
           </template>
         </DisclosurePanel>
       </div>

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
@@ -11,7 +11,7 @@ describe('SchemaComposition', () => {
       const wrapper = mount(SchemaComposition, {
         props: {
           composition: 'anyOf',
-          value: coerceValue(SchemaObjectSchema, {
+          schema: coerceValue(SchemaObjectSchema, {
             anyOf: [
               {
                 title: 'Any',
@@ -20,6 +20,7 @@ describe('SchemaComposition', () => {
             ],
           }),
           level: 0,
+          options: {},
         },
       })
 
@@ -31,7 +32,7 @@ describe('SchemaComposition', () => {
       const wrapper = mount(SchemaComposition, {
         props: {
           composition: 'oneOf',
-          value: coerceValue(SchemaObjectSchema, {
+          schema: coerceValue(SchemaObjectSchema, {
             oneOf: [
               {
                 type: 'object',
@@ -39,6 +40,7 @@ describe('SchemaComposition', () => {
             ],
           }),
           level: 0,
+          options: {},
         },
       })
 
@@ -50,7 +52,7 @@ describe('SchemaComposition', () => {
       const wrapper = mount(SchemaComposition, {
         props: {
           composition: 'anyOf',
-          value: coerceValue(SchemaObjectSchema, {
+          schema: coerceValue(SchemaObjectSchema, {
             anyOf: [
               {
                 type: 'array',
@@ -61,6 +63,7 @@ describe('SchemaComposition', () => {
             ],
           }),
           level: 0,
+          options: {},
         },
       })
 
@@ -74,10 +77,11 @@ describe('SchemaComposition', () => {
       const wrapper = mount(SchemaComposition, {
         props: {
           composition: 'oneOf',
-          value: coerceValue(SchemaObjectSchema, {
+          schema: coerceValue(SchemaObjectSchema, {
             oneOf: [{ type: 'object' }],
           }),
           level: 0,
+          options: {},
         },
       })
 
@@ -89,10 +93,11 @@ describe('SchemaComposition', () => {
       const wrapper = mount(SchemaComposition, {
         props: {
           composition: 'oneOf',
-          value: coerceValue(SchemaObjectSchema, {
+          schema: coerceValue(SchemaObjectSchema, {
             oneOf: [{ type: 'boolean' }, { type: 'object', properties: { foo: { type: 'string' } } }],
           }),
           level: 0,
+          options: {},
         },
       })
 
@@ -103,17 +108,19 @@ describe('SchemaComposition', () => {
       const wrapper = mount(SchemaComposition, {
         props: {
           composition: 'anyOf',
-          value: {
+          schema: {
             anyOf: [
               {
                 type: 'object',
                 properties: { foo: { type: 'string' } },
               },
+              // @ts-expect-error - Test nullable here
               { nullable: true },
             ],
           },
+          options: {},
           level: 0,
-        } as any,
+        },
       })
 
       const listbox = wrapper.findComponent({ name: 'ScalarListbox' })
@@ -128,7 +135,7 @@ describe('SchemaComposition', () => {
       const wrapper = mount(SchemaComposition, {
         props: {
           composition: 'anyOf',
-          value: coerceValue(SchemaObjectSchema, {
+          schema: coerceValue(SchemaObjectSchema, {
             anyOf: [
               {
                 type: 'object',
@@ -143,6 +150,7 @@ describe('SchemaComposition', () => {
             ],
           }),
           level: 0,
+          options: {},
         },
       })
 
@@ -159,7 +167,7 @@ describe('SchemaComposition', () => {
       const wrapper = mount(SchemaComposition, {
         props: {
           composition: 'oneOf',
-          value: coerceValue(SchemaObjectSchema, {
+          schema: coerceValue(SchemaObjectSchema, {
             oneOf: [
               {
                 type: 'string',
@@ -170,6 +178,7 @@ describe('SchemaComposition', () => {
               },
             ],
           }),
+          options: {},
           level: 0,
         },
       })
@@ -186,13 +195,14 @@ describe('SchemaComposition', () => {
       const wrapper = mount(SchemaComposition, {
         props: {
           composition: 'oneOf',
-          value: coerceValue(SchemaObjectSchema, {
+          schema: coerceValue(SchemaObjectSchema, {
             oneOf: [
               { title: 'Planet', type: 'object' },
               { type: 'object', properties: { test: { type: 'string' } } },
             ],
           }),
           level: 0,
+          options: {},
         },
       })
 
@@ -205,7 +215,7 @@ describe('SchemaComposition', () => {
     const wrapper = mount(SchemaComposition, {
       props: {
         composition: 'anyOf',
-        value: coerceValue(SchemaObjectSchema, {
+        schema: coerceValue(SchemaObjectSchema, {
           anyOf: [
             {
               type: 'object',
@@ -223,6 +233,7 @@ describe('SchemaComposition', () => {
           ],
         }),
         level: 0,
+        options: {},
       },
     })
 
@@ -240,7 +251,7 @@ describe('SchemaComposition', () => {
     const wrapper = mount(SchemaComposition, {
       props: {
         composition: 'anyOf',
-        value: coerceValue(SchemaObjectSchema, {
+        schema: coerceValue(SchemaObjectSchema, {
           anyOf: [
             {
               type: 'string',
@@ -268,6 +279,7 @@ describe('SchemaComposition', () => {
           ],
         }),
         level: 0,
+        options: {},
       },
     })
 
@@ -290,7 +302,7 @@ describe('SchemaComposition', () => {
     const wrapper = mount(SchemaComposition, {
       props: {
         composition: 'anyOf',
-        value: coerceValue(SchemaObjectSchema, {
+        schema: coerceValue(SchemaObjectSchema, {
           anyOf: [
             {
               type: 'string',
@@ -318,6 +330,7 @@ describe('SchemaComposition', () => {
           ],
         }),
         level: 0,
+        options: {},
       },
     })
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -23,7 +23,7 @@ const props = withDefaults(
     /** Optional name for the schema */
     name?: string
     /** The schema value containing the composition */
-    value: SchemaObject
+    schema: SchemaObject
     /** Nesting level for proper indentation */
     level: number
     /** Whether to use compact layout */
@@ -45,7 +45,7 @@ const props = withDefaults(
 
 /** The current composition */
 const composition = computed(() =>
-  [props.value[props.composition]]
+  [props.schema[props.composition]]
     .flat()
     .map((schema) => ({ value: getResolvedRef(schema), original: schema }))
     .filter((it) => isDefined(it.value)),
@@ -99,7 +99,7 @@ const selectedComposition = computed(
       :level="level"
       :name="name"
       :noncollapsible="true"
-      :schema="mergeAllOfSchemas(props.value)" />
+      :schema="mergeAllOfSchemas(schema)" />
 
     <template v-else>
       <!-- Composition selector and panel for nested compositions -->

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -9,6 +9,8 @@ import type {
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed, ref } from 'vue'
 
+import type { SchemaOptions } from '@/components/Content/Schema/types'
+
 import { getSchemaType } from './helpers/get-schema-type'
 import { mergeAllOfSchemas } from './helpers/merge-all-of-schemas'
 import { type CompositionKeyword } from './helpers/schema-composition'
@@ -30,12 +32,10 @@ const props = withDefaults(
     compact?: boolean
     /** Whether to hide the heading */
     hideHeading?: boolean
-    /** Whether to hide read-only properties */
-    hideReadOnly?: boolean
-    /** Hide write-only properties */
-    hideWriteOnly?: boolean
     /** Breadcrumb for navigation */
     breadcrumb?: string[]
+    /** Move the options into  single prop so they are easy to pass around */
+    options: SchemaOptions
   }>(),
   {
     compact: false,
@@ -94,11 +94,10 @@ const selectedComposition = computed(
       :compact="compact"
       :discriminator="discriminator"
       :hideHeading="hideHeading"
-      :hideReadOnly="hideReadOnly"
-      :hideWriteOnly="hideWriteOnly"
       :level="level"
       :name="name"
       :noncollapsible="true"
+      :options="options"
       :schema="mergeAllOfSchemas(schema)" />
 
     <template v-else>
@@ -134,11 +133,10 @@ const selectedComposition = computed(
           :compact="compact"
           :discriminator="discriminator"
           :hideHeading="hideHeading"
-          :hideReadOnly="hideReadOnly"
-          :hideWriteOnly="hideWriteOnly"
           :level="level + 1"
           :name="name"
           :noncollapsible="true"
+          :options="options"
           :schema="selectedComposition" />
       </div>
     </template>

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.test.ts
@@ -14,7 +14,7 @@ vi.mock('./SchemaProperty.vue', () => ({
       'name',
       'variant',
       'resolvedSchema',
-      'value',
+      'schema',
       'level',
       'compact',
       'hideHeading',
@@ -41,10 +41,9 @@ describe('SchemaObjectProperties', () => {
     })
 
     const wrapper = mount(SchemaObjectProperties, {
-      props: { schema },
+      props: { schema, options: {} },
     })
     const props = wrapper.findAll('.schema-property')
-    expect(props).toHaveLength(2)
     expect(props[0].attributes('data-name')).toBe('foo')
     expect(props[1].attributes('data-name')).toBe('bar')
   })
@@ -60,7 +59,7 @@ describe('SchemaObjectProperties', () => {
     })
 
     const wrapper = mount(SchemaObjectProperties, {
-      props: { schema },
+      props: { schema, options: {} },
     })
     // The required prop is passed to SchemaProperty, but since we mock it, we cannot check directly.
     // Instead, check that both properties are rendered.
@@ -77,7 +76,7 @@ describe('SchemaObjectProperties', () => {
     })
 
     const wrapper = mount(SchemaObjectProperties, {
-      props: { schema },
+      props: { schema, options: {} },
     })
 
     const props = wrapper.findAll('.schema-property')
@@ -93,7 +92,7 @@ describe('SchemaObjectProperties', () => {
     })
 
     const wrapper = mount(SchemaObjectProperties, {
-      props: { schema },
+      props: { schema, options: {} },
     })
 
     const prop = wrapper.find('.schema-property')
@@ -111,7 +110,7 @@ describe('SchemaObjectProperties', () => {
     })
 
     const wrapper = mount(SchemaObjectProperties, {
-      props: { schema },
+      props: { schema, options: {} },
     })
 
     const prop = wrapper.find('.schema-property')
@@ -126,7 +125,7 @@ describe('SchemaObjectProperties', () => {
     })
 
     const wrapper = mount(SchemaObjectProperties, {
-      props: { schema },
+      props: { schema, options: {} },
     })
 
     const prop = wrapper.find('.schema-property')
@@ -141,7 +140,7 @@ describe('SchemaObjectProperties', () => {
     })
 
     const wrapper = mount(SchemaObjectProperties, {
-      props: { schema },
+      props: { schema, options: {} },
     })
 
     const prop = wrapper.find('.schema-property')
@@ -155,7 +154,7 @@ describe('SchemaObjectProperties', () => {
     })
 
     const wrapper = mount(SchemaObjectProperties, {
-      props: { schema },
+      props: { schema, options: {} },
     })
 
     expect(wrapper.findAll('.schema-property')).toHaveLength(0)
@@ -172,7 +171,7 @@ describe('SchemaObjectProperties', () => {
     })
 
     const wrapper = mount(SchemaObjectProperties, {
-      props: { schema },
+      props: { schema, options: {} },
     })
 
     const props = wrapper.findAll('.schema-property')
@@ -195,7 +194,7 @@ describe('SchemaObjectProperties', () => {
     })
 
     const wrapper = mount(SchemaObjectProperties, {
-      props: { schema },
+      props: { schema, options: {} },
     })
 
     const props = wrapper.findAll('.schema-property')
@@ -223,7 +222,9 @@ describe('SchemaObjectProperties', () => {
     const wrapper = mount(SchemaObjectProperties, {
       props: {
         schema,
-        orderRequiredPropertiesFirst: false,
+        options: {
+          orderRequiredPropertiesFirst: false,
+        },
       },
     })
 
@@ -252,8 +253,10 @@ describe('SchemaObjectProperties', () => {
     const wrapper = mount(SchemaObjectProperties, {
       props: {
         schema,
-        orderSchemaPropertiesBy: 'preserve',
-        orderRequiredPropertiesFirst: false,
+        options: {
+          orderSchemaPropertiesBy: 'preserve',
+          orderRequiredPropertiesFirst: false,
+        },
       },
     })
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
@@ -117,7 +117,7 @@ const getAdditionalPropertiesValue = (
       :level
       :name="property"
       :required="schema.required?.includes(property)"
-      :value="getResolvedRef(schema.properties[property])" />
+      :schema="getResolvedRef(schema.properties[property])" />
   </template>
 
   <!-- patternProperties -->
@@ -134,7 +134,7 @@ const getAdditionalPropertiesValue = (
       :hideWriteOnly="hideWriteOnly"
       :level
       :name="key"
-      :value="getResolvedRef(property)" />
+      :schema="getResolvedRef(property)" />
   </template>
 
   <!-- additionalProperties -->
@@ -150,7 +150,7 @@ const getAdditionalPropertiesValue = (
       :level
       :name="getAdditionalPropertiesName(schema.additionalProperties)"
       noncollapsible
-      :value="getAdditionalPropertiesValue(schema.additionalProperties)"
+      :schema="getAdditionalPropertiesValue(schema.additionalProperties)"
       variant="additionalProperties" />
   </template>
 </template>

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type {
   DiscriminatorObject,
@@ -9,30 +8,19 @@ import { computed } from 'vue'
 
 import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
 import { sortPropertyNames } from '@/components/Content/Schema/helpers/sort-property-names'
+import type { SchemaOptions } from '@/components/Content/Schema/types'
 
 import SchemaProperty from './SchemaProperty.vue'
 
-const {
-  schema,
-  discriminator,
-  hideReadOnly,
-  hideWriteOnly,
-  orderSchemaPropertiesBy = 'alpha',
-  orderRequiredPropertiesFirst = true,
-} = defineProps<{
+const { schema, discriminator, options } = defineProps<{
   schema: SchemaObject
   discriminator?: DiscriminatorObject
   compact?: boolean
   hideHeading?: boolean
   level?: number
   hideModelNames?: boolean
-  /** Hide readonly properties */
-  hideReadOnly?: boolean
-  /** Hide write-only properties */
-  hideWriteOnly?: boolean
   breadcrumb?: string[]
-  orderSchemaPropertiesBy?: ApiReferenceConfiguration['orderSchemaPropertiesBy']
-  orderRequiredPropertiesFirst?: ApiReferenceConfiguration['orderRequiredPropertiesFirst']
+  options: SchemaOptions
 }>()
 
 /**
@@ -40,12 +28,7 @@ const {
  * Required properties appear first, followed by optional properties.
  */
 const sortedProperties = computed(() =>
-  sortPropertyNames(schema, discriminator, {
-    hideReadOnly,
-    hideWriteOnly,
-    orderSchemaPropertiesBy,
-    orderRequiredPropertiesFirst,
-  }),
+  sortPropertyNames(schema, discriminator, options),
 )
 
 /**
@@ -112,10 +95,9 @@ const getAdditionalPropertiesValue = (
       :discriminator
       :hideHeading
       :hideModelNames
-      :hideReadOnly="hideReadOnly"
-      :hideWriteOnly="hideWriteOnly"
       :level
       :name="property"
+      :options="options"
       :required="schema.required?.includes(property)"
       :schema="getResolvedRef(schema.properties[property])" />
   </template>
@@ -130,10 +112,9 @@ const getAdditionalPropertiesValue = (
       :discriminator
       :hideHeading
       :hideModelNames="hideModelNames"
-      :hideReadOnly="hideReadOnly"
-      :hideWriteOnly="hideWriteOnly"
       :level
       :name="key"
+      :options="options"
       :schema="getResolvedRef(property)" />
   </template>
 
@@ -145,11 +126,10 @@ const getAdditionalPropertiesValue = (
       :discriminator
       :hideHeading
       :hideModelNames
-      :hideReadOnly="hideReadOnly"
-      :hideWriteOnly="hideWriteOnly"
       :level
       :name="getAdditionalPropertiesName(schema.additionalProperties)"
       noncollapsible
+      :options="options"
       :schema="getAdditionalPropertiesValue(schema.additionalProperties)"
       variant="additionalProperties" />
   </template>

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -13,12 +13,13 @@ describe('SchemaProperty', () => {
       it('displays expandable sub-schema for object with additional properties', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               type: 'object',
               additionalProperties: {
                 nullable: true,
               },
             }),
+            options: {},
           },
         })
 
@@ -32,7 +33,7 @@ describe('SchemaProperty', () => {
       it('displays expandable sub-schema for object with defined properties', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               type: 'object',
               properties: {
                 test: {
@@ -40,6 +41,7 @@ describe('SchemaProperty', () => {
                 },
               },
             }),
+            options: {},
           },
         })
 
@@ -53,9 +55,10 @@ describe('SchemaProperty', () => {
       it('hides expand button for object without properties or additional properties', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               type: 'object',
             }),
+            options: {},
           },
         })
 
@@ -71,7 +74,7 @@ describe('SchemaProperty', () => {
       it('displays expandable sub-schema for array with object items', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               type: 'array',
               items: {
                 type: 'object',
@@ -82,6 +85,7 @@ describe('SchemaProperty', () => {
                 },
               },
             }),
+            options: {},
           },
         })
 
@@ -95,12 +99,13 @@ describe('SchemaProperty', () => {
       it('hides expand button for array with primitive items', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               type: 'array',
               items: {
                 type: 'string',
               },
             }),
+            options: {},
           },
         })
 
@@ -116,9 +121,10 @@ describe('SchemaProperty', () => {
       it('hides expand button for string type', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               type: 'string',
             }),
+            options: {},
           },
         })
 
@@ -132,9 +138,10 @@ describe('SchemaProperty', () => {
       it('hides expand button for integer type', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               type: 'integer',
             }),
+            options: {},
           },
         })
 
@@ -148,9 +155,10 @@ describe('SchemaProperty', () => {
       it('hides expand button for number type', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               type: 'number',
             }),
+            options: {},
           },
         })
 
@@ -164,9 +172,10 @@ describe('SchemaProperty', () => {
       it('hides expand button for boolean type', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               type: 'boolean',
             }),
+            options: {},
           },
         })
 
@@ -184,9 +193,10 @@ describe('SchemaProperty', () => {
       it('displays all enum values when count is 9 or fewer', () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               enum: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'],
             }),
+            options: {},
           },
         })
 
@@ -200,9 +210,10 @@ describe('SchemaProperty', () => {
       it('displays first 5 enum values with toggle button when count exceeds 9', () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               enum: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
             }),
+            options: {},
           },
         })
 
@@ -217,9 +228,10 @@ describe('SchemaProperty', () => {
       it('expands to show all enum values when toggle button is clicked', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               enum: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
             }),
+            options: {},
           },
         })
 
@@ -234,9 +246,10 @@ describe('SchemaProperty', () => {
       it('displays single enum value correctly', () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               enum: ['a'],
             }),
+            options: {},
           },
         })
 
@@ -249,11 +262,12 @@ describe('SchemaProperty', () => {
       it('displays enum values from array items property', () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               items: {
                 enum: ['a', 'b', 'c'],
               },
             }),
+            options: {},
           },
         })
 
@@ -264,7 +278,7 @@ describe('SchemaProperty', () => {
       it('displays enum values with their descriptions', () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               'type': 'string',
               'enum': ['Ice giant', 'Dwarf', 'Gas', 'Iron'],
               'title': 'Planet',
@@ -276,6 +290,7 @@ describe('SchemaProperty', () => {
                 'Iron': 'A planet made mostly of iron',
               },
             }),
+            options: {},
           },
         })
 
@@ -295,9 +310,10 @@ describe('SchemaProperty', () => {
       it('displays enum values within composition schemas', () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               anyOf: [{ type: 'string', enum: ['a', 'b', 'c'] }, { type: 'null' }],
             }),
+            options: {},
           },
         })
 
@@ -313,9 +329,10 @@ describe('SchemaProperty', () => {
         props: {
           variant: 'patternProperties',
           name: '^foo-',
-          value: coerceValue(SchemaObjectSchema, {
+          schema: coerceValue(SchemaObjectSchema, {
             type: 'string',
           }),
+          options: {},
         },
       })
 
@@ -331,9 +348,10 @@ describe('SchemaProperty', () => {
           variant: 'additionalProperties',
           name: 'propertyName*',
           // @ts-ignore
-          value: {
+          schema: {
             type: 'anything',
           },
+          options: {},
         },
       })
 
@@ -347,9 +365,10 @@ describe('SchemaProperty', () => {
       const wrapper = mount(SchemaProperty, {
         props: {
           name: 'regularProperty',
-          value: coerceValue(SchemaObjectSchema, {
+          schema: coerceValue(SchemaObjectSchema, {
             type: 'string',
           }),
+          options: {},
         },
       })
 
@@ -370,7 +389,7 @@ describe('SchemaProperty', () => {
       it('renders composition schemas for array items with oneOf', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               type: 'array',
               items: {
                 oneOf: [
@@ -382,6 +401,7 @@ describe('SchemaProperty', () => {
                 ],
               },
             }),
+            options: {},
           },
         })
 
@@ -396,7 +416,7 @@ describe('SchemaProperty', () => {
       it('renders array items with oneOf composition after expansion', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               type: 'array',
               items: {
                 type: 'object',
@@ -408,6 +428,7 @@ describe('SchemaProperty', () => {
                 ],
               },
             }),
+            options: {},
           },
         })
 
@@ -431,7 +452,7 @@ describe('SchemaProperty', () => {
       it('renders object compositions with allOf with an object button', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               allOf: [
                 {
                   properties: {
@@ -442,6 +463,7 @@ describe('SchemaProperty', () => {
                 },
               ],
             }),
+            options: {},
           },
         })
 
@@ -459,7 +481,7 @@ describe('SchemaProperty', () => {
       it.todo('renders nested composition selectors with correct titles', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: coerceValue(SchemaObjectSchema, {
+            schema: coerceValue(SchemaObjectSchema, {
               allOf: [
                 {
                   type: 'object',
@@ -491,6 +513,7 @@ describe('SchemaProperty', () => {
                 },
               ],
             }),
+            options: {},
           },
         })
 
@@ -512,7 +535,7 @@ describe('SchemaProperty', () => {
       it('renders object properties with descriptions after expansion', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
-            value: {
+            schema: {
               type: ['object', 'null'],
               properties: {
                 galaxy: {
@@ -532,6 +555,7 @@ describe('SchemaProperty', () => {
                 },
               },
             } as any,
+            options: {},
           },
         })
 
@@ -568,9 +592,10 @@ describe('SchemaProperty', () => {
 
       const wrapper = mount(SchemaProperty, {
         props: {
-          value: childPropertySchema,
+          schema: childPropertySchema,
           name: 'Satellites',
           level: 1,
+          options: {},
         },
       })
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -11,6 +11,7 @@ import { computed, type Component } from 'vue'
 
 import { WithBreadcrumb } from '@/components/Anchor'
 import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
+import type { SchemaOptions } from '@/components/Content/Schema/types'
 import { SpecificationExtension } from '@/features/specification-extension'
 
 import { optimizeValueForDisplay } from './helpers/optimize-value-for-display'
@@ -40,12 +41,9 @@ const props = withDefaults(
     description?: string
     hideModelNames?: boolean
     hideHeading?: boolean
-    /** Hide read-only properties */
-    hideReadOnly?: boolean
-    /** Hide write-only properties */
-    hideWriteOnly?: boolean
     variant?: 'additionalProperties' | 'patternProperties'
     breadcrumb?: string[]
+    options: SchemaOptions
   }>(),
   {
     level: 0,
@@ -333,11 +331,10 @@ const compositionsToRender = computed(() => {
       <Schema
         :breadcrumb="breadcrumb && name ? [...breadcrumb, name] : undefined"
         :compact="compact"
-        :hideReadOnly="hideReadOnly"
-        :hideWriteOnly="hideWriteOnly"
         :level="level + 1"
         :name="name"
         :noncollapsible="noncollapsible"
+        :options="options"
         :schema="optimizedValue" />
     </div>
 
@@ -353,11 +350,10 @@ const compositionsToRender = computed(() => {
         class="children">
         <Schema
           :compact="compact"
-          :hideReadOnly="hideReadOnly"
-          :hideWriteOnly="hideWriteOnly"
           :level="level + 1"
           :name="name"
           :noncollapsible="noncollapsible"
+          :options="options"
           :schema="getResolvedRef(optimizedValue.items)" />
       </div>
     </template>
@@ -371,11 +367,10 @@ const compositionsToRender = computed(() => {
       :composition="compositionData.composition"
       :discriminator="schema?.discriminator"
       :hideHeading="hideHeading"
-      :hideReadOnly="hideReadOnly"
-      :hideWriteOnly="hideWriteOnly"
       :level="level"
       :name="name"
       :noncollapsible="noncollapsible"
+      :options="options"
       :schema="getResolvedRef(props.schema)!" />
     <SpecificationExtension :value="optimizedValue" />
   </component>

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -30,7 +30,7 @@ import SchemaPropertyHeading from './SchemaPropertyHeading.vue'
 const props = withDefaults(
   defineProps<{
     is?: string | Component
-    value: SchemaObject | undefined
+    schema: SchemaObject | undefined
     noncollapsible?: boolean
     level?: number
     name?: string
@@ -91,7 +91,7 @@ const getEnumFromValue = (value?: Record<string, any>): any[] | [] =>
   value?.enum || value?.items?.enum || []
 
 /** Simplified composition with `null` type. */
-const optimizedValue = computed(() => optimizeValueForDisplay(props.value))
+const optimizedValue = computed(() => optimizeValueForDisplay(props.schema))
 
 const displayDescription = computed(() => {
   const value = optimizedValue.value
@@ -369,14 +369,14 @@ const compositionsToRender = computed(() => {
       :breadcrumb="breadcrumb"
       :compact="compact"
       :composition="compositionData.composition"
-      :discriminator="value?.discriminator"
+      :discriminator="schema?.discriminator"
       :hideHeading="hideHeading"
       :hideReadOnly="hideReadOnly"
       :hideWriteOnly="hideWriteOnly"
       :level="level"
       :name="name"
       :noncollapsible="noncollapsible"
-      :value="getResolvedRef(props.value)!" />
+      :schema="getResolvedRef(props.schema)!" />
     <SpecificationExtension :value="optimizedValue" />
   </component>
 </template>

--- a/packages/api-reference/src/components/Content/Schema/types.ts
+++ b/packages/api-reference/src/components/Content/Schema/types.ts
@@ -1,0 +1,17 @@
+import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
+
+/**
+ * Options for the schema component tree
+ *
+ * These options should be prop drilled through the Schema component tree and shouldn't be changed
+ */
+export type SchemaOptions = {
+  /** Hide read-only properties */
+  hideReadOnly?: boolean
+  /** Hide write-only properties */
+  hideWriteOnly?: boolean
+  /** Order schema properties, defaults to 'alpha' */
+  orderSchemaPropertiesBy?: ApiReferenceConfiguration['orderSchemaPropertiesBy']
+  /** Order required properties first */
+  orderRequiredPropertiesFirst?: ApiReferenceConfiguration['orderRequiredPropertiesFirst']
+}

--- a/packages/api-reference/src/features/Operation/components/Header.vue
+++ b/packages/api-reference/src/features/Operation/components/Header.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { HeaderObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
@@ -8,6 +9,7 @@ const { name, header, breadcrumb } = defineProps<{
   header: HeaderObject
   name: string
   breadcrumb?: string[]
+  config: ApiReferenceConfiguration
 }>()
 </script>
 <template>
@@ -16,5 +18,9 @@ const { name, header, breadcrumb } = defineProps<{
     :breadcrumb="breadcrumb ? [...breadcrumb, 'headers'] : undefined"
     :description="header.description"
     :name="name"
+    :options="{
+      orderRequiredPropertiesFirst: config.orderRequiredPropertiesFirst,
+      orderSchemaPropertiesBy: config.orderSchemaPropertiesBy,
+    }"
     :schema="getResolvedRef(header.schema)" />
 </template>

--- a/packages/api-reference/src/features/Operation/components/Header.vue
+++ b/packages/api-reference/src/features/Operation/components/Header.vue
@@ -16,5 +16,5 @@ const { name, header, breadcrumb } = defineProps<{
     :breadcrumb="breadcrumb ? [...breadcrumb, 'headers'] : undefined"
     :description="header.description"
     :name="name"
-    :value="getResolvedRef(header.schema)" />
+    :schema="getResolvedRef(header.schema)" />
 </template>

--- a/packages/api-reference/src/features/Operation/components/Headers.vue
+++ b/packages/api-reference/src/features/Operation/components/Headers.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
 import { ScalarIcon } from '@scalar/components'
+import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { HeaderObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
@@ -9,6 +10,7 @@ import Header from './Header.vue'
 const { headers, breadcrumb } = defineProps<{
   headers: Record<string, HeaderObject>
   breadcrumb?: string[]
+  config: ApiReferenceConfiguration
 }>()
 </script>
 <template>
@@ -38,6 +40,7 @@ const { headers, breadcrumb } = defineProps<{
             :key="key">
             <Header
               :breadcrumb="breadcrumb ? [...breadcrumb, 'headers'] : undefined"
+              :config="config"
               :header="getResolvedRef(header)"
               :name="key" />
           </template>

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -127,7 +127,7 @@ const shouldCollapse = computed<boolean>(() =>
           :name="shouldCollapse ? '' : name"
           :noncollapsible="true"
           :required="'required' in parameter && parameter.required"
-          :value="value"
+          :schema="value"
           :withExamples="withExamples" />
       </DisclosurePanel>
     </Disclosure>

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -12,6 +12,7 @@ import type {
 import { computed, ref } from 'vue'
 
 import SchemaProperty from '@/components/Content/Schema/SchemaProperty.vue'
+import { useConfig } from '@/hooks/useConfig'
 
 import ContentTypeSelect from './ContentTypeSelect.vue'
 import Headers from './Headers.vue'
@@ -29,6 +30,8 @@ const {
   withExamples?: boolean
   breadcrumb?: string[]
 }>()
+
+const config = useConfig()
 
 /** Responses and params may both have a schema */
 const schema = computed<SchemaObject | null>(() =>
@@ -115,6 +118,7 @@ const shouldCollapse = computed<boolean>(() =>
         <Headers
           v-if="headers"
           :breadcrumb="breadcrumb"
+          :config="config"
           :headers="headers" />
 
         <!-- Schema -->
@@ -126,6 +130,11 @@ const shouldCollapse = computed<boolean>(() =>
           :hideWriteOnly="true"
           :name="shouldCollapse ? '' : name"
           :noncollapsible="true"
+          :options="{
+            hideWriteOnly: true,
+            orderRequiredPropertiesFirst: config.orderRequiredPropertiesFirst,
+            orderSchemaPropertiesBy: config.orderSchemaPropertiesBy,
+          }"
           :required="'required' in parameter && parameter.required"
           :schema="value"
           :withExamples="withExamples" />

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -121,17 +121,25 @@ const partitionedSchema = computed(() => {
       <Schema
         :breadcrumb
         compact
-        :hideReadOnly="true"
         name="Request Body"
         noncollapsible
+        :options="{
+          hideReadOnly: true,
+          orderRequiredPropertiesFirst: config.orderRequiredPropertiesFirst,
+          orderSchemaPropertiesBy: config.orderSchemaPropertiesBy,
+        }"
         :schema="partitionedSchema.visibleProperties" />
 
       <Schema
         additionalProperties
         :breadcrumb
         compact
-        :hideReadOnly="true"
         name="Request Body"
+        :options="{
+          hideReadOnly: true,
+          orderRequiredPropertiesFirst: config.orderRequiredPropertiesFirst,
+          orderSchemaPropertiesBy: config.orderSchemaPropertiesBy,
+        }"
         :schema="partitionedSchema.collapsedProperties" />
     </div>
 
@@ -145,6 +153,11 @@ const partitionedSchema = computed(() => {
         :hideReadOnly="true"
         name="Request Body"
         noncollapsible
+        :options="{
+          hideReadOnly: true,
+          orderRequiredPropertiesFirst: config.orderRequiredPropertiesFirst,
+          orderSchemaPropertiesBy: config.orderSchemaPropertiesBy,
+        }"
         :schema />
     </div>
   </div>


### PR DESCRIPTION
**Problem**
closes #6921 
Currently, the sorting property options weren't working. Our tests work but we weren't actually passing the props down!

**Solution**

With this PR we pass around the props to schema at all depths

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
