### PR TITLE
chore: revert release

### DIFF
--- a/.changeset/friendly-brooms-search.md
+++ b/.changeset/friendly-brooms-search.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix(fastify): remove empty customTheme

--- a/.changeset/loud-hotels-pay.md
+++ b/.changeset/loud-hotels-pay.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+fix: fails on 204 No Content responses

--- a/.changeset/lovely-toys-sniff.md
+++ b/.changeset/lovely-toys-sniff.md
@@ -1,0 +1,5 @@
+---
+'@scalar/json-magic': minor
+---
+
+feat(json-magic): use `@scalar/helpers/node/path` polyfill

--- a/.changeset/mean-crabs-lick.md
+++ b/.changeset/mean-crabs-lick.md
@@ -1,0 +1,8 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-client': patch
+'@scalar/json-magic': patch
+'@scalar/helpers': patch
+---
+
+fix: remove useage of crypto.subtle in all contexts

--- a/.changeset/slow-beers-film.md
+++ b/.changeset/slow-beers-film.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': minor
+---
+
+feat: use `document`, not `specification` for the configuration

--- a/.changeset/small-tigers-wait.md
+++ b/.changeset/small-tigers-wait.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': minor
+'@scalar/api-client': minor
+---
+
+feat: integrate operation page mutators

--- a/.changeset/strange-carrots-perform.md
+++ b/.changeset/strange-carrots-perform.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+fix(openapi-parser): use `node:path` instead of polyfill

--- a/.changeset/stupid-books-unite.md
+++ b/.changeset/stupid-books-unite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': minor
+---
+
+feat(helpers): add `node:path` polyfill

--- a/.changeset/tasty-olives-worry.md
+++ b/.changeset/tasty-olives-worry.md
@@ -1,0 +1,17 @@
+---
+'@scalar/api-reference-react': patch
+'@scalar/api-client-react': patch
+'@scalar/webjar': patch
+'@scalar/openapi-parser': patch
+'@scalar/api-reference': patch
+'@scalar/express-api-reference': patch
+'@scalar/nestjs-api-reference': patch
+'@scalar/api-client': patch
+'@scalar/oas-utils': patch
+'@scalar/hono-api-reference': patch
+'scalar_api_reference': patch
+'@scalar/galaxy': patch
+'@scalar/core': patch
+---
+
+chore: use "current" not "latest" scalar registry url

--- a/integrations/docker/CHANGELOG.md
+++ b/integrations/docker/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalarapi/docker-api-reference
 
-## 0.4.6
-
-### Patch Changes
-
-- Updated dependencies [[`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/api-reference@1.39.2
-
 ## 0.4.5
 
 ### Patch Changes

--- a/integrations/docker/package.json
+++ b/integrations/docker/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/docker"
   },
-  "version": "0.4.6",
+  "version": "0.4.5",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/integrations/dotnet/aspire/CHANGELOG.md
+++ b/integrations/dotnet/aspire/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/aspire
 
-## 0.7.2
-
-### Patch Changes
-
-- Updated dependencies [[`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/api-reference@1.39.2
-
 ## 0.7.1
 
 ### Patch Changes

--- a/integrations/dotnet/aspire/package.json
+++ b/integrations/dotnet/aspire/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/dotnet/aspire"
   },
-  "version": "0.7.2",
+  "version": "0.7.1",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/integrations/dotnet/aspnetcore/CHANGELOG.md
+++ b/integrations/dotnet/aspnetcore/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/aspnetcore
 
-## 2.10.2
-
-### Patch Changes
-
-- Updated dependencies [[`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/api-reference@1.39.2
-
 ## 2.10.1
 
 ### Patch Changes

--- a/integrations/dotnet/aspnetcore/package.json
+++ b/integrations/dotnet/aspnetcore/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/dotnet/aspnetcore"
   },
-  "version": "2.10.2",
+  "version": "2.10.1",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/integrations/express/CHANGELOG.md
+++ b/integrations/express/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/express-api-reference
 
-## 0.8.24
-
-### Patch Changes
-
-- [#7241](https://github.com/scalar/scalar/pull/7241) [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d) Thanks [@hanspagel](https://github.com/hanspagel)! - chore: use "current" not "latest" scalar registry url
-
-- Updated dependencies [[`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/core@0.3.22
-
 ## 0.8.23
 
 ### Patch Changes

--- a/integrations/express/package.json
+++ b/integrations/express/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/express"
   },
-  "version": "0.8.24",
+  "version": "0.8.23",
   "engines": {
     "node": ">=20"
   },

--- a/integrations/fastify/CHANGELOG.md
+++ b/integrations/fastify/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/fastify-api-reference
 
-## 1.39.2
-
-### Patch Changes
-
-- [#7233](https://github.com/scalar/scalar/pull/7233) [`d7f9845`](https://github.com/scalar/scalar/commit/d7f98454b54b92a497ea9e2addaa4fa42b25d452) Thanks [@marcalexiei](https://github.com/marcalexiei)! - fix(fastify): remove empty customTheme
-
-- Updated dependencies [[`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/openapi-parser@0.23.1
-  - @scalar/core@0.3.22
-
 ## 1.39.1
 
 ## 1.39.0

--- a/integrations/fastify/package.json
+++ b/integrations/fastify/package.json
@@ -17,7 +17,7 @@
     "openapi",
     "swagger"
   ],
-  "version": "1.39.2",
+  "version": "1.39.1",
   "engines": {
     "node": ">=20"
   },

--- a/integrations/hono/CHANGELOG.md
+++ b/integrations/hono/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/hono-api-reference
 
-## 0.9.24
-
-### Patch Changes
-
-- [#7241](https://github.com/scalar/scalar/pull/7241) [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d) Thanks [@hanspagel](https://github.com/hanspagel)! - chore: use "current" not "latest" scalar registry url
-
-- Updated dependencies [[`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/core@0.3.22
-
 ## 0.9.23
 
 ### Patch Changes

--- a/integrations/hono/package.json
+++ b/integrations/hono/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/hono"
   },
-  "version": "0.9.24",
+  "version": "0.9.23",
   "engines": {
     "node": ">=20"
   },

--- a/integrations/java/webjar/CHANGELOG.md
+++ b/integrations/java/webjar/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/webjar
 
-## 0.4.2
-
-### Patch Changes
-
-- [#7241](https://github.com/scalar/scalar/pull/7241) [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d) Thanks [@hanspagel](https://github.com/hanspagel)! - chore: use "current" not "latest" scalar registry url
-
-- Updated dependencies [[`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/api-reference@1.39.2
-
 ## 0.4.1
 
 ### Patch Changes

--- a/integrations/java/webjar/package.json
+++ b/integrations/java/webjar/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/java/webjar"
   },
-  "version": "0.4.2",
+  "version": "0.4.1",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/integrations/nestjs/CHANGELOG.md
+++ b/integrations/nestjs/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/nestjs-api-reference
 
-## 1.0.7
-
-### Patch Changes
-
-- [#7241](https://github.com/scalar/scalar/pull/7241) [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d) Thanks [@hanspagel](https://github.com/hanspagel)! - chore: use "current" not "latest" scalar registry url
-
-- Updated dependencies [[`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/core@0.3.22
-
 ## 1.0.6
 
 ### Patch Changes

--- a/integrations/nestjs/package.json
+++ b/integrations/nestjs/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/nestjs"
   },
-  "version": "1.0.7",
+  "version": "1.0.6",
   "engines": {
     "node": ">=20"
   },

--- a/integrations/nextjs/CHANGELOG.md
+++ b/integrations/nextjs/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/nextjs-api-reference
 
-## 0.9.1
-
-### Patch Changes
-
-- Updated dependencies [[`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/core@0.3.22
-
 ## 0.9.0
 
 ### Minor Changes

--- a/integrations/nextjs/package.json
+++ b/integrations/nextjs/package.json
@@ -18,7 +18,7 @@
     "openapi",
     "swagger"
   ],
-  "version": "0.9.1",
+  "version": "0.9.0",
   "engines": {
     "node": ">=20"
   },

--- a/integrations/nuxt/CHANGELOG.md
+++ b/integrations/nuxt/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/nuxt
 
-## 0.5.24
-
-### Patch Changes
-
-- Updated dependencies [[`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`d6154a2`](https://github.com/scalar/scalar/commit/d6154a24d97fc28977def486f99b2eeee52d268c), [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/workspace-store@0.19.0
-  - @scalar/api-client@2.10.0
-  - @scalar/api-reference@1.39.2
-
 ## 0.5.23
 
 ### Patch Changes

--- a/integrations/nuxt/package.json
+++ b/integrations/nuxt/package.json
@@ -20,7 +20,7 @@
     "testing",
     "vue"
   ],
-  "version": "0.5.24",
+  "version": "0.5.23",
   "engines": {
     "node": ">=20"
   },

--- a/integrations/rust/CHANGELOG.md
+++ b/integrations/rust/CHANGELOG.md
@@ -1,11 +1,5 @@
 # scalar_api_reference
 
-## 0.1.2
-
-### Patch Changes
-
-- [#7241](https://github.com/scalar/scalar/pull/7241) [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d) Thanks [@hanspagel](https://github.com/hanspagel)! - chore: use "current" not "latest" scalar registry url
-
 ## 0.1.1
 
 ### Patch Changes

--- a/integrations/rust/package.json
+++ b/integrations/rust/package.json
@@ -22,7 +22,7 @@
     "actix-web",
     "warp"
   ],
-  "version": "0.1.2",
+  "version": "0.1.1",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/integrations/sveltekit/CHANGELOG.md
+++ b/integrations/sveltekit/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/sveltekit
 
-## 0.1.28
-
-### Patch Changes
-
-- Updated dependencies [[`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/core@0.3.22
-
 ## 0.1.27
 
 ### Patch Changes

--- a/integrations/sveltekit/package.json
+++ b/integrations/sveltekit/package.json
@@ -18,7 +18,7 @@
     "openapi",
     "swagger"
   ],
-  "version": "0.1.28",
+  "version": "0.1.27",
   "engines": {
     "node": ">=20"
   },

--- a/packages/api-client-react/CHANGELOG.md
+++ b/packages/api-client-react/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/api-client-react
 
-## 1.3.49
-
-### Patch Changes
-
-- [#7241](https://github.com/scalar/scalar/pull/7241) [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d) Thanks [@hanspagel](https://github.com/hanspagel)! - chore: use "current" not "latest" scalar registry url
-
-- Updated dependencies [[`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`d6154a2`](https://github.com/scalar/scalar/commit/d6154a24d97fc28977def486f99b2eeee52d268c), [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/api-client@2.10.0
-
 ## 1.3.48
 
 ### Patch Changes

--- a/packages/api-client-react/package.json
+++ b/packages/api-client-react/package.json
@@ -19,7 +19,7 @@
     "testing",
     "react"
   ],
-  "version": "1.3.49",
+  "version": "1.3.48",
   "engines": {
     "node": ">=20"
   },

--- a/packages/api-client/CHANGELOG.md
+++ b/packages/api-client/CHANGELOG.md
@@ -1,30 +1,5 @@
 # @scalar/api-client
 
-## 2.10.0
-
-### Minor Changes
-
-- [#7251](https://github.com/scalar/scalar/pull/7251) [`d6154a2`](https://github.com/scalar/scalar/commit/d6154a24d97fc28977def486f99b2eeee52d268c) Thanks [@DemonHa](https://github.com/DemonHa)! - feat: integrate operation page mutators
-
-### Patch Changes
-
-- [#7266](https://github.com/scalar/scalar/pull/7266) [`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d) Thanks [@amritk](https://github.com/amritk)! - fix: remove useage of crypto.subtle in all contexts
-
-- [#7241](https://github.com/scalar/scalar/pull/7241) [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d) Thanks [@hanspagel](https://github.com/hanspagel)! - chore: use "current" not "latest" scalar registry url
-
-- Updated dependencies [[`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`d6154a2`](https://github.com/scalar/scalar/commit/d6154a24d97fc28977def486f99b2eeee52d268c), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/json-magic@0.8.0
-  - @scalar/workspace-store@0.19.0
-  - @scalar/helpers@0.1.0
-  - @scalar/openapi-parser@0.23.1
-  - @scalar/oas-utils@0.6.2
-  - @scalar/sidebar@0.2.2
-  - @scalar/components@0.16.2
-  - @scalar/import@0.4.33
-  - @scalar/object-utils@1.2.10
-  - @scalar/postman-to-openapi@0.3.43
-  - @scalar/use-codemirror@0.12.46
-
 ## 2.9.1
 
 ### Patch Changes

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -18,7 +18,7 @@
     "rest",
     "testing"
   ],
-  "version": "2.10.0",
+  "version": "2.9.1",
   "engines": {
     "node": ">=20"
   },

--- a/packages/api-reference-react/CHANGELOG.md
+++ b/packages/api-reference-react/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/api-reference-react
 
-## 0.8.4
-
-### Patch Changes
-
-- [#7241](https://github.com/scalar/scalar/pull/7241) [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d) Thanks [@hanspagel](https://github.com/hanspagel)! - chore: use "current" not "latest" scalar registry url
-
-- Updated dependencies [[`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/api-reference@1.39.2
-
 ## 0.8.3
 
 ### Patch Changes

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -18,7 +18,7 @@
     "testing",
     "react"
   ],
-  "version": "0.8.4",
+  "version": "0.8.3",
   "engines": {
     "node": ">=20"
   },

--- a/packages/api-reference/CHANGELOG.md
+++ b/packages/api-reference/CHANGELOG.md
@@ -1,22 +1,5 @@
 # @scalar/api-reference
 
-## 1.39.2
-
-### Patch Changes
-
-- [#7241](https://github.com/scalar/scalar/pull/7241) [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d) Thanks [@hanspagel](https://github.com/hanspagel)! - chore: use "current" not "latest" scalar registry url
-
-- Updated dependencies [[`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`d6154a2`](https://github.com/scalar/scalar/commit/d6154a24d97fc28977def486f99b2eeee52d268c), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/json-magic@0.8.0
-  - @scalar/workspace-store@0.19.0
-  - @scalar/api-client@2.10.0
-  - @scalar/helpers@0.1.0
-  - @scalar/openapi-parser@0.23.1
-  - @scalar/oas-utils@0.6.2
-  - @scalar/sidebar@0.2.2
-  - @scalar/components@0.16.2
-  - @scalar/object-utils@1.2.10
-
 ## 1.39.1
 
 ### Patch Changes

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -20,7 +20,7 @@
     "vue",
     "vue3"
   ],
-  "version": "1.39.2",
+  "version": "1.39.1",
   "engines": {
     "node": ">=20"
   },

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/components
 
-## 0.16.2
-
-### Patch Changes
-
-- Updated dependencies [[`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/helpers@0.1.0
-  - @scalar/oas-utils@0.6.2
-
 ## 0.16.1
 
 ### Patch Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/components"
   },
-  "version": "0.16.2",
+  "version": "0.16.1",
   "engines": {
     "node": ">=20"
   },

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @scalar/core
 
-## 0.3.22
-
-### Patch Changes
-
-- [#7241](https://github.com/scalar/scalar/pull/7241) [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d) Thanks [@hanspagel](https://github.com/hanspagel)! - chore: use "current" not "latest" scalar registry url
-
 ## 0.3.21
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/core"
   },
   "keywords": [],
-  "version": "0.3.22",
+  "version": "0.3.21",
   "engines": {
     "node": ">=20"
   },

--- a/packages/galaxy/CHANGELOG.md
+++ b/packages/galaxy/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @scalar/galaxy
 
-## 0.5.10
-
-### Patch Changes
-
-- [#7241](https://github.com/scalar/scalar/pull/7241) [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d) Thanks [@hanspagel](https://github.com/hanspagel)! - chore: use "current" not "latest" scalar registry url
-
 ## 0.5.9
 
 ### Patch Changes

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -16,7 +16,7 @@
     "swagger",
     "petstore"
   ],
-  "version": "0.5.10",
+  "version": "0.5.9",
   "engines": {
     "node": ">=20"
   },

--- a/packages/helpers/CHANGELOG.md
+++ b/packages/helpers/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/helpers
 
-## 0.1.0
-
-### Minor Changes
-
-- [#7235](https://github.com/scalar/scalar/pull/7235) [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66) Thanks [@marcalexiei](https://github.com/marcalexiei)! - feat(helpers): add `node:path` polyfill
-
-### Patch Changes
-
-- [#7266](https://github.com/scalar/scalar/pull/7266) [`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d) Thanks [@amritk](https://github.com/amritk)! - fix: remove useage of crypto.subtle in all contexts
-
 ## 0.0.13
 
 ### Patch Changes

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -14,7 +14,7 @@
     "helpers",
     "js"
   ],
-  "version": "0.1.0",
+  "version": "0.0.13",
   "engines": {
     "node": ">=20"
   },

--- a/packages/import/CHANGELOG.md
+++ b/packages/import/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/import
 
-## 0.4.33
-
-### Patch Changes
-
-- Updated dependencies [[`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/helpers@0.1.0
-  - @scalar/openapi-parser@0.23.1
-
 ## 0.4.32
 
 ### Patch Changes

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -16,7 +16,7 @@
     "postman",
     "scalar"
   ],
-  "version": "0.4.33",
+  "version": "0.4.32",
   "engines": {
     "node": ">=20"
   },

--- a/packages/json-magic/CHANGELOG.md
+++ b/packages/json-magic/CHANGELOG.md
@@ -1,18 +1,5 @@
 # @scalar/json-magic
 
-## 0.8.0
-
-### Minor Changes
-
-- [#7235](https://github.com/scalar/scalar/pull/7235) [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66) Thanks [@marcalexiei](https://github.com/marcalexiei)! - feat(json-magic): use `@scalar/helpers/node/path` polyfill
-
-### Patch Changes
-
-- [#7266](https://github.com/scalar/scalar/pull/7266) [`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d) Thanks [@amritk](https://github.com/amritk)! - fix: remove useage of crypto.subtle in all contexts
-
-- Updated dependencies [[`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66)]:
-  - @scalar/helpers@0.1.0
-
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/json-magic/package.json
+++ b/packages/json-magic/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/json-magic"
   },
-  "version": "0.8.0",
+  "version": "0.7.0",
   "engines": {
     "node": ">=20"
   },

--- a/packages/mock-server/CHANGELOG.md
+++ b/packages/mock-server/CHANGELOG.md
@@ -1,20 +1,5 @@
 # @scalar/mock-server
 
-## 0.7.0
-
-### Minor Changes
-
-- [#7247](https://github.com/scalar/scalar/pull/7247) [`a4f862c`](https://github.com/scalar/scalar/commit/a4f862c73ee509579c96ab86c703e8af74d8efcf) Thanks [@hanspagel](https://github.com/hanspagel)! - feat: use `document`, not `specification` for the configuration
-
-### Patch Changes
-
-- [#7247](https://github.com/scalar/scalar/pull/7247) [`a4f862c`](https://github.com/scalar/scalar/commit/a4f862c73ee509579c96ab86c703e8af74d8efcf) Thanks [@hanspagel](https://github.com/hanspagel)! - fix: fails on 204 No Content responses
-
-- Updated dependencies [[`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/helpers@0.1.0
-  - @scalar/openapi-parser@0.23.1
-  - @scalar/oas-utils@0.6.2
-
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -16,7 +16,7 @@
     "swagger",
     "cli"
   ],
-  "version": "0.7.0",
+  "version": "0.6.1",
   "engines": {
     "node": ">=20"
   },

--- a/packages/nextjs-openapi/CHANGELOG.md
+++ b/packages/nextjs-openapi/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/nextjs-openapi
 
-## 0.2.25
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @scalar/nextjs-api-reference@0.9.1
-
 ## 0.2.24
 
 ### Patch Changes

--- a/packages/nextjs-openapi/package.json
+++ b/packages/nextjs-openapi/package.json
@@ -16,7 +16,7 @@
     "scalar",
     "references"
   ],
-  "version": "0.2.25",
+  "version": "0.2.24",
   "engines": {
     "node": ">=20"
   },

--- a/packages/oas-utils/CHANGELOG.md
+++ b/packages/oas-utils/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @scalar/oas-utils
 
-## 0.6.2
-
-### Patch Changes
-
-- [#7241](https://github.com/scalar/scalar/pull/7241) [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d) Thanks [@hanspagel](https://github.com/hanspagel)! - chore: use "current" not "latest" scalar registry url
-
-- Updated dependencies [[`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`d6154a2`](https://github.com/scalar/scalar/commit/d6154a24d97fc28977def486f99b2eeee52d268c), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66)]:
-  - @scalar/json-magic@0.8.0
-  - @scalar/workspace-store@0.19.0
-  - @scalar/helpers@0.1.0
-  - @scalar/object-utils@1.2.10
-
 ## 0.6.1
 
 ### Patch Changes

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -16,7 +16,7 @@
     "specification",
     "yaml"
   ],
-  "version": "0.6.2",
+  "version": "0.6.1",
   "engines": {
     "node": ">=20"
   },

--- a/packages/object-utils/CHANGELOG.md
+++ b/packages/object-utils/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/object-utils
 
-## 1.2.10
-
-### Patch Changes
-
-- Updated dependencies [[`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66)]:
-  - @scalar/helpers@0.1.0
-
 ## 1.2.9
 
 ### Patch Changes

--- a/packages/object-utils/package.json
+++ b/packages/object-utils/package.json
@@ -13,7 +13,7 @@
   "keywords": [
     "typescript object transforms"
   ],
-  "version": "1.2.10",
+  "version": "1.2.9",
   "engines": {
     "node": ">=20"
   },

--- a/packages/openapi-parser/CHANGELOG.md
+++ b/packages/openapi-parser/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @scalar/openapi-parser
 
-## 0.23.1
-
-### Patch Changes
-
-- [#7235](https://github.com/scalar/scalar/pull/7235) [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66) Thanks [@marcalexiei](https://github.com/marcalexiei)! - fix(openapi-parser): use `node:path` instead of polyfill
-
-- [#7241](https://github.com/scalar/scalar/pull/7241) [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d) Thanks [@hanspagel](https://github.com/hanspagel)! - chore: use "current" not "latest" scalar registry url
-
-- Updated dependencies [[`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d)]:
-  - @scalar/json-magic@0.8.0
-
 ## 0.23.0
 
 ### Minor Changes

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -17,7 +17,7 @@
     "parser",
     "typescript"
   ],
-  "version": "0.23.1",
+  "version": "0.23.0",
   "engines": {
     "node": ">=20"
   },

--- a/packages/openapi-to-markdown/CHANGELOG.md
+++ b/packages/openapi-to-markdown/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/openapi-to-markdown
 
-## 0.3.2
-
-### Patch Changes
-
-- Updated dependencies [[`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/helpers@0.1.0
-  - @scalar/openapi-parser@0.23.1
-  - @scalar/oas-utils@0.6.2
-  - @scalar/components@0.16.2
-
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/openapi-to-markdown/package.json
+++ b/packages/openapi-to-markdown/package.json
@@ -16,7 +16,7 @@
     "llm",
     "swagger"
   ],
-  "version": "0.3.2",
+  "version": "0.3.1",
   "engines": {
     "node": ">=20"
   },

--- a/packages/postman-to-openapi/CHANGELOG.md
+++ b/packages/postman-to-openapi/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/postman-to-openapi
 
-## 0.3.43
-
-### Patch Changes
-
-- Updated dependencies [[`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/helpers@0.1.0
-  - @scalar/oas-utils@0.6.2
-
 ## 0.3.42
 
 ### Patch Changes

--- a/packages/postman-to-openapi/package.json
+++ b/packages/postman-to-openapi/package.json
@@ -19,7 +19,7 @@
     "export",
     "scalar"
   ],
-  "version": "0.3.43",
+  "version": "0.3.42",
   "engines": {
     "node": ">=20"
   },

--- a/packages/pre-post-request-scripts/CHANGELOG.md
+++ b/packages/pre-post-request-scripts/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/scripts
 
-## 0.0.46
-
-### Patch Changes
-
-- Updated dependencies [[`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/oas-utils@0.6.2
-  - @scalar/components@0.16.2
-
 ## 0.0.45
 
 ### Patch Changes

--- a/packages/pre-post-request-scripts/package.json
+++ b/packages/pre-post-request-scripts/package.json
@@ -19,7 +19,7 @@
     "post-response scripts",
     "api client"
   ],
-  "version": "0.0.46",
+  "version": "0.0.45",
   "private": true,
   "engines": {
     "node": ">=18"

--- a/packages/sidebar/CHANGELOG.md
+++ b/packages/sidebar/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/sidebar
 
-## 0.2.2
-
-### Patch Changes
-
-- Updated dependencies [[`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`d6154a2`](https://github.com/scalar/scalar/commit/d6154a24d97fc28977def486f99b2eeee52d268c), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66)]:
-  - @scalar/workspace-store@0.19.0
-  - @scalar/helpers@0.1.0
-  - @scalar/components@0.16.2
-
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/sidebar/package.json
+++ b/packages/sidebar/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/sidebar"
   },
-  "version": "0.2.2",
+  "version": "0.2.1",
   "engines": {
     "node": ">=20"
   },

--- a/packages/use-codemirror/CHANGELOG.md
+++ b/packages/use-codemirror/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/use-codemirror
 
-## 0.12.46
-
-### Patch Changes
-
-- Updated dependencies []:
-  - @scalar/components@0.16.2
-
 ## 0.12.45
 
 ### Patch Changes

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -16,7 +16,7 @@
     "vue",
     "vue3"
   ],
-  "version": "0.12.46",
+  "version": "0.12.45",
   "engines": {
     "node": ">=20"
   },

--- a/packages/void-server/CHANGELOG.md
+++ b/packages/void-server/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @scalar/void-server
 
-## 2.2.8
-
-### Patch Changes
-
-- Updated dependencies [[`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66)]:
-  - @scalar/helpers@0.1.0
-
 ## 2.2.7
 
 ### Patch Changes

--- a/packages/void-server/package.json
+++ b/packages/void-server/package.json
@@ -15,7 +15,7 @@
     "http testing",
     "hono"
   ],
-  "version": "2.2.8",
+  "version": "2.2.7",
   "engines": {
     "node": ">=20"
   },

--- a/packages/workspace-store/CHANGELOG.md
+++ b/packages/workspace-store/CHANGELOG.md
@@ -1,19 +1,5 @@
 # @scalar/workspace-store
 
-## 0.19.0
-
-### Minor Changes
-
-- [#7251](https://github.com/scalar/scalar/pull/7251) [`d6154a2`](https://github.com/scalar/scalar/commit/d6154a24d97fc28977def486f99b2eeee52d268c) Thanks [@DemonHa](https://github.com/DemonHa)! - feat: integrate operation page mutators
-
-### Patch Changes
-
-- [#7266](https://github.com/scalar/scalar/pull/7266) [`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d) Thanks [@amritk](https://github.com/amritk)! - fix: remove useage of crypto.subtle in all contexts
-
-- Updated dependencies [[`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66), [`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`c1ecd0c`](https://github.com/scalar/scalar/commit/c1ecd0c6096f3fbe2e3d8ad3794ea718bb6bce66)]:
-  - @scalar/json-magic@0.8.0
-  - @scalar/helpers@0.1.0
-
 ## 0.18.1
 
 ### Patch Changes

--- a/packages/workspace-store/package.json
+++ b/packages/workspace-store/package.json
@@ -16,7 +16,7 @@
     "openapi",
     "scalar"
   ],
-  "version": "0.19.0",
+  "version": "0.18.1",
   "engines": {
     "node": ">=18"
   },

--- a/projects/scalar-app/CHANGELOG.md
+++ b/projects/scalar-app/CHANGELOG.md
@@ -1,14 +1,5 @@
 # scalar-app
 
-## 0.1.242
-
-### Patch Changes
-
-- Updated dependencies [[`fddf294`](https://github.com/scalar/scalar/commit/fddf294b00dd8c9eb5c713c338f2ec6e3f62523d), [`d6154a2`](https://github.com/scalar/scalar/commit/d6154a24d97fc28977def486f99b2eeee52d268c), [`2377b76`](https://github.com/scalar/scalar/commit/2377b76d050f8de70037b17a32d0dd1181d3311d)]:
-  - @scalar/api-client@2.10.0
-  - @scalar/components@0.16.2
-  - @scalar/import@0.4.33
-
 ## 0.1.241
 
 ### Patch Changes

--- a/projects/scalar-app/package.json
+++ b/projects/scalar-app/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "projects/scalar-app"
   },
-  "version": "0.1.242",
+  "version": "0.1.241",
   "private": true,
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
EDIT: Forget that! What happened: The type check randomly failed, the publish was stopped. The next commit in main passed and the publish went through then. Situation normal: all … good.

<img width="1326" height="498" alt="image" src="https://github.com/user-attachments/assets/9ca24dfc-68bd-4d26-96aa-8a76a75dc183" />


The last release didn’t go through, for some reason the type check failed just for the release commit.

Let’s replay the release.

Reverts scalar/scalar#7268

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the last release by rolling back package versions and changelog entries across the repo and re-adding changesets for pending fixes/features.
> 
> - **Release Revert**:
>   - Roll back versions in many `package.json` files across integrations and packages.
>   - Remove the latest entries from numerous `CHANGELOG.md` files.
> - **Changesets Added**:
>   - `fix(fastify)`: remove empty `customTheme`.
>   - `@scalar/mock-server`: fix 204 No Content handling; config now uses `document` over `specification`.
>   - `@scalar/json-magic`: use `@scalar/helpers/node/path` polyfill.
>   - `@scalar/helpers`: add `node:path` polyfill.
>   - Fix: remove usage of `crypto.subtle` across packages.
>   - Chore: use "current" (not "latest") Scalar registry URL.
>   - `openapi-parser`: use `node:path` instead of polyfill.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f16cd8c5ef76b4bd41fbfad393e808b91aa901b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->