### PR TITLE
fix: ci release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,6 +565,8 @@ jobs:
     needs: [required-jobs-main]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.sha }}
       - name: Build
         uses: ./.github/actions/build
         with:


### PR DESCRIPTION
## Problem

We have been having some issues lately where our packages do not release.

## Solution

It may be due to the changesets branch being deleted. Not sure what changed BUT this should just checkout the commit instead.

<img width="1626" height="1062" alt="image" src="https://github.com/user-attachments/assets/aa886402-3ec2-40e8-b316-a344038c1b20" />

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that narrows checkout behavior to a specific SHA; primary risk is accidental mis-checkout impacting release runs, not runtime code.
> 
> **Overview**
> Ensures the `npm-publish` job in `.github/workflows/ci.yml` checks out `ref: ${{ github.sha }}` so the release build/publish runs against the exact commit that triggered the workflow rather than relying on a branch ref (e.g., a deleted `changeset-release/*` branch).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36289bbdae21dc842ba0c2296e568351ce35c8bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->