### PR TITLE
test: remove `node:timers/promises` usage

### DIFF
--- a/integrations/hono/src/scalar.test.ts
+++ b/integrations/hono/src/scalar.test.ts
@@ -1,16 +1,18 @@
-import { setTimeout } from 'node:timers/promises'
-
 import { Hono } from 'hono'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { Scalar, apiReference } from './scalar'
+import { Scalar } from './scalar'
 
 type Bindings = {
   SOME_VAR: string
   ENVIRONMENT: string
 }
 
-describe('apiReference', () => {
+describe('Scalar', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('returns HTML with default theme CSS when theme is not provided', async () => {
     const app = new Hono()
     const config = {
@@ -186,7 +188,7 @@ describe('apiReference', () => {
       content: { info: { title: 'Test API' } },
     }
 
-    app.get('/', apiReference(config))
+    app.get('/', Scalar(config))
 
     const response = await app.request('/')
     expect(response.status).toBe(200)
@@ -230,6 +232,8 @@ describe('apiReference', () => {
   })
 
   it('works with config resolver (async)', async () => {
+    vi.useFakeTimers()
+
     const app = new Hono<{ Bindings: Bindings }>()
     // mock env
     app.use('*', (c, next) => {
@@ -239,22 +243,28 @@ describe('apiReference', () => {
 
     const config = { content: { info: { title: 'Test API' } } }
 
-    const getTheme = (): Promise<'deepSpace' | 'laserwave'> => {
-      return setTimeout(100, 'deepSpace')
-    }
-
     app.get(
       '/',
       Scalar<{ Bindings: Bindings }>(async (c) => {
         expect(c.env.SOME_VAR).toBe('SOME_VAR')
         expect(c.env.ENVIRONMENT).toBe('development')
 
-        const theme = await getTheme()
+        const theme = await new Promise<'deepSpace'>((resolve) => {
+          setTimeout(
+            () => resolve('deepSpace'),
+            // advance time by the same amount below
+            100,
+          )
+        })
         return { ...config, theme }
       }),
     )
 
-    const response = await app.request('/')
+    const req = app.request('/')
+    // Same time of handler Promise above
+    vi.advanceTimersByTime(100)
+    const response = await req
+
     expect(response.status).toBe(200)
     expect(response.headers.get('content-type')).toContain('text/html')
     const text = await response.text()

--- a/packages/json-magic/src/bundle/bundle.test.ts
+++ b/packages/json-magic/src/bundle/bundle.test.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'node:crypto'
 import fs from 'node:fs/promises'
-import { setTimeout } from 'node:timers/promises'
 
 import { consoleWarnSpy, resetConsoleSpies } from '@scalar/helpers/testing/console-spies'
 import fastify, { type FastifyInstance } from 'fastify'
@@ -35,7 +34,6 @@ describe('bundle', () => {
 
       return async () => {
         await server.close()
-        await setTimeout(100)
       }
     })
 
@@ -1992,7 +1990,6 @@ describe('bundle', () => {
 
       return async () => {
         await server.close()
-        await setTimeout(100)
       }
     })
 
@@ -2071,7 +2068,6 @@ describe('bundle', () => {
 
       return async () => {
         await server.close()
-        await setTimeout(100)
       }
     })
 

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/index.test.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/index.test.ts
@@ -1,5 +1,3 @@
-import { setTimeout } from 'node:timers/promises'
-
 import { type FastifyInstance, fastify } from 'fastify'
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -16,7 +14,6 @@ describe('fetchUrl', () => {
 
     return async () => {
       await server.close()
-      await setTimeout(100)
     }
   })
 

--- a/packages/json-magic/src/dereference/dereference.test.ts
+++ b/packages/json-magic/src/dereference/dereference.test.ts
@@ -1,7 +1,5 @@
-import { setTimeout } from 'node:timers/promises'
-
 import { type FastifyInstance, fastify } from 'fastify'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { dereference } from '@/dereference/dereference'
 
@@ -68,11 +66,10 @@ describe('dereference', () => {
 
     beforeEach(() => {
       server = fastify({ logger: false })
-    })
 
-    afterEach(async () => {
-      await server.close()
-      await setTimeout(100)
+      return async () => {
+        await server.close()
+      }
     })
 
     it('should dereference JSON pointers asynchronously', async () => {

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -1,5 +1,3 @@
-import { setTimeout } from 'node:timers/promises'
-
 import { consoleErrorSpy, resetConsoleSpies } from '@scalar/helpers/testing/console-spies'
 import { getRaw } from '@scalar/json-magic/magic-proxy'
 import fastify, { type FastifyInstance } from 'fastify'
@@ -69,7 +67,6 @@ describe('create-workspace-store', () => {
 
     return async () => {
       await server.close()
-      await setTimeout(100)
     }
   })
 
@@ -2241,7 +2238,6 @@ describe('create-workspace-store', () => {
 
       return async () => {
         await server.close()
-        await setTimeout(100)
       }
     })
 

--- a/packages/workspace-store/src/plugins/bundler/index.test.ts
+++ b/packages/workspace-store/src/plugins/bundler/index.test.ts
@@ -1,5 +1,3 @@
-import { setTimeout } from 'node:timers/promises'
-
 import { bundle } from '@scalar/json-magic/bundle'
 import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
 import { type FastifyInstance, fastify } from 'fastify'
@@ -117,7 +115,6 @@ describe('plugins', () => {
 
       return async () => {
         await server.close()
-        await setTimeout(100)
       }
     })
 
@@ -160,7 +157,6 @@ describe('plugins', () => {
 
       return async () => {
         await server.close()
-        await setTimeout(100)
       }
     })
 
@@ -236,7 +232,6 @@ describe('plugins', () => {
 
       return async () => {
         await server.close()
-        await setTimeout(100)
       }
     })
 

--- a/packages/workspace-store/src/server.test.ts
+++ b/packages/workspace-store/src/server.test.ts
@@ -1,10 +1,9 @@
 import { randomUUID } from 'node:crypto'
 import fs from 'node:fs/promises'
 import { cwd } from 'node:process'
-import { setTimeout } from 'node:timers/promises'
 
 import { type FastifyInstance, fastify } from 'fastify'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { coerceValue } from '@/schemas/typebox-coerce'
 import { SchemaObjectSchema } from '@/schemas/v3.1/strict/openapi-document'
@@ -403,11 +402,10 @@ describe('create-server-store', () => {
 
       beforeEach(() => {
         server = fastify({ logger: false })
-      })
 
-      afterEach(async () => {
-        await server.close()
-        await setTimeout(100)
+        return async () => {
+          await server.close()
+        }
       })
 
       it('should load a document on the workspace from an external url', async () => {


### PR DESCRIPTION
**Problem**

- Followup of https://github.com/scalar/scalar/pull/7368

**Solution**

Due to the issue experienced in https://github.com/scalar/scalar/pull/7349#discussion_r2525971592 I reviewed all `node:times/promises` usage.

Most of them were only adding a delay after calling `fastify.close()`, 
but since that method already returns a Promise, the extra 100 ms wait was unnecessary.

`integrations/hono/src/scalar.test.ts` `setTimeout` usage has been replaced 
with a callback and is now resolved using fake timers.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`) (Not needed).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `node:timers/promises` from tests, simplifies Fastify teardown, and updates Hono Scalar tests to use fake timers for async config resolution.
> 
> - **Tests**:
>   - **Hono (`integrations/hono/src/scalar.test.ts`)**:
>     - Replace deprecated `apiReference` usage with `Scalar` and update `describe` name.
>     - Add `afterEach` to restore timers; use `vi.useFakeTimers()` and `vi.advanceTimersByTime` for async config resolver.
>   - **Fastify-based tests** (`packages/json-magic/...`, `packages/workspace-store/...`):
>     - Remove `node:timers/promises` `setTimeout` delays after `server.close()`; teardown now just awaits `server.close()`.
>   - **Dereference tests** (`packages/json-magic/src/dereference/dereference.test.ts`):
>     - Consolidate teardown via `beforeEach` returning an async cleanup; remove extra delay.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6541b7a0c43e92c4c4367bbf68388d832b241bfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->