### PR TITLE
fix(workspace-store): quick fix for sibling props

### DIFF
--- a/.changeset/ninety-weeks-guess.md
+++ b/.changeset/ninety-weeks-guess.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: merge sibling params in getResolvedRef

--- a/packages/workspace-store/src/helpers/get-resolved-ref.test.ts
+++ b/packages/workspace-store/src/helpers/get-resolved-ref.test.ts
@@ -84,6 +84,23 @@ describe('get-resolved-ref', () => {
       expect(result).toEqual({ id: 1, name: 'John' })
     })
 
+    it('should merge sibling properties with $ref-value properties', () => {
+      const refNode = {
+        $ref: '#/components/schemas/User',
+        '$ref-value': { id: 1, name: 'John' },
+        description: 'A user object',
+        example: { id: 1, name: 'Jane' },
+      }
+      const result = getResolvedRef(refNode)
+
+      expect(result).toEqual({
+        id: 1,
+        name: 'John',
+        description: 'A user object',
+        example: { id: 1, name: 'Jane' },
+      })
+    })
+
     it('should work with custom transform function', () => {
       const refNode = { $ref: '#/components/schemas/User', '$ref-value': { id: 1, name: 'John' } }
       const customTransform = (node: any) => ({ ...node['$ref-value'], transformed: true })

--- a/packages/workspace-store/src/helpers/get-resolved-ref.ts
+++ b/packages/workspace-store/src/helpers/get-resolved-ref.ts
@@ -1,7 +1,20 @@
+import { isObject } from '@scalar/helpers/object/is-object'
+
 export type RefNode<Node> = Partial<Node> & { $ref: string; '$ref-value': Node }
 export type NodeInput<Node> = Node | RefNode<Node>
 
-const defaultTransform = <Node>(node: RefNode<Node>) => {
+/** Default transform function that overwrites the $ref properties with the $ref-value properties */
+const defaultTransform = <Node>(node: RefNode<Node>): Node => {
+  // For objects we should merge the $ref-value properties with the node properties
+  if (isObject(node['$ref-value'])) {
+    const { $ref: _, '$ref-value': refValue, ...rest } = node
+    return {
+      ...rest,
+      ...refValue,
+    } as Node
+  }
+
+  // Otherwise we just return the ref-value
   return node['$ref-value']
 }
 


### PR DESCRIPTION
## Problem

fixes #7956

Good ol sibling props has come up again. In this case the base param was validated against the schema but the ref-value was not, making our types incorrect and causing the bug.

## Solution

This is a quick fix for sibling params and _should_ be type safe now. However in the future we should ensure that we parse the schema again after merging these properties for the best type safety.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to `getResolvedRef` default behavior for object refs; risk is limited to potential edge-case differences in merge precedence for consumers relying on previous `$ref-value`-only output.
> 
> **Overview**
> `getResolvedRef` now merges *sibling properties* on a `$ref` node with the resolved `'$ref-value'` when the ref value is an object, instead of returning only the ref value.
> 
> Adds a unit test covering the sibling-props merge behavior and includes a changeset to publish a patch release for `@scalar/workspace-store`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0771653174bdfec6a5b8c8a9f8842d6f7d9e3b39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->