### PR TITLE
refactor(turbo): rename globalEnv  and simplify task dependencies

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/turbo/schema.json",
-  "globalEnv": ["GOCACHE", "LOCALAPPDATA", "REMOTE_CONTAINERS"],
+  "globalPassThroughEnv": ["GOCACHE", "LOCALAPPDATA", "REMOTE_CONTAINERS"],
   "ui": "tui",
   "tasks": {
     "lint:fix": {},
@@ -9,12 +9,10 @@
       "dependsOn": ["^build"]
     },
     "types:check": {
-      "dependsOn": ["^build"],
-      "cache": true
+      "dependsOn": ["build"]
     },
     "types:build": {
-      "dependsOn": ["^build"],
-      "cache": true
+      "dependsOn": ["build"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
**Problem**

The `types:check` and `types:build` tasks use `^build` in their `dependsOn` configuration, which means they wait for the build task to complete in all upstream dependencies before running. This is inefficient because type checking and type building only require the current package to be built, not all of its dependencies.


**Solution**

Changed the `dependsOn` configuration for `types:check` and `types:build` from `^build` to `build`. This ensures these tasks only wait for the build task in the current package, not in upstream dependencies. We also removed the `cache` entry because the default is `true`.

`globalEnv` has an impact on the file hashes, which could result in rebuilding packages. `globalPassThroughEnv` just forwards the variables without having an impact on the hashes.


**Context**
https://turborepo.com/docs/crafting-your-repository/configuring-tasks#dependent-tasks-that-can-be-run-in-parallel

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `globalPassThroughEnv` for env passthrough and make `types:*` tasks depend on local `build`, removing explicit cache flags.
> 
> - **Turbo config**:
>   - Rename `globalEnv` to `globalPassThroughEnv` to forward `GOCACHE`, `LOCALAPPDATA`, `REMOTE_CONTAINERS` without affecting hashing.
> - **Tasks**:
>   - Change `types:check` and `types:build` `dependsOn` from `^build` to `build`.
>   - Remove explicit `cache: true` entries for these type tasks (defaults applied).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f6b38f14b1f6eb29ac2e06450540c5cd706c4b3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->