### PR TITLE
chore: dedupe `supertest` dev dependency

### DIFF
--- a/examples/nestjs/nestjs-api-reference-express/package.json
+++ b/examples/nestjs/nestjs-api-reference-express/package.json
@@ -66,13 +66,13 @@
     "@swc/core": "^1.3.64",
     "@types/jest": "^29.5.2",
     "@types/node": "catalog:*",
-    "@types/supertest": "^2.0.12",
+    "@types/supertest": "catalog:*",
     "@typescript-eslint/parser": "catalog:*",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.5.0",
     "source-map-support": "^0.5.21",
-    "supertest": "^6.3.3",
+    "supertest": "catalog:*",
     "ts-jest": "^29.1.0",
     "ts-loader": "^9.4.3"
   }

--- a/examples/nestjs/nestjs-api-reference-fastify/package.json
+++ b/examples/nestjs/nestjs-api-reference-fastify/package.json
@@ -65,13 +65,13 @@
     "@swc/core": "^1.3.64",
     "@types/jest": "^29.5.2",
     "@types/node": "catalog:*",
-    "@types/supertest": "^2.0.12",
+    "@types/supertest": "catalog:*",
     "@typescript-eslint/parser": "catalog:*",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.5.0",
     "source-map-support": "^0.5.21",
-    "supertest": "^6.3.3",
+    "supertest": "catalog:*",
     "ts-jest": "^29.1.0",
     "ts-loader": "^9.4.3"
   }

--- a/integrations/express/package.json
+++ b/integrations/express/package.json
@@ -64,10 +64,10 @@
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
     "@types/express": "catalog:*",
-    "@types/supertest": "^2.0.12",
+    "@types/supertest": "catalog:*",
     "@types/swagger-jsdoc": "^6.0.3",
     "express": "catalog:*",
-    "supertest": "^6.3.3",
+    "supertest": "catalog:*",
     "swagger-jsdoc": "^6.2.8",
     "vite": "catalog:*",
     "vitest": "catalog:*"

--- a/integrations/nestjs/package.json
+++ b/integrations/nestjs/package.json
@@ -74,10 +74,10 @@
     "@nestjs/testing": "^11.1.6",
     "@scalar/api-reference": "workspace:*",
     "@types/express": "catalog:*",
-    "@types/supertest": "^2.0.12",
+    "@types/supertest": "catalog:*",
     "express": "catalog:*",
     "fastify": "^5.4.0",
-    "supertest": "^7.1.4",
+    "supertest": "catalog:*",
     "tsup": "^8.3.5",
     "vite": "catalog:*",
     "vitest": "catalog:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ catalogs:
     '@types/semver':
       specifier: 7.5.8
       version: 7.5.8
+    '@types/supertest':
+      specifier: 6.0.2
+      version: 6.0.2
     '@typescript-eslint/parser':
       specifier: ^8.0.0
       version: 8.24.0
@@ -144,6 +147,9 @@ catalogs:
     shx:
       specifier: ^0.4.0
       version: 0.4.0
+    supertest:
+      specifier: 7.2.2
+      version: 7.2.2
     tailwindcss:
       specifier: ^4.1.18
       version: 4.1.18
@@ -322,8 +328,8 @@ importers:
         specifier: catalog:*
         version: 22.19.3
       '@types/supertest':
-        specifier: ^2.0.12
-        version: 2.0.16
+        specifier: catalog:*
+        version: 6.0.2
       '@typescript-eslint/parser':
         specifier: catalog:*
         version: 8.24.0(eslint@9.20.1(jiti@2.6.1))(typescript@5.8.3)
@@ -340,8 +346,8 @@ importers:
         specifier: ^0.5.21
         version: 0.5.21
       supertest:
-        specifier: ^6.3.3
-        version: 6.3.4
+        specifier: catalog:*
+        version: 7.2.2
       ts-jest:
         specifier: ^29.1.0
         version: 29.1.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@22.19.3)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@22.19.3)(typescript@5.8.3)))(typescript@5.8.3)
@@ -395,8 +401,8 @@ importers:
         specifier: catalog:*
         version: 22.19.3
       '@types/supertest':
-        specifier: ^2.0.12
-        version: 2.0.16
+        specifier: catalog:*
+        version: 6.0.2
       '@typescript-eslint/parser':
         specifier: catalog:*
         version: 8.24.0(eslint@9.20.1(jiti@2.6.1))(typescript@5.8.3)
@@ -413,8 +419,8 @@ importers:
         specifier: ^0.5.21
         version: 0.5.21
       supertest:
-        specifier: ^6.3.3
-        version: 6.3.4
+        specifier: catalog:*
+        version: 7.2.2
       ts-jest:
         specifier: ^29.1.0
         version: 29.1.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@22.19.3)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@22.19.3)(typescript@5.8.3)))(typescript@5.8.3)
@@ -811,8 +817,8 @@ importers:
         specifier: catalog:*
         version: 5.0.3
       '@types/supertest':
-        specifier: ^2.0.12
-        version: 2.0.16
+        specifier: catalog:*
+        version: 6.0.2
       '@types/swagger-jsdoc':
         specifier: ^6.0.3
         version: 6.0.4
@@ -820,8 +826,8 @@ importers:
         specifier: catalog:*
         version: 5.1.0
       supertest:
-        specifier: ^6.3.3
-        version: 6.3.4
+        specifier: catalog:*
+        version: 7.2.2
       swagger-jsdoc:
         specifier: ^6.2.8
         version: 6.2.8(openapi-types@12.1.3)
@@ -946,8 +952,8 @@ importers:
         specifier: catalog:*
         version: 5.0.3
       '@types/supertest':
-        specifier: ^2.0.12
-        version: 2.0.16
+        specifier: catalog:*
+        version: 6.0.2
       express:
         specifier: catalog:*
         version: 5.1.0
@@ -955,8 +961,8 @@ importers:
         specifier: ^5.4.0
         version: 5.6.2
       supertest:
-        specifier: ^7.1.4
-        version: 7.1.4
+        specifier: catalog:*
+        version: 7.2.2
       tsup:
         specifier: ^8.3.5
         version: 8.4.0(@microsoft/api-extractor@7.48.1(@types/node@22.19.3))(@swc/core@1.5.29(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.19.1)(typescript@5.8.3)(yaml@2.8.0)
@@ -8102,8 +8108,8 @@ packages:
   '@types/superagent@8.1.7':
     resolution: {integrity: sha512-NmIsd0Yj4DDhftfWvvAku482PZum4DBW7U51OvS8gvOkDDY0WT1jsVyDV3hK+vplrsYw8oDwi9QxOM7U68iwww==}
 
-  '@types/supertest@2.0.16':
-    resolution: {integrity: sha512-6c2ogktZ06tr2ENoZivgm7YnprnhYE4ZoXGMY+oA7IuAf17M8FWvujXZGmxLv8y0PTyts4x5A+erSwVUFA8XSg==}
+  '@types/supertest@6.0.2':
+    resolution: {integrity: sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==}
 
   '@types/supports-color@8.1.3':
     resolution: {integrity: sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg==}
@@ -11145,8 +11151,8 @@ packages:
     resolution: {integrity: sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==}
     engines: {node: '>= 0.12'}
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -15207,8 +15213,8 @@ packages:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -16421,8 +16427,8 @@ packages:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
 
-  superagent@10.2.3:
-    resolution: {integrity: sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==}
+  superagent@10.3.0:
+    resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
     engines: {node: '>=14.18.0'}
 
   superagent@7.1.6:
@@ -16430,22 +16436,12 @@ packages:
     engines: {node: '>=6.4.0 <13 || >=14'}
     deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
-  superagent@8.1.2:
-    resolution: {integrity: sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==}
-    engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
-
   superjson@2.2.2:
     resolution: {integrity: sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==}
     engines: {node: '>=16'}
 
-  supertest@6.3.4:
-    resolution: {integrity: sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==}
-    engines: {node: '>=6.4.0'}
-    deprecated: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
-
-  supertest@7.1.4:
-    resolution: {integrity: sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==}
+  supertest@7.2.2:
+    resolution: {integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==}
     engines: {node: '>=14.18.0'}
 
   supports-color@10.0.0:
@@ -24711,8 +24707,9 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/node': 22.19.3
 
-  '@types/supertest@2.0.16':
+  '@types/supertest@6.0.2':
     dependencies:
+      '@types/methods': 1.1.4
       '@types/superagent': 8.1.7
 
   '@types/supports-color@8.1.3': {}
@@ -25874,7 +25871,7 @@ snapshots:
   axios@1.7.7:
     dependencies:
       follow-redirects: 1.15.6
-      form-data: 4.0.4
+      form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -26078,7 +26075,7 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
-      qs: 6.14.0
+      qs: 6.14.1
       raw-body: 3.0.0
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -28140,7 +28137,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.0
+      qs: 6.14.1
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.0
@@ -28620,7 +28617,7 @@ snapshots:
       mime-types: 2.1.35
       safe-buffer: 5.2.1
 
-  form-data@4.0.4:
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -28644,7 +28641,7 @@ snapshots:
       dezalgo: 1.0.4
       hexoid: 1.0.0
       once: 1.4.0
-      qs: 6.14.0
+      qs: 6.14.1
 
   formidable@3.5.4:
     dependencies:
@@ -31701,7 +31698,7 @@ snapshots:
       micro-api-client: 3.3.0
       node-fetch: 3.3.2
       p-wait-for: 5.0.2
-      qs: 6.14.0
+      qs: 6.14.1
     optional: true
 
   next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
@@ -33695,7 +33692,7 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  qs@6.14.0:
+  qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
 
@@ -35218,17 +35215,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  superagent@10.2.3:
+  superagent@10.3.0:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
       debug: 4.4.3(supports-color@5.5.0)
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.4
+      form-data: 4.0.5
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.14.0
+      qs: 6.14.1
     transitivePeerDependencies:
       - supports-color
 
@@ -35238,27 +35235,12 @@ snapshots:
       cookiejar: 2.1.4
       debug: 4.4.3(supports-color@5.5.0)
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.4
+      form-data: 4.0.5
       formidable: 2.1.2
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.14.0
+      qs: 6.14.1
       readable-stream: 3.6.2
-      semver: 7.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  superagent@8.1.2:
-    dependencies:
-      component-emitter: 1.3.1
-      cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@5.5.0)
-      fast-safe-stringify: 2.1.1
-      form-data: 4.0.4
-      formidable: 2.1.2
-      methods: 1.1.2
-      mime: 2.6.0
-      qs: 6.14.0
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
@@ -35267,17 +35249,11 @@ snapshots:
     dependencies:
       copy-anything: 3.0.5
 
-  supertest@6.3.4:
+  supertest@7.2.2:
     dependencies:
+      cookie-signature: 1.2.2
       methods: 1.1.2
-      superagent: 8.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  supertest@7.1.4:
-    dependencies:
-      methods: 1.1.2
-      superagent: 10.2.3
+      superagent: 10.3.0
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,7 @@ catalogs:
     '@types/react': ^19.2.7
     '@types/react-dom': ^19.2.3
     '@types/semver': 7.5.8
+    '@types/supertest': 6.0.2
     '@typescript-eslint/parser': ^8.0.0
     '@vitejs/plugin-react': 5.0.4
     '@vitejs/plugin-vue': ^6.0.3
@@ -58,6 +59,7 @@ catalogs:
     react: ^19.2.3
     react-dom: ^19.2.3
     semver: 7.7.2
+    supertest: '7.2.2'
     shx: ^0.4.0
     tailwindcss: ^4.1.18
     type-fest: ^5.3.1


### PR DESCRIPTION
## Problem

Starting working on enabling `knip` on `express` integration and noticed that the monorepo has two version of `supertest` and `@types/supertest`:
- 6
- 7

## Solution

Add entry for both `supertest` and `@types/supertest` packages in `*` catalog.
This should resolve 2 deprecation warnings displayed while running `pnpm install`.

I'm doing a standalone PR since this change affects multiple integrations packages.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
