### PR TITLE
fix(examples/web): remove broken `api-reference` link

### DIFF
--- a/examples/web/src/pages/StartPage.vue
+++ b/examples/web/src/pages/StartPage.vue
@@ -29,12 +29,6 @@ const inDevelopment = import.meta.env.DEV
           and whistles.
         </template>
       </PageLink>
-      <PageLink to="api-reference">
-        <template #title>Basic API Reference</template>
-        <template #description>
-          The customizable API documentation, pretty bare bones if you ask me.
-        </template>
-      </PageLink>
       <PageLink to="classic-api-reference">
         <template #title>API Reference (Classic Layout)</template>
         <template #description>


### PR DESCRIPTION
**Problem**

- Found while opening https://github.com/scalar/scalar/discussions/7113

The `example:web` homepage is blank to a due error involving a missing match in Vue `RouterLink`:

<img width="596" height="337" alt="image" src="https://github.com/user-attachments/assets/c7cb43a7-e999-4260-8a65-cc84ab6386ff" />

---

`examples/web/src/routes.ts` seems to not contain any `api-reference` link:

https://github.com/scalar/scalar/blob/d1934c231bdc09544d79f75f046a61ec47a0c6ef/examples/web/src/routes.ts#L7-L33

**Solution**

Remove the link from `StartPage` component

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`) (Not needed).
- [x] I've added tests for the regression or new feature (N/A).
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the broken `api-reference` link from `examples/web/src/pages/StartPage.vue`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efce061d5ec5a407481b4327bb47c965d9912357. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->