### PR TITLE
feat(mock-server): convert `createMockServer` and all dependent references to synchronous implementation

### DIFF
--- a/.changeset/little-dolls-clap.md
+++ b/.changeset/little-dolls-clap.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': minor
+---
+
+feat(mock-server): convert `createMockServer` and all dependent references to synchronous implementation

--- a/packages/mock-server/README.md
+++ b/packages/mock-server/README.md
@@ -69,7 +69,7 @@ const specification = {
 }
 
 // Create the mocked routes
-const app = await createMockServer({
+const app = createMockServer({
   specification,
   // Custom logging
   onRequest({ context, operation }) {
@@ -157,7 +157,7 @@ const specification = {
 }
 
 // Create the mocked routes
-const app = await createMockServer({
+const app = createMockServer({
   specification,
   // Custom logging
   onRequest({ context, operation }) {

--- a/packages/mock-server/playground/src/galaxy-scalar-com.test.ts
+++ b/packages/mock-server/playground/src/galaxy-scalar-com.test.ts
@@ -1,9 +1,11 @@
 import { readFile } from 'node:fs/promises'
+
 import { serve } from '@hono/node-server'
 import { Scalar } from '@scalar/hono-api-reference'
 import { createMockServer } from '@scalar/mock-server'
-import type { Context } from 'hono'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Context, Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { configureApiReference, createApp, loadDocument, main, startServer } from './galaxy-scalar-com'
 
 // Mock all external dependencies
@@ -12,13 +14,16 @@ vi.mock('@hono/node-server')
 vi.mock('@scalar/hono-api-reference')
 vi.mock('@scalar/mock-server')
 
-// Mock environment variables
-const originalEnv = process.env
-
 describe('galaxy-scalar-com', () => {
+  const mockApp = {
+    get: vi.fn(),
+    fetch: vi.fn(),
+  } as Partial<Hono>
+
   beforeEach(() => {
+    vi.unstubAllEnvs()
+
     vi.clearAllMocks()
-    process.env = { ...originalEnv }
 
     // Reset mocks
     vi.mocked(readFile).mockReset()
@@ -27,13 +32,12 @@ describe('galaxy-scalar-com', () => {
     vi.mocked(createMockServer).mockReset()
 
     // Mock console methods
-    vi.spyOn(console, 'log').mockImplementation(() => {})
-    vi.spyOn(console, 'error').mockImplementation(() => {})
-  })
+    vi.spyOn(console, 'log').mockImplementation(vi.fn())
+    vi.spyOn(console, 'error').mockImplementation(vi.fn())
 
-  afterEach(() => {
-    process.env = originalEnv
-    vi.restoreAllMocks()
+    return () => {
+      vi.restoreAllMocks()
+    }
   })
 
   describe('loadDocument', () => {
@@ -64,11 +68,7 @@ describe('galaxy-scalar-com', () => {
       const mockDocument = 'openapi: 3.1.0'
       vi.mocked(readFile).mockResolvedValue(mockDocument)
 
-      const mockApp = {
-        get: vi.fn(),
-        fetch: vi.fn(),
-      }
-      vi.mocked(createMockServer).mockResolvedValue(mockApp as any)
+      vi.mocked(createMockServer).mockReturnValue(mockApp as Hono)
 
       const app = await createApp()
 
@@ -83,11 +83,7 @@ describe('galaxy-scalar-com', () => {
       const mockDocument = 'openapi: 3.1.0'
       vi.mocked(readFile).mockResolvedValue(mockDocument)
 
-      const mockApp = {
-        get: vi.fn(),
-        fetch: vi.fn(),
-      }
-      vi.mocked(createMockServer).mockResolvedValue(mockApp as any)
+      vi.mocked(createMockServer).mockReturnValue(mockApp as Hono)
 
       await createApp()
 
@@ -118,12 +114,7 @@ describe('galaxy-scalar-com', () => {
 
   describe('configureApiReference', () => {
     it('configures Scalar with correct options', () => {
-      const mockApp = {
-        get: vi.fn(),
-        fetch: vi.fn(),
-      }
-
-      configureApiReference(mockApp as any, 5052, false)
+      configureApiReference(mockApp as Hono, 5052, false)
 
       expect(Scalar).toHaveBeenCalledWith({
         pageTitle: 'Scalar Galaxy',
@@ -149,12 +140,7 @@ describe('galaxy-scalar-com', () => {
     })
 
     it('configures Scalar with local JS bundle when enabled', () => {
-      const mockApp = {
-        get: vi.fn(),
-        fetch: vi.fn(),
-      }
-
-      configureApiReference(mockApp as any, 5052, true)
+      configureApiReference(mockApp as Hono, 5052, true)
 
       expect(Scalar).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -165,23 +151,13 @@ describe('galaxy-scalar-com', () => {
     })
 
     it('adds scalar.js route when local JS bundle is enabled', () => {
-      const mockApp = {
-        get: vi.fn(),
-        fetch: vi.fn(),
-      }
-
-      configureApiReference(mockApp as any, 5052, true)
+      configureApiReference(mockApp as Hono, 5052, true)
 
       expect(mockApp.get).toHaveBeenCalledWith('/scalar.js', expect.any(Function))
     })
 
     it('does not add scalar.js route when local JS bundle is disabled', () => {
-      const mockApp = {
-        get: vi.fn(),
-        fetch: vi.fn(),
-      }
-
-      configureApiReference(mockApp as any, 5052, false)
+      configureApiReference(mockApp as Hono, 5052, false)
 
       expect(mockApp.get).not.toHaveBeenCalledWith('/scalar.js', expect.any(Function))
     })
@@ -189,12 +165,7 @@ describe('galaxy-scalar-com', () => {
 
   describe('startServer', () => {
     it('starts server with correct configuration', () => {
-      const mockApp = {
-        get: vi.fn(),
-        fetch: vi.fn(),
-      }
-
-      startServer(mockApp as any, 5052)
+      startServer(mockApp as Hono, 5052)
 
       expect(serve).toHaveBeenCalledWith(
         {
@@ -207,19 +178,14 @@ describe('galaxy-scalar-com', () => {
     })
 
     it('logs server startup message', () => {
-      const mockApp = {
-        get: vi.fn(),
-        fetch: vi.fn(),
-      }
-
-      startServer(mockApp as any, 5052)
+      startServer(mockApp as Hono, 5052)
 
       // Get the callback passed to serve
       const serveCall = vi.mocked(serve).mock.calls[0]
-      const callback = serveCall?.[1] as any
+      const callback = serveCall?.[1]
 
       // Call the callback with mock info
-      callback({ port: 5052, address: '0.0.0.0', family: 'IPv4' })
+      callback?.({ port: 5052, address: '0.0.0.0', family: 'IPv4' })
 
       expect(console.log).toHaveBeenCalledWith()
       expect(console.log).toHaveBeenCalledWith('🚧 Mock Server listening on http://localhost:5052')
@@ -229,16 +195,10 @@ describe('galaxy-scalar-com', () => {
 
   describe('main', () => {
     it('uses default port when PORT is not set', async () => {
-      delete process.env.PORT
-
       const mockDocument = 'openapi: 3.1.0'
       vi.mocked(readFile).mockResolvedValue(mockDocument)
 
-      const mockApp = {
-        get: vi.fn(),
-        fetch: vi.fn(),
-      }
-      vi.mocked(createMockServer).mockResolvedValue(mockApp as any)
+      vi.mocked(createMockServer).mockReturnValue(mockApp as Hono)
 
       await main()
 
@@ -251,16 +211,12 @@ describe('galaxy-scalar-com', () => {
     })
 
     it('uses custom port when PORT is set', async () => {
-      process.env.PORT = '8080'
+      vi.stubEnv('PORT', '8080')
 
       const mockDocument = 'openapi: 3.1.0'
       vi.mocked(readFile).mockResolvedValue(mockDocument)
 
-      const mockApp = {
-        get: vi.fn(),
-        fetch: vi.fn(),
-      }
-      vi.mocked(createMockServer).mockResolvedValue(mockApp as any)
+      vi.mocked(createMockServer).mockReturnValue(mockApp as Hono)
 
       await main()
 
@@ -273,16 +229,12 @@ describe('galaxy-scalar-com', () => {
     })
 
     it('uses local JS bundle when LOCAL_JS_BUNDLE is true', async () => {
-      process.env.LOCAL_JS_BUNDLE = 'true'
+      vi.stubEnv('LOCAL_JS_BUNDLE', 'true')
 
       const mockDocument = 'openapi: 3.1.0'
       vi.mocked(readFile).mockResolvedValue(mockDocument)
 
-      const mockApp = {
-        get: vi.fn(),
-        fetch: vi.fn(),
-      }
-      vi.mocked(createMockServer).mockResolvedValue(mockApp as any)
+      vi.mocked(createMockServer).mockReturnValue(mockApp as Hono)
 
       await main()
 
@@ -296,16 +248,12 @@ describe('galaxy-scalar-com', () => {
     })
 
     it('does not use local JS bundle when LOCAL_JS_BUNDLE is not true', async () => {
-      process.env.LOCAL_JS_BUNDLE = 'false'
+      vi.stubEnv('LOCAL_JS_BUNDLE', 'false')
 
       const mockDocument = 'openapi: 3.1.0'
       vi.mocked(readFile).mockResolvedValue(mockDocument)
 
-      const mockApp = {
-        get: vi.fn(),
-        fetch: vi.fn(),
-      }
-      vi.mocked(createMockServer).mockResolvedValue(mockApp as any)
+      vi.mocked(createMockServer).mockReturnValue(mockApp as Hono)
 
       await main()
 

--- a/packages/mock-server/playground/src/galaxy-scalar-com.ts
+++ b/packages/mock-server/playground/src/galaxy-scalar-com.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises'
 import { serve } from '@hono/node-server'
 import { Scalar } from '@scalar/hono-api-reference'
 import { createMockServer } from '@scalar/mock-server'
-import type { Context } from 'hono'
+import type { Context, Hono } from 'hono'
 
 /**
  * Read the OpenAPI document from the filesystem.
@@ -21,7 +21,7 @@ export async function loadDocument(): Promise<string> {
 /**
  * Create and configure the mock server application.
  */
-export async function createApp(): Promise<any> {
+export async function createApp(): Promise<Hono> {
   const document = await loadDocument()
 
   return createMockServer({
@@ -35,7 +35,7 @@ export async function createApp(): Promise<any> {
 /**
  * Configure the API reference with Scalar.
  */
-export function configureApiReference(app: any, port: number, useLocalJsBundle: boolean): void {
+export function configureApiReference(app: Hono, port: number, useLocalJsBundle: boolean): void {
   app.get(
     '/',
     Scalar({
@@ -62,14 +62,14 @@ export function configureApiReference(app: any, port: number, useLocalJsBundle: 
   )
 
   if (useLocalJsBundle) {
-    app.get('/scalar.js', async (c: any) => c.text(await readFile(new URL('./scalar.js', import.meta.url), 'utf8')))
+    app.get('/scalar.js', async (c) => c.text(await readFile(new URL('./scalar.js', import.meta.url), 'utf8')))
   }
 }
 
 /**
  * Start the server with the given configuration.
  */
-export function startServer(app: any, port: number): void {
+export function startServer(app: Hono, port: number): void {
   serve(
     {
       fetch: app.fetch,

--- a/packages/mock-server/src/createMockServer.ts
+++ b/packages/mock-server/src/createMockServer.ts
@@ -17,7 +17,7 @@ import { respondWithOpenApiDocument } from './routes/respondWithOpenApiDocument'
 /**
  * Create a mock server instance
  */
-export function createMockServer(options: MockServerOptions) {
+export function createMockServer(options: MockServerOptions): Hono {
   const app = new Hono()
 
   /** Dereferenced OpenAPI document */

--- a/packages/mock-server/tests/authentication/apiKey.test.ts
+++ b/packages/mock-server/tests/authentication/apiKey.test.ts
@@ -17,7 +17,7 @@ describe('API Key Authentication', () => {
       },
     }
 
-    const server = await createMockServer({ specification })
+    const server = createMockServer({ specification })
     const response = await server.request('/api-key-test', {
       headers: { 'X-API-Key': 'test-api-key' },
     })
@@ -40,7 +40,7 @@ describe('API Key Authentication', () => {
       },
     }
 
-    const server = await createMockServer({ specification })
+    const server = createMockServer({ specification })
     const response = await server.request('/api-key-test')
 
     expect(response.status).toBe(401)

--- a/packages/mock-server/tests/authentication/basicAuthentication.test.ts
+++ b/packages/mock-server/tests/authentication/basicAuthentication.test.ts
@@ -17,7 +17,7 @@ describe('HTTP Basic Authentication', () => {
       },
     }
 
-    const server = await createMockServer({ specification })
+    const server = createMockServer({ specification })
     const response = await server.request('/basic-auth-test', {
       headers: { Authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=' },
     })
@@ -38,7 +38,7 @@ describe('HTTP Basic Authentication', () => {
       },
     }
 
-    const server = await createMockServer({ specification })
+    const server = createMockServer({ specification })
     const response = await server.request('/basic-auth-test')
 
     expect(response.status).toBe(401)

--- a/packages/mock-server/tests/authentication/bearerAuthentication.test.ts
+++ b/packages/mock-server/tests/authentication/bearerAuthentication.test.ts
@@ -17,7 +17,7 @@ describe('Bearer Token Authentication', () => {
       },
     }
 
-    const server = await createMockServer({ specification })
+    const server = createMockServer({ specification })
     const response = await server.request('/bearer-test', {
       headers: { Authorization: 'Bearer test-token' },
     })
@@ -40,7 +40,7 @@ describe('Bearer Token Authentication', () => {
       },
     }
 
-    const server = await createMockServer({ specification })
+    const server = createMockServer({ specification })
     const response = await server.request('/bearer-test')
 
     expect(response.status).toBe(401)

--- a/packages/mock-server/tests/authentication/oAuth.test.ts
+++ b/packages/mock-server/tests/authentication/oAuth.test.ts
@@ -27,7 +27,7 @@ describe('OAuth 2.0 Authentication', () => {
     }
 
     it('succeeds with valid OAuth token', async () => {
-      const server = await createMockServer({ specification })
+      const server = createMockServer({ specification })
       const response = await server.request('/oauth-test', {
         headers: { Authorization: 'Bearer valid-token' },
       })
@@ -36,7 +36,7 @@ describe('OAuth 2.0 Authentication', () => {
     })
 
     it('fails without OAuth token', async () => {
-      const server = await createMockServer({ specification })
+      const server = createMockServer({ specification })
       const response = await server.request('/oauth-test')
 
       expect(response.status).toBe(401)
@@ -65,7 +65,7 @@ describe('OAuth 2.0 Authentication', () => {
     }
 
     it('succeeds with valid OAuth token', async () => {
-      const server = await createMockServer({ specification })
+      const server = createMockServer({ specification })
       const response = await server.request('/oauth-test', {
         headers: { Authorization: 'Bearer valid-token' },
       })
@@ -74,7 +74,7 @@ describe('OAuth 2.0 Authentication', () => {
     })
 
     it('fails without OAuth token', async () => {
-      const server = await createMockServer({ specification })
+      const server = createMockServer({ specification })
       const response = await server.request('/oauth-test')
 
       expect(response.status).toBe(401)
@@ -103,7 +103,7 @@ describe('OAuth 2.0 Authentication', () => {
     }
 
     it('succeeds with valid OAuth token', async () => {
-      const server = await createMockServer({ specification })
+      const server = createMockServer({ specification })
       const response = await server.request('/oauth-test', {
         headers: { Authorization: 'Bearer valid-token' },
       })
@@ -112,7 +112,7 @@ describe('OAuth 2.0 Authentication', () => {
     })
 
     it('fails without OAuth token', async () => {
-      const server = await createMockServer({ specification })
+      const server = createMockServer({ specification })
       const response = await server.request('/oauth-test')
 
       expect(response.status).toBe(401)
@@ -142,7 +142,7 @@ describe('OAuth 2.0 Authentication', () => {
     }
 
     it('succeeds with valid OAuth token', async () => {
-      const server = await createMockServer({ specification })
+      const server = createMockServer({ specification })
 
       const response = await server.request('/oauth-test', {
         headers: { Authorization: 'Bearer valid-token' },
@@ -152,7 +152,7 @@ describe('OAuth 2.0 Authentication', () => {
     })
 
     it('fails without OAuth token', async () => {
-      const server = await createMockServer({ specification })
+      const server = createMockServer({ specification })
       const response = await server.request('/oauth-test')
 
       expect(response.status).toBe(401)

--- a/packages/mock-server/tests/authentication/openIdConnect.test.ts
+++ b/packages/mock-server/tests/authentication/openIdConnect.test.ts
@@ -27,7 +27,7 @@ describe('OpenID Connect', () => {
   }
 
   it('returns OpenID configuration', async () => {
-    const server = await createMockServer({ specification })
+    const server = createMockServer({ specification })
     const response = await server.request('/.well-known/openid-configuration')
 
     expect(response.status).toBe(200)
@@ -42,7 +42,7 @@ describe('OpenID Connect', () => {
   })
 
   it('succeeds with valid OAuth token', async () => {
-    const server = await createMockServer({ specification })
+    const server = createMockServer({ specification })
 
     const response = await server.request('/oauth-test', {
       headers: { Authorization: 'Bearer valid-token' },
@@ -52,7 +52,7 @@ describe('OpenID Connect', () => {
   })
 
   it('succeeds with valid OAuth token for scoped endpoint', async () => {
-    const server = await createMockServer({ specification })
+    const server = createMockServer({ specification })
 
     const response = await server.request('/protected', {
       headers: { Authorization: 'Bearer valid-token' },
@@ -62,7 +62,7 @@ describe('OpenID Connect', () => {
   })
 
   it('fails without OAuth token', async () => {
-    const server = await createMockServer({ specification })
+    const server = createMockServer({ specification })
     const response = await server.request('/oauth-test')
 
     expect(response.status).toBe(401)

--- a/packages/mock-server/tests/galaxy.test.ts
+++ b/packages/mock-server/tests/galaxy.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-// @ts-expect-error TODO
 import galaxy from '../../galaxy/src/documents/3.1.yaml?raw'
 import { createMockServer } from '../src/createMockServer'
 
 describe('createMockServer', () => {
   it('GET /planets -> example JSON', async () => {
-    const server = await createMockServer({
+    const server = createMockServer({
       specification: galaxy,
     })
 

--- a/packages/mock-server/tests/onRequest.test.ts
+++ b/packages/mock-server/tests/onRequest.test.ts
@@ -22,7 +22,7 @@ describe('onRequest', () => {
 
     const onRequestSpy = vi.fn<NonNullable<MockServerOptions['onRequest']>>()
 
-    const server = await createMockServer({
+    const server = createMockServer({
       specification,
       onRequest: onRequestSpy,
     })

--- a/packages/mock-server/tests/openapi.test.ts
+++ b/packages/mock-server/tests/openapi.test.ts
@@ -14,7 +14,7 @@ describe('openapi.{json|yaml}', () => {
       paths: {},
     }
 
-    const server = await createMockServer({
+    const server = createMockServer({
       specification,
     })
 
@@ -35,7 +35,7 @@ describe('openapi.{json|yaml}', () => {
       paths: {},
     }
 
-    const server = await createMockServer({
+    const server = createMockServer({
       specification: JSON.stringify(specification),
     })
 
@@ -56,7 +56,7 @@ describe('openapi.{json|yaml}', () => {
       paths: {},
     }
 
-    const server = await createMockServer({
+    const server = createMockServer({
       specification: toYaml(specification),
     })
 
@@ -77,7 +77,7 @@ describe('openapi.{json|yaml}', () => {
       paths: {},
     }
 
-    const server = await createMockServer({
+    const server = createMockServer({
       specification,
     })
 
@@ -98,7 +98,7 @@ describe('openapi.{json|yaml}', () => {
       paths: {},
     }
 
-    const server = await createMockServer({
+    const server = createMockServer({
       specification: toYaml(specification),
     })
 
@@ -119,7 +119,7 @@ describe('openapi.{json|yaml}', () => {
       paths: {},
     }
 
-    const server = await createMockServer({
+    const server = createMockServer({
       specification: JSON.stringify(specification),
     })
 


### PR DESCRIPTION
**Problem**

[Another change related to the `useAwait` rule](https://github.com/scalar/scalar/pull/7091#discussion_r2429906517):

`createMockServer` has no asynchronous logic but most of its usage have an `await`.

**Solution**

Add an explicit return type to `createMockServer` and update all its usage and references

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `createMockServer` return synchronously (typed `Hono`) and update docs, playground, and tests to remove unnecessary `await`.
> 
> - **Core**
>   - `createMockServer` now returns synchronously with explicit `Hono` type (`packages/mock-server/src/createMockServer.ts`).
> - **Playground**
>   - Update `galaxy-scalar-com.ts` and tests to use synchronous `createMockServer` and `Hono` typings; minor handler/callback type cleanups.
> - **Tests**
>   - Remove `await` from all `createMockServer` calls across authentication/OpenID/OpenAPI tests and `galaxy` tests.
>   - Use `vi.stubEnv`/`vi.unstubAllEnvs`; refine console mocks and optional callback invocation.
> - **Docs**
>   - README examples updated to drop `await` when creating the mock server.
> - **Release**
>   - Add changeset for `@scalar/mock-server` minor version bump.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8c9a9575f2c492ddfc45b2fc679a8af743e7b3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->