### PR TITLE
chore: remove unused `biome-ignore-all lint/performance/noBarrelFile` directives

### DIFF
--- a/packages/api-client/src/v2/components/resize/index.ts
+++ b/packages/api-client/src/v2/components/resize/index.ts
@@ -1,2 +1,1 @@
-/** biome-ignore-all lint/performance/noBarrelFile: Component entry point */
 export { default as Resize } from './Resize.vue'

--- a/packages/api-client/src/v2/features/operation/index.ts
+++ b/packages/api-client/src/v2/features/operation/index.ts
@@ -1,3 +1,1 @@
-/** biome-ignore-all lint/performance/noBarrelFile: It's an entry point for this feature */
-
 export { default as Operation } from './Operation.vue'

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/index.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/index.ts
@@ -1,4 +1,3 @@
-/** biome-ignore-all lint/performance/noBarrelFile: these are exported publicly */
 export { restoreAuthFromLocalStorage } from './helpers/restore-auth-from-local-storage'
 export { default as RequestAuth } from './RequestAuth.vue'
 export { default as RequestAuthDataTable } from './RequestAuthDataTable.vue'

--- a/packages/api-reference/src/index.ts
+++ b/packages/api-reference/src/index.ts
@@ -1,4 +1,3 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 import type { AnyApiReferenceConfiguration } from '@scalar/types/api-reference'
 
 export type { ApiReferenceConfiguration } from '@scalar/types/api-reference'

--- a/packages/build-tooling/src/esbuild/index.ts
+++ b/packages/build-tooling/src/esbuild/index.ts
@@ -1,2 +1,1 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export { build } from './build'

--- a/packages/build-tooling/src/index.ts
+++ b/packages/build-tooling/src/index.ts
@@ -1,2 +1,1 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export { addPackageFileExports, findEntryPoints } from './helpers'

--- a/packages/build-tooling/src/vite/index.ts
+++ b/packages/build-tooling/src/vite/index.ts
@@ -1,3 +1,2 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export { alias, createViteBuildOptions } from './options'
 export { ViteWatchWorkspace } from './plugins/workspace-reload'

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -1,2 +1,1 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export { resolve } from './resolve'

--- a/packages/json-magic/src/bundle/index.ts
+++ b/packages/json-magic/src/bundle/index.ts
@@ -1,3 +1,2 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export type { LifecyclePlugin, LoaderPlugin, Plugin, ResolveResult } from './bundle'
 export { bundle, resolveAndCopyReferences } from './bundle'

--- a/packages/oas-utils/src/entities/environment/index.ts
+++ b/packages/oas-utils/src/entities/environment/index.ts
@@ -1,2 +1,1 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export { type Environment, type EnvironmentPayload, environmentSchema } from './environment'

--- a/packages/oas-utils/src/entities/spec/index.ts
+++ b/packages/oas-utils/src/entities/spec/index.ts
@@ -1,4 +1,3 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 /** Re-exported here for ease of use but we should use the other ones directly */
 export {
   type Oauth2Flow,

--- a/packages/openapi-parser/src/index.ts
+++ b/packages/openapi-parser/src/index.ts
@@ -1,10 +1,15 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint file */
-/** @deprecated Please import from @scalar/json-magic/helpers/escape-json-pointer instead */
-export { escapeJsonPointer } from '@scalar/json-magic/helpers/escape-json-pointer'
-/** @deprecated Please import from @scalar/openapi-upgrader/2.0-to-3.0 instead */
-export { upgradeFromTwoToThree } from '@scalar/openapi-upgrader/2.0-to-3.0'
-/** @deprecated Please import from @scalar/openapi-upgrader/3.0-to-3.1 instead */
-export { upgradeFromThreeToThreeOne } from '@scalar/openapi-upgrader/3.0-to-3.1'
+export {
+  /** @deprecated Please import from @scalar/json-magic/helpers/escape-json-pointer instead */
+  escapeJsonPointer,
+} from '@scalar/json-magic/helpers/escape-json-pointer'
+export {
+  /** @deprecated Please import from @scalar/openapi-upgrader/2.0-to-3.0 instead */
+  upgradeFromTwoToThree,
+} from '@scalar/openapi-upgrader/2.0-to-3.0'
+export {
+  /** @deprecated Please import from @scalar/openapi-upgrader/3.0-to-3.1 instead */
+  upgradeFromThreeToThreeOne,
+} from '@scalar/openapi-upgrader/3.0-to-3.1'
 
 export type { AnyObject, ErrorObject, Filesystem, LoadResult } from './types'
 export { type DereferenceOptions, dereference } from './utils/dereference'

--- a/packages/openapi-parser/src/utils/join/index.ts
+++ b/packages/openapi-parser/src/utils/join/index.ts
@@ -1,2 +1,1 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export { join } from './join'

--- a/packages/openapi-parser/src/utils/load/index.ts
+++ b/packages/openapi-parser/src/utils/load/index.ts
@@ -1,2 +1,1 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export { load } from './load'

--- a/packages/openapi-parser/src/utils/transform/sanitize.ts
+++ b/packages/openapi-parser/src/utils/transform/sanitize.ts
@@ -1,4 +1,3 @@
-/** biome-ignore-all lint/performance/noBarrelFile: re-exports utilities */
 import type { OpenAPI } from '@scalar/openapi-types'
 
 import type { AnyObject } from '@/types/index'
@@ -9,6 +8,7 @@ import { addMissingTags } from './utils/addMissingTags'
 import { normalizeSecuritySchemes } from './utils/normalizeSecuritySchemes'
 import { rejectSwaggerDocuments } from './utils/rejectSwaggerDocuments'
 
+// biome-ignore lint/performance/noBarrelFile: re-exports utilities
 export { DEFAULT_TITLE } from './utils/addInfoObject'
 export { DEFAULT_OPENAPI_VERSION } from './utils/addLatestOpenApiVersion'
 

--- a/packages/openapi-types/src/index.ts
+++ b/packages/openapi-types/src/index.ts
@@ -1,2 +1,1 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export * from './openapi-types'

--- a/packages/openapi-types/src/schemas/extensions/index.ts
+++ b/packages/openapi-types/src/schemas/extensions/index.ts
@@ -1,4 +1,3 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export { XAdditionalPropertiesNameSchema } from './x-additional-properties-name'
 export { type XCodeSample, XCodeSampleSchema, XCodeSamplesSchema } from './x-code-samples'
 export { XEnumDescriptionsSchema } from './x-enum-descriptions'

--- a/packages/sidebar/src/index.ts
+++ b/packages/sidebar/src/index.ts
@@ -1,4 +1,3 @@
-/** biome-ignore-all lint/performance/noBarrelFile: It's a library entrypoint */
 import './style.css'
 
 export { default as HttpMethod } from './components/HttpMethod.vue'

--- a/packages/types/src/entities/index.ts
+++ b/packages/types/src/entities/index.ts
@@ -1,4 +1,3 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export {
   type Oauth2Flow,
   type Oauth2FlowPayload,

--- a/packages/types/src/legacy/index.ts
+++ b/packages/types/src/legacy/index.ts
@@ -1,4 +1,3 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export type {
   ContentType,
   Heading,

--- a/packages/types/src/snippetz/index.ts
+++ b/packages/types/src/snippetz/index.ts
@@ -1,4 +1,3 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export type {
   AvailableClient,
   AvailableClients,

--- a/packages/types/src/utils/index.ts
+++ b/packages/types/src/utils/index.ts
@@ -1,4 +1,3 @@
-/** biome-ignore-all lint/performance/noBarrelFile: entrypoint */
 export type { ENTITY_BRANDS } from './nanoid'
 export { nanoidSchema } from './nanoid'
 export type { UnknownObject } from './utility-types'

--- a/packages/workspace-store/src/mutators/index.ts
+++ b/packages/workspace-store/src/mutators/index.ts
@@ -1,4 +1,3 @@
-/** biome-ignore-all lint/performance/noBarrelFile: Mutators entry point */
 import type { WorkspaceStore } from '@/client'
 import { getDocument } from '@/mutators/helpers'
 import { requestMutators } from '@/mutators/request'

--- a/packages/workspace-store/src/plugins/client/index.ts
+++ b/packages/workspace-store/src/plugins/client/index.ts
@@ -1,2 +1,1 @@
-/** biome-ignore-all lint/performance/noBarrelFile: Plugins entry point */
 export { persistencePlugin } from './persistence'


### PR DESCRIPTION
## Problem

- Followup of #7428

## Solution

During #7428, I did not notice that `biome-ignore-all lint/performance/noBarrelFile` directives were not being flagged as unused 😅. 

This directive should no longer be necessary due to the override introduced in that PR:
https://github.com/scalar/scalar/blob/daeaef15e470a0b94633658c5c58b57e31a2404f/biome.json#L259-L268

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset (Not needed). <!-- pnpm changeset -->
- [x] I added tests (Not needed).
- [x] I updated the documentation (Not needed).

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
