### PR TITLE
chore(draggable): enable `knip`

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -7,7 +7,6 @@
     "packages/api-client-react/**",
     "packages/api-reference/**",
     "packages/api-reference-react/**",
-    "packages/draggable/**",
     "packages/galaxy/**",
     "packages/nextjs-openapi/**",
     "packages/openapi-upgrader/**",
@@ -84,6 +83,13 @@
     },
     "packages/core": {
       "entry": ["src/libs/html-rendering/index.ts"]
+    },
+    "packages/draggable": {
+      "entry": [
+        "src/index.ts",
+        //
+        "playground/main.ts"
+      ]
     },
     "packages/helpers": {
       "entry": ["src/*/*.ts", "!src/*/*.test.ts"]

--- a/packages/draggable/package.json
+++ b/packages/draggable/package.json
@@ -19,12 +19,11 @@
   },
   "scripts": {
     "build": "scalar-build-vite",
-    "dev": "vite",
+    "dev": "vite ./playground -c ./vite.config.ts",
     "format": "scalar-format",
     "format:check": "scalar-format-check",
-    "lint:check": "eslint .",
-    "lint:fix": "eslint .  --fix",
-    "preview": "vite preview",
+    "lint:check": "scalar-lint-check",
+    "lint:fix": "scalar-lint-fix",
     "test": "vitest",
     "types:build": "scalar-types-build-vue",
     "types:check": "scalar-types-check-vue"
@@ -60,7 +59,6 @@
     "@scalar/build-tooling": "workspace:*",
     "@vitejs/plugin-vue": "catalog:*",
     "vite": "catalog:*",
-    "vite-svg-loader": "catalog:*",
     "vue": "catalog:*"
   }
 }

--- a/packages/draggable/playground/components/SidebarItem.vue
+++ b/packages/draggable/playground/components/SidebarItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Draggable } from '../../src'
+import { Draggable } from '../../src/index'
 import type { DraggingItem, HoveredItem } from '../../src/store'
 
 export type Items = Record<

--- a/packages/draggable/playground/index.html
+++ b/packages/draggable/playground/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0" />
+    <title>Scalar Draggable Playground</title>
+    <script
+      type="module"
+      src="./main.ts"></script>
+  </head>
+  <body>
+    <div id="playground" />
+  </body>
+</html>

--- a/packages/draggable/playground/main.ts
+++ b/packages/draggable/playground/main.ts
@@ -2,4 +2,4 @@ import { createApp } from 'vue'
 
 import App from './App.vue'
 
-createApp(App).mount('#app')
+createApp(App).mount('#playground')

--- a/packages/draggable/src/index.ts
+++ b/packages/draggable/src/index.ts
@@ -1,6 +1,3 @@
-import Draggable from './Draggable.vue'
-
 export type { DraggableProps } from './Draggable.vue'
+export { default as Draggable } from './Draggable.vue'
 export type { DraggingItem, HoveredItem } from './store'
-
-export { Draggable }

--- a/packages/draggable/src/thottle.test.ts
+++ b/packages/draggable/src/thottle.test.ts
@@ -1,8 +1,15 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { throttle } from './throttle'
-import { it, describe, expect, vi } from 'vitest'
 
 describe('throttle', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+
   it('should throttle a function', async () => {
+    vi.useFakeTimers()
+
     const fn = vi.fn()
 
     const throttledFn = throttle(fn, 100)
@@ -13,7 +20,7 @@ describe('throttle', () => {
     throttledFn()
     throttledFn()
 
-    await new Promise((resolve) => setTimeout(resolve, 100))
+    await vi.advanceTimersByTimeAsync(100)
 
     expect(fn).toHaveBeenCalledTimes(1)
   })

--- a/packages/draggable/src/throttle.ts
+++ b/packages/draggable/src/throttle.ts
@@ -1,10 +1,13 @@
 /**
  * Simple throttle function to avoid package dependencies
  */
-export const throttle = (callback: (...args: any) => void, limit: number) => {
+export const throttle = <TArgs extends Array<unknown>>(
+  callback: (...args: TArgs) => void,
+  limit: number,
+): ((...args: TArgs) => void) => {
   let wait = false
 
-  return (...args: unknown[]) => {
+  return (...args) => {
     if (wait) {
       return
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1723,7 +1723,7 @@ importers:
         version: 3.5.21(typescript@5.8.3)
       vue-component-type-helpers:
         specifier: ^3.0.4
-        version: 3.1.5
+        version: 3.2.1
     devDependencies:
       '@headlessui/tailwindcss':
         specifier: catalog:*
@@ -1820,9 +1820,6 @@ importers:
       vite:
         specifier: catalog:*
         version: 7.1.11(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
-      vite-svg-loader:
-        specifier: catalog:*
-        version: 5.1.0(vue@3.5.21(typescript@5.8.3))
 
   packages/galaxy:
     devDependencies:
@@ -18428,11 +18425,8 @@ packages:
   vue-component-type-helpers@2.2.10:
     resolution: {integrity: sha512-iDUO7uQK+Sab2tYuiP9D1oLujCWlhHELHMgV/cB13cuGbG4qwkLHvtfWb6FzvxrIOPDnU0oHsz2MlQjhYDeaHA==}
 
-  vue-component-type-helpers@3.1.5:
-    resolution: {integrity: sha512-7V3yJuNWW7/1jxCcI1CswnpDsvs02Qcx/N43LkV+ZqhLj2PKj50slUflHAroNkN4UWiYfzMUUUXiNuv9khmSpQ==}
-
-  vue-component-type-helpers@3.1.8:
-    resolution: {integrity: sha512-oaowlmEM6BaYY+8o+9D9cuzxpWQWHqHTMKakMxXu0E+UCIOMTljyIPO15jcnaCwJtZu/zWDotK7mOIHvWD9mcw==}
+  vue-component-type-helpers@3.2.1:
+    resolution: {integrity: sha512-gKV7XOkQl4urSuLHNY1tnVQf7wVgtb/mKbRyxSLWGZUY9RK7aDPhBenTjm+i8ZFe0zC2PZeHMPtOZXZfyaFOzQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -18641,6 +18635,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -25678,7 +25673,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.21(typescript@5.8.3)
-      vue-component-type-helpers: 3.1.8
+      vue-component-type-helpers: 3.2.1
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -38861,9 +38856,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.10: {}
 
-  vue-component-type-helpers@3.1.5: {}
-
-  vue-component-type-helpers@3.1.8: {}
+  vue-component-type-helpers@3.2.1: {}
 
   vue-demi@0.14.10(vue@3.5.21(typescript@5.8.3)):
     dependencies:


### PR DESCRIPTION
## Problem

- Followup of #7233

## Solution

- remove `vite-svg-loader` unused devDependency 
- use `scalar-lint-*` scripts
- update `dev` script serving `playground` folder
  - remove `preview` script
- refine `throttle` function to infer arguments from the callback
  (no changeset added since is not part of the public API)
- use fake timers in `thottle.test.ts`
- reorder import in a test
  - `biome check` no longer reports error for this package

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset (Not needed). <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation (Not needed).

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
