### PR TITLE
chore: update `peter-evans/create-pull-request` action

### DIFF
--- a/.github/workflows/update-scalar-cli-documentation.yml
+++ b/.github/workflows/update-scalar-cli-documentation.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check-changes.outputs.has-changes == 'true'
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
         with:
           base: main
           commit-message: 'docs(cli): update commands'


### PR DESCRIPTION
we need to update to make the cli docs update workflow work agian:

https://github.com/peter-evans/create-pull-request/issues/4272

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pin update of a third-party GitHub Action in a docs-only automation workflow; impact is limited to whether the scheduled job can open PRs.
> 
> **Overview**
> Updates the scheduled `update-scalar-cli-documentation` GitHub Actions workflow to use `peter-evans/create-pull-request` **v8** (pinned to a new commit SHA) when opening the auto-generated CLI docs PRs.
> 
> No other workflow behavior is changed; this is intended to restore/maintain PR creation compatibility with upstream action updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 489fa70387f5131266fb198f5050b9ec789b6d23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->