### PR TITLE
refactor: enable `noFloatingPromises`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -191,7 +191,9 @@
         "noReExportAll": "warn",
         "noBarrelFile": "warn"
       },
-      "nursery": {}
+      "nursery": {
+        "noFloatingPromises": "warn"
+      }
     }
   },
   "overrides": [

--- a/examples/nestjs/nestjs-api-reference-express/src/main.ts
+++ b/examples/nestjs/nestjs-api-reference-express/src/main.ts
@@ -1,8 +1,8 @@
 import { NestFactory } from '@nestjs/core'
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
-import { AppModule } from './app.module'
-
 import { apiReference } from '@scalar/nestjs-api-reference'
+
+import { AppModule } from './app.module'
 
 const PORT = Number(process.env.PORT || 5056)
 const HOST = process.env.HOST || '0.0.0.0'
@@ -29,4 +29,4 @@ async function bootstrap() {
     console.log(`🦁 NestJS listening at http://${HOST}:${PORT}/reference`)
   })
 }
-bootstrap()
+void bootstrap()

--- a/examples/nestjs/nestjs-api-reference-fastify/src/main.ts
+++ b/examples/nestjs/nestjs-api-reference-fastify/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core'
 import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify'
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 import { apiReference } from '@scalar/nestjs-api-reference'
+
 import { AppModule } from './app.module'
 
 const PORT = Number(process.env.PORT) || 5057
@@ -30,4 +31,4 @@ async function bootstrap() {
     console.log(`🦁 NestJS listening at http://${HOST}:${PORT}/reference`)
   })
 }
-bootstrap()
+void bootstrap()

--- a/integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets/scalar.aspnetcore.test.js
+++ b/integrations/aspnetcore/src/Scalar.AspNetCore/StaticAssets/scalar.aspnetcore.test.js
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { getBasePath, initialize } from './scalar.aspnetcore'
 
 describe('scalar.aspnetcore', () => {
@@ -76,12 +77,12 @@ describe('scalar.aspnetcore', () => {
       vi.clearAllMocks()
     })
 
-    it('transforms URLs to absolute paths when using relative URLs', () => {
+    it('transforms URLs to absolute paths when using relative URLs', async () => {
       const configuration = {
         sources: [{ url: 'swagger.json' }, { url: 'openapi.json' }],
       }
 
-      initialize('/docs', false, configuration)
+      await initialize('/docs', false, configuration)
 
       // Get the configuration object passed to createApiReference
       const normalizedConfig = mockScalar.createApiReference.mock.calls[0][1]
@@ -90,13 +91,13 @@ describe('scalar.aspnetcore', () => {
       expect(mockScalar.createApiReference).toHaveBeenCalledWith('#app', normalizedConfig)
     })
 
-    it('preserves URLs when using absolute paths', () => {
+    it('preserves URLs when using absolute paths', async () => {
       const configuration = {
         sources: [{ url: 'https://foo.bar/swagger.json' }, { url: 'htTP://foo.bar/openapi.json' }],
       }
 
       const originalUrls = configuration.sources.map((s) => s.url)
-      initialize('/docs', false, configuration)
+      await initialize('/docs', false, configuration)
 
       expect(configuration.sources[0].url).toBe(originalUrls[0])
       expect(configuration.sources[1].url).toBe(originalUrls[1])
@@ -107,9 +108,9 @@ describe('scalar.aspnetcore', () => {
       expect(() => initialize('/docs', false, {})).not.toThrow()
     })
 
-    it('handles empty sources array', () => {
+    it('handles empty sources array', async () => {
       const configuration = { sources: [] }
-      initialize('/docs', false, configuration)
+      await initialize('/docs', false, configuration)
       expect(mockScalar.createApiReference).toHaveBeenCalledWith('#app', configuration)
     })
 
@@ -122,12 +123,12 @@ describe('scalar.aspnetcore', () => {
       expect(() => initialize('/docs', false, configuration)).not.toThrow()
     })
 
-    it('handles sources without url property', () => {
+    it('handles sources without url property', async () => {
       const configuration = {
         sources: [{ title: 'Source without URL' }, { url: 'swagger.json' }],
       }
 
-      initialize('/docs', false, configuration)
+      await initialize('/docs', false, configuration)
 
       // Get the normalized config that was passed to createApiReference
       const normalizedConfig = mockScalar.createApiReference.mock.calls[0][1]
@@ -139,23 +140,23 @@ describe('scalar.aspnetcore', () => {
       expect(mockScalar.createApiReference).toHaveBeenCalledWith('#app', normalizedConfig)
     })
 
-    it('sets baseServerURL when useDynamicBaseServerUrl is true', () => {
+    it('sets baseServerURL when useDynamicBaseServerUrl is true', async () => {
       const configuration = {
         sources: [{ url: 'swagger.json' }],
       }
 
-      initialize('/docs', true, configuration)
+      await initialize('/docs', true, configuration)
 
       const normalizedConfig = mockScalar.createApiReference.mock.calls[0][1]
       expect(normalizedConfig.baseServerURL).toBe('https://example.com/api')
     })
 
-    it('does not set baseServerURL when useDynamicBaseServerUrl is false', () => {
+    it('does not set baseServerURL when useDynamicBaseServerUrl is false', async () => {
       const configuration = {
         sources: [{ url: 'swagger.json' }],
       }
 
-      initialize('/docs', false, configuration)
+      await initialize('/docs', false, configuration)
 
       const normalizedConfig = mockScalar.createApiReference.mock.calls[0][1]
       expect(normalizedConfig.baseServerURL).toBeUndefined()

--- a/integrations/fastify/test/exports.test.ts
+++ b/integrations/fastify/test/exports.test.ts
@@ -2,24 +2,21 @@ import Fastify from 'fastify'
 import { describe, expect, it } from 'vitest'
 
 describe('exports', () => {
-  it('ESM export', () =>
-    new Promise((resolve) => {
-      const fastify = Fastify({
-        logger: false,
-      })
+  it('ESM export', async () => {
+    const fastify = Fastify({
+      logger: false,
+    })
 
-      fastify.register(import('../dist/index.js'), {
-        routePrefix: '/foobar',
-        configuration: {
-          url: '/openapi.json',
-        },
-      })
+    fastify.register(import('../dist/index.js'), {
+      routePrefix: '/foobar',
+      configuration: {
+        url: '/openapi.json',
+      },
+    })
 
-      fastify.listen({ port: 0 }, (_err, address) => {
-        fetch(`${address}/foobar`).then((response) => {
-          expect(response.status).toBe(200)
-          resolve(null)
-        })
-      })
-    }))
+    const address = await fastify.listen({ port: 0 })
+
+    const response = await fetch(`${address}/foobar`)
+    expect(response.status).toBe(200)
+  })
 })

--- a/packages/api-client-react/src/ApiClientModalProvider.tsx
+++ b/packages/api-client-react/src/ApiClientModalProvider.tsx
@@ -47,7 +47,7 @@ export const ApiClientModalProvider = ({ children, initialRequest, configuration
       clientStore.setCreateClient(createApiClientModalSync)
     }
     if (!isLoading) {
-      loadApiClientJs()
+      void loadApiClientJs()
     }
   }, [])
 
@@ -74,7 +74,7 @@ export const ApiClientModalProvider = ({ children, initialRequest, configuration
     clientDict[key] = _client
 
     // We update the config as we are using the sync version
-    updateConfig()
+    void updateConfig()
 
     // Ensure we unmount the vue app on unmount
     return () => {

--- a/packages/api-client/playground/app/main.ts
+++ b/packages/api-client/playground/app/main.ts
@@ -2,6 +2,6 @@ import '@/style.css'
 
 import { createApiClientApp } from '@/layouts/App'
 
-createApiClientApp(document.getElementById('scalar-client'), {
+void createApiClientApp(document.getElementById('scalar-client'), {
   proxyUrl: 'https://proxy.scalar.com',
 })

--- a/packages/api-client/playground/web/main.ts
+++ b/packages/api-client/playground/web/main.ts
@@ -2,6 +2,6 @@ import '@/style.css'
 
 import { createApiClientWeb } from '@/layouts/Web'
 
-createApiClientWeb(document.getElementById('scalar-client'), {
+void createApiClientWeb(document.getElementById('scalar-client'), {
   proxyUrl: 'https://proxy.scalar.com',
 })

--- a/packages/api-client/src/layouts/App/create-api-client-app.test.ts
+++ b/packages/api-client/src/layouts/App/create-api-client-app.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { createApiClientApp } from './create-api-client-app'
 import { enableConsoleWarn } from '@/vitest.setup'
+
+import { createApiClientApp } from './create-api-client-app'
 
 describe('createApiClientApp', () => {
   it('renders something', async () => {
@@ -16,7 +17,7 @@ describe('createApiClientApp', () => {
     expect(element).not.toBeNull()
     expect(element.innerHTML).not.toContain('Request')
 
-    createApiClientApp(element, {
+    await createApiClientApp(element, {
       proxyUrl: 'https://proxy.scalar.com',
     })
 

--- a/packages/api-client/src/layouts/Modal/create-api-client-modal.test.ts
+++ b/packages/api-client/src/layouts/Modal/create-api-client-modal.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { createApiClientModal } from './create-api-client-modal'
 import { enableConsoleWarn } from '@/vitest.setup'
+
+import { createApiClientModal } from './create-api-client-modal'
 
 describe('createApiClientModal', () => {
   it('renders something', async () => {
@@ -16,7 +17,7 @@ describe('createApiClientModal', () => {
     expect(element).not.toBeNull()
     expect(element.innerHTML).not.toContain('scalar-app')
 
-    createApiClientModal({
+    await createApiClientModal({
       el: element,
       configuration: {
         proxyUrl: 'https://proxy.scalar.com',

--- a/packages/api-client/src/layouts/Web/create-api-client-web.test.ts
+++ b/packages/api-client/src/layouts/Web/create-api-client-web.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { createApiClientWeb } from './create-api-client-web'
 import { enableConsoleWarn } from '@/vitest.setup'
+
+import { createApiClientWeb } from './create-api-client-web'
 
 describe('createApiClientWeb', () => {
   it('renders the client with no warnings or errors', async () => {
@@ -16,7 +17,7 @@ describe('createApiClientWeb', () => {
     expect(element).not.toBeNull()
     expect(element.innerHTML).not.toContain('App Navigation')
 
-    createApiClientWeb(element, {
+    await createApiClientWeb(element, {
       proxyUrl: 'https://proxy.scalar.com',
     })
     expect(element.innerHTML).toContain('App Navigation')

--- a/packages/api-client/src/libs/create-client.test.ts
+++ b/packages/api-client/src/libs/create-client.test.ts
@@ -1,15 +1,17 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { createApiClient, type CreateApiClientParams, type OpenClientPayload } from './create-client'
-import { createWorkspaceStore, type CreateWorkspaceStoreOptions } from '@/store/store'
-import { createActiveEntitiesStore } from '@/store/active-entities'
-import { createSidebarState } from '@/hooks/useSidebar'
-import { loadAllResources } from '@/libs/local-storage'
 import {
   requestExampleSchema,
   requestSchema,
   securitySchemeSchema,
   serverSchema,
 } from '@scalar/oas-utils/entities/spec'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createSidebarState } from '@/hooks/useSidebar'
+import { loadAllResources } from '@/libs/local-storage'
+import { createActiveEntitiesStore } from '@/store/active-entities'
+import { type CreateWorkspaceStoreOptions, createWorkspaceStore } from '@/store/store'
+
+import { type CreateApiClientParams, type OpenClientPayload, createApiClient } from './create-client'
 
 // Mock dependencies
 vi.mock('@/store/store', () => ({
@@ -182,11 +184,11 @@ describe('createApiClient', () => {
     expect(loadAllResources).toHaveBeenCalled()
   })
 
-  it('should update config and reset store when spec is provided', () => {
+  it('should update config and reset store when spec is provided', async () => {
     const client = createApiClient(defaultParams)
     const mockStore = client.store
 
-    client.updateConfig({
+    await client.updateConfig({
       url: 'https://example.com/openapi.json',
     })
 

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
@@ -277,7 +277,7 @@ describe('oauth', () => {
         },
       } satisfies OAuthFlowsObject
 
-      authorizeOauth2(flows, 'authorizationCode', selectedScopes, mockServer)
+      void authorizeOauth2(flows, 'authorizationCode', selectedScopes, mockServer)
 
       // Test the window.open call for full redirect
       expect(window.open).toHaveBeenCalledWith(

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
@@ -196,6 +196,7 @@ export const authorizeOauth2 = async (
               const _state = new URL(authWindow.location.href).searchParams.get('state')
 
               if (_state === state) {
+                // biome-ignore lint/nursery/noFloatingPromises: output of authorizeServers must be returned
                 authorizeServers(flows, type, scopes, {
                   code,
                   pkce,

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -1,9 +1,9 @@
 import { securityOauthSchema, serverSchema } from '@scalar/oas-utils/entities/spec'
 import { flushPromises } from '@vue/test-utils'
+import { encode } from 'js-base64'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { authorizeOauth2 } from './oauth2'
-import { encode } from 'js-base64'
 
 const baseScheme = {
   uid: 'test-scheme',
@@ -286,7 +286,9 @@ describe('oauth2', () => {
         ...flow,
         'x-scalar-redirect-uri': '/callback',
       } as const
-      authorizeOauth2(_flow, mockServer)
+
+      // voiding since we are testing window.open
+      void authorizeOauth2(_flow, mockServer)
 
       // Test the window.open call for full redirect
       expect(window.open).toHaveBeenCalledWith(

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -1,7 +1,8 @@
-import type { ErrorResponse } from '@/libs/errors'
 import type { Oauth2Flow, Server } from '@scalar/oas-utils/entities/spec'
 import { shouldUseProxy } from '@scalar/oas-utils/helpers'
 import { encode, fromUint8Array } from 'js-base64'
+
+import type { ErrorResponse } from '@/libs/errors'
 
 /** Oauth2 security schemes which are not implicit */
 type NonImplicitFlow = Exclude<Oauth2Flow, { type: 'implicit' }>
@@ -190,6 +191,7 @@ export const authorizeOauth2 = async (
               const _state = new URL(authWindow.location.href).searchParams.get('state')
 
               if (_state === state) {
+                // biome-ignore lint/nursery/noFloatingPromises: output of authorizeServers must be returned
                 authorizeServers(flow as NonImplicitFlow, scopes, {
                   code,
                   pkce,

--- a/packages/build-tooling/src/esbuild/build.ts
+++ b/packages/build-tooling/src/esbuild/build.ts
@@ -1,11 +1,13 @@
 import fs from 'node:fs/promises'
-import { addPackageFileExports, findEntryPoints } from '../helpers'
-import * as esbuild from 'esbuild'
-import chokidar from 'chokidar'
 import path from 'node:path'
+
 import as from 'ansis'
-import { runCommand } from './helpers'
+import chokidar from 'chokidar'
+import * as esbuild from 'esbuild'
 import { glob } from 'glob'
+
+import { addPackageFileExports, findEntryPoints } from '../helpers'
+import { runCommand } from './helpers'
 
 function makeEntryPoints(allowJs?: boolean) {
   const entryPoints = ['src/**/*.ts']
@@ -139,8 +141,8 @@ export async function build({
   console.log(as.blue('[esbuild]: Initial build complete'))
 
   const start = performance.now()
-  runCommand('tsc       -p tsconfig.build.json --watch', 'tsc')
-  runCommand('tsc-alias -p tsconfig.build.json --watch', 'tsc-alias')
+  void runCommand('tsc       -p tsconfig.build.json --watch', 'tsc')
+  void runCommand('tsc-alias -p tsconfig.build.json --watch', 'tsc-alias')
   const end = performance.now()
   console.log(as.blue(`[esbuild]: Types build completed in ${(end - start).toFixed(0)}ms`))
 

--- a/packages/mock-server/playground/esbuild.ts
+++ b/packages/mock-server/playground/esbuild.ts
@@ -1,6 +1,6 @@
 import { build } from '@scalar/build-tooling/esbuild'
 
-build({
+await build({
   entries: ['./src/index.ts'],
   platform: 'shared',
 })

--- a/packages/mock-server/playground/src/galaxy-scalar-com.ts
+++ b/packages/mock-server/playground/src/galaxy-scalar-com.ts
@@ -2,7 +2,6 @@ import { readFile } from 'node:fs/promises'
 
 import { serve } from '@hono/node-server'
 import { Scalar } from '@scalar/hono-api-reference'
-
 import { createMockServer } from '@scalar/mock-server'
 import type { Context } from 'hono'
 
@@ -99,5 +98,5 @@ export async function main(): Promise<void> {
 
 // Start the server when this module is executed directly
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main()
+  void main()
 }

--- a/packages/mock-server/playground/src/index.ts
+++ b/packages/mock-server/playground/src/index.ts
@@ -1,3 +1,3 @@
 import { main } from './galaxy-scalar-com'
 
-main()
+void main()

--- a/packages/mock-server/tests/onRequest.test.ts
+++ b/packages/mock-server/tests/onRequest.test.ts
@@ -1,38 +1,40 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { createMockServer } from '../src/createMockServer'
+import type { MockServerOptions } from '../src/types'
 
 describe('onRequest', () => {
   it('call custom onRequest hook', async () => {
-    return new Promise((resolve) => {
-      const specification = {
-        openapi: '3.1.0',
-        info: {
-          title: 'Hello World',
-          version: '1.0.0',
-        },
-        paths: {
-          '/foobar': {
-            get: {
-              operationId: 'foobar',
-            },
+    const specification = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            operationId: 'foobar',
           },
         },
-      }
+      },
+    }
 
-      createMockServer({
-        specification,
-        onRequest({ context, operation }) {
-          expect(context.req.method).toBe('GET')
-          expect(context.req.path).toBe('/foobar')
+    const onRequestSpy = vi.fn<NonNullable<MockServerOptions['onRequest']>>()
 
-          expect(operation.operationId).toBe('foobar')
-
-          resolve(null)
-        },
-      }).then((server) => {
-        return server.request('/foobar')
-      })
+    const server = await createMockServer({
+      specification,
+      onRequest: onRequestSpy,
     })
+
+    await server.request('/foobar')
+
+    expect(onRequestSpy).toHaveBeenCalledOnce()
+
+    const [{ context, operation }] = onRequestSpy.mock.lastCall!
+    expect(context.req.method).toBe('GET')
+    expect(context.req.path).toBe('/foobar')
+
+    expect(operation.operationId).toBe('foobar')
   })
 })

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -2656,7 +2656,7 @@ describe('create-workspace-store', () => {
       const store = createWorkspaceStore()
 
       // Spy on console.warn
-      store.replaceDocument('non-existing', {
+      void store.replaceDocument('non-existing', {
         openapi: '3.0.0',
         info: {
           title: 'My API',

--- a/packages/workspace-store/src/plugins.test.ts
+++ b/packages/workspace-store/src/plugins.test.ts
@@ -3,7 +3,7 @@ import { setTimeout } from 'node:timers/promises'
 import { bundle } from '@scalar/json-magic/bundle'
 import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
 import { type FastifyInstance, fastify } from 'fastify'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { deepClone } from '@/helpers/general'
 import { externalValueResolver, loadingStatus, refsEverywhere, restoreOriginalRefs } from '@/plugins'
@@ -37,7 +37,7 @@ describe('plugins', () => {
         },
       } as any
 
-      bundle(input, {
+      void bundle(input, {
         plugins: [
           {
             type: 'loader',
@@ -88,7 +88,7 @@ describe('plugins', () => {
 
       const resolveErrored = deferred<null>()
 
-      bundle(input, {
+      void bundle(input, {
         plugins: [
           {
             type: 'loader',
@@ -125,11 +125,11 @@ describe('plugins', () => {
 
     beforeEach(() => {
       server = fastify({ logger: false })
-    })
 
-    afterEach(async () => {
-      await server.close()
-      await setTimeout(100)
+      return async () => {
+        await server.close()
+        await setTimeout(100)
+      }
     })
 
     it('resolves external values', async () => {
@@ -168,11 +168,11 @@ describe('plugins', () => {
 
     beforeEach(() => {
       server = fastify({ logger: false })
-    })
 
-    afterEach(async () => {
-      await server.close()
-      await setTimeout(100)
+      return async () => {
+        await server.close()
+        await setTimeout(100)
+      }
     })
 
     it('inline refs on the info object', async () => {
@@ -244,11 +244,11 @@ describe('plugins', () => {
 
     beforeEach(() => {
       server = fastify({ logger: false })
-    })
 
-    afterEach(async () => {
-      await server.close()
-      await setTimeout(100)
+      return async () => {
+        await server.close()
+        await setTimeout(100)
+      }
     })
 
     it('restores the original references', { timeout: 100000 }, async () => {

--- a/projects/client-scalar-com/src/main.ts
+++ b/projects/client-scalar-com/src/main.ts
@@ -2,6 +2,6 @@ import { createApiClientWeb } from '@scalar/api-client/layouts/Web'
 import '@scalar/api-client/style.css'
 import './style.css'
 
-createApiClientWeb(document.getElementById('scalar-client'), {
+void createApiClientWeb(document.getElementById('scalar-client'), {
   proxyUrl: 'https://proxy.scalar.com',
 })


### PR DESCRIPTION
**Problem**

- https://github.com/scalar/scalar/pull/7060#discussion_r2420757796

**Solution**

This PR enables the `noFloatingPromises` rule with severity set to `warn`.

Currently, on the `main` branch, there are **114** issues reported by this rule.  
All warnings in JavaScript and TypeScript files have been fixed in this PR.  
The remaining **82** issues are located in `*.vue` files.

Most of these are related to the Vue router’s `push` method.

According to the [Vue documentation](https://router.vuejs.org/guide/advanced/navigation-failures), 
it’s recommended to handle the navigation result explicitly.  
Since I’m not very familiar with Vue, I’ve chosen to leave these cases as they are for now.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable Biome `noFloatingPromises` (warn) and update code/tests to properly await or explicitly discard async calls across packages and examples.
> 
> - **Config**:
>   - Enable `linter.nursery.noFloatingPromises: "warn"` in `biome.json`.
> - **Examples/Playgrounds**:
>   - Use `void` on startup calls in `examples/nestjs/*/src/main.ts`, `projects/client-scalar-com/src/main.ts`, and `packages/api-client/playground/*/main.ts`.
>   - Await build in `packages/mock-server/playground/esbuild.ts` and use `void` for `main()` in mock-server playground.
> - **Packages**:
>   - `api-client-react`: prefix async effects with `void` in `ApiClientModalProvider`.
>   - OAuth helpers (`packages/api-client/src/v2/.../oauth.ts`, `packages/api-client/src/views/Request/libs/oauth2.ts`): ensure promise handling; add comments to ignore lints where promises intentionally float.
>   - Build tooling: prefix long-running `runCommand` calls with `void`.
> - **Tests/Integrations**:
>   - Convert Promise wrappers to `async/await` and await async APIs in tests: Fastify export, ASP.NET Core static assets, API client (App/Web/Modal), client creation, OAuth tests, OpenAPI parser, workspace-store, mock-server.
>   - Replace ad-hoc globals with spies (e.g., `fetch`) and improve setup/teardown in tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e328fb9eb37d4484c69a11b75c27501a31c3b3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->