### PR TITLE
docs: replace the custom subdomain

### DIFF
--- a/documentation/guides/docs/github-sync.md
+++ b/documentation/guides/docs/github-sync.md
@@ -35,7 +35,7 @@ Your docs site will be automatically available at `https://<subdomain>.apidocume
 ```json
 {
   "$schema": "https://cdn.scalar.com/schema/scalar-config.json",
-  "subdomain": "my-awesome-documentation",
+  "subdomain": "YOUR_CUSTOM_SUBDOMAIN_HERE", // e.g. "subdomain": "acme"
   "guides": [
     {
       "name": "My awesome documentation",


### PR DESCRIPTION
a user said: 

> best to clarify this in docs because my instinct was to just copy paste.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the hardcoded subdomain in the GitHub Sync `scalar.config.json` example with a clear placeholder and example comment.
> 
> - **Documentation**:
>   - Update `documentation/guides/docs/github-sync.md` config snippet: replace `subdomain` example with `"YOUR_CUSTOM_SUBDOMAIN_HERE"` and an inline example comment (e.g., `"acme"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c18a7d28494009877826adb56e4c44f526a5d873. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->