### PR TITLE
fix: docker build fails because of hono version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ catalogs:
       specifier: ^7.1.0
       version: 7.1.0
     hono:
-      specifier: 4.9.10
-      version: 4.9.10
+      specifier: 4.9.11
+      version: 4.9.11
     js-base64:
       specifier: ^3.7.8
       version: 3.7.8
@@ -425,7 +425,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@22.15.3)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.1.4(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@22.15.3)(typescript@5.8.3)))(typescript@5.8.3)
       ts-loader:
         specifier: ^9.4.3
         version: 9.5.1(typescript@5.8.3)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.15)))
@@ -498,7 +498,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.4(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@22.15.3)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.1.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@22.15.3)(typescript@5.8.3)))(typescript@5.8.3)
       ts-loader:
         specifier: ^9.4.3
         version: 9.5.1(typescript@5.8.3)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.15)))
@@ -927,10 +927,10 @@ importers:
     devDependencies:
       '@hono/node-server':
         specifier: catalog:*
-        version: 1.19.5(hono@4.9.10)
+        version: 1.19.5(hono@4.9.11)
       '@hono/zod-openapi':
         specifier: ^1.1.3
-        version: 1.1.3(hono@4.9.10)(zod@4.1.11)
+        version: 1.1.3(hono@4.9.11)(zod@4.1.11)
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../../packages/build-tooling
@@ -939,7 +939,7 @@ importers:
         version: link:../../packages/openapi-to-markdown
       hono:
         specifier: catalog:*
-        version: 4.9.10
+        version: 4.9.11
       vite:
         specifier: catalog:*
         version: 7.1.5(@types/node@22.15.3)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
@@ -1430,7 +1430,7 @@ importers:
     devDependencies:
       '@hono/node-server':
         specifier: catalog:*
-        version: 1.19.5(hono@4.9.10)
+        version: 1.19.5(hono@4.9.11)
       '@playwright/test':
         specifier: catalog:*
         version: 1.56.0
@@ -1466,7 +1466,7 @@ importers:
         version: 2.4.6
       hono:
         specifier: catalog:*
-        version: 4.9.10
+        version: 4.9.11
       react:
         specifier: catalog:*
         version: 19.1.0
@@ -1545,7 +1545,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:*
-        version: 1.19.5(hono@4.9.10)
+        version: 1.19.5(hono@4.9.11)
       '@scalar/api-reference':
         specifier: workspace:*
         version: link:../..
@@ -1554,7 +1554,7 @@ importers:
         version: 1.8.0
       hono:
         specifier: catalog:*
-        version: 4.9.10
+        version: 4.9.11
       sirv:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1989,11 +1989,11 @@ importers:
         version: link:../openapi-types
       hono:
         specifier: catalog:*
-        version: 4.9.10
+        version: 4.9.11
     devDependencies:
       '@hono/node-server':
         specifier: catalog:*
-        version: 1.19.5(hono@4.9.10)
+        version: 1.19.5(hono@4.9.11)
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../build-tooling
@@ -2277,7 +2277,7 @@ importers:
     devDependencies:
       '@hono/node-server':
         specifier: catalog:*
-        version: 1.19.5(hono@4.9.10)
+        version: 1.19.5(hono@4.9.11)
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../build-tooling
@@ -2295,7 +2295,7 @@ importers:
         version: 2.4.6
       hono:
         specifier: catalog:*
-        version: 4.9.10
+        version: 4.9.11
       vite:
         specifier: catalog:*
         version: 7.1.5(@types/node@22.15.3)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
@@ -2701,13 +2701,13 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:*
-        version: 1.19.5(hono@4.9.10)
+        version: 1.19.5(hono@4.9.11)
       '@scalar/helpers':
         specifier: workspace:*
         version: link:../helpers
       hono:
         specifier: catalog:*
-        version: 4.9.10
+        version: 4.9.11
       js-base64:
         specifier: catalog:*
         version: 3.7.8
@@ -12621,10 +12621,6 @@ packages:
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
-
-  hono@4.9.10:
-    resolution: {integrity: sha512-AlI15ijFyKTXR7eHo7QK7OR4RoKIedZvBuRjO8iy4zrxvlY5oFCdiRG/V/lFJHCNXJ0k72ATgnyzx8Yqa5arug==}
-    engines: {node: '>=16.9.0'}
 
   hono@4.9.11:
     resolution: {integrity: sha512-MyJ4xop3boTyXl8bJBh4i20AAZTLM3AXUJphyrUb0CpgTKYb1N703z53XiKUKchGUpcPqiiYkiLOXA3kqK3icA==}
@@ -23753,25 +23749,21 @@ snapshots:
       '@tanstack/vue-virtual': 3.8.5(vue@3.5.17(typescript@5.8.3))
       vue: 3.5.17(typescript@5.8.3)
 
-  '@hono/node-server@1.19.5(hono@4.9.10)':
-    dependencies:
-      hono: 4.9.10
-
   '@hono/node-server@1.19.5(hono@4.9.11)':
     dependencies:
       hono: 4.9.11
 
-  '@hono/zod-openapi@1.1.3(hono@4.9.10)(zod@4.1.11)':
+  '@hono/zod-openapi@1.1.3(hono@4.9.11)(zod@4.1.11)':
     dependencies:
       '@asteasolutions/zod-to-openapi': 8.1.0(zod@4.1.11)
-      '@hono/zod-validator': 0.7.3(hono@4.9.10)(zod@4.1.11)
-      hono: 4.9.10
+      '@hono/zod-validator': 0.7.3(hono@4.9.11)(zod@4.1.11)
+      hono: 4.9.11
       openapi3-ts: 4.5.0
       zod: 4.1.11
 
-  '@hono/zod-validator@0.7.3(hono@4.9.10)(zod@4.1.11)':
+  '@hono/zod-validator@0.7.3(hono@4.9.11)(zod@4.1.11)':
     dependencies:
-      hono: 4.9.10
+      hono: 4.9.11
       zod: 4.1.11
 
   '@humanfs/core@0.19.1': {}
@@ -33040,8 +33032,6 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
-
-  hono@4.9.10: {}
 
   hono@4.9.11: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,7 @@ minimumReleaseAgeExclude:
   - vue
   - vite-node
   - vitest
+  - hono
 
 catalogs:
   '*':
@@ -52,7 +53,7 @@ catalogs:
     fastify: ^5.3.3
     flatted: ^3.3.3
     fuse.js: ^7.1.0
-    hono: 4.9.10
+    hono: 4.9.11
     js-base64: ^3.7.8
     microdiff: ^1.5.0
     nanoid: 5.1.5


### PR DESCRIPTION
I’m a simple man, I want to use hono.

The docker build still fails, because @hono/node-server has a very fresh release of hono as a peer dep.

I think it’s okay, and we should just allow fresh releases for the big players (vue, react, hono …).

If those actually have security issues, they are probably fixed in minutes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades hono to 4.9.11 across the workspace and lockfile, aligns related @hono packages, and adds hono to minimumReleaseAgeExclude.
> 
> - **Dependencies**:
>   - Bump `hono` to `4.9.11` across workspace and lockfile.
>   - Align `@hono/node-server`, `@hono/zod-openapi`, and `@hono/zod-validator` to the new `hono` peer version.
> - **Workspace/Tooling**:
>   - Add `hono` to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`.
>   - Update catalogs to pin `hono` to `4.9.11`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62381e9b43d398e81fddac276f52a575c8eb887c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->