### PR TITLE
chore(components): upgrade pretty-bytes, move to catalog

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -356,7 +356,7 @@
     "js-base64": "catalog:*",
     "microdiff": "catalog:*",
     "nanoid": "catalog:*",
-    "pretty-bytes": "^7.1.0",
+    "pretty-bytes": "catalog:*",
     "pretty-ms": "^9.3.0",
     "shell-quote": "^1.8.1",
     "type-fest": "catalog:*",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -60,7 +60,7 @@
     "@vueuse/core": "catalog:*",
     "cva": "1.0.0-beta.2",
     "nanoid": "catalog:*",
-    "pretty-bytes": "^6.1.1",
+    "pretty-bytes": "catalog:*",
     "radix-vue": "^1.9.3",
     "vue": "catalog:*",
     "vue-component-type-helpers": "^3.0.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ catalogs:
     postcss:
       specifier: ^8.4.38
       version: 8.5.6
+    pretty-bytes:
+      specifier: ^7.1.0
+      version: 7.1.0
     react:
       specifier: ^19.2.3
       version: 19.2.3
@@ -1234,7 +1237,7 @@ importers:
         specifier: catalog:*
         version: 5.1.6
       pretty-bytes:
-        specifier: ^7.1.0
+        specifier: catalog:*
         version: 7.1.0
       pretty-ms:
         specifier: ^9.3.0
@@ -1682,8 +1685,8 @@ importers:
         specifier: catalog:*
         version: 5.1.6
       pretty-bytes:
-        specifier: ^6.1.1
-        version: 6.1.1
+        specifier: catalog:*
+        version: 7.1.0
       radix-vue:
         specifier: ^1.9.3
         version: 1.9.3(vue@3.5.26(typescript@5.8.3))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,14 @@ catalogs:
     '@headlessui/tailwindcss': ^0.2.2
     '@headlessui/vue': 1.7.23
     '@hono/node-server': ^1.19.7
+    '@nestjs/cli': '^11.0.14'
+    '@nestjs/common': '^11.1.11'
+    '@nestjs/core': '^11.1.11'
+    '@nestjs/platform-express': '^11.1.11'
+    '@nestjs/platform-fastify': '^11.1.11'
+    '@nestjs/schematics': '^11.0.9'
+    '@nestjs/swagger': '^7.3.1'
+    '@nestjs/testing': '^11.1.11'
     '@playwright/test': 1.56.0
     '@scalar/typebox': 0.1.3
     '@tailwindcss/vite': ^4.1.18
@@ -39,14 +47,7 @@ catalogs:
     '@vueuse/core': 13.9.0
     '@vueuse/integrations': 13.9.0
     'fastify-plugin': ^4.5.1
-    '@nestjs/cli': '^11.0.14'
-    '@nestjs/common': '^11.1.11'
-    '@nestjs/core': '^11.1.11'
-    '@nestjs/platform-express': '^11.1.11'
-    '@nestjs/platform-fastify': '^11.1.11'
-    '@nestjs/schematics': '^11.0.9'
-    '@nestjs/swagger': '^7.3.1'
-    '@nestjs/testing': '^11.1.11'
+    'pretty-bytes': ^7.1.0
     ansis: 4.1.0
     astro: 5.15.9
     chokidar: 4.0.3
@@ -70,8 +71,8 @@ catalogs:
     react-dom: ^19.2.3
     react: ^19.2.3
     semver: 7.7.2
-    supertest: '7.2.2'
     shx: ^0.4.0
+    supertest: '7.2.2'
     tailwindcss: ^4.1.18
     type-fest: ^5.3.1
     vite-node: 5.2.0


### PR DESCRIPTION
upgraded to v7 in the api client, forgot the components package

let’s put it in the catalog, so it never happens again

both are upgraded to v7