### PR TITLE
docs: add AsyncAPI page

### DIFF
--- a/documentation/asyncapi.md
+++ b/documentation/asyncapi.md
@@ -1,0 +1,13 @@
+# AsyncAPI Specification
+
+We're in the process of adding [AsyncAPI](https://www.asyncapi.com/) support.
+
+You can already load AsyncAPI documents. The rendering is very limited, though:
+
+```js
+Scalar.createApiReference('#app', {
+  url: '/asyncapi.json'
+})
+```
+
+The process is tracked on GitHub in [issue #7080](https://github.com/scalar/scalar/issues/7080). You can subscribe to the issue to receive updates.

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -258,6 +258,11 @@
               "type": "page"
             },
             {
+              "name": "AsyncAPI",
+              "path": "documentation/asyncapi.md",
+              "type": "page"
+            },
+            {
               "name": "Markdown",
               "path": "documentation/markdown.md",
               "type": "page"


### PR DESCRIPTION
This PR adds a tiny AsyncAPI page to the documentation.

I’ll add to the page while we work on the AsyncAPI support.

Just having this page makes it appear in the analytics, so we can see whether there is some interest.