### PR TITLE
feat(api-client): OpenID Connect 🔐

### DIFF
--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
@@ -21,9 +21,9 @@ import { computed, watch } from 'vue'
 import { DataTableRow } from '@/components/DataTable'
 import OAuthScopesInput from '@/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue'
 import { authorizeOauth2 } from '@/v2/blocks/scalar-auth-selector-block/helpers/oauth'
-import type { OpenIDConnectDiscovery } from '@/v2/blocks/scalar-auth-selector-block/helpers/openid-connect'
+import type { OpenIDConnectDiscovery as OpenIDConnectDiscoveryDocument } from '@/v2/blocks/scalar-auth-selector-block/helpers/openid-connect'
 
-import OpenIDConnectDiscovery from './OpenIDConnectDiscovery.vue'
+import OpenIDConnectDiscoveryInput from './OpenIDConnectDiscovery.vue'
 import RequestAuthDataTableInput from './RequestAuthDataTableInput.vue'
 
 const {
@@ -142,9 +142,10 @@ const handleSecretLocationUpdate = (value: string): void =>
  * Maps the discovered endpoints to the appropriate OAuth2 flow fields.
  */
 const handleOpenIDConnectDiscovered = (
-  discovery: OpenIDConnectDiscovery,
+  discovery: OpenIDConnectDiscoveryDocument,
 ): void => {
-  const updates: Partial<OAuthFlow> = {}
+  // Use a flexible type since different flow types have different properties
+  const updates: Record<string, string | Record<string, string>> = {}
 
   // Map authorization endpoint
   if (discovery.authorization_endpoint && 'authorizationUrl' in flow.value) {
@@ -168,7 +169,7 @@ const handleOpenIDConnectDiscovered = (
 
   // Apply all updates at once
   if (Object.keys(updates).length > 0) {
-    handleOauth2Update(updates)
+    handleOauth2Update(updates as Partial<OAuthFlow>)
   }
 }
 </script>
@@ -207,7 +208,7 @@ const handleOpenIDConnectDiscovered = (
   <!-- Authorization Form: Shows when user needs to authorize -->
   <template v-else>
     <!-- OpenID Connect Discovery -->
-    <OpenIDConnectDiscovery
+    <OpenIDConnectDiscoveryInput
       :environment
       @discovered="handleOpenIDConnectDiscovered" />
 

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OpenIDConnectDiscovery.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OpenIDConnectDiscovery.vue
@@ -42,7 +42,7 @@ const handleFetchDiscovery = async (): Promise<void> => {
 
   if (discovery) {
     emits('discovered', discovery)
-    toast('OpenID Connect configuration loaded successfully', 'success')
+    toast('OpenID Connect configuration loaded successfully', 'info')
   } else {
     console.error(error)
     toast(

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OpenIDConnectDiscovery.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OpenIDConnectDiscovery.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { ScalarButton, ScalarIcon, useLoadingState } from '@scalar/components'
+import { useToasts } from '@scalar/use-toasts'
+import { ref } from 'vue'
+
+import { DataTableRow } from '@/components/DataTable'
+import {
+  fetchOpenIDConnectDiscovery,
+  type OpenIDConnectDiscovery as OpenIDConnectDiscoveryType,
+} from '@/v2/blocks/scalar-auth-selector-block/helpers/openid-connect'
+
+import RequestAuthDataTableInput from './RequestAuthDataTableInput.vue'
+
+const { environment } = defineProps<{
+  environment: any
+}>()
+
+const emits = defineEmits<{
+  (e: 'discovered', payload: OpenIDConnectDiscoveryType): void
+}>()
+
+const discoveryUrl = ref('')
+const loader = useLoadingState()
+const { toast } = useToasts()
+
+/**
+ * Fetches the OpenID Connect discovery document and emits the result.
+ * This will pre-fill the OAuth2 form fields with the discovered values.
+ */
+const handleFetchDiscovery = async (): Promise<void> => {
+  if (loader.isLoading || !discoveryUrl.value) {
+    return
+  }
+
+  loader.start()
+
+  const [error, discovery] = await fetchOpenIDConnectDiscovery(
+    discoveryUrl.value,
+  )
+
+  await loader.clear()
+
+  if (discovery) {
+    emits('discovered', discovery)
+    toast('OpenID Connect configuration loaded successfully', 'success')
+  } else {
+    console.error(error)
+    toast(
+      error?.message ?? 'Failed to fetch OpenID Connect configuration',
+      'error',
+    )
+  }
+}
+</script>
+
+<template>
+  <DataTableRow>
+    <RequestAuthDataTableInput
+      v-model="discoveryUrl"
+      class="border-r-transparent"
+      :environment
+      placeholder="https://accounts.example.com or https://accounts.example.com/.well-known/openid-configuration"
+      @keydown.enter="handleFetchDiscovery">
+      <div class="flex items-center gap-1.5">
+        <ScalarIcon
+          icon="Lock"
+          size="sm" />
+        <span>OpenID Connect URL</span>
+      </div>
+    </RequestAuthDataTableInput>
+  </DataTableRow>
+
+  <DataTableRow class="min-w-full">
+    <div class="flex h-8 items-center justify-end gap-2 border-t">
+      <ScalarButton
+        class="mr-1 p-0 px-2 py-0.5"
+        :disabled="!discoveryUrl"
+        :loader
+        size="sm"
+        variant="outlined"
+        @click="handleFetchDiscovery">
+        Fetch Configuration
+      </ScalarButton>
+    </div>
+  </DataTableRow>
+</template>

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/openid-connect.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/openid-connect.test.ts
@@ -1,11 +1,297 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import {
-  fetchOpenIDConnectDiscovery,
+  OPENID_SCOPE,
   type OpenIDConnectDiscovery,
+  STANDARD_OIDC_SCOPES,
+  buildClaimsParameter,
+  buildOIDCResponseType,
+  ensureOpenIDScope,
+  fetchOpenIDConnectDiscovery,
+  isOIDCRequest,
+  isValidOIDCResponseType,
+  parseClaimsParameter,
 } from './openid-connect'
 
 describe('openid-connect', () => {
+  describe('isOIDCRequest', () => {
+    it('returns true when openid scope is present in array', () => {
+      expect(isOIDCRequest(['openid', 'profile', 'email'])).toBe(true)
+    })
+
+    it('returns true when openid scope is the only scope', () => {
+      expect(isOIDCRequest(['openid'])).toBe(true)
+    })
+
+    it('returns false when openid scope is not present', () => {
+      expect(isOIDCRequest(['profile', 'email'])).toBe(false)
+    })
+
+    it('returns false for empty array', () => {
+      expect(isOIDCRequest([])).toBe(false)
+    })
+
+    it('handles space-separated scope string with openid', () => {
+      expect(isOIDCRequest('openid profile email')).toBe(true)
+    })
+
+    it('handles space-separated scope string without openid', () => {
+      expect(isOIDCRequest('read write')).toBe(false)
+    })
+
+    it('handles empty string', () => {
+      expect(isOIDCRequest('')).toBe(false)
+    })
+
+    it('is case-insensitive for openid scope', () => {
+      expect(isOIDCRequest(['OPENID', 'profile'])).toBe(true)
+      expect(isOIDCRequest(['OpenID', 'email'])).toBe(true)
+      expect(isOIDCRequest('OpenId profile')).toBe(true)
+    })
+
+    it('does not match partial scope names containing openid', () => {
+      expect(isOIDCRequest(['openid_extended'])).toBe(false)
+      expect(isOIDCRequest(['my_openid'])).toBe(false)
+    })
+  })
+
+  describe('ensureOpenIDScope', () => {
+    it('returns scopes unchanged if openid is already present', () => {
+      const scopes = ['openid', 'profile', 'email']
+      expect(ensureOpenIDScope(scopes)).toEqual(['openid', 'profile', 'email'])
+    })
+
+    it('adds openid at the beginning if not present', () => {
+      const scopes = ['profile', 'email']
+      expect(ensureOpenIDScope(scopes)).toEqual(['openid', 'profile', 'email'])
+    })
+
+    it('adds openid to empty array', () => {
+      expect(ensureOpenIDScope([])).toEqual(['openid'])
+    })
+
+    it('handles case-insensitive openid check', () => {
+      const scopes = ['OPENID', 'profile']
+      expect(ensureOpenIDScope(scopes)).toEqual(['OPENID', 'profile'])
+    })
+  })
+
+  describe('isValidOIDCResponseType', () => {
+    describe('OAuth 2.0 (non-OIDC) requests', () => {
+      it('accepts code response type', () => {
+        expect(isValidOIDCResponseType('code', false)).toBe(true)
+      })
+
+      it('accepts token response type', () => {
+        expect(isValidOIDCResponseType('token', false)).toBe(true)
+      })
+
+      it('rejects id_token response type', () => {
+        expect(isValidOIDCResponseType('id_token', false)).toBe(false)
+      })
+
+      it('rejects combined response types', () => {
+        expect(isValidOIDCResponseType('code id_token', false)).toBe(false)
+        expect(isValidOIDCResponseType('code token', false)).toBe(false)
+      })
+    })
+
+    describe('OIDC requests', () => {
+      it('accepts code response type', () => {
+        expect(isValidOIDCResponseType('code', true)).toBe(true)
+      })
+
+      it('accepts token response type', () => {
+        expect(isValidOIDCResponseType('token', true)).toBe(true)
+      })
+
+      it('accepts id_token response type', () => {
+        expect(isValidOIDCResponseType('id_token', true)).toBe(true)
+      })
+
+      it('accepts code id_token response type', () => {
+        expect(isValidOIDCResponseType('code id_token', true)).toBe(true)
+      })
+
+      it('accepts code token response type', () => {
+        expect(isValidOIDCResponseType('code token', true)).toBe(true)
+      })
+
+      it('accepts id_token token response type', () => {
+        expect(isValidOIDCResponseType('id_token token', true)).toBe(true)
+      })
+
+      it('accepts code id_token token response type', () => {
+        expect(isValidOIDCResponseType('code id_token token', true)).toBe(true)
+      })
+
+      it('rejects invalid response types', () => {
+        expect(isValidOIDCResponseType('invalid', true)).toBe(false)
+        expect(isValidOIDCResponseType('', true)).toBe(false)
+      })
+    })
+  })
+
+  describe('buildOIDCResponseType', () => {
+    it('builds code response type', () => {
+      expect(buildOIDCResponseType({ code: true })).toBe('code')
+    })
+
+    it('builds token response type', () => {
+      expect(buildOIDCResponseType({ token: true })).toBe('token')
+    })
+
+    it('builds id_token response type', () => {
+      expect(buildOIDCResponseType({ idToken: true })).toBe('id_token')
+    })
+
+    it('builds code id_token response type', () => {
+      expect(buildOIDCResponseType({ code: true, idToken: true })).toBe('code id_token')
+    })
+
+    it('builds code token response type', () => {
+      expect(buildOIDCResponseType({ code: true, token: true })).toBe('code token')
+    })
+
+    it('builds id_token token response type', () => {
+      expect(buildOIDCResponseType({ idToken: true, token: true })).toBe('id_token token')
+    })
+
+    it('builds code id_token token response type', () => {
+      expect(buildOIDCResponseType({ code: true, idToken: true, token: true })).toBe('code id_token token')
+    })
+
+    it('returns empty string when no options are specified', () => {
+      expect(buildOIDCResponseType({})).toBe('')
+    })
+
+    it('ignores false values', () => {
+      expect(buildOIDCResponseType({ code: true, idToken: false, token: false })).toBe('code')
+    })
+  })
+
+  describe('buildClaimsParameter', () => {
+    it('builds claims for id_token', () => {
+      const claims = {
+        id_token: {
+          name: null,
+          email: { essential: true },
+        },
+      }
+      const result = buildClaimsParameter(claims)
+      expect(result).toBe('{"id_token":{"name":null,"email":{"essential":true}}}')
+    })
+
+    it('builds claims for userinfo', () => {
+      const claims = {
+        userinfo: {
+          name: null,
+          picture: null,
+        },
+      }
+      const result = buildClaimsParameter(claims)
+      expect(result).toBe('{"userinfo":{"name":null,"picture":null}}')
+    })
+
+    it('builds claims for both id_token and userinfo', () => {
+      const claims = {
+        id_token: {
+          email: { essential: true },
+        },
+        userinfo: {
+          name: null,
+        },
+      }
+      const result = buildClaimsParameter(claims)
+      expect(result).toBe('{"id_token":{"email":{"essential":true}},"userinfo":{"name":null}}')
+    })
+
+    it('handles claims with specific values', () => {
+      const claims = {
+        id_token: {
+          acr: { value: 'urn:mace:incommon:iap:silver' },
+        },
+      }
+      const result = buildClaimsParameter(claims)
+      expect(result).toBe('{"id_token":{"acr":{"value":"urn:mace:incommon:iap:silver"}}}')
+    })
+
+    it('handles claims with multiple acceptable values', () => {
+      const claims = {
+        id_token: {
+          acr: { values: ['urn:example:silver', 'urn:example:bronze'] },
+        },
+      }
+      const result = buildClaimsParameter(claims)
+      expect(result).toBe('{"id_token":{"acr":{"values":["urn:example:silver","urn:example:bronze"]}}}')
+    })
+
+    it('returns null for empty claims', () => {
+      expect(buildClaimsParameter({})).toBeNull()
+    })
+
+    it('returns null for empty id_token and userinfo objects', () => {
+      expect(buildClaimsParameter({ id_token: {}, userinfo: {} })).toBeNull()
+    })
+
+    it('filters out empty objects', () => {
+      const claims = {
+        id_token: { name: null },
+        userinfo: {},
+      }
+      const result = buildClaimsParameter(claims)
+      expect(result).toBe('{"id_token":{"name":null}}')
+    })
+  })
+
+  describe('parseClaimsParameter', () => {
+    it('parses valid claims JSON', () => {
+      const claimsString = '{"id_token":{"name":null,"email":{"essential":true}}}'
+      const result = parseClaimsParameter(claimsString)
+      expect(result).toEqual({
+        id_token: {
+          name: null,
+          email: { essential: true },
+        },
+      })
+    })
+
+    it('parses claims with both id_token and userinfo', () => {
+      const claimsString = '{"id_token":{"email":null},"userinfo":{"name":null}}'
+      const result = parseClaimsParameter(claimsString)
+      expect(result).toEqual({
+        id_token: { email: null },
+        userinfo: { name: null },
+      })
+    })
+
+    it('returns null for invalid JSON', () => {
+      expect(parseClaimsParameter('not valid json')).toBeNull()
+      expect(parseClaimsParameter('{incomplete')).toBeNull()
+    })
+
+    it('returns null for non-object JSON', () => {
+      expect(parseClaimsParameter('"string"')).toBeNull()
+      expect(parseClaimsParameter('123')).toBeNull()
+      expect(parseClaimsParameter('null')).toBeNull()
+      expect(parseClaimsParameter('[]')).toBeNull()
+    })
+
+    it('handles empty object', () => {
+      expect(parseClaimsParameter('{}')).toEqual({})
+    })
+  })
+
+  describe('constants', () => {
+    it('exports OPENID_SCOPE constant', () => {
+      expect(OPENID_SCOPE).toBe('openid')
+    })
+
+    it('exports STANDARD_OIDC_SCOPES', () => {
+      expect(STANDARD_OIDC_SCOPES).toEqual(['openid', 'profile', 'email', 'address', 'phone'])
+    })
+  })
+
   describe('fetchOpenIDConnectDiscovery', () => {
     it('appends well-known path when not present', async () => {
       const mockDiscovery: OpenIDConnectDiscovery = {
@@ -19,15 +305,11 @@ describe('openid-connect', () => {
         json: async () => mockDiscovery,
       })
 
-      const [error, result] = await fetchOpenIDConnectDiscovery(
-        'https://example.com',
-      )
+      const [error, result] = await fetchOpenIDConnectDiscovery('https://example.com')
 
       expect(error).toBeNull()
       expect(result).toEqual(mockDiscovery)
-      expect(global.fetch).toHaveBeenCalledWith(
-        'https://example.com/.well-known/openid-configuration',
-      )
+      expect(global.fetch).toHaveBeenCalledWith('https://example.com/.well-known/openid-configuration')
     })
 
     it('handles URLs with trailing slash', async () => {
@@ -41,15 +323,11 @@ describe('openid-connect', () => {
         json: async () => mockDiscovery,
       })
 
-      const [error, result] = await fetchOpenIDConnectDiscovery(
-        'https://example.com/',
-      )
+      const [error, result] = await fetchOpenIDConnectDiscovery('https://example.com/')
 
       expect(error).toBeNull()
       expect(result).toEqual(mockDiscovery)
-      expect(global.fetch).toHaveBeenCalledWith(
-        'https://example.com/.well-known/openid-configuration',
-      )
+      expect(global.fetch).toHaveBeenCalledWith('https://example.com/.well-known/openid-configuration')
     })
 
     it('uses full discovery URL when provided', async () => {
@@ -63,15 +341,11 @@ describe('openid-connect', () => {
         json: async () => mockDiscovery,
       })
 
-      const [error, result] = await fetchOpenIDConnectDiscovery(
-        'https://example.com/.well-known/openid-configuration',
-      )
+      const [error, result] = await fetchOpenIDConnectDiscovery('https://example.com/.well-known/openid-configuration')
 
       expect(error).toBeNull()
       expect(result).toEqual(mockDiscovery)
-      expect(global.fetch).toHaveBeenCalledWith(
-        'https://example.com/.well-known/openid-configuration',
-      )
+      expect(global.fetch).toHaveBeenCalledWith('https://example.com/.well-known/openid-configuration')
     })
 
     it('returns error for empty URL', async () => {
@@ -89,9 +363,7 @@ describe('openid-connect', () => {
         statusText: 'Not Found',
       })
 
-      const [error, result] = await fetchOpenIDConnectDiscovery(
-        'https://example.com',
-      )
+      const [error, result] = await fetchOpenIDConnectDiscovery('https://example.com')
 
       expect(error).not.toBeNull()
       expect(error?.message).toContain('404')
@@ -104,9 +376,7 @@ describe('openid-connect', () => {
         json: async () => ({}),
       })
 
-      const [error, result] = await fetchOpenIDConnectDiscovery(
-        'https://example.com',
-      )
+      const [error, result] = await fetchOpenIDConnectDiscovery('https://example.com')
 
       expect(error).not.toBeNull()
       expect(error?.message).toContain('missing required endpoints')
@@ -116,9 +386,7 @@ describe('openid-connect', () => {
     it('handles network errors', async () => {
       global.fetch = vi.fn().mockRejectedValue(new Error('Network error'))
 
-      const [error, result] = await fetchOpenIDConnectDiscovery(
-        'https://example.com',
-      )
+      const [error, result] = await fetchOpenIDConnectDiscovery('https://example.com')
 
       expect(error).not.toBeNull()
       expect(error?.message).toBe('Network error')
@@ -137,16 +405,89 @@ describe('openid-connect', () => {
         json: async () => mockDiscovery,
       })
 
-      const [error, result] = await fetchOpenIDConnectDiscovery(
-        'https://example.com',
-      )
+      const [error, result] = await fetchOpenIDConnectDiscovery('https://example.com')
 
       expect(error).toBeNull()
-      expect(result?.scopes_supported).toEqual([
-        'openid',
-        'profile',
-        'email',
-      ])
+      expect(result?.scopes_supported).toEqual(['openid', 'profile', 'email'])
+    })
+
+    it('parses response_types_supported from discovery document', async () => {
+      const mockDiscovery: OpenIDConnectDiscovery = {
+        authorization_endpoint: 'https://example.com/authorize',
+        token_endpoint: 'https://example.com/token',
+        response_types_supported: ['code', 'token', 'id_token', 'code id_token'],
+      }
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockDiscovery,
+      })
+
+      const [error, result] = await fetchOpenIDConnectDiscovery('https://example.com')
+
+      expect(error).toBeNull()
+      expect(result?.response_types_supported).toEqual(['code', 'token', 'id_token', 'code id_token'])
+    })
+
+    it('parses claims_supported from discovery document', async () => {
+      const mockDiscovery: OpenIDConnectDiscovery = {
+        authorization_endpoint: 'https://example.com/authorize',
+        token_endpoint: 'https://example.com/token',
+        claims_supported: ['sub', 'name', 'email', 'picture', 'locale'],
+      }
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockDiscovery,
+      })
+
+      const [error, result] = await fetchOpenIDConnectDiscovery('https://example.com')
+
+      expect(error).toBeNull()
+      expect(result?.claims_supported).toEqual(['sub', 'name', 'email', 'picture', 'locale'])
+    })
+
+    it('parses claims_parameter_supported from discovery document', async () => {
+      const mockDiscovery: OpenIDConnectDiscovery = {
+        authorization_endpoint: 'https://example.com/authorize',
+        token_endpoint: 'https://example.com/token',
+        claims_parameter_supported: true,
+      }
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockDiscovery,
+      })
+
+      const [error, result] = await fetchOpenIDConnectDiscovery('https://example.com')
+
+      expect(error).toBeNull()
+      expect(result?.claims_parameter_supported).toBe(true)
+    })
+
+    it('parses full OIDC discovery document', async () => {
+      const mockDiscovery: OpenIDConnectDiscovery = {
+        issuer: 'https://example.com',
+        authorization_endpoint: 'https://example.com/authorize',
+        token_endpoint: 'https://example.com/token',
+        userinfo_endpoint: 'https://example.com/userinfo',
+        jwks_uri: 'https://example.com/.well-known/jwks.json',
+        scopes_supported: ['openid', 'profile', 'email', 'address', 'phone'],
+        response_types_supported: ['code', 'id_token', 'code id_token'],
+        grant_types_supported: ['authorization_code', 'implicit', 'refresh_token'],
+        claims_supported: ['sub', 'name', 'email', 'email_verified', 'picture'],
+        claims_parameter_supported: true,
+      }
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockDiscovery,
+      })
+
+      const [error, result] = await fetchOpenIDConnectDiscovery('https://example.com')
+
+      expect(error).toBeNull()
+      expect(result).toEqual(mockDiscovery)
     })
   })
 })

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/openid-connect.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/openid-connect.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  fetchOpenIDConnectDiscovery,
+  type OpenIDConnectDiscovery,
+} from './openid-connect'
+
+describe('openid-connect', () => {
+  describe('fetchOpenIDConnectDiscovery', () => {
+    it('appends well-known path when not present', async () => {
+      const mockDiscovery: OpenIDConnectDiscovery = {
+        authorization_endpoint: 'https://example.com/authorize',
+        token_endpoint: 'https://example.com/token',
+        issuer: 'https://example.com',
+      }
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockDiscovery,
+      })
+
+      const [error, result] = await fetchOpenIDConnectDiscovery(
+        'https://example.com',
+      )
+
+      expect(error).toBeNull()
+      expect(result).toEqual(mockDiscovery)
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://example.com/.well-known/openid-configuration',
+      )
+    })
+
+    it('handles URLs with trailing slash', async () => {
+      const mockDiscovery: OpenIDConnectDiscovery = {
+        authorization_endpoint: 'https://example.com/authorize',
+        token_endpoint: 'https://example.com/token',
+      }
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockDiscovery,
+      })
+
+      const [error, result] = await fetchOpenIDConnectDiscovery(
+        'https://example.com/',
+      )
+
+      expect(error).toBeNull()
+      expect(result).toEqual(mockDiscovery)
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://example.com/.well-known/openid-configuration',
+      )
+    })
+
+    it('uses full discovery URL when provided', async () => {
+      const mockDiscovery: OpenIDConnectDiscovery = {
+        authorization_endpoint: 'https://example.com/oauth/authorize',
+        token_endpoint: 'https://example.com/oauth/token',
+      }
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockDiscovery,
+      })
+
+      const [error, result] = await fetchOpenIDConnectDiscovery(
+        'https://example.com/.well-known/openid-configuration',
+      )
+
+      expect(error).toBeNull()
+      expect(result).toEqual(mockDiscovery)
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://example.com/.well-known/openid-configuration',
+      )
+    })
+
+    it('returns error for empty URL', async () => {
+      const [error, result] = await fetchOpenIDConnectDiscovery('')
+
+      expect(error).not.toBeNull()
+      expect(error?.message).toBe('URL cannot be empty')
+      expect(result).toBeNull()
+    })
+
+    it('handles fetch errors', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      })
+
+      const [error, result] = await fetchOpenIDConnectDiscovery(
+        'https://example.com',
+      )
+
+      expect(error).not.toBeNull()
+      expect(error?.message).toContain('404')
+      expect(result).toBeNull()
+    })
+
+    it('validates discovery document has required endpoints', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      })
+
+      const [error, result] = await fetchOpenIDConnectDiscovery(
+        'https://example.com',
+      )
+
+      expect(error).not.toBeNull()
+      expect(error?.message).toContain('missing required endpoints')
+      expect(result).toBeNull()
+    })
+
+    it('handles network errors', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'))
+
+      const [error, result] = await fetchOpenIDConnectDiscovery(
+        'https://example.com',
+      )
+
+      expect(error).not.toBeNull()
+      expect(error?.message).toBe('Network error')
+      expect(result).toBeNull()
+    })
+
+    it('parses scopes_supported from discovery document', async () => {
+      const mockDiscovery: OpenIDConnectDiscovery = {
+        authorization_endpoint: 'https://example.com/authorize',
+        token_endpoint: 'https://example.com/token',
+        scopes_supported: ['openid', 'profile', 'email'],
+      }
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockDiscovery,
+      })
+
+      const [error, result] = await fetchOpenIDConnectDiscovery(
+        'https://example.com',
+      )
+
+      expect(error).toBeNull()
+      expect(result?.scopes_supported).toEqual([
+        'openid',
+        'profile',
+        'email',
+      ])
+    })
+  })
+})

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/openid-connect.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/openid-connect.ts
@@ -1,0 +1,89 @@
+import type { ErrorResponse } from '@/libs/errors'
+
+/**
+ * OpenID Connect Discovery Document
+ * Represents the metadata returned from the .well-known/openid-configuration endpoint
+ *
+ * @see https://openid.net/specs/openid-connect-discovery-1_0.html
+ */
+export type OpenIDConnectDiscovery = {
+  /** URL of the OAuth 2.0 Authorization Endpoint */
+  authorization_endpoint?: string
+  /** URL of the OAuth 2.0 Token Endpoint */
+  token_endpoint?: string
+  /** URL of the UserInfo Endpoint */
+  userinfo_endpoint?: string
+  /** URL of the JSON Web Key Set document */
+  jwks_uri?: string
+  /** List of OAuth 2.0 scope values that this server supports */
+  scopes_supported?: string[]
+  /** List of OAuth 2.0 grant type values that this server supports */
+  grant_types_supported?: string[]
+  /** URL using the https scheme with no query or fragment component that the OP asserts as its Issuer Identifier */
+  issuer?: string
+  /** List of the OAuth 2.0 response_type values that this OP supports */
+  response_types_supported?: string[]
+}
+
+/**
+ * Fetches the OpenID Connect discovery document from the specified URL.
+ * Supports both full discovery URLs and issuer URLs.
+ *
+ * @param url - The OpenID Connect discovery URL or issuer URL
+ * @returns The discovery document or an error
+ */
+export const fetchOpenIDConnectDiscovery = async (
+  url: string,
+): Promise<ErrorResponse<OpenIDConnectDiscovery>> => {
+  try {
+    // If the URL does not end with the well-known path, append it
+    let discoveryUrl = url.trim()
+
+    if (!discoveryUrl) {
+      return [new Error('URL cannot be empty'), null]
+    }
+
+    // Remove trailing slash if present
+    if (discoveryUrl.endsWith('/')) {
+      discoveryUrl = discoveryUrl.slice(0, -1)
+    }
+
+    // If the URL does not already include the well-known path, append it
+    if (!discoveryUrl.includes('/.well-known/openid-configuration')) {
+      discoveryUrl = `${discoveryUrl}/.well-known/openid-configuration`
+    }
+
+    const response = await fetch(discoveryUrl)
+
+    if (!response.ok) {
+      return [
+        new Error(
+          `Failed to fetch OpenID Connect discovery document: ${response.status} ${response.statusText}`,
+        ),
+        null,
+      ]
+    }
+
+    const data = (await response.json()) as OpenIDConnectDiscovery
+
+    // Validate that we have the essential fields
+    if (!data.authorization_endpoint && !data.token_endpoint) {
+      return [
+        new Error(
+          'Invalid OpenID Connect discovery document: missing required endpoints',
+        ),
+        null,
+      ]
+    }
+
+    return [null, data]
+  } catch (error) {
+    if (error instanceof Error) {
+      return [error, null]
+    }
+    return [
+      new Error('Failed to fetch OpenID Connect discovery document'),
+      null,
+    ]
+  }
+}

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/openid-connect.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/openid-connect.ts
@@ -23,6 +23,182 @@ export type OpenIDConnectDiscovery = {
   issuer?: string
   /** List of the OAuth 2.0 response_type values that this OP supports */
   response_types_supported?: string[]
+  /** List of Claim Names that the OpenID Provider may be able to supply values for */
+  claims_supported?: string[]
+  /** Boolean value specifying whether the OP supports use of the claims parameter */
+  claims_parameter_supported?: boolean
+}
+
+/**
+ * OIDC Claims Request structure for the claims parameter.
+ * Allows requesting specific claims to be returned in the ID Token or UserInfo response.
+ *
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter
+ */
+export type OIDCClaimsRequest = {
+  /** Claims requested to be returned in the ID Token */
+  id_token?: Record<string, OIDCClaimConfig | null>
+  /** Claims requested to be returned from the UserInfo Endpoint */
+  userinfo?: Record<string, OIDCClaimConfig | null>
+}
+
+/**
+ * Configuration for an individual claim request.
+ * null means the claim is requested voluntarily.
+ */
+export type OIDCClaimConfig = {
+  /** Indicates whether the claim is essential (must be returned) */
+  essential?: boolean
+  /** Specific value the claim must have */
+  value?: string
+  /** List of acceptable values for the claim */
+  values?: string[]
+}
+
+/**
+ * Valid OIDC response types.
+ * OIDC extends OAuth 2.0 response types with support for id_token.
+ */
+export type OIDCResponseType =
+  | 'code'
+  | 'token'
+  | 'id_token'
+  | 'code id_token'
+  | 'code token'
+  | 'id_token token'
+  | 'code id_token token'
+
+/**
+ * The required scope for OpenID Connect requests.
+ * If this scope is present, the request is an OIDC request; otherwise, it is a standard OAuth 2.0 request.
+ */
+export const OPENID_SCOPE = 'openid'
+
+/**
+ * Standard OIDC scopes that can be requested in addition to 'openid'.
+ */
+export const STANDARD_OIDC_SCOPES = ['openid', 'profile', 'email', 'address', 'phone'] as const
+
+/**
+ * Determines if a request is an OpenID Connect request based on the scopes.
+ * A request is considered OIDC if it includes the 'openid' scope.
+ *
+ * @param scopes - Array of scope strings or a space-separated scope string
+ * @returns true if the request is an OIDC request
+ */
+export const isOIDCRequest = (scopes: string[] | string): boolean => {
+  const scopeArray = Array.isArray(scopes) ? scopes : scopes.split(' ').filter(Boolean)
+  return scopeArray.some((scope) => scope.toLowerCase() === OPENID_SCOPE)
+}
+
+/**
+ * Ensures the 'openid' scope is included in the scopes array for OIDC requests.
+ * If 'openid' is not present, it is added at the beginning.
+ *
+ * @param scopes - Array of scope strings
+ * @returns Array of scopes with 'openid' included
+ */
+export const ensureOpenIDScope = (scopes: string[]): string[] => {
+  if (isOIDCRequest(scopes)) {
+    return scopes
+  }
+  return [OPENID_SCOPE, ...scopes]
+}
+
+/**
+ * Validates that the response_type is valid for OIDC.
+ * For OIDC requests (with openid scope), certain response types require an ID token to be returned.
+ *
+ * @param responseType - The response_type parameter value
+ * @param isOIDC - Whether this is an OIDC request (has openid scope)
+ * @returns true if the response_type is valid for the request type
+ */
+export const isValidOIDCResponseType = (responseType: string, isOIDC: boolean): boolean => {
+  const validOAuth2ResponseTypes = ['code', 'token']
+  const validOIDCResponseTypes: OIDCResponseType[] = [
+    'code',
+    'token',
+    'id_token',
+    'code id_token',
+    'code token',
+    'id_token token',
+    'code id_token token',
+  ]
+
+  if (isOIDC) {
+    return validOIDCResponseTypes.includes(responseType as OIDCResponseType)
+  }
+  return validOAuth2ResponseTypes.includes(responseType)
+}
+
+/**
+ * Builds the response_type parameter for OIDC requests.
+ * Can combine multiple response types as needed.
+ *
+ * @param options - Configuration for which response types to include
+ * @returns The space-separated response_type string
+ */
+export const buildOIDCResponseType = (options: { code?: boolean; token?: boolean; idToken?: boolean }): string => {
+  const types: string[] = []
+
+  if (options.code) {
+    types.push('code')
+  }
+  if (options.idToken) {
+    types.push('id_token')
+  }
+  if (options.token) {
+    types.push('token')
+  }
+
+  return types.join(' ')
+}
+
+/**
+ * Builds the claims parameter for OIDC requests.
+ * The claims parameter allows requesting specific user profile details in the ID Token or UserInfo response.
+ *
+ * @param claims - The claims request object
+ * @returns JSON string representation of the claims parameter, or null if no claims are specified
+ */
+export const buildClaimsParameter = (claims: OIDCClaimsRequest): string | null => {
+  if (!claims.id_token && !claims.userinfo) {
+    return null
+  }
+
+  // Filter out empty objects
+  const filteredClaims: OIDCClaimsRequest = {}
+
+  if (claims.id_token && Object.keys(claims.id_token).length > 0) {
+    filteredClaims.id_token = claims.id_token
+  }
+  if (claims.userinfo && Object.keys(claims.userinfo).length > 0) {
+    filteredClaims.userinfo = claims.userinfo
+  }
+
+  if (Object.keys(filteredClaims).length === 0) {
+    return null
+  }
+
+  return JSON.stringify(filteredClaims)
+}
+
+/**
+ * Parses a claims parameter string back into an OIDCClaimsRequest object.
+ *
+ * @param claimsString - The JSON string representation of claims
+ * @returns The parsed claims request, or null if invalid
+ */
+export const parseClaimsParameter = (claimsString: string): OIDCClaimsRequest | null => {
+  try {
+    const parsed = JSON.parse(claimsString) as OIDCClaimsRequest
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return null
+    }
+    return parsed
+  } catch {
+    return null
+  }
 }
 
 /**
@@ -32,9 +208,7 @@ export type OpenIDConnectDiscovery = {
  * @param url - The OpenID Connect discovery URL or issuer URL
  * @returns The discovery document or an error
  */
-export const fetchOpenIDConnectDiscovery = async (
-  url: string,
-): Promise<ErrorResponse<OpenIDConnectDiscovery>> => {
+export const fetchOpenIDConnectDiscovery = async (url: string): Promise<ErrorResponse<OpenIDConnectDiscovery>> => {
   try {
     // If the URL does not end with the well-known path, append it
     let discoveryUrl = url.trim()
@@ -57,9 +231,7 @@ export const fetchOpenIDConnectDiscovery = async (
 
     if (!response.ok) {
       return [
-        new Error(
-          `Failed to fetch OpenID Connect discovery document: ${response.status} ${response.statusText}`,
-        ),
+        new Error(`Failed to fetch OpenID Connect discovery document: ${response.status} ${response.statusText}`),
         null,
       ]
     }
@@ -68,12 +240,7 @@ export const fetchOpenIDConnectDiscovery = async (
 
     // Validate that we have the essential fields
     if (!data.authorization_endpoint && !data.token_endpoint) {
-      return [
-        new Error(
-          'Invalid OpenID Connect discovery document: missing required endpoints',
-        ),
-        null,
-      ]
+      return [new Error('Invalid OpenID Connect discovery document: missing required endpoints'), null]
     }
 
     return [null, data]
@@ -81,9 +248,6 @@ export const fetchOpenIDConnectDiscovery = async (
     if (error instanceof Error) {
       return [error, null]
     }
-    return [
-      new Error('Failed to fetch OpenID Connect discovery document'),
-      null,
-    ]
+    return [new Error('Failed to fetch OpenID Connect discovery document'), null]
   }
 }


### PR DESCRIPTION
Add OpenID Connect discovery functionality to the API client's OAuth2 authentication flow. Users can now enter an OpenID Connect issuer URL or discovery endpoint URL, fetch the configuration automatically, and have OAuth2 fields pre-filled with the discovered endpoints and scopes.

Changes:
- Add fetchOpenIDConnectDiscovery helper function with support for both issuer URLs and full discovery URLs
- Create OpenIDConnectDiscovery component with URL input and "Fetch Configuration" button
- Integrate OpenIDConnectDiscovery component into OAuth2 flow
- Add handler to map discovery document fields to OAuth2 flow fields (authorization_endpoint, token_endpoint, scopes_supported)
- Include comprehensive unit tests for OpenID Connect discovery functionality

The implementation follows the OpenID Connect Discovery 1.0 specification and gracefully handles errors with user-friendly toast notifications.

## Problem

<!--
  What problem does the PR solve?
  WHY did you submit the PR?

  We are interested in the WHY (LLMs won't know).
-->

## Solution

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

fixes #3656 

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
