### PR TITLE
fix(api-reference): reintroduce request data when opening client via `TestRequestButton`

### DIFF
--- a/.changeset/flat-ads-sit.md
+++ b/.changeset/flat-ads-sit.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: "Test request" button doesn't open the correct API request panel

--- a/.changeset/old-turtles-listen.md
+++ b/.changeset/old-turtles-listen.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: re-add request method and path to `scalar-open-client` event

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -392,8 +392,8 @@ const { activeServer, getSecuritySchemes, openClient } = mapConfigToClientStore(
 // Top level event handlers and user specified callbacks
 
 /** Open the client modal on the custom event */
-onCustomEvent(root, 'scalar-open-client', () => {
-  openClient()
+onCustomEvent(root, 'scalar-open-client', (event) => {
+  openClient(event.detail)
 })
 
 /** Set the sidebar item to open and run any config handlers */

--- a/packages/api-reference/src/features/test-request-button/TestRequestButton.test.ts
+++ b/packages/api-reference/src/features/test-request-button/TestRequestButton.test.ts
@@ -44,6 +44,9 @@ describe('TestRequestButton', () => {
     const customEvent = captureCustomEvent(wrapper.find('button').element, 'scalar-open-client')
     await wrapper.find('button').trigger('click')
 
-    await customEvent({})
+    await customEvent({
+      method: 'delete',
+      path: '/users/1',
+    })
   })
 })

--- a/packages/api-reference/src/features/test-request-button/TestRequestButton.vue
+++ b/packages/api-reference/src/features/test-request-button/TestRequestButton.vue
@@ -13,7 +13,7 @@ const { method, path } = defineProps<{
 
 const el = ref<HTMLElement | null>(null)
 const handleClick = () => {
-  emitCustomEvent(el.value, 'scalar-open-client', {})
+  emitCustomEvent(el.value, 'scalar-open-client', { method, path })
 }
 </script>
 <template>

--- a/packages/api-reference/src/v2/helpers/map-config-to-client-store.ts
+++ b/packages/api-reference/src/v2/helpers/map-config-to-client-store.ts
@@ -8,6 +8,7 @@ import {
 } from '@scalar/api-client/store'
 import { mutateSecuritySchemeDiff } from '@scalar/api-client/views/Request/libs'
 import { filterSecurityRequirements } from '@scalar/api-client/views/Request/RequestSection'
+import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import { getServersFromDocument } from '@scalar/oas-utils/helpers'
 import type { ApiReferenceConfigurationRaw, OpenAPIV3_1 } from '@scalar/types'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
@@ -238,7 +239,7 @@ export function mapConfigToClientStore({
     activeEnvironment,
     activeWorkspace,
     getSecuritySchemes,
-    openClient: () => client?.open(),
+    openClient: (payload: { method: HttpMethod; path: string }) => client?.open(payload),
   }
 }
 

--- a/packages/workspace-store/src/events/definitions.ts
+++ b/packages/workspace-store/src/events/definitions.ts
@@ -1,3 +1,4 @@
+import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import type { AvailableClients } from '@scalar/snippetz'
 import type { Simplify } from 'type-fest'
 
@@ -162,7 +163,10 @@ export type ApiReferenceEvents<T extends keyof ServerObject = keyof ServerObject
   }
   /** Add a new document to the store */
   'scalar-open-client': {
-    detail: {}
+    detail: {
+      method: HttpMethod
+      path: string
+    }
   }
   /** Fired when the user clicks the "Show more" button on the references */
   'scalar-on-show-more': {


### PR DESCRIPTION
**Problem**

- Closes #7134

**Solution**

Provide request method and path to `scalar-open-client` event in order to open the request panel with the correct API data

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation (not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wires request method and path through `scalar-open-client` to `client.open(...)` so the Test Request button opens the correct API request panel.
> 
> - **API client wiring**:
>   - `packages/api-reference/src/features/test-request-button/TestRequestButton.vue`: emit `scalar-open-client` with `{ method, path }`.
>   - `packages/api-reference/src/components/ApiReference.vue`: handle `scalar-open-client` event and call `openClient(event.detail)`.
>   - `packages/api-reference/src/v2/helpers/map-config-to-client-store.ts`: update `openClient` to accept `{ method: HttpMethod; path: string }` and forward to `client.open(payload)`.
> - **Events typing**:
>   - `packages/workspace-store/src/events/definitions.ts`: add payload shape to `scalar-open-client` (`method`, `path`).
> - **Tests**:
>   - `TestRequestButton.test.ts`: update custom event payload assertions to include `{ method, path }`.
> - **Changesets**:
>   - Patch releases for `@scalar/api-reference` and `@scalar/workspace-store` noting the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2ce7c66c05a3f43bb085e70dcf6a5ad8c89ba60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->