### PR TITLE
test(api-reference): use local scalar galaxy registry to test default http client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ test-*.json
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+playwright-results.json
 
 # Temporary Vite/Vitest config files
 *.config.ts.timestamp-*.mjs

--- a/packages/api-client/src/v2/blocks/operation-code-sample/index.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/index.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/performance/noBarrelFile: exporting from a block
 export { default as ExamplePicker } from './components/ExamplePicker.vue'
 export { default as OperationCodeSample } from './components/OperationCodeSample.vue'
 export { DEFAULT_CLIENT, findClient, isClient } from './helpers/find-client'

--- a/packages/api-reference/test/configuration/default-http-client.e2e.ts
+++ b/packages/api-reference/test/configuration/default-http-client.e2e.ts
@@ -1,9 +1,14 @@
 import { expect, test } from '@playwright/test'
+import galaxy from '@scalar/galaxy/latest.json' with { type: 'json' }
 import { serveExample } from '@test/utils/serve-example'
 
 test.describe('defaultHttpClient', () => {
   test('default value is shell/curl', async ({ page }) => {
-    const example = await serveExample()
+    const example = await serveExample({
+      // Use a local copy because the registry contains `x-codeSamples` property
+      // which modifies the request to use custom `csharp` / `typescript` snippets.
+      content: galaxy,
+    })
 
     await page.goto(example)
 

--- a/packages/api-reference/test/configuration/hidden-clients.e2e.ts
+++ b/packages/api-reference/test/configuration/hidden-clients.e2e.ts
@@ -1,9 +1,14 @@
 import { expect, test } from '@playwright/test'
+import galaxy from '@scalar/galaxy/latest.json' with { type: 'json' }
 import { serveExample } from '@test/utils/serve-example'
 
 test.describe('hiddenClients', () => {
   test('default value shows all clients', async ({ page }) => {
-    const example = await serveExample()
+    const example = await serveExample({
+      // Use a local copy because the registry contains `x-codeSamples` property
+      // which modifies the request to use custom `csharp` / `typescript` snippets.
+      content: galaxy,
+    })
 
     await page.goto(example)
 


### PR DESCRIPTION
**Problem**

PR `test-e2e-api-reference` check is failing.

E.g., 
- https://github.com/scalar/scalar/actions/runs/19605957665/job/56144922875?pr=7407
- https://github.com/scalar/scalar/actions/runs/19606074193/job/56145194605?pr=7408

**Solution**

Seems like that https://registry.scalar.com/@scalar/apis/galaxy?format=json 
now contains `x-codeSamples` property which change the default client set on each API endpoint.

Using repository stored `@scalar/galaxy/latest.json` should solve the issue since doesn't contain any `x-codeSamples` property.

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`) (Not needed).
- [x] I've added tests for the regression or new feature (Not needed).
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> E2E tests now load `@scalar/galaxy/latest.json` locally via `serveExample({ content })` to avoid registry-driven code sample changes; added `playwright-results.json` to `.gitignore`.
> 
> - **Tests (api-reference)**:
>   - `packages/api-reference/test/configuration/default-http-client.e2e.ts`: Import local `@scalar/galaxy/latest.json` and pass as `content` to `serveExample` to assert default client (Shell/curl).
>   - `packages/api-reference/test/configuration/hidden-clients.e2e.ts`: Same local spec usage to validate tab visibility and hidden client behavior.
> - **Chore**:
>   - `.gitignore`: Ignore `playwright-results.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a4e28f94a0e3a247a9b3c3020f44e1f4a57a379. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->