### PR TITLE
chore(renovate): do not group major updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,13 +19,6 @@
     },
 
     {
-      "description": "Group major dependencies",
-      "matchUpdateTypes": ["major"],
-      "matchPackageNames": ["*"],
-      "groupName": "major dependencies"
-    },
-
-    {
       "description": "Group minor and patch dependencies",
       "matchUpdateTypes": ["patch", "minor"],
       "matchPackageNames": ["*"],


### PR DESCRIPTION
## Problem

<!--
  What problem does the PR solve?
  WHY did you submit the PR?

  We are interested in the WHY (LLMs won't know).
-->

Currently, we group major updates of our dependencies. This makes us hesitate to update them.

## Solution

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

This PR removes the existing Renovate rule. Each major release of a dependency gets its PR.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
