### PR TITLE
docs: rename the scalar docs > github actions sidebar entry

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -44,6 +44,7 @@
               "type": "page"
             },
             {
+              "name": "GitHub Actions",
               "path": "documentation/guides/docs/github-actions.md",
               "type": "page"
             },
@@ -573,17 +574,8 @@
         "from": "/scalar/scalar-registry/github-workflows",
         "to": "/scalar/scalar-registry/github-actions"
       }, {
-        "from": "/regex/one/*",
-        "to": "/scalar/scalar-registry/github-actions"
-      }, {
-        "from": "/regex/two/:pathMatch(.*)*",
-        "to": "/scalar/scalar-registry/github-actions"
-      }, {
-        "from": "/regex/three/:wildcard",
-        "to": "/scalar/scalar-registry/github-actions"
-      }, {
-        "from": "/regex/four/prefix-:wildcard",
-        "to": "/scalar/scalar-registry/github-actions"
+        "from": "/scalar/scalar-docs/publish-scalar-projects-using-github-actions",
+        "to": "/scalar/scalar-docs/github-actions"
       }]
     }
   }


### PR DESCRIPTION
uses the first heading now, let’s just call it "GitHub Actions"

added a redirect too

<img width="311" height="196" alt="Screenshot 2025-10-31 at 12 31 07" src="https://github.com/user-attachments/assets/e2641a8d-484d-4be3-9c3c-287866fca0ee" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Names the Scalar Docs GitHub Actions page in the sidebar and adds a redirect while removing unused regex redirects.
> 
> - **Docs config**:
>   - Set explicit name "GitHub Actions" for `documentation/guides/docs/github-actions.md` in the `Scalar Docs` sidebar.
> - **Routing**:
>   - Add redirect from `/scalar/scalar-docs/publish-scalar-projects-using-github-actions` to `/scalar/scalar-docs/github-actions`.
>   - Remove several unused regex redirects in `siteConfig.routing.redirects`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71cb4ecf75e530129e44883e4c44425e0750d5a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->