### PR TITLE
fix(workspace-store): use `measureSync` for `mergeObjects` metric

### DIFF
--- a/.changeset/tall-spiders-deliver.md
+++ b/.changeset/tall-spiders-deliver.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix(workspace-store): use `measureSync` for `mergeObjects` metric

--- a/packages/helpers/src/testing/measure.test-d.ts
+++ b/packages/helpers/src/testing/measure.test-d.ts
@@ -1,0 +1,21 @@
+import { describe, vi } from 'vitest'
+
+import { measureAsync, measureSync } from './measure'
+
+const asyncFunction = vi.fn<() => Promise<number>>()
+
+describe('measureAsync types', async () => {
+  // works with async methods
+  await measureAsync('test', asyncFunction)
+
+  // @ts-expect-error should error because `fn` doesn't return a Promise
+  await measureAsync('test', () => 1)
+})
+
+describe('measureSync types', () => {
+  // works with sync methods
+  measureSync('test', () => 1)
+
+  // @ts-expect-error should error because `fn` doesn't return a Promise
+  measureSync('test', asyncFunction)
+})

--- a/packages/helpers/src/testing/measure.test.ts
+++ b/packages/helpers/src/testing/measure.test.ts
@@ -1,15 +1,17 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { measureSync, measureAsync } from './measure'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { measureAsync, measureSync } from './measure'
 
 describe('measure', () => {
+  const consoleInfoSpy = vi.spyOn(console, 'info').mockReturnValue(undefined)
   beforeEach(() => {
-    vi.spyOn(console, 'info').mockImplementation(() => {})
+    consoleInfoSpy.mockClear()
   })
 
   it('should measure and log synchronous function execution time', () => {
     const result = measureSync('sync-test', () => 42)
     expect(result).toBe(42)
-    expect(console.info).toHaveBeenCalledWith(expect.stringMatching(/sync-test: \d+ ms/))
+    expect(consoleInfoSpy).toHaveBeenCalledWith(expect.stringMatching(/sync-test: \d+ ms/))
   })
 
   it('should measure and log asynchronous function execution time', async () => {
@@ -18,7 +20,7 @@ describe('measure', () => {
       return 42
     })
     expect(result).toBe(42)
-    expect(console.info).toHaveBeenCalledWith(expect.stringMatching(/async-test: \d+ ms/))
+    expect(consoleInfoSpy).toHaveBeenCalledWith(expect.stringMatching(/async-test: \d+ ms/))
   })
 
   it('should preserve the return type of the measured function', () => {

--- a/packages/helpers/src/testing/measure.ts
+++ b/packages/helpers/src/testing/measure.ts
@@ -12,7 +12,10 @@
  * })
  * ```
  */
-export const measureSync = <T>(name: string, fn: () => T): T => {
+export const measureSync = <F extends () => unknown>(
+  name: string,
+  fn: ReturnType<F> extends Promise<unknown> ? never : F,
+): ReturnType<F> => {
   const start = performance.now()
 
   const result = fn()
@@ -22,7 +25,7 @@ export const measureSync = <T>(name: string, fn: () => T): T => {
 
   console.info(`${name}: ${duration} ms`)
 
-  return result
+  return result as ReturnType<F>
 }
 
 /**

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -614,7 +614,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       const coerced = measureSync('coerceValue', () =>
         coerceValue(OpenAPIDocumentSchemaStrict, deepClone(strictDocument)),
       )
-      measureAsync('mergeObjects', async () => mergeObjects(strictDocument, coerced))
+      measureSync('mergeObjects', () => mergeObjects(strictDocument, coerced))
     }
 
     const isValid = Value.Check(OpenAPIDocumentSchemaStrict, strictDocument)


### PR DESCRIPTION
**Problem**

[Always coming from noFloatingPromises 😅](https://github.com/scalar/scalar/pull/7060#discussion_r2420757796):

`mergeObjects` is a synchronous method it performance time shouldn't be calculated using `measureAsync`

**Solution**

Use `measureSync` to measure `mergeObjects` time.

I have also refined `measureSync` to avoid accepting `async` functions.
To test this I added a `packages/helpers/src/testing/measure.test-d.ts` file that contains only test files.
Its errors should be caught by `types:check` scripts.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation (not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `mergeObjects` timing to `measureSync` and tightens `measureSync` types, adding type/runtime tests.
> 
> - **Workspace Store**:
>   - Use `measureSync` for `mergeObjects` metric in `packages/workspace-store/src/client.ts`.
> - **Helpers/Testing**:
>   - Refine `measureSync` signature in `packages/helpers/src/testing/measure.ts` to disallow async functions and preserve return types.
>   - Add `packages/helpers/src/testing/measure.test-d.ts` for type checks of `measureAsync`/`measureSync` (with `@ts-expect-error` cases).
>   - Update `packages/helpers/src/testing/measure.test.ts` to use a shared `console.info` spy and expectations.
> - **Release**:
>   - Add changeset for `@scalar/workspace-store` (patch).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8900047715a679a9f93540a50ff37f68804c60f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->