### PR TITLE
fix(api-reference): prevent re-rendering of ready items in lazy-bus

### DIFF
--- a/.changeset/fix-lazy-bus-performance.md
+++ b/.changeset/fix-lazy-bus-performance.md
@@ -1,0 +1,15 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: prevent re-rendering of already-ready items in lazy-bus queue
+
+Restores the readyQueue guard in addToPendingQueue to prevent items that are
+already rendered from being re-added to the pending queue. This fixes a
+performance regression introduced in #7497 where large API specs would
+experience severe slowdowns due to items being reprocessed on every scroll
+or interaction.
+
+The fix maintains the callback functionality from #7497 by still allowing
+items to be added to the priority queue (for callback triggering), but
+processQueue now skips adding items that are already in readyQueue.

--- a/packages/api-reference/src/helpers/lazy-bus.ts
+++ b/packages/api-reference/src/helpers/lazy-bus.ts
@@ -77,7 +77,10 @@ const runLazyBus = () => {
       isRunning.value = true
 
       for (const id of [...pendingQueue, ...priorityQueue]) {
-        readyQueue.add(id)
+        // Only add to readyQueue if not already there to avoid re-rendering
+        if (!readyQueue.has(id)) {
+          readyQueue.add(id)
+        }
         pendingQueue.delete(id)
         priorityQueue.delete(id)
       }
@@ -122,16 +125,18 @@ watchDebounced(
  * We only make elements pending if they are not already in the priority or ready queue
  */
 const addToPendingQueue = (id: string | undefined) => {
-  if (!!id && !priorityQueue.has(id)) {
+  if (!!id && !readyQueue.has(id) && !priorityQueue.has(id)) {
     pendingQueue.add(id)
   }
 }
 
 /**
- * We only add elements to the priority queue if they are not already in the ready queue
+ * Add elements to the priority queue for immediate rendering.
+ * We allow adding items already in readyQueue so that callbacks are still triggered,
+ * but processQueue will skip actual re-rendering for items already ready.
  */
 const addToPriorityQueue = (id: string | undefined) => {
-  if (id) {
+  if (id && !priorityQueue.has(id)) {
     priorityQueue.add(id)
   }
 }


### PR DESCRIPTION
## Problem

Fixes a performance regression introduced in #7497 where large API specs experience severe slowdowns due to items being reprocessed on every scroll or interaction. We were seeing our spec unusable (scrolling stopped working) in Firefox & Chrome after a few clicks.

- Restore readyQueue guard in addToPendingQueue
- Add priorityQueue guard in addToPriorityQueue to prevent duplicates
- Skip adding to readyQueue in processQueue if item already ready

This preserves the callback fix from #7497 while preventing re-rendering.

## Solution

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

Made with 🦊 at GitLab. 