### PR TITLE
fix(oas-utils): enable `knip`

### DIFF
--- a/.changeset/honest-lies-complain.md
+++ b/.changeset/honest-lies-complain.md
@@ -1,0 +1,12 @@
+---
+'@scalar/oas-utils': patch
+---
+
+fix(oas-utils): remove unused dependencies
+
+- `@hyperjump/browser`
+- `@hyperjump/json-schema`
+- `@types/har-format`
+- `js-base64`
+- `microdiff`
+- `nanoid`

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -19,7 +19,6 @@
     "packages/import/**",
     "packages/json-magic/**",
     "packages/nextjs-openapi/**",
-    "packages/oas-utils/**",
     "packages/object-utils/**",
     "packages/openapi-parser/**",
     "packages/openapi-to-markdown/**",
@@ -73,6 +72,16 @@
   ],
   "ignoreBinaries": ["netlify"],
   "workspaces": {
+    "packages/oas-utils": {
+      "entry": [
+        "src/entities/*/index.ts",
+        "src/helpers/index.ts",
+        "src/helpers/security/index.ts",
+        "src/migrations/index.ts",
+        "src/spec-getters/index.ts",
+        "src/transforms/index.ts"
+      ]
+    },
     "integrations/docusaurus": {
       "ignoreFiles": [
         // Loaded dynamically by index.ts

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -67,11 +67,6 @@
       "types": "./dist/helpers/index.d.ts",
       "default": "./dist/helpers/index.js"
     },
-    "./helpers/operation-to-har": {
-      "import": "./dist/helpers/operation-to-har/index.js",
-      "types": "./dist/helpers/operation-to-har/index.d.ts",
-      "default": "./dist/helpers/operation-to-har/index.js"
-    },
     "./helpers/security": {
       "import": "./dist/helpers/security/index.js",
       "types": "./dist/helpers/security/index.d.ts",
@@ -99,8 +94,6 @@
   ],
   "module": "dist/index.js",
   "dependencies": {
-    "@hyperjump/browser": "^1.1.0",
-    "@hyperjump/json-schema": "^1.9.6",
     "@scalar/helpers": "workspace:*",
     "@scalar/json-magic": "workspace:*",
     "@scalar/object-utils": "workspace:*",
@@ -108,11 +101,7 @@
     "@scalar/themes": "workspace:*",
     "@scalar/types": "workspace:*",
     "@scalar/workspace-store": "workspace:*",
-    "@types/har-format": "^1.2.15",
     "flatted": "catalog:*",
-    "js-base64": "catalog:*",
-    "microdiff": "catalog:*",
-    "nanoid": "catalog:*",
     "type-fest": "catalog:*",
     "yaml": "catalog:*",
     "zod": "catalog:*"

--- a/packages/oas-utils/src/entities/environment/environment.ts
+++ b/packages/oas-utils/src/entities/environment/environment.ts
@@ -1,6 +1,5 @@
-import { z } from 'zod'
-
 import type { ENTITY_BRANDS } from '@scalar/types/utils'
+import { z } from 'zod'
 
 export const environmentSchema = z.object({
   uid: z.string().brand<ENTITY_BRANDS['ENVIRONMENT']>(),

--- a/packages/oas-utils/src/entities/environment/index.ts
+++ b/packages/oas-utils/src/entities/environment/index.ts
@@ -1,1 +1,2 @@
-export { type Environment, environmentSchema } from './environment'
+/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
+export { type Environment, type EnvironmentPayload, environmentSchema } from './environment'

--- a/packages/oas-utils/src/entities/spec/collection.ts
+++ b/packages/oas-utils/src/entities/spec/collection.ts
@@ -1,16 +1,16 @@
-import { selectedSecuritySchemeUidSchema } from '@/entities/shared/utility'
-import { xScalarEnvironmentsSchema } from '@/entities/spec/x-scalar-environments'
-import { xScalarSecretsSchema } from '@/entities/spec/x-scalar-secrets'
 import { oasSecurityRequirementSchema } from '@scalar/types/entities'
 import { type ENTITY_BRANDS, nanoidSchema } from '@scalar/types/utils'
 import { z } from 'zod'
 
+import { selectedSecuritySchemeUidSchema } from '@/entities/shared/utility'
+import { xScalarEnvironmentsSchema } from '@/entities/spec/x-scalar-environments'
+import { xScalarSecretsSchema } from '@/entities/spec/x-scalar-secrets'
+
 import { oasExternalDocumentationSchema, oasInfoSchema } from './spec-objects'
 
-export const oasCollectionSchema = z.object({
+const oasCollectionSchema = z.object({
   /**
    * @deprecated
-   *
    * Needs to be remove as it is not a spec property
    */
   'type': z.literal('collection').optional().default('collection'),
@@ -49,7 +49,7 @@ export const oasCollectionSchema = z.object({
   // security
 })
 
-export const extendedCollectionSchema = z.object({
+const extendedCollectionSchema = z.object({
   uid: nanoidSchema.brand<ENTITY_BRANDS['COLLECTION']>(),
   /** A list of security schemes UIDs associated with the collection */
   securitySchemes: z.string().array().default([]),

--- a/packages/oas-utils/src/entities/spec/index.ts
+++ b/packages/oas-utils/src/entities/spec/index.ts
@@ -1,45 +1,4 @@
-export { collectionSchema, type Collection, type CollectionPayload } from './collection'
-export { oasParameterSchema, type RequestParameter, type RequestParameterPayload } from './parameters'
-export { serverSchema, type Server, type ServerPayload } from './server'
-export {
-  requestSchema,
-  type Request,
-  type RequestPayload,
-  type RequestMethod,
-  type ResponseInstance,
-  type RequestEvent,
-} from './requests'
-
-export {
-  requestExampleSchema,
-  createExampleFromRequest,
-  requestExampleParametersSchema,
-  type RequestExample,
-  type RequestExampleParameter,
-} from './request-examples'
-
-export {
-  tagSchema,
-  oasExternalDocumentationSchema,
-  oasInfoSchema,
-  oasContactSchema,
-  oasLicenseSchema,
-  type Tag,
-  type TagPayload,
-} from './spec-objects'
-
-export {
-  type Operation,
-  type OperationPayload,
-  operationSchema,
-} from './operation'
-
-export {
-  xScalarEnvironmentsSchema,
-  type XScalarEnvironment,
-  type XScalarEnvironments,
-} from './x-scalar-environments'
-
+/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 /** Re-exported here for ease of use but we should use the other ones directly */
 export {
   type Oauth2Flow,
@@ -61,7 +20,44 @@ export {
   securitySchemeSchema,
 } from '@scalar/types/entities'
 
+export { type Collection, type CollectionPayload, collectionSchema } from './collection'
+export {
+  type Operation,
+  type OperationPayload,
+  operationSchema,
+} from './operation'
+export { type RequestParameter, type RequestParameterPayload, oasParameterSchema } from './parameters'
+export {
+  type RequestExample,
+  type RequestExampleParameter,
+  createExampleFromRequest,
+  requestExampleParametersSchema,
+  requestExampleSchema,
+} from './request-examples'
+export {
+  type Request,
+  type RequestEvent,
+  type RequestMethod,
+  type RequestPayload,
+  type ResponseInstance,
+  requestSchema,
+} from './requests'
 export type {
   PostResponseScript,
   PostResponseScripts,
 } from './requests.ts'
+export { type Server, type ServerPayload, serverSchema } from './server'
+export {
+  type Tag,
+  type TagPayload,
+  oasContactSchema,
+  oasExternalDocumentationSchema,
+  oasInfoSchema,
+  oasLicenseSchema,
+  tagSchema,
+} from './spec-objects'
+export {
+  type XScalarEnvironment,
+  type XScalarEnvironments,
+  xScalarEnvironmentsSchema,
+} from './x-scalar-environments'

--- a/packages/oas-utils/src/entities/spec/parameters.ts
+++ b/packages/oas-utils/src/entities/spec/parameters.ts
@@ -1,12 +1,13 @@
-import type { OpenAPI } from '@scalar/openapi-types'
+import type { OpenAPI, OpenAPIV3_1 } from '@scalar/openapi-types'
 import { type ZodSchema, z } from 'zod'
-import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
 import type { RequestExampleParameter } from './request-examples'
 
-export const parameterTypeSchema = z.enum(['path', 'query', 'header', 'cookie'])
-export type ParamType = z.infer<typeof parameterTypeSchema>
+const parameterTypeSchema = z.enum(['path', 'query', 'header', 'cookie'])
+// not used but kept for consistency
+// export type ParamType = z.infer<typeof parameterTypeSchema>
 
-export const parameterStyleSchema = z.enum([
+const parameterStyleSchema = z.enum([
   'matrix',
   'simple',
   'form',
@@ -15,7 +16,9 @@ export const parameterStyleSchema = z.enum([
   'pipeDelimited',
   'deepObject',
 ])
-export type ParameterStyle = z.infer<typeof parameterStyleSchema>
+// not used but kept for consistency
+// export type ParameterStyle = z.infer<typeof parameterStyleSchema>
+
 export type ParameterContent = Record<
   string,
   {
@@ -24,7 +27,6 @@ export type ParameterContent = Record<
     example?: RequestExampleParameter
   }
 >
-export const parameterExampleSchema = z.unknown()
 
 /**
  * OpenAPI compliant parameters object

--- a/packages/oas-utils/src/entities/spec/request-examples.ts
+++ b/packages/oas-utils/src/entities/spec/request-examples.ts
@@ -72,7 +72,7 @@ export const parameterArrayToObject = (params: RequestExampleParameter[]) =>
 /** Request examples - formerly known as instances - are "children" of requests */
 export type RequestExampleParameter = z.infer<typeof requestExampleParametersSchema>
 
-export const xScalarFileValueSchema = z
+const xScalarFileValueSchema = z
   .object({
     url: z.string(),
     base64: z.string().optional(),
@@ -83,14 +83,15 @@ export const xScalarFileValueSchema = z
  * When files are required for an example we provide the options
  * to provide a public URL or a base64 encoded string
  */
-export type XScalarFileValue = z.infer<typeof xScalarFileValueSchema>
+// not used but kept for consistency
+// export type XScalarFileValue = z.infer<typeof xScalarFileValueSchema>
 
 /**
  * Schema for the OAS serialization of request example parameters
  *
  * File values can be optionally fetched on import OR inserted as a base64 encoded string
  */
-export const xScalarFormDataValue = z.union([
+const xScalarFormDataValue = z.union([
   z.object({
     type: z.literal('string'),
     value: z.string(),
@@ -101,7 +102,7 @@ export const xScalarFormDataValue = z.union([
   }),
 ])
 
-export type XScalarFormDataValue = z.infer<typeof xScalarFormDataValue>
+type XScalarFormDataValue = z.infer<typeof xScalarFormDataValue>
 
 // ---------------------------------------------------------------------------
 // Example Body
@@ -111,11 +112,11 @@ export type XScalarFormDataValue = z.infer<typeof xScalarFormDataValue>
  *
  * TODO: This list may not be comprehensive enough
  */
-export const exampleRequestBodyEncoding = ['json', 'text', 'html', 'javascript', 'xml', 'yaml', 'edn'] as const
+const exampleRequestBodyEncoding = ['json', 'text', 'html', 'javascript', 'xml', 'yaml', 'edn'] as const
 
-export type BodyEncoding = (typeof exampleRequestBodyEncoding)[number]
+type BodyEncoding = (typeof exampleRequestBodyEncoding)[number]
 
-export const exampleBodyMime = [
+const exampleBodyMime = [
   'application/json',
   'text/plain',
   'text/html',
@@ -130,7 +131,7 @@ export const exampleBodyMime = [
   'binary',
 ] as const
 
-export type BodyMime = (typeof exampleBodyMime)[number]
+type BodyMime = (typeof exampleBodyMime)[number]
 
 const contentMapping: Record<BodyEncoding, BodyMime> = {
   json: 'application/json',
@@ -147,7 +148,7 @@ const contentMapping: Record<BodyEncoding, BodyMime> = {
  *
  * If a user changes the encoding of the body we expect the content to change as well
  */
-export const exampleRequestBodySchema = z.object({
+const exampleRequestBodySchema = z.object({
   raw: z
     .object({
       encoding: z.enum(exampleRequestBodyEncoding),
@@ -165,10 +166,10 @@ export const exampleRequestBodySchema = z.object({
   activeBody: z.union([z.literal('raw'), z.literal('formData'), z.literal('binary')]).default('raw'),
 })
 
-export type ExampleRequestBody = z.infer<typeof exampleRequestBodySchema>
+type ExampleRequestBody = z.infer<typeof exampleRequestBodySchema>
 
 /** Schema for the OAS serialization of request example bodies */
-export const xScalarExampleBodySchema = z.object({
+const xScalarExampleBodySchema = z.object({
   encoding: z.enum(exampleBodyMime),
   /**
    * Body content as an object with a separately specified encoding or a simple pre-encoded string value
@@ -180,7 +181,7 @@ export const xScalarExampleBodySchema = z.object({
   file: xScalarFileValueSchema.optional(),
 })
 
-export type XScalarExampleBody = z.infer<typeof xScalarExampleBodySchema>
+type XScalarExampleBody = z.infer<typeof xScalarExampleBodySchema>
 
 // ---------------------------------------------------------------------------
 // Example Schema
@@ -227,7 +228,7 @@ export const xScalarExampleSchema = z.object({
   }),
 })
 
-export type XScalarExample = z.infer<typeof xScalarExampleSchema>
+type XScalarExample = z.infer<typeof xScalarExampleSchema>
 
 /**
  * Convert a request example to the xScalar serialized format

--- a/packages/oas-utils/src/entities/spec/requests.ts
+++ b/packages/oas-utils/src/entities/spec/requests.ts
@@ -1,7 +1,3 @@
-import { selectedSecuritySchemeUidSchema } from '@/entities/shared/utility'
-import { type ENTITY_BRANDS, nanoidSchema } from '@scalar/types/utils'
-import { type ZodSchema, z } from 'zod'
-
 import {
   type PostResponseSchema,
   XCodeSamplesSchema,
@@ -9,11 +5,16 @@ import {
 } from '@scalar/openapi-types/schemas/extensions'
 import { XScalarStability } from '@scalar/types'
 import { oasSecurityRequirementSchema } from '@scalar/types/entities'
+import { type ENTITY_BRANDS, nanoidSchema } from '@scalar/types/utils'
+import { type ZodSchema, z } from 'zod'
+
+import { selectedSecuritySchemeUidSchema } from '@/entities/shared/utility'
+
 import { oasParameterSchema } from './parameters'
 import { type RequestExample, xScalarExampleSchema } from './request-examples'
 import { oasExternalDocumentationSchema } from './spec-objects'
 
-export const requestMethods = ['delete', 'get', 'head', 'options', 'patch', 'post', 'put', 'trace'] as const
+const requestMethods = ['delete', 'get', 'head', 'options', 'patch', 'post', 'put', 'trace'] as const
 
 export type RequestMethod = (typeof requestMethods)[number]
 
@@ -58,7 +59,7 @@ type RequestBody = object
 const requestBodySchema = z.any() satisfies ZodSchema<RequestBody>
 
 /** Open API Compliant Request Validator */
-export const oasRequestSchema = z.object({
+const oasRequestSchema = z.object({
   /**
    * A list of tags for API documentation control. Tags can be used for logical
    * grouping of operations by resources or any other qualifier.

--- a/packages/oas-utils/src/entities/spec/server.ts
+++ b/packages/oas-utils/src/entities/spec/server.ts
@@ -8,7 +8,7 @@ import { z } from 'zod'
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#server-variable-object
  */
-export const oasServerVariableSchema = z.object({
+const oasServerVariableSchema = z.object({
   /**
    * An enumeration of string values to be used if the substitution options are from a limited set. The array MUST NOT be empty.
    */
@@ -52,7 +52,7 @@ const extendedServerVariableSchema = oasServerVariableSchema
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#server-object
  */
-export const oasServerSchema = z.object({
+const oasServerSchema = z.object({
   /**
    * REQUIRED. A URL to the target host. This URL supports Server Variables and MAY be relative, to indicate that
    * the host location is relative to the location where the OpenAPI document is being served. Variable substitutions

--- a/packages/oas-utils/src/entities/spec/spec-objects.ts
+++ b/packages/oas-utils/src/entities/spec/spec-objects.ts
@@ -88,9 +88,10 @@ export const oasExternalDocumentationSchema = z
   })
   .transform(omitUndefinedValues)
 
-export type ExternalDocumentation = z.infer<typeof oasExternalDocumentationSchema>
+// not used but kept for consistency
+// export type ExternalDocumentation = z.infer<typeof oasExternalDocumentationSchema>
 
-export const xScalarNestedSchema = z
+const xScalarNestedSchema = z
   .object({
     tagName: z.string(),
   })
@@ -104,7 +105,7 @@ export const xScalarNestedSchema = z
  *
  * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#tag-object
  */
-export const oasTagSchema = z.object({
+const oasTagSchema = z.object({
   // TODO: Remove
   /**
    * @deprecated Needs to be remove as it is not a spec property

--- a/packages/oas-utils/src/entities/spec/x-scalar-environments.ts
+++ b/packages/oas-utils/src/entities/spec/x-scalar-environments.ts
@@ -1,16 +1,16 @@
 import { z } from 'zod'
 
-export type XScalarEnvVar = z.infer<typeof xScalarEnvVarSchema>
-
-export const xScalarEnvVarSchema = z.union([
+const xScalarEnvVarSchema = z.union([
   z.object({
     description: z.string().optional(),
     default: z.string().default(''),
   }),
   z.string(),
 ])
+// not used but kept for consistency
+// export type XScalarEnvVar = z.infer<typeof xScalarEnvVarSchema>
 
-export const xScalarEnvironmentSchema = z.object({
+const xScalarEnvironmentSchema = z.object({
   description: z.string().optional(),
   color: z.string().optional(),
   /** A map of variables by name */

--- a/packages/oas-utils/src/entities/spec/x-scalar-secrets.ts
+++ b/packages/oas-utils/src/entities/spec/x-scalar-secrets.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod'
 
-export const xScalarSecretVarSchema = z.object({
+const xScalarSecretVarSchema = z.object({
   description: z.string().optional(),
   example: z.string().optional(),
 })
 
 export const xScalarSecretsSchema = z.record(z.string(), xScalarSecretVarSchema)
-export type XScalarSecrets = z.infer<typeof xScalarSecretsSchema>
+// not used but kept for consistency
+// export type XScalarSecrets = z.infer<typeof xScalarSecretsSchema>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2029,12 +2029,6 @@ importers:
 
   packages/oas-utils:
     dependencies:
-      '@hyperjump/browser':
-        specifier: ^1.1.0
-        version: 1.1.6
-      '@hyperjump/json-schema':
-        specifier: ^1.9.6
-        version: 1.9.8(@hyperjump/browser@1.1.6)
       '@scalar/helpers':
         specifier: workspace:*
         version: link:../helpers
@@ -2056,21 +2050,9 @@ importers:
       '@scalar/workspace-store':
         specifier: workspace:*
         version: link:../workspace-store
-      '@types/har-format':
-        specifier: ^1.2.15
-        version: 1.2.15
       flatted:
         specifier: catalog:*
         version: 3.3.3
-      js-base64:
-        specifier: catalog:*
-        version: 3.7.8
-      microdiff:
-        specifier: catalog:*
-        version: 1.5.0
-      nanoid:
-        specifier: catalog:*
-        version: 5.1.5
       type-fest:
         specifier: catalog:*
         version: 5.0.0
@@ -5572,24 +5554,6 @@ packages:
   '@humanwhocodes/retry@0.4.1':
     resolution: {integrity: sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==}
     engines: {node: '>=18.18'}
-
-  '@hyperjump/browser@1.1.6':
-    resolution: {integrity: sha512-i27uPV7SxK1GOn7TLTRxTorxchYa5ur9JHgtl6TxZ1MHuyb9ROAnXxEeu4q4H1836Xb7lL2PGPsaa5Jl3p+R6g==}
-    engines: {node: '>=18.0.0'}
-
-  '@hyperjump/json-pointer@1.1.0':
-    resolution: {integrity: sha512-tFCKxMKDKK3VEdtUA3EBOS9GmSOS4mbrTjh9v3RnK10BphDMOb6+bxTh++/ae1AyfHyWb6R54O/iaoAtPMZPCg==}
-
-  '@hyperjump/json-schema@1.9.8':
-    resolution: {integrity: sha512-qmdMpYn8CpYR7z3fxkL6fgkDvMaAEFKtmYu3XDi6hWW2BT+rLl7T4Y4QpafEIR4wkcmCxcJf9me9FmxKpv3i9g==}
-    peerDependencies:
-      '@hyperjump/browser': ^1.1.0
-
-  '@hyperjump/pact@1.3.0':
-    resolution: {integrity: sha512-/UIKatOtyZ3kN4A7AQmqZKzg/6es9jKyeWbfrenb2rDb3I9W4ZrVZT8q1zDrI/G+849I6Eq0ybzV1mmEC9zoDg==}
-
-  '@hyperjump/uri@1.2.2':
-    resolution: {integrity: sha512-Zn8AZb/j54KKUCckmcOzKCSCKpIpMVBc60zYaajD8Dq/1g4UN6TfAFi+uDa5o/6rf+I+5xDZjZpdzwfuhlC0xQ==}
 
   '@ianvs/prettier-plugin-sort-imports@4.4.1':
     resolution: {integrity: sha512-F0/Hrcfpy8WuxlQyAWJTEren/uxKhYonOGY4OyWmwRdeTvkh9mMSCxowZLjNkhwi/2ipqCgtXwwOk7tW0mWXkA==}
@@ -13272,10 +13236,6 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  json-stringify-deterministic@1.0.12:
-    resolution: {integrity: sha512-q3PN0lbUdv0pmurkBNdJH3pfFvOTL/Zp0lquqpvcjfKzt6Y0j49EPHAmVHCAS4Ceq/Y+PejWTzyiVpoY71+D6g==}
-    engines: {node: '>= 4'}
-
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -13309,9 +13269,6 @@ packages:
 
   just-clone@6.2.0:
     resolution: {integrity: sha512-1IynUYEc/HAwxhi3WDpIpxJbZpMCvvrrmZVqvj9EhpvbH8lls7HhdhiByjL7DkAaWlLIzpC0Xc/VPvy/UxLNjA==}
-
-  just-curry-it@5.3.0:
-    resolution: {integrity: sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw==}
 
   just-diff@6.0.2:
     resolution: {integrity: sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==}
@@ -22458,32 +22415,6 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.1': {}
-
-  '@hyperjump/browser@1.1.6':
-    dependencies:
-      '@hyperjump/json-pointer': 1.1.0
-      '@hyperjump/uri': 1.2.2
-      content-type: 1.0.5
-      just-curry-it: 5.3.0
-
-  '@hyperjump/json-pointer@1.1.0': {}
-
-  '@hyperjump/json-schema@1.9.8(@hyperjump/browser@1.1.6)':
-    dependencies:
-      '@hyperjump/browser': 1.1.6
-      '@hyperjump/json-pointer': 1.1.0
-      '@hyperjump/pact': 1.3.0
-      '@hyperjump/uri': 1.2.2
-      content-type: 1.0.5
-      json-stringify-deterministic: 1.0.12
-      just-curry-it: 5.3.0
-      uuid: 9.0.1
-
-  '@hyperjump/pact@1.3.0':
-    dependencies:
-      just-curry-it: 5.3.0
-
-  '@hyperjump/uri@1.2.2': {}
 
   '@ianvs/prettier-plugin-sort-imports@4.4.1(@vue/compiler-sfc@3.5.21)(prettier@3.6.2)':
     dependencies:
@@ -32434,8 +32365,6 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stringify-deterministic@1.0.12: {}
-
   json-stringify-safe@5.0.1:
     optional: true
 
@@ -32468,8 +32397,6 @@ snapshots:
       promise: 7.3.1
 
   just-clone@6.2.0: {}
-
-  just-curry-it@5.3.0: {}
 
   just-diff@6.0.2: {}
 


### PR DESCRIPTION
**Problem**

- Followup of #7233

**Solution**

- remove unused dependencies
- remove export pointing to non-existing files
- removed unused schema
- removed export for schema used only internally on not export from entry poiint
- commented out exported types that were not part of the public API

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes unused dependencies and dead exports in `@scalar/oas-utils`, narrows its public API, and adds `knip` workspace entries.
> 
> - **oas-utils**:
>   - **Dependencies**: Remove unused deps (`@hyperjump/browser`, `@hyperjump/json-schema`, `@types/har-format`, `js-base64`, `microdiff`, `nanoid`).
>   - **Exports/Public API**:
>     - Drop `"./helpers/operation-to-har"` export from `package.json`.
>     - Convert multiple schemas/types to internal-only (non-exported `const`), comment out unused exported types, and tidy imports.
>     - Adjust barrel exports: re-export only used entities; add `EnvironmentPayload`; keep internal-only types unexported.
>   - **Code cleanup**: Minor import ordering and schema visibility tweaks (e.g., `const` for internal schemas).
> - **Tooling**:
>   - **knip**: Add workspace config for `packages/oas-utils` with explicit `entry` globs; include package in knip scanning.
>   - **Lockfile**: Prune removed deps from `pnpm-lock.yaml`.
> - **Changeset**: Add patch changeset documenting dependency removals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5983cecb6a3d4ec931b992d91769e56de1be49e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->