### PR TITLE
feat(json-magic): allow custom LoaderPlugin plugins in dereference

### DIFF
--- a/.changeset/custom-plugins-dereference.md
+++ b/.changeset/custom-plugins-dereference.md
@@ -1,0 +1,5 @@
+---
+'@scalar/json-magic': minor
+---
+
+feat: allow custom LoaderPlugin plugins in dereference


### PR DESCRIPTION
## Problem

We use the [Zephyr RTOS](https://www.zephyrproject.org/) build tooling to enable/disable multiple openapi specs via the autoconf build system. We created a custom LoaderPlugin to resolve $ref's declared within the Zephyr workspace environment. For example, an embedded hardware product such as a sensor, can switch on various api's the hardware supports using CMake configuration infrastructure.

Our solution currently has to walk our entire specs for x-ext and dereference the result of our loader manually. Your tooling has a dereference api that does exactly this, and is purpose built for doing exactly what our workaround does. It may be an oversight that there is a LoaderPlugin interface, but the dereference solution does not accept custom plugins?

fixes: https://github.com/scalar/scalar/issues/8051

<!--
  What problem does the PR solve?
  WHY did you submit the PR?

  We are interested in the WHY (LLMs won't know).
-->

## Solution

So, this PR adds a Plugin[] option to the dereference API, which will override the defaults when custom loaders are used. It is backward compatible because the default loaders when no plugins are provided, fallback to the original hard coded fetchUrls plugin.

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
