### PR TITLE
docs: Scalar not scalar

### DIFF
--- a/documentation/integrations/aspnetcore/legacy-integration.md
+++ b/documentation/integrations/aspnetcore/legacy-integration.md
@@ -29,7 +29,7 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     // Enable the endpoint for generating the OpenAPI documents
     app.UseSwagger();
 
-    // Required for serving static scalar files
+    // Required for serving static Scalar files
     app.UseStaticFiles();
 
     // Other middleware

--- a/documentation/integrations/nuxt.md
+++ b/documentation/integrations/nuxt.md
@@ -16,8 +16,7 @@ That's it! You can now use @scalar/nuxt in your Nuxt app ✨
 
 ## Configuration
 
-If you are using nuxt server routes you can enable scalar simply by enabling openAPI in the nitro
-config in your nuxt.config.ts
+If you are using nuxt server routes you can enable Scalar simply by enabling openAPI in the nitro config in your nuxt.config.ts
 
 ```ts
 export default defineNuxtConfig({

--- a/documentation/integrations/spring-boot.md
+++ b/documentation/integrations/spring-boot.md
@@ -82,7 +82,7 @@ To enable actuator support, add the following configuration:
 # Enable actuator support
 scalar.actuatorEnabled=true
 
-# Expose the scalar endpoint
+# Expose the Scalar endpoint
 management.endpoints.web.exposure.include=scalar
 ```
 
@@ -177,7 +177,7 @@ spring.autoconfigure.exclude=com.scalar.maven.webjar.ScalarAutoConfiguration
 
 | Property                       | Default                                                              | Description                                                                                                                                                      |
 | ------------------------------ | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scalar.enabled`               | `false`                                                               | Enable or disable the Scalar API reference                                                                                                                       |
+| `scalar.enabled`               | `false`                                                              | Enable or disable the Scalar API reference                                                                                                                       |
 | `scalar.path`                  | `/scalar`                                                            | Path where the API reference will be available                                                                                                                   |
 | `scalar.url`                   | `https://registry.scalar.com/@scalar/apis/galaxy/latest?format=json` | URL of your OpenAPI document                                                                                                                                     |
 | `scalar.showSidebar`           | `true`                                                               | Whether the sidebar should be shown                                                                                                                              |


### PR DESCRIPTION
let’s write about Scalar, not about scalar

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Capitalizes “Scalar” in ASP.NET Core, Nuxt, and Spring Boot integration docs, with a minor table formatting tweak.
> 
> - **Documentation (integrations)**:
>   - `documentation/integrations/aspnetcore/legacy-integration.md`: Update comment to “Scalar” in middleware section.
>   - `documentation/integrations/nuxt.md`: Capitalize “Scalar” and streamline config sentence.
>   - `documentation/integrations/spring-boot.md`:
>     - Capitalize “Scalar” in actuator exposure comment.
>     - Minor table formatting adjustment for `scalar.enabled` default cell.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76c343b8e4a29ced6bc8c5a881b6337bffb788f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->