### PR TITLE
docs: update Spring Boot starter version from 0.1.0 to 0.4.4

### DIFF
--- a/documentation/integrations/spring-boot.md
+++ b/documentation/integrations/spring-boot.md
@@ -73,7 +73,7 @@ Add the [WebJar dependency](https://central.sonatype.com/artifact/com.scalar.mav
 <dependency>
     <groupId>com.scalar.maven</groupId>
     <artifactId>scalar</artifactId>
-    <version>0.1.0</version>
+    <version>0.4.4</version>
 </dependency>
 ```
 
@@ -83,7 +83,7 @@ Add the dependency to your `build.gradle`:
 
 ```gradle
 dependencies {
-    implementation 'com.scalar.maven:scalar:0.1.0'
+    implementation 'com.scalar.maven:scalar:0.4.4'
 }
 ```
 
@@ -91,7 +91,7 @@ Or if using Kotlin DSL (`build.gradle.kts`):
 
 ```kotlin
 dependencies {
-    implementation("com.scalar.maven:scalar:0.1.0")
+    implementation("com.scalar.maven:scalar:0.4.4")
 }
 ```
 


### PR DESCRIPTION
## Problem
The documentation currently instructs users to install version `0.1.0` of the Spring Boot starter, but all configuration examples (theme, layout, darkMode, authentication, etc.) require version `0.4.4` or later.

This version mismatch causes confusion as users following the installation guide cannot use any of the documented configuration properties, leading to unnecessary debugging and workarounds.

## Solution
With this PR, the installation instructions are updated to recommend version `0.4.4`, aligning with the configuration examples already present in the documentation.

This allows users to immediately utilize all documented features without version-related issues.

## Checklist
- [x] I've added an explanation _why_ this change is needed.
- [ ] I've added a changeset (`pnpm changeset`).
- [ ] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Spring Boot integration docs to reference `com.scalar.maven:scalar` version `0.4.4` across Maven, Gradle, and Kotlin DSL examples.
> 
> - **Documentation** (`documentation/integrations/spring-boot.md`):
>   - Update dependency version for `com.scalar.maven:scalar` to `0.4.4` in:
>     - Maven `pom.xml` example
>     - Gradle `build.gradle` example
>     - Kotlin DSL `build.gradle.kts` example
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8425d99ee7829dde9fe792f4195b6bb2a8f3b680. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->