### PR TITLE
ci: workflow can not create pr

### DIFF
--- a/.github/workflows/update-scalar-cli-documentation.yml
+++ b/.github/workflows/update-scalar-cli-documentation.yml
@@ -63,7 +63,6 @@ jobs:
         if: steps.check-changes.outputs.has-changes == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           base: main
           commit-message: 'docs(cli): update commands'
           title: 'docs(cli): update commands'


### PR DESCRIPTION
workflow to update the CLI docs fails:

<img width="905" height="589" alt="Screenshot 2026-02-13 at 13 01 05" src="https://github.com/user-attachments/assets/c02916bd-94ba-47eb-86be-c4ae67e75869" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI workflow change limited to PR creation configuration; low impact outside the scheduled docs update automation.
> 
> **Overview**
> Fixes the `update-scalar-cli-documentation` GitHub Action so the `peter-evans/create-pull-request` step no longer explicitly passes `secrets.GITHUB_TOKEN`, allowing the workflow to create the automated docs update PR successfully.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65677f509d4ad48d8dc3e2dcdb357bf30ce5126e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->