### PR TITLE
chore(java): enable `knip`

### DIFF
--- a/integrations/java/package.json
+++ b/integrations/java/package.json
@@ -40,5 +40,7 @@
   "dependencies": {
     "@scalar/api-reference": "workspace:*"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@scalar/snippetz": "workspace:*"
+  }
 }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -310,7 +310,12 @@
     },
     "integrations/java": {
       "ignoreDependencies": [
-        "@scalar/api-reference" // build step copy standalone file from this package
+        "@scalar/api-reference", // build step copy standalone file from this package
+
+        // Included for convenience.
+        // Java enums are dynamically generated from the snippetz package.
+        // Having snippetz as a dependency ensures they are regenerated whenever clients or targets change.
+        "@scalar/snippetz"
       ],
       "ignoreBinaries": ["mvn"]
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -913,6 +913,10 @@ importers:
       '@scalar/api-reference':
         specifier: workspace:*
         version: link:../../packages/api-reference
+    devDependencies:
+      '@scalar/snippetz':
+        specifier: workspace:*
+        version: link:../../packages/snippetz
 
   integrations/nestjs:
     dependencies:


### PR DESCRIPTION
## Problem

- Followup of #7233

## Solution

- removed unused dev dependencies
  - `@scalar/build-tooling`
  - `@scalar/snippetz` 
    (`generate:java-enums` is located in this package so there is no reference to it here)

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
