### PR TITLE
fix: patch header ID generation

### DIFF
--- a/packages/api-reference/src/blocks/scalar-info-block/components/InfoDescription.vue
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/InfoDescription.vue
@@ -47,10 +47,10 @@ const sections = computed(() => {
   return items
 })
 
-const slugger = new GitHubSlugger()
-
 /** Add ids to all headings */
 const transformHeading = (node: Record<string, any>) => {
+  const slugger = new GitHubSlugger()
+
   node.data = {
     hProperties: {
       id: headingSlugGenerator({


### PR DESCRIPTION
**Problem**

Slugger instance was not in the correct place. 

**Solution**

With this PR …

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Instantiate GitHubSlugger within transformHeading to generate per-heading IDs, removing the shared instance.
> 
> - **API Reference › `InfoDescription.vue`**:
>   - Move `GitHubSlugger` instantiation inside `transformHeading` for heading ID generation.
>   - Update heading ID creation to use a locally scoped slug via `slugger.slug(...)`.
>   - Remove the previously shared `slugger` instance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1a00d4ec0de94dd44a808c211c2b5af20ca921f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->