### PR TITLE
docs: clean up the footer

### DIFF
--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -279,7 +279,6 @@ They are open source. So I can get in on free features and stay with Scalar no m
         <div class="w-1/3 flex flex-col gap-2">
           <b>Company</b>
           <a class="text-c-2 hover:text-c-1 font-normal" href="mailto:support@scalar.com" target="_blank">Support</a>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/changelog" target="_blank">Changelog</a>
           <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/terms-and-conditions" target="_blank">Terms of Service</a>
           <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/privacy-policy" target="_blank">Privacy Policy</a>
         </div>

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -443,7 +443,6 @@ They are open source. So I can get in on free features and stay with Scalar no m
         <div class="w-1/3 flex flex-col gap-2">
           <b>Company</b>
           <a class="text-c-2 hover:text-c-1 font-normal" href="mailto:support@scalar.com" target="_blank">Support</a>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/changelog" target="_blank">Changelog</a>
           <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/terms-and-conditions" target="_blank">Terms of Service</a>
           <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/privacy-policy" target="_blank">Privacy Policy</a>
         </div>

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -595,7 +595,6 @@
         <div class="w-1/3 flex flex-col gap-2">
           <b>Company</b>
           <a class="text-c-2 hover:text-c-1 font-normal" href="mailto:support@scalar.com" target="_blank">Support</a>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/changelog" target="_blank">Changelog</a>
           <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/terms-and-conditions" target="_blank">Terms of Service</a>
           <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/privacy-policy" target="_blank">Privacy Policy</a>
         </div>

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -251,7 +251,6 @@ They are open source. So I can get in on free features and stay with Scalar no m
         <div class="w-1/3 flex flex-col gap-2">
           <b>Company</b>
           <a class="text-c-2 hover:text-c-1 font-normal" href="mailto:support@scalar.com" target="_blank">Support</a>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/changelog" target="_blank">Changelog</a>
           <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/terms-and-conditions" target="_blank">Terms of Service</a>
           <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/privacy-policy" target="_blank">Privacy Policy</a>
         </div>

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -254,7 +254,6 @@ They are open source. So I can get in on free features and stay with Scalar no m
         <div class="w-1/3 flex flex-col gap-2">
           <b>Company</b>
           <a class="text-c-2 hover:text-c-1 font-normal" href="mailto:support@scalar.com" target="_blank">Support</a>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/changelog" target="_blank">Changelog</a>
           <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/terms-and-conditions" target="_blank">Terms of Service</a>
           <a class="text-c-2 hover:text-c-1 font-normal" href="https://scalar.com/privacy-policy" target="_blank">Privacy Policy</a>
         </div>


### PR DESCRIPTION
* removed the Changelog, we didn’t update it in a while
* removed Agent Scalar link (we can add a product page, but we don't need to point to the subdomain yet)
* Twitter not twitter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes Agent Scalar and Changelog links from footers, corrects Twitter label capitalization, and makes minor whitespace/CSS cleanups on the pricing page.
> 
> - **Docs footers** (in `documentation/guides/**`):
>   - Remove `Agent Scalar` link under `Products`.
>   - Remove `Changelog` link under `Company`.
>   - Correct social link label to `x (formerly Twitter)`.
> - **Pricing page** (`documentation/guides/pricing.md`):
>   - Trim trailing spaces and normalize CSS formatting (whitespace/braces).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07ab91b5615eb807a98c132d748dfe1e2795d577. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->