### PR TITLE
docs(README): add Scalar OpenAPI to Markdown link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Ready? [Create your Scalar Account](https://scalar.com)
 | [Scalar Galaxy](packages/galaxy/README.md)                                                     | Our OpenAPI Example              |
 | [Scalar Editor](https://editor.scalar.com/)                                                    | OpenAPI Online Editor            |
 | [Scalar OpenAPI Parser](packages/openapi-parser/README.md)                                     | Parse OpenAPI documents          |
+| [Scalar OpenAPI to Markdown](packages/openapi-to-markdown/README.md)                           | OpenAPI > Markdown/HTML          |
 | [Scalar OpenAPI Upgrader](packages/openapi-upgrader/README.md)                                 | Upgrade OpenAPI documents        |
 | [Scalar Void Server](packages/void-server/README.md)                                           | HTTP Request Mirror              |
 


### PR DESCRIPTION
at 40.000 downloads/week it’s time to add it to our root README 😅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates documentation index to include the OpenAPI→Markdown/HTML tool.
> 
> - Adds `Scalar OpenAPI to Markdown` entry in `README.md` Projects table linking to `packages/openapi-to-markdown/README.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71fe9d77a8386064646f70affe475ca733f263f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->