### PR TITLE
docs: add starter kit page

### DIFF
--- a/documentation/guides/docs/starter-kit.md
+++ b/documentation/guides/docs/starter-kit.md
@@ -1,0 +1,65 @@
+# Scalar Docs Starter Kit
+
+The [Scalar Docs Starter Kit](https://github.com/scalar/starter) is a ready-to-use template for building beautiful documentation with Markdown and OpenAPI. Fork or clone the repository and make it your own — everything in the template is meant to be modified, extended, or replaced to fit your project.
+
+## Project structure
+
+The starter includes a minimal layout: a `docs/` folder (with `api-reference/` for OpenAPI documents and `content/` for free-form content) and a `scalar.config.json` file at the repository root.
+
+## 1. Preview your docs
+
+Run a local development server to see your changes in real-time:
+
+```bash
+npx @scalar/cli project preview
+```
+
+This starts a live preview at `http://localhost:7971` where every edit you make is instantly visible.
+
+Read more about [Preview deployments](deployment/preview-deployments.md) and the [CLI](deployment/cli.md).
+
+## 2. Include OpenAPI documents
+
+Drop your OpenAPI files into `docs/api-reference/`, and add them to `scalar.config.json` to have them automatically become interactive API references.
+
+The starter kit includes an example OpenAPI document to show you how it works.
+
+Read more about [scalar.config.json](configuration/scalar.config.json.md) and [Getting started](getting-started.md) with Scalar Docs.
+
+## 3. Customize everything
+
+Make it yours with themes, custom CSS, and MDX. Configure your documentation structure, navigation, and styling through [scalar.config.json](configuration/scalar.config.json.md).
+
+For appearance options, see [Themes](configuration/themes.md).
+
+## 4. Publish your docs
+
+First, authenticate with your Scalar account:
+
+```bash
+npx @scalar/cli auth login
+```
+
+Then publish your documentation:
+
+```bash
+npx @scalar/cli project publish
+```
+
+Your site will be available at `<your-slug>.apidocumentation.com`.
+
+## Stuck?
+
+Check whether your `scalar.config.json` is valid:
+
+```bash
+npx @scalar/cli project check-config
+```
+
+For full options, see the [Configuration reference](configuration/scalar.config.json.md).
+
+We are here to help:
+
+- [Email support@scalar.com](mailto:support@scalar.com)
+- [Chat with us on Discord](https://discord.gg/scalar)
+- [Schedule a call](https://scalar.cal.com/scalar/chat-with-scalar)

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -665,6 +665,11 @@
                       ]
                     }
                   },
+                  "starter-kit": {
+                    "filepath": "documentation/guides/docs/starter-kit.md",
+                    "type": "page",
+                    "title": "Starter Kit"
+                  },
                   "configuration": {
                     "title": "Configuration",
                     "type": "group",


### PR DESCRIPTION
I think we don't mention the starter kit anywhere? Let's change this!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus a simple navigation entry; minimal chance of impacting runtime behavior beyond the new page being linked.
> 
> **Overview**
> Adds a new `starter-kit.md` guide introducing the Scalar Docs Starter Kit and basic steps for previewing, adding OpenAPI docs, customizing, and publishing.
> 
> Updates `scalar.config.json` navigation to include the new **Starter Kit** page under `Scalar Docs` so it’s discoverable in the docs sidebar.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6beef054ddf2a595adebea55b036e2166b1ef33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->