### PR TITLE
feat: Change enum line width to 1px for consistency

### DIFF
--- a/packages/api-reference/src/components/Content/Schema/SchemaEnumPropertyItem.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnumPropertyItem.vue
@@ -29,7 +29,7 @@ defineProps<{
   align-items: stretch;
   position: relative;
 
-  --decorator-width: 0.5px;
+  --decorator-width: 1px;
 }
 
 .property-enum-value-content {


### PR DESCRIPTION
**Problem**

Currently, …

**Solution**

Before high DPI:
<img width="661" height="476" alt="image" src="https://github.com/user-attachments/assets/7dad55da-973a-466d-b9f2-86600fcb1ae6" />

After high DPI:
<img width="661" height="476" alt="image" src="https://github.com/user-attachments/assets/c9f0707c-1b67-4820-a286-7b3a63667e24" />


Before low DPI:
<img width="651" height="370" alt="image" src="https://github.com/user-attachments/assets/4873be6d-bb7b-4d23-a035-965349ea62a5" />


After low DPI
<img width="651" height="370" alt="image" src="https://github.com/user-attachments/assets/3f78658d-a9e4-4a0c-8398-97d5b57d4bb5" />


**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes enum connector line thickness to 1px via a new CSS variable and cleans up redundant styling.
> 
> - **UI (Schema enum list styling)** in `packages/api-reference/src/components/Content/Schema/SchemaEnumPropertyItem.vue`:
>   - Introduces `--decorator-width: 1px` and uses it for enum connector lines (`.property-enum-value::before`, `.property-enum-value-label::after`).
>   - Replaces previous width references with the new variable to standardize line thickness.
>   - Removes redundant rule for non-last children connector styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70492442170db9970520e34a1cdffdd73db97173. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->