### PR TITLE
fix(nextjs-openapi): enable `knip`

### DIFF
--- a/.changeset/tame-bees-notice.md
+++ b/.changeset/tame-bees-notice.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nextjs-openapi': patch
+---
+
+fix: export public API via named exports

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -8,7 +8,6 @@
     "packages/api-reference/**",
     "packages/api-reference-react/**",
     "packages/galaxy/**",
-    "packages/nextjs-openapi/**",
     "packages/postman-to-openapi/**",
     "projects/**",
     "integrations/docker/**",
@@ -105,6 +104,10 @@
         "src/bundle/plugins/browser.ts",
         "src/helpers/escape-json-pointer.ts"
       ]
+    },
+    "packages/nextjs-openapi": {
+      "entry": ["src/index.ts", "playground/app/api/**/*.ts"],
+      "ignoreFiles": ["playground/next.config.js"]
     },
     "packages/oas-utils": {
       "entry": [

--- a/packages/nextjs-openapi/playground/next-env.d.ts
+++ b/packages/nextjs-openapi/playground/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/nextjs-openapi/src/index.ts
+++ b/packages/nextjs-openapi/src/index.ts
@@ -1,1 +1,2 @@
-export * from './openapi'
+export type { OpenAPIConfig } from './openapi'
+export { OpenAPI } from './openapi'

--- a/packages/nextjs-openapi/src/openapi.ts
+++ b/packages/nextjs-openapi/src/openapi.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs'
+
 import { ApiReference } from '@scalar/nextjs-api-reference'
 import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
 import { sync } from 'fast-glob'

--- a/packages/nextjs-openapi/src/path.ts
+++ b/packages/nextjs-openapi/src/path.ts
@@ -1,6 +1,7 @@
+import { extname, join } from 'node:path'
+
 import { generateResponses, getJSDocFromNode, getSchemaFromTypeNode } from '@scalar/ts-to-openapi'
 import type { OpenAPIV3_1 } from 'openapi-types'
-import { extname, join } from 'node:path'
 import {
   type Identifier,
   type ParameterDeclaration,
@@ -15,13 +16,13 @@ import {
 } from 'typescript'
 
 /** Check if identifier is a supported http method */
-const checkForMethod = (identifier: Pick<Identifier, 'escapedText'> | undefined) => {
+const checkForMethod = (identifier: Pick<Identifier, 'escapedText'> | undefined): OpenAPIV3_1.HttpMethods | null => {
   const method = identifier?.escapedText?.toLowerCase()
 
   return method?.match(/^(get|post|put|patch|delete|head|options)$/) ? (method as OpenAPIV3_1.HttpMethods) : null
 }
 
-const fileNameResolver = (source: string, target: string) => {
+const fileNameResolver = (source: string, target: string): string => {
   const sourceExt = extname(source)
   const targetExt = extname(target)
 
@@ -67,7 +68,7 @@ const extractPathParams = (node: ParameterDeclaration | undefined, program: Prog
 /**
  * Traverse the typescript file and extract as much info as we can for the openapi spec
  */
-export const getPathSchema = (sourceFile: SourceFile, program: Program) => {
+export const getPathSchema = (sourceFile: SourceFile, program: Program): OpenAPIV3_1.PathsObject => {
   const path: OpenAPIV3_1.PathsObject = {}
   const typeChecker = program.getTypeChecker()
 


### PR DESCRIPTION
## Problem

- Followup of #7233

## Solution

- use named export of star export
- add few return types to path functions
- fix biome issues

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
