### PR TITLE
fix(fastify-api-reference): account from plugin prefix in redirect without trailing slash

### DIFF
--- a/.changeset/nice-items-tie.md
+++ b/.changeset/nice-items-tie.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix(fastify-api-reference): account from plugin prefix in redirect without trailing slash


### PR DESCRIPTION
**Problem**

- closes #7126 

**Solution**

- Use complete route path when redirecting from the route without trailing slash
- Use 301 HTTP status code when redirect from route without trailing slash
- Remove unneeded `@ts-ignore`

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use full request URL to 301-redirect non-trailing-slash routes (respecting plugin prefix), update tests, and clean up types/comments.
> 
> - **Fastify plugin (`integrations/fastify/src/fastifyApiReference.ts`)**:
>   - **Redirects**: Use `request.url`/`request.protocol`/`request.hostname` to build path and 301-redirect from non-trailing-slash routes, accounting for plugin `prefix`.
>   - **Trailing-slash route**: Use `request.routerPath` to detect and redirect; switch handlers to receive `request`.
>   - **Types/Docs**: Replace `@ts-ignore` with `@ts-expect-error` where applicable and expand schema documentation comments.
> - **Tests (`integrations/fastify/src/fastifyApiReference.test.ts`)**:
>   - Update expected redirect status to 301 and location.
>   - Add test to verify redirects respect plugin `prefix`.
>   - Import `FastifyPluginAsync`; replace `@ts-ignore` with `@ts-expect-error`.
> - **Changeset**: Add patch notes for `@scalar/fastify-api-reference`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 705224fbff5a92a244889d35b3e298795c340fb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->