### PR TITLE
fix(build-tooling): correct `fast-glob` import

### DIFF
--- a/.changeset/lemon-ants-tan.md
+++ b/.changeset/lemon-ants-tan.md
@@ -1,0 +1,5 @@
+---
+'@scalar/build-tooling': patch
+---
+
+fix(build-tooling): correct `fast-glob` import

--- a/packages/build-tooling/scripts/lint-check.js
+++ b/packages/build-tooling/scripts/lint-check.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { globSync } from 'fast-glob'
+import fg from 'fast-glob'
 
 import { executeCommand } from './utils/utils.js'
 
@@ -8,7 +8,7 @@ import { executeCommand } from './utils/utils.js'
 executeCommand('biome lint --diagnostic-level=error', 'Error during linting check')
 
 // Check if Vue files exist and run ESLint on them if they do
-const vueFiles = globSync('**/*.vue', { ignore: 'node_modules/**' })
+const vueFiles = fg.sync('**/*.vue', { ignore: ['node_modules/**'] })
 if (vueFiles.length > 0) {
   executeCommand("pnpm eslint '**/*.vue'", 'Error during Vue files linting')
 }

--- a/packages/build-tooling/scripts/lint-fix.js
+++ b/packages/build-tooling/scripts/lint-fix.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { globSync } from 'fast-glob'
+
+import fg from 'fast-glob'
 
 import { executeCommand } from './utils/utils.js'
 
@@ -7,7 +8,7 @@ import { executeCommand } from './utils/utils.js'
 executeCommand('biome lint --fix', 'Error during linting check')
 
 // Check if Vue files exist and run ESLint on them if they do
-const vueFiles = globSync('**/*.vue', { ignore: 'node_modules/**' })
+const vueFiles = fg.sync('**/*.vue', { ignore: ['node_modules/**'] })
 if (vueFiles.length > 0) {
   executeCommand("pnpm eslint '**/*.vue' --fix", 'Error during Vue files linting')
 }


### PR DESCRIPTION
**Problem**

Followup of #7411

Got the following error when running lint-check of lint-fix scripts:

```txt
import { globSync } from 'fast-glob'
         ^^^^^^^^
SyntaxError: Named export 'globSync' not found. The requested module 'fast-glob' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'fast-glob';
const { globSync } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:226:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:335:5)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:665:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
```

**Solution**

- Correct `fast-glob` imports
- use array as `ignore` option.
   <img width="881" height="129" alt="image" src="https://github.com/user-attachments/assets/30f9af75-ebb3-4a8f-afd7-0b6fb6fb9077" />


**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation.

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix fast-glob usage in lint scripts (default import + array ignore) and add a patch changeset.
> 
> - **Build tooling**:
>   - Update `packages/build-tooling/scripts/lint-check.js` and `packages/build-tooling/scripts/lint-fix.js`:
>     - Replace `globSync` named import with default `fg` and use `fg.sync`.
>     - Change `ignore` option to an array `['node_modules/**']`.
> - **Changeset**: add patch for `@scalar/build-tooling`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9742c33e032efc30c3f5673843a3e42f979f3ff4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->