### PR TITLE
chore(api-reference-react): enable `knip`

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -5,7 +5,6 @@
     "examples/**",
     "packages/api-client/**",
     "packages/api-reference/**",
-    "packages/api-reference-react/**",
     "packages/postman-to-openapi/**",
     "projects/**",
     "integrations/docker/**",
@@ -50,6 +49,9 @@
   "ignoreBinaries": ["netlify"],
   "workspaces": {
     "packages/api-client-react": {
+      "entry": ["playground/main.tsx"]
+    },
+    "packages/api-reference-react": {
       "entry": ["playground/main.tsx"]
     },
     "packages/build-tooling": {

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -24,7 +24,11 @@
   },
   "scripts": {
     "build": "scalar-build-vite",
-    "playground": "vite ./playground -c ./vite.config.ts",
+    "dev": "vite ./playground -c ./vite.config.ts",
+    "format": "scalar-format",
+    "format:check": "scalar-format-check",
+    "lint:check": "scalar-lint-check",
+    "lint:fix": "scalar-lint-fix",
     "types:build": "scalar-types-build",
     "types:check": "scalar-types-check"
   },
@@ -53,15 +57,11 @@
     "@types/react": "catalog:*",
     "@types/react-dom": "catalog:*",
     "@vitejs/plugin-react": "catalog:*",
-    "character-entities": "^2.0.2",
-    "decode-named-character-reference": "^1.0.2",
-    "path": "^0.12.7",
     "random-words": "^2.0.1",
     "react": "catalog:*",
     "react-dom": "catalog:*",
     "rollup-preserve-directives": "^1.1.1",
-    "vite": "catalog:*",
-    "vue": "catalog:*"
+    "vite": "catalog:*"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0"

--- a/packages/api-reference-react/playground/App.tsx
+++ b/packages/api-reference-react/playground/App.tsx
@@ -1,7 +1,7 @@
+import type { ApiReferenceConfiguration } from '@scalar/api-reference'
 import { generate } from 'random-words'
 import { useEffect, useState } from 'react'
 
-import type { ApiReferenceConfiguration } from '@scalar/api-reference'
 import { ApiReferenceReact } from '../src'
 
 function App() {

--- a/packages/api-reference-react/tsconfig.build.json
+++ b/packages/api-reference-react/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["playground"],
+  "include": ["src"],
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1480,15 +1480,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: catalog:*
         version: 5.0.4(vite@7.1.11(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))
-      character-entities:
-        specifier: ^2.0.2
-        version: 2.0.2
-      decode-named-character-reference:
-        specifier: ^1.0.2
-        version: 1.0.2
-      path:
-        specifier: ^0.12.7
-        version: 0.12.7
       random-words:
         specifier: ^2.0.1
         version: 2.0.1
@@ -1504,9 +1495,6 @@ importers:
       vite:
         specifier: catalog:*
         version: 7.1.11(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
-      vue:
-        specifier: catalog:*
-        version: 3.5.21(typescript@5.8.3)
 
   packages/api-reference/playground/ssr:
     dependencies:


### PR DESCRIPTION
## Problem

- Followup of #7233

## Solution

- add format and lint scripts using scalar bins from `@scalar/build-tooling`
- remove unused dev dependencies
   - `character-entities`
   - `decode-named-character-reference`
   - `path`
   - `vue`
- change `tsconfig.build.json` to include `src` instead of excluding `playground`

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
