### PR TITLE
feat(import): enable `knip`

### DIFF
--- a/.changeset/sweet-books-perform.md
+++ b/.changeset/sweet-books-perform.md
@@ -1,0 +1,5 @@
+---
+'@scalar/import': patch
+---
+
+fix(import): remove `@scalar/openapi-parser` unused dependency

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -13,7 +13,6 @@
     "packages/draggable/**",
     "packages/galaxy/**",
     "packages/icons/**",
-    "packages/import/**",
     "packages/json-magic/**",
     "packages/nextjs-openapi/**",
     "packages/openapi-upgrader/**",

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -45,7 +45,6 @@
   ],
   "dependencies": {
     "@scalar/helpers": "workspace:*",
-    "@scalar/openapi-parser": "workspace:*",
     "yaml": "catalog:*"
   },
   "devDependencies": {

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -1,1 +1,2 @@
+/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export { resolve } from './resolve'

--- a/packages/import/src/resolve.test.ts
+++ b/packages/import/src/resolve.test.ts
@@ -2,20 +2,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { resolve } from './resolve'
 
-global.fetch = vi.fn()
-
-function createFetchResponse(data: string, headers: Record<string, string> = {}) {
-  return {
-    ok: true,
-    text: () => new Promise((r) => r(data)),
+function createFetchResponse(data: string, headers: Record<string, string> = {}): Response {
+  return new Response(data, {
     headers: new Headers(headers),
-  }
+  })
 }
+
+const globalFetchSpy = vi.spyOn(global, 'fetch').mockImplementation(vi.fn())
 
 describe('resolve', () => {
   beforeEach(() => {
-    // @ts-expect-error
-    global.fetch.mockReset()
+    globalFetchSpy.mockClear()
   })
 
   it('returns JSON urls', async () => {
@@ -62,8 +59,7 @@ describe('resolve', () => {
   </body>
 </html>`
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -88,8 +84,7 @@ describe('resolve', () => {
   </body>
 </html>`
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -115,8 +110,7 @@ describe('resolve', () => {
   </body>
 </html>`
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -142,8 +136,7 @@ describe('resolve', () => {
   </body>
 </html>`
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(
+    globalFetchSpy.mockResolvedValueOnce(
       createFetchResponse(html, {
         'X-Forwarded-Host': 'https://example.com/somewhere/else/',
       }),
@@ -177,8 +170,7 @@ describe('resolve', () => {
   </body>
 </html>`
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -200,8 +192,7 @@ describe('resolve', () => {
   </body>
 </html>`
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -222,8 +213,7 @@ describe('resolve', () => {
 </html>
     `
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -264,8 +254,7 @@ describe('resolve', () => {
 </html>
     `
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -307,8 +296,7 @@ describe('resolve', () => {
 </html>
     `
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -329,8 +317,7 @@ describe('resolve', () => {
 </html>
     `
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -351,8 +338,7 @@ describe('resolve', () => {
         </body>
       </html>`
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -384,8 +370,7 @@ describe('resolve', () => {
 </html>
     `
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -410,8 +395,7 @@ describe('resolve', () => {
 </html>
     `
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -443,8 +427,7 @@ info:
 </html>
     `
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -466,8 +449,7 @@ info:
 </html>
     `
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -495,8 +477,7 @@ info:
 </html>
     `
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(html))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(html))
 
     const result = await resolve('https://example.com/reference')
 
@@ -513,8 +494,7 @@ info:
       paths: {},
     }
 
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(createFetchResponse(JSON.stringify(openApiDoc)))
+    globalFetchSpy.mockResolvedValueOnce(createFetchResponse(JSON.stringify(openApiDoc)))
 
     const result = await resolve('https://example.com/swagger/json')
 
@@ -522,8 +502,7 @@ info:
   })
 
   it('finds the URL in an escaped JS object', async () => {
-    // @ts-expect-error Mocking types are missing
-    fetch.mockResolvedValue(
+    globalFetchSpy.mockResolvedValueOnce(
       createFetchResponse(
         `<html>\\"$L8e\\",null,{\\"configuration\\":{\\"spec\\":{\\"url\\":\\"https://raw.githubusercontent.com/Foo/Bar/main/api/foobar.json\\"}},\\"initialRequest`,
       ),

--- a/packages/import/src/resolve.ts
+++ b/packages/import/src/resolve.ts
@@ -294,7 +294,7 @@ export function getConfigurationAttribute(html: string): string | undefined {
 }
 
 /** Grab the URL from the configuration data attribute */
-export const getConfigurationAttributeUrl = (html: string): string | undefined => {
+const getConfigurationAttributeUrl = (html: string): string | undefined => {
   const configString = getConfigurationAttribute(html)
   if (!configString) {
     return undefined

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1938,9 +1938,6 @@ importers:
       '@scalar/helpers':
         specifier: workspace:*
         version: link:../helpers
-      '@scalar/openapi-parser':
-        specifier: workspace:*
-        version: link:../openapi-parser
       yaml:
         specifier: catalog:*
         version: 2.8.0
@@ -18758,6 +18755,9 @@ packages:
   vue-component-type-helpers@3.1.3:
     resolution: {integrity: sha512-V1dOD8XYfstOKCnXbWyEJIrhTBMwSyNjv271L1Jlx9ExpNlCSuqOs3OdWrGJ0V544zXufKbcYabi/o+gK8lyfQ==}
 
+  vue-component-type-helpers@3.1.4:
+    resolution: {integrity: sha512-Uws7Ew1OzTTqHW8ZVl/qLl/HB+jf08M0NdFONbVWAx0N4gMLK8yfZDgeB77hDnBmaigWWEn5qP8T9BG59jIeyQ==}
+
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
     engines: {node: '>=12'}
@@ -26159,7 +26159,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.21(typescript@5.8.3)
-      vue-component-type-helpers: 3.1.3
+      vue-component-type-helpers: 3.1.4
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -39593,6 +39593,8 @@ snapshots:
   vue-component-type-helpers@2.2.10: {}
 
   vue-component-type-helpers@3.1.3: {}
+
+  vue-component-type-helpers@3.1.4: {}
 
   vue-demi@0.14.10(vue@3.5.21(typescript@5.8.3)):
     dependencies:


### PR DESCRIPTION
**Problem**

- Followup of #7233

**Solution**

- Removed `@scalar/openapi-parser` unused dependency
- `resolve` tests now use a spy on fetch, instead of overwriting it with a mock function.
   This allows to remove all `@ts-expect-error` directives.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `@scalar/openapi-parser` from `@scalar/import`, refactors `resolve` tests to use a `fetch` spy, and enables `knip` for the package.
> 
> - **@scalar/import**:
>   - **Dependencies**: Remove unused `@scalar/openapi-parser` from `packages/import/package.json`.
>   - **Tests**: Refactor `packages/import/src/resolve.test.ts` to use `vi.spyOn(global, 'fetch')` with a `Response`-based helper; removes `@ts-expect-error` usages.
>   - **API**: Make `getConfigurationAttributeUrl` internal (no longer exported) in `packages/import/src/resolve.ts`.
>   - **Entrypoint**: Add barrel file ignore comment in `packages/import/src/index.ts`.
> - **Tooling**:
>   - Enable `knip` for `packages/import` by removing it from `knip.jsonc` `ignoreWorkspaces`.
>   - Add changeset `.changeset/sweet-books-perform.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9888411d7388b5048729674e684af206dd926ea2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->