### PR TITLE
test: use `vitest` mock utils instead of manual mock

### DIFF
--- a/packages/oas-utils/src/helpers/servers.test.ts
+++ b/packages/oas-utils/src/helpers/servers.test.ts
@@ -1,56 +1,21 @@
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { getServersFromDocument } from './servers'
 
 describe('servers', () => {
-  // Store original window object
-  const originalWindow = global.window
-
   beforeEach(() => {
-    // Mock window.location for tests
-    Object.defineProperty(global, 'window', {
-      value: {
-        location: {
-          origin: 'https://example.com',
-        },
+    vi.unstubAllGlobals()
+    vi.stubGlobal('window', {
+      location: {
+        origin: 'https://example.com',
       },
-      writable: true,
-      configurable: true,
     })
-  })
-
-  afterEach(() => {
-    // Restore original window object
-    if (originalWindow) {
-      Object.defineProperty(global, 'window', {
-        value: originalWindow,
-        writable: true,
-        configurable: true,
-      })
-    } else {
-      // Only delete if it's configurable
-      try {
-        delete (global as any).window
-      } catch {
-        // If deletion fails, just set to undefined
-        Object.defineProperty(global, 'window', {
-          value: undefined,
-          writable: true,
-          configurable: true,
-        })
-      }
-    }
-    vi.clearAllMocks()
   })
 
   describe('getServersFromDocument', () => {
     it('returns empty array when no servers provided and no fallback available', () => {
-      // Mock window to be undefined
-      Object.defineProperty(global, 'window', {
-        value: undefined,
-        writable: true,
-        configurable: true,
-      })
+      vi.stubGlobal('window', undefined)
 
       const result = getServersFromDocument(undefined)
       expect(result).toEqual([])

--- a/packages/use-hooks/src/useBreakpoints/useBreakpoints.test.ts
+++ b/packages/use-hooks/src/useBreakpoints/useBreakpoints.test.ts
@@ -41,12 +41,12 @@ describe('useBreakpoints', () => {
     expect(breakpoints.value.md).toEqual(true)
   })
 
-  it('works in SSG environment without window', () => {
-    const originalWindow = global.window
-
+  it('works in SSG environment without window', ({ onTestFinished }) => {
     // Mock SSG environment by removing window
-    // @ts-expect-error
-    delete global.window
+    vi.stubGlobal('window', undefined)
+    onTestFinished(() => {
+      vi.unstubAllGlobals()
+    })
 
     // Mock useMediaQuery to return false since there's no window
     vi.mocked(useMediaQuery).mockImplementation(() => computed(() => false))
@@ -65,8 +65,5 @@ describe('useBreakpoints', () => {
     Object.values(breakpoints.value).forEach((value) => {
       expect(value).toBe(false)
     })
-
-    // Restore window
-    global.window = originalWindow
   })
 })

--- a/packages/use-hooks/src/useClipboard/useClipboard.test.ts
+++ b/packages/use-hooks/src/useClipboard/useClipboard.test.ts
@@ -78,12 +78,12 @@ describe('useClipboard', () => {
     expect(mockConsole).toHaveBeenCalledWith('Clipboard error')
   })
 
-  it('works in SSG environment without navigator', async () => {
-    const originalNavigator = global.navigator
-
+  it('works in SSG environment without navigator', async ({ onTestFinished }) => {
     // Mock SSG environment by removing navigator
-    // @ts-expect-error
-    delete global.navigator
+    vi.stubGlobal('navigator', undefined)
+    onTestFinished(() => {
+      vi.unstubAllGlobals()
+    })
 
     const notify = vi.fn()
     const { copyToClipboard } = useClipboard({ notify })
@@ -92,8 +92,5 @@ describe('useClipboard', () => {
 
     // Should show error notification since clipboard is not available
     expect(notify).toHaveBeenCalledWith('Failed to copy to clipboard')
-
-    // Restore navigator
-    global.navigator = originalNavigator
   })
 })

--- a/packages/workspace-store/src/preprocessing/server.test.ts
+++ b/packages/workspace-store/src/preprocessing/server.test.ts
@@ -1,58 +1,22 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ServerObject } from '@/schemas/v3.1/strict/server'
 
 import { getServersFromDocument } from './server'
 
 describe('servers', () => {
-  // Store original window object
-  const originalWindow = global.window
-
   beforeEach(() => {
-    // Mock window.location for tests
-    Object.defineProperty(global, 'window', {
-      value: {
-        location: {
-          origin: 'https://example.com',
-        },
+    vi.unstubAllGlobals()
+    vi.stubGlobal('window', {
+      location: {
+        origin: 'https://example.com',
       },
-      writable: true,
-      configurable: true,
     })
-  })
-
-  afterEach(() => {
-    // Restore original window object
-    if (originalWindow) {
-      Object.defineProperty(global, 'window', {
-        value: originalWindow,
-        writable: true,
-        configurable: true,
-      })
-    } else {
-      // Only delete if it's configurable
-      try {
-        delete (global as any).window
-      } catch {
-        // If deletion fails, just set to undefined
-        Object.defineProperty(global, 'window', {
-          value: undefined,
-          writable: true,
-          configurable: true,
-        })
-      }
-    }
-    vi.clearAllMocks()
   })
 
   describe('getServersFromDocument', () => {
     it('returns empty array when no servers provided and no fallback available', () => {
-      // Mock window to be undefined
-      Object.defineProperty(global, 'window', {
-        value: undefined,
-        writable: true,
-        configurable: true,
-      })
+      vi.stubGlobal('window', undefined)
 
       const result = getServersFromDocument(undefined)
       expect(result).toEqual([])
@@ -272,7 +236,8 @@ describe('servers', () => {
     })
 
     it('handles edge case with null servers', () => {
-      const result = getServersFromDocument(null as any)
+      // @ts-expect-error testing null value
+      const result = getServersFromDocument(null)
 
       expect(result).toHaveLength(1)
       expect(result[0]?.url).toBe('https://example.com')


### PR DESCRIPTION
## Problem

I noticed that many tests are mocking global properties manually (store value and restore it manually at the end of the test)

## Solution

Use `vitest` mock utils (`stubGlobal`, `unstubAllGlobals`, spies...) to handle global variables mock.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset (Not needed). <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation (Not needed).

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
