### PR TITLE
fix(build-tooling): revert correct `fast-glob` import

### DIFF
--- a/.changeset/lemon-ants-tan.md
+++ b/.changeset/lemon-ants-tan.md
@@ -1,5 +1,0 @@
----
-'@scalar/build-tooling': patch
----
-
-fix(build-tooling): correct `fast-glob` import

--- a/packages/build-tooling/scripts/lint-check.js
+++ b/packages/build-tooling/scripts/lint-check.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import fg from 'fast-glob'
+import { globSync } from 'fast-glob'
 
 import { executeCommand } from './utils/utils.js'
 
@@ -8,7 +8,7 @@ import { executeCommand } from './utils/utils.js'
 executeCommand('biome lint --diagnostic-level=error', 'Error during linting check')
 
 // Check if Vue files exist and run ESLint on them if they do
-const vueFiles = fg.sync('**/*.vue', { ignore: ['node_modules/**'] })
+const vueFiles = globSync('**/*.vue', { ignore: 'node_modules/**' })
 if (vueFiles.length > 0) {
   executeCommand("pnpm eslint '**/*.vue'", 'Error during Vue files linting')
 }

--- a/packages/build-tooling/scripts/lint-fix.js
+++ b/packages/build-tooling/scripts/lint-fix.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-
-import fg from 'fast-glob'
+import { globSync } from 'fast-glob'
 
 import { executeCommand } from './utils/utils.js'
 
@@ -8,7 +7,7 @@ import { executeCommand } from './utils/utils.js'
 executeCommand('biome lint --fix', 'Error during linting check')
 
 // Check if Vue files exist and run ESLint on them if they do
-const vueFiles = fg.sync('**/*.vue', { ignore: ['node_modules/**'] })
+const vueFiles = globSync('**/*.vue', { ignore: 'node_modules/**' })
 if (vueFiles.length > 0) {
   executeCommand("pnpm eslint '**/*.vue' --fix", 'Error during Vue files linting')
 }


### PR DESCRIPTION
Reverts scalar/scalar#7413

~~I think cursor is right, let’s try again~~ Cursor was wrong

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use fast-glob’s globSync named import in lint scripts and update usages; remove obsolete changeset.
> 
> - **Build tooling**:
>   - Update `packages/build-tooling/scripts/lint-check.js` and `lint-fix.js` to use `fast-glob`'s `globSync` named import and replace `fg.sync` calls.
>   - Normalize `ignore` option format for globbing Vue files.
> - **Chore**:
>   - Remove `.changeset/lemon-ants-tan.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d8e9e22ba7a0c6b76929194c8ffc6b8248ad529. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->