### PR TITLE
ci: do ont use blacksmith runner when creating a PR

### DIFF
--- a/.github/workflows/update-scalar-cli-documentation.yml
+++ b/.github/workflows/update-scalar-cli-documentation.yml
@@ -14,7 +14,8 @@ jobs:
       contents: write
       pull-requests: write
     if: ${{ github.repository_owner == 'scalar' }}
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    # Fails to create a PR on blacksmith runners.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       matrix:


### PR DESCRIPTION
the CLI docs update workflow still fails to create a PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runner selection change in a scheduled CI workflow; impact is limited to how the automation executes and should be easy to revert if needed.
> 
> **Overview**
> Switches the `update-scalar-cli-documentation` GitHub Actions workflow to run on `ubuntu-latest` instead of the `blacksmith-2vcpu-ubuntu-2204` runner to fix failures when the job tries to create an automated PR.
> 
> No functional changes to the documentation generation steps; this is a CI runner/environment change only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5bd885992ef557bccb812590eee4cc7161843c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->