### PR TITLE
fix(api-reference): ranking explicit title declaration as highest friendly name

### DIFF
--- a/.changeset/wise-buses-hug.md
+++ b/.changeset/wise-buses-hug.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+`title` is now given the highest precedence when choosing a friendly name for `anyof`

--- a/packages/api-reference/src/components/Content/Schema/helpers/get-schema-type.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/get-schema-type.test.ts
@@ -513,7 +513,7 @@ describe('get-schema-type', () => {
         expect(result).toBe('CustomArray')
       })
 
-      it('ignores the title for an array type if items are defined', () => {
+      it('Does not ignore the title for an array type if items are defined', () => {
         const schema = coerceValue(SchemaObjectSchema, {
           title: 'CustomArray',
           type: 'array',
@@ -522,7 +522,7 @@ describe('get-schema-type', () => {
           },
         })
         const result = getSchemaType(schema)
-        expect(result).toBe('array string[]')
+        expect(result).toBe('CustomArray')
       })
     })
 

--- a/packages/api-reference/src/components/Content/Schema/helpers/get-schema-type.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/get-schema-type.ts
@@ -39,9 +39,9 @@ const processArrayType = (value: Extract<SchemaObject, { type: 'array' }>, isUni
  * Computes the human-readable type for a schema.
  *
  * Priority order:
- * 1. const values
+ * 1. title property.
  * 2. Array types (with special handling for items)
- * 3. title property
+ * 3. const values
  * 4. xml.name property
  * 5. type with contentEncoding
  * 6. $ref names


### PR DESCRIPTION
When a `title` is given, it should be given the highest precedence for use in a friendly name since it's explicity stated and that is the purpose of `title`.

Closes #6952

**Problem**

Currently, even when you use `title` to give your dropdown a friendly name, it wont be used (see #6952).

**Solution**

`title` is given the highest precedence since it is explicitly used as a friendly name by the user.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation. (Looked through and don't see anything pertaining to this explicitly).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `getSchemaType` to prefer `title` over array/union types, consts, and `xml.name`, with tests adjusted and expanded; adds changeset.
> 
> - **API Reference Helpers**:
>   - Update `get-schema-type.ts` to make `title` the top priority when deriving a friendly name, ahead of array/union handling, `const`, and `xml.name`.
>   - Preserve existing logic for arrays, unions, content encoding, `$ref`, and fallbacks.
> - **Tests**:
>   - Revise expectations in `get-schema-type.test.ts` to reflect `title` precedence (e.g., arrays/unions now return the `title` when present).
>   - Add cases for arrays whose `items` have `title`, ensuring `title` is used (e.g., `array Mixed Item[]`).
> - **Changeset**:
>   - Add minor release note: `title` now has highest precedence for friendly names (incl. `anyof`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a86d63a89397bfa53d6cd0842dc1a22621c454b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->