### PR TITLE
fix(snippetz): copy docs to docker to prevent base from breaking

### DIFF
--- a/tooling/base-docker-builder/Dockerfile
+++ b/tooling/base-docker-builder/Dockerfile
@@ -19,6 +19,7 @@ COPY tsconfig.json .
 COPY turbo.json .
 COPY packages ./packages
 COPY integrations ./integrations
+COPY documentation ./documentation
 RUN pnpm install
 RUN pnpm turbo \
   run build \


### PR DESCRIPTION
**Problem**

Currently, our base building is broken

**Solution**

With this PR we just add the docs to the docker image which should fix the issue. The issue actually comes from snippetz as it generates documentation.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [ ] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Copies `documentation/` into the `tooling/base-docker-builder` Docker image to fix builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc123542b1bd04b514315918a7fa4472ac4e12c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->