### PR TITLE
chore: package bump due to ci failure

### DIFF
--- a/.changeset/strict-bears-jump.md
+++ b/.changeset/strict-bears-jump.md
@@ -1,0 +1,13 @@
+---
+'@scalar/aspnetcore': patch
+'@scalar/dotnet-shared': patch
+'@scalar/agent-chat': patch
+'@scalar/api-client': patch
+'@scalar/api-reference': patch
+'@scalar/components': patch
+'@scalar/helpers': patch
+'@scalar/sidebar': patch
+'@scalar/workspace-store': patch
+---
+
+chore: package bump due to ci failure


### PR DESCRIPTION
## Problem

We released but nothing came out!

## Solution

Give the packages a little bumpity bump

## Checklist

- [ ] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a Changesets metadata file to bump package versions; no runtime code changes or logic modifications.
> 
> **Overview**
> Adds a Changesets entry (`.changeset/strict-bears-jump.md`) to trigger **patch version bumps** for multiple `@scalar/*` packages (`aspnetcore`, `dotnet-shared`, `agent-chat`, `api-client`, `api-reference`, `components`, `helpers`, `sidebar`, `workspace-store`) with the note “chore: package bump due to ci failure.”
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90868f2f5a5b2d4f986190a143c04252a5a3c66e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->