### PR TITLE
fix(api-reference): add missing dependency for lazy bus run

### DIFF
--- a/.changeset/calm-weeks-taste.md
+++ b/.changeset/calm-weeks-taste.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Correct dependency triggers for lazy bus running

--- a/packages/api-reference/src/helpers/lazy-bus.ts
+++ b/packages/api-reference/src/helpers/lazy-bus.ts
@@ -73,7 +73,7 @@ const runLazyBus = () => {
    * After waiting for Vue to update the DOM we execute the callbacks and unblock intersection
    */
   const executeRender = async () => {
-    if (pendingQueue.size > 0) {
+    if (pendingQueue.size > 0 || priorityQueue.size > 0) {
       isRunning.value = true
 
       for (const id of pendingQueue.values()) {


### PR DESCRIPTION
**Problem**
 
Scroll will freeze when there is not enough child tags. 

**Solution**

Lazy bus should also be run when the priority queue changes. 

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure lazy bus runs on priority queue changes and processes both pending and priority items.
> 
> - **api-reference**:
>   - **Lazy bus triggers (`packages/api-reference/src/helpers/lazy-bus.ts`)**:
>     - Run when `priorityQueue` changes by adding it to `watchDebounced` dependencies and run condition.
>     - Execute render when either `pendingQueue` or `priorityQueue` has items; move both into `readyQueue`.
>     - Add notes clarifying dependency on priority-based finish callbacks.
> - **Changeset**: Patch release for `@scalar/api-reference`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5291cc8f71db97d38199f3f4833c968d4780d394. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->