### PR TITLE
refactor: use dedicated imports for all icons

### DIFF
--- a/packages/api-client/src/components/AddressBar/AddressBar.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBar.vue
@@ -241,8 +241,7 @@ function updateRequestPath(url: string) {
           aria-hidden="true"
           class="inline-flex items-center gap-1">
           <ScalarIconPlay
-            class="relative shrink-0"
-            size="xs"
+            class="relative size-3 shrink-0"
             weight="fill" />
           <span class="text-xxs hidden lg:flex">Send</span>
         </span>

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -49,7 +49,7 @@ function handleHistoryClick(requestHistoryItem: RequestEvent) {
         v-if="history?.length"
         class="address-bar-history-button z-context-plus text-c-3 focus:text-c-1 relative mr-1 rounded-lg p-1.5">
         <ScalarIconClockClockwise
-          size="sm"
+          class="size-3.5"
           weight="regular" />
         <span class="sr-only">Request History</span>
       </MenuButton>

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
 import { ScalarFloating, ScalarFloatingBackdrop } from '@scalar/components'
-import { ScalarIconClockClockwise } from '@scalar/icons'
 import type { Operation, RequestEvent } from '@scalar/oas-utils/entities/spec'
 import { httpStatusCodes } from '@scalar/oas-utils/helpers'
 import { computed } from 'vue'

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -50,7 +50,7 @@ function handleHistoryClick(requestHistoryItem: RequestEvent) {
         class="address-bar-history-button z-context-plus text-c-3 focus:text-c-1 relative mr-1 rounded-lg p-1.5">
         <ScalarIconClockClockwise
           size="sm"
-          thickness="2.25" />
+          weight="regular" />
         <span class="sr-only">Request History</span>
       </MenuButton>
       <!-- History shadow and placement-->

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -1,10 +1,7 @@
 <script setup lang="ts">
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
-import {
-  ScalarFloating,
-  ScalarFloatingBackdrop,
-  ScalarIcon,
-} from '@scalar/components'
+import { ScalarFloating, ScalarFloatingBackdrop } from '@scalar/components'
+import { ScalarIconClockClockwise } from '@scalar/icons'
 import type { Operation, RequestEvent } from '@scalar/oas-utils/entities/spec'
 import { httpStatusCodes } from '@scalar/oas-utils/helpers'
 import { computed } from 'vue'
@@ -52,8 +49,7 @@ function handleHistoryClick(requestHistoryItem: RequestEvent) {
       <MenuButton
         v-if="history?.length"
         class="address-bar-history-button z-context-plus text-c-3 focus:text-c-1 relative mr-1 rounded-lg p-1.5">
-        <ScalarIcon
-          icon="History"
+        <ScalarIconClockClockwise
           size="sm"
           thickness="2.25" />
         <span class="sr-only">Request History</span>

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
 import { ScalarFloating, ScalarFloatingBackdrop } from '@scalar/components'
+import { ScalarIconClockClockwise } from '@scalar/icons'
 import type { Operation, RequestEvent } from '@scalar/oas-utils/entities/spec'
 import { httpStatusCodes } from '@scalar/oas-utils/helpers'
 import { computed } from 'vue'

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
@@ -104,9 +104,7 @@ const visibleRequests = computed<Request[]>(() =>
           {{ selectedRequest.summary }}
           <div class="flex items-center gap-2">
             <HttpMethod :method="selectedRequest.method" />
-            <ScalarIconCaretDown
-              class="text-c-3"
-              size="md" />
+            <ScalarIconCaretDown class="text-c-3 size-4" />
           </div>
         </ScalarButton>
         <template #items>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteExample.vue
@@ -3,8 +3,8 @@ import {
   ScalarButton,
   ScalarDropdown,
   ScalarDropdownItem,
-  ScalarIcon,
 } from '@scalar/components'
+import { ScalarIconCaretDown } from '@scalar/icons'
 import type { Request } from '@scalar/oas-utils/entities/spec'
 import { isDefined } from '@scalar/oas-utils/helpers'
 import { useToasts } from '@scalar/use-toasts'
@@ -104,9 +104,8 @@ const visibleRequests = computed<Request[]>(() =>
           {{ selectedRequest.summary }}
           <div class="flex items-center gap-2">
             <HttpMethod :method="selectedRequest.method" />
-            <ScalarIcon
+            <ScalarIconCaretDown
               class="text-c-3"
-              icon="ChevronDown"
               size="md" />
           </div>
         </ScalarButton>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
@@ -2,10 +2,10 @@
 import {
   ScalarButton,
   ScalarCodeBlock,
-  ScalarIcon,
   ScalarTooltip,
   useLoadingState,
 } from '@scalar/components'
+import { ScalarIconUpload } from '@scalar/icons'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
@@ -235,9 +235,8 @@ const handleInput = (value: string) => {
           variant="outlined"
           @click="openSpecFileDialog">
           JSON, or YAML File
-          <ScalarIcon
+          <ScalarIconUpload
             class="text-c-3"
-            icon="Upload"
             size="md" />
         </ScalarButton>
 

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteImport.vue
@@ -235,9 +235,7 @@ const handleInput = (value: string) => {
           variant="outlined"
           @click="openSpecFileDialog">
           JSON, or YAML File
-          <ScalarIconUpload
-            class="text-c-3"
-            size="md" />
+          <ScalarIconUpload class="text-c-3 size-4" />
         </ScalarButton>
 
         <!-- Watch -->

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteImportCurl.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteImportCurl.vue
@@ -174,9 +174,7 @@ const wrapper = useTemplateRef('wrapper-ref')
                   : 'Select Collection'
               }}
             </span>
-            <ScalarIconCaretDown
-              class="text-c-3"
-              size="md" />
+            <ScalarIconCaretDown class="text-c-3 size-4" />
           </ScalarButton>
         </ScalarListbox>
       </div>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteImportCurl.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteImportCurl.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import {
   ScalarButton,
-  ScalarIcon,
   ScalarListbox,
   type ScalarComboboxOption,
 } from '@scalar/components'
+import { ScalarIconCaretDown } from '@scalar/icons'
 import type {
   RequestMethod,
   RequestPayload,
@@ -174,9 +174,8 @@ const wrapper = useTemplateRef('wrapper-ref')
                   : 'Select Collection'
               }}
             </span>
-            <ScalarIcon
+            <ScalarIconCaretDown
               class="text-c-3"
-              icon="ChevronDown"
               size="md" />
           </ScalarButton>
         </ScalarListbox>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
+import { ScalarButton, ScalarListbox } from '@scalar/components'
+import { ScalarIconCaretDown } from '@scalar/icons'
 import { useToasts } from '@scalar/use-toasts'
 import { emitCustomEvent } from '@scalar/workspace-store/events'
 import { computed, ref, useTemplateRef } from 'vue'
@@ -124,9 +125,8 @@ const wrapper = useTemplateRef('wrapper-ref')
           <span :class="selectedCollection ? 'text-c-1' : 'text-c-3'">{{
             selectedCollection ? selectedCollection.label : 'Select Collection'
           }}</span>
-          <ScalarIcon
+          <ScalarIconCaretDown
             class="text-c-3"
-            icon="ChevronDown"
             size="md" />
         </ScalarButton>
         <ScalarButton

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteServer.vue
@@ -125,9 +125,7 @@ const wrapper = useTemplateRef('wrapper-ref')
           <span :class="selectedCollection ? 'text-c-1' : 'text-c-3'">{{
             selectedCollection ? selectedCollection.label : 'Select Collection'
           }}</span>
-          <ScalarIconCaretDown
-            class="text-c-3"
-            size="md" />
+          <ScalarIconCaretDown class="text-c-3 size-4" />
         </ScalarButton>
         <ScalarButton
           v-else

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteTag.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteTag.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
+import { ScalarButton, ScalarListbox } from '@scalar/components'
+import { ScalarIconCaretDown } from '@scalar/icons'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref } from 'vue'
 
@@ -71,9 +72,8 @@ const handleSubmit = () => {
           <span :class="selectedCollection ? 'text-c-1' : 'text-c-3'">{{
             selectedCollection ? selectedCollection.label : 'Select Collection'
           }}</span>
-          <ScalarIcon
+          <ScalarIconCaretDown
             class="text-c-3"
-            icon="ChevronDown"
             size="md" />
         </ScalarButton>
       </ScalarListbox>

--- a/packages/api-client/src/components/CommandPalette/CommandPaletteTag.vue
+++ b/packages/api-client/src/components/CommandPalette/CommandPaletteTag.vue
@@ -72,9 +72,7 @@ const handleSubmit = () => {
           <span :class="selectedCollection ? 'text-c-1' : 'text-c-3'">{{
             selectedCollection ? selectedCollection.label : 'Select Collection'
           }}</span>
-          <ScalarIconCaretDown
-            class="text-c-3"
-            size="md" />
+          <ScalarIconCaretDown class="text-c-3 size-4" />
         </ScalarButton>
       </ScalarListbox>
     </template>

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -47,7 +47,7 @@ export type CommandPaletteEvent = {
 
 <script setup lang="ts">
 import { Dialog, DialogPanel, DialogTitle } from '@headlessui/vue'
-import { useModal } from '@scalar/components'
+import { ScalarIconLegacyAdapter, useModal } from '@scalar/components'
 import { ScalarIconCaretLeft, ScalarIconMagnifyingGlass } from '@scalar/icons'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
@@ -393,9 +393,9 @@ onBeforeUnmount(() => {
               'bg-b-2': command.name === selectedCommand?.name,
             }"
             @click="executeCommand(command)">
-            <component
-              :is="command.icon"
+            <ScalarIconLegacyAdapter
               class="text-c-2 mr-2.5"
+              :icon="command.icon"
               size="md"
               thickness="1.5" />
             {{ command.name }}

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -345,7 +345,7 @@ onBeforeUnmount(() => {
             <ScalarIconMagnifyingGlass
               class="text-c-2 mr-2.5"
               size="md"
-              thickness="1.5" />
+              weight="light" />
           </label>
           <input
             id="commandmenu"
@@ -397,7 +397,7 @@ onBeforeUnmount(() => {
               class="text-c-2 mr-2.5"
               :icon="command.icon"
               size="md"
-              thickness="1.5" />
+              weight="light" />
             {{ command.name }}
           </div>
         </template>
@@ -417,7 +417,7 @@ onBeforeUnmount(() => {
           @click="activeCommand = null">
           <ScalarIconCaretLeft
             size="md"
-            thickness="1.5" />
+            weight="light" />
         </button>
         <component
           :is="PaletteComponents[activeCommand]"

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -343,8 +343,7 @@ onBeforeUnmount(() => {
           class="bg-b-2 focus-within:bg-b-1 sticky top-0 flex items-center rounded-md border border-transparent pl-2 shadow-[0_-8px_0_8px_var(--scalar-background-1),0_0_8px_8px_var(--scalar-background-1)] focus-within:border-(--scalar-background-3)">
           <label for="commandmenu">
             <ScalarIconMagnifyingGlass
-              class="text-c-2 mr-2.5"
-              size="md"
+              class="text-c-2 mr-2.5 size-4"
               weight="light" />
           </label>
           <input
@@ -416,7 +415,7 @@ onBeforeUnmount(() => {
           type="button"
           @click="activeCommand = null">
           <ScalarIconCaretLeft
-            size="md"
+            class="size-4"
             weight="light" />
         </button>
         <component

--- a/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
+++ b/packages/api-client/src/components/CommandPalette/TheCommandPalette.vue
@@ -47,7 +47,8 @@ export type CommandPaletteEvent = {
 
 <script setup lang="ts">
 import { Dialog, DialogPanel, DialogTitle } from '@headlessui/vue'
-import { ScalarIcon, useModal } from '@scalar/components'
+import { useModal } from '@scalar/components'
+import { ScalarIconCaretLeft, ScalarIconMagnifyingGlass } from '@scalar/icons'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
@@ -341,9 +342,8 @@ onBeforeUnmount(() => {
         <div
           class="bg-b-2 focus-within:bg-b-1 sticky top-0 flex items-center rounded-md border border-transparent pl-2 shadow-[0_-8px_0_8px_var(--scalar-background-1),0_0_8px_8px_var(--scalar-background-1)] focus-within:border-(--scalar-background-3)">
           <label for="commandmenu">
-            <ScalarIcon
+            <ScalarIconMagnifyingGlass
               class="text-c-2 mr-2.5"
-              icon="Search"
               size="md"
               thickness="1.5" />
           </label>
@@ -393,9 +393,9 @@ onBeforeUnmount(() => {
               'bg-b-2': command.name === selectedCommand?.name,
             }"
             @click="executeCommand(command)">
-            <ScalarIcon
+            <component
+              :is="command.icon"
               class="text-c-2 mr-2.5"
-              :icon="command.icon"
               size="md"
               thickness="1.5" />
             {{ command.name }}
@@ -415,8 +415,7 @@ onBeforeUnmount(() => {
           class="hover:bg-b-3 text-c-3 active:text-c-1 absolute z-1 mt-[0.5px] rounded p-1.5"
           type="button"
           @click="activeCommand = null">
-          <ScalarIcon
-            icon="ChevronLeft"
+          <ScalarIconCaretLeft
             size="md"
             thickness="1.5" />
         </button>

--- a/packages/api-client/src/components/CommandPalette/WatchModeToggle.vue
+++ b/packages/api-client/src/components/CommandPalette/WatchModeToggle.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarIcon, ScalarToggle } from '@scalar/components'
+import { ScalarToggle } from '@scalar/components'
+import { ScalarIconEye } from '@scalar/icons'
 import { computed } from 'vue'
 
 const props = withDefaults(
@@ -30,9 +31,7 @@ const modelValue = computed({
     <span
       class="text-c-1 flex items-center gap-1 text-xs font-medium"
       :class="{ 'text-c-3': !modelValue }">
-      <ScalarIcon
-        icon="Watch"
-        size="sm" />
+      <ScalarIconEye size="sm" />
       Watch Mode
     </span>
     <ScalarToggle

--- a/packages/api-client/src/components/CommandPalette/WatchModeToggle.vue
+++ b/packages/api-client/src/components/CommandPalette/WatchModeToggle.vue
@@ -31,7 +31,7 @@ const modelValue = computed({
     <span
       class="text-c-1 flex items-center gap-1 text-xs font-medium"
       :class="{ 'text-c-3': !modelValue }">
-      <ScalarIconEye size="sm" />
+      <ScalarIconEye class="size-3.5" />
       Watch Mode
     </span>
     <ScalarToggle

--- a/packages/api-client/src/components/DataTable/DataTableCheckbox.vue
+++ b/packages/api-client/src/components/DataTable/DataTableCheckbox.vue
@@ -46,7 +46,7 @@ const variants = cva({
         " />
       <ScalarIconCheck
         size="xs"
-        thickness="2.5" />
+        weight="bold" />
     </div>
   </DataTableCell>
 </template>

--- a/packages/api-client/src/components/DataTable/DataTableCheckbox.vue
+++ b/packages/api-client/src/components/DataTable/DataTableCheckbox.vue
@@ -45,7 +45,7 @@ const variants = cva({
           'group-has-[:focus-visible]/cell:border-c-accent group-hover/cell:opacity-100 group-has-[:focus-visible]/cell:opacity-100'
         " />
       <ScalarIconCheck
-        size="xs"
+        class="size-3"
         weight="bold" />
     </div>
   </DataTableCell>

--- a/packages/api-client/src/components/DataTable/DataTableCheckbox.vue
+++ b/packages/api-client/src/components/DataTable/DataTableCheckbox.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { cva, ScalarIcon } from '@scalar/components'
+import { cva } from '@scalar/components'
+import { ScalarIconCheck } from '@scalar/icons'
 
 import DataTableCell from './DataTableCell.vue'
 
@@ -43,8 +44,7 @@ const variants = cva({
           !disabled &&
           'group-has-[:focus-visible]/cell:border-c-accent group-hover/cell:opacity-100 group-has-[:focus-visible]/cell:opacity-100'
         " />
-      <ScalarIcon
-        icon="Checkmark"
+      <ScalarIconCheck
         size="xs"
         thickness="2.5" />
     </div>

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -108,9 +108,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
               ? selectedArrayOptions.map((option) => option.label).join(', ')
               : 'Select a value'
           }}</span>
-          <ScalarIconCaretDown
-            class="min-w-4"
-            size="md" />
+          <ScalarIconCaretDown class="size-4 min-w-4" />
         </ScalarButton>
       </ScalarComboboxMultiselect>
     </template>
@@ -134,7 +132,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
           <span class="text-c-1 overflow-hidden text-ellipsis">{{
             initialValue || 'Select a value'
           }}</span>
-          <ScalarIconCaretDown size="md" />
+          <ScalarIconCaretDown class="size-4" />
         </ScalarButton>
         <template #items>
           <ScalarDropdownItem
@@ -162,7 +160,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
               class="flex items-center gap-1.5"
               @click="addingCustomValue = true">
               <div class="flex h-4 w-4 items-center justify-center">
-                <ScalarIconPlus size="sm" />
+                <ScalarIconPlus class="size-3.5" />
               </div>
               <span>Add value</span>
             </ScalarDropdownItem>

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -152,7 +152,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
               ">
               <ScalarIconCheck
                 class="size-2.5"
-                thickness="3" />
+                weight="bold" />
             </div>
             <span class="overflow-hidden text-ellipsis">{{ option }}</span>
           </ScalarDropdownItem>

--- a/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
+++ b/packages/api-client/src/components/DataTable/DataTableInputSelect.vue
@@ -5,8 +5,12 @@ import {
   ScalarDropdown,
   ScalarDropdownDivider,
   ScalarDropdownItem,
-  ScalarIcon,
 } from '@scalar/components'
+import {
+  ScalarIconCaretDown,
+  ScalarIconCheck,
+  ScalarIconPlus,
+} from '@scalar/icons'
 import { computed, nextTick, ref, watch } from 'vue'
 
 const props = withDefaults(
@@ -104,10 +108,9 @@ const updateSelectedOptions = (selectedOptions: any) => {
               ? selectedArrayOptions.map((option) => option.label).join(', ')
               : 'Select a value'
           }}</span>
-          <ScalarIcon
-            icon="ChevronDown"
-            size="md"
-            class="min-w-4" />
+          <ScalarIconCaretDown
+            class="min-w-4"
+            size="md" />
         </ScalarButton>
       </ScalarComboboxMultiselect>
     </template>
@@ -131,9 +134,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
           <span class="text-c-1 overflow-hidden text-ellipsis">{{
             initialValue || 'Select a value'
           }}</span>
-          <ScalarIcon
-            icon="ChevronDown"
-            size="md" />
+          <ScalarIconCaretDown size="md" />
         </ScalarButton>
         <template #items>
           <ScalarDropdownItem
@@ -149,9 +150,8 @@ const updateSelectedOptions = (selectedOptions: any) => {
                   ? 'bg-c-accent text-b-1'
                   : 'shadow-border text-transparent'
               ">
-              <ScalarIcon
+              <ScalarIconCheck
                 class="size-2.5"
-                icon="Checkmark"
                 thickness="3" />
             </div>
             <span class="overflow-hidden text-ellipsis">{{ option }}</span>
@@ -162,9 +162,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
               class="flex items-center gap-1.5"
               @click="addingCustomValue = true">
               <div class="flex h-4 w-4 items-center justify-center">
-                <ScalarIcon
-                  icon="Add"
-                  size="sm" />
+                <ScalarIconPlus size="sm" />
               </div>
               <span>Add value</span>
             </ScalarDropdownItem>

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -144,7 +144,7 @@ onMounted(() => {
         class="flex items-center gap-1.5"
         @click="redirectToEnvironments">
         <div class="flex h-4 w-4 items-center justify-center">
-          <ScalarIconBracketsCurly size="sm" />
+          <ScalarIconBracketsCurly class="size-3.5" />
         </div>
         <span class="leading-none">Manage Environments</span>
       </ScalarDropdownItem>

--- a/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
+++ b/packages/api-client/src/components/EnvironmentSelector/EnvironmentSelector.vue
@@ -4,9 +4,9 @@ import {
   ScalarDropdown,
   ScalarDropdownDivider,
   ScalarDropdownItem,
-  ScalarIcon,
   ScalarListboxCheckbox,
 } from '@scalar/components'
+import { ScalarIconBracketsCurly } from '@scalar/icons'
 import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
@@ -144,9 +144,7 @@ onMounted(() => {
         class="flex items-center gap-1.5"
         @click="redirectToEnvironments">
         <div class="flex h-4 w-4 items-center justify-center">
-          <ScalarIcon
-            icon="Brackets"
-            size="sm" />
+          <ScalarIconBracketsCurly size="sm" />
         </div>
         <span class="leading-none">Manage Environments</span>
       </ScalarDropdownItem>

--- a/packages/api-client/src/components/Form/Form.vue
+++ b/packages/api-client/src/components/Form/Form.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconMarkdownLogo } from '@scalar/icons'
 import type { Cookie } from '@scalar/oas-utils/entities/cookie'
 import type { Path, PathValue } from '@scalar/object-utils/nested'
 import { useId } from 'vue'
@@ -41,18 +41,18 @@ const id = useId()
     <div class="flex flex-1 flex-col gap-1.5">
       <DataTable
         v-if="Object.keys(data).length > 0 && activeWorkspace"
-        :columns="['']"
-        class="rounded-b-lg">
+        class="rounded-b-lg"
+        :columns="['']">
         <DataTableRow
           v-for="(option, index) in options"
           :key="index"
           :class="{ 'border-t': index === 0 }">
           <DataTableInput
-            class="pr-9"
-            lineWrapping
             :id="id"
+            class="pr-9"
             :envVariables="activeEnvVariables"
             :environment="activeEnvironment"
+            lineWrapping
             :modelValue="data[option.key] ?? ''"
             :placeholder="option.placeholder"
             :workspace="activeWorkspace"
@@ -67,9 +67,7 @@ const id = useId()
               #icon>
               <div
                 class="centered-y bg-b-2 flex-center absolute right-1 z-1 rounded px-1 py-0.5">
-                <ScalarIcon
-                  icon="Markdown"
-                  size="lg" />
+                <ScalarIconMarkdownLogo size="lg" />
               </div>
             </template>
           </DataTableInput>

--- a/packages/api-client/src/components/Form/Form.vue
+++ b/packages/api-client/src/components/Form/Form.vue
@@ -67,7 +67,7 @@ const id = useId()
               #icon>
               <div
                 class="centered-y bg-b-2 flex-center absolute right-1 z-1 rounded px-1 py-0.5">
-                <ScalarIconMarkdownLogo size="lg" />
+                <ScalarIconMarkdownLogo class="size-5" />
               </div>
             </template>
           </DataTableInput>

--- a/packages/api-client/src/components/ImportCollection/DropEventListener.vue
+++ b/packages/api-client/src/components/ImportCollection/DropEventListener.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconDownload } from '@scalar/icons'
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 
 const emit = defineEmits<{
@@ -119,8 +119,7 @@ function handleDragEnter(event: DragEvent) {
       class="bg-b-2 fixed right-1/2 bottom-1/2 z-50 h-64 w-64 translate-x-1/2 translate-y-1/2 rounded-xl border transition-opacity duration-200 md:right-10 md:bottom-10 md:translate-x-0 md:translate-y-0">
       <div class="flex h-full flex-col items-center justify-center">
         <div>
-          <ScalarIcon
-            icon="Download"
+          <ScalarIconDownload
             size="xl"
             thickness="2" />
         </div>

--- a/packages/api-client/src/components/ImportCollection/DropEventListener.vue
+++ b/packages/api-client/src/components/ImportCollection/DropEventListener.vue
@@ -121,7 +121,7 @@ function handleDragEnter(event: DragEvent) {
         <div>
           <ScalarIconDownload
             size="xl"
-            thickness="2" />
+            weight="regular" />
         </div>
         <div class="text-c-1 m-4 text-center">
           Drop your OpenAPI document here

--- a/packages/api-client/src/components/ImportCollection/DropEventListener.vue
+++ b/packages/api-client/src/components/ImportCollection/DropEventListener.vue
@@ -120,7 +120,7 @@ function handleDragEnter(event: DragEvent) {
       <div class="flex h-full flex-col items-center justify-center">
         <div>
           <ScalarIconDownload
-            size="xl"
+            class="size-6"
             weight="regular" />
         </div>
         <div class="text-c-1 m-4 text-center">

--- a/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
+++ b/packages/api-client/src/components/ImportCollection/ImportCollectionModal.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
-import { ScalarIcon, ScalarModal, useModal } from '@scalar/components'
+import {
+  ScalarIconLegacyAdapter,
+  ScalarModal,
+  useModal,
+} from '@scalar/components'
 import { isLocalUrl } from '@scalar/oas-utils/helpers'
 import { normalize } from '@scalar/openapi-parser'
 import type { OpenAPI } from '@scalar/openapi-types'
@@ -323,7 +327,7 @@ function handleImportFinished() {
             <a
               href="https://scalar.com/download"
               target="_blank">
-              <ScalarIcon
+              <ScalarIconLegacyAdapter
                 icon="Logo"
                 size="xl" />
             </a>

--- a/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
+++ b/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
@@ -73,7 +73,7 @@ const handleCreateWorkspace = () => {
           <h2 class="line-clamp-1 w-[calc(100%-10px)] text-left text-xs">
             {{ activeWorkspace?.name }}
           </h2>
-          <ScalarIconCaretDown size="md" />
+          <ScalarIconCaretDown class="size-4" />
         </div>
       </ScalarButton>
 
@@ -106,7 +106,7 @@ const handleCreateWorkspace = () => {
           class="flex items-center gap-1.5"
           @click="modal.show()">
           <div class="flex h-4 w-4 items-center justify-center">
-            <ScalarIconPlus size="sm" />
+            <ScalarIconPlus class="size-3.5" />
           </div>
           <span>New Workspace</span>
         </ScalarDropdownItem>

--- a/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
+++ b/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
@@ -4,10 +4,14 @@ import {
   ScalarDropdown,
   ScalarDropdownDivider,
   ScalarDropdownItem,
-  ScalarIcon,
   ScalarModal,
   useModal,
 } from '@scalar/components'
+import {
+  ScalarIconCaretDown,
+  ScalarIconCheck,
+  ScalarIconPlus,
+} from '@scalar/icons'
 import { useToasts } from '@scalar/use-toasts'
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
@@ -69,9 +73,7 @@ const handleCreateWorkspace = () => {
           <h2 class="line-clamp-1 w-[calc(100%-10px)] text-left text-xs">
             {{ activeWorkspace?.name }}
           </h2>
-          <ScalarIcon
-            icon="ChevronDown"
-            size="md" />
+          <ScalarIconCaretDown size="md" />
         </div>
       </ScalarButton>
 
@@ -89,9 +91,8 @@ const handleCreateWorkspace = () => {
                 ? 'bg-c-accent text-b-1'
                 : 'shadow-border text-transparent'
             ">
-            <ScalarIcon
+            <ScalarIconCheck
               class="size-2.5"
-              icon="Checkmark"
               thickness="3" />
           </div>
           <span class="overflow-hidden text-ellipsis">{{
@@ -105,9 +106,7 @@ const handleCreateWorkspace = () => {
           class="flex items-center gap-1.5"
           @click="modal.show()">
           <div class="flex h-4 w-4 items-center justify-center">
-            <ScalarIcon
-              icon="Add"
-              size="sm" />
+            <ScalarIconPlus size="sm" />
           </div>
           <span>New Workspace</span>
         </ScalarDropdownItem>

--- a/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
+++ b/packages/api-client/src/components/ImportCollection/WorkspaceSelector.vue
@@ -93,7 +93,7 @@ const handleCreateWorkspace = () => {
             ">
             <ScalarIconCheck
               class="size-2.5"
-              thickness="3" />
+              weight="bold" />
           </div>
           <span class="overflow-hidden text-ellipsis">{{
             workspace.name

--- a/packages/api-client/src/components/OpenApiClientButton.vue
+++ b/packages/api-client/src/components/OpenApiClientButton.vue
@@ -80,7 +80,7 @@ const href = computed((): string | undefined => {
     :href="href"
     target="_blank">
     <ScalarIconArrowSquareOut
-      size="xs"
+      class="size-3"
       weight="regular" />
     Open API Client
   </a>

--- a/packages/api-client/src/components/OpenApiClientButton.vue
+++ b/packages/api-client/src/components/OpenApiClientButton.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconArrowSquareOut } from '@scalar/icons'
 import { makeUrlAbsolute } from '@scalar/oas-utils/helpers'
 import { computed } from 'vue'
 
@@ -79,8 +79,7 @@ const href = computed((): string | undefined => {
     class="open-api-client-button"
     :href="href"
     target="_blank">
-    <ScalarIcon
-      icon="ExternalLink"
+    <ScalarIconArrowSquareOut
       size="xs"
       thickness="2" />
     Open API Client

--- a/packages/api-client/src/components/OpenApiClientButton.vue
+++ b/packages/api-client/src/components/OpenApiClientButton.vue
@@ -81,7 +81,7 @@ const href = computed((): string | undefined => {
     target="_blank">
     <ScalarIconArrowSquareOut
       size="xs"
-      thickness="2" />
+      weight="regular" />
     Open API Client
   </a>
 </template>

--- a/packages/api-client/src/components/SectionFilter.vue
+++ b/packages/api-client/src/components/SectionFilter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts" generic="T extends string">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconFunnel } from '@scalar/icons'
 import { nextTick, ref } from 'vue'
 
 import SectionFilterButton from '@/components/SectionFilterButton.vue'
@@ -58,8 +58,7 @@ const navigateSection = (direction: 'next' | 'prev') => {
       <div
         class="filter-button context-bar-group-hover:text-c-1 absolute -right-[30px] flex items-center">
         <span class="context-bar-group-hover:hidden mr-1.5">{{ model }}</span>
-        <ScalarIcon
-          icon="FilterList"
+        <ScalarIconFunnel
           size="md"
           thickness="2" />
       </div>

--- a/packages/api-client/src/components/SectionFilter.vue
+++ b/packages/api-client/src/components/SectionFilter.vue
@@ -59,7 +59,7 @@ const navigateSection = (direction: 'next' | 'prev') => {
         class="filter-button context-bar-group-hover:text-c-1 absolute -right-[30px] flex items-center">
         <span class="context-bar-group-hover:hidden mr-1.5">{{ model }}</span>
         <ScalarIconFunnel
-          size="md"
+          class="size-4"
           weight="regular" />
       </div>
     </div>

--- a/packages/api-client/src/components/SectionFilter.vue
+++ b/packages/api-client/src/components/SectionFilter.vue
@@ -60,7 +60,7 @@ const navigateSection = (direction: 'next' | 'prev') => {
         <span class="context-bar-group-hover:hidden mr-1.5">{{ model }}</span>
         <ScalarIconFunnel
           size="md"
-          thickness="2" />
+          weight="regular" />
       </div>
     </div>
   </div>

--- a/packages/api-client/src/components/Server/ServerDropdown.vue
+++ b/packages/api-client/src/components/Server/ServerDropdown.vue
@@ -3,9 +3,9 @@ import {
   ScalarButton,
   ScalarDropdownDivider,
   ScalarFloatingBackdrop,
-  ScalarIcon,
   ScalarPopover,
 } from '@scalar/components'
+import { ScalarIconPlus } from '@scalar/icons'
 import type {
   Collection,
   Request as Operation,
@@ -123,9 +123,7 @@ const wrapper = useTemplateRef('wrapper-ref')
       </template>
       <template v-else>
         <span class="sr-only">Add Server</span>
-        <ScalarIcon
-          icon="Add"
-          size="xs" />
+        <ScalarIconPlus size="xs" />
       </template>
     </ScalarButton>
     <template #popover="{ close }">
@@ -163,9 +161,7 @@ const wrapper = useTemplateRef('wrapper-ref')
             type="button"
             @click="handleAddServer">
             <div class="flex h-4 w-4 items-center justify-center">
-              <ScalarIcon
-                icon="Add"
-                size="sm" />
+              <ScalarIconPlus size="sm" />
             </div>
             <span>Add Server</span>
           </button>

--- a/packages/api-client/src/components/Server/ServerDropdown.vue
+++ b/packages/api-client/src/components/Server/ServerDropdown.vue
@@ -123,7 +123,7 @@ const wrapper = useTemplateRef('wrapper-ref')
       </template>
       <template v-else>
         <span class="sr-only">Add Server</span>
-        <ScalarIconPlus size="xs" />
+        <ScalarIconPlus class="size-3" />
       </template>
     </ScalarButton>
     <template #popover="{ close }">
@@ -161,7 +161,7 @@ const wrapper = useTemplateRef('wrapper-ref')
             type="button"
             @click="handleAddServer">
             <div class="flex h-4 w-4 items-center justify-center">
-              <ScalarIconPlus size="sm" />
+              <ScalarIconPlus class="size-3.5" />
             </div>
             <span>Add Server</span>
           </button>

--- a/packages/api-client/src/components/SideNav/DownloadAppButton.vue
+++ b/packages/api-client/src/components/SideNav/DownloadAppButton.vue
@@ -14,7 +14,7 @@ const { layout } = useLayout()
     <template #icon>
       <ScalarIconDownload
         size="sm"
-        thickness="2" />
+        weight="regular" />
     </template>
     <span
       class="sr-only text-sm font-medium"

--- a/packages/api-client/src/components/SideNav/DownloadAppButton.vue
+++ b/packages/api-client/src/components/SideNav/DownloadAppButton.vue
@@ -13,7 +13,7 @@ const { layout } = useLayout()
     target="_blank">
     <template #icon>
       <ScalarIconDownload
-        size="sm"
+        class="size-3.5"
         weight="regular" />
     </template>
     <span

--- a/packages/api-client/src/components/SideNav/DownloadAppButton.vue
+++ b/packages/api-client/src/components/SideNav/DownloadAppButton.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconDownload } from '@scalar/icons'
 
 import SideNavLink from '@/components/SideNav/SideNavLink.vue'
 import { useLayout } from '@/hooks'
@@ -10,11 +10,9 @@ const { layout } = useLayout()
   <SideNavLink
     class="download-app-button gap-2 !px-3 !py-1.5 sm:px-3"
     href="https://scalar.com/download?utm_source=web_client&utm_medium=download_button&utm_campaign=topnav"
-    icon="Download"
     target="_blank">
     <template #icon>
-      <ScalarIcon
-        icon="Download"
+      <ScalarIconDownload
         size="sm"
         thickness="2" />
     </template>

--- a/packages/api-client/src/components/SideNav/SideHelp.vue
+++ b/packages/api-client/src/components/SideNav/SideHelp.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
+import { ScalarDropdown, ScalarDropdownItem } from '@scalar/components'
 import {
-  ScalarDropdown,
-  ScalarDropdownItem,
-  ScalarIcon,
-} from '@scalar/components'
+  ScalarIconDiscordLogo,
+  ScalarIconEnvelope,
+  ScalarIconGithubLogo,
+  ScalarIconMapTrifold,
+  ScalarIconNote,
+  ScalarIconQuestion,
+} from '@scalar/icons'
 
 import SideNavLink from './SideNavLink.vue'
 </script>
@@ -13,7 +17,7 @@ import SideNavLink from './SideNavLink.vue'
     :placement="'top-end'">
     <SideNavLink
       is="button"
-      icon="Help"
+      :icon="ScalarIconQuestion"
       type="button">
       About
     </SideNavLink>
@@ -27,8 +31,7 @@ import SideNavLink from './SideNavLink.vue'
         target="_blank">
         <ScalarDropdownItem class="flex w-full items-center gap-1.5">
           <div class="flex items-center justify-center">
-            <ScalarIcon
-              icon="Discord"
+            <ScalarIconDiscordLogo
               size="xs"
               thickness="1.75" />
           </div>
@@ -41,8 +44,7 @@ import SideNavLink from './SideNavLink.vue'
         target="_blank">
         <ScalarDropdownItem class="flex w-full items-center gap-1.5">
           <div class="flex items-center justify-center">
-            <ScalarIcon
-              icon="GitHubLine"
+            <ScalarIconGithubLogo
               size="xs"
               thickness="1.75" />
           </div>
@@ -55,9 +57,7 @@ import SideNavLink from './SideNavLink.vue'
         target="_blank">
         <ScalarDropdownItem class="flex w-full items-center gap-1.5">
           <div class="flex items-center justify-center">
-            <ScalarIcon
-              icon="Email"
-              size="xs" />
+            <ScalarIconEnvelope size="xs" />
           </div>
           <span>Email</span>
         </ScalarDropdownItem>
@@ -69,8 +69,7 @@ import SideNavLink from './SideNavLink.vue'
         target="_blank">
         <ScalarDropdownItem class="flex w-full items-center gap-1.5">
           <div class="flex items-center justify-center">
-            <ScalarIcon
-              icon="Changelog"
+            <ScalarIconNote
               size="xs"
               thickness="1.75" />
           </div>
@@ -83,8 +82,7 @@ import SideNavLink from './SideNavLink.vue'
         target="_blank">
         <ScalarDropdownItem class="flex w-full items-center gap-1.5">
           <div class="flex items-center justify-center">
-            <ScalarIcon
-              icon="Roadmap"
+            <ScalarIconMapTrifold
               size="xs"
               thickness="1.75" />
           </div>

--- a/packages/api-client/src/components/SideNav/SideHelp.vue
+++ b/packages/api-client/src/components/SideNav/SideHelp.vue
@@ -32,7 +32,7 @@ import SideNavLink from './SideNavLink.vue'
         <ScalarDropdownItem class="flex w-full items-center gap-1.5">
           <div class="flex items-center justify-center">
             <ScalarIconDiscordLogo
-              size="xs"
+              class="size-3"
               weight="light" />
           </div>
           <span>Discord</span>
@@ -45,7 +45,7 @@ import SideNavLink from './SideNavLink.vue'
         <ScalarDropdownItem class="flex w-full items-center gap-1.5">
           <div class="flex items-center justify-center">
             <ScalarIconGithubLogo
-              size="xs"
+              class="size-3"
               weight="light" />
           </div>
           <span>GitHub</span>
@@ -57,7 +57,7 @@ import SideNavLink from './SideNavLink.vue'
         target="_blank">
         <ScalarDropdownItem class="flex w-full items-center gap-1.5">
           <div class="flex items-center justify-center">
-            <ScalarIconEnvelope size="xs" />
+            <ScalarIconEnvelope class="size-3" />
           </div>
           <span>Email</span>
         </ScalarDropdownItem>
@@ -70,7 +70,7 @@ import SideNavLink from './SideNavLink.vue'
         <ScalarDropdownItem class="flex w-full items-center gap-1.5">
           <div class="flex items-center justify-center">
             <ScalarIconNote
-              size="xs"
+              class="size-3"
               weight="light" />
           </div>
           <span>Changelog</span>
@@ -83,7 +83,7 @@ import SideNavLink from './SideNavLink.vue'
         <ScalarDropdownItem class="flex w-full items-center gap-1.5">
           <div class="flex items-center justify-center">
             <ScalarIconMapTrifold
-              size="xs"
+              class="size-3"
               weight="light" />
           </div>
           <span>Roadmap</span>

--- a/packages/api-client/src/components/SideNav/SideHelp.vue
+++ b/packages/api-client/src/components/SideNav/SideHelp.vue
@@ -33,7 +33,7 @@ import SideNavLink from './SideNavLink.vue'
           <div class="flex items-center justify-center">
             <ScalarIconDiscordLogo
               size="xs"
-              thickness="1.75" />
+              weight="light" />
           </div>
           <span>Discord</span>
         </ScalarDropdownItem>
@@ -46,7 +46,7 @@ import SideNavLink from './SideNavLink.vue'
           <div class="flex items-center justify-center">
             <ScalarIconGithubLogo
               size="xs"
-              thickness="1.75" />
+              weight="light" />
           </div>
           <span>GitHub</span>
         </ScalarDropdownItem>
@@ -71,7 +71,7 @@ import SideNavLink from './SideNavLink.vue'
           <div class="flex items-center justify-center">
             <ScalarIconNote
               size="xs"
-              thickness="1.75" />
+              weight="light" />
           </div>
           <span>Changelog</span>
         </ScalarDropdownItem>
@@ -84,7 +84,7 @@ import SideNavLink from './SideNavLink.vue'
           <div class="flex items-center justify-center">
             <ScalarIconMapTrifold
               size="xs"
-              thickness="1.75" />
+              weight="light" />
           </div>
           <span>Roadmap</span>
         </ScalarDropdownItem>

--- a/packages/api-client/src/components/SideNav/SideNav.vue
+++ b/packages/api-client/src/components/SideNav/SideNav.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconLegacyAdapter } from '@scalar/components'
 import { ScalarIconGear } from '@scalar/icons'
 import { useRouter } from 'vue-router'
 
@@ -34,7 +34,7 @@ const { activeWorkspace } = useActiveEntities()
         }"
         href="https://www.scalar.com"
         target="_blank">
-        <ScalarIcon
+        <ScalarIconLegacyAdapter
           icon="Logo"
           size="xl" />
       </a>

--- a/packages/api-client/src/components/SideNav/SideNav.vue
+++ b/packages/api-client/src/components/SideNav/SideNav.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ScalarIcon } from '@scalar/components'
+import { ScalarIconGear } from '@scalar/icons'
 import { useRouter } from 'vue-router'
 
 import { ROUTES } from '@/constants'
@@ -67,7 +68,7 @@ const { activeWorkspace } = useActiveEntities()
       <li class="flex items-center">
         <SideNavRouterLink
           :active="currentRoute.name === 'settings'"
-          icon="Settings"
+          :icon="ScalarIconGear"
           :to="{
             name: `settings.default`,
             params: {

--- a/packages/api-client/src/components/SideNav/SideNavLink.vue
+++ b/packages/api-client/src/components/SideNav/SideNavLink.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { ScalarIcon, type Icon } from '@scalar/components'
 import type { Component } from 'vue'
 
 import { useLayout } from '@/hooks'
@@ -7,7 +6,7 @@ import { useLayout } from '@/hooks'
 defineProps<{
   is?: Component | string
   active?: boolean
-  icon: Icon
+  icon?: Component
 }>()
 
 const { layout } = useLayout()
@@ -22,9 +21,9 @@ const { layout } = useLayout()
       'sm:max-w-max sm:min-w-max sm:rounded sm:py-1.5': layout === 'web',
     }">
     <slot name="icon">
-      <ScalarIcon
+      <component
+        :is="icon"
         :class="layout === 'web' ? 'sm:hidden' : ''"
-        :icon="icon"
         thickness="1.5" />
     </slot>
     <span

--- a/packages/api-client/src/components/SideNav/SideNavLink.vue
+++ b/packages/api-client/src/components/SideNav/SideNavLink.vue
@@ -24,7 +24,7 @@ const { layout } = useLayout()
       <component
         :is="icon"
         :class="layout === 'web' ? 'sm:hidden' : ''"
-        thickness="1.5" />
+        weight="light" />
     </slot>
     <span
       class="sr-only text-sm font-medium"

--- a/packages/api-client/src/components/SideNav/SideNavRouterLink.vue
+++ b/packages/api-client/src/components/SideNav/SideNavRouterLink.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import type { Icon } from '@scalar/components'
+import type { Component } from 'vue'
 import { RouterLink, type RouteLocationRaw } from 'vue-router'
 
 import SideNavLink from '@/components/SideNav/SideNavLink.vue'
 
 defineProps<{
-  icon: Icon
+  icon?: Component
   to: RouteLocationRaw
   active?: boolean
 }>()

--- a/packages/api-client/src/components/Sidebar/SidebarListElement.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElement.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIcon, type Icon } from '@scalar/components'
+import { ScalarIconLegacyAdapter, type Icon } from '@scalar/components'
 import {
   Draggable,
   type DraggableProps,
@@ -113,7 +113,7 @@ const getDraggableOffsets = computed(() => ({
             class="h-2.5 w-2.5 rounded-xl"
             :style="{ backgroundColor: variable.color }"></div>
         </button>
-        <ScalarIcon
+        <ScalarIconLegacyAdapter
           v-if="variable.icon"
           class="text-sidebar-c-2 size-3.5 stroke-[2.25]"
           :icon="variable.icon" />

--- a/packages/api-client/src/components/Sidebar/SidebarListElementActions.vue
+++ b/packages/api-client/src/components/Sidebar/SidebarListElementActions.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import { ScalarIcon, ScalarModal, useModal } from '@scalar/components'
+import { ScalarModal, useModal } from '@scalar/components'
+import {
+  ScalarIconClipboard,
+  ScalarIconPencil,
+  ScalarIconX,
+} from '@scalar/icons'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { ref } from 'vue'
 
@@ -54,27 +59,21 @@ function handleDelete(id: string) {
       class="text-c-3 hover:bg-b-3 hover:text-c-1 rounded p-[5px]"
       type="button"
       @click="copyToClipboard(variable.name)">
-      <ScalarIcon
-        class="h-3 w-3"
-        icon="Clipboard" />
+      <ScalarIconClipboard class="h-3 w-3" />
     </button>
     <button
       v-if="isRenameable"
       class="text-c-3 hover:bg-b-3 hover:text-c-1 rounded p-[5px]"
       type="button"
       @click="emit('rename', variable.uid)">
-      <ScalarIcon
-        class="h-3 w-3"
-        icon="Edit" />
+      <ScalarIconPencil class="h-3 w-3" />
     </button>
     <button
       v-if="!variable.isDefault && isDeletable"
       class="text-c-3 hover:bg-b-3 hover:text-c-1 rounded p-1"
       type="button"
       @click.prevent="startActionFlow(ModalAction.Delete)">
-      <ScalarIcon
-        class="h-3.5 w-3.5"
-        icon="Close" />
+      <ScalarIconX class="h-3.5 w-3.5" />
     </button>
   </div>
   <ScalarModal

--- a/packages/api-client/src/components/TopNav/TopNav.vue
+++ b/packages/api-client/src/components/TopNav/TopNav.vue
@@ -245,7 +245,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                     : {}
                 "
                 size="xs"
-                thickness="2.5" />
+                weight="bold" />
               <span>{{ topNavItems[0]?.label }}</span>
             </template>
             <template #content>
@@ -257,7 +257,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                       @click="addNavItem">
                       <ScalarIconPlus
                         size="sm"
-                        thickness="1.5" />
+                        weight="light" />
                       New Tab
                       <ScalarHotkey
                         class="bg-b-2 ml-auto"
@@ -268,7 +268,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                       @click="copyUrl(activeNavItemIdxValue)">
                       <ScalarIconLink
                         size="sm"
-                        thickness="1.5" />
+                        weight="light" />
                       Copy URL
                     </ScalarDropdownButton>
                   </ScalarDropdownMenu>
@@ -303,7 +303,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
         @click="addNavItem">
         <ScalarIconPlus
           size="sm"
-          thickness="2.5" />
+          weight="bold" />
       </button>
     </div>
   </nav>

--- a/packages/api-client/src/components/TopNav/TopNav.vue
+++ b/packages/api-client/src/components/TopNav/TopNav.vue
@@ -5,7 +5,7 @@ import {
   ScalarDropdownMenu,
   ScalarFloating,
   ScalarHotkey,
-  ScalarIcon,
+  ScalarIconLegacyAdapter,
   type Icon,
 } from '@scalar/components'
 import { ScalarIconLink, ScalarIconPlus } from '@scalar/icons'
@@ -235,7 +235,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
               <component
                 :is="
                   typeof topNavItems[0]?.icon === 'string'
-                    ? ScalarIcon
+                    ? ScalarIconLegacyAdapter
                     : topNavItems[0]?.icon
                 "
                 v-else-if="topNavItems[0]?.icon"

--- a/packages/api-client/src/components/TopNav/TopNav.vue
+++ b/packages/api-client/src/components/TopNav/TopNav.vue
@@ -241,10 +241,9 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                 v-else-if="topNavItems[0]?.icon"
                 v-bind="
                   typeof topNavItems[0]?.icon === 'string'
-                    ? { icon: topNavItems[0]?.icon as Icon }
-                    : {}
+                    ? { icon: topNavItems[0]?.icon as Icon, size: 'xs' }
+                    : { class: 'size-3' }
                 "
-                size="xs"
                 weight="bold" />
               <span>{{ topNavItems[0]?.label }}</span>
             </template>
@@ -256,7 +255,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                       class="flex items-center gap-1.5"
                       @click="addNavItem">
                       <ScalarIconPlus
-                        size="sm"
+                        class="size-3.5"
                         weight="light" />
                       New Tab
                       <ScalarHotkey
@@ -267,7 +266,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                       class="flex items-center gap-1.5"
                       @click="copyUrl(activeNavItemIdxValue)">
                       <ScalarIconLink
-                        size="sm"
+                        class="size-3.5"
                         weight="light" />
                       Copy URL
                     </ScalarDropdownButton>
@@ -302,7 +301,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
         type="button"
         @click="addNavItem">
         <ScalarIconPlus
-          size="sm"
+          class="size-3.5"
           weight="bold" />
       </button>
     </div>

--- a/packages/api-client/src/components/TopNav/TopNav.vue
+++ b/packages/api-client/src/components/TopNav/TopNav.vue
@@ -8,10 +8,19 @@ import {
   ScalarIcon,
   type Icon,
 } from '@scalar/components'
+import { ScalarIconLink, ScalarIconPlus } from '@scalar/icons'
 import { LibraryIcon } from '@scalar/icons/library'
 import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
-import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  reactive,
+  ref,
+  watch,
+  type Component,
+} from 'vue'
 import { useRouter } from 'vue-router'
 
 import { ROUTES } from '@/constants'
@@ -34,7 +43,7 @@ const topNavItems = reactive([
   {
     label: '',
     path: '',
-    icon: 'Add' as Icon | Collection['x-scalar-icon'],
+    icon: 'Add' as Component | Icon | Collection['x-scalar-icon'],
     isCollection: false,
   },
 ])
@@ -223,9 +232,18 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                 v-if="isCollection"
                 class="size-3.5 min-w-3.5 stroke-2"
                 :src="activeCollection?.['x-scalar-icon'] || 'Collection'" />
-              <ScalarIcon
+              <component
+                :is="
+                  typeof topNavItems[0]?.icon === 'string'
+                    ? ScalarIcon
+                    : topNavItems[0]?.icon
+                "
                 v-else-if="topNavItems[0]?.icon"
-                :icon="topNavItems[0]?.icon as Icon"
+                v-bind="
+                  typeof topNavItems[0]?.icon === 'string'
+                    ? { icon: topNavItems[0]?.icon as Icon }
+                    : {}
+                "
                 size="xs"
                 thickness="2.5" />
               <span>{{ topNavItems[0]?.label }}</span>
@@ -237,8 +255,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                     <ScalarDropdownButton
                       class="flex items-center gap-1.5"
                       @click="addNavItem">
-                      <ScalarIcon
-                        icon="AddTab"
+                      <ScalarIconPlus
                         size="sm"
                         thickness="1.5" />
                       New Tab
@@ -249,8 +266,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
                     <ScalarDropdownButton
                       class="flex items-center gap-1.5"
                       @click="copyUrl(activeNavItemIdxValue)">
-                      <ScalarIcon
-                        icon="Link"
+                      <ScalarIconLink
                         size="sm"
                         thickness="1.5" />
                       Copy URL
@@ -285,8 +301,7 @@ onBeforeUnmount(() => events.hotKeys.off(handleHotKey))
         class="text-c-3 hover:bg-b-3 app-no-drag-region rounded p-1.5"
         type="button"
         @click="addNavItem">
-        <ScalarIcon
-          icon="Add"
+        <ScalarIconPlus
           size="sm"
           thickness="2.5" />
       </button>

--- a/packages/api-client/src/components/TopNav/TopNavItem.vue
+++ b/packages/api-client/src/components/TopNav/TopNavItem.vue
@@ -56,7 +56,7 @@ defineEmits<{
             <component
               :is="icon"
               v-else
-              size="xs"
+              class="size-3"
               weight="bold" />
             <span class="custom-scroll nav-item-copy text-sm">{{ label }}</span>
           </div>
@@ -77,7 +77,7 @@ defineEmits<{
               class="flex items-center gap-1.5"
               @click="$emit('newTab')">
               <ScalarIconPlus
-                size="sm"
+                class="size-3.5"
                 weight="light" />
               New Tab
               <ScalarHotkey
@@ -88,7 +88,7 @@ defineEmits<{
               class="flex items-center gap-1.5"
               @click="$emit('copyUrl')">
               <ScalarIconLink
-                size="sm"
+                class="size-3.5"
                 weight="light" />
               Copy URL
             </ScalarDropdownButton>
@@ -97,7 +97,7 @@ defineEmits<{
               class="flex items-center gap-1.5"
               @click="$emit('close')">
               <ScalarIconX
-                size="sm"
+                class="size-3.5"
                 weight="light" />
               Close Tab
               <ScalarHotkey
@@ -108,7 +108,7 @@ defineEmits<{
               class="flex items-center gap-1.5"
               @click="$emit('closeOtherTabs')">
               <ScalarIconX
-                size="sm"
+                class="size-3.5"
                 weight="light" />
               Close Other Tabs
             </ScalarDropdownButton>

--- a/packages/api-client/src/components/TopNav/TopNavItem.vue
+++ b/packages/api-client/src/components/TopNav/TopNavItem.vue
@@ -52,19 +52,19 @@ defineEmits<{
               v-else-if="typeof icon === 'string'"
               :icon="icon as any"
               size="xs"
-              thickness="2.5" />
+              weight="bold" />
             <component
               :is="icon"
               v-else
               size="xs"
-              thickness="2.5" />
+              weight="bold" />
             <span class="custom-scroll nav-item-copy text-sm">{{ label }}</span>
           </div>
           <button
             class="nav-item-close"
             type="button"
             @click="$emit('close')">
-            <ScalarIconX thickness="1.75" />
+            <ScalarIconX weight="light" />
           </button>
         </div>
       </ScalarTooltip>
@@ -78,7 +78,7 @@ defineEmits<{
               @click="$emit('newTab')">
               <ScalarIconPlus
                 size="sm"
-                thickness="1.5" />
+                weight="light" />
               New Tab
               <ScalarHotkey
                 class="bg-b-2 ml-auto"
@@ -89,7 +89,7 @@ defineEmits<{
               @click="$emit('copyUrl')">
               <ScalarIconLink
                 size="sm"
-                thickness="1.5" />
+                weight="light" />
               Copy URL
             </ScalarDropdownButton>
             <ScalarDropdownDivider />
@@ -98,7 +98,7 @@ defineEmits<{
               @click="$emit('close')">
               <ScalarIconX
                 size="sm"
-                thickness="1.5" />
+                weight="light" />
               Close Tab
               <ScalarHotkey
                 class="bg-b-2 ml-auto"
@@ -109,7 +109,7 @@ defineEmits<{
               @click="$emit('closeOtherTabs')">
               <ScalarIconX
                 size="sm"
-                thickness="1.5" />
+                weight="light" />
               Close Other Tabs
             </ScalarDropdownButton>
           </ScalarDropdownMenu>

--- a/packages/api-client/src/components/TopNav/TopNavItem.vue
+++ b/packages/api-client/src/components/TopNav/TopNavItem.vue
@@ -6,7 +6,7 @@ import {
   ScalarDropdownMenu,
   ScalarFloating,
   ScalarHotkey,
-  ScalarIcon,
+  ScalarIconLegacyAdapter,
   ScalarTooltip,
   type Icon,
 } from '@scalar/components'
@@ -48,9 +48,9 @@ defineEmits<{
               v-if="isCollection"
               class="size-3.5 min-w-3.5 stroke-2"
               :src="icon as string" />
-            <ScalarIcon
+            <ScalarIconLegacyAdapter
               v-else-if="typeof icon === 'string'"
-              :icon="icon as any"
+              :icon="icon as Icon"
               size="xs"
               weight="bold" />
             <component

--- a/packages/api-client/src/components/TopNav/TopNavItem.vue
+++ b/packages/api-client/src/components/TopNav/TopNavItem.vue
@@ -50,7 +50,7 @@ defineEmits<{
               :src="icon as string" />
             <ScalarIconLegacyAdapter
               v-else-if="typeof icon === 'string'"
-              :icon="icon as Icon"
+              :icon="icon"
               size="xs"
               weight="bold" />
             <component

--- a/packages/api-client/src/components/TopNav/TopNavItem.vue
+++ b/packages/api-client/src/components/TopNav/TopNavItem.vue
@@ -11,20 +11,22 @@ import {
   type Icon,
 } from '@scalar/components'
 import { isMacOS } from '@scalar/helpers/general/is-mac-os'
+import { ScalarIconLink, ScalarIconPlus, ScalarIconX } from '@scalar/icons'
 import { LibraryIcon } from '@scalar/icons/library'
+import type { Component } from 'vue'
 
 defineProps<{
   hotkey?: string
   active: boolean
   label: string
-  icon: Icon
+  icon: Component | Icon
   isCollection?: boolean
 }>()
 
 defineEmits<{
   (e: 'click'): void
-  (e: 'close'): void
   (e: 'newTab'): void
+  (e: 'close'): void
   (e: 'copyUrl'): void
   (e: 'closeOtherTabs'): void
 }>()
@@ -45,10 +47,15 @@ defineEmits<{
             <LibraryIcon
               v-if="isCollection"
               class="size-3.5 min-w-3.5 stroke-2"
-              :src="icon" />
+              :src="icon as string" />
             <ScalarIcon
+              v-else-if="typeof icon === 'string'"
+              :icon="icon as any"
+              size="xs"
+              thickness="2.5" />
+            <component
+              :is="icon"
               v-else
-              :icon="icon"
               size="xs"
               thickness="2.5" />
             <span class="custom-scroll nav-item-copy text-sm">{{ label }}</span>
@@ -57,9 +64,7 @@ defineEmits<{
             class="nav-item-close"
             type="button"
             @click="$emit('close')">
-            <ScalarIcon
-              icon="Close"
-              thickness="1.75" />
+            <ScalarIconX thickness="1.75" />
           </button>
         </div>
       </ScalarTooltip>
@@ -71,8 +76,7 @@ defineEmits<{
             <ScalarDropdownButton
               class="flex items-center gap-1.5"
               @click="$emit('newTab')">
-              <ScalarIcon
-                icon="AddTab"
+              <ScalarIconPlus
                 size="sm"
                 thickness="1.5" />
               New Tab
@@ -83,8 +87,7 @@ defineEmits<{
             <ScalarDropdownButton
               class="flex items-center gap-1.5"
               @click="$emit('copyUrl')">
-              <ScalarIcon
-                icon="Link"
+              <ScalarIconLink
                 size="sm"
                 thickness="1.5" />
               Copy URL
@@ -93,8 +96,7 @@ defineEmits<{
             <ScalarDropdownButton
               class="flex items-center gap-1.5"
               @click="$emit('close')">
-              <ScalarIcon
-                icon="CloseTab"
+              <ScalarIconX
                 size="sm"
                 thickness="1.5" />
               Close Tab
@@ -105,8 +107,7 @@ defineEmits<{
             <ScalarDropdownButton
               class="flex items-center gap-1.5"
               @click="$emit('closeOtherTabs')">
-              <ScalarIcon
-                icon="CloseTabs"
+              <ScalarIconX
                 size="sm"
                 thickness="1.5" />
               Close Other Tabs

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconCaretRight } from '@scalar/icons'
 import { onMounted, ref, useId } from 'vue'
 
 const {
@@ -51,12 +51,11 @@ onMounted(() => {
             { '!pl-3': layout === 'reference' },
           ]"
           :disabled="layout === 'reference'">
-          <ScalarIcon
+          <ScalarIconCaretRight
             v-if="layout !== 'reference'"
             :class="[
               'text-c-3 group-hover:text-c-1 ui-open:rotate-90 ui-not-open:rotate-0 rounded-px outline-offset-2 group-focus-visible:outline',
             ]"
-            icon="ChevronRight"
             size="md" />
           <h2
             class="text-c-1 m-0 flex flex-1 items-center gap-1.5 leading-[20px]">

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -54,9 +54,8 @@ onMounted(() => {
           <ScalarIconCaretRight
             v-if="layout !== 'reference'"
             :class="[
-              'text-c-3 group-hover:text-c-1 ui-open:rotate-90 ui-not-open:rotate-0 rounded-px outline-offset-2 group-focus-visible:outline',
-            ]"
-            size="md" />
+              'text-c-3 group-hover:text-c-1 ui-open:rotate-90 ui-not-open:rotate-0 rounded-px size-4 outline-offset-2 group-focus-visible:outline',
+            ]" />
           <h2
             class="text-c-1 m-0 flex flex-1 items-center gap-1.5 leading-[20px]">
             <span

--- a/packages/api-client/src/constants.ts
+++ b/packages/api-client/src/constants.ts
@@ -1,31 +1,33 @@
+import { ScalarIconArrowSquareOut, ScalarIconBracketsCurly, ScalarIconCookie, ScalarIconGear } from '@scalar/icons'
+
 export const ROUTES = [
   {
     displayName: 'Request',
     to: {
       name: 'request.root',
     },
-    icon: 'ExternalLink',
+    icon: ScalarIconArrowSquareOut,
   },
   {
     displayName: 'Cookies',
     to: {
       name: 'cookies.default',
     },
-    icon: 'Cookie',
+    icon: ScalarIconCookie,
   },
   {
     displayName: 'Environment',
     to: {
       name: 'environment.default',
     },
-    icon: 'Brackets',
+    icon: ScalarIconBracketsCurly,
   },
   {
     displayName: 'Settings',
     to: {
       name: 'settings.default',
     },
-    icon: 'Settings',
+    icon: ScalarIconGear,
   },
   // {
   //   displayName: 'Servers',

--- a/packages/api-client/src/constants.ts
+++ b/packages/api-client/src/constants.ts
@@ -1,4 +1,5 @@
 import { ScalarIconArrowSquareOut, ScalarIconBracketsCurly, ScalarIconCookie, ScalarIconGear } from '@scalar/icons'
+import { markRaw } from 'vue'
 
 export const ROUTES = [
   {
@@ -6,28 +7,28 @@ export const ROUTES = [
     to: {
       name: 'request.root',
     },
-    icon: ScalarIconArrowSquareOut,
+    icon: markRaw(ScalarIconArrowSquareOut),
   },
   {
     displayName: 'Cookies',
     to: {
       name: 'cookies.default',
     },
-    icon: ScalarIconCookie,
+    icon: markRaw(ScalarIconCookie),
   },
   {
     displayName: 'Environment',
     to: {
       name: 'environment.default',
     },
-    icon: ScalarIconBracketsCurly,
+    icon: markRaw(ScalarIconBracketsCurly),
   },
   {
     displayName: 'Settings',
     to: {
       name: 'settings.default',
     },
-    icon: ScalarIconGear,
+    icon: markRaw(ScalarIconGear),
   },
   // {
   //   displayName: 'Servers',

--- a/packages/api-client/src/v2/blocks/operation-block/components/Header.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/components/Header.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
+import { ScalarIconX } from '@scalar/icons'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
@@ -122,8 +122,7 @@ const handleAddEnvironment = () => {
         class="app-exit-button zoomed:static zoomed:p-1 fixed top-2 right-2 rounded-full p-2"
         type="button"
         @click="eventBus.emit('ui:close:client-modal')">
-        <ScalarIcon
-          icon="Close"
+        <ScalarIconX
           size="lg"
           thickness="2" />
         <span class="sr-only">Close Client</span>
@@ -139,8 +138,7 @@ const handleAddEnvironment = () => {
         class="text-c-1 hover:bg-b-2 active:text-c-1 -mr-1.5 rounded p-2"
         type="button"
         @click="eventBus.emit('ui:close:client-modal')">
-        <ScalarIcon
-          icon="Close"
+        <ScalarIconX
           size="md"
           thickness="1.75" />
         <span class="sr-only">Close Client</span>

--- a/packages/api-client/src/v2/blocks/operation-block/components/Header.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/components/Header.vue
@@ -123,7 +123,7 @@ const handleAddEnvironment = () => {
         type="button"
         @click="eventBus.emit('ui:close:client-modal')">
         <ScalarIconX
-          size="lg"
+          class="size-5"
           weight="regular" />
         <span class="sr-only">Close Client</span>
       </button>
@@ -139,7 +139,7 @@ const handleAddEnvironment = () => {
         type="button"
         @click="eventBus.emit('ui:close:client-modal')">
         <ScalarIconX
-          size="md"
+          class="size-4"
           weight="light" />
         <span class="sr-only">Close Client</span>
       </button>

--- a/packages/api-client/src/v2/blocks/operation-block/components/Header.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/components/Header.vue
@@ -124,7 +124,7 @@ const handleAddEnvironment = () => {
         @click="eventBus.emit('ui:close:client-modal')">
         <ScalarIconX
           size="lg"
-          thickness="2" />
+          weight="regular" />
         <span class="sr-only">Close Client</span>
       </button>
 
@@ -140,7 +140,7 @@ const handleAddEnvironment = () => {
         @click="eventBus.emit('ui:close:client-modal')">
         <ScalarIconX
           size="md"
-          thickness="1.75" />
+          weight="light" />
         <span class="sr-only">Close Client</span>
       </button>
     </div>

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestBody.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestBody.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
+import { ScalarButton, ScalarListbox } from '@scalar/components'
+import { ScalarIconCaretDown, ScalarIconUpload } from '@scalar/icons'
 import type { ApiReferenceEvents } from '@scalar/workspace-store/events'
 import { unpackProxyObject } from '@scalar/workspace-store/helpers/unpack-proxy'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
@@ -163,9 +164,7 @@ const bodyValue = computed(() => {
               contentTypes[selectedContentType as keyof typeof contentTypes] ??
               selectedContentType
             }}</span>
-            <ScalarIcon
-              icon="ChevronDown"
-              size="md" />
+            <ScalarIconCaretDown size="sm" />
           </ScalarButton>
         </ScalarListbox>
       </DataTableHeader>
@@ -219,9 +218,8 @@ const bodyValue = computed(() => {
                     )
                 ">
                 <span>Select File</span>
-                <ScalarIcon
+                <ScalarIconUpload
                   class="ml-1"
-                  icon="Upload"
                   size="xs"
                   thickness="2.5" />
               </ScalarButton>

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestBody.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestBody.vue
@@ -221,7 +221,7 @@ const bodyValue = computed(() => {
                 <ScalarIconUpload
                   class="ml-1"
                   size="xs"
-                  thickness="2.5" />
+                  weight="bold" />
               </ScalarButton>
             </template>
           </div>

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestBody.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestBody.vue
@@ -164,7 +164,7 @@ const bodyValue = computed(() => {
               contentTypes[selectedContentType as keyof typeof contentTypes] ??
               selectedContentType
             }}</span>
-            <ScalarIconCaretDown size="sm" />
+            <ScalarIconCaretDown class="size-3.5" />
           </ScalarButton>
         </ScalarListbox>
       </DataTableHeader>
@@ -219,8 +219,7 @@ const bodyValue = computed(() => {
                 ">
                 <span>Select File</span>
                 <ScalarIconUpload
-                  class="ml-1"
-                  size="xs"
+                  class="ml-1 size-3"
                   weight="bold" />
               </ScalarButton>
             </template>

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -293,7 +293,7 @@ const handleUpdateRow = (
             <ScalarIconUpload
               class="ml-1"
               size="xs"
-              thickness="2.5" />
+              weight="bold" />
           </ScalarButton>
         </div>
       </template>

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarIcon, ScalarIconButton } from '@scalar/components'
-import { ScalarIconGlobe, ScalarIconTrash } from '@scalar/icons'
+import { ScalarButton, ScalarIconButton } from '@scalar/components'
+import {
+  ScalarIconGlobe,
+  ScalarIconTrash,
+  ScalarIconUpload,
+} from '@scalar/icons'
 import { unpackProxyObject } from '@scalar/workspace-store/helpers/unpack-proxy'
 import { resolve } from '@scalar/workspace-store/resolve'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
@@ -286,9 +290,8 @@ const handleUpdateRow = (
             variant="outlined"
             @click="emit('uploadFile')">
             <span>Select File</span>
-            <ScalarIcon
+            <ScalarIconUpload
               class="ml-1"
-              icon="Upload"
               size="xs"
               thickness="2.5" />
           </ScalarButton>

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -291,8 +291,7 @@ const handleUpdateRow = (
             @click="emit('uploadFile')">
             <span>Select File</span>
             <ScalarIconUpload
-              class="ml-1"
-              size="xs"
+              class="ml-1 size-3"
               weight="bold" />
           </ScalarButton>
         </div>

--- a/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyDownload.vue
+++ b/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyDownload.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconDownload } from '@scalar/icons'
 import { computed } from 'vue'
 
 import { getMediaTypeConfig } from '@/views/Request/consts'
@@ -22,9 +22,7 @@ const filenameExtension = computed(() => {
     :download="`${filenameExtension}`"
     :href="href"
     @click.stop>
-    <ScalarIcon
-      icon="Download"
-      size="xs" />
+    <ScalarIconDownload size="md" />
     <span>
       <span>Download</span>
       <span class="sr-only">Response Body</span>

--- a/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyDownload.vue
+++ b/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyDownload.vue
@@ -22,7 +22,7 @@ const filenameExtension = computed(() => {
     :download="`${filenameExtension}`"
     :href="href"
     @click.stop>
-    <ScalarIconDownload size="md" />
+    <ScalarIconDownload class="size-4" />
     <span>
       <span>Download</span>
       <span class="sr-only">Response Body</span>

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarWrappingText } from '@scalar/components'
+import {
+  ScalarButton,
+  ScalarIconButton,
+  ScalarWrappingText,
+} from '@scalar/components'
 import { REQUEST_METHODS } from '@scalar/helpers/http/http-info'
 import type { HttpMethod as HttpMethodType } from '@scalar/helpers/http/http-methods'
 import {
@@ -265,14 +269,12 @@ defineExpose({
       </div>
 
       <!-- Copy url button -->
-      <ScalarButton
-        class="hover:bg-b-3 mx-1"
-        size="xs"
-        variant="ghost"
-        @click="copyUrl">
-        <ScalarIconCopy />
-        <span class="sr-only">Copy URL</span>
-      </ScalarButton>
+      <ScalarIconButton
+        class="hover:bg-b-3 z-context-plus relative size-6.5 self-center p-1.25"
+        :icon="ScalarIconCopy"
+        size="sm"
+        label="Copy URL"
+        @click="copyUrl" />
 
       <AddressBarHistory
         :history="history"
@@ -304,8 +306,8 @@ defineExpose({
           aria-hidden="true"
           class="inline-flex items-center gap-1">
           <ScalarIconPlay
-            class="relative shrink-0 fill-current"
-            size="xs" />
+            class="relative size-3 shrink-0 fill-current"
+            weight="fill" />
           <span class="text-xxs hidden lg:flex">Send</span>
         </span>
         <span class="sr-only">

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -287,7 +287,7 @@ defineExpose({
         class="absolute inset-x-0 top-[calc(100%+4px)] flex flex-col items-center rounded px-6">
         <div
           class="text-c-danger bg-b-danger border-c-danger flex items-center gap-1 rounded border p-1">
-          <ScalarIconWarningCircle size="sm" />
+          <ScalarIconWarningCircle class="size-3.5" />
           <div class="min-w-0 flex-1">
             A
             <em>{{ methodConflict?.toUpperCase() ?? method.toUpperCase() }}</em>

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import {
-  ScalarButton,
-  ScalarIcon,
-  ScalarWrappingText,
-} from '@scalar/components'
+import { ScalarButton, ScalarWrappingText } from '@scalar/components'
 import { REQUEST_METHODS } from '@scalar/helpers/http/http-info'
 import type { HttpMethod as HttpMethodType } from '@scalar/helpers/http/http-methods'
-import { ScalarIconCopy, ScalarIconWarningCircle } from '@scalar/icons'
+import {
+  ScalarIconCopy,
+  ScalarIconPlay,
+  ScalarIconWarningCircle,
+} from '@scalar/icons'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import type {
   ApiReferenceEvents,
@@ -303,9 +303,8 @@ defineExpose({
         <span
           aria-hidden="true"
           class="inline-flex items-center gap-1">
-          <ScalarIcon
+          <ScalarIconPlay
             class="relative shrink-0 fill-current"
-            icon="Play"
             size="xs" />
           <span class="text-xxs hidden lg:flex">Send</span>
         </span>

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBarHistory.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBarHistory.vue
@@ -51,7 +51,7 @@ const emits = defineEmits<{
         v-if="history.length"
         class="address-bar-history-button text-c-3 focus:text-c-1 relative mr-1 rounded-lg p-1.5">
         <ScalarIconClockClockwise
-          size="sm"
+          class="size-3.5"
           weight="regular" />
         <span class="sr-only">Request History</span>
       </MenuButton>

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBarHistory.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBarHistory.vue
@@ -1,11 +1,8 @@
 <script setup lang="ts">
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
-import {
-  ScalarFloating,
-  ScalarFloatingBackdrop,
-  ScalarIcon,
-} from '@scalar/components'
+import { ScalarFloating, ScalarFloatingBackdrop } from '@scalar/components'
 import type { HttpMethod as HttpMethodType } from '@scalar/helpers/http/http-methods'
+import { ScalarIconClockClockwise } from '@scalar/icons'
 import { httpStatusCodes } from '@scalar/oas-utils/helpers'
 
 import { HttpMethod } from '@/components/HttpMethod'
@@ -53,8 +50,7 @@ const emits = defineEmits<{
       <MenuButton
         v-if="history.length"
         class="address-bar-history-button text-c-3 focus:text-c-1 relative mr-1 rounded-lg p-1.5">
-        <ScalarIcon
-          icon="History"
+        <ScalarIconClockClockwise
           size="sm"
           thickness="2.25" />
         <span class="sr-only">Request History</span>

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBarHistory.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBarHistory.vue
@@ -52,7 +52,7 @@ const emits = defineEmits<{
         class="address-bar-history-button text-c-3 focus:text-c-1 relative mr-1 rounded-lg p-1.5">
         <ScalarIconClockClockwise
           size="sm"
-          thickness="2.25" />
+          weight="regular" />
         <span class="sr-only">Request History</span>
       </MenuButton>
       <!-- History shadow and placement-->

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/EnvironmentSelector.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/EnvironmentSelector.vue
@@ -4,8 +4,13 @@ import {
   ScalarDropdown,
   ScalarDropdownDivider,
   ScalarDropdownItem,
-  ScalarIcon,
 } from '@scalar/components'
+import {
+  ScalarIconCaretDown,
+  ScalarIconCheck,
+  ScalarIconGlobe,
+  ScalarIconPlus,
+} from '@scalar/icons'
 import { computed } from 'vue'
 
 const { environments = [], activeEnvironment } = defineProps<{
@@ -77,10 +82,9 @@ const handleSelectEnvironment = (environmentName: string) => {
         variant="ghost">
         <div class="flex items-center gap-1.5">
           <!-- Icon indicator -->
-          <ScalarIcon
+          <ScalarIconGlobe
             class="shrink-0"
             :class="hasActiveEnvironment ? 'text-c-accent' : 'text-c-3'"
-            icon="Globe"
             size="sm" />
 
           <!-- Environment name -->
@@ -90,9 +94,8 @@ const handleSelectEnvironment = (environmentName: string) => {
           </span>
 
           <!-- Dropdown arrow -->
-          <ScalarIcon
+          <ScalarIconCaretDown
             class="shrink-0"
-            icon="ChevronDown"
             size="xs" />
         </div>
       </ScalarButton>
@@ -110,9 +113,8 @@ const handleSelectEnvironment = (environmentName: string) => {
                 ? 'bg-c-accent text-b-1'
                 : 'shadow-border text-transparent'
             ">
-            <ScalarIcon
+            <ScalarIconCheck
               class="size-2.5"
-              icon="Checkmark"
               weight="bold" />
           </div>
           <span class="text-c-2">No Environment</span>
@@ -133,9 +135,8 @@ const handleSelectEnvironment = (environmentName: string) => {
                 ? 'bg-c-accent text-b-1'
                 : 'shadow-border text-transparent'
             ">
-            <ScalarIcon
+            <ScalarIconCheck
               class="size-2.5"
-              icon="Checkmark"
               weight="bold" />
           </div>
           <span class="overflow-hidden text-ellipsis">{{
@@ -150,9 +151,9 @@ const handleSelectEnvironment = (environmentName: string) => {
           class="text-c-accent flex items-center gap-1.5"
           @click="handleAddEnvironment">
           <div class="flex h-4 w-4 items-center justify-center">
-            <ScalarIcon
-              icon="Add"
-              size="sm" />
+            <ScalarIconPlus
+              size="sm"
+              weight="light" />
           </div>
           <span>{{
             hasEnvironments ? 'New Environment' : 'Create Environment'

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/EnvironmentSelector.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/EnvironmentSelector.vue
@@ -83,9 +83,8 @@ const handleSelectEnvironment = (environmentName: string) => {
         <div class="flex items-center gap-1.5">
           <!-- Icon indicator -->
           <ScalarIconGlobe
-            class="shrink-0"
-            :class="hasActiveEnvironment ? 'text-c-accent' : 'text-c-3'"
-            size="sm" />
+            class="size-3.5 shrink-0"
+            :class="hasActiveEnvironment ? 'text-c-accent' : 'text-c-3'" />
 
           <!-- Environment name -->
           <span
@@ -94,9 +93,7 @@ const handleSelectEnvironment = (environmentName: string) => {
           </span>
 
           <!-- Dropdown arrow -->
-          <ScalarIconCaretDown
-            class="shrink-0"
-            size="xs" />
+          <ScalarIconCaretDown class="size-3 shrink-0" />
         </div>
       </ScalarButton>
 
@@ -152,7 +149,7 @@ const handleSelectEnvironment = (environmentName: string) => {
           @click="handleAddEnvironment">
           <div class="flex h-4 w-4 items-center justify-center">
             <ScalarIconPlus
-              size="sm"
+              class="size-3.5"
               weight="light" />
           </div>
           <span>{{

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/EnvironmentSelector.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/EnvironmentSelector.vue
@@ -113,7 +113,7 @@ const handleSelectEnvironment = (environmentName: string) => {
             <ScalarIcon
               class="size-2.5"
               icon="Checkmark"
-              thickness="3" />
+              weight="bold" />
           </div>
           <span class="text-c-2">No Environment</span>
         </ScalarDropdownItem>
@@ -136,7 +136,7 @@ const handleSelectEnvironment = (environmentName: string) => {
             <ScalarIcon
               class="size-2.5"
               icon="Checkmark"
-              thickness="3" />
+              weight="bold" />
           </div>
           <span class="overflow-hidden text-ellipsis">{{
             environmentName

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue
@@ -1,11 +1,7 @@
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import {
-  ScalarButton,
-  ScalarIcon,
-  ScalarSearchInput,
-  useModal,
-} from '@scalar/components'
+import { ScalarButton, ScalarSearchInput, useModal } from '@scalar/components'
+import { ScalarIconCaretDown, ScalarIconCaretRight } from '@scalar/icons'
 import type { ApiReferenceEvents } from '@scalar/workspace-store/events'
 import type {
   OAuthFlow,
@@ -142,9 +138,13 @@ const addNewScopeModal = useModal()
               Select All
             </ScalarButton>
 
-            <ScalarIcon
+            <ScalarIconCaretDown
+              v-if="open"
               class="text-c-3 group-hover/scopes-accordion:text-c-2"
-              :icon="open ? 'ChevronDown' : 'ChevronRight'"
+              size="md" />
+            <ScalarIconCaretRight
+              v-else
+              class="text-c-3 group-hover/scopes-accordion:text-c-2"
               size="md" />
           </div>
         </DisclosureButton>

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue
@@ -140,12 +140,10 @@ const addNewScopeModal = useModal()
 
             <ScalarIconCaretDown
               v-if="open"
-              class="text-c-3 group-hover/scopes-accordion:text-c-2"
-              size="md" />
+              class="text-c-3 group-hover/scopes-accordion:text-c-2 size-4" />
             <ScalarIconCaretRight
               v-else
-              class="text-c-3 group-hover/scopes-accordion:text-c-2"
-              size="md" />
+              class="text-c-3 group-hover/scopes-accordion:text-c-2 size-4" />
           </div>
         </DisclosureButton>
         <!-- Scopes List -->

--- a/packages/api-client/src/v2/components/data-table/DataTableCheckbox.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTableCheckbox.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { cva, ScalarIcon } from '@scalar/components'
+import { cva } from '@scalar/components'
+import { ScalarIconCheck } from '@scalar/icons'
 
 import DataTableCell from './DataTableCell.vue'
 
@@ -43,8 +44,7 @@ const variants = cva({
           !disabled &&
           'group-has-[:focus-visible]/cell:border-c-accent group-hover:opacity-100 group-has-[:focus-visible]/cell:opacity-100'
         " />
-      <ScalarIcon
-        icon="Checkmark"
+      <ScalarIconCheck
         size="xs"
         thickness="2.5" />
     </div>

--- a/packages/api-client/src/v2/components/data-table/DataTableCheckbox.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTableCheckbox.vue
@@ -45,7 +45,7 @@ const variants = cva({
           'group-has-[:focus-visible]/cell:border-c-accent group-hover:opacity-100 group-has-[:focus-visible]/cell:opacity-100'
         " />
       <ScalarIconCheck
-        size="xs"
+        class="size-3"
         weight="bold" />
     </div>
   </DataTableCell>

--- a/packages/api-client/src/v2/components/data-table/DataTableCheckbox.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTableCheckbox.vue
@@ -46,7 +46,7 @@ const variants = cva({
         " />
       <ScalarIconCheck
         size="xs"
-        thickness="2.5" />
+        weight="bold" />
     </div>
   </DataTableCell>
 </template>

--- a/packages/api-client/src/v2/components/data-table/DataTableInputSelect.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTableInputSelect.vue
@@ -5,8 +5,12 @@ import {
   ScalarDropdown,
   ScalarDropdownDivider,
   ScalarDropdownItem,
-  ScalarIcon,
 } from '@scalar/components'
+import {
+  ScalarIconCaretDown,
+  ScalarIconCheck,
+  ScalarIconPlus,
+} from '@scalar/icons'
 import { computed, nextTick, ref, watch } from 'vue'
 
 import type { CodeInputModelValue } from '@/v2/components/code-input/CodeInput.vue'
@@ -107,9 +111,8 @@ const updateSelectedOptions = (selectedOptions: any) => {
               ? selectedArrayOptions.map((option) => option.label).join(', ')
               : 'Select a value'
           }}</span>
-          <ScalarIcon
+          <ScalarIconCaretDown
             class="min-w-4"
-            icon="ChevronDown"
             size="md" />
         </ScalarButton>
       </ScalarComboboxMultiselect>
@@ -134,9 +137,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
           <span class="text-c-1 overflow-hidden text-ellipsis">{{
             initialValue ?? 'Select a value'
           }}</span>
-          <ScalarIcon
-            icon="ChevronDown"
-            size="md" />
+          <ScalarIconCaretDown size="md" />
         </ScalarButton>
         <template #items>
           <ScalarDropdownItem
@@ -152,9 +153,8 @@ const updateSelectedOptions = (selectedOptions: any) => {
                   ? 'bg-c-accent text-b-1'
                   : 'shadow-border text-transparent'
               ">
-              <ScalarIcon
+              <ScalarIconCheck
                 class="size-2.5"
-                icon="Checkmark"
                 thickness="3" />
             </div>
             <span class="overflow-hidden text-ellipsis">{{ option }}</span>
@@ -165,9 +165,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
               class="flex items-center gap-1.5"
               @click="addingCustomValue = true">
               <div class="flex h-4 w-4 items-center justify-center">
-                <ScalarIcon
-                  icon="Add"
-                  size="sm" />
+                <ScalarIconPlus size="sm" />
               </div>
               <span>Add value</span>
             </ScalarDropdownItem>

--- a/packages/api-client/src/v2/components/data-table/DataTableInputSelect.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTableInputSelect.vue
@@ -111,9 +111,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
               ? selectedArrayOptions.map((option) => option.label).join(', ')
               : 'Select a value'
           }}</span>
-          <ScalarIconCaretDown
-            class="min-w-4"
-            size="md" />
+          <ScalarIconCaretDown class="size-4 min-w-4" />
         </ScalarButton>
       </ScalarComboboxMultiselect>
     </template>
@@ -137,7 +135,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
           <span class="text-c-1 overflow-hidden text-ellipsis">{{
             initialValue ?? 'Select a value'
           }}</span>
-          <ScalarIconCaretDown size="md" />
+          <ScalarIconCaretDown class="size-4" />
         </ScalarButton>
         <template #items>
           <ScalarDropdownItem
@@ -165,7 +163,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
               class="flex items-center gap-1.5"
               @click="addingCustomValue = true">
               <div class="flex h-4 w-4 items-center justify-center">
-                <ScalarIconPlus size="sm" />
+                <ScalarIconPlus class="size-3.5" />
               </div>
               <span>Add value</span>
             </ScalarDropdownItem>

--- a/packages/api-client/src/v2/components/data-table/DataTableInputSelect.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTableInputSelect.vue
@@ -155,7 +155,7 @@ const updateSelectedOptions = (selectedOptions: any) => {
               ">
               <ScalarIconCheck
                 class="size-2.5"
-                thickness="3" />
+                weight="bold" />
             </div>
             <span class="overflow-hidden text-ellipsis">{{ option }}</span>
           </ScalarDropdownItem>

--- a/packages/api-client/src/v2/components/layout/CollapsibleSection.vue
+++ b/packages/api-client/src/v2/components/layout/CollapsibleSection.vue
@@ -11,7 +11,7 @@ export default {
 
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconCaretRight } from '@scalar/icons'
 import { useId } from 'vue'
 
 import ValueEmitter from './ValueEmitter.vue'
@@ -60,10 +60,9 @@ const headingId = useId()
           class="hover:text-c-1 group box-content flex max-h-8 flex-1 items-center gap-2.5 overflow-hidden px-1 py-1.5 text-base font-medium outline-none md:px-1.5 xl:pr-0.5 xl:pl-2"
           :class="isStatic && '!pl-3'"
           :disabled="isStatic">
-          <ScalarIcon
+          <ScalarIconCaretRight
             v-if="!isStatic"
             class="text-c-3 group-hover:text-c-1 rounded-px ui-open:rotate-90 ui-not-open:rotate-0 outline-offset-2 group-focus-visible:outline"
-            icon="ChevronRight"
             size="md" />
 
           <!-- Heading with title -->

--- a/packages/api-client/src/v2/components/layout/CollapsibleSection.vue
+++ b/packages/api-client/src/v2/components/layout/CollapsibleSection.vue
@@ -62,8 +62,7 @@ const headingId = useId()
           :disabled="isStatic">
           <ScalarIconCaretRight
             v-if="!isStatic"
-            class="text-c-3 group-hover:text-c-1 rounded-px ui-open:rotate-90 ui-not-open:rotate-0 outline-offset-2 group-focus-visible:outline"
-            size="md" />
+            class="text-c-3 group-hover:text-c-1 rounded-px ui-open:rotate-90 ui-not-open:rotate-0 size-4 outline-offset-2 group-focus-visible:outline" />
 
           <!-- Heading with title -->
           <h2

--- a/packages/api-client/src/v2/features/app/components/DesktopTabs.vue
+++ b/packages/api-client/src/v2/features/app/components/DesktopTabs.vue
@@ -64,7 +64,7 @@ const handleCopyTabUrl = (index: number): void => {
       type="button"
       @click="handleAddTab">
       <ScalarIconPlus
-        size="sm"
+        class="size-3.5"
         weight="bold" />
     </button>
   </nav>

--- a/packages/api-client/src/v2/features/app/components/DesktopTabs.vue
+++ b/packages/api-client/src/v2/features/app/components/DesktopTabs.vue
@@ -65,7 +65,7 @@ const handleCopyTabUrl = (index: number): void => {
       @click="handleAddTab">
       <ScalarIconPlus
         size="sm"
-        thickness="2.5" />
+        weight="bold" />
     </button>
   </nav>
 </template>

--- a/packages/api-client/src/v2/features/app/components/DesktopTabs.vue
+++ b/packages/api-client/src/v2/features/app/components/DesktopTabs.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconPlus } from '@scalar/icons'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { Tab } from '@scalar/workspace-store/schemas/extensions/workspace/x-scalar-tabs'
 import { computed } from 'vue'
@@ -63,8 +63,7 @@ const handleCopyTabUrl = (index: number): void => {
       class="text-c-3 hover:bg-b-3 app-no-drag-region rounded p-1.5"
       type="button"
       @click="handleAddTab">
-      <ScalarIcon
-        icon="Add"
+      <ScalarIconPlus
         size="sm"
         thickness="2.5" />
     </button>

--- a/packages/api-client/src/v2/features/app/components/DownloadAppButton.vue
+++ b/packages/api-client/src/v2/features/app/components/DownloadAppButton.vue
@@ -7,7 +7,7 @@ import { ScalarIconDownloadSimple } from '@scalar/icons'
     href="https://scalar.com/download?utm_source=web_client&utm_medium=download_button&utm_campaign=topnav"
     target="_blank"
     type="button">
-    <ScalarIconDownloadSimple size="sm" />
+    <ScalarIconDownloadSimple class="size-3.5" />
     <span class="sr-only text-sm font-medium sm:not-sr-only">
       Download App
     </span>

--- a/packages/api-client/src/v2/features/app/components/SidebarItemMenu.vue
+++ b/packages/api-client/src/v2/features/app/components/SidebarItemMenu.vue
@@ -3,8 +3,8 @@ import {
   ScalarDropdown,
   ScalarDropdownDivider,
   ScalarDropdownItem,
-  ScalarIcon,
 } from '@scalar/components'
+import { ScalarIconPlus, ScalarIconTrash } from '@scalar/icons'
 import type { SidebarState } from '@scalar/sidebar'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getParentEntry } from '@scalar/workspace-store/navigation'
@@ -121,9 +121,7 @@ const handleAddExample = () => {
         v-if="canAddOperation()"
         @click="handleAddOperation()">
         <div class="flex items-center gap-2">
-          <ScalarIcon
-            icon="Add"
-            size="sm" />
+          <ScalarIconPlus size="sm" />
           Add Operation
         </div>
       </ScalarDropdownItem>
@@ -132,9 +130,7 @@ const handleAddExample = () => {
         v-if="canAddTag()"
         @click="handleAddTag()">
         <div class="flex items-center gap-2">
-          <ScalarIcon
-            icon="Add"
-            size="sm" />
+          <ScalarIconPlus size="sm" />
           Add Tag
         </div>
       </ScalarDropdownItem>
@@ -143,9 +139,7 @@ const handleAddExample = () => {
         v-if="canAddExample()"
         @click="handleAddExample()">
         <div class="flex items-center gap-2">
-          <ScalarIcon
-            icon="Add"
-            size="sm" />
+          <ScalarIconPlus size="sm" />
           Add Example
         </div>
       </ScalarDropdownItem>
@@ -157,9 +151,7 @@ const handleAddExample = () => {
         v-if="canDelete()"
         @click="emit('showDeleteModal')">
         <div class="text-red flex items-center gap-2">
-          <ScalarIcon
-            icon="Delete"
-            size="sm" />
+          <ScalarIconTrash size="sm" />
           Delete
         </div>
       </ScalarDropdownItem>

--- a/packages/api-client/src/v2/features/app/components/SidebarItemMenu.vue
+++ b/packages/api-client/src/v2/features/app/components/SidebarItemMenu.vue
@@ -121,7 +121,7 @@ const handleAddExample = () => {
         v-if="canAddOperation()"
         @click="handleAddOperation()">
         <div class="flex items-center gap-2">
-          <ScalarIconPlus size="sm" />
+          <ScalarIconPlus class="size-3.5" />
           Add Operation
         </div>
       </ScalarDropdownItem>
@@ -130,7 +130,7 @@ const handleAddExample = () => {
         v-if="canAddTag()"
         @click="handleAddTag()">
         <div class="flex items-center gap-2">
-          <ScalarIconPlus size="sm" />
+          <ScalarIconPlus class="size-3.5" />
           Add Tag
         </div>
       </ScalarDropdownItem>
@@ -139,7 +139,7 @@ const handleAddExample = () => {
         v-if="canAddExample()"
         @click="handleAddExample()">
         <div class="flex items-center gap-2">
-          <ScalarIconPlus size="sm" />
+          <ScalarIconPlus class="size-3.5" />
           Add Example
         </div>
       </ScalarDropdownItem>
@@ -151,7 +151,7 @@ const handleAddExample = () => {
         v-if="canDelete()"
         @click="emit('showDeleteModal')">
         <div class="text-red flex items-center gap-2">
-          <ScalarIconTrash size="sm" />
+          <ScalarIconTrash class="size-3.5" />
           Delete
         </div>
       </ScalarDropdownItem>

--- a/packages/api-client/src/v2/features/app/components/SplashScreen.vue
+++ b/packages/api-client/src/v2/features/app/components/SplashScreen.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconLegacyAdapter } from '@scalar/components'
 </script>
 
 <template>
   <div
     class="splash-screen bg-b-1 fixed inset-0 z-50 flex items-center justify-center">
     <div class="flex flex-col items-center gap-4">
-      <ScalarIcon
+      <ScalarIconLegacyAdapter
         class="logo-icon text-c-1 h-16 w-16"
         icon="Logo" />
     </div>

--- a/packages/api-client/src/v2/features/collection/DocumentCollection.vue
+++ b/packages/api-client/src/v2/features/collection/DocumentCollection.vue
@@ -78,7 +78,7 @@ const saveChanges = () => {
               variant="solid"
               @click="saveChanges">
               <ScalarIconFloppyDisk
-                size="sm"
+                class="size-3.5"
                 weight="light" />
               <span>Save</span>
             </ScalarButton>

--- a/packages/api-client/src/v2/features/collection/DocumentCollection.vue
+++ b/packages/api-client/src/v2/features/collection/DocumentCollection.vue
@@ -79,7 +79,7 @@ const saveChanges = () => {
               @click="saveChanges">
               <ScalarIconFloppyDisk
                 size="sm"
-                thickness="1.5" />
+                weight="light" />
               <span>Save</span>
             </ScalarButton>
           </template>

--- a/packages/api-client/src/v2/features/collection/components/Form.vue
+++ b/packages/api-client/src/v2/features/collection/components/Form.vue
@@ -58,7 +58,7 @@ const id = useId()
               #icon>
               <div
                 class="centered-y bg-b-2 flex-center absolute right-1 z-1 rounded px-1 py-0.5">
-                <ScalarIconMarkdownLogo size="lg" />
+                <ScalarIconMarkdownLogo class="size-5" />
               </div>
             </template>
           </DataTableInput>

--- a/packages/api-client/src/v2/features/collection/components/Form.vue
+++ b/packages/api-client/src/v2/features/collection/components/Form.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconMarkdownLogo } from '@scalar/icons'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
 import { useId } from 'vue'
 
@@ -58,9 +58,7 @@ const id = useId()
               #icon>
               <div
                 class="centered-y bg-b-2 flex-center absolute right-1 z-1 rounded px-1 py-0.5">
-                <ScalarIcon
-                  icon="Markdown"
-                  size="lg" />
+                <ScalarIconMarkdownLogo size="lg" />
               </div>
             </template>
           </DataTableInput>

--- a/packages/api-client/src/v2/features/collection/components/Overview.vue
+++ b/packages/api-client/src/v2/features/collection/components/Overview.vue
@@ -50,7 +50,7 @@ const switchMode = async (newMode: 'edit' | 'preview'): Promise<void> => {
         variant="outlined"
         @click="switchMode('edit')">
         <ScalarIconPencil
-          size="sm"
+          class="size-3.5"
           weight="light" />
         <span>Edit</span>
       </ScalarButton>
@@ -77,7 +77,7 @@ const switchMode = async (newMode: 'edit' | 'preview'): Promise<void> => {
             variant="ghost"
             @click="switchMode('edit')">
             <ScalarIconPencil
-              size="sm"
+              class="size-3.5"
               weight="light" />
             <span>Write a description</span>
           </ScalarButton>

--- a/packages/api-client/src/v2/features/collection/components/Overview.vue
+++ b/packages/api-client/src/v2/features/collection/components/Overview.vue
@@ -51,7 +51,7 @@ const switchMode = async (newMode: 'edit' | 'preview'): Promise<void> => {
         @click="switchMode('edit')">
         <ScalarIconPencil
           size="sm"
-          thickness="1.5" />
+          weight="light" />
         <span>Edit</span>
       </ScalarButton>
     </div>
@@ -78,7 +78,7 @@ const switchMode = async (newMode: 'edit' | 'preview'): Promise<void> => {
             @click="switchMode('edit')">
             <ScalarIconPencil
               size="sm"
-              thickness="1.5" />
+              weight="light" />
             <span>Write a description</span>
           </ScalarButton>
         </div>

--- a/packages/api-client/src/v2/features/command-palette/TheCommandPalette.vue
+++ b/packages/api-client/src/v2/features/command-palette/TheCommandPalette.vue
@@ -218,7 +218,7 @@ onBeforeUnmount(() => eventBus.off('ui:open:command-palette', onOpen))
             <ScalarIconMagnifyingGlass
               class="text-c-2 mr-2.5"
               size="md"
-              thickness="1.5" />
+              weight="light" />
           </label>
           <input
             id="commandmenu"
@@ -262,7 +262,7 @@ onBeforeUnmount(() => eventBus.off('ui:open:command-palette', onOpen))
               v-if="'icon' in command"
               class="text-c-2 mr-2.5"
               size="md"
-              thickness="1.5" />
+              weight="light" />
             {{ command.name }}
           </button>
         </template>

--- a/packages/api-client/src/v2/features/command-palette/TheCommandPalette.vue
+++ b/packages/api-client/src/v2/features/command-palette/TheCommandPalette.vue
@@ -216,8 +216,7 @@ onBeforeUnmount(() => eventBus.off('ui:open:command-palette', onOpen))
           class="bg-b-2 focus-within:bg-b-1 sticky top-0 flex items-center rounded-md border border-transparent pl-2 shadow-[0_-8px_0_8px_var(--scalar-background-1),0_0_8px_8px_var(--scalar-background-1)] focus-within:border-(--scalar-background-3)">
           <label for="commandmenu">
             <ScalarIconMagnifyingGlass
-              class="text-c-2 mr-2.5"
-              size="md"
+              class="text-c-2 mr-2.5 size-4"
               weight="light" />
           </label>
           <input
@@ -260,8 +259,7 @@ onBeforeUnmount(() => eventBus.off('ui:open:command-palette', onOpen))
             <component
               :is="command.icon"
               v-if="'icon' in command"
-              class="text-c-2 mr-2.5"
-              size="md"
+              class="text-c-2 mr-2.5 size-4"
               weight="light" />
             {{ command.name }}
           </button>
@@ -287,7 +285,7 @@ onBeforeUnmount(() => eventBus.off('ui:open:command-palette', onOpen))
           class="hover:bg-b-3 text-c-3 active:text-c-1 absolute z-1 mt-[0.5px] rounded p-1.5"
           type="button"
           @click="handleBackEvent">
-          <ScalarIconCaretLeft size="md" />
+          <ScalarIconCaretLeft class="size-4" />
         </button>
 
         <!-- Dynamic command component -->

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteExample.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteExample.vue
@@ -23,6 +23,7 @@ import {
   ScalarButton,
   ScalarDropdown,
   ScalarDropdownItem,
+  ScalarListbox,
 } from '@scalar/components'
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import { ScalarIconCaretDown } from '@scalar/icons'

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteExample.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteExample.vue
@@ -23,10 +23,9 @@ import {
   ScalarButton,
   ScalarDropdown,
   ScalarDropdownItem,
-  ScalarIcon,
-  ScalarListbox,
 } from '@scalar/components'
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
+import { ScalarIconCaretDown } from '@scalar/icons'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type {
   TraversedEntry,
@@ -224,9 +223,8 @@ const handleBack = (event: KeyboardEvent): void => {
                 selectedDocument ? selectedDocument.label : 'Select Document'
               }}
             </span>
-            <ScalarIcon
+            <ScalarIconCaretDown
               class="text-c-3"
-              icon="ChevronDown"
               size="md" />
           </ScalarButton>
         </ScalarListbox>
@@ -253,9 +251,8 @@ const handleBack = (event: KeyboardEvent): void => {
               <HttpMethodBadge
                 v-if="selectedOperation"
                 :method="selectedOperation.method" />
-              <ScalarIcon
+              <ScalarIconCaretDown
                 class="text-c-3"
-                icon="ChevronDown"
                 size="md" />
             </div>
           </ScalarButton>

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteExample.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteExample.vue
@@ -223,9 +223,7 @@ const handleBack = (event: KeyboardEvent): void => {
                 selectedDocument ? selectedDocument.label : 'Select Document'
               }}
             </span>
-            <ScalarIconCaretDown
-              class="text-c-3"
-              size="md" />
+            <ScalarIconCaretDown class="text-c-3 size-4" />
           </ScalarButton>
         </ScalarListbox>
 
@@ -251,9 +249,7 @@ const handleBack = (event: KeyboardEvent): void => {
               <HttpMethodBadge
                 v-if="selectedOperation"
                 :method="selectedOperation.method" />
-              <ScalarIconCaretDown
-                class="text-c-3"
-                size="md" />
+              <ScalarIconCaretDown class="text-c-3 size-4" />
             </div>
           </ScalarButton>
 

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.test.ts
@@ -1,3 +1,4 @@
+import { ScalarIconUpload } from '@scalar/icons'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import { mount } from '@vue/test-utils'
@@ -546,9 +547,8 @@ describe('CommandPaletteImport', () => {
       },
     })
 
-    const icons = wrapper.findAllComponents({ name: 'ScalarIcon' })
-    const uploadIcon = icons.find((icon) => icon.props('icon') === 'Upload')
-    expect(uploadIcon).toBeDefined()
+    const uploadIcon = wrapper.findComponent(ScalarIconUpload)
+    expect(uploadIcon.exists()).toBe(true)
   })
 
   it('passes loading state to form', () => {

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.vue
@@ -37,11 +37,11 @@ export default {
 import {
   ScalarButton,
   ScalarCodeBlock,
-  ScalarIcon,
   ScalarTooltip,
   useLoadingState,
 } from '@scalar/components'
 import { isLocalUrl } from '@scalar/helpers/url/is-local-url'
+import { ScalarIconUpload } from '@scalar/icons'
 import type { LoaderPlugin } from '@scalar/json-magic/bundle'
 import { useToasts } from '@scalar/use-toasts'
 import {
@@ -327,9 +327,8 @@ const handleBack = (event: KeyboardEvent): void => {
             variant="outlined"
             @click="openSpecFileDialog">
             JSON, or YAML File
-            <ScalarIcon
+            <ScalarIconUpload
               class="text-c-3"
-              icon="Upload"
               size="md" />
           </ScalarButton>
         </slot>

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.vue
@@ -327,9 +327,7 @@ const handleBack = (event: KeyboardEvent): void => {
             variant="outlined"
             @click="openSpecFileDialog">
             JSON, or YAML File
-            <ScalarIconUpload
-              class="text-c-3"
-              size="md" />
+            <ScalarIconUpload class="text-c-3 size-4" />
           </ScalarButton>
         </slot>
 

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportCurl.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportCurl.test.ts
@@ -1,3 +1,4 @@
+import { ScalarIconCaretDown } from '@scalar/icons'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -697,9 +698,8 @@ describe('CommandPaletteImportCurl', () => {
       },
     })
 
-    const icon = wrapper.findComponent({ name: 'ScalarIcon' })
+    const icon = wrapper.findComponent(ScalarIconCaretDown)
     expect(icon.exists()).toBe(true)
-    expect(icon.props('icon')).toBe('ChevronDown')
   })
 
   it('updates selected document when listbox value changes', async () => {

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportCurl.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportCurl.vue
@@ -25,10 +25,10 @@ export default {
 <script setup lang="ts">
 import {
   ScalarButton,
-  ScalarIcon,
   ScalarListbox,
   type ScalarComboboxOption,
 } from '@scalar/components'
+import { ScalarIconCaretDown } from '@scalar/icons'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { computed, ref } from 'vue'
@@ -188,9 +188,8 @@ const handleBack = (event: KeyboardEvent): void => {
                 selectedDocument ? selectedDocument.label : 'Select Collection'
               }}
             </span>
-            <ScalarIcon
+            <ScalarIconCaretDown
               class="text-c-3"
-              icon="ChevronDown"
               size="md" />
           </ScalarButton>
         </ScalarListbox>

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportCurl.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportCurl.vue
@@ -188,9 +188,7 @@ const handleBack = (event: KeyboardEvent): void => {
                 selectedDocument ? selectedDocument.label : 'Select Collection'
               }}
             </span>
-            <ScalarIconCaretDown
-              class="text-c-3"
-              size="md" />
+            <ScalarIconCaretDown class="text-c-3 size-4" />
           </ScalarButton>
         </ScalarListbox>
       </div>

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteRequest.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteRequest.vue
@@ -27,13 +27,13 @@ import {
   ScalarButton,
   ScalarDropdown,
   ScalarDropdownItem,
-  ScalarIcon,
   ScalarListbox,
 } from '@scalar/components'
 import {
   HTTP_METHODS,
   type HttpMethod,
 } from '@scalar/helpers/http/http-methods'
+import { ScalarIconCaretDown } from '@scalar/icons'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { computed, ref, watch } from 'vue'
@@ -276,9 +276,8 @@ const handleBack = (event: KeyboardEvent): void => {
                 selectedDocument ? selectedDocument.label : 'Select Document'
               }}
             </span>
-            <ScalarIcon
+            <ScalarIconCaretDown
               class="text-c-3"
-              icon="ChevronDown"
               size="md" />
           </ScalarButton>
         </ScalarListbox>
@@ -294,9 +293,8 @@ const handleBack = (event: KeyboardEvent): void => {
               <HttpMethodBadge
                 v-if="selectedMethod"
                 :method="selectedMethod.method" />
-              <ScalarIcon
+              <ScalarIconCaretDown
                 class="text-c-3"
-                icon="ChevronDown"
                 size="md" />
             </div>
           </ScalarButton>
@@ -326,9 +324,8 @@ const handleBack = (event: KeyboardEvent): void => {
             <span :class="selectedTag ? 'text-c-1 truncate' : 'text-c-3'">
               {{ selectedTag ? selectedTag.label : 'Select Tag (Optional)' }}
             </span>
-            <ScalarIcon
+            <ScalarIconCaretDown
               class="text-c-3"
-              icon="ChevronDown"
               size="md" />
           </ScalarButton>
 

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteRequest.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteRequest.vue
@@ -276,9 +276,7 @@ const handleBack = (event: KeyboardEvent): void => {
                 selectedDocument ? selectedDocument.label : 'Select Document'
               }}
             </span>
-            <ScalarIconCaretDown
-              class="text-c-3"
-              size="md" />
+            <ScalarIconCaretDown class="text-c-3 size-4" />
           </ScalarButton>
         </ScalarListbox>
 
@@ -293,9 +291,7 @@ const handleBack = (event: KeyboardEvent): void => {
               <HttpMethodBadge
                 v-if="selectedMethod"
                 :method="selectedMethod.method" />
-              <ScalarIconCaretDown
-                class="text-c-3"
-                size="md" />
+              <ScalarIconCaretDown class="text-c-3 size-4" />
             </div>
           </ScalarButton>
 
@@ -324,9 +320,7 @@ const handleBack = (event: KeyboardEvent): void => {
             <span :class="selectedTag ? 'text-c-1 truncate' : 'text-c-3'">
               {{ selectedTag ? selectedTag.label : 'Select Tag (Optional)' }}
             </span>
-            <ScalarIconCaretDown
-              class="text-c-3"
-              size="md" />
+            <ScalarIconCaretDown class="text-c-3 size-4" />
           </ScalarButton>
 
           <!-- Dropdown list of available tags -->

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteTag.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteTag.vue
@@ -140,9 +140,7 @@ const handleBack = (event: KeyboardEvent): void => {
               selectedDocument ? selectedDocument.label : 'Select Collection'
             }}
           </span>
-          <ScalarIconCaretDown
-            class="text-c-3"
-            size="md" />
+          <ScalarIconCaretDown class="text-c-3 size-4" />
         </ScalarButton>
       </ScalarListbox>
     </template>

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteTag.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteTag.vue
@@ -22,7 +22,8 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
+import { ScalarButton, ScalarListbox } from '@scalar/components'
+import { ScalarIconCaretDown } from '@scalar/icons'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { computed, ref } from 'vue'
@@ -139,9 +140,8 @@ const handleBack = (event: KeyboardEvent): void => {
               selectedDocument ? selectedDocument.label : 'Select Collection'
             }}
           </span>
-          <ScalarIcon
+          <ScalarIconCaretDown
             class="text-c-3"
-            icon="ChevronDown"
             size="md" />
         </ScalarButton>
       </ScalarListbox>

--- a/packages/api-client/src/v2/features/command-palette/components/WatchModeToggle.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/WatchModeToggle.vue
@@ -51,7 +51,7 @@ const model = computed<boolean>({
     <span
       class="text-c-1 flex items-center gap-1 text-xs font-medium"
       :class="{ 'text-c-3': !modelValue }">
-      <ScalarIconEye size="sm" />
+      <ScalarIconEye class="size-3.5" />
       Watch Mode
     </span>
 

--- a/packages/api-client/src/v2/features/command-palette/components/WatchModeToggle.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/WatchModeToggle.vue
@@ -19,7 +19,8 @@ export default {}
 </script>
 
 <script setup lang="ts">
-import { ScalarIcon, ScalarToggle } from '@scalar/components'
+import { ScalarToggle } from '@scalar/components'
+import { ScalarIconEye } from '@scalar/icons'
 import { computed } from 'vue'
 
 const { modelValue, disabled = false } = defineProps<{
@@ -50,9 +51,7 @@ const model = computed<boolean>({
     <span
       class="text-c-1 flex items-center gap-1 text-xs font-medium"
       :class="{ 'text-c-3': !modelValue }">
-      <ScalarIcon
-        icon="Watch"
-        size="sm" />
+      <ScalarIconEye size="sm" />
       Watch Mode
     </span>
 

--- a/packages/api-client/src/v2/features/environments/components/EnvironmentColors.test.ts
+++ b/packages/api-client/src/v2/features/environments/components/EnvironmentColors.test.ts
@@ -1,3 +1,4 @@
+import { ScalarIconCheck } from '@scalar/icons'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 
@@ -21,9 +22,7 @@ describe('EnvironmentColors', () => {
       },
     })
 
-    const icons = wrapper.findAllComponents({ name: 'ScalarIcon' })
-    const checkmarks = icons.filter((icon) => icon.props('icon') === 'Checkmark')
-
+    const checkmarks = wrapper.findAllComponents(ScalarIconCheck)
     expect(checkmarks.length).toBeGreaterThan(0)
   })
 

--- a/packages/api-client/src/v2/features/environments/components/EnvironmentColors.vue
+++ b/packages/api-client/src/v2/features/environments/components/EnvironmentColors.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconCheck } from '@scalar/icons'
 import { computed, nextTick, ref } from 'vue'
 
 const { activeColor } = defineProps<{
@@ -114,10 +114,9 @@ const handleCustomColorInput = (): void => {
       class="flex h-4 w-4 cursor-pointer items-center justify-center rounded-full"
       :style="{ backgroundColor: activeColor }"
       @click="toggleSelector">
-      <ScalarIcon
+      <ScalarIconCheck
         v-if="activeColor"
         class="text-c-btn p-0.5"
-        icon="Checkmark"
         size="xs" />
     </div>
 
@@ -132,10 +131,9 @@ const handleCustomColorInput = (): void => {
         class="flex h-4 w-4 cursor-pointer items-center justify-center rounded-full"
         :style="{ backgroundColor: option }"
         @click="selectColor(option)">
-        <ScalarIcon
+        <ScalarIconCheck
           v-if="isActiveColor(option)"
           class="text-c-btn p-0.5"
-          icon="Checkmark"
           size="xs" />
       </div>
 
@@ -148,10 +146,9 @@ const handleCustomColorInput = (): void => {
         :style="customButtonStyle"
         type="button"
         @click="toggleCustomInput">
-        <ScalarIcon
+        <ScalarIconCheck
           v-if="isCustomColor"
           class="text-c-btn"
-          icon="Checkmark"
           size="xs" />
       </button>
     </div>
@@ -175,9 +172,7 @@ const handleCustomColorInput = (): void => {
         class="text-c-3 hover:bg-b-2 rounded-lg p-1.5"
         type="button"
         @click="toggleCustomInput">
-        <ScalarIcon
-          icon="Checkmark"
-          size="xs" />
+        <ScalarIconCheck size="xs" />
       </button>
     </div>
   </div>

--- a/packages/api-client/src/v2/features/environments/components/EnvironmentColors.vue
+++ b/packages/api-client/src/v2/features/environments/components/EnvironmentColors.vue
@@ -116,8 +116,7 @@ const handleCustomColorInput = (): void => {
       @click="toggleSelector">
       <ScalarIconCheck
         v-if="activeColor"
-        class="text-c-btn p-0.5"
-        size="xs" />
+        class="text-c-btn size-3 p-0.5" />
     </div>
 
     <!-- Expanded view: color palette selector -->
@@ -133,8 +132,7 @@ const handleCustomColorInput = (): void => {
         @click="selectColor(option)">
         <ScalarIconCheck
           v-if="isActiveColor(option)"
-          class="text-c-btn p-0.5"
-          size="xs" />
+          class="text-c-btn size-3 p-0.5" />
       </div>
 
       <!-- Divider -->
@@ -148,8 +146,7 @@ const handleCustomColorInput = (): void => {
         @click="toggleCustomInput">
         <ScalarIconCheck
           v-if="isCustomColor"
-          class="text-c-btn"
-          size="xs" />
+          class="text-c-btn size-3" />
       </button>
     </div>
 
@@ -172,7 +169,7 @@ const handleCustomColorInput = (): void => {
         class="text-c-3 hover:bg-b-2 rounded-lg p-1.5"
         type="button"
         @click="toggleCustomInput">
-        <ScalarIconCheck size="xs" />
+        <ScalarIconCheck class="size-3" />
       </button>
     </div>
   </div>

--- a/packages/api-client/src/v2/features/settings/CollectionSettings.vue
+++ b/packages/api-client/src/v2/features/settings/CollectionSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { cva, cx, ScalarButton, ScalarIcon } from '@scalar/components'
+import { cva, cx, ScalarButton } from '@scalar/components'
+import { ScalarIconCheck } from '@scalar/icons'
 import {
   themeLabels,
   type IntegrationThemeId,
@@ -91,9 +92,8 @@ const buttonStyles = cva({
               'bg-c-accent text-b-1 border-transparent':
                 activeProxyUrl === DEFAULT_PROXY_URL,
             }">
-            <ScalarIcon
+            <ScalarIconCheck
               v-if="activeProxyUrl === DEFAULT_PROXY_URL"
-              icon="Checkmark"
               size="xs"
               thickness="3.5" />
           </div>
@@ -113,9 +113,8 @@ const buttonStyles = cva({
           @click="emit('update:proxyUrl', customProxyUrl)">
           <div
             class="bg-c-accent text-b-1 flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] border-transparent p-1">
-            <ScalarIcon
+            <ScalarIconCheck
               v-if="customProxyUrl === activeProxyUrl"
-              icon="Checkmark"
               size="xs"
               thickness="3.5" />
           </div>
@@ -131,9 +130,8 @@ const buttonStyles = cva({
             :class="
               !activeProxyUrl && 'bg-c-accent text-b-1 border-transparent'
             ">
-            <ScalarIcon
+            <ScalarIconCheck
               v-if="!activeProxyUrl"
-              icon="Checkmark"
               size="xs"
               thickness="3.5" />
           </div>
@@ -169,9 +167,8 @@ const buttonStyles = cva({
                   'bg-c-accent text-b-1 border-transparent':
                     activeThemeId === themeId,
                 }">
-                <ScalarIcon
+                <ScalarIconCheck
                   v-if="activeThemeId === themeId"
-                  icon="Checkmark"
                   size="xs"
                   thickness="3.5" />
               </div>
@@ -226,9 +223,8 @@ const buttonStyles = cva({
                 'bg-c-accent text-b-1 border-transparent':
                   activeThemeId === themeId,
               }">
-              <ScalarIcon
+              <ScalarIconCheck
                 v-if="activeThemeId === themeId"
-                icon="Checkmark"
                 size="xs"
                 thickness="3.5" />
             </div>

--- a/packages/api-client/src/v2/features/settings/CollectionSettings.vue
+++ b/packages/api-client/src/v2/features/settings/CollectionSettings.vue
@@ -95,7 +95,7 @@ const buttonStyles = cva({
             <ScalarIconCheck
               v-if="activeProxyUrl === DEFAULT_PROXY_URL"
               size="xs"
-              thickness="3.5" />
+              weight="bold" />
           </div>
           Use proxy.scalar.com (default)
         </ScalarButton>
@@ -116,7 +116,7 @@ const buttonStyles = cva({
             <ScalarIconCheck
               v-if="customProxyUrl === activeProxyUrl"
               size="xs"
-              thickness="3.5" />
+              weight="bold" />
           </div>
           Use custom proxy ({{ customProxyUrl }})
         </ScalarButton> -->
@@ -133,7 +133,7 @@ const buttonStyles = cva({
             <ScalarIconCheck
               v-if="!activeProxyUrl"
               size="xs"
-              thickness="3.5" />
+              weight="bold" />
           </div>
           Skip the proxy
         </ScalarButton>
@@ -170,7 +170,7 @@ const buttonStyles = cva({
                 <ScalarIconCheck
                   v-if="activeThemeId === themeId"
                   size="xs"
-                  thickness="3.5" />
+                  weight="bold" />
               </div>
               {{ themeLabels[themeId] }}
             </div>
@@ -226,7 +226,7 @@ const buttonStyles = cva({
               <ScalarIconCheck
                 v-if="activeThemeId === themeId"
                 size="xs"
-                thickness="3.5" />
+                weight="bold" />
             </div>
             {{ themeLabels[themeId] }}
           </div>

--- a/packages/api-client/src/v2/features/settings/CollectionSettings.vue
+++ b/packages/api-client/src/v2/features/settings/CollectionSettings.vue
@@ -94,7 +94,7 @@ const buttonStyles = cva({
             }">
             <ScalarIconCheck
               v-if="activeProxyUrl === DEFAULT_PROXY_URL"
-              size="xs"
+              class="size-3"
               weight="bold" />
           </div>
           Use proxy.scalar.com (default)
@@ -115,7 +115,7 @@ const buttonStyles = cva({
             class="bg-c-accent text-b-1 flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] border-transparent p-1">
             <ScalarIconCheck
               v-if="customProxyUrl === activeProxyUrl"
-              size="xs"
+              class="size-3"
               weight="bold" />
           </div>
           Use custom proxy ({{ customProxyUrl }})
@@ -132,7 +132,7 @@ const buttonStyles = cva({
             ">
             <ScalarIconCheck
               v-if="!activeProxyUrl"
-              size="xs"
+              class="size-3"
               weight="bold" />
           </div>
           Skip the proxy
@@ -169,7 +169,7 @@ const buttonStyles = cva({
                 }">
                 <ScalarIconCheck
                   v-if="activeThemeId === themeId"
-                  size="xs"
+                  class="size-3"
                   weight="bold" />
               </div>
               {{ themeLabels[themeId] }}
@@ -225,7 +225,7 @@ const buttonStyles = cva({
               }">
               <ScalarIconCheck
                 v-if="activeThemeId === themeId"
-                size="xs"
+                class="size-3"
                 weight="bold" />
             </div>
             {{ themeLabels[themeId] }}

--- a/packages/api-client/src/v2/features/settings/DocumentSettings.vue
+++ b/packages/api-client/src/v2/features/settings/DocumentSettings.vue
@@ -89,9 +89,7 @@ const handleDocumentDelete = () => {
               </a>
             </template>
             <template v-else>
-              <ScalarIconProhibit
-                class="text-c-2 mr-2 ml-3 w-4"
-                size="sm" />
+              <ScalarIconProhibit class="text-c-2 mr-2 ml-3 size-3.5 w-4" />
               <span class="text-c-2 pr-3">
                 No URL configured. Try importing an OpenAPI document from an
                 URL.

--- a/packages/api-client/src/v2/features/settings/DocumentSettings.vue
+++ b/packages/api-client/src/v2/features/settings/DocumentSettings.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import {
   ScalarButton,
-  ScalarIcon,
   ScalarModal,
   ScalarToggle,
   useModal,
 } from '@scalar/components'
+import { ScalarIconArrowSquareOut, ScalarIconProhibit } from '@scalar/icons'
 
 import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
 
@@ -84,15 +84,13 @@ const handleDocumentDelete = () => {
                 :href="documentUrl"
                 target="_blank">
                 {{ documentUrl }}
-                <ScalarIcon
-                  class="ml-1 hidden w-2.5 group-hover:inline"
-                  icon="ExternalLink" />
+                <ScalarIconArrowSquareOut
+                  class="ml-1 hidden w-2.5 group-hover:inline" />
               </a>
             </template>
             <template v-else>
-              <ScalarIcon
+              <ScalarIconProhibit
                 class="text-c-2 mr-2 ml-3 w-4"
-                icon="NotAllowed"
                 size="sm" />
               <span class="text-c-2 pr-3">
                 No URL configured. Try importing an OpenAPI document from an

--- a/packages/api-client/src/v2/features/settings/components/Appearance.vue
+++ b/packages/api-client/src/v2/features/settings/components/Appearance.vue
@@ -32,7 +32,7 @@ const buttonStyles = cva({
         }">
         <ScalarIconCheck
           v-if="colorMode === 'system'"
-          size="xs"
+          class="size-3"
           weight="bold" />
       </div>
       System Preference (default)
@@ -47,7 +47,7 @@ const buttonStyles = cva({
         }">
         <ScalarIconCheck
           v-if="colorMode === 'light'"
-          size="xs"
+          class="size-3"
           weight="bold" />
       </div>
       Light Mode Always
@@ -62,7 +62,7 @@ const buttonStyles = cva({
         }">
         <ScalarIconCheck
           v-if="colorMode === 'dark'"
-          size="xs"
+          class="size-3"
           weight="bold" />
       </div>
       Dark Mode Always

--- a/packages/api-client/src/v2/features/settings/components/Appearance.vue
+++ b/packages/api-client/src/v2/features/settings/components/Appearance.vue
@@ -33,7 +33,7 @@ const buttonStyles = cva({
         <ScalarIconCheck
           v-if="colorMode === 'system'"
           size="xs"
-          thickness="3.5" />
+          weight="bold" />
       </div>
       System Preference (default)
     </ScalarButton>
@@ -48,7 +48,7 @@ const buttonStyles = cva({
         <ScalarIconCheck
           v-if="colorMode === 'light'"
           size="xs"
-          thickness="3.5" />
+          weight="bold" />
       </div>
       Light Mode Always
     </ScalarButton>
@@ -63,7 +63,7 @@ const buttonStyles = cva({
         <ScalarIconCheck
           v-if="colorMode === 'dark'"
           size="xs"
-          thickness="3.5" />
+          weight="bold" />
       </div>
       Dark Mode Always
     </ScalarButton>

--- a/packages/api-client/src/v2/features/settings/components/Appearance.vue
+++ b/packages/api-client/src/v2/features/settings/components/Appearance.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { cva, cx, ScalarButton, ScalarIcon } from '@scalar/components'
+import { cva, cx, ScalarButton } from '@scalar/components'
+import { ScalarIconCheck } from '@scalar/icons'
 
 defineProps<{
   colorMode: 'system' | 'light' | 'dark'
@@ -29,9 +30,8 @@ const buttonStyles = cva({
         :class="{
           'bg-c-accent text-b-1 border-transparent': colorMode === 'system',
         }">
-        <ScalarIcon
+        <ScalarIconCheck
           v-if="colorMode === 'system'"
-          icon="Checkmark"
           size="xs"
           thickness="3.5" />
       </div>
@@ -45,9 +45,8 @@ const buttonStyles = cva({
         :class="{
           'bg-c-accent text-b-1 border-transparent': colorMode === 'light',
         }">
-        <ScalarIcon
+        <ScalarIconCheck
           v-if="colorMode === 'light'"
-          icon="Checkmark"
           size="xs"
           thickness="3.5" />
       </div>
@@ -61,9 +60,8 @@ const buttonStyles = cva({
         :class="{
           'bg-c-accent text-b-1 border-transparent': colorMode === 'dark',
         }">
-        <ScalarIcon
+        <ScalarIconCheck
           v-if="colorMode === 'dark'"
-          icon="Checkmark"
           size="xs"
           thickness="3.5" />
       </div>

--- a/packages/api-client/src/views/Collection/CollectionEnvironment.vue
+++ b/packages/api-client/src/views/Collection/CollectionEnvironment.vue
@@ -1,12 +1,7 @@
 <script setup lang="ts">
-import {
-  ScalarButton,
-  ScalarIcon,
-  ScalarModal,
-  useModal,
-} from '@scalar/components'
+import { ScalarButton, ScalarModal, useModal } from '@scalar/components'
 import { Draggable } from '@scalar/draggable'
-import { ScalarIconTrash } from '@scalar/icons'
+import { ScalarIconPlus, ScalarIconTrash } from '@scalar/icons'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import { computed, ref } from 'vue'
 
@@ -277,9 +272,8 @@ const handleDragEnd = (
             size="sm"
             variant="ghost"
             @click="environmentModal.show()">
-            <ScalarIcon
+            <ScalarIconPlus
               class="inline-flex"
-              icon="Add"
               size="sm"
               weight="light" />
             <span>Add Environment</span>

--- a/packages/api-client/src/views/Collection/CollectionEnvironment.vue
+++ b/packages/api-client/src/views/Collection/CollectionEnvironment.vue
@@ -281,7 +281,7 @@ const handleDragEnd = (
               class="inline-flex"
               icon="Add"
               size="sm"
-              thickness="1.5" />
+              weight="light" />
             <span>Add Environment</span>
           </ScalarButton>
         </div>

--- a/packages/api-client/src/views/Collection/CollectionEnvironment.vue
+++ b/packages/api-client/src/views/Collection/CollectionEnvironment.vue
@@ -273,8 +273,7 @@ const handleDragEnd = (
             variant="ghost"
             @click="environmentModal.show()">
             <ScalarIconPlus
-              class="inline-flex"
-              size="sm"
+              class="inline-flex size-3.5"
               weight="light" />
             <span>Add Environment</span>
           </ScalarButton>

--- a/packages/api-client/src/views/Collection/CollectionServers.vue
+++ b/packages/api-client/src/views/Collection/CollectionServers.vue
@@ -110,7 +110,7 @@ const openDeleteModal = (serverUid: Server['uid']) => {
             class="inline-flex"
             icon="Add"
             size="sm"
-            thickness="1.5" />
+            weight="light" />
           <span>Add Server</span>
         </ScalarButton>
       </div>

--- a/packages/api-client/src/views/Collection/CollectionServers.vue
+++ b/packages/api-client/src/views/Collection/CollectionServers.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 import {
   ScalarButton,
-  ScalarIcon,
   ScalarMarkdown,
   ScalarModal,
   useModal,
 } from '@scalar/components'
-import { ScalarIconTrash } from '@scalar/icons'
+import { ScalarIconPlus, ScalarIconTrash } from '@scalar/icons'
 import type { Server } from '@scalar/oas-utils/entities/spec'
 import { computed, ref } from 'vue'
 
@@ -106,9 +105,8 @@ const openDeleteModal = (serverUid: Server['uid']) => {
           size="sm"
           variant="ghost"
           @click="handleAddServer">
-          <ScalarIcon
+          <ScalarIconPlus
             class="inline-flex"
-            icon="Add"
             size="sm"
             weight="light" />
           <span>Add Server</span>

--- a/packages/api-client/src/views/Collection/CollectionServers.vue
+++ b/packages/api-client/src/views/Collection/CollectionServers.vue
@@ -106,8 +106,7 @@ const openDeleteModal = (serverUid: Server['uid']) => {
           variant="ghost"
           @click="handleAddServer">
           <ScalarIconPlus
-            class="inline-flex"
-            size="sm"
+            class="inline-flex size-3.5"
             weight="light" />
           <span>Add Server</span>
         </ScalarButton>

--- a/packages/api-client/src/views/Collection/CollectionSettings.vue
+++ b/packages/api-client/src/views/Collection/CollectionSettings.vue
@@ -99,9 +99,7 @@ function handleDeleteCollection() {
               </a>
             </template>
             <template v-else>
-              <ScalarIconProhibit
-                class="text-c-2 mr-2 ml-3 w-4"
-                size="sm" />
+              <ScalarIconProhibit class="text-c-2 mr-2 ml-3 size-3.5 w-4" />
               <span class="text-c-2 pr-3">
                 No URL configured. Try importing an OpenAPI document from an
                 URL.

--- a/packages/api-client/src/views/Collection/CollectionSettings.vue
+++ b/packages/api-client/src/views/Collection/CollectionSettings.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import {
   ScalarButton,
-  ScalarIcon,
   ScalarModal,
   ScalarToggle,
   useModal,
 } from '@scalar/components'
+import { ScalarIconArrowSquareOut, ScalarIconProhibit } from '@scalar/icons'
 import { useRouter } from 'vue-router'
 
 import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
@@ -94,15 +94,13 @@ function handleDeleteCollection() {
                 :href="activeCollection.documentUrl"
                 target="_blank">
                 {{ activeCollection.documentUrl }}
-                <ScalarIcon
-                  class="ml-1 hidden w-2.5 group-hover:inline"
-                  icon="ExternalLink" />
+                <ScalarIconArrowSquareOut
+                  class="ml-1 hidden w-2.5 group-hover:inline" />
               </a>
             </template>
             <template v-else>
-              <ScalarIcon
+              <ScalarIconProhibit
                 class="text-c-2 mr-2 ml-3 w-4"
-                icon="NotAllowed"
                 size="sm" />
               <span class="text-c-2 pr-3">
                 No URL configured. Try importing an OpenAPI document from an

--- a/packages/api-client/src/views/Collection/components/MarkdownInput.vue
+++ b/packages/api-client/src/views/Collection/components/MarkdownInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarIcon, ScalarMarkdown } from '@scalar/components'
+import { ScalarButton, ScalarMarkdown } from '@scalar/components'
+import { ScalarIconPencil } from '@scalar/icons'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { nextTick, ref, watch } from 'vue'
@@ -47,8 +48,7 @@ const handleBlur = () => {
         type="button"
         variant="outlined"
         @click="mode = 'edit'">
-        <ScalarIcon
-          icon="Pencil"
+        <ScalarIconPencil
           size="sm"
           thickness="1.5" />
         <span>Edit</span>
@@ -77,8 +77,7 @@ const handleBlur = () => {
               size="sm"
               variant="ghost"
               @click="mode = 'edit'">
-              <ScalarIcon
-                icon="Pencil"
+              <ScalarIconPencil
                 size="sm"
                 thickness="1.5" />
               <span>Write a description</span>

--- a/packages/api-client/src/views/Collection/components/MarkdownInput.vue
+++ b/packages/api-client/src/views/Collection/components/MarkdownInput.vue
@@ -49,7 +49,7 @@ const handleBlur = () => {
         variant="outlined"
         @click="mode = 'edit'">
         <ScalarIconPencil
-          size="sm"
+          class="size-3.5"
           weight="light" />
         <span>Edit</span>
       </ScalarButton>
@@ -78,7 +78,7 @@ const handleBlur = () => {
               variant="ghost"
               @click="mode = 'edit'">
               <ScalarIconPencil
-                size="sm"
+                class="size-3.5"
                 weight="light" />
               <span>Write a description</span>
             </ScalarButton>

--- a/packages/api-client/src/views/Collection/components/MarkdownInput.vue
+++ b/packages/api-client/src/views/Collection/components/MarkdownInput.vue
@@ -50,7 +50,7 @@ const handleBlur = () => {
         @click="mode = 'edit'">
         <ScalarIconPencil
           size="sm"
-          thickness="1.5" />
+          weight="light" />
         <span>Edit</span>
       </ScalarButton>
     </div>
@@ -79,7 +79,7 @@ const handleBlur = () => {
               @click="mode = 'edit'">
               <ScalarIconPencil
                 size="sm"
-                thickness="1.5" />
+                weight="light" />
               <span>Write a description</span>
             </ScalarButton>
           </div>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -1,11 +1,6 @@
 <script setup lang="ts">
-import {
-  ScalarButton,
-  ScalarIcon,
-  ScalarModal,
-  useModal,
-} from '@scalar/components'
-import { ScalarIconPlus } from '@scalar/icons'
+import { ScalarButton, ScalarModal, useModal } from '@scalar/components'
+import { ScalarIconCaretRight, ScalarIconPlus } from '@scalar/icons'
 import { LibraryIcon } from '@scalar/icons/library'
 import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { useToasts } from '@scalar/use-toasts'
@@ -459,9 +454,8 @@ watch(
                     :class="{
                       'rotate-90': collapsedSidebarFolders[collection.uid],
                     }">
-                    <ScalarIcon
+                    <ScalarIconCaretRight
                       class="text-c-3 hover:text-c-1 hidden text-sm group-hover:block"
-                      icon="ChevronRight"
                       size="md" />
                   </div>
                 </span>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -5,6 +5,7 @@ import {
   ScalarModal,
   useModal,
 } from '@scalar/components'
+import { ScalarIconPlus } from '@scalar/icons'
 import { LibraryIcon } from '@scalar/icons/library'
 import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { useToasts } from '@scalar/use-toasts'
@@ -482,9 +483,9 @@ watch(
                   :collectionId="collection.uid"
                   :isCopyable="false"
                   :isDeletable="true"
-                  :isRenameable="true"
                   :isDraggable="true"
                   :isDroppable="isDroppable"
+                  :isRenameable="true"
                   :to="{
                     name: 'environment.collection',
                     params: {
@@ -505,8 +506,8 @@ watch(
                   "
                   @colorModal="handleOpenColorModal(environmentName)"
                   @delete="removeCollectionEnvironment(environmentName)"
-                  @rename="openRenameModal(environmentName, collection.uid)"
-                  @onDragEnd="handleDragEnd" />
+                  @onDragEnd="handleDragEnd"
+                  @rename="openRenameModal(environmentName, collection.uid)" />
                 <ScalarButton
                   v-if="
                     Object.keys(collection['x-scalar-environments'] || {})
@@ -515,9 +516,7 @@ watch(
                   class="text-c-1 hover:bg-b-2 flex h-8 w-full justify-start gap-1.5 py-0 pl-6 text-xs"
                   variant="ghost"
                   @click="openEnvironmentModal(collection.uid)">
-                  <ScalarIcon
-                    icon="Add"
-                    size="sm" />
+                  <ScalarIconPlus size="sm" />
                   <span>Add Environment</span>
                 </ScalarButton>
               </div>

--- a/packages/api-client/src/views/Environment/Environment.vue
+++ b/packages/api-client/src/views/Environment/Environment.vue
@@ -455,8 +455,7 @@ watch(
                       'rotate-90': collapsedSidebarFolders[collection.uid],
                     }">
                     <ScalarIconCaretRight
-                      class="text-c-3 hover:text-c-1 hidden text-sm group-hover:block"
-                      size="md" />
+                      class="text-c-3 hover:text-c-1 hidden size-4 text-sm group-hover:block" />
                   </div>
                 </span>
                 {{ collection.info?.title ?? '' }}
@@ -510,7 +509,7 @@ watch(
                   class="text-c-1 hover:bg-b-2 flex h-8 w-full justify-start gap-1.5 py-0 pl-6 text-xs"
                   variant="ghost"
                   @click="openEnvironmentModal(collection.uid)">
-                  <ScalarIconPlus size="sm" />
+                  <ScalarIconPlus class="size-3.5" />
                   <span>Add Environment</span>
                 </ScalarButton>
               </div>

--- a/packages/api-client/src/views/Environment/EnvironmentColors.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentColors.vue
@@ -83,9 +83,8 @@ const selectColor = (color: string) => {
         @click="handleSelectorClick">
         <ScalarIconCheck
           v-if="activeColor"
-          class="text-c-btn"
-          :class="props.selector && 'p-0.5'"
-          size="xs" />
+          class="text-c-btn size-3"
+          :class="props.selector && 'p-0.5'" />
       </div>
       <div
         v-if="showSelector || !props.selector"
@@ -100,9 +99,8 @@ const selectColor = (color: string) => {
           @click="selectColor(option.color)">
           <ScalarIconCheck
             v-if="activeColor === option.color && !customColor"
-            class="text-c-btn"
-            :class="props.selector && 'p-0.5'"
-            size="xs" />
+            class="text-c-btn size-3"
+            :class="props.selector && 'p-0.5'" />
         </div>
         <hr class="border-ghost h-5 w-0.5 border-l" />
         <label
@@ -117,8 +115,7 @@ const selectColor = (color: string) => {
                 (activeColor &&
                   !colorOptions.some((option) => option.color === activeColor)))
             "
-            class="text-c-btn"
-            size="xs" />
+            class="text-c-btn size-3" />
         </label>
       </div>
     </template>
@@ -145,7 +142,7 @@ const selectColor = (color: string) => {
         class="text-c-3 hover:bg-b-2 rounded-lg p-1.5"
         type="button"
         @click="handleClick">
-        <ScalarIconCheck size="xs" />
+        <ScalarIconCheck class="size-3" />
       </button>
     </div>
   </div>

--- a/packages/api-client/src/views/Environment/EnvironmentColors.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentColors.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconCheck } from '@scalar/icons'
 import { computed, nextTick, ref, watch } from 'vue'
 
 const props = withDefaults(
@@ -52,7 +52,7 @@ const handleClick = () => {
   })
 }
 
-watch(customColor, (newColor) => {
+watch(customColor, (newColor: string) => {
   if (newColor && !newColor.startsWith('#')) {
     customColor.value = `#${newColor}`
   }
@@ -81,11 +81,10 @@ const selectColor = (color: string) => {
         :class="props.selector ? 'h-4 w-4' : 'h-5 w-5'"
         :style="{ backgroundColor: activeColor }"
         @click="handleSelectorClick">
-        <ScalarIcon
+        <ScalarIconCheck
           v-if="activeColor"
           class="text-c-btn"
           :class="props.selector && 'p-0.5'"
-          icon="Checkmark"
           size="xs" />
       </div>
       <div
@@ -99,11 +98,10 @@ const selectColor = (color: string) => {
           :class="props.selector ? 'h-4 w-4' : 'h-5 w-5'"
           :style="{ backgroundColor: option.color }"
           @click="selectColor(option.color)">
-          <ScalarIcon
+          <ScalarIconCheck
             v-if="activeColor === option.color && !customColor"
             class="text-c-btn"
             :class="props.selector && 'p-0.5'"
-            icon="Checkmark"
             size="xs" />
         </div>
         <hr class="border-ghost h-5 w-0.5 border-l" />
@@ -112,7 +110,7 @@ const selectColor = (color: string) => {
           :class="props.selector ? 'h-4 w-4' : 'h-5 w-5'"
           :style="backgroundStyle"
           @click="handleClick">
-          <ScalarIcon
+          <ScalarIconCheck
             v-if="
               !showCustomInput &&
               (activeColor === customColor ||
@@ -120,7 +118,6 @@ const selectColor = (color: string) => {
                   !colorOptions.some((option) => option.color === activeColor)))
             "
             class="text-c-btn"
-            icon="Checkmark"
             size="xs" />
         </label>
       </div>
@@ -148,9 +145,7 @@ const selectColor = (color: string) => {
         class="text-c-3 hover:bg-b-2 rounded-lg p-1.5"
         type="button"
         @click="handleClick">
-        <ScalarIcon
-          icon="Checkmark"
-          size="xs" />
+        <ScalarIconCheck size="xs" />
       </button>
     </div>
   </div>

--- a/packages/api-client/src/views/Environment/EnvironmentModal.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentModal.vue
@@ -137,9 +137,7 @@ const redirectToCreateCollection = () => {
                 ? selectedEnvironment.label
                 : 'Select Collection'
             }}</span>
-            <ScalarIconCaretDown
-              class="text-c-3"
-              size="xs" />
+            <ScalarIconCaretDown class="text-c-3 size-3" />
           </ScalarButton>
           <ScalarButton
             v-else

--- a/packages/api-client/src/views/Environment/EnvironmentModal.vue
+++ b/packages/api-client/src/views/Environment/EnvironmentModal.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import {
   ScalarButton,
-  ScalarIcon,
   ScalarListbox,
   ScalarModal,
   type ModalState,
 } from '@scalar/components'
+import { ScalarIconCaretDown } from '@scalar/icons'
 import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { useToasts } from '@scalar/use-toasts'
 import { computed, ref, watch } from 'vue'
@@ -137,9 +137,8 @@ const redirectToCreateCollection = () => {
                 ? selectedEnvironment.label
                 : 'Select Collection'
             }}</span>
-            <ScalarIcon
+            <ScalarIconCaretDown
               class="text-c-3"
-              icon="ChevronDown"
               size="xs" />
           </ScalarButton>
           <ScalarButton

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuthScopesInput.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuthScopesInput.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarButton, ScalarIcon } from '@scalar/components'
+import { ScalarButton } from '@scalar/components'
+import { ScalarIconCaretDown, ScalarIconCaretRight } from '@scalar/icons'
 import type { Oauth2Flow } from '@scalar/oas-utils/entities/spec'
 import { computed } from 'vue'
 
@@ -99,9 +100,13 @@ const deselectAllScopes = () => {
               Select All
             </ScalarButton>
 
-            <ScalarIcon
+            <ScalarIconCaretDown
+              v-if="open"
               class="text-c-3 group-hover/scopes-accordion:text-c-2"
-              :icon="open ? 'ChevronDown' : 'ChevronRight'"
+              size="md" />
+            <ScalarIconCaretRight
+              v-else
+              class="text-c-3 group-hover/scopes-accordion:text-c-2"
               size="md" />
           </div>
         </DisclosureButton>

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuthScopesInput.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuthScopesInput.vue
@@ -102,12 +102,10 @@ const deselectAllScopes = () => {
 
             <ScalarIconCaretDown
               v-if="open"
-              class="text-c-3 group-hover/scopes-accordion:text-c-2"
-              size="md" />
+              class="text-c-3 group-hover/scopes-accordion:text-c-2 size-4" />
             <ScalarIconCaretRight
               v-else
-              class="text-c-3 group-hover/scopes-accordion:text-c-2"
-              size="md" />
+              class="text-c-3 group-hover/scopes-accordion:text-c-2 size-4" />
           </div>
         </DisclosureButton>
         <DisclosurePanel as="template">

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -583,7 +583,7 @@ const selectedExample = computed({
                 <ScalarIconUpload
                   class="ml-1"
                   size="xs"
-                  thickness="2.5" />
+                  weight="bold" />
               </ScalarButton>
             </template>
           </div>

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -531,7 +531,7 @@ const selectedExample = computed({
               class="text-c-2 hover:text-c-1 flex h-full w-fit gap-1.5 px-3 font-normal"
               variant="ghost">
               <span>{{ selectedContentType?.label }}</span>
-              <ScalarIconCaretDown size="md" />
+              <ScalarIconCaretDown class="size-4" />
             </ScalarButton>
           </ScalarListbox>
           <ScalarListbox
@@ -545,7 +545,7 @@ const selectedExample = computed({
               fullWidth
               variant="ghost">
               <span>{{ selectedExample?.label }}</span>
-              <ScalarIconCaretDown size="md" />
+              <ScalarIconCaretDown class="size-4" />
             </ScalarButton>
           </ScalarListbox>
         </DataTableHeader>
@@ -581,8 +581,7 @@ const selectedExample = computed({
                 @click="handleFileUpload">
                 <span>Upload File</span>
                 <ScalarIconUpload
-                  class="ml-1"
-                  size="xs"
+                  class="ml-1 size-3"
                   weight="bold" />
               </ScalarButton>
             </template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
+import { ScalarButton, ScalarListbox } from '@scalar/components'
+import { ScalarIconCaretDown, ScalarIconUpload } from '@scalar/icons'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import {
   requestExampleParametersSchema,
@@ -530,9 +531,7 @@ const selectedExample = computed({
               class="text-c-2 hover:text-c-1 flex h-full w-fit gap-1.5 px-3 font-normal"
               variant="ghost">
               <span>{{ selectedContentType?.label }}</span>
-              <ScalarIcon
-                icon="ChevronDown"
-                size="md" />
+              <ScalarIconCaretDown size="md" />
             </ScalarButton>
           </ScalarListbox>
           <ScalarListbox
@@ -546,9 +545,7 @@ const selectedExample = computed({
               fullWidth
               variant="ghost">
               <span>{{ selectedExample?.label }}</span>
-              <ScalarIcon
-                icon="ChevronDown"
-                size="md" />
+              <ScalarIconCaretDown size="md" />
             </ScalarButton>
           </ScalarListbox>
         </DataTableHeader>
@@ -583,9 +580,8 @@ const selectedExample = computed({
                 variant="outlined"
                 @click="handleFileUpload">
                 <span>Upload File</span>
-                <ScalarIcon
+                <ScalarIconUpload
                   class="ml-1"
-                  icon="Upload"
                   size="xs"
                   thickness="2.5" />
               </ScalarButton>

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
@@ -235,7 +235,7 @@ const customCodeContent = computed(() => {
               class="text-c-2 hover:text-c-1 flex h-full w-fit gap-1.5 px-1.25 py-0.75 font-normal"
               variant="ghost">
               <span>{{ selectedPlugin?.label }}</span>
-              <ScalarIconCaretDown size="md" />
+              <ScalarIconCaretDown class="size-4" />
             </ScalarButton>
           </ScalarCombobox>
         </div>

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
@@ -3,9 +3,9 @@ import {
   ScalarButton,
   ScalarCodeBlock,
   ScalarCombobox,
-  ScalarIcon,
   type ScalarComboboxOption,
 } from '@scalar/components'
+import { ScalarIconCaretDown } from '@scalar/icons'
 import type {
   Collection,
   Operation,
@@ -235,9 +235,7 @@ const customCodeContent = computed(() => {
               class="text-c-2 hover:text-c-1 flex h-full w-fit gap-1.5 px-1.25 py-0.75 font-normal"
               variant="ghost">
               <span>{{ selectedPlugin?.label }}</span>
-              <ScalarIcon
-                icon="ChevronDown"
-                size="md" />
+              <ScalarIconCaretDown size="md" />
             </ScalarButton>
           </ScalarCombobox>
         </div>
@@ -258,12 +256,12 @@ const customCodeContent = computed(() => {
             <template v-else>
               <CodeSnippet
                 :client="selectedClient"
+                :environment="environment"
                 :example="example"
                 :operation="operation"
                 :securitySchemes="selectedSecuritySchemes"
                 :server="server"
-                :target="selectedTarget"
-                :environment="environment" />
+                :target="selectedTarget" />
             </template>
           </div>
         </DataTableRow>

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -105,8 +105,9 @@ const showDeleteButton = (item: RequestExampleParameter) => {
             content="Global cookies are shared across the whole workspace."
             placement="top">
             <ScalarIconGlobe
-              class="text-c-2"
-              size="sm" />
+              class="text-c-1"
+              size="xs"
+              tabindex="0" />
           </ScalarTooltip>
         </RouterLink>
       </template>

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarIcon, ScalarTooltip } from '@scalar/components'
-import { ScalarIconTrash } from '@scalar/icons'
+import { ScalarButton, ScalarTooltip } from '@scalar/components'
+import {
+  ScalarIconGlobe,
+  ScalarIconTrash,
+  ScalarIconUpload,
+} from '@scalar/icons'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type { RequestExampleParameter } from '@scalar/oas-utils/entities/spec'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
@@ -100,11 +104,9 @@ const showDeleteButton = (item: RequestExampleParameter) => {
           <ScalarTooltip
             content="Global cookies are shared across the whole workspace."
             placement="top">
-            <ScalarIcon
-              tabindex="0"
-              class="text-c-1"
-              icon="Globe"
-              size="xs" />
+            <ScalarIconGlobe
+              class="text-c-2"
+              size="sm" />
           </ScalarTooltip>
         </RouterLink>
       </template>
@@ -122,9 +124,9 @@ const showDeleteButton = (item: RequestExampleParameter) => {
           :disabled="props.isReadOnly"
           disableEnter
           disableTabIndent
-          lineWrapping
           :envVariables="envVariables"
           :environment="environment"
+          lineWrapping
           :modelValue="item.key"
           placeholder="Key"
           :required="Boolean(item.required)"
@@ -149,11 +151,11 @@ const showDeleteButton = (item: RequestExampleParameter) => {
           :disabled="props.isReadOnly"
           disableEnter
           disableTabIndent
-          lineWrapping
           :enum="item.enum ?? []"
           :envVariables="envVariables"
           :environment="environment"
           :examples="item.examples ?? []"
+          lineWrapping
           :max="item.maximum"
           :min="item.minimum"
           :modelValue="item.value"
@@ -170,10 +172,10 @@ const showDeleteButton = (item: RequestExampleParameter) => {
           <template #icon>
             <ScalarButton
               v-if="showDeleteButton(item) && !item.required"
+              class="text-c-2 hover:text-c-1 hover:bg-b-2 z-context hidden h-fit rounded p-1 group-hover:flex group-has-[.cm-focused]:flex"
               :class="{
                 '-mr-0.5': hasItemProperties(item),
               }"
-              class="text-c-2 hover:text-c-1 hover:bg-b-2 z-context hidden h-fit rounded p-1 group-hover:flex group-has-[.cm-focused]:flex"
               size="sm"
               variant="ghost"
               @click="emit('deleteRow', idx)">
@@ -208,9 +210,8 @@ const showDeleteButton = (item: RequestExampleParameter) => {
               variant="outlined"
               @click="handleFileUpload(idx)">
               <span>Upload File</span>
-              <ScalarIcon
+              <ScalarIconUpload
                 class="ml-1"
-                icon="Upload"
                 size="xs"
                 thickness="2.5" />
             </ScalarButton>

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -105,8 +105,7 @@ const showDeleteButton = (item: RequestExampleParameter) => {
             content="Global cookies are shared across the whole workspace."
             placement="top">
             <ScalarIconGlobe
-              class="text-c-1"
-              size="xs"
+              class="text-c-1 size-3"
               tabindex="0" />
           </ScalarTooltip>
         </RouterLink>
@@ -212,8 +211,7 @@ const showDeleteButton = (item: RequestExampleParameter) => {
               @click="handleFileUpload(idx)">
               <span>Upload File</span>
               <ScalarIconUpload
-                class="ml-1"
-                size="xs"
+                class="ml-1 size-3"
                 weight="bold" />
             </ScalarButton>
           </div>

--- a/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestTable.vue
@@ -214,7 +214,7 @@ const showDeleteButton = (item: RequestExampleParameter) => {
               <ScalarIconUpload
                 class="ml-1"
                 size="xs"
-                thickness="2.5" />
+                weight="bold" />
             </ScalarButton>
           </div>
         </template>

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -387,7 +387,7 @@ function handleBlur(e: FocusEvent) {
               <ScalarIconScribbleLoop
                 v-if="collection.info?.title === 'Drafts'"
                 class="text-sidebar-c-2 group-hover:hidden"
-                thickness="2.25" />
+                weight="regular" />
               <LibraryIcon
                 v-else
                 class="text-sidebar-c-2 size-3.5 min-w-3.5 stroke-2 group-hover:hidden"

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
 import {
   ScalarButton,
-  ScalarIcon,
   ScalarSearchResultItem,
   ScalarSearchResultList,
   ScalarSidebarSearchInput,
 } from '@scalar/components'
+import {
+  ScalarIconCaretRight,
+  ScalarIconMagnifyingGlass,
+  ScalarIconScribbleLoop,
+} from '@scalar/icons'
 import { LibraryIcon } from '@scalar/icons/library'
 import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { useToasts } from '@scalar/use-toasts'
@@ -304,9 +308,8 @@ function handleBlur(e: FocusEvent) {
           <span class="sr-only">
             {{ isSearchVisible ? 'Hide' : 'Show' }} search
           </span>
-          <ScalarIcon
-            class="text-c-3 hover:bg-b-2 max-h-8 max-w-8 rounded-lg p-1.75 text-sm"
-            icon="Search" />
+          <ScalarIconMagnifyingGlass
+            class="text-c-3 hover:bg-b-2 max-h-8 max-w-8 rounded-lg p-1.75 text-sm" />
         </button>
       </div>
       <div
@@ -316,14 +319,14 @@ function handleBlur(e: FocusEvent) {
         <ScalarSidebarSearchInput
           ref="searchInputRef"
           v-model="searchText"
-          autofocus
           :aria-controls="searchResultsId"
+          autofocus
           :label="srLabel"
+          @blur="handleBlur"
           @input="fuseSearch"
           @keydown.down.stop="navigateSearchResults('down')"
           @keydown.enter.stop="selectSearchResult()"
-          @keydown.up.stop="navigateSearchResults('up')"
-          @blur="handleBlur" />
+          @keydown.up.stop="navigateSearchResults('up')" />
       </div>
       <div
         class="gap-1/2 flex flex-1 flex-col overflow-visible overflow-y-auto px-3 pt-0 pb-3"
@@ -348,9 +351,9 @@ function handleBlur(e: FocusEvent) {
               :id="`#search-input-${entry.item.id}`"
               :key="entry.refIndex"
               :ref="(el) => (searchResultRefs[index] = el as HTMLElement)"
-              :selected="selectedSearchResult === index"
               class="px-2"
               :href="entry.item.link"
+              :selected="selectedSearchResult === index"
               @click.prevent="onSearchResultClick(entry)"
               @focus="selectedSearchResult = index">
               {{ entry.item.title }}
@@ -381,10 +384,9 @@ function handleBlur(e: FocusEvent) {
             @onDragEnd="handleDragEnd"
             @openMenu="(item) => Object.assign(menuItem, item)">
             <template #leftIcon>
-              <ScalarIcon
+              <ScalarIconScribbleLoop
                 v-if="collection.info?.title === 'Drafts'"
                 class="text-sidebar-c-2 group-hover:hidden"
-                icon="Scribble"
                 thickness="2.25" />
               <LibraryIcon
                 v-else
@@ -396,9 +398,8 @@ function handleBlur(e: FocusEvent) {
                 :class="{
                   'rotate-90': collapsedSidebarFolders[collection.uid],
                 }">
-                <ScalarIcon
+                <ScalarIconCaretRight
                   class="text-c-3 hover:text-c-1 hidden text-sm group-hover:block"
-                  icon="ChevronRight"
                   size="md" />
               </div>
             </template>

--- a/packages/api-client/src/views/Request/RequestSidebar.vue
+++ b/packages/api-client/src/views/Request/RequestSidebar.vue
@@ -399,8 +399,7 @@ function handleBlur(e: FocusEvent) {
                   'rotate-90': collapsedSidebarFolders[collection.uid],
                 }">
                 <ScalarIconCaretRight
-                  class="text-c-3 hover:text-c-1 hidden text-sm group-hover:block"
-                  size="md" />
+                  class="text-c-3 hover:text-c-1 hidden size-4 text-sm group-hover:block" />
               </div>
             </template>
           </RequestSidebarItem>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -542,7 +542,7 @@ const shouldShowItem = computed(() => {
                 @click.stop.prevent="addRequest(item.entity.uid)">
                 <ScalarIconPlus
                   size="md"
-                  thickness="2" />
+                  weight="regular" />
               </ScalarButton>
             </div>
             <ScalarTooltip
@@ -557,7 +557,7 @@ const shouldShowItem = computed(() => {
                   class="ml-0.5 text-sm"
                   :class="watchIconColor"
                   size="md"
-                  thickness="2" />
+                  weight="regular" />
               </button>
             </ScalarTooltip>
             <span>&hairsp;</span>
@@ -622,7 +622,7 @@ const shouldShowItem = computed(() => {
                 @click.stop.prevent="addRequest(item.entity.uid)">
                 <ScalarIconPlus
                   size="md"
-                  thickness="2" />
+                  weight="regular" />
               </ScalarButton>
             </div>
             <ScalarTooltip
@@ -637,7 +637,7 @@ const shouldShowItem = computed(() => {
                   class="ml-0.5 text-sm"
                   :class="watchIconColor"
                   size="md"
-                  thickness="2" />
+                  weight="regular" />
               </button>
             </ScalarTooltip>
             <span>&hairsp;</span>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -455,7 +455,7 @@ const shouldShowItem = computed(() => {
                       open: !menuItem.open,
                     })
                 ">
-                <ScalarIconDotsThree size="md" />
+                <ScalarIconDotsThree class="size-4" />
               </ScalarButton>
             </div>
             <span class="flex items-start">
@@ -532,7 +532,7 @@ const shouldShowItem = computed(() => {
                       open: true,
                     })
                 ">
-                <ScalarIconDotsThree size="md" />
+                <ScalarIconDotsThree class="size-4" />
               </ScalarButton>
               <ScalarButton
                 v-if="layout !== 'modal'"
@@ -541,7 +541,7 @@ const shouldShowItem = computed(() => {
                 variant="ghost"
                 @click.stop.prevent="addRequest(item.entity.uid)">
                 <ScalarIconPlus
-                  size="md"
+                  class="size-4"
                   weight="regular" />
               </ScalarButton>
             </div>
@@ -554,9 +554,8 @@ const shouldShowItem = computed(() => {
                 class="flex items-center justify-center"
                 type="button">
                 <ScalarIconEye
-                  class="ml-0.5 text-sm"
+                  class="ml-0.5 size-4 text-sm"
                   :class="watchIconColor"
-                  size="md"
                   weight="regular" />
               </button>
             </ScalarTooltip>
@@ -612,7 +611,7 @@ const shouldShowItem = computed(() => {
                       open: true,
                     })
                 ">
-                <ScalarIconDotsThree size="md" />
+                <ScalarIconDotsThree class="size-4" />
               </ScalarButton>
               <ScalarButton
                 v-if="layout !== 'modal'"
@@ -621,7 +620,7 @@ const shouldShowItem = computed(() => {
                 variant="ghost"
                 @click.stop.prevent="addRequest(item.entity.uid)">
                 <ScalarIconPlus
-                  size="md"
+                  class="size-4"
                   weight="regular" />
               </ScalarButton>
             </div>
@@ -634,9 +633,8 @@ const shouldShowItem = computed(() => {
                 class="flex items-center justify-center"
                 type="button">
                 <ScalarIconEye
-                  class="ml-0.5 text-sm"
+                  class="ml-0.5 size-4 text-sm"
                   :class="watchIconColor"
-                  size="md"
                   weight="regular" />
               </button>
             </ScalarTooltip>
@@ -665,7 +663,7 @@ const shouldShowItem = computed(() => {
           :class="parentUids.length ? 'pl-9' : ''"
           variant="ghost"
           @click="addRequest(item.entity.uid)">
-          <ScalarIconPlus size="sm" />
+          <ScalarIconPlus class="size-3.5" />
           <span>Add Request</span>
         </ScalarButton>
       </ul>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import {
   ScalarButton,
-  ScalarIcon,
   ScalarSidebarGroupToggle,
   ScalarTooltip,
 } from '@scalar/components'
@@ -11,6 +10,11 @@ import {
   type DraggingItem,
   type HoveredItem,
 } from '@scalar/draggable'
+import {
+  ScalarIconDotsThree,
+  ScalarIconEye,
+  ScalarIconPlus,
+} from '@scalar/icons'
 import type { Collection, Request } from '@scalar/oas-utils/entities/spec'
 import { shouldIgnoreEntity } from '@scalar/oas-utils/helpers'
 import { computed, nextTick, ref } from 'vue'
@@ -451,9 +455,7 @@ const shouldShowItem = computed(() => {
                       open: !menuItem.open,
                     })
                 ">
-                <ScalarIcon
-                  icon="Ellipses"
-                  size="md" />
+                <ScalarIconDotsThree size="md" />
               </ScalarButton>
             </div>
             <span class="flex items-start">
@@ -530,9 +532,7 @@ const shouldShowItem = computed(() => {
                       open: true,
                     })
                 ">
-                <ScalarIcon
-                  icon="Ellipses"
-                  size="md" />
+                <ScalarIconDotsThree size="md" />
               </ScalarButton>
               <ScalarButton
                 v-if="layout !== 'modal'"
@@ -540,24 +540,22 @@ const shouldShowItem = computed(() => {
                 size="sm"
                 variant="ghost"
                 @click.stop.prevent="addRequest(item.entity.uid)">
-                <ScalarIcon
-                  icon="Add"
+                <ScalarIconPlus
                   size="md"
                   thickness="2" />
               </ScalarButton>
             </div>
             <ScalarTooltip
               v-if="item.watchMode"
-              placement="right"
+              :content="`Watching: ${item.documentUrl}`"
               :offset="12"
-              :content="`Watching: ${item.documentUrl}`">
+              placement="right">
               <button
                 class="flex items-center justify-center"
                 type="button">
-                <ScalarIcon
+                <ScalarIconEye
                   class="ml-0.5 text-sm"
                   :class="watchIconColor"
-                  icon="Watch"
                   size="md"
                   thickness="2" />
               </button>
@@ -614,9 +612,7 @@ const shouldShowItem = computed(() => {
                       open: true,
                     })
                 ">
-                <ScalarIcon
-                  icon="Ellipses"
-                  size="md" />
+                <ScalarIconDotsThree size="md" />
               </ScalarButton>
               <ScalarButton
                 v-if="layout !== 'modal'"
@@ -624,8 +620,7 @@ const shouldShowItem = computed(() => {
                 size="sm"
                 variant="ghost"
                 @click.stop.prevent="addRequest(item.entity.uid)">
-                <ScalarIcon
-                  icon="Add"
+                <ScalarIconPlus
                   size="md"
                   thickness="2" />
               </ScalarButton>
@@ -633,15 +628,14 @@ const shouldShowItem = computed(() => {
             <ScalarTooltip
               v-if="item.watchMode"
               content="Watching: {{ item.documentUrl }}"
-              placement="right"
-              :offset="12">
+              :offset="12"
+              placement="right">
               <button
                 class="flex items-center justify-center"
                 type="button">
-                <ScalarIcon
+                <ScalarIconEye
                   class="ml-0.5 text-sm"
                   :class="watchIconColor"
-                  icon="Watch"
                   size="md"
                   thickness="2" />
               </button>
@@ -671,9 +665,7 @@ const shouldShowItem = computed(() => {
           :class="parentUids.length ? 'pl-9' : ''"
           variant="ghost"
           @click="addRequest(item.entity.uid)">
-          <ScalarIcon
-            icon="Add"
-            size="sm" />
+          <ScalarIconPlus size="sm" />
           <span>Add Request</span>
         </ScalarButton>
       </ul>

--- a/packages/api-client/src/views/Request/RequestSidebarItem.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItem.vue
@@ -455,7 +455,9 @@ const shouldShowItem = computed(() => {
                       open: !menuItem.open,
                     })
                 ">
-                <ScalarIconDotsThree class="size-4" />
+                <ScalarIconDotsThree
+                  class="size-4"
+                  weight="bold" />
               </ScalarButton>
             </div>
             <span class="flex items-start">
@@ -532,7 +534,9 @@ const shouldShowItem = computed(() => {
                       open: true,
                     })
                 ">
-                <ScalarIconDotsThree class="size-4" />
+                <ScalarIconDotsThree
+                  class="size-4"
+                  weight="bold" />
               </ScalarButton>
               <ScalarButton
                 v-if="layout !== 'modal'"
@@ -611,7 +615,9 @@ const shouldShowItem = computed(() => {
                       open: true,
                     })
                 ">
-                <ScalarIconDotsThree class="size-4" />
+                <ScalarIconDotsThree
+                  class="size-4"
+                  weight="bold" />
               </ScalarButton>
               <ScalarButton
                 v-if="layout !== 'modal'"

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -184,19 +184,6 @@ const isDraftsMenuItem = computed(() => {
           </span>
         </ScalarDropdownButton>
 
-        <!-- Duplicate -->
-        <!-- <ScalarDropdownButton
-        class="flex  items-center !gap-2"
-        @click="handleItemDuplicate">
-        <ScalarIcon
-          class="inline-flex"
-          weight="light"
-          icon="Duplicate"
-          size="sm" />
-        <span>Duplicate</span>
-      </ScalarDropdownButton>
-      <ScalarDropdownDivider /> -->
-
         <!-- Watch -->
         <ScalarDropdownButton
           v-if="menuItem.item?.documentUrl"

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -3,11 +3,17 @@ import {
   ScalarDropdownButton,
   ScalarDropdownMenu,
   ScalarFloating,
-  ScalarIcon,
   ScalarModal,
   useModal,
   type ScalarDropdown,
 } from '@scalar/components'
+import {
+  ScalarIconEye,
+  ScalarIconEyeSlash,
+  ScalarIconPencil,
+  ScalarIconPuzzlePiece,
+  ScalarIconTrash,
+} from '@scalar/icons'
 import type { Collection } from '@scalar/oas-utils/entities/spec'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
@@ -153,9 +159,8 @@ const isDraftsMenuItem = computed(() => {
           v-if="menuItem.item?.entity.type === 'request'"
           class="flex items-center gap-2"
           @click="handleAddExample">
-          <ScalarIcon
+          <ScalarIconPuzzlePiece
             class="inline-flex"
-            icon="Example"
             size="md"
             thickness="1.5" />
           <span>Add Example</span>
@@ -167,9 +172,8 @@ const isDraftsMenuItem = computed(() => {
           ref="menuRef"
           class="flex items-center gap-2"
           @click="editModal.show()">
-          <ScalarIcon
+          <ScalarIconPencil
             class="inline-flex"
-            icon="Edit"
             size="md"
             thickness="1.5" />
           <span>
@@ -199,9 +203,9 @@ const isDraftsMenuItem = computed(() => {
           ref="menuRef"
           class="flex items-center gap-2"
           @click="toggleWatchMode">
-          <ScalarIcon
+          <component
+            :is="menuItem.item?.watchMode ? ScalarIconEyeSlash : ScalarIconEye"
             class="inline-flex"
-            :icon="menuItem.item?.watchMode ? 'Unwatch' : 'Watch'"
             size="md"
             thickness="1.5" />
           <span>
@@ -218,9 +222,8 @@ const isDraftsMenuItem = computed(() => {
           v-if="!isDraftsMenuItem"
           class="flex items-center gap-2"
           @click="deleteModal.show()">
-          <ScalarIcon
+          <ScalarIconTrash
             class="inline-flex"
-            icon="Delete"
             size="md"
             thickness="1.5" />
           <span>Delete</span>
@@ -231,9 +234,8 @@ const isDraftsMenuItem = computed(() => {
           v-if="isDraftsMenuItem"
           class="flex items-center gap-2"
           @click="clearDraftsModal.show()">
-          <ScalarIcon
+          <ScalarIconTrash
             class="inline-flex"
-            icon="Delete"
             size="md"
             thickness="1.5" />
           <span>Clear Drafts</span>

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -162,7 +162,7 @@ const isDraftsMenuItem = computed(() => {
           <ScalarIconPuzzlePiece
             class="inline-flex"
             size="md"
-            thickness="1.5" />
+            weight="light" />
           <span>Add Example</span>
         </ScalarDropdownButton>
 
@@ -175,7 +175,7 @@ const isDraftsMenuItem = computed(() => {
           <ScalarIconPencil
             class="inline-flex"
             size="md"
-            thickness="1.5" />
+            weight="light" />
           <span>
             <template v-if="menuItem.item?.entity.type === 'collection'">
               Edit
@@ -190,7 +190,7 @@ const isDraftsMenuItem = computed(() => {
         @click="handleItemDuplicate">
         <ScalarIcon
           class="inline-flex"
-          thickness="1.5"
+          weight="light"
           icon="Duplicate"
           size="sm" />
         <span>Duplicate</span>
@@ -207,7 +207,7 @@ const isDraftsMenuItem = computed(() => {
             :is="menuItem.item?.watchMode ? ScalarIconEyeSlash : ScalarIconEye"
             class="inline-flex"
             size="md"
-            thickness="1.5" />
+            weight="light" />
           <span>
             {{
               menuItem.item?.watchMode
@@ -225,7 +225,7 @@ const isDraftsMenuItem = computed(() => {
           <ScalarIconTrash
             class="inline-flex"
             size="md"
-            thickness="1.5" />
+            weight="light" />
           <span>Delete</span>
         </ScalarDropdownButton>
 
@@ -237,7 +237,7 @@ const isDraftsMenuItem = computed(() => {
           <ScalarIconTrash
             class="inline-flex"
             size="md"
-            thickness="1.5" />
+            weight="light" />
           <span>Clear Drafts</span>
         </ScalarDropdownButton>
       </ScalarDropdownMenu>

--- a/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
+++ b/packages/api-client/src/views/Request/RequestSidebarItemMenu.vue
@@ -160,8 +160,7 @@ const isDraftsMenuItem = computed(() => {
           class="flex items-center gap-2"
           @click="handleAddExample">
           <ScalarIconPuzzlePiece
-            class="inline-flex"
-            size="md"
+            class="inline-flex size-4"
             weight="light" />
           <span>Add Example</span>
         </ScalarDropdownButton>
@@ -173,8 +172,7 @@ const isDraftsMenuItem = computed(() => {
           class="flex items-center gap-2"
           @click="editModal.show()">
           <ScalarIconPencil
-            class="inline-flex"
-            size="md"
+            class="inline-flex size-4"
             weight="light" />
           <span>
             <template v-if="menuItem.item?.entity.type === 'collection'">
@@ -192,8 +190,7 @@ const isDraftsMenuItem = computed(() => {
           @click="toggleWatchMode">
           <component
             :is="menuItem.item?.watchMode ? ScalarIconEyeSlash : ScalarIconEye"
-            class="inline-flex"
-            size="md"
+            class="inline-flex size-4"
             weight="light" />
           <span>
             {{
@@ -210,8 +207,7 @@ const isDraftsMenuItem = computed(() => {
           class="flex items-center gap-2"
           @click="deleteModal.show()">
           <ScalarIconTrash
-            class="inline-flex"
-            size="md"
+            class="inline-flex size-4"
             weight="light" />
           <span>Delete</span>
         </ScalarDropdownButton>
@@ -222,8 +218,7 @@ const isDraftsMenuItem = computed(() => {
           class="flex items-center gap-2"
           @click="clearDraftsModal.show()">
           <ScalarIconTrash
-            class="inline-flex"
-            size="md"
+            class="inline-flex size-4"
             weight="light" />
           <span>Clear Drafts</span>
         </ScalarDropdownButton>

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -75,7 +75,7 @@ const { currentRoute } = useRouter()
         @click="$emit('hideModal')">
         <ScalarIconX
           size="lg"
-          thickness="2" />
+          weight="regular" />
         <span class="sr-only">Close Client</span>
       </button>
       <!-- TODO: temporary solution: 2nd button (not fixed position) for our friends at GitBook -->
@@ -86,7 +86,7 @@ const { currentRoute } = useRouter()
         @click="$emit('hideModal')">
         <ScalarIconX
           size="md"
-          thickness="1.75" />
+          weight="light" />
         <span class="sr-only">Close Client</span>
       </button>
     </div>

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -74,7 +74,7 @@ const { currentRoute } = useRouter()
         type="button"
         @click="$emit('hideModal')">
         <ScalarIconX
-          size="lg"
+          class="size-5"
           weight="regular" />
         <span class="sr-only">Close Client</span>
       </button>
@@ -85,7 +85,7 @@ const { currentRoute } = useRouter()
         type="button"
         @click="$emit('hideModal')">
         <ScalarIconX
-          size="md"
+          class="size-4"
           weight="light" />
         <span class="sr-only">Close Client</span>
       </button>

--- a/packages/api-client/src/views/Request/RequestSubpageHeader.vue
+++ b/packages/api-client/src/views/Request/RequestSubpageHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconX } from '@scalar/icons'
 import type { Environment } from '@scalar/oas-utils/entities/environment'
 import type {
   Collection,
@@ -73,8 +73,7 @@ const { currentRoute } = useRouter()
         class="app-exit-button gitbook-hidden zoomed:static zoomed:p-1 fixed top-2 right-2 rounded-full p-2"
         type="button"
         @click="$emit('hideModal')">
-        <ScalarIcon
-          icon="Close"
+        <ScalarIconX
           size="lg"
           thickness="2" />
         <span class="sr-only">Close Client</span>
@@ -85,8 +84,7 @@ const { currentRoute } = useRouter()
         class="text-c-1 hover:bg-b-2 active:text-c-1 gitbook-show -mr-1.5 rounded p-2"
         type="button"
         @click="$emit('hideModal')">
-        <ScalarIcon
-          icon="Close"
+        <ScalarIconX
           size="md"
           thickness="1.75" />
         <span class="sr-only">Close Client</span>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyDownload.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyDownload.vue
@@ -22,7 +22,7 @@ const filenameExtension = computed(() => {
     :download="`${filenameExtension}`"
     :href="href"
     @click.stop>
-    <ScalarIconDownload size="xs" />
+    <ScalarIconDownload class="size-3" />
     <span>
       <span>Download</span>
       <span class="sr-only">Response Body</span>

--- a/packages/api-client/src/views/Request/ResponseSection/ResponseBodyDownload.vue
+++ b/packages/api-client/src/views/Request/ResponseSection/ResponseBodyDownload.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconDownload } from '@scalar/icons'
 import { computed } from 'vue'
 
 import { getMediaTypeConfig } from '@/views/Request/consts'
@@ -22,9 +22,7 @@ const filenameExtension = computed(() => {
     :download="`${filenameExtension}`"
     :href="href"
     @click.stop>
-    <ScalarIcon
-      icon="Download"
-      size="xs" />
+    <ScalarIconDownload size="xs" />
     <span>
       <span>Download</span>
       <span class="sr-only">Response Body</span>

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -149,7 +149,7 @@ const deleteWorkspace = async () => {
                   <ScalarIconPencil
                     class="inline-flex"
                     size="md"
-                    thickness="1.5" />
+                    weight="light" />
                   <span>Rename</span>
                 </ScalarDropdownItem>
                 <ScalarDropdownItem
@@ -160,7 +160,7 @@ const deleteWorkspace = async () => {
                   <ScalarIconTrash
                     class="inline-flex"
                     size="md"
-                    thickness="1.5" />
+                    weight="light" />
                   <span>Delete</span>
                 </ScalarDropdownItem>
               </template>

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -4,11 +4,16 @@ import {
   ScalarDropdown,
   ScalarDropdownDivider,
   ScalarDropdownItem,
-  ScalarIcon,
   ScalarListboxCheckbox,
   ScalarModal,
   useModal,
 } from '@scalar/components'
+import {
+  ScalarIconDotsThree,
+  ScalarIconPencil,
+  ScalarIconPlus,
+  ScalarIconTrash,
+} from '@scalar/icons'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
@@ -134,18 +139,15 @@ const deleteWorkspace = async () => {
                 size="sm"
                 type="button"
                 variant="ghost">
-                <ScalarIcon
-                  icon="Ellipses"
-                  size="sm" />
+                <ScalarIconDotsThree size="md" />
               </ScalarButton>
               <template #items>
                 <ScalarDropdownItem
                   class="flex gap-2"
                   @mousedown="openRenameModal(workspace.uid)"
                   @touchend.prevent="openRenameModal(workspace.uid)">
-                  <ScalarIcon
+                  <ScalarIconPencil
                     class="inline-flex"
-                    icon="Edit"
                     size="md"
                     thickness="1.5" />
                   <span>Rename</span>
@@ -155,9 +157,8 @@ const deleteWorkspace = async () => {
                   class="flex gap-2"
                   @mousedown.prevent="openDeleteModal(workspace.uid)"
                   @touchend.prevent="openDeleteModal(workspace.uid)">
-                  <ScalarIcon
+                  <ScalarIconTrash
                     class="inline-flex"
-                    icon="Delete"
                     size="md"
                     thickness="1.5" />
                   <span>Delete</span>
@@ -172,9 +173,7 @@ const deleteWorkspace = async () => {
             class="flex items-center gap-1.5"
             @click="createNewWorkspace">
             <div class="flex h-4 w-4 items-center justify-center">
-              <ScalarIcon
-                icon="Add"
-                size="sm" />
+              <ScalarIconPlus size="sm" />
             </div>
             <span>Create Workspace</span>
           </ScalarDropdownItem>

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -139,7 +139,9 @@ const deleteWorkspace = async () => {
                 size="sm"
                 type="button"
                 variant="ghost">
-                <ScalarIconDotsThree class="size-4" />
+                <ScalarIconDotsThree
+                  class="size-4"
+                  weight="bold" />
               </ScalarButton>
               <template #items>
                 <ScalarDropdownItem

--- a/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
+++ b/packages/api-client/src/views/Request/components/WorkspaceDropdown.vue
@@ -139,7 +139,7 @@ const deleteWorkspace = async () => {
                 size="sm"
                 type="button"
                 variant="ghost">
-                <ScalarIconDotsThree size="md" />
+                <ScalarIconDotsThree class="size-4" />
               </ScalarButton>
               <template #items>
                 <ScalarDropdownItem
@@ -147,8 +147,7 @@ const deleteWorkspace = async () => {
                   @mousedown="openRenameModal(workspace.uid)"
                   @touchend.prevent="openRenameModal(workspace.uid)">
                   <ScalarIconPencil
-                    class="inline-flex"
-                    size="md"
+                    class="inline-flex size-4"
                     weight="light" />
                   <span>Rename</span>
                 </ScalarDropdownItem>
@@ -158,8 +157,7 @@ const deleteWorkspace = async () => {
                   @mousedown.prevent="openDeleteModal(workspace.uid)"
                   @touchend.prevent="openDeleteModal(workspace.uid)">
                   <ScalarIconTrash
-                    class="inline-flex"
-                    size="md"
+                    class="inline-flex size-4"
                     weight="light" />
                   <span>Delete</span>
                 </ScalarDropdownItem>
@@ -173,7 +171,7 @@ const deleteWorkspace = async () => {
             class="flex items-center gap-1.5"
             @click="createNewWorkspace">
             <div class="flex h-4 w-4 items-center justify-center">
-              <ScalarIconPlus size="sm" />
+              <ScalarIconPlus class="size-3.5" />
             </div>
             <span>Create Workspace</span>
           </ScalarDropdownItem>

--- a/packages/api-client/src/views/Settings/SettingsGeneral.vue
+++ b/packages/api-client/src/views/Settings/SettingsGeneral.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { cva, cx, ScalarButton, ScalarIcon } from '@scalar/components'
+import { cva, cx, ScalarButton } from '@scalar/components'
+import { ScalarIconCheck } from '@scalar/icons'
 import {
   themeLabels,
   type IntegrationThemeId,
@@ -123,9 +124,8 @@ const setProxy = (newProxy: string | undefined) =>
                   'bg-c-accent text-b-1 border-transparent':
                     activeWorkspace?.proxyUrl === DEFAULT_PROXY_URL,
                 }">
-                <ScalarIcon
+                <ScalarIconCheck
                   v-if="activeWorkspace?.proxyUrl === DEFAULT_PROXY_URL"
-                  icon="Checkmark"
                   size="xs"
                   thickness="3.5" />
               </div>
@@ -149,9 +149,8 @@ const setProxy = (newProxy: string | undefined) =>
                   'bg-c-accent text-b-1 border-transparent':
                     activeWorkspace?.proxyUrl === proxyUrl,
                 }">
-                <ScalarIcon
+                <ScalarIconCheck
                   v-if="activeWorkspace?.proxyUrl === proxyUrl"
-                  icon="Checkmark"
                   size="xs"
                   thickness="3.5" />
               </div>
@@ -168,9 +167,8 @@ const setProxy = (newProxy: string | undefined) =>
                   !activeWorkspace?.proxyUrl &&
                   'bg-c-accent text-b-1 border-transparent'
                 ">
-                <ScalarIcon
+                <ScalarIconCheck
                   v-if="!activeWorkspace?.proxyUrl"
-                  icon="Checkmark"
                   size="xs"
                   thickness="3.5" />
               </div>
@@ -206,9 +204,8 @@ const setProxy = (newProxy: string | undefined) =>
                       'bg-c-accent text-b-1 border-transparent':
                         activeWorkspace?.themeId === themeId,
                     }">
-                    <ScalarIcon
+                    <ScalarIconCheck
                       v-if="activeWorkspace?.themeId === themeId"
-                      icon="Checkmark"
                       size="xs"
                       thickness="3.5" />
                   </div>
@@ -263,9 +260,8 @@ const setProxy = (newProxy: string | undefined) =>
                     'bg-c-accent text-b-1 border-transparent':
                       activeWorkspace?.themeId === themeId,
                   }">
-                  <ScalarIcon
+                  <ScalarIconCheck
                     v-if="activeWorkspace?.themeId === themeId"
-                    icon="Checkmark"
                     size="xs"
                     thickness="3.5" />
                 </div>

--- a/packages/api-client/src/views/Settings/SettingsGeneral.vue
+++ b/packages/api-client/src/views/Settings/SettingsGeneral.vue
@@ -126,7 +126,7 @@ const setProxy = (newProxy: string | undefined) =>
                 }">
                 <ScalarIconCheck
                   v-if="activeWorkspace?.proxyUrl === DEFAULT_PROXY_URL"
-                  size="xs"
+                  class="size-3"
                   weight="bold" />
               </div>
               Use proxy.scalar.com (default)
@@ -151,7 +151,7 @@ const setProxy = (newProxy: string | undefined) =>
                 }">
                 <ScalarIconCheck
                   v-if="activeWorkspace?.proxyUrl === proxyUrl"
-                  size="xs"
+                  class="size-3"
                   weight="bold" />
               </div>
               Use custom proxy ({{ proxyUrl }})
@@ -169,7 +169,7 @@ const setProxy = (newProxy: string | undefined) =>
                 ">
                 <ScalarIconCheck
                   v-if="!activeWorkspace?.proxyUrl"
-                  size="xs"
+                  class="size-3"
                   weight="bold" />
               </div>
               Skip the proxy
@@ -206,7 +206,7 @@ const setProxy = (newProxy: string | undefined) =>
                     }">
                     <ScalarIconCheck
                       v-if="activeWorkspace?.themeId === themeId"
-                      size="xs"
+                      class="size-3"
                       weight="bold" />
                   </div>
                   {{ themeLabels[themeId] }}
@@ -262,7 +262,7 @@ const setProxy = (newProxy: string | undefined) =>
                   }">
                   <ScalarIconCheck
                     v-if="activeWorkspace?.themeId === themeId"
-                    size="xs"
+                    class="size-3"
                     weight="bold" />
                 </div>
                 {{ themeLabels[themeId] }}

--- a/packages/api-client/src/views/Settings/SettingsGeneral.vue
+++ b/packages/api-client/src/views/Settings/SettingsGeneral.vue
@@ -127,7 +127,7 @@ const setProxy = (newProxy: string | undefined) =>
                 <ScalarIconCheck
                   v-if="activeWorkspace?.proxyUrl === DEFAULT_PROXY_URL"
                   size="xs"
-                  thickness="3.5" />
+                  weight="bold" />
               </div>
               Use proxy.scalar.com (default)
             </ScalarButton>
@@ -152,7 +152,7 @@ const setProxy = (newProxy: string | undefined) =>
                 <ScalarIconCheck
                   v-if="activeWorkspace?.proxyUrl === proxyUrl"
                   size="xs"
-                  thickness="3.5" />
+                  weight="bold" />
               </div>
               Use custom proxy ({{ proxyUrl }})
             </ScalarButton>
@@ -170,7 +170,7 @@ const setProxy = (newProxy: string | undefined) =>
                 <ScalarIconCheck
                   v-if="!activeWorkspace?.proxyUrl"
                   size="xs"
-                  thickness="3.5" />
+                  weight="bold" />
               </div>
               Skip the proxy
             </ScalarButton>
@@ -207,7 +207,7 @@ const setProxy = (newProxy: string | undefined) =>
                     <ScalarIconCheck
                       v-if="activeWorkspace?.themeId === themeId"
                       size="xs"
-                      thickness="3.5" />
+                      weight="bold" />
                   </div>
                   {{ themeLabels[themeId] }}
                 </div>
@@ -263,7 +263,7 @@ const setProxy = (newProxy: string | undefined) =>
                   <ScalarIconCheck
                     v-if="activeWorkspace?.themeId === themeId"
                     size="xs"
-                    thickness="3.5" />
+                    weight="bold" />
                 </div>
                 {{ themeLabels[themeId] }}
               </div>

--- a/packages/api-client/src/views/Settings/components/SettingsAppearance.vue
+++ b/packages/api-client/src/views/Settings/components/SettingsAppearance.vue
@@ -27,7 +27,7 @@ const buttonStyles = cva({
         }">
         <ScalarIconCheck
           v-if="colorMode === 'system'"
-          size="xs"
+          class="size-3"
           weight="bold" />
       </div>
       System Preference (default)
@@ -42,7 +42,7 @@ const buttonStyles = cva({
         }">
         <ScalarIconCheck
           v-if="colorMode === 'light'"
-          size="xs"
+          class="size-3"
           weight="bold" />
       </div>
       Light Mode Always
@@ -57,7 +57,7 @@ const buttonStyles = cva({
         }">
         <ScalarIconCheck
           v-if="colorMode === 'dark'"
-          size="xs"
+          class="size-3"
           weight="bold" />
       </div>
       Dark Mode Always

--- a/packages/api-client/src/views/Settings/components/SettingsAppearance.vue
+++ b/packages/api-client/src/views/Settings/components/SettingsAppearance.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { cva, cx, ScalarButton, ScalarIcon } from '@scalar/components'
+import { cva, cx, ScalarButton } from '@scalar/components'
+import { ScalarIconCheck } from '@scalar/icons'
 import { useColorMode } from '@scalar/use-hooks/useColorMode'
 
 const { colorMode, setColorMode } = useColorMode()
@@ -24,9 +25,8 @@ const buttonStyles = cva({
         :class="{
           'bg-c-accent text-b-1 border-transparent': colorMode === 'system',
         }">
-        <ScalarIcon
+        <ScalarIconCheck
           v-if="colorMode === 'system'"
-          icon="Checkmark"
           size="xs"
           thickness="3.5" />
       </div>
@@ -40,9 +40,8 @@ const buttonStyles = cva({
         :class="{
           'bg-c-accent text-b-1 border-transparent': colorMode === 'light',
         }">
-        <ScalarIcon
+        <ScalarIconCheck
           v-if="colorMode === 'light'"
-          icon="Checkmark"
           size="xs"
           thickness="3.5" />
       </div>
@@ -56,9 +55,8 @@ const buttonStyles = cva({
         :class="{
           'bg-c-accent text-b-1 border-transparent': colorMode === 'dark',
         }">
-        <ScalarIcon
+        <ScalarIconCheck
           v-if="colorMode === 'dark'"
-          icon="Checkmark"
           size="xs"
           thickness="3.5" />
       </div>

--- a/packages/api-client/src/views/Settings/components/SettingsAppearance.vue
+++ b/packages/api-client/src/views/Settings/components/SettingsAppearance.vue
@@ -28,7 +28,7 @@ const buttonStyles = cva({
         <ScalarIconCheck
           v-if="colorMode === 'system'"
           size="xs"
-          thickness="3.5" />
+          weight="bold" />
       </div>
       System Preference (default)
     </ScalarButton>
@@ -43,7 +43,7 @@ const buttonStyles = cva({
         <ScalarIconCheck
           v-if="colorMode === 'light'"
           size="xs"
-          thickness="3.5" />
+          weight="bold" />
       </div>
       Light Mode Always
     </ScalarButton>
@@ -58,7 +58,7 @@ const buttonStyles = cva({
         <ScalarIconCheck
           v-if="colorMode === 'dark'"
           size="xs"
-          thickness="3.5" />
+          weight="bold" />
       </div>
       Dark Mode Always
     </ScalarButton>

--- a/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientDropdown.vue
+++ b/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientDropdown.vue
@@ -6,7 +6,7 @@ import {
   type ClientOptionGroup,
   type CustomClientOption,
 } from '@scalar/api-client/v2/blocks/operation-code-sample'
-import { ScalarCombobox, ScalarIcon } from '@scalar/components'
+import { ScalarCombobox, ScalarIconLegacyAdapter } from '@scalar/components'
 import { freezeElement } from '@scalar/helpers/dom/freeze-element'
 import type { AvailableClients, TargetId } from '@scalar/types/snippetz'
 import { type WorkspaceEventBus } from '@scalar/workspace-store/events'
@@ -70,7 +70,7 @@ const selectedTargetKey = computed(
         'client-libraries__active': featuredClient.id === selectedClient,
       }">
       <div :class="`client-libraries-icon__${featuredClient.targetKey}`">
-        <ScalarIcon
+        <ScalarIconLegacyAdapter
           class="client-libraries-icon"
           :icon="getIconByLanguageKey(featuredClient.targetKey)" />
       </div>
@@ -98,7 +98,7 @@ const selectedTargetKey = computed(
           class="client-libraries-icon__more">
           <template v-if="selectedClient && !isFeaturedClient(selectedClient)">
             <div :class="`client-libraries-icon__${selectedTargetKey}`">
-              <ScalarIcon
+              <ScalarIconLegacyAdapter
                 v-if="selectedTargetKey"
                 class="client-libraries-icon"
                 :icon="getIconByLanguageKey(selectedTargetKey)" />

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components'
+import { ScalarIconPlus } from '@scalar/icons'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type {
   DiscriminatorObject,
@@ -139,9 +140,8 @@ const handleClick = (e: MouseEvent) => noncollapsible && e.stopPropagation()
             as="button"
             class="schema-card-title schema-card-title--compact"
             @click.capture="handleClick">
-            <ScalarIcon
+            <ScalarIconPlus
               class="schema-card-title-icon"
-              icon="Add"
               size="sm" />
             Show additional properties
             <ScreenReader v-if="name">for {{ name }}</ScreenReader>
@@ -159,10 +159,9 @@ const handleClick = (e: MouseEvent) => noncollapsible && e.stopPropagation()
           }"
           @click.capture="handleClick">
           <template v-if="compact">
-            <ScalarIcon
+            <ScalarIconPlus
               class="schema-card-title-icon"
               :class="{ 'schema-card-title-icon--open': open }"
-              icon="Add"
               size="sm" />
             <template v-if="open">
               Hide {{ schema?.title ?? 'Child Attributes' }}
@@ -173,10 +172,9 @@ const handleClick = (e: MouseEvent) => noncollapsible && e.stopPropagation()
             <ScreenReader v-if="name">for {{ name }}</ScreenReader>
           </template>
           <template v-else>
-            <ScalarIcon
+            <ScalarIconPlus
               class="schema-card-title-icon"
               :class="{ 'schema-card-title-icon--open': open }"
-              icon="Add"
               size="sm" />
             <SchemaHeading
               :name="schema?.title ?? name"

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -140,9 +140,7 @@ const handleClick = (e: MouseEvent) => noncollapsible && e.stopPropagation()
             as="button"
             class="schema-card-title schema-card-title--compact"
             @click.capture="handleClick">
-            <ScalarIconPlus
-              class="schema-card-title-icon"
-              size="sm" />
+            <ScalarIconPlus class="schema-card-title-icon size-3.5" />
             Show additional properties
             <ScreenReader v-if="name">for {{ name }}</ScreenReader>
           </DisclosureButton>
@@ -160,9 +158,8 @@ const handleClick = (e: MouseEvent) => noncollapsible && e.stopPropagation()
           @click.capture="handleClick">
           <template v-if="compact">
             <ScalarIconPlus
-              class="schema-card-title-icon"
-              :class="{ 'schema-card-title-icon--open': open }"
-              size="sm" />
+              class="schema-card-title-icon size-3.5"
+              :class="{ 'schema-card-title-icon--open': open }" />
             <template v-if="open">
               Hide {{ schema?.title ?? 'Child Attributes' }}
             </template>
@@ -173,9 +170,8 @@ const handleClick = (e: MouseEvent) => noncollapsible && e.stopPropagation()
           </template>
           <template v-else>
             <ScalarIconPlus
-              class="schema-card-title-icon"
-              :class="{ 'schema-card-title-icon--open': open }"
-              size="sm" />
+              class="schema-card-title-icon size-3.5"
+              :class="{ 'schema-card-title-icon--open': open }" />
             <SchemaHeading
               :name="schema?.title ?? name"
               :value="schema" />

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
@@ -29,8 +29,7 @@ const { copyToClipboard } = useClipboard()
             {{ formatExample(example) }}
           </span>
           <ScalarIconClipboard
-            class="group-hover:text-c-1 text-c-3 ml-auto min-h-3 min-w-3"
-            size="xs" />
+            class="group-hover:text-c-1 text-c-3 ml-auto size-3 min-h-3 min-w-3" />
         </button>
       </div>
     </div>
@@ -60,8 +59,7 @@ const { copyToClipboard } = useClipboard()
           @click="copyToClipboard(formatExample(ex))">
           <span>{{ formatExample(ex) }} </span>
           <ScalarIconClipboard
-            class="text-c-3 group-hover:text-c-1 ml-auto min-h-3 min-w-3"
-            size="xs" />
+            class="text-c-3 group-hover:text-c-1 ml-auto size-3 min-h-3 min-w-3" />
         </button>
       </div>
     </div>

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconClipboard } from '@scalar/icons'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 
 import { formatExample } from './helpers/format-example'
@@ -28,9 +28,8 @@ const { copyToClipboard } = useClipboard()
           <span>
             {{ formatExample(example) }}
           </span>
-          <ScalarIcon
+          <ScalarIconClipboard
             class="group-hover:text-c-1 text-c-3 ml-auto min-h-3 min-w-3"
-            icon="Clipboard"
             size="xs" />
         </button>
       </div>
@@ -60,9 +59,8 @@ const { copyToClipboard } = useClipboard()
           type="button"
           @click="copyToClipboard(formatExample(ex))">
           <span>{{ formatExample(ex) }} </span>
-          <ScalarIcon
+          <ScalarIconClipboard
             class="text-c-3 group-hover:text-c-1 ml-auto min-h-3 min-w-3"
-            icon="Clipboard"
             size="xs" />
         </button>
       </div>

--- a/packages/api-reference/src/features/Operation/components/Headers.vue
+++ b/packages/api-reference/src/features/Operation/components/Headers.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconPlus } from '@scalar/icons'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { HeaderObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
@@ -28,10 +28,9 @@ const { headers, breadcrumb } = defineProps<{
           :style="{
             top: `calc(var(--refs-viewport-offset)))`,
           }">
-          <ScalarIcon
+          <ScalarIconPlus
             class="headers-card-title-icon"
             :class="{ 'headers-card-title-icon--open': open }"
-            icon="Add"
             size="sm" />
           <template v-if="open"> Hide Headers </template>
           <template v-else> Show Headers </template>

--- a/packages/api-reference/src/features/Operation/components/Headers.vue
+++ b/packages/api-reference/src/features/Operation/components/Headers.vue
@@ -29,9 +29,8 @@ const { headers, breadcrumb } = defineProps<{
             top: `calc(var(--refs-viewport-offset)))`,
           }">
           <ScalarIconPlus
-            class="headers-card-title-icon"
-            :class="{ 'headers-card-title-icon--open': open }"
-            size="sm" />
+            class="headers-card-title-icon size-3.5"
+            :class="{ 'headers-card-title-icon--open': open }" />
           <template v-if="open"> Hide Headers </template>
           <template v-else> Show Headers </template>
         </DisclosureButton>

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.vue
@@ -9,9 +9,9 @@ import {
   ScalarCardFooter,
   ScalarCardSection,
   ScalarCodeBlock,
-  ScalarIcon,
   ScalarMarkdown,
 } from '@scalar/components'
+import { ScalarIconClipboard } from '@scalar/icons'
 import {
   getObjectKeys,
   normalizeMimeTypeObject,
@@ -157,9 +157,7 @@ const showSchema = ref(false)
           class="code-copy"
           type="button"
           @click="() => copyToClipboard(currentResponseContent?.example)">
-          <ScalarIcon
-            icon="Clipboard"
-            width="12px" />
+          <ScalarIconClipboard class="size-3" />
         </button>
         <label
           v-if="currentResponseContent?.schema"

--- a/packages/api-reference/src/features/toolbar/ApiReferenceToolbarSdks.vue
+++ b/packages/api-reference/src/features/toolbar/ApiReferenceToolbarSdks.vue
@@ -13,6 +13,10 @@ import ApiReferenceToolbarBlurb from '@/features/toolbar/ApiReferenceToolbarBlur
 import ApiReferenceToolbarPopover from '@/features/toolbar/ApiReferenceToolbarPopover.vue'
 import ApiReferenceToolbarRegisterButton from '@/features/toolbar/ApiReferenceToolbarRegisterButton.vue'
 
+const { workspace } = defineProps<{
+  workspace: WorkspaceStore
+}>()
+
 const LANGUAGES = [
   {
     key: 'typescript',
@@ -32,10 +36,6 @@ const LANGUAGES = [
 }>
 
 type LanguageKey = (typeof LANGUAGES)[number]['key']
-
-const { workspace } = defineProps<{
-  workspace: WorkspaceStore
-}>()
 
 const selectedLanguages = ref<LanguageKey[]>([])
 </script>
@@ -59,8 +59,8 @@ const selectedLanguages = ref<LanguageKey[]>([])
           ">
           <span class="inline-flex items-center gap-2">
             <ScalarIconLegacyAdapter
-              :icon="icon"
-              class="text-c-2 size-3.5" />
+              class="text-c-2 size-3.5"
+              :icon="icon" />
             {{ label }}
           </span>
         </ScalarToggleInput>

--- a/packages/api-reference/src/features/toolbar/ApiReferenceToolbarSdks.vue
+++ b/packages/api-reference/src/features/toolbar/ApiReferenceToolbarSdks.vue
@@ -2,7 +2,7 @@
 import {
   ScalarFormInputGroup,
   ScalarFormSection,
-  ScalarIcon,
+  ScalarIconLegacyAdapter,
   ScalarToggleInput,
   type Icon as LegacyIcon,
 } from '@scalar/components'
@@ -58,7 +58,7 @@ const selectedLanguages = ref<LanguageKey[]>([])
                   ))
           ">
           <span class="inline-flex items-center gap-2">
-            <ScalarIcon
+            <ScalarIconLegacyAdapter
               :icon="icon"
               class="text-c-2 size-3.5" />
             {{ label }}

--- a/packages/components/src/components/ScalarIcon/IconList.vue
+++ b/packages/components/src/components/ScalarIcon/IconList.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
+import type { ScalarIconWeight } from '@scalar/icons/types'
 import { ref } from 'vue'
 
 import { ScalarIconButton } from '../ScalarIconButton'
 import { ICONS } from './icons'
 
 defineProps<{
-  thickness?: string
+  weight?: ScalarIconWeight
 }>()
 
 defineOptions({ inheritAttrs: false })
@@ -28,7 +29,7 @@ const copied = ref(false)
         class="hover:bg-b-2"
         :icon="icon"
         :label="icon"
-        :thickness="thickness"
+        :weight="weight"
         v-bind="$attrs"
         @click="copyToClipboard(icon)"
         @mouseenter="selected = icon" />

--- a/packages/components/src/components/ScalarIcon/ScalarIcon.stories.ts
+++ b/packages/components/src/components/ScalarIcon/ScalarIcon.stories.ts
@@ -13,7 +13,6 @@ const meta = {
       control: 'select',
       options: ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl'],
     },
-    thickness: { control: { type: 'range', min: 0, max: 3, step: 0.1 } },
     class: { control: 'text' },
     style: { control: 'text' },
   },

--- a/packages/components/src/components/ScalarIcon/ScalarIcon.vue
+++ b/packages/components/src/components/ScalarIcon/ScalarIcon.vue
@@ -14,16 +14,16 @@ import type { ScalarIconProps } from './types'
 import { getIcon, getLogo } from './utils'
 import { variants } from './variants'
 
-const props = defineProps<ScalarIconProps>()
+const { icon, logo, size, thickness, label } = defineProps<ScalarIconProps>()
 
 defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
 
-const stroke = computed(() => props.thickness ?? '2')
+const stroke = computed(() => thickness ?? '2')
 
 const accessibilityAttrs = computed(() =>
-  props.label
-    ? { 'aria-label': props.label }
+  label
+    ? { 'aria-label': label }
     : {
         'aria-hidden': true,
         'role': 'presentation',
@@ -31,11 +31,11 @@ const accessibilityAttrs = computed(() =>
 )
 
 const svg = computed(() => {
-  if (props.icon) {
-    return getIcon(props.icon)
+  if (icon) {
+    return getIcon(icon)
   }
-  if (props.logo) {
-    return getLogo(props.logo)
+  if (logo) {
+    return getLogo(logo)
   }
 
   return undefined

--- a/packages/components/src/components/ScalarIcon/ScalarIconLegacyAdapter.vue
+++ b/packages/components/src/components/ScalarIcon/ScalarIconLegacyAdapter.vue
@@ -22,7 +22,7 @@ import { variants } from './variants'
 /**
  * Icon wrapper for all icons and logos
  */
-const props = defineProps<
+const { icon, size, label, weight, thickness } = defineProps<
   {
     icon: Icon | ScalarIconComponent
   } & ScalarIconProps &
@@ -43,21 +43,19 @@ const WEIGHT_TO_THICKNESS: Record<ScalarIconWeight, string> = {
 }
 
 defineOptions({ inheritAttrs: false })
+
 const { cx } = useBindCx()
 
 const legacyThickness = computed(
-  () =>
-    (props.weight != null
-      ? WEIGHT_TO_THICKNESS[props.weight]
-      : props.thickness) ?? '2',
+  () => (weight != null ? WEIGHT_TO_THICKNESS[weight] : thickness) ?? '2',
 )
 
 /** Pass only props the legacy ScalarIcon accepts so weight is never forwarded (legacy uses thickness). */
 const legacyIconBind = computed(
   (): LegacyScalarIconProps & { thickness: string } => ({
-    icon: props.icon as Icon,
-    size: props.size,
-    label: props.label,
+    icon: icon as Icon,
+    size: size,
+    label: label,
     thickness: legacyThickness.value,
   }),
 )

--- a/packages/components/src/components/ScalarIcon/ScalarIconLegacyAdapter.vue
+++ b/packages/components/src/components/ScalarIcon/ScalarIconLegacyAdapter.vue
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script setup lang="ts">
 /**
  * Scalar Icon Legacy Adapter
  *
@@ -6,9 +6,6 @@
  * as a prop to accept a component instead to be compatible with `@scalar/icons`
  * while staying backwards compatible with the legacy ScalarIcon component
  */
-export default {}
-</script>
-<script setup lang="ts">
 import type {
   ScalarIconComponent,
   ScalarIconProps,
@@ -54,13 +51,21 @@ const legacyThickness = computed(
       ? WEIGHT_TO_THICKNESS[props.weight]
       : props.thickness) ?? '2',
 )
+
+/** Pass only props the legacy ScalarIcon accepts so weight is never forwarded (legacy uses thickness). */
+const legacyIconBind = computed(
+  (): LegacyScalarIconProps & { thickness: string } => ({
+    icon: props.icon as Icon,
+    size: props.size,
+    label: props.label,
+    thickness: legacyThickness.value,
+  }),
+)
 </script>
 <template>
   <ScalarIcon
     v-if="typeof icon === 'string'"
-    v-bind="{ ...$props, ...$attrs }"
-    :icon="icon"
-    :thickness="legacyThickness" />
+    v-bind="legacyIconBind" />
   <component
     :is="icon"
     v-else

--- a/packages/components/src/components/ScalarIcon/ScalarIconLegacyAdapter.vue
+++ b/packages/components/src/components/ScalarIcon/ScalarIconLegacyAdapter.vue
@@ -9,8 +9,13 @@
 export default {}
 </script>
 <script setup lang="ts">
-import type { ScalarIconComponent, ScalarIconProps } from '@scalar/icons/types'
+import type {
+  ScalarIconComponent,
+  ScalarIconProps,
+  ScalarIconWeight,
+} from '@scalar/icons/types'
 import { useBindCx } from '@scalar/use-hooks/useBindCx'
+import { computed } from 'vue'
 
 import ScalarIcon from './ScalarIcon.vue'
 import type { ScalarIconProps as LegacyScalarIconProps } from './types'
@@ -18,10 +23,22 @@ import type { Icon } from './utils'
 import { variants } from './variants'
 
 /**
+ * Maps weight to legacy thickness for the string-icon branch.
+ * Lets callers pass only weight; legacy ScalarIcon still receives a thickness value.
+ */
+const WEIGHT_TO_THICKNESS: Record<ScalarIconWeight, string> = {
+  thin: '1',
+  light: '1.5',
+  regular: '2',
+  bold: '2.5',
+  fill: '2.5',
+  duotone: '2.5',
+}
+
+/**
  * Icon wrapper for all icons and logos
  */
-
-defineProps<
+const props = defineProps<
   {
     icon: Icon | ScalarIconComponent
   } & ScalarIconProps &
@@ -30,12 +47,20 @@ defineProps<
 
 defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
+
+const legacyThickness = computed(
+  () =>
+    (props.weight != null
+      ? WEIGHT_TO_THICKNESS[props.weight]
+      : props.thickness) ?? '2',
+)
 </script>
 <template>
   <ScalarIcon
     v-if="typeof icon === 'string'"
     v-bind="{ ...$props, ...$attrs }"
-    :icon="icon" />
+    :icon="icon"
+    :thickness="legacyThickness" />
   <component
     :is="icon"
     v-else

--- a/packages/components/src/components/ScalarIcon/ScalarIconLegacyAdapter.vue
+++ b/packages/components/src/components/ScalarIcon/ScalarIconLegacyAdapter.vue
@@ -23,6 +23,16 @@ import type { Icon } from './utils'
 import { variants } from './variants'
 
 /**
+ * Icon wrapper for all icons and logos
+ */
+const props = defineProps<
+  {
+    icon: Icon | ScalarIconComponent
+  } & ScalarIconProps &
+    Omit<LegacyScalarIconProps, 'icon'>
+>()
+
+/**
  * Maps weight to legacy thickness for the string-icon branch.
  * Lets callers pass only weight; legacy ScalarIcon still receives a thickness value.
  */
@@ -34,16 +44,6 @@ const WEIGHT_TO_THICKNESS: Record<ScalarIconWeight, string> = {
   fill: '2.5',
   duotone: '2.5',
 }
-
-/**
- * Icon wrapper for all icons and logos
- */
-const props = defineProps<
-  {
-    icon: Icon | ScalarIconComponent
-  } & ScalarIconProps &
-    Omit<LegacyScalarIconProps, 'icon'>
->()
 
 defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()

--- a/packages/components/src/components/ScalarIcon/ScalarIconLegacyAdapter.vue
+++ b/packages/components/src/components/ScalarIcon/ScalarIconLegacyAdapter.vue
@@ -63,7 +63,7 @@ const legacyIconBind = computed(
 <template>
   <ScalarIcon
     v-if="typeof icon === 'string'"
-    v-bind="legacyIconBind" />
+    v-bind="{ ...legacyIconBind, ...$attrs }" />
   <component
     :is="icon"
     v-else

--- a/packages/components/src/components/ScalarIcon/utils/index.ts
+++ b/packages/components/src/components/ScalarIcon/utils/index.ts
@@ -45,5 +45,6 @@ export const getLogo = (name: Logo) => {
     console.warn(`Could not find icon: ${name}`)
     return null
   }
+
   return logos[filename]
 }

--- a/packages/components/src/components/ScalarIconButton/ScalarIconButton.test.ts
+++ b/packages/components/src/components/ScalarIconButton/ScalarIconButton.test.ts
@@ -196,24 +196,24 @@ describe('ScalarIconButton', () => {
       expect(iconComponent.props('weight')).toBe('bold')
     })
 
-    it('passes thickness prop to icon component (deprecated)', () => {
+    it('passes weight prop to icon component', () => {
       const wrapper = mount(ScalarIconButton, {
         props: {
           icon: 'Logo',
-          label: 'Thick Icon',
-          thickness: '2',
+          label: 'Icon with weight',
+          weight: 'regular',
         },
       })
 
       const iconComponent = wrapper.findComponent(ScalarIconLegacyAdapter)
-      expect(iconComponent.props('thickness')).toBe('2')
+      expect(iconComponent.props('weight')).toBe('regular')
     })
 
-    it('passes both weight and thickness props', () => {
+    it('passes weight and does not forward deprecated thickness', () => {
       const wrapper = mount(ScalarIconButton, {
         props: {
           icon: 'Logo',
-          label: 'Icon with both props',
+          label: 'Icon with weight',
           weight: 'light',
           thickness: '1.5',
         },
@@ -221,7 +221,7 @@ describe('ScalarIconButton', () => {
 
       const iconComponent = wrapper.findComponent(ScalarIconLegacyAdapter)
       expect(iconComponent.props('weight')).toBe('light')
-      expect(iconComponent.props('thickness')).toBe('1.5')
+      expect(iconComponent.props('thickness')).toBeUndefined()
     })
   })
 

--- a/packages/components/src/components/ScalarIconButton/ScalarIconButton.test.ts
+++ b/packages/components/src/components/ScalarIconButton/ScalarIconButton.test.ts
@@ -215,7 +215,6 @@ describe('ScalarIconButton', () => {
           icon: 'Logo',
           label: 'Icon with weight',
           weight: 'light',
-          thickness: '1.5',
         },
       })
 

--- a/packages/components/src/components/ScalarIconButton/ScalarIconButton.vue
+++ b/packages/components/src/components/ScalarIconButton/ScalarIconButton.vue
@@ -77,7 +77,6 @@ useTooltip({
     v-bind="cx(variants({ size, variant, disabled }))">
     <ScalarIconLegacyAdapter
       :icon="icon"
-      :thickness="thickness"
       :weight="weight" />
     <span
       v-if="!tooltip"

--- a/packages/components/src/components/ScalarMenu/ScalarMenuButton.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuButton.vue
@@ -2,7 +2,7 @@
 import { ScalarIconCaretDown } from '@scalar/icons'
 
 import { ScalarHeaderButton } from '../ScalarHeader'
-import { ScalarIcon } from '../ScalarIcon'
+import { ScalarIconLegacyAdapter } from '../ScalarIcon'
 import type { ScalarMenuButtonProps, ScalarMenuButtonSlots } from './types'
 
 defineProps<ScalarMenuButtonProps>()
@@ -13,7 +13,7 @@ defineSlots<ScalarMenuButtonSlots>()
   <ScalarHeaderButton class="gap-0.75 px-2">
     <div class="h-5 w-auto">
       <slot name="logo">
-        <ScalarIcon icon="Logo" />
+        <ScalarIconLegacyAdapter icon="Logo" />
       </slot>
     </div>
     <span class="sr-only">

--- a/packages/components/src/components/ScalarMenu/ScalarMenuLink.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuLink.vue
@@ -25,7 +25,7 @@ defineOptions({ inheritAttrs: false })
       v-if="icon"
       :class="[
         strong ? 'text-c-1' : 'text-c-2',
-        typeof icon === 'string' ? 'size-3' : 'size-3.5 -mx-0.25',
+        typeof icon === 'string' ? 'size-3' : 'size-3.5 -mx-px',
       ]"
       :icon="icon"
       :weight="strong ? 'bold' : 'regular'" />

--- a/packages/components/src/components/ScalarMenu/ScalarMenuLink.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuLink.vue
@@ -28,7 +28,6 @@ defineOptions({ inheritAttrs: false })
         typeof icon === 'string' ? 'size-3' : 'size-3.5 -mx-0.25',
       ]"
       :icon="icon"
-      :thickness="strong ? '2.5' : '2'"
       :weight="strong ? 'bold' : 'regular'" />
     <div
       v-else

--- a/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
+++ b/packages/components/src/components/ScalarSearchResults/ScalarSearchResultItem.vue
@@ -50,7 +50,7 @@ const { cx } = useBindCx()
       </div>
       <div
         v-if="$slots.description"
-        class="truncate zoomed:!whitespace-normal break-words text-base text-c-2">
+        class="truncate zoomed:!whitespace-normal wrap-break-word text-base text-c-2">
         <slot name="description" />
       </div>
     </div>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -80,7 +80,7 @@ const { cx } = useBindCx()
     </slot>
     <div
       v-if="icon || $slots.icon"
-      class="h-[1lh] *:size-4 mr-1">
+      class="h-lh *:size-4 mr-1">
       <slot name="icon">
         <ScalarIconLegacyAdapter
           v-if="icon"

--- a/packages/pre-post-request-scripts/package.json
+++ b/packages/pre-post-request-scripts/package.json
@@ -82,6 +82,7 @@
     "@codemirror/lang-javascript": "^6.2.4",
     "@headlessui/vue": "catalog:*",
     "@scalar/components": "workspace:*",
+    "@scalar/icons": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
     "vue": "catalog:*"
   },

--- a/packages/pre-post-request-scripts/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/pre-post-request-scripts/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -39,9 +39,8 @@ const id = useId()
           <ScalarIconCaretRight
             v-if="layout !== 'reference'"
             :class="[
-              'text-c-3 group-hover:text-c-1 ui-open:rotate-90 ui-not-open:rotate-0 rounded-px outline-offset-2 group-focus-visible:outline',
-            ]"
-            size="md" />
+              'text-c-3 group-hover:text-c-1 ui-open:rotate-90 ui-not-open:rotate-0 rounded-px size-4 outline-offset-2 group-focus-visible:outline',
+            ]" />
           <h2
             class="text-c-1 m-0 flex flex-1 items-center gap-1.5 leading-[20px]">
             <span

--- a/packages/pre-post-request-scripts/src/components/ViewLayout/ViewLayoutCollapse.vue
+++ b/packages/pre-post-request-scripts/src/components/ViewLayout/ViewLayoutCollapse.vue
@@ -3,7 +3,7 @@
 // I've copied it here, so we can move the scripts to a separate package.
 // But maybe we can move the component to a shared package?
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIconCaretRight } from '@scalar/icons'
 import { useId } from 'vue'
 
 const {
@@ -36,12 +36,11 @@ const id = useId()
             { '!pl-3': layout === 'reference' },
           ]"
           :disabled="layout === 'reference'">
-          <ScalarIcon
+          <ScalarIconCaretRight
             v-if="layout !== 'reference'"
             :class="[
               'text-c-3 group-hover:text-c-1 ui-open:rotate-90 ui-not-open:rotate-0 rounded-px outline-offset-2 group-focus-visible:outline',
             ]"
-            icon="ChevronRight"
             size="md" />
           <h2
             class="text-c-1 m-0 flex flex-1 items-center gap-1.5 leading-[20px]">

--- a/packages/pre-post-request-scripts/src/plugins/post-response-scripts/components/TestResults/TestResultIndicator.vue
+++ b/packages/pre-post-request-scripts/src/plugins/post-response-scripts/components/TestResults/TestResultIndicator.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
-import { cva, ScalarIcon, useBindCx, type Icon } from '@scalar/components'
-import { computed } from 'vue'
+import { cva, useBindCx } from '@scalar/components'
+import {
+  ScalarIconCheck,
+  ScalarIconDotsThree,
+  ScalarIconX,
+} from '@scalar/icons'
+import { computed, type Component } from 'vue'
 
 import type { TestResult } from '@/libs/execute-scripts'
 
@@ -17,14 +22,17 @@ const { cx } = useBindCx()
 
 const icon = computed(() => {
   if (state === 'passed') {
-    return { name: 'Checkmark', color: 'text-green p-0.25' }
+    return {
+      component: ScalarIconCheck as Component,
+      color: 'text-green p-0.25',
+    }
   }
 
   if (state === 'failed') {
-    return { name: 'Close', color: 'text-red' }
+    return { component: ScalarIconX as Component, color: 'text-red' }
   }
 
-  return { name: 'Ellipses', color: 'text-c-1' }
+  return { component: ScalarIconDotsThree as Component, color: 'text-c-1' }
 })
 
 const statusVariants = cva({
@@ -69,10 +77,10 @@ const getTestCountDisplay = computed(() => {
 
 <template>
   <div v-bind="cx(statusVariants({ status: state }))">
-    <ScalarIcon
+    <component
+      :is="icon.component"
       v-if="state"
       :class="icon.color"
-      :icon="icon.name as Icon"
       size="sm" />
     <span
       v-if="!inline"

--- a/packages/pre-post-request-scripts/src/plugins/post-response-scripts/components/TestResults/TestResultIndicator.vue
+++ b/packages/pre-post-request-scripts/src/plugins/post-response-scripts/components/TestResults/TestResultIndicator.vue
@@ -80,8 +80,7 @@ const getTestCountDisplay = computed(() => {
     <component
       :is="icon.component"
       v-if="state"
-      :class="icon.color"
-      size="sm" />
+      :class="[icon.color, 'size-3.5']" />
     <span
       v-if="!inline"
       class="ml-1.25 capitalize">

--- a/packages/pre-post-request-scripts/src/plugins/post-response-scripts/components/TestResults/TestResultItem.vue
+++ b/packages/pre-post-request-scripts/src/plugins/post-response-scripts/components/TestResults/TestResultItem.vue
@@ -38,8 +38,7 @@ const resultStatus = computed(() => {
       <div class="flex items-center gap-3 p-2">
         <component
           :is="resultStatus.component"
-          :class="resultStatus.color"
-          size="sm" />
+          :class="[resultStatus.color, 'size-3.5']" />
 
         <span class="text-c-2 overflow-hidden text-ellipsis whitespace-nowrap">
           {{ result.title }}

--- a/packages/pre-post-request-scripts/src/plugins/post-response-scripts/components/TestResults/TestResultItem.vue
+++ b/packages/pre-post-request-scripts/src/plugins/post-response-scripts/components/TestResults/TestResultItem.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { ScalarIcon, type Icon } from '@scalar/components'
-import { computed } from 'vue'
+import {
+  ScalarIconCheck,
+  ScalarIconDotsThree,
+  ScalarIconX,
+} from '@scalar/icons'
+import { computed, type Component } from 'vue'
 
 import type { TestResult } from '@/libs/execute-scripts'
 
@@ -11,14 +15,17 @@ const { currentState, result } = defineProps<{
 
 const resultStatus = computed(() => {
   if (result.passed) {
-    return { icon: 'Checkmark', color: 'text-green p-0.25' }
+    return {
+      component: ScalarIconCheck as Component,
+      color: 'text-green p-0.25',
+    }
   }
 
   if (!result.passed && currentState !== 'pending') {
-    return { icon: 'Close', color: 'text-red' }
+    return { component: ScalarIconX as Component, color: 'text-red' }
   }
 
-  return { icon: 'Ellipses', color: 'text-c-1' }
+  return { component: ScalarIconDotsThree as Component, color: 'text-c-1' }
 })
 </script>
 
@@ -29,9 +36,9 @@ const resultStatus = computed(() => {
       :class="result.error && 'bg-b-danger'">
       <!-- Title -->
       <div class="flex items-center gap-3 p-2">
-        <ScalarIcon
+        <component
+          :is="resultStatus.component"
           :class="resultStatus.color"
-          :icon="resultStatus.icon as Icon"
           size="sm" />
 
         <span class="text-c-2 overflow-hidden text-ellipsis whitespace-nowrap">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2343,6 +2343,9 @@ importers:
       '@scalar/components':
         specifier: workspace:*
         version: link:../components
+      '@scalar/icons':
+        specifier: workspace:*
+        version: link:../icons
       '@scalar/oas-utils':
         specifier: workspace:*
         version: link:../oas-utils


### PR DESCRIPTION
## Problem

 Moves most icons to discrete imports

## Solution

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Predominantly a UI refactor changing icon imports/types and sizing; main risk is regressions where icons are passed/stored incorrectly (string vs component) or weight/size props render unexpectedly.
> 
> **Overview**
> Migrates the API client and API reference UIs away from `ScalarIcon` string identifiers to **direct icon component imports from `@scalar/icons`**, updating icon sizing/weights across buttons, dropdowns, nav, schemas, and toolbars.
> 
> Introduces/expands use of `ScalarIconLegacyAdapter` for places that still rely on legacy icon string keys, updates navigation icon plumbing (`ROUTES`, `SideNavLink`/`SideNavRouterLink`, `TopNav` items) to accept Vue `Component` icons (using `markRaw` where stored in constants), and adjusts unit tests to assert against the new icon components. Also updates components tooling to use `weight` terminology (e.g., `IconList`) and slightly refactors `ScalarIcon.vue` prop usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82f78e5872c0fcda55c7f3e2ca8f4a9a3c296c1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->