### PR TITLE
fix(api-client): catch non-JSON example data

### DIFF
--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -485,14 +485,20 @@ const exampleOptions = computed(() => {
 const selectedExample = computed({
   get: () => {
     const rawValue = example.body.raw?.value ?? '{}'
-    const parsedValue = JSON.parse(rawValue)
-    const getExample = exampleOptions.value.find((e) => {
-      const exampleValue = e.value as {
-        value: Record<string, string>
-      }
-      return JSON.stringify(exampleValue.value) === JSON.stringify(parsedValue)
-    })
-    return getExample ?? exampleOptions.value[0]
+    try {
+      const parsedValue = JSON.parse(rawValue)
+      const getExample = exampleOptions.value.find((e) => {
+        const exampleValue = e.value as {
+          value: Record<string, string>
+        }
+        return (
+          JSON.stringify(exampleValue.value) === JSON.stringify(parsedValue)
+        )
+      })
+      return getExample ?? exampleOptions.value[0]
+    } catch {
+      return exampleOptions.value[0]
+    }
   },
   set: (opt) => {
     if (opt?.id) {


### PR DESCRIPTION
Looks like we were assuming a string was JSON and `JSON.parse` was throwing on `xml` content.

@hanspagel @amritk you might have a better way to fix this.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->
