### PR TITLE
ci: fix version patching script in rust-publish job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1547,7 +1547,7 @@ jobs:
         env:
           VERSION: ${{ steps.package-version.outputs.VERSION }}
         run: |
-          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+          sed -i "0,/^version = \".*\"/{s/^version = \".*\"/version = \"$VERSION\"/}" Cargo.toml
           cat Cargo.toml | grep version
 
       - name: Publish to crates.io


### PR DESCRIPTION
## Problem

`rust-publish` CI is broken because the step to update the version is updating also the dependency versions incorrectly.

## Solution

Instead of updating ALL occurrences of `version = "..."`, update only the first occurrence.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.
