### PR TITLE
docs: tweak quotes

### DIFF
--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -75,24 +75,35 @@
   <div class="flex flex-wrap quotes-container">
     <div class="quotes-item">
       <p>
-        <b>"After years of helping enterprises implement API strategies at SmartBear, I can confidently say Scalar is what the industry has been waiting for.</b> The strict OpenAPI compliance, robust CLI/API registry, and seamless CI/CD integration solve the exact pain points I watched customers struggle with daily. This is the modern API platform developers deserve."
+        <strong>“After years of helping enterprises implement API strategies at SmartBear, I can confidently say Scalar is what the industry has been waiting for.</strong>
       </p>
-      <p class="mt-3 text-c-3">Michael - Former Solutions Architect @ Smartbear</p>
+      <p>
+        The strict OpenAPI compliance, robust CLI/API registry, and seamless CI/CD integration solve the exact pain points I watched customers struggle with daily. This is the modern API platform developers deserve.”
+      </p>
+      <p class="text-c-3">
+        Michael, Former Solutions Architect @ Smartbear
+      </p>
     </div>
     <div class="quotes-item">
       <p>
-        "One of my most recent favorites is a in-browser ad hoc testing UI called Scalar.
-One of the things that I really love about Scalar, it's got this modern UI experience, and it provides <b>built-in test generation code for a variety of targets, from cURL to HttpClient in C#.</b>"
+        “One of my most recent favorites is a in-browser ad hoc testing UI called Scalar.
       </p>
-      <p class="mt-3 text-c-3">Captain Safia - Engineer @ Microsoft ASP.NET</p>
+      <p>
+        One of the things that I really love about Scalar, it's got this modern UI experience, and it provides <b>built-in test generation code for a variety of targets, from cURL to HttpClient in C#.</b>”
+      </p>
+      <p class="text-c-3">Captain Safia, Engineer @ Microsoft ASP.NET</p>
     </div>
     <div class="quotes-item">
       <p>
-        "Scalar's "golden ticket" is... Scalar!
-<b>They are (in my own words) building a product ecosystem for API design, docs, testing, and governance-</b> with offerings at every price point.
-They are open source. So I can get in on free features and stay with Scalar no matter how big my API needs blow up."
+        “Scalar's ‘golden ticket’ is… Scalar!
       </p>
-      <p class="mt-3 text-c-3">Eron - Documentation Engineer @ Qrvey</p>
+      <p>
+        <strong>They are (in my own words) building a product ecosystem for API design, docs, testing, and governance</strong> – with offerings at every price point.
+      </p>
+      <p>
+        They are open source. So I can get in on free features and stay with Scalar no matter how big my API needs blow up.”
+      </p>
+      <p class="text-c-3">Eron, Documentation Engineer @ Qrvey</p>
     </div>
   </div>
 </div>
@@ -689,6 +700,10 @@ They are open source. So I can get in on free features and stay with Scalar no m
   .quotes-item {
     flex: 0 0 calc(50% - 22px);
   }
+  .quotes-item p {
+    margin-bottom: 10px;
+  }
+
   /* new stuff  */
   .expander {
     display: grid;


### PR DESCRIPTION
**Changes**

* added paragraphs to the HTML where the text plain text had breaks already
* proper use of double and single quotes
* some spacing between paragraphs

**Before**

<img width="1023" height="608" alt="Screenshot 2025-10-15 at 13 06 42" src="https://github.com/user-attachments/assets/fc5032cf-3a2f-4b5f-9590-74a26dbc6b93" />

**After**

<img width="1061" height="637" alt="Screenshot 2025-10-15 at 13 06 32" src="https://github.com/user-attachments/assets/ae7dc8dc-b183-4ff0-bbb6-9e711a55e9b1" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the testimonials in `documentation/guides/introduction.md` into multiple paragraphs with semantic emphasis and proper quotes, and adds spacing via CSS.
> 
> - **Docs (Introduction page)**
>   - **Testimonials markup**: Split long quote blocks into multiple `p` elements; replace `b` with `strong`; use typographic quotes; normalize attributions (e.g., `Michael, Former Solutions Architect @ Smartbear`).
> - **Styles**
>   - Add `margin-bottom` spacing for `p` inside `.quotes-item` via `.quotes-item p { margin-bottom: 10px; }`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f182d716f262603e77a24d3ea8a89c1e544ecd60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->