### PR TITLE
ci: fetch release notes from release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,12 +480,12 @@ jobs:
 
   # We use this job for automated changelog generation
   create-github-release:
-    # if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
+    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 5
     permissions:
       contents: write
-    # needs: [required-jobs-main]
+    needs: [required-jobs-main]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -504,7 +504,7 @@ jobs:
         id: pr-body
         run: |
           # Find the PR that contains this commit
-          PR_DATA=$(gh api repos/${{ github.repository }}/commits/31c3ac7faecaaaef1e615da3e02fbf62a23ff3e1/pulls --jq '.[0]')
+          PR_DATA=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0]')
           PR_BODY=$(echo "$PR_DATA" | jq -r '.body // ""')
 
           # Fallback if PR body is empty
@@ -513,7 +513,7 @@ jobs:
             echo "Release ${{ steps.tag.outputs.date }}" > release-notes.md
           else
             # Extract only the relevant content:
-            # - Start from "# Releases" heading (using awk for reliability)
+            # - Start from "# Releases" heading
             # - Stop before "<!-- CURSOR_SUMMARY -->" marker
             echo "$PR_BODY" | awk '
               /^# Releases/ { found=1 }
@@ -526,13 +526,11 @@ jobs:
               echo "$PR_BODY" > release-notes.md
             fi
           fi
-
-          cat release-notes.md
-      # - name: Create GitHub Release
-      #   run: |
-      #     gh release create "${{ steps.tag.outputs.tag }}" \
-      #       --title "Release ${{ steps.tag.outputs.date }}" \
-      #       --notes-file release-notes.md
+      - name: Create GitHub Release
+        run: |
+          gh release create "${{ steps.tag.outputs.tag }}" \
+            --title "Release ${{ steps.tag.outputs.date }}" \
+            --notes-file release-notes.md
 
   npm-publish:
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Problem

<!--
  What problem does the PR solve?
  WHY did you submit the PR?

  We are interested in the WHY (LLMs won't know).
-->

Our `create-github-release` job fails due to a large description body.

## Solution

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

This PR updates the job to use the PR body of the release PR as release notes. So instead of PR titles, we use our changeset descriptions.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
