### PR TITLE
fix(openapi-parser): make `validate` synchronous

### DIFF
--- a/.changeset/six-knives-remain.md
+++ b/.changeset/six-knives-remain.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': minor
+---
+
+fix(openapi-parser): make`validate` synchronous

--- a/packages/openapi-parser/src/utils/errors.test.ts
+++ b/packages/openapi-parser/src/utils/errors.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest'
 import { validate } from './validate'
 
 describe('errors', () => {
-  it('info required', async () => {
-    const result = await validate({
+  it('info required', () => {
+    const result = validate({
       openapi: '3.1.0',
       paths: {},
     })
@@ -19,7 +19,7 @@ describe('errors', () => {
     })
   })
 
-  it('unevaluated property', async () => {
+  it('unevaluated property', () => {
     const spec = {
       openapi: '3.1.0',
       info: {
@@ -38,7 +38,7 @@ describe('errors', () => {
         },
       },
     }
-    const result = await validate(spec)
+    const result = validate(spec)
 
     expect(result).toMatchObject({
       errors: [

--- a/packages/openapi-parser/src/utils/openapi/utils/workThroughQueue.ts
+++ b/packages/openapi-parser/src/utils/openapi/utils/workThroughQueue.ts
@@ -63,7 +63,7 @@ export async function workThroughQueue<T extends Task[]>(queue: Queue<T>): Promi
     else if (name === 'validate') {
       result = {
         ...result,
-        ...(await validate(currentSpecification, options as Commands['validate']['task']['options'])),
+        ...validate(currentSpecification, options as Commands['validate']['task']['options']),
       }
     }
 

--- a/packages/openapi-parser/src/utils/validate.test.ts
+++ b/packages/openapi-parser/src/utils/validate.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest'
 
 import { validate } from './validate'
 
-describe('validate', async () => {
-  it('fails on invalid schema', async () => {
-    const result = await validate('')
+describe('validate', () => {
+  it('fails on invalid schema', () => {
+    const result = validate('')
 
     expect(result.valid).toBe(false)
     expect(result.errors).toMatchObject([
@@ -14,8 +14,8 @@ describe('validate', async () => {
     ])
   })
 
-  it('returns errors for an invalid schema', async () => {
-    const result = await validate(
+  it('returns errors for an invalid schema', () => {
+    const result = validate(
       `{
         "openapi": "3.1.0",
         "paths": {}
@@ -32,15 +32,15 @@ describe('validate', async () => {
     })
   })
 
-  it('returns errors for an invalid specification', async () => {
-    const result = await validate('pineapples')
+  it('returns errors for an invalid specification', () => {
+    const result = validate('pineapples')
 
     expect(result.errors).toHaveLength(1)
     expect(result.errors[0].message).toBe("Can't find JSON, YAML or filename in data.")
   })
 
-  it('works with YAML', async () => {
-    const result = await validate(`openapi: 3.1.0
+  it('works with YAML', () => {
+    const result = validate(`openapi: 3.1.0
 info:
   title: Hello World
   version: 1.0.0
@@ -50,8 +50,8 @@ paths: {}
     expect(result.schema.info.title).toBe('Hello World')
   })
 
-  it('works with OpenAPI 3.2.0', async () => {
-    const result = await validate(`{
+  it('works with OpenAPI 3.2.0', () => {
+    const result = validate(`{
       "openapi": "3.2.0",
       "info": {
           "title": "Hello World",
@@ -64,8 +64,8 @@ paths: {}
     expect(result.schema.info.title).toBe('Hello World')
   })
 
-  it(`doesn't work with OpenAPI 4.0.0`, async () => {
-    const result = await validate(`{
+  it(`doesn't work with OpenAPI 4.0.0`, () => {
+    const result = validate(`{
       "openapi": "4.0.0",
       "info": {
           "title": "Hello World",
@@ -78,11 +78,11 @@ paths: {}
     expect(result.errors[0].message).toContain("Can't find supported Swagger/OpenAPI version in the provided document")
   })
 
-  it('throws an error', async () => {
-    expect(async () => {
-      await validate(undefined, {
+  it('throws an error', () => {
+    expect(() => {
+      validate(undefined, {
         throwOnError: true,
       })
-    }).rejects.toThrowError("Can't find JSON, YAML or filename in data")
+    }).toThrowError("Can't find JSON, YAML or filename in data")
   })
 })

--- a/packages/openapi-parser/src/utils/validate.ts
+++ b/packages/openapi-parser/src/utils/validate.ts
@@ -2,6 +2,7 @@ import type { OpenAPI } from '@scalar/openapi-types'
 
 import { Validator } from '@/lib/Validator/Validator'
 import type { AnyObject, Filesystem, ThrowOnErrorOption, ValidateResult } from '@/types/index'
+
 import { makeFilesystem } from './make-filesystem'
 
 export type ValidateOptions = ThrowOnErrorOption
@@ -9,14 +10,11 @@ export type ValidateOptions = ThrowOnErrorOption
 /**
  * Validates an OpenAPI document
  */
-export async function validate(
-  value: string | AnyObject | Filesystem,
-  options?: ValidateOptions,
-): Promise<ValidateResult> {
+export function validate(value: string | AnyObject | Filesystem, options?: ValidateOptions): ValidateResult {
   const filesystem = makeFilesystem(value)
 
   const validator = new Validator()
-  const result = await validator.validate(filesystem, options)
+  const result = validator.validate(filesystem, options)
 
   return {
     ...result,

--- a/packages/openapi-parser/tests/migration-layer.test.ts
+++ b/packages/openapi-parser/tests/migration-layer.test.ts
@@ -43,7 +43,7 @@ class SwaggerParser {
         throwOnError: true,
       })
 
-      const result = await validate(filesystem, {
+      const result = validate(filesystem, {
         throwOnError: true,
       })
       callback(null, result.schema)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/OAI/OAI.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/OAI/OAI.test.ts
@@ -6,8 +6,8 @@ import apiWithExamples from './api-with-examples.yaml?raw'
 // TODO: The example is in the `fail` folder, but I don't know why it's supposed to fail.
 // I think the YAML is just wrong ("YAMLException: deficient indentation"), but we can't test this with an import.
 describe.todo('OAI', () => {
-  it('apiWithExamples', async () => {
-    const result = await validate(apiWithExamples)
+  it('apiWithExamples', () => {
+    const result = validate(apiWithExamples)
 
     expect(result.errors?.[0]?.message).toBe('something went wrong')
     expect(result.valid).toBe(false)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/api-with-examples.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/api-with-examples.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import apiWithExamples from './api-with-examples.yaml?raw'
 
 describe('api-with-examples', () => {
-  it('returns an error', async () => {
-    const result = await validate(apiWithExamples)
+  it('returns an error', () => {
+    const result = validate(apiWithExamples)
 
     // TODO: Swagger Editor:
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/comp_pathitems.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/comp_pathitems.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import comp_pathitems from './comp_pathitems.yaml?raw'
 
 describe('comp_pathitems', () => {
-  it('returns an error', async () => {
-    const result = await validate(comp_pathitems)
+  it('returns an error', () => {
+    const result = validate(comp_pathitems)
 
     // TODO: Should probably complain about the pathItems?
     expect(result.errors?.[0]?.message).toBe(`must have required property 'paths'`)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import deprecated from './deprecated.yaml?raw'
 
 describe('deprecated', () => {
-  it('returns an error', async () => {
-    const result = await validate(deprecated)
+  it('returns an error', () => {
+    const result = validate(deprecated)
 
     expect(result.errors?.[0]?.message).toBe('type must be boolean')
     expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated2.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated2.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import deprecated2 from './deprecated2.yaml?raw'
 
 describe.todo('deprecated2', () => {
-  it('returns an error', async () => {
-    const result = await validate(deprecated2)
+  it('returns an error', () => {
+    const result = validate(deprecated2)
 
     expect(result.errors?.[0]?.message).toBe('something something deprecated')
     expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated3.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated3.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import deprecated3 from './deprecated3.yaml?raw'
 
 describe.todo('deprecated3', () => {
-  it('returns an error', async () => {
-    const result = await validate(deprecated3)
+  it('returns an error', () => {
+    const result = validate(deprecated3)
 
     expect(result.errors?.[0]?.message).toBe('something something deprecated')
     expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateOperationId.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateOperationId.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import duplicateOperationId from './duplicateOperationId.yaml?raw'
 
 describe.todo('duplicateOperationId', () => {
-  it('returns an error', async () => {
-    const result = await validate(duplicateOperationId)
+  it('returns an error', () => {
+    const result = validate(duplicateOperationId)
 
     expect(result.errors?.[0]?.message).toBe('something something duplicate operationId')
     expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateParameter.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateParameter.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import duplicateParameter from './duplicateParameter.yaml?raw'
 
 describe.todo('duplicateParameter', () => {
-  it('returns an error', async () => {
-    const result = await validate(duplicateParameter)
+  it('returns an error', () => {
+    const result = validate(duplicateParameter)
 
     expect(result.errors?.[0]?.message).toBe('something something duplicate parameter')
     expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateRequired.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateRequired.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import duplicateRequired from './duplicateRequired.yaml?raw'
 
 describe.todo('duplicateRequired', () => {
-  it('returns an error', async () => {
-    const result = await validate(duplicateRequired)
+  it('returns an error', () => {
+    const result = validate(duplicateRequired)
 
     expect(result.errors?.[0]?.message).toBe('something something duplicate required properties')
     expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/event-backend/event-backend.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/event-backend/event-backend.test.ts
@@ -6,24 +6,24 @@ import openapi2 from './openapi2.json'
 import openapi3 from './openapi3.json'
 
 describe('event-backend', () => {
-  it('openapi1', async () => {
-    const result = await validate(openapi1)
+  it('openapi1', () => {
+    const result = validate(openapi1)
 
     // TODO: What does that mean?
     expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)
     expect(result.valid).toBe(false)
   })
 
-  it('openapi2', async () => {
-    const result = await validate(openapi2)
+  it('openapi2', () => {
+    const result = validate(openapi2)
 
     // TODO: What does that mean?
     expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)
     expect(result.valid).toBe(false)
   })
 
-  it('openapi3', async () => {
-    const result = await validate(openapi3)
+  it('openapi3', () => {
+    const result = validate(openapi3)
 
     // TODO: What does that mean?
     expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/hasFlowNotFlows.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/hasFlowNotFlows.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import hasFlowNotFlows from './hasFlowNotFlows.json'
 
 describe('hasFlowNotFlows', () => {
-  it('returns an error', async () => {
-    const result = await validate(hasFlowNotFlows)
+  it('returns an error', () => {
+    const result = validate(hasFlowNotFlows)
 
     // TODO: This should probably mention the incorrect security type?
     expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/incorrectSecType.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/incorrectSecType.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import incorrectSecType from './incorrectSecType.json'
 
 describe('incorrectSecType', () => {
-  it('returns an error', async () => {
-    const result = await validate(incorrectSecType)
+  it('returns an error', () => {
+    const result = validate(incorrectSecType)
 
     // TODO: Shouldn't this metnion the incorrect security type?
     expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/info_summary.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/info_summary.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import info_summary from './info_summary.yaml?raw'
 
 describe('info_summary', () => {
-  it('returns an error', async () => {
-    const result = await validate(info_summary)
+  it('returns an error', () => {
+    const result = validate(info_summary)
 
     expect(result.errors?.[0]?.message).toBe('Property summary is not expected to be here')
     expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/internalPathItemRef.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/internalPathItemRef.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import internalPathItemRef from './internalPathItemRef.yaml?raw'
 
 describe.todo('internalPathItemRef', () => {
-  it('returns an error', async () => {
-    await validate(internalPathItemRef)
+  it('returns an error', () => {
+    validate(internalPathItemRef)
 
     // expect(result.errors?.[0]?.message).toBe(`Can't resolve URI: #/paths/test2`)
     // expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidPattern.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidPattern.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import invalidPattern from './invalidPattern.yaml?raw'
 
 describe('invalidPattern', () => {
-  it('returns an error', async () => {
-    const result = await validate(invalidPattern)
+  it('returns an error', () => {
+    const result = validate(invalidPattern)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidSchema.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidSchema.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import invalidSchema from './invalidSchema.json'
 
 describe('invalidSchema', () => {
-  it('returns an error', async () => {
-    const result = await validate(invalidSchema)
+  it('returns an error', () => {
+    const result = validate(invalidSchema)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidSchemaName.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidSchemaName.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import invalidSchemaName from './invalidSchemaName.json'
 
 describe('invalidSchemaName', () => {
-  it('returns an error', async () => {
-    const result = await validate(invalidSchemaName)
+  it('returns an error', () => {
+    const result = validate(invalidSchemaName)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/license_identifier.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/license_identifier.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import license_identifier from './license_identifier.yaml?raw'
 
 describe('license_identifier', () => {
-  it('returns an error', async () => {
-    const result = await validate(license_identifier)
+  it('returns an error', () => {
+    const result = validate(license_identifier)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathItemRef.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathItemRef.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import missingPathItemRef from './missingPathItemRef.yaml?raw'
 
 describe.todo('missingPathItemRef', () => {
-  it('returns an error', async () => {
-    const result = await validate(missingPathItemRef)
+  it('returns an error', () => {
+    const result = validate(missingPathItemRef)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathParam.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathParam.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import missingPathParam from './missingPathParam.yaml?raw'
 
 describe.todo('missingPathParam', () => {
-  it('returns an error', async () => {
-    const result = await validate(missingPathParam)
+  it('returns an error', () => {
+    const result = validate(missingPathParam)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathParam2.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathParam2.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import missingPathParam2 from './missingPathParam2.yaml?raw'
 
 describe.todo('missingPathParam2', () => {
-  it('returns an error', async () => {
-    const result = await validate(missingPathParam2)
+  it('returns an error', () => {
+    const result = validate(missingPathParam2)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/openapi-ui/openapi-ui.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/openapi-ui/openapi-ui.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../../src/index'
 import openApiUi from './openapi-ui.yaml?raw'
 
 describe('openapi-ui', () => {
-  it('apiWithExamples', async () => {
-    const result = await validate(openApiUi)
+  it('apiWithExamples', () => {
+    const result = validate(openApiUi)
 
     // TODO: SwaggerUI has a more helpful error message:
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/openapi-vue/openapi-vue.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/openapi-vue/openapi-vue.test.ts
@@ -5,8 +5,8 @@ import edit1 from './edit1.json'
 import openApiVue from './openapi.json'
 
 describe('openapi-vue', () => {
-  it('openapi', async () => {
-    const result = await validate(openApiVue)
+  it('openapi', () => {
+    const result = validate(openApiVue)
 
     // TODO: SwaggerUI has a more helpful error message:
     //
@@ -17,8 +17,8 @@ describe('openapi-vue', () => {
     expect(result.valid).toBe(false)
   })
 
-  it('edit1', async () => {
-    const result = await validate(edit1)
+  it('edit1', () => {
+    const result = validate(edit1)
 
     // TODO: SwaggerUI has a more helpful error message:
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/pathitem-property.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/pathitem-property.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import pathitemProperty from './pathitem-property.yaml?raw'
 
 describe('pathitem-property', () => {
-  it('returns an error', async () => {
-    const result = await validate(pathitemProperty)
+  it('returns an error', () => {
+    const result = validate(pathitemProperty)
 
     expect(result.errors?.[0]?.message).toBe('Property GET is not expected to be here')
     expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/refAsInteger.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/refAsInteger.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import refAsInteger from './refAsInteger.yaml?raw'
 
 describe('refAsInteger', () => {
-  it('returns an error', async () => {
-    const result = await validate(refAsInteger)
+  it('returns an error', () => {
+    const result = validate(refAsInteger)
 
     // TODO: Swagger Editor
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/schemaProperties.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/schemaProperties.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import schemaProperties from './schemaProperties.yaml?raw'
 
 describe('schemaProperties', () => {
-  it('returns an error', async () => {
-    const { valid, errors, schema } = await validate(schemaProperties)
+  it('returns an error', () => {
+    const { valid, errors, schema } = validate(schemaProperties)
 
     expect(schema?.components?.schemas?.SomeObject).not.toBe(undefined)
 

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/serverVariableEnumType.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/serverVariableEnumType.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import serverVariableEnumType from './serverVariableEnumType.yaml?raw'
 
 describe('serverVariableEnumType', () => {
-  it('returns an error', async () => {
-    const result = await validate(serverVariableEnumType)
+  it('returns an error', () => {
+    const result = validate(serverVariableEnumType)
 
     // TODO: Swagger Editor has a better error message
     //

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/cyclical.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/cyclical.test.ts
@@ -3,7 +3,7 @@ import { validate } from '@/utils/validate'
 import { describe, expect, it } from 'vitest'
 
 describe('cyclical', () => {
-  it('resolves circular references', async () => {
+  it('resolves circular references', () => {
     const specification = {
       openapi: '3.0.0',
       info: {
@@ -36,7 +36,7 @@ describe('cyclical', () => {
       },
     }
 
-    const result = await validate(specification)
+    const result = validate(specification)
 
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')
@@ -46,7 +46,7 @@ describe('cyclical', () => {
     expect(category.subcategories.items.properties.subcategories.type).toEqual('array')
   })
 
-  it.todo('resolves circular dependencies in referenced files', async () => {
+  it.todo('resolves circular dependencies in referenced files', () => {
     const baseFile = {
       openapi: '3.0.0',
       info: {
@@ -89,7 +89,7 @@ describe('cyclical', () => {
       },
     }
 
-    const result = await validate([
+    const result = validate([
       {
         isEntrypoint: true,
         specification: baseFile,

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/deprecated.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/deprecated.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import deprecated from './deprecated.yaml?raw'
 
 describe('deprecated', () => {
-  it('passes', async () => {
-    const result = await validate(deprecated)
+  it('passes', () => {
+    const result = validate(deprecated)
 
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/extensionsEverywhere.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/extensionsEverywhere.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import extensionsEverywhere from './extensionsEverywhere.yaml?raw'
 
 describe('extensionsEverywhere', () => {
-  it('passes', async () => {
-    const result = await validate(extensionsEverywhere)
+  it('passes', () => {
+    const result = validate(extensionsEverywhere)
 
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/externalPathItemRef.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/externalPathItemRef.test.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 
 import { load, validate } from '../../../../src/index'
@@ -12,7 +13,7 @@ describe('externalPathItemRef', () => {
       plugins: [readFiles()],
     })
 
-    const { schema } = await validate(filesystem)
+    const { schema } = validate(filesystem)
 
     expect(schema.paths['/test'].get).not.toBeUndefined()
     expect(schema.paths['/test'].get).toMatchObject({

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/fiendish/ref-encoding2.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/fiendish/ref-encoding2.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../../src/index'
 import refEncoding2 from './ref-encoding2.yaml?raw'
 
 describe('ref-encoding2', () => {
-  it('passes', async () => {
-    const result = await validate(refEncoding2)
+  it('passes', () => {
+    const result = validate(refEncoding2)
 
     expect(result.errors).toStrictEqual([])
     expect(result.valid).toBe(true)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/fiendish/ref-encoding3.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/fiendish/ref-encoding3.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../../src/index'
 import refEncoding3 from './ref-encoding3.yaml?raw'
 
 describe('ref-encoding3', () => {
-  it('passes', async () => {
-    const result = await validate(refEncoding3)
+  it('passes', () => {
+    const result = validate(refEncoding3)
 
     expect(result.errors).toStrictEqual([])
     expect(result.valid).toBe(true)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/hello.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/hello.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import hello from './hello.yaml?raw'
 
 describe('hello', () => {
-  it('passes', async () => {
-    const result = await validate(hello)
+  it('passes', () => {
+    const result = validate(hello)
 
     expect(result.errors?.length).toBe(0)
     expect(result.version).toBe('3.0')

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/minimal.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/minimal.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import minimal from './minimal.yaml?raw'
 
 describe('minimal', () => {
-  it('passes', async () => {
-    const result = await validate(minimal)
+  it('passes', () => {
+    const result = validate(minimal)
 
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/nonBearerHttpSec.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/nonBearerHttpSec.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import nonBearerHttpSec from './nonBearerHttpSec.yaml?raw'
 
 describe('nonBearerHttpSec', () => {
-  it('passes', async () => {
-    const result = await validate(nonBearerHttpSec)
+  it('passes', () => {
+    const result = validate(nonBearerHttpSec)
 
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/openapi.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/openapi.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import openapi from './openapi.yaml?raw'
 
 describe('openapi', () => {
-  it('passes', async () => {
-    const result = await validate(openapi)
+  it('passes', () => {
+    const result = validate(openapi)
 
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/server_enum_empty.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/server_enum_empty.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import server_enum_empty from './server_enum_empty.yaml?raw'
 
 describe.todo('server_enum_empty', () => {
-  it('passes', async () => {
-    const result = await validate(server_enum_empty)
+  it('passes', () => {
+    const result = validate(server_enum_empty)
 
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/server_enum_unknown.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/server_enum_unknown.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import server_enum_unknown from './server_enum_unknown.yaml?raw'
 
 describe.todo('server_enum_unknown', () => {
-  it('passes', async () => {
-    const result = await validate(server_enum_unknown)
+  it('passes', () => {
+    const result = validate(server_enum_unknown)
 
     expect(result.valid).toBe(false)
     expect(result.errors?.length).toBe(1)

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/fail/no_containers.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/fail/no_containers.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import no_containers from './no_containers.yaml?raw'
 
 describe('no_containers', () => {
-  it('returns an error', async () => {
-    const result = await validate(no_containers)
+  it('returns an error', () => {
+    const result = validate(no_containers)
 
     // TODO: Fix the expected error message should mention 'paths'
     expect(result.errors?.[0]?.message).toBe(`must have required property 'webhooks'`)

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/fail/server_enum_empty.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/fail/server_enum_empty.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import server_enum_empty from './server_enum_empty.yaml?raw'
 
 describe('server_enum_empty', () => {
-  it('returns an error', async () => {
-    const result = await validate(server_enum_empty)
+  it('returns an error', () => {
+    const result = validate(server_enum_empty)
 
     expect(result.errors?.[0]?.message).toBe('minItems must NOT have fewer than 1 items')
 

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/fail/server_enum_unknown.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/fail/server_enum_unknown.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import server_enum_unknown from './server_enum_unknown.yaml?raw'
 
 describe('server_enum_unknown', () => {
-  it.todo('returns an error', async () => {
-    const result = await validate(server_enum_unknown)
+  it.todo('returns an error', () => {
+    const result = validate(server_enum_unknown)
 
     // TODO: The message should return something related to the unknown enum value
     // expect(result.errors?.[0]?.message).toBe(

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/fail/unknown_container.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/fail/unknown_container.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import unknown_container from './unknown_container.yaml?raw'
 
 describe('unknown_container', () => {
-  it('returns an error', async () => {
-    const result = await validate(unknown_container)
+  it('returns an error', () => {
+    const result = validate(unknown_container)
 
     // TODO: The message should complain about the unknown container
     expect(result.errors?.[0]?.message).toBe(`must have required property 'webhooks'`)

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/comp_pathitems.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/comp_pathitems.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import comp_pathitems from './comp_pathitems.yaml?raw'
 
 describe('comp_pathitems', () => {
-  it('passes', async () => {
-    const result = await validate(comp_pathitems)
+  it('passes', () => {
+    const result = validate(comp_pathitems)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/info_summary.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/info_summary.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import info_summary from './info_summary.yaml?raw'
 
 describe('info_summary', () => {
-  it('passes', async () => {
-    const result = await validate(info_summary)
+  it('passes', () => {
+    const result = validate(info_summary)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/license_identifier.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/license_identifier.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import license_identifier from './license_identifier.yaml?raw'
 
 describe('license_identifier', () => {
-  it('passes', async () => {
-    const result = await validate(license_identifier)
+  it('passes', () => {
+    const result = validate(license_identifier)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/mega.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/mega.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import mega from './mega.yaml?raw'
 
 describe('mega', () => {
-  it('passes', async () => {
-    const result = await validate(mega)
+  it('passes', () => {
+    const result = validate(mega)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/minimal_comp.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/minimal_comp.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import minimal_comp from './minimal_comp.yaml?raw'
 
 describe('minimal_comp', () => {
-  it('passes', async () => {
-    const result = await validate(minimal_comp)
+  it('passes', () => {
+    const result = validate(minimal_comp)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/minimal_hooks.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/minimal_hooks.test.ts
@@ -4,8 +4,9 @@ import { validate } from '../../../../src/index'
 import minimal_hooks from './minimal_hooks.yaml?raw'
 
 describe('minimal_hooks', () => {
-  it('passes', async () => {
-    const result = await validate(minimal_hooks)
+  it('passes', () => {
+    const result = validate(minimal_hooks)
+
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/minimal_paths.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/minimal_paths.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import minimal_paths from './minimal_paths.yaml?raw'
 
 describe('minimal_paths', () => {
-  it('passes', async () => {
-    const result = await validate(minimal_paths)
+  it('passes', () => {
+    const result = validate(minimal_paths)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/path_no_response.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/path_no_response.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import path_no_response from './path_no_response.yaml?raw'
 
 describe('path_no_response', () => {
-  it('passes', async () => {
-    const result = await validate(path_no_response)
+  it('passes', () => {
+    const result = validate(path_no_response)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/path_var_empty_pathitem.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/path_var_empty_pathitem.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import path_var_empty_pathitem from './path_var_empty_pathitem.yaml?raw'
 
 describe('path_var_empty_pathitem', () => {
-  it('passes', async () => {
-    const result = await validate(path_var_empty_pathitem)
+  it('passes', () => {
+    const result = validate(path_var_empty_pathitem)
     expect(result.valid).toBe(true)
     expect(result.errors).toStrictEqual([])
     expect(result.version).toBe('3.1')

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/pass/schema.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/pass/schema.test.ts
@@ -4,8 +4,8 @@ import { validate } from '../../../../src/index'
 import schema from './schema.yaml?raw'
 
 describe('schema', () => {
-  it('passes', async () => {
-    const result = await validate(schema)
+  it('passes', () => {
+    const result = validate(schema)
     expect(result.errors).toStrictEqual([])
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.1')


### PR DESCRIPTION
**Problem**

[Another change related to the `useAwait` rule](https://github.com/scalar/scalar/pull/7091#discussion_r2429906517):

`Validator.getAjvValidator` is actually synchronous. 
Making it synchronous will remove the `await` requiremen from `Validator.validate` and `validate` (function exported by `@scalar/openapi-parser`)

> [!CAUTION]
> Even if this is actually is a breaking,
> I marked it as a minor change since the package has a `0.x` version.

**Solution**

Make all the above mentioned  function chain synchronous.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation (Not needed, I haven't found mentation on this function in the documentation).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `validate` synchronous across the parser, updating the validator, utilities, queue workflow, and tests accordingly.
> 
> - **openapi-parser**
>   - **Validator** (`packages/openapi-parser/src/lib/Validator/Validator.ts`):
>     - Make `validate` and `getAjvValidator` synchronous; remove `async/await` usage.
>     - Type `ajvValidators` as `Record<string, ValidateFunction>` and cast Ajv instance.
>     - Throw error using `errors[0].message`; only aggregate reference resolution errors in result.
>   - **Utils**:
>     - `validate` (`src/utils/validate.ts`): now synchronous; calls `new Validator().validate` directly.
>     - `workThroughQueue` (`utils/openapi/utils/workThroughQueue.ts`): call synchronous `validate` in command chain.
>   - **Tests**: Remove `async/await` from validation calls and adjust expectations across test suites to match synchronous API.
>   - **Changeset**: Minor version bump for `@scalar/openapi-parser`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b6e0fa82c66485c20d97209536c4d742ba3953b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->