### PR TITLE
fix(api-client): prevent empty body from auto-setting content-type

### DIFF
--- a/packages/api-client/src/libs/send-request/create-fetch-body.test.ts
+++ b/packages/api-client/src/libs/send-request/create-fetch-body.test.ts
@@ -22,4 +22,23 @@ describe('createFetchBody', () => {
       contentType: 'text',
     })
   })
+
+  it('should return undefined body for empty string', () => {
+    const example = requestExampleSchema.parse({
+      body: {
+        activeBody: 'raw',
+        raw: {
+          value: '',
+          encoding: 'json',
+        },
+      },
+    })
+
+    const result = createFetchBody('post', example, {})
+
+    expect(result).toEqual({
+      body: undefined,
+      contentType: 'json',
+    })
+  })
 })

--- a/packages/api-client/src/libs/send-request/create-fetch-body.ts
+++ b/packages/api-client/src/libs/send-request/create-fetch-body.ts
@@ -39,7 +39,7 @@ export function createFetchBody(method: RequestMethod, example: RequestExample, 
 
   if (example.body.activeBody === 'raw') {
     return {
-      body: replaceTemplateVariables(example.body.raw?.value ?? '', env),
+      body: replaceTemplateVariables(example.body.raw?.value ?? '', env) || undefined,
       contentType: example.body.raw?.encoding,
     }
   }


### PR DESCRIPTION
## Problem

When a POST request has no body content (empty string), browsers automatically add `Content-Type: text/plain;charset=UTF-8` header. This causes unnecessary headers to be sent, which can lead to server rejections or unexpected behavior.

## Solution

Modified createFetchBody to return undefined instead of an empty string when the body is empty after template variable replacement. Using body: undefined prevents the browser from adding the default Content-Type header, ensuring clean requests without unnecessary headers.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
