### PR TITLE
docs: add swagger-editor redirect

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -52,6 +52,10 @@
     "routing": {
       "redirects": [
         {
+          "from": "/swagger-editor",
+          "to": "/"
+        },
+        {
           "from": "/scalar",
           "to": "/"
         },


### PR DESCRIPTION
ooops, this url is out and leads to a 404

saw it in the apichangelog blog

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a broken docs URL by updating site routing.
> 
> - Adds redirect mapping `/swagger-editor` → `/` in `scalar.config.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cffb20fbce228a59f6a4a5f364be67cb5faaded. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->