### PR TITLE
ci(update-scalar-cli-documentation): switch back to blacksmith runner

### DIFF
--- a/.github/workflows/update-scalar-cli-documentation.yml
+++ b/.github/workflows/update-scalar-cli-documentation.yml
@@ -14,8 +14,7 @@ jobs:
       contents: write
       pull-requests: write
     if: ${{ github.repository_owner == 'scalar' }}
-    # Fails to create a PR on blacksmith runners.
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 15
     strategy:
       matrix:


### PR DESCRIPTION
that was not the problem, we can revert the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only runner selection change; risk is limited to the scheduled CLI-doc update workflow behaving differently on the Blacksmith environment.
> 
> **Overview**
> Switches the `update-scalar-cli-documentation` GitHub Actions workflow runner from `ubuntu-latest` back to `blacksmith-2vcpu-ubuntu-2204`, reverting the prior attempt to fix PR creation failures on Blacksmith runners.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2471ca8da9866832337b70bdd0c3a7f39111a64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->