### PR TITLE
feat(openapi-types): version 3.1.2

### DIFF
--- a/.changeset/chilled-tigers-juggle.md
+++ b/.changeset/chilled-tigers-juggle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-types': patch
+---
+
+feat: adds vesion 3.1.2 to the type definitions

--- a/packages/openapi-types/src/openapi-types.ts
+++ b/packages/openapi-types/src/openapi-types.ts
@@ -80,7 +80,7 @@ export namespace OpenAPIV3_1 {
        * Version of the OpenAPI specification
        * @see https://github.com/OAI/OpenAPI-Specification/tree/main/versions
        */
-      openapi?: '3.1.0' | '3.1.1'
+      openapi?: '3.1.0' | '3.1.1' | '3.1.2'
       swagger?: undefined
       info?: InfoObject
       jsonSchemaDialect?: string


### PR DESCRIPTION
version [3.1.2](https://spec.openapis.org/oas/v3.1.2.html) is out, it's identical to 3.1.1 from an object model perspective

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `3.1.2` to the `OpenAPIV3_1.Document['openapi']` union type.
> 
> - **OpenAPI v3.1 types**:
>   - Extend `OpenAPIV3_1.Document['openapi']` to include `"3.1.2"`.
> - **Changeset**:
>   - Add patch changeset for `@scalar/openapi-types`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 495dc9d9870016b22dcf4c442209f54f4454fe59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->