### PR TITLE
docs: improve themes list

### DIFF
--- a/documentation/themes.md
+++ b/documentation/themes.md
@@ -2,10 +2,24 @@
 
 You don't like the color scheme? We've prepared some themes for you:
 
-```vue
-/* theme?: 'alternate' | 'default' | 'moon' | 'purple' | 'solarized' |
-'bluePlanet' | 'saturn' | 'kepler' | 'mars' | 'deepSpace' | 'laserwave' | 'none' */
-<ApiReference :configuration="{ theme: 'moon' }" />
+* `alternate`
+* `default`
+* `moon`
+* `purple`
+* `solarized`
+* `bluePlanet`
+* `saturn`
+* `kepler`
+* `mars`
+* `deepSpace`
+* `laserwave`
+
+Just pass the theme name to your [Scalar API Reference configuration](https://guides.scalar.com/scalar/scalar-api-references/configuration):
+
+```js
+{
+  theme: 'moon'
+}
 ```
 
 > [!NOTE]


### PR DESCRIPTION
themes code block looks strange?

before

<img width="735" height="372" alt="Screenshot 2026-01-05 at 13 38 28" src="https://github.com/user-attachments/assets/557a12d3-729b-4df5-b5d9-cb77db0c2260" />

after

<img width="738" height="714" alt="Screenshot 2026-01-05 at 13 37 56" src="https://github.com/user-attachments/assets/3f4bda83-c1d7-4297-bae1-f334da873e8e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies how to select a theme in `documentation/themes.md`.
> 
> - Replaces the prior Vue-style code block with a bullet list of available themes (`alternate`, `default`, `moon`, etc.)
> - Adds a concise example showing how to pass `theme` in the Scalar API Reference configuration (`{ theme: 'moon' }`)
> - Keeps existing notes about `default` and `none`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 365bc041e5811766017c34bf49b4864c8168d801. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->