### PR TITLE
fix(api-client): remove `async` from `convertPostmanToOpenApi`

### DIFF
--- a/.changeset/curvy-gifts-sell.md
+++ b/.changeset/curvy-gifts-sell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): remove `async` from `convertPostmanToOpenApi`

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
@@ -80,7 +80,7 @@ const { open: openSpecFileDialog } = useFileDialog({
         try {
           if (isPostmanCollection(text)) {
             const workspace = await importSpecFile(
-              await convertPostmanToOpenApi(text),
+              convertPostmanToOpenApi(text),
               activeWorkspace.value?.uid ?? '',
             )
             navigateToCollectionPage(workspace?.collection)
@@ -151,7 +151,7 @@ async function importCollection() {
     } else if (isInputDocument.value) {
       if (isPostmanCollection(inputContent.value)) {
         const workspace = await importSpecFile(
-          await convertPostmanToOpenApi(inputContent.value),
+          convertPostmanToOpenApi(inputContent.value),
           activeWorkspace.value?.uid ?? '',
         )
         navigateToCollectionPage(workspace?.collection)

--- a/packages/api-client/src/libs/postman.ts
+++ b/packages/api-client/src/libs/postman.ts
@@ -13,7 +13,7 @@ export function isPostmanCollection(content: string): boolean {
 }
 
 /** Converts a Postman collection JSON string to an OpenAPI JSON string */
-export async function convertPostmanToOpenApi(postmanJson: string): Promise<string> {
+export function convertPostmanToOpenApi(postmanJson: string): string {
   try {
     const postmanCollection = JSON.parse(postmanJson)
     const openApiDoc = convert(postmanCollection)


### PR DESCRIPTION
**Problem**

[Another small change related to `useAwait` rule](https://github.com/scalar/scalar/pull/7091#discussion_r2429906517):

`convertPostmanToOpenApi` in `api-client` doesn't contain asynchronous code.

**Solution**

Make `convertPostmanToOpenApi` a synchronous function.

> [!NOTE]
> Quick update on the ongoing work for the `useAwait` rule:
>
> I still have 259 errors left to fix (down from the original 321).

Since this might take a bit longer, here’s how I plan to continue the work:

All notable changes so far are related to test files and build scripts, no modifications to source files yet.  
You can follow the progress on this [branch](https://github.com/marcalexiei/scalar/tree/use-await).

- Whenever I need to modify user-facing code, I open a separate PR to keep this branch focused and avoid an overwhelming number of changesets.  
- I’m regularly rebasing the branch on `main` to stay up to date and minimize potential merge conflicts.

If you’d like me to adjust anything or take a different approach, please let me know, thanks!


**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature (Not needed).
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `convertPostmanToOpenApi` synchronous and update its usages in the command palette import flow.
> 
> - **API Client**
>   - **Libs**: `packages/api-client/src/libs/postman.ts`
>     - Change `convertPostmanToOpenApi` from `async` to synchronous (`Promise<string>` -> `string`).
>   - **UI Import Flow**: `packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue`
>     - Update calls to `convertPostmanToOpenApi(...)` to remove unnecessary `await` in file and input import paths.
> - **Changeset**: Add patch entry for `@scalar/api-client` noting the sync conversion change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90228a935bd5bda0f3e2de493f4f11e3f542f1a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->