### PR TITLE
docs: button/icon-dark

### DIFF
--- a/documentation/guides/docs/components/buttons.md
+++ b/documentation/guides/docs/components/buttons.md
@@ -76,10 +76,10 @@ An icon to display alongside the button text in dark mode. If not provided, the 
 
 <scalar-tab title="Directive">
 
-::scalar-button{ title="Download SDK" href="https://github.com/scalar/scalar" icon="phosphor/regular/house"} 
+::scalar-button{ title="Download SDK" href="https://github.com/scalar/scalar" icon="phosphor/regular/house"}
 
 ```markdown
-::scalar-button{ title="Download SDK" href="https://github.com/scalar/scalar" icon="phosphor/regular/house"} 
+::scalar-button{ title="Download SDK" href="https://github.com/scalar/scalar" icon="phosphor/regular/house"}
 ```
 </scalar-tab>
 </scalar-tabs>
@@ -91,26 +91,26 @@ An icon to display alongside the button text in dark mode. If not provided, the 
 <scalar-button
   title="Visit Website"
   href="https://scalar.com"
-  icon="https://avatars.githubusercontent.com/u/301879?s=200&v=4"
-  icon-dark="https://scalar.com/logo-dark.svg">
+  icon="https://cdn.scalar.com/images/logo-light.svg"
+  icon-dark="https://cdn.scalar.com/images/logo-dark.svg">
 </scalar-button>
 
 ```html
 <scalar-button
   title="Visit Website"
   href="https://scalar.com"
-  icon="https://avatars.githubusercontent.com/u/301879?s=200&v=4"
-  icon-dark="https://scalar.com/logo-dark.svg">
+  icon="https://cdn.scalar.com/images/logo-light.svg"
+  icon-dark="https://cdn.scalar.com/images/logo-dark.svg">
 </scalar-button>
 ```
 </scalar-tab>
 
 <scalar-tab title="Directive">
 
-::scalar-button{ title="Visit Website" href="https://scalar.com" icon="https://avatars.githubusercontent.com/u/301879?s=200&v=4" icon-dark="https://scalar.com/logo-dark.svg"}
+::scalar-button{ title="Visit Website" href="https://scalar.com" icon="https://cdn.scalar.com/images/logo-light.svg" icon-dark="https://cdn.scalar.com/images/logo-dark.svg"}
 
 ```markdown
-::scalar-button{ title="Visit Website" href="https://scalar.com" icon="https://avatars.githubusercontent.com/u/301879?s=200&v=4" icon-dark="https://scalar.com/logo-dark.svg"}
+::scalar-button{ title="Visit Website" href="https://scalar.com" icon="https://cdn.scalar.com/images/logo-light.svg" icon-dark="https://cdn.scalar.com/images/logo-dark.svg"}
 ```
 </scalar-tab>
 </scalar-tabs>


### PR DESCRIPTION
**Problem**

Currently, the buttons documentation does not describe the image-dark property.  When viewing this page in light mode, you cannot see the scalar icon that is added to the button in the last example

**Solution**

With this PR, we include icon-dark as an optional property in the properties documentation and update the example to show a button with both light and dark images.

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `icon-dark` property to button docs and update examples to show light/dark icons.
> 
> - **Docs: `documentation/guides/docs/components/buttons.md`**
>   - Add `icon-dark` optional property to button properties.
>   - Update external icon examples to include `icon` (light) and `icon-dark` (dark) URLs.
>   - Tidy directive examples for consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccc12a6b71600b9b2f68d6ca3c59e26b01756d6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->