### PR TITLE
test(oas-utils): update message for running test-servers

### DIFF
--- a/.changeset/late-pots-rush.md
+++ b/.changeset/late-pots-rush.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+Improve error message when running oas-utils tests while test-servers are not running

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -20,9 +20,9 @@ beforeAll(async () => {
 
 [sendRequest.test.ts] Looks like you're not running @scalar/proxy-server on <http://127.0.0.1:${PROXY_PORT}>, but it's required for this test file.
 
-Try to run it like this:
+Try to run it like this from the repo root:
 
-$ pnpm dev:proxy-server
+$ pnpm script run test-servers
 `)
   }
 

--- a/packages/oas-utils/src/helpers/fetch-document.test.ts
+++ b/packages/oas-utils/src/helpers/fetch-document.test.ts
@@ -18,9 +18,9 @@ beforeAll(async () => {
 
 [sendRequest.test.ts] Looks like you're not running @scalar/proxy-server on <http://127.0.0.1:${PROXY_PORT}>, but it's required for this test file.
 
-Try to run it like this:
+Try to run it like this from the repo root:
 
-$ pnpm dev:proxy-server
+$ pnpm script run test-servers
 `)
   }
 })


### PR DESCRIPTION
## Problem

It seems this message was outdated.

## Solution

This makes the error message match the instructions from [CONTRIBUTING.md](https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md#tests)

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
