### PR TITLE
fix(use-toasts): enable `knip`

### DIFF
--- a/.changeset/shy-panthers-tickle.md
+++ b/.changeset/shy-panthers-tickle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-toasts': patch
+---
+
+fix: remove `nanoid` unused dependency

--- a/.changeset/smart-jobs-sort.md
+++ b/.changeset/smart-jobs-sort.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-toasts': patch
+---
+
+fix: use named exports instead of star

--- a/packages/use-toasts/index.d.ts
+++ b/packages/use-toasts/index.d.ts
@@ -1,5 +1,0 @@
-declare module '@scalar/use-toasts' {
-  export const useToasts: () => {
-    toast: (message: string, type: 'error' | 'warn' | 'info', options?: { timeout: number }) => void
-  }
-}

--- a/packages/use-toasts/package.json
+++ b/packages/use-toasts/package.json
@@ -35,12 +35,18 @@
   },
   "type": "module",
   "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "files": [
     "dist",
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "nanoid": "catalog:*",
     "vue": "catalog:*",
     "vue-sonner": "^1.0.3"
   },

--- a/packages/use-toasts/src/components/ScalarToasts.test.ts
+++ b/packages/use-toasts/src/components/ScalarToasts.test.ts
@@ -4,28 +4,23 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
-import { type Toaster, toast } from 'vue-sonner'
+import { toast } from 'vue-sonner'
 
 import { useToasts } from '../hooks/useToasts'
 import ScalarToasts from './ScalarToasts.vue'
 
-vi.mock('../hooks/useToasts', () => ({
+vi.mock(import('../hooks/useToasts'), () => ({
+  initializeToasts: vi.fn(),
   useToasts: vi.fn(() => ({
     initializeToasts: vi.fn(),
+    toast: vi.fn(),
   })),
 }))
 
-vi.mock('vue-sonner', async (importOriginal) => {
-  const actual = await importOriginal<{
-    Toaster: typeof Toaster
-    toast: typeof toast
-  }>()
-
-  return {
-    ...actual,
-    toast: vi.fn(),
-  }
-})
+vi.mock(import('vue-sonner'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  toast: vi.fn() as unknown as typeof toast,
+}))
 
 describe('ScalarToasts', () => {
   it('should not render Toaster before mount', () => {

--- a/packages/use-toasts/src/components/ScalarToasts.vue
+++ b/packages/use-toasts/src/components/ScalarToasts.vue
@@ -2,7 +2,7 @@
 import { onMounted, ref } from 'vue'
 import { toast, Toaster } from 'vue-sonner'
 
-import { useToasts, type ToastOptions } from '../hooks'
+import { useToasts, type ToastOptions } from '../hooks/useToasts'
 
 // The toaster is only required on the client
 const isClientMounted = ref(false)

--- a/packages/use-toasts/src/hooks/index.ts
+++ b/packages/use-toasts/src/hooks/index.ts
@@ -1,1 +1,0 @@
-export * from './useToasts'

--- a/packages/use-toasts/src/index.ts
+++ b/packages/use-toasts/src/index.ts
@@ -1,2 +1,7 @@
 export { default as ScalarToasts } from './components/ScalarToasts.vue'
-export * from './hooks'
+export {
+  type ToastFunction,
+  type ToastOptions,
+  initializeToasts,
+  useToasts,
+} from './hooks/useToasts'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2615,9 +2615,6 @@ importers:
 
   packages/use-toasts:
     dependencies:
-      nanoid:
-        specifier: catalog:*
-        version: 5.1.5
       vue:
         specifier: catalog:*
         version: 3.5.21(typescript@5.8.3)


### PR DESCRIPTION
## Problem

- Followup of #7233

## Solution

- remove `nanoid` unused dependency
- remove `index.d.ts` from the root
- add `exports` field
- use named exports instead of start export (so this package is now free from any `biome check` error)
- use `import()` instead of plain string in `vi.mock`.
   Improves type information and reference the actual module in file tracking / reference.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation (Not needed).

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
