### PR TITLE
fix(workspace-store): remove `async` from synchronous functions

### DIFF
--- a/.changeset/few-readers-approve.md
+++ b/.changeset/few-readers-approve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix(workspace-store): remove `async` from synchronous functions

--- a/packages/api-client/src/v2/hooks/use-document-watcher.test.ts
+++ b/packages/api-client/src/v2/hooks/use-document-watcher.test.ts
@@ -1,9 +1,8 @@
-import assert from 'node:assert'
 import { setTimeout } from 'node:timers/promises'
 
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import { type FastifyInstance, fastify } from 'fastify'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import { useDocumentWatcher } from '@/v2/hooks/use-document-watcher'
@@ -18,14 +17,14 @@ describe('useDocumentWatcher', () => {
     vi.useFakeTimers()
 
     server = fastify({ logger: false })
-  })
 
-  afterEach(async () => {
-    vi.clearAllTimers()
-    vi.useRealTimers()
-    vi.restoreAllMocks()
-    await server.close()
-    await setTimeout(100)
+    return async () => {
+      vi.clearAllTimers()
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+      await server.close()
+      await setTimeout(100)
+    }
   })
 
   it('watch the document and rebase it with the remote source', async () => {

--- a/packages/workspace-store/src/persistence/index.test.ts
+++ b/packages/workspace-store/src/persistence/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import 'fake-indexeddb/auto'
 
 import { createWorkspaceStorePersistence } from './index'
@@ -9,17 +9,17 @@ describe('createWorkspaceStorePersistence', { concurrent: false }, () => {
 
   beforeEach(async () => {
     persistence = await createWorkspaceStorePersistence()
-  })
 
-  afterEach(async () => {
-    await persistence.close()
+    return async () => {
+      persistence.close()
 
-    // Clean up: delete database
-    const deleteRequest = indexedDB.deleteDatabase(testDbName)
-    await new Promise((resolve, reject) => {
-      deleteRequest.onsuccess = () => resolve(undefined)
-      deleteRequest.onerror = () => reject(deleteRequest.error)
-    })
+      // Clean up: delete database
+      const deleteRequest = indexedDB.deleteDatabase(testDbName)
+      await new Promise((resolve, reject) => {
+        deleteRequest.onsuccess = () => resolve(undefined)
+        deleteRequest.onerror = () => reject(deleteRequest.error)
+      })
+    }
   })
 
   describe('workspace.getAll', () => {

--- a/packages/workspace-store/src/persistence/index.ts
+++ b/packages/workspace-store/src/persistence/index.ts
@@ -66,8 +66,8 @@ export const createWorkspaceStorePersistence = async () => {
 
   // The returned persistence API with logical sections for each table and mapping.
   return {
-    close: async () => {
-      return connection.closeDatabase()
+    close: () => {
+      connection.closeDatabase()
     },
     meta: {
       /**

--- a/packages/workspace-store/src/persistence/indexdb.test.ts
+++ b/packages/workspace-store/src/persistence/indexdb.test.ts
@@ -1,5 +1,5 @@
 import { Type } from '@scalar/typebox'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import 'fake-indexeddb/auto'
 
 import { createIndexDbConnection } from './indexdb'
@@ -38,16 +38,16 @@ describe('indexdb', () => {
         orders: { schema: OrderSchema, index: ['userId', 'orderId'] as const },
       },
     })
-  })
 
-  afterEach(async () => {
-    // Clean up: close connection and delete database
-    dbConnection.closeDatabase()
-    const deleteRequest = indexedDB.deleteDatabase(testDbName)
-    await new Promise((resolve, reject) => {
-      deleteRequest.onsuccess = () => resolve(undefined)
-      deleteRequest.onerror = () => reject(deleteRequest.error)
-    })
+    return async () => {
+      // Clean up: close connection and delete database
+      dbConnection.closeDatabase()
+      const deleteRequest = indexedDB.deleteDatabase(testDbName)
+      await new Promise((resolve, reject) => {
+        deleteRequest.onsuccess = () => resolve(undefined)
+        deleteRequest.onerror = () => reject(deleteRequest.error)
+      })
+    }
   })
 
   it('adds and retrieves a single item', async () => {

--- a/packages/workspace-store/src/persistence/indexdb.ts
+++ b/packages/workspace-store/src/persistence/indexdb.ts
@@ -149,7 +149,7 @@ function createTableWrapper<T extends TRecord | TObject, const K extends keyof S
   /**
    * Gets the object store from the latest DB connection, for the given transaction mode.
    */
-  const getStore = async (mode: IDBTransactionMode) => {
+  const getStore = (mode: IDBTransactionMode): IDBObjectStore => {
     const tx = db.transaction(name, mode)
     return tx.objectStore(name)
   }
@@ -161,7 +161,7 @@ function createTableWrapper<T extends TRecord | TObject, const K extends keyof S
    * @returns The full inserted/updated object
    */
   async function addItem(key: Record<K, IDBValidKey>, value: Omit<Static<T>, K>): Promise<Static<T>> {
-    const store = await getStore('readwrite')
+    const store = getStore('readwrite')
     const keyObj: any = { ...key }
     const finalValue = { ...keyObj, ...value }
     await requestAsPromise(store.put(finalValue))
@@ -174,8 +174,8 @@ function createTableWrapper<T extends TRecord | TObject, const K extends keyof S
    * @param key - Key values. For a single key: { id: '...' }
    * @returns The found object or undefined
    */
-  async function getItem(key: Record<K, IDBValidKey>): Promise<Static<T> | undefined> {
-    const store = await getStore('readonly')
+  function getItem(key: Record<K, IDBValidKey>): Promise<Static<T> | undefined> {
+    const store = getStore('readonly')
     const keyValues = Object.values(key)
     // For single keys, pass value directly; for compound keys, pass array
     const keyToUse = keyValues.length === 1 ? keyValues[0] : keyValues
@@ -193,8 +193,8 @@ function createTableWrapper<T extends TRecord | TObject, const K extends keyof S
    *   getRange(['foo']) // All with a === 'foo'
    *   getRange(['foo', 'bar']) // All with a === 'foo' and b === 'bar'
    */
-  async function getRange(partialKey: IDBValidKey[]): Promise<Static<T>[]> {
-    const store = await getStore('readonly')
+  function getRange(partialKey: IDBValidKey[]): Promise<Static<T>[]> {
+    const store = getStore('readonly')
     const results: Static<T>[] = []
 
     // Construct upper bound to match all keys starting with partialKey
@@ -223,7 +223,7 @@ function createTableWrapper<T extends TRecord | TObject, const K extends keyof S
    * @returns void
    */
   async function deleteItem(key: Record<K, IDBValidKey>): Promise<void> {
-    const store = await getStore('readwrite')
+    const store = getStore('readwrite')
     const keyValues = Object.values(key)
     // For single keys, pass value directly; for compound keys, pass array
     const keyToUse = keyValues.length === 1 ? keyValues[0] : keyValues
@@ -241,8 +241,8 @@ function createTableWrapper<T extends TRecord | TObject, const K extends keyof S
    *   deleteRange(['foo']) // Delete all with a === 'foo'
    *   deleteRange(['foo', 'bar']) // Delete all with a === 'foo' and b === 'bar'
    */
-  async function deleteRange(partialKey: IDBValidKey[]): Promise<number> {
-    const store = await getStore('readwrite')
+  function deleteRange(partialKey: IDBValidKey[]): Promise<number> {
+    const store = getStore('readwrite')
     let deletedCount = 0
 
     // Construct upper bound to match all keys starting with partialKey
@@ -270,8 +270,8 @@ function createTableWrapper<T extends TRecord | TObject, const K extends keyof S
    * Retrieves all items from the table.
    * @returns Array of all objects in the store
    */
-  async function getAll(): Promise<Static<T>[]> {
-    const store = await getStore('readonly')
+  function getAll(): Promise<Static<T>[]> {
+    const store = getStore('readonly')
     return requestAsPromise(store.getAll())
   }
 


### PR DESCRIPTION
**Problem**

[Another change related to the `useAwait` rule](https://github.com/scalar/scalar/pull/7091#discussion_r2429906517)

The following methods in `workspace-store` persistence were marked as `async` but they contain only synchronous logic:

- `createWorkspaceStorePersistence` method
-  `createTableWrapper` 
   - internal helper `getStore`
   - `getItem`
   - `deleteRange`
   - `getAll`

**Solution**

- remove `async` from the methods mentioned above
- use cleanup functions in tests instead of `beforeEach` + `afterEach`

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove unnecessary async from persistence helpers and switch tests to beforeEach cleanup functions.
> 
> - **Workspace Store Persistence**
>   - Make `close()` in `packages/workspace-store/src/persistence/index.ts` synchronous (remove `async`).
> - **IndexedDB Wrapper** (`packages/workspace-store/src/persistence/indexdb.ts`)
>   - Make `getStore` synchronous and update `addItem`, `getItem`, `getRange`, `deleteItem`, `deleteRange`, `getAll` to call it without `await`.
> - **Tests**
>   - Replace `afterEach` with cleanup returned from `beforeEach` in `use-document-watcher.test.ts`, `index.test.ts`, and `indexdb.test.ts`.
>   - Use `assert` from `vitest` in `use-document-watcher.test.ts`.
> - **Changeset**
>   - Add patch changeset for `@scalar/workspace-store`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2abf64dbfa9cb9148d5f79813abaa0917b3ba5a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->