### PR TITLE
fix: agent docs

### DIFF
--- a/documentation/guides/agent/getting-started.md
+++ b/documentation/guides/agent/getting-started.md
@@ -58,7 +58,7 @@ The `agent` configuration accepts:
 | Property  | Type      | Default     | Description                    |
 | --------- | --------- | ----------- | ------------------------------ |
 | `key`     | `string`  | `undefined` | Your Agent Scalar API key      |
-| `enabled` | `boolean` | `true`      | Enable or disable Agent Scalar |
+| `disabled`| `boolean` | `false`     | Enable or disable Agent Scalar |
 
 ### Per-Source Configuration
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that corrects a config option name/default; no runtime behavior changes.
> 
> **Overview**
> Updates Agent Scalar getting-started documentation to use `agent.disabled` (default `false`) instead of an `enabled` flag in the configuration reference, aligning the docs with the intended disable behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adfbcc445f4a4a0401ecfdff6d2fef17551dfb3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->