### PR TITLE
fix(api-reference): configuration handling and server list reset on document replacement

### DIFF
--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
@@ -306,9 +306,9 @@ useFavicon(favicon)
       <template #content-start>
         <!-- Only appears on localhost -->
         <ApiReferenceToolbar
-          :workspace="store"
+          v-model:overrides="configurationOverrides"
           :configuration="selectedConfiguration"
-          v-model:overrides="configurationOverrides" />
+          :workspace="store" />
         <slot name="content-start" />
       </template>
       <template #content-end><slot name="content-end" /></template>

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -640,7 +640,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
 
       // Do some document processing
       processDocument(getRaw(strictDocument as OpenApiDocument), {
-        ...input.config,
+        ...(documentConfigs[name] ?? {}),
         documentSource: input.documentSource,
       })
     }
@@ -708,7 +708,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
   // merging (in order of increasing priority): the default config, workspace-level config, and document-specific config.
   const getDocumentConfiguration = (name: string) => {
     return mergeObjects<typeof defaultConfig>(
-      mergeObjects(defaultConfig, workspaceProps?.config ?? {}),
+      mergeObjects(deepClone(defaultConfig), workspaceProps?.config ?? {}),
       documentConfigs[name] ?? {},
     )
   }


### PR DESCRIPTION
**Summary**

This PR fixes issues in document replacement and configuration handling that were causing incorrect behavior across documents and workspaces.

**Problems**

When replacing a document, it was processed with an empty configuration object, which caused the document’s server list to become empty.

The defaultConfiguration object was being mutated, resulting in document-level configuration leaking across different documents and workspaces.

**Solution**

Ensure documents are processed with the correct configuration when replaced.
Prevent mutation of defaultConfiguration so configuration remains isolated per document/workspace.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
