### PR TITLE
docs(configuration): auto-generate hiddenClients section

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -616,18 +616,61 @@ Pass an array of individual clients to hide just those clients:
 
 Here's a list of all clients that you can potentially hide:
 
+<!-- AUTO-GENERATED:CLIENTS START -->
+<!-- This section is automatically generated. Do not edit manually. -->
+<!-- Source: packages/snippetz/src/clients/index.ts -->
+<!-- Generator: packages/snippetz/scripts/generate-markdown-docs.ts -->
+
 ```js
 {
-  hiddenClients: [
-    'libcurl', 'clj_http', 'httpclient', 'restsharp', 'native', 'http1.1',
-    'asynchttp', 'nethttp', 'okhttp', 'unirest', 'xhr', 'axios', 'fetch',
-    'jquery', 'okhttp', 'native', 'request', 'unirest', 'axios', 'fetch',
-    'nsurlsession', 'cohttp', 'curl', 'guzzle', 'http1', 'http2',
-    'webrequest', 'restmethod', 'python3', 'requests', 'httr', 'native',
-    'curl', 'httpie', 'wget', 'nsurlsession', 'undici'
-  ],
+  hiddenClients: {
+    // C
+    c: ['libcurl'],
+    // Clojure
+    clojure: ['clj_http'],
+    // C#
+    csharp: ['httpclient', 'restsharp'],
+    // Dart
+    dart: ['http'],
+    // F#
+    fsharp: ['httpclient'],
+    // Go
+    go: ['native'],
+    // HTTP
+    http: ['http1.1'],
+    // Java
+    java: ['asynchttp', 'nethttp', 'okhttp', 'unirest'],
+    // JavaScript
+    js: ['axios', 'fetch', 'jquery', 'ofetch', 'xhr'],
+    // Kotlin
+    kotlin: ['okhttp'],
+    // Node.js
+    node: ['axios', 'fetch', 'ofetch', 'undici'],
+    // Objective-C
+    objc: ['nsurlsession'],
+    // OCaml
+    ocaml: ['cohttp'],
+    // PHP
+    php: ['curl', 'guzzle'],
+    // PowerShell
+    powershell: ['restmethod', 'webrequest'],
+    // Python
+    python: ['httpx_async', 'httpx_sync', 'python3', 'requests'],
+    // R
+    r: ['httr'],
+    // Ruby
+    ruby: ['native'],
+    // Rust
+    rust: ['reqwest'],
+    // Shell
+    shell: ['curl', 'httpie', 'wget'],
+    // Swift
+    swift: ['nsurlsession'],
+  }
 }
 ```
+
+<!-- AUTO-GENERATED:CLIENTS END -->
 
 But you can also pass `true` to **hide all** HTTP clients. If you have any custom code examples (`x-scalar-examples`) in your API definition, these still render:
 

--- a/packages/snippetz/package.json
+++ b/packages/snippetz/package.json
@@ -17,9 +17,10 @@
     "build": "scalar-build-esbuild",
     "generate:dotnet-enums": "vite-node scripts/generate-dotnet-enums.ts",
     "generate:java-enums": "vite-node scripts/generate-java-enums.ts",
+    "generate:markdown-docs": "vite-node scripts/generate-markdown-docs.ts",
     "lint:check": "scalar-lint-check",
     "lint:fix": "scalar-lint-fix",
-    "postbuild": "pnpm generate:dotnet-enums && pnpm generate:java-enums",
+    "postbuild": "pnpm generate:dotnet-enums && pnpm generate:java-enums && pnpm generate:markdown-docs",
     "test": "vitest",
     "types:build": "scalar-types-build",
     "types:check": "scalar-types-check"

--- a/packages/snippetz/scripts/README.md
+++ b/packages/snippetz/scripts/README.md
@@ -1,6 +1,6 @@
-# Enum Generation Scripts
+# Generation Scripts
 
-Automatically generates language-specific enums from TypeScript clients configuration. These scripts directly import the clients array, ensuring the generated enums stay in perfect sync with the TypeScript source of truth.
+Automatically generates language-specific enums and documentation from TypeScript clients configuration. These scripts directly import the clients array, ensuring the generated files stay in perfect sync with the TypeScript source of truth.
 
 ## Usage
 
@@ -34,6 +34,23 @@ Generates Java enums for the Java integration packages.
 - `ScalarClient.java` - HTTP clients (OkHttp, AsyncHttp, etc.)
 
 Generated in: `integrations/java/webjar/src/main/java/com/scalar/maven/webjar/enums/`
+
+### Markdown Documentation Generation
+
+```bash
+pnpm generate:markdown-docs
+```
+
+Automatically updates the `hiddenClients` property documentation in `configuration.md` with the current list of available clients, grouped by target/language.
+
+#### Generated Content
+
+Updates the `hiddenClients` section in `documentation/configuration.md` with:
+- All available clients grouped by target/language
+- Comments indicating which language each target represents
+- Automatically kept in sync with the TypeScript source
+
+The generated section is marked with HTML comments (`<!-- AUTO-GENERATED:CLIENTS START -->` and `<!-- AUTO-GENERATED:CLIENTS END -->`) to prevent manual edits.
 
 ## Customization
 

--- a/packages/snippetz/scripts/generate-markdown-docs.ts
+++ b/packages/snippetz/scripts/generate-markdown-docs.ts
@@ -1,0 +1,118 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import type { Target } from '@scalar/snippetz'
+import { clients } from '@scalar/snippetz/clients'
+
+/**
+ * Generator script to update the hiddenClients documentation in configuration.md
+ * with the current list of available clients from the TypeScript source.
+ */
+
+const CONFIG_MD_PATH = resolve(__dirname, '../../../documentation/configuration.md')
+const START_MARKER = '<!-- AUTO-GENERATED:CLIENTS START -->'
+const END_MARKER = '<!-- AUTO-GENERATED:CLIENTS END -->'
+
+/**
+ * Generates the markdown content for the hiddenClients documentation.
+ * Groups clients by target/language with comments.
+ */
+function generateClientsDocumentation(targets: Target[]): string {
+  // Sort targets by key for consistent order
+  const sortedTargets = [...targets].sort((a, b) => a.key.localeCompare(b.key))
+
+  const lines: string[] = []
+  lines.push('```js')
+  lines.push('{')
+  lines.push('  hiddenClients: {')
+
+  for (const target of sortedTargets) {
+    // Sort clients within each target for consistent order
+    const sortedClients = [...target.clients]
+      .sort((a, b) => a.client.localeCompare(b.client))
+      .map((client) => `'${client.client}'`)
+
+    // Add comment with target title
+    lines.push(`    // ${target.title}`)
+    // Add target key with array of clients
+    lines.push(`    ${target.key}: [${sortedClients.join(', ')}],`)
+  }
+
+  lines.push('  }')
+  lines.push('}')
+  lines.push('```')
+
+  return lines.join('\n')
+}
+
+/**
+ * Updates the configuration.md file with the generated documentation.
+ */
+function updateConfigurationMd(): void {
+  try {
+    // Read the current file
+    const content = readFileSync(CONFIG_MD_PATH, 'utf-8')
+
+    // Find the markers
+    const startIndex = content.indexOf(START_MARKER)
+    const endIndex = content.indexOf(END_MARKER)
+
+    if (startIndex === -1 || endIndex === -1) {
+      throw new Error(
+        `Could not find markers in ${CONFIG_MD_PATH}. Make sure both ${START_MARKER} and ${END_MARKER} are present.`,
+      )
+    }
+
+    if (startIndex >= endIndex) {
+      throw new Error(`Start marker appears after end marker in ${CONFIG_MD_PATH}`)
+    }
+
+    // Parse clients from import
+    const sortedTargets = [...clients].sort((a, b) => a.key.localeCompare(b.key))
+
+    // Generate the new content
+    const generatedContent = generateClientsDocumentation(sortedTargets)
+
+    // Build the new section with markers and comments
+    const newSection = [
+      START_MARKER,
+      '<!-- This section is automatically generated. Do not edit manually. -->',
+      '<!-- Source: packages/snippetz/src/clients/index.ts -->',
+      '<!-- Generator: packages/snippetz/scripts/generate-markdown-docs.ts -->',
+      '',
+      generatedContent,
+      '',
+      END_MARKER,
+    ].join('\n')
+
+    // Replace the content between markers
+    const before = content.substring(0, startIndex)
+    const after = content.substring(endIndex + END_MARKER.length)
+
+    const newContent = before + newSection + after
+
+    // Write the updated file
+    writeFileSync(CONFIG_MD_PATH, newContent, 'utf-8')
+
+    console.log(`Successfully updated ${CONFIG_MD_PATH}`)
+    console.log(`Generated documentation for ${sortedTargets.length} targets`)
+  } catch (error) {
+    console.error('Error generating markdown documentation:', error)
+    process.exit(1)
+  }
+}
+
+/**
+ * Main function
+ */
+function main(): void {
+  // Skip generation in CI environments
+  if (process.env.CI) {
+    console.log('Skipping markdown documentation generation in CI environment')
+    return
+  }
+
+  updateConfigurationMd()
+}
+
+main()


### PR DESCRIPTION
**Problem**

Currently, we have to maintain the list of available clients manually in our docs.

**Solution**

With this PR, we automate this by adding a `generate:markdown-docs` script that works the same way as the other generator scripts.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automates the `hiddenClients` docs by adding a generator script and wiring it into build, updating `configuration.md` to the auto-generated format.
> 
> - **Docs**:
>   - Replace manual `hiddenClients` list in `documentation/configuration.md` with an auto-generated, grouped mapping between `<!-- AUTO-GENERATED:CLIENTS START/END -->` markers.
> - **Scripts/Tooling**:
>   - Add `packages/snippetz/scripts/generate-markdown-docs.ts` to generate the `hiddenClients` section from `@scalar/snippetz/clients`.
>   - Document usage in `packages/snippetz/scripts/README.md`.
> - **Build**:
>   - Add `generate:markdown-docs` npm script and include it in `postbuild` in `packages/snippetz/package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 274a7b4ac7624b06921ca53c7a064cf8be8f5b17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->