### PR TITLE
docs: add missing java configuration

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -390,6 +390,11 @@
                   "type": "page"
                 },
                 {
+                  "name": "Java",
+                  "path": "documentation/integrations/java.md",
+                  "type": "page"
+                },
+                {
                   "name": "Laravel",
                   "path": "documentation/integrations/laravel.md",
                   "type": "page"


### PR DESCRIPTION
I forgot to add the new Java documentation to the configuration. 🙃