### PR TITLE
ci: replace personal access token with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -11,6 +11,9 @@ jobs:
     if: ${{ github.repository_owner == 'scalar' }}
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Update the list of contributors
@@ -18,7 +21,4 @@ jobs:
         with:
           use_username: true
         env:
-          # https://github.com/settings/tokens/new
-          # Expiration: No expiration
-          # Select: read:org
-          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-scalar-cli-documentation.yml
+++ b/.github/workflows/update-scalar-cli-documentation.yml
@@ -11,7 +11,7 @@ jobs:
   update-cli-docs:
     name: Update CLI Documentation
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     if: ${{ github.repository_owner == 'scalar' }}
     runs-on: blacksmith-2vcpu-ubuntu-2204
@@ -22,8 +22,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
         with:
@@ -58,7 +56,7 @@ jobs:
         if: steps.check-changes.outputs.has-changes == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         with:
-          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           base: main
           commit-message: 'docs(cli): update commands'
           title: 'docs(cli): update commands'


### PR DESCRIPTION
## Problem

<!--
  What problem does the PR solve?
  WHY did you submit the PR?

  We are interested in the WHY (LLMs won't know).
-->

Currently, we use a personal access token for some workflows.

## Solution

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

This PR updates the permissions of the workflows to use the default `GITHUB_TOKEN` instead of PAT.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
