### PR TITLE
docs(configuration): add tagsSorter back

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -542,7 +542,7 @@ Every operation can have a `operationId`, a unique string used to identify the o
 
 By default we don't render it in the UI. If it's helpful to show it to your users, enable it like this:
 
-`@default false`
+**Default:** `false`
 
 ```js
 {
@@ -1027,6 +1027,18 @@ Customize how webhook URLs are generated. This function receives the webhook obj
 {
   generateWebhookSlug: (webhook) =>
     `v1-${webhook.method?.toLowerCase()}-${webhook.name}`
+}
+```
+
+#### tagsSorter
+
+**Type:** `'alpha' | (a: Tag, b: Tag) => number`
+
+Sort tags alphanumerically (`'alpha'`):
+
+```js
+{
+  tagsSorter: 'alpha'
 }
 ```
 


### PR DESCRIPTION
It looks like I accidentally removed the docs for the `tagsSorter` configuration in a recent PR.  Lets bring it back!

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
