### PR TITLE
refactor(biome): disable `noBarrelFile` for index files

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -194,7 +194,7 @@
       "performance": {
         "noDelete": "off",
         "noReExportAll": "warn",
-        "noBarrelFile": "warn"
+        "noBarrelFile": "error"
       },
       "nursery": {
         "noFloatingPromises": "warn"
@@ -258,21 +258,21 @@
       }
     },
     {
-      "includes": ["**/packages/api-reference/**/*.ts", "**/packages/openapi-parser/**/*.ts"],
+      "includes": ["packages/*/src/**/index.{js,ts}", "integrations/*/index.ts", "integrations/*/src/**/index.ts"],
       "linter": {
         "rules": {
           "performance": {
-            "noReExportAll": "error"
+            "noBarrelFile": "off"
           }
         }
       }
     },
     {
-      "includes": ["**/components/**/index.ts", "**/features/*/index.ts", "**/blocks/*/index.ts"],
+      "includes": ["**/packages/api-reference/**/*.ts", "**/packages/openapi-parser/**/*.ts"],
       "linter": {
         "rules": {
           "performance": {
-            "noBarrelFile": "off"
+            "noReExportAll": "error"
           }
         }
       }

--- a/examples/nextjs-api-reference/app/another-client/page.tsx
+++ b/examples/nextjs-api-reference/app/another-client/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 
-import { Button, ClientWrapper } from '../client/components'
+import { Button } from '../client/components/Button'
+import { ClientWrapper } from '../client/components/ClientWrapper'
 
 const Page = () => {
   return (

--- a/examples/nextjs-api-reference/app/client/components/index.ts
+++ b/examples/nextjs-api-reference/app/client/components/index.ts
@@ -1,2 +1,0 @@
-export * from './Button'
-export * from './ClientWrapper'

--- a/examples/nextjs-api-reference/app/client/page.tsx
+++ b/examples/nextjs-api-reference/app/client/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 
-import { Button, ClientWrapper } from './components'
+import { Button } from '../client/components/Button'
+import { ClientWrapper } from '../client/components/ClientWrapper'
 
 const Page = () => {
   return (

--- a/integrations/nextjs/src/index.ts
+++ b/integrations/nextjs/src/index.ts
@@ -1,2 +1,1 @@
-// biome-ignore lint/performance/noBarrelFile: package entrypoint
 export * from './ApiReference'

--- a/packages/api-client/src/store/index.ts
+++ b/packages/api-client/src/store/index.ts
@@ -1,8 +1,7 @@
-// biome-ignore lint/performance/noBarrelFile: <explanation>
-export * from './store'
 export {
   ACTIVE_ENTITIES_SYMBOL,
+  type EnvVariable,
   createActiveEntitiesStore,
   useActiveEntities,
-  type EnvVariable,
 } from './active-entities'
+export * from './store'

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/index.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/index.ts
@@ -1,3 +1,2 @@
-// biome-ignore lint/performance/noBarrelFile: It's a block
 export { default as AddressBar } from './components/AddressBar.vue'
 export type { History } from './components/AddressBarHistory.vue'

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/index.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/index.ts
@@ -1,2 +1,1 @@
-// biome-ignore lint/performance/noBarrelFile: It is a block
 export { default as AuthSelector } from './components/AuthSelector.vue'

--- a/packages/api-reference/src/blocks/scalar-auth-selector-block/index.ts
+++ b/packages/api-reference/src/blocks/scalar-auth-selector-block/index.ts
@@ -1,2 +1,1 @@
-// biome-ignore lint/performance/noBarrelFile: <explanation>
 export { default as AuthSelector } from './components/AuthSelector.vue'

--- a/packages/api-reference/src/blocks/scalar-client-selector-block/index.ts
+++ b/packages/api-reference/src/blocks/scalar-client-selector-block/index.ts
@@ -1,2 +1,1 @@
-// biome-ignore lint/performance/noBarrelFile: <explanation>
 export { default as ClientSelector } from './components/ClientSelector.vue'

--- a/packages/api-reference/src/blocks/scalar-info-block/index.ts
+++ b/packages/api-reference/src/blocks/scalar-info-block/index.ts
@@ -1,3 +1,2 @@
-// biome-ignore lint/performance/noBarrelFile: <explanation>
 export { default as InfoBlock } from './components/InfoBlock.vue'
 export { default as IntroductionCardItem } from './components/IntroductionCardItem.vue'

--- a/packages/api-reference/src/blocks/scalar-server-selector-block/index.ts
+++ b/packages/api-reference/src/blocks/scalar-server-selector-block/index.ts
@@ -1,2 +1,1 @@
-// biome-ignore lint/performance/noBarrelFile: It's a block
 export { default as ServerSelector } from './components/ServerSelector.vue'

--- a/packages/api-reference/src/features/specification-extension/index.ts
+++ b/packages/api-reference/src/features/specification-extension/index.ts
@@ -1,3 +1,2 @@
-// biome-ignore lint/performance/noBarrelFile: <explanation>
-export { default as SpecificationExtension } from './SpecificationExtension.vue'
 export { getXKeysFromObject } from './helpers'
+export { default as SpecificationExtension } from './SpecificationExtension.vue'

--- a/packages/api-reference/src/helpers/index.ts
+++ b/packages/api-reference/src/helpers/index.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/performance/noBarrelFile: package entrypoint
 export { useLegacyStoreEvents } from '@/hooks/use-legacy-store-events'
 export { useWorkspaceStoreEvents } from '@/hooks/use-workspace-store-events'
 

--- a/packages/json-magic/src/dereference/index.ts
+++ b/packages/json-magic/src/dereference/index.ts
@@ -1,2 +1,1 @@
-// biome-ignore lint/performance/noBarrelFile: entrypoint
 export { dereference } from './dereference'

--- a/packages/json-magic/src/magic-proxy/index.ts
+++ b/packages/json-magic/src/magic-proxy/index.ts
@@ -1,2 +1,1 @@
-// biome-ignore lint/performance/noBarrelFile: entrypoint
 export { createMagicProxy, getRaw } from './proxy'

--- a/packages/openapi-parser/esbuild.ts
+++ b/packages/openapi-parser/esbuild.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises'
+
 import { build } from '@scalar/build-tooling/esbuild'
 
 async function convertSchema(version: string) {

--- a/packages/openapi-parser/src/utils/transform/sanitize.ts
+++ b/packages/openapi-parser/src/utils/transform/sanitize.ts
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/performance/noBarrelFile: re-exports utilities */
 import type { OpenAPI } from '@scalar/openapi-types'
 
 import type { AnyObject } from '@/types/index'

--- a/packages/openapi-to-markdown/src/index.ts
+++ b/packages/openapi-to-markdown/src/index.ts
@@ -1,2 +1,1 @@
-export { createMarkdownFromOpenApi } from './create-markdown-from-openapi'
-export { createHtmlFromOpenApi } from './create-markdown-from-openapi'
+export { createHtmlFromOpenApi, createMarkdownFromOpenApi } from './create-markdown-from-openapi'

--- a/packages/openapi-upgrader/src/index.ts
+++ b/packages/openapi-upgrader/src/index.ts
@@ -1,2 +1,1 @@
-// biome-ignore lint/performance/noBarrelFile: root entry point
 export { upgrade } from './upgrade'

--- a/packages/types/src/api-reference/index.ts
+++ b/packages/types/src/api-reference/index.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/performance/noBarrelFile: exporting from a block
 export {
   type ApiClientConfiguration,
   apiClientConfigurationSchema,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,7 +1,6 @@
 /**
  * We should not use these exports anymore, but we need them for commonjs compatibility.
  */
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 
 // biome-ignore lint/performance/noReExportAll: leave this to avoid copy exports
 export * from './api-reference/index'

--- a/packages/workspace-store/src/events/index.ts
+++ b/packages/workspace-store/src/events/index.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/performance/noBarrelFile: Entry point for /events
 export { type WorkspaceEventBus, createWorkspaceEventBus } from './bus'
 export type { ApiReferenceEvents, CollectionType } from './definitions'
 export { onCustomEvent } from './listeners'

--- a/packages/workspace-store/src/navigation/index.ts
+++ b/packages/workspace-store/src/navigation/index.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/performance/noBarrelFile: Entry point for /navigation
 export { getOpenapiObject } from './helpers/get-openapi-object'
 export { getParentEntry } from './helpers/get-parent-entry'
 export { traverseDocument as createNavigation } from './helpers/traverse-document'


### PR DESCRIPTION
## Problem

`biome` reports warning for `noBarrelFile` rule on `index` files.

## Solution

Since the purpose of these files conflicts with the purpose of `noBarrelFile` rule,
I turned off this rule for all index files. For other files the rule is set to `error`.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset (Not needed).
- [x] I added tests (Not needed).
- [x] I updated the documentation (Not needed).

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
