### PR TITLE
ci: use stickydisk delete

### DIFF
--- a/.github/workflows/blacksmith-cleanup.yml
+++ b/.github/workflows/blacksmith-cleanup.yml
@@ -11,14 +11,9 @@ jobs:
     strategy:
       matrix:
         node-version: [22]
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - name: Attach sticky disk
-        uses: useblacksmith/stickydisk@a652394bf1bf95399f406e648482b41fbd25c51f # v1
+        uses: useblacksmith/stickydisk-delete@b41313d28b8647d72114c9ba3c96bb04061562b6 # v1
         with:
-          key: ${{ github.repository }}-${{ matrix.node-version }}-turbo-cache
-          path: /
-      - name: Check
-        run: echo Removing on ${{ matrix.node-version }}
-      - name: Cleanup Turbo Cache
-        run: rm -rf *
+          delete-key: ${{ github.repository }}-${{ matrix.node-version }}-turbo-cache


### PR DESCRIPTION
Blacksmith has a custom action for deleting a stickydisk. Let's use this one instead of manually removing folders.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace manual turbo cache cleanup with `stickydisk-delete` action and reduce workflow timeout to 5 minutes.
> 
> - **CI/CD**:
>   - Update `/.github/workflows/blacksmith-cleanup.yml`:
>     - Switch from `useblacksmith/stickydisk` to `useblacksmith/stickydisk-delete` with `delete-key` for turbo cache removal.
>     - Remove manual cleanup steps (`rm -rf *`) and unused inputs.
>     - Reduce `timeout-minutes` from `10` to `5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49dbc0761f741ca96fb4bb940e6c0990e9510b93. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->