### PR TITLE
feat(changelog-generator): preserve indentation when changelog files contain multiple lines

### DIFF
--- a/tooling/changelog-generator/src/formatter.ts
+++ b/tooling/changelog-generator/src/formatter.ts
@@ -2,17 +2,6 @@ import type { NewChangesetWithCommit } from '@changesets/types'
 
 import type { GitHubInfo } from './types'
 
-export function formatReleaseLine(changeset: NewChangesetWithCommit, githubInfo: GitHubInfo | null): string {
-  const description = changeset.summary.trim()
-
-  const prLink = getPRLink(githubInfo)
-  if (prLink) {
-    return `- ${prLink}: ${description}`
-  }
-
-  return `- ${description}`
-}
-
 /**
  * Checks if the text already contains a markdown PR link (e.g. "[#123](https://github.com/scalar/scalar/pull/123)")
  * Pattern: [#\d+](...)
@@ -20,6 +9,62 @@ export function formatReleaseLine(changeset: NewChangesetWithCommit, githubInfo:
 function containsPRLink(text: string): boolean {
   const prLinkPattern = /^\[#\d+\].*/
   return prLinkPattern.test(text.trim())
+}
+
+/**
+ * Converts a multi-line changelog fragment into a single Markdown list entry.
+ *
+ * The first non-empty line becomes the parent list item. Any subsequent
+ * non-empty lines are indented so they render as nested list items under
+ * the parent entry. Blank lines are preserved.
+ *
+ * Optionally prefixes the parent entry with a PR link and applies an
+ * additional indentation level to all output lines.
+ */
+function formatChangelogEntry(
+  text: string,
+  {
+    prLink,
+    indentLevel: indentWith = 0,
+  }: {
+    prLink?: string | null
+    /**
+     * two spaces will be added for each indent level
+     */
+    indentLevel?: number
+  } = {},
+): string {
+  const lines = text.trim().split('\n')
+
+  const firstNonEmpty = lines.findIndex((l) => l.trim() !== '')
+  if (firstNonEmpty === -1) {
+    return ''
+  }
+
+  return (
+    lines
+      .map((line, i) => {
+        if (i === firstNonEmpty) {
+          if (prLink) {
+            return `- ${prLink}: ${line.trim()}`
+          }
+          return `- ${line.trim()}`
+        }
+
+        if (line.trim() === '') {
+          return ''
+        }
+        return `  ${line.trim()}`
+      })
+      // Add indent for each line with some content
+      .map((it) => (it.trim() !== '' ? `${'  '.repeat(indentWith)}${it}` : ''))
+      .join('\n')
+  )
+}
+
+export function formatReleaseLine(changeset: NewChangesetWithCommit, githubInfo: GitHubInfo | null): string {
+  const prLink = getPRLink(githubInfo)
+  return formatChangelogEntry(changeset.summary, { prLink })
 }
 
 function getPRLink(githubInfo: GitHubInfo | null): string | null {
@@ -39,16 +84,10 @@ export function formatDependencyHeader(packageName: string, version: string): st
 }
 
 export function formatDependencyChange(githubInfo: GitHubInfo | null, description: string): string {
-  const trimmedDescription = description.trim()
-
-  if (containsPRLink(trimmedDescription)) {
-    return `  - ${trimmedDescription}`
+  if (containsPRLink(description)) {
+    return formatChangelogEntry(description, { indentLevel: 1 })
   }
 
   const prLink = getPRLink(githubInfo)
-  if (prLink) {
-    return `  - ${prLink}: ${trimmedDescription}`
-  }
-
-  return `  - ${trimmedDescription}`
+  return formatChangelogEntry(description, { prLink, indentLevel: 1 })
 }

--- a/tooling/changelog-generator/src/index.test.ts
+++ b/tooling/changelog-generator/src/index.test.ts
@@ -40,6 +40,45 @@ describe('formatter helpers', () => {
     expect(result).toBe('- Do something else')
   })
 
+  it('account for multiple lines', () => {
+    const changeset = {
+      summary: [
+        'fix: remove internal unused export',
+        '',
+        '- `CARD_Heading_SYMBOL`',
+        '- `FORM_GROUP_SYMBOL`',
+        '- `formatHotKey#isDefault`',
+        '- `LoadingCompletionOptions`',
+        '- `MaybeElement`',
+        '- `ScalarComboBox#isGroup`',
+      ].join('\n'),
+    } as any
+    const githubInfo = {
+      pull: 123,
+      user: null,
+      links: {
+        commit: '',
+        pull: 'https://github.com/scalar/scalar/pull/123',
+        user: null,
+      },
+    }
+
+    const result = formatReleaseLine(changeset, githubInfo)
+
+    expect(result).toBe(
+      [
+        '- [#123](https://github.com/scalar/scalar/pull/123): fix: remove internal unused export',
+        '',
+        '  - `CARD_Heading_SYMBOL`',
+        '  - `FORM_GROUP_SYMBOL`',
+        '  - `formatHotKey#isDefault`',
+        '  - `LoadingCompletionOptions`',
+        '  - `MaybeElement`',
+        '  - `ScalarComboBox#isGroup`',
+      ].join('\n'),
+    )
+  })
+
   it('formats dependency header and change', () => {
     expect(formatDependencyHeader('@scalar/api-reference', '1.2.3')).toBe('- **@scalar/api-reference@1.2.3**')
 


### PR DESCRIPTION
## Problem

I noticed that changesets with multiple lines are not properly formatted in the CHANGELOG (#7625):

<img width="498" height="482" alt="Screenshot 2026-01-06 at 14 42 01" src="https://github.com/user-attachments/assets/7b99957d-24b3-459e-af46-301758b05bae" />

## Solution

implement `formatChangelogEntry` that can help formatting changeset summary that go into multiple lines

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation (Not needed).

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
