### PR TITLE
feat: migrate do Zod 4

### DIFF
--- a/.changeset/old-squids-fetch.md
+++ b/.changeset/old-squids-fetch.md
@@ -1,0 +1,9 @@
+---
+'@scalar/api-reference': minor
+'@scalar/openapi-types': minor
+'@scalar/api-client': minor
+'@scalar/oas-utils': minor
+'@scalar/types': minor
+---
+
+feat: migrate to Zod 4

--- a/packages/api-client/src/libs/local-storage.ts
+++ b/packages/api-client/src/libs/local-storage.ts
@@ -1,4 +1,3 @@
-import type { WorkspaceStore } from '@/store'
 import { cookieSchema } from '@scalar/oas-utils/entities/cookie'
 import { environmentSchema } from '@scalar/oas-utils/entities/environment'
 import {
@@ -12,12 +11,14 @@ import {
 import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
 import { schemaModel } from '@scalar/oas-utils/helpers'
 import { DATA_VERSION, DATA_VERSION_LS_LEY, migrator } from '@scalar/oas-utils/migrations'
-import type { ZodSchema, ZodTypeDef } from 'zod'
+import type { ZodSchema } from 'zod'
+
+import type { WorkspaceStore } from '@/store'
 
 /** Loads the migrated resource into the mutator safely */
 const loadResources = <T extends (object & { uid: string })[]>(
   resources: T,
-  schema: ZodSchema<T[number], ZodTypeDef, any>,
+  schema: ZodSchema<T[number], any>,
   add: (payload: T[number]) => void | T[number],
 ) =>
   resources.forEach((payload) => {

--- a/packages/api-client/src/views/Request/libs/watch-mode.test.ts
+++ b/packages/api-client/src/views/Request/libs/watch-mode.test.ts
@@ -1429,6 +1429,18 @@ describe('traverseZodSchema', () => {
     const result = traverseZodSchema(testSchema, ['formBody', 0, 'more', 0])
     expect(result).toBeInstanceOf(z.ZodAny)
   })
+
+  it('returns the value schema for a record string key', () => {
+    const recordSchema = z.record(z.string(), z.object({ prop: z.string() }))
+    const result = traverseZodSchema(recordSchema, ['someKey'])
+    expect(result).toBeInstanceOf(z.ZodObject)
+  })
+
+  it('returns the correct schema for a property of a record value', () => {
+    const recordSchema = z.record(z.string(), z.object({ prop: z.string() }))
+    const result = traverseZodSchema(recordSchema, ['someKey', 'prop'])
+    expect(result).toBeInstanceOf(z.ZodString)
+  })
 })
 
 describe('parseDiff', () => {

--- a/packages/api-client/src/views/Request/libs/watch-mode.ts
+++ b/packages/api-client/src/views/Request/libs/watch-mode.ts
@@ -190,14 +190,10 @@ export const traverseZodSchema = (schema: ZodSchema, path: (string | number)[]):
         return null
       }
       if (typeof key === 'string') {
-        // For string keys, we're accessing a property of the record value
+        // For string keys, we're accessing a value in the record
         currentSchema = valueSchema
         // Unwrap optional/default wrappers around the value schema
         currentSchema = unwrapSchema(currentSchema)
-        // If the value schema is an object, try to access the property
-        if (currentSchema instanceof z.ZodObject && key in currentSchema.shape) {
-          currentSchema = currentSchema.shape[key] as ZodSchema
-        }
       } else if (typeof key === 'number') {
         // For number keys, we're accessing an element of an array within the record value
         currentSchema = valueSchema

--- a/packages/api-client/src/views/Request/libs/watch-mode.ts
+++ b/packages/api-client/src/views/Request/libs/watch-mode.ts
@@ -15,7 +15,7 @@ import { isHttpMethod, schemaModel } from '@scalar/oas-utils/helpers'
 import { type Path, type PathValue, getNestedValue } from '@scalar/object-utils/nested'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import microdiff, { type Difference } from 'microdiff'
-import { type ZodSchema, type ZodTypeDef, z } from 'zod'
+import { type ZodSchema, z } from 'zod'
 
 import type { WorkspaceStore } from '@/store'
 import type { ActiveEntitiesStore } from '@/store/active-entities'
@@ -204,7 +204,7 @@ export const traverseZodSchema = (schema: ZodSchema, path: (string | number)[]):
  * We return a tuple to make it easier to pass into the mutators
  */
 export const parseDiff = <T>(
-  schema: ZodSchema<T, ZodTypeDef, any>,
+  schema: ZodSchema<T, any>,
   diff: Difference,
 ): {
   /** Typed path as it has been checked agains the schema */

--- a/packages/api-client/src/views/Request/libs/watch-mode.ts
+++ b/packages/api-client/src/views/Request/libs/watch-mode.ts
@@ -1,5 +1,3 @@
-import type { WorkspaceStore } from '@/store'
-import type { ActiveEntitiesStore } from '@/store/active-entities'
 import {
   type Request,
   type RequestParameterPayload,
@@ -18,6 +16,9 @@ import { type Path, type PathValue, getNestedValue } from '@scalar/object-utils/
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import microdiff, { type Difference } from 'microdiff'
 import { type ZodSchema, type ZodTypeDef, z } from 'zod'
+
+import type { WorkspaceStore } from '@/store'
+import type { ActiveEntitiesStore } from '@/store/active-entities'
 
 /**
  * Combine Rename Diffs

--- a/packages/api-reference/src/components/ApiReferenceContent.vue
+++ b/packages/api-reference/src/components/ApiReferenceContent.vue
@@ -78,6 +78,7 @@ const configuration = computed(() => ({
   layout: providedConfiguration.layout ?? 'modern',
   persistAuth: providedConfiguration.persistAuth ?? false,
   documentDownloadType: providedConfiguration.documentDownloadType ?? 'both',
+  onBeforeRequest: providedConfiguration.onBeforeRequest,
 }))
 
 // ---------------------------------------------------------------------------

--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -90,6 +90,7 @@ const configuration = computed(() => ({
   layout: providedConfiguration.layout ?? 'modern',
   persistAuth: providedConfiguration.persistAuth ?? false,
   documentDownloadType: providedConfiguration.documentDownloadType ?? 'both',
+  onBeforeRequest: providedConfiguration.onBeforeRequest,
 }))
 
 // ---------------------------------------------------------------------------

--- a/packages/api-reference/src/features/api-client-modal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/api-client-modal/ApiClientModal.vue
@@ -49,7 +49,10 @@ onMounted(() => {
     configuration: {
       ...configuration,
       // If the onBeforeRequest hook is configured, we add the plugin to the API client.
-      plugins: configuration.onBeforeRequest ? [OnBeforeRequestPlugin] : [],
+      plugins:
+        typeof configuration.onBeforeRequest === 'function'
+          ? [OnBeforeRequestPlugin]
+          : [],
     },
     store,
   })

--- a/packages/api-reference/src/features/multiple-documents/useMultipleDocuments.ts
+++ b/packages/api-reference/src/features/multiple-documents/useMultipleDocuments.ts
@@ -245,7 +245,9 @@ export const useMultipleDocuments = ({
       }
 
       // Fire the onDocumentSelect event
-      selectedConfiguration.value.onDocumentSelect?.()
+      if (typeof selectedConfiguration.value.onDocumentSelect === 'function') {
+        selectedConfiguration.value.onDocumentSelect?.()
+      }
     },
     { flush: 'sync' },
   )

--- a/packages/api-reference/src/plugins/plugin-manager.test.ts
+++ b/packages/api-reference/src/plugins/plugin-manager.test.ts
@@ -1,5 +1,6 @@
 import type { ApiReferencePlugin } from '@scalar/types/api-reference'
 import { describe, expect, it } from 'vitest'
+
 import { createPluginManager } from './plugin-manager'
 
 describe('plugin-manager', () => {
@@ -13,44 +14,44 @@ describe('plugin-manager', () => {
     it('registers and retrieves plugins correctly', () => {
       const mockPlugin: ApiReferencePlugin = () => ({
         name: 'testPlugin',
-        extensions: [{ name: 'x-test', value: 'testValue' }],
+        extensions: [{ name: 'x-test', component: 'testComponent' }],
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
       const extensions = manager.getSpecificationExtensions('x-test')
-      expect(extensions).toEqual([{ name: 'x-test', value: 'testValue' }])
+      expect(extensions).toEqual([{ name: 'x-test', component: 'testComponent' }])
     })
 
     it('filters extensions by name', () => {
       const mockPlugin: ApiReferencePlugin = () => ({
         name: 'testPlugin',
         extensions: [
-          { name: 'x-test', value: 'testValue' },
-          { name: 'x-other', value: 'otherValue' },
+          { name: 'x-test', component: 'testComponent' },
+          { name: 'x-other', component: 'otherComponent' },
         ],
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
       const extensions = manager.getSpecificationExtensions('x-test')
-      expect(extensions).toEqual([{ name: 'x-test', value: 'testValue' }])
+      expect(extensions).toEqual([{ name: 'x-test', component: 'testComponent' }])
     })
 
     it('registers multiple plugins correctly', () => {
       const mockPlugin1: ApiReferencePlugin = () => ({
         name: 'testPlugin1',
-        extensions: [{ name: 'x-test', value: 'testValue1' }],
+        extensions: [{ name: 'x-test', component: 'testComponent1' }],
       })
 
       const mockPlugin2: ApiReferencePlugin = () => ({
         name: 'testPlugin2',
-        extensions: [{ name: 'x-test', value: 'testValue2' }],
+        extensions: [{ name: 'x-test', component: 'testComponent2' }],
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin1, mockPlugin2] })
       const extensions = manager.getSpecificationExtensions('x-test')
       expect(extensions).toEqual([
-        { name: 'x-test', value: 'testValue1' },
-        { name: 'x-test', value: 'testValue2' },
+        { name: 'x-test', component: 'testComponent1' },
+        { name: 'x-test', component: 'testComponent2' },
       ])
     })
   })

--- a/packages/api-reference/src/v2/blocks/scalar-info-block/components/InfoBlock.vue
+++ b/packages/api-reference/src/v2/blocks/scalar-info-block/components/InfoBlock.vue
@@ -35,7 +35,7 @@ const { options } = defineProps<{
     /** The URL of the OpenAPI document. */
     url?: string | undefined
     /** Optional callback invoked when the component has finished loading. */
-    onLoaded?: () => void
+    onLoaded?: (() => void) | unknown
     /** The original document content. */
     getOriginalDocument: () => string
   }

--- a/packages/api-reference/src/v2/blocks/scalar-info-block/components/IntroductionLayout.vue
+++ b/packages/api-reference/src/v2/blocks/scalar-info-block/components/IntroductionLayout.vue
@@ -29,11 +29,11 @@ const { onLoaded } = defineProps<{
   documentExtensions?: Record<string, unknown>
   infoExtensions?: Record<string, unknown>
   isLoading?: boolean
-  onLoaded?: () => void
+  onLoaded?: (() => void) | unknown
 }>()
 
 /** Trigger the onLoaded event when the component is mounted */
-onMounted(() => onLoaded?.())
+onMounted(() => (typeof onLoaded === 'function' ? onLoaded?.() : onLoaded))
 </script>
 
 <template>

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -202,7 +202,7 @@ export const requestExampleSchema = z.object({
     .default({
       path: [],
       query: [],
-      headers: [],
+      headers: [{ key: 'Accept', value: '*/*', enabled: true }],
       cookies: [],
     }),
   /** TODO: Should this be deprecated? */

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -1,12 +1,13 @@
-import { schemaModel } from '@/helpers/schema-model'
-import { getServerVariableExamples } from '@/spec-getters/get-server-variable-examples'
+import { isDefined } from '@scalar/helpers/array/is-defined'
+import { objectKeys } from '@scalar/helpers/object/object-keys'
 import { keysOf } from '@scalar/object-utils/arrays'
 import { type ENTITY_BRANDS, nanoidSchema } from '@scalar/types/utils'
 import { z } from 'zod'
 
+import { schemaModel } from '@/helpers/schema-model'
 import { getRequestBodyFromOperation } from '@/spec-getters/get-request-body-from-operation'
-import { isDefined } from '@scalar/helpers/array/is-defined'
-import { objectKeys } from '@scalar/helpers/object/object-keys'
+import { getServerVariableExamples } from '@/spec-getters/get-server-variable-examples'
+
 import type { ParameterContent, RequestParameter } from './parameters'
 import type { Request } from './requests'
 import type { Server } from './server'
@@ -189,7 +190,7 @@ export const requestExampleSchema = z.object({
   type: z.literal('requestExample').optional().default('requestExample'),
   requestUid: z.string().brand<ENTITY_BRANDS['OPERATION']>().optional(),
   name: z.string().optional().default('Name'),
-  body: exampleRequestBodySchema.optional().default({}),
+  body: exampleRequestBodySchema.optional().default({ activeBody: 'raw' }),
   parameters: z
     .object({
       path: requestExampleParametersSchema.array().default([]),
@@ -198,7 +199,12 @@ export const requestExampleSchema = z.object({
       cookies: requestExampleParametersSchema.array().default([]),
     })
     .optional()
-    .default({}),
+    .default({
+      path: [],
+      query: [],
+      headers: [],
+      cookies: [],
+    }),
   /** TODO: Should this be deprecated? */
   serverVariables: z.record(z.string(), z.array(z.string())).optional(),
 })
@@ -287,7 +293,7 @@ export function convertExampleToXScalar(example: RequestExample) {
 // Example Helpers
 
 /** Create new instance parameter from a request parameter */
-export function createParamInstance(param: RequestParameter) {
+export function createParamInstance(param: RequestParameter): RequestExampleParameter {
   const schema = param.schema as any
 
   const firstExample = (() => {

--- a/packages/oas-utils/src/entities/workspace/workspace.ts
+++ b/packages/oas-utils/src/entities/workspace/workspace.ts
@@ -11,7 +11,7 @@ const modifiers = z
 
 export type HotKeyModifiers = z.infer<typeof modifiers>
 
-const hotKeys = z.record(
+const hotKeys = z.partialRecord(
   z.enum(KEYDOWN_KEYS),
   z.object({
     modifiers: modifiers.optional(),

--- a/packages/oas-utils/src/entities/workspace/workspace.ts
+++ b/packages/oas-utils/src/entities/workspace/workspace.ts
@@ -1,14 +1,13 @@
 import { themeIds } from '@scalar/themes'
+import { type ENTITY_BRANDS, nanoidSchema } from '@scalar/types/utils'
 import { z } from 'zod'
 
-import { type ENTITY_BRANDS, nanoidSchema } from '@scalar/types/utils'
 import { HOTKEY_EVENT_NAMES, KEYDOWN_KEYS } from '../hotkeys/hotkeys'
 
-const modifier = z
-  .enum(['Meta', 'Control', 'Shift', 'Alt', 'default'] as const)
+const modifiers = z
+  .array(z.union([z.literal('Meta'), z.literal('Control'), z.literal('Shift'), z.literal('Alt'), z.literal('default')]))
   .optional()
-  .default('default')
-const modifiers = z.array(modifier).optional().default(['default'])
+  .default(['default'])
 
 export type HotKeyModifiers = z.infer<typeof modifiers>
 
@@ -36,7 +35,7 @@ export const workspaceSchema = z.object({
   /** List of all collection uids in a given workspace */
   collections: z.array(z.string().brand<ENTITY_BRANDS['COLLECTION']>()).default([]),
   /** List of all environment uids in a given workspace, TODO: why is this a record? */
-  environments: z.record(z.string()).default({}),
+  environments: z.record(z.string(), z.string()).default({}),
   /** Customize hotkeys */
   hotKeyConfig: hotKeyConfigSchema,
   /** Active Environment ID to use for requests  */

--- a/packages/oas-utils/src/helpers/schema-model.ts
+++ b/packages/oas-utils/src/helpers/schema-model.ts
@@ -1,22 +1,22 @@
-import type { ZodSchema, ZodTypeDef } from 'zod'
+import type z from 'zod'
 
 /** Parse an value from a given schema with optional error or null return */
-export function schemaModel<T, I = any>(
+export function schemaModel<T extends z.ZodType, I = any>(
   data: I,
-  schema: ZodSchema<T, ZodTypeDef, any>,
+  schema: T,
   throwError?: true,
   errorLocation?: string,
-): T
+): z.infer<T>
 export function schemaModel<T, I = any>(
   data: I,
-  schema: ZodSchema<T, ZodTypeDef, any>,
+  schema: T,
   throwError?: false,
   errorLocation?: string,
-): T | null
+): z.infer<T> | null
 /** Parse a Zod */
-export function schemaModel<T, I = any>(
+export function schemaModel<T extends z.ZodType, I = any>(
   data: I,
-  schema: ZodSchema<T, ZodTypeDef, any>,
+  schema: T,
   throwError = true,
   errorLocation?: string,
 ) {

--- a/packages/oas-utils/src/migrations/v-2.5.0/migration.ts
+++ b/packages/oas-utils/src/migrations/v-2.5.0/migration.ts
@@ -1,4 +1,5 @@
 import type { v_2_4_0 } from '@/migrations/v-2.4.0/types.generated'
+
 import type { v_2_5_0 } from './types.generated'
 
 /** V-2.4.0 to V-2.5.0 migration */
@@ -137,6 +138,7 @@ export const migrate_v_2_5_0 = (data: v_2_4_0.DataRecord): v_2_5_0['DataRecord']
 
   const workspaces = Object.entries(data.workspaces || {}).reduce<Record<string, v_2_5_0['Workspace']>>(
     (acc, [key, workspace]) => {
+      // @ts-expect-error
       acc[key] = {
         ...workspace,
         uid: workspace.uid as v_2_5_0['Workspace']['uid'],

--- a/packages/oas-utils/src/migrations/v-2.5.0/migration.ts
+++ b/packages/oas-utils/src/migrations/v-2.5.0/migration.ts
@@ -138,7 +138,6 @@ export const migrate_v_2_5_0 = (data: v_2_4_0.DataRecord): v_2_5_0['DataRecord']
 
   const workspaces = Object.entries(data.workspaces || {}).reduce<Record<string, v_2_5_0['Workspace']>>(
     (acc, [key, workspace]) => {
-      // @ts-expect-error
       acc[key] = {
         ...workspace,
         uid: workspace.uid as v_2_5_0['Workspace']['uid'],

--- a/packages/openapi-types/src/schemas/3.1/processed/runtime-expression.ts
+++ b/packages/openapi-types/src/schemas/3.1/processed/runtime-expression.ts
@@ -101,8 +101,8 @@ const validatePureExpression = (value: string): boolean => {
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#runtime-expressions
  */
-export const RuntimeExpressionSchema = z.string().refine(isValidRuntimeExpression, (value) => ({
-  message: `Invalid runtime expression: "${value}". Runtime expressions must:
+export const RuntimeExpressionSchema = z.string().refine(isValidRuntimeExpression, {
+  message: `Invalid runtime expression. Runtime expressions must:
   - Start with $ or contain expressions in curly braces {}
   - Use one of: $method, $url, $statusCode
   - Or follow pattern: $request|response.(header|query|path|body)
@@ -111,4 +111,4 @@ export const RuntimeExpressionSchema = z.string().refine(isValidRuntimeExpressio
   Example valid expressions:
   - Pure: $method, $request.path.id, $response.body#/status
   - Embedded: "Hello {$request.body#/name}!", "Status: {$statusCode}"`,
-}))
+})

--- a/packages/openapi-types/src/schemas/3.1/processed/schema-object.ts
+++ b/packages/openapi-types/src/schemas/3.1/processed/schema-object.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+
 import { DiscriminatorObjectSchema } from './discriminator-object'
 import { ExternalDocumentationObjectSchema } from './external-documentation-object'
 import { XmlObjectSchema } from './xml-object'
@@ -55,7 +56,12 @@ export const SchemaObjectSchema: z.ZodType<Record<string, any>> = z.object({
   $ref: z.string().optional(),
   $id: z.string().optional(),
   $schema: z.string().optional(),
-  $defs: z.record(z.lazy(() => SchemaObjectSchema)).optional(),
+  $defs: z
+    .record(
+      z.string(),
+      z.lazy(() => SchemaObjectSchema),
+    )
+    .optional(),
   const: z.any().optional(),
   $dynamicRef: z.string().optional(),
   $dynamicAnchor: z.string().optional(),

--- a/packages/openapi-types/src/schemas/3.1/unprocessed/schema-object.ts
+++ b/packages/openapi-types/src/schemas/3.1/unprocessed/schema-object.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+
 import { SchemaObjectSchema as OriginalSchemaObjectSchema } from '../processed/schema-object'
 import { ReferenceObjectSchema } from './reference-object'
 
@@ -15,7 +16,12 @@ export const SchemaObjectSchema: z.ZodType<any> = z.lazy(() =>
       $ref: z.string().optional(),
       $id: z.string().optional(),
       $schema: z.string().optional(),
-      $defs: z.record(z.lazy(() => SchemaObjectSchema)).optional(),
+      $defs: z
+        .record(
+          z.string(),
+          z.lazy(() => SchemaObjectSchema),
+        )
+        .optional(),
       $dynamicRef: z.string().optional(),
       $dynamicAnchor: z.string().optional(),
 

--- a/packages/types/src/api-client/api-client-plugin.ts
+++ b/packages/types/src/api-client/api-client-plugin.ts
@@ -28,7 +28,7 @@ export const HooksSchema = z.object({
 })
 
 export const ApiClientPluginSchema = z.function({
-  input: [z.void()],
+  input: [],
   output: z.object({
     name: z.string(),
     views: ViewsSchema.optional(),

--- a/packages/types/src/api-client/api-client-plugin.ts
+++ b/packages/types/src/api-client/api-client-plugin.ts
@@ -4,7 +4,7 @@ const SectionViewSchema = z.object({
   title: z.string().optional(),
   // Since this is meant to be a Vue component, we'll use unknown
   component: z.unknown(),
-  props: z.record(z.any()).optional(),
+  props: z.record(z.string(), z.any()).optional(),
 })
 
 const ViewsSchema = z.object({
@@ -14,29 +14,26 @@ const ViewsSchema = z.object({
 
 export const HooksSchema = z.object({
   onBeforeRequest: z
-    .function()
-    .args(z.object({ request: z.instanceof(Request) }))
-    .returns(z.union([z.void(), z.promise(z.void())]))
+    .function({
+      input: [z.object({ request: z.instanceof(Request) })],
+      output: z.union([z.void(), z.promise(z.void())]),
+    })
     .optional(),
   onResponseReceived: z
-    .function()
-    .args(
-      z.object({
-        response: z.instanceof(Response),
-        // Ideally, we'd have the Operation type here, but we don't.
-        operation: z.record(z.any()),
-      }),
-    )
-    .returns(z.union([z.void(), z.promise(z.void())]))
+    .function({
+      input: [z.object({ response: z.instanceof(Response), operation: z.record(z.string(), z.any()) })],
+      output: z.union([z.void(), z.promise(z.void())]),
+    })
     .optional(),
 })
 
-export const ApiClientPluginSchema = z.function().returns(
-  z.object({
+export const ApiClientPluginSchema = z.function({
+  input: [z.void()],
+  output: z.object({
     name: z.string(),
     views: ViewsSchema.optional(),
     hooks: HooksSchema.optional(),
   }),
-)
+})
 
 export type ApiClientPlugin = z.infer<typeof ApiClientPluginSchema>

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -383,11 +383,11 @@ const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
     /** onDocumentSelect is fired when the config is selected */
     onDocumentSelect: z.function().optional() as z.ZodType<(() => Promise<void> | void) | undefined>,
     /** Callback fired when the reference is fully loaded */
-    onLoaded: z.function().optional() as z.ZodType<() => Promise<void> | void> | undefined,
+    onLoaded: z.function().optional() as z.ZodType<(() => Promise<void> | void) | undefined>,
     /** onBeforeRequest is fired before the request is sent. You can modify the request here. */
     onBeforeRequest: z
       .function({ input: [z.object({ request: z.instanceof(Request) })], output: z.void() })
-      .optional() as z.ZodType<(a: { request: Request }) => Promise<void> | void>,
+      .optional() as z.ZodType<((a: { request: Request }) => Promise<void> | void) | undefined>,
     /**
      * onShowMore is fired when the user clicks the "Show more" button on the references
      * @param tagId - The ID of the tag that was clicked
@@ -397,7 +397,7 @@ const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
         input: [z.string()],
         output: z.void(),
       })
-      .optional() as z.ZodType<(a: string) => Promise<void> | void>,
+      .optional() as z.ZodType<((a: string) => Promise<void> | void) | undefined>,
     /**
      * onSidebarClick is fired when the user clicks on a sidebar item
      * @param href - The href of the sidebar item that was clicked
@@ -407,7 +407,7 @@ const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
         input: [z.string()],
         output: z.void(),
       })
-      .optional() as z.ZodType<(a: string) => Promise<void> | void>,
+      .optional() as z.ZodType<((a: string) => Promise<void> | void) | undefined>,
     /**
      * Route using paths instead of hashes, your server MUST support this
      * @example '/standalone-api-reference/:custom(.*)?'

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -381,7 +381,7 @@ const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
       })
       .optional(),
     /** onDocumentSelect is fired when the config is selected */
-    onDocumentSelect: z.function().optional() as z.ZodType<() => Promise<void> | void> | undefined,
+    onDocumentSelect: z.function().optional() as z.ZodType<(() => Promise<void> | void) | undefined>,
     /** Callback fired when the reference is fully loaded */
     onLoaded: z.function().optional() as z.ZodType<() => Promise<void> | void> | undefined,
     /** onBeforeRequest is fired before the request is sent. You can modify the request here. */

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -132,7 +132,7 @@ export const specConfigurationSchema = z.object({
       z.null(),
       z.record(z.string(), z.any()),
       z.function({
-        input: [z.void()],
+        input: [],
         output: z.record(z.string(), z.any()),
       }),
     ])
@@ -184,7 +184,7 @@ export const apiClientConfigurationSchema = z.object({
       z.null(),
       z.record(z.string(), z.any()),
       z.function({
-        input: [z.void()],
+        input: [],
         output: z.record(z.string(), z.any()),
       }),
     ])

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -262,12 +262,11 @@ export const apiClientConfigurationSchema = z.object({
 
 export type ApiClientConfiguration = z.infer<typeof apiClientConfigurationSchema>
 
-export const FetchLike = z
-  .function({
-    input: [z.union([z.string(), z.instanceof(URL), z.instanceof(Request)]), z.any().optional()],
-    output: z.promise(z.instanceof(Response)),
-  })
-  .optional()
+// TODO: This doesn't seem to match the native fetch function.
+const FetchLikeSchema = z.function({
+  input: [z.union([z.string(), z.instanceof(URL), z.instanceof(Request)]), z.any().optional()],
+  output: z.promise(z.instanceof(Response)),
+})
 
 /** Configuration for the Api Client without the transform since it cannot be merged */
 const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
@@ -287,7 +286,7 @@ const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(
      *
      * Can be used to add custom headers, handle auth, etc.
      */
-    fetch: FetchLike,
+    fetch: FetchLikeSchema.optional(),
     /**
      * Plugins for the API reference
      */

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -262,11 +262,8 @@ export const apiClientConfigurationSchema = z.object({
 
 export type ApiClientConfiguration = z.infer<typeof apiClientConfigurationSchema>
 
-// TODO: This doesn't seem to match the native fetch function.
-const FetchLikeSchema = z.function({
-  input: [z.union([z.string(), z.instanceof(URL), z.instanceof(Request)]), z.any().optional()],
-  output: z.promise(z.instanceof(Response)),
-})
+// Zod Schemas don't work well with async functions, so we use a custom type instead.
+const FetchLikeSchema = z.custom<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>()
 
 /** Configuration for the Api Client without the transform since it cannot be merged */
 const _apiReferenceConfigurationSchema = apiClientConfigurationSchema.merge(

--- a/packages/types/src/api-reference/api-reference-plugin.ts
+++ b/packages/types/src/api-reference/api-reference-plugin.ts
@@ -24,7 +24,7 @@ export const OpenApiExtensionSchema = z.object({
 })
 
 export const ApiReferencePluginSchema = z.function({
-  input: [z.void()],
+  input: [],
   output: z.object({
     name: z.string(),
     extensions: z.array(OpenApiExtensionSchema),

--- a/packages/types/src/api-reference/api-reference-plugin.ts
+++ b/packages/types/src/api-reference/api-reference-plugin.ts
@@ -23,12 +23,13 @@ export const OpenApiExtensionSchema = z.object({
   renderer: z.unknown().optional(),
 })
 
-export const ApiReferencePluginSchema = z.function().returns(
-  z.object({
+export const ApiReferencePluginSchema = z.function({
+  input: [z.void()],
+  output: z.object({
     name: z.string(),
     extensions: z.array(OpenApiExtensionSchema),
   }),
-)
+})
 
 // Infer the types from the schemas
 export type SpecificationExtension = z.infer<typeof OpenApiExtensionSchema>

--- a/packages/types/src/entities/security-scheme.ts
+++ b/packages/types/src/entities/security-scheme.ts
@@ -176,7 +176,16 @@ const oasSecuritySchemeOauth2 = commonProps.extend({
     })
     .partial()
     .default({
-      implicit: { type: 'implicit', authorizationUrl: 'http://localhost:8080' },
+      implicit: {
+        selectedScopes: [],
+        scopes: {},
+        'x-scalar-client-id': '',
+        refreshUrl: '',
+        token: '',
+        type: 'implicit',
+        authorizationUrl: 'http://localhost:8080',
+        'x-scalar-redirect-uri': defaultRedirectUri,
+      },
     }),
 })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,8 +178,8 @@ catalogs:
       specifier: 2.8.0
       version: 2.8.0
     zod:
-      specifier: 3.24.1
-      version: 3.24.1
+      specifier: 4.1.11
+      version: 4.1.11
 
 importers:
 
@@ -939,7 +939,7 @@ importers:
         version: 1.11.3
       '@hono/zod-openapi':
         specifier: ^0.8.6
-        version: 0.8.6(hono@4.9.7)(zod@3.24.1)
+        version: 0.8.6(hono@4.9.7)(zod@4.1.11)
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../../packages/build-tooling
@@ -1135,7 +1135,7 @@ importers:
     dependencies:
       zod:
         specifier: catalog:*
-        version: 3.24.1
+        version: 4.1.11
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -1262,7 +1262,7 @@ importers:
         version: 2.8.0
       zod:
         specifier: catalog:*
-        version: 3.24.1
+        version: 4.1.11
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -1432,7 +1432,7 @@ importers:
         version: 3.5.17(typescript@5.8.3)
       zod:
         specifier: catalog:*
-        version: 3.24.1
+        version: 4.1.11
     devDependencies:
       '@hono/node-server':
         specifier: ^1.11.0
@@ -2123,7 +2123,7 @@ importers:
         version: 2.8.0
       zod:
         specifier: catalog:*
-        version: 3.24.1
+        version: 4.1.11
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -2142,7 +2142,7 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
       zod-to-ts:
         specifier: github:amritk/zod-to-ts#build
-        version: https://codeload.github.com/amritk/zod-to-ts/tar.gz/1f956fe246b5b3e70bbeb9e3a928396f9c22e400(typescript@5.8.3)(zod@3.24.1)
+        version: https://codeload.github.com/amritk/zod-to-ts/tar.gz/1f956fe246b5b3e70bbeb9e3a928396f9c22e400(typescript@5.8.3)(zod@4.1.11)
 
   packages/object-utils:
     dependencies:
@@ -2310,7 +2310,7 @@ importers:
     dependencies:
       zod:
         specifier: catalog:*
-        version: 3.24.1
+        version: 4.1.11
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -2495,7 +2495,7 @@ importers:
         version: 4.41.0
       zod:
         specifier: catalog:*
-        version: 3.24.1
+        version: 4.1.11
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -2596,7 +2596,7 @@ importers:
         version: 3.5.17(typescript@5.8.3)
       zod:
         specifier: catalog:*
-        version: 3.24.1
+        version: 4.1.11
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -2612,7 +2612,7 @@ importers:
         version: 7.1.5(@types/node@22.15.3)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
       zod-to-ts:
         specifier: ^1.2.0
-        version: 1.2.0(typescript@5.8.3)(zod@3.24.1)
+        version: 1.2.0(typescript@5.8.3)(zod@4.1.11)
 
   packages/use-toasts:
     dependencies:
@@ -2854,7 +2854,7 @@ importers:
         version: 2.8.0
       zod:
         specifier: catalog:*
-        version: 3.24.1
+        version: 4.1.11
     devDependencies:
       '@types/picomatch':
         specifier: catalog:*
@@ -3743,28 +3743,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.2.4':
     resolution: {integrity: sha512-M/Iz48p4NAzMXOuH+tsn5BvG/Jb07KOMTdSVwJpicmhN309BeEyRyQX+n1XDF0JVSlu28+hiTQ2L4rZPvu7nMw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.2.4':
     resolution: {integrity: sha512-m41nFDS0ksXK2gwXL6W6yZTYPMH0LughqbsxInSKetoH6morVj43szqKx79Iudkp8WRT5SxSh7qVb8KCUiewGg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.2.4':
     resolution: {integrity: sha512-orr3nnf2Dpb2ssl6aihQtvcKtLySLta4E2UcXdp7+RTa7mfJjBgIsbS0B9GC8gVu0hjOu021aU8b3/I1tn+pVQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.2.4':
     resolution: {integrity: sha512-NXnfTeKHDFUWfxAefa57DiGmu9VyKi0cDqFpdI+1hJWQjGJhJutHPX0b5m+eXvTKOaf+brU+P0JrQAZMb5yYaQ==}
@@ -5830,92 +5826,78 @@ packages:
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
     resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.3':
     resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.3':
     resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
     resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.3':
     resolution: {integrity: sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==}
@@ -6362,28 +6344,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.2':
     resolution: {integrity: sha512-s6N8k8dF9YGc5T01UPQ08yxsK6fUow5gG1/axWc1HVVBYQBgOjca4oUZF7s4p+kwhkB1bDSGR8QznWrFZ/Rt5g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.2':
     resolution: {integrity: sha512-o1RV/KOODQh6dM6ZRJGZbc+MOAHww33Vbs5JC9Mp1gDk8cpEO+cYC/l7rweiEalkSm5/1WGa4zY7xrNwObN4+Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.2':
     resolution: {integrity: sha512-/VUnh7w8RElYZ0IV83nUcP/J4KJ6LLYliiBIri3p3aW2giF+PAVgZb6mk8jbQSB3WlTai8gEmCAr7kptFa1H6g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.2':
     resolution: {integrity: sha512-sMPyTvRcNKXseNQ/7qRfVRLa0VhR0esmQ29DD6pqvG71+JdVnESJaHPA8t7bc67KD5spP3+DOCNLhqlEI2ZgQg==}
@@ -6842,42 +6820,36 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-minify/binding-linux-arm64-musl@0.87.0':
     resolution: {integrity: sha512-pgWeYfSprtpnJVea9Q5eI6Eo80lDGlMw2JdcSMXmShtBjEhBl6bvDNHlV+6kNfh7iT65y/uC6FR8utFrRghu8A==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-minify/binding-linux-riscv64-gnu@0.87.0':
     resolution: {integrity: sha512-O1QPczlT+lqNZVeKOdFxxL+s1RIlnixaJYFLrcqDcRyn82MGKLz7sAenBTFRQoIfLnSxtMGL6dqHOefYkQx7Cg==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-minify/binding-linux-s390x-gnu@0.87.0':
     resolution: {integrity: sha512-tcwt3ZUWOKfNLXN2edxFVHMlIuPvbuyMaKmRopgljSCfFcNHWhfTNlxlvmECRNhuQ91EcGwte6F1dwoeMCNd7A==}
     engines: {node: '>=14.0.0'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-gnu@0.87.0':
     resolution: {integrity: sha512-Xf4AXF14KXUzSnfgTcFLFSM0TykJhFw14+xwNvlAb6WdqXAKlMrz9joIAezc8dkW1NNscCVTsqBUPJ4RhvCM1Q==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-musl@0.87.0':
     resolution: {integrity: sha512-LIqvpx9UihEW4n9QbEljDnfUdAWqhr6dRqmzSFwVAeLZRUECluLCDdsdwemrC/aZkvnisA4w0LFcFr3HmeTLJg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-minify/binding-wasm32-wasi@0.87.0':
     resolution: {integrity: sha512-h0xluvc+YryfH5G5dndjGHuA/D4Kp85EkPMxqoOjNudOKDCtdobEaC9horhCqnOOQ0lgn+PGFl3w8u4ToOuRrA==}
@@ -6937,42 +6909,36 @@ packages:
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.87.0':
     resolution: {integrity: sha512-tBPkSPgRSSbmrje8CUovISi/Hj/tWjZJ3n/qnrjx2B+u86hWtwLsngtPDQa5d4seSyDaHSx6tNEUcH7+g5Ee0Q==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.87.0':
     resolution: {integrity: sha512-z4UKGM4wv2wEAQAlx2pBq6+pDJw5J/5oDEXqW6yBSLbWLjLDo4oagmRSE3+giOWteUa+0FVJ+ypq4iYxBkYSWg==}
     engines: {node: '>=20.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.87.0':
     resolution: {integrity: sha512-6W1ENe/nZtr2TBnrEzmdGEraEAdZOiH3YoUNNeQWuqwLkmpoHTJJdclieToPe/l2IKJ4WL3FsSLSGHE8yt/OEg==}
     engines: {node: '>=20.0.0'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.87.0':
     resolution: {integrity: sha512-s3kB/Ii3X3IOZ27Iu7wx2zYkIcDO22Emu32SNC6kkUSy09dPBc1yaW14TnAkPMe/rvtuzR512JPWj3iGpl+Dng==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.87.0':
     resolution: {integrity: sha512-3+M9hfrZSDi4+Uy4Ll3rtOuVG3IHDQlj027jgtmAAHJK1eqp4CQfC7rrwE+LFUqUwX+KD2GwlxR+eHyyEf5Gbg==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-wasm32-wasi@0.87.0':
     resolution: {integrity: sha512-2jgeEeOa4GbQQg2Et/gFTgs5wKS/+CxIg+CN2mMOJ4EqbmvUVeGiumO01oFOWTYnJy1oONwIocBzrnMuvOcItA==}
@@ -7035,42 +7001,36 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-musl@0.87.0':
     resolution: {integrity: sha512-MZ1/TNaebhXK73j1UDfwyBFnAy0tT3n6otOkhlt1vlJwqboUS/D7E/XrCZmAuHIfVPxAXRPovkl7kfxLB43SKw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.87.0':
     resolution: {integrity: sha512-JCWE6n4Hicu0FVbvmLdH/dS8V6JykOUsbrbDYm6JwFlHr4eFTTlS2B+mh5KPOxcdeOlv/D/XRnvMJ6WGYs25EA==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.87.0':
     resolution: {integrity: sha512-n2NTgM+3PqFagJV9UXRDNOmYesF+TO9SF9FeHqwVmW893ayef9KK+vfWAAhvOYHXYaKWT5XoHd87ODD7nruyhw==}
     engines: {node: '>=14.0.0'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.87.0':
     resolution: {integrity: sha512-ZOKW3wx0bW2O7jGdOzr8DyLZqX2C36sXvJdsHj3IueZZ//d/NjLZqEiUKz+q0JlERHtCVKShQ5PLaCx7NpuqNg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-musl@0.87.0':
     resolution: {integrity: sha512-eIspx/JqkVMPK1CAYEOo2J8o49s4ZTf+32MSMUknIN2ZS1fvRmWS0D/xFFaLP/9UGhdrXRIPbn/iSYEA8JnV/g==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-wasm32-wasi@0.87.0':
     resolution: {integrity: sha512-4uRjJQnt/+kmJUIC6Iwzn+MqqZhLP1zInPtDwgL37KI4VuUewUQWoL+sggMssMEgm7ZJwOPoZ6piuSWwMgOqgQ==}
@@ -7121,35 +7081,30 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-glibc@2.4.1':
     resolution: {integrity: sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.4.1':
     resolution: {integrity: sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.4.1':
     resolution: {integrity: sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.4.1':
     resolution: {integrity: sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-wasm@2.4.1':
     resolution: {integrity: sha512-/ZR0RxqxU/xxDGzbzosMjh4W6NdYFMqq2nvo2b8SLi7rsl/4jkL8S5stIikorNkdR50oVDvqb/3JT05WM+CRRA==}
@@ -7602,133 +7557,111 @@ packages:
     resolution: {integrity: sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.50.2':
     resolution: {integrity: sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.45.1':
     resolution: {integrity: sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.50.2':
     resolution: {integrity: sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.45.1':
     resolution: {integrity: sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.50.2':
     resolution: {integrity: sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.45.1':
     resolution: {integrity: sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.50.2':
     resolution: {integrity: sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.50.2':
     resolution: {integrity: sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.45.1':
     resolution: {integrity: sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.45.1':
     resolution: {integrity: sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.50.2':
     resolution: {integrity: sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.45.1':
     resolution: {integrity: sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.50.2':
     resolution: {integrity: sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.45.1':
     resolution: {integrity: sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.50.2':
     resolution: {integrity: sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.45.1':
     resolution: {integrity: sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.50.2':
     resolution: {integrity: sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.45.1':
     resolution: {integrity: sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.50.2':
     resolution: {integrity: sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.45.1':
     resolution: {integrity: sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.50.2':
     resolution: {integrity: sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.50.2':
     resolution: {integrity: sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==}
@@ -8218,28 +8151,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.5.29':
     resolution: {integrity: sha512-TERh2OICAJz+SdDIK9+0GyTUwF6r4xDlFmpoiHKHrrD/Hh3u+6Zue0d7jQ/he/i80GDn4tJQkHlZys+RZL5UZg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.5.29':
     resolution: {integrity: sha512-WMDPqU7Ji9dJpA+Llek2p9t7pcy7Bob8ggPUvgsIlv3R/eesF9DIzSbrgl6j3EAEPB9LFdSafsgf6kT/qnvqFg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.5.29':
     resolution: {integrity: sha512-DO14glwpdKY4POSN0201OnGg1+ziaSVr6/RFzuSLggshwXeeyVORiHv3baj7NENhJhWhUy3NZlDsXLnRFkmhHQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.5.29':
     resolution: {integrity: sha512-V3Y1+a1zG1zpYXUMqPIHEMEOd+rHoVnIpO/KTyFwAmKVu8v+/xPEVx/AGoYE67x4vDAAvPQrKI3Aokilqa5yVg==}
@@ -8327,28 +8256,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.8':
     resolution: {integrity: sha512-O6b8QesPbJCRshsNApsOIpzKt3ztG35gfX9tEf4arD7mwNinsoCKxkj8TgEE0YRjmjtO3r9FlJnT/ENd9EVefQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.8':
     resolution: {integrity: sha512-32iEXX/pXwikshNOGnERAFwFSfiltmijMIAbUhnNyjFr3tmWmMJWQKU2vNcFX0DACSXJ3ZWcSkzNbaKTdngH6g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.8':
     resolution: {integrity: sha512-s+VSSD+TfZeMEsCaFaHTaY5YNj3Dri8rST09gMvYQKwPphacRG7wbuQ5ZJMIJXN/puxPcg/nU+ucvWguPpvBDg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.8':
     resolution: {integrity: sha512-CXBPVFkpDjM67sS1psWohZ6g/2/cd+cq56vPxK4JeawelxwK4YECgl9Y9TjkE2qfF+9/s1tHHJqrC4SS6cVvSg==}
@@ -13805,28 +13730,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -18950,8 +18871,8 @@ packages:
   vue-component-type-helpers@3.0.6:
     resolution: {integrity: sha512-6CRM8X7EJqWCJOiKPvSLQG+hJPb/Oy2gyJx3pLjUEhY7PuaCthQu3e0zAGI1lqUBobrrk9IT0K8sG2GsCluxoQ==}
 
-  vue-component-type-helpers@3.1.0-alpha.0:
-    resolution: {integrity: sha512-K1guwS1Oy0gNfBdIdIn8JMkUV+S38sriR1zf5dP+KkPS7/r5nHnPZUL74meY2CYlxYBH4qSQ+k7bpHfwiRvaMg==}
+  vue-component-type-helpers@3.0.8:
+    resolution: {integrity: sha512-WyR30Eq15Y/+odrUUMax6FmPbZwAp/HnC7qgR1r3lVFAcqwQ4wUoV79Mbh4SxDy3NiqDa+G4TOKD5xXSgBHo5A==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -19458,6 +19379,9 @@ packages:
   zod@3.24.1:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
 
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -19660,10 +19584,10 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@asteasolutions/zod-to-openapi@5.5.0(zod@3.24.1)':
+  '@asteasolutions/zod-to-openapi@5.5.0(zod@4.1.11)':
     dependencies:
       openapi3-ts: 4.3.3
-      zod: 3.24.1
+      zod: 4.1.11
 
   '@aw-web-design/x-default-browser@1.4.126':
     dependencies:
@@ -23180,17 +23104,17 @@ snapshots:
 
   '@hono/node-server@1.11.3': {}
 
-  '@hono/zod-openapi@0.8.6(hono@4.9.7)(zod@3.24.1)':
+  '@hono/zod-openapi@0.8.6(hono@4.9.7)(zod@4.1.11)':
     dependencies:
-      '@asteasolutions/zod-to-openapi': 5.5.0(zod@3.24.1)
-      '@hono/zod-validator': 0.1.11(hono@4.9.7)(zod@3.24.1)
+      '@asteasolutions/zod-to-openapi': 5.5.0(zod@4.1.11)
+      '@hono/zod-validator': 0.1.11(hono@4.9.7)(zod@4.1.11)
       hono: 4.9.7
-      zod: 3.24.1
+      zod: 4.1.11
 
-  '@hono/zod-validator@0.1.11(hono@4.9.7)(zod@3.24.1)':
+  '@hono/zod-validator@0.1.11(hono@4.9.7)(zod@4.1.11)':
     dependencies:
       hono: 4.9.7
-      zod: 3.24.1
+      zod: 4.1.11
 
   '@humanfs/core@0.19.1': {}
 
@@ -26568,7 +26492,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.17(typescript@5.8.3)
-      vue-component-type-helpers: 3.1.0-alpha.0
+      vue-component-type-helpers: 3.0.8
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -40217,7 +40141,7 @@ snapshots:
 
   vue-component-type-helpers@3.0.6: {}
 
-  vue-component-type-helpers@3.1.0-alpha.0: {}
+  vue-component-type-helpers@3.0.8: {}
 
   vue-demi@0.14.10(vue@3.5.17(typescript@5.8.3)):
     dependencies:
@@ -40868,16 +40792,18 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.5.2
 
-  zod-to-ts@1.2.0(typescript@5.8.3)(zod@3.24.1):
+  zod-to-ts@1.2.0(typescript@5.8.3)(zod@4.1.11):
     dependencies:
       typescript: 5.8.3
-      zod: 3.24.1
+      zod: 4.1.11
 
-  zod-to-ts@https://codeload.github.com/amritk/zod-to-ts/tar.gz/1f956fe246b5b3e70bbeb9e3a928396f9c22e400(typescript@5.8.3)(zod@3.24.1):
+  zod-to-ts@https://codeload.github.com/amritk/zod-to-ts/tar.gz/1f956fe246b5b3e70bbeb9e3a928396f9c22e400(typescript@5.8.3)(zod@4.1.11):
     dependencies:
       typescript: 5.8.3
-      zod: 3.24.1
+      zod: 4.1.11
 
   zod@3.24.1: {}
+
+  zod@4.1.11: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,17 +9,6 @@ packages:
   - '!**/dist/**'
   - '!**/.output/**'
   - '!**/target/**'
-
-# To reduce the risk of installing compromised packages, we delay the installation of newly published versions.
-minimumReleaseAge: 10080 # 1 week
-
-minimumReleaseAgeExclude:
-  - rollup
-  - vite
-  - vue
-  - vite-node
-  - vitest
-
 catalogs:
   '*':
     '@electron-toolkit/preload': ^3.0.0
@@ -80,25 +69,4 @@ catalogs:
     vue: ^3.5.17
     vue-tsc: ^2.2.0
     yaml: 2.8.0
-    zod: 3.24.1
-
-ignoredBuiltDependencies:
-  - '@firebase/util'
-  - core-js
-  - core-js-pure
-  - dtrace-provider
-  - protobufjs
-  - sharp
-  - unrs-resolver
-  - vue-demi
-  - workerd
-
-onlyBuiltDependencies:
-  - '@nestjs/core'
-  - '@parcel/watcher'
-  - '@swc/core'
-  - '@tailwindcss/oxide'
-  - '@todesktop/cli'
-  - electron
-  - esbuild
-  - lefthook
+    zod: 4.1.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,17 @@ packages:
   - '!**/dist/**'
   - '!**/.output/**'
   - '!**/target/**'
+
+# To reduce the risk of installing compromised packages, we delay the installation of newly published versions.
+minimumReleaseAge: 10080 # 1 week
+
+minimumReleaseAgeExclude:
+  - rollup
+  - vite
+  - vue
+  - vite-node
+  - vitest
+
 catalogs:
   '*':
     '@electron-toolkit/preload': ^3.0.0
@@ -70,3 +81,24 @@ catalogs:
     vue-tsc: ^2.2.0
     yaml: 2.8.0
     zod: 4.1.11
+
+ignoredBuiltDependencies:
+  - '@firebase/util'
+  - core-js
+  - core-js-pure
+  - dtrace-provider
+  - protobufjs
+  - sharp
+  - unrs-resolver
+  - vue-demi
+  - workerd
+
+onlyBuiltDependencies:
+  - '@nestjs/core'
+  - '@parcel/watcher'
+  - '@swc/core'
+  - '@tailwindcss/oxide'
+  - '@todesktop/cli'
+  - electron
+  - esbuild
+  - lefthook


### PR DESCRIPTION
initial work by @geoffgscott

Let’s migrate to Zod 4!

I made it a minor release.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates the codebase to Zod 4, updating schemas, helpers, tests, and configuration APIs, plus adjusting defaults and types across api-client, api-reference, oas-utils, openapi-types, and types; updates dependencies accordingly.
> 
> - **Core migration to Zod 4**:
>   - Update schema typings and APIs (`z.function({ input, output })`, `partialRecord`, records with key schema, refined errors).
>   - Adjust helpers for Zod internals (`unwrapSchema`, `schemaModel` typings) and union narrowing.
> - **API Client**:
>   - Refactor `watch-mode` traversal/parsing to Zod 4, add record/array handling; update `parseDiff` types; improve union narrowing; add tests for record keys.
>   - Tests: create fresh fixtures per test, remove `beforeEach`; ensure deterministic cloning.
> - **API Reference**:
>   - Update plugin/config schemas to Zod 4 function signatures; type guards for optional callbacks; adjust `ApiClientModal` plugin injection.
>   - Multiple documents: guard `onDocumentSelect` invocation.
> - **OAS Utils**:
>   - Request example defaults: explicit `activeBody: 'raw'`; default `parameters` object with `Accept: */*`; strengthen `createParamInstance` return type.
>   - Workspace schema: revise hotkey modifiers and `environments` typing; use `partialRecord`.
>   - Migration v2.5.0: headers normalization and uid casts.
> - **OpenAPI Types**:
>   - Runtime expression refine message and refine shape; schema-object records use keyed `record` signatures.
> - **Types package**:
>   - Update plugin/hook schemas to Zod 4; stricter shapes for props and callbacks.
> - **Dependencies**:
>   - Bump `zod` to `4.1.11` across workspace; align peer deps (e.g., `@hono/zod-openapi`, `zod-to-ts`); update pnpm workspace catalog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2868d02749ee654ef934f73c8ecaaa7a480b425. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->