### PR TITLE
fix: use caret version for `zod` and `yaml`

### DIFF
--- a/.changeset/khaki-ears-collect.md
+++ b/.changeset/khaki-ears-collect.md
@@ -1,0 +1,11 @@
+---
+'@scalar/fastify-api-reference': patch
+'@scalar/api-client': patch
+'@scalar/import': patch
+'@scalar/json-magic': patch
+'@scalar/oas-utils': patch
+'@scalar/openapi-parser': patch
+'@scalar/workspace-store': patch
+---
+
+fix: use caret version for `yaml`

--- a/.changeset/six-students-wait.md
+++ b/.changeset/six-students-wait.md
@@ -1,0 +1,11 @@
+---
+'@scalar/analytics-client': patch
+'@scalar/api-client': patch
+'@scalar/api-reference': patch
+'@scalar/oas-utils': patch
+'@scalar/openapi-types': patch
+'@scalar/types': patch
+'@scalar/use-hooks': patch
+---
+
+fix: use caret version for `zod`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,10 +178,10 @@ catalogs:
       specifier: ^2.2.0
       version: 2.2.12
     yaml:
-      specifier: 2.8.0
+      specifier: ^2.8.0
       version: 2.8.0
     zod:
-      specifier: 4.1.11
+      specifier: ^4.1.11
       version: 4.1.11
 
 importers:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -84,8 +84,8 @@ catalogs:
     vue-router: 4.6.2
     vue-tsc: ^2.2.0
     vue: ^3.5.21
-    yaml: 2.8.0
-    zod: 4.1.11
+    yaml: ^2.8.0
+    zod: ^4.1.11
 
 ignoredBuiltDependencies:
   - '@firebase/util'


### PR DESCRIPTION
## Problem

The versions of `zod` and `yaml` are currently pinned.  
If a consuming project uses different versions of these dependencies, package deduplication cannot occur.

## Solution

Use caret-based version ranges for `zod` and `yaml` to allow greater compatibility and enable deduplication.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation (Not needed).

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
