### PR TITLE
ci: push AsyncAPI example to the registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -839,10 +839,10 @@ jobs:
       - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
         name: Push OpenAPI Example to Scalar Registry
         run: npx @scalar/cli registry publish --namespace scalar --slug galaxy --version ${{ env.VERSION }} packages/galaxy/dist/latest.yaml
-      # TODO: The Scalar Registry does not support AsyncAPI yet.
-      # - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
-      #   name: Push AsyncAPI Example to Scalar Registry
-      #   run: npx @scalar/cli registry publish --namespace scalar --slug asyncapi --version ${{ env.VERSION }} packages/galaxy/dist/asyncapi/latest.yaml
+      - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
+        name: Push AsyncAPI Example to Scalar Registry
+        # We're uploading it as a schema, because for documents do not support AsyncAPI yet.
+        run: npx @scalar/cli schema publish --namespace scalar --slug asyncapi --version ${{ env.VERSION }} packages/galaxy/dist/asyncapi/latest.yaml
 
   deploy-examples:
     # Main Branch or PR from the same repository


### PR DESCRIPTION
This PR pushes the new AsyncAPI example to the registry (on release).

For documents we only support OpenAPI, as a workaround we can just use the schemas.

We can replace this whenever we added AsyncAPI support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a CI step to publish the Galaxy AsyncAPI example to the Scalar Registry as a schema on release.
> 
> - **CI Workflow (`.github/workflows/ci.yml`)**:
>   - **Scalar Registry publish**:
>     - Adds step to push `packages/galaxy/dist/asyncapi/latest.yaml` using `npx @scalar/cli schema publish` (uploaded as a schema since documents don’t support AsyncAPI yet).
>     - Removes the previously commented-out AsyncAPI publish block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2afdeb1d9b9053412192b1225c47950839882d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->