### PR TITLE
docs: update Scalar Docs pricing page

### DIFF
--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -70,25 +70,37 @@
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
             </div>
             <div class="pricing-table-row">
-              <div class="pricing-table-column">viewer seats</div>
+              <div class="pricing-table-column">Email Domain Access Control</div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
             </div>
             <div class="pricing-table-row">
-              <div class="pricing-table-column">editor seats</div>
+              <div class="pricing-table-column">Viewer Seats</div>
+              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
+              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
+              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
+            </div>
+            <div class="pricing-table-row">
+              <div class="pricing-table-column">Editor Seats</div>
               <div class="pricing-table-column">1</div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
             </div>
             <div class="pricing-table-row">
-              <div class="pricing-table-column">Markdown + MDX</div>
+              <div class="pricing-table-column">Custom Domains</div>
               <div class="pricing-table-column"></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
             </div>
             <div class="pricing-table-row">
-              <div class="pricing-table-column">Custom Domains</div>
+              <div class="pricing-table-column">Guides</div>
+              <div class="pricing-table-column"></div>
+              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
+              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
+            </div>
+            <div class="pricing-table-row">
+              <div class="pricing-table-column">Versions</div>
               <div class="pricing-table-column"></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
@@ -100,7 +112,7 @@
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
             </div>
             <div class="pricing-table-row">
-              <div class="pricing-table-column">Guides & Versions</div>
+              <div class="pricing-table-column">Markdown + MDX</div>
               <div class="pricing-table-column"></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
@@ -130,13 +142,13 @@
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
             </div>
             <div class="pricing-table-row">
-              <div class="pricing-table-column">Dedicated Slack/Teams Channel</div>
+              <div class="pricing-table-column">Priority Support</div>
               <div class="pricing-table-column"></div>
               <div class="pricing-table-column"></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
             </div>
             <div class="pricing-table-row">
-              <div class="pricing-table-column">Priority Support</div>
+              <div class="pricing-table-column">Dedicated Slack/Teams Channel</div>
               <div class="pricing-table-column"></div>
               <div class="pricing-table-column"></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>


### PR DESCRIPTION
* editor seats > Editor Seats
* viewer seats > Viewer Seats
* reordered the items a bit (makes more sense in my head)
* added: "Email Domain Access Control"
* made Guides & Versions two features

<img width="1003" height="897" alt="Screenshot 2025-10-20 at 15 53 49" src="https://github.com/user-attachments/assets/6c7530f5-06be-443a-b0a0-2344b9af9f94" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `documentation/guides/pricing.md` to add Email Domain Access Control, split Guides and Versions, capitalize and separate seat rows, and reorder features/support items.
> 
> - **Documentation**:
>   - **`documentation/guides/pricing.md` (Scalar Docs table)**:
>     - Add `Email Domain Access Control` feature row.
>     - Split `Guides & Versions` into separate `Guides` and `Versions` rows.
>     - Capitalize and separate `Viewer Seats` and `Editor Seats` (Editor shows `1` on Free).
>     - Reorder feature rows: move `Markdown + MDX`, `Custom Domains`, etc.
>     - Reorder support rows: `Priority Support` and `Dedicated Slack/Teams Channel` positions swapped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfc5a1790933237b9e6b0f34ab8b680a9f9b8d1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->