### PR TITLE
docs(api-reference-react): update react getting started docs

### DIFF
--- a/documentation/integrations/react.md
+++ b/documentation/integrations/react.md
@@ -105,25 +105,25 @@ Cool, you've got your (existing) React project and want to render an API referen
 pnpm add @scalar/api-reference-react
 ```
 
-And then, add a new component or just replace the `App.jsx` with the following content:
+And then, add a new component or just replace the `main.jsx` with the following content:
 
 ```jsx
-// src/App.jsx
-import { ApiReferenceReact } from '@scalar/api-reference-react'
+// src/main.jsx
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
 
+import { ApiReferenceReact } from '@scalar/api-reference-react'
 import '@scalar/api-reference-react/style.css'
 
-function App() {
-  return (
+createRoot(document.getElementById('root')).render(
+  <StrictMode>
     <ApiReferenceReact
       configuration={{
         url: 'https://registry.scalar.com/@scalar/apis/galaxy?format=yaml',
       }}
     />
-  )
-}
-
-export default App
+  </StrictMode>,
+)
 ```
 
 Open <http://localhost:5173/> and you should see your API reference. Done!


### PR DESCRIPTION
Because of a change in the Vite React starter template our instructions created a broken app. Specifically the started added some global CSS which breaks our app.

Rather than add complicated instructions I just made it so you overwrite into `main.jsx` (which is where the bad css is being imported) instead of `App.jsx`. I figure if anyone needs it in another component they can modify the project themselves.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
