### PR TITLE
docs(docusaurus): Improve wording for multiple API references

### DIFF
--- a/documentation/integrations/docusaurus.md
+++ b/documentation/integrations/docusaurus.md
@@ -38,7 +38,7 @@ Is it possible to show multiple API references? Yes, it is! :)
 
 You can either display each API reference in its own page, or display multiple API references on a single page. 
 
-**Create a page for each API reference:**
+#### Create a page for each API reference
 
 ```ts
 import type { ScalarOptions } from '@scalar/docusaurus'
@@ -75,7 +75,7 @@ plugins: [
 ],
 ```
 
-**Create a page that contains multiple API references**
+#### Create a page that contains multiple API references
 
 ```ts
 import type { ScalarOptions } from '@scalar/docusaurus'


### PR DESCRIPTION
**Problem**
Using the word 'header' is less clear then just saying 'page', the structure for the doc was also not the best.

**Solution**
Use better wording and structure

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've updated the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the Docusaurus docs to clarify handling multiple API references, splitting into per-page and single-page approaches with updated code examples.
> 
> - **Documentation (Docusaurus integration)**
>   - **Wording/structure**: Rename “Multiple API descriptions” to “Multiple API references” and split guidance into two approaches: per-page and single-page.
>   - **Per-page approach**: Show multiple plugin instances, each with its own `id`, `label`, `route`, and `configuration.url`.
>   - **Single-page approach**: Demonstrate using `configuration.sources` with multiple entries (each with `title` and `url`) under one `id/route`.
>   - **Examples**: Update example URLs (use `format=json`) and add titles for sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3fa018f6fc381cb3573099da41ba3743e40a783. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->