### PR TITLE
refactor(changelog-generator): improvements

### DIFF
--- a/tooling/changelog-generator/src/formatter.test.ts
+++ b/tooling/changelog-generator/src/formatter.test.ts
@@ -1,0 +1,125 @@
+import type { NewChangesetWithCommit } from '@changesets/types'
+import { describe, expect, it } from 'vitest'
+
+import type { GitHubInfo } from '@/types'
+
+import { formatDependencyChange, formatDependencyHeader, formatReleaseLine } from './formatter'
+
+describe('formatter helpers', () => {
+  it('formats release line with PR link', () => {
+    const changeset: Partial<NewChangesetWithCommit> = {
+      summary: 'Do something great',
+    }
+    const githubInfo: GitHubInfo = {
+      pull: 123,
+      user: null,
+      links: {
+        commit: '',
+        pull: 'https://github.com/scalar/scalar/pull/123',
+        user: null,
+      },
+    }
+
+    const result = formatReleaseLine(changeset as NewChangesetWithCommit, githubInfo)
+
+    expect(result).toBe('- [#123](https://github.com/scalar/scalar/pull/123): Do something great')
+  })
+
+  it('formats release line without PR link', () => {
+    const changeset: Partial<NewChangesetWithCommit> = {
+      summary: 'Do something else',
+    }
+
+    const result = formatReleaseLine(changeset as NewChangesetWithCommit, null)
+
+    expect(result).toBe('- Do something else')
+  })
+
+  it('account for multiple lines', () => {
+    const changeset: Partial<NewChangesetWithCommit> = {
+      summary: [
+        'fix: remove internal unused export',
+        '',
+        '- `CARD_Heading_SYMBOL`',
+        '- `FORM_GROUP_SYMBOL`',
+        '- `formatHotKey#isDefault`',
+        '- `LoadingCompletionOptions`',
+        '- `MaybeElement`',
+        '- `ScalarComboBox#isGroup`',
+      ].join('\n'),
+    }
+    const githubInfo: GitHubInfo = {
+      pull: 123,
+      user: null,
+      links: {
+        commit: '',
+        pull: 'https://github.com/scalar/scalar/pull/123',
+        user: null,
+      },
+    }
+
+    const result = formatReleaseLine(changeset as NewChangesetWithCommit, githubInfo)
+
+    expect(result).toBe(
+      [
+        '- [#123](https://github.com/scalar/scalar/pull/123): fix: remove internal unused export',
+        '',
+        '  - `CARD_Heading_SYMBOL`',
+        '  - `FORM_GROUP_SYMBOL`',
+        '  - `formatHotKey#isDefault`',
+        '  - `LoadingCompletionOptions`',
+        '  - `MaybeElement`',
+        '  - `ScalarComboBox#isGroup`',
+      ].join('\n'),
+    )
+  })
+
+  it('formats dependency header and change', () => {
+    expect(formatDependencyHeader('@scalar/api-reference', '1.2.3')).toBe('- **@scalar/api-reference@1.2.3**')
+
+    const githubInfo: GitHubInfo = {
+      pull: 10,
+      user: null,
+      links: {
+        commit: '',
+        pull: 'https://github.com/scalar/scalar/pull/10',
+        user: null,
+      },
+    }
+
+    expect(formatDependencyChange(githubInfo, 'Fixed things')).toBe(
+      '  - [#10](https://github.com/scalar/scalar/pull/10): Fixed things',
+    )
+    expect(formatDependencyChange(null, 'No PR')).toBe('  - No PR')
+  })
+
+  it('formats changelog entries with higher indent levels', () => {
+    const githubInfo: GitHubInfo = {
+      pull: 42,
+      user: null,
+      links: {
+        commit: '',
+        pull: 'https://github.com/scalar/scalar/pull/42',
+        user: null,
+      },
+    }
+
+    const description = [
+      'Update dependency internals',
+      '',
+      '- feat: improve caching',
+      '- fix: reduce bundle size',
+    ].join('\n')
+
+    const result = formatDependencyChange(githubInfo, description)
+
+    expect(result).toBe(
+      [
+        '  - [#42](https://github.com/scalar/scalar/pull/42): Update dependency internals',
+        '',
+        '    - feat: improve caching',
+        '    - fix: reduce bundle size',
+      ].join('\n'),
+    )
+  })
+})

--- a/tooling/changelog-generator/src/index.test.ts
+++ b/tooling/changelog-generator/src/index.test.ts
@@ -1,7 +1,7 @@
 import { getInfo } from '@changesets/get-github-info'
+import type { ModCompWithPackage, NewChangesetWithCommit } from '@changesets/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { formatDependencyChange, formatDependencyHeader, formatReleaseLine } from './formatter'
 import changelogFunctions from './index'
 
 vi.mock('@changesets/get-github-info', () => ({
@@ -9,95 +9,6 @@ vi.mock('@changesets/get-github-info', () => ({
 }))
 
 const mockGetInfo = vi.mocked(getInfo)
-
-describe('formatter helpers', () => {
-  it('formats release line with PR link', () => {
-    const changeset = {
-      summary: 'Do something great',
-    } as any
-    const githubInfo = {
-      pull: 123,
-      user: null,
-      links: {
-        commit: '',
-        pull: 'https://github.com/scalar/scalar/pull/123',
-        user: null,
-      },
-    }
-
-    const result = formatReleaseLine(changeset, githubInfo)
-
-    expect(result).toBe('- [#123](https://github.com/scalar/scalar/pull/123): Do something great')
-  })
-
-  it('formats release line without PR link', () => {
-    const changeset = {
-      summary: 'Do something else',
-    } as any
-
-    const result = formatReleaseLine(changeset, null)
-
-    expect(result).toBe('- Do something else')
-  })
-
-  it('account for multiple lines', () => {
-    const changeset = {
-      summary: [
-        'fix: remove internal unused export',
-        '',
-        '- `CARD_Heading_SYMBOL`',
-        '- `FORM_GROUP_SYMBOL`',
-        '- `formatHotKey#isDefault`',
-        '- `LoadingCompletionOptions`',
-        '- `MaybeElement`',
-        '- `ScalarComboBox#isGroup`',
-      ].join('\n'),
-    } as any
-    const githubInfo = {
-      pull: 123,
-      user: null,
-      links: {
-        commit: '',
-        pull: 'https://github.com/scalar/scalar/pull/123',
-        user: null,
-      },
-    }
-
-    const result = formatReleaseLine(changeset, githubInfo)
-
-    expect(result).toBe(
-      [
-        '- [#123](https://github.com/scalar/scalar/pull/123): fix: remove internal unused export',
-        '',
-        '  - `CARD_Heading_SYMBOL`',
-        '  - `FORM_GROUP_SYMBOL`',
-        '  - `formatHotKey#isDefault`',
-        '  - `LoadingCompletionOptions`',
-        '  - `MaybeElement`',
-        '  - `ScalarComboBox#isGroup`',
-      ].join('\n'),
-    )
-  })
-
-  it('formats dependency header and change', () => {
-    expect(formatDependencyHeader('@scalar/api-reference', '1.2.3')).toBe('- **@scalar/api-reference@1.2.3**')
-
-    const githubInfo = {
-      pull: 10,
-      user: null,
-      links: {
-        commit: '',
-        pull: 'https://github.com/scalar/scalar/pull/10',
-        user: null,
-      },
-    }
-
-    expect(formatDependencyChange(githubInfo, 'Fixed things')).toBe(
-      '  - [#10](https://github.com/scalar/scalar/pull/10): Fixed things',
-    )
-    expect(formatDependencyChange(null, 'No PR')).toBe('  - No PR')
-  })
-})
 
 describe('changelog functions', () => {
   beforeEach(() => {
@@ -115,11 +26,12 @@ describe('changelog functions', () => {
       },
     })
 
-    const changeset = {
+    const changeset: NewChangesetWithCommit = {
+      id: '123',
       summary: 'Add feature X',
       releases: [],
       commit: 'abcdef',
-    } as any
+    }
 
     const line = await changelogFunctions.getReleaseLine(changeset, 'patch', { repo: 'scalar/scalar' })
 
@@ -137,15 +49,21 @@ describe('changelog functions', () => {
       },
     })
 
-    const changesets = [
+    const changesets: Array<NewChangesetWithCommit> = [
       {
+        id: '123',
         summary: 'Fix api ref',
         releases: [{ name: '@scalar/api-reference', type: 'patch' }],
         commit: 'abc123',
       },
-    ] as any
+    ]
 
-    const deps = [{ name: '@scalar/api-reference', newVersion: '1.0.1' }] as any
+    const deps = [
+      {
+        name: '@scalar/api-reference',
+        newVersion: '1.0.1',
+      },
+    ] as Array<ModCompWithPackage>
 
     const output = await changelogFunctions.getDependencyReleaseLine(changesets, deps, { repo: 'scalar/scalar' })
 

--- a/tooling/changelog-generator/src/index.ts
+++ b/tooling/changelog-generator/src/index.ts
@@ -1,10 +1,12 @@
 import { getInfo } from '@changesets/get-github-info'
-import type { ChangelogFunctions, ModCompWithPackage, NewChangesetWithCommit } from '@changesets/types'
+import type { ChangelogFunctions } from '@changesets/types'
 
 import { formatDependencyChange, formatDependencyHeader, formatReleaseLine } from './formatter'
 
+type Options = Partial<{ repo?: string }> | null
+
 const changelogFunctions: ChangelogFunctions = {
-  getReleaseLine: async (changeset: NewChangesetWithCommit, _type: string, options: Record<string, any> | null) => {
+  getReleaseLine: async (changeset, _type, options: Options) => {
     const repo = options?.repo
     if (!repo) {
       throw new Error('Please provide a `repo` option. It should be a string like "user/repo".')
@@ -61,11 +63,7 @@ const changelogFunctions: ChangelogFunctions = {
     return formatReleaseLine(changeset, githubInfoWithPR)
   },
 
-  getDependencyReleaseLine: async (
-    changesets: NewChangesetWithCommit[],
-    dependenciesUpdated: ModCompWithPackage[],
-    options: Record<string, any> | null,
-  ) => {
+  getDependencyReleaseLine: async (changesets, dependenciesUpdated, options: Options) => {
     const repo = options?.repo
     if (!repo) {
       throw new Error('Please provide a `repo` option. It should be a string like "user/repo".')

--- a/tooling/changelog-generator/tsconfig.build.json
+++ b/tooling/changelog-generator/tsconfig.build.json
@@ -1,11 +1,12 @@
 {
   "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
-    "outDir": "./dist",
+    "outDir": "dist",
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": false,
     "noEmit": false
-  },
-  "include": ["src"]
+  }
 }


### PR DESCRIPTION
## Problem

- small followup of #7640

## Solution

### formatter

- `containsPRLink`
  - move regexp to match PR at the top of the module
  - renamed into `startsWithPRLink` to better reflect the match
- `formatChangelogEntry` 
  - avoid to cycle and add indentation if `indentLevel` is 0
- add test on `formatDependencyChange` to check `indentLevel: 1` behaviour 

### `index`

  - remove `any` usage from `index` tests and add explicit type on mock variable declarations
  - remove redundant type annotations from index functions (they are inferred from `ChangelogFunctions` type)
  - add `Options` type

### Other changes

- separate `formatter` from `index` tests
- exclude test files from package build

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
