### PR TITLE
refactor(openapi-parser): include `openapi3-examples` TS files in `biome` and exclude `.pnpm-store`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,7 @@
       "!**/dist/**",
       "!**/playwright-report/**",
       "!**/pnpm-lock.yaml",
-      "!**/openapi3-examples/**",
+      "!**/.pnpm-store/**",
       "!**/.docusaurus/**",
       "!**/examples/nestjs-api-reference-fastify/**",
       "!**/examples/nestjs-api-reference-express/**",
@@ -33,6 +33,7 @@
       "!**/obj/**",
       "!**/bin/**",
       "!**/packages/openapi-parser/src/schemas/**/*.ts",
+      "!**/packages/openapi-parser/tests/openapi3-examples/**/*.{yml,yaml,json}",
       "!integrations/**/scalar.js",
       "!integrations/**/standalone.js",
       "!**/rust/**/target"

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/OAI/OAI.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/OAI/OAI.test.ts
@@ -9,7 +9,7 @@ describe.todo('OAI', () => {
   it('apiWithExamples', async () => {
     const result = await validate(apiWithExamples)
 
-    expect(result.errors?.[0]?.message).toBe(`something went wrong`)
+    expect(result.errors?.[0]?.message).toBe('something went wrong')
     expect(result.valid).toBe(false)
   })
 })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/api-with-examples.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/api-with-examples.test.ts
@@ -12,9 +12,7 @@ describe('api-with-examples', () => {
     // Structural error at paths./.get.responses.200.content.application/json.examples
     // should be object
     // …
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property '$ref'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/comp_pathitems.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/comp_pathitems.test.ts
@@ -8,9 +8,7 @@ describe('comp_pathitems', () => {
     const result = await validate(comp_pathitems)
 
     // TODO: Should probably complain about the pathItems?
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property 'paths'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property 'paths'`)
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated.test.ts
@@ -7,7 +7,7 @@ describe('deprecated', () => {
   it('returns an error', async () => {
     const result = await validate(deprecated)
 
-    expect(result.errors?.[0]?.message).toBe(`type must be boolean`)
+    expect(result.errors?.[0]?.message).toBe('type must be boolean')
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated2.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated2.test.ts
@@ -7,7 +7,7 @@ describe.todo('deprecated2', () => {
   it('returns an error', async () => {
     const result = await validate(deprecated2)
 
-    expect(result.errors?.[0]?.message).toBe(`something something deprecated`)
+    expect(result.errors?.[0]?.message).toBe('something something deprecated')
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated3.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/deprecated3.test.ts
@@ -7,7 +7,7 @@ describe.todo('deprecated3', () => {
   it('returns an error', async () => {
     const result = await validate(deprecated3)
 
-    expect(result.errors?.[0]?.message).toBe(`something something deprecated`)
+    expect(result.errors?.[0]?.message).toBe('something something deprecated')
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateOperationId.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateOperationId.test.ts
@@ -7,9 +7,7 @@ describe.todo('duplicateOperationId', () => {
   it('returns an error', async () => {
     const result = await validate(duplicateOperationId)
 
-    expect(result.errors?.[0]?.message).toBe(
-      `something something duplicate operationId`,
-    )
+    expect(result.errors?.[0]?.message).toBe('something something duplicate operationId')
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateParameter.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateParameter.test.ts
@@ -7,9 +7,7 @@ describe.todo('duplicateParameter', () => {
   it('returns an error', async () => {
     const result = await validate(duplicateParameter)
 
-    expect(result.errors?.[0]?.message).toBe(
-      `something something duplicate parameter`,
-    )
+    expect(result.errors?.[0]?.message).toBe('something something duplicate parameter')
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateRequired.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/duplicateRequired.test.ts
@@ -7,9 +7,7 @@ describe.todo('duplicateRequired', () => {
   it('returns an error', async () => {
     const result = await validate(duplicateRequired)
 
-    expect(result.errors?.[0]?.message).toBe(
-      `something something duplicate required properties`,
-    )
+    expect(result.errors?.[0]?.message).toBe('something something duplicate required properties')
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/event-backend/event-backend.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/event-backend/event-backend.test.ts
@@ -10,9 +10,7 @@ describe('event-backend', () => {
     const result = await validate(openapi1)
 
     // TODO: What does that mean?
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property '$ref'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)
     expect(result.valid).toBe(false)
   })
 
@@ -20,9 +18,7 @@ describe('event-backend', () => {
     const result = await validate(openapi2)
 
     // TODO: What does that mean?
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property '$ref'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)
     expect(result.valid).toBe(false)
   })
 
@@ -30,9 +26,7 @@ describe('event-backend', () => {
     const result = await validate(openapi3)
 
     // TODO: What does that mean?
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property '$ref'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)
     expect(result.valid).toBe(false)
   })
 })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/hasFlowNotFlows.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/hasFlowNotFlows.test.ts
@@ -8,9 +8,7 @@ describe('hasFlowNotFlows', () => {
     const result = await validate(hasFlowNotFlows)
 
     // TODO: This should probably mention the incorrect security type?
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property '$ref'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/incorrectSecType.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/incorrectSecType.test.ts
@@ -8,9 +8,7 @@ describe('incorrectSecType', () => {
     const result = await validate(incorrectSecType)
 
     // TODO: Shouldn't this metnion the incorrect security type?
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property '$ref'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/info_summary.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/info_summary.test.ts
@@ -7,9 +7,7 @@ describe('info_summary', () => {
   it('returns an error', async () => {
     const result = await validate(info_summary)
 
-    expect(result.errors?.[0]?.message).toBe(
-      'Property summary is not expected to be here',
-    )
+    expect(result.errors?.[0]?.message).toBe('Property summary is not expected to be here')
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidPattern.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidPattern.test.ts
@@ -11,9 +11,7 @@ describe('invalidPattern', () => {
     //
     // Resolver error at paths./test.$ref
     // Could not resolve reference: undefined undefined
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property '$ref'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidSchema.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidSchema.test.ts
@@ -11,9 +11,7 @@ describe('invalidSchema', () => {
     //
     // Resolver error at paths./test.$ref
     // Could not resolve reference: undefined undefined
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property '$ref'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidSchemaName.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/invalidSchemaName.test.ts
@@ -10,9 +10,7 @@ describe('invalidSchemaName', () => {
     // TODO: Swagger Editor
     //
     // * Could not resolve reference: undefined undefined
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property '$ref'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/license_identifier.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/license_identifier.test.ts
@@ -12,9 +12,7 @@ describe('license_identifier', () => {
     // Structural error at info.license
     // should NOT have additional properties
     // additionalProperty: identifier
-    expect(result.errors?.[0]?.message).toBe(
-      `Property identifier is not expected to be here`,
-    )
+    expect(result.errors?.[0]?.message).toBe('Property identifier is not expected to be here')
     expect(result.valid).toBe(false)
   })
 })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathItemRef.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathItemRef.test.ts
@@ -11,7 +11,7 @@ describe.todo('missingPathItemRef', () => {
     //
     // * Resolver error at paths./test.$ref
     // Could not resolve reference: undefined undefined
-    expect(result.errors?.[0]?.message).toBe(`something something test`)
+    expect(result.errors?.[0]?.message).toBe('something something test')
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathParam.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathParam.test.ts
@@ -11,7 +11,7 @@ describe.todo('missingPathParam', () => {
     //
     // * Declared path parameter "test2" needs to be defined as a path parameter at either the path or operation level
     // * Path parameter "test" must have the corresponding {test} segment in the "/test/{test2}" path
-    expect(result.errors?.[0]?.message).toBe(`something something test`)
+    expect(result.errors?.[0]?.message).toBe('something something test')
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathParam2.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/missingPathParam2.test.ts
@@ -11,7 +11,7 @@ describe.todo('missingPathParam2', () => {
     //
     // Semantic error at paths./test/{test}/{test2}
     // Declared path parameter "test2" needs to be defined as a path parameter at either the path or operation level
-    expect(result.errors?.[0]?.message).toBe(`something something test2`)
+    expect(result.errors?.[0]?.message).toBe('something something test2')
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/openapi-ui/openapi-ui.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/openapi-ui/openapi-ui.test.ts
@@ -13,9 +13,7 @@ describe('openapi-ui', () => {
     // should NOT have additional properties
     // additionalProperty: schema
     // …
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property '$ref'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)
     expect(result.valid).toBe(false)
   })
 })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/openapi-vue/openapi-vue.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/openapi-vue/openapi-vue.test.ts
@@ -13,9 +13,7 @@ describe('openapi-vue', () => {
     // Semantic error at paths./pet.post.requestBody.content.application/json.schema.$ref
     // requestBody schema $refs must point to a position where a Schema Object can be legally placed
     // …
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property '$ref'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)
     expect(result.valid).toBe(false)
   })
 
@@ -26,9 +24,7 @@ describe('openapi-vue', () => {
     //
     // Structural error at paths./pet.post.requestBody.content.application/xml.examples
     // should be object
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property '$ref'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property '$ref'`)
     expect(result.valid).toBe(false)
   })
 })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/pathitem-property.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/pathitem-property.test.ts
@@ -7,9 +7,7 @@ describe('pathitem-property', () => {
   it('returns an error', async () => {
     const result = await validate(pathitemProperty)
 
-    expect(result.errors?.[0]?.message).toBe(
-      `Property GET is not expected to be here`,
-    )
+    expect(result.errors?.[0]?.message).toBe('Property GET is not expected to be here')
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/refAsInteger.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/refAsInteger.test.ts
@@ -11,13 +11,9 @@ describe('refAsInteger', () => {
     //
     // Structural error at components.schemas.mySchema.$ref
     // should be string
-    expect(result.errors?.[0]?.message).toBe(
-      `Property $ref is not expected to be here`,
-    )
+    expect(result.errors?.[0]?.message).toBe('Property $ref is not expected to be here')
     expect(result.errors?.[1]?.message).toBe('type must be string')
-    expect(result.errors?.[2]?.message).toBe(
-      'oneOf must match exactly one schema in oneOf',
-    )
+    expect(result.errors?.[2]?.message).toBe('oneOf must match exactly one schema in oneOf')
     expect(result.errors?.length).toBe(3)
 
     expect(result.valid).toBe(false)

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/schemaProperties.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/schemaProperties.test.ts
@@ -11,9 +11,7 @@ describe('schemaProperties', () => {
 
     expect(errors).not.toBe(undefined)
     expect(errors).not.toStrictEqual([])
-    expect(errors[0]?.message).toBe(
-      "Can't resolve external reference: ../resources/myobject.yml",
-    )
+    expect(errors[0]?.message).toBe("Can't resolve external reference: ../resources/myobject.yml")
     expect(errors.length).toBe(1)
     expect(valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/serverVariableEnumType.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/serverVariableEnumType.test.ts
@@ -10,7 +10,7 @@ describe('serverVariableEnumType', () => {
     // TODO: Swagger Editor has a better error message
     //
     // Structural error at servers.0.variables.version.enum.1 should be string
-    expect(result.errors?.[0]?.message).toBe(`type must be string`)
+    expect(result.errors?.[0]?.message).toBe('type must be string')
     expect(result.errors?.length).toBe(1)
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/cyclical.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/cyclical.test.ts
@@ -2,7 +2,6 @@ import { getListOfReferences } from '@/utils/get-list-of-references'
 import { validate } from '@/utils/validate'
 import { describe, expect, it } from 'vitest'
 
-
 describe('cyclical', () => {
   it('resolves circular references', async () => {
     const specification = {
@@ -42,14 +41,9 @@ describe('cyclical', () => {
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')
     expect(result.schema.components.schemas.top.type).toEqual('object')
-    expect(result.schema.components.schemas.top.properties.cat.type).toEqual(
-      'object',
-    )
-    const category =
-      result.schema.components.schemas.top.properties.cat.properties
-    expect(category.subcategories.items.properties.subcategories.type).toEqual(
-      'array',
-    )
+    expect(result.schema.components.schemas.top.properties.cat.type).toEqual('object')
+    const category = result.schema.components.schemas.top.properties.cat.properties
+    expect(category.subcategories.items.properties.subcategories.type).toEqual('array')
   })
 
   it.todo('resolves circular dependencies in referenced files', async () => {
@@ -115,8 +109,6 @@ describe('cyclical', () => {
     expect(result.valid).toBe(true)
     expect(result.version).toBe('3.0')
     expect(result.schema.components.schemas.top.type).toEqual('object')
-    expect(result.schema.components.schemas.top.properties.cat.type).toEqual(
-      'object',
-    )
+    expect(result.schema.components.schemas.top.properties.cat.type).toEqual('object')
   })
 })

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/externalPathItemRef.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/externalPathItemRef.test.ts
@@ -4,10 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { load, validate } from '../../../../src/index'
 import { readFiles } from '../../../../src/plugins/read-files/read-files'
 
-const EXAMPLE_FILE = path.join(
-  new URL(import.meta.url).pathname,
-  '../../pass/externalPathItemRef.yaml',
-)
+const EXAMPLE_FILE = path.join(new URL(import.meta.url).pathname, '../../pass/externalPathItemRef.yaml')
 
 describe('externalPathItemRef', () => {
   it('passes', async () => {

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/server_enum_unknown.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/server_enum_unknown.test.ts
@@ -9,8 +9,6 @@ describe.todo('server_enum_unknown', () => {
 
     expect(result.valid).toBe(false)
     expect(result.errors?.length).toBe(1)
-    expect(result.errors?.[0]?.message).toBe(
-      'should be equal to one of the allowed values',
-    )
+    expect(result.errors?.[0]?.message).toBe('should be equal to one of the allowed values')
   })
 })

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/fail/no_containers.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/fail/no_containers.test.ts
@@ -8,9 +8,7 @@ describe('no_containers', () => {
     const result = await validate(no_containers)
 
     // TODO: Fix the expected error message should mention 'paths'
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property 'webhooks'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property 'webhooks'`)
     expect(result.valid).toBe(false)
   })
 })

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/fail/server_enum_empty.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/fail/server_enum_empty.test.ts
@@ -7,9 +7,7 @@ describe('server_enum_empty', () => {
   it('returns an error', async () => {
     const result = await validate(server_enum_empty)
 
-    expect(result.errors?.[0]?.message).toBe(
-      `minItems must NOT have fewer than 1 items`,
-    )
+    expect(result.errors?.[0]?.message).toBe('minItems must NOT have fewer than 1 items')
 
     expect(result.valid).toBe(false)
   })

--- a/packages/openapi-parser/tests/openapi3-examples/3.1/fail/unknown_container.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.1/fail/unknown_container.test.ts
@@ -8,9 +8,7 @@ describe('unknown_container', () => {
     const result = await validate(unknown_container)
 
     // TODO: The message should complain about the unknown container
-    expect(result.errors?.[0]?.message).toBe(
-      `must have required property 'webhooks'`,
-    )
+    expect(result.errors?.[0]?.message).toBe(`must have required property 'webhooks'`)
     expect(result.valid).toBe(false)
   })
 })


### PR DESCRIPTION
**Problem**

While working on enabling the [`useAwait` rule](https://github.com/scalar/scalar/pull/7091#discussion_r2429906517), I discovered the following issues:

- TypeScript files in `packages/openapi-parser/tests/openapi3-examples` are not being processed by `biome`.
- Files within `.pnpm-store` are being incorrectly processed by `biome`.

**Solution**

- Include `packages/openapi-parser/tests/openapi3-examples` TypeScript files in Biome’s processing scope.
- Exclude `.pnpm-store` from Biome’s processed files.


| | Files | Time |
|--------|--------|--------|
| Before | 5571 | ~1488ms |
| With this PR | 2209 | ~215ms | 

<details><summary>System info</summary>
<p>

```text
    OS: macOS 26.0.1
    CPU: (8) arm64 Apple M3
    Memory: 135.86 MB / 16.00 GB
    Shell: 5.9 - /bin/zsh
```

</p>
</details> 

<details><summary>Results screenshot</summary>
<p>

<img width="542" height="653" alt="Screenshot 2025-10-23 at 00 47 16" src="https://github.com/user-attachments/assets/fa7d2275-64bf-40b0-91ce-1cca8ad15990" />


</p>
</details> 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`) (not needed).
- [x] I've added tests for the regression or new feature (not needed).
- [x] I've updated the documentation (not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust Biome config to lint TS in `packages/openapi-parser/tests/openapi3-examples` while excluding `.pnpm-store` and YAML/JSON fixtures; reformat tests to match Biome style.
> 
> - **Config (Biome)**:
>   - Remove blanket exclude for `openapi3-examples`; add targeted exclude for `packages/openapi-parser/tests/openapi3-examples/**/*.{yml,yaml,json}` so TS tests are linted.
>   - Exclude `**/.pnpm-store/**` from processing.
> - **Tests (openapi-parser)**:
>   - Stylistic cleanup across `tests/openapi3-examples/**`: normalize quotes, inline long `expect(...).toBe(...)`, minor path joining simplification; no behavioral changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4da1c7ccdfcc8f5c7bf2bfd50c001294ac9a4df8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->