### PR TITLE
fix(helpers): `scrollToId` is not an async function

### DIFF
--- a/.changeset/dull-otters-tap.md
+++ b/.changeset/dull-otters-tap.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': patch
+---
+
+fix(helpers): `scrollToId` is not an async function

--- a/packages/helpers/src/dom/scroll-to-id.test.ts
+++ b/packages/helpers/src/dom/scroll-to-id.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { scrollToId } from './scroll-to-id'
 
 describe('scroll-to-id', () => {
+  const getElementByIdSpy = vi.spyOn(document, 'getElementById')
+  const requestAnimationFrameSpy = vi.spyOn(global, 'requestAnimationFrame')
+
   let mockElement: HTMLElement
-  let originalGetElementById: typeof document.getElementById
-  let originalRequestAnimationFrame: typeof requestAnimationFrame
 
   beforeEach(() => {
     // Setup test DOM element
@@ -16,35 +18,27 @@ describe('scroll-to-id', () => {
     mockElement.scrollIntoView = vi.fn()
     mockElement.focus = vi.fn()
 
-    // Store original methods
-    originalGetElementById = document.getElementById
-    originalRequestAnimationFrame = globalThis.requestAnimationFrame
-
     // Mock Date.now for timing tests
     vi.useFakeTimers()
+
+    return () => {
+      document.body.removeChild(mockElement)
+
+      vi.resetAllMocks()
+      vi.useRealTimers()
+    }
   })
 
-  afterEach(() => {
-    document.body.innerHTML = ''
-
-    // Restore original methods
-    document.getElementById = originalGetElementById
-    globalThis.requestAnimationFrame = originalRequestAnimationFrame
-
-    vi.restoreAllMocks()
-    vi.useRealTimers()
-  })
-
-  it('scrolls to element when found immediately', async () => {
-    await scrollToId('test-element')
+  it('scrolls to element when found immediately', () => {
+    scrollToId('test-element')
 
     expect(mockElement.scrollIntoView).toHaveBeenCalledOnce()
   })
 
-  it('retries finding element using requestAnimationFrame', async () => {
+  it('retries finding element using requestAnimationFrame', () => {
     let callCount = 0
 
-    document.getElementById = vi.fn().mockImplementation((id) => {
+    getElementByIdSpy.mockImplementation((id) => {
       callCount++
       if (callCount === 1) {
         return null
@@ -55,46 +49,45 @@ describe('scroll-to-id', () => {
 
     const rafCallbacks: FrameRequestCallback[] = []
 
-    globalThis.requestAnimationFrame = vi.fn((callback) => {
+    requestAnimationFrameSpy.mockImplementation((callback) => {
       rafCallbacks.push(callback)
       return 1
     })
 
-    await scrollToId('test-element')
+    scrollToId('test-element')
 
     rafCallbacks[0]?.(0)
 
-    expect(document.getElementById).toHaveBeenCalledTimes(2)
+    expect(getElementByIdSpy).toHaveBeenCalledTimes(2)
     expect(mockElement.scrollIntoView).toHaveBeenCalledOnce()
   })
 
-  it('stops retrying after 1 second timeout', async () => {
-    document.getElementById = vi.fn().mockReturnValue(null)
+  it('stops retrying after 1 second timeout', () => {
+    getElementByIdSpy.mockReturnValue(null)
 
     let currentTime = 0
     vi.spyOn(Date, 'now').mockImplementation(() => currentTime)
 
     const rafCallbacks: FrameRequestCallback[] = []
 
-    const mockRaf = vi.fn((callback) => {
+    requestAnimationFrameSpy.mockImplementation((callback) => {
       rafCallbacks.push(callback)
       return rafCallbacks.length
     })
-    globalThis.requestAnimationFrame = mockRaf
 
     scrollToId('non-existent-element')
 
     rafCallbacks[0]?.(0)
-    expect(mockRaf).toHaveBeenCalledTimes(2)
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(2)
 
     currentTime = 1001
 
     rafCallbacks[1]?.(0)
-    expect(mockRaf).toHaveBeenCalledTimes(2)
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(2)
   })
 
-  it('handles all parameters correctly', async () => {
-    await scrollToId('test-element', true)
+  it('handles all parameters correctly', () => {
+    scrollToId('test-element', true)
 
     expect(mockElement.scrollIntoView).toHaveBeenCalledOnce()
     expect(mockElement.focus).toHaveBeenCalledOnce()

--- a/packages/helpers/src/dom/scroll-to-id.ts
+++ b/packages/helpers/src/dom/scroll-to-id.ts
@@ -3,7 +3,7 @@
  *
  * Also focuses the element if the focus flag is true
  */
-export const scrollToId = async (id: string, focus?: boolean) => {
+export const scrollToId = (id: string, focus?: boolean): void => {
   const scrollToElement = (element: HTMLElement) => {
     element.scrollIntoView()
     if (focus) {
@@ -23,7 +23,7 @@ export const scrollToId = async (id: string, focus?: boolean) => {
    */
   const stopTime = Date.now() + 1000
 
-  const tryScroll = () => {
+  const tryScroll = (): void => {
     const element = document.getElementById(id)
     if (element) {
       scrollToElement(element)


### PR DESCRIPTION
**Problem**

While [working on enabling the noFloatingPromise rule](https://github.com/scalar/scalar/pull/7060#discussion_r2420757796), 
I discovered that `@scalar/helper#scrollToId` is not an asynchronous function.

> [!NOTE]  
> I'm working on `noFloatingPromise` in another branch and opened this as a separate PR to keep that one cleaner.

**Solution**

Type `scrollToId` as a sync void function.

From a quick search, it seems the consumer of this function never `await`-ed its result, 
so this change should not have a great impact.

I have also updated the test logic to spy on `getElementById` and `requestAnimationFrame` 
in order to simplify setup and execution.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `scrollToId` a synchronous `void` function and refactor tests to remove async/await and use spies for DOM/RAF.
> 
> - **Helpers (`packages/helpers/src/dom/scroll-to-id.ts`)**
>   - Change `scrollToId` signature from `async` to synchronous `void`.
>   - Add explicit `void` return types to `scrollToId` and `tryScroll`.
> - **Tests (`packages/helpers/src/dom/scroll-to-id.test.ts`)**
>   - Remove async/await usage; update tests to call `scrollToId` synchronously.
>   - Use spies for `document.getElementById` and `requestAnimationFrame`; simplify setup/teardown.
>   - Adjust expectations to use the new spies and sync behavior.
> - **Changeset**
>   - Add patch changeset for `@scalar/helpers`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 567c1a8436b1670f7465cc19942f2e5dc3172c75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->