### PR TITLE
fix(nextjs): enable `knip`

### DIFF
--- a/.changeset/fresh-heads-say.md
+++ b/.changeset/fresh-heads-say.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nextjs-api-reference': patch
+---
+
+fix: use named instead of star exports

--- a/integrations/nextjs/index.ts
+++ b/integrations/nextjs/index.ts
@@ -1,1 +1,1 @@
-export * from './src'
+export { ApiReference } from './src'

--- a/integrations/nextjs/package.json
+++ b/integrations/nextjs/package.json
@@ -63,7 +63,7 @@
     "@scalar/core": "workspace:*"
   },
   "devDependencies": {
-    "@scalar/api-reference": "workspace:*",
+    "@scalar/build-tooling": "workspace:*",
     "@types/node": "catalog:*",
     "@types/react": "catalog:*",
     "@types/react-dom": "catalog:*",

--- a/integrations/nextjs/src/index.ts
+++ b/integrations/nextjs/src/index.ts
@@ -1,1 +1,1 @@
-export * from './ApiReference'
+export { ApiReference } from './ApiReference'

--- a/integrations/nextjs/vite.config.ts
+++ b/integrations/nextjs/vite.config.ts
@@ -1,5 +1,6 @@
-import react from '@vitejs/plugin-react'
 import * as path from 'node:path'
+
+import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
 

--- a/integrations/sveltekit/package.json
+++ b/integrations/sveltekit/package.json
@@ -67,6 +67,7 @@
     "@scalar/core": "workspace:*"
   },
   "devDependencies": {
+    "@sveltejs/kit": "^2.25.0",
     "@sveltejs/package": "^2.0.0",
     "publint": "^0.3.2",
     "svelte": "^5.0.0",

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -9,10 +9,7 @@
     "integrations/express/**",
     "integrations/fastapi/**",
     "integrations/hono/**",
-    "integrations/nestjs/**",
-    "integrations/nextjs/**",
-    "integrations/nuxt/**",
-    "integrations/sveltekit/**"
+    "integrations/nestjs/**"
   ],
   "ignoreFiles": [
     // test types files are marked as unused
@@ -325,6 +322,7 @@
       ],
       "ignoreBinaries": ["mvn"]
     },
+    "integrations/next": {},
     "integrations/nuxt": {
       "entry": [
         "src/module.ts",
@@ -337,6 +335,13 @@
       ],
       "ignoreDependencies": [
         "@scalar/api-client" // referenced in /src/runtime/components/nuxt-theme.css
+      ]
+    },
+    "integrations/sveltekit": {
+      "ignoreDependencies": [
+        // Automatically added to devDependencies by `pnpm script packages format`
+        // because it's a peer dependency but not used directly.
+        "@sveltejs/kit"
       ]
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1015,9 +1015,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
     devDependencies:
-      '@scalar/api-reference':
+      '@scalar/build-tooling':
         specifier: workspace:*
-        version: link:../../packages/api-reference
+        version: link:../../packages/build-tooling
       '@types/node':
         specifier: catalog:*
         version: 22.19.3
@@ -1093,10 +1093,10 @@ importers:
       '@scalar/core':
         specifier: workspace:*
         version: link:../../packages/core
+    devDependencies:
       '@sveltejs/kit':
         specifier: ^2.25.0
         version: 2.25.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.25.10)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)))(svelte@5.25.10)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))
-    devDependencies:
       '@sveltejs/package':
         specifier: ^2.0.0
         version: 2.3.10(svelte@5.25.10)(typescript@5.9.3)


### PR DESCRIPTION
## Problem

- Followup of #7233

## Solution

- refine sveltekit config 
  (not strictly related to this one but since it was a simple entry in `knip.json` I hijacked this PR 😅)
- update dev dendencies
  - removed  `@scalar/api-reference` 
  - added `@scalar/build-tooling`
- replaced star with named exports

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
