### PR TITLE
ci(build): avoid executing `Upload webpack stats to RelativeCI` step in forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           name: scalar-js
           path: temp-artifacts/scalar.js
           retention-days: 3
-      - if: github.event.pull_request.head.repo.full_name == github.repository && matrix.node-version == 22
+      - if: matrix.node-version == 22 && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false))
         name: Upload webpack stats to RelativeCI
         uses: relative-ci/agent-action@1707825cbfcc7452b2913d273414705415ae64d4 # v3
         with:


### PR DESCRIPTION
**Problem**

Coming from https://github.com/scalar/scalar/pull/7337

CI `build` step fails with an error due to a missing `key` in `relative-ci/agent-action` invocation:

```text
[dotenv@17.2.1] injecting env (0) from .env -- tip: 🔐 prevent committing .env to code: https://dotenvx.com/precommit
fatal: bad object ee10b33b7534fb14e353b530acaaef75a9244a49
Faild to read the commit message from git: Command failed: git show -s --format=%B ee10b33b7534fb14e353b530acaaef75a9244a49
fatal: bad object ee10b33b7534fb14e353b530acaaef75a9244a49

[dotenv@17.2.1] injecting env (0) from .env -- tip: ⚙️  override existing env vars with { override: true }
[dotenv@17.2.1] injecting env (0) from .env -- tip: ⚙️  specify custom .env file path with { path: '/custom/path/.env' }
Error: Error: "key" parameter is missing, make sure to set RELATIVE_CI_KEY environment variable! Read more about RelativeCI agent setup at https://relative-ci.com/documentation/setup.
```

https://github.com/scalar/scalar/actions/runs/19286763772/job/55149096468

**Solution**

relativeCI `key` is read from `secrets`, so  the value is not available from forks.
~~To avoid errors execute `Upload webpack stats to RelativeCI` step only when repository owner is `scalar`~~
[Cursor knows best 😅](https://github.com/scalar/scalar/pull/7338#pullrequestreview-3451473388)

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`) (Not needed).
- [x] I've added tests for the regression or new feature (Not needed).
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gate the `Upload webpack stats to RelativeCI` step to only run on pushes and PRs from the same repo (not forks).
> 
> - **CI workflow (`.github/workflows/ci.yml`)**:
>   - Tighten condition for `Upload webpack stats to RelativeCI` step in `build` job to run only on `push` events or `pull_request` events where `github.event.pull_request.head.repo.fork == false` (avoids running on forks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 971636bd786a7a5810abe4c11b609e709eb6bb75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->