### PR TITLE
feat: merge yaml aliases for in-mem representation

### DIFF
--- a/.changeset/silent-mice-marry.md
+++ b/.changeset/silent-mice-marry.md
@@ -1,0 +1,6 @@
+---
+'@scalar/openapi-parser': minor
+'@scalar/json-magic': minor
+---
+
+feat: merge yaml aliases for in-mem representation

--- a/packages/json-magic/src/bundle/plugins/parse-yaml/index.ts
+++ b/packages/json-magic/src/bundle/plugins/parse-yaml/index.ts
@@ -21,7 +21,7 @@ export function parseYaml(): LoaderPlugin {
       try {
         return {
           ok: true,
-          data: YAML.parse(value),
+          data: YAML.parse(value, { merge: true, maxAliasCount: 10000 }),
         }
       } catch {
         return {

--- a/packages/json-magic/src/helpers/normalize.ts
+++ b/packages/json-magic/src/helpers/normalize.ts
@@ -26,6 +26,7 @@ export function normalize(content: any) {
 
       return parse(content, {
         maxAliasCount: 10000,
+        merge: true,
       })
     }
   }

--- a/packages/oas-utils/src/helpers/parse.ts
+++ b/packages/oas-utils/src/helpers/parse.ts
@@ -7,7 +7,7 @@ type PrimitiveOrObject = object | string | null | number | boolean | undefined
 export const yaml = {
   /** Parse and throw if the return value is not an object */
   parse: (val: string) => {
-    const yamlObject = parse(val)
+    const yamlObject = parse(val, { merge: true, maxAliasCount: 10000 })
     if (typeof yamlObject !== 'object') {
       throw Error('Invalid YAML object')
     }

--- a/packages/openapi-parser/src/utils/normalize.ts
+++ b/packages/openapi-parser/src/utils/normalize.ts
@@ -2,6 +2,7 @@ import type { UnknownObject } from '@scalar/types/utils'
 import { parse } from 'yaml'
 
 import type { Filesystem } from '@/types/index'
+
 import { isFilesystem } from './is-filesystem'
 
 /**
@@ -32,6 +33,7 @@ export function normalize(content: string | UnknownObject | Filesystem): Unknown
 
       return parse(content, {
         maxAliasCount: 10000,
+        merge: true,
       })
     }
   }

--- a/scripts/src/commands/packages/catalog.ts
+++ b/scripts/src/commands/packages/catalog.ts
@@ -1,13 +1,15 @@
 import { readFileSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
-import yaml from 'yaml'
-import { z } from 'zod'
+
 import as from 'ansis'
+import { Command } from 'commander'
 import pm from 'picomatch'
 import { format } from 'prettier'
-import { Command } from 'commander'
-import { getWorkspaceRoot } from '@/helpers'
 import semver, { type ReleaseType } from 'semver'
+import yaml from 'yaml'
+import { z } from 'zod'
+
+import { getWorkspaceRoot } from '@/helpers'
 import { latestVersion } from '@/helpers/npm-version'
 
 export const outdated = new Command('outdated')
@@ -73,7 +75,7 @@ function loadWorkspace() {
   console.log(as.green(`Loading ${filepath}...`))
   const packages = readFileSync(filepath, 'utf8')
 
-  return pnpmWorkspaceSchema.parse(yaml.parse(packages))
+  return pnpmWorkspaceSchema.parse(yaml.parse(packages, { merge: true, maxAliasCount: 10000 }))
 }
 
 /** Check each catalog version to see if there is a newer version available */


### PR DESCRIPTION
YAML aliases and merge keys (<<:) are currently not enabled. This means when aliases are used, the resulting JSON loses structure or overrides incorrectly, causing inconsistencies between the intended YAML definition and the parsed output.

Example:

```yaml
user: &user-def
  name:
    type: string

data:
  <<: *user-def
  name:
    type: date
```

In the current implementation, data does not properly merge with user.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable YAML merge keys and high alias limits across parsing utilities for correct in-memory merges, plus update workspace catalog parsing and add changesets.
> 
> - **Parsing enhancements**:
>   - `packages/json-magic`:
>     - `parseYaml()` now parses with `{ merge: true, maxAliasCount: 10000 }`.
>     - `helpers/normalize.ts` YAML fallback parse adds `merge: true`.
>   - `packages/oas-utils`:
>     - `yaml.parse()` uses `{ merge: true, maxAliasCount: 10000 }`.
>   - `packages/openapi-parser`:
>     - `utils/normalize.ts` YAML parse adds `merge: true`.
> - **Scripts**:
>   - `scripts/src/commands/packages/catalog.ts` `loadWorkspace()` parses `pnpm-workspace.yaml` with `{ merge: true, maxAliasCount: 10000 }`.
> - **Release**:
>   - Changesets: minor bumps for `@scalar/openapi-parser` and `@scalar/json-magic`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0451ce90bab19748000daf3e466e42769fb5d288. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->