### PR TITLE
docs: fix broken mock server links

### DIFF
--- a/documentation/guides/mock-server/custom-request-handler.md
+++ b/documentation/guides/mock-server/custom-request-handler.md
@@ -276,9 +276,8 @@ The error response will be:
 
 ## Best Practices
 
-1. **Use meaningful collection names**: Match your schema names (e.g., `'Post'` for a `Post` schema)
-2. **Generate IDs**: Use `faker.string.uuid()` for consistent ID generation
-3. **Handle missing data**: Check for `null` or `undefined` when using `store.get()`
-4. **Keep handlers simple**: Extract complex logic into helper functions if needed
-5. **Use Faker for realistic data**: Generate realistic test data instead of hardcoding values
+1. Use meaningful collection names: Match your schema names (e.g., `'Post'` for a `Post` schema)
+2. Generate IDs: Use `faker.string.uuid()` for consistent ID generation
+3. Handle missing data: Check for `null` or `undefined` when using `store.get()`
+4. Use Faker for realistic data: Generate realistic test data instead of hardcoding values
 

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -9,9 +9,8 @@ A powerful Node.js mock server that automatically generates realistic API respon
 - Generates realistic mock data based on your schemas
 - Handles authentication and responds with defined HTTP headers
 - Supports Swagger 2.0 and OpenAPI 3.x documents
-- Customizable response handling
-- **x-handler**: Write custom JavaScript handlers for dynamic responses
-- **x-seed**: Automatically seed initial data on server startup
+- Write custom JavaScript handlers for dynamic responses
+- Automatically seed initial data on server startup
 
 ## Quickstart
 
@@ -184,10 +183,10 @@ The given OpenAPI document is automatically exposed:
 
 Use the `x-handler` extension to write custom JavaScript code for handling requests. This gives you access to a `store` helper for data persistence, `faker` for generating realistic data, and full access to request/response objects.
 
-[Learn more about custom request handlers →](./custom-request-handler)
+[Learn more about custom request handlers →](https://guides.scalar.com/scalar/scalar-mock-server/custom-request-handlers)
 
 ### Data Seeding
 
 Use the `x-seed` extension on your schemas to automatically populate initial data when the server starts. Perfect for having realistic test data available immediately.
 
-[Learn more about data seeding →](./data-seeding)
+[Learn more about data seeding →](https://guides.scalar.com/scalar/scalar-mock-server/data-seeding)


### PR DESCRIPTION
Two mock server links are broken, let’s fix them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes broken links in mock server docs and streamlines features/best-practices lists.
> 
> - **Documentation**
>   - **Links**:
>     - Update references in `documentation/guides/mock-server/getting-started.md` from relative to absolute URLs for custom request handlers and data seeding.
>   - **Features list** (`getting-started.md`):
>     - Consolidate/customize bullets to “Write custom JavaScript handlers…” and “Automatically seed initial data…”.
>   - **Best Practices** (`custom-request-handler.md`):
>     - Simplify numbered list formatting and remove the “Keep handlers simple” item.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7f1552afd9c443ca742f8d44d839c9e22edf813. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->