### PR TITLE
docs(scalar-docs): GitHub Actions guide

### DIFF
--- a/documentation/guides/cli/getting-started.md
+++ b/documentation/guides/cli/getting-started.md
@@ -105,7 +105,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Validate OpenAPI File
         # Replace `./my-openapi-file.yaml` with the correct path and filename for your project.
         # Or: run `npx @scalar/cli init` and add the config file to your repository.

--- a/documentation/guides/docs/github-actions.md
+++ b/documentation/guides/docs/github-actions.md
@@ -1,0 +1,78 @@
+# Publish Scalar Projects using GitHub Actions
+
+You can add a GitHub Actions workflow to automatically publish your Scalar projects.
+
+## Basic Workflow
+
+Here's a simple workflow that publishes a Scalar project:
+
+```yaml
+name: Publish Scalar Project
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Log in to Scalar
+        run: npx @scalar/cli auth login --token ${{ secrets.SCALAR_API_KEY }}
+
+      - name: Publish Project
+        run: npx @scalar/cli project publish --slug your-project-slug
+```
+
+## Environment-Based Deployment
+
+For different environments:
+
+```yaml
+name: Publish Scalar Project
+
+on:
+  push:
+    branches:
+      - main
+      - development
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Scalar CLI
+        run: npm install -g @scalar/cli
+
+      - name: Authenticate Scalar
+        env:
+          SCALAR_API_KEY: ${{ secrets.SCALAR_API_KEY }}
+        run: scalar auth login
+
+      - name: Set project slug
+        if: github.ref == 'refs/heads/main'
+        run: echo "PROJECT_SLUG=production-project" >> $GITHUB_ENV
+
+      - name: Set development slug
+        if: github.ref == 'refs/heads/development'
+        run: echo "PROJECT_SLUG=development-project" >> $GITHUB_ENV
+
+      - name: Publish Project
+        run: scalar project publish --slug "$PROJECT_SLUG"
+```
+
+## Secrets
+
+To get a `SCALAR_API_KEY` and add it to your GitHub repository, go to https://dashboard.scalar.com/user/api-keys

--- a/documentation/guides/docs/github-sync.md
+++ b/documentation/guides/docs/github-sync.md
@@ -1,16 +1,14 @@
 # GitHub Sync
 
-Scalar GitHub Sync allows you to author your documentation as markdown in your own repository and automatically publish it as a beautiful website.
+The GitHub Sync for Scalar Docs allows you to author your documentation as Markdown in your own repository and automatically publish it as a beautiful website.
 
-## Getting started
+The following guide takes you from zero to deployed documentation in just a few minutes:
 
-The following guide takes you from zero to deployed documentation in just a few minutes.
-
-### Set up your docs repository
+## Set up your GitHub repository
 
 Use your existing [GitHub](https://github.com/) repository, or create a new one from our [template repository](https://github.com/scalar/starter). If you're using the template repository, you can skip to "Configuration".
 
-#### Add some content
+## Add content
 
 If you have a few Markdown files already, that's awesome. Otherwise, just create a new `docs` folder and add at least one [Markdown file](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax):
 
@@ -28,9 +26,11 @@ That should be enough to prepare your content. Time to configure your project, l
 touch scalar.config.json
 ```
 
-#### Configuration
+## Configuration
 
-Add the content below to your `scalar.config.json` file. Note: You want to modify the subdomain. The one in the example is already taken. 😉 Your docs site will be automatically available at `https://<subdomain>.apidocumentation.com`, but you can also use a custom domain, see [Advanced configuration](#advanced-configuration__use-a-custom-domain) for more information.
+Add the content below to your `scalar.config.json` file. Note: You want to modify the subdomain. The one in the example is already taken. 😉
+
+Your docs site will be automatically available at `https://<subdomain>.apidocumentation.com`, but you can also use a custom domain, see [Advanced configuration](#advanced-configuration__use-a-custom-domain) for more information.
 
 ```json
 {
@@ -53,7 +53,7 @@ Add the content below to your `scalar.config.json` file. Note: You want to modif
 
 Make sure to commit and push the changes to your repository.
 
-### Connect your repository to Scalar
+## Connect your repository
 
 Create a free Scalar account here: https://dashboard.scalar.com/register
 
@@ -61,11 +61,36 @@ Once signed in, click on “Link GitHub Account”. You'll be redirected to GitH
 
 Find your repository and click on “Link Repository”.
 
-### Publish changes
+## Publish changes
 
-To publish your site for the first time, click on “Publish". Now sit back and relax, your documentation is being generated for you and deployed to our super fast edge servers, this will take a few minutes.
+To publish your site for the first time, click on “Publish". Now sit back and relax, your documentation is being generated for you and deployed to our super fast edge servers. This will take a few minutes.
 
 Once done, you'll see "Deployment Live" in the right hand column and a link to your new documentation site. Congratulations, you've made it!
+
+### Auto-deploy
+
+You can use the UI on https://dashboard.scalar.com or the Scalar configuration file to enable _Publish on Merge_, which – you might have guessed it — publishes your documentation when a branch is merged into the default branch (`main`):
+
+```json
+// scalar.config.json
+{
+  "publishOnMerge": true
+}
+```
+
+### Trigger a deployment using the CLI
+
+You can use the [Scalar CLI](https://guides.scalar.com/scalar/scalar-cli/getting-started) to trigger a deployment:
+
+```bash
+npx @scalar/cli project publish --slug your-project-slug
+```
+
+### Trigger a deployment in CI/CD
+
+You can [use GitHub Actions](https://guides.scalar.com/scalar/scalar-docs/github-actions) to trigger a deployment.
+
+Or [use the Scalar CLI](https://guides.scalar.com/scalar/scalar-cli/getting-started) for any other CI/CD environments.
 
 ## Advanced configuration
 
@@ -87,16 +112,6 @@ Add an OpenAPI/Swagger file to your configuration file:
 ```
 
 That's it. :) The next time your documentation is published, it'll include a super cool API reference.
-
-### Deploy on merge
-
-You can use the UI on https://dashboard.scalar.com or the Scalar configuration file to enable _Publish on Merge_, which – you might have guessed it — publishes your documentation when a branch is merged into the default branch (`main`):
-
-```json
-{
-  "publishOnMerge": true
-}
-```
 
 ### Use a custom theme
 

--- a/documentation/guides/registry/github-actions.md
+++ b/documentation/guides/registry/github-actions.md
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Validate OpenAPI Document
         run: npx @scalar/cli document validate api/openapi.json
@@ -100,7 +100,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Validate OpenAPI Document
         run: npx @scalar/cli document validate api/openapi.json
@@ -143,7 +143,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Validate ${{ matrix.api.name }}
         run: npx @scalar/cli document validate ${{ matrix.api.file }}

--- a/documentation/integrations/aspnetcore/build-time-generation.md
+++ b/documentation/integrations/aspnetcore/build-time-generation.md
@@ -105,7 +105,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Validate OpenAPI Document
         run: |

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -44,6 +44,10 @@
               "type": "page"
             },
             {
+              "path": "documentation/guides/docs/github-actions.md",
+              "type": "page"
+            },
+            {
               "name": "Components",
               "type": "folder",
               "defaultOpen": true,


### PR DESCRIPTION
This PR does three things:

* Update the GitHub Sync guide
* Adds an GitHub Actions guide for Scalar Docs
* Use Node 22 (instead of 20) for all GitHub Action examples