### PR TITLE
Geoff/cleanup config types

### DIFF
--- a/.changeset/twelve-needles-cry.md
+++ b/.changeset/twelve-needles-cry.md
@@ -1,0 +1,11 @@
+---
+'@scalar/api-reference-react': minor
+'@scalar/api-reference': minor
+'@scalar/pre-post-request-scripts': patch
+'@scalar/api-client': patch
+'@scalar/nuxt': patch
+'@scalar/types': patch
+'@scalar/core': patch
+---
+
+Adds a new ApiReferenceConfigWithSource type and make the base ApiReferenceConfig type agnostic of any document sources.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -89,5 +89,5 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "vitest.commandLine": "pnpm vitest",
   "vitest.enable": true,
-  "cSpell.words": ["microdiff"]
+  "cSpell.words": ["microdiff", "Typeguard"]
 }

--- a/examples/web/src/pages/ApiReferencePage.vue
+++ b/examples/web/src/pages/ApiReferencePage.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
-import {
-  ApiReferenceLayout,
-  type ApiReferenceConfiguration,
-} from '@scalar/api-reference'
+import { ApiReferenceLayout } from '@scalar/api-reference'
+import type { ApiReferenceConfigurationWithSource } from '@scalar/types'
 import { useColorMode } from '@scalar/use-hooks/useColorMode'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import { computed, reactive, ref, watch } from 'vue'
@@ -35,7 +33,7 @@ const DEFAULT_CONTENT = {
 
 const content = ref(JSON.stringify(DEFAULT_CONTENT, null, 2))
 
-const configuration = reactive<Partial<ApiReferenceConfiguration>>({
+const configuration = reactive<Partial<ApiReferenceConfigurationWithSource>>({
   theme: 'default',
   proxyUrl: import.meta.env.VITE_REQUEST_PROXY_URL,
   isEditable: true,

--- a/examples/web/src/pages/ApiReferenceTestPage.vue
+++ b/examples/web/src/pages/ApiReferenceTestPage.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { ApiReference } from '@scalar/api-reference'
 import content from '@scalar/galaxy/latest.yaml?raw'
-import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
+import { apiReferenceConfigurationWithSourceSchema } from '@scalar/types/api-reference'
 import { reactive } from 'vue'
 import { useRoute } from 'vue-router'
 
 const route = useRoute()
 
 const configuration = reactive(
-  apiReferenceConfigurationSchema.parse({
+  apiReferenceConfigurationWithSourceSchema.parse({
     theme: `${route.params['theme']}`,
     isEditable: false,
     layout: `${route.params['layout']}`,

--- a/examples/web/src/pages/ClassicApiReferencePage.vue
+++ b/examples/web/src/pages/ClassicApiReferencePage.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { ApiReference } from '@scalar/api-reference'
 import content from '@scalar/galaxy/latest.yaml?raw'
-import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
+import { apiReferenceConfigurationWithSourceSchema } from '@scalar/types/api-reference'
 import { reactive } from 'vue'
 
 const configuration = reactive(
-  apiReferenceConfigurationSchema.parse({
+  apiReferenceConfigurationWithSourceSchema.parse({
     theme: 'default',
     proxyUrl: import.meta.env.VITE_REQUEST_PROXY_URL,
     isEditable: false,

--- a/examples/web/src/pages/EmbeddedApiReferencePage.vue
+++ b/examples/web/src/pages/EmbeddedApiReferencePage.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { ApiReference } from '@scalar/api-reference'
 import content from '@scalar/galaxy/latest.yaml?raw'
-import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
+import { apiReferenceConfigurationWithSourceSchema } from '@scalar/types/api-reference'
 import { reactive } from 'vue'
 
 import SlotPlaceholder from '../components/SlotPlaceholder.vue'
 
 const configuration = reactive(
-  apiReferenceConfigurationSchema.parse({
+  apiReferenceConfigurationWithSourceSchema.parse({
     proxyUrl: import.meta.env.VITE_REQUEST_PROXY_URL,
     isEditable: false,
     content,

--- a/integrations/nuxt/src/runtime/components/ScalarApiReference.vue
+++ b/integrations/nuxt/src/runtime/components/ScalarApiReference.vue
@@ -12,7 +12,7 @@ import {
   useSeoMeta,
   useState,
 } from '#imports'
-import { onMounted, ref, toRaw, watch } from 'vue'
+import { onMounted, ref, watch } from 'vue'
 
 import type { Configuration } from '../../types'
 
@@ -23,7 +23,7 @@ const props = defineProps<{
 const isDark = ref(props.configuration.darkMode)
 const forcedMode = props.configuration.forceDarkModeState
 
-const { colorMode, toggleColorMode } = useColorMode({
+const { colorMode } = useColorMode({
   initialColorMode: props.configuration.darkMode ? 'dark' : 'light',
   overrideColorMode: props.configuration.forceDarkModeState,
 })
@@ -162,8 +162,8 @@ store.addDocument({
 
 <template>
   <ApiReferenceWorkspace
-    :store
-    :configuration="config" />
+    :configuration="config"
+    :store />
 </template>
 
 <style>

--- a/integrations/nuxt/src/types.ts
+++ b/integrations/nuxt/src/types.ts
@@ -1,7 +1,7 @@
-import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
+import type { ApiReferenceConfiguration, ApiReferenceConfigurationWithSource } from '@scalar/types/api-reference'
 
 export type Configuration = Omit<
-  Partial<ApiReferenceConfiguration>,
+  Partial<ApiReferenceConfigurationWithSource>,
   'layout' | 'isEditable' | 'onSpecUpdate' | 'theme'
 > & {
   /**

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -97,7 +97,7 @@ open()
 /** Configuration options for the Scalar API client */
 export type ClientConfiguration = {
   /** The Swagger/OpenAPI document to render */
-  spec: SpecConfiguration
+  spec: SourceConfiguration
   /** Pass in a proxy to the API client */
   proxyUrl?: string
   /** Pass in a theme API client */

--- a/packages/api-client/src/plugins/plugin-manager.test.ts
+++ b/packages/api-client/src/plugins/plugin-manager.test.ts
@@ -1,5 +1,6 @@
-import type { ApiClientPlugin } from '@scalar/types/api-client'
+import type { ApiClientPlugin } from '@scalar/types/api-reference'
 import { describe, expect, it, vi } from 'vitest'
+
 import { createPluginManager } from './plugin-manager'
 
 describe('plugin-manager', () => {

--- a/packages/api-client/src/plugins/plugin-manager.ts
+++ b/packages/api-client/src/plugins/plugin-manager.ts
@@ -1,10 +1,10 @@
-import type { ApiClientPlugin, HooksSchema } from '@scalar/types/api-client'
+import type { ApiClientPlugin, hooksSchema } from '@scalar/types/api-reference'
 import type { InjectionKey } from 'vue'
 import type { z } from 'zod'
 
 export type { ApiClientPlugin }
 
-type HookFunctions = z.infer<typeof HooksSchema>
+type HookFunctions = z.infer<typeof hooksSchema>
 
 type CreatePluginManagerParams = {
   plugins?: ApiClientPlugin[]

--- a/packages/api-reference-react/src/index.ts
+++ b/packages/api-reference-react/src/index.ts
@@ -1,9 +1,9 @@
-export { ApiReferenceReact } from './ApiReferenceReact'
-
+export type { ReferenceProps } from '@scalar/api-reference'
 /** Re-export types for ease of use */
 export type {
-  ApiReferenceConfiguration,
-  ApiReferenceConfigurationWithSources,
   AnyApiReferenceConfiguration,
+  ApiReferenceConfiguration,
+  ApiReferenceConfigurationWithMultipleSources,
 } from '@scalar/types/api-reference'
-export type { ReferenceProps } from '@scalar/api-reference'
+
+export { ApiReferenceReact } from './ApiReferenceReact'

--- a/packages/api-reference/playground/vue/src/App.vue
+++ b/packages/api-reference/playground/vue/src/App.vue
@@ -3,7 +3,7 @@ import { createApiReference } from '../../../src/index'
 
 import '@scalar/api-reference/style.css'
 
-import type { ApiReferenceConfigurationWithSources } from '@scalar/types/api-reference'
+import type { ApiReferenceConfigurationWithSource } from '@scalar/types/api-reference'
 import { onMounted, reactive, ref } from 'vue'
 
 import DebugBar from './components/DebugBar.vue'
@@ -30,7 +30,7 @@ onMounted(async () => {
 })
 
 const updateConfiguration = (
-  newConfiguration: Partial<ApiReferenceConfigurationWithSources>,
+  newConfiguration: Partial<ApiReferenceConfigurationWithSource>,
 ) => {
   Object.assign(configuration, newConfiguration)
   app?.updateConfiguration({

--- a/packages/api-reference/playground/vue/src/components/DebugBar.vue
+++ b/packages/api-reference/playground/vue/src/components/DebugBar.vue
@@ -1,17 +1,17 @@
 <script setup lang="ts">
 import type { ThemeId } from '@scalar/types'
-import type { ApiReferenceConfigurationWithSources } from '@scalar/types/api-reference'
+import type { ApiReferenceConfigurationWithMultipleSources } from '@scalar/types/api-reference'
 
 import { sources } from '../content/sources'
 
 defineProps<{
-  modelValue: Partial<ApiReferenceConfigurationWithSources>
+  modelValue: Partial<ApiReferenceConfigurationWithMultipleSources>
 }>()
 
 defineEmits<{
   (
     e: 'update:modelValue',
-    value: Partial<ApiReferenceConfigurationWithSources>,
+    value: Partial<ApiReferenceConfigurationWithMultipleSources>,
   ): void
 }>()
 

--- a/packages/api-reference/src/components/Content/Operations/TraversedEntry.test.ts
+++ b/packages/api-reference/src/components/Content/Operations/TraversedEntry.test.ts
@@ -1,5 +1,5 @@
 import { collectionSchema, serverSchema } from '@scalar/oas-utils/entities/spec'
-import { apiReferenceConfigurationSchema } from '@scalar/types'
+import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import type {
   TraversedEntry,

--- a/packages/api-reference/src/esm.ts
+++ b/packages/api-reference/src/esm.ts
@@ -1,9 +1,9 @@
-import type { ApiReferenceConfiguration, SpecConfiguration } from '@scalar/types/api-reference'
+import { objectReplace } from '@scalar/helpers/object/object-replace'
+import type { ApiReferenceConfiguration, SourceConfiguration } from '@scalar/types/api-reference'
 import { createHead } from '@unhead/vue'
 import { createApp, reactive } from 'vue'
 
 import ApiReference from './components/ApiReference.vue'
-import { objectReplace } from '@scalar/helpers/object/object-replace'
 
 /**
  * Initialize Scalar References
@@ -54,7 +54,7 @@ export function createScalarReferences(
         objectReplace(configuration, newConfig)
       }
     },
-    updateSpec(spec: SpecConfiguration) {
+    updateSpec(spec: SourceConfiguration) {
       if (Array.isArray(configuration)) {
         console.error('Cannot update the content for multiple configurations.')
       } else {

--- a/packages/api-reference/src/features/api-client-modal/ApiClientModal.vue
+++ b/packages/api-reference/src/features/api-client-modal/ApiClientModal.vue
@@ -3,9 +3,9 @@ import { useActiveEntities, useWorkspace } from '@scalar/api-client/store'
 import { mutateSecuritySchemeDiff } from '@scalar/api-client/views/Request/libs'
 import { getServersFromDocument } from '@scalar/oas-utils/helpers'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
-import type { ApiClientPlugin } from '@scalar/types/api-client'
 import type {
   ApiClientConfiguration,
+  ApiClientPlugin,
   ApiReferenceConfiguration,
 } from '@scalar/types/api-reference'
 import { emitCustomEvent } from '@scalar/workspace-store/events'

--- a/packages/api-reference/src/features/document-source/hooks/useDocumentFetcher.test.ts
+++ b/packages/api-reference/src/features/document-source/hooks/useDocumentFetcher.test.ts
@@ -1,5 +1,5 @@
 import { prettyPrintJson } from '@scalar/oas-utils/helpers'
-import type { SpecConfiguration } from '@scalar/types/api-reference'
+import type { SourceConfiguration } from '@scalar/types/api-reference'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, nextTick, reactive, watch } from 'vue'
 
@@ -182,7 +182,7 @@ describe('useDocumentFetcher', () => {
   })
 
   it('handles reactive configuration', async () => {
-    const configurationRef = reactive<SpecConfiguration>({
+    const configurationRef = reactive<SourceConfiguration>({
       content: EXAMPLE_DOCUMENT,
     })
 
@@ -211,7 +211,7 @@ describe('useDocumentFetcher', () => {
   })
 
   it('handles computed configuration', async () => {
-    const configurationRef = reactive<SpecConfiguration>({
+    const configurationRef = reactive<SourceConfiguration>({
       content: EXAMPLE_DOCUMENT,
     })
 
@@ -240,7 +240,7 @@ describe('useDocumentFetcher', () => {
   })
 
   it('preserves content when configuration is undefined', async () => {
-    const configurationRef = reactive<SpecConfiguration>({
+    const configurationRef = reactive<SourceConfiguration>({
       content: EXAMPLE_DOCUMENT,
     })
 

--- a/packages/api-reference/src/features/document-source/hooks/useDocumentFetcher.ts
+++ b/packages/api-reference/src/features/document-source/hooks/useDocumentFetcher.ts
@@ -1,6 +1,6 @@
 import { makeUrlAbsolute } from '@scalar/helpers/url/make-url-absolute'
 import { fetchDocument, prettyPrintJson } from '@scalar/oas-utils/helpers'
-import type { ApiReferenceConfiguration, SpecConfiguration } from '@scalar/types/api-reference'
+import type { ApiReferenceConfigurationWithSource, SourceConfiguration } from '@scalar/types/api-reference'
 import { type MaybeRefOrGetter, ref, toValue, watch } from 'vue'
 
 /**
@@ -9,7 +9,7 @@ import { type MaybeRefOrGetter, ref, toValue, watch } from 'vue'
 export function useDocumentFetcher({
   configuration,
 }: {
-  configuration?: MaybeRefOrGetter<Pick<ApiReferenceConfiguration, 'url' | 'content' | 'proxyUrl' | 'fetch'>>
+  configuration?: MaybeRefOrGetter<Pick<ApiReferenceConfigurationWithSource, 'url' | 'content' | 'proxyUrl' | 'fetch'>>
 }) {
   /** OpenAPI document as a string */
   const originalDocument = ref<string>('')
@@ -45,7 +45,7 @@ export function useDocumentFetcher({
  * 5. Otherwise, return an empty string.
  */
 const getContent = async (
-  { url, content }: SpecConfiguration,
+  { url, content }: SourceConfiguration,
   proxyUrl?: string,
   fetch?: (input: string | URL | globalThis.Request, init?: RequestInit) => Promise<Response>,
 ): Promise<string | undefined> => {

--- a/packages/api-reference/src/features/document-source/hooks/useDocumentSource.test.ts
+++ b/packages/api-reference/src/features/document-source/hooks/useDocumentSource.test.ts
@@ -1,5 +1,5 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
-import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
+import { apiReferenceConfigurationWithSourceSchema } from '@scalar/types/api-reference'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { inject, nextTick, ref } from 'vue'
 
@@ -25,7 +25,7 @@ describe('useDocumentSource', () => {
     paths: {},
   }
 
-  const mockConfiguration = apiReferenceConfigurationSchema.parse({
+  const mockConfiguration = apiReferenceConfigurationWithSourceSchema.parse({
     content: {
       openapi: '3.1.0',
       info: {

--- a/packages/api-reference/src/features/document-source/hooks/useDocumentSource.ts
+++ b/packages/api-reference/src/features/document-source/hooks/useDocumentSource.ts
@@ -3,7 +3,7 @@ import { measureAsync } from '@scalar/helpers/testing/measure'
 import { dereference, normalize } from '@scalar/openapi-parser'
 import type { OpenAPI, OpenAPIV3_1 } from '@scalar/openapi-types'
 import { upgrade } from '@scalar/openapi-upgrader'
-import { type ApiReferenceConfiguration, apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
+import { type ApiReferenceConfigurationWithSource, apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
 import { type MaybeRefOrGetter, type Ref, computed, ref, toValue, watch } from 'vue'
 
 import { useDocumentFetcher } from './useDocumentFetcher'
@@ -20,7 +20,7 @@ export function useDocumentSource({
   dereferencedDocument?: MaybeRefOrGetter<OpenAPIV3_1.Document>
   configuration?: MaybeRefOrGetter<
     Pick<
-      ApiReferenceConfiguration,
+      ApiReferenceConfigurationWithSource,
       | 'url'
       | 'content'
       | 'proxyUrl'
@@ -129,10 +129,16 @@ export function useDocumentSource({
     { immediate: true },
   )
 
+  const config = toValue(configuration) ?? apiReferenceConfigurationSchema.parse({})
+
   /** API Client Store */
   const workspaceStore = createWorkspaceStore({
     useLocalStorage: false,
-    ...(toValue(configuration) ?? apiReferenceConfigurationSchema.parse({})),
+    proxyUrl: config.proxyUrl,
+    theme: config.theme,
+    showSidebar: config.showSidebar,
+    hideClientButton: config.hideClientButton,
+    _integration: config._integration,
   })
 
   /** Active Entities Store */

--- a/packages/api-reference/src/features/multiple-documents/DocumentSelector.vue
+++ b/packages/api-reference/src/features/multiple-documents/DocumentSelector.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { ScalarListbox, type ScalarListboxOption } from '@scalar/components'
 import { ScalarIconCaretUpDown } from '@scalar/icons'
-import type { SpecConfiguration } from '@scalar/types/api-reference'
+import type { SourceConfiguration } from '@scalar/types/api-reference'
 import { computed } from 'vue'
 
 const { options, modelValue } = defineProps<{
-  options?: SpecConfiguration[]
+  options?: SourceConfiguration[]
   modelValue?: number
 }>()
 

--- a/packages/api-reference/src/features/multiple-documents/useMultipleDocuments.ts
+++ b/packages/api-reference/src/features/multiple-documents/useMultipleDocuments.ts
@@ -2,8 +2,8 @@ import { isDefined } from '@scalar/oas-utils/helpers'
 import {
   type AnyApiReferenceConfiguration,
   type ApiReferenceConfiguration,
-  type SpecConfiguration,
-  apiReferenceConfigurationSchema,
+  type SourceConfiguration,
+  apiReferenceConfigurationWithSourceSchema,
   isConfigurationWithSources,
 } from '@scalar/types/api-reference'
 import GithubSlugger from 'github-slugger'
@@ -35,7 +35,7 @@ const slugger = new GithubSlugger()
  */
 export const normalizeConfigurations = (
   configuration: AnyApiReferenceConfiguration | undefined,
-): SpecConfiguration[] => {
+): SourceConfiguration[] => {
   if (!configuration) {
     return []
   }
@@ -67,10 +67,10 @@ export const normalizeConfigurations = (
 }
 
 /** Process a single spec configuration so that it has a title and a slug */
-const addSlugAndTitle = (_source: SpecConfiguration, index = 0): SpecConfiguration | undefined => {
+const addSlugAndTitle = (_source: SourceConfiguration, index = 0): SourceConfiguration | undefined => {
   const source = {
     ..._source,
-    // @ts-expect-error this is before parsing so we transform the old style
+    // this is before parsing so we transform the old style
     ...(_source.spec ?? {}),
   }
 
@@ -119,8 +119,8 @@ export const useMultipleDocuments = ({
   hash,
   hashPrefix,
 }: UseMultipleDocumentsProps): {
-  selectedConfiguration: ComputedRef<z.infer<typeof apiReferenceConfigurationSchema>>
-  availableDocuments: Ref<SpecConfiguration[]>
+  selectedConfiguration: ComputedRef<z.infer<typeof apiReferenceConfigurationWithSourceSchema>>
+  availableDocuments: Ref<SourceConfiguration[]>
   selectedDocumentIndex: Ref<number>
   isIntersectionEnabled: Ref<boolean>
   hash: Ref<string>
@@ -129,7 +129,7 @@ export const useMultipleDocuments = ({
   /**
    * All available documents that can be selected
    */
-  const availableDocuments = computed((): SpecConfiguration[] => normalizeConfigurations(configuration.value))
+  const availableDocuments = computed((): SourceConfiguration[] => normalizeConfigurations(configuration.value))
 
   /**
    * Determines the initially selected API definition from the URL
@@ -182,11 +182,11 @@ export const useMultipleDocuments = ({
    * The currently selected API configuration
    * we also add the source options (slug, title, etc) to the configuration
    */
-  const selectedConfiguration = computed((): z.infer<typeof apiReferenceConfigurationSchema> => {
+  const selectedConfiguration = computed((): z.infer<typeof apiReferenceConfigurationWithSourceSchema> => {
     const overrides = configurationOverrides?.value ?? {}
     // Multiple sources
     if (configuration.value && isConfigurationWithSources(configuration.value)) {
-      return apiReferenceConfigurationSchema.parse({
+      return apiReferenceConfigurationWithSourceSchema.parse({
         ...configuration.value,
         ...configuration.value?.sources?.[selectedDocumentIndex.value],
         ...availableDocuments.value[selectedDocumentIndex.value],
@@ -195,7 +195,7 @@ export const useMultipleDocuments = ({
     }
 
     const flattenedConfig = [configuration.value].flat()[selectedDocumentIndex.value] ?? {}
-    return apiReferenceConfigurationSchema.parse({
+    return apiReferenceConfigurationWithSourceSchema.parse({
       ...flattenedConfig,
       ...availableDocuments.value[selectedDocumentIndex.value],
       ...overrides,

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -1,21 +1,21 @@
-import type { ReferenceProps } from '@/types'
-import {
-  type AnyApiReferenceConfiguration,
-  type ApiReferenceConfiguration,
-  type CreateApiReference,
-  apiReferenceConfigurationSchema,
+import { apiReferenceConfigurationWithSourceSchema } from '@scalar/types'
+import type {
+  AnyApiReferenceConfiguration,
+  ApiReferenceConfigurationWithSource,
+  CreateApiReference,
 } from '@scalar/types/api-reference'
 import { createHead } from '@unhead/vue'
 import { createApp, h, reactive } from 'vue'
 
 import { default as ApiReference } from '@/components/ApiReference.vue'
+import type { ReferenceProps } from '@/types'
 
 const getSpecScriptTag = (doc: Document) => doc.getElementById('api-reference')
 
 /**
  * Reading the configuration from the data-attributes.
  */
-export function getConfigurationFromDataAttributes(doc: Document): ApiReferenceConfiguration {
+export function getConfigurationFromDataAttributes(doc: Document): ApiReferenceConfigurationWithSource {
   const specElement = doc.querySelector('[data-spec]')
   const specUrlElement = doc.querySelector('[data-spec-url]')
   const configurationScriptElement = doc.querySelector('#api-reference[data-configuration]')
@@ -33,7 +33,7 @@ export function getConfigurationFromDataAttributes(doc: Document): ApiReferenceC
       }
     }
 
-    return apiReferenceConfigurationSchema.parse({ _integration: 'html' })
+    return apiReferenceConfigurationWithSourceSchema.parse({ _integration: 'html' })
   }
 
   const getUrl = () => {
@@ -117,7 +117,7 @@ export function getConfigurationFromDataAttributes(doc: Document): ApiReferenceC
   } else {
     const urlOrContent = getContent() ? { content: getContent() } : { url: getUrl() }
 
-    return apiReferenceConfigurationSchema.parse({
+    return apiReferenceConfigurationWithSourceSchema.parse({
       _integration: 'html',
       proxyUrl: getProxyUrl(),
       ...getConfiguration(),
@@ -125,14 +125,14 @@ export function getConfigurationFromDataAttributes(doc: Document): ApiReferenceC
     })
   }
 
-  return apiReferenceConfigurationSchema.parse({ _integration: 'html' })
+  return apiReferenceConfigurationWithSourceSchema.parse({ _integration: 'html' })
 }
 
 /**
  * Mount the Scalar API Reference on a given document.
  * Read the HTML data-attributes for configuration.
  */
-export function findDataAttributes(doc: Document, configuration: ApiReferenceConfiguration) {
+export function findDataAttributes(doc: Document, configuration: ApiReferenceConfigurationWithSource) {
   /** @deprecated Use the new <script id="api-reference" data-url="/scalar.json" /> API instead. */
   const specElement = doc.querySelector('[data-spec]')
   /** @deprecated Use the new <script id="api-reference" data-url="/scalar.json" /> API instead. */

--- a/packages/api-reference/src/standalone/lib/register-globals.ts
+++ b/packages/api-reference/src/standalone/lib/register-globals.ts
@@ -1,5 +1,6 @@
-import { createApiReference } from '@/standalone/lib/html-api'
 import type { CreateApiReference } from '@scalar/types/api-reference'
+
+import { createApiReference } from '@/standalone/lib/html-api'
 
 // Register the createApiReference function in the global Scalar object (new)
 declare global {

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -1,4 +1,8 @@
-import type { AnyApiReferenceConfiguration, ApiReferenceConfiguration } from '@scalar/types/api-reference'
+import type {
+  AnyApiReferenceConfiguration,
+  ApiReferenceConfiguration,
+  ApiReferenceConfigurationWithSource,
+} from '@scalar/types/api-reference'
 import type { OpenAPIV3_1 } from '@scalar/types/legacy'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 export type { ApiReferenceConfiguration }
@@ -11,7 +15,7 @@ export type ReferenceProps = {
  * Before the configuration is parsed, we can use the broader types.
  */
 export type ReferenceLayoutProps = {
-  configuration: Partial<ApiReferenceConfiguration>
+  configuration: Partial<ApiReferenceConfigurationWithSource>
   /**
    *
    * The OpenAPI 3.1 document, but all $ref's are resolved already.

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
@@ -24,7 +24,7 @@ import { redirectToProxy } from '@scalar/oas-utils/helpers'
 import type {
   AnyApiReferenceConfiguration,
   ApiReferenceConfiguration,
-  ApiReferenceConfigurationWithSources,
+  ApiReferenceConfigurationWithMultipleSources,
 } from '@scalar/types'
 import { useColorMode } from '@scalar/use-hooks/useColorMode'
 import { type WorkspaceStore } from '@scalar/workspace-store/client'
@@ -136,7 +136,7 @@ onBeforeMount(() => {
  * @returns The result of adding the document to the store, or undefined if skipped
  */
 const addOrUpdateDocument = async (
-  config: Partial<ApiReferenceConfigurationWithSources>,
+  config: Partial<ApiReferenceConfigurationWithMultipleSources>,
 ) => {
   const document = normalizeContent(config.content)
 

--- a/packages/api-reference/src/v2/blocks/scalar-info-block/components/DownloadLink.test.ts
+++ b/packages/api-reference/src/v2/blocks/scalar-info-block/components/DownloadLink.test.ts
@@ -1,4 +1,4 @@
-import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
+import { apiReferenceConfigurationWithSourceSchema } from '@scalar/types/api-reference'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed } from 'vue'
@@ -26,7 +26,7 @@ describe('DownloadLink', () => {
 
   const createWrapper = (configOverrides = {}, props = {}) => {
     const config = computed(() =>
-      apiReferenceConfigurationSchema.parse({
+      apiReferenceConfigurationWithSourceSchema.parse({
         documentDownloadType: 'json',
         ...configOverrides,
       }),

--- a/packages/api-reference/src/v2/helpers/map-configuration.ts
+++ b/packages/api-reference/src/v2/helpers/map-configuration.ts
@@ -2,7 +2,7 @@ import type { ApiReferenceConfiguration } from '@scalar/types'
 import type { DocumentConfiguration } from '@scalar/workspace-store/schemas/workspace-specification/config'
 
 /**
- * Maps a partial ApiReferenceConfigurationWithSources object to a DocumentConfiguration
+ * Maps a partial ApiReferenceConfigurationWithMultipleSources object to a DocumentConfiguration
  * for use in the API Reference. This function transforms configuration options
  * into the expected structure for the 'x-scalar-reference-config' property.
  *

--- a/packages/api-reference/test/utils/serve-example.ts
+++ b/packages/api-reference/test/utils/serve-example.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
+
 import { serve } from '@hono/node-server'
 import { getHtmlDocument } from '@scalar/core/libs/html-rendering'
 import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'

--- a/packages/core/src/libs/html-rendering/html-rendering.test.ts
+++ b/packages/core/src/libs/html-rendering/html-rendering.test.ts
@@ -1,6 +1,6 @@
 import {
-  type ApiReferenceConfiguration,
-  apiReferenceConfigurationSchema,
+  type ApiReferenceConfigurationWithSource,
+  apiReferenceConfigurationWithSourceSchema,
   htmlRenderingConfigurationSchema,
 } from '@scalar/types/api-reference'
 import { describe, expect, it } from 'vitest'
@@ -99,7 +99,7 @@ describe('html-rendering', () => {
   describe('getScriptTags', () => {
     it('returns script tags with default CDN', () => {
       const tags = getScriptTags(
-        apiReferenceConfigurationSchema.parse({}),
+        apiReferenceConfigurationWithSourceSchema.parse({}),
         'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
       )
       expect(tags).toContain('<!-- Load the Script -->')
@@ -108,7 +108,7 @@ describe('html-rendering', () => {
     })
 
     it('uses custom CDN when provided', () => {
-      const tags = getScriptTags(apiReferenceConfigurationSchema.parse({}), 'https://example.com/script.js')
+      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema.parse({}), 'https://example.com/script.js')
       expect(tags).toContain('https://example.com/script.js')
     })
 
@@ -130,7 +130,7 @@ describe('html-rendering', () => {
         onShowMore: (tagId) => console.log('show more', tagId),
         onSidebarClick: (href) => console.log('sidebar click', href),
         onRequestSent: (request) => console.log('request sent', request),
-      } satisfies Partial<ApiReferenceConfiguration>
+      } satisfies Partial<ApiReferenceConfigurationWithSource>
 
       const tags = getScriptTags(config, 'https://example.com/script.js')
 
@@ -245,19 +245,19 @@ describe('html-rendering', () => {
 
   describe('getConfiguration', () => {
     it('returns configuration object', () => {
-      const config = getConfiguration({ theme: 'kepler' } as ApiReferenceConfiguration)
+      const config = getConfiguration({ theme: 'kepler' } as ApiReferenceConfigurationWithSource)
       expect(config).toEqual({ theme: 'kepler' })
     })
 
     it('does not remove content when url is not provided', () => {
       const content = { foo: 'bar' }
-      const config = getConfiguration(apiReferenceConfigurationSchema.parse({ content }))
+      const config = getConfiguration(apiReferenceConfigurationWithSourceSchema.parse({ content }))
       expect(config).toMatchObject({ content })
     })
 
     it('removes content only when url is provided', () => {
       const config = getConfiguration(
-        apiReferenceConfigurationSchema.parse({
+        apiReferenceConfigurationWithSourceSchema.parse({
           url: 'https://api.example.com/spec',
           content: { foo: 'bar' },
         }),
@@ -268,7 +268,7 @@ describe('html-rendering', () => {
 
     it('executes content when it is a function', () => {
       const contentFn = () => ({ foo: 'bar' })
-      const config = getConfiguration(apiReferenceConfigurationSchema.parse({ content: contentFn }))
+      const config = getConfiguration(apiReferenceConfigurationWithSourceSchema.parse({ content: contentFn }))
       expect(config).toMatchObject({ content: { foo: 'bar' } })
     })
   })

--- a/packages/core/src/libs/html-rendering/html-rendering.ts
+++ b/packages/core/src/libs/html-rendering/html-rendering.ts
@@ -1,4 +1,4 @@
-import type { ApiReferenceConfiguration, HtmlRenderingConfiguration } from '@scalar/types/api-reference'
+import type { ApiReferenceConfigurationWithSource, HtmlRenderingConfiguration } from '@scalar/types/api-reference'
 
 // Re-export the type for convenience
 export type { HtmlRenderingConfiguration }
@@ -90,7 +90,7 @@ const serializeArrayWithFunctions = (arr: unknown[]): string => {
 /**
  * The script tags to load the @scalar/api-reference package from the CDN.
  */
-export function getScriptTags(configuration: Partial<ApiReferenceConfiguration>, cdn?: string) {
+export function getScriptTags(configuration: Partial<ApiReferenceConfigurationWithSource>, cdn?: string) {
   const restConfig = { ...configuration }
 
   const functionProps: string[] = []
@@ -129,8 +129,8 @@ export function getScriptTags(configuration: Partial<ApiReferenceConfiguration>,
  * The configuration to pass to the @scalar/api-reference package.
  */
 export const getConfiguration = (
-  givenConfiguration: Partial<ApiReferenceConfiguration>,
-): Partial<ApiReferenceConfiguration> => {
+  givenConfiguration: Partial<ApiReferenceConfigurationWithSource>,
+): Partial<ApiReferenceConfigurationWithSource> => {
   // Clone the given configuration
   const configuration = {
     ...givenConfiguration,

--- a/packages/pre-post-request-scripts/src/plugins/post-response-scripts/post-response-scripts-plugin.ts
+++ b/packages/pre-post-request-scripts/src/plugins/post-response-scripts/post-response-scripts-plugin.ts
@@ -1,5 +1,6 @@
-import type { ApiClientPlugin } from '@scalar/types/api-client'
+import type { ApiClientPlugin } from '@scalar/types/api-reference'
 import { ref } from 'vue'
+
 import { type TestResult, executePostResponseScript } from '../../libs/execute-scripts'
 import { PostResponseScripts } from './components/PostResponseScripts'
 import { TestResults } from './components/TestResults'

--- a/packages/types/src/api-client/index.ts
+++ b/packages/types/src/api-client/index.ts
@@ -1,1 +1,0 @@
-export { type ApiClientPlugin, ApiClientPluginSchema, HooksSchema } from './api-client-plugin'

--- a/packages/types/src/api-reference/api-client-configuration.ts
+++ b/packages/types/src/api-reference/api-client-configuration.ts
@@ -1,0 +1,8 @@
+import type z from 'zod'
+
+import { baseConfigurationSchema } from './base-configuration'
+import { sourceConfigurationSchema } from './source-configuration'
+
+export const apiClientConfigurationSchema = baseConfigurationSchema.extend(sourceConfigurationSchema.shape)
+
+export type ApiClientConfiguration = z.infer<typeof apiClientConfigurationSchema>

--- a/packages/types/src/api-reference/api-client-plugin.ts
+++ b/packages/types/src/api-reference/api-client-plugin.ts
@@ -1,18 +1,18 @@
 import { z } from 'zod'
 
-const SectionViewSchema = z.object({
+const sectionViewSchema = z.object({
   title: z.string().optional(),
   // Since this is meant to be a Vue component, we'll use unknown
   component: z.unknown(),
   props: z.record(z.string(), z.any()).optional(),
 })
 
-const ViewsSchema = z.object({
-  'request.section': z.array(SectionViewSchema).optional(),
-  'response.section': z.array(SectionViewSchema).optional(),
+const viewsSchema = z.object({
+  'request.section': z.array(sectionViewSchema).optional(),
+  'response.section': z.array(sectionViewSchema).optional(),
 })
 
-export const HooksSchema = z.object({
+export const hooksSchema = z.object({
   onBeforeRequest: z
     .function({
       input: [z.object({ request: z.instanceof(Request) })],
@@ -27,13 +27,16 @@ export const HooksSchema = z.object({
     .optional(),
 })
 
-export const ApiClientPluginSchema = z.function({
+/**
+ * An API client plugin that can connect into request and response hooks
+ */
+export const apiClientPluginSchema = z.function({
   input: [],
   output: z.object({
     name: z.string(),
-    views: ViewsSchema.optional(),
-    hooks: HooksSchema.optional(),
+    views: viewsSchema.optional(),
+    hooks: hooksSchema.optional(),
   }),
 })
 
-export type ApiClientPlugin = z.infer<typeof ApiClientPluginSchema>
+export type ApiClientPlugin = z.infer<typeof apiClientPluginSchema>

--- a/packages/types/src/api-reference/api-reference-configuration.test.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { type ApiReferenceConfiguration, apiReferenceConfigurationSchema } from './api-reference-configuration'
+
+import {
+  type ApiReferenceConfiguration,
+  apiReferenceConfigurationSchema,
+  apiReferenceConfigurationWithSourceSchema,
+} from './api-reference-configuration'
 
 describe('api-reference-configuration', () => {
   describe('schema', () => {
@@ -217,7 +222,7 @@ describe('api-reference-configuration', () => {
         },
       }
 
-      const migratedConfig = apiReferenceConfigurationSchema.parse(config)
+      const migratedConfig = apiReferenceConfigurationWithSourceSchema.parse(config)
 
       expect(migratedConfig.spec).toBeUndefined()
       expect(migratedConfig.url).toBe('https://example.com/openapi.json')
@@ -230,7 +235,7 @@ describe('api-reference-configuration', () => {
         },
       }
 
-      const migratedConfig = apiReferenceConfigurationSchema.parse(config)
+      const migratedConfig = apiReferenceConfigurationWithSourceSchema.parse(config)
 
       expect(migratedConfig.spec).toBeUndefined()
       expect(migratedConfig.content).toBe('{"openapi": "3.1.0"}')

--- a/packages/types/src/api-reference/api-reference-plugin.ts
+++ b/packages/types/src/api-reference/api-reference-plugin.ts
@@ -1,9 +1,6 @@
-// TODO: Oh, do we really want to make this a dependency?
-// import type { Component } from 'vue'
-
 import { z } from 'zod'
 
-export const OpenApiExtensionSchema = z.object({
+export const openApiExtensionSchema = z.object({
   /**
    * Name of specification extension property. Has to start with `x-`.
    *
@@ -23,14 +20,14 @@ export const OpenApiExtensionSchema = z.object({
   renderer: z.unknown().optional(),
 })
 
-export const ApiReferencePluginSchema = z.function({
+export const apiReferencePluginSchema = z.function({
   input: [],
   output: z.object({
     name: z.string(),
-    extensions: z.array(OpenApiExtensionSchema),
+    extensions: z.array(openApiExtensionSchema),
   }),
 })
 
 // Infer the types from the schemas
-export type SpecificationExtension = z.infer<typeof OpenApiExtensionSchema>
-export type ApiReferencePlugin = z.infer<typeof ApiReferencePluginSchema>
+export type SpecificationExtension = z.infer<typeof openApiExtensionSchema>
+export type ApiReferencePlugin = z.infer<typeof apiReferencePluginSchema>

--- a/packages/types/src/api-reference/base-configuration.ts
+++ b/packages/types/src/api-reference/base-configuration.ts
@@ -1,0 +1,146 @@
+import z from 'zod'
+
+import { apiClientPluginSchema } from './api-client-plugin'
+
+export const OLD_PROXY_URL = 'https://api.scalar.com/request-proxy'
+export const NEW_PROXY_URL = 'https://proxy.scalar.com'
+
+/** Shared configuration for the Api Reference and Api Client */
+export const baseConfigurationSchema = z.object({
+  /**
+   * The title of the OpenAPI document.
+   *
+   * @example 'Scalar Galaxy'
+   */
+  title: z.string().optional(),
+  /**
+   * The slug of the OpenAPI document used in the URL.
+   *
+   * If none is passed, the title will be used.
+   *
+   * If no title is used, it'll just use the index.
+   *
+   * @example 'scalar-galaxy'
+   */
+  slug: z.string().optional(),
+  /** Prefill authentication */
+  authentication: z.any().optional(), // Temp until we bring in the new auth
+  /** Base URL for the API server */
+  baseServerURL: z.string().optional(),
+  /**
+   * Whether to hide the client button
+   * @default false
+   */
+  hideClientButton: z.boolean().optional().default(false).catch(false),
+  /** URL to a request proxy for the API client */
+  proxyUrl: z.string().optional(),
+  /** Key used with CTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k) */
+  searchHotKey: z
+    .enum([
+      'a',
+      'b',
+      'c',
+      'd',
+      'e',
+      'f',
+      'g',
+      'h',
+      'i',
+      'j',
+      'k',
+      'l',
+      'm',
+      'n',
+      'o',
+      'p',
+      'q',
+      'r',
+      's',
+      't',
+      'u',
+      'v',
+      'w',
+      'x',
+      'y',
+      'z',
+    ])
+    .optional(),
+  /** List of OpenAPI server objects */
+  servers: z.array(z.any()).optional(), // Using any for OpenAPIV3_1.ServerObject
+  /**
+   * Whether to show the sidebar
+   * @default true
+   */
+  showSidebar: z.boolean().optional().default(true).catch(true),
+  /**
+   * Sets the visibility of the developer tools
+   * @default 'localhost' to only show the toolbar on localhost or similar hosts
+   */
+  showToolbar: z.enum(['always', 'localhost', 'never']).optional().default('localhost').catch('localhost'),
+  /**
+   * Whether to use the operation summary or the operation path for the sidebar and search
+   * @default 'summary'
+   */
+  operationTitleSource: z.enum(['summary', 'path']).optional().default('summary').catch('summary'),
+  /** A string to use one of the color presets */
+  theme: z
+    .enum([
+      'alternate',
+      'default',
+      'moon',
+      'purple',
+      'solarized',
+      'bluePlanet',
+      'deepSpace',
+      'saturn',
+      'kepler',
+      'elysiajs',
+      'fastify',
+      'mars',
+      'laserwave',
+      'none',
+    ])
+    .optional()
+    .default('default')
+    .catch('default'),
+  /** Integration type identifier */
+  _integration: z
+    .enum([
+      'adonisjs',
+      'docusaurus',
+      'dotnet',
+      'elysiajs',
+      'express',
+      'fastapi',
+      'fastify',
+      'go',
+      'hono',
+      'html',
+      'laravel',
+      'litestar',
+      'nestjs',
+      'nextjs',
+      'nitro',
+      'nuxt',
+      'platformatic',
+      'react',
+      'rust',
+      'svelte',
+      'vue',
+    ])
+    .nullable()
+    .optional(),
+  /** onRequestSent is fired when a request is sent */
+  onRequestSent: z
+    .function({
+      input: [z.string()],
+      output: z.void(),
+    })
+    .optional(),
+  /** Whether to persist auth to local storage */
+  persistAuth: z.boolean().optional().default(false).catch(false),
+  /** Plugins for the API client */
+  plugins: z.array(apiClientPluginSchema).optional(),
+  /** Enables / disables telemetry*/
+  telemetry: z.boolean().optional().default(true),
+})

--- a/packages/types/src/api-reference/html-rendering-configuration.ts
+++ b/packages/types/src/api-reference/html-rendering-configuration.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
-import type { ApiReferenceConfigurationWithSources } from './api-reference-configuration'
+
+import type { ApiReferenceConfigurationWithMultipleSources } from './api-reference-configuration'
 
 /**
  * Zod schema for HTML rendering configuration
@@ -26,5 +27,5 @@ export const htmlRenderingConfigurationSchema = z.object({
  *
  * It's the ApiReferenceConfiguration, but extended with the `pageTitle` and `cdn` options.
  */
-export type HtmlRenderingConfiguration = Partial<ApiReferenceConfigurationWithSources> &
+export type HtmlRenderingConfiguration = Partial<ApiReferenceConfigurationWithMultipleSources> &
   z.infer<typeof htmlRenderingConfigurationSchema>

--- a/packages/types/src/api-reference/index.ts
+++ b/packages/types/src/api-reference/index.ts
@@ -1,23 +1,29 @@
+// biome-ignore lint/performance/noBarrelFile: exporting from a block
 export {
   type ApiClientConfiguration,
-  type ApiReferenceConfiguration,
-  type ApiReferenceConfigurationWithSources,
-  type AnyApiReferenceConfiguration,
-  type SpecConfiguration,
   apiClientConfigurationSchema,
+} from './api-client-configuration'
+export { type ApiClientPlugin, apiClientPluginSchema, hooksSchema } from './api-client-plugin'
+export {
+  type AnyApiReferenceConfiguration,
+  type ApiReferenceConfiguration,
+  type ApiReferenceConfigurationWithDefault,
+  type ApiReferenceConfigurationWithMultipleSources,
+  type ApiReferenceConfigurationWithSource,
   apiReferenceConfigurationSchema,
-  specConfigurationSchema,
+  apiReferenceConfigurationWithSourceSchema,
   isConfigurationWithSources,
 } from './api-reference-configuration'
-
+export type {
+  ApiReferencePlugin,
+  SpecificationExtension,
+} from './api-reference-plugin'
+export type { ApiReferenceInstance, CreateApiReference } from './html-api'
 export {
   type HtmlRenderingConfiguration,
   htmlRenderingConfigurationSchema,
 } from './html-rendering-configuration'
-
-export type {
-  SpecificationExtension,
-  ApiReferencePlugin,
-} from './api-reference-plugin'
-
-export type { ApiReferenceInstance, CreateApiReference } from './html-api'
+export {
+  type SourceConfiguration,
+  sourceConfigurationSchema,
+} from './source-configuration'

--- a/packages/types/src/api-reference/source-configuration.ts
+++ b/packages/types/src/api-reference/source-configuration.ts
@@ -1,0 +1,97 @@
+import z from 'zod'
+
+/**
+ * A source is any potential document input used for API Reference
+ * and API Client integrations. Sources may be specified in the configuration
+ * or used independently. Some configurations may have multiple sources.
+ */
+export const sourceConfigurationSchema = z.object({
+  /**
+   * URL to an OpenAPI/Swagger document
+   * @example
+   * ```ts
+   * const oldConfiguration = {
+   *   spec: {
+   *     url: 'https://example.com/openapi.json',
+   *   },
+   * }
+   *
+   * const newConfiguration = {
+   *   url: 'https://example.com/openapi.json',
+   * }
+   * ```
+   **/
+  url: z.string().optional(),
+  /**
+   * Directly embed the OpenAPI document.
+   * Can be a string, object, function returning an object, or null.
+   *
+   * @remarks It's recommended to pass a URL instead of content.
+   * @example
+   * ```ts
+   * const oldConfiguration = {
+   *   spec: {
+   *     content: '…',
+   *   },
+   * }
+   *
+   * const newConfiguration = {
+   *   content: '…',
+   * }
+   * ```
+   **/
+  content: z
+    .union([
+      z.string(),
+      z.null(),
+      z.record(z.string(), z.any()),
+      z.function({
+        input: [],
+        output: z.record(z.string(), z.any()),
+      }),
+    ])
+    .optional(),
+  /**
+   * The title of the OpenAPI document.
+   *
+   * @example 'Scalar Galaxy'
+   *
+   * @deprecated Please move `title` to the top level and remove the `spec` prefix.
+   */
+  title: z.string().optional(),
+  /**
+   * The slug of the OpenAPI document used in the URL.
+   *
+   * If none is passed, the title will be used.
+   *
+   * If no title is used, it'll just use the index.
+   *
+   * @example 'scalar-galaxy'
+   *
+   * @deprecated Please move `slug` to the top level and remove the `spec` prefix.
+   */
+  slug: z.string().optional(),
+  /**
+   * The OpenAPI/Swagger document to render
+   *
+   * @deprecated Use `url` and `content` on the top level instead.
+   **/
+  spec: z
+    .object({
+      url: z.string().optional(),
+      content: z
+        .union([
+          z.string(),
+          z.null(),
+          z.record(z.string(), z.any()),
+          z.function({
+            input: [],
+            output: z.record(z.string(), z.any()),
+          }),
+        ])
+        .optional(),
+    })
+    .optional(),
+})
+
+export type SourceConfiguration = z.infer<typeof sourceConfigurationSchema>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,4 @@
 /** We should not use these exports anymore, but we need them for commonjs compatibility. */
-export * from './legacy/index'
+
 export * from './api-reference/index'
+export * from './legacy/index'


### PR DESCRIPTION
**Problem**

The configurations should be agnostic of any document sources. In the future it is likely no sources will be provided in the configuration.

**Solution**

This PR removes the sources from the base `ApiReferenceConfig` type to discourage the access of the sources anywhere except at the application entrypoints. Follow up work will streamline the document ingress. 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
