### PR TITLE
fix(api-reference): schema names are not displayed

### DIFF
--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -98,6 +98,8 @@ const schemaDescription = computed(() => {
   return schema.description
 })
 
+// console.info('Schema', JSON.stringify(schema, null, 2))
+
 // Prevent click action if noncollapsible
 const handleClick = (e: MouseEvent) => noncollapsible && e.stopPropagation()
 </script>

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
@@ -8,6 +8,7 @@ import type {
 import { computed } from 'vue'
 
 import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
+import { getResolvedRefWithSchemaName } from '@/components/Content/Schema/helpers/schema-name'
 import { sortPropertyNames } from '@/components/Content/Schema/helpers/sort-property-names'
 import type { SchemaOptions } from '@/components/Content/Schema/types'
 
@@ -84,6 +85,8 @@ const getAdditionalPropertiesValue = (
 
   return additionalProperties
 }
+
+// console.info('SchemaObjectProperties', JSON.stringify(schema, null, 2))
 </script>
 
 <template>
@@ -102,7 +105,7 @@ const getAdditionalPropertiesValue = (
       :name="property"
       :options="options"
       :required="schema.required?.includes(property)"
-      :schema="getResolvedRef(schema.properties[property])" />
+      :schema="getResolvedRefWithSchemaName(schema.properties[property])" />
   </template>
 
   <!-- patternProperties -->

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -12,6 +12,7 @@ import { computed, type Component } from 'vue'
 
 import { WithBreadcrumb } from '@/components/Anchor'
 import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
+import { getResolvedRefWithSchemaName } from '@/components/Content/Schema/helpers/schema-name'
 import type { SchemaOptions } from '@/components/Content/Schema/types'
 import { SpecificationExtension } from '@/features/specification-extension'
 
@@ -257,6 +258,12 @@ const compositionsToRender = computed(() => {
     })
     .filter(isDefined)
 })
+
+// console.info(
+//   'SchemaProperty',
+//   JSON.stringify(props.schema, null, 2),
+//   optimizedValue.value.__schemaName,
+// )
 </script>
 <template>
   <component
@@ -286,21 +293,21 @@ const compositionsToRender = computed(() => {
           <template v-if="variant === 'patternProperties'">
             <span class="property-name-pattern-properties">
               <ScalarWrappingText
-                :text="name"
-                preset="property" />
+                preset="property"
+                :text="name" />
             </span>
           </template>
           <template v-else-if="variant === 'additionalProperties'">
             <span class="property-name-additional-properties">
               <ScalarWrappingText
-                :text="name"
-                preset="property" />
+                preset="property"
+                :text="name" />
             </span>
           </template>
           <template v-else>
             <ScalarWrappingText
-              :text="name"
-              preset="property" />
+              preset="property"
+              :text="name" />
           </template>
         </WithBreadcrumb>
       </template>
@@ -370,7 +377,7 @@ const compositionsToRender = computed(() => {
           :name="name"
           :noncollapsible="noncollapsible"
           :options="options"
-          :schema="getResolvedRef(optimizedValue.items)" />
+          :schema="getResolvedRefWithSchemaName(optimizedValue.items)" />
       </div>
     </template>
 
@@ -388,7 +395,7 @@ const compositionsToRender = computed(() => {
       :name="name"
       :noncollapsible="noncollapsible"
       :options="options"
-      :schema="getResolvedRef(props.schema)!" />
+      :schema="getResolvedRefWithSchemaName(props.schema)!" />
     <SpecificationExtension :value="optimizedValue" />
   </component>
 </template>

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -184,15 +184,6 @@ const validationProperties = computed(() => {
   return properties
 })
 
-/** Gets the model name */
-const modelName = computed(() => {
-  if (!props.value) {
-    return null
-  }
-
-  return getModelName(props.value, props.hideModelNames)
-})
-
 /** Check if we should show the type information */
 const shouldShowType = computed(() => {
   if (!props.value || !('type' in props.value)) {
@@ -213,7 +204,11 @@ const displayType = computed(() => {
   if (!props.value) {
     return ''
   }
-  return modelName.value || getSchemaType(props.value)
+
+  return (
+    getModelName(props.value, props.hideModelNames) ||
+    getSchemaType(props.value)
+  )
 })
 
 /**

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
@@ -1,9 +1,19 @@
-import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { type NodeInput, getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import type { ReferenceType } from '@scalar/workspace-store/schemas/v3.1/strict/reference'
 import { isArraySchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
 
 import { getRefName } from './get-ref-name'
+
+export const getResolvedRefWithSchemaName = <Node extends SchemaObject>(
+  node: NodeInput<Node>,
+): Node & { __schemaName?: string } => {
+  const output = getResolvedRef(node, (_node) => {
+    return { ..._node['$ref-value'], __schemaName: getRefName(_node) }
+  })
+  console.warn('getResolvedRefWithSchemaName', node, output.__schemaName)
+  return output
+}
 
 /**
  * Extract schema name from various schema formats
@@ -50,6 +60,10 @@ export const formatTypeWithModel = (type: Extract<SchemaObject, { type: any }>['
 export const getModelName = (value: SchemaObject, hideModelNames = false): string | null => {
   if (!('type' in value) || hideModelNames) {
     return null
+  }
+
+  if ('__schemaName' in value) {
+    return value.__schemaName as string
   }
 
   const valueType = value.type

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -84,6 +84,13 @@ const value = computed(() => {
   } as SchemaObject
 })
 
+// console.info('list parameter', JSON.stringify(parameter, null, 2), value.value)
+// console.info(
+//   'list parameter __schemaName',
+
+//   value.value?.__schemaName,
+// )
+
 /**
  * Determines whether this parameter item should be rendered as a collapsible disclosure.
  * Only collapses when collapsableItems is enabled and the parameter has additional
@@ -110,8 +117,8 @@ const shouldCollapse = computed<boolean>(() =>
             weight="bold" />
           <div>
             <ScalarWrappingText
-              :text="name"
-              preset="property" />
+              preset="property"
+              :text="name" />
           </div>
         </div>
         <ScalarMarkdownSummary

--- a/packages/api-reference/test/utils/sources.ts
+++ b/packages/api-reference/test/utils/sources.ts
@@ -60,23 +60,89 @@ export const sources = [
     title: 'Hello World (string)',
     slug: 'hello-world-string',
     content: JSON.stringify({
-      openapi: '3.0.0',
-      info: {
-        title: 'Hello World',
-        version: '1.0.0',
+      'openapi': '3.1.0',
+      'info': {
+        'title': 'SampleApi',
+        'version': '1.0.1',
       },
-      paths: {
-        '/hello': {
-          get: {
-            summary: 'Hello World',
-            description: 'Hello World',
-            responses: {
-              200: {
-                description: 'Hello World',
-                content: {
+      'components': {
+        'schemas': {
+          'UserIdInput': {
+            'description': 'User identifier',
+            'example': 'U234',
+            'default': 'J1',
+            'type': 'string',
+          },
+          'User': {
+            'description': 'User Data',
+            'example': {
+              'name': 'Someone',
+            },
+            'type': 'object',
+            'properties': {
+              'name': {
+                'default': 'Unknown',
+                'type': 'string',
+              },
+            },
+            'required': ['name'],
+            'additionalProperties': false,
+          },
+        },
+      },
+      'paths': {
+        '/login': {
+          'post': {
+            'requestBody': {
+              'content': {
+                'application/json': {
+                  'schema': {
+                    'type': 'object',
+                    'properties': {
+                      'userId': {
+                        '$ref': '#/components/schemas/UserIdInput',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            // 'parameters': [
+            //   {
+            //     'schema': {
+            //       'example': 'wiiiiiiiiii',
+            //       'type': 'string',
+            //     },
+            //     'in': 'query',
+            //     'name': 'baz',
+            //     'required': true,
+            //     'description': 'query string example',
+            //   },
+            // ],
+            'responses': {
+              '200': {
+                'description': 'Default Response',
+                'content': {
                   'application/json': {
-                    schema: {
-                      type: 'string',
+                    'schema': {
+                      'type': 'object',
+                      'properties': {
+                        'user': {
+                          '$ref': '#/components/schemas/User',
+                        },
+                        // 'users': {
+                        //   'type': 'array',
+                        //   'items': {
+                        //     '$ref': '#/components/schemas/User',
+                        //   },
+                        // },
+                      },
+                      'required': [
+                        'user',
+                        //
+                        // 'users',
+                      ],
+                      'additionalProperties': false,
                     },
                   },
                 },
@@ -85,6 +151,7 @@ export const sources = [
           },
         },
       },
+      'servers': [],
     }),
   },
   {


### PR DESCRIPTION
## Problem

Schema names are not displayed in path parameters and responses.

- Related to #5711

## Solution

To expose the schema name to the UI, I introduced a new helper function, `getResolvedRefWithSchemaName`.  
It stores the schema name under a custom key, allowing the UI to read and display the correct schema name later on.

This PR is a draft, and I’m looking for feedback from @hanspagel or anyone else 
to validate that this approach is acceptable before I continue.

> [!WARNING]
> Note: This is only a "runtime" POC. 
> Types haven’t been updated and tests hasn't been added yet.

<details><summary>Result comparing the OpenAPI document I temporally committed "Hello World (string)" source</summary>
<p>

<img width="1710" height="901" alt="Screenshot 2025-12-01 at 07 56 25" src="https://github.com/user-attachments/assets/bc094f57-23f6-46ac-a9db-0c77a4565c38" />

</p>
</details> 

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
