### PR TITLE
fix(json-magic): enable `knip`

### DIFF
--- a/.changeset/orange-jobs-care.md
+++ b/.changeset/orange-jobs-care.md
@@ -1,0 +1,5 @@
+---
+'@scalar/json-magic': patch
+---
+
+fix(json-margic): remove `helpers/generate-hash` invalid entrypoint

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -13,7 +13,6 @@
     "packages/draggable/**",
     "packages/galaxy/**",
     "packages/icons/**",
-    "packages/json-magic/**",
     "packages/nextjs-openapi/**",
     "packages/openapi-upgrader/**",
     "packages/postman-to-openapi/**",
@@ -68,10 +67,27 @@
   "ignoreBinaries": ["netlify"],
   "workspaces": {
     "packages/build-tooling": {
-      "entry": ["src/index.ts", "src/{esbuild,rollup,vite}/index.ts"]
+      "entry": [
+        //
+        "src/index.ts",
+        "src/esbuild/index.ts",
+        "src/rollup/index.ts",
+        "src/vite/index.ts"
+      ]
     },
     "packages/helpers": {
       "entry": ["src/*/*.ts", "!src/*/*.test.ts"]
+    },
+    "packages/json-magic": {
+      "entry": [
+        "src/bundle/index.ts",
+        "src/magic-proxy/index.ts",
+        "src/diff/index.ts",
+        "src/dereference/index.ts",
+        "src/bundle/plugins/node.ts",
+        "src/bundle/plugins/browser.ts",
+        "src/helpers/escape-json-pointer.ts"
+      ]
     },
     "packages/oas-utils": {
       "entry": [
@@ -87,10 +103,21 @@
       "entry": ["src/*/index.ts"]
     },
     "packages/openapi-parser": {
-      "entry": ["src/index.ts", "src/plugins/fetch-urls/index.ts", "src/plugins/read-files/index.ts"]
+      "entry": [
+        //
+        "src/index.ts",
+        "src/plugins/fetch-urls/index.ts",
+        "src/plugins/read-files/index.ts"
+      ]
     },
     "packages/openapi-types": {
-      "entry": ["src/index.ts", "src/helpers/index.ts", "src/schemas/extensions/index.ts", "src/schemas/3.1/*/index.ts"]
+      "entry": [
+        //
+        "src/index.ts",
+        "src/helpers/index.ts",
+        "src/schemas/extensions/index.ts",
+        "src/schemas/3.1/*/index.ts"
+      ]
     },
     "packages/types": {
       "entry": [

--- a/packages/json-magic/esbuild.ts
+++ b/packages/json-magic/esbuild.ts
@@ -10,6 +10,5 @@ await build({
     'src/bundle/plugins/node.ts',
     'src/bundle/plugins/browser.ts',
     'src/helpers/escape-json-pointer.ts',
-    'src/helpers/generate-hash.ts',
   ],
 })

--- a/packages/json-magic/package.json
+++ b/packages/json-magic/package.json
@@ -52,11 +52,6 @@
       "types": "./dist/helpers/escape-json-pointer.d.ts",
       "default": "./dist/helpers/escape-json-pointer.js"
     },
-    "./helpers/generate-hash": {
-      "import": "./dist/helpers/generate-hash.js",
-      "types": "./dist/helpers/generate-hash.d.ts",
-      "default": "./dist/helpers/generate-hash.js"
-    },
     "./magic-proxy": {
       "import": "./dist/magic-proxy/index.js",
       "types": "./dist/magic-proxy/index.d.ts",

--- a/packages/json-magic/src/bundle/bundle.test.ts
+++ b/packages/json-magic/src/bundle/bundle.test.ts
@@ -38,8 +38,6 @@ describe('bundle', () => {
     })
 
     it('bundles external urls', async () => {
-      const url = `http://localhost:${port}`
-
       const external = {
         prop: 'I am external json prop',
       }
@@ -83,7 +81,6 @@ describe('bundle', () => {
     })
 
     it('bundles external urls from resolved external piece', async () => {
-      const url = `http://localhost:${port}`
       const chunk2 = {
         hey: 'hey',
         nested: {
@@ -146,8 +143,6 @@ describe('bundle', () => {
     })
 
     it('should correctly handle only urls without a pointer', async () => {
-      const url = `http://localhost:${port}`
-
       server.get('/', (_, reply) => {
         reply.send({
           a: 'a',
@@ -182,7 +177,6 @@ describe('bundle', () => {
 
     it('caches results for same resource', async () => {
       const fn = vi.fn()
-      const url = `http://localhost:${port}`
 
       server.get('/', (_, reply) => {
         fn()
@@ -221,12 +215,10 @@ describe('bundle', () => {
       })
 
       // We expect the bundler to cache the result for the same url
-      expect(fn.mock.calls.length).toBe(1)
+      expect(fn).toHaveBeenCalledOnce()
     })
 
     it('handles correctly external nested refs', async () => {
-      const url = `http://localhost:${port}`
-
       server.get('/nested/another-file.json', (_, reply) => {
         reply.send({
           c: 'c',
@@ -269,8 +261,6 @@ describe('bundle', () => {
     })
 
     it('does not merge paths when we use absolute urls', async () => {
-      const url = `http://localhost:${port}`
-
       server.get('/top-level', (_, reply) => {
         reply.send({
           c: 'c',
@@ -313,8 +303,6 @@ describe('bundle', () => {
     })
 
     it('bundles from a url input', async () => {
-      const url = `http://localhost:${port}`
-
       server.get('/top-level', (_, reply) => {
         reply.send({
           c: 'c',
@@ -359,8 +347,6 @@ describe('bundle', () => {
     })
 
     it('generated a map when we turn the urlMap on', async () => {
-      const url = `http://localhost:${port}`
-
       server.get('/top-level', (_, reply) => {
         reply.send({
           c: 'c',
@@ -413,8 +399,6 @@ describe('bundle', () => {
     })
 
     it('prefixes the refs only once', async () => {
-      const url = `http://localhost:${port}`
-
       const chunk2 = {
         a: 'a',
         b: {
@@ -497,8 +481,6 @@ describe('bundle', () => {
     })
 
     it('bundles array references', async () => {
-      const url = `http://localhost:${port}`
-
       const chunk1 = {
         a: {
           hello: 'hello',
@@ -540,8 +522,6 @@ describe('bundle', () => {
     })
 
     it('bundles subpart of the document', async () => {
-      const url = `http://localhost:${port}`
-
       const chunk1 = {
         a: {
           hello: 'hello',
@@ -635,8 +615,6 @@ describe('bundle', () => {
     })
 
     it('always emits the url mappings when doing partial bundle', async () => {
-      const url = `http://localhost:${port}`
-
       const chunk1 = {
         a: {
           hello: 'hello',
@@ -697,8 +675,6 @@ describe('bundle', () => {
     })
 
     it('tree shakes the external documents correctly', async () => {
-      const url = `http://localhost:${port}`
-
       const chunk1 = {
         a: {
           b: {
@@ -752,8 +728,6 @@ describe('bundle', () => {
     })
 
     it('tree shakes correctly when working with nested external refs', async () => {
-      const url = `http://localhost:${port}`
-
       const chunk2 = {
         a: {
           b: {
@@ -836,8 +810,6 @@ describe('bundle', () => {
     })
 
     it('handles circular references when we treeshake', async () => {
-      const url = `http://localhost:${port}`
-
       const chunk1 = {
         a: {
           b: {
@@ -891,8 +863,6 @@ describe('bundle', () => {
     })
 
     it('handles chunks', async () => {
-      const url = `http://localhost:${port}`
-
       const chunk1 = {
         description: 'Chunk 1',
         someRef: {
@@ -989,8 +959,6 @@ describe('bundle', () => {
     })
 
     it('when bundle partial document we ensure all the dependencies references are resolved', async () => {
-      const url = `http://localhost:${port}`
-
       const chunk1 = {
         a: {
           hello: 'hello',
@@ -1054,8 +1022,6 @@ describe('bundle', () => {
     })
 
     it('should correctly handle nested chunk urls', async () => {
-      const url = `http://localhost:${port}`
-
       const chunk1 = {
         chunk1: 'chunk1',
         someRef: {
@@ -1182,8 +1148,6 @@ describe('bundle', () => {
     })
 
     it('run success hook', async () => {
-      const url = `http://localhost:${port}`
-
       const chunk1 = {
         description: 'Chunk 1',
       }
@@ -1230,8 +1194,6 @@ describe('bundle', () => {
     })
 
     it('run error hook', async () => {
-      const url = `http://localhost:${port}`
-
       server.get('/chunk1', (_, reply) => {
         reply.code(404).send()
       })
@@ -1328,8 +1290,6 @@ describe('bundle', () => {
     })
 
     it('does not modify external URLs when already defined by $id property', async () => {
-      const url = `http://localhost:${port}`
-
       const input = {
         $id: 'https://example.com/root',
         components: {
@@ -1447,8 +1407,6 @@ describe('bundle', () => {
     })
 
     it('does not modify external URLs when prefix is already defined by $id', async () => {
-      const url = `http://localhost:${port}`
-
       const input = {
         $id: `${url}/schema`,
         components: {
@@ -1557,8 +1515,6 @@ describe('bundle', () => {
     })
 
     it('prioritizes $id when resolving refs with origin #1', async () => {
-      const url = `http://localhost:${port}`
-
       const input = {
         $id: '/root',
         a: {
@@ -1608,13 +1564,11 @@ describe('bundle', () => {
         },
       })
 
-      expect(exec).toHaveBeenCalled()
+      expect(exec).toHaveBeenCalledOnce()
       expect(exec).toHaveBeenCalledWith('/b')
     })
 
     it('prioritizes $id when resolving refs with origin #2', async () => {
-      const url = `http://localhost:${port}`
-
       const input = {
         $id: 'http://example.com/root',
         a: {

--- a/packages/json-magic/src/bundle/index.ts
+++ b/packages/json-magic/src/bundle/index.ts
@@ -1,3 +1,3 @@
+/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export type { LifecyclePlugin, LoaderPlugin, Plugin, ResolveResult } from './bundle'
-// biome-ignore lint/performance/noBarrelFile: exporting bundle
 export { bundle, resolveAndCopyReferences } from './bundle'

--- a/packages/json-magic/src/bundle/plugins/browser.ts
+++ b/packages/json-magic/src/bundle/plugins/browser.ts
@@ -1,4 +1,4 @@
-// biome-ignore lint/performance/noBarrelFile: <explanation>
+// biome-ignore lint/performance/noBarrelFile: entrypoint
 export { fetchUrls } from './fetch-urls'
 export { parseJson } from './parse-json'
 export { parseYaml } from './parse-yaml'

--- a/packages/json-magic/src/bundle/plugins/node.ts
+++ b/packages/json-magic/src/bundle/plugins/node.ts
@@ -1,5 +1,5 @@
-// biome-ignore lint/performance/noBarrelFile: <explanation>
+// biome-ignore lint/performance/noBarrelFile: entrypoint
 export { fetchUrls } from './fetch-urls'
-export { readFiles } from './read-files'
 export { parseJson } from './parse-json'
 export { parseYaml } from './parse-yaml'
+export { readFiles } from './read-files'

--- a/packages/json-magic/src/dereference/index.ts
+++ b/packages/json-magic/src/dereference/index.ts
@@ -1,2 +1,2 @@
-// biome-ignore lint/performance/noBarrelFile: <explanation>
+// biome-ignore lint/performance/noBarrelFile: entrypoint
 export { dereference } from './dereference'

--- a/packages/json-magic/src/diff/apply.test.ts
+++ b/packages/json-magic/src/diff/apply.test.ts
@@ -1,5 +1,6 @@
-import { apply, InvalidChangesDetectedError } from '@/diff/apply'
 import { describe, expect, test } from 'vitest'
+
+import { InvalidChangesDetectedError, apply } from '@/diff/apply'
 
 const deepClone = <T extends object>(obj: T) => JSON.parse(JSON.stringify(obj)) as T
 

--- a/packages/json-magic/src/diff/diff.test.ts
+++ b/packages/json-magic/src/diff/diff.test.ts
@@ -1,5 +1,6 @@
-import { diff } from '@/diff'
 import { describe, expect, test } from 'vitest'
+
+import { diff } from '@/diff'
 
 describe('diff', () => {
   describe('Should correctly detect `add` type diff', () => {

--- a/packages/json-magic/src/diff/index.test.ts
+++ b/packages/json-magic/src/diff/index.test.ts
@@ -1,6 +1,7 @@
+import { describe, expect, test } from 'vitest'
+
 import { apply } from '@/diff/apply'
 import { diff } from '@/diff/diff'
-import { describe, expect, test } from 'vitest'
 
 describe('if we get list of operations we need to perform A -> B, when we apply them on A it should give us B', () => {
   test.each([

--- a/packages/json-magic/src/diff/index.ts
+++ b/packages/json-magic/src/diff/index.ts
@@ -1,5 +1,5 @@
-import { diff, type Difference } from '@/diff/diff'
 import { apply } from '@/diff/apply'
+import { type Difference, diff } from '@/diff/diff'
 import { merge } from '@/diff/merge'
 
 export { diff, apply, merge, type Difference }

--- a/packages/json-magic/src/diff/merge.test.ts
+++ b/packages/json-magic/src/diff/merge.test.ts
@@ -1,6 +1,7 @@
-import { merge } from '@/diff/merge'
-import { diff } from '@/diff/diff'
 import { describe, expect, test } from 'vitest'
+
+import { diff } from '@/diff/diff'
+import { merge } from '@/diff/merge'
 
 const deepClone = <T extends object>(obj: T) => JSON.parse(JSON.stringify(obj)) as T
 

--- a/packages/json-magic/src/diff/trie.test.ts
+++ b/packages/json-magic/src/diff/trie.test.ts
@@ -1,5 +1,6 @@
-import { Trie } from '@/diff/trie'
 import { describe, expect, test, vi } from 'vitest'
+
+import { Trie } from '@/diff/trie'
 
 describe('trie', () => {
   test('should correctly find matched', () => {

--- a/packages/json-magic/src/diff/utils.test.ts
+++ b/packages/json-magic/src/diff/utils.test.ts
@@ -1,5 +1,6 @@
-import { isArrayEqual, isKeyCollisions, mergeObjects } from '@/diff/utils'
 import { describe, expect, test } from 'vitest'
+
+import { isArrayEqual, isKeyCollisions, mergeObjects } from '@/diff/utils'
 
 describe('isKeyCollisions', () => {
   test.each([

--- a/packages/json-magic/src/magic-proxy/index.ts
+++ b/packages/json-magic/src/magic-proxy/index.ts
@@ -1,2 +1,2 @@
-// biome-ignore lint/performance/noBarrelFile: <explanation>
+// biome-ignore lint/performance/noBarrelFile: entrypoint
 export { createMagicProxy, getRaw } from './proxy'

--- a/packages/json-magic/src/magic-proxy/proxy.ts
+++ b/packages/json-magic/src/magic-proxy/proxy.ts
@@ -84,7 +84,7 @@ export const createMagicProxy = <T extends Record<keyof T & symbol, unknown>, S 
     schemas: getSchemas(target),
     currentContext: '',
   },
-) => {
+): T => {
   if (!isObject(target) && !Array.isArray(target)) {
     return target
   }
@@ -296,7 +296,7 @@ export const createMagicProxy = <T extends Record<keyof T & symbol, unknown>, S 
   return proxied
 }
 
-export const isMagicProxyObject = (obj: unknown): boolean => {
+const isMagicProxyObject = (obj: unknown): boolean => {
   return typeof obj === 'object' && obj !== null && (obj as { [isMagicProxy]: boolean })[isMagicProxy] === true
 }
 


### PR DESCRIPTION
**Problem**

- Followup of #7233

**Solution**

- resolve knip issues
- fix imports order (all reported by `pnpm biome check packages/json-magic`)
- removed shadow `url` variables in `packages/json-magic/src/bundle/bundle.test.ts`

**Checklist**

I've gone through the following:

- [x] I've added an explanation _why_ this change is needed.
- [x] I've added a changeset (`pnpm changeset`).
- [x] I've added tests for the regression or new feature.
- [x] I've updated the documentation (Not needed).

<!-- See the [contributing guide](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md) for more information. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the invalid `helpers/generate-hash` export, enables knip for `@scalar/json-magic`, and updates tests/entrypoints and minor internals for stability.
> 
> - **json-magic package**:
>   - Remove invalid entrypoint `./helpers/generate-hash` from `package.json` exports and `esbuild` entries.
>   - Add explicit return type to `createMagicProxy` and make `isMagicProxyObject` internal in `src/magic-proxy/proxy.ts`.
>   - Tidy barrel entrypoints and plugin exports; add biome ignore markers.
> - **Tooling (knip)**:
>   - Enable knip for `packages/json-magic` with explicit `workspaces` entries in `knip.jsonc`.
>   - Normalize `packages/build-tooling` and other workspace entry lists.
> - **Tests**:
>   - Refactor tests for determinism and clarity (use fake timers in `create-limiter`, consolidate expectations, remove shadowed vars) across bundler/diff suites.
> - **Changeset**:
>   - Add patch changeset documenting removal of invalid entrypoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c83a6dbf511a5c26da06c7eddaa06b10f83f3caf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->