### PR TITLE
fix(fastify-api-reference): use `currentUrl.pathname` instead of deprecated `request.routerPath`

### DIFF
--- a/.changeset/tough-eyes-smile.md
+++ b/.changeset/tough-eyes-smile.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix(fastify-api-reference): use `currentUrl.pathname` instead of deprecated `request.routerPath`

--- a/integrations/fastify/package.json
+++ b/integrations/fastify/package.json
@@ -65,8 +65,6 @@
     "@scalar/api-reference": "workspace:*",
     "@scalar/build-tooling": "workspace:*",
     "fastify": "^4.26.2",
-    "rollup-plugin-node-externals": "^7.1.2",
-    "terser": "^5.30.0",
     "vite": "catalog:*",
     "vitest": "catalog:*",
     "yaml": "catalog:*"

--- a/integrations/fastify/src/fastifyApiReference.test.ts
+++ b/integrations/fastify/src/fastifyApiReference.test.ts
@@ -62,6 +62,29 @@ describe('fastifyApiReference', () => {
     expect(finalResponse.status).toBe(200)
   })
 
+  it('returns 200 OK for the HTML and redirects to the route with a trailing slash (ignoreTrailingSlash: true)', async () => {
+    const fastify = Fastify({
+      logger: false,
+      ignoreTrailingSlash: true,
+    })
+
+    await fastify.register(fastifyApiReference, {
+      routePrefix: '/reference',
+      configuration: {
+        url: '/openapi.json',
+      },
+    })
+
+    const address = await fastify.listen({ port: 0 })
+    const response = await fetch(`${address}/reference`, { redirect: 'manual' })
+
+    expect(response.status).toBe(301)
+    expect(response.headers.get('location')).toBe('/reference/')
+
+    const finalResponse = await fetch(`${address}/reference/`)
+    expect(finalResponse.status).toBe(200)
+  })
+
   it('accounts for plugin `prefix` during redirects to add trailing slash', async () => {
     const innerPlugin: FastifyPluginAsync = async (fastify) => {
       await fastify.register(fastifyApiReference, {

--- a/integrations/fastify/src/fastifyApiReference.ts
+++ b/integrations/fastify/src/fastifyApiReference.ts
@@ -209,7 +209,7 @@ const fastifyApiReference = fp<
       handler(request, reply) {
         // Redirect if it's the route without a slash
         const currentUrl = new URL(request.url, `${request.protocol}://${request.hostname}`)
-        if (!request.routerPath.endsWith('/')) {
+        if (!currentUrl.pathname.endsWith('/')) {
           return reply.redirect(`${currentUrl.pathname}/`, 301)
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -912,12 +912,6 @@ importers:
       fastify:
         specifier: ^4.26.2
         version: 4.28.0
-      rollup-plugin-node-externals:
-        specifier: ^7.1.2
-        version: 7.1.2(rollup@4.50.2)
-      terser:
-        specifier: ^5.30.0
-        version: 5.31.2
       vite:
         specifier: catalog:*
         version: 7.1.11(@types/node@22.15.3)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
@@ -16962,12 +16956,6 @@ packages:
   rollup-plugin-inject@3.0.2:
     resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
-
-  rollup-plugin-node-externals@7.1.2:
-    resolution: {integrity: sha512-cVJFKs+ulZxpMmn/s+oi431d93Jq5+G7Sc5ixWDrL2k+Gj+MqXg0KMNWgKf8Mw5qpaG4jVDpsvuqFfiCvRcGeA==}
-    engines: {node: '>= 21 || ^20.6.0 || ^18.19.0'}
-    peerDependencies:
-      rollup: ^3.0.0 || ^4.0.0
 
   rollup-plugin-node-polyfills@0.2.1:
     resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
@@ -35925,7 +35913,7 @@ snapshots:
       unctx: 2.4.1
       unimport: 5.2.0
       unplugin: 2.3.10
-      unplugin-vue-router: 0.15.0(@vue/compiler-sfc@3.5.21)(typescript@5.8.3)(vue-router@4.5.1(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))
+      unplugin-vue-router: 0.15.0(@vue/compiler-sfc@3.5.21)(typescript@5.8.3)(vue-router@4.5.1(vue@3.5.17(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))
       unstorage: 1.17.1(@netlify/blobs@9.1.2)(db0@0.3.2)(ioredis@5.7.0)
       untyped: 2.0.0
       vue: 3.5.21(typescript@5.8.3)
@@ -36048,7 +36036,7 @@ snapshots:
       unctx: 2.4.1
       unimport: 5.2.0
       unplugin: 2.3.10
-      unplugin-vue-router: 0.15.0(@vue/compiler-sfc@3.5.21)(typescript@5.8.3)(vue-router@4.5.1(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))
+      unplugin-vue-router: 0.15.0(@vue/compiler-sfc@3.5.21)(typescript@5.8.3)(vue-router@4.5.1(vue@3.5.17(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))
       unstorage: 1.17.1(@netlify/blobs@9.1.2)(db0@0.3.2)(ioredis@5.7.0)
       untyped: 2.0.0
       vue: 3.5.21(typescript@5.8.3)
@@ -38367,10 +38355,6 @@ snapshots:
       magic-string: 0.25.9
       rollup-pluginutils: 2.8.2
 
-  rollup-plugin-node-externals@7.1.2(rollup@4.50.2):
-    dependencies:
-      rollup: 4.50.2
-
   rollup-plugin-node-polyfills@0.2.1:
     dependencies:
       rollup-plugin-inject: 3.0.2
@@ -40281,7 +40265,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.3
 
-  unplugin-vue-router@0.15.0(@vue/compiler-sfc@3.5.21)(typescript@5.8.3)(vue-router@4.5.1(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3)):
+  unplugin-vue-router@0.15.0(@vue/compiler-sfc@3.5.21)(typescript@5.8.3)(vue-router@4.5.1(vue@3.5.17(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3)):
     dependencies:
       '@vue-macros/common': 3.0.0-beta.16(vue@3.5.21(typescript@5.8.3))
       '@vue/compiler-sfc': 3.5.21


### PR DESCRIPTION
**Problem**

While working on #7148 I noticed a few deprecation warning coming from `fastify`:

```text
[FSTDEP017] DeprecationWarning: You are accessing the deprecated "request. routerPath" property. 
Use "request. routeOptions.url" instead. Property "req. routerPath" will be removed in 'fastify@5'
```

<img width="985" height="312" alt="Screenshot 2025-10-21 at 20 33 43" src="https://github.com/user-attachments/assets/ccba048f-84e9-4c5b-a236-35220e24f805" />

**Solution**

- Use `currentUrl.pathname` instead of deprecated `request.routerPath`
   ~~Use `request.url` instead of `request.routerPath`.~~
   ~~I opted to use `request.url` since it was already use to compute redirect path across plugin code~~
- added a test to test redirect behaviour with `ignoreTrailingSlash` set to `true`
- I have removed two unused `devDependencies` from this package
  - `rollup-plugin-node-externals`
  - `terser`

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation (not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces deprecated Fastify API usage for trailing-slash redirects, adds a test for ignoreTrailingSlash, and removes two unused devDependencies.
> 
> - **Fastify plugin (`integrations/fastify/src/fastifyApiReference.ts`)**:
>   - Use `request.url` instead of deprecated `request.routerPath` when handling trailing-slash redirects.
> - **Tests (`integrations/fastify/src/fastifyApiReference.test.ts`)**:
>   - Add test validating redirect behavior with `ignoreTrailingSlash: true`.
> - **Package (`integrations/fastify/package.json`)**:
>   - Remove unused dev dependencies: `rollup-plugin-node-externals`, `terser`.
> - **Release**:
>   - Add changeset for a patch version bump.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 765bb874ebe1451e555cf1e5ae9f442930a0d948. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->