### PR TITLE
docs: update the scalar docs getting started page

### DIFF
--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -2,11 +2,14 @@
   <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/v1Pu6_BCmly6VhPAuotVZ.svg"></scalar-icon>
 </div>
 <div class="flex flex-col gap-3 hero small-test">
-  <scalar-heading level="2" slug="developer-docs" class="text-balance">
-    Developer Docs
+  <scalar-heading level="2" slug="scalar-docs" class="text-balance">
+    Scalar Docs
   </scalar-heading>
   <p>
-    Get started with Scalar Docs, literally in minutes. You don't need anything to get started, not even an account if you just want to play around.
+    Documentation that stays in sync with your API and code. Pull content from GitHub, get previews on every pull request, deploy on merge, or publish from anywhere with the CLI.
+  </p>
+  <p>
+    The site you're looking at was built using Scalar Docs. It's not just us, those wonderful folks use it too:
   </p>
 </div>
 <div class="logowall">
@@ -36,50 +39,8 @@
 <div class="flex">
   <div class="full-container-constrained">
 
-  ## Getting Started
-
-  :::scalar-callout{ type=info }
-  Guides are part of our Scalar Pro plan (read below, or [visit our pricing page for more info](https://scalar.com/#pricing)).
-  :::
-  In the top left corner of <https://docs.scalar.com>, you'll see a “Guide” tab. This is where you land by default.
-
-  Guides are basically a blank sheet of paper. These pages are where you will publish your non-reference content (API reference pages are [discussed below](#api-references)). You can start writing your documentation, your guidelines, your knowledge base — whatever you want to write — using our editor. You can alternatively manage your guides using a Git repository.
-
-  If you're serious about this, you can [create an account here](https://docs.scalar.com/register) to make sure your changes are saved.
-
-  ## API References
-
-  :::scalar-callout{ type=neutral }
-  This is a free feature. You'll even get a nice `${whatever-you-like}.apidocumentation.com` subdomain.
-  :::
-
-  Every project can have one, or even multiple API references: In the top left corner, you'll see a “Reference” tab. Try to click on it to switch to our OpenAPI editor.
-
-  OpenAPI is the most popular standard to describe your API in a machine readable format. No matter which languages, libraries or frameworks you're using to build your API, it's very, very likely there's a tool, plugin or package to generate an OpenAPI document for you. If you don't find something which says “OpenAPI”, look for “Swagger”. It's what it used be called a few years ago, before it was an open standard.
-
-  Those OpenAPI documents are what we base all our tools on. So once you've got one, it should be straight-forward to use our tools.
-
-  Scalar Docs offers multiple ways to connect your OpenAPI document. Pick whatever fits your workflow:
-
-  - Paste your OpenAPI document in the editor
-  - Upload an OpenAPI document to the editor
-  - Import an URL (you can even create a “Live Link”, which means it'll fetch updates from the URL vs. just fetching it once)
-  - Sync your OpenAPI document from GitHub
-
-  ## Scalar Pro
-
-  Most of our stuff is actually freely available. Upgrading to Scalar Pro unlocks a set of additional features, including:
-
-  * Custom domains,
-  * GitHub Sync,
-  * Guides (and versioning of your guides),
-  * TypeSense search and
-  * priority support (including a private Discord channel or a dedicated Slack connect channel if you like).
-
-  [Pricing information can be found here](../pricing.md).
-
 <div class="feature">
-  <h2>Features</h2>
+  <h2>Your documentation, always up to date</h2>
   <div class="flex flex-wrap feature-container">
     <div class="feature-item">
       <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
@@ -95,29 +56,84 @@
     </div>
     <div class="feature-item">
       <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
-        <scalar-icon src="phosphor/bold/arrow-up-right"></scalar-icon>
-        OpenAPI Documents
+        <scalar-icon src="phosphor/bold/cloud-arrow-up"></scalar-icon>
+        Fast CDN
       </b>
     </div>
     <div class="feature-item">
       <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
-        <scalar-icon src="phosphor/bold/github-logo"></scalar-icon>
-        GitHub Sync
+        <scalar-icon src="phosphor/bold/arrow-up-right"></scalar-icon>
+        Multiple API references
       </b>
     </div>
     <div class="feature-item">
       <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
         <scalar-icon src="phosphor/bold/palette"></scalar-icon>
-        Customize Everything
+        Custom themes & layouts
+      </b>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
+        <scalar-icon src="phosphor/bold/globe"></scalar-icon>
+        Custom domains
       </b>
     </div>
     <div class="feature-item">
       <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
         <scalar-icon src="phosphor/bold/users"></scalar-icon>
-        Fine-grained Access
+        Fine-grained access
+      </b>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
+        <scalar-icon src="phosphor/bold/github-logo"></scalar-icon>
+        Sync with GitHub
+      </b>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
+        <scalar-icon src="phosphor/bold/headset"></scalar-icon>
+        LLM-chat for your API
+      </b>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
+        <scalar-icon src="phosphor/bold/robot"></scalar-icon>
+        CI/CD integration
       </b>
     </div>
   </div>
+</div>
+
+## The modern API documentation
+
+Include interactive API references, for a single API or for hundreds of APIs. All based on the OpenAPI standard. And the best part: Your documentation stays in sync with your actual API.
+
+> [!TIP]
+> Just need an API Reference and that's all? Use the [Scalar API Reference](../../guides/api-references/getting-started.md). It is open-source, free, and has integrations for all REST API frameworks.
+
+## Write anywhere
+
+Put your content where you want: in your repository, any folder, or the Scalar Editor.
+
+| Source                   | Description                                                                                                                                                                                                                                                                     |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **GitHub** (recommended) | Content and OpenAPI in your repository. CI/CD: [preview deployments](deployment/preview-deployments.md), [automatic deployment](deployment/automatic-deployment.md), [GitHub Actions](deployment/github-actions.md), [scalar.config.json](configuration/scalar.config.json.md). |
+| **Any folder / CLI**     | No repository access needed. Content in any folder or repository, run [`npx @scalar/cli project publish`](deployment/cli.md).                                                                                                                                                   |
+| **Web editor**           | Edit and store docs at [docs.scalar.com](https://docs.scalar.com). No Git required.                                                                                                                                                                                             |
+
+## Plans: Free, Pro, Enterprise
+
+|                                                                                                  | Free | Pro | Enterprise |
+| ------------------------------------------------------------------------------------------------ | ---- | --- | ---------- |
+| Subdomains, API references, themes, custom HTML/CSS/JS, email domain access                      | ✓    | ✓   | ✓          |
+| Custom domains, Guides, versions, Git Sync, Markdown + MDX, landing pages, full developer portal |      | ✓   | ✓          |
+| SSO/SAML, RBAC, priority support, dedicated Slack/Teams                                          |      |     | ✓          |
+
+
+[See the full comparison](../pricing.md) for Scalar Docs and the other Scalar products.
+
+<div class="feature">
   <div class="cta flex flex-col gap-3 small-test">
     <scalar-heading level="2" class="text-balance" slug="what-are-you-waiting-for">What are you waiting for?</scalar-heading>
   <p>
@@ -140,10 +156,25 @@
         <b class="font-medium">Additional Reading</b>
       </p>
       <p>
-        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/configuration/scalar.config.json"><scalar-icon src="phosphor/bold/git-branch"></scalar-icon> GitHub Sync</a>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/configuration/scalar.config.json"><scalar-icon src="phosphor/bold/git-branch"></scalar-icon>Configuration</a>
       </p>
       <p>
-        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/components/markdown-support"><scalar-icon src="phosphor/bold/file-md"></scalar-icon> Markdown Support</a>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/deployment/automatic-deployment"><scalar-icon src="phosphor/bold/arrow-square-out"></scalar-icon> Automatic Deployment</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/deployment/preview-deployments"><scalar-icon src="phosphor/bold/code"></scalar-icon> Preview Deployments</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/deployment/cli"><scalar-icon src="phosphor/bold/terminal"></scalar-icon> CLI</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/starter-kit"><scalar-icon src="phosphor/bold/rocket-launch"></scalar-icon> Starter Kit</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/configuration/themes"><scalar-icon src="phosphor/bold/palette"></scalar-icon> Themes</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/configuration/private-docs"><scalar-icon src="phosphor/bold/users"></scalar-icon> Private Docs</a>
       </p>
       <p class="mt-3 mb-1 pl-2">
         <b class="font-medium">Community</b>
@@ -228,13 +259,13 @@
       <div class="expander-hover-sticker">
         <object class="sticker-clip-docs" width="113" height="143" data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/HLhbFqJ4vSzo4UDEZX2dq.svg"></object>
       </div>
-      <div class="expander-hover-title">API Docs</div>
+      <div class="expander-hover-title">Scalar Docs</div>
       <div class="expander">
         <div class="expander-content">
-          Write beautiful documentation with Markdown + MDX + Git Sync.
+          Documentation that stays in sync with your API. Markdown, MDX, Git Sync, and stunning API references.
         </div>
       </div>
-      <a class="expander-hover-link" href="/products/docs/getting-started" aria-label="Learn more about API Docs">Learn More</a>
+      <a class="expander-hover-link" href="/products/docs/getting-started" aria-label="Learn more about Scalar Docs">Learn More</a>
     </div>
   </div>
 </div>
@@ -252,7 +283,7 @@
           <b>Products</b>
           <a class="text-c-2 hover:text-c-1 font-normal" href="/products/api-references/getting-started" target="_blank">API References</a>
           <a class="text-c-2 hover:text-c-1 font-normal" href="https://client.scalar.com/" target="_blank">API Client</a>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="https://docs.scalar.com/" target="_blank">API Docs</a>
+          <a class="text-c-2 hover:text-c-1 font-normal" href="https://docs.scalar.com/" target="_blank">Scalar Docs</a>
           <a class="text-c-2 hover:text-c-1 font-normal" href="https://editor.scalar.com/" target="_blank">Swagger Editor</a>
         </div>
         <div class="w-1/3 flex flex-col gap-2">


### PR DESCRIPTION
the all new scalar docs landing page

here it is

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only update to a documentation landing page; main risk is broken links or layout regressions.
> 
> **Overview**
> Reworks the `getting-started.md` page from a step-by-step “Getting Started / API References / Pro” guide into a marketing-style Scalar Docs landing page with updated hero copy, feature highlights, and new sections for *modern API documentation*, *write anywhere* options, and a *Free/Pro/Enterprise* plan comparison.
> 
> Updates product naming from “API Docs” to “Scalar Docs” and refreshes navigation/CTA content, including a revamped “Additional Reading” sidebar with new links (deployment, CLI, starter kit, themes, private docs) and updated descriptive text for the Scalar Docs card.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0018c7201d012f75e200c2d27896f7ed8b400b9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->