### PR TITLE
fix(galaxy): nullable not supported in OpenAPI 3.1

### DIFF
--- a/.changeset/twenty-cups-hunt.md
+++ b/.changeset/twenty-cups-hunt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+fix: nullable not supported in OpenAPI 3.1

--- a/packages/galaxy/src/documents/3.1.yaml
+++ b/packages/galaxy/src/documents/3.1.yaml
@@ -963,8 +963,9 @@ components:
           examples:
             - '1610-01-07T00:00:00Z'
         image:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           examples:
             - https://cdn.scalar.com/photos/mars.jpg
         satellites:


### PR DESCRIPTION
Just ran Scalar Galaxy through the OpenAPI Doctor and it correctly pointed out that `nullable` is not supported in OpenAPI 3.1. :)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces unsupported `nullable: true` with `type: [string, 'null']` for `Planet.properties.image` in `packages/galaxy/src/documents/3.1.yaml` and adds a patch changeset.
> 
> - **OpenAPI 3.1 document (`packages/galaxy/src/documents/3.1.yaml`)**:
>   - Update `Planet` schema: change `properties.image` from `nullable: true` to `type: [string, 'null']`.
> - **Release**:
>   - Add patch changeset in `.changeset/twenty-cups-hunt.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e042935ae644f66b3c32759711720b121a775778. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->