### PR TITLE
style(headings): update h3 font size to 16px

### DIFF
--- a/packages/themes/src/base/variables.css
+++ b/packages/themes/src/base/variables.css
@@ -18,7 +18,7 @@
   --scalar-heading-1: 24px; /* Editor Page heading */
   --scalar-page-description: 16px;
   --scalar-heading-2: 20px; /* Editor section headings */
-  --scalar-heading-3: 20px;
+  --scalar-heading-3: 16px;
   --scalar-heading-4: 16px;
   --scalar-heading-5: 16px;
   --scalar-heading-6: 16px;

--- a/packages/themes/src/presets/custom-theme-starter.css
+++ b/packages/themes/src/presets/custom-theme-starter.css
@@ -21,7 +21,7 @@
   --scalar-heading-1: 24px; /* Page headings */
   --scalar-page-description: 16px;
   --scalar-heading-2: 20px; /* Section headings */
-  --scalar-heading-3: 20px;
+  --scalar-heading-3: 16px;
   --scalar-heading-4: 16px;
   --scalar-heading-5: 16px;
   --scalar-heading-6: 16px;


### PR DESCRIPTION
**Problem**

Currently, h3 font size is defaulted to `20px`.

**Solution**

With this PR the default size is changed to `16px`.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduce h3 font size (`--scalar-heading-3`) from 20px to 16px in base and custom theme starter CSS.
> 
> - **Typography variables**:
>   - Reduce `--scalar-heading-3` from `20px` to `16px` in:
>     - `packages/themes/src/base/variables.css`
>     - `packages/themes/src/presets/custom-theme-starter.css`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a789b17a9c0c1f5cf8177a6f7f3f3c9c5e77054. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->