### PR TITLE
refactor: enable `useAwait` Biome rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -31,6 +31,7 @@
       "!**/*/storybook-static/**/*",
       "!**/httpsnippet-lite/**",
       "!**/.next/**",
+      "!**/.svelte-kit",
       "!**/obj/**",
       "!**/bin/**",
       "!**/packages/openapi-parser/src/schemas/**/*.ts",
@@ -187,6 +188,7 @@
         "noExportsInTest": "warn",
         "noWith": "warn",
         "noVar": "warn",
+        "useAwait": "error",
         "useGuardForIn": "warn"
       },
       "performance": {

--- a/integrations/docusaurus/src/index.ts
+++ b/integrations/docusaurus/src/index.ts
@@ -59,11 +59,11 @@ const ScalarDocusaurus = (
       }
     },
 
-    async loadContent() {
+    loadContent() {
       return defaultOptions
     },
 
-    async contentLoaded({ content, actions }) {
+    contentLoaded({ content, actions }) {
       const { addRoute } = actions
 
       // If showNavLink is true, add a link to the navbar

--- a/integrations/hono/playground/index.ts
+++ b/integrations/hono/playground/index.ts
@@ -205,9 +205,7 @@ const content = app.getOpenAPI31Document({
 
 const markdown = await createMarkdownFromOpenApi(JSON.stringify(content))
 
-app.get('/llms.txt', async (c) => {
-  return c.text(markdown)
-})
+app.get('/llms.txt', (c) => c.text(markdown))
 
 // Listen
 serve(

--- a/integrations/hono/src/scalar.test.ts
+++ b/integrations/hono/src/scalar.test.ts
@@ -1,5 +1,8 @@
+import { setTimeout } from 'node:timers/promises'
+
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
+
 import { Scalar, apiReference } from './scalar'
 
 type Bindings = {
@@ -236,12 +239,8 @@ describe('apiReference', () => {
 
     const config = { content: { info: { title: 'Test API' } } }
 
-    const getTheme = async (): Promise<'deepSpace' | 'laserwave'> => {
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          resolve('deepSpace')
-        }, 100)
-      })
+    const getTheme = (): Promise<'deepSpace' | 'laserwave'> => {
+      return setTimeout(100, 'deepSpace')
     }
 
     app.get(

--- a/packages/api-client/src/components/CodeInput/CodeInput.test.ts
+++ b/packages/api-client/src/components/CodeInput/CodeInput.test.ts
@@ -1,12 +1,14 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mount, type VueWrapper } from '@vue/test-utils'
-import CodeInput from './CodeInput.vue'
-import { useCodeMirror } from '@scalar/use-codemirror'
-import { enableConsoleError, enableConsoleWarn } from '@/vitest.setup'
-import { ref, toValue } from 'vue'
 import { environmentSchema } from '@scalar/oas-utils/entities/environment'
 import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
+import { useCodeMirror } from '@scalar/use-codemirror'
+import { type VueWrapper, mount } from '@vue/test-utils'
 import { nanoid } from 'nanoid'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref, toValue } from 'vue'
+
+import { enableConsoleError, enableConsoleWarn } from '@/vitest.setup'
+
+import CodeInput from './CodeInput.vue'
 
 // Mock dependencies
 vi.mock('@scalar/use-codemirror', async (importOriginal) => {
@@ -86,18 +88,18 @@ describe('CodeInput', () => {
 
   let wrapper: VueWrapper<InstanceType<typeof CodeInput>>
 
-  it('renders correctly when not disabled', async () => {
+  it('renders correctly when not disabled', () => {
     wrapper = createWrapper()
     expect(wrapper.exists()).toBe(true)
     expect(useCodeMirror).toHaveBeenCalled()
   })
 
-  it('renders in disabled state correctly', async () => {
+  it('renders in disabled state correctly', () => {
     wrapper = createWrapper({ disabled: true })
     expect(wrapper.html()).toContain('data-testid="code-input-disabled"')
   })
 
-  it('emits update:modelValue when value changes', async () => {
+  it('emits update:modelValue when value changes', () => {
     wrapper = createWrapper()
     wrapper.vm.handleChange('new value')
 
@@ -105,7 +107,7 @@ describe('CodeInput', () => {
     expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['new value'])
   })
 
-  it('emits submit event when handleSubmit is called', async () => {
+  it('emits submit event when handleSubmit is called', () => {
     wrapper = createWrapper()
     wrapper.vm.handleSubmit('test value')
 
@@ -113,7 +115,7 @@ describe('CodeInput', () => {
     expect(wrapper.emitted('submit')?.[0]).toEqual(['test value'])
   })
 
-  it('emits blur event when handleBlur is called', async () => {
+  it('emits blur event when handleBlur is called', () => {
     wrapper = createWrapper()
     wrapper.vm.handleBlur('test value')
 
@@ -121,7 +123,7 @@ describe('CodeInput', () => {
     expect(wrapper.emitted('blur')?.[0]).toEqual(['test value'])
   })
 
-  it('uses custom field handler when provided', async () => {
+  it('uses custom field handler when provided', () => {
     const handleFieldChange = vi.fn()
     wrapper = createWrapper({ handleFieldChange })
     wrapper.vm.handleChange('handle field change')
@@ -129,7 +131,7 @@ describe('CodeInput', () => {
     expect(handleFieldChange).toHaveBeenCalledWith('handle field change')
   })
 
-  it('computes booleanOptions correctly for boolean type', async () => {
+  it('computes booleanOptions correctly for boolean type', () => {
     wrapper = createWrapper({
       type: 'boolean',
       nullable: false,
@@ -137,7 +139,7 @@ describe('CodeInput', () => {
     expect(wrapper.vm.booleanOptions).toEqual(['true', 'false'])
   })
 
-  it('computes booleanOptions correctly for boolean type with nullable', async () => {
+  it('computes booleanOptions correctly for boolean type with nullable', () => {
     wrapper = createWrapper({
       type: 'boolean',
       nullable: true,
@@ -145,7 +147,7 @@ describe('CodeInput', () => {
     expect(wrapper.vm.booleanOptions).toEqual(['true', 'false', 'null'])
   })
 
-  it('exposes focus method that calls codeMirror.focus', async () => {
+  it('exposes focus method that calls codeMirror.focus', () => {
     wrapper = createWrapper()
 
     // Get the mocked focus function from the useCodeMirror mock
@@ -158,12 +160,12 @@ describe('CodeInput', () => {
     expect(mockCodeMirror.focus).toHaveBeenCalled()
   })
 
-  it('applies error class when error prop is true', async () => {
+  it('applies error class when error prop is true', () => {
     wrapper = createWrapper({ error: true })
     expect(wrapper.html()).toContain('flow-code-input--error')
   })
 
-  it('sets up extensions correctly based on props', async () => {
+  it('sets up extensions correctly based on props', () => {
     wrapper = createWrapper({
       language: 'json',
       colorPicker: true,

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
@@ -71,7 +71,7 @@ const isInputUrl = computed(() => isUrl(inputContent.value))
 const isInputDocument = computed(() => !!documentDetails.value)
 
 const { open: openSpecFileDialog } = useFileDialog({
-  onChange: async (files) => {
+  onChange: (files) => {
     const file = files?.[0]
     if (file) {
       const reader = new FileReader()

--- a/packages/api-client/src/components/ImportCollection/DropEventListener.vue
+++ b/packages/api-client/src/components/ImportCollection/DropEventListener.vue
@@ -31,7 +31,7 @@ function isFromApp(event: DragEvent): boolean {
 }
 
 // Drop
-async function handleDrop(event: DragEvent) {
+function handleDrop(event: DragEvent) {
   event.preventDefault()
   isDragging.value = false
   dragCounter = 0
@@ -57,7 +57,7 @@ async function handleDrop(event: DragEvent) {
 
       const reader = new FileReader()
 
-      reader.onload = async (e) => {
+      reader.onload = (e) => {
         if (e.target && typeof e.target.result === 'string') {
           emit('input', e.target.result, null, 'drop')
         }

--- a/packages/api-client/src/components/ImportCollection/ImportCollectionListener.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportCollectionListener.vue
@@ -62,15 +62,15 @@ const router = useRouter()
 const { activeWorkspace } = useActiveEntities()
 const { toast } = useToasts()
 
-async function handleImportCollection(
+function handleImportCollection(
   source: string | null | undefined,
 ): Promise<boolean> {
   if (!source) {
-    return false
+    return Promise.resolve(false)
   }
 
   return new Promise<boolean>((resolve) => {
-    importCollection({
+    void importCollection({
       store,
       workspace: activeWorkspace.value,
       source,

--- a/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
@@ -113,7 +113,7 @@ watch(
       }
 
       // Query parameters:
-      prefetchUrl(value, activeWorkspace.value?.proxyUrl)
+      void prefetchUrl(value, activeWorkspace.value?.proxyUrl)
 
       modalState.show()
 
@@ -249,7 +249,7 @@ function handleImportFinished() {
           </div>
           <PrefetchError :url="prefetchResult?.input || props.source" />
         </template>
-        <!-- Sucess -->
+        <!-- Success -->
         <template v-else>
           <!-- Integration Logo -->
           <div

--- a/packages/api-client/src/components/ImportCollection/ImportNowButton.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportNowButton.vue
@@ -24,8 +24,8 @@ const store = useWorkspace()
 const { activeWorkspace } = useActiveEntities()
 const { toast } = useToasts()
 
-async function handleImportCollection() {
-  importCollection({
+function handleImportCollection() {
+  void importCollection({
     store,
     workspace: activeWorkspace.value,
     source: source,

--- a/packages/api-client/src/components/ImportCollection/OpenAppButton.vue
+++ b/packages/api-client/src/components/ImportCollection/OpenAppButton.vue
@@ -46,7 +46,7 @@ function openScalarApp() {
   }
 }
 
-async function redirectToWaitList() {
+function redirectToWaitList() {
   window.location.href = APP_DOWNLOAD_URL
 }
 </script>

--- a/packages/api-client/src/components/ImportCollection/PasteEventListener.vue
+++ b/packages/api-client/src/components/ImportCollection/PasteEventListener.vue
@@ -17,7 +17,7 @@ onBeforeUnmount(() => {
 })
 
 // Handle the paste event
-async function handlePaste(event: ClipboardEvent) {
+function handlePaste(event: ClipboardEvent) {
   // Ignore paste events in input, textarea, or contenteditable elements
   const target = event.target as HTMLElement
 

--- a/packages/api-client/src/components/ImportCollection/hooks/useUrlPrefetcher.ts
+++ b/packages/api-client/src/components/ImportCollection/hooks/useUrlPrefetcher.ts
@@ -1,7 +1,8 @@
-import { isUrl } from '@/libs'
 import { resolve } from '@scalar/import'
 import { fetchWithProxyFallback, redirectToProxy } from '@scalar/oas-utils/helpers'
 import { reactive } from 'vue'
+
+import { isUrl } from '@/libs'
 
 export type PrefetchResult = {
   state: 'idle' | 'loading'
@@ -23,7 +24,7 @@ export function useUrlPrefetcher() {
     error: null,
   })
 
-  async function resetPrefetchResult() {
+  function resetPrefetchResult() {
     Object.assign(prefetchResult, {
       state: 'idle',
       content: null,

--- a/packages/api-client/src/libs/event-bus.test.ts
+++ b/packages/api-client/src/libs/event-bus.test.ts
@@ -12,16 +12,12 @@ describe('createEventBus', () => {
     expect(listeners()).toEqual([])
   })
   it('should listen on emit', () => {
-    let val = false
     const { emit, on, reset, listeners } = createEventBus<boolean>()
-    on((_event) => {
-      if (!_event) {
-        return
-      }
-      val = _event
-    })
+    const listener = vi.fn()
+    on(listener)
     emit(true)
-    expect(val).toBe(true)
+    expect(listener).toHaveBeenCalledOnce()
+    expect(listener).toHaveBeenCalledWith(true)
     reset()
     expect(listeners()).toEqual([])
   })
@@ -79,7 +75,7 @@ describe('createEventBus', () => {
     expect(listeners()).toEqual([])
   })
 
-  it('should work with a complex payload', async () => {
+  it('should work with a complex payload', () => {
     const { on, emit } = createEventBus<['inc' | 'dec', number]>()
     const counter = useCounter(0)
     on((value) => {

--- a/packages/api-client/src/libs/send-request/create-fetch-auth.test.ts
+++ b/packages/api-client/src/libs/send-request/create-fetch-auth.test.ts
@@ -1,9 +1,9 @@
+import type { SelectedSecuritySchemeUids } from '@scalar/oas-utils/entities/shared'
 import { requestExampleSchema, securitySchemeSchema } from '@scalar/oas-utils/entities/spec'
 import { describe, expect, it } from 'vitest'
 
 import { createRequestOperation } from './create-request-operation'
 import { VOID_URL, createRequestPayload } from './create-request-operation.test'
-import type { SelectedSecuritySchemeUids } from '@scalar/oas-utils/entities/shared'
 
 describe('authentication', () => {
   it('adds apiKey auth in header', async () => {
@@ -243,6 +243,7 @@ describe('authentication', () => {
     const [requestError, result] = await requestOperation.sendRequest()
 
     expect(requestError).toBe(null)
+
     if (!result || !('data' in result.response)) {
       throw new Error('No data')
     }
@@ -251,7 +252,7 @@ describe('authentication', () => {
     })
   })
 
-  it('ensures we only have one auth header', async () => {
+  it('ensures we only have one auth header', () => {
     const [error, requestOperation] = createRequestOperation({
       ...createRequestPayload({
         serverPayload: { url: VOID_URL },

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -296,7 +296,7 @@ describe('create-request-operation', () => {
     })
   })
 
-  it('creates query parameters from the url', async () => {
+  it('creates query parameters from the url', () => {
     const [error, requestOperation] = createRequestOperation(
       createRequestPayload({
         serverPayload: { url: VOID_URL },

--- a/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.test.ts
@@ -689,8 +689,11 @@ describe('RequestExample', () => {
           ...defaultProps,
           operation: {
             summary: 'Referenced operation',
-            // @ts-expect-error - this is a test
-            requestBody: { $ref: '#/components/requestBodies/TestBody', '$ref-value': undefined },
+            requestBody: {
+              $ref: '#/components/requestBodies/TestBody',
+              // @ts-expect-error - this is a test
+              '$ref-value': undefined,
+            },
           },
         },
       })
@@ -1139,7 +1142,7 @@ describe('RequestExample', () => {
       expect(copiedContent).toContain('2024-01-15T10:30:00Z')
     })
 
-    it('handles handles null payload gracefully', async () => {
+    it('handles handles null payload gracefully', () => {
       const wrapper = mount(RequestExample, {
         props: {
           ...defaultProps,

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.test.ts
@@ -121,21 +121,21 @@ describe('AddressBar', () => {
     expect(withServers.find('.server-dropdown').exists()).toBe(true)
   })
 
-  it('focuses CodeInput on focusAddressBar event in web layout', async () => {
+  it('focuses CodeInput on focusAddressBar event in web layout', () => {
     const wrapper = makeWrapper({ layout: 'web' })
     bus.focusAddressBar.emit()
     const input = wrapper.find('[data-test="code-input"]').element
     expect(document.activeElement).toBe(input)
   })
 
-  it('focuses Send button on focusAddressBar event in modal layout', async () => {
+  it('focuses Send button on focusAddressBar event in modal layout', () => {
     const wrapper = makeWrapper({ layout: 'modal' })
     bus.focusAddressBar.emit()
     const sendBtn = wrapper.findAll('button').find((b) => b.text().includes('Send'))!.element as HTMLButtonElement
     expect(document.activeElement).toBe(sendBtn)
   })
 
-  it('focuses CodeInput when hotKeys event indicates focusAddressBar', async () => {
+  it('focuses CodeInput when hotKeys event indicates focusAddressBar', () => {
     const wrapper = makeWrapper({ layout: 'web' })
     bus.hotKeys.emit({ focusAddressBar: new KeyboardEvent('keydown', {}) })
     const input = wrapper.find('[data-test="code-input"]').element

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/DeleteRequestAuthModal.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/DeleteRequestAuthModal.test.ts
@@ -22,7 +22,7 @@ describe.todo('DeleteRequestAuthModal', () => {
     open,
   })
 
-  it('renders modal content with label', async () => {
+  it('renders modal content with label', () => {
     const label = 'Test Label'
     const wrapper = mount(DeleteRequestAuthModal, {
       attachTo: document.body,

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
@@ -269,7 +269,7 @@ describe('oauth', () => {
     })
 
     // Test relative redirect URIs
-    it('should handle relative redirect URIs', async () => {
+    it('should handle relative redirect URIs', () => {
       const flows = {
         'authorizationCode': {
           ...scheme.authorizationCode,

--- a/packages/api-client/src/v2/blocks/scalar-operation-block/components/OperationBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-operation-block/components/OperationBlock.test.ts
@@ -53,7 +53,7 @@ describe('OperationBlock', () => {
     expect(emitted?.[0]?.[0]).toEqual({ name: 'New Name' })
   })
 
-  it('renders summary text instead of input in modal layout', async () => {
+  it('renders summary text instead of input in modal layout', () => {
     const wrapper = mount(OperationBlock, {
       props: { ...defaultProps, operation: { summary: 'My request' }, layout: 'modal' },
       global: {
@@ -142,7 +142,7 @@ describe('OperationBlock', () => {
     expect(auth.isVisible()).toBe(true)
   })
 
-  it('hides request body for methods without a body', async () => {
+  it('hides request body for methods without a body', () => {
     const wrapper = mount(OperationBlock, {
       props: { ...defaultProps, method: 'get' },
       global: {
@@ -157,7 +157,7 @@ describe('OperationBlock', () => {
     expect(bodyGet.isVisible()).toBe(false)
   })
 
-  it('shows request body for methods with a body', async () => {
+  it('shows request body for methods with a body', () => {
     const wrapper = mount(OperationBlock, {
       props: { ...defaultProps, method: 'post' },
       global: {

--- a/packages/api-client/src/v2/blocks/scalar-operation-block/components/OperationBody.vue
+++ b/packages/api-client/src/v2/blocks/scalar-operation-block/components/OperationBody.vue
@@ -95,7 +95,7 @@ const selectedContentTypeModel = computed<{ id: string; label: string }>({
 
 function handleFileUpload(callback: (file: File | undefined) => void) {
   const { open } = useFileDialog({
-    onChange: async (files) => {
+    onChange: (files) => {
       const file = files?.[0]
       if (file) {
         callback(file)

--- a/packages/api-client/src/v2/blocks/scalar-operation-block/components/OperationParams.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-operation-block/components/OperationParams.test.ts
@@ -44,7 +44,7 @@ describe('OperationParams', () => {
     expect(table.exists()).toBe(true)
   })
 
-  it('re-emits add, update, and delete events from OperationTable', async () => {
+  it('re-emits add, update, and delete events from OperationTable', () => {
     const wrapper = mount(OperationParams, {
       props: {
         parameters: [{ name: 'id', in: 'path', schema: { type: 'string' } } as any],

--- a/packages/api-client/src/v2/blocks/scalar-response-block/components/ResponseBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-response-block/components/ResponseBlock.test.ts
@@ -73,7 +73,7 @@ describe('ResponseBlock', () => {
       expect(emptyComponent.props('layout')).toBe('desktop')
     })
 
-    it('emits addRequest when ResponseEmpty emits it', async () => {
+    it('emits addRequest when ResponseEmpty emits it', () => {
       const wrapper = mount(ResponseBlock, {
         props: defaultProps,
       })
@@ -84,7 +84,7 @@ describe('ResponseBlock', () => {
       expect(wrapper.emitted('addRequest')).toBeTruthy()
     })
 
-    it('emits sendRequest when ResponseEmpty emits it', async () => {
+    it('emits sendRequest when ResponseEmpty emits it', () => {
       const wrapper = mount(ResponseBlock, {
         props: defaultProps,
       })
@@ -95,7 +95,7 @@ describe('ResponseBlock', () => {
       expect(wrapper.emitted('sendRequest')).toBeTruthy()
     })
 
-    it('emits openCommandPalette when ResponseEmpty emits it', async () => {
+    it('emits openCommandPalette when ResponseEmpty emits it', () => {
       const wrapper = mount(ResponseBlock, {
         props: defaultProps,
       })

--- a/packages/api-client/src/v2/blocks/scalar-response-block/components/ResponseBodyStreaming.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-response-block/components/ResponseBodyStreaming.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { flushPromises, mount } from '@vue/test-utils'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import ResponseBodyStreaming from './ResponseBodyStreaming.vue'
@@ -10,10 +10,10 @@ describe('ResponseBodyStreaming', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-  })
 
-  afterEach(() => {
-    vi.restoreAllMocks()
+    return () => {
+      vi.restoreAllMocks()
+    }
   })
 
   const createMockReader = (chunks: string[], shouldError = false): ReadableStreamDefaultReader<Uint8Array> => {
@@ -21,7 +21,7 @@ describe('ResponseBodyStreaming', () => {
     const encoder = new TextEncoder()
 
     return {
-      read: vi.fn(async () => {
+      read: vi.fn(() => {
         if (shouldError && index === 1) {
           throw new Error('Stream read error')
         }
@@ -29,15 +29,15 @@ describe('ResponseBodyStreaming', () => {
         if (index < chunks.length) {
           const value = encoder.encode(chunks[index])
           index++
-          return { done: false, value }
+          return Promise.resolve({ done: false as const, value })
         }
 
-        return { done: true, value: undefined }
+        return Promise.resolve({ done: true as const, value: undefined })
       }),
       cancel: vi.fn(),
       releaseLock: vi.fn(),
       closed: Promise.resolve(undefined),
-    } as unknown as ReadableStreamDefaultReader<Uint8Array>
+    }
   }
 
   describe('rendering', () => {
@@ -155,16 +155,15 @@ describe('ResponseBodyStreaming', () => {
     it('shows loading indicator while streaming', async () => {
       // Create a reader that never completes
       mockReader = {
-        read: vi.fn(
-          () =>
-            new Promise(() => {
-              // Never resolves to keep loading state
-            }),
+        read: vi.fn().mockReturnValue(
+          new Promise(() => {
+            // Never resolves to keep loading state
+          }),
         ),
         cancel: vi.fn(),
         releaseLock: vi.fn(),
         closed: Promise.resolve(undefined),
-      } as unknown as ReadableStreamDefaultReader<Uint8Array>
+      }
 
       const wrapper = mount(ResponseBodyStreaming, {
         props: { reader: mockReader },
@@ -301,16 +300,15 @@ describe('ResponseBodyStreaming', () => {
 
     it('stops loading on unmount', async () => {
       mockReader = {
-        read: vi.fn(
-          () =>
-            new Promise(() => {
-              // Never resolves to test unmount behavior
-            }),
+        read: vi.fn().mockReturnValue(
+          new Promise(() => {
+            // Never resolves to test unmount behavior
+          }),
         ),
         cancel: vi.fn(),
         releaseLock: vi.fn(),
         closed: Promise.resolve(undefined),
-      } as unknown as ReadableStreamDefaultReader<Uint8Array>
+      }
 
       const wrapper = mount(ResponseBodyStreaming, {
         props: { reader: mockReader },
@@ -352,16 +350,15 @@ describe('ResponseBodyStreaming', () => {
 
     it('does not display content before stream starts', async () => {
       mockReader = {
-        read: vi.fn(
-          () =>
-            new Promise(() => {
-              // Never resolves to test initial state
-            }),
+        read: vi.fn().mockReturnValue(
+          new Promise(() => {
+            // Never resolves to test initial state
+          }),
         ),
         cancel: vi.fn(),
         releaseLock: vi.fn(),
         closed: Promise.resolve(undefined),
-      } as unknown as ReadableStreamDefaultReader<Uint8Array>
+      }
 
       const wrapper = mount(ResponseBodyStreaming, {
         props: { reader: mockReader },
@@ -547,18 +544,18 @@ describe('ResponseBodyStreaming', () => {
       const chunks = [chunk1, chunk2, chunk3]
 
       mockReader = {
-        read: vi.fn(async () => {
+        read: vi.fn(() => {
           if (index < chunks.length) {
-            const value = chunks[index]
+            const value = chunks[index]!
             index++
-            return { done: false, value }
+            return Promise.resolve({ done: false as const, value })
           }
-          return { done: true, value: undefined }
+          return Promise.resolve({ done: true as const, value: undefined })
         }),
         cancel: vi.fn(),
         releaseLock: vi.fn(),
         closed: Promise.resolve(undefined),
-      } as unknown as ReadableStreamDefaultReader<Uint8Array>
+      }
 
       const wrapper = mount(ResponseBodyStreaming, {
         props: { reader: mockReader },

--- a/packages/api-client/src/v2/features/environments/EnvironmentsList.test.ts
+++ b/packages/api-client/src/v2/features/environments/EnvironmentsList.test.ts
@@ -557,7 +557,7 @@ describe('EnvironmentsList', () => {
       expect(icon.exists()).toBe(true)
     })
 
-    it('opens create modal when add button is clicked', async () => {
+    it('opens create modal when add button is clicked', () => {
       const wrapper = mountWithProps({ documentName: 'My API' })
 
       // We cannot directly test modal.show() being called, but we can verify the modal exists

--- a/packages/api-client/src/v2/features/global-cookies/components/CookiesTable.test.ts
+++ b/packages/api-client/src/v2/features/global-cookies/components/CookiesTable.test.ts
@@ -134,7 +134,7 @@ describe('CookiesTable', () => {
     expect(rows.length).toBe(3)
   })
 
-  it('emits updateRow event when updating an existing cookie name', async () => {
+  it('emits updateRow event when updating an existing cookie name', () => {
     const wrapper = mount(CookiesTable, {
       props: {
         data: [

--- a/packages/api-client/src/views/Components/CodeSnippet/helpers/get-snippet.test.ts
+++ b/packages/api-client/src/views/Components/CodeSnippet/helpers/get-snippet.test.ts
@@ -75,9 +75,11 @@ describe('getSnippet', () => {
     )
 
     expect(error).toBeNull()
-    expect(result).toEqual(`import { request } from 'undici'
+    expect(result).toMatchInlineSnapshot(`
+      "import { request } from 'undici'
 
-const { statusCode, body } = await request('https://example.com/users')`)
+      const { statusCode, body } = await request('https://example.com/users')"
+    `)
   })
 
   it('generates a basic javascript/jquery example (httpsnippet-lite)', () => {
@@ -92,17 +94,19 @@ const { statusCode, body } = await request('https://example.com/users')`)
     )
 
     expect(error).toBeNull()
-    expect(result).toEqual(`const settings = {
-  async: true,
-  crossDomain: true,
-  url: 'https://example.com/users',
-  method: 'GET',
-  headers: {}
-};
+    expect(result).toMatchInlineSnapshot(`
+      "const settings = {
+        async: true,
+        crossDomain: true,
+        url: 'https://example.com/users',
+        method: 'GET',
+        headers: {}
+      };
 
-$.ajax(settings).done(function (response) {
-  console.log(response);
-});`)
+      $.ajax(settings).done(function (response) {
+        console.log(response);
+      });"
+    `)
   })
 
   it('returns an empty string if passed rubbish', () => {
@@ -249,7 +253,7 @@ $.ajax(settings).done(function (response) {
     expect(result).toEqual(`fetch('https://example.com/users?query-param=query-value')`)
   })
 
-  it('should show the security headers, cookies and query', async () => {
+  it('should show the security headers, cookies and query', () => {
     const [error, result] = getSnippet(
       'javascript',
       'fetch',
@@ -286,13 +290,15 @@ $.ajax(settings).done(function (response) {
     )
 
     expect(error).toBeNull()
-    expect(result).toEqual(`fetch('https://example.com/users?query-api-key=33333', {
-  headers: {
-    'X-Header-Token': '22222',
-    Authorization: 'Bearer 44444',
-    'Set-Cookie': 'x-cookie-token=YOUR_SECRET_TOKEN'
-  }
-})`)
+    expect(result).toMatchInlineSnapshot(`
+      "fetch('https://example.com/users?query-api-key=33333', {
+        headers: {
+          'X-Header-Token': '22222',
+          Authorization: 'Bearer 44444',
+          'Set-Cookie': 'x-cookie-token=YOUR_SECRET_TOKEN'
+        }
+      })"
+    `)
   })
 
   it('should include the invalid url', () => {
@@ -306,12 +312,14 @@ $.ajax(settings).done(function (response) {
     )
 
     expect(error).toBeNull()
-    expect(result).toEqual(`CURL *hnd = curl_easy_init();
+    expect(result).toMatchInlineSnapshot(`
+      "CURL *hnd = curl_easy_init();
 
-curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
-curl_easy_setopt(hnd, CURLOPT_URL, "/users");
+      curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
+      curl_easy_setopt(hnd, CURLOPT_URL, "/users");
 
-CURLcode ret = curl_easy_perform(hnd);`)
+      CURLcode ret = curl_easy_perform(hnd);"
+    `)
   })
 
   describe('it should generate a snipped without a proper URL for every client', () => {

--- a/packages/api-client/src/views/Request/RequestRoot.test.ts
+++ b/packages/api-client/src/views/Request/RequestRoot.test.ts
@@ -1,12 +1,13 @@
-import { useWorkspace } from '@/store'
-import { useActiveEntities } from '@/store/active-entities'
-import { createStoreEvents } from '@/store/events'
-import { mockUseLayout } from '@/vitest.setup'
+import { collectionSchema } from '@scalar/oas-utils/entities/spec'
 import { mount } from '@vue/test-utils'
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
-import { collectionSchema } from '@scalar/oas-utils/entities/spec'
+import { useWorkspace } from '@/store'
+import { useActiveEntities } from '@/store/active-entities'
+import { createStoreEvents } from '@/store/events'
+import { mockUseLayout } from '@/vitest.setup'
+
 import RequestRoot from './RequestRoot.vue'
 
 // Mock vue-router
@@ -99,7 +100,7 @@ describe('RequestRoot', () => {
     expect(wrapper.find('.scalar-sidebar-toggle').exists()).toBe(true)
   })
 
-  it('applies correct classes for modal layout', async () => {
+  it('applies correct classes for modal layout', () => {
     vi.mocked(mockUseLayout).mockReturnValue({ layout: 'modal' })
     const wrapper = createWrapper()
     const sidebarToggle = wrapper.find('.scalar-sidebar-toggle')

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/RequestAuth.test.ts
@@ -132,7 +132,7 @@ describe('RequestAuth.vue', () => {
     await nextTick()
   }
 
-  it('renders the basics', async () => {
+  it('renders the basics', () => {
     const wrapper = mount(RequestAuth, {
       props: createBaseProps(),
     })
@@ -166,7 +166,7 @@ describe('RequestAuth.vue', () => {
     expect(requestMutators.edit).toHaveBeenCalledWith('test-operation', 'selectedSecuritySchemeUids', ['bearer-auth'])
   })
 
-  it('shows optional status when security is optional', async () => {
+  it('shows optional status when security is optional', () => {
     const props = createBaseProps()
     props.operation.security = [{}]
 
@@ -177,7 +177,7 @@ describe('RequestAuth.vue', () => {
     expect(wrapper.text()).toContain('Optional')
   })
 
-  it('displays multiple when multiple schemes are selected', async () => {
+  it('displays multiple when multiple schemes are selected', () => {
     const props = {
       ...createBaseProps(),
       selectedSecuritySchemeUids: ['bearer-auth', 'api-key'] as Collection['selectedSecuritySchemeUids'],

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
@@ -1,12 +1,13 @@
-import { useWorkspace } from '@/store'
+import { environmentSchema } from '@scalar/oas-utils/entities/environment'
 import { operationSchema, requestExampleSchema } from '@scalar/oas-utils/entities/spec'
-import { createStoreEvents } from '@/store/events'
+import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
 import { mount } from '@vue/test-utils'
-import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useWorkspace } from '@/store'
+import { createStoreEvents } from '@/store/events'
 
 import RequestBody from './RequestBody.vue'
-import { environmentSchema } from '@scalar/oas-utils/entities/environment'
-import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
 
 // Mock the useWorkspace hook
 vi.mock('@/store', () => ({
@@ -32,8 +33,9 @@ describe('RequestBody.vue', () => {
     uid: 'mockWorkspaceUid',
   })
   const mockRequestExampleMutators = {
-    edit: vi.fn(),
+    edit: vi.fn<ReturnType<typeof useWorkspace>['requestExampleMutators']['edit']>(),
   }
+
   const props = {
     props: {
       title: 'Body',
@@ -52,23 +54,23 @@ describe('RequestBody.vue', () => {
 
   // Mock our request + example
   beforeEach(() => {
-    ;(useWorkspace as Mock).mockReturnValue({
+    vi.mocked(useWorkspace).mockReturnValue({
       events: createStoreEvents(),
       requestExampleMutators: mockRequestExampleMutators,
-    })
+    } as unknown as ReturnType<typeof useWorkspace>)
+
+    return () => {
+      vi.clearAllMocks()
+    }
   })
 
-  afterEach(() => {
-    vi.clearAllMocks()
-  })
-
-  it('renders correctly with no body', async () => {
+  it('renders correctly with no body', () => {
     const wrapper = mount(RequestBody, props)
     expect(wrapper.findComponent({ name: 'ScalarListbox' }).text()).toContain('None')
     wrapper.unmount()
   })
 
-  it('renders with multipart form', async () => {
+  it('renders with multipart form', () => {
     mockActiveExample.body = {
       activeBody: 'formData',
       formData: {
@@ -82,8 +84,8 @@ describe('RequestBody.vue', () => {
     wrapper.unmount()
   })
 
-  it('renders with url encoded form', async () => {
-    mockActiveExample.body = mockActiveExample.body = {
+  it('renders with url encoded form', () => {
+    mockActiveExample.body = {
       activeBody: 'formData',
       formData: {
         encoding: 'urlencoded',
@@ -96,7 +98,7 @@ describe('RequestBody.vue', () => {
     wrapper.unmount()
   })
 
-  it('renders with binary file', async () => {
+  it('renders with binary file', () => {
     mockActiveExample.body = {
       activeBody: 'binary',
     }
@@ -122,7 +124,7 @@ describe('RequestBody.vue', () => {
     wrapper.unmount()
   })
 
-  it('renders with xml', async () => {
+  it('renders with xml', () => {
     mockActiveExample.body = {
       activeBody: 'raw',
       raw: {
@@ -136,7 +138,7 @@ describe('RequestBody.vue', () => {
     wrapper.unmount()
   })
 
-  it('renders with yaml', async () => {
+  it('renders with yaml', () => {
     mockActiveExample.body = {
       activeBody: 'raw',
       raw: {
@@ -150,7 +152,7 @@ describe('RequestBody.vue', () => {
     wrapper.unmount()
   })
 
-  it('renders with edn', async () => {
+  it('renders with edn', () => {
     mockActiveExample.body = {
       activeBody: 'raw',
       raw: {
@@ -164,7 +166,7 @@ describe('RequestBody.vue', () => {
     wrapper.unmount()
   })
 
-  it('renders with other', async () => {
+  it('renders with other', () => {
     mockActiveExample.body = {
       activeBody: 'raw',
       raw: {
@@ -303,13 +305,13 @@ describe('RequestBody.vue', () => {
       }
 
       const wrapper = mount(RequestBody, props)
-      const initialCallCount = mockRequestExampleMutators.edit.mock.calls.length
+      const initialCallCount = vi.mocked(mockRequestExampleMutators.edit).mock.calls.length
 
       const requestTable = wrapper.findComponent({ name: 'RequestTable' })
       await requestTable.vm.$emit('deleteRow', 5) // Invalid index
 
       // Verify that edit was not called for the invalid deletion
-      expect(mockRequestExampleMutators.edit.mock.calls.length).toBe(initialCallCount)
+      expect(vi.mocked(mockRequestExampleMutators.edit).mock.calls.length).toBe(initialCallCount)
 
       wrapper.unmount()
     })

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -372,9 +372,9 @@ const updateActiveBody = (type: ContentType) => {
   requestExampleMutators.edit(example.uid, 'parameters.headers', headers)
 }
 
-const handleFileUploadFormData = async (rowIdx: number) => {
+const handleFileUploadFormData = (rowIdx: number) => {
   const { open } = useFileDialog({
-    onChange: async (files) => {
+    onChange: (files) => {
       const file = files?.[0]
       if (file) {
         const currentParams = formParams.value
@@ -428,7 +428,7 @@ function handleRemoveFileFormData(rowIdx: number) {
 
 function handleFileUpload() {
   const { open } = useFileDialog({
-    onChange: async (files) => {
+    onChange: (files) => {
       const file = files?.[0]
       if (file) {
         requestExampleMutators.edit(example.uid, 'body.binary', file)

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.test.ts
@@ -1,4 +1,3 @@
-import { useWorkspace } from '@/store'
 import {
   collectionSchema,
   operationSchema,
@@ -6,12 +5,12 @@ import {
   securitySchemeSchema,
   serverSchema,
 } from '@scalar/oas-utils/entities/spec'
-import type { ClientId, TargetId } from '@scalar/snippetz'
-
-import { mount } from '@vue/test-utils'
-import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { workspaceSchema } from '@scalar/oas-utils/entities/workspace'
-import { useActiveEntities } from '@/store/active-entities'
+import type { ClientId, TargetId } from '@scalar/snippetz'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useWorkspace } from '@/store'
 
 import RequestCodeExample from './RequestCodeExample.vue'
 
@@ -77,28 +76,18 @@ const mockWorkspace = workspaceSchema.parse({
 // Mock the workspace mutators
 const mockWorkspaceMutators = {
   edit: vi.fn(),
-}
-
-vi.mock('@/store/active-entities', () => ({
-  useActiveEntities: vi.fn(),
-}))
-const mockUseActiveEntities = useActiveEntities as Mock
-const mockActiveEntities = {
-  setActiveRequest: vi.fn(),
-  setActiveExample: vi.fn(),
-}
+} as Partial<ReturnType<typeof useWorkspace>['requestExampleMutators']>
 
 describe('RequestCodeExample.vue', () => {
   beforeEach(() => {
-    ;(useWorkspace as Mock).mockReturnValue({
+    vi.mocked(useWorkspace).mockReturnValue({
       securitySchemes: {},
       workspaceMutators: mockWorkspaceMutators,
-    })
-    mockUseActiveEntities.mockReturnValue(mockActiveEntities)
-  })
+    } as unknown as ReturnType<typeof useWorkspace>)
 
-  afterEach(() => {
-    vi.clearAllMocks()
+    return () => {
+      vi.clearAllMocks()
+    }
   })
 
   const props = {
@@ -111,7 +100,7 @@ describe('RequestCodeExample.vue', () => {
     environment: [],
   }
 
-  it('renders correctly with default props', async () => {
+  it('renders correctly with default props', () => {
     const wrapper = mount(RequestCodeExample, {
       props,
     })
@@ -136,7 +125,7 @@ describe('RequestCodeExample.vue', () => {
     wrapper.unmount()
   })
 
-  it('filters security schemes correctly', async () => {
+  it('filters security schemes correctly', () => {
     const scheme = securitySchemeSchema.parse({
       uid: 'authUid',
       type: 'apiKey',
@@ -150,10 +139,10 @@ describe('RequestCodeExample.vue', () => {
 
     mockOperation.security = [{ [scheme.nameKey]: [] }]
     mockOperation.selectedSecuritySchemeUids = [scheme.uid]
-    ;(useWorkspace as Mock).mockReturnValue({
+    vi.mocked(useWorkspace).mockReturnValue({
       securitySchemes,
       workspaceMutators: mockWorkspaceMutators,
-    })
+    } as unknown as ReturnType<typeof useWorkspace>)
 
     const wrapper = mount(RequestCodeExample, {
       props,
@@ -165,7 +154,7 @@ describe('RequestCodeExample.vue', () => {
     wrapper.unmount()
   })
 
-  it('includes optional selected security schemes', async () => {
+  it('includes optional selected security schemes', () => {
     const requiredScheme = securitySchemeSchema.parse({
       uid: 'requiredUid',
       type: 'apiKey',
@@ -189,10 +178,10 @@ describe('RequestCodeExample.vue', () => {
     mockOperation.security = [{ [requiredScheme.nameKey]: [] }]
     // Both are selected
     mockOperation.selectedSecuritySchemeUids = [requiredScheme.uid, optionalScheme.uid]
-    ;(useWorkspace as Mock).mockReturnValue({
+    vi.mocked(useWorkspace).mockReturnValue({
       securitySchemes,
       workspaceMutators: mockWorkspaceMutators,
-    })
+    } as unknown as ReturnType<typeof useWorkspace>)
 
     const wrapper = mount(RequestCodeExample, {
       props,

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -115,7 +115,7 @@ const handleItemDelete = () => {
 
 // Manually focus the popup - not pretty but it works
 const menuRef = ref<typeof ScalarDropdown | null>(null)
-watch([() => props.menuItem.open, menuRef], async ([open]) => {
+watch([() => props.menuItem.open, menuRef], ([open]) => {
   if (open && menuRef.value?.$parent?.$el) {
     menuRef.value.$parent.$el.focus()
   }

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -281,7 +281,7 @@ describe('oauth2', () => {
     })
 
     // Test relative redirect URIs
-    it('should handle relative redirect URIs', async () => {
+    it('should handle relative redirect URIs', () => {
       const _flow = {
         ...flow,
         'x-scalar-redirect-uri': '/callback',

--- a/packages/api-reference/playground/vue/src/App.vue
+++ b/packages/api-reference/playground/vue/src/App.vue
@@ -25,7 +25,7 @@ const configuration = reactive({
 
 let app: ReturnType<typeof createApiReference> | null = null
 
-onMounted(async () => {
+onMounted(() => {
   app = createApiReference(containerRef.value, configuration)
 })
 

--- a/packages/api-reference/src/blocks/scalar-auth-selector-block/components/AuthSelector.test.ts
+++ b/packages/api-reference/src/blocks/scalar-auth-selector-block/components/AuthSelector.test.ts
@@ -112,7 +112,7 @@ describe('AuthSelector.vue', () => {
     selectedSecuritySchemeUids.value = []
   })
 
-  it('renders the basics', async () => {
+  it('renders the basics', () => {
     const wrapper = mount(AuthSelector, {
       props: createBaseProps(),
     })
@@ -150,7 +150,7 @@ describe('AuthSelector.vue', () => {
     })
   })
 
-  it('shows optional status when security is optional', async () => {
+  it('shows optional status when security is optional', () => {
     const props = createBaseProps()
     props.operation.security = [{}]
 
@@ -161,7 +161,7 @@ describe('AuthSelector.vue', () => {
     expect(wrapper.text()).toContain('Optional')
   })
 
-  it('displays multiple when multiple schemes are selected', async () => {
+  it('displays multiple when multiple schemes are selected', () => {
     const props = createBaseProps()
     selectedSecuritySchemeUids.value = ['bearer-auth', 'api-key'] as Collection['selectedSecuritySchemeUids']
 

--- a/packages/api-reference/src/blocks/scalar-server-selector-block/components/Selector.test.ts
+++ b/packages/api-reference/src/blocks/scalar-server-selector-block/components/Selector.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest'
-import { mount } from '@vue/test-utils'
-import { nextTick } from 'vue'
-import Selector from './Selector.vue'
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+
+import Selector from './Selector.vue'
 
 describe('Selector', () => {
   const mockServers: ServerObject[] = [
@@ -191,7 +192,7 @@ describe('Selector', () => {
     expect(wrapper.vm.selectedServer).toBeUndefined()
   })
 
-  it('component emits update:modelValue through v-model integration', async () => {
+  it('component emits update:modelValue through v-model integration', () => {
     const wrapper = mount(Selector, {
       props: {
         servers: mockServers,

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -688,7 +688,7 @@ onCustomEvent(root, 'scalar-download-document', async (event) => {
  * - Operation:
  *        Open all parents and scroll to the operation
  */
-const handleSelectItem = async (id: string) => {
+const handleSelectItem = (id: string) => {
   const item = sidebarState.getEntryById(id)
 
   if (

--- a/packages/api-reference/src/components/Content/Models/Model.test.ts
+++ b/packages/api-reference/src/components/Content/Models/Model.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 
 import Model from './Model.vue'
 
-describe('Model', async () => {
+describe('Model', () => {
   const mockDocument = coerceValue(OpenAPIDocumentSchema, {
     openapi: '3.1.0',
     info: {

--- a/packages/api-reference/src/components/Content/Operations/TraversedEntry.test.ts
+++ b/packages/api-reference/src/components/Content/Operations/TraversedEntry.test.ts
@@ -195,7 +195,7 @@ beforeEach(() => {
 })
 
 describe('operation rendering', () => {
-  it('renders a single operation correctly', async () => {
+  it('renders a single operation correctly', () => {
     const operation = createMockOperation()
     const entries: TraversedEntry[] = [operation]
 

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -206,7 +206,7 @@ describe('Schema', () => {
       expect(disclosurePanelAfter.exists()).toBe(true)
     })
 
-    it('prevents click propagation when noncollapsible is true', async () => {
+    it('prevents click propagation when noncollapsible is true', () => {
       const wrapper = mount(Schema, {
         props: {
           eventBus: null,
@@ -233,7 +233,7 @@ describe('Schema', () => {
       expect(wrapper.find('.schema-card').exists()).toBe(true)
     })
 
-    it('does not prevent click propagation when noncollapsible is false', async () => {
+    it('does not prevent click propagation when noncollapsible is false', () => {
       const wrapper = mount(Schema, {
         props: {
           eventBus: null,

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
@@ -170,7 +170,7 @@ describe('SchemaComposition', () => {
       expect(schemaComponent.props('schema')).toEqual({ '__scalar_': '', const: 'Baz' })
     })
 
-    it('renders enum schema in composition panel', async () => {
+    it('renders enum schema in composition panel', () => {
       const wrapper = mount(SchemaComposition, {
         props: {
           eventBus: null,

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -54,7 +54,7 @@ describe('SchemaProperty', () => {
         expect(schemas).toHaveLength(1)
       })
 
-      it('hides expand button for object without properties or additional properties', async () => {
+      it('hides expand button for object without properties or additional properties', () => {
         const wrapper = mount(SchemaProperty, {
           props: {
             eventBus: null,
@@ -100,7 +100,7 @@ describe('SchemaProperty', () => {
         expect(schemas).toHaveLength(1)
       })
 
-      it('hides expand button for array with primitive items', async () => {
+      it('hides expand button for array with primitive items', () => {
         const wrapper = mount(SchemaProperty, {
           props: {
             eventBus: null,
@@ -123,7 +123,7 @@ describe('SchemaProperty', () => {
     })
 
     describe('primitive types', () => {
-      it('hides expand button for string type', async () => {
+      it('hides expand button for string type', () => {
         const wrapper = mount(SchemaProperty, {
           props: {
             eventBus: null,
@@ -141,7 +141,7 @@ describe('SchemaProperty', () => {
         expect(schemas).toHaveLength(0)
       })
 
-      it('hides expand button for integer type', async () => {
+      it('hides expand button for integer type', () => {
         const wrapper = mount(SchemaProperty, {
           props: {
             eventBus: null,
@@ -159,7 +159,7 @@ describe('SchemaProperty', () => {
         expect(schemas).toHaveLength(0)
       })
 
-      it('hides expand button for number type', async () => {
+      it('hides expand button for number type', () => {
         const wrapper = mount(SchemaProperty, {
           props: {
             eventBus: null,
@@ -177,7 +177,7 @@ describe('SchemaProperty', () => {
         expect(schemas).toHaveLength(0)
       })
 
-      it('hides expand button for boolean type', async () => {
+      it('hides expand button for boolean type', () => {
         const wrapper = mount(SchemaProperty, {
           props: {
             eventBus: null,
@@ -340,7 +340,7 @@ describe('SchemaProperty', () => {
   })
 
   describe('variant prop', () => {
-    it('displays pattern properties with variant prop', async () => {
+    it('displays pattern properties with variant prop', () => {
       const wrapper = mount(SchemaProperty, {
         props: {
           eventBus: null,
@@ -359,7 +359,7 @@ describe('SchemaProperty', () => {
       expect(patternName.text()).toBe('^foo-')
     })
 
-    it('displays additional properties with variant prop', async () => {
+    it('displays additional properties with variant prop', () => {
       const wrapper = mount(SchemaProperty, {
         props: {
           variant: 'additionalProperties',
@@ -378,7 +378,7 @@ describe('SchemaProperty', () => {
       expect(additionalName.text()).toBe('propertyName*')
     })
 
-    it('displays regular property names without variant styling', async () => {
+    it('displays regular property names without variant styling', () => {
       const wrapper = mount(SchemaProperty, {
         props: {
           name: 'regularProperty',
@@ -469,7 +469,7 @@ describe('SchemaProperty', () => {
     })
 
     describe('object compositions', () => {
-      it('renders object compositions with allOf with an object button', async () => {
+      it('renders object compositions with allOf with an object button', () => {
         const wrapper = mount(SchemaProperty, {
           props: {
             eventBus: null,

--- a/packages/api-reference/src/components/Content/Tags/components/ModernLayout.test.ts
+++ b/packages/api-reference/src/components/Content/Tags/components/ModernLayout.test.ts
@@ -102,7 +102,7 @@ describe('TagSection rendering', () => {
 })
 
 describe('ShowMoreButton rendering', () => {
-  it('renders ShowMoreButton when tag is collapsed and moreThanOneTag is true', async () => {
+  it('renders ShowMoreButton when tag is collapsed and moreThanOneTag is true', () => {
     const wrapper = mount(ModernLayout, {
       props: {
         ...mockProps,
@@ -115,7 +115,7 @@ describe('ShowMoreButton rendering', () => {
     expect(wrapper.findComponent({ name: 'ShowMoreButton' }).exists()).toBe(true)
   })
 
-  it('does not render ShowMoreButton when tag is not collapsed', async () => {
+  it('does not render ShowMoreButton when tag is not collapsed', () => {
     const wrapper = mount(ModernLayout, {
       props: {
         ...mockProps,
@@ -127,7 +127,7 @@ describe('ShowMoreButton rendering', () => {
     expect(wrapper.findComponent({ name: 'ShowMoreButton' }).exists()).toBe(false)
   })
 
-  it('does not render ShowMoreButton when moreThanOneTag is false', async () => {
+  it('does not render ShowMoreButton when moreThanOneTag is false', () => {
     const wrapper = mount(ModernLayout, {
       props: {
         ...mockProps,
@@ -141,7 +141,7 @@ describe('ShowMoreButton rendering', () => {
 })
 
 describe('slot content rendering', () => {
-  it('renders slot content when ShowMoreButton is not shown', async () => {
+  it('renders slot content when ShowMoreButton is not shown', () => {
     const wrapper = mount(ModernLayout, {
       props: {
         ...mockProps,

--- a/packages/api-reference/src/components/OperationsList/OperationsList.test.ts
+++ b/packages/api-reference/src/components/OperationsList/OperationsList.test.ts
@@ -173,7 +173,7 @@ describe('OperationsList', () => {
     expect(wrapper.html()).toBe('<!--v-if-->')
   })
 
-  it('applies correct CSS classes', async () => {
+  it('applies correct CSS classes', () => {
     const operations = [createMockOperation()]
     const tag = createMockTag({ children: operations })
 

--- a/packages/api-reference/src/features/Operation/components/ContentTypeSelect.test.ts
+++ b/packages/api-reference/src/features/Operation/components/ContentTypeSelect.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import ContentTypeSelect from './ContentTypeSelect.vue'
 
 describe('ContentTypeSelect', () => {
-  it('renders with multiple content types as a dropdown', async () => {
+  it('renders with multiple content types as a dropdown', () => {
     const wrapper = mount(ContentTypeSelect, {
       props: {
         content: {
@@ -19,7 +19,7 @@ describe('ContentTypeSelect', () => {
     expect(wrapper.text()).toContain('application/json')
   })
 
-  it('renders with a single content type as plain text', async () => {
+  it('renders with a single content type as plain text', () => {
     const wrapper = mount(ContentTypeSelect, {
       props: {
         content: {

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.test.ts
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.test.ts
@@ -7,7 +7,7 @@ import OperationParameters from './OperationParameters.vue'
 
 describe('OperationParameters', () => {
   describe('path parameters', () => {
-    it('renders path parameters', async () => {
+    it('renders path parameters', () => {
       const wrapper = mount(OperationParameters, {
         props: {
           eventBus: null,
@@ -36,7 +36,7 @@ describe('OperationParameters', () => {
   })
 
   describe('query parameters', () => {
-    it('renders query parameters', async () => {
+    it('renders query parameters', () => {
       const wrapper = mount(OperationParameters, {
         props: {
           eventBus: null,
@@ -64,7 +64,7 @@ describe('OperationParameters', () => {
   })
 
   describe('header parameters', () => {
-    it('renders header parameters', async () => {
+    it('renders header parameters', () => {
       const wrapper = mount(OperationParameters, {
         props: {
           eventBus: null,
@@ -93,7 +93,7 @@ describe('OperationParameters', () => {
   })
 
   describe('cookie parameters', () => {
-    it('renders a required cookie parameter', async () => {
+    it('renders a required cookie parameter', () => {
       const wrapper = mount(OperationParameters, {
         props: {
           eventBus: null,
@@ -122,7 +122,7 @@ describe('OperationParameters', () => {
       expect(wrapper.text()).toContain('required')
     })
 
-    it('renders an optional cookie parameter', async () => {
+    it('renders an optional cookie parameter', () => {
       const wrapper = mount(OperationParameters, {
         props: {
           eventBus: null,
@@ -152,7 +152,7 @@ describe('OperationParameters', () => {
   })
 
   describe('request body', () => {
-    it('renders request body', async () => {
+    it('renders request body', () => {
       const wrapper = mount(OperationParameters, {
         props: {
           options: {
@@ -182,7 +182,7 @@ describe('OperationParameters', () => {
     })
 
     // TODO: Not implemented yet
-    it.skip('renders request body without readOnly properties', async () => {
+    it.skip('renders request body without readOnly properties', () => {
       const wrapper = mount(OperationParameters, {
         props: {
           eventBus: null,
@@ -223,7 +223,7 @@ describe('OperationParameters', () => {
   })
 
   describe('form data', () => {
-    it('renders form data parameters', async () => {
+    it('renders form data parameters', () => {
       const wrapper = mount(OperationParameters, {
         props: {
           eventBus: null,

--- a/packages/api-reference/src/helpers/openapi.test.ts
+++ b/packages/api-reference/src/helpers/openapi.test.ts
@@ -5,7 +5,7 @@ import { createParameterMap, deepMerge } from './openapi'
 
 describe('openapi', () => {
   describe('deepMerge', () => {
-    it('merges objects', async () => {
+    it('merges objects', () => {
       expect(
         deepMerge(
           {
@@ -21,7 +21,7 @@ describe('openapi', () => {
       })
     })
 
-    it('merges objects in objects', async () => {
+    it('merges objects in objects', () => {
       expect(
         deepMerge(
           {
@@ -48,7 +48,7 @@ describe('openapi', () => {
       })
     })
 
-    it("doesn't merge undefined properties", async () => {
+    it("doesn't merge undefined properties", () => {
       expect(
         deepMerge(
           {

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -53,7 +53,7 @@ describe('createContainer', () => {
 })
 
 describe('createApiReference', () => {
-  it('creates and mounts the API reference component', async () => {
+  it('creates and mounts the API reference component', () => {
     const element = document.querySelector('#mount-point')
     expect(element).toBeInstanceOf(HTMLElement)
 
@@ -65,7 +65,7 @@ describe('createApiReference', () => {
     expect(element?.innerHTML).toContain('Powered by Scalar')
   })
 
-  it('handles string selectors for mounting', async () => {
+  it('handles string selectors for mounting', () => {
     const config = { _integration: 'html' }
     const apiReference = createApiReference('#mount-point', apiReferenceConfigurationSchema.parse(config))
 
@@ -227,7 +227,7 @@ describe('findDataAttributes (legacy)', () => {
 })
 
 describe('getConfigurationFromDataAttributes', () => {
-  it('createApiReference', async () => {
+  it('createApiReference', () => {
     global.document = createHtmlDocument(`
         <html>
           <body>

--- a/packages/api-reference/test/utils/serve-example.ts
+++ b/packages/api-reference/test/utils/serve-example.ts
@@ -31,7 +31,7 @@ const DEFAULT_CONFIGURATION: Partial<HtmlRenderingConfiguration> = {
  * await page.goto(url)
  * ```
  */
-export async function serveExample(givenConfiguration?: Partial<HtmlRenderingConfiguration>): Promise<string> {
+export function serveExample(givenConfiguration?: Partial<HtmlRenderingConfiguration>): Promise<string> {
   // Check if JS bundle exists
   const pathToJavaScriptBundle = getPathToJavaScriptBundle()
 
@@ -92,7 +92,7 @@ export async function serveExample(givenConfiguration?: Partial<HtmlRenderingCon
   })
 }
 
-export async function serveHTMLExample(
+export function serveHTMLExample(
   htmlPath: string,
   port = 3745,
 ): Promise<{

--- a/packages/build-tooling/src/esbuild/helpers.ts
+++ b/packages/build-tooling/src/esbuild/helpers.ts
@@ -1,7 +1,8 @@
 import { exec } from 'node:child_process'
+
 import as, { type AnsiColors } from 'ansis'
 
-export async function runCommand(command: string, processName: string) {
+export function runCommand(command: string, processName: string): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const comm = exec(command)
 

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.test.ts
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.test.ts
@@ -2,9 +2,9 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
-import ScalarComboboxOptions from './ScalarComboboxOptions.vue'
 import ScalarComboboxOption from './ScalarComboboxOption.vue'
 import ScalarComboboxOptionGroup from './ScalarComboboxOptionGroup.vue'
+import ScalarComboboxOptions from './ScalarComboboxOptions.vue'
 import type { Option, OptionGroup } from './types'
 
 // Mock data
@@ -110,7 +110,7 @@ describe('ScalarComboboxOptions', () => {
   })
 
   describe('slot functionality', () => {
-    it('passes correct props to option slot', async () => {
+    it('passes correct props to option slot', () => {
       const wrapper = mount(ScalarComboboxOptions, {
         props: {
           options: extendedOptions,
@@ -148,7 +148,7 @@ describe('ScalarComboboxOptions', () => {
       expect(secondOption?.find('[data-test="option-selected"]').text()).toBe('false')
     })
 
-    it('passes correct props to group slot', async () => {
+    it('passes correct props to group slot', () => {
       const wrapper = mount(ScalarComboboxOptions, {
         props: { options: extendedGroups },
         slots: {
@@ -217,7 +217,7 @@ describe('ScalarComboboxOptions', () => {
       expect(visibleGroups[0]?.text()).toBe('Fruits')
     })
 
-    it('handles multiselect mode with custom slots', async () => {
+    it('handles multiselect mode with custom slots', () => {
       const wrapper = mount(ScalarComboboxOptions, {
         props: {
           options: extendedOptions,
@@ -374,7 +374,7 @@ describe('ScalarComboboxOptions', () => {
       expect(filteredOptions).toHaveLength(0)
     })
 
-    it('handles empty grouped options array gracefully', async () => {
+    it('handles empty grouped options array gracefully', () => {
       const wrapper = mount(ScalarComboboxOptions, {
         props: { options: [] as OptionGroup[] },
       })

--- a/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
+++ b/packages/components/src/components/ScalarCombobox/ScalarComboboxOptions.vue
@@ -24,9 +24,9 @@ const props = defineProps<{
   multiselect?: boolean
 }>()
 
-const model = defineModel<O[]>({ default: [] })
-
 const emit = defineEmits<ComboboxEmits>()
+
+const model = defineModel<O[]>({ default: [] })
 
 const slots = defineSlots<Omit<ComboboxSlots<O, G>, 'default'>>()
 
@@ -66,7 +66,7 @@ const query = ref<string>('')
 const active = ref<Option | undefined>(model.value?.[0] ?? options.value[0])
 
 // Clear the query on open and close
-onMounted(async () => {
+onMounted(() => {
   // Clear the query
   query.value = ''
 
@@ -179,8 +179,8 @@ onMounted(() => setTimeout(() => input.value?.focus(), 0))
     <ScalarIconMagnifyingGlass
       class="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-c-3 size-4" />
     <input
-      v-model="query"
       ref="input"
+      v-model="query"
       :aria-activedescendant="active ? getOptionId(active) : undefined"
       aria-autocomplete="list"
       :aria-controls="id"
@@ -214,8 +214,8 @@ onMounted(() => setTimeout(() => input.value?.focus(), 0))
       <template #label>
         <slot
           v-if="$slots.group"
-          name="group"
-          :group />
+          :group
+          name="group" />
         <template v-else>
           {{ group.label }}
         </template>
@@ -226,22 +226,22 @@ onMounted(() => setTimeout(() => input.value?.focus(), 0))
         <ComboboxOption
           v-if="group.options.some((o) => o.id === option.id)"
           :id="getOptionId(option)"
+          v-slot="{ active, selected }"
           :active="active?.id === option.id"
           :selected="model.some((o) => o.id === option.id)"
           @click="toggleSelected(option)"
           @mousedown.prevent
-          @mouseenter="active = option"
-          v-slot="{ active, selected }">
+          @mouseenter="active = option">
           <slot
             v-if="$slots.option"
+            :active
             name="option"
             :option
-            :active
             :selected />
           <template v-else>
             <ScalarListboxCheckbox
-              :selected="model.some((o) => o.id === option.id)"
-              :multiselect />
+              :multiselect
+              :selected="model.some((o) => o.id === option.id)" />
             <span class="inline-block min-w-0 flex-1 truncate text-c-1">
               {{ option.label }}
             </span>
@@ -252,15 +252,15 @@ onMounted(() => setTimeout(() => input.value?.focus(), 0))
     <ComboboxOption
       v-if="slots.add"
       :id="getOptionId(addOption)"
+      v-slot="{ active }"
       :active="active?.id === addOption.id"
       @click="addNew"
       @mousedown.prevent
-      @mouseenter="active = addOption"
-      v-slot="{ active }">
+      @mouseenter="active = addOption">
       <ScalarIconPlus class="size-4 p-px" />
       <slot
-        name="add"
-        :active />
+        :active
+        name="add" />
     </ComboboxOption>
   </ul>
 </template>

--- a/packages/components/src/components/ScalarContextMenu/ScalarContextMenu.test.ts
+++ b/packages/components/src/components/ScalarContextMenu/ScalarContextMenu.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import ScalarContextMenu from './ScalarContextMenu.vue'
 
 describe('ScalarContextMenu', () => {
-  it('renders properly', async () => {
+  it('renders properly', () => {
     const wrapper = mount(ScalarContextMenu, {
       props: {
         items: [

--- a/packages/components/src/components/ScalarErrorBoundary/ScalarErrorBoundary.test.ts
+++ b/packages/components/src/components/ScalarErrorBoundary/ScalarErrorBoundary.test.ts
@@ -5,7 +5,7 @@ import { h, nextTick } from 'vue'
 import ScalarErrorBoundary from './ScalarErrorBoundary.vue'
 
 describe('ScalarErrorBoundary', () => {
-  it('renders properly', async () => {
+  it('renders properly', () => {
     const wrapper = mount(ScalarErrorBoundary, {
       props: {},
     })

--- a/packages/components/src/components/ScalarFileUpload/ScalarFileUpload.test.ts
+++ b/packages/components/src/components/ScalarFileUpload/ScalarFileUpload.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import ScalarFileUpload from './ScalarFileUpload.vue'
 
 describe('ScalarFileUpload', () => {
-  it('renders properly', async () => {
+  it('renders properly', () => {
     const wrapper = mount(ScalarFileUpload, {})
     expect(wrapper.exists()).toBeTruthy()
   })

--- a/packages/components/src/components/ScalarFloating/useResizeWithTarget.test.ts
+++ b/packages/components/src/components/ScalarFloating/useResizeWithTarget.test.ts
@@ -7,21 +7,21 @@ import { useResizeWithTarget } from './useResizeWithTarget'
  * Unfortunately we can't test the ResizeObserver with vitest but we can test the hook options
  */
 describe('useResizeWithTarget', () => {
-  it('returns a width by default', async () => {
+  it('returns a width by default', () => {
     const el = ref<Element>()
     const { width } = useResizeWithTarget(el)
 
     expect(width.value).toBe('0px')
   })
 
-  it('returns undefined if enabled is false', async () => {
+  it('returns undefined if enabled is false', () => {
     const el = ref<Element>()
     const { width } = useResizeWithTarget(el, { enabled: ref(false) })
 
     expect(width.value).toBeUndefined()
   })
 
-  it('is reactive to changing the enabled ref', async () => {
+  it('is reactive to changing the enabled ref', () => {
     const el = ref<Element>()
     const enabled = ref(false)
 

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.test.ts
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import ScalarListbox from './ScalarListbox.vue'
 
 describe('ScalarListbox', () => {
-  it('renders properly', async () => {
+  it('renders properly', () => {
     const wrapper = mount(ScalarListbox, {
       props: {
         options: [

--- a/packages/components/src/components/ScalarLoading/ScalarLoading.test.ts
+++ b/packages/components/src/components/ScalarLoading/ScalarLoading.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import ScalarLoading, { useLoadingState } from './ScalarLoading.vue'
 
 describe('ScalarLoading', () => {
-  it('renders properly', async () => {
+  it('renders properly', () => {
     const loadingState = useLoadingState()
     loadingState.startLoading()
 

--- a/packages/components/src/components/ScalarPopover/ScalarPopover.test.ts
+++ b/packages/components/src/components/ScalarPopover/ScalarPopover.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import ScalarPopover from './ScalarPopover.vue'
 
 describe('ScalarPopover', () => {
-  it('renders properly', async () => {
+  it('renders properly', () => {
     const wrapper = mount(ScalarPopover, {
       props: {},
       slots: {

--- a/packages/components/src/components/ScalarTooltip/ScalarHotkeyTooltip.test.ts
+++ b/packages/components/src/components/ScalarTooltip/ScalarHotkeyTooltip.test.ts
@@ -1,9 +1,10 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
+
+import { ELEMENT_ID } from './constants'
 import ScalarHotkeyTooltip from './ScalarHotkeyTooltip.vue'
 import { cleanupTooltipElement } from './useTooltip'
-import { ELEMENT_ID } from './constants'
 
 describe('ScalarHotkeyTooltip', () => {
   beforeEach(() => {
@@ -16,7 +17,7 @@ describe('ScalarHotkeyTooltip', () => {
     vi.useRealTimers()
   })
 
-  it('renders trigger element and is hidden initially', async () => {
+  it('renders trigger element and is hidden initially', () => {
     const wrapper = mount(ScalarHotkeyTooltip, {
       props: {
         hotkey: 'K',

--- a/packages/components/src/components/ScalarTooltip/ScalarTooltip.test.ts
+++ b/packages/components/src/components/ScalarTooltip/ScalarTooltip.test.ts
@@ -1,9 +1,10 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
+
+import { ELEMENT_ID } from './constants'
 import ScalarTooltip from './ScalarTooltip.vue'
 import { cleanupTooltipElement } from './useTooltip'
-import { ELEMENT_ID } from './constants'
 
 describe('ScalarTooltip', () => {
   beforeEach(() => {
@@ -20,7 +21,7 @@ describe('ScalarTooltip', () => {
     vi.useRealTimers()
   })
 
-  it('renders trigger element and tooltip content', async () => {
+  it('renders trigger element and tooltip content', () => {
     const wrapper = mount(ScalarTooltip, {
       props: {
         content: 'Tooltip Content',

--- a/packages/components/src/components/ScalarTooltip/useTooltip.test.ts
+++ b/packages/components/src/components/ScalarTooltip/useTooltip.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { cleanupTooltipElement, useTooltip } from './useTooltip'
-import { ELEMENT_ID } from './constants'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
+
+import { ELEMENT_ID } from './constants'
+import { cleanupTooltipElement, useTooltip } from './useTooltip'
 
 describe('useTooltip', () => {
   let targetElement: HTMLElement
@@ -24,7 +25,7 @@ describe('useTooltip', () => {
     vi.useRealTimers()
   })
 
-  it('should initialize tooltip element on first use', async () => {
+  it('should initialize tooltip element on first use', () => {
     useTooltip({
       content: 'Test tooltip',
       targetRef: targetElement,
@@ -76,7 +77,7 @@ describe('useTooltip', () => {
     expect(tooltipElement?.textContent).toBe('Test tooltip')
   })
 
-  it('should hide tooltip on mouseleave', async () => {
+  it('should hide tooltip on mouseleave', () => {
     useTooltip({
       content: 'Test tooltip',
       targetRef: targetElement,
@@ -197,7 +198,7 @@ describe('useTooltip', () => {
     expect(document.getElementById(ELEMENT_ID)?.textContent).toBe('Updated content')
   })
 
-  it('should set aria-describedby on target element', async () => {
+  it('should set aria-describedby on target element', () => {
     useTooltip({
       content: 'Test tooltip',
       targetRef: targetElement,

--- a/packages/components/src/components/ScalarVirtualText/ScalarVirtualText.test.ts
+++ b/packages/components/src/components/ScalarVirtualText/ScalarVirtualText.test.ts
@@ -83,7 +83,7 @@ describe('ScalarVirtualText', () => {
     expect(content.attributes('style')).toContain('transform: translateY')
   })
 
-  it('updates container height on window resize', async () => {
+  it('updates container height on window resize', () => {
     vi.spyOn(window, 'addEventListener')
     vi.spyOn(window, 'removeEventListener')
 

--- a/packages/galaxy/esbuild.ts
+++ b/packages/galaxy/esbuild.ts
@@ -6,7 +6,7 @@ import { normalize, toJson } from '@scalar/openapi-parser'
 await build({
   entries: ['./src/index.ts'],
   platform: 'shared',
-  onSuccess: async () => {
+  onSuccess: () => {
     // Get the package meta data
     const packageFile = JSON.parse(fs.readFileSync('./package.json', 'utf-8'))
 

--- a/packages/helpers/src/regex/find-variables.test.ts
+++ b/packages/helpers/src/regex/find-variables.test.ts
@@ -3,23 +3,23 @@ import { describe, expect, it } from 'vitest'
 import { findVariables } from './find-variables'
 
 describe('findVariables', () => {
-  it('finds variables', async () => {
+  it('finds variables', () => {
     expect(findVariables('http://{baseUrl}/foobar')).toEqual(['baseUrl'])
   })
 
-  it('finds variables with double curly braces', async () => {
+  it('finds variables with double curly braces', () => {
     expect(findVariables('http://{{baseUrl}}/foobar')).toEqual(['baseUrl'])
   })
 
-  it('ignores whitespace', async () => {
+  it('ignores whitespace', () => {
     expect(findVariables('http://{ baseUrl }/foobar')).toEqual(['baseUrl'])
   })
 
-  it('works with special characters', async () => {
+  it('works with special characters', () => {
     expect(findVariables('http://{Example123_}/foobar')).toEqual(['Example123_'])
   })
 
-  it("returns an empty array if there's no variable", async () => {
+  it("returns an empty array if there's no variable", () => {
     expect(findVariables('http://example.com/foobar')).toEqual([])
   })
 })

--- a/packages/json-magic/src/bundle/bundle.ts
+++ b/packages/json-magic/src/bundle/bundle.ts
@@ -80,16 +80,16 @@ export type ResolveResult = { ok: true; data: unknown; raw: string } | { ok: fal
  * // No matching plugin returns { ok: false }
  * await resolveContents('#/components/schemas/User', [urlPlugin, filePlugin])
  */
-async function resolveContents(value: string, plugins: LoaderPlugin[]): Promise<ResolveResult> {
+function resolveContents(value: string, plugins: LoaderPlugin[]): Promise<ResolveResult> {
   const plugin = plugins.find((p) => p.validate(value))
 
   if (plugin) {
     return plugin.exec(value)
   }
 
-  return {
+  return Promise.resolve({
     ok: false,
-  }
+  })
 }
 
 /**

--- a/packages/json-magic/src/bundle/plugins/parse-json/index.ts
+++ b/packages/json-magic/src/bundle/plugins/parse-json/index.ts
@@ -1,4 +1,4 @@
-import type { LoaderPlugin, ResolveResult } from '@/bundle'
+import type { LoaderPlugin } from '@/bundle'
 import { isJsonObject } from '@/helpers/is-json-object'
 
 /**
@@ -15,17 +15,17 @@ export function parseJson(): LoaderPlugin {
   return {
     type: 'loader',
     validate: isJsonObject,
-    exec: async (value): Promise<ResolveResult> => {
+    exec: (value) => {
       try {
-        return {
+        return Promise.resolve({
           ok: true,
           data: JSON.parse(value),
           raw: value,
-        }
+        })
       } catch {
-        return {
+        return Promise.resolve({
           ok: false,
-        }
+        })
       }
     },
   }

--- a/packages/json-magic/src/bundle/plugins/parse-yaml/index.ts
+++ b/packages/json-magic/src/bundle/plugins/parse-yaml/index.ts
@@ -1,6 +1,6 @@
 import YAML from 'yaml'
 
-import type { LoaderPlugin, ResolveResult } from '@/bundle'
+import type { LoaderPlugin } from '@/bundle'
 import { isYaml } from '@/helpers/is-yaml'
 
 /**
@@ -17,17 +17,17 @@ export function parseYaml(): LoaderPlugin {
   return {
     type: 'loader',
     validate: isYaml,
-    exec: async (value): Promise<ResolveResult> => {
+    exec: (value) => {
       try {
-        return {
+        return Promise.resolve({
           ok: true,
           data: YAML.parse(value, { merge: true, maxAliasCount: 10000 }),
           raw: value,
-        }
+        })
       } catch {
-        return {
+        return Promise.resolve({
           ok: false,
-        }
+        })
       }
     },
   }

--- a/packages/json-magic/src/bundle/value-generator.test.ts
+++ b/packages/json-magic/src/bundle/value-generator.test.ts
@@ -1,9 +1,10 @@
-import { generateUniqueValue, uniqueValueGeneratorFactory } from './value-generator'
 import { describe, expect, it } from 'vitest'
+
+import { generateUniqueValue, uniqueValueGeneratorFactory } from './value-generator'
 
 describe('generateUniqueHash', () => {
   it('should generate hash values from the function we pass in', async () => {
-    const hashFunction = async (value: string) => {
+    const hashFunction = (value: string) => {
       if (value === 'a') {
         return 'a'
       }
@@ -16,7 +17,7 @@ describe('generateUniqueHash', () => {
   })
 
   it('should return same value for the same input', async () => {
-    const hashFunction = async (value: string) => {
+    const hashFunction = (value: string) => {
       if (value === 'a') {
         return value
       }
@@ -33,7 +34,7 @@ describe('generateUniqueHash', () => {
   })
 
   it('should handle hash collisions', async () => {
-    const hashFunction = async (value: string) => {
+    const hashFunction = (value: string) => {
       // Hash a, b and c will produce collisions
       if (value === 'a' || value === 'b' || value === 'c') {
         return 'd'
@@ -83,9 +84,7 @@ describe('generateUniqueHash', () => {
   })
 
   it('should throw when it reaches max depth', async () => {
-    const hashFunction = async () => {
-      return 'a'
-    }
+    const hashFunction = () => 'a'
 
     const map = {}
     const result1 = await generateUniqueValue(hashFunction, 'a', map)
@@ -94,7 +93,7 @@ describe('generateUniqueHash', () => {
     const result2 = await generateUniqueValue(hashFunction, 'a', map)
     expect(result2).toBe('a')
 
-    expect(() => generateUniqueValue(hashFunction, 'b', map)).rejects.toThrowError()
+    await expect(() => generateUniqueValue(hashFunction, 'b', map)).rejects.toThrowError()
   })
 })
 

--- a/packages/json-magic/src/dereference/dereference.test.ts
+++ b/packages/json-magic/src/dereference/dereference.test.ts
@@ -1,11 +1,13 @@
-import { dereference } from '@/dereference/dereference'
-import { fastify, type FastifyInstance } from 'fastify'
 import { setTimeout } from 'node:timers/promises'
+
+import { type FastifyInstance, fastify } from 'fastify'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { dereference } from '@/dereference/dereference'
 
 describe('dereference', () => {
   describe('sync', () => {
-    it('should dereference JSON pointers', async () => {
+    it('should dereference JSON pointers', () => {
       const data = {
         users: {
           name: 'John Doe',
@@ -82,9 +84,7 @@ describe('dereference', () => {
           street: 'Sunset Boulevard',
         },
       }
-      server.get('/users', async () => {
-        return userProfile
-      })
+      server.get('/users', () => userProfile)
 
       await server.listen({ port: port })
 

--- a/packages/json-magic/src/helpers/escape-json-pointer.test.ts
+++ b/packages/json-magic/src/helpers/escape-json-pointer.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { escapeJsonPointer } from './escape-json-pointer'
 
-describe('escapeJsonPointer', async () => {
+describe('escapeJsonPointer', () => {
   it('should escape a slash', () => {
     expect(escapeJsonPointer('application/json')).toBe('application~1json')
   })

--- a/packages/json-magic/src/helpers/unescape-json-pointer.test.ts
+++ b/packages/json-magic/src/helpers/unescape-json-pointer.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { unescapeJsonPointer } from './unescape-json-pointer'
 
-describe('unescapeJsonPointer', async () => {
+describe('unescapeJsonPointer', () => {
   it('unescapes a slash', () => {
     expect(unescapeJsonPointer('/foo~1bar~1baz')).toBe('/foo/bar/baz')
   })

--- a/packages/mock-server/playground/src/galaxy-scalar-com.ts
+++ b/packages/mock-server/playground/src/galaxy-scalar-com.ts
@@ -12,10 +12,12 @@ import type { Hono } from 'hono'
  * for its playground.
  */
 export async function loadDocument(): Promise<string> {
-  return readFile(new URL('../../../galaxy/src/documents/3.1.yaml', import.meta.url), 'utf8').catch(() => {
+  try {
+    return await readFile(new URL('../../../galaxy/src/documents/3.1.yaml', import.meta.url), 'utf8')
+  } catch {
     console.error('[@scalar/mock-server] Missing @scalar/galaxy. Please build it and try again.')
     return ''
-  })
+  }
 }
 
 /**

--- a/packages/mock-server/src/routes/respondWithOpenApiDocument.ts
+++ b/packages/mock-server/src/routes/respondWithOpenApiDocument.ts
@@ -4,7 +4,7 @@ import type { Context } from 'hono'
 /**
  * OpenAPI endpoints
  */
-export async function respondWithOpenApiDocument(
+export function respondWithOpenApiDocument(
   c: Context,
   input?: string | Record<string, any>,
   format: 'json' | 'yaml' = 'json',

--- a/packages/nextjs-openapi/playground/app/api/characters/[id]/route.ts
+++ b/packages/nextjs-openapi/playground/app/api/characters/[id]/route.ts
@@ -1,12 +1,10 @@
 import { type NextRequest, NextResponse } from 'next/server'
 
-export type Troothy = boolean
-
 /**
  * Get a simpsons character
- * @desc Hits up the sampleapis simpsons characters and narrows it down by id
+ * @desc Hits up the sample apis simpsons characters and narrows it down by id
  */
-export async function GET(
+export function GET(
   _request: NextRequest,
   {
     params,

--- a/packages/oas-utils/src/helpers/normalize-mime-type-object.test.ts
+++ b/packages/oas-utils/src/helpers/normalize-mime-type-object.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { normalizeMimeTypeObject } from './normalize-mime-type-object'
 
 describe('normalizeMimeTypeObject', () => {
-  it('removes charset', async () => {
+  it('removes charset', () => {
     const content = {
       'application/json; charset=utf-8': {},
     }
@@ -13,7 +13,7 @@ describe('normalizeMimeTypeObject', () => {
     })
   })
 
-  it('removes semicolon', async () => {
+  it('removes semicolon', () => {
     const content = {
       'application/json;': {},
     }
@@ -23,7 +23,7 @@ describe('normalizeMimeTypeObject', () => {
     })
   })
 
-  it('removes whitespace', async () => {
+  it('removes whitespace', () => {
     const content = {
       ' application/json ': {},
     }
@@ -33,7 +33,7 @@ describe('normalizeMimeTypeObject', () => {
     })
   })
 
-  it('removes mimetype variants', async () => {
+  it('removes mimetype variants', () => {
     const content = {
       'application/problem+json': {},
     }
@@ -43,7 +43,7 @@ describe('normalizeMimeTypeObject', () => {
     })
   })
 
-  it('removes mimetype variants with special characters', async () => {
+  it('removes mimetype variants with special characters', () => {
     const content = {
       'application/problem+json': {},
     }
@@ -53,7 +53,7 @@ describe('normalizeMimeTypeObject', () => {
     })
   })
 
-  it('removes all the clutter', async () => {
+  it('removes all the clutter', () => {
     const content = {
       'application/problem-foobar+json; charset=utf-8': {},
     }

--- a/packages/oas-utils/src/helpers/normalize-mime-type.test.ts
+++ b/packages/oas-utils/src/helpers/normalize-mime-type.test.ts
@@ -3,43 +3,43 @@ import { describe, expect, it } from 'vitest'
 import { normalizeMimeType } from './normalize-mime-type'
 
 describe('normalizeMimeType', () => {
-  it('removes charset', async () => {
+  it('removes charset', () => {
     const content = 'application/json; charset=utf-8'
 
     expect(normalizeMimeType(content)).toBe('application/json')
   })
 
-  it('removes semicolon', async () => {
+  it('removes semicolon', () => {
     const content = 'application/json;'
 
     expect(normalizeMimeType(content)).toBe('application/json')
   })
 
-  it('removes whitespace', async () => {
+  it('removes whitespace', () => {
     const content = ' application/json '
 
     expect(normalizeMimeType(content)).toBe('application/json')
   })
 
-  it('removes unsupported mimetype variants', async () => {
+  it('removes unsupported mimetype variants', () => {
     const content = 'application/problem+json'
 
     expect(normalizeMimeType(content)).toBe('application/json')
   })
 
-  it('removes all the clutter', async () => {
+  it('removes all the clutter', () => {
     const content = 'application/problem-foobar+json; charset=utf-8'
 
     expect(normalizeMimeType(content)).toBe('application/json')
   })
 
-  it('keeps vendor specific mimetypes', async () => {
+  it('keeps vendor specific mimetypes', () => {
     const content = 'application/vnd.api+json'
 
     expect(normalizeMimeType(content)).toBe('application/vnd.api+json')
   })
 
-  it('removes all the clutter but keeps vendor specific part', async () => {
+  it('removes all the clutter but keeps vendor specific part', () => {
     const content = 'application/fhir+json; charset=utf-8'
 
     expect(normalizeMimeType(content)).toBe('application/fhir+json')

--- a/packages/oas-utils/src/helpers/parse.test.ts
+++ b/packages/oas-utils/src/helpers/parse.test.ts
@@ -24,15 +24,15 @@ describe('Handles yaml and json parsing', () => {
 })
 
 describe('isJsonString', () => {
-  it('keeps a path as is', async () => {
+  it('keeps a path as is', () => {
     expect(isJsonString('foobar')).toBe(false)
   })
 
-  it('removes slash', async () => {
+  it('removes slash', () => {
     expect(isJsonString('{ "foo": "bar" }')).toBe(true)
   })
 
-  it('trims whitespace', async () => {
+  it('trims whitespace', () => {
     expect(isJsonString({ foo: 'bar' })).toBe(false)
   })
 })

--- a/packages/oas-utils/src/helpers/pretty-print-json.test.ts
+++ b/packages/oas-utils/src/helpers/pretty-print-json.test.ts
@@ -3,23 +3,23 @@ import { describe, expect, it } from 'vitest'
 import { prettyPrintJson } from './pretty-print-json'
 
 describe('prettyPrintJson', () => {
-  it('makes JSON strings beautiful', async () => {
+  it('makes JSON strings beautiful', () => {
     expect(prettyPrintJson('{ "foo": "bar" }')).toMatch(`{\n  "foo": "bar"\n}`)
   })
 
-  it('makes JS objects beautiful', async () => {
+  it('makes JS objects beautiful', () => {
     expect(prettyPrintJson({ foo: 'bar' })).toMatch(`{\n  "foo": "bar"\n}`)
   })
 
-  it("doesn't touch regular strings", async () => {
+  it("doesn't touch regular strings", () => {
     expect(prettyPrintJson('foo')).toBe('foo')
   })
 
-  it('transforms numbers', async () => {
+  it('transforms numbers', () => {
     expect(prettyPrintJson(123)).toBe('123')
   })
 
-  it('deals with circular references', async () => {
+  it('deals with circular references', () => {
     const foo: Record<string, any> = { foo: 'bar' }
 
     // Add a circular reference

--- a/packages/openapi-parser/src/plugins/fetch-urls/fetch-urls.test.ts
+++ b/packages/openapi-parser/src/plugins/fetch-urls/fetch-urls.test.ts
@@ -1,39 +1,37 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { fetchUrls } from './fetch-urls'
 
-global.fetch = vi.fn()
+const globalFetchSpy = vi.spyOn(global, 'fetch')
+afterEach(() => {
+  globalFetchSpy.mockReset()
+})
 
-describe('fetchUrls', async () => {
-  beforeEach(() => {
-    // @ts-expect-error
-    global.fetch.mockReset()
-  })
-
-  it('returns true for an url', async () => {
+describe('fetchUrls', () => {
+  it('returns true for an url', () => {
     expect(fetchUrls().check('http://example.com/specification/openapi.yaml')).toBe(true)
   })
 
-  it('returns false for a filename', async () => {
+  it('returns false for a filename', () => {
     expect(fetchUrls().check('openapi.yaml')).toBe(false)
   })
 
-  it('returns false for a path', async () => {
+  it('returns false for a path', () => {
     expect(fetchUrls().check('specification/openapi.yaml')).toBe(false)
   })
 
-  it('returns false for an object', async () => {
+  it('returns false for an object', () => {
     expect(fetchUrls().check({})).toBe(false)
   })
 
-  it('returns false for undefinded', async () => {
+  it('returns false for undefined', () => {
     expect(fetchUrls().check()).toBe(false)
   })
 
   it('fetches the URL', async () => {
     // @ts-expect-error
-    fetch.mockImplementation(async (url: string) => ({
-      text: async () => {
+    globalFetchSpy.mockImplementation(async (url: string) => ({
+      text: () => {
         if (url === 'http://example.com/specification/openapi.yaml') {
           return 'OK'
         }
@@ -47,8 +45,8 @@ describe('fetchUrls', async () => {
 
   it('rewrites the URL', async () => {
     // @ts-expect-error
-    fetch.mockImplementation(async (url: string) => ({
-      text: async () => {
+    globalFetchSpy.mockImplementation(async (url: string) => ({
+      text: () => {
         if (url === 'http://foobar.com/specification/openapi.yaml') {
           return 'OK'
         }

--- a/packages/openapi-parser/src/plugins/read-files/read-files.test.ts
+++ b/packages/openapi-parser/src/plugins/read-files/read-files.test.ts
@@ -2,24 +2,24 @@ import { describe, expect, it } from 'vitest'
 
 import { readFiles } from './read-files'
 
-describe('readFiles', async () => {
-  it('returns true for a filename', async () => {
+describe('readFiles', () => {
+  it('returns true for a filename', () => {
     expect(readFiles().check('openapi.yaml')).toBe(true)
   })
 
-  it('returns true for a path', async () => {
+  it('returns true for a path', () => {
     expect(readFiles().check('../specification/openapi.yaml')).toBe(true)
   })
 
-  it('returns false for an object', async () => {
+  it('returns false for an object', () => {
     expect(readFiles().check({})).toBe(false)
   })
 
-  it('returns false for undefinded', async () => {
+  it('returns false for undefinded', () => {
     expect(readFiles().check()).toBe(false)
   })
 
-  it('returns false for an url', async () => {
+  it('returns false for an url', () => {
     expect(readFiles().check('http://example.com/specification/openapi.yaml')).toBe(false)
   })
 })

--- a/packages/openapi-parser/src/plugins/read-files/read-files.ts
+++ b/packages/openapi-parser/src/plugins/read-files/read-files.ts
@@ -36,7 +36,7 @@ export const readFiles: () => LoadPlugin = () => {
 
       return true
     },
-    async get(value?: any) {
+    get(value?: any) {
       if (!fs.existsSync(value)) {
         throw new Error(ERRORS.FILE_DOES_NOT_EXIST.replace('%s', value))
       }

--- a/packages/openapi-parser/src/utils/openapi/openapi.test.ts
+++ b/packages/openapi-parser/src/utils/openapi/openapi.test.ts
@@ -1,8 +1,10 @@
 import { join } from 'node:path'
+
 import { describe, expect, it } from 'vitest'
 import { stringify } from 'yaml'
 
 import { readFiles } from '@/plugins/read-files/read-files'
+
 import { openapi } from './openapi'
 
 const example = {
@@ -264,7 +266,7 @@ describe('pipeline', () => {
     expect(result.schema.info.title).toBe('Hello World')
   })
 
-  it('throws an error when dereference fails (global)', async () => {
+  it('throws an error when dereference fails (global)', () => {
     expect(async () => {
       await openapi({
         throwOnError: true,
@@ -288,7 +290,7 @@ describe('pipeline', () => {
   })
 
   it('throws an error when dereference fails (only dereference)', async () => {
-    expect(async () => {
+    await expect(async () => {
       await openapi()
         .load({
           openapi: '3.1.0',
@@ -311,7 +313,7 @@ describe('pipeline', () => {
   })
 
   it('throws an error when validate fails (global)', async () => {
-    expect(async () => {
+    await expect(async () => {
       await openapi({
         throwOnError: true,
       })
@@ -336,7 +338,7 @@ describe('pipeline', () => {
   })
 
   it('throws an error when validate fails (only validate)', async () => {
-    expect(async () => {
+    await expect(async () => {
       await openapi()
         .load({
           openapi: '3.1.0',
@@ -361,35 +363,32 @@ describe('pipeline', () => {
   })
 
   it('works with then & catch', async () => {
-    return new Promise((resolve, reject) => {
-      openapi()
-        .load({
-          openapi: '3.1.0',
-          info: {
-            title: 'Hello World',
-          },
-          paths: {
-            '/foobar': {
-              post: {
-                requestBody: {
-                  $ref: '#/components/requestBodies/DoesNotExist',
-                },
+    expect.assertions(1)
+
+    await openapi()
+      .load({
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+        },
+        paths: {
+          '/foobar': {
+            post: {
+              requestBody: {
+                $ref: '#/components/requestBodies/DoesNotExist',
               },
             },
           },
-        })
-        .validate({
-          throwOnError: true,
-        })
-        .get()
-        .then(() => {
-          reject()
-        })
-        .catch((error) => {
-          expect(error.message).toBe("Can't resolve reference: #/components/requestBodies/DoesNotExist")
-
-          resolve(null)
-        })
-    })
+        },
+      })
+      .validate({
+        throwOnError: true,
+      })
+      .get()
+      // biome-ignore lint/suspicious/noEmptyBlockStatements: should never come here
+      .then(() => {})
+      .catch((error) => {
+        expect(error.message).toBe("Can't resolve reference: #/components/requestBodies/DoesNotExist")
+      })
   })
 })

--- a/packages/openapi-parser/src/utils/resolve-references.test.ts
+++ b/packages/openapi-parser/src/utils/resolve-references.test.ts
@@ -1,21 +1,23 @@
-import path from 'node:path'
 /**
  * This file has some simple tests to cover the basics of the resolveReferences function.
  * Doesn't cover all edge cases, doesn't have big files, but if this works you're almost there.
  */
+import path from 'node:path'
+
 import SwaggerParser from '@apidevtools/swagger-parser'
+import type { OpenAPI } from '@scalar/openapi-types'
 import { describe, expect, it } from 'vitest'
 
 import { readFiles } from '@/plugins/read-files/read-files'
 import type { AnyObject } from '@/types/index'
+
 import { load } from './load/load'
 import { resolveReferences } from './resolve-references'
-import type { OpenAPI } from '@scalar/openapi-types'
 
 const EXAMPLE_FILE = path.join(new URL(import.meta.url).pathname, '../../../tests/filesystem/api/openapi.yaml')
 
 describe('resolveReferences', () => {
-  it('resolves a media type reference', async () => {
+  it('resolves a media type reference', () => {
     const specification: OpenAPI.Document = {
       openapi: '3.2.0',
       info: {},
@@ -52,7 +54,7 @@ describe('resolveReferences', () => {
     expect(schema.paths['/foobar'].get.responses[200].content['application/json'].schema).not.toBe(undefined)
   })
 
-  it('resolves a single reference', async () => {
+  it('resolves a single reference', () => {
     const specification = {
       openapi: '3.1.0',
       info: {},
@@ -81,7 +83,7 @@ describe('resolveReferences', () => {
     expect(schema.paths['/foobar'].post.requestBody.content).not.toBe(undefined)
   })
 
-  it("returns an error when a reference can't be found", async () => {
+  it("returns an error when a reference can't be found", () => {
     const specification = {
       openapi: '3.1.0',
       info: {},
@@ -107,7 +109,7 @@ describe('resolveReferences', () => {
     expect(valid).toBe(false)
   })
 
-  it("returns an error when an external reference can't be found", async () => {
+  it("returns an error when an external reference can't be found", () => {
     const specification = {
       openapi: '3.1.0',
       info: {},
@@ -236,7 +238,7 @@ describe('resolveReferences', () => {
     )
   })
 
-  it('resolves references in arrays', async () => {
+  it('resolves references in arrays', () => {
     const specification = {
       openapi: '3.1.0',
       info: {},
@@ -285,7 +287,7 @@ describe('resolveReferences', () => {
     })
   })
 
-  it('merges original properties and referenced content', async () => {
+  it('merges original properties and referenced content', () => {
     const specification = {
       openapi: '3.1.0',
       info: {},
@@ -335,7 +337,7 @@ describe('resolveReferences', () => {
     })
   })
 
-  it('references inside references still keep the reference to the original JS object', async () => {
+  it('references inside references still keep the reference to the original JS object', () => {
     const specification = {
       swagger: '2.0',
       info: {
@@ -409,7 +411,7 @@ describe('resolveReferences', () => {
     })
   })
 
-  it('resolves a simple circular reference', async () => {
+  it('resolves a simple circular reference', () => {
     const partialSpecification: AnyObject = {
       foo: {
         bar: {
@@ -427,7 +429,7 @@ describe('resolveReferences', () => {
     expect(schema.foo.bar.bar.bar.bar.bar.bar.bar.bar).toBeTypeOf('object')
   })
 
-  it('resolves a more advanced circular reference', async () => {
+  it('resolves a more advanced circular reference', () => {
     const partialSpecification: AnyObject = {
       type: 'object',
       properties: {
@@ -460,7 +462,7 @@ describe('resolveReferences', () => {
     expect(schema.schemas.element.properties.element.properties.element.properties.element).toBeTypeOf('object')
   })
 
-  it('resolves an OpenAPI-like circular reference', async () => {
+  it('resolves an OpenAPI-like circular reference', () => {
     const specification = {
       type: 'object',
       properties: {
@@ -490,7 +492,7 @@ describe('resolveReferences', () => {
     expect(() => JSON.stringify(schema, null, 2)).toThrow()
   })
 
-  it('composes two files', async () => {
+  it('composes two files', () => {
     const filesystem = [
       {
         dir: '/Foobar',
@@ -534,7 +536,7 @@ describe('resolveReferences', () => {
     expect(schema.paths['/foobar'].post.requestBody.content['application/json'].schema.example).toBe('foobar')
   })
 
-  it('resolves reference to a part of an external file', async () => {
+  it('resolves reference to a part of an external file', () => {
     const filesystem = [
       {
         dir: '/Foobar',
@@ -583,7 +585,7 @@ describe('resolveReferences', () => {
     expect(schema.paths['/foobar'].post.requestBody.content['application/json'].schema.example).toBe('foobar')
   })
 
-  it('resolves references in external files', async () => {
+  it('resolves references in external files', () => {
     const filesystem = [
       {
         dir: '/Foobar',
@@ -652,7 +654,7 @@ describe('resolveReferences', () => {
     expect(schema.components.schemas.Upload.allOf[0].title).toBe('Coordinates')
   })
 
-  it('resolves reference to self by filename', async () => {
+  it('resolves reference to self by filename', () => {
     const filesystem = [
       {
         dir: '/Foobar',

--- a/packages/openapi-parser/src/utils/unescape-json-pointer.test.ts
+++ b/packages/openapi-parser/src/utils/unescape-json-pointer.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { unescapeJsonPointer } from './unescape-json-pointer'
 
-describe('unescapeJsonPointer', async () => {
+describe('unescapeJsonPointer', () => {
   it('unescapes a slash', () => {
     expect(unescapeJsonPointer('/foo~1bar~1baz')).toBe('/foo/bar/baz')
   })

--- a/packages/openapi-parser/src/utils/upgrade.test.ts
+++ b/packages/openapi-parser/src/utils/upgrade.test.ts
@@ -4,7 +4,7 @@ import { makeFilesystem } from './make-filesystem'
 import { upgrade } from './upgrade'
 
 describe('upgrade', () => {
-  it('upgrades documents from Swagger 2.0 to OpenAPI 3.1', async () => {
+  it('upgrades documents from Swagger 2.0 to OpenAPI 3.1', () => {
     const { specification } = upgrade({
       swagger: '2.0',
       info: {
@@ -18,7 +18,7 @@ describe('upgrade', () => {
     expect(specification.openapi).toBe('3.1.1')
   })
 
-  it('changes the version to from 3.0.0 to 3.1.0', async () => {
+  it('changes the version to from 3.0.0 to 3.1.0', () => {
     const { specification } = upgrade({
       openapi: '3.0.0',
       info: {
@@ -31,7 +31,7 @@ describe('upgrade', () => {
     expect(specification.openapi).toBe('3.1.1')
   })
 
-  it('changes the version to 3.0.3 to 3.1.0', async () => {
+  it('changes the version to 3.0.3 to 3.1.0', () => {
     const { specification } = upgrade({
       openapi: '3.0.3',
       info: {
@@ -44,7 +44,7 @@ describe('upgrade', () => {
     expect(specification.openapi).toBe('3.1.1')
   })
 
-  it('works with a filesystem', async () => {
+  it('works with a filesystem', () => {
     const { specification } = upgrade(
       makeFilesystem({
         openapi: '3.0.0',
@@ -59,7 +59,7 @@ describe('upgrade', () => {
     expect(specification.openapi).toBe('3.1.1')
   })
 
-  it('deals with null', async () => {
+  it('deals with null', () => {
     const { specification } = upgrade(null)
 
     expect(specification).toStrictEqual(null)

--- a/packages/openapi-parser/tests/benchmark/no-reference.bench.ts
+++ b/packages/openapi-parser/tests/benchmark/no-reference.bench.ts
@@ -18,8 +18,8 @@ describe('no reference', () => {
     await resolveOld(specification)
   })
 
-  bench('@scalar/openapi-parser', async () => {
+  bench('@scalar/openapi-parser', () => {
     // Action!
-    await resolveNew(specification)
+    resolveNew(specification)
   })
 })

--- a/packages/openapi-parser/tests/benchmark/petstore.bench.ts
+++ b/packages/openapi-parser/tests/benchmark/petstore.bench.ts
@@ -10,8 +10,8 @@ describe('petstore', () => {
     await resolveOld(specification)
   })
 
-  bench('@scalar/openapi-parser', async () => {
+  bench('@scalar/openapi-parser', () => {
     // Action!
-    await resolveNew(specification)
+    resolveNew(specification)
   })
 })

--- a/packages/openapi-parser/tests/benchmark/single-reference.bench.ts
+++ b/packages/openapi-parser/tests/benchmark/single-reference.bench.ts
@@ -46,13 +46,11 @@ describe('single reference', () => {
     )
   })
 
-  bench('@scalar/openapi-parser', async () => {
+  bench('@scalar/openapi-parser', () => {
     // Action!
-    const { schema } = await resolveNew(specification)
+    const { schema } = resolveNew(specification)
 
     // Check whether the reference was resolved
-    expect((schema as any).paths['/foobar'].post.requestBody.content['application/json'].schema.example).toBe(
-      'Hello World!',
-    )
+    expect(schema.paths['/foobar'].post.requestBody.content['application/json'].schema.example).toBe('Hello World!')
   })
 })

--- a/packages/openapi-parser/tests/benchmark/utils/resolveNew.ts
+++ b/packages/openapi-parser/tests/benchmark/utils/resolveNew.ts
@@ -1,7 +1,7 @@
+import type { AnyObject } from '@/types'
 import { normalize } from '@/utils/normalize'
 import { resolveReferences } from '@/utils/resolve-references'
-import type { AnyObject } from '@/types'
 
-export async function resolveNew(specification: AnyObject) {
+export function resolveNew(specification: AnyObject) {
   return resolveReferences(normalize(specification))
 }

--- a/packages/openapi-parser/tests/migration-layer.test.ts
+++ b/packages/openapi-parser/tests/migration-layer.test.ts
@@ -63,7 +63,7 @@ class SwaggerParser {
 }
 
 // https://github.com/APIDevTools/swagger-parser?tab=readme-ov-file#example
-describe('validate', async () => {
+describe('validate', () => {
   beforeEach(() => {
     globalFetchSpy.mockReset()
   })
@@ -112,7 +112,7 @@ describe('dereference', () => {
   it('dereferences URLs', async () => {
     // @ts-expect-error
     globalFetchSpy.mockImplementation(async (url: string) => ({
-      text: async () => {
+      text: () => {
         if (url === 'http://example.com/specification/openapi.yaml') {
           return myAPI
         }

--- a/packages/openapi-parser/tests/references/ancestor/ancestor.test.ts
+++ b/packages/openapi-parser/tests/references/ancestor/ancestor.test.ts
@@ -1,22 +1,23 @@
 import { describe, expect, it } from 'vitest'
 
-import specification from './specification.json'
-import { resolveReferences } from '@/utils/resolve-references'
 import { normalize } from '@/utils/normalize'
+import { resolveReferences } from '@/utils/resolve-references'
+
+import specification from './specification.json'
 
 // Circular $refs to ancestor
 describe.todo('ancestor', () => {
-  it('relative path', async () => {
+  it('relative path', () => {
     const schema = resolveReferences(normalize(specification))
 
     expect(schema).not.toBe(undefined)
   })
 
-  it('absolute path', async () => {
+  it('absolute path', () => {
     //
   })
 
-  it('URL', async () => {
+  it('URL', () => {
     //
   })
 })

--- a/packages/openapi-parser/tests/references/one-file/one-file.test.ts
+++ b/packages/openapi-parser/tests/references/one-file/one-file.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import specification from './specification.json'
-import { resolveReferences } from '@/utils/resolve-references'
 import { normalize } from '@/utils/normalize'
+import { resolveReferences } from '@/utils/resolve-references'
+
+import specification from './specification.json'
 
 // Single-file schema with internal $refs
 describe.todo('one-file', () => {
-  it('relative path', async () => {
+  it('relative path', () => {
     const schema = resolveReferences(normalize(specification))
 
     expect(schema).not.toBe(undefined)

--- a/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.test.ts
+++ b/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { upgradeFromTwoToThree } from './upgrade-from-two-to-three'
 
 describe('upgradeFromTwoToThree', () => {
-  it('changes the version to from 3.0.0 to 3.1.0', async () => {
+  it('changes the version to from 3.0.0 to 3.1.0', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',
       info: {
@@ -18,7 +18,7 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.swagger).toBeUndefined()
   })
 
-  it('upgrades URLs to new server syntax', async () => {
+  it('upgrades URLs to new server syntax', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',
       basePath: '/v1',
@@ -37,7 +37,7 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.host).toBeUndefined()
   })
 
-  it('upgrades basePath to new server syntax', async () => {
+  it('upgrades basePath to new server syntax', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',
       basePath: '/v2',
@@ -54,7 +54,7 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.host).toBeUndefined()
   })
 
-  it('upgrades host to new server syntax', async () => {
+  it('upgrades host to new server syntax', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',
       host: 'api.example.com',
@@ -71,7 +71,7 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.host).toBeUndefined()
   })
 
-  it('moves definitions to components', async () => {
+  it('moves definitions to components', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',
       definitions: {
@@ -102,7 +102,7 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.definitions).toBeUndefined()
   })
 
-  it('rewrites $refs to definitions', async () => {
+  it('rewrites $refs to definitions', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',
       paths: {
@@ -132,7 +132,7 @@ describe('upgradeFromTwoToThree', () => {
     )
   })
 
-  it('transforms responses', async () => {
+  it('transforms responses', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',
       paths: {
@@ -190,7 +190,7 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.paths?.['/planets']?.get?.produces).toBeUndefined()
   })
 
-  it('uses global produces for responses', async () => {
+  it('uses global produces for responses', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',
       produces: ['application/json', 'application/xml'],
@@ -248,7 +248,7 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.paths?.['/planets']?.get?.produces).toBeUndefined()
   })
 
-  it('transforms requestBody', async () => {
+  it('transforms requestBody', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',
 
@@ -300,7 +300,7 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.paths?.['/planets']?.get?.produces).toBeUndefined()
   })
 
-  it('uses global consumes for requestBody', async () => {
+  it('uses global consumes for requestBody', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',
       produces: ['application/json', 'application/xml'],
@@ -352,7 +352,7 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.paths?.['/planets']?.get?.produces).toBeUndefined()
   })
 
-  it('migrates formData', async () => {
+  it('migrates formData', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',
       paths: {
@@ -873,7 +873,7 @@ describe('upgradeFromTwoToThree', () => {
     ])
   })
 
-  it('upgrades parameters defined globally and path wide - without body and formData', async () => {
+  it('upgrades parameters defined globally and path wide - without body and formData', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',
       produces: ['application/json'],
@@ -926,7 +926,7 @@ describe('upgradeFromTwoToThree', () => {
     })
   })
 
-  it('upgrades parameters defined globally and path wide - body and formData', async () => {
+  it('upgrades parameters defined globally and path wide - body and formData', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',
       produces: ['application/json'],
@@ -1015,7 +1015,7 @@ describe('upgradeFromTwoToThree', () => {
     })
   })
 
-  it('upgrades parameters defined globally and correctly update all the references - body', async () => {
+  it('upgrades parameters defined globally and correctly update all the references - body', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',
       produces: ['application/json'],
@@ -1110,7 +1110,7 @@ describe('upgradeFromTwoToThree', () => {
     })
   })
 
-  it('upgrades parameters defined globally and correctly update all the references - parameters', async () => {
+  it('upgrades parameters defined globally and correctly update all the references - parameters', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       'swagger': '2.0',
       'info': { 'version': '1.0.0', 'title': 'Minimal API' },

--- a/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
+++ b/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
@@ -24,7 +24,7 @@ describe('isSchemaPath', () => {
 
 describe('upgradeFromThreeToThreeOne', () => {
   describe('version', () => {
-    it(`doesn't modify Swagger 2.0 files`, async () => {
+    it(`doesn't modify Swagger 2.0 files`, () => {
       const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
         swagger: '2.0',
         info: {
@@ -37,7 +37,7 @@ describe('upgradeFromThreeToThreeOne', () => {
       expect(result.swagger).toBe('2.0')
     })
 
-    it('changes the version to from 3.0.0 to 3.1.1', async () => {
+    it('changes the version to from 3.0.0 to 3.1.1', () => {
       const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -50,7 +50,7 @@ describe('upgradeFromThreeToThreeOne', () => {
       expect(result.openapi).toBe('3.1.1')
     })
 
-    it('changes the version to 3.0.3 to 3.1.1', async () => {
+    it('changes the version to 3.0.3 to 3.1.1', () => {
       const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
         openapi: '3.0.3',
         info: {
@@ -65,7 +65,7 @@ describe('upgradeFromThreeToThreeOne', () => {
   })
 
   describe('nullable types', () => {
-    it('migrates nullable types', async () => {
+    it('migrates nullable types', () => {
       const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -98,7 +98,7 @@ describe('upgradeFromThreeToThreeOne', () => {
       })
     })
 
-    it('migrates nullable types with properties', async () => {
+    it('migrates nullable types with properties', () => {
       const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -142,7 +142,7 @@ describe('upgradeFromThreeToThreeOne', () => {
   })
 
   describe('exclusiveMinimum and exclusiveMaximum', () => {
-    it('migrate exclusiveMinimum and exclusiveMaximum', async () => {
+    it('migrate exclusiveMinimum and exclusiveMaximum', () => {
       const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -182,7 +182,7 @@ describe('upgradeFromThreeToThreeOne', () => {
   })
 
   describe('migrates example to examples', () => {
-    it('uses arrays in schemas', async () => {
+    it('uses arrays in schemas', () => {
       const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -216,7 +216,7 @@ describe('upgradeFromThreeToThreeOne', () => {
       })
     })
 
-    it('uses example objects everywhere else', async () => {
+    it('uses example objects everywhere else', () => {
       const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -487,7 +487,7 @@ describe('upgradeFromThreeToThreeOne', () => {
   })
 
   describe('describing File Upload Payloads', () => {
-    it('removes schema for binary file uploads', async () => {
+    it('removes schema for binary file uploads', () => {
       const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -515,7 +515,7 @@ describe('upgradeFromThreeToThreeOne', () => {
       expect(result.paths?.['/upload']?.post?.requestBody?.content['application/octet-stream']).toEqual({})
     })
 
-    it('migrates base64 format to contentEncoding for image uploads', async () => {
+    it('migrates base64 format to contentEncoding for image uploads', () => {
       const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -548,7 +548,7 @@ describe('upgradeFromThreeToThreeOne', () => {
       })
     })
 
-    it('migrates binary format for multipart file uploads', async () => {
+    it('migrates binary format for multipart file uploads', () => {
       const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -600,7 +600,7 @@ describe('upgradeFromThreeToThreeOne', () => {
     })
   })
 
-  it('migrates byte format', async () => {
+  it('migrates byte format', () => {
     const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
       openapi: '3.0.0',
       info: {
@@ -635,7 +635,7 @@ describe('upgradeFromThreeToThreeOne', () => {
   })
 
   describe.skip('declaring $schema', () => {
-    it('adds a $schema', async () => {
+    it('adds a $schema', () => {
       const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -650,7 +650,7 @@ describe('upgradeFromThreeToThreeOne', () => {
   })
 
   describe('binary format handling with oneOf', () => {
-    it('correctly handles format: binary in oneOf schemas', async () => {
+    it('correctly handles format: binary in oneOf schemas', () => {
       const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {
@@ -707,7 +707,7 @@ describe('upgradeFromThreeToThreeOne', () => {
   })
 
   describe('webhooks', () => {
-    it('correctly upgrades x-webhooks to webhooks', async () => {
+    it('correctly upgrades x-webhooks to webhooks', () => {
       const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
         openapi: '3.0.0',
         info: {

--- a/packages/openapi-upgrader/src/3.1-to-3.2/upgrade-from-three-one-to-three-two.test.ts
+++ b/packages/openapi-upgrader/src/3.1-to-3.2/upgrade-from-three-one-to-three-two.test.ts
@@ -5,7 +5,7 @@ import { upgradeFromThreeOneToThreeTwo } from '@/3.1-to-3.2/upgrade-from-three-o
 
 describe('upgradeFromThreeOneToThreeTwo', () => {
   describe('version', () => {
-    it(`doesn't modify Swagger 2.0 files`, async () => {
+    it(`doesn't modify Swagger 2.0 files`, () => {
       const result: OpenAPIV3_2.Document = upgradeFromThreeOneToThreeTwo({
         swagger: '2.0',
         info: {
@@ -18,7 +18,7 @@ describe('upgradeFromThreeOneToThreeTwo', () => {
       expect(result.swagger).toBe('2.0')
     })
 
-    it('changes the version to from 3.1.0 to 3.2.0', async () => {
+    it('changes the version to from 3.1.0 to 3.2.0', () => {
       const result: OpenAPIV3_2.Document = upgradeFromThreeOneToThreeTwo({
         openapi: '3.1.0',
         info: {
@@ -31,7 +31,7 @@ describe('upgradeFromThreeOneToThreeTwo', () => {
       expect(result.openapi).toBe('3.2.0')
     })
 
-    it('changes the version to 3.1.1 to 3.2.0', async () => {
+    it('changes the version to 3.1.1 to 3.2.0', () => {
       const result: OpenAPIV3_2.Document = upgradeFromThreeOneToThreeTwo({
         openapi: '3.1.1',
         info: {

--- a/packages/openapi-upgrader/src/upgrade.test.ts
+++ b/packages/openapi-upgrader/src/upgrade.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { upgrade } from './upgrade'
 
 describe('upgrade', () => {
-  it('upgrades documents from Swagger 2.0 to OpenAPI 3.1', async () => {
+  it('upgrades documents from Swagger 2.0 to OpenAPI 3.1', () => {
     const document = upgrade(
       {
         swagger: '2.0',
@@ -21,7 +21,7 @@ describe('upgrade', () => {
     expect(document?.openapi).toBe('3.1.1')
   })
 
-  it('changes the version to from 3.0.0 to 3.1.0', async () => {
+  it('changes the version to from 3.0.0 to 3.1.0', () => {
     const document = upgrade(
       {
         openapi: '3.0.0',
@@ -37,7 +37,7 @@ describe('upgrade', () => {
     expect(document?.openapi).toBe('3.1.1')
   })
 
-  it('changes the version to 3.0.3 to 3.1.0', async () => {
+  it('changes the version to 3.0.3 to 3.1.0', () => {
     const document = upgrade(
       {
         openapi: '3.0.3',
@@ -53,7 +53,7 @@ describe('upgrade', () => {
     expect(document?.openapi).toBe('3.1.1')
   })
 
-  it('deals with null', async () => {
+  it('deals with null', () => {
     const document = upgrade(null as unknown as UnknownObject, '3.1')
 
     expect(document).toStrictEqual(null)

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/context/postman-scripts/create-response-utils.test.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/context/postman-scripts/create-response-utils.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it } from 'vitest'
+
 import { createExtendedSynchronousResponse } from './create-response-utils'
 
 describe('createExtendedSynchronousResponse', () => {
   let mockedResponse: Response
-  let responseText: string
 
-  beforeEach(async () => {
-    responseText = JSON.stringify({ data: 'test' })
+  beforeEach(() => {
+    const responseText = JSON.stringify({ data: 'test' })
 
     mockedResponse = new Response(responseText, {
       status: 200,
@@ -15,10 +15,8 @@ describe('createExtendedSynchronousResponse', () => {
   })
 
   it('parses JSON response correctly', async () => {
-    const utils = await createExtendedSynchronousResponse(mockedResponse)
-    // Wait for the text promise to resolve
-    utils.text()
-    const result = utils.json()
+    const syncResponse = await createExtendedSynchronousResponse(mockedResponse)
+    const result = syncResponse.json()
     expect(result).toEqual({ data: 'test' })
   })
 
@@ -27,25 +25,23 @@ describe('createExtendedSynchronousResponse', () => {
     invalidResponse.text = () => Promise.resolve('invalid json')
     invalidResponse.json = () => Promise.reject(new Error('Response is not valid JSON'))
 
-    const utils = await createExtendedSynchronousResponse(invalidResponse)
-    // Wait for the text promise to resolve
-    utils.text()
-    expect(() => utils.json()).toThrow('Response is not valid JSON')
+    const syncResponse = await createExtendedSynchronousResponse(invalidResponse)
+    expect(() => syncResponse.json()).toThrow('Response is not valid JSON')
   })
 
   it('returns response text', async () => {
-    const utils = await createExtendedSynchronousResponse(mockedResponse)
-    const result = utils.text()
+    const syncResponse = await createExtendedSynchronousResponse(mockedResponse)
+    const result = syncResponse.text()
     expect(result).toBe('{"data":"test"}')
   })
 
   it('provides status code', async () => {
-    const utils = await createExtendedSynchronousResponse(mockedResponse)
-    expect(utils.code).toBe(200)
+    const syncResponse = await createExtendedSynchronousResponse(mockedResponse)
+    expect(syncResponse.code).toBe(200)
   })
 
   it('provides headers as object', async () => {
-    const utils = await createExtendedSynchronousResponse(mockedResponse)
-    expect(utils.headers['content-type']).toBe('application/json')
+    const syncResponse = await createExtendedSynchronousResponse(mockedResponse)
+    expect(syncResponse.headers['content-type']).toBe('application/json')
   })
 })

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/context/postman-scripts/create-response-utils.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/context/postman-scripts/create-response-utils.ts
@@ -1,5 +1,6 @@
 import { createSynchronousResponse } from '@/helpers/create-synchronous-response'
 import type { SynchronousResponse } from '@/types'
+
 import { type ResponseAssertions, createResponseAssertions } from './create-response-assertions'
 
 export type ExtendedSynchronousResponse = Omit<SynchronousResponse, 'headers'> & {

--- a/packages/pre-post-request-scripts/src/plugins/post-response-scripts/post-response-scripts-plugin.ts
+++ b/packages/pre-post-request-scripts/src/plugins/post-response-scripts/post-response-scripts-plugin.ts
@@ -29,7 +29,7 @@ export const postResponseScriptsPlugin = (): ApiClientPlugin => {
     },
     hooks: {
       // Reset test results when a new request is sent
-      async onBeforeRequest() {
+      onBeforeRequest() {
         results.value = []
       },
       // Execute post-response scripts when a response is received

--- a/packages/pre-post-request-scripts/test/utils/mock-synchronous-response.ts
+++ b/packages/pre-post-request-scripts/test/utils/mock-synchronous-response.ts
@@ -1,7 +1,7 @@
 import { createSynchronousResponse } from '@/helpers/create-synchronous-response'
-import type { SynchronousResponse } from '@/types.ts'
+import type { SynchronousResponse } from '@/types'
 
-export const mockSynchronousResponse = async (body?: string): Promise<SynchronousResponse> => {
+export const mockSynchronousResponse = (body?: string): Promise<SynchronousResponse> => {
   return createSynchronousResponse(
     new Response(body ?? '', {
       status: 200,

--- a/packages/sidebar/src/components/ScalarSidebar.test.ts
+++ b/packages/sidebar/src/components/ScalarSidebar.test.ts
@@ -401,7 +401,7 @@ describe('ScalarSidebar', () => {
   })
 
   describe('drag and drop', () => {
-    it('emits reorder event when onDragEnd is triggered', async () => {
+    it('emits reorder event when onDragEnd is triggered', () => {
       const items: Item[] = [
         {
           id: '1',
@@ -435,7 +435,7 @@ describe('ScalarSidebar', () => {
       expect(wrapper.emitted('reorder')?.[0]).toEqual([draggingItem, hoveredItem])
     })
 
-    it('passes drag event data correctly to parent', async () => {
+    it('passes drag event data correctly to parent', () => {
       const items: Item[] = [
         {
           id: 'item-a',
@@ -682,7 +682,7 @@ describe('ScalarSidebar', () => {
       expect(sidebarItems.length).toBe(1)
     })
 
-    it.skip('handles rapid successive clicks', async () => {
+    it.skip('handles rapid successive clicks', () => {
       const items: Item[] = [
         {
           id: '1',

--- a/packages/sidebar/src/components/SidebarItem.test.ts
+++ b/packages/sidebar/src/components/SidebarItem.test.ts
@@ -65,7 +65,7 @@ describe('SidebarItem', () => {
       expect(sidebarItem.props('is')).toBe('button')
     })
 
-    it('emits click event when item is clicked', async () => {
+    it('emits click event when item is clicked', () => {
       const item: Item = {
         id: '1',
         title: 'Test Item',
@@ -712,7 +712,7 @@ describe('SidebarItem', () => {
       expect(group.props('open')).toBe(false)
     })
 
-    it('emits click event when group is toggled', async () => {
+    it('emits click event when group is toggled', () => {
       const item: Item = {
         id: 'group-1',
         title: 'Expandable',

--- a/packages/sidebar/src/helpers/create-sidebar-state.test.ts
+++ b/packages/sidebar/src/helpers/create-sidebar-state.test.ts
@@ -80,7 +80,7 @@ describe('create-sidebar-state', () => {
   })
 
   describe('setSelected', () => {
-    it('selects a single item', async () => {
+    it('selects a single item', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const state = createSidebarState(items)
 
@@ -89,7 +89,7 @@ describe('create-sidebar-state', () => {
       expect(state.selectedItems.value).toEqual({ item1: true })
     })
 
-    it('selects a nested item and marks all parents as selected', async () => {
+    it('selects a nested item and marks all parents as selected', () => {
       const items: SidebarItem[] = [
         {
           id: 'root',
@@ -114,7 +114,7 @@ describe('create-sidebar-state', () => {
       })
     })
 
-    it('clears previous selection when selecting a new item', async () => {
+    it('clears previous selection when selecting a new item', () => {
       const items: SidebarItem[] = [
         {
           id: 'root',
@@ -134,7 +134,7 @@ describe('create-sidebar-state', () => {
       expect(state.selectedItems.value).toEqual({ child2: true, root: true })
     })
 
-    it('handles selecting non-existent item', async () => {
+    it('handles selecting non-existent item', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const state = createSidebarState(items)
 
@@ -143,7 +143,7 @@ describe('create-sidebar-state', () => {
       expect(state.selectedItems.value).toEqual({})
     })
 
-    it('handles deeply nested item selection', async () => {
+    it('handles deeply nested item selection', () => {
       const items: SidebarItem[] = [
         {
           id: 'level1',
@@ -182,7 +182,7 @@ describe('create-sidebar-state', () => {
       })
     })
 
-    it('calls onBeforeSelect hook', async () => {
+    it('calls onBeforeSelect hook', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const onBeforeSelect = vi.fn()
       const state = createSidebarState(items, {
@@ -195,7 +195,7 @@ describe('create-sidebar-state', () => {
       expect(onBeforeSelect).toHaveBeenCalledTimes(1)
     })
 
-    it('calls onAfterSelect hook', async () => {
+    it('calls onAfterSelect hook', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const onAfterSelect = vi.fn()
       const state = createSidebarState(items, {
@@ -208,7 +208,7 @@ describe('create-sidebar-state', () => {
       expect(onAfterSelect).toHaveBeenCalledTimes(1)
     })
 
-    it('calls hooks in correct order', async () => {
+    it('calls hooks in correct order', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const callOrder: string[] = []
 
@@ -228,7 +228,7 @@ describe('create-sidebar-state', () => {
       expect(callOrder).toEqual(['before', 'after'])
     })
 
-    it('updates selection even if hooks are not provided', async () => {
+    it('updates selection even if hooks are not provided', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const state = createSidebarState(items)
 
@@ -239,7 +239,7 @@ describe('create-sidebar-state', () => {
   })
 
   describe('setExpanded', () => {
-    it('expands a single item', async () => {
+    it('expands a single item', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const state = createSidebarState(items)
 
@@ -248,7 +248,7 @@ describe('create-sidebar-state', () => {
       expect(state.expandedItems.value).toEqual({ item1: true })
     })
 
-    it('collapses a single item', async () => {
+    it('collapses a single item', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const state = createSidebarState(items)
 
@@ -258,7 +258,7 @@ describe('create-sidebar-state', () => {
       expect(state.expandedItems.value).toEqual({ item1: false })
     })
 
-    it('expands nested item and all parents', async () => {
+    it('expands nested item and all parents', () => {
       const items: SidebarItem[] = [
         {
           id: 'root',
@@ -283,7 +283,7 @@ describe('create-sidebar-state', () => {
       })
     })
 
-    it('collapsing an item does not collapse parents', async () => {
+    it('collapsing an item does not collapse parents', () => {
       const items: SidebarItem[] = [
         {
           id: 'root',
@@ -309,7 +309,7 @@ describe('create-sidebar-state', () => {
       })
     })
 
-    it('handles expanding non-existent item', async () => {
+    it('handles expanding non-existent item', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const state = createSidebarState(items)
 
@@ -318,7 +318,7 @@ describe('create-sidebar-state', () => {
       expect(state.expandedItems.value).toEqual({})
     })
 
-    it('handles deeply nested item expansion', async () => {
+    it('handles deeply nested item expansion', () => {
       const items: SidebarItem[] = [
         {
           id: 'level1',
@@ -357,7 +357,7 @@ describe('create-sidebar-state', () => {
       })
     })
 
-    it('calls onBeforeExpand hook', async () => {
+    it('calls onBeforeExpand hook', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const onBeforeExpand = vi.fn()
       const state = createSidebarState(items, {
@@ -370,7 +370,7 @@ describe('create-sidebar-state', () => {
       expect(onBeforeExpand).toHaveBeenCalledTimes(1)
     })
 
-    it('calls onAfterExpand hook', async () => {
+    it('calls onAfterExpand hook', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const onAfterExpand = vi.fn()
       const state = createSidebarState(items, {
@@ -383,7 +383,7 @@ describe('create-sidebar-state', () => {
       expect(onAfterExpand).toHaveBeenCalledTimes(1)
     })
 
-    it('calls hooks in correct order', async () => {
+    it('calls hooks in correct order', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const callOrder: string[] = []
 
@@ -403,7 +403,7 @@ describe('create-sidebar-state', () => {
       expect(callOrder).toEqual(['before', 'after'])
     })
 
-    it('calls hooks when collapsing', async () => {
+    it('calls hooks when collapsing', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const onBeforeExpand = vi.fn()
       const onAfterExpand = vi.fn()
@@ -418,7 +418,7 @@ describe('create-sidebar-state', () => {
       expect(onAfterExpand).toHaveBeenCalledWith('item1')
     })
 
-    it('maintains expanded state across multiple operations', async () => {
+    it('maintains expanded state across multiple operations', () => {
       const items: SidebarItem[] = [
         {
           id: 'root',
@@ -445,7 +445,7 @@ describe('create-sidebar-state', () => {
   })
 
   describe('combined operations', () => {
-    it('handles selection and expansion independently', async () => {
+    it('handles selection and expansion independently', () => {
       const items: SidebarItem[] = [
         {
           id: 'root',
@@ -465,7 +465,7 @@ describe('create-sidebar-state', () => {
       expect(state.expandedItems.value).toEqual({ child2: true, root: true })
     })
 
-    it('handles multiple selections and expansions', async () => {
+    it('handles multiple selections and expansions', () => {
       const items: SidebarItem[] = [
         {
           id: 'root1',
@@ -493,7 +493,7 @@ describe('create-sidebar-state', () => {
       })
     })
 
-    it('allows selecting a collapsed item', async () => {
+    it('allows selecting a collapsed item', () => {
       const items: SidebarItem[] = [
         {
           id: 'root',
@@ -512,7 +512,7 @@ describe('create-sidebar-state', () => {
   })
 
   describe('edge cases', () => {
-    it('handles empty string ids', async () => {
+    it('handles empty string ids', () => {
       const items: SidebarItem[] = [{ id: '', title: 'Empty ID' }]
       const state = createSidebarState(items)
 
@@ -521,7 +521,7 @@ describe('create-sidebar-state', () => {
       expect(state.selectedItems.value).toEqual({ '': true })
     })
 
-    it('handles items with special characters in ids', async () => {
+    it('handles items with special characters in ids', () => {
       const items: SidebarItem[] = [
         { id: 'item-with-dashes', title: 'Item' },
         { id: 'item_with_underscores', title: 'Item' },
@@ -543,7 +543,7 @@ describe('create-sidebar-state', () => {
       expect(state.selectedItems.value['item/with/slashes']).toBe(true)
     })
 
-    it('handles very large tree structures', async () => {
+    it('handles very large tree structures', () => {
       const items: SidebarItem[] = []
 
       // Create a tree with 100 parents, each with 10 children
@@ -573,7 +573,7 @@ describe('create-sidebar-state', () => {
       expect(state.expandedItems.value['parent-99']).toBe(true)
     })
 
-    it('handles rapid consecutive operations', async () => {
+    it('handles rapid consecutive operations', () => {
       const items: SidebarItem[] = [
         {
           id: 'root',
@@ -598,7 +598,7 @@ describe('create-sidebar-state', () => {
       expect(state.selectedItems.value['child1']).toBe(true)
     })
 
-    it('handles all hooks provided', async () => {
+    it('handles all hooks provided', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const onBeforeSelect = vi.fn()
       const onAfterSelect = vi.fn()
@@ -623,7 +623,7 @@ describe('create-sidebar-state', () => {
       expect(onAfterExpand).toHaveBeenCalledTimes(1)
     })
 
-    it('handles partial hooks configuration', async () => {
+    it('handles partial hooks configuration', () => {
       const items: SidebarItem[] = [{ id: 'item1', title: 'Item 1' }]
       const onBeforeSelect = vi.fn()
 

--- a/packages/snippetz/src/snippetz.test.ts
+++ b/packages/snippetz/src/snippetz.test.ts
@@ -2,18 +2,20 @@ import { describe, expect, it } from 'vitest'
 
 import { snippetz } from './snippetz'
 
-describe('snippetz', async () => {
-  it('returns code for undici', async () => {
+describe('snippetz', () => {
+  it('returns code for undici', () => {
     const snippet = snippetz().print('node', 'undici', {
       url: 'https://example.com',
     })
 
-    expect(snippet).toBe(`import { request } from 'undici'
+    expect(snippet).toMatchInlineSnapshot(`
+      "import { request } from 'undici'
 
-const { statusCode, body } = await request('https://example.com')`)
+      const { statusCode, body } = await request('https://example.com')"
+    `)
   })
 
-  it('loads some clients by default', async () => {
+  it('loads some clients by default', () => {
     expect(snippetz().clients()).toEqual(
       expect.arrayContaining([
         {
@@ -50,8 +52,8 @@ const { statusCode, body } = await request('https://example.com')`)
   })
 })
 
-describe('plugins', async () => {
-  it('returns true if it has the plugin', async () => {
+describe('plugins', () => {
+  it('returns true if it has the plugin', () => {
     const result = snippetz().plugins()
 
     expect(result).toEqual(
@@ -73,14 +75,14 @@ describe('plugins', async () => {
   })
 })
 
-describe('hasPlugin', async () => {
-  it('returns true if it has the plugin', async () => {
+describe('hasPlugin', () => {
+  it('returns true if it has the plugin', () => {
     const result = snippetz().hasPlugin('node', 'undici')
 
     expect(result).toBe(true)
   })
 
-  it("returns false if it doesn't know the plugin", async () => {
+  it("returns false if it doesn't know the plugin", () => {
     const result = snippetz().hasPlugin('node', 'fantasy')
 
     expect(result).toBe(false)

--- a/packages/types/src/api-reference/api-reference-configuration.test.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.test.ts
@@ -255,7 +255,7 @@ describe('api-reference-configuration', () => {
       expect(migratedConfig.onDocumentSelect).toBeInstanceOf(Function)
     })
 
-    it('allows an async function as onDocumentSelect', async () => {
+    it('allows an async function as onDocumentSelect', () => {
       const config = {
         onDocumentSelect: vi.fn().mockResolvedValue(undefined),
       } satisfies Partial<ApiReferenceConfiguration>
@@ -272,7 +272,7 @@ describe('api-reference-configuration', () => {
       expect(migratedConfig.onBeforeRequest).toBeInstanceOf(Function)
     })
 
-    it('allows an async function as onBeforeRequest', async () => {
+    it('allows an async function as onBeforeRequest', () => {
       const config = {
         onBeforeRequest: vi.fn().mockResolvedValue(undefined),
       } satisfies Partial<ApiReferenceConfiguration>
@@ -289,7 +289,7 @@ describe('api-reference-configuration', () => {
       expect(migratedConfig.onShowMore).toBeInstanceOf(Function)
     })
 
-    it('allows an async function as onShowMore', async () => {
+    it('allows an async function as onShowMore', () => {
       const config = {
         onShowMore: vi.fn().mockResolvedValue(undefined),
       } satisfies Partial<ApiReferenceConfiguration>
@@ -306,7 +306,7 @@ describe('api-reference-configuration', () => {
       expect(migratedConfig.onSidebarClick).toBeInstanceOf(Function)
     })
 
-    it('allows an async function as onSidebarClick', async () => {
+    it('allows an async function as onSidebarClick', () => {
       const config = {
         onSidebarClick: vi.fn().mockResolvedValue(undefined),
       } satisfies Partial<ApiReferenceConfiguration>

--- a/packages/use-toasts/src/components/ScalarToasts.test.ts
+++ b/packages/use-toasts/src/components/ScalarToasts.test.ts
@@ -16,15 +16,14 @@ vi.mock('../hooks/useToasts', () => ({
 }))
 
 vi.mock('vue-sonner', async (importOriginal) => {
-  const actual = (await importOriginal()) as {
+  const actual = await importOriginal<{
     Toaster: typeof Toaster
     toast: typeof toast
-  }
+  }>()
 
   return {
     ...actual,
     toast: vi.fn(),
-    Toaster: actual.Toaster,
   }
 })
 
@@ -40,7 +39,7 @@ describe('ScalarToasts', () => {
     expect(wrapper.find('.scalar-toaster').exists()).toBe(true)
   })
 
-  it('should initialize toasts with correct parameters', async () => {
+  it('should initialize toasts with correct parameters', () => {
     const mockInitializeToasts = vi.fn()
     vi.mocked(useToasts).mockImplementation(() => ({
       initializeToasts: mockInitializeToasts,

--- a/packages/workspace-store/src/helpers/debounce.test.ts
+++ b/packages/workspace-store/src/helpers/debounce.test.ts
@@ -220,9 +220,7 @@ describe('debounce', () => {
 
   it('handles async functions', () => {
     const { execute } = debounce({ delay: 100 })
-    const asyncFn = vi.fn(async () => {
-      return Promise.resolve('result')
-    })
+    const asyncFn = vi.fn().mockResolvedValue('result')
 
     execute(['test'], asyncFn)
     vi.advanceTimersByTime(100)
@@ -232,9 +230,7 @@ describe('debounce', () => {
 
   it('handles rejected promises', () => {
     const { execute } = debounce({ delay: 100 })
-    const rejectFn = vi.fn(async () => {
-      return Promise.reject(new Error('Async error'))
-    })
+    const rejectFn = vi.fn().mockRejectedValue(new Error('Async error'))
 
     execute(['test'], rejectFn)
 

--- a/packages/workspace-store/src/plugins/bundler/index.test.ts
+++ b/packages/workspace-store/src/plugins/bundler/index.test.ts
@@ -8,25 +8,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { deepClone } from '@/helpers/general'
 import { externalValueResolver, loadingStatus, refsEverywhere, restoreOriginalRefs } from '@/plugins/bundler'
 
-function deferred<T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void
-  let reject!: (reason?: any) => void
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res
-    reject = rej
-  })
-  return { promise, resolve, reject }
-}
-
 describe('plugins', () => {
   describe('loadingStatus', () => {
     it('sets the loading status to the correct value during ref resolution', async () => {
-      const onResolveStart = vi.fn()
-      const onResolveError = vi.fn()
-      const onResolveSuccess = vi.fn()
+      const createDeferred = <T>() => {
+        let resolve!: (value: T) => void
+        const promise = new Promise<T>((res) => (resolve = res))
+        return { promise, resolve }
+      }
 
-      const resolveStarted = deferred<null>()
-      const resolveSucceeded = deferred<null>()
+      const started = createDeferred<void>()
+      const succeeded = createDeferred<void>()
+
+      const onResolveStart = vi.fn(() => started.resolve())
+      const onResolveSuccess = vi.fn(() => succeeded.resolve())
+      const onResolveError = vi.fn()
 
       const input = {
         a: {
@@ -42,42 +38,37 @@ describe('plugins', () => {
           {
             type: 'loader',
             validate: (value: string) => value === 'some-ref',
-            exec: async () => {
-              return {
+            exec: () =>
+              Promise.resolve({
                 ok: true,
                 data: { resolved: true },
                 raw: JSON.stringify({ message: 'Resolved document' }),
-              }
-            },
+              }),
           },
           {
             type: 'lifecycle',
-            onResolveStart: (...args) => {
-              onResolveStart(args)
-              resolveStarted.resolve(null)
-            },
+            onResolveStart,
             onResolveError,
-            onResolveSuccess: (...args) => {
-              onResolveSuccess(args)
-              resolveSucceeded.resolve(null)
-            },
+            onResolveSuccess,
           },
           loadingStatus(),
         ],
         treeShake: false,
       })
 
-      await resolveStarted.promise
+      await started.promise
 
       // Verify that the loading status was set during resolution
       expect(onResolveStart).toHaveBeenCalled()
       expect(input.c['$status']).toBe('loading')
 
-      await resolveSucceeded.promise
+      await succeeded.promise
 
       // Verify that the loading status was set during resolution
       expect(onResolveSuccess).toHaveBeenCalled()
       expect(input.c['$status']).toBeUndefined() // Should be removed after successful resolution
+
+      expect(onResolveError).not.toHaveBeenCalled()
     })
 
     it('sets error status when ref resolution fails', async () => {
@@ -87,32 +78,29 @@ describe('plugins', () => {
         },
       } as any
 
-      const resolveErrored = deferred<null>()
+      const onResolveError = vi.fn()
 
       void bundle(input, {
         plugins: [
           {
             type: 'loader',
             validate: (value: string) => value === 'invalid-ref',
-            exec: async () => {
-              return {
+            exec: () =>
+              Promise.resolve({
                 ok: false,
                 error: 'Failed to resolve reference',
-              }
-            },
+              }),
           },
           {
             type: 'lifecycle',
-            onResolveError: () => {
-              resolveErrored.resolve(null)
-            },
+            onResolveError,
           },
           loadingStatus(),
         ],
         treeShake: false,
       })
 
-      await resolveErrored.promise
+      await vi.waitFor(() => expect(onResolveError).toHaveBeenCalled())
 
       // Verify that the error status was set
       expect(input.c.$status).toBe('error')
@@ -238,7 +226,7 @@ describe('plugins', () => {
     })
   })
 
-  describe('restoreOriginalRefs', async () => {
+  describe('restoreOriginalRefs', () => {
     let server: FastifyInstance
     const port = 9088
     const url = `http://localhost:${port}`

--- a/packages/workspace-store/src/server.ts
+++ b/packages/workspace-store/src/server.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 import { cwd } from 'node:process'
 
+import type { LoaderPlugin } from '@scalar/json-magic/bundle'
 import { fetchUrls, readFiles } from '@scalar/json-magic/bundle/plugins/node'
 import { escapeJsonPointer } from '@scalar/json-magic/helpers/escape-json-pointer'
 import { upgrade } from '@scalar/openapi-upgrader'
@@ -217,7 +218,7 @@ export function externalizePathReferences(
  *   document: { openapi: '3.0.0', paths: {} }
  * })
  */
-async function loadDocument(workspaceDocument: WorkspaceDocumentInput) {
+function loadDocument(workspaceDocument: WorkspaceDocumentInput): ReturnType<LoaderPlugin['exec']> {
   if ('url' in workspaceDocument) {
     return fetchUrls().exec(workspaceDocument.url)
   }
@@ -226,10 +227,11 @@ async function loadDocument(workspaceDocument: WorkspaceDocumentInput) {
     return readFiles().exec(workspaceDocument.path)
   }
 
-  return {
-    ok: true as const,
+  return Promise.resolve({
+    ok: true,
     data: workspaceDocument.document,
-  }
+    raw: JSON.stringify(workspaceDocument.document),
+  })
 }
 
 /**

--- a/projects/scalar-app/src/main/index.ts
+++ b/projects/scalar-app/src/main/index.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+
 import { electronApp, is, optimizer } from '@electron-toolkit/utils'
 import todesktop from '@todesktop/runtime'
 import { BrowserWindow, type IpcMainInvokeEvent, Menu, app, dialog, ipcMain, session, shell } from 'electron'
@@ -22,7 +23,7 @@ if (!app.requestSingleInstanceLock()) {
 todesktop.init({
   updateReadyAction: {
     showNotification: 'never',
-    showInstallAndRestartPrompt: async (context) => {
+    showInstallAndRestartPrompt: (context) => {
       if (!context.appIsInForeground) {
         return
       }
@@ -436,7 +437,7 @@ async function handleFileOpen() {
 /**
  * Read the file content
  */
-async function handleReadFile(_: IpcMainInvokeEvent | undefined, filePath: string) {
+function handleReadFile(_: IpcMainInvokeEvent | undefined, filePath: string) {
   if (filePath) {
     console.info('[handleReadFile] Reading', filePath, '…')
 

--- a/scripts/src/commands/cat.ts
+++ b/scripts/src/commands/cat.ts
@@ -1,7 +1,7 @@
 import as, { type AnsiColors } from 'ansis'
 import { Command } from 'commander'
 
-export const cat = new Command('cat').description('Cat to test your terminal color output').action(async () => {
+export const cat = new Command('cat').description('Cat to test your terminal color output').action(() => {
   const p = (val: string, c: AnsiColors) => console.log(as[c](val))
 
   p('⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⣀⣠⣤⣤⣤⣤⣤⣤⣤⣤⣤⣤⣤⣤⣴⣶⣶⣶⣶⣶⣶⣶⣶⣶⣶⣶⣶⣶⣦⣤⣤⣤⣤⣤⣤⣄⣀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀', 'red')
@@ -42,7 +42,9 @@ export const cat = new Command('cat').description('Cat to test your terminal col
   p('I am very blueBright', 'blueBright')
   p('I am very magentaBright', 'magentaBright')
   p('I am very whiteBright', 'whiteBright')
-  p('I am very blackBright', 'blackBright')
   p('I am very gray', 'gray')
-  p('I am very grey', 'grey')
+  // p('I am very grey', 'grey') this is throwing an error:
+  // const p = (val, c) => console.log(__vite_ssr_import_0__.default[c](val));
+  //                                                                ^
+  // TypeError: __vite_ssr_import_0__.default[c] is not a function
 })

--- a/scripts/src/commands/output.ts
+++ b/scripts/src/commands/output.ts
@@ -1,5 +1,6 @@
-import UpdateManager from 'stdout-update'
 import as from 'ansis'
+import UpdateManager from 'stdout-update'
+
 const manager = UpdateManager.getInstance()
 const frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
 
@@ -14,7 +15,9 @@ export const useMessages = (title: string) => {
     const frame = frames[i % frames.length]
     i += 1
 
-    if (line1) manager.update([as.blueBright(`${frame} Running ${title}...`), as.green(line1), as.green(line2)])
+    if (line1) {
+      manager.update([as.blueBright(`${frame} Running ${title}...`), as.green(line1), as.green(line2)])
+    }
   }, 100)
 
   return {

--- a/scripts/src/commands/packages/format.ts
+++ b/scripts/src/commands/packages/format.ts
@@ -1,10 +1,11 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
+
+import as from 'ansis'
+import { Command } from 'commander'
 import prettier from 'prettier'
 
 import { getWorkspaceRoot } from '@/helpers'
-import as from 'ansis'
-import { Command } from 'commander'
 
 const command = new Command('format')
 

--- a/scripts/src/helpers/index.ts
+++ b/scripts/src/helpers/index.ts
@@ -1,7 +1,8 @@
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { exec } from 'node:child_process'
 import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import as from 'ansis'
 
 /** Returns the monorepo root directory path */
@@ -13,7 +14,7 @@ export function getWorkspaceRoot() {
   return path.resolve(`${__dirname}/../../..`)
 }
 
-export async function runCommand(command: string, logFilename?: string) {
+export function runCommand(command: string, logFilename?: string): Promise<unknown> {
   const output = logFilename ? fs.createWriteStream(logFilename) : null
 
   return new Promise((resolve, reject) => {

--- a/scripts/src/helpers/npm-version.ts
+++ b/scripts/src/helpers/npm-version.ts
@@ -1,13 +1,20 @@
-/** Get the latest npm version of a package. Fallbacks to the current version if the fetch fails */
-export async function latestVersion(packageName: string, current: string) {
-  return fetch(`https://registry.npmjs.org/${packageName}/latest`)
-    .then((res: any) => res.json())
-    .then((data: any) => ({
+/**
+ * Get the latest npm version of a package.
+ * Fallbacks to the current version if the fetch fails.
+ */
+export async function latestVersion(packageName: string, current: string): Promise<{ error: string; version: string }> {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${packageName}/latest`)
+    const data = await res.json()
+
+    return {
       error: '',
       version: data.version,
-    }))
-    .catch((err: any) => ({
-      error: `Failed to fetch latest version for ${packageName}: ${err.message}`,
+    }
+  } catch (err) {
+    return {
+      error: `Failed to fetch latest version for ${packageName}: ${(err as Error).message}`,
       version: current,
-    }))
+    }
+  }
 }


### PR DESCRIPTION
**Problem**

- https://github.com/scalar/scalar/pull/7091#discussion_r2429906517

> Another useful rule for managing `Promise`s is [`useAwait`](https://biomejs.dev/linter/rules/use-await/).  
When used alongside `noFloatingPromises`, it can help eliminate unnecessary `async`/`await` usage.

**Solution**

<details><summary>Outdated content</summary>
<p>

> [!CAUTION]
> This PR is marked as **draft** because it depends on:
>
> - #7196  
> - #7216  
>
> Once those PRs are merged, I'll rebase the branch and mark this one as ready for review. 
> It’s being opened early because all issues reported by `useAwait` have been addressed.


</p>
</details> 


Enable the Biome rule [`useAwait`](https://biomejs.dev/linter/rules/use-await/) to report cases where an `async` function does not contain asynchronous code or an `await` expression.

Most of the changes are within test files. User affected code changes are minimal.
Since the majority of changes is just removing an `async` I opened a single PR but let me know if you prefer something different.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`) (not needed) .
- [x] I've added tests for the regression or new feature (not needed).
- [x] I've updated the documentation (not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable Biome’s `useAwait` rule and refactor code/tests to drop unnecessary async/await, return Promises directly, and simplify handlers and mocks.
> 
> - **Lint/Config**:
>   - Enable Biome `useAwait` rule; add `.svelte-kit` ignore.
> - **Codebase**:
>   - Remove unnecessary `async`/`await` across integrations, server routes, and utilities; convert functions to sync or to return `Promise.resolve(...)` where needed.
>   - Simplify Hono handlers and other callbacks (e.g., file dialogs, event listeners) to non-async forms; streamline arrow returns.
>   - Adjust helper APIs to explicit Promise-returning signatures (e.g., loaders, runCommand, latestVersion, loadDocument/resolve).
> - **Tests**:
>   - Convert many `it(...)`/hooks from async to sync; replace ad-hoc async patterns with direct returns and spies; use inline snapshots where appropriate.
>   - Update mocks to non-async or promise-based implementations; use `vi.fn().mockResolvedValue`/`mockReturnValue`.
>   - Minor fixes (cleanup via returned functions, typo “Success”, improved assertions).
> - **Tooling/Build**:
>   - Update build/serve helpers to non-async callbacks; minor type tweaks and Promise types alignment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df51a44acf6a12db66a50f08520770b8bdcfb6f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->