### PR TITLE
chore(docusaurus): enable `knip`

### DIFF
--- a/integrations/docusaurus/package.json
+++ b/integrations/docusaurus/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@docusaurus/core": "^3.9.2",
+    "@docusaurus/plugin-content-docs": "^3.9.2",
     "@docusaurus/preset-classic": "^3.9.2",
     "@docusaurus/tsconfig": "^3.9.2",
     "@docusaurus/types": "^3.9.2",

--- a/integrations/docusaurus/playground/docusaurus.config.ts
+++ b/integrations/docusaurus/playground/docusaurus.config.ts
@@ -1,6 +1,6 @@
 import type * as Preset from '@docusaurus/preset-classic'
 import type { Config } from '@docusaurus/types'
-import type { ScalarOptions } from '@scalar/docusaurus'
+import ScalarDocusaurus, { type ScalarOptions } from '@scalar/docusaurus'
 
 const config: Config = {
   title: 'My Site',
@@ -54,7 +54,7 @@ const config: Config = {
 
   plugins: [
     [
-      '@scalar/docusaurus',
+      ScalarDocusaurus,
       {
         id: 'json-url-cdn',
         label: 'json-url-cdn',
@@ -66,7 +66,7 @@ const config: Config = {
       } as ScalarOptions,
     ],
     [
-      '@scalar/docusaurus',
+      ScalarDocusaurus,
       {
         id: 'yaml-url',
         label: 'yaml-url',
@@ -77,7 +77,7 @@ const config: Config = {
       } as ScalarOptions,
     ],
     [
-      '@scalar/docusaurus',
+      ScalarDocusaurus,
       {
         id: 'json-string',
         label: 'json-string',
@@ -95,7 +95,7 @@ const config: Config = {
       } as ScalarOptions,
     ],
     [
-      '@scalar/docusaurus',
+      ScalarDocusaurus,
       {
         id: 'yaml-string',
         label: 'yaml-string',

--- a/integrations/docusaurus/playground/tsconfig.json
+++ b/integrations/docusaurus/playground/tsconfig.json
@@ -2,6 +2,9 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "paths": {
+      "@scalar/docusaurus": ["../"]
+    }
   }
 }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -4,7 +4,6 @@
     // Allows a progressive adoption
     "examples/**",
     "projects/**",
-    "integrations/docusaurus/**",
     "integrations/dotnet/**",
     "integrations/fastapi/**"
   ],
@@ -18,12 +17,10 @@
     "documentation/assets/landing.js",
     "documentation/assets/fathom.js"
   ],
-
   "ignore": [
     // We will use this in the future, just removed it from the workspace store for now
     "packages/workspace-store/src/schemas/reference-config/index.ts"
   ],
-
   "ignoreDependencies": [
     // Used by `ci.yml` `npm-publish` job
     "@changesets/cli",
@@ -38,6 +35,9 @@
     "tsconfig-paths"
   ],
   "ignoreBinaries": ["netlify"],
+  "ignoreIssues": {
+    "integrations/docusaurus/src/ScalarDocusaurus.tsx": ["duplicates"]
+  },
   "workspaces": {
     "packages/api-client": {
       "entry": [
@@ -309,6 +309,32 @@
     "integrations/docker": {
       "ignoreDependencies": [
         "@scalar/api-reference" // uses standalone.js during docker build
+      ]
+    },
+    "integrations/docusaurus": {
+      "docusaurus": {
+        "config": ["playground/docusaurus.config.ts"],
+        "entry": [
+          "playground/sidebars.ts",
+          "playground/src/{pages,components}/**/*.tsx",
+          "playground/{blog,docs}/**/*.mdx",
+          "playground/versioned_docs/**/*.{mdx,jsx,tsx}",
+
+          // Referenced by src/index.ts `addRoute`
+          "src/ScalarDocusaurus.tsx"
+        ]
+      },
+      "typescript": {
+        "config": ["tsconfig.json", "tsconfig.build.json", "playground/tsconfig.json"]
+      },
+      "ignoreFiles": ["playground/.docusaurus/**"],
+      "ignoreDependencies": [
+        // Used by webpack
+        "path",
+
+        // Docusaurus aliases
+        "@theme/*",
+        "@site/*"
       ]
     },
     "integrations/fastify": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -781,6 +781,9 @@ importers:
       '@docusaurus/core':
         specifier: ^3.9.2
         version: 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs':
+        specifier: ^3.9.2
+        version: 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       '@docusaurus/preset-classic':
         specifier: ^3.9.2
         version: 3.9.2(@algolia/client-search@5.47.0)(@mdx-js/react@3.1.1(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.14.0)(typescript@5.9.3)


### PR DESCRIPTION
## Problem

- Followup of #7233

## Solution

- import plugin as module instead of string
  solves `knip` warning about a `@scalar/docusaurus-plugin-docusaurus` import
- add path to `playground` `tsconfig.json` to correctly resolve `@scalar/docusaurus`
- add `@docusaurus/plugin-content-docs` to devDependencies

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
