### PR TITLE
feat: enable post response scripts plugin

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -364,7 +364,8 @@
     "vue-router": "catalog:*",
     "whatwg-mimetype": "catalog:*",
     "yaml": "catalog:*",
-    "zod": "catalog:*"
+    "zod": "catalog:*",
+    "@scalar/pre-post-request-scripts": "workspace:*"
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",

--- a/packages/api-client/playground/v2/web/main.ts
+++ b/packages/api-client/playground/v2/web/main.ts
@@ -1,8 +1,10 @@
 import '@/style.css'
 
+import { postResponseScriptsPlugin } from '@scalar/pre-post-request-scripts'
+
 import { createApiClientApp } from '@/v2/features/app'
 
 const el = document.getElementById('scalar-client')
 
 /** Initialize the API client application with the 'web' layout */
-createApiClientApp(el, { layout: 'web' })
+createApiClientApp(el, { layout: 'web', plugins: [postResponseScriptsPlugin()] })

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
@@ -24,6 +24,7 @@ import { computed, ref, useId, watch } from 'vue'
 import SectionFilter from '@/components/SectionFilter.vue'
 import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
 import type { ClientLayout } from '@/hooks'
+import { usePluginManager } from '@/plugins'
 import { filterGlobalCookie } from '@/v2/blocks/operation-block/helpers/filter-global-cookies'
 import { getExample } from '@/v2/blocks/operation-block/helpers/get-example'
 import { getResolvedUrl } from '@/v2/blocks/operation-block/helpers/get-resolved-url'
@@ -381,6 +382,14 @@ const handleUpdateBodyFormValue = ({
 }
 
 const labelRequestNameId = useId()
+
+// Plugins
+const pluginManager = usePluginManager()
+const requestSectionViews = pluginManager.getViewComponents('request.section')
+// TODO: Receives edited scripts, we need to update the document using the event bus
+const updateOperationHandler = (key: string, value: string) => {
+  console.log('updateOperationHandler', key, value)
+}
 </script>
 <template>
   <ViewLayoutSection :aria-label="`Request: ${operation.summary}`">
@@ -497,6 +506,19 @@ const labelRequestNameId = useId()
           :operation
           :selectedExample="exampleKey" />
       </ScalarErrorBoundary>
+
+      <!-- Plugins -->
+      <template
+        v-for="(view, index) in requestSectionViews"
+        :key="view.title ?? index">
+        <ScalarErrorBoundary>
+          <component
+            :is="view.component"
+            v-show="selectedFilter === 'All' || selectedFilter === view.title"
+            :operation="operation"
+            @update:operation="updateOperationHandler" />
+        </ScalarErrorBoundary>
+      </template>
 
       <!-- Spacer -->
       <div class="flex grow" />

--- a/packages/api-client/src/v2/features/app/helpers/create-api-client-app.ts
+++ b/packages/api-client/src/v2/features/app/helpers/create-api-client-app.ts
@@ -1,6 +1,7 @@
 import { createApp } from 'vue'
 import { createRouter as createVueRouter, createWebHashHistory, createWebHistory } from 'vue-router'
 
+import { PLUGIN_MANAGER_SYMBOL, createPluginManager } from '@/plugins'
 import App from '@/v2/features/app/App.vue'
 import { createAppState } from '@/v2/features/app/app-state'
 import { ROUTES } from '@/v2/features/app/helpers/routes'
@@ -48,6 +49,13 @@ export const createApiClientApp = async (
   const state = await createAppState({ router })
   const commandPaletteState = useCommandPaletteState()
 
+  // Create plugin manager for ApiClientPlugin-compatible plugins (functions)
+  // ClientPlugin can be either object ({ hooks, components }) or ApiClientPlugin (function)
+  const apiClientPlugins = (plugins ?? []).filter((p) => typeof p === 'function')
+  const pluginManager = createPluginManager({
+    plugins: apiClientPlugins as Parameters<typeof createPluginManager>[0]['plugins'],
+  })
+
   // Pass in our initial props at the top level
   const app = createApp(App, {
     layout,
@@ -55,6 +63,7 @@ export const createApiClientApp = async (
     getAppState: () => state,
     getCommandPaletteState: () => commandPaletteState,
   })
+  app.provide(PLUGIN_MANAGER_SYMBOL, pluginManager)
   app.use(router)
 
   // Mount the vue app

--- a/packages/api-reference/src/plugins/hooks/usePluginManager.ts
+++ b/packages/api-reference/src/plugins/hooks/usePluginManager.ts
@@ -1,5 +1,6 @@
-import { type PluginManager, createPluginManager } from '@/plugins/plugin-manager'
 import { type InjectionKey, inject } from 'vue'
+
+import { type PluginManager, createPluginManager } from '@/plugins/plugin-manager'
 
 export const PLUGIN_MANAGER_SYMBOL = Symbol() as InjectionKey<PluginManager>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1267,6 +1267,9 @@ importers:
       '@scalar/postman-to-openapi':
         specifier: workspace:*
         version: link:../postman-to-openapi
+      '@scalar/pre-post-request-scripts':
+        specifier: workspace:*
+        version: link:../pre-post-request-scripts
       '@scalar/sidebar':
         specifier: workspace:*
         version: link:../sidebar
@@ -2754,6 +2757,9 @@ importers:
 
   projects/client-scalar-com:
     dependencies:
+      '@scalar/pre-post-request-scripts':
+        specifier: workspace:*
+        version: link:../../packages/pre-post-request-scripts
       posthog-js:
         specifier: ^1.336.1
         version: 1.336.1

--- a/projects/client-scalar-com/package.json
+++ b/projects/client-scalar-com/package.json
@@ -30,7 +30,8 @@
   "type": "module",
   "dependencies": {
     "posthog-js": "^1.336.1",
-    "vue": "catalog:*"
+    "vue": "catalog:*",
+    "@scalar/pre-post-request-scripts": "workspace:*"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260120.0",

--- a/projects/client-scalar-com/src/main.ts
+++ b/projects/client-scalar-com/src/main.ts
@@ -1,5 +1,8 @@
 import { createApiClientWeb } from '@scalar/api-client/layouts/Web'
 import '@scalar/api-client/style.css'
+
+import { postResponseScriptsPlugin } from '@scalar/pre-post-request-scripts'
+
 import './style.css'
 
 import posthog from 'posthog-js'
@@ -11,4 +14,5 @@ posthog.init('phc_3elIjSOvGOo5aEwg6krzIY9IcQiRubsBtglOXsQ4Uu4', {
 
 void createApiClientWeb(document.getElementById('scalar-client'), {
   proxyUrl: 'https://proxy.scalar.com',
+  plugins: [postResponseScriptsPlugin()],
 })


### PR DESCRIPTION
this is just a draft to play around

* enables the post-response scripts in projects/client-scalar-com (works, but we don't want that)
* adds the post-response scripts in `packages/api-client/playground/v2/web/main.ts` (doesn’t work, but we want that)

- [ ] write script updates to the document
- [ ] execute scripts when sending requests
- [ ] show the test results in the response pane again

**Preview**

<img width="1268" height="492" alt="image" src="https://github.com/user-attachments/assets/17b5c563-7ef9-4917-af47-632e6395e4a2" />

<img width="1244" height="240" alt="image" src="https://github.com/user-attachments/assets/6e5376b2-5271-4ef3-8156-74d8e4e13ab7" />
