### PR TITLE
fix(build-tooling): include only relevant files in published package

### DIFF
--- a/.changeset/warm-chefs-care.md
+++ b/.changeset/warm-chefs-care.md
@@ -1,0 +1,5 @@
+---
+'@scalar/build-tooling': patch
+---
+
+fix: include only relevant files in published package

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -48,6 +48,10 @@
       "default": "./dist/vite/index.js"
     }
   },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
   "bin": {
     "scalar-build-esbuild": "scripts/build-esbuild.js",
     "scalar-build-rollup": "scripts/build-rollup.js",


### PR DESCRIPTION
## Problem


The entire `@scalar/build-tooling` is published to `npm`:

https://www.npmjs.com/package/@scalar/build-tooling?activeTab=code

<details><summary>Ref</summary>
<p>

<img width="801" height="666" alt="image" src="https://github.com/user-attachments/assets/7dab97e4-a6cc-4432-bc56-6394864cff37" />


</p>
</details> 

Noticed after opening #7516

## Solution

Add `files` field to `package.json`:

```js
"files": [
  "dist",
  "CHANGELOG.md"
],
```

> [!NOTE]
> `scripts` folder files referenced from `bin` field are include by default

Below you can find `pnpm --filter build-tooling pack` output:

<details><summary>Details</summary>
<p>

<img width="280" height="747" alt="image" src="https://github.com/user-attachments/assets/b4d01aac-0750-471b-a5b0-329d575fde3d" />


</p>
</details> 


## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests (Not needed).
- [x] I updated the documentation (Not needed).

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
