### PR TITLE
docs: fix broken scalar.config.json

### DIFF
--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -37,15 +37,17 @@ The `navigation.header` array defines links that appear in the top navigation ba
   "navigation": {
     "header": [
       {
+        "type": "link",
         "title": "Log in",
-        "url": "https://dashboard.scalar.com/login"
+        "to": "https://dashboard.scalar.com/login"
       },
       {
+        "type": "link",
         "title": "Register",
         "style": "button",
         "icon": "phosphor/regular/user-plus",
         "newTab": true,
-        "url": "https://dashboard.scalar.com/register"
+        "to": "https://dashboard.scalar.com/register"
       }
     ],
     "routes": {
@@ -60,7 +62,8 @@ The `navigation.header` array defines links that appear in the top navigation ba
 | Property | Type                 | Required | Description                           |
 | -------- | -------------------- | -------- | ------------------------------------- |
 | `title`  | `string`             | Yes      | The display text for the header link  |
-| `url`    | `string`             | Yes      | The URL the link points to            |
+| `type`   | `"link"`             | Yes      | Must be `"link"`                      |
+| `to`     | `string`             | Yes      | The route path or URL the link points to |
 | `style`  | `"button" \| "link"` | No       | Display style (defaults to `"link"`)  |
 | `icon`   | `string`             | No       | An icon to display next to the link   |
 | `newTab` | `boolean`            | No       | Whether to open the link in a new tab |

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -505,13 +505,15 @@
   "navigation": {
     "header": [
       {
+        "type": "link",
         "title": "Log in",
-        "url": "https://dashboard.scalar.com/login"
+        "to": "https://dashboard.scalar.com/login"
       },
       {
+        "type": "link",
         "title": "Register",
         "style": "button",
-        "url": "https://dashboard.scalar.com/register"
+        "to": "https://dashboard.scalar.com/register"
       }
     ],
     "routes": {


### PR DESCRIPTION
## Problem

`npx @scalar/cli project check-config` fails
looks like the schema changed

## Solution

fixed

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/config-only changes that update link field names; low blast radius aside from potential navigation mislinks if values were mistyped.
> 
> **Overview**
> Aligns header navigation configuration with the updated Scalar config schema.
> 
> Updates `documentation/guides/docs/configuration/navigation.md` and the root `scalar.config.json` so `navigation.header` items explicitly include `type: "link"` and use `to` (route/URL) instead of the old `url` field, fixing schema validation failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07b4689d30eb18aa9a110dd0ac6daeeb1f0aff30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->