### PR TITLE
feat(use-codemirror): enable `knip`

### DIFF
--- a/.changeset/curly-pugs-talk.md
+++ b/.changeset/curly-pugs-talk.md
@@ -1,0 +1,7 @@
+---
+'@scalar/use-codemirror': minor
+---
+
+feat: hooks are now only exported from root 
+
+replace `@scalar/use-codemirror/hooks` with `@scalar/use-codemirror`

--- a/.changeset/neat-ants-greet.md
+++ b/.changeset/neat-ants-greet.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-codemirror': patch
+---
+
+fix: remove unused `codemirror` dependency

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -20,7 +20,6 @@
     "packages/sidebar/**",
     "packages/snippetz/**",
     "packages/ts-to-openapi/**",
-    "packages/use-codemirror/**",
     "packages/void-server/**",
     "projects/**",
     "integrations/docker/**",
@@ -134,6 +133,14 @@
         "src/legacy/index.ts",
         "src/snippetz/index.ts",
         "src/utils/index.ts"
+      ]
+    },
+    "packages/use-codemirror": {
+      "entry": [
+        "src/index.ts",
+        "src/themes/index.ts",
+        //
+        "playground/main.ts"
       ]
     },
     "packages/use-hooks": {

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -38,11 +38,6 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./hooks": {
-      "import": "./dist/hooks/index.js",
-      "types": "./dist/hooks/index.d.ts",
-      "default": "./dist/hooks/index.js"
-    },
     "./themes": {
       "import": "./dist/themes/index.js",
       "types": "./dist/themes/index.d.ts",
@@ -69,7 +64,6 @@
     "@lezer/highlight": "^1.2.1",
     "@replit/codemirror-css-color-picker": "^6.3.0",
     "@scalar/components": "workspace:*",
-    "codemirror": "^6.0.0",
     "vue": "catalog:*"
   },
   "devDependencies": {

--- a/packages/use-codemirror/src/hooks/index.ts
+++ b/packages/use-codemirror/src/hooks/index.ts
@@ -1,2 +1,0 @@
-export * from './useCodeMirror'
-export * from './useDropdown'

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -1,6 +1,5 @@
 import { autocompletion, closeBrackets, closeBracketsKeymap, completionKeymap } from '@codemirror/autocomplete'
-import { indentWithTab, insertNewline } from '@codemirror/commands'
-import { history, historyKeymap } from '@codemirror/commands'
+import { history, historyKeymap, indentWithTab, insertNewline } from '@codemirror/commands'
 import { css } from '@codemirror/lang-css'
 import { html } from '@codemirror/lang-html'
 import { json } from '@codemirror/lang-json'

--- a/packages/use-codemirror/src/index.ts
+++ b/packages/use-codemirror/src/index.ts
@@ -14,5 +14,9 @@ export {
 } from '@codemirror/view'
 export { colorPicker } from '@replit/codemirror-css-color-picker'
 
-export * from './hooks'
-export * from './types'
+export {
+  type UseCodeMirrorParameters,
+  useCodeMirror,
+} from './hooks/useCodeMirror'
+export { useDropdown } from './hooks/useDropdown'
+export type { CodeMirrorLanguage } from './types'

--- a/packages/use-codemirror/src/themes/createCodeMirrorTheme.ts
+++ b/packages/use-codemirror/src/themes/createCodeMirrorTheme.ts
@@ -13,7 +13,7 @@ type StyleSpec = {
   [propOrSelector: string]: string | number | StyleSpec | null
 }
 
-export type CreateThemeOptions = {
+type CreateThemeOptions = {
   /**
    * Theme inheritance. Determines which styles CodeMirror will apply by default.
    */
@@ -28,7 +28,7 @@ export type CreateThemeOptions = {
 
 type Theme = 'light' | 'dark'
 
-export type Settings = {
+type Settings = {
   /** Editor background color. */
   background?: string
   /** Editor background image. */

--- a/packages/use-codemirror/vite.config.ts
+++ b/packages/use-codemirror/vite.config.ts
@@ -1,7 +1,9 @@
 import { alias } from '@scalar/build-tooling/vite'
+import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  plugins: [vue()],
   resolve: {
     alias: alias(import.meta.url),
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2556,9 +2556,6 @@ importers:
       '@scalar/components':
         specifier: workspace:*
         version: link:../components
-      codemirror:
-        specifier: ^6.0.0
-        version: 6.0.1(@lezer/common@1.2.3)
       vue:
         specifier: catalog:*
         version: 3.5.21(typescript@5.8.3)
@@ -3908,9 +3905,6 @@ packages:
 
   '@codemirror/lint@6.8.4':
     resolution: {integrity: sha512-u4q7PnZlJUojeRe8FJa/njJcMctISGgPQ4PnWsd9268R4ZTtU+tfFYmwkBvgcrK2+QQ8tYFVALVb5fVJykKc5A==}
-
-  '@codemirror/search@6.5.6':
-    resolution: {integrity: sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==}
 
   '@codemirror/state@6.5.0':
     resolution: {integrity: sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==}
@@ -10168,9 +10162,6 @@ packages:
   code-excerpt@3.0.0:
     resolution: {integrity: sha512-VHNTVhd7KsLGOqfX3SyeO8RyYPMp1GJOg194VITk04WMYCv4plV68YWe6TJZxd9MhobjtpMRnVky01gqZsalaw==}
     engines: {node: '>=10'}
-
-  codemirror@6.0.1:
-    resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -20759,12 +20750,6 @@ snapshots:
       '@codemirror/view': 6.35.3
       crelt: 1.0.6
 
-  '@codemirror/search@6.5.6':
-    dependencies:
-      '@codemirror/state': 6.5.0
-      '@codemirror/view': 6.35.3
-      crelt: 1.0.6
-
   '@codemirror/state@6.5.0':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
@@ -29017,18 +29002,6 @@ snapshots:
   code-excerpt@3.0.0:
     dependencies:
       convert-to-spaces: 1.0.2
-
-  codemirror@6.0.1(@lezer/common@1.2.3):
-    dependencies:
-      '@codemirror/autocomplete': 6.18.3(@codemirror/language@6.10.7)(@codemirror/state@6.5.0)(@codemirror/view@6.35.3)(@lezer/common@1.2.3)
-      '@codemirror/commands': 6.7.1
-      '@codemirror/language': 6.10.7
-      '@codemirror/lint': 6.8.4
-      '@codemirror/search': 6.5.6
-      '@codemirror/state': 6.5.0
-      '@codemirror/view': 6.35.3
-    transitivePeerDependencies:
-      - '@lezer/common'
 
   collapse-white-space@2.1.0: {}
 


### PR DESCRIPTION
## Problem

- Followup of #7233

## Solution

- remove unused `codemirror` dependency
- make `dev` environment work again by including `vue` plugin in `vite.config.ts`
- removed `/hooks` export: its content is already exported from the root and this allows to get rid of barrel file.
  In addition all public hooks APIs are now exported with named exports instead of start export  that navigate 2 barrel files   
  (`index` → `hooks/index` → `hooks/*`)
  (no biome errors reported for this package)

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation (Not needed).

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
