### PR TITLE
fix(sidebar): enable `knip`

### DIFF
--- a/.changeset/modern-sails-cover.md
+++ b/.changeset/modern-sails-cover.md
@@ -1,0 +1,5 @@
+---
+'@scalar/sidebar': patch
+---
+
+fix: remove cjs file from index export

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -15,7 +15,6 @@
     "packages/postman-to-openapi/**",
     "packages/pre-post-request-scripts/**",
     "packages/react-renderer/**",
-    "packages/sidebar/**",
     "packages/void-server/**",
     "projects/**",
     "integrations/docker/**",
@@ -120,6 +119,16 @@
         "src/helpers/index.ts",
         "src/schemas/extensions/index.ts",
         "src/schemas/3.1/*/index.ts"
+      ]
+    },
+    "packages/sidebar": {
+      "entry": [
+        "src/index.ts",
+        //
+        "playground/main.ts"
+      ],
+      "ignoreDependencies": [
+        "@scalar/themes" // Used by src/style.css
       ]
     },
     "packages/snippetz": {

--- a/packages/sidebar/package.json
+++ b/packages/sidebar/package.json
@@ -17,8 +17,8 @@
   "scripts": {
     "build": "scalar-build-vite",
     "dev": "vite ./playground -c ./vite.config.ts",
-    "format": "pnpm prettier --write .",
-    "format:check": "pnpm prettier --check .",
+    "format": "scalar-format",
+    "format:check": "scalar-format-check",
     "lint:check": "scalar-lint-check",
     "lint:fix": "scalar-lint-fix",
     "test": "vitest",
@@ -32,7 +32,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./style.css": "./dist/style.css"
   },
@@ -58,7 +59,6 @@
     "jsdom": "catalog:*",
     "tailwindcss": "catalog:*",
     "vite": "catalog:*",
-    "vite-svg-loader": "catalog:*",
     "vitest": "catalog:*"
   }
 }

--- a/packages/sidebar/src/hooks/use-draggable.test.ts
+++ b/packages/sidebar/src/hooks/use-draggable.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 
 import { useDraggable } from './use-draggable'
 
 describe('useDraggable', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+
   it('initializes with default values', () => {
     const {
       draggableAttrs: draggableProps,
@@ -151,6 +155,8 @@ describe('useDraggable', () => {
   })
 
   it('sets and removes data-dragging attribute during drag lifecycle', async () => {
+    vi.useFakeTimers()
+
     const onDragEnd = vi.fn()
     const draggable1 = useDraggable({
       id: 'test-1',
@@ -214,7 +220,7 @@ describe('useDraggable', () => {
 
     draggable2.draggableEvents.dragover(dragOverEvent)
     // Wait for throttle to execute
-    await new Promise((resolve) => setTimeout(resolve, 30))
+    await vi.advanceTimersByTimeAsync(30)
 
     // Verify hover state is set (required for handleDragEnd to clean up)
     expect(draggable1.hoveredItem.value).not.toBeNull()

--- a/packages/sidebar/src/hooks/use-draggable.ts
+++ b/packages/sidebar/src/hooks/use-draggable.ts
@@ -2,19 +2,13 @@ import { cva } from '@scalar/use-hooks/useBindCx'
 import { type MaybeRef, type Ref, computed, ref, toValue } from 'vue'
 
 /**
- * Drag offset options
- */
-export const DRAG_OFFSETS = [
-  'before', // Insert before the hovered item
-  'after', // Insert after the hovered item
-  'into', // Drop into the hovered item
-] as const
-
-/**
  * Drag offsets
- *
  */
-export type DragOffset = (typeof DRAG_OFFSETS)[number] | null
+export type DragOffset =
+  | 'before' // Insert before the hovered item
+  | 'after' // Insert after the hovered item
+  | 'into' // Drop into the hovered item
+  | null
 
 /**
  * Item you are currently dragging over
@@ -33,10 +27,13 @@ export type DraggingItem = Omit<HoveredItem, 'offset'>
 /**
  * Simple throttle function to avoid package dependencies
  */
-const throttle = (callback: (...args: any) => void, limit: number) => {
+const throttle = <TArgs extends Array<unknown>>(
+  callback: (...args: TArgs) => void,
+  limit: number,
+): ((...args: TArgs) => void) => {
   let wait = false
 
-  return (...args: unknown[]) => {
+  return (...args: TArgs) => {
     if (wait) {
       return
     }
@@ -128,7 +125,7 @@ export function useDraggable(options: UseDraggableOptions) {
   const parentId = computed(() => parentIds.at(-1) ?? null)
 
   /** Check if isDroppable guard */
-  const _isDroppable = (offset: DragOffset | null): boolean =>
+  const _isDroppable = (offset: DragOffset): boolean =>
     typeof isDroppable === 'function'
       ? isDroppable(draggingItem.value!, {
           id: id,
@@ -164,7 +161,7 @@ export function useDraggable(options: UseDraggableOptions) {
     const height = (ev.target as HTMLDivElement).offsetHeight
     const _floor = floor * height
     const _ceiling = ceiling * height
-    let offset: DragOffset | null = null
+    let offset: DragOffset = null
 
     // handle negative offset to be previous offset
     if (ev.offsetY <= 0 && previousOffset && previousOffset !== 'after') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2418,9 +2418,6 @@ importers:
       vite:
         specifier: catalog:*
         version: 7.1.11(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
-      vite-svg-loader:
-        specifier: catalog:*
-        version: 5.1.0(vue@3.5.21(typescript@5.8.3))
       vitest:
         specifier: catalog:*
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)


### PR DESCRIPTION
## Problem

- Followup of #7233

## Solution

- remove index `exports` field  pointing to non-existing cjs file
- use `scalar-format-*` bins in `format` scripts
- remove unused `vite-svg-loader` dev dependency
- remove `DRAG_OFFSETS` and inline its values directly into `DragOffset` type, 
   as it was not referenced by any runtime code
- remove redundant `null` in `DragOffset` type usage
- refine `throttle` signature to infer callback parameters in return type function
- use fake timers in `use-draggable` "sets and removes data-dragging attribute during drag lifecycle" test

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation (Not needed).

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
