### PR TITLE
docs: fix some broken links

### DIFF
--- a/documentation/integrations/aspnetcore/integration.md
+++ b/documentation/integrations/aspnetcore/integration.md
@@ -238,7 +238,7 @@ You can also specify a document name directly in the URL path (e.g., `/scalar/v1
 
 ### Agent Scalar
 
-Agent Scalar adds an AI chat interface to your API reference. It is enabled by default on localhost with a limited free tier (10 messages). For production, you need an [Agent Scalar key](guides/agent/key.md).
+Agent Scalar adds an AI chat interface to your API reference. It is enabled by default on localhost with a limited free tier (10 messages). For production, you need an [Agent Scalar key](../../guides/agent/key.md).
 
 To set an Agent Scalar key globally:
 
@@ -261,7 +261,7 @@ app.MapScalarApiReference(options => options
     .AddDocument("v2", "API v2"));
 ```
 
-For more details, see [Agent Scalar](configuration.md#agent-scalar) and [How to get an Agent Scalar key](guides/agent/key.md).
+For more details, see [Agent Scalar](../../configuration.md#agent-scalar) and [How to get an Agent Scalar key](../../guides/agent/key.md).
 
 ### Authentication
 


### PR DESCRIPTION
some broken links that I saw in the build logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only link path updates; no runtime or API behavior changes.
> 
> **Overview**
> Fixes broken relative links in the ASP.NET Core integration docs by updating `Agent Scalar` references to use the correct `../../` paths for the key guide and configuration section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fc31ab9c9c139fcd77a6a3f7bed6a02a2f337ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->