### PR TITLE
docs(configuration): no generic reverse proxies

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -835,7 +835,9 @@ You can use our hosted proxy:
 }
 ```
 
-If you like to run your own, check out our [example proxy written in Go](https://github.com/scalar/scalar/tree/main/projects/proxy-scalar-com). Please note: you may not use any reverse proxy, but need to use a proxy that adheres to the 'Scalar proxy' API. See the example for more.
+If you like to run your own, check out our [example proxy written in Go](https://github.com/scalar/scalar/tree/main/projects/proxy-scalar-com).
+
+Please note: You may not use just any reverse proxy, but need to use a proxy that adheres to the Scalar Proxy API. See the example to learn more.
 
 #### searchHotKey
 


### PR DESCRIPTION
**Problem**

Scalar does not support generic proxies. The documentation does not clearly state this, which can lead people down a wrong path and spending time debugging why the `proxyUrl` does not work with a generic reverse proxy.

**Solution**

Document clearly that generic reverse proxies are not supported.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've updated the documentation.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies that `proxyUrl` must point to a proxy implementing the Scalar Proxy API, not a generic reverse proxy.
> 
> - **Docs**: In `documentation/configuration.md`, add note under `proxyUrl` that only proxies adhering to the Scalar Proxy API are supported; generic reverse proxies won't work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74d6b0f58fba7d229fbbfcb2e8d6e3d00bd10283. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->