### PR TITLE
chore(agent): slight tweak for agent docs

### DIFF
--- a/documentation/guides/agent/getting-started.md
+++ b/documentation/guides/agent/getting-started.md
@@ -5,7 +5,7 @@ Agent Scalar adds an AI chat interface to your API reference. Users can ask ques
 ## How It Works
 
 1. User opens the chat interface in your API reference
-2. On first message, your OpenAPI document is uploaded to Scalar
+2. Your OpenAPI document is AI ready by Scalar
 3. The AI uses your document to answer questions about endpoints, parameters, authentication, and more
 
 ## Local Development

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1044,7 +1044,7 @@
                     "filepath": "documentation/guides/agent/pricing.md"
                   },
                   "key": {
-                    "title": "Key",
+                    "title": "API Key",
                     "type": "page",
                     "filepath": "documentation/guides/agent/key.md"
                   }


### PR DESCRIPTION
v smol tweaks to the agent docs

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only text and navigation label changes; no runtime or API behavior impact.
> 
> **Overview**
> Updates Agent Scalar “How It Works” docs to remove the claim that the OpenAPI document is uploaded on first message, replacing it with “AI ready by Scalar.”
> 
> Renames the Agent docs navigation entry from `Key` to `API Key` in `scalar.config.json` to better match page intent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad30f1fb791fc7253c4e66fc1d646f2bfb84f450. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->