### PR TITLE
ci(renovate): minor improvements

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -245,9 +245,15 @@
     },
 
     {
-      "description": "Global dependencies",
-      "matchFileNames": ["package.json", "pnpm-workspace.yaml"],
-      "additionalBranchPrefix": "global"
+      "description": "Workspace Dependencies",
+      "matchFileNames": ["pnpm-workspace.yaml"],
+      "additionalBranchPrefix": "workspace"
+    },
+
+    {
+      "description": "Root Dependencies",
+      "matchFileNames": ["package.json"],
+      "additionalBranchPrefix": "root"
     },
 
     {
@@ -390,6 +396,12 @@
       "matchPackageNames": ["Aspire.Hosting"],
       "matchUpdateTypes": ["patch"],
       "enabled": false
+    },
+
+    {
+      "description": "Allow unstable updates for Aspire.Hosting.Docker and Aspire.Hosting.Keycloak since no stable packages exist yet",
+      "matchPackageNames": ["Aspire.Hosting.Docker", "Aspire.Hosting.Keycloak"],
+      "ignoreUnstable": false
     },
 
     {


### PR DESCRIPTION
See Cursor summary.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines Renovate rules by splitting global dependency scope into separate workspace/root rules and permitting unstable updates for Aspire.Hosting.Docker/Keycloak.
> 
> - **Renovate configuration**:
>   - Split former `Global dependencies` rule into:
>     - `Workspace Dependencies`: matches `pnpm-workspace.yaml`, branch prefix `workspace`.
>     - `Root Dependencies`: matches `package.json`, branch prefix `root`.
>   - Enable unstable updates for `Aspire.Hosting.Docker` and `Aspire.Hosting.Keycloak` (`ignoreUnstable: false`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7de634ff7b9a0220ae5242ec011338f24f8c2521. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->