### PR TITLE
Adds reference to hide all clients

### DIFF
--- a/documentation/integrations/astro.md
+++ b/documentation/integrations/astro.md
@@ -90,3 +90,36 @@ import { ScalarComponent } from '@scalar/astro'
   proxyUrl: 'https://proxy.scalar.com',
 }} />
 ```
+
+### Hide clients
+
+ You can control which code examples are shown by passing an array of clients, to hide the given clients.
+
+```
+{
+  hiddenClients: {
+    c: ['libcurl'],
+    csharp: ['httpclient', 'restsharp'],
+    clojure: ['clj_http'],
+    dart: ['http'],
+    go: ['native'],
+    http: ['http1.1', 'http1', 'http2'],
+    java: ['asynchttp', 'okhttp', 'unirest', 'nethttp'],
+    js: ['xhr', 'fetch', 'axios', 'jquery', 'ofetch', 'request'],
+    kotlin: ['okhttp'],
+    node: ['undici', 'axios', 'fetch', 'ofetch'],
+    objc: ['nsurlsession'],
+    ocaml: ['cohttp'],
+    // Some Scalar builds expose F# separately; hide its HttpClient if present
+    fsharp: ['httpclient'],
+    php: ['curl', 'guzzle'],
+    powershell: ['restmethod', 'webrequest'],
+    python: ['python3', 'requests', 'httpx_sync', 'httpx_async'],
+    r: ['httr'],
+    ruby: ['native'],
+    rust: ['reqwest'],
+    shell: ['httpie', 'wget'],
+    swift: ['nsurlsession'],
+  }
+}
+```


### PR DESCRIPTION
**Problem**

Currently, there are only few examples of the variables that can be passed as per documentation. It also makes it difficult to how to hide paricular code example (client) per  programming language

**Solution**

With this PR, all of them are documented. Since it's well tested on astro integration, I've added the section to this page instead of `configuration.md`

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new "Hide clients" section to the Astro integration docs with a full `hiddenClients` configuration example across languages.
> 
> - **Documentation (Astro integration)**:
>   - **New section: "Hide clients"**
>     - Documents `hiddenClients` configuration for controlling which code example clients are shown.
>     - Provides a comprehensive per-language example list (e.g., `js`, `python`, `java`, `node`, etc.).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10f3b25479727d7aa0b8d53e7b91f681747c0287. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->