### PR TITLE
feat(sveltekit): make `ScalarApiReference` return a synchronous route handler

### DIFF
--- a/.changeset/tall-beans-kneel.md
+++ b/.changeset/tall-beans-kneel.md
@@ -1,0 +1,5 @@
+---
+'@scalar/sveltekit': patch
+---
+
+feat(sveltekit): make `ScalarApiReference` return a synchronous route handler

--- a/examples/sveltekit/src/routes/+server.ts
+++ b/examples/sveltekit/src/routes/+server.ts
@@ -1,4 +1,5 @@
 import { ScalarApiReference } from '@scalar/sveltekit'
+
 import type { RequestHandler } from './$types'
 
 const handler = ScalarApiReference({

--- a/integrations/sveltekit/src/scalar-api-reference.ts
+++ b/integrations/sveltekit/src/scalar-api-reference.ts
@@ -15,19 +15,18 @@ const DEFAULT_CONFIGURATION: Partial<ApiReferenceConfiguration> = {
  *
  * {@link https://github.com/scalar/scalar/tree/main/documentation/configuration.md Configuration}
  */
-export const ScalarApiReference = (givenConfiguration: Partial<ApiReferenceConfiguration>) => {
+export const ScalarApiReference = (givenConfiguration: Partial<ApiReferenceConfiguration>): (() => Response) => {
   // Merge the defaults
-  const configuration = {
+  const configuration: Partial<ApiReferenceConfiguration> = {
     ...DEFAULT_CONFIGURATION,
     ...givenConfiguration,
-  } satisfies Partial<ApiReferenceConfiguration>
+  }
 
-  return async () => {
-    return new Response(getHtmlDocument(configuration, customTheme), {
+  return () => {
+    const referenceDocument = getHtmlDocument(configuration, customTheme)
+    return new Response(referenceDocument, {
       status: 200,
-      headers: {
-        'Content-Type': 'text/html',
-      },
+      headers: { 'Content-Type': 'text/html' },
     })
   }
 }


### PR DESCRIPTION
**Problem**

[Another small change related to `useAwait` rule](https://github.com/scalar/scalar/pull/7091#discussion_r2429906517):

Same as #7105

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.\
        (Tested via `pnpm --filter="@scalar-examples/sveltekit" run dev`)
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `ScalarApiReference` return a synchronous `() => Response` and update the SvelteKit example; add changeset (patch).
> 
> - **SvelteKit Integration (`integrations/sveltekit/src/scalar-api-reference.ts`)**:
>   - Change `ScalarApiReference` to return a synchronous `() => Response` (remove `async`).
>   - Compute `referenceDocument` before `Response` creation; keep `Content-Type: text/html`.
>   - Tighten typing with explicit `Partial<ApiReferenceConfiguration>`.
> - **Example (`examples/sveltekit/src/routes/+server.ts`)**:
>   - Use new synchronous handler for `GET` route.
> - **Release**:
>   - Add changeset marking a patch for `@scalar/sveltekit`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82852d6e24362e1a4d651318b14d63adfd6f4b19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->