### PR TITLE
fix(code-highlight): enable `knip`

### DIFF
--- a/.changeset/khaki-swans-promise.md
+++ b/.changeset/khaki-swans-promise.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+fix(code-highlight): remove `highlightjs-vue` unused dependency

--- a/.changeset/strong-geckos-rush.md
+++ b/.changeset/strong-geckos-rush.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+fix(code-highlight): remove unused languages

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -7,7 +7,6 @@
     "packages/api-client-react/**",
     "packages/api-reference/**",
     "packages/api-reference-react/**",
-    "packages/code-highlight/**",
     "packages/components/**",
     "packages/core/**",
     "packages/draggable/**",
@@ -73,6 +72,18 @@
         "src/esbuild/index.ts",
         "src/rollup/index.ts",
         "src/vite/index.ts"
+      ]
+    },
+    "packages/code-highlight": {
+      "entry": [
+        "src/index.ts",
+        "src/code/index.ts",
+        "src/languages/index.ts",
+        "src/markdown/index.ts",
+        "src/rehype-alert/index.ts",
+        "src/rehype-highlight/index.ts",
+        //
+        "playground/main.ts"
       ]
     },
     "packages/helpers": {

--- a/packages/code-highlight/esbuild.ts
+++ b/packages/code-highlight/esbuild.ts
@@ -1,14 +1,15 @@
 import fs from 'node:fs/promises'
-import { build } from '@scalar/build-tooling/esbuild'
 
-console.log('Copying CSS files...')
+import { build } from '@scalar/build-tooling/esbuild'
 
 await build({
   entries: 'auto',
   platform: 'shared',
   allowCss: true,
   onSuccess: async () => {
+    console.log('Copying CSS files...')
     await fs.mkdir('./dist/css')
     await fs.cp('./src/css', './dist/css', { recursive: true })
+    console.log('CSS files copy completed')
   },
 })

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -23,9 +23,10 @@
   "scripts": {
     "build": "scalar-build-esbuild",
     "dev": "vite",
-    "format": "scalar-format-js",
-    "lint:check": "eslint .",
-    "lint:fix": "eslint .  --fix",
+    "format": "scalar-format",
+    "format:check": "scalar-format-check",
+    "lint:check": "scalar-lint-check",
+    "lint:fix": "scalar-lint-fix",
     "test": "vitest",
     "types:build": "scalar-types-build",
     "types:check": "scalar-types-check"
@@ -84,7 +85,6 @@
     "hast-util-to-text": "^4.0.2",
     "highlight.js": "^11.9.0",
     "highlightjs-curl": "^1.3.0",
-    "highlightjs-vue": "^1.0.0",
     "lowlight": "^3.1.0",
     "rehype-external-links": "^3.0.0",
     "rehype-format": "^5.0.0",
@@ -100,14 +100,12 @@
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
-    "@rollup/plugin-typescript": "^12.1.2",
     "@scalar/build-tooling": "workspace:*",
     "@scalar/themes": "workspace:*",
     "@types/hast": "^3.0.4",
     "@types/mdast": "^4.0.4",
     "@types/unist": "^3.0.2",
     "vfile": "^6.0.1",
-    "vite": "catalog:*",
-    "vue": "catalog:*"
+    "vite": "catalog:*"
   }
 }

--- a/packages/code-highlight/playground/main.ts
+++ b/packages/code-highlight/playground/main.ts
@@ -3,7 +3,6 @@
  */
 import { presets } from '@scalar/themes'
 
-import '@scalar/themes/base.css'
 import '@scalar/themes/style.css'
 
 import { syntaxHighlight } from '../src/code'

--- a/packages/code-highlight/src/code/highlight.ts
+++ b/packages/code-highlight/src/code/highlight.ts
@@ -2,7 +2,7 @@ import type { Element, Root } from 'hast'
 import type { LanguageFn } from 'highlight.js'
 import rehypeParse from 'rehype-parse'
 import rehypeStringify from 'rehype-stringify'
-import { unified, type Plugin } from 'unified'
+import { type Plugin, unified } from 'unified'
 import { visit } from 'unist-util-visit'
 
 import { lowlightLanguageMappings } from '@/constants'
@@ -37,6 +37,7 @@ export function syntaxHighlight(
   // Classname is used by lowlight to select the language model
   const className = `language-${lowlightLanguageMappings[options.lang] ?? options.lang}`
 
+  // biome-ignore lint/suspicious/noEmptyBlockStatements: empty plugin
   const nullPlugin = (() => {}) satisfies Plugin
 
   const html = unified()

--- a/packages/code-highlight/src/code/line-numbers.ts
+++ b/packages/code-highlight/src/code/line-numbers.ts
@@ -4,19 +4,19 @@ import { visit } from 'unist-util-visit'
 // ---------------------------------------------------------------------------
 // Line Numbering plugin
 
-export function isText(element?: ElementContent): element is Text {
+function isText(element?: ElementContent): element is Text {
   return element?.type === 'text'
 }
 
-export function isElement(node?: ElementContent): node is Element {
+function isElement(node?: ElementContent): node is Element {
   return node?.type === 'element'
 }
 
-export function textElement(value: string): Text {
+function textElement(value: string): Text {
   return { type: 'text', value }
 }
 
-export function lineBreak(): Text {
+function lineBreak(): Text {
   return { type: 'text', value: '\n' }
 }
 

--- a/packages/code-highlight/src/index.ts
+++ b/packages/code-highlight/src/index.ts
@@ -1,5 +1,5 @@
-export { rehypeHighlight } from './rehype-highlight'
-export { lowlightLanguageMappings } from './constants'
-export { htmlFromMarkdown } from './markdown'
 export { syntaxHighlight } from './code'
+export { lowlightLanguageMappings } from './constants'
 export * from './languages'
+export { htmlFromMarkdown } from './markdown'
+export { rehypeHighlight } from './rehype-highlight'

--- a/packages/code-highlight/src/languages/index.ts
+++ b/packages/code-highlight/src/languages/index.ts
@@ -1,3 +1,3 @@
+export { basicLanguages } from './basic'
 export { jsonYamlLanguages } from './json-yaml'
 export { standardLanguages } from './standard'
-export { basicLanguages } from './basic'

--- a/packages/code-highlight/src/languages/standard.ts
+++ b/packages/code-highlight/src/languages/standard.ts
@@ -1,79 +1,47 @@
 import type { LanguageFn } from 'highlight.js'
-import ada from 'highlight.js/lib/languages/ada'
-import apache from 'highlight.js/lib/languages/apache'
-import applescript from 'highlight.js/lib/languages/applescript'
-import asciidoc from 'highlight.js/lib/languages/asciidoc'
-import awk from 'highlight.js/lib/languages/awk'
 import bash from 'highlight.js/lib/languages/bash'
 import c from 'highlight.js/lib/languages/c'
 import clojure from 'highlight.js/lib/languages/clojure'
-import cmake from 'highlight.js/lib/languages/cmake'
-import coffeescript from 'highlight.js/lib/languages/coffeescript'
-import coq from 'highlight.js/lib/languages/coq'
 import cpp from 'highlight.js/lib/languages/cpp'
-import crystal from 'highlight.js/lib/languages/crystal'
 import csharp from 'highlight.js/lib/languages/csharp'
 import css from 'highlight.js/lib/languages/css'
-import d from 'highlight.js/lib/languages/d'
 import dart from 'highlight.js/lib/languages/dart'
-import delphi from 'highlight.js/lib/languages/delphi'
 import diff from 'highlight.js/lib/languages/diff'
 import dockerfile from 'highlight.js/lib/languages/dockerfile'
 import elixir from 'highlight.js/lib/languages/elixir'
-import elm from 'highlight.js/lib/languages/elm'
-import erlang from 'highlight.js/lib/languages/erlang'
 import fsharp from 'highlight.js/lib/languages/fsharp'
-import glsl from 'highlight.js/lib/languages/glsl'
 import go from 'highlight.js/lib/languages/go'
 import graphql from 'highlight.js/lib/languages/graphql'
-import groovy from 'highlight.js/lib/languages/groovy'
-import haml from 'highlight.js/lib/languages/haml'
-import handlebars from 'highlight.js/lib/languages/handlebars'
 import haskell from 'highlight.js/lib/languages/haskell'
 import http from 'highlight.js/lib/languages/http'
 import ini from 'highlight.js/lib/languages/ini'
 import java from 'highlight.js/lib/languages/java'
 import javascript from 'highlight.js/lib/languages/javascript'
 import json from 'highlight.js/lib/languages/json'
-import julia from 'highlight.js/lib/languages/julia'
 import kotlin from 'highlight.js/lib/languages/kotlin'
-import latex from 'highlight.js/lib/languages/latex'
 import less from 'highlight.js/lib/languages/less'
-import lisp from 'highlight.js/lib/languages/lisp'
 import lua from 'highlight.js/lib/languages/lua'
 import makefile from 'highlight.js/lib/languages/makefile'
 import markdown from 'highlight.js/lib/languages/markdown'
 import matlab from 'highlight.js/lib/languages/matlab'
 import nginx from 'highlight.js/lib/languages/nginx'
-import nim from 'highlight.js/lib/languages/nim'
-import nix from 'highlight.js/lib/languages/nix'
 import objectivec from 'highlight.js/lib/languages/objectivec'
 import ocaml from 'highlight.js/lib/languages/ocaml'
 import perl from 'highlight.js/lib/languages/perl'
 import php from 'highlight.js/lib/languages/php'
 import plaintext from 'highlight.js/lib/languages/plaintext'
 import powershell from 'highlight.js/lib/languages/powershell'
-import prolog from 'highlight.js/lib/languages/prolog'
 import properties from 'highlight.js/lib/languages/properties'
-import protobuf from 'highlight.js/lib/languages/protobuf'
 import python from 'highlight.js/lib/languages/python'
 import r from 'highlight.js/lib/languages/r'
 import ruby from 'highlight.js/lib/languages/ruby'
 import rust from 'highlight.js/lib/languages/rust'
 import scala from 'highlight.js/lib/languages/scala'
-import scheme from 'highlight.js/lib/languages/scheme'
 import scss from 'highlight.js/lib/languages/scss'
 import shell from 'highlight.js/lib/languages/shell'
-import smalltalk from 'highlight.js/lib/languages/smalltalk'
 import sql from 'highlight.js/lib/languages/sql'
-import stylus from 'highlight.js/lib/languages/stylus'
 import swift from 'highlight.js/lib/languages/swift'
-import tcl from 'highlight.js/lib/languages/tcl'
-import twig from 'highlight.js/lib/languages/twig'
 import typescript from 'highlight.js/lib/languages/typescript'
-import verilog from 'highlight.js/lib/languages/verilog'
-import vhdl from 'highlight.js/lib/languages/vhdl'
-import vim from 'highlight.js/lib/languages/vim'
 import xml from 'highlight.js/lib/languages/xml'
 import yaml from 'highlight.js/lib/languages/yaml'
 // @ts-expect-error No types available
@@ -98,7 +66,7 @@ import curl from 'highlightjs-curl'
 /**
  * These are the most popular languages that cover the majority of use cases.
  */
-const standardLanguages: Record<string, LanguageFn> = {
+export const standardLanguages: Record<string, LanguageFn> = {
   bash,
   c,
   clojure,
@@ -149,68 +117,3 @@ const standardLanguages: Record<string, LanguageFn> = {
   xml,
   yaml,
 }
-
-/**
- * These languages are not as popular as the ones in `standardLanguages`, but
- * still have a decent amount of users.
- */
-const mediumLanguages: Record<string, LanguageFn> = {
-  cmake,
-  crystal,
-  elm,
-  erl: erlang,
-  erlang,
-  glsl,
-  groovy,
-  handlebars,
-  hbs: handlebars,
-  jl: julia,
-  julia,
-  nim,
-  nix,
-  proto: protobuf,
-  protobuf,
-  styl: stylus,
-  stylus,
-  twig,
-  verilog,
-  vhdl,
-}
-
-/**
- * These languages are more specialized and have a smaller user base.
- */
-const specializedLanguages: Record<string, LanguageFn> = {
-  ada,
-  adoc: asciidoc,
-  apache,
-  applescript,
-  asciidoc,
-  awk,
-  coffee: coffeescript,
-  coffeescript,
-  coq,
-  d,
-  haml,
-  hs: haskell,
-  lisp,
-  latex,
-  pascal: delphi,
-  prolog,
-  scheme,
-  smalltalk,
-  tcl,
-  tex: latex,
-  vim,
-}
-
-/**
- * A combined list of all languages.
- */
-const allLanguages: Record<string, LanguageFn> = {
-  ...standardLanguages,
-  ...mediumLanguages,
-  ...specializedLanguages,
-}
-
-export { standardLanguages, mediumLanguages, specializedLanguages, allLanguages }

--- a/packages/code-highlight/src/markdown/markdown.ts
+++ b/packages/code-highlight/src/markdown/markdown.ts
@@ -15,6 +15,7 @@ import { SKIP, visit } from 'unist-util-visit'
 import { standardLanguages } from '@/languages'
 import { rehypeAlert } from '@/rehype-alert'
 import { rehypeHighlight } from '@/rehype-highlight'
+
 type Options = {
   transform?: (node: Record<string, any>) => Record<string, any>
   type?: string

--- a/packages/code-highlight/src/rehype-alert/rehype-alert.test.ts
+++ b/packages/code-highlight/src/rehype-alert/rehype-alert.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'vitest'
-import { unified } from 'unified'
+import rehypeStringify from 'rehype-stringify'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
-import rehypeStringify from 'rehype-stringify'
+import { unified } from 'unified'
+import { describe, expect, it } from 'vitest'
+
 import { rehypeAlert } from './rehype-alert'
 
 describe('rehype-alert', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1642,9 +1642,6 @@ importers:
       highlightjs-curl:
         specifier: ^1.3.0
         version: 1.3.0
-      highlightjs-vue:
-        specifier: ^1.0.0
-        version: 1.0.0
       lowlight:
         specifier: ^3.1.0
         version: 3.1.0
@@ -1685,9 +1682,6 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
     devDependencies:
-      '@rollup/plugin-typescript':
-        specifier: ^12.1.2
-        version: 12.1.2(rollup@4.50.2)(tslib@2.8.1)(typescript@5.8.3)
       '@scalar/build-tooling':
         specifier: workspace:*
         version: link:../build-tooling
@@ -1709,9 +1703,6 @@ importers:
       vite:
         specifier: catalog:*
         version: 7.1.11(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
-      vue:
-        specifier: catalog:*
-        version: 3.5.21(typescript@5.8.3)
 
   packages/components:
     dependencies:
@@ -12387,9 +12378,6 @@ packages:
 
   highlightjs-curl@1.3.0:
     resolution: {integrity: sha512-50UEfZq1KR0Lfk2Tr6xb/MUIZH3h10oNC0OTy9g7WELcs5Fgy/mKN1vEhuKTkKbdo8vr5F9GXstu2eLhApfQ3A==}
-
-  highlightjs-vue@1.0.0:
-    resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
   history@4.10.1:
     resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
@@ -25143,15 +25131,6 @@ snapshots:
       rollup: 4.45.1
       tslib: 2.8.1
 
-  '@rollup/plugin-typescript@12.1.2(rollup@4.50.2)(tslib@2.8.1)(typescript@5.8.3)':
-    dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.50.2)
-      resolve: 1.22.8
-      typescript: 5.8.3
-    optionalDependencies:
-      rollup: 4.50.2
-      tslib: 2.8.1
-
   '@rollup/plugin-yaml@4.1.2(rollup@4.45.1)':
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.45.1)
@@ -31925,8 +31904,6 @@ snapshots:
   highlight.js@11.9.0: {}
 
   highlightjs-curl@1.3.0: {}
-
-  highlightjs-vue@1.0.0: {}
 
   history@4.10.1:
     dependencies:


### PR DESCRIPTION
## Problem

- Followup of #7233

## Solution

- removed unused languages
- removed `highlightjs-vue` unused dependency
- remove export from internal functions
- fix formatting
- use `scalar-*` from `@scalar/build-tooling` script for `format` and `lint` checks

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests (Not needed).
- [x] I updated the documentation (Not needed).

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
