### PR TITLE
ci: adds “Required CI OK” to simplify branch rule protection match

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1480,3 +1480,22 @@ jobs:
         run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  required-ci-ok:
+    name: Required CI OK
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions: {}
+    if: always()
+    needs:
+      - build
+      - format
+      - test-packages-shard-1
+      - test-packages-shard-2
+      - test-integrations
+      - test-proxy-server
+      - types
+    steps:
+      - name: Exit with error if some jobs are not successful
+        run: exit 1
+        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')) }}


### PR DESCRIPTION
**Problem**

While working on #7187, I noticed that the required job `test-packages` was no longer reporting its status:

<img width="932" height="213" alt="image" src="https://github.com/user-attachments/assets/bad5e6ee-51e5-46e8-b1b9-ae87a5fc9a6a" />

---

After a quick investigation, I found that this job was removed in #7179.

**Solution**

This PR introduces a new job called "Required CI OK", which depends on all currently required CI jobs.  
If any of those dependent jobs end with a non-`success` result, this job will exit with code `1`.

With this approach, you only need to mark `Required CI OK` as a required check in your repository settings.  
This makes it possible to update required CI jobs directly in the `CI.yml` file,
without needing to modify branch protection rules or rulesets each time.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`) (Not needed).
- [x] I've added tests for the regression or new feature (Not needed).
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `required-ci-ok` job that aggregates required CI jobs and fails if any are not successful, enabling a single required check.
> 
> - **CI**:
>   - Add `required-ci-ok` job in `.github/workflows/ci.yml`.
>     - Depends on `build`, `format`, `test-packages-shard-1`, `test-packages-shard-2`, `test-integrations`, `test-proxy-server`, `types`.
>     - Always runs and exits with error if any dependency is `failure`, `skipped`, or `cancelled`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 022afaa85777dea03d5d8d094f8712b209d65cd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->