### PR TITLE
feat(Scalar.AspNetCore): add F# client

### DIFF
--- a/.changeset/spotty-dryers-yell.md
+++ b/.changeset/spotty-dryers-yell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+feat: add F# client

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/ScalarTarget.Generated.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Enums/ScalarTarget.Generated.cs
@@ -47,6 +47,12 @@ public enum ScalarTarget
     Dart,
 
     /// <summary>
+    /// F#.
+    /// </summary>
+    [Description("fsharp")]
+    Fsharp,
+
+    /// <summary>
     /// Go.
     /// </summary>
     [Description("go")]

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.Generated.cs
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/Mapper/ScalarOptionsMapper.Generated.cs
@@ -24,6 +24,7 @@ internal static partial class ScalarOptionsMapper
         { ScalarTarget.Clojure, [ScalarClient.CljHttp] },
         { ScalarTarget.CSharp, [ScalarClient.HttpClient, ScalarClient.RestSharp] },
         { ScalarTarget.Dart, [ScalarClient.Http] },
+        { ScalarTarget.Fsharp, [ScalarClient.HttpClient] },
         { ScalarTarget.Go, [ScalarClient.Native] },
         { ScalarTarget.Http, [ScalarClient.Http11] },
         { ScalarTarget.Java, [ScalarClient.AsyncHttp, ScalarClient.NetHttp, ScalarClient.OkHttp, ScalarClient.Unirest] },

--- a/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -176,7 +176,7 @@ public class ScalarOptionsMapperTests
         var hiddenClients = (IDictionary<ScalarTarget, ScalarClient[]>) options.ToScalarConfiguration().HiddenClients!;
 
         // Assert
-        hiddenClients.Should().HaveCount(ScalarOptionsMapper.AvailableClientsByTarget.Count);
+        hiddenClients.Should().HaveCount(ScalarOptionsMapper.AvailableClientsByTarget.Count - 1);
         hiddenClients.Should().ContainKey(ScalarTarget.CSharp)
             .WhoseValue.Should().ContainSingle().Which.Should().Be(ScalarClient.RestSharp);
         hiddenClients.Should().ContainKey(ScalarTarget.Python)


### PR DESCRIPTION
I ran the `pnpm generate:enums` command 🤝 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
