### PR TITLE
chore(api-reference): wording share popover

### DIFF
--- a/.changeset/clean-ears-search.md
+++ b/.changeset/clean-ears-search.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: wording configuration toolbar

--- a/packages/api-reference/src/features/toolbar/ApiReferenceToolbarPopover.vue
+++ b/packages/api-reference/src/features/toolbar/ApiReferenceToolbarPopover.vue
@@ -28,7 +28,7 @@ import { ScalarIconCaretDown, ScalarIconInfo } from '@scalar/icons'
         <ScalarIconInfo class="size-3.5 shrink-0" />
         <div>
           <slot name="info">
-            "<slot name="label" />" will only appear when running on localhost
+            "<slot name="label" />" will only appear when running on localhost.
           </slot>
         </div>
       </div>

--- a/packages/api-reference/src/features/toolbar/ApiReferenceToolbarShare.vue
+++ b/packages/api-reference/src/features/toolbar/ApiReferenceToolbarShare.vue
@@ -18,7 +18,7 @@ const { workspace } = defineProps<{
       <ApiReferenceToolbarShareTemporary :workspace />
     </ScalarFormSection>
     <ScalarFormSection>
-      <template #label>Permanent Link</template>
+      <template #label>Cloud Hosting</template>
       <ApiReferenceToolbarShareRegister :workspace />
     </ScalarFormSection>
   </ApiReferenceToolbarPopover>

--- a/packages/api-reference/src/features/toolbar/ApiReferenceToolbarShareRegister.vue
+++ b/packages/api-reference/src/features/toolbar/ApiReferenceToolbarShareRegister.vue
@@ -13,21 +13,21 @@ import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import ApiReferenceToolbarBlurb from '@/features/toolbar/ApiReferenceToolbarBlurb.vue'
 import ApiReferenceToolbarRegisterButton from '@/features/toolbar/ApiReferenceToolbarRegisterButton.vue'
 
+const { workspace } = defineProps<{
+  workspace: WorkspaceStore
+}>()
+
 const FEATURES = [
-  { icon: ScalarIconLockSimple, label: 'Password Protected' },
   { icon: ScalarIconGlobeSimple, label: 'Custom Domains' },
-  { icon: ScalarIconWarningOctagon, label: 'Spectral Rules' },
-  { icon: ScalarIconGitBranch, label: 'Bi-directional Git' },
-  { icon: ScalarIconFileMd, label: 'Markdown Files' },
-  { icon: ScalarIconBracketsCurly, label: 'Json Schema Support' },
+  { icon: ScalarIconGitBranch, label: 'GitHub Sync' },
+  { icon: ScalarIconFileMd, label: 'Markdown/MDX' },
+  { icon: ScalarIconLockSimple, label: 'Password Protection' },
+  { icon: ScalarIconWarningOctagon, label: 'Spectral Linting' },
+  { icon: ScalarIconBracketsCurly, label: 'JSON Schema Support' },
 ] as const satisfies ReadonlyArray<{
   icon: ScalarIconComponent
   label: string
 }>
-
-const { workspace } = defineProps<{
-  workspace: WorkspaceStore
-}>()
 </script>
 <template>
   <ul class="text-c-2 grid grid-cols-2 gap-2.5 font-medium">
@@ -37,15 +37,17 @@ const { workspace } = defineProps<{
       class="flex items-center gap-2">
       <component
         :is="feature.icon"
-        weight="bold"
-        class="text-c-3 size-3.5" />
+        class="text-c-3 size-3.5"
+        weight="bold" />
       {{ feature.label }}
     </li>
   </ul>
-  <ApiReferenceToolbarRegisterButton :workspace />
+  <ApiReferenceToolbarRegisterButton :workspace>
+    Deploy on Scalar
+  </ApiReferenceToolbarRegisterButton>
   <ApiReferenceToolbarBlurb>
-    Uploading links to Scalar Registry, is part of Scalar's Premium features.
-    Explore all features on our
+    Uploading documents to the Scalar Registry is a Premium feature. See what
+    else is included in our
     <a
       href="https://guides.scalar.com/"
       target="_blank">


### PR DESCRIPTION
in the share popover, we write "temporary link" and "permanent link". 

I think we should talk about a "temporary link" and "generate" to quickly share something, and "hosting in the cloud" and "deploy" (and all the benefits that you get from it) to distinguish those more. 

* also, it’s not password protected, but it offers password protection.
* it's not "bi-sync git" but syncs to github specifically
* and we also support mdx, right?
* it’s JSON, not Json

wdyt?

**Before**

<img width="511" height="478" alt="Screenshot 2025-09-30 at 10 51 05" src="https://github.com/user-attachments/assets/4fc809e7-c463-454d-a1ac-9bf2da4ccf97" />

**After**

<img width="507" height="480" alt="Screenshot 2025-09-30 at 10 41 52" src="https://github.com/user-attachments/assets/61f8a52e-c643-4d5b-a3af-dfa886a4ace8" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines Share popover wording (Cloud Hosting), updates feature labels (GitHub Sync, Markdown/MDX, JSON, Spectral Linting), adds “Deploy on Scalar” button text, and fixes a minor punctuation issue.
> 
> - **UI copy – Share popover**:
>   - In `ApiReferenceToolbarShare.vue`: rename section label from `Permanent Link` to `Cloud Hosting`.
>   - In `ApiReferenceToolbarShareRegister.vue`:
>     - Update FEATURES labels: `GitHub Sync`, `Markdown/MDX`, `Password Protection`, `Spectral Linting`, `JSON Schema Support`; keep `Custom Domains`.
>     - Add button text slot to `ApiReferenceToolbarRegisterButton`: "Deploy on Scalar".
>     - Revise blurb text to reference uploading documents and Premium features.
> - **Misc**:
>   - In `ApiReferenceToolbarPopover.vue`: add period to the localhost info line.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 789f792c26b56f1b6862f2879bac3d798d0bd84b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->