### PR TITLE
fix(documentation): update spectral rulesets link

### DIFF
--- a/documentation/guides/registry/rules.md
+++ b/documentation/guides/registry/rules.md
@@ -30,7 +30,7 @@ You can customize your rule by:
 - Adding custom rules
 - Overriding existing rules
 
-For more information about Spectral rules and how to write custom rules, see the [Spectral documentation](https://meta.stoplight.io/docs/spectral/docs/getting-started/rulesets.md).
+For more information about Spectral rules and how to write custom rules, see the [Spectral documentation](https://docs.stoplight.io/docs/spectral/01baf06bdd05a-create-a-ruleset).
 
 ## Access Control
 


### PR DESCRIPTION
Looks like this link broke.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
