### PR TITLE
docs: update subdomain to avoid safety warning

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -11,7 +11,7 @@
   "pullRequestComments": true,
   "insertPageTitles": false,
   "siteConfig": {
-    "subdomain": "guides-scalar-com",
+    "subdomain": "scalar",
     "customDomain": "scalar.com",
     "head": {
       "scripts": [


### PR DESCRIPTION
## Problem

we have scalar-com in the subdomain which might trigger a safety warning for preview links:

<img width="1598" height="1016" alt="image" src="https://github.com/user-attachments/assets/123eaf33-cf62-4baf-9484-ef57edea0e4d" />

## Solution

just call it scalar

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Docs config update**
> 
> - Changes `siteConfig.subdomain` in `scalar.config.json` from `guides-scalar-com` to `scalar`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bddd1a0bb80b9232fecfef668f41a109e639405. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->