### PR TITLE
docs: headset icon for agent

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1031,7 +1031,7 @@
                 "title": "Agent Scalar",
                 "type": "group",
                 "mode": "nested",
-                "icon": "phosphor/regular/robot",
+                "icon": "phosphor/regular/headset",
                 "children": {
                   "getting-started": {
                     "title": "Getting Started",


### PR DESCRIPTION
let’s use the headset icon, not the robot icon

<img width="176" height="105" alt="Screenshot 2026-02-02 at 11 48 46" src="https://github.com/user-attachments/assets/ca3366ab-0bc9-420f-9e04-7c1e0e907dfb" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure documentation navigation metadata change that only affects sidebar icon rendering; no functional or data-handling impact.
> 
> **Overview**
> Updates the docs navigation config (`scalar.config.json`) to change the `/agent` section icon from `phosphor/regular/robot` to `phosphor/regular/headset`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e3bb8f5b01fa0ee5fb9ad16c48ccae901f53a5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->