### PR TITLE
ci: use @scalar/cli@latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -835,14 +835,14 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
         name: Login to Scalar Registry
-        run: npx @scalar/cli auth login --token ${{ secrets.SCALAR_API_KEY }}
+        run: npx @scalar/cli@latest auth login --token ${{ secrets.SCALAR_API_KEY }}
       - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
         name: Push OpenAPI Example to Scalar Registry
-        run: npx @scalar/cli registry publish --namespace scalar --slug galaxy --version ${{ env.VERSION }} packages/galaxy/dist/latest.yaml
+        run: npx @scalar/cli@latest registry publish --namespace scalar --slug galaxy --version ${{ env.VERSION }} packages/galaxy/dist/latest.yaml
       - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
         name: Push AsyncAPI Example to Scalar Registry
         # We're uploading it as a schema, because for documents do not support AsyncAPI yet.
-        run: npx @scalar/cli schema publish --namespace scalar --slug asyncapi --version ${{ env.VERSION }} packages/galaxy/dist/asyncapi/latest.yaml
+        run: npx @scalar/cli@latest schema publish --namespace scalar --slug asyncapi --version ${{ env.VERSION }} packages/galaxy/dist/asyncapi/latest.yaml
 
   deploy-examples:
     # Main Branch or PR from the same repository


### PR DESCRIPTION
publishing the registry failed because CI was using an outdated version of the CLI, we need to use @latest

ideally, we wouldn’t need that going forward, because we keep backwards compatibility at least for a bit, but we’re here now so this is the fix

```
Run npx @scalar/cli registry publish --namespace scalar --slug galaxy --version 0.5.9 packages/galaxy/dist/latest.yaml
25l
New version available! Run `scalar upgrade` to install the latest version


25l25hZod Schema Error
25h  Path: email 
  Error: Required
  Path: projects 
  Error: Required
25l[ERROR] An error occurred when fetching your team.

Zod validation failure


25l25h
25h
Error: Process completed wit
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Scalar Registry auth and publish steps to `npx @scalar/cli@latest` in the CI workflow.
> 
> - **CI Workflow (`.github/workflows/ci.yml`)**:
>   - **push-to-scalar-registry**:
>     - Use `npx @scalar/cli@latest` for:
>       - `auth login`
>       - `registry publish` (OpenAPI)
>       - `schema publish` (AsyncAPI)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f059793cd16701ac522c4bd3b1ee9d802a40f855. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->