### PR TITLE
docs: add gin-openapi

### DIFF
--- a/documentation/integrations/go.md
+++ b/documentation/integrations/go.md
@@ -1,8 +1,28 @@
 # Scalar API Reference for Go
 
-- [go-scalar-api-reference](https://github.com/MarceloPetrucio/go-scalar-api-reference/) by [@MarceloPetrucio](https://github.com/MarceloPetrucio/) offers a convenient way to generate API references in Go
-- [scalar-go](https://github.com/bdpiprava/scalar-go) by [@bdpiprava](https://github.com/bdpiprava)
-  - Offers a convenient way to generate the API references in Go for microservices.
-  - Allows [splitting](https://github.com/bdpiprava/scalar-go/tree/main/data/loader-multiple-files) big OpenAPI documents into smaller files for schemas and paths.
-  - Supports [xTagGroups](https://github.com/bdpiprava/scalar-go/tree/main/data/xTagGroups)
-- [gofiber-scalar](https://github.com/yokeTH/gofiber-scalar) bt [@yokeTH](https://github.com/yokeTH) offers the middleware for gofiber
+## go-scalar-api-reference
+
+Generate API references in Go
+
+https://github.com/MarceloPetrucio/go-scalar-api-reference/
+
+## scalar-go
+
+Generate API references in Go for microservices
+
+- Supports [splitting](https://github.com/bdpiprava/scalar-go/tree/main/data/loader-multiple-files) big OpenAPI documents into smaller files
+- Supports [xTagGroups](https://github.com/bdpiprava/scalar-go/tree/main/data/xTagGroups)
+
+https://github.com/bdpiprava/scalar-go
+
+## gofiber-scalar
+
+GoFiber middleware for serving Scalar
+
+https://github.com/yokeTH/gofiber-scalar
+
+## gin-openapi
+
+Gin middleware to render OpenAPI Documents with Scalar
+
+https://github.com/PeterTakahashi/gin-openapi


### PR DESCRIPTION
This PR adds https://github.com/PeterTakahashi/gin-openapi

Thanks @PeterTakahashi! :)

I’ve also updated the whole Go page streamline the listing of the various options a bit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds the gin-openapi integration and restructures the Go integrations page into clear sections with descriptions, features, and links.
> 
> - **Documentation**:
>   - **Go integrations** (`documentation/integrations/go.md`):
>     - Add `gin-openapi` section with description and link.
>     - Restructure existing entries into dedicated sections: `go-scalar-api-reference`, `scalar-go`, `gofiber-scalar`.
>     - Add concise descriptions and feature bullets for `scalar-go` (splitting and xTagGroups).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 104d535f0dede6bed9f43272d81787be00081c42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->