### PR TITLE
docs: fix use scalar heading tags

### DIFF
--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -2,9 +2,9 @@
   <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/v1Pu6_BCmly6VhPAuotVZ.svg"></scalar-icon>
 </div>
 <div class="flex flex-col gap-3 hero small-test">
-  <h2 class="text-balance">
+  <scalar-heading level="2" slug="developer-docs" class="text-balance">
     Developer Docs.
-  </h2>
+  </scalar-heading>
   <p>
     Get started with Scalar Docs, literally in minutes. You don't need anything to get started, not even an account if you just want to play around.
   </p>
@@ -140,7 +140,7 @@ They are open source. So I can get in on free features and stay with Scalar no m
     </div>
   </div>
   <div class="cta flex flex-col gap-3 small-test">
-  <h2 class="text-balance">What are you waiting for?</h2>
+    <scalar-heading level="2" class="text-balance" slug="what-are-you-waiting-for">What are you waiting for?</scalar-heading>
   <p>
     We're committed to enabling developers and companies to practice the highest
     of API industry standards.

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -1,7 +1,7 @@
 <div class="flex flex-col gap-3 hero small-test">
-  <h2 class="text-balance">
+  <scalar-heading level="2" slug="introduction" class="text-balance">
     A modern API platform built for the OpenAPI™ standard.
-  </h2>
+  </scalar-heading>
   <p>
     Industry leading Developer Docs, SDKs, API Client & Registry that your APIs
     deserve
@@ -156,9 +156,9 @@ They are open source. So I can get in on free features and stay with Scalar no m
   <div class="product">
     <div class="product-copy">
       <span class="font-bold text-orange">Scalar API Client</span>
-      <h2 class="c">
+      <scalar-heading level="2" slug="scalar-api-client" class="c">
         The Postman Alternative Your Team Is Dreaming Of
-      </h2>
+      </scalar-heading>
       <p>
         Fully open-source & offline first API Client built on the OpenAPI standard, by us & our community.
       </p>
@@ -203,9 +203,9 @@ They are open source. So I can get in on free features and stay with Scalar no m
   <div class="product product-reversed">
     <div class="product-copy">
       <span class="font-bold text-blue">Scalar Docs</span>
-      <h2>
+      <scalar-heading level="2" slug="scalar-docs" class="c">
         The Modern Documentation Platform for Your API and Everything Else
-      </h2>
+      </scalar-heading>
       <p>
         Write documentation with our WYSIWYG, pull Markdown and MDX files from your repository or generate API References from your OpenAPI documents. No matter how you work, your new documentation will always be up to date.
       </p>
@@ -250,9 +250,9 @@ They are open source. So I can get in on free features and stay with Scalar no m
   <div class="product">
     <div class="product-copy">
       <span class="font-bold text-purple">Scalar SDK Generation</span>
-      <h2 class="c">
+      <scalar-heading level="2" slug="scalar-sdk-generation" class="c">
         One Commit To Update All Your SDKs
-      </h2>
+      </scalar-heading>
       <p>
         Bring your OpenAPI document and get type-safe client libraries for TypeScript, Python, Golang, PHP, Java and Ruby with more languages coming soon.
       </p>
@@ -333,7 +333,7 @@ They are open source. So I can get in on free features and stay with Scalar no m
   </div>
 </div>
 <div class="cta flex flex-col gap-3 small-test">
-  <h2 class="text-balance">What are you waiting for?</h2>
+  <scalar-heading level="2" class="text-balance" slug="what-are-you-waiting-for">What are you waiting for?</scalar-heading>
   <p>
     We're committed to enabling developers and companies to practice the highest
     of API industry standards.

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -1,7 +1,7 @@
 <div class="flex flex-col gap-3 hero small-test">
-  <h2 class="text-balance">
+  <scalar-heading level="2" slug="pricing" class="text-balance">
     Pricing
-  </h2>
+  </scalar-heading>
   <p>
  One platform for all your API needs: Docs, SDKs, Governance & API Client all based on OpenAPI™. 
   </p>
@@ -44,11 +44,7 @@
           </header>
           <div class="st_wrap_table text-sm" data-table_id="0">
           <div class="pricing-table-group">
-            <header class="pricing-table-group-heading">
-                <h3>
-                Scalar Docs
-                </h3>
-            </header>
+            <header class="pricing-table-group-heading">Scalar Docs</header>
             <div class="pricing-table-row">
               <div class="pricing-table-column">Subdomains</div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
@@ -148,11 +144,7 @@
           </div>
         </div>
         <div class="st_wrap_table" data-table_id="1">
-          <header class="pricing-table-group-heading">
-            <h3>
-              Scalar API Client
-            </h3>
-          </header>
+          <header class="pricing-table-group-heading">Scalar API Client</header>
                     <div class="pricing-table-group">
            <div class="pricing-table-row">
              <div class="pricing-table-column">REST Client</div>
@@ -289,11 +281,7 @@
            </div>
         </div>
         <div class="st_wrap_table" data-table_id="2">
-          <header class="pricing-table-group-heading">
-            <h3>
-              Scalar SDKs
-            </h3>
-          </header>
+          <header class="pricing-table-group-heading">Scalar SDKs</header>
           <div class="pricing-table-group">
             <div class="pricing-table-row">
               <div class="pricing-table-column">TypeScript SDK</div>
@@ -406,11 +394,7 @@
           </div>
         </div>
         <div class="st_wrap_table" data-table_id="3">
-          <header class="pricing-table-group-heading">
-            <h3>
-              Scalar Registry
-            </h3>
-          </header>
+          <header class="pricing-table-group-heading">Scalar Registry</header>
           <div class="pricing-table-group">
             <div class="pricing-table-row">
               <div class="pricing-table-column">OpenAPI, JSON Schema support</div>
@@ -501,7 +485,7 @@
       </main>
     </div>
 <div class="cta flex flex-col gap-3 small-test">
-  <h2 class="text-balance">What are you waiting for?</h2>
+  <scalar-heading level="2" class="text-balance" slug="what-are-you-waiting-for">What are you waiting for?</scalar-heading>
   <p>
     We're committed to enabling developers and companies to practice the highest
     of API industry standards.
@@ -738,13 +722,11 @@ h4.t-editor__heading {
 .pricing-table-group-heading {
     position: sticky;
     top: 228px;
-    background: var(--scalar-background-1)
+    padding: 8px 12px;
+    background: var(--pricing-table-bg);
+    font-weight: var(--scalar-bold);
 }
 .pricing-table-group-heading {
-    padding: 8px 12px;
-    background: var(--pricing-table-bg)
-}
-.pricing-table-group-heading h4 {
     color: var(--scalar-background-1);
     font-size: var(--scalar-font-size-4);
 }

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -2,9 +2,9 @@
   <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/v1Pu6_BCmly6VhPAuotVZ.svg"></scalar-icon>
 </div>
 <div class="flex flex-col gap-3 hero small-test">
-  <h2 class="text-balance">
+  <scalar-heading level="2" slug="scalar-registry" class="text-balance">
     Scalar Registry
-  </h2>
+  </scalar-heading>
   <p>
     Get started with Scalar Registry for managing & versioning OpenAPI Documents, JSON Schema, Spectral Rules as your source of truth with a deep Git integration.
   </p>
@@ -112,7 +112,7 @@ They are open source. So I can get in on free features and stay with Scalar no m
     </div>
   </div>
   <div class="cta flex flex-col gap-3 small-test">
-  <h2 class="text-balance">What are you waiting for?</h2>
+    <scalar-heading level="2" class="text-balance" slug="what-are-you-waiting-for">What are you waiting for?</scalar-heading>
   <p>
     We're committed to enabling developers and companies to practice the highest
     of API industry standards.

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -2,9 +2,9 @@
   <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/v1Pu6_BCmly6VhPAuotVZ.svg"></scalar-icon>
 </div>
 <div class="flex flex-col gap-3 hero small-test">
-  <h2 class="text-balance">
+  <scalar-heading level="2" slug="scalar-sdks" class="text-balance">
     Scalar SDKs
-  </h2>
+  </scalar-heading>
   <p>
     Get started with generating world-class SDKs in minutes on scalar.com in several languages: TypeScript, Python, Golang & more.
   </p>
@@ -115,7 +115,7 @@ They are open source. So I can get in on free features and stay with Scalar no m
     </div>
   </div>
   <div class="cta flex flex-col gap-3 small-test">
-  <h2 class="text-balance">What are you waiting for?</h2>
+    <scalar-heading level="2" class="text-balance" slug="what-are-you-waiting-for">What are you waiting for?</scalar-heading>
   <p>
     We're committed to enabling developers and companies to practice the highest
     of API industry standards.


### PR DESCRIPTION
**Problem**

Currently, we use `<h1>` and `<h2>` for tags, however these are now passed thru as-is.

**Solution**

With this PR these tags are updated to `<scalar-heading>` tags to preserve original behaviour.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `h2` tags with `scalar-heading` across guides and refactors pricing table group headers/stylesheet for consistent styling.
> 
> - **Docs/Guides**:
>   - Replace `h2` with `scalar-heading` (with `level="2"` and `slug`s) in `documentation/guides/docs/getting-started.md`, `documentation/guides/introduction.md`, `documentation/guides/registry/getting-started.md`, and `documentation/guides/sdks/getting-started.md`.
>   - Update CTA headings to `scalar-heading` in affected pages.
> - **Pricing Page (`documentation/guides/pricing.md`)**:
>   - Simplify group header markup: remove nested `h3` and use plain `header.pricing-table-group-heading` text for sections (e.g., "Scalar Docs", "Scalar API Client", "Scalar SDKs", "Scalar Registry").
>   - Consolidate and adjust CSS for `.pricing-table-group-heading` (single rule set, set `background: var(--pricing-table-bg)`, add `font-weight: var(--scalar-bold)`, define color/font-size on the heading selector) and minor sticky/header tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21ea660cb77b49c5384f71ca5604a6188dab1bdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->