### PR TITLE
fix(build-tooling): add scripts directory to package files

### DIFF
--- a/.changeset/thirty-plants-train.md
+++ b/.changeset/thirty-plants-train.md
@@ -1,0 +1,5 @@
+---
+'@scalar/build-tooling': patch
+---
+
+fix(build-tooling): add scripts directory to package files

--- a/packages/build-tooling/package.json
+++ b/packages/build-tooling/package.json
@@ -45,6 +45,7 @@
   },
   "files": [
     "dist",
+    "scripts",
     "CHANGELOG.md"
   ],
   "bin": {


### PR DESCRIPTION
We now expect the `scripts/utils` directory to be available.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
