### PR TITLE
chore(prettier): exclude target directories

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -22,6 +22,7 @@
 **/.docusaurus/**
 **/obj/**
 **/bin/**
+**/target/**
 integrations/docker/assets/**
 
 **/vite.config.ts.timestamp-*.mjs

--- a/biome.json
+++ b/biome.json
@@ -38,7 +38,7 @@
       "!**/packages/openapi-parser/tests/openapi3-examples/**/*.{yml,yaml,json}",
       "!integrations/**/scalar.js",
       "!integrations/**/standalone.js",
-      "!**/rust/**/target"
+      "!**/target/**"
     ]
   },
   "assist": {


### PR DESCRIPTION
**Problem**

Currently, some  files generated by Maven are formatted.

**Solution**

With this PR, we exclude all `target/**` folders. This is the same pattern that turbo uses for caching.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude all `target/**` directories from Prettier and Biome processing.
> 
> - **Config**:
>   - **Prettier**: Add `**/target/**` to `.prettierignore`.
>   - **Biome**: Broaden ignore pattern from `!**/rust/**/target` to `!**/target/**` in `biome.json` to exclude all `target` dirs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7e117d6b9852df1df7e1aa1ca3099bc3e4e3f33. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->