### PR TITLE
chore(CODEOWNERS): add xC0dex as code owner for java and docker

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,13 +20,13 @@
 # Packages
 /integrations/django-ninja @marclave
 /integrations/docusaurus @amritk @marclave
-/integrations/docker @hanspagel @xC0dex
+/integrations/docker @marclave @hanspagel @xC0dex
 /integrations/dotnet @marclave @hanspagel @xC0dex
 /integrations/express @hanspagel @marclave
 /integrations/fastapi @marclave
 /integrations/fastify @hanspagel @marclave
 /integrations/hono @hanspagel @marclave
-/integrations/java @hanspagel @xC0dex
+/integrations/java @marclave @hanspagel @xC0dex
 /integrations/nestjs @marclave
 /integrations/nextjs @amritk @marclave
 /integrations/nuxt @amritk @marclave


### PR DESCRIPTION
This PR adds me as code owner for our docker and java integration 👀 

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds @xC0dex as code owner for `/integrations/docker` and `/integrations/java`, and groups `/.github/renovate.json` under a dedicated Renovate section.
> 
> - **CODEOWNERS**:
>   - Add `@xC0dex` to ` /integrations/docker` and `/integrations/java`.
>   - Move `/.github/renovate.json` under a new **Renovate** section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51e0d2bdad04d17820d800cd4ed62808b27e0a3e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->