### PR TITLE
fix(api-client): long header names break the response headers table

### DIFF
--- a/.changeset/stupid-tips-attack.md
+++ b/.changeset/stupid-tips-attack.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: long header names break the response headers table

--- a/packages/api-client/src/views/Request/ResponseSection/RequestHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/RequestHeaders.vue
@@ -40,7 +40,7 @@ const findHeaderInfo = (name: string) => {
           :key="item.name"
           class="group/row text-c-1">
           <DataTableText
-            class="bg-b-1 sticky left-0 z-1 max-w-48 group-first/row:border-t-0">
+            class="bg-b-1 sticky left-0 z-1 max-w-fit group-first/row:border-t-0">
             <template v-if="typeof findHeaderInfo(item.name)?.url === 'string'">
               <HelpfulLink
                 class="decoration-c-3"

--- a/packages/api-client/src/views/Request/ResponseSection/RequestHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/RequestHeaders.vue
@@ -40,7 +40,7 @@ const findHeaderInfo = (name: string) => {
           :key="item.name"
           class="group/row text-c-1">
           <DataTableText
-            class="bg-b-1 sticky left-0 z-1 max-w-fit group-first/row:border-t-0">
+            class="bg-b-1 sticky left-0 z-1 max-w-full group-first/row:border-t-0">
             <template v-if="typeof findHeaderInfo(item.name)?.url === 'string'">
               <HelpfulLink
                 class="decoration-c-3"

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
@@ -40,7 +40,7 @@ const findHeaderInfo = (name: string) => {
           :key="item.name"
           class="group/row text-c-1">
           <DataTableText
-            class="bg-b-1 sticky left-0 z-1 max-w-48 group-first/row:border-t-0">
+            class="bg-b-1 sticky left-0 z-1 max-w-fit group-first/row:border-t-0">
             <template v-if="typeof findHeaderInfo(item.name)?.url === 'string'">
               <HelpfulLink
                 class="decoration-c-3"

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseHeaders.vue
@@ -40,7 +40,7 @@ const findHeaderInfo = (name: string) => {
           :key="item.name"
           class="group/row text-c-1">
           <DataTableText
-            class="bg-b-1 sticky left-0 z-1 max-w-fit group-first/row:border-t-0">
+            class="bg-b-1 sticky left-0 z-1 max-w-full group-first/row:border-t-0">
             <template v-if="typeof findHeaderInfo(item.name)?.url === 'string'">
               <HelpfulLink
                 class="decoration-c-3"


### PR DESCRIPTION
**Problem**

Long headings like `Access-Control-Request-Method` do not fit in the table
<img width="300" height="182" alt="image_September-29-06-25" src="https://github.com/user-attachments/assets/bed08b98-3a02-4e2f-b107-32d998bb3188" />


**Solution**

Long headings are now placed in the table

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expand the header key column to full width so long header names render correctly in request/response headers tables.
> 
> - **Frontend (API Client)**:
>   - *Headers tables*: In `RequestHeaders.vue` and `ResponseHeaders.vue`, change header key cell class from `max-w-48` to `max-w-full` to prevent long header names from breaking the layout.
> - **Release**:
>   - Add changeset: patch for `@scalar/api-client`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 493bdaaa1b5c831f425844bc7b107794fe8935ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->