### PR TITLE
chore: downgrade hono to 4.9.10

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ catalogs:
       specifier: ^7.1.0
       version: 7.1.0
     hono:
-      specifier: 4.9.11
-      version: 4.9.11
+      specifier: 4.9.10
+      version: 4.9.10
     js-base64:
       specifier: ^3.7.8
       version: 3.7.8
@@ -927,10 +927,10 @@ importers:
     devDependencies:
       '@hono/node-server':
         specifier: catalog:*
-        version: 1.19.5(hono@4.9.11)
+        version: 1.19.5(hono@4.9.10)
       '@hono/zod-openapi':
         specifier: ^1.1.3
-        version: 1.1.3(hono@4.9.11)(zod@4.1.11)
+        version: 1.1.3(hono@4.9.10)(zod@4.1.11)
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../../packages/build-tooling
@@ -939,7 +939,7 @@ importers:
         version: link:../../packages/openapi-to-markdown
       hono:
         specifier: catalog:*
-        version: 4.9.11
+        version: 4.9.10
       vite:
         specifier: catalog:*
         version: 7.1.5(@types/node@22.15.3)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
@@ -1427,7 +1427,7 @@ importers:
     devDependencies:
       '@hono/node-server':
         specifier: catalog:*
-        version: 1.19.5(hono@4.9.11)
+        version: 1.19.5(hono@4.9.10)
       '@playwright/test':
         specifier: catalog:*
         version: 1.56.0
@@ -1463,7 +1463,7 @@ importers:
         version: 2.4.6
       hono:
         specifier: catalog:*
-        version: 4.9.11
+        version: 4.9.10
       react:
         specifier: catalog:*
         version: 19.1.0
@@ -1542,7 +1542,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:*
-        version: 1.19.5(hono@4.9.11)
+        version: 1.19.5(hono@4.9.10)
       '@scalar/api-reference':
         specifier: workspace:*
         version: link:../..
@@ -1551,7 +1551,7 @@ importers:
         version: 1.8.0
       hono:
         specifier: catalog:*
-        version: 4.9.11
+        version: 4.9.10
       sirv:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1986,11 +1986,11 @@ importers:
         version: link:../openapi-types
       hono:
         specifier: catalog:*
-        version: 4.9.11
+        version: 4.9.10
     devDependencies:
       '@hono/node-server':
         specifier: catalog:*
-        version: 1.19.5(hono@4.9.11)
+        version: 1.19.5(hono@4.9.10)
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../build-tooling
@@ -2274,7 +2274,7 @@ importers:
     devDependencies:
       '@hono/node-server':
         specifier: catalog:*
-        version: 1.19.5(hono@4.9.11)
+        version: 1.19.5(hono@4.9.10)
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../build-tooling
@@ -2292,7 +2292,7 @@ importers:
         version: 2.4.6
       hono:
         specifier: catalog:*
-        version: 4.9.11
+        version: 4.9.10
       vite:
         specifier: catalog:*
         version: 7.1.5(@types/node@22.15.3)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
@@ -2698,13 +2698,13 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:*
-        version: 1.19.5(hono@4.9.11)
+        version: 1.19.5(hono@4.9.10)
       '@scalar/helpers':
         specifier: workspace:*
         version: link:../helpers
       hono:
         specifier: catalog:*
-        version: 4.9.11
+        version: 4.9.10
       js-base64:
         specifier: catalog:*
         version: 3.7.8
@@ -12618,6 +12618,10 @@ packages:
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
+  hono@4.9.10:
+    resolution: {integrity: sha512-AlI15ijFyKTXR7eHo7QK7OR4RoKIedZvBuRjO8iy4zrxvlY5oFCdiRG/V/lFJHCNXJ0k72ATgnyzx8Yqa5arug==}
+    engines: {node: '>=16.9.0'}
 
   hono@4.9.11:
     resolution: {integrity: sha512-MyJ4xop3boTyXl8bJBh4i20AAZTLM3AXUJphyrUb0CpgTKYb1N703z53XiKUKchGUpcPqiiYkiLOXA3kqK3icA==}
@@ -23746,21 +23750,25 @@ snapshots:
       '@tanstack/vue-virtual': 3.8.5(vue@3.5.17(typescript@5.8.3))
       vue: 3.5.17(typescript@5.8.3)
 
+  '@hono/node-server@1.19.5(hono@4.9.10)':
+    dependencies:
+      hono: 4.9.10
+
   '@hono/node-server@1.19.5(hono@4.9.11)':
     dependencies:
       hono: 4.9.11
 
-  '@hono/zod-openapi@1.1.3(hono@4.9.11)(zod@4.1.11)':
+  '@hono/zod-openapi@1.1.3(hono@4.9.10)(zod@4.1.11)':
     dependencies:
       '@asteasolutions/zod-to-openapi': 8.1.0(zod@4.1.11)
-      '@hono/zod-validator': 0.7.3(hono@4.9.11)(zod@4.1.11)
-      hono: 4.9.11
+      '@hono/zod-validator': 0.7.3(hono@4.9.10)(zod@4.1.11)
+      hono: 4.9.10
       openapi3-ts: 4.5.0
       zod: 4.1.11
 
-  '@hono/zod-validator@0.7.3(hono@4.9.11)(zod@4.1.11)':
+  '@hono/zod-validator@0.7.3(hono@4.9.10)(zod@4.1.11)':
     dependencies:
-      hono: 4.9.11
+      hono: 4.9.10
       zod: 4.1.11
 
   '@humanfs/core@0.19.1': {}
@@ -33029,6 +33037,8 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
+
+  hono@4.9.10: {}
 
   hono@4.9.11: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,7 +52,7 @@ catalogs:
     fastify: ^5.3.3
     flatted: ^3.3.3
     fuse.js: ^7.1.0
-    hono: 4.9.11
+    hono: 4.9.10
     js-base64: ^3.7.8
     microdiff: ^1.5.0
     nanoid: 5.1.5


### PR DESCRIPTION
**Problem**

Docker build failing:

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for hono@4.9.11 while fetching it from https://registry.npmjs.org/
--
  |  
  | This error happened while installing a direct dependency of /app/packages/mock-server/playground
  |  
  | The latest release of hono is "4.9.12".
  |  
  | Other releases are:
  | * v4: 4.0.0-rc.4
  | * next: 4.5.0-rc.2
```

which isn’t true, but it’s blocked by our "min 1 week old releases" setting, so we need to pick a minor version that’s a few days older.

I wonder why that didn’t happen locally, but anyway:

**Solution**

This PR goes back in time just a bit.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Downgrades Hono to 4.9.10 across the workspace and lockfile, aligning @hono/* packages to match.
> 
> - **Dependencies**:
>   - Downgrade `hono` from `4.9.11` to `4.9.10` in `pnpm-workspace.yaml` catalog and multiple lockfile entries.
>   - Align related packages to `hono@4.9.10`, including `@hono/node-server`, `@hono/zod-openapi`, and `@hono/zod-validator` across integrations and packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dc2b87a43f1e8465fe4923d725436a5986f56a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->