### PR TITLE
test(api-reference): wait for sidebar expansions to complete

### DIFF
--- a/packages/api-reference/test/snapshots/sidebar.e2e.ts
+++ b/packages/api-reference/test/snapshots/sidebar.e2e.ts
@@ -19,30 +19,32 @@ toTest.forEach((source) => {
 
     // Expand the tag
     const nav = page.getByRole('navigation', { name: 'Sidebar for' })
+
     // Wait for the sidebar to load
     await expect(nav.getByRole('button', { name: 'Models' })).toBeVisible()
     await expect(nav).toHaveScreenshot(`${slug}-sidebar.png`)
 
-    // Open all the sections - wait for each expansion to complete
+    // Open all the sections
     const closedTag = nav.getByRole('button', { name: 'Open Group', expanded: false })
-    while ((await closedTag.count()) > 0) {
-      const button = closedTag.first()
-      await button.click()
-      // Wait for this button to become expanded (ensures expansion completes)
-      await expect(button).toHaveAttribute('aria-expanded', 'true', { timeout: 1000 })
-    }
+    do {
+      await closedTag.first().click()
 
-    // Wait for expanded sections to be visible and stable
+      // Small delay to allow expansion animation to start
+      await page.waitForTimeout(100)
+    } while ((await closedTag.count()) > 0)
+
+    // Wait for all expanded sections to be visible and stable
     const sections = nav
       .getByRole('listitem')
       .filter({ has: page.getByRole('button', { name: 'Close Group', expanded: true }) })
 
-    // Ensure sections are visible before taking screenshots
-    await expect(sections.first()).toBeVisible()
+    // Wait for sections to appear and be stable
+    await expect(sections.first()).toBeVisible({ timeout: 1000 })
 
     // Playwright's toHaveScreenshot already waits for stability and fonts,
     // but we ensure the DOM is ready by waiting for visibility above
-    await expect(await sections.count()).toBeGreaterThan(0)
+    expect(await sections.count()).toBeGreaterThan(0)
+
     for (const [index, section] of (await sections.all()).entries()) {
       await expect(section).toHaveScreenshot(`${slug}-section-${index + 1}.png`)
     }


### PR DESCRIPTION
## Problem

The sidebar.e2e.ts test still fails most of the time. I think it’s a timing issue.

## Solution

Let’s wait a little bit.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes the sidebar snapshot e2e by waiting for expansion animations and section visibility before taking screenshots.
> 
> - **Tests**
>   - Update `packages/api-reference/test/snapshots/sidebar.e2e.ts` to improve stability:
>     - Add small delay after clicking to allow expansion animations to start.
>     - Wait for expanded sections to become visible before screenshots.
>     - Use role-based filters to target only expanded groups for section screenshots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 868ec83a82b83edc375b5956ee02dbb1e93463d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->