### PR TITLE
ci: set fetch depth to 0 on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,6 +567,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.sha }}
+          fetch-depth: 0
       - name: Build
         uses: ./.github/actions/build
         with:


### PR DESCRIPTION
We added checking out a hash, this ensures we have the complete history. 

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change limited to the release/publish job; main risk is slightly longer checkout time on release runs.
> 
> **Overview**
> Ensures the release `npm-publish` workflow checks out the repository with **full git history** by setting `actions/checkout` `fetch-depth: 0` when using `ref: ${{ github.sha }}`.
> 
> This prevents shallow clones during release publishing, which can break steps that rely on commit history/tags during `changesets/action`/release generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ff5eee33b9c50b400a2e0be1d848d1325c85cba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->