### PR TITLE
chore: forgotten changeset

### DIFF
--- a/.changeset/many-baboons-march.md
+++ b/.changeset/many-baboons-march.md
@@ -1,0 +1,6 @@
+---
+'@scalar/helpers': patch
+'@scalar/object-utils': patch
+---
+
+feat: move debounce to helpers and add max wait


### PR DESCRIPTION
Forgot a changeset in my other PR

**Checklist**

I've gone through the following:

- [ ] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a changeset publishing patch updates for @scalar/helpers and @scalar/object-utils to reflect moving debounce to helpers and adding max wait.
> 
> - **Changeset**:
>   - Publish patch updates for `@scalar/helpers` and `@scalar/object-utils`, noting debounce moved to helpers with added max wait support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 327b63067bccda9a138e44b38e1663033c3b0912. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->