### PR TITLE
fix(docs): slider flickers on wide screens

### DIFF
--- a/documentation/assets/landing.js
+++ b/documentation/assets/landing.js
@@ -112,7 +112,7 @@ const initGallery = debounce(() => {
       entries.forEach((entry) => {
         const isMobile = window.innerWidth < 540
 
-        if (isMobile ? entry.intersectionRatio > 0.5 : entry.intersectionRatio > 0.75) {
+        if (isMobile ? entry.intersectionRatio > 0.5 : entry.intersectionRatio === 1) {
           const slideId = entry.target.id
 
           const button = document.querySelector(`button[data-target^="#${slideId}"]`)


### PR DESCRIPTION
## Problem

<!--
  What problem does the PR solve?
  WHY did you submit the PR?

  We are interested in the WHY (LLMs won't know).
-->

The scroll does not work great on really wide screens.

## Solution

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

Set the intersection ratio to 1 to prevent it from flickering between two high ratio gallery items.

before:


https://github.com/user-attachments/assets/1e5cce1f-0ce6-4c61-a3e5-4f112a9da462

after:


https://github.com/user-attachments/assets/b8cba109-2eb9-4c05-b51c-16df66591e27



## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
