### PR TITLE
fix(docs): don't hide header on docs intro page

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -512,10 +512,7 @@
                   "getting-started": {
                     "filepath": "documentation/guides/docs/getting-started.md",
                     "type": "page",
-                    "title": "Getting Started",
-                    "layout": {
-                      "header": false
-                    }
+                    "title": "Getting Started"
                   },
                   "github-sync": {
                     "filepath": "documentation/guides/docs/github-sync.md",


### PR DESCRIPTION
This config log wasn't doing anything but now it does (and we don't want it to do that thing).

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
