### PR TITLE
fix(api-client): setting and storing formData

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build": "scalar-build-vite",
-    "dev": "pnpm playground:app",
+    "dev": "pnpm playground:v2:web",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
     "playground:app": "vite ./playground/app -c ./vite.config.ts",

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
@@ -4,7 +4,10 @@ import { canMethodHaveBody } from '@scalar/helpers/http/can-method-have-body'
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import { REGEX } from '@scalar/helpers/regex/regex-helpers'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
-import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import type {
+  ApiReferenceEvents,
+  WorkspaceEventBus,
+} from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { AuthMeta } from '@scalar/workspace-store/mutators'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
@@ -199,32 +202,6 @@ const parameterHandlers = computed(() => ({
   query: createParameterHandlers('query', eventBus, meta.value),
 }))
 
-/** Handle request body form row addition */
-const handleAddFormRow = (payload: {
-  data: Partial<{ key: string; value?: string | File }>
-  contentType: string
-}): void => {
-  eventBus.emit('operation:add:requestBody:formRow', {
-    contentType: payload.contentType,
-    meta: meta.value,
-    payload: {
-      key: payload.data.key ?? '',
-      value: payload.data.value ?? '',
-    },
-  })
-}
-
-/** Handle request body form row deletion */
-const handleDeleteFormRow = (payload: {
-  contentType: string
-  index: number
-}): void =>
-  eventBus.emit('operation:delete:requestBody:formRow', {
-    contentType: payload.contentType,
-    index: payload.index,
-    meta: meta.value,
-  })
-
 /** Handle request body content type update */
 const handleUpdateContentType = (payload: { value: string }): void =>
   eventBus.emit('operation:update:requestBody:contentType', {
@@ -232,51 +209,25 @@ const handleUpdateContentType = (payload: { value: string }): void =>
     meta: meta.value,
   })
 
-/** Handle request body form row update */
-const handleUpdateFormRow = (payload: {
-  index: number
-  data: Partial<{
-    key: string
-    value: string | File | null
-    isDisabled: boolean
-  }>
-  contentType: string
-}): void =>
-  eventBus.emit(
-    'operation:update:requestBody:formRow',
-    {
-      contentType: payload.contentType,
-      meta: meta.value,
-      index: payload.index,
-      payload: payload.data,
-    },
-    {
-      debounceKey: `update:requestBody:formRow-${payload.index}-${Object.keys(payload.data).join('-')}`,
-    },
-  )
-
 /** Handle request body value update */
-const handleUpdateBodyValue = (payload: {
-  value?: string | File
-  contentType: string
-}): void => {
-  const debounceKey =
-    typeof payload.value === 'string'
-      ? `update:requestBody:value-${payload.contentType}`
-      : undefined
-
+const handleUpdateBodyValue = ({
+  payload,
+  contentType,
+}: Pick<
+  ApiReferenceEvents['operation:update:requestBody:value'],
+  'payload' | 'contentType'
+>): void =>
   eventBus.emit(
     'operation:update:requestBody:value',
     {
-      contentType: payload.contentType,
-      payload: { value: payload.value ?? '' },
+      payload,
+      contentType,
       meta: meta.value,
     },
     {
-      debounceKey,
+      debounceKey: `update:requestBody:value-${contentType}`,
     },
   )
-}
 
 const labelRequestNameId = useId()
 </script>
@@ -377,10 +328,7 @@ const labelRequestNameId = useId()
         :exampleKey
         :requestBody="getResolvedRef(operation.requestBody)"
         title="Request Body"
-        @add:formRow="handleAddFormRow"
-        @delete:fromRow="handleDeleteFormRow"
         @update:contentType="handleUpdateContentType"
-        @update:formRow="handleUpdateFormRow"
         @update:value="handleUpdateBodyValue" />
 
       <!-- Inject request section plugin components -->

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestBody.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestBody.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
 import { objectEntries } from '@scalar/helpers/object/object-entries'
+import type { ApiReferenceEvents } from '@scalar/workspace-store/events'
 import { unpackProxyObject } from '@scalar/workspace-store/helpers/unpack-proxy'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
 import type { RequestBodyObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
@@ -35,29 +36,11 @@ const emits = defineEmits<{
   /** We use this event to update raw values */
   (
     e: 'update:value',
-    payload: { value?: string | File; contentType: string },
+    payload: Pick<
+      ApiReferenceEvents['operation:update:requestBody:value'],
+      'payload' | 'contentType'
+    >,
   ): void
-  /** We use this event to update  */
-  (
-    e: 'add:formRow',
-    payload: {
-      data: Partial<{ key: string; value?: string | File }>
-      contentType: string
-    },
-  ): void
-  (
-    e: 'update:formRow',
-    payload: {
-      index: number
-      data: Partial<{
-        key: string
-        value: string | File | null
-        isDisabled: boolean
-      }>
-      contentType: string
-    },
-  ): void
-  (e: 'delete:fromRow', payload: { index: number; contentType: string }): void
 }>()
 
 // Map a content type to a language for the code editor
@@ -118,7 +101,7 @@ const selectedContentTypeModel = computed<{ id: string; label: string }>({
   },
 })
 
-function handleFileUpload(callback: (file: File | undefined) => void) {
+function handleFileUpload(callback: (file: File) => void) {
   const { open } = useFileDialog({
     onChange: (files) => {
       const file = files?.[0]
@@ -171,6 +154,41 @@ const tableRows = computed(() => {
 
   return []
 })
+
+/** Adds a new row safely by defaulting the rest of the values */
+const handleAddRow = (
+  payload: Partial<{ name: string; value: string | File; isDisabled: boolean }>,
+) =>
+  emits('update:value', {
+    contentType: selectedContentType.value,
+    payload: [
+      ...tableRows.value,
+      { name: '', value: '', isDisabled: false, ...payload },
+    ],
+  })
+
+/** Update a row in the table, combines with the previous data so we emit a whole row */
+const handleUpdateRow = (
+  index: number,
+  payload: Partial<{
+    name: string
+    value: string | File | undefined
+    isDisabled: boolean
+  }>,
+) =>
+  emits('update:value', {
+    contentType: selectedContentType.value,
+    payload: tableRows.value.map((row, i) =>
+      i === index ? { ...row, ...payload } : row,
+    ),
+  })
+
+/** Delete a row from the table */
+const handleDeleteRow = (index: number) =>
+  emits('update:value', {
+    contentType: selectedContentType.value,
+    payload: tableRows.value.filter((_, i) => i !== index),
+  })
 </script>
 <template>
   <CollapsibleSection>
@@ -199,12 +217,15 @@ const tableRows = computed(() => {
         </ScalarListbox>
       </DataTableHeader>
       <DataTableRow>
+        <!-- No Body -->
         <template v-if="selectedContentType === 'none'">
           <div
             class="text-c-3 flex min-h-10 w-full items-center justify-center border-t p-2 text-sm">
             <span>No Body</span>
           </div>
         </template>
+
+        <!-- Binary File -->
         <template
           v-else-if="selectedContentType === 'application/octet-stream'">
           <div
@@ -223,7 +244,7 @@ const tableRows = computed(() => {
                 variant="outlined"
                 @click="
                   emits('update:value', {
-                    value: undefined,
+                    payload: undefined,
                     contentType: selectedContentType,
                   })
                 ">
@@ -239,7 +260,7 @@ const tableRows = computed(() => {
                   () =>
                     handleFileUpload((file) =>
                       emits('update:value', {
-                        value: file,
+                        payload: file,
                         contentType: selectedContentType,
                       }),
                     )
@@ -254,60 +275,30 @@ const tableRows = computed(() => {
             </template>
           </div>
         </template>
+
+        <!-- Form Data -->
         <template v-else-if="selectedContentType === 'multipart/form-data'">
           <RequestTable
             :data="tableRows"
             :environment="environment"
             showUploadButton
-            @addRow="
-              (payload) =>
-                emits('add:formRow', {
-                  data: payload,
-                  contentType: selectedContentType,
-                })
-            "
-            @deleteRow="
-              (index) =>
-                emits('delete:fromRow', {
-                  contentType: selectedContentType,
-                  index,
-                })
-            "
+            @addRow="handleAddRow"
+            @deleteRow="(index) => handleDeleteRow(index)"
             @removeFile="
-              (index) =>
-                emits('update:formRow', {
-                  contentType: selectedContentType,
-                  index,
-                  data: {
-                    value: undefined,
-                  },
-                })
+              (index) => handleUpdateRow(index, { value: undefined })
             "
-            @updateRow="
-              (index, payload) =>
-                emits('update:formRow', {
-                  index,
-                  data: payload,
-                  contentType: selectedContentType,
-                })
-            "
+            @updateRow="(index, payload) => handleUpdateRow(index, payload)"
             @uploadFile="
               (index) =>
-                handleFileUpload((file) => {
-                  if (index !== undefined && index < tableRows.length) {
-                    return emits('update:formRow', {
-                      index,
-                      data: { value: file },
-                      contentType: selectedContentType,
-                    })
-                  }
-                  emits('add:formRow', {
-                    data: { key: file?.name ?? 'file', value: file },
-                    contentType: selectedContentType,
-                  })
-                })
+                handleFileUpload((file) =>
+                  index >= tableRows.length
+                    ? handleAddRow({ name: file.name, value: file })
+                    : handleUpdateRow(index, { name: file.name, value: file }),
+                )
             " />
         </template>
+
+        <!-- Form URL Encoded -->
         <template
           v-else-if="
             selectedContentType === 'application/x-www-form-urlencoded'
@@ -315,29 +306,12 @@ const tableRows = computed(() => {
           <RequestTable
             :data="tableRows"
             :environment="environment"
-            @addRow="
-              (payload) =>
-                emits('add:formRow', {
-                  data: payload,
-                  contentType: selectedContentType,
-                })
-            "
-            @deleteRow="
-              (index) =>
-                emits('delete:fromRow', {
-                  contentType: selectedContentType,
-                  index,
-                })
-            "
-            @updateRow="
-              (index, payload) =>
-                emits('update:formRow', {
-                  index,
-                  data: payload,
-                  contentType: selectedContentType,
-                })
-            " />
+            @addRow="handleAddRow"
+            @deleteRow="handleDeleteRow"
+            @updateRow="handleUpdateRow" />
         </template>
+
+        <!-- Code/Other -->
         <template v-else>
           <CodeInput
             class="border-t px-3"
@@ -354,7 +328,7 @@ const tableRows = computed(() => {
             @update:modelValue="
               (value) =>
                 emits('update:value', {
-                  value,
+                  payload: value,
                   contentType: selectedContentType,
                 })
             " />

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestBody.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestBody.vue
@@ -146,10 +146,18 @@ const tableRows = computed(() => {
 
   // We got an object try to convert it to an array of rows
   if (typeof example.value.value === 'object' && example.value.value) {
-    return objectEntries(example.value.value).map(([key, value]) => ({
-      name: key,
-      value,
-    }))
+    return objectEntries(example.value.value).map(([key, value]) =>
+      // This is for our formData hack
+      'value' in value
+        ? {
+            name: key,
+            ...value,
+          }
+        : {
+            name: key,
+            value,
+          },
+    )
   }
 
   return []

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestParams.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestParams.vue
@@ -30,12 +30,12 @@ const {
 }>()
 
 const emits = defineEmits<{
-  (e: 'add', payload: Partial<{ key: string; value: string }>): void
+  (e: 'add', payload: Partial<{ name: string; value: string }>): void
   (
     e: 'update',
     payload: {
       index: number
-      payload: Partial<{ key: string; value: string; isDisabled: boolean }>
+      payload: Partial<{ name: string; value: string; isDisabled: boolean }>
     },
   ): void
   (e: 'delete', payload: { index: number }): void

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTable.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTable.vue
@@ -35,11 +35,11 @@ const {
  */
 
 const emits = defineEmits<{
-  (e: 'addRow', payload: Partial<{ key: string; value: string }>): void
+  (e: 'addRow', payload: Partial<{ name: string; value: string }>): void
   (
     e: 'updateRow',
     index: number,
-    payload: Partial<{ key: string; value: string; isDisabled: boolean }>,
+    payload: Partial<{ name: string; value: string; isDisabled: boolean }>,
   ): void
   (e: 'deleteRow', index: number): void
 
@@ -50,13 +50,9 @@ const emits = defineEmits<{
    * when the file is selected. If the index is undefined, it means we add the
    * file to the new row at the bottom of the table.
    */
-  (e: 'uploadFile', index?: number): void
+  (e: 'uploadFile', index: number): void
   (e: 'removeFile', index: number): void
 }>()
-
-const uploadFile = (index?: number) => {
-  emits('uploadFile', index)
-}
 
 const columns = computed(() => {
   if (showUploadButton) {
@@ -88,7 +84,7 @@ const updateOrAdd = ({
   payload,
 }: {
   index: number
-  payload: Partial<{ key: string; value: string; isDisabled: boolean }>
+  payload: Partial<{ name: string; value: string; isDisabled: boolean }>
 }) => {
   /** If the update happen on the last row, it means we need to add a new row */
   if (index >= data.length) {
@@ -123,7 +119,7 @@ const updateOrAdd = ({
       @deleteRow="emits('deleteRow', idx)"
       @removeFile="emits('removeFile', idx)"
       @updateRow="(payload) => updateOrAdd({ index: idx, payload })"
-      @uploadFile="() => uploadFile(idx)" />
+      @uploadFile="emits('uploadFile', idx)" />
   </DataTable>
 </template>
 <style scoped>

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -38,7 +38,7 @@ const {
 const emits = defineEmits<{
   (
     e: 'updateRow',
-    payload: Partial<{ key: string; value: string; isDisabled: boolean }>,
+    payload: Partial<{ name: string; value: string; isDisabled: boolean }>,
   ): void
   (e: 'deleteRow'): void
   (e: 'uploadFile'): void
@@ -126,7 +126,8 @@ const valueModel = computed({
         :modelValue="!data.isDisabled"
         @update:modelValue="(v) => emits('updateRow', { isDisabled: !v })" />
     </template>
-    <!-- Key -->
+
+    <!-- Name -->
     <DataTableCell>
       <CodeInput
         :aria-label="`${label} Key`"
@@ -139,8 +140,8 @@ const valueModel = computed({
         :modelValue="data.name"
         placeholder="Key"
         :required="Boolean(data.isRequired)"
-        @selectVariable="(v: string) => emits('updateRow', { key: v })"
-        @update:modelValue="(v: string) => emits('updateRow', { key: v })" />
+        @selectVariable="(v: string) => emits('updateRow', { name: v })"
+        @update:modelValue="(v: string) => emits('updateRow', { name: v })" />
     </DataTableCell>
 
     <!-- Value -->

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -9,11 +9,11 @@ export const createParameterHandlers = (
   eventBus: WorkspaceEventBus,
   meta: OperationExampleMeta,
 ) => ({
-  add: (payload: { key?: string; value?: string }) =>
+  add: (payload: { name?: string; value?: string }) =>
     eventBus.emit('operation:add:parameter', {
       type,
       payload: {
-        key: payload.key ?? '',
+        name: payload.name ?? '',
         value: payload.value ?? '',
         isDisabled: false,
       },
@@ -30,13 +30,12 @@ export const createParameterHandlers = (
       type,
       meta,
     }),
-  update: (payload: { index: number; payload: Partial<{ key: string; value: string; isDisabled: boolean }> }) =>
+  update: (payload: { index: number; payload: Partial<{ name: string; value: string; isDisabled: boolean }> }) =>
     eventBus.emit(
       'operation:update:parameter',
       {
         type,
-        index: payload.index,
-        payload: payload.payload,
+        ...payload,
         meta,
       },
       {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-request-body-example.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-request-body-example.ts
@@ -1,9 +1,12 @@
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { ExampleObject, RequestBodyObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
+import { getExample } from '@/v2/blocks/operation-block/helpers/get-example'
 import { getExampleFromSchema } from '@/v2/blocks/operation-code-sample/helpers/get-example-from-schema'
 
-/** Grab the resolved reference to the example from the request body, or build an example from the schema */
+/**
+ * Basically getExample + we generate an example from the schema if no example is found
+ */
 export const getExampleFromBody = (
   requestBody: RequestBodyObject,
   contentType: string,
@@ -12,9 +15,9 @@ export const getExampleFromBody = (
   const content = requestBody.content?.[contentType]
 
   // Return existing example value if we have one
-  const resolved = getResolvedRef(content?.examples?.[exampleKey])
-  if (resolved) {
-    return resolved
+  const example = getExample(requestBody, exampleKey, contentType)
+  if (example) {
+    return example
   }
 
   const schema = getResolvedRef(content?.schema)
@@ -23,10 +26,10 @@ export const getExampleFromBody = (
   }
 
   // Generate an example from the schema
-  const example = getExampleFromSchema(schema)
-  if (!example) {
+  const schemaExample = getExampleFromSchema(schema)
+  if (!schemaExample) {
     return null
   }
 
-  return { value: example }
+  return { value: schemaExample }
 }

--- a/packages/api-client/src/v2/features/app/hooks/use-workspace-client-app-events.ts
+++ b/packages/api-client/src/v2/features/app/hooks/use-workspace-client-app-events.ts
@@ -5,7 +5,6 @@ import { mergeObjects } from '@scalar/workspace-store/helpers/merge-object'
 import {
   type OperationExampleMeta,
   addOperationParameter,
-  addOperationRequestBodyFormRow,
   addServer,
   addTab,
   closeOtherTabs,
@@ -19,7 +18,6 @@ import {
   deleteOperation,
   deleteOperationExample,
   deleteOperationParameter,
-  deleteOperationRequestBodyFormRow,
   deleteSecurityScheme,
   deleteServer,
   deleteTag,
@@ -35,7 +33,6 @@ import {
   updateOperationPathMethod,
   updateOperationRequestBodyContentType,
   updateOperationRequestBodyExample,
-  updateOperationRequestBodyFormRow,
   updateOperationSummary,
   updateSecurityScheme,
   updateSelectedAuthTab,
@@ -366,16 +363,6 @@ export const useWorkspaceClientAppEvents = ({
     updateOperationRequestBodyExample(document.value, payload)
     refreshSidebarAfterExampleCreation(payload.meta)
   })
-  eventBus.on('operation:add:requestBody:formRow', (payload) => {
-    addOperationRequestBodyFormRow(document.value, payload)
-    refreshSidebarAfterExampleCreation(payload.meta)
-  })
-  eventBus.on('operation:update:requestBody:formRow', (payload) =>
-    updateOperationRequestBodyFormRow(document.value, payload),
-  )
-  eventBus.on('operation:delete:requestBody:formRow', (payload) =>
-    deleteOperationRequestBodyFormRow(document.value, payload),
-  )
 
   //------------------------------------------------------------------------------------
   // Tag Related Event Handlers

--- a/packages/api-client/src/v2/features/modal/hooks/use-workspace-client-modal-events.ts
+++ b/packages/api-client/src/v2/features/modal/hooks/use-workspace-client-modal-events.ts
@@ -3,17 +3,14 @@ import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import {
   addOperationParameter,
-  addOperationRequestBodyFormRow,
   addServer,
   deleteAllOperationParameters,
   deleteOperationParameter,
-  deleteOperationRequestBodyFormRow,
   deleteSecurityScheme,
   deleteServer,
   updateOperationParameter,
   updateOperationRequestBodyContentType,
   updateOperationRequestBodyExample,
-  updateOperationRequestBodyFormRow,
   updateSecurityScheme,
   updateSelectedAuthTab,
   updateSelectedClient,
@@ -86,17 +83,8 @@ export const useWorkspaceClientModalEvents = ({
   eventBus.on('operation:update:requestBody:contentType', (payload) =>
     updateOperationRequestBodyContentType(document.value, payload),
   )
-  eventBus.on('operation:update:requestBody:value', (payload) => {
-    updateOperationRequestBodyExample(document.value, payload)
-  })
-  eventBus.on('operation:add:requestBody:formRow', (payload) => {
-    addOperationRequestBodyFormRow(document.value, payload)
-  })
-  eventBus.on('operation:update:requestBody:formRow', (payload) =>
-    updateOperationRequestBodyFormRow(document.value, payload),
-  )
-  eventBus.on('operation:delete:requestBody:formRow', (payload) =>
-    deleteOperationRequestBodyFormRow(document.value, payload),
+  eventBus.on('operation:update:requestBody:value', (payload) =>
+    updateOperationRequestBodyExample(document.value, payload),
   )
 
   //------------------------------------------------------------------------------------

--- a/packages/api-client/src/v2/features/operation/Operation.vue
+++ b/packages/api-client/src/v2/features/operation/Operation.vue
@@ -77,7 +77,7 @@ watch(
         type: 'header',
         meta: { method, path, exampleKey: exampleName ?? 'default' },
         payload: {
-          key: 'Accept',
+          name: 'Accept',
           value: '*/*',
           isDisabled: false,
         },

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -2,6 +2,7 @@
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
 import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { isTypeObject } from '@scalar/workspace-store/helpers/is-type-object'
 import type {
   DiscriminatorObject,
   SchemaObject,
@@ -12,7 +13,6 @@ import type { SchemaOptions } from '@/components/Content/Schema/types'
 import ScreenReader from '@/components/ScreenReader.vue'
 
 import { isEmptySchemaObject } from './helpers/is-empty-schema-object'
-import { isTypeObject } from './helpers/is-type-object'
 import SchemaHeading from './SchemaHeading.vue'
 import SchemaObjectProperties from './SchemaObjectProperties.vue'
 import SchemaProperty from './SchemaProperty.vue'

--- a/packages/api-reference/src/components/Content/Schema/SchemaHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaHeading.vue
@@ -1,10 +1,9 @@
 <script lang="ts" setup>
 import { ScalarWrappingText } from '@scalar/components'
+import { isTypeObject } from '@scalar/workspace-store/helpers/is-type-object'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { isArraySchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
 import { computed } from 'vue'
-
-import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
 
 const { value } = defineProps<{
   value: SchemaObject
@@ -52,8 +51,8 @@ const failsafeType = computed(() => {
     </span>
     <template v-if="name">
       <ScalarWrappingText
-        :text="name"
-        preset="property" />
+        preset="property"
+        :text="name" />
     </template>
     <template v-else>
       {{ failsafeType }}

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { isTypeObject } from '@scalar/workspace-store/helpers/is-type-object'
 import type {
   DiscriminatorObject,
   SchemaObject,
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed } from 'vue'
 
-import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
 import { sortPropertyNames } from '@/components/Content/Schema/helpers/sort-property-names'
 import type { SchemaOptions } from '@/components/Content/Schema/types'
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -3,6 +3,7 @@ import { ScalarMarkdown, ScalarWrappingText } from '@scalar/components'
 import { isDefined } from '@scalar/helpers/array/is-defined'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { isTypeObject } from '@scalar/workspace-store/helpers/is-type-object'
 import type {
   DiscriminatorObject,
   SchemaObject,
@@ -11,7 +12,6 @@ import { isArraySchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-
 import { computed, type Component } from 'vue'
 
 import { WithBreadcrumb } from '@/components/Anchor'
-import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
 import type { SchemaOptions } from '@/components/Content/Schema/types'
 import { SpecificationExtension } from '@/features/specification-extension'
 
@@ -286,21 +286,21 @@ const compositionsToRender = computed(() => {
           <template v-if="variant === 'patternProperties'">
             <span class="property-name-pattern-properties">
               <ScalarWrappingText
-                :text="name"
-                preset="property" />
+                preset="property"
+                :text="name" />
             </span>
           </template>
           <template v-else-if="variant === 'additionalProperties'">
             <span class="property-name-additional-properties">
               <ScalarWrappingText
-                :text="name"
-                preset="property" />
+                preset="property"
+                :text="name" />
             </span>
           </template>
           <template v-else>
             <ScalarWrappingText
-              :text="name"
-              preset="property" />
+              preset="property"
+              :text="name" />
           </template>
         </WithBreadcrumb>
       </template>

--- a/packages/api-reference/src/components/Content/Schema/helpers/is-empty-schema-object.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/is-empty-schema-object.ts
@@ -1,6 +1,5 @@
+import { isTypeObject } from '@scalar/workspace-store/helpers/is-type-object'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-
-import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
 
 /**
  * Determines if the given schema is an empty object schema.

--- a/packages/api-reference/src/components/Content/Schema/helpers/sort-property-names.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/sort-property-names.ts
@@ -1,8 +1,7 @@
 import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { isTypeObject } from '@scalar/workspace-store/helpers/is-type-object'
 import type { DiscriminatorObject, SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-
-import { isTypeObject } from './is-type-object'
 
 /** Extract the type of properties */
 type Properties = NonNullable<Extract<SchemaObject, { type: 'object' }>['properties']>

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -2,11 +2,11 @@
 import { ScalarMarkdown } from '@scalar/components'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { isTypeObject } from '@scalar/workspace-store/helpers/is-type-object'
 import type { RequestBodyObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed, ref } from 'vue'
 
 import { Schema } from '@/components/Content/Schema'
-import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
 import {
   reduceNamesToObject,
   sortPropertyNames,

--- a/packages/workspace-store/src/events/definitions/operation.ts
+++ b/packages/workspace-store/src/events/definitions/operation.ts
@@ -109,7 +109,7 @@ export type OperationEvents = {
      */
     payload: {
       /** The name of the parameter to add */
-      key: string
+      name: string
       /** The example value for the parameter to add */
       value: string
       /** Whether the parameter is enabled */
@@ -134,12 +134,12 @@ export type OperationEvents = {
     index: number
     /**
      * Partial payload with new properties for the parameter (optional).
-     * - key: The new name of the parameter (if being renamed).
+     * - name: The new name of the parameter (if being renamed).
      * - value: The new example value for the parameter.
      * - isDisabled: Whether the parameter is marked as disabled.
      */
     payload: Partial<{
-      key: string
+      name: string
       value: string
       isDisabled: boolean
     }>
@@ -194,54 +194,11 @@ export type OperationEvents = {
    * Triggers when the user updates the example value for a specific request body content type.
    */
   'operation:update:requestBody:value': {
-    payload: {
-      /** The new value for the request body example */
-      value: string | File | undefined
-    }
+    /** The new value for the request body example */
+    payload: string | File | undefined | { name: string; value: string | File; isDisabled: boolean }[]
     /** The content type of the request body */
     contentType: string
     /** Identifies the target operation and example variant for the updated request body value */
-    meta: OperationExampleMeta
-  }
-
-  /**
-   * Add a form-data row to the request body example.
-   * Triggers when the user adds a new form-data row to the request body in the UI.
-   */
-  'operation:add:requestBody:formRow': {
-    /** The payload containing the details of the form-data row to add */
-    payload: Partial<{ key: string; value: string | File }>
-    /** The content type of the request body */
-    contentType: string
-    /** Identifies the target operation and example variant for the added form-data row */
-    meta: OperationExampleMeta
-  }
-
-  /**
-   * Update a form-data row at the specified index for the request body example.
-   * Triggers when the user updates an existing form-data row (name, value) in the UI for a given operation.
-   */
-  'operation:update:requestBody:formRow': {
-    /** The zero-based index of the form-data row to update within the operation. */
-    index: number
-    /** The payload containing the details of the form-data row to update */
-    payload: Partial<{ key: string; value: string | File | null; isDisabled: boolean }>
-    /** The content type of the request body */
-    contentType: string
-    /** Identifies the target operation and example variant for the updated form-data row */
-    meta: OperationExampleMeta
-  }
-
-  /**
-   * Delete a form-data row from the request body example.
-   * Triggers when the user removes a form-data row (by type and index) from the request body in the UI.
-   */
-  'operation:delete:requestBody:formRow': {
-    /** The zero-based index of the form-data row to delete within the operation. */
-    index: number
-    /** The content type of the request body */
-    contentType: string
-    /** Identifies the target operation and example variant for the deleted form-data row */
     meta: OperationExampleMeta
   }
 }

--- a/packages/workspace-store/src/events/definitions/operation.ts
+++ b/packages/workspace-store/src/events/definitions/operation.ts
@@ -195,7 +195,21 @@ export type OperationEvents = {
    */
   'operation:update:requestBody:value': {
     /** The new value for the request body example */
-    payload: string | File | undefined | { name: string; value: string | File; isDisabled: boolean }[]
+    payload: string | File | undefined
+    /** The content type of the request body */
+    contentType: string
+    /** Identifies the target operation and example variant for the updated request body value */
+    meta: OperationExampleMeta
+  }
+
+  /**
+   * Update the form data for the request body example.
+   * Triggers when the user updates the form data for a specific request body content type.
+   * It will go through and add each example to the respective schema object
+   */
+  'operation:update:requestBody:form': {
+    /** The new value for the request body example */
+    payload: { name: string; value: string | File; isDisabled: boolean }[]
     /** The content type of the request body */
     contentType: string
     /** Identifies the target operation and example variant for the updated request body value */

--- a/packages/workspace-store/src/helpers/is-type-object.test.ts
+++ b/packages/workspace-store/src/helpers/is-type-object.test.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { describe, expect, it } from 'vitest'
+
 import { isTypeObject } from './is-type-object'
 
 describe('is-type-object', () => {

--- a/packages/workspace-store/src/helpers/is-type-object.ts
+++ b/packages/workspace-store/src/helpers/is-type-object.ts
@@ -1,6 +1,6 @@
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
-/*
+/**
  * Checks whether a JSON schema is of type object
  */
 export const isTypeObject = (schema: unknown): schema is Extract<SchemaObject, { type: 'object' }> => {

--- a/packages/workspace-store/src/mutators/index.ts
+++ b/packages/workspace-store/src/mutators/index.ts
@@ -148,18 +148,15 @@ export {
   type OperationExampleMeta,
   type OperationMeta,
   addOperationParameter,
-  addOperationRequestBodyFormRow,
   createOperation,
   deleteAllOperationParameters,
   deleteOperation,
   deleteOperationExample,
   deleteOperationParameter,
-  deleteOperationRequestBodyFormRow,
   updateOperationParameter,
   updateOperationPathMethod,
   updateOperationRequestBodyContentType,
   updateOperationRequestBodyExample,
-  updateOperationRequestBodyFormRow,
   updateOperationSummary,
 } from './operation'
 export {

--- a/packages/workspace-store/src/mutators/operation.test.ts
+++ b/packages/workspace-store/src/mutators/operation.test.ts
@@ -7,19 +7,16 @@ import type { OperationObject } from '@/schemas/v3.1/strict/openapi-document'
 
 import {
   addOperationParameter,
-  addOperationRequestBodyFormRow,
   createOperation,
   deleteAllOperationParameters,
   deleteOperation,
   deleteOperationExample,
   deleteOperationParameter,
-  deleteOperationRequestBodyFormRow,
   setHeader,
   updateOperationParameter,
   updateOperationPathMethod,
   updateOperationRequestBodyContentType,
   updateOperationRequestBodyExample,
-  updateOperationRequestBodyFormRow,
   updateOperationSummary,
 } from './operation'
 
@@ -972,7 +969,7 @@ describe('addOperationParameter', () => {
     addOperationParameter(document, {
       type: 'query',
       meta: { method: 'get', path: '/search', exampleKey: 'default' },
-      payload: { key: 'q', value: 'john', isDisabled: false },
+      payload: { name: 'q', value: 'john', isDisabled: false },
     })
 
     const op = getResolvedRef(document.paths?.['/search']?.get)
@@ -998,7 +995,7 @@ describe('addOperationParameter', () => {
     addOperationParameter(document, {
       type: 'path',
       meta: { method: 'get', path: '/users/{id}', exampleKey: 'default' },
-      payload: { key: 'id', value: '123', isDisabled: true },
+      payload: { name: 'id', value: '123', isDisabled: true },
     })
 
     const op = getResolvedRef(document.paths?.['/users/{id}']?.get)
@@ -1017,7 +1014,7 @@ describe('addOperationParameter', () => {
       addOperationParameter(null, {
         type: 'query',
         meta: { method: 'get', path: '/search', exampleKey: 'default' },
-        payload: { key: 'q', value: 'x', isDisabled: false },
+        payload: { name: 'q', value: 'x', isDisabled: false },
       }),
     ).not.toThrow()
   })
@@ -1032,7 +1029,7 @@ describe('addOperationParameter', () => {
     addOperationParameter(document, {
       type: 'query',
       meta: { method: 'get', path: '/missing', exampleKey: 'default' },
-      payload: { key: 'q', value: 'x', isDisabled: false },
+      payload: { name: 'q', value: 'x', isDisabled: false },
     })
 
     expect(document.paths?.['/missing']).toEqual({})
@@ -1055,20 +1052,20 @@ describe('updateOperationParameter', () => {
     addOperationParameter(document, {
       type: 'query',
       meta: { method: 'get', path: '/search', exampleKey: 'default' },
-      payload: { key: 'q', value: 'one', isDisabled: false },
+      payload: { name: 'q', value: 'one', isDisabled: false },
     })
 
     addOperationParameter(document, {
       type: 'query',
       meta: { method: 'get', path: '/search', exampleKey: 'default' },
-      payload: { key: 'p', value: 'two', isDisabled: false },
+      payload: { name: 'p', value: 'two', isDisabled: false },
     })
 
     updateOperationParameter(document, {
       type: 'query',
       index: 1,
       meta: { method: 'get', path: '/search', exampleKey: 'default' },
-      payload: { key: 'page', value: '2', isDisabled: false },
+      payload: { name: 'page', value: '2', isDisabled: false },
     })
 
     const op = getResolvedRef(document.paths?.['/search']?.get)
@@ -1102,7 +1099,7 @@ describe('updateOperationParameter', () => {
     addOperationParameter(document, {
       type: 'query',
       meta: { method: 'get', path: '/search', exampleKey: 'default' },
-      payload: { key: 'q', value: 'one', isDisabled: false },
+      payload: { name: 'q', value: 'one', isDisabled: false },
     })
 
     updateOperationParameter(document, {
@@ -1133,14 +1130,14 @@ describe('updateOperationParameter', () => {
     addOperationParameter(document, {
       type: 'query',
       meta: { method: 'get', path: '/search', exampleKey: 'default' },
-      payload: { key: 'q', value: 'one', isDisabled: false },
+      payload: { name: 'q', value: 'one', isDisabled: false },
     })
 
     updateOperationParameter(document, {
       type: 'query',
       index: 0,
       meta: { method: 'get', path: '/search', exampleKey: 'other' },
-      payload: { key: 'query', value: 'new value', isDisabled: false },
+      payload: { name: 'query', value: 'new value', isDisabled: false },
     })
 
     const op = getResolvedRef(document.paths?.['/search']?.get)
@@ -1166,12 +1163,12 @@ describe('updateOperationParameter', () => {
     addOperationParameter(document, {
       type: 'header',
       meta: { method: 'get', path: '/search', exampleKey: 'default' },
-      payload: { key: 'X-Trace', value: 'abc', isDisabled: false },
+      payload: { name: 'X-Trace', value: 'abc', isDisabled: false },
     })
     addOperationParameter(document, {
       type: 'query',
       meta: { method: 'get', path: '/search', exampleKey: 'default' },
-      payload: { key: 'q', value: 'one', isDisabled: false },
+      payload: { name: 'q', value: 'one', isDisabled: false },
     })
 
     // index 0 for type 'query' refers to the second element in the raw array
@@ -1179,7 +1176,7 @@ describe('updateOperationParameter', () => {
       type: 'query',
       index: 0,
       meta: { method: 'get', path: '/search', exampleKey: 'default' },
-      payload: { key: 'query', value: '1' },
+      payload: { name: 'query', value: '1' },
     })
 
     const op = getResolvedRef(document.paths?.['/search']?.get)
@@ -1198,7 +1195,7 @@ describe('updateOperationParameter', () => {
         type: 'query',
         index: 0,
         meta: { method: 'get', path: '/search', exampleKey: 'default' },
-        payload: { key: 'q' },
+        payload: { name: 'q' },
       }),
     ).not.toThrow()
   })
@@ -1214,7 +1211,7 @@ describe('updateOperationParameter', () => {
       type: 'query',
       index: 0,
       meta: { method: 'get', path: '/search', exampleKey: 'default' },
-      payload: { key: 'q' },
+      payload: { name: 'q' },
     })
 
     expect(document.paths?.['/search']).toEqual({})
@@ -1235,17 +1232,17 @@ describe('deleteOperationParameter', () => {
     addOperationParameter(document, {
       type: 'header',
       meta: { method: 'get', path: '/search', exampleKey: 'default' },
-      payload: { key: 'X-Trace', value: 'a', isDisabled: false },
+      payload: { name: 'X-Trace', value: 'a', isDisabled: false },
     })
     addOperationParameter(document, {
       type: 'query',
       meta: { method: 'get', path: '/search', exampleKey: 'default' },
-      payload: { key: 'q', value: 'one', isDisabled: false },
+      payload: { name: 'q', value: 'one', isDisabled: false },
     })
     addOperationParameter(document, {
       type: 'query',
       meta: { method: 'get', path: '/search', exampleKey: 'default' },
-      payload: { key: 'page', value: '2', isDisabled: false },
+      payload: { name: 'page', value: '2', isDisabled: false },
     })
 
     // Delete the second query (index 1 within filtered query params)
@@ -1304,22 +1301,22 @@ describe('deleteAllOperationParameters', () => {
     addOperationParameter(document, {
       type: 'header',
       meta: { method: 'get', path: '/users/{id}', exampleKey: 'default' },
-      payload: { key: 'X-Trace', value: 'a', isDisabled: false },
+      payload: { name: 'X-Trace', value: 'a', isDisabled: false },
     })
     addOperationParameter(document, {
       type: 'query',
       meta: { method: 'get', path: '/users/{id}', exampleKey: 'default' },
-      payload: { key: 'q', value: 'one', isDisabled: false },
+      payload: { name: 'q', value: 'one', isDisabled: false },
     })
     addOperationParameter(document, {
       type: 'query',
       meta: { method: 'get', path: '/users/{id}', exampleKey: 'default' },
-      payload: { key: 'page', value: '2', isDisabled: false },
+      payload: { name: 'page', value: '2', isDisabled: false },
     })
     addOperationParameter(document, {
       type: 'path',
       meta: { method: 'get', path: '/users/{id}', exampleKey: 'default' },
-      payload: { key: 'id', value: '123', isDisabled: false },
+      payload: { name: 'id', value: '123', isDisabled: false },
     })
 
     deleteAllOperationParameters(document, {
@@ -1477,7 +1474,7 @@ describe('updateOperationRequestBodyExample', () => {
     updateOperationRequestBodyExample(document, {
       contentType: 'application/json',
       meta: { method: 'post', path: '/users', exampleKey: 'default' },
-      payload: { value: '{"name":"Ada"}' },
+      payload: '{"name":"Ada"}',
     })
 
     const op = getResolvedRef(document.paths?.['/users']?.post)
@@ -1503,13 +1500,13 @@ describe('updateOperationRequestBodyExample', () => {
     updateOperationRequestBodyExample(document, {
       contentType: 'application/json',
       meta: { method: 'post', path: '/users', exampleKey: 'default' },
-      payload: { value: 'v1' },
+      payload: 'v1',
     })
 
     updateOperationRequestBodyExample(document, {
       contentType: 'application/json',
       meta: { method: 'post', path: '/users', exampleKey: 'default' },
-      payload: { value: 'v2' },
+      payload: 'v2',
     })
 
     const op = getResolvedRef(document.paths?.['/users']?.post)
@@ -1535,13 +1532,13 @@ describe('updateOperationRequestBodyExample', () => {
     updateOperationRequestBodyExample(document, {
       contentType: 'application/json',
       meta: { method: 'post', path: '/users', exampleKey: 'A' },
-      payload: { value: 'one' },
+      payload: 'one',
     })
 
     updateOperationRequestBodyExample(document, {
       contentType: 'application/json',
       meta: { method: 'post', path: '/users', exampleKey: 'B' },
-      payload: { value: 'two' },
+      payload: 'two',
     })
 
     const op = getResolvedRef(document.paths?.['/users']?.post)
@@ -1561,7 +1558,7 @@ describe('updateOperationRequestBodyExample', () => {
       updateOperationRequestBodyExample(null, {
         contentType: 'application/json',
         meta: { method: 'post', path: '/users', exampleKey: 'default' },
-        payload: { value: 'x' },
+        payload: 'x',
       }),
     ).not.toThrow()
   })
@@ -1576,238 +1573,17 @@ describe('updateOperationRequestBodyExample', () => {
     updateOperationRequestBodyExample(document, {
       contentType: 'application/json',
       meta: { method: 'post', path: '/users', exampleKey: 'default' },
-      payload: { value: 'x' },
+      payload: 'x',
     })
 
     expect(document.paths?.['/users']).toEqual({})
   })
 })
 
-describe('addOperationRequestBodyFormRow', () => {
-  it('initializes example value as array when missing and appends the first row', () => {
-    const document = createDocument({
-      paths: {
-        '/upload': {
-          post: {},
-        },
-      },
-    })
-
-    addOperationRequestBodyFormRow(document, {
-      contentType: 'multipart/form-data',
-      meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-      payload: { key: 'file', value: new File(['x'], 'a.txt') },
-    })
-
-    const op = getResolvedRef(document.paths?.['/upload']?.post)
-    assert(op)
-    const rb = getResolvedRef(op.requestBody)
-    assert(rb)
-    const media = rb.content?.['multipart/form-data']
-    assert(media)
-    const examples = getResolvedRef(media.examples)
-    assert(examples)
-    const ex = getResolvedRef(examples.default)
-    assert(ex && Array.isArray(ex.value))
-    expect(ex.value).toEqual([{ name: 'file', value: expect.any(File), isDisabled: false }])
-  })
-
-  it('appends a new row when example value is already an array', () => {
-    const document = createDocument({
-      paths: {
-        '/upload': {
-          post: {},
-        },
-      },
-    })
-
-    addOperationRequestBodyFormRow(document, {
-      contentType: 'multipart/form-data',
-      meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-      payload: { key: 'file', value: new File(['x'], 'a.txt') },
-    })
-    addOperationRequestBodyFormRow(document, {
-      contentType: 'multipart/form-data',
-      meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-      payload: { key: 'description', value: 'Profile picture' },
-    })
-
-    const op = getResolvedRef(document.paths?.['/upload']?.post)
-    assert(op)
-    const rb = getResolvedRef(op.requestBody)
-    assert(rb)
-    const ex = getResolvedRef(rb.content?.['multipart/form-data']?.examples?.default)
-    assert(ex && Array.isArray(ex.value))
-    expect(ex.value).toHaveLength(2)
-    expect(ex.value[1]).toEqual({ name: 'description', value: 'Profile picture', isDisabled: false })
-  })
-
-  it('no-ops when document is null', () => {
-    expect(() =>
-      addOperationRequestBodyFormRow(null, {
-        contentType: 'multipart/form-data',
-        meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-        payload: { key: 'file', value: new File(['x'], 'a.txt') },
-      }),
-    ).not.toThrow()
-  })
-
-  it('no-ops when operation does not exist', () => {
-    const document = createDocument({ paths: { '/upload': {} } })
-
-    addOperationRequestBodyFormRow(document, {
-      contentType: 'multipart/form-data',
-      meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-      payload: { key: 'file', value: new File(['x'], 'a.txt') },
-    })
-
-    expect(document.paths?.['/upload']).toEqual({})
-  })
-})
-
-describe('updateOperationRequestBodyFormRow', () => {
-  it('updates an existing row by index; undefined value clears to undefined', () => {
-    const document = createDocument({
-      paths: {
-        '/upload': {
-          post: {},
-        },
-      },
-    })
-
-    addOperationRequestBodyFormRow(document, {
-      contentType: 'multipart/form-data',
-      meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-      payload: { key: 'file', value: new File(['x'], 'a.txt') },
-    })
-    addOperationRequestBodyFormRow(document, {
-      contentType: 'multipart/form-data',
-      meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-      payload: { key: 'description', value: 'Profile picture' },
-    })
-
-    updateOperationRequestBodyFormRow(document, {
-      index: 1,
-      contentType: 'multipart/form-data',
-      meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-      payload: { key: 'desc', value: undefined },
-    })
-
-    const op = getResolvedRef(document.paths?.['/upload']?.post)
-    assert(op)
-    const rb2 = getResolvedRef(op.requestBody)
-    const ex = getResolvedRef(rb2?.content?.['multipart/form-data']?.examples?.default)
-    assert(ex && Array.isArray(ex.value))
-    expect(ex.value[1]).toEqual({ name: 'desc', value: undefined, isDisabled: false })
-  })
-
-  it('no-ops when content type or example array is missing', () => {
-    const document = createDocument({
-      paths: {
-        '/upload': {
-          post: {},
-        },
-      },
-    })
-
-    // No requestBody/content/examples present
-    updateOperationRequestBodyFormRow(document, {
-      index: 0,
-      contentType: 'multipart/form-data',
-      meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-      payload: { key: 'x', value: 'y' },
-    })
-
-    const op = getResolvedRef(document.paths?.['/upload']?.post)
-    assert(op)
-    expect(op.requestBody).toEqual({ content: {} })
-  })
-})
-
-describe('deleteOperationRequestBodyFormRow', () => {
-  it('deletes a row by index; removes example when last row removed', () => {
-    const document = createDocument({
-      paths: {
-        '/upload': {
-          post: {},
-        },
-      },
-    })
-
-    addOperationRequestBodyFormRow(document, {
-      contentType: 'multipart/form-data',
-      meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-      payload: { key: 'file', value: new File(['x'], 'a.txt') },
-    })
-
-    deleteOperationRequestBodyFormRow(document, {
-      index: 0,
-      contentType: 'multipart/form-data',
-      meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-    })
-
-    const op = getResolvedRef(document.paths?.['/upload']?.post)
-    assert(op)
-    const rb3 = getResolvedRef(op.requestBody)
-    const examples = rb3?.content?.['multipart/form-data']?.examples
-    expect(examples?.default).toBeUndefined()
-  })
-
-  it('deletes the correct row and keeps others intact', () => {
-    const document = createDocument({
-      paths: {
-        '/upload': {
-          post: {},
-        },
-      },
-    })
-
-    addOperationRequestBodyFormRow(document, {
-      contentType: 'multipart/form-data',
-      meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-      payload: { key: 'a', value: '1' },
-    })
-    addOperationRequestBodyFormRow(document, {
-      contentType: 'multipart/form-data',
-      meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-      payload: { key: 'b', value: '2' },
-    })
-
-    deleteOperationRequestBodyFormRow(document, {
-      index: 0,
-      contentType: 'multipart/form-data',
-      meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-    })
-
-    const op = getResolvedRef(document.paths?.['/upload']?.post)
-    assert(op)
-    const rb4 = getResolvedRef(op.requestBody)
-    const ex = getResolvedRef(rb4?.content?.['multipart/form-data']?.examples?.default)
-    assert(ex && Array.isArray(ex.value))
-    expect(ex.value).toHaveLength(1)
-    expect(ex.value[0]).toEqual({ name: 'b', value: '2', isDisabled: false })
-  })
-
-  it('no-ops when document is null or operation does not exist', () => {
-    expect(() =>
-      deleteOperationRequestBodyFormRow(null, {
-        index: 0,
-        contentType: 'multipart/form-data',
-        meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-      }),
-    ).not.toThrow()
-
-    const document = createDocument({ paths: { '/upload': {} } })
-
-    deleteOperationRequestBodyFormRow(document, {
-      index: 0,
-      contentType: 'multipart/form-data',
-      meta: { method: 'post', path: '/upload', exampleKey: 'default' },
-    })
-
-    expect(document.paths?.['/upload']).toEqual({})
-  })
-})
+// Note: Form row functions (addOperationRequestBodyFormRow, updateOperationRequestBodyFormRow,
+// deleteOperationRequestBodyFormRow) do not exist. Form data is handled through
+// updateOperationRequestBodyExample with array payloads.
+// These tests have been removed as they test non-existent functionality.
 
 describe('deleteOperation', () => {
   it('deletes an operation from a path', async () => {


### PR DESCRIPTION
## Problem
closes #7708
closes #7695

There are some issues with the way we are storing formData examples. This PR _almost_ gets there but not quite. I think we will actually have to store the values on schema properties and create them on the fly.
<!--
  What problem does the PR solve?
  WHY did you submit the PR?

  We are interested in the WHY (LLMs won't know).
-->

## Solution

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
