### PR TITLE
chore(docs): format image parameter heading

### DIFF
--- a/documentation/guides/docs/components/images.md
+++ b/documentation/guides/docs/components/images.md
@@ -4,7 +4,8 @@ Images display visual content with support for light/dark mode variants, clickab
 
 ## Properties
 
-### src `string` _required_
+### src
+`string` _required_
 
 The primary image source URL. This is the image that will be displayed in light mode or as the fallback.
 


### PR DESCRIPTION
**Problem**

Currently, the parameter `src`, and it's description (type and required/optional) are on the same line. This breaks with the formatting found throughout the rest of the docs, and creates a longer heading entry for ToC.

**Solution**

With this PR, the parameter name and description are on separate lines.


**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Split the `src` property heading in `documentation/guides/docs/components/images.md` so the name and its type/requirement are on separate lines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cad1d20e2feb7eac8481a190ab8ad087665c82a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->