### PR TITLE
refactor: enable biome `noTsIgnore` rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -175,6 +175,7 @@
         "noRedeclare": "warn",
         "noShadowRestrictedNames": "warn",
         "noSparseArray": "warn",
+        "noTsIgnore": "error",
         "noUnsafeDeclarationMerging": "warn",
         "noUnsafeNegation": "warn",
         "useGetterReturn": "warn",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "build": "turbo build",
     "build:packages": "turbo --filter './packages/**' --concurrency=100% build",
-    "build:integrations": "turbo --filter ./integrations/** build",
+    "build:integrations": "turbo --filter './integrations/**' build",
     "clean": "shx rm -rf \"**/dist\" \"**/.turbo\" \"**/.nuxt\" \"**/.next\" \"**/target\" \"**/node_modules\"",
     "clean:build": "pnpm clean && pnpm install && pnpm build:packages",
     "dev:docs": "npx @scalar/cli@latest project preview",

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -364,7 +364,7 @@ describe('SchemaProperty', () => {
         props: {
           variant: 'additionalProperties',
           name: 'propertyName*',
-          // @ts-ignore
+          // @ts-expect-error
           schema: {
             type: 'anything',
           },

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
@@ -87,12 +87,12 @@ const mergeSchemaIntoResult = (result: SchemaObject, schema: SchemaObject, overr
     if ((key as string) === 'required') {
       // Merge required fields with deduplication
       if (Array.isArray(value) && value.length > 0) {
-        // @ts-ignore
+        // @ts-expect-error
         if (result.required?.length) {
-          // @ts-ignore
+          // @ts-expect-error
           result.required = [...new Set([...result.required, ...value])]
         } else {
-          // @ts-ignore
+          // @ts-expect-error
           result.required = value.slice()
         }
       }
@@ -101,13 +101,13 @@ const mergeSchemaIntoResult = (result: SchemaObject, schema: SchemaObject, overr
     else if ((key as string) === 'properties') {
       // Merge properties recursively
       if (value && typeof value === 'object') {
-        // @ts-ignore
+        // @ts-expect-error
         if (!result.properties) {
-          // @ts-ignore
+          // @ts-expect-error
           result.properties = {}
         }
 
-        // @ts-ignore
+        // @ts-expect-error
         mergePropertiesIntoResult(result.properties, value)
       }
     }
@@ -117,19 +117,19 @@ const mergeSchemaIntoResult = (result: SchemaObject, schema: SchemaObject, overr
       const items = getResolvedRef(value)
       if (items) {
         if (isArraySchema(schema)) {
-          // @ts-ignore
+          // @ts-expect-error
           if (!result.items) {
-            // @ts-ignore
+            // @ts-expect-error
             result.items = {}
           }
 
           // Handle allOf within array items
           if (items.allOf) {
             const mergedItems = mergeAllOfSchemas(items)
-            // @ts-ignore
+            // @ts-expect-error
             Object.assign(result.items, mergedItems)
           } else {
-            // @ts-ignore
+            // @ts-expect-error
             mergeItemsIntoResult(getResolvedRef(result.items), items)
           }
         }
@@ -138,7 +138,7 @@ const mergeSchemaIntoResult = (result: SchemaObject, schema: SchemaObject, overr
           const mergedItems = mergeAllOfSchemas(items)
           if ('properties' in mergedItems) {
             if (!('properties' in result)) {
-              // @ts-ignore
+              // @ts-expect-error
               result.properties = {}
             }
 
@@ -147,7 +147,7 @@ const mergeSchemaIntoResult = (result: SchemaObject, schema: SchemaObject, overr
         }
         // For non-array types without allOf, still set items if not already set
         else if (!('items' in result)) {
-          // @ts-ignore
+          // @ts-expect-error
           result.items = items
         }
       }
@@ -163,7 +163,7 @@ const mergeSchemaIntoResult = (result: SchemaObject, schema: SchemaObject, overr
       // Merge oneOf/anyOf subschema
       if (Array.isArray(value)) {
         if (!('properties' in result)) {
-          // @ts-ignore
+          // @ts-expect-error
           result.properties = {}
         }
         for (const _option of value) {
@@ -181,7 +181,7 @@ const mergeSchemaIntoResult = (result: SchemaObject, schema: SchemaObject, overr
     // For all other properties, preserve the first occurrence or override if specified
     else {
       if (override || result[key] === undefined) {
-        // @ts-ignore
+        // @ts-expect-error
         result[key] = value
       }
     }
@@ -249,7 +249,6 @@ const mergePropertiesIntoResult = (
       }
       // Simple merge without property recursion
       else {
-        // @ts-ignore
         result[key] = { ...schema, ...existing }
       }
     }
@@ -327,9 +326,9 @@ const mergeItems = (existing: SchemaObject, incoming: SchemaObject): SchemaObjec
 
   // Recursively merge properties if both have properties
   if ('properties' in existing && 'properties' in incoming) {
-    // @ts-ignore
+    // @ts-expect-error
     merged.properties = { ...existing.properties }
-    // @ts-ignore
+    // @ts-expect-error
     mergePropertiesIntoResult(merged.properties, incoming.properties)
   }
 

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
@@ -52,7 +52,6 @@ export function optimizeValueForDisplay(value: SchemaObject | undefined): Schema
   if (filteredSchemas.length === 1) {
     const mergedSchema = { ...rootProperties, ...filteredSchemas[0] }
     if (shouldBeNullable) {
-      // @ts-ignore
       mergedSchema.nullable = true
     }
     return mergedSchema
@@ -78,7 +77,7 @@ export function optimizeValueForDisplay(value: SchemaObject | undefined): Schema
     // @ts-expect-error - We avoid using coerceValue here as it may be dangerous, so we type cast
     const result = { [composition]: mergedSchemas } as SchemaObject
     if (shouldBeNullable) {
-      // @ts-ignore We use nullable
+      // @ts-expect-error We use nullable
       result.nullable = true
     }
     return result
@@ -88,7 +87,7 @@ export function optimizeValueForDisplay(value: SchemaObject | undefined): Schema
   if (filteredSchemas.length !== schemas.length) {
     const result: SchemaObject = { ...value, [composition]: filteredSchemas }
     if (shouldBeNullable) {
-      // @ts-ignore We use nullable
+      // @ts-expect-error We use nullable
       result.nullable = true
     }
     return result

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
@@ -29,7 +29,7 @@ describe('schema-name', () => {
   describe('getModelName', () => {
     it('returns null when value has no type', () => {
       const value = { properties: { name: { type: 'string' } } }
-      // @ts-ignore
+      // @ts-expect-error
       expect(getModelName(value)).toBe(null)
     })
 

--- a/packages/json-magic/src/diff/diff.ts
+++ b/packages/json-magic/src/diff/diff.ts
@@ -76,7 +76,6 @@ export const diff = <T extends Record<string, unknown>>(doc1: Record<string, unk
       const keys = new Set([...Object.keys(el1), ...Object.keys(el2)])
 
       for (const key of keys) {
-        // @ts-ignore
         bfs(el1[key], el2[key], [...prefix, key])
       }
       return

--- a/packages/json-magic/src/diff/utils.test.ts
+++ b/packages/json-magic/src/diff/utils.test.ts
@@ -148,7 +148,7 @@ describe('isArrayEqual', () => {
       [1, 2, 3],
       [1, 2, 3],
     ],
-    // @ts-ignore
+    // @ts-expect-error
   ])('should return true', (a, b) => expect(isArrayEqual(a, b)).toEqual(true))
 
   test.each([
@@ -164,6 +164,6 @@ describe('isArrayEqual', () => {
       [2, 2, 4],
       [1, 2, 3],
     ],
-    // @ts-ignore
+    // @ts-expect-error
   ])('should return false', (a, b) => expect(isArrayEqual(a, b)).toEqual(false))
 })

--- a/packages/json-magic/src/diff/utils.ts
+++ b/packages/json-magic/src/diff/utils.ts
@@ -28,9 +28,7 @@ export const isKeyCollisions = (a: unknown, b: unknown) => {
     const keys = new Set([...Object.keys(a), ...Object.keys(b)])
 
     for (const key of keys) {
-      // @ts-ignore
       if (a[key] !== undefined && b[key] !== undefined) {
-        // @ts-ignore
         if (isKeyCollisions(a[key], b[key])) {
           return true
         }

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -886,7 +886,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       return workspace
     },
     update<K extends keyof WorkspaceMeta>(key: K, value: WorkspaceMeta[K]) {
-      // @ts-ignore
+      // @ts-expect-error
       if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
         throw new Error('Invalid key: cannot modify prototype')
       }

--- a/packages/workspace-store/src/server.test.ts
+++ b/packages/workspace-store/src/server.test.ts
@@ -646,7 +646,7 @@ describe('externalize-path-references', () => {
             get: {
               description: 'string',
             },
-            // @ts-ignore
+            // @ts-expect-error
             otherProperty: {
               description: 'I should still be in the output',
             },


### PR DESCRIPTION
**Problem**

While working on #7217 I noticed some `@ts-ignore` around the codebase.

**Solution**

[`noTsIgnore`](https://biomejs.dev/linter/rules/no-ts-ignore/) Biome rule reports `@ts-ignore` directive.
The proposed fix is to replace them with a `@ts-expect-error` directive which is more safe.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`) (Not needed).
- [x] I've added tests for the regression or new feature (Not needed).
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable Biome `noTsIgnore` rule and replace `@ts-ignore` with `@ts-expect-error` across code/tests; fix integration build script quoting.
> 
> - **Lint/Config**
>   - Enable Biome rule `noTsIgnore` as `error` in `biome.json`.
> - **TypeScript Annotations**
>   - Replace `// @ts-ignore` with `// @ts-expect-error` across:
>     - `packages/api-reference/**` helpers and tests.
>     - `packages/json-magic/**` diff and tests.
>     - `packages/workspace-store/**` client and server tests.
>   - Remove a few unnecessary `@ts-ignore` comments; keep behavior unchanged.
> - **Scripts**
>   - Fix `build:integrations` filter quoting in `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 673bc0a1f1b31a36d959d0f51705ac24e37986a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->