### PR TITLE
fix(docs): Vue.js redierct

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -428,7 +428,7 @@
           "to": "/products/api-references/integrations/tsed"
         },
         {
-          "from": "/scalar/scalar-api-references/integrations/vue",
+          "from": "/scalar/scalar-api-references/integrations/vuejs",
           "to": "/products/api-references/integrations/vue"
         },
         {


### PR DESCRIPTION
wrong url

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates documentation redirects in `scalar.config.json`.
> 
> - Changes `from` path for Vue.js integration from `/scalar/scalar-api-references/integrations/vue` to `/scalar/scalar-api-references/integrations/vuejs`, pointing to `products/api-references/integrations/vue`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0b4a6b9dc419b628f8016af080663ced9a63a55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->