### PR TITLE
fix(integrations): Add ElysiaJs and Fastify themes to ScalarTheme enum

### DIFF
--- a/integrations/dotnet/shared/src/Scalar.Shared/Enums/ScalarTheme.cs
+++ b/integrations/dotnet/shared/src/Scalar.Shared/Enums/ScalarTheme.cs
@@ -90,7 +90,7 @@ public enum ScalarTheme
     /// <summary>
     /// Elysia.js theme.
     /// </summary>
-    [Description("elysiaJs")]
+    [Description("elysiajs")]
     ElysiaJs,
 
     /// <summary>


### PR DESCRIPTION
## Problem

ElysiaJs and Fastify themes are missing in the ScalarTheme enum.

## Solution

Add ElysiaJs and Fastify themes to ScalarTheme enum.
