### PR TITLE
docs(configuration): update header level for showOperationId section

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -534,7 +534,7 @@ Whether to show the dark mode toggle.
 }
 ```
 
-### showOperationId
+#### showOperationId
 
 **Type:** `boolean`
 


### PR DESCRIPTION
The title says everything. 👀 


**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the `showOperationId` section heading from H3 to H4 in the configuration documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86bf8d88c4311801482835cca2aa2676484a298f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->