### PR TITLE
chore(api-reference): Add changelog missing from PR

### DIFF
--- a/.changeset/thick-schools-tell.md
+++ b/.changeset/thick-schools-tell.md
@@ -1,0 +1,14 @@
+---
+'@scalar/api-reference': minor
+'@scalar/api-client-react': patch
+'@scalar/workspace-store': patch
+'@scalar/openapi-parser': patch
+'@scalar/api-client': patch
+'@scalar/components': patch
+'scalar-app': patch
+'@scalar/use-hooks': patch
+'@scalar/nuxt': patch
+'@scalar/types': patch
+---
+
+Migrate to workspace store as primary source of truth.

--- a/packages/api-reference/index.html
+++ b/packages/api-reference/index.html
@@ -26,21 +26,6 @@
         // Avoid CORS issues
         proxyUrl: 'https://proxy.scalar.com',
       })
-
-      setTimeout(() => {
-        app.updateConfiguration({
-          sources: [
-            {
-              ...sources[0],
-              content: {
-                ...sources[0].content,
-                info: { ...sources[0].content.info, title: 'LETS GO API' },
-              },
-            },
-            ...sources.slice(1),
-          ],
-        })
-      }, 5000)
     </script>
   </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a changeset bumping multiple packages for the workspace-store migration and removes the delayed demo config update in the API Reference example.
> 
> - **Release / Changeset**:
>   - Add `/.changeset/thick-schools-tell.md` with minor bump for `@scalar/api-reference` and patch bumps for multiple packages, noting migration to workspace store as primary source of truth.
> - **API Reference example**:
>   - Remove delayed `setTimeout` `app.updateConfiguration(...)` block from `packages/api-reference/index.html`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1164fb8b1c01607814ce462083e0f6fe83d1b7ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->