### PR TITLE
chore(global): revert: update dependency astro to v5.15.6 [security]

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,7 +46,7 @@ catalogs:
     '@vueuse/core': 13.9.0
     '@vueuse/integrations': 13.9.0
     ansis: 4.1.0
-    astro: 5.15.6
+    astro: 5.15.3
     chokidar: 4.0.3
     commander: 13.1.0
     concurrently: 9.1.2


### PR DESCRIPTION
Reverts scalar/scalar#7364

docker base build fails

Progress: resolved 210, reused 0, downloaded 210, added 0
/app/integrations/astro/playground:
 ERR_PNPM_NO_MATCHING_VERSION  No matching version found for astro@5.15.6 while fetching it from https://registry.npmjs.org/
This error happened while installing a direct dependency of /app/integrations/astro/playground

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts `astro` in `pnpm-workspace.yaml` catalog from `5.15.6` to `5.15.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2097179a8b586458501fc24070d9ec908691e81b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->