### PR TITLE
feat: implement environment variables management in api reference

### DIFF
--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { provideUseId } from '@headlessui/vue'
 import { OpenApiClientButton } from '@scalar/api-client/components'
+import { EnvironmentManagementButton } from '@/features/environment-management'
 import { LAYOUT_SYMBOL } from '@scalar/api-client/hooks'
 import {
   ACTIVE_ENTITIES_SYMBOL,
@@ -91,6 +92,7 @@ const configuration = computed(() => ({
   persistAuth: providedConfiguration.persistAuth ?? false,
   documentDownloadType: providedConfiguration.documentDownloadType ?? 'both',
   onBeforeRequest: providedConfiguration.onBeforeRequest,
+  allowEnvironmentManagement: providedConfiguration.allowEnvironmentManagement ?? false,
 }))
 
 // ---------------------------------------------------------------------------
@@ -377,6 +379,7 @@ useLegacyStoreEvents(store, workspaceStore, activeEntitiesStore, documentEl)
                     :integration="configuration._integration"
                     :isDevelopment="isDevelopment"
                     :url="configuration.url" />
+                  <EnvironmentManagementButton />
                   <!-- Override the dark mode toggle slot to hide it -->
                   <template #toggle>
                     <ScalarColorModeToggleButton

--- a/packages/api-reference/src/features/environment-management/components/EnvironmentManagementButton.vue
+++ b/packages/api-reference/src/features/environment-management/components/EnvironmentManagementButton.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { ScalarIcon, useModal } from '@scalar/components'
+
+import EnvironmentManagementModal from '@/features/environment-management/components/EnvironmentManagementModal.vue'
+import { useActiveEntities } from '@/store'
+
+const { activeWorkspaceCollections } = useActiveEntities()
+const environmentManagementModal = useModal()
+
+
+function openEnvironmentManagement() {
+  environmentManagementModal.show()
+}
+</script>
+
+<template>
+  <button
+    class="environment-management-button"
+    type="button"
+    @click="openEnvironmentManagement">
+    <ScalarIcon
+      icon="Brackets"
+      size="xs"
+      thickness="2.5" />
+    Manage Environments
+  </button>
+  
+  <!-- Environment Management Modal -->
+  <EnvironmentManagementModal
+    :activeWorkspaceCollections="activeWorkspaceCollections"
+    :state="environmentManagementModal"
+    @cancel="environmentManagementModal.hide()" />
+</template>
+
+<style scoped>
+.environment-management-button {
+  cursor: pointer;
+  width: 100%;
+  padding: 9px 12px;
+  height: 31px;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  font-size: var(--scalar-mini);
+  font-weight: var(--scalar-semibold);
+  line-height: 1.385;
+  text-decoration: none;
+  border-radius: var(--scalar-radius);
+  box-shadow: 0 0 0 0.5px var(--scalar-border-color);
+  gap: 6px;
+  color: var(--scalar-sidebar-color-1);
+  background: transparent;
+  border: none;
+}
+
+.environment-management-button:hover {
+  background: var(
+    --scalar-sidebar-item-hover-background,
+    var(--scalar-background-2)
+  );
+}
+</style>

--- a/packages/api-reference/src/features/environment-management/components/EnvironmentManagementModal.vue
+++ b/packages/api-reference/src/features/environment-management/components/EnvironmentManagementModal.vue
@@ -1,0 +1,466 @@
+<script setup lang="ts">
+import {
+  ScalarButton,
+  ScalarIcon,
+  ScalarModal,
+  useModal,
+  type ModalState,
+} from '@scalar/components'
+import type { Collection } from '@scalar/oas-utils/entities/spec'
+import { useToasts } from '@scalar/use-toasts'
+import { computed, ref, watch } from 'vue'
+
+import { CodeInput } from '@scalar/api-client/components/CodeInput'
+import { useActiveEntities, useWorkspace } from '@scalar/api-client/store'
+
+import EnvironmentModal from './EnvironmentModal.vue'
+
+const props = defineProps<{
+  state: ModalState
+  activeWorkspaceCollections: Collection[]
+}>()
+
+const emit = defineEmits<{
+  (event: 'cancel'): void
+}>()
+
+const { activeWorkspace, activeWorkspaceCollections, activeEnvVariables } = useActiveEntities()
+const { collectionMutators, workspaceMutators } = useWorkspace()
+const { toast } = useToasts()
+
+// Modal states
+const environmentModal = useModal()
+const selectedEnvironment = ref<string | null>(null)
+const selectedCollection = ref<string | null>(null)
+const environmentValue = ref('{}')
+
+// Get all environments from all collections
+const allEnvironments = computed(() => {
+  const environments: Array<{
+    name: string
+    collectionId: string
+    collectionName: string
+    color: string
+    variables: Record<string, string>
+  }> = []
+
+  // Add global environment
+  if (activeWorkspace.value?.environments) {
+    const globalVars: Record<string, string> = {}
+    Object.entries(activeWorkspace.value.environments).forEach(([key, value]) => {
+      if (typeof value === 'string') {
+        globalVars[key] = value
+      } else if (typeof value === 'object' && value && 'default' in value) {
+        globalVars[key] = (value as any).default || ''
+      }
+    })
+  }
+
+  // Add collection environments
+  activeWorkspaceCollections.value.forEach((collection) => {
+    if (collection['x-scalar-environments']) {
+      Object.entries(collection['x-scalar-environments']).forEach(([name, env]) => {
+        if (env) {
+          const envVars: Record<string, string> = {}
+          if (env.variables) {
+            Object.entries(env.variables).forEach(([key, value]) => {
+              if (typeof value === 'string') {
+                envVars[key] = value
+              } else if (typeof value === 'object' && value && 'default' in value) {
+                envVars[key] = (value as any).default || ''
+              }
+            })
+          }
+          
+          environments.push({
+            name,
+            collectionId: collection.uid,
+            collectionName: collection.info?.title ?? 'Untitled Collection',
+            color: env?.color || '#FFFFFF',
+            variables: envVars,
+          })
+        }
+      })
+    }
+  })
+
+  return environments
+})
+
+// Current environment data
+const currentEnvironment = computed(() => {
+  if (!selectedEnvironment.value || !selectedCollection.value) {
+    return null
+  }
+
+  const collection = activeWorkspaceCollections.value.find(
+    (c) => c.uid === selectedCollection.value
+  )
+  if (collection?.['x-scalar-environments']?.[selectedEnvironment.value]) {
+    const env = collection['x-scalar-environments'][selectedEnvironment.value]
+    return {
+      name: selectedEnvironment.value,
+      collectionId: collection.uid,
+      collectionName: collection.info?.title ?? 'Untitled Collection',
+      color: env?.color || '#FFFFFF',
+      variables: env?.variables || {},
+    }
+  }
+
+  return null
+})
+
+// Update environment value when selection changes
+watch(
+  () => currentEnvironment.value,
+  (env) => {
+    if (env) {
+      environmentValue.value = JSON.stringify(env.variables, null, 2)
+    } else {
+      environmentValue.value = '{}'
+    }
+  },
+  { immediate: true }
+)
+
+// Handle environment variable updates
+function handleEnvironmentUpdate(raw: string) {
+  if (!currentEnvironment.value) {
+    return
+  }
+
+  try {
+    const updatedValue = JSON.parse(raw)
+    
+    if (currentEnvironment.value.collectionId === 'global') {
+      // Update global environment
+      workspaceMutators.edit(
+        activeWorkspace.value?.uid,
+        'environments',
+        updatedValue,
+      )
+    } else {
+      // Update collection environment
+      const collection = activeWorkspaceCollections.value.find(
+        (c) => c.uid === currentEnvironment.value?.collectionId
+      )
+      if (collection?.['x-scalar-environments']?.[currentEnvironment.value.name]) {
+        const environments = {
+          ...collection['x-scalar-environments'],
+          [currentEnvironment.value.name]: {
+            ...collection['x-scalar-environments'][currentEnvironment.value.name],
+            variables: updatedValue,
+          },
+        }
+        collectionMutators.edit(
+          collection.uid,
+          'x-scalar-environments',
+          environments,
+        )
+      }
+    }
+  } catch (error) {
+    toast('Invalid JSON format', 'error')
+  }
+}
+
+// Handle environment creation
+function handleEnvironmentSubmit(environment: {
+  name: string
+  color: string
+  type: string
+  collectionId: string | undefined
+}) {
+  if (environment.collectionId) {
+    collectionMutators.addEnvironment(
+      environment.name,
+      {
+        variables: {},
+        color: environment.color,
+      },
+      environment.collectionId as any,
+    )
+    
+    // Select the newly created environment
+    selectedEnvironment.value = environment.name
+    selectedCollection.value = environment.collectionId
+    
+    // Set the active environment ID in the workspace
+    if (activeWorkspace.value) {
+      workspaceMutators.edit(
+        activeWorkspace.value.uid,
+        'activeEnvironmentId',
+        environment.name
+      )
+    }
+    
+    toast(`Environment "${environment.name}" created successfully!`, 'info')
+  }
+  environmentModal.hide()
+}
+
+// Handle environment selection
+function selectEnvironment(environment: typeof allEnvironments.value[0]) {
+  selectedEnvironment.value = environment.name
+  selectedCollection.value = environment.collectionId
+  
+  // Set the active environment ID in the workspace
+  if (activeWorkspace.value) {
+    workspaceMutators.edit(
+      activeWorkspace.value.uid,
+      'activeEnvironmentId',
+      environment.name
+    )
+  }
+}
+
+// Initialize selection when modal opens
+watch(
+  () => props.state.open,
+  (isOpen) => {
+    if (isOpen) {
+      // Initialize with the currently active environment
+      const activeEnvId = activeWorkspace.value?.activeEnvironmentId
+      if (activeEnvId) {
+        // Find the active environment in the collections
+        const activeEnv = allEnvironments.value.find(env => env.name === activeEnvId)
+        if (activeEnv) {
+          selectedEnvironment.value = activeEnv.name
+          selectedCollection.value = activeEnv.collectionId
+          // The environment value will be set by the watch function
+        } else {
+          // No active environment found, auto-select if environments exist
+          if (allEnvironments.value.length > 0) {
+            const firstEnv = allEnvironments.value[0]
+            if (firstEnv) {
+              selectedEnvironment.value = firstEnv.name
+              selectedCollection.value = firstEnv.collectionId
+              // Set as active environment in workspace
+              if (activeWorkspace.value) {
+                workspaceMutators.edit(
+                  activeWorkspace.value.uid,
+                  'activeEnvironmentId',
+                  firstEnv.name
+                )
+              }
+            } else {
+              selectedEnvironment.value = null
+              selectedCollection.value = null
+              environmentValue.value = '{}'
+            }
+          } else {
+            selectedEnvironment.value = null
+            selectedCollection.value = null
+            environmentValue.value = '{}'
+          }
+        }
+      } else {
+        // No active environment, auto-select if environments exist
+        if (allEnvironments.value.length > 0) {
+          const firstEnv = allEnvironments.value[0]
+          if (firstEnv) {
+            selectedEnvironment.value = firstEnv.name
+            selectedCollection.value = firstEnv.collectionId
+            // Set as active environment in workspace
+            if (activeWorkspace.value) {
+              workspaceMutators.edit(
+                activeWorkspace.value.uid,
+                'activeEnvironmentId',
+                firstEnv.name
+              )
+            }
+          } else {
+            selectedEnvironment.value = null
+            selectedCollection.value = null
+            environmentValue.value = '{}'
+          }
+        } else {
+          selectedEnvironment.value = null
+          selectedCollection.value = null
+          environmentValue.value = '{}'
+        }
+      }
+    }
+  }
+)
+</script>
+
+<template>
+  <ScalarModal
+    size="xl"
+    :state="state"
+    @cancel="emit('cancel')">
+    <div class="flex h-[600px] flex-col">
+      <!-- Header -->
+      <div class="border-b border-gray-200 dark:border-gray-700 p-4">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+          Environment Management
+        </h2>
+        <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
+          Manage your environment variables and configurations
+        </p>
+      </div>
+
+      <div class="flex flex-1 overflow-hidden">
+        <!-- Sidebar - Environment List -->
+        <div class="w-80 border-r border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
+          <div class="p-4">
+            <div class="flex items-center justify-between mb-4">
+              <h3 class="font-medium text-gray-900 dark:text-white">Environments</h3>
+              <ScalarButton
+                size="sm"
+                variant="outlined"
+                @click="environmentModal.show()">
+                <ScalarIcon
+                  icon="Add"
+                  size="xs" />
+                Add
+              </ScalarButton>
+            </div>
+            
+            <div class="space-y-2 max-h-96 overflow-y-auto">
+              <div
+                v-for="env in allEnvironments"
+                :key="`${env.collectionId}-${env.name}`"
+                class="environment-item"
+                :class="{
+                  'environment-item--selected': 
+                    selectedEnvironment === env.name && selectedCollection === env.collectionId
+                }"
+                @click="selectEnvironment(env)">
+                <div class="flex items-center gap-2">
+                  <div
+                    class="w-3 h-3 rounded-full"
+                    :style="{ backgroundColor: env.color }" />
+                  <div class="flex-1 min-w-0">
+                    <div class="font-medium text-sm text-gray-900 dark:text-white truncate">
+                      {{ env.name }}
+                    </div>
+                    <div class="text-xs text-gray-500 dark:text-gray-400 truncate">
+                      {{ env.collectionName }}
+                    </div>
+                  </div>
+                </div>
+              </div>
+              
+              <div
+                v-if="allEnvironments.length === 0"
+                class="text-center py-8 text-gray-500 dark:text-gray-400">
+                <ScalarIcon
+                  class="mx-auto mb-2 opacity-50"
+                  icon="Brackets"
+                  size="lg" />
+                <p class="text-sm">No environments found</p>
+                <p class="text-xs">Create your first environment to get started</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Main Content - Environment Editor -->
+        <div class="flex-1 flex flex-col">
+          <div
+            v-if="!currentEnvironment"
+            class="flex-1 flex items-center justify-center text-gray-500 dark:text-gray-400">
+            <div class="text-center">
+              <ScalarIcon
+                class="mx-auto mb-4 opacity-50"
+                icon="Brackets"
+                size="xl" />
+              <h3 class="text-lg font-medium mb-2">Select an Environment</h3>
+              <p class="text-sm">Choose an environment from the sidebar to edit its variables</p>
+            </div>
+          </div>
+          
+          <div
+            v-else
+            class="flex-1 flex flex-col">
+            <!-- Environment Header -->
+            <div class="p-4 border-b border-gray-200 dark:border-gray-700">
+              <div class="flex items-center gap-3">
+                <div
+                  class="w-4 h-4 rounded-full"
+                  :style="{ backgroundColor: currentEnvironment.color }" />
+                <div>
+                  <h3 class="font-medium text-gray-900 dark:text-white">
+                    {{ currentEnvironment.name }}
+                  </h3>
+                  <p class="text-sm text-gray-500 dark:text-gray-400">
+                    {{ currentEnvironment.collectionName }}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <!-- Environment Variables Editor -->
+            <div class="flex-1 p-4">
+              <div class="mb-3">
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Environment Variables (JSON)
+                </label>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                  Define your environment variables as a JSON object. Example: <code class="bg-gray-100 dark:bg-gray-700 px-1 rounded">{"API_URL": "https://api.example.com", "API_KEY": "your-key-here"}</code>
+                </p>
+              </div>
+              
+              <div class="flex-1 min-h-0">
+                <CodeInput
+                  v-model="environmentValue"
+                  class="h-full"
+                  :envVariables="activeEnvVariables"
+                  :environment="{
+                    uid: currentEnvironment.name as any,
+                    name: currentEnvironment.name,
+                    value: JSON.stringify(currentEnvironment.variables),
+                    color: currentEnvironment.color,
+                  }"
+                  language="json"
+                  lineNumbers
+                  lint
+                  @update:modelValue="handleEnvironmentUpdate" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Footer -->
+      <div class="border-t border-gray-200 dark:border-gray-700 p-4">
+        <div class="flex justify-end gap-3">
+          <ScalarButton
+            variant="outlined"
+            @click="emit('cancel')">
+            Close
+          </ScalarButton>
+        </div>
+      </div>
+    </div>
+
+    <!-- Environment Creation Modal -->
+    <EnvironmentModal
+      :activeWorkspaceCollections="activeWorkspaceCollections"
+      :collectionId="undefined"
+      :state="environmentModal"
+      @cancel="environmentModal.hide()"
+      @submit="handleEnvironmentSubmit" />
+  </ScalarModal>
+</template>
+
+<style scoped>
+.environment-item {
+  padding: 12px;
+  border-radius: var(--scalar-radius);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1px solid var(--scalar-border-color);
+  background: var(--scalar-background-1);
+}
+
+.environment-item:hover {
+  background: var(--scalar-background-2);
+}
+
+.environment-item--selected {
+  background: var(--scalar-background-2);
+}
+</style>

--- a/packages/api-reference/src/features/environment-management/components/EnvironmentModal.vue
+++ b/packages/api-reference/src/features/environment-management/components/EnvironmentModal.vue
@@ -1,0 +1,218 @@
+<script setup lang="ts">
+import {
+  ScalarButton,
+  ScalarIcon,
+  ScalarListbox,
+  ScalarModal,
+  type ModalState,
+} from '@scalar/components'
+import type { Collection } from '@scalar/oas-utils/entities/spec'
+import { useToasts } from '@scalar/use-toasts'
+import { computed, ref, watch } from 'vue'
+
+const props = defineProps<{
+  state: ModalState
+  activeWorkspaceCollections: Collection[]
+  collectionId: string | undefined
+}>()
+
+const emit = defineEmits<{
+  (event: 'cancel'): void
+  (
+    event: 'submit',
+    environment: {
+      name: string
+      color: string
+      type: string
+      collectionId: Collection['uid'] | undefined
+    },
+  ): void
+}>()
+
+const environmentName = ref('')
+const selectedColor = ref('#069061')
+
+/**
+ * Available color options for environments
+ */
+const colorOptions = [
+  '#FFFFFF',
+  '#EF0006',
+  '#EDBE20',
+  '#069061',
+  '#FB892C',
+  '#0082D0',
+  '#5203D1',
+  '#FFC0CB',
+]
+
+const collections = computed(() => [
+  ...props.activeWorkspaceCollections
+    .filter((collection) => collection.info?.title !== 'Drafts')
+    .map((collection) => ({
+      id: collection.uid,
+      label: collection.info?.title ?? 'Untitled Collection',
+    })),
+])
+
+const selectedEnvironment = ref(
+  collections.value.find((collection) => collection.id === props.collectionId),
+)
+
+const { toast } = useToasts()
+
+/**
+ * Handle color selection
+ */
+function handleColorSelect(color: string): void {
+  selectedColor.value = color
+}
+
+/**
+ * Reset environment name and selected color when modal opens
+ */
+watch(
+  () => props.state.open,
+  (isOpen) => {
+    if (isOpen) {
+      environmentName.value = ''
+      selectedColor.value = '#069061'
+      if (props.collectionId) {
+        selectedEnvironment.value = collections.value.find(
+          (collection) => collection.id === props.collectionId,
+        )
+      } else {
+        selectedEnvironment.value = undefined
+      }
+    }
+  },
+)
+
+/**
+ * Handle form submission
+ */
+function handleSubmit(): void {
+  if (!environmentName.value.trim()) {
+    toast('Please enter a name before adding an environment.', 'error')
+    return
+  }
+  if (!selectedEnvironment.value?.id) {
+    toast('Please select a collection before adding an environment.', 'error')
+    return
+  }
+  emit('submit', {
+    name: environmentName.value,
+    color: selectedColor.value,
+    type: selectedEnvironment.value?.id === 'global' ? 'global' : 'collection',
+    collectionId:
+      selectedEnvironment.value?.id !== 'global'
+        ? selectedEnvironment.value?.id
+        : undefined,
+  })
+}
+</script>
+
+<template>
+  <ScalarModal
+    size="xs"
+    :state="state"
+    @cancel="emit('cancel')">
+    <div class="p-4">
+      <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+        Create Environment
+      </h3>
+      
+      <form
+        @submit.prevent="handleSubmit">
+        <!-- Environment Name -->
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Environment Name
+          </label>
+          <input
+            v-model="environmentName"
+            class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="e.g. Production, Staging"
+            type="text" />
+        </div>
+
+        <!-- Color Picker -->
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Color
+          </label>
+          <div class="flex gap-2">
+            <button
+              v-for="color in colorOptions"
+              :key="color"
+              class="w-8 h-8 rounded-full border-2 flex items-center justify-center transition-all"
+              :class="
+                selectedColor === color
+                  ? 'border-gray-900 dark:border-white scale-110'
+                  : 'border-gray-200 dark:border-gray-700 hover:scale-105'
+              "
+              :style="{ backgroundColor: color }"
+              type="button"
+              @click="handleColorSelect(color)">
+              <ScalarIcon
+                v-if="selectedColor === color"
+                class="text-white"
+                icon="Checkmark"
+                size="xs" />
+            </button>
+          </div>
+        </div>
+
+        <!-- Collection Selector -->
+        <div class="mb-6">
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Collection
+          </label>
+          <ScalarListbox
+            v-model="selectedEnvironment"
+            :options="collections"
+            placeholder="Select Collection">
+            <ScalarButton
+              v-if="collections.length > 0"
+              class="w-full justify-between"
+              variant="outlined">
+              <span :class="selectedEnvironment ? 'text-c-1' : 'text-c-3'">
+                {{
+                  selectedEnvironment
+                    ? selectedEnvironment.label
+                    : 'Select Collection'
+                }}
+              </span>
+              <ScalarIcon
+                class="text-c-3"
+                icon="ChevronDown"
+                size="xs" />
+            </ScalarButton>
+            <ScalarButton
+              v-else
+              class="w-full"
+              disabled
+              variant="outlined">
+              <span class="text-c-3">No collections available</span>
+            </ScalarButton>
+          </ScalarListbox>
+        </div>
+
+        <!-- Actions -->
+        <div class="flex justify-end gap-3">
+          <ScalarButton
+            variant="outlined"
+            @click="emit('cancel')">
+            Cancel
+          </ScalarButton>
+          <ScalarButton
+            :disabled="!selectedEnvironment || !environmentName.trim()"
+            type="submit">
+            Add Environment
+          </ScalarButton>
+        </div>
+      </form>
+    </div>
+  </ScalarModal>
+</template>
+

--- a/packages/api-reference/src/features/environment-management/index.ts
+++ b/packages/api-reference/src/features/environment-management/index.ts
@@ -1,0 +1,1 @@
+export { default as EnvironmentManagementButton } from './components/EnvironmentManagementButton.vue'

--- a/packages/api-reference/src/store/index.ts
+++ b/packages/api-reference/src/store/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Re-export store composables from api-client for convenience
+ * This allows components to use @/store instead of @scalar/api-client/store
+ */
+export { useActiveEntities, useWorkspace } from '@scalar/api-client/store'

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -220,6 +220,11 @@ export const apiClientConfigurationSchema = z.object({
    * @default false
    */
   hideClientButton: z.boolean().optional().default(false).catch(false),
+  /**
+   * Whether to allow the environment variablesmanagement
+   * @default false
+   */
+  allowEnvironmentManagement: z.boolean().optional().default(false).catch(false),
   /** URL to a request proxy for the API client */
   proxyUrl: z.string().optional(),
   /** Key used with CTRL/CMD to open the search modal (defaults to 'k' e.g. CMD+k) */


### PR DESCRIPTION
**Problem**

Currently, there is no way to manage environment variables in the api reference defined through `x-scalar-environments ` in the openapi spec. If we have a value bieng repeatedly used in various endpoints, we have no way to define it globally and access it as an variable, for example, like in postman.

**Solution**

With this PR, we will able to view, edit, delete the variables defined in the openapi spec.

**Checklist**

I've gone through the following:

- [X] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
