### PR TITLE
fix(build-tooling): addPackageFileExports - handle fs.stat error using try-catch

### DIFF
--- a/.changeset/warm-news-deny.md
+++ b/.changeset/warm-news-deny.md
@@ -1,0 +1,5 @@
+---
+'@scalar/build-tooling': patch
+---
+
+fix(build-tooling): addPackageFileExports - handle fs.stat error using try-catch

--- a/package.json
+++ b/package.json
@@ -60,18 +60,6 @@
     "renovate:validate": "pnpm dlx --package renovate renovate-config-validator",
     "script": "pnpm --filter @scalar-internal/build-scripts start"
   },
-  "exports": {
-    "./*.css": {
-      "import": "./dist/*.css",
-      "require": "./dist/*.css",
-      "default": "./dist/*.css"
-    },
-    "./css/*.css": {
-      "import": "./dist/css/*.css",
-      "require": "./dist/css/*.css",
-      "default": "./dist/css/*.css"
-    }
-  },
   "remarkConfig": {
     "plugins": [
       "remark-validate-links",

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -21,6 +21,7 @@
     "format": "node scripts/format.js",
     "lint:check": "node scripts/lint-check.js",
     "lint:fix": "node scripts/lint-fix.js",
+    "test": "vitest",
     "types:build": "node scripts/types-build.js",
     "types:check": "node scripts/types-check.js"
   },

--- a/packages/build-tooling/src/helpers.test.ts
+++ b/packages/build-tooling/src/helpers.test.ts
@@ -1,0 +1,173 @@
+import fs from 'node:fs/promises'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { addPackageFileExports } from '../src/helpers'
+
+/**
+ * !!! WARNING !!!
+ *
+ * Mock `readFile` and `writeFile` implementation only once per test.
+ *
+ * Since Vitest uses `node:fs/promises` for file operations
+ * mocking them multiple times can prevent snapshot updates.
+ *
+ * If you need custom values for a mock inside a single test,
+ * you have to reset it first
+ */
+describe('addPackageFileExports', () => {
+  const readFileMock = vi.spyOn(fs, 'readFile')
+  const writeFileMock = vi.spyOn(fs, 'writeFile')
+  const statMock = vi.spyOn(fs, 'stat')
+  const consoleInfoMock = vi.spyOn(console, 'info')
+  const processCwdMock = vi.spyOn(process, 'cwd')
+
+  beforeEach(() => {
+    readFileMock.mockResolvedValueOnce('{ "name": "test" }')
+    writeFileMock.mockResolvedValueOnce(void 0)
+
+    return () => {
+      vi.resetAllMocks()
+    }
+  })
+
+  it('should set `exports` to empty if no entries are provided', async () => {
+    await addPackageFileExports({ entries: [] })
+
+    expect(writeFileMock.mock.lastCall?.at(1)).toMatchInlineSnapshot(`
+      "{
+        "name": "test",
+        "exports": {}
+      }
+      "
+    `)
+  })
+
+  it('should throw if no package json is found within cwd', async () => {
+    statMock.mockRejectedValue(Error('file not found'))
+
+    await expect(() => addPackageFileExports({ entries: ['./src/index.ts'] })).rejects.toThrow(
+      /package.json not found in/,
+    )
+  })
+
+  it('should set `exports` field to `{}` when package had properties and no entries are provided', async () => {
+    readFileMock.mockReset()
+    readFileMock.mockResolvedValueOnce('{ "name": "test", "exports": { ".": "./dist/index.js" } }')
+
+    await addPackageFileExports({ entries: [] })
+
+    expect(writeFileMock.mock.lastCall?.at(1)).toMatchInlineSnapshot(`
+      "{
+        "name": "test",
+        "exports": {}
+      }
+      "
+    `)
+  })
+
+  it('should do nothing if cwd includes `dist`', async () => {
+    processCwdMock.mockReturnValueOnce('something/dist')
+
+    await addPackageFileExports({ entries: ['./src/index.ts'] })
+
+    expect(readFileMock).not.toHaveBeenCalled()
+    expect(writeFileMock).not.toHaveBeenCalled()
+  })
+
+  it('should process "src/index"', async () => {
+    await addPackageFileExports({ entries: ['./src/index.ts'] })
+
+    expect(writeFileMock.mock.lastCall?.at(1)).toMatchInlineSnapshot(`
+      "{
+        "name": "test",
+        "exports": {
+          ".": {
+            "import": "./dist/index.js",
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+          }
+        }
+      }
+      "
+    `)
+  })
+
+  it('should process multiple entry points', async () => {
+    await addPackageFileExports({ entries: ['./src/index.ts', './src/array/index.ts'] })
+
+    expect(writeFileMock.mock.lastCall?.at(1)).toMatchInlineSnapshot(`
+      "{
+        "name": "test",
+        "exports": {
+          ".": {
+            "import": "./dist/index.js",
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+          },
+          "./array": {
+            "import": "./dist/array/index.js",
+            "types": "./dist/array/index.d.ts",
+            "default": "./dist/array/index.js"
+          }
+        }
+      }
+      "
+    `)
+  })
+
+  it('should process entry points with wildcard', async () => {
+    await addPackageFileExports({ entries: ['./src/schemas/*.ts'] })
+
+    expect(writeFileMock.mock.lastCall?.at(1)).toMatchInlineSnapshot(`
+      "{
+        "name": "test",
+        "exports": {
+          "./schemas/*": {
+            "import": "./dist/schemas/*.js",
+            "types": "./dist/schemas/*.d.ts",
+            "default": "./dist/schemas/*.js"
+          }
+        }
+      }
+      "
+    `)
+  })
+
+  it('should process entry points pointing to file with name different from index', async () => {
+    await addPackageFileExports({ entries: ['./src/plugin/node.ts'] })
+
+    expect(writeFileMock.mock.lastCall?.at(1)).toMatchInlineSnapshot(`
+      "{
+        "name": "test",
+        "exports": {
+          "./plugin/node": {
+            "import": "./dist/plugin/node.js",
+            "types": "./dist/plugin/node.d.ts",
+            "default": "./dist/plugin/node.js"
+          }
+        }
+      }
+      "
+    `)
+  })
+
+  it('should not include playground files inside exports', async () => {
+    await addPackageFileExports({ entries: ['./src/plugin/index.ts', './src/playground/index.ts'] })
+
+    expect(consoleInfoMock).toHaveBeenCalledWith('INFO: will not add ./playground file exports to package.json')
+    expect(writeFileMock.mock.lastCall?.at(1)).toMatchInlineSnapshot(`
+      "{
+        "name": "test",
+        "exports": {
+          "./plugin": {
+            "import": "./dist/plugin/index.js",
+            "types": "./dist/plugin/index.d.ts",
+            "default": "./dist/plugin/index.js"
+          }
+        }
+      }
+      "
+    `)
+  })
+})

--- a/packages/build-tooling/src/helpers.ts
+++ b/packages/build-tooling/src/helpers.ts
@@ -114,7 +114,9 @@ export async function addPackageFileExports({ allowCss, entries }: { allowCss?: 
     return
   }
 
-  if (!(await fs.stat('./package.json'))) {
+  try {
+    await fs.stat('./package.json')
+  } catch {
     throw new Error(`package.json not found in ${process.cwd()}`)
   }
 

--- a/packages/build-tooling/vitest.config.ts
+++ b/packages/build-tooling/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({})


### PR DESCRIPTION
**Problem**

Received a review request on https://github.com/scalar/scalar/pull/7387#event-21053435379, 
but since the PR has already been merged, I’m submitting a small followup.

**Solution**

- remove `exports` from repository root `package.json`
- handle `fs.stat` error using try-catch
- add unit test for `addPackageFileExports` 
  (updated version of #7349 tests)

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature (Not needed).
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap fs.stat in try/catch in addPackageFileExports, add Vitest tests/config and test script, and remove root package exports.
> 
> - **Build tooling (@scalar/build-tooling)**
>   - **Error handling**: Wrap `fs.stat('./package.json')` in try/catch in `src/helpers.ts` to throw a clear "package.json not found" error.
>   - **Tests**: Add `src/helpers.test.ts` and `vitest.config.ts`; enable testing via `"test": "vitest"` in `packages/build-tooling/package.json`.
> - **Repo root**:
>   - Remove `exports` mappings from root `package.json`.
> - **Changeset**: Add patch entry for `@scalar/build-tooling`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 329556d716c851423771c72a391a71afcc354380. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->