### PR TITLE
fix(mock-server): restore `async` on `createMockServer`

### DIFF
--- a/.changeset/young-turtles-battle.md
+++ b/.changeset/young-turtles-battle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+fix(mock-server): restore `async` on `createMockServer`

--- a/packages/mock-server/playground/src/galaxy-scalar-com.ts
+++ b/packages/mock-server/playground/src/galaxy-scalar-com.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises'
 import { serve } from '@hono/node-server'
 import { Scalar } from '@scalar/hono-api-reference'
 import { createMockServer } from '@scalar/mock-server'
-import type { Context } from 'hono'
+import type { Hono } from 'hono'
 
 /**
  * Read the OpenAPI document from the filesystem.
@@ -21,12 +21,12 @@ export async function loadDocument(): Promise<string> {
 /**
  * Create and configure the mock server application.
  */
-export async function createApp(): Promise<any> {
+export async function createApp(): Promise<Hono> {
   const document = await loadDocument()
 
   return createMockServer({
     specification: document,
-    onRequest: (opts: { context: Context }) => {
+    onRequest: (opts) => {
       console.log(`${opts.context.req.method} ${opts.context.req.url}`)
     },
   })
@@ -35,7 +35,7 @@ export async function createApp(): Promise<any> {
 /**
  * Configure the API reference with Scalar.
  */
-export function configureApiReference(app: any, port: number, useLocalJsBundle: boolean): void {
+export function configureApiReference(app: Hono, port: number, useLocalJsBundle: boolean): void {
   app.get(
     '/',
     Scalar({
@@ -62,14 +62,14 @@ export function configureApiReference(app: any, port: number, useLocalJsBundle: 
   )
 
   if (useLocalJsBundle) {
-    app.get('/scalar.js', async (c: any) => c.text(await readFile(new URL('./scalar.js', import.meta.url), 'utf8')))
+    app.get('/scalar.js', async (c) => c.text(await readFile(new URL('./scalar.js', import.meta.url), 'utf8')))
   }
 }
 
 /**
  * Start the server with the given configuration.
  */
-export function startServer(app: any, port: number): void {
+export function startServer(app: Hono, port: number): void {
   serve(
     {
       fetch: app.fetch,

--- a/packages/mock-server/src/createMockServer.test.ts
+++ b/packages/mock-server/src/createMockServer.test.ts
@@ -30,7 +30,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     const response = await server.request('/foobar')
 
@@ -83,7 +83,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     const response = await server.request('/foobar')
 
@@ -128,7 +128,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     const response = await server.request('/foobar', {
       headers: {
@@ -170,7 +170,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     const response = await server.request('/foobar')
 
@@ -207,7 +207,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     const response = await server.request('/foobar')
 
@@ -246,7 +246,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     const response = await server.request('/foobar')
 
@@ -283,7 +283,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     const response = await server.request('/foobar', {
       method: 'POST',
@@ -322,7 +322,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     const response = await server.request('/foobar', {
       method: 'POST',
@@ -361,7 +361,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     const response = await server.request('/foobar/123')
 
@@ -405,7 +405,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     const response = await server.request('/foobar/123')
 
@@ -448,7 +448,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     const response = await server.request('/foobar')
 
@@ -491,7 +491,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     const response = await server.request('/foobar/123')
 
@@ -528,7 +528,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     // Options request
     let response = await server.request('/foobar', {
@@ -591,7 +591,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     const response = await server.request('/foobar')
 
@@ -627,7 +627,7 @@ describe('createMockServer', () => {
       },
     }
 
-    const server = createMockServer({ specification })
+    const server = await createMockServer({ specification })
 
     const response = await server.request('/redirect')
 

--- a/packages/mock-server/src/createMockServer.ts
+++ b/packages/mock-server/src/createMockServer.ts
@@ -1,6 +1,6 @@
 import { dereference } from '@scalar/openapi-parser'
 import type { OpenAPI, OpenAPIV3_1 } from '@scalar/openapi-types'
-import { type Context, Hono } from 'hono'
+import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 
 import type { HttpMethod, MockServerOptions } from '@/types'
@@ -17,7 +17,7 @@ import { respondWithOpenApiDocument } from './routes/respondWithOpenApiDocument'
 /**
  * Create a mock server instance
  */
-export function createMockServer(options: MockServerOptions) {
+export function createMockServer(options: MockServerOptions): Promise<Hono> {
   const app = new Hono()
 
   /** Dereferenced OpenAPI document */
@@ -50,7 +50,7 @@ export function createMockServer(options: MockServerOptions) {
       }
 
       // Actual route
-      app[method](route, (c: Context) => mockAnyResponse(c, operation, options))
+      app[method](route, (c) => mockAnyResponse(c, operation, options))
     })
   })
 
@@ -60,5 +60,9 @@ export function createMockServer(options: MockServerOptions) {
   // OpenAPI YAML file
   app.get('/openapi.yaml', (c) => respondWithOpenApiDocument(c, options?.specification, 'yaml'))
 
-  return app
+  /**
+   * No async code, but returning a Promise to allow future async logic to be implemented
+   * @see https://github.com/scalar/scalar/pull/7174#discussion_r2470046281
+   */
+  return Promise.resolve(app)
 }

--- a/packages/mock-server/tests/galaxy.test.ts
+++ b/packages/mock-server/tests/galaxy.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 
-// @ts-expect-error TODO
 import galaxy from '../../galaxy/src/documents/3.1.yaml?raw'
 import { createMockServer } from '../src/createMockServer'
 


### PR DESCRIPTION
**Problem**

- Followup of https://github.com/scalar/scalar/pull/7174#discussion_r2470046281

**Solution**

- Explicitly declare the return type as `Promise<Hono>` to ensure the public API remains unchanged.
- Use `Promise.resolve` to satisfy static code analysis, which flags asynchronous functions without an `await` 
  (see the [`useAwait` rule](https://github.com/scalar/scalar/pull/7091#discussion_r2429906517)).
- Made a few minor improvements across several tests (I'll let Cursor summarize those 😅).

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restore async `createMockServer` (now returns `Promise<Hono>`) and update playground and tests to await it and use proper Hono types.
> 
> - **Mock Server Core (`packages/mock-server/src/createMockServer.ts`)**:
>   - Change `createMockServer` to return `Promise<Hono>`; wrap return with `Promise.resolve(app)`.
>   - Simplify handler signatures (remove explicit `Context` type usage).
> - **Playground (`packages/mock-server/playground/src/galaxy-scalar-com.ts`)**:
>   - `createApp` now returns `Promise<Hono>`; `configureApiReference`/`startServer` typed to `Hono`.
>   - Adjust `onRequest` callback param typing and `/scalar.js` handler parameter.
> - **Tests**:
>   - Update all tests to `await createMockServer(...)` across `createMockServer.test.ts`, `galaxy.test.ts`.
>   - Refactor `galaxy-scalar-com.test.ts`: use `Hono` typing for mocks, `vi.unstubAllEnvs`/`vi.stubEnv`, streamline console spies, and minor callback/typing fixes.
> - **Release**:
>   - Add changeset for `@scalar/mock-server` patch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b04d6fbc70e6dee24d33001913deaef04a918d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->