### PR TITLE
docs: headings and image documentation corrections

### DIFF
--- a/documentation/guides/docs/components/images.md
+++ b/documentation/guides/docs/components/images.md
@@ -5,46 +5,55 @@ Images display visual content with support for light/dark mode variants, clickab
 ## Properties
 
 ### src
+
 `string` _required_
 
 The primary image source URL. This is the image that will be displayed in light mode or as the fallback.
 
 ### activeSrc
+
 `string` _optional_
 
 An alternative image source that takes precedence over `src`. Useful for dynamic image switching or when you need to override the primary source.
 
-### darkModeSrc
+### src-dark
+
 `string` _optional_
 
 A separate image source for dark mode. When provided, this image will be displayed when the user's theme is set to dark mode.
 
 ### width
+
 `number` _optional_
 
 The width of the image in pixels. When specified, the image size will automatically be set to `custom`.
 
 ### height
+
 `number` _optional_
 
 The height of the image in pixels. When specified, the image size will automatically be set to `custom`.
 
 ### alt
+
 `string` _optional_
 
 Alternative text for accessibility. This describes the image for screen readers and other assistive technologies.
 
 ### caption
+
 `string` _optional_
 
 A descriptive caption for the image. This appears below the image and provides context or explanation.
 
 ### href
+
 `string` _optional_
 
 A URL that the image links to. When provided, the image becomes clickable and opens the link in a new tab.
 
 ### size
+
 `'actual' | 'custom' | 'full'` _optional_
 
 The display size of the image:
@@ -73,6 +82,7 @@ Defaults to `actual`.
   alt="Application screenshot">
 </scalar-image>
 ```
+
 </scalar-tab>
 
 <scalar-tab title="Directive">
@@ -82,6 +92,7 @@ Defaults to `actual`.
 ```markdown
 ::scalar-image{ src="https://avatars.githubusercontent.com/u/6176314?v=4" alt="Application screenshot" }
 ```
+
 </scalar-tab>
 </scalar-tabs>
 
@@ -103,6 +114,7 @@ Defaults to `actual`.
   caption="High-level system architecture showing data flow">
 </scalar-image>
 ```
+
 </scalar-tab>
 
 <scalar-tab title="Directive">
@@ -110,8 +122,11 @@ Defaults to `actual`.
 ::scalar-image{ src="https://avatars.githubusercontent.com/u/6176314?v=4" alt="System architecture diagram" caption="High-level system architecture showing data flow" }
 
 ```html
-::scalar-image{ src="https://avatars.githubusercontent.com/u/6176314?v=4" alt="System architecture diagram" caption="High-level system architecture showing data flow" }
+::scalar-image{ src="https://avatars.githubusercontent.com/u/6176314?v=4"
+alt="System architecture diagram" caption="High-level system architecture
+showing data flow" }
 ```
+
 </scalar-tab>
 </scalar-tabs>
 
@@ -135,6 +150,7 @@ Defaults to `actual`.
   caption="Click to access the link">
 </scalar-image>
 ```
+
 </scalar-tab>
 
 <scalar-tab title="Directive">
@@ -144,6 +160,7 @@ Defaults to `actual`.
 ```markdown
 ::scalar-image{ src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" alt="Click to view full size" href="https://github.com/scalar/scalar" caption="Click to access the link" }
 ```
+
 </scalar-tab>
 </scalar-tabs>
 
@@ -169,6 +186,7 @@ Defaults to `actual`.
   caption="Company branding">
 </scalar-image>
 ```
+
 </scalar-tab>
 
 <scalar-tab title="Directive">
@@ -178,6 +196,7 @@ Defaults to `actual`.
 ```markdown
 ::scalar-image{ src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" alt="Company logo" width="200" height="100" caption="Company branding" }
 ```
+
 </scalar-tab>
 </scalar-tabs>
 
@@ -188,7 +207,7 @@ Defaults to `actual`.
 
 <scalar-image
   src="https://avatars.githubusercontent.com/u/301879?s=200&v=4"
-  darkModeSrc="https://avatars.githubusercontent.com/u/6176314?s=200&v=4"
+  src-dark="https://avatars.githubusercontent.com/u/6176314?s=200&v=4"
   alt="Theme-aware illustration"
   caption="Automatically adapts to user's theme preference">
 </scalar-image>
@@ -196,20 +215,22 @@ Defaults to `actual`.
 ```html
 <scalar-image
   src="https://avatars.githubusercontent.com/u/301879?s=200&v=4"
-  darkModeSrc="https://avatars.githubusercontent.com/u/6176314?s=200&v=4"
+  src-dark="https://avatars.githubusercontent.com/u/6176314?s=200&v=4"
   alt="Theme-aware illustration"
   caption="Automatically adapts to user's theme preference">
 </scalar-image>
 ```
+
 </scalar-tab>
 
 <scalar-tab title="Directive">
 
-::scalar-image{ src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" darkModeSrc="https://avatars.githubusercontent.com/u/6176314?s=200&v=4" alt="Theme-aware illustration" caption="Automatically adapts to user's theme preference" }
+::scalar-image{ src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" src-dark="https://avatars.githubusercontent.com/u/6176314?s=200&v=4" alt="Theme-aware illustration" caption="Automatically adapts to user's theme preference" }
 
 ```markdown
-::scalar-image{ src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" darkModeSrc="https://avatars.githubusercontent.com/u/6176314?s=200&v=4" alt="Theme-aware illustration" caption="Automatically adapts to user's theme preference" }
+::scalar-image{ src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" src-dark="https://avatars.githubusercontent.com/u/6176314?s=200&v=4" alt="Theme-aware illustration" caption="Automatically adapts to user's theme preference" }
 ```
+
 </scalar-tab>
 </scalar-tabs>
 
@@ -233,13 +254,16 @@ Defaults to `actual`.
   caption="Full-width hero image">
 </scalar-image>
 ```
+
 </scalar-tab>
 
 <scalar-tab title="Directive">
 
 ::scalar-image{ src="https://pbs.twimg.com/profile_banners/1599772885857538051/1740351609/1500x500" alt="Hero section background" size="full" caption="Full-width hero image" }
+
 ```markdown
 ::scalar-image{ src="https://pbs.twimg.com/profile_banners/1599772885857538051/1740351609/1500x500" alt="Hero section background" size="full" caption="Full-width hero image" }
 ```
+
 </scalar-tab>
 </scalar-tabs>

--- a/documentation/guides/docs/components/images.md
+++ b/documentation/guides/docs/components/images.md
@@ -122,9 +122,7 @@ Defaults to `actual`.
 ::scalar-image{ src="https://avatars.githubusercontent.com/u/6176314?v=4" alt="System architecture diagram" caption="High-level system architecture showing data flow" }
 
 ```html
-::scalar-image{ src="https://avatars.githubusercontent.com/u/6176314?v=4"
-alt="System architecture diagram" caption="High-level system architecture
-showing data flow" }
+::scalar-image{ src="https://avatars.githubusercontent.com/u/6176314?v=4" alt="System architecture diagram" caption="High-level system architecture showing data flow" }
 ```
 
 </scalar-tab>

--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -1,4 +1,3 @@
-<h1>Getting Started</h1>
 <div class="hero-animation container-full">
   <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/v1Pu6_BCmly6VhPAuotVZ.svg"></scalar-icon>
 </div>

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -1,4 +1,3 @@
-<h1>Scalar - The OpenAPI Company</h1>
 <div class="flex flex-col gap-3 hero small-test">
   <h2 class="text-balance">
     A modern API platform built for the OpenAPI™ standard.

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -1,4 +1,3 @@
-<h1>Scalar - The OpenAPI Company</h1>
 <div class="flex flex-col gap-3 hero small-test">
   <h2 class="text-balance">
     Pricing

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -1,4 +1,3 @@
-<h1>Getting Started</h1>
 <div class="hero-animation container-full">
   <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/v1Pu6_BCmly6VhPAuotVZ.svg"></scalar-icon>
 </div>

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -1,4 +1,3 @@
-<h1>Getting Started</h1>
 <div class="hero-animation container-full">
   <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/v1Pu6_BCmly6VhPAuotVZ.svg"></scalar-icon>
 </div>

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -8,6 +8,7 @@
   "subdomain": "guides",
   "customDomain": "guides.scalar.com",
   "assetsDir": "documentation/assets",
+  "insertPageTitles": false,
   "theme": "default",
   "guides": [
     {


### PR DESCRIPTION
**Problem**

Currently, we include `<h1>` tags in some of our documentation files that we then hide with custom CSS in order to prevent them from showing up and to prevent the auto-injection of metadata that would result from them not being present.

Also, the documentation for the dark-mode parameter for `image` is out-of-date.

**Solution**

With this PR we are able to remove the unwanted `<h1>` elements without page injection. It also corrects the documentation for `image`.

_after image of the intro page_
<img width="1524" height="806" alt="image" src="https://github.com/user-attachments/assets/3338ca4e-29d6-4759-9364-7ee3d6db271c" />

_after images of dark/light mode src toggling_
| dark | light |
| ---- | ----- |
| <img width="692" height="483" alt="image" src="https://github.com/user-attachments/assets/43849b51-2450-450f-835b-a8dd870029a4" /> |  <img width="698" height="488" alt="image" src="https://github.com/user-attachments/assets/a5496101-34b8-4875-a6d3-e1e8159579a7" /> |

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
