### PR TITLE
docs: add effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,12 +160,13 @@ And there's an ever-growing list of plugins and integrations:
 
 The following frameworks have chosen Scalar API Reference as their default OpenAPI documentation UI, recognizing its developer-friendly features and modern design:
 
+- [Effect](https://guides.scalar.com/scalar/scalar-api-references/integrations/effect)
 - [ElysiaJS](https://guides.scalar.com/scalar/scalar-api-references/integrations/elysiajs)
 - [HappyX](https://github.com/HapticX/happyx)
 - [Litestar](https://docs.litestar.dev/latest/usage/openapi/ui_plugins.html)
 - [Nitro](https://guides.scalar.com/scalar/scalar-api-references/integrations/nitro)
-- [Platformatic](https://guides.scalar.com/scalar/scalar-api-references/integrations/platformatic)
 - [oRPC](https://orpc.unnoq.com/docs/openapi/plugins/openapi-reference)
+- [Platformatic](https://guides.scalar.com/scalar/scalar-api-references/integrations/platformatic)
 
 <br>
 

--- a/documentation/integrations/effect.md
+++ b/documentation/integrations/effect.md
@@ -1,0 +1,57 @@
+# Scalar API Reference for Effect
+
+The wonderful TypeScript comes with Scalar already.
+
+## Usage
+
+```diff
+// https://github.com/Effect-TS/effect/tree/main/packages/platform#registering-a-httpapi
+import {
+  HttpApi,
+  HttpApiBuilder,
+  HttpApiEndpoint,
+  HttpApiGroup,
++   HttpApiScalar,
+  HttpLayerRouter
+} from "@effect/platform"
+import { NodeHttpServer, NodeRuntime } from "@effect/platform-node"
+import { Effect, Layer } from "effect"
+import { createServer } from "http"
+
+// First, we define our HttpApi
+class MyApi extends HttpApi.make("api").add(
+  HttpApiGroup.make("users")
+    .add(HttpApiEndpoint.get("me", "/me"))
+    .prefix("/users")
+) {}
+
+// Implement the handlers for the API
+const UsersApiLayer = HttpApiBuilder.group(MyApi, "users", (handers) =>
+  handers.handle("me", () => Effect.void)
+)
+
+// Use `HttpLayerRouter.addHttpApi` to register the API with the router
+const HttpApiRoutes = HttpLayerRouter.addHttpApi(MyApi, {
+  openapiPath: "/docs/openapi.json"
+}).pipe(
+  // Provide the api handlers layer
+  Layer.provide(UsersApiLayer)
+)
+
++ // Create a /docs route for the API documentation
++ const DocsRoute = HttpApiScalar.layerHttpLayerRouter({
++   api: MyApi,
++   path: "/docs"
++ })
+
+// Finally, we merge all routes and serve them using the Node HTTP server
+const AllRoutes = Layer.mergeAll(HttpApiRoutes, DocsRoute).pipe(
+  Layer.provide(HttpLayerRouter.cors())
+)
+
+HttpLayerRouter.serve(AllRoutes).pipe(
+  Layer.provide(NodeHttpServer.layer(createServer, { port: 3000 })),
+  Layer.launch,
+  NodeRuntime.runMain
+)
+```

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -345,6 +345,11 @@
                   "type": "page"
                 },
                 {
+                  "name": "Effect",
+                  "path": "documentation/integrations/effect.md",
+                  "type": "page"
+                },
+                {
                   "name": "Elixir",
                   "path": "documentation/integrations/elixir.md",
                   "type": "page"


### PR DESCRIPTION
let’s add the effect integration to the docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces documentation for the Effect integration and surfaces it in navigation.
> 
> - New `documentation/integrations/effect.md` with usage example showing `HttpApiScalar` and a `/docs` route
> - README Built-in Support list updated to include `Effect` and fix `Platformatic` bullet formatting/order
> - `scalar.config.json` updated to add `Effect` to Integrations sidebar
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1205ea2943431b76d4247bd81754f03a59bf84e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->