### PR TITLE
fix(express): enable `knip`

### DIFF
--- a/.changeset/orange-loops-do.md
+++ b/.changeset/orange-loops-do.md
@@ -1,0 +1,5 @@
+---
+'@scalar/express-api-reference': patch
+---
+
+fix(express): remove unused `customTheme`

--- a/integrations/express/playground/index.ts
+++ b/integrations/express/playground/index.ts
@@ -1,5 +1,6 @@
 import Express from 'express'
 import swaggerJsdoc from 'swagger-jsdoc'
+
 import { apiReference } from '../src/index'
 
 // Initialize Express

--- a/integrations/express/src/apiReference.ts
+++ b/integrations/express/src/apiReference.ts
@@ -1,14 +1,7 @@
 import { getHtmlDocument } from '@scalar/core/libs/html-rendering'
-import type { Request, Response } from 'express'
+import type { RequestHandler } from 'express'
 
 import type { ApiReferenceConfiguration } from './types'
-
-/**
- * The custom theme CSS for the Express theme
- *
- * @deprecated we have removed this custom theme, the variable is just here because it is exported
- */
-export const customTheme = ''
 
 /**
  * The default configuration for the API Reference.
@@ -20,7 +13,7 @@ const DEFAULT_CONFIGURATION: Partial<ApiReferenceConfiguration> = {
 /**
  * The route handler to render the Scalar API Reference.
  */
-export function apiReference(givenConfiguration: Partial<ApiReferenceConfiguration>) {
+export function apiReference(givenConfiguration: Partial<ApiReferenceConfiguration>): RequestHandler<never, string> {
   // Merge the defaults
   const configuration = {
     ...DEFAULT_CONFIGURATION,
@@ -28,7 +21,7 @@ export function apiReference(givenConfiguration: Partial<ApiReferenceConfigurati
   }
 
   // Respond with the HTML document
-  return (_: Request, res: Response) => {
-    res.type('text/html').send(getHtmlDocument(configuration, customTheme))
+  return (_, res) => {
+    res.type('text/html').send(getHtmlDocument(configuration))
   }
 }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -6,7 +6,6 @@
     "projects/**",
     "integrations/docusaurus/**",
     "integrations/dotnet/**",
-    "integrations/express/**",
     "integrations/fastapi/**"
   ],
   "ignoreFiles": [


### PR DESCRIPTION
## Problem

- Followup of #7233

## Solution

- remove unused `customTheme` variable
- use `RequestHandler` as return type in `apiReference`
   Correct types are inferred correctly from the explicit return type

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
