### PR TITLE
ci: skip the PR comment if we don’t have any links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -888,6 +888,7 @@ jobs:
   preview-comment:
     # Only run for PRs from the same repository
     if: |
+      always() &&
       (needs.deploy-api-reference.result == 'success' ||
        needs.deploy-components.result == 'success' ||
        needs.galaxy-registry-preview.result == 'success') &&


### PR DESCRIPTION
## Problem

<!--
  What problem does the PR solve?
  WHY did you submit the PR?

  We are interested in the WHY (LLMs won't know).
-->

- Inconsistent way of determining the version.
- Preview comments even if there are no preview URLs to show.

## Solution

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

- Unify the way of determining the version.
- Check for job status before running the `preview-comment` job.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
