### PR TITLE
ci(renovate): add grouping for official GitHub actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -378,6 +378,14 @@
     },
 
     {
+      "description": "Group official patch and minor updates for official GitHub actions",
+      "matchDepTypes": ["action"],
+      "matchPackageNames": ["actions/**"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "official-github-actions"
+    },
+
+    {
       "description": "Disable engine updates like node, github runner, and uses-with",
       "matchDepTypes": ["engines", "github-runner", "uses-with"],
       "enabled": false


### PR DESCRIPTION
## Problem

<!--
  What problem does the PR solve?
  WHY did you submit the PR?

  We are interested in the WHY (LLMs won't know).
-->

A lot of noise and maintenance work from Renovate.

## Solution

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

This PR groups official GitHub actions into one PR.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
