### PR TITLE
fix: openapi typo on docs

### DIFF
--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -244,7 +244,7 @@
         <span class="text-c-1">
           <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
         </span>
-        <p class="mt-10 text-c-3 text-sm text-balance">The Open API company.</p>
+        <p class="mt-10 text-c-3 text-sm text-balance">The OpenAPI company.</p>
         <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
       </div>
       <div class="flex text-sm">

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -446,7 +446,7 @@
         <span class="text-c-1">
           <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
         </span>
-        <p class="mt-10 text-c-3 text-sm text-balance">The Open API company.</p>
+        <p class="mt-10 text-c-3 text-sm text-balance">The OpenAPI company.</p>
         <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
       </div>
       <div class="flex text-sm">

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -593,7 +593,7 @@
         <span class="text-c-1">
           <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
         </span>
-        <p class="mt-10 text-c-3 text-sm text-balance">The Open API company.</p>
+        <p class="mt-10 text-c-3 text-sm text-balance">The OpenAPI company.</p>
         <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
       </div>
       <div class="flex text-sm">

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -219,7 +219,7 @@ All of this with just a couple clicks or a few API requests! You handle making y
         <span class="text-c-1">
           <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
         </span>
-        <p class="mt-10 text-c-3 text-sm text-balance">The Open API company.</p>
+        <p class="mt-10 text-c-3 text-sm text-balance">The OpenAPI company.</p>
         <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
       </div>
       <div class="flex text-sm">

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -221,7 +221,7 @@ Once created, you will get redirected to the SDK Overview page where you can:
         <span class="text-c-1">
           <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
         </span>
-        <p class="mt-10 text-c-3 text-sm text-balance">The Open API company.</p>
+        <p class="mt-10 text-c-3 text-sm text-balance">The OpenAPI company.</p>
         <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
       </div>
       <div class="flex text-sm">


### PR DESCRIPTION
OpenAPI not Open API :)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes branding in documentation footers.
> 
> - Updates footer tagline to `The OpenAPI company.` in `docs/getting-started.md`, `introduction.md`, `pricing.md`, `registry/getting-started.md`, and `sdks/getting-started.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84d576345883809126b925e27ba74cb49bffc84c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->