### PR TITLE
docs(configuration): add `hiddenClients` `object` variant

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -594,7 +594,7 @@ Whether to show the "Test Request" button.
 
 #### hiddenClients
 
-**Type:** `array | true`
+**Type:** `array | true | object`
 
 We're generating code examples for a long list of popular HTTP clients. You can control which are shown by passing an array of clients, to hide the given clients.
 
@@ -634,6 +634,25 @@ But you can also pass `true` to **hide all** HTTP clients. If you have any custo
 ```js
 {
   hiddenClients: true
+}
+```
+
+---
+
+You can also provide an `object` where each **key** corresponds to a language,
+and each **value** specifies the visibility behavior for the clients of that language.
+
+* `true` — hides all clients for the specified language
+* `false` — shows all clients for the specified language
+* `['client1', 'client2']` — hides only the listed clients for the specified language
+
+```ts
+{
+  hiddenClients: {
+    c: false,
+    js: true,
+    shell: ['httpie'], // show all except `httpie`
+  },
 }
 ```
 


### PR DESCRIPTION
**Problem**

- Related to #7272 

[Scalar `hiddenClients` configuration documentation](https://guides.scalar.com/scalar/scalar-api-references/configuration#configuration__configuration-options__showoperationid__hiddenclients) doesn't mention that the property can also be passed as `object`

**Solution**

Add mention of `hiddenClients` `object` variant to the documentation

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed (not needed).
- [x] I've added a changeset (`pnpm changeset`) (not needed).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents that `hiddenClients` can be an object with per-language visibility settings (booleans or client lists), with examples.
> 
> - **Docs** (`documentation/configuration.md`):
>   - Expand `hiddenClients` type to include `object` (`array | true | object`).
>   - Add per-language configuration options and example for `hiddenClients` object (support `true`, `false`, or array of clients per language).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24fdb8d8d9ef1d41494f013a53b37a8c9f6e6936. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->