### PR TITLE
chore: bump packages

### DIFF
--- a/.changeset/tall-chicken-cross.md
+++ b/.changeset/tall-chicken-cross.md
@@ -1,7 +1,14 @@
 ---
-'@scalar/astro': patch
-'@scalarapi/docker-api-reference': patch
-'@scalar/docusaurus': patch
+'@scalar/api-client': patch
+'@scalar/api-reference': patch
+'@scalar/galaxy': patch
+'@scalar/helpers': patch
+'@scalar/json-magic': patch
+'@scalar/oas-utils': patch
+'@scalar/pre-post-request-scripts': minor
+'@scalar/sidebar': patch
+'@scalar/types': patch
+'@scalar/workspace-store': patch
 ---
 
 chore: version bump


### PR DESCRIPTION
It happened again, release did not release. Maybe we gotta sort this one out @hanspagel 


## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a Changesets release metadata file; no runtime logic or behavior changes.
> 
> **Overview**
> Adds a new Changesets entry (`.changeset/tall-chicken-cross.md`) to trigger a release with patch bumps across several `@scalar/*` packages and a minor bump for `@scalar/pre-post-request-scripts`.
> 
> No functional code changes are included; this PR only updates release metadata/versioning instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2e7b2569d91d4553627fc1752768850266a1fe9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->