### PR TITLE
ci: use node 24 for @scalar/cli

### DIFF
--- a/.github/workflows/scalar-registry-preview-delete.yml
+++ b/.github/workflows/scalar-registry-preview-delete.yml
@@ -17,8 +17,12 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version: 24
 
       - name: Check whether galaxy files were modified in the PR
         id: changed-files

--- a/.github/workflows/update-scalar-cli-documentation.yml
+++ b/.github/workflows/update-scalar-cli-documentation.yml
@@ -22,16 +22,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
-          node-version-file: '.nvmrc'
+          node-version: 24
           package-manager-cache: false
+
       - name: Generate CLI documentation
         run: npx @scalar/cli@latest readme generate --output ${{ matrix.commands-markdown }}
+
       - name: Extract just the commands
         run: |
           sed -n '/^## Commands$/,/^## /p' ${{ matrix.commands-markdown }} | sed '$d' > ${{ matrix.commands-markdown }}-extracted.md
+
       - name: Update the heading levels
         run: |
           awk '
@@ -42,8 +46,10 @@ jobs:
             }
             { print }
           ' ${{ matrix.commands-markdown }}-extracted.md > ${{ matrix.commands-markdown }}
+
       - name: Remove the temporary files
         run: rm -Rf ${{ matrix.commands-markdown }}-*.md
+
       - name: Check for changes
         id: check-changes
         run: |
@@ -52,6 +58,7 @@ jobs:
           else
             echo "has-changes=true" >> $GITHUB_OUTPUT
           fi
+
       - name: Create Pull Request
         if: steps.check-changes.outputs.has-changes == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7


### PR DESCRIPTION
## Problem

The CLI requires Node 24. Some workflows, e.g. the one to update the CLI documentation, were failing because we default to 22 here.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that bumps the CI runtime to a required Node version; low risk aside from potential runner/Node 24 compatibility issues.
> 
> **Overview**
> Updates GitHub Actions workflows that run `npx @scalar/cli@latest` to explicitly install Node.js 24 via `actions/setup-node`, avoiding failures from the prior default/`.nvmrc` Node version.
> 
> This affects the scheduled `update-scalar-cli-documentation` job and the `scalar-registry-preview-delete` workflow by adding a Node setup step and pinning the runtime to Node 24.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 033fb3b9d939bebe5ea01ba72103c790b5c5ae1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->