### PR TITLE
chore(openapi-upgrader): enable `knip`

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -8,7 +8,6 @@
     "packages/api-reference-react/**",
     "packages/galaxy/**",
     "packages/nextjs-openapi/**",
-    "packages/openapi-upgrader/**",
     "packages/postman-to-openapi/**",
     "projects/**",
     "integrations/docker/**",

--- a/packages/openapi-upgrader/package.json
+++ b/packages/openapi-upgrader/package.json
@@ -67,7 +67,6 @@
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
     "@scalar/types": "workspace:*",
-    "tinybench": "^2.8.0",
     "vite": "catalog:*"
   }
 }

--- a/packages/openapi-upgrader/src/upgrade.ts
+++ b/packages/openapi-upgrader/src/upgrade.ts
@@ -1,10 +1,10 @@
 import type { OpenAPIV3, OpenAPIV3_1, OpenAPIV3_2 } from '@scalar/openapi-types'
+import type { UnknownObject } from '@scalar/types/utils'
 
 import { upgradeFromThreeOneToThreeTwo } from '@/3.1-to-3.2'
 
 import { upgradeFromTwoToThree } from './2.0-to-3.0'
 import { upgradeFromThreeToThreeOne } from './3.0-to-3.1'
-import type { UnknownObject } from '@scalar/types/utils'
 
 /**
  * Upgrade OpenAPI documents from Swagger 2.0 or OpenAPI 3.0 to the specified target version

--- a/packages/openapi-upgrader/tsconfig.build.json
+++ b/packages/openapi-upgrader/tsconfig.build.json
@@ -8,6 +8,6 @@
     "declarationMap": true,
     "noEmit": false,
     "emitDeclarationOnly": true,
-    "outDir": "dist/"
+    "outDir": "dist"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2246,9 +2246,6 @@ importers:
       '@scalar/types':
         specifier: workspace:*
         version: link:../types
-      tinybench:
-        specifier: ^2.8.0
-        version: 2.9.0
       vite:
         specifier: catalog:*
         version: 7.1.11(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)


### PR DESCRIPTION
## Problem

- Followup of #7233

## Solution

Nothing fancy here

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
