### PR TITLE
chore(Scalar.AspNetCore): correct typo in TargetFramework

### DIFF
--- a/integrations/aspnetcore/tests/Directory.Packages.props
+++ b/integrations/aspnetcore/tests/Directory.Packages.props
@@ -11,15 +11,15 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFrameWork) == 'net8.0'">
+  <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.20" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFrameWork) == 'net9.0'">
+  <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFrameWork) == 'net10.0'">
+  <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0-rc.1.25451.107" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR just fixes a minor typo in the test configuration of the AspNetCore integration.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
