### PR TITLE
fix(api-reference): preserve oneOf/anyOf in allOf schema compositions

### DIFF
--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
@@ -543,43 +543,171 @@ describe('mergeAllOfSchemas', () => {
     })
   })
 
-  it('merges properties from oneOf/anyOf subschemas within allOf', () => {
+  it('preserves oneOf structure when wrapped in allOf', () => {
     const schema = {
       allOf: [
         {
-          allOf: [
+          type: 'object',
+          properties: {
+            commonProp: { type: 'string' },
+          },
+        },
+        {
+          oneOf: [
             {
               properties: {
-                a: { type: 'string', example: 'foo' },
+                optionA: { type: 'string' },
               },
             },
             {
-              oneOf: [
-                {
-                  properties: {
-                    b: { type: 'number', example: 42 },
-                  },
-                },
-                {
-                  properties: {
-                    c: { type: 'boolean', example: true },
-                  },
-                },
-              ],
+              properties: {
+                optionB: { type: 'number' },
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(mergeAllOfSchemas(schema as any)).toEqual({
+      type: 'object',
+      properties: {
+        commonProp: { type: 'string' },
+      },
+      oneOf: [
+        {
+          properties: {
+            optionA: { type: 'string' },
+          },
+        },
+        {
+          properties: {
+            optionB: { type: 'number' },
+          },
+        },
+      ],
+    })
+  })
+
+  it('preserves anyOf structure when wrapped in allOf', () => {
+    const schema = {
+      allOf: [
+        {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        {
+          anyOf: [
+            {
+              properties: {
+                typeA: { type: 'boolean' },
+              },
             },
             {
-              anyOf: [
-                {
-                  properties: {
-                    d: { type: 'integer', example: 7 },
-                  },
-                },
-                {
-                  properties: {
-                    e: { type: 'array', items: { type: 'string' }, example: ['x', 'y'] },
-                  },
-                },
-              ],
+              properties: {
+                typeB: { type: 'integer' },
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(mergeAllOfSchemas(schema as any)).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+      },
+      anyOf: [
+        {
+          properties: {
+            typeA: { type: 'boolean' },
+          },
+        },
+        {
+          properties: {
+            typeB: { type: 'integer' },
+          },
+        },
+      ],
+    })
+  })
+
+  it('preserves oneOf when it is the only item in allOf', () => {
+    const schema = {
+      allOf: [
+        {
+          oneOf: [
+            {
+              type: 'object',
+              properties: {
+                card: { type: 'string' },
+              },
+            },
+            {
+              type: 'object',
+              properties: {
+                bank: { type: 'string' },
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(mergeAllOfSchemas(schema as any)).toEqual({
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            card: { type: 'string' },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            bank: { type: 'string' },
+          },
+        },
+      ],
+    })
+  })
+
+  it('preserves both oneOf and anyOf when wrapped in allOf together', () => {
+    const schema = {
+      allOf: [
+        {
+          properties: {
+            base: { type: 'string' },
+          },
+        },
+        {
+          oneOf: [
+            {
+              properties: {
+                option1: { type: 'string' },
+              },
+            },
+            {
+              properties: {
+                option2: { type: 'number' },
+              },
+            },
+          ],
+        },
+        {
+          anyOf: [
+            {
+              properties: {
+                variant1: { type: 'boolean' },
+              },
+            },
+            {
+              properties: {
+                variant2: { type: 'integer' },
+              },
             },
           ],
         },
@@ -588,12 +716,32 @@ describe('mergeAllOfSchemas', () => {
 
     expect(mergeAllOfSchemas(schema as any)).toEqual({
       properties: {
-        a: { type: 'string', example: 'foo' },
-        b: { type: 'number', example: 42 },
-        c: { type: 'boolean', example: true },
-        d: { type: 'integer', example: 7 },
-        e: { type: 'array', items: { type: 'string' }, example: ['x', 'y'] },
+        base: { type: 'string' },
       },
+      oneOf: [
+        {
+          properties: {
+            option1: { type: 'string' },
+          },
+        },
+        {
+          properties: {
+            option2: { type: 'number' },
+          },
+        },
+      ],
+      anyOf: [
+        {
+          properties: {
+            variant1: { type: 'boolean' },
+          },
+        },
+        {
+          properties: {
+            variant2: { type: 'integer' },
+          },
+        },
+      ],
     })
   })
 

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
@@ -160,17 +160,14 @@ const mergeSchemaIntoResult = (result: SchemaObject, schema: SchemaObject, overr
     }
     // OneOf/AnyOf
     else if (key === 'oneOf' || key === 'anyOf') {
-      // Merge oneOf/anyOf subschema
-      if (Array.isArray(value)) {
-        if (!('properties' in result)) {
-          // @ts-expect-error
-          result.properties = {}
-        }
-        for (const _option of value) {
-          const option = getResolvedRef(_option)
-          if (option.properties && 'properties' in result) {
-            mergePropertiesIntoResult(result.properties, option.properties)
-          }
+      /**
+       * Preserve oneOf/anyOf composition structures instead of flattening them.
+       * When these compositions are wrapped in allOf, they should remain as selectable
+       * options in the schema selector dropdown, not be merged into a single schema.
+       */
+      if (Array.isArray(value) && value.length > 0) {
+        if (override || result[key] === undefined) {
+          result[key] = value
         }
       }
     }


### PR DESCRIPTION
When oneOf or anyOf schemas were wrapped inside allOf, the merge function
was incorrectly flattening them by extracting and merging all properties
from their options. This caused the schema selector dropdown to appear
empty because the composition structure was lost.

The fix preserves oneOf/anyOf structures when merging allOf schemas,
allowing the dropdown selector to properly display available options.

Fixes #7613

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures composition structures remain selectable instead of being flattened during `allOf` merges.
> 
> - Updates `merge-all-of-schemas.ts` to keep `oneOf`/`anyOf` arrays intact when encountered inside `allOf` (no longer merges their properties), with override behavior respected
> - Expands `merge-all-of-schemas.test.ts` with cases verifying preservation of `oneOf`, `anyOf`, solo `oneOf` in `allOf`, and both together alongside base properties
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8dabecec17149c999409d74d5aa522c7287f0d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->