### PR TITLE
docs: fix a few broken links

### DIFF
--- a/documentation/guides/agent/key.md
+++ b/documentation/guides/agent/key.md
@@ -28,6 +28,4 @@ Scalar.createApiReference('#app', {
 
 ## Keeping Documents in Sync
 
-For production, use GitHub Actions to automatically sync your OpenAPI document with the Scalar Registry. This ensures your Agent always has the latest API information.
-
-See [GitHub Sync](../docs/github-sync.md) for setup instructions.
+For production, use [GitHub Actions](../registry/github-actions.md) to automatically sync your OpenAPI document with the Scalar Registry. This ensures your Agent always has the latest API information.

--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -140,7 +140,7 @@
         <b class="font-medium">Additional Reading</b>
       </p>
       <p>
-        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/github-sync"><scalar-icon src="phosphor/bold/git-branch"></scalar-icon> GitHub Sync</a>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/configuration/scalar.config.json"><scalar-icon src="phosphor/bold/git-branch"></scalar-icon> GitHub Sync</a>
       </p>
       <p>
         <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/components/markdown-support"><scalar-icon src="phosphor/bold/file-md"></scalar-icon> Markdown Support</a>

--- a/documentation/integrations/java.md
+++ b/documentation/integrations/java.md
@@ -244,7 +244,7 @@ Agent Scalar adds an AI chat interface to your API reference. Users can ask ques
 
 - Enabled by default on `http://localhost` for testing (with limited free messages).
 - In production, the agent does not appear unless you provide a key.
-- To use Agent Scalar in production, configure an [Agent Scalar key](guides/agent/key.md).
+- To use Agent Scalar in production, configure an [Agent Scalar key](../guides/agent/key.md).
 
 **Single-URL mode** (when using `scalar.url` without `sources`):
 
@@ -293,7 +293,7 @@ scalar.sources[0].agent.key=put-your-agent-scalar-key-here
 scalar.sources[1].agent.disabled=true
 ```
 
-Related: [How to get an Agent Scalar key](guides/agent/key.md).
+Related: [How to get an Agent Scalar key](../guides/agent/key.md).
 
 ### Authentication
 
@@ -505,19 +505,19 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class CustomScalarController extends ScalarWebMvcController {
-    
+
     @Override
     protected ScalarProperties configureProperties(
-            ScalarProperties properties, 
+            ScalarProperties properties,
             HttpServletRequest request) {
         // Customize properties based on request
         if (request.isUserInRole("ADMIN")) {
             properties.setPageTitle("Admin API Documentation");
         }
-        
+
         // Modify other properties as needed
         properties.setDarkMode(true);
-        
+
         return properties;
     }
 }
@@ -533,20 +533,20 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class CustomScalarController extends ScalarWebFluxController {
-    
+
     @Override
     protected ScalarProperties configureProperties(
-            ScalarProperties properties, 
+            ScalarProperties properties,
             ServerHttpRequest request) {
         // Customize properties based on request
         String path = request.getPath().value();
         if (path.contains("/admin")) {
             properties.setPageTitle("Admin API Documentation");
         }
-        
+
         // Modify other properties as needed
         properties.setDarkMode(true);
-        
+
         return properties;
     }
 }

--- a/documentation/integrations/rust.md
+++ b/documentation/integrations/rust.md
@@ -119,7 +119,7 @@ See the documentation for [the complete configuration reference](../configuratio
 
 ### Agent Scalar
 
-Agent Scalar adds an AI chat interface to your API reference. It is enabled by default on localhost with a limited free tier (10 messages). For production, you need an [Agent Scalar key](guides/agent/key.md).
+Agent Scalar adds an AI chat interface to your API reference. It is enabled by default on localhost with a limited free tier (10 messages). For production, you need an [Agent Scalar key](../guides/agent/key.md).
 
 To set an Agent Scalar API key (top-level):
 
@@ -187,5 +187,5 @@ let sources = vec![
 let config = json!({ "sources": serde_json::to_value(&sources).unwrap() });
 ```
 
-For more details, see [Agent Scalar](../configuration.md#agent-scalar) and [How to get an Agent Scalar key](guides/agent/key.md).
+For more details, see [Agent Scalar](../configuration.md#agent-scalar) and [How to get an Agent Scalar key](../guides/agent/key.md).
 


### PR DESCRIPTION
let’s fix a few dead ends

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and formatting fixes with no impact on runtime code paths.
> 
> **Overview**
> Fixes broken relative links in docs so Agent Scalar key instructions correctly resolve from the Java and Rust integration guides.
> 
> Updates GitHub Sync references to point at the current GitHub Actions/registry documentation, including the Agent key guide and the Docs getting-started “Additional Reading” link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e604e28d019e384f1eb2bbe36825028b745162d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->