### PR TITLE
feat(api-reference): virtualized operations

### DIFF
--- a/packages/api-reference/src/features/Operation/Operation.vue
+++ b/packages/api-reference/src/features/Operation/Operation.vue
@@ -10,10 +10,11 @@ import type {
   SecurityRequirementObject,
   ServerObject,
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-import { computed } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 
 import { combineParams } from '@/features/Operation/helpers/combine-params'
 import type { SecuritySchemeGetter } from '@/helpers/map-config-to-client-store'
+import { useVirtual } from '@/hooks/use-virtual'
 
 import { getFirstServer } from './helpers/get-first-server'
 import ClassicLayout from './layouts/ClassicLayout.vue'
@@ -88,32 +89,41 @@ const selectedServer = computed<ServerObject | undefined>(() =>
     server,
   ),
 )
+
+const virtual = useTemplateRef<HTMLElement>('virtual')
+
+const { isVisible, placeholderHeight } = useVirtual(virtual)
 </script>
 
 <template>
-  <template v-if="operation">
-    <ClassicLayout
-      v-if="options?.layout === 'classic'"
-      :id="id"
-      :eventBus="eventBus"
-      :isCollapsed="isCollapsed"
-      :method="method"
-      :operation="operation"
-      :options="options"
-      :path="path"
-      :securitySchemes="selectedSecuritySchemes"
-      :server="selectedServer"
-      :xScalarDefaultClient="xScalarDefaultClient" />
-    <ModernLayout
-      v-else
-      :id="id"
-      :eventBus="eventBus"
-      :method="method"
-      :operation="operation"
-      :options="options"
-      :path="path"
-      :securitySchemes="selectedSecuritySchemes"
-      :server="selectedServer"
-      :xScalarDefaultClient="xScalarDefaultClient" />
-  </template>
+  <div
+    :id="id"
+    ref="virtual"
+    :style="{ minHeight: `${placeholderHeight}px` }">
+    <template v-if="isVisible && operation">
+      <ClassicLayout
+        v-if="options?.layout === 'classic'"
+        :id="id"
+        :eventBus="eventBus"
+        :isCollapsed="isCollapsed"
+        :method="method"
+        :operation="operation"
+        :options="options"
+        :path="path"
+        :securitySchemes="selectedSecuritySchemes"
+        :server="selectedServer"
+        :xScalarDefaultClient="xScalarDefaultClient" />
+      <ModernLayout
+        v-else
+        :id="id"
+        :eventBus="eventBus"
+        :method="method"
+        :operation="operation"
+        :options="options"
+        :path="path"
+        :securitySchemes="selectedSecuritySchemes"
+        :server="selectedServer"
+        :xScalarDefaultClient="xScalarDefaultClient" />
+    </template>
+  </div>
 </template>

--- a/packages/api-reference/src/hooks/use-virtual.ts
+++ b/packages/api-reference/src/hooks/use-virtual.ts
@@ -1,0 +1,35 @@
+import { type TemplateRef, nextTick, ref, watch } from 'vue'
+
+export const useVirtual = (el: TemplateRef<HTMLElement | undefined>) => {
+  const isVisible = ref(false)
+  const observer = ref<IntersectionObserver | null>(null)
+  const placeholderHeight = ref(1000)
+
+  watch(el, () => {
+    if (el.value) {
+      observer.value?.disconnect()
+
+      observer.value = new IntersectionObserver(
+        ([entry]) => {
+          if (entry?.isIntersecting) {
+            isVisible.value = true
+            nextTick(() => {
+              placeholderHeight.value = el.value?.offsetHeight || 1000
+            })
+          }
+        },
+        {
+          rootMargin: '9000px',
+        },
+      )
+      observer.value.observe(el.value)
+    } else {
+      observer.value?.disconnect()
+    }
+  })
+
+  return {
+    isVisible,
+    placeholderHeight,
+  }
+}


### PR DESCRIPTION
**Problem**

When there is very large tags open we have too many DOM elements to handle elegantly. 

**Solution**

Virtualizes operations with a fixed estimated height and a fairly long render window. 

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lazily renders `Operation.vue` using a new `useVirtual` hook that shows a placeholder height and mounts content only when in view.
> 
> - **API Reference**
>   - **Operation virtualization**:
>     - `features/Operation/Operation.vue`: wraps layouts in a container with `ref="virtual"`, applies `minHeight` from `placeholderHeight`, and conditionally renders when `isVisible` using `useTemplateRef` and `useVirtual`.
>     - Preserves both `ClassicLayout` and `ModernLayout` rendering paths behind visibility check.
>   - **New hook**:
>     - `hooks/use-virtual.ts`: adds `useVirtual` using `IntersectionObserver` (large `rootMargin`) to expose `isVisible` and `placeholderHeight` for lazy mounting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 012c286258fe24ecbc45ab7b6d1caf33b1812556. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->