### PR TITLE
fix(api-client): resolve oauth URLs for relative servers

### DIFF
--- a/.changeset/relative-oauth-urls.md
+++ b/.changeset/relative-oauth-urls.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/api-reference': patch
+---
+
+fix: resolve oauth2 relative URLs against relative server URLs

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
@@ -1129,5 +1129,62 @@ describe('oauth', () => {
         },
       })
     })
+
+    it('should resolve relative token URLs against relative server URLs', async () => {
+      const flows = {
+        password: {
+          ...scheme.password,
+          tokenUrl: 'auth/token',
+        },
+      } satisfies OAuthFlowsObject
+      const relativeServer = {
+        ...mockServer,
+        url: '/partners',
+      } satisfies ServerObject
+
+      const originalLocation = window.location
+      Object.defineProperty(window, 'location', {
+        value: {
+          origin: 'https://example.com',
+          pathname: '/docs',
+          href: 'https://example.com/docs',
+        },
+        writable: true,
+      })
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            access_token: 'access_token_123',
+            token_type: 'Bearer',
+            expires_in: 3600,
+            refresh_token: 'refresh_token_123',
+            scope: scope.join(' '),
+          }),
+      })
+
+      const [error, result] = await authorizeOauth2(flows, 'password', selectedScopes, relativeServer, '')
+      expect(error).toBe(null)
+      expect(result).toBe('access_token_123')
+
+      expect(global.fetch).toHaveBeenCalledWith('https://example.com/partners/auth/token', {
+        method: 'POST',
+        body: new URLSearchParams({
+          scope: scope.join(' '),
+          grant_type: 'password',
+          username: flows.password['x-scalar-secret-username'],
+          password: flows.password['x-scalar-secret-password'],
+        }),
+        headers: {
+          'Authorization': `Basic ${secretAuth}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      })
+
+      Object.defineProperty(window, 'location', {
+        value: originalLocation,
+        writable: true,
+      })
+    })
   })
 })

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
@@ -1,3 +1,4 @@
+import { isRelativePath } from '@scalar/helpers/url/is-relative-path'
 import { makeUrlAbsolute } from '@scalar/helpers/url/make-url-absolute'
 import { shouldUseProxy } from '@scalar/oas-utils/helpers'
 import type { OAuthFlowsObject, ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
@@ -12,6 +13,20 @@ type PKCEState = {
   codeVerifier: string
   codeChallenge: string
   codeChallengeMethod: string
+}
+
+const getActiveServerBase = (activeServer: ServerObject | null) => {
+  const serverUrl = activeServer?.url
+
+  if (!serverUrl) {
+    return {}
+  }
+
+  if (isRelativePath(serverUrl)) {
+    return typeof window === 'undefined' ? {} : { basePath: serverUrl }
+  }
+
+  return { baseUrl: serverUrl }
 }
 
 /**
@@ -90,9 +105,7 @@ export const authorizeOauth2 = async (
     // Generate a random state string with the length of 8 characters
     const state = (Math.random() + 1).toString(36).substring(2, 10)
 
-    const authorizationUrl = makeUrlAbsolute(flows[type]!.authorizationUrl, {
-      baseUrl: activeServer?.url,
-    })
+    const authorizationUrl = makeUrlAbsolute(flows[type]!.authorizationUrl, getActiveServerBase(activeServer))
 
     const url = new URL(authorizationUrl)
 
@@ -328,7 +341,7 @@ const authorizeServers = async (
     }
 
     // Check if we should use the proxy
-    const tokenUrl = makeUrlAbsolute(flow.tokenUrl, { baseUrl: activeServer?.url })
+    const tokenUrl = makeUrlAbsolute(flow.tokenUrl, getActiveServerBase(activeServer))
     const url = shouldUseProxy(proxyUrl, tokenUrl)
       ? `${proxyUrl}?${new URLSearchParams([['scalar_url', tokenUrl]]).toString()}`
       : tokenUrl

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -1,3 +1,4 @@
+import { isRelativePath } from '@scalar/helpers/url/is-relative-path'
 import { makeUrlAbsolute } from '@scalar/helpers/url/make-url-absolute'
 import type { Oauth2Flow, Server } from '@scalar/oas-utils/entities/spec'
 import { shouldUseProxy } from '@scalar/oas-utils/helpers'
@@ -12,6 +13,20 @@ type PKCEState = {
   codeVerifier: string
   codeChallenge: string
   codeChallengeMethod: string
+}
+
+const getActiveServerBase = (activeServer?: Server) => {
+  const serverUrl = activeServer?.url
+
+  if (!serverUrl) {
+    return {}
+  }
+
+  if (isRelativePath(serverUrl)) {
+    return typeof window === 'undefined' ? {} : { basePath: serverUrl }
+  }
+
+  return { baseUrl: serverUrl }
 }
 
 /**
@@ -86,9 +101,7 @@ export const authorizeOauth2 = async (
 
     // Generate a random state string with the length of 8 characters
     const state = (Math.random() + 1).toString(36).substring(2, 10)
-    const authorizationUrl = makeUrlAbsolute(flow.authorizationUrl, {
-      baseUrl: activeServer?.url,
-    })
+    const authorizationUrl = makeUrlAbsolute(flow.authorizationUrl, getActiveServerBase(activeServer))
     const url = new URL(authorizationUrl)
 
     /** Special PKCE state */
@@ -323,7 +336,7 @@ export const authorizeServers = async (
     }
 
     // Check if we should use the proxy
-    const tokenUrl = makeUrlAbsolute(flow.tokenUrl, { baseUrl: activeServer?.url })
+    const tokenUrl = makeUrlAbsolute(flow.tokenUrl, getActiveServerBase(activeServer))
     const url = shouldUseProxy(proxyUrl, tokenUrl)
       ? `${proxyUrl}?${new URLSearchParams([['scalar_url', tokenUrl]]).toString()}`
       : tokenUrl


### PR DESCRIPTION
## Summary
- resolve OAuth2 authorization/token URLs against relative server URLs
- cover relative server + relative tokenUrl in oauth tests
- add changeset for api-client/api-reference

## Testing
- not run (not requested)

Closes #7524