### PR TITLE
chore: add zed workspace settings

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -69,6 +69,7 @@
   },
   "auto_install_extensions": {
     "biome": true,
+    "html": true,
     "vue": true
   }
 }


### PR DESCRIPTION
Recently picked up zed, thought I would share the settings for all of the formatting and what not we need if anyone else wants to try it!

https://zed.dev/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Zed workspace settings using Biome (and Prettier for Vue) with format-on-save and auto-installed extensions.
> 
> - **Editor/Tooling**:
>   - Add `/.zed/settings.json` for Zed workspace configuration.
>     - Enable `format_on_save`.
>     - Use `biome` as formatter for `JavaScript`, `TypeScript`, `TSX`, `JSON`, `JSONC`, and `CSS` with code actions (`fixAll`, `organizeImports`).
>     - Configure `Vue.js` to format with `biome` then external `prettier`; enable `eslint` and `biome` fixers.
>     - Set global formatter to `biome` and auto-install `biome`, `html`, `vue` extensions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77d38879d260eabfe14eaa8b094cc7897d1f2f4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->