### PR TITLE
fix(build-tooling): import fast glob as commonJS

### DIFF
--- a/.changeset/nice-parts-own.md
+++ b/.changeset/nice-parts-own.md
@@ -1,0 +1,5 @@
+---
+'@scalar/build-tooling': patch
+---
+
+fix(build-tooling): import fast glob as commonJS

--- a/packages/build-tooling/src/esbuild/build.ts
+++ b/packages/build-tooling/src/esbuild/build.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import as from 'ansis'
 import chokidar from 'chokidar'
 import * as esbuild from 'esbuild'
-import { glob } from 'fast-glob'
+import fg from 'fast-glob'
 
 import { addPackageFileExports, findEntryPoints } from '../helpers'
 import { runCommand } from './helpers'
@@ -16,7 +16,7 @@ function makeEntryPoints(allowJs?: boolean) {
     entryPoints.push('src/**/*.js')
   }
 
-  const entryPointsWithoutTests = glob.sync(entryPoints, {
+  const entryPointsWithoutTests = fg.sync(entryPoints, {
     ignore: ['**/*.@(test|spec).@(ts|js)'],
   })
 


### PR DESCRIPTION
This was breaking a bunch of the builds in the Org

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
