### PR TITLE
chore: remove `vite-cleanup` from lefthooks, not needed anymore

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,8 +1,5 @@
 pre-commit:
   commands:
-    vite-cleanup:
-      glob: '*'
-      run: find . -name 'vite.config.ts.timestamp-*' -delete
     package-format:
       glob: 'pnpm-lock.yaml'
       run: pnpm script packages format; git add \*package.json pnpm-lock.yaml; echo PACKAGE FILES FORMATTED


### PR DESCRIPTION
looks like Vite fixed it a while ago and those temporary files are in the node_modules folder now

see https://github.com/vitejs/vite/pull/18509

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the obsolete `vite-cleanup` pre-commit hook from `lefthook.yml`; other pre-commit commands remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5520ea93e30310df7451ac79228dc45d05751984. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->