### PR TITLE
fix(api-client): use timeouts instead of interval in `use-document-watcher`

### DIFF
--- a/.changeset/tasty-pigs-develop.md
+++ b/.changeset/tasty-pigs-develop.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): use timeouts instead of interval in `use-document-watcher`


### PR DESCRIPTION
**Problem**

https://github.com/scalar/scalar/pull/7349#discussion_r2525971592

I encountered the following error:

```text
Error: TypeError: setTimeout is not a function
```

in these 2 runs:
- https://github.com/scalar/scalar/actions/runs/19353930932/job/55371600469
- https://github.com/scalar/scalar/actions/runs/19353619597/job/55370715844

In `api-client` `vitest` environment is set to `jsdom`. 
I think that, sometimes, there might be conflicts between it and node internal modules.


**Solution**

Switched to `vitest`'s fake timer utilities.  
However, after the change I noticed the test became non-deterministic:  
sometimes the `does exponential backoff on failure` test would call the `fn` 2 or 4 times instead of the expected 3.

I updated the hook to use timeouts instead of intervals, and the test behavior is now stable.

Hopefully this will prevent similar issues in the future 🤞

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces interval-based polling with timeout-based scheduling in `use-document-watcher` and updates tests to use Vitest async fake timers for deterministic behavior.
> 
> - **API Client Hook** (`packages/api-client/src/v2/hooks/use-document-watcher.ts`):
>   - Replace `setInterval` with `setTimeout`-based scheduling (`timer`, `scheduleNext`) to manage a single timer at a time.
>   - Preserve behavior: poll remote, auto-apply remote-side conflict resolutions, and use exponential backoff by doubling `timeout` on failures.
>   - Minor refactor in conflict handling (`conflicts.flatMap(([remote]) => remote)`) and doc comment update.
> - **Tests** (`packages/api-client/src/v2/hooks/use-document-watcher.test.ts`):
>   - Use Vitest async fake timers (`vi.advanceTimersByTimeAsync`, `vi.advanceTimersToNextTimerAsync`) and `nextTick` for deterministic timing.
>   - Remove Node timers dependency; ensure single-timeout behavior and backoff are verified.
> - **Changeset**: Patch release for `@scalar/api-client`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdb83a1e2f8b5ccd7f8c9b5e54960f38b1a37c3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->