### PR TITLE
fix(agent): pass state as prop vs inject for better consumption in other apps

### DIFF
--- a/packages/agent-chat/src/App.vue
+++ b/packages/agent-chat/src/App.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { provide, type Ref } from 'vue'
+import type { Ref } from 'vue'
 
 import Chat from '@/Chat.vue'
-import { createState, STATE_SYMBOL, type RegistryDocument } from '@/state/state'
+import { createState, type RegistryDocument } from '@/state/state'
 import { type ChatMode } from '@/types'
 
 const {
@@ -27,24 +27,21 @@ const {
   prefilledMessage?: Ref<string>
 }>()
 
-provide(
-  STATE_SYMBOL,
-  createState({
-    getActiveDocumentJson,
-    initialRegistryDocuments: registryDocuments,
-    prefilledMessageRef: prefilledMessage,
-    registryUrl,
-    baseUrl,
-    mode,
-    getAccessToken,
-    getAgentKey,
-    dashboardUrl,
-  }),
-)
+const store = createState({
+  getActiveDocumentJson,
+  initialRegistryDocuments: registryDocuments,
+  prefilledMessageRef: prefilledMessage,
+  registryUrl,
+  baseUrl,
+  mode,
+  getAccessToken,
+  getAgentKey,
+  dashboardUrl,
+})
 </script>
 
 <template>
-  <Chat />
+  <Chat :store="store" />
 </template>
 
 <style scoped></style>

--- a/packages/agent-chat/src/Chat.vue
+++ b/packages/agent-chat/src/Chat.vue
@@ -9,9 +9,15 @@ import { useAgentKeyDocuments } from '@/hooks/use-agent-key-documents'
 import { useChatScroll } from '@/hooks/use-chat-scroll'
 import { useCuratedDocuments } from '@/hooks/use-curated-documents'
 import { getTmpDocFromLocalStorage } from '@/hooks/use-upload-tmp-document'
-import { useState } from '@/state/state'
+import { clearState, setState, type State } from '@/state/state'
 import Layout from '@/views/Layout.vue'
 import Settings from '@/views/Settings/Settings.vue'
+
+const { store } = defineProps<{
+  store: State
+}>()
+
+setState(store)
 
 const {
   chat,
@@ -22,7 +28,7 @@ const {
   config,
   mode,
   addDocument,
-} = useState()
+} = store
 
 const clientModalRef = useTemplateRef<HTMLElement>('clientModal')
 const apiClient = ref<ApiClientModal | null>(null)
@@ -52,6 +58,7 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   apiClient.value?.app.unmount()
+  clearState()
 })
 
 useChatScroll()

--- a/packages/agent-chat/src/index.ts
+++ b/packages/agent-chat/src/index.ts
@@ -1,3 +1,4 @@
 import './style.css'
 
-export { default as Chat } from '@/App.vue'
+export { default as Chat } from '@/Chat.vue'
+export { type State, createState, useState } from '@/state/state'

--- a/packages/agent-chat/src/state/state.ts
+++ b/packages/agent-chat/src/state/state.ts
@@ -10,7 +10,7 @@ import {
   type UIMessage,
   lastAssistantMessageIsCompleteWithApprovalResponses,
 } from 'ai'
-import { type ComputedRef, type InjectionKey, type Ref, computed, inject, ref, watch } from 'vue'
+import { type ComputedRef, type Ref, computed, ref, watch } from 'vue'
 
 import { type Api, createApi, createAuthorizationHeaders } from '@/api'
 import type { ApiMetadata } from '@/entities/registry/document'
@@ -62,9 +62,23 @@ export type Tools = {
   }
 }
 
-export const STATE_SYMBOL: InjectionKey<State> = Symbol('STATE_SYMBOL')
+let currentState: State | null = null
 
-type State = {
+/**
+ * Sets the global store instance. Called by Chat.vue when it mounts with the store prop.
+ */
+export function setState(state: State): void {
+  currentState = state
+}
+
+/**
+ * Clears the global store instance. Called by Chat.vue on unmount.
+ */
+export function clearState(): void {
+  currentState = null
+}
+
+export type State = {
   prompt: Ref<string>
   chat: Chat<UIMessage<unknown, UIDataTypes, Tools>>
   workspaceStore: WorkspaceStore
@@ -258,12 +272,10 @@ export function createState({
   }
 }
 
-export function useState() {
-  const state = inject(STATE_SYMBOL)
-
-  if (!state) {
-    throw new Error('No state provided.')
+export function useState(): State {
+  if (!currentState) {
+    throw new Error('No state set. Ensure Chat is mounted with a store prop.')
   }
 
-  return state
+  return currentState
 }

--- a/packages/api-reference/src/components/AgentScalar/AgentScalarChatInterface.vue
+++ b/packages/api-reference/src/components/AgentScalar/AgentScalarChatInterface.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Chat } from '@scalar/agent-chat'
+import { Chat, createState } from '@scalar/agent-chat'
 import { type ApiReferenceConfigurationWithSource } from '@scalar/types/api-reference'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { Ref } from 'vue'
@@ -12,20 +12,21 @@ const { agentScalarConfiguration, workspaceStore, prefilledMessage } =
     workspaceStore: WorkspaceStore
     prefilledMessage?: Ref<string>
   }>()
+
+const store = createState({
+  baseUrl: API_BASE_URL,
+  dashboardUrl: DASHBOARD_URL,
+  getActiveDocumentJson: () => workspaceStore.exportActiveDocument('json')!,
+  getAgentKey: agentScalarConfiguration?.key
+    ? () => agentScalarConfiguration?.key ?? ''
+    : undefined,
+  initialRegistryDocuments: [],
+  mode: agentScalarConfiguration?.key ? 'full' : 'preview',
+  prefilledMessageRef: prefilledMessage,
+  registryUrl: REGISTRY_URL,
+})
 </script>
 
 <template>
-  <Chat
-    :baseUrl="API_BASE_URL"
-    :dashboardUrl="DASHBOARD_URL"
-    :getActiveDocumentJson="() => workspaceStore.exportActiveDocument('json')!"
-    :getAgentKey="
-      agentScalarConfiguration?.key
-        ? () => agentScalarConfiguration?.key ?? ''
-        : undefined
-    "
-    :mode="agentScalarConfiguration?.key ? 'full' : 'preview'"
-    :prefilledMessage="prefilledMessage"
-    :registryDocuments="[]"
-    :registryUrl="REGISTRY_URL" />
+  <Chat :store="store" />
 </template>


### PR DESCRIPTION
## Problem

It's hard to consume the agent from agent-web with provide inject, now we can control the state and use it in other applications

## Solution

We pass the state as a prop before mount

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes component/public API and replaces injection with a global singleton state, which could break existing consumers or cause state leakage if multiple chat instances are mounted concurrently.
> 
> **Overview**
> Refactors `@scalar/agent-chat` to use an explicit `store` object passed into `Chat` instead of Vue `provide/inject`: `App.vue` now builds a store via `createState()` and passes it as `:store`, while `Chat.vue` takes the prop and wires it into the module via new `setState()`/`clearState()` calls.
> 
> Updates the public package surface to export `Chat` from `Chat.vue` (and export `State`, `createState`, `useState`), and adapts `AgentScalarChatInterface.vue` to construct the store with `createState()` and render `<Chat :store="store" />`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6019cef5c02b9252141f327d68433d262d065c28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->