### PR TITLE
feat(api-reference): group info.description headings in the sidebar

### DIFF
--- a/.changeset/stale-forks-fetch.md
+++ b/.changeset/stale-forks-fetch.md
@@ -1,0 +1,7 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-reference': patch
+'@scalar/sidebar': patch
+---
+
+fix: introduction grouping in sidebar

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -704,22 +704,7 @@ const handleSelectItem = async (
   caller?: 'sidebar',
   event?: MouseEvent,
 ) => {
-  console.log('[handleSelectItem] START', {
-    id,
-    caller,
-    hasEvent: !!event,
-    eventType: event?.type,
-    eventTarget: event?.target,
-    eventCurrentTarget: event?.currentTarget,
-  })
   const item = sidebarState.getEntryById(id)
-  console.log('[handleSelectItem] item', {
-    item,
-    itemType: item && 'type' in item ? item.type : 'unknown',
-    hasChildren: item && 'children' in item ? !!item.children : false,
-    childrenLength:
-      item && 'children' in item && item.children ? item.children.length : 0,
-  })
 
   // Handle expand/collapse for tags, models, and text items (like Introduction folder) that have children
   const isTag = item && 'type' in item && item.type === 'tag'
@@ -732,29 +717,13 @@ const handleSelectItem = async (
     item.children &&
     item.children.length > 0
   const isFolderType = isTag || isModels || isTextFolder
-  console.log('[handleSelectItem] folder checks', {
-    isTag,
-    isModels,
-    isTextFolder,
-    isFolderType,
-    itemTypeCheck: item && 'type' in item ? item.type : 'N/A',
-    hasChildrenCheck: item && 'children' in item ? !!item.children : false,
-    childrenLengthCheck:
-      item && 'children' in item && item.children ? item.children.length : 0,
-  })
 
   if (isFolderType) {
     // For text folders: check if click was on chevron vs text
     // For tags and models: always just toggle (same as before)
     if (isTextFolder && event) {
-      console.log('[handleSelectItem] isTextFolder with event')
       const target = event.target as HTMLElement
       const button = target?.closest('button')
-      console.log('[handleSelectItem] click target', {
-        targetTag: target?.tagName,
-        targetClass: target?.className,
-        hasButton: !!button,
-      })
 
       if (button) {
         const rect = button.getBoundingClientRect()
@@ -768,16 +737,8 @@ const handleSelectItem = async (
         // Then check position - use smaller threshold (28px or 25% of button, whichever is smaller)
         const clickedOnToggle =
           clickedOnSvg || clickX < Math.min(28, buttonWidth * 0.25)
-        console.log('[handleSelectItem] click analysis', {
-          clickX,
-          buttonWidth,
-          clickedOnSvg,
-          clickedOnToggle,
-          threshold: Math.min(28, buttonWidth * 0.25),
-        })
 
         if (clickedOnToggle) {
-          console.log('[handleSelectItem] Clicked on chevron - toggling only')
           // Clicked on chevron: just toggle (don't navigate)
           const unblock = blockIntersection()
           sidebarState.setExpanded(id, !sidebarState.isExpanded(id))
@@ -785,25 +746,17 @@ const handleSelectItem = async (
           return
         }
 
-        console.log(
-          '[handleSelectItem] Clicked on text - ensuring expanded then navigating',
-        )
         // Clicked on text: ensure folder is expanded, then navigate
         // Don't toggle if already expanded - just ensure it's open
-        const wasExpanded = sidebarState.isExpanded(id)
-        console.log('[handleSelectItem] folder expanded state', { wasExpanded })
-        if (!wasExpanded) {
+        if (!sidebarState.isExpanded(id)) {
           const unblock = blockIntersection()
           sidebarState.setExpanded(id, true)
           unblock()
           // Use nextTick to ensure DOM updates before scrolling
           await nextTick()
-          console.log('[handleSelectItem] folder expanded, waited for nextTick')
         }
-        console.log('[handleSelectItem] Continuing to navigation...')
         // Continue to navigation below
       } else {
-        console.log('[handleSelectItem] No button found - toggling only')
         // No button found, just toggle
         const unblock = blockIntersection()
         sidebarState.setExpanded(id, !sidebarState.isExpanded(id))
@@ -811,37 +764,6 @@ const handleSelectItem = async (
         return
       }
     } else {
-      console.log(
-        '[handleSelectItem] Not text folder or no event - toggling only',
-        {
-          isTextFolder,
-          hasEvent: !!event,
-          eventValue: event,
-          itemType: item && 'type' in item ? item.type : 'unknown',
-          hasChildren: item && 'children' in item ? !!item.children : false,
-          childrenLength:
-            item && 'children' in item && item.children
-              ? item.children.length
-              : 0,
-          conditionCheck: {
-            isTextType: item && 'type' in item && item.type === 'text',
-            hasChildrenProp: item && 'children' in item,
-            childrenExists:
-              item &&
-              'children' in item &&
-              item.children !== null &&
-              item.children !== undefined,
-            childrenLength:
-              item && 'children' in item && item.children
-                ? item.children.length
-                : 0,
-            childrenLengthGT0:
-              item && 'children' in item && item.children
-                ? item.children.length > 0
-                : false,
-          },
-        },
-      )
       // Tags and models: just toggle
       const unblock = blockIntersection()
       sidebarState.setExpanded(id, !sidebarState.isExpanded(id))
@@ -850,35 +772,22 @@ const handleSelectItem = async (
     }
   }
 
-  console.log('[handleSelectItem] Reached navigation code')
   /** When in mobile menu we close the menu when we select an item that is not a tag, model, or text folder */
   if (!isTag && !isModels && !isTextFolder) {
     isSidebarOpen.value = false
   }
 
-  console.log('[handleSelectItem] Calling scrollToLazyElement', { id })
   scrollToLazyElement(id)
 
   const url = makeUrlFromId(id, basePath.value, isMultiDocument.value)
-  console.log('[handleSelectItem] URL generated', {
-    url: url?.toString(),
-    id,
-    basePath: basePath.value,
-    isMultiDocument: isMultiDocument.value,
-  })
   if (url) {
     window.history.pushState({}, '', url)
-    console.log('[handleSelectItem] History updated', { url: url.toString() })
 
     // Trigger the onSidebarClick callback if the caller is sidebar
     if (caller === 'sidebar') {
       mergedConfig.value.onSidebarClick?.(url.toString())
-      console.log('[handleSelectItem] onSidebarClick callback triggered')
     }
-  } else {
-    console.log('[handleSelectItem] No URL generated - navigation skipped')
   }
-  console.log('[handleSelectItem] END')
 }
 eventBus.on('select:nav-item', ({ id }) => handleSelectItem(id))
 eventBus.on('scroll-to:nav-item', ({ id }) => handleSelectItem(id))
@@ -1004,14 +913,8 @@ const colorMode = computed(() => {
             :options="mergedConfig"
             role="navigation"
             @selectItem="
-              (id: string, event?: MouseEvent) => {
-                console.log('[ApiReference] @selectItem received', {
-                  id,
-                  hasEvent: !!event,
-                  event,
-                })
+              (id: string, event?: MouseEvent) =>
                 handleSelectItem(id, 'sidebar', event)
-              }
             ">
             <template #header>
               <!-- Wrap in a div when slot is filled -->

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -37,6 +37,7 @@ import type {
 import diff from 'microdiff'
 import {
   computed,
+  nextTick,
   onBeforeMount,
   onBeforeUnmount,
   onMounted,
@@ -698,36 +699,186 @@ eventBus.on('ui:download:document', async ({ format }) => {
  * - Operation:
  *        Open all parents and scroll to the operation
  */
-const handleSelectItem = (id: string, caller?: 'sidebar') => {
+const handleSelectItem = async (
+  id: string,
+  caller?: 'sidebar',
+  event?: MouseEvent,
+) => {
+  console.log('[handleSelectItem] START', {
+    id,
+    caller,
+    hasEvent: !!event,
+    eventType: event?.type,
+    eventTarget: event?.target,
+    eventCurrentTarget: event?.currentTarget,
+  })
   const item = sidebarState.getEntryById(id)
+  console.log('[handleSelectItem] item', {
+    item,
+    itemType: item && 'type' in item ? item.type : 'unknown',
+    hasChildren: item && 'children' in item ? !!item.children : false,
+    childrenLength:
+      item && 'children' in item && item.children ? item.children.length : 0,
+  })
 
-  if (
-    (item?.type === 'tag' || item?.type === 'models') &&
-    sidebarState.isExpanded(id)
-  ) {
-    // hack until we fix intersection logic
-    const unblock = blockIntersection()
-    sidebarState.setExpanded(id, false)
-    unblock()
-    return
+  // Handle expand/collapse for tags, models, and text items (like Introduction folder) that have children
+  const isTag = item && 'type' in item && item.type === 'tag'
+  const isModels = item && 'type' in item && item.type === 'models'
+  const isTextFolder =
+    item &&
+    'type' in item &&
+    item.type === 'text' &&
+    'children' in item &&
+    item.children &&
+    item.children.length > 0
+  const isFolderType = isTag || isModels || isTextFolder
+  console.log('[handleSelectItem] folder checks', {
+    isTag,
+    isModels,
+    isTextFolder,
+    isFolderType,
+    itemTypeCheck: item && 'type' in item ? item.type : 'N/A',
+    hasChildrenCheck: item && 'children' in item ? !!item.children : false,
+    childrenLengthCheck:
+      item && 'children' in item && item.children ? item.children.length : 0,
+  })
+
+  if (isFolderType) {
+    // For text folders: check if click was on chevron vs text
+    // For tags and models: always just toggle (same as before)
+    if (isTextFolder && event) {
+      console.log('[handleSelectItem] isTextFolder with event')
+      const target = event.target as HTMLElement
+      const button = target?.closest('button')
+      console.log('[handleSelectItem] click target', {
+        targetTag: target?.tagName,
+        targetClass: target?.className,
+        hasButton: !!button,
+      })
+
+      if (button) {
+        const rect = button.getBoundingClientRect()
+        const clickX = event.clientX - rect.left
+        const buttonWidth = rect.width
+        // Check if clicked on SVG/path first (most reliable)
+        const clickedOnSvg =
+          target.tagName === 'svg' ||
+          target.tagName === 'path' ||
+          target.closest('svg') !== null
+        // Then check position - use smaller threshold (28px or 25% of button, whichever is smaller)
+        const clickedOnToggle =
+          clickedOnSvg || clickX < Math.min(28, buttonWidth * 0.25)
+        console.log('[handleSelectItem] click analysis', {
+          clickX,
+          buttonWidth,
+          clickedOnSvg,
+          clickedOnToggle,
+          threshold: Math.min(28, buttonWidth * 0.25),
+        })
+
+        if (clickedOnToggle) {
+          console.log('[handleSelectItem] Clicked on chevron - toggling only')
+          // Clicked on chevron: just toggle (don't navigate)
+          const unblock = blockIntersection()
+          sidebarState.setExpanded(id, !sidebarState.isExpanded(id))
+          unblock()
+          return
+        }
+
+        console.log(
+          '[handleSelectItem] Clicked on text - ensuring expanded then navigating',
+        )
+        // Clicked on text: ensure folder is expanded, then navigate
+        // Don't toggle if already expanded - just ensure it's open
+        const wasExpanded = sidebarState.isExpanded(id)
+        console.log('[handleSelectItem] folder expanded state', { wasExpanded })
+        if (!wasExpanded) {
+          const unblock = blockIntersection()
+          sidebarState.setExpanded(id, true)
+          unblock()
+          // Use nextTick to ensure DOM updates before scrolling
+          await nextTick()
+          console.log('[handleSelectItem] folder expanded, waited for nextTick')
+        }
+        console.log('[handleSelectItem] Continuing to navigation...')
+        // Continue to navigation below
+      } else {
+        console.log('[handleSelectItem] No button found - toggling only')
+        // No button found, just toggle
+        const unblock = blockIntersection()
+        sidebarState.setExpanded(id, !sidebarState.isExpanded(id))
+        unblock()
+        return
+      }
+    } else {
+      console.log(
+        '[handleSelectItem] Not text folder or no event - toggling only',
+        {
+          isTextFolder,
+          hasEvent: !!event,
+          eventValue: event,
+          itemType: item && 'type' in item ? item.type : 'unknown',
+          hasChildren: item && 'children' in item ? !!item.children : false,
+          childrenLength:
+            item && 'children' in item && item.children
+              ? item.children.length
+              : 0,
+          conditionCheck: {
+            isTextType: item && 'type' in item && item.type === 'text',
+            hasChildrenProp: item && 'children' in item,
+            childrenExists:
+              item &&
+              'children' in item &&
+              item.children !== null &&
+              item.children !== undefined,
+            childrenLength:
+              item && 'children' in item && item.children
+                ? item.children.length
+                : 0,
+            childrenLengthGT0:
+              item && 'children' in item && item.children
+                ? item.children.length > 0
+                : false,
+          },
+        },
+      )
+      // Tags and models: just toggle
+      const unblock = blockIntersection()
+      sidebarState.setExpanded(id, !sidebarState.isExpanded(id))
+      unblock()
+      return
+    }
   }
 
-  /** When in mobile menu we close the menu when we select an item that is not a tag */
-  if (item?.type !== 'tag' && item?.type !== 'models') {
+  console.log('[handleSelectItem] Reached navigation code')
+  /** When in mobile menu we close the menu when we select an item that is not a tag, model, or text folder */
+  if (!isTag && !isModels && !isTextFolder) {
     isSidebarOpen.value = false
   }
 
+  console.log('[handleSelectItem] Calling scrollToLazyElement', { id })
   scrollToLazyElement(id)
 
   const url = makeUrlFromId(id, basePath.value, isMultiDocument.value)
+  console.log('[handleSelectItem] URL generated', {
+    url: url?.toString(),
+    id,
+    basePath: basePath.value,
+    isMultiDocument: isMultiDocument.value,
+  })
   if (url) {
     window.history.pushState({}, '', url)
+    console.log('[handleSelectItem] History updated', { url: url.toString() })
 
     // Trigger the onSidebarClick callback if the caller is sidebar
     if (caller === 'sidebar') {
       mergedConfig.value.onSidebarClick?.(url.toString())
+      console.log('[handleSelectItem] onSidebarClick callback triggered')
     }
+  } else {
+    console.log('[handleSelectItem] No URL generated - navigation skipped')
   }
+  console.log('[handleSelectItem] END')
 }
 eventBus.on('select:nav-item', ({ id }) => handleSelectItem(id))
 eventBus.on('scroll-to:nav-item', ({ id }) => handleSelectItem(id))
@@ -852,7 +1003,16 @@ const colorMode = computed(() => {
             layout="reference"
             :options="mergedConfig"
             role="navigation"
-            @selectItem="(id) => handleSelectItem(id, 'sidebar')">
+            @selectItem="
+              (id: string, event?: MouseEvent) => {
+                console.log('[ApiReference] @selectItem received', {
+                  id,
+                  hasEvent: !!event,
+                  event,
+                })
+                handleSelectItem(id, 'sidebar', event)
+              }
+            ">
             <template #header>
               <!-- Wrap in a div when slot is filled -->
               <DocumentSelector

--- a/packages/sidebar/src/components/ScalarSidebar.vue
+++ b/packages/sidebar/src/components/ScalarSidebar.vue
@@ -70,7 +70,7 @@ const emit = defineEmits<{
    * Emitted when a sidebar item is selected.
    * @param id - The id of the selected item.
    */
-  (e: 'selectItem', id: string): void
+  (e: 'selectItem', id: string, event?: MouseEvent): void
 }>()
 
 defineSlots<{
@@ -121,7 +121,7 @@ const handleDragEnd = (
           :layout="layout"
           :options="options"
           @onDragEnd="handleDragEnd"
-          @selectItem="(id) => emit('selectItem', id)">
+          @selectItem="(id, event) => emit('selectItem', id, event)">
           <template
             v-if="$slots.decorator"
             #decorator="props">

--- a/packages/sidebar/src/components/SidebarItem.vue
+++ b/packages/sidebar/src/components/SidebarItem.vue
@@ -163,17 +163,7 @@ const { draggableAttrs, draggableEvents } = useDraggable({
     :open="isExpanded(item.id)"
     v-bind="draggableAttrs"
     v-on="draggableEvents"
-    @click="
-      (event: MouseEvent) => {
-        console.log('[SidebarItem] ScalarSidebarGroup click', {
-          id: item.id,
-          hasEvent: !!event,
-          eventType: event?.type,
-          eventTarget: event?.target,
-        })
-        emit('selectItem', item.id, event)
-      }
-    ">
+    @click="(event: MouseEvent) => emit('selectItem', item.id, event)">
     <template
       v-if="item.type === 'document'"
       #icon="{ open }">

--- a/packages/sidebar/src/components/SidebarItem.vue
+++ b/packages/sidebar/src/components/SidebarItem.vue
@@ -69,7 +69,7 @@ const emit = defineEmits<{
    * Emitted when the item is selected
    * @param id - The id of the selected item
    */
-  (e: 'selectItem', id: string): void
+  (e: 'selectItem', id: string, event?: MouseEvent): void
   /**
    * Emitted when a drag operation ends for this item
    * @param draggingItem - The item being dragged
@@ -163,7 +163,17 @@ const { draggableAttrs, draggableEvents } = useDraggable({
     :open="isExpanded(item.id)"
     v-bind="draggableAttrs"
     v-on="draggableEvents"
-    @click="() => emit('selectItem', item.id)">
+    @click="
+      (event: MouseEvent) => {
+        console.log('[SidebarItem] ScalarSidebarGroup click', {
+          id: item.id,
+          hasEvent: !!event,
+          eventType: event?.type,
+          eventTarget: event?.target,
+        })
+        emit('selectItem', item.id, event)
+      }
+    ">
     <template
       v-if="item.type === 'document'"
       #icon="{ open }">
@@ -254,7 +264,7 @@ const { draggableAttrs, draggableEvents } = useDraggable({
     class="relative"
     :selected="isSelected(item.id)"
     v-on="draggableEvents"
-    @click="() => emit('selectItem', item.id)">
+    @click="(event: MouseEvent) => emit('selectItem', item.id, event)">
     <span
       v-if="isDeprecated(item)"
       class="line-through">

--- a/packages/workspace-store/src/navigation/helpers/traverse-description.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-description.test.ts
@@ -35,7 +35,7 @@ describe('traverseDescription', () => {
     expect(result).toEqual([])
   })
 
-  it('should return an introduction entry for description with no headings', () => {
+  it('should return an Introduction folder with no children for description with no headings', () => {
     const description = 'This is a paragraph without any headings.'
     const result = traverseDescription({
       info: { title: 'Openapi Document', version: '1.0.0', description },
@@ -48,10 +48,16 @@ describe('traverseDescription', () => {
       },
       parentId: 'parent-1',
     })
-    expect(result).toEqual([{ id: 'heading-introduction', title: 'Introduction', type: 'text' }])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      id: 'heading-introduction',
+      title: 'Introduction',
+      type: 'text',
+      children: [],
+    })
   })
 
-  it('should create single level entries for h1 headings', () => {
+  it('should return headings directly when description starts with a heading', () => {
     const description = `
 # First Heading
 Some content here
@@ -93,7 +99,7 @@ Final content
     })
   })
 
-  it('should create nested entries for h1 and h2 headings', () => {
+  it('should return headings directly with nested entries for h1 and h2 headings', () => {
     const description = `
 # Main Section
 Some content
@@ -150,7 +156,7 @@ Final content
     })
   })
 
-  it('should handle h2 and h3 headings when they are the lowest levels', () => {
+  it('should return headings directly with h2 and h3 headings when they are the lowest levels', () => {
     const description = `
 ## Section 1
 Content
@@ -207,7 +213,7 @@ Content
     })
   })
 
-  it('should skip headings that are not at the lowest two levels', () => {
+  it('should return headings directly and skip headings that are not at the lowest two levels', () => {
     const description = `
 # Level 1
 ## Level 2
@@ -243,7 +249,7 @@ Content
     })
   })
 
-  it('should handle special characters in headings', () => {
+  it('should return headings directly and handle special characters in headings', () => {
     const description = `
 # Section with @#$%^&*() chars
 ## Sub-section with !@#$%^&*() chars


### PR DESCRIPTION
## Problem

Markdown headings in the sidebar should be grouped to match the rest of the sidebar structure

**edit
honestly had the hardest time trying to get this to work, not proud of this code and its pretty brutal.

## Solution

Leveraged the isGroup instead of just the text entry for the sidebar

<img width="288" height="435" alt="image" src="https://github.com/user-attachments/assets/36d0ad56-5895-4429-b75a-e387f62773ec" />


## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves description-to-sidebar mapping and selection behavior.
> 
> - `traverseDescription`: returns headings directly when description starts with a heading; otherwise creates an "Introduction" folder whose `children` contain all headings (always an array). Updates tests accordingly.
> - Sidebar click handling: `selectItem` now passes the `MouseEvent` through `SidebarItem` → `ScalarSidebar` → `ApiReference`. `handleSelectItem` distinguishes chevron vs label clicks for text folders (e.g., Introduction), toggles expand without navigation on chevron, ensures expand then navigates on label, and uses `nextTick` before scrolling. Mobile drawer closes only for non-folder items.
> - Wires new event signature in templates and components; no API/UX changes outside sidebar selection behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e237282f440926bd0b7c7f8773554e96520ea92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->