### PR TITLE
Revert "chore: release"

### DIFF
--- a/.changeset/afraid-geckos-wear.md
+++ b/.changeset/afraid-geckos-wear.md
@@ -1,0 +1,9 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/oas-utils': patch
+'@scalar/helpers': patch
+---
+
+fix: local storage migration script

--- a/.changeset/cyan-radios-spend.md
+++ b/.changeset/cyan-radios-spend.md
@@ -1,0 +1,7 @@
+---
+'@scalar/code-highlight': patch
+'@scalar/api-reference': patch
+'@scalar/components': patch
+---
+
+feat: slugs for headings with nested content

--- a/.changeset/goofy-radios-worry.md
+++ b/.changeset/goofy-radios-worry.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: selecting multiply security schemes doesn't render Markdown in descriptions

--- a/.changeset/huge-rules-press.md
+++ b/.changeset/huge-rules-press.md
@@ -1,0 +1,6 @@
+---
+'@scalar/components': patch
+'@scalar/sidebar': patch
+---
+
+feat: add optional chevron click handler for the sidebar

--- a/.changeset/hungry-pears-fail.md
+++ b/.changeset/hungry-pears-fail.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+fix: duplicate http headers for PHP CURL

--- a/.changeset/late-worlds-divide.md
+++ b/.changeset/late-worlds-divide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: correctly display header in classic layout

--- a/.changeset/orange-facts-matter.md
+++ b/.changeset/orange-facts-matter.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat: always show the schema type

--- a/.changeset/orange-loops-do.md
+++ b/.changeset/orange-loops-do.md
@@ -1,0 +1,5 @@
+---
+'@scalar/express-api-reference': patch
+---
+
+fix(express): remove unused `customTheme`

--- a/.changeset/purple-games-cover.md
+++ b/.changeset/purple-games-cover.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-reference': patch
+---
+
+feat: nest description headings in the sidebar

--- a/.changeset/real-areas-strive.md
+++ b/.changeset/real-areas-strive.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+feat: add option to open first tag by default

--- a/.changeset/sharp-emus-sleep.md
+++ b/.changeset/sharp-emus-sleep.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-client": patch
+"@scalar/oas-utils": patch
+---
+
+fix: remove unnecessary property truncation in example generation

--- a/.changeset/yummy-lizards-float.md
+++ b/.changeset/yummy-lizards-float.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/oas-utils': patch
+---
+
+chore: map themeId to slug and add default operation to drafts

--- a/integrations/astro/CHANGELOG.md
+++ b/integrations/astro/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/astro
 
-## 0.1.21
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/core@0.3.42**
-
 ## 0.1.20
 
 ### Patch Changes

--- a/integrations/astro/package.json
+++ b/integrations/astro/package.json
@@ -17,7 +17,7 @@
     "openapi",
     "swagger"
   ],
-  "version": "0.1.21",
+  "version": "0.1.20",
   "engines": {
     "node": ">=20"
   },

--- a/integrations/docker/CHANGELOG.md
+++ b/integrations/docker/CHANGELOG.md
@@ -1,19 +1,5 @@
 # @scalarapi/docker-api-reference
 
-## 0.4.65
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/api-reference@1.45.0**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-  - [#8243](https://github.com/scalar/scalar/pull/8243): chore: correctly display header in classic layout
-  - [#8129](https://github.com/scalar/scalar/pull/8129): feat: always show the schema type
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: nest description headings in the sidebar
-  - [#8238](https://github.com/scalar/scalar/pull/8238): feat: add option to open first tag by default
-
 ## 0.4.64
 
 ### Patch Changes

--- a/integrations/docker/package.json
+++ b/integrations/docker/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/docker"
   },
-  "version": "0.4.65",
+  "version": "0.4.64",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/integrations/docusaurus/CHANGELOG.md
+++ b/integrations/docusaurus/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/docusaurus
 
-## 0.7.41
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/types@0.6.7**
-
 ## 0.7.40
 
 ### Patch Changes

--- a/integrations/docusaurus/package.json
+++ b/integrations/docusaurus/package.json
@@ -19,7 +19,7 @@
     "testing",
     "react"
   ],
-  "version": "0.7.41",
+  "version": "0.7.40",
   "engines": {
     "node": ">=20"
   },

--- a/integrations/dotnet/aspire/CHANGELOG.md
+++ b/integrations/dotnet/aspire/CHANGELOG.md
@@ -1,21 +1,5 @@
 # @scalar/aspire
 
-## 0.8.56
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/api-reference@1.45.0**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-  - [#8243](https://github.com/scalar/scalar/pull/8243): chore: correctly display header in classic layout
-  - [#8129](https://github.com/scalar/scalar/pull/8129): feat: always show the schema type
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: nest description headings in the sidebar
-  - [#8238](https://github.com/scalar/scalar/pull/8238): feat: add option to open first tag by default
-
-- **@scalar/dotnet-shared@0.1.3**
-
 ## 0.8.55
 
 ### Patch Changes

--- a/integrations/dotnet/aspire/package.json
+++ b/integrations/dotnet/aspire/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/dotnet/aspire"
   },
-  "version": "0.8.56",
+  "version": "0.8.55",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/integrations/dotnet/aspnetcore/CHANGELOG.md
+++ b/integrations/dotnet/aspnetcore/CHANGELOG.md
@@ -1,21 +1,5 @@
 # @scalar/aspnetcore
 
-## 2.12.47
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/api-reference@1.45.0**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-  - [#8243](https://github.com/scalar/scalar/pull/8243): chore: correctly display header in classic layout
-  - [#8129](https://github.com/scalar/scalar/pull/8129): feat: always show the schema type
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: nest description headings in the sidebar
-  - [#8238](https://github.com/scalar/scalar/pull/8238): feat: add option to open first tag by default
-
-- **@scalar/dotnet-shared@0.1.3**
-
 ## 2.12.46
 
 ### Patch Changes

--- a/integrations/dotnet/aspnetcore/package.json
+++ b/integrations/dotnet/aspnetcore/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/dotnet/aspnetcore"
   },
-  "version": "2.12.47",
+  "version": "2.12.46",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/integrations/express/CHANGELOG.md
+++ b/integrations/express/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/express-api-reference
 
-## 0.8.45
-
-### Patch Changes
-
-- [#8239](https://github.com/scalar/scalar/pull/8239): fix(express): remove unused `customTheme`
-
-#### Updated Dependencies
-
-- **@scalar/core@0.3.42**
-
 ## 0.8.44
 
 ### Patch Changes

--- a/integrations/express/package.json
+++ b/integrations/express/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/express"
   },
-  "version": "0.8.45",
+  "version": "0.8.44",
   "engines": {
     "node": ">=20"
   },

--- a/integrations/fastify/CHANGELOG.md
+++ b/integrations/fastify/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @scalar/fastify-api-reference
 
-## 1.45.0
-
-### Patch Changes
-
-- [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
-#### Updated Dependencies
-
-- **@scalar/openapi-parser@0.24.14**
-
-- **@scalar/core@0.3.42**
-
 ## 1.44.25
 
 ## 1.44.24

--- a/integrations/fastify/package.json
+++ b/integrations/fastify/package.json
@@ -17,7 +17,7 @@
     "openapi",
     "swagger"
   ],
-  "version": "1.45.0",
+  "version": "1.44.25",
   "engines": {
     "node": ">=20"
   },

--- a/integrations/hono/CHANGELOG.md
+++ b/integrations/hono/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/hono-api-reference
 
-## 0.9.45
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/core@0.3.42**
-
 ## 0.9.44
 
 ### Patch Changes

--- a/integrations/hono/package.json
+++ b/integrations/hono/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/hono"
   },
-  "version": "0.9.45",
+  "version": "0.9.44",
   "engines": {
     "node": ">=20"
   },

--- a/integrations/java/CHANGELOG.md
+++ b/integrations/java/CHANGELOG.md
@@ -1,19 +1,5 @@
 # @scalar/java-integration
 
-## 0.5.56
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/api-reference@1.45.0**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-  - [#8243](https://github.com/scalar/scalar/pull/8243): chore: correctly display header in classic layout
-  - [#8129](https://github.com/scalar/scalar/pull/8129): feat: always show the schema type
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: nest description headings in the sidebar
-  - [#8238](https://github.com/scalar/scalar/pull/8238): feat: add option to open first tag by default
-
 ## 0.5.55
 
 ### Patch Changes

--- a/integrations/java/package.json
+++ b/integrations/java/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/java"
   },
-  "version": "0.5.56",
+  "version": "0.5.55",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/integrations/nestjs/CHANGELOG.md
+++ b/integrations/nestjs/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/nestjs-api-reference
 
-## 1.0.28
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/core@0.3.42**
-
 ## 1.0.27
 
 ### Patch Changes

--- a/integrations/nestjs/package.json
+++ b/integrations/nestjs/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "integrations/nestjs"
   },
-  "version": "1.0.28",
+  "version": "1.0.27",
   "engines": {
     "node": ">=20"
   },

--- a/integrations/nextjs/CHANGELOG.md
+++ b/integrations/nextjs/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/nextjs-api-reference
 
-## 0.9.23
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/core@0.3.42**
-
 ## 0.9.22
 
 ### Patch Changes

--- a/integrations/nextjs/package.json
+++ b/integrations/nextjs/package.json
@@ -18,7 +18,7 @@
     "openapi",
     "swagger"
   ],
-  "version": "0.9.23",
+  "version": "0.9.22",
   "engines": {
     "node": ">=20"
   },

--- a/integrations/nuxt/CHANGELOG.md
+++ b/integrations/nuxt/CHANGELOG.md
@@ -1,25 +1,5 @@
 # @scalar/nuxt
 
-## 0.5.83
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/api-reference@1.45.0**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-  - [#8243](https://github.com/scalar/scalar/pull/8243): chore: correctly display header in classic layout
-  - [#8129](https://github.com/scalar/scalar/pull/8129): feat: always show the schema type
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: nest description headings in the sidebar
-  - [#8238](https://github.com/scalar/scalar/pull/8238): feat: add option to open first tag by default
-
-- **@scalar/api-client@2.29.3**
-  - [#8225](https://github.com/scalar/scalar/pull/8225): fix: selecting multiply security schemes doesn't render Markdown in descriptions
-  - [#8227](https://github.com/scalar/scalar/pull/8227): fix: remove unnecessary property truncation in example generation
-
-- **@scalar/types@0.6.7**
-
 ## 0.5.82
 
 ### Patch Changes

--- a/integrations/nuxt/package.json
+++ b/integrations/nuxt/package.json
@@ -20,7 +20,7 @@
     "testing",
     "vue"
   ],
-  "version": "0.5.83",
+  "version": "0.5.82",
   "engines": {
     "node": ">=20"
   },

--- a/integrations/sveltekit/CHANGELOG.md
+++ b/integrations/sveltekit/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/sveltekit
 
-## 0.1.49
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/core@0.3.42**
-
 ## 0.1.48
 
 ### Patch Changes

--- a/integrations/sveltekit/package.json
+++ b/integrations/sveltekit/package.json
@@ -18,7 +18,7 @@
     "openapi",
     "swagger"
   ],
-  "version": "0.1.49",
+  "version": "0.1.48",
   "engines": {
     "node": ">=20"
   },

--- a/packages/agent-chat/CHANGELOG.md
+++ b/packages/agent-chat/CHANGELOG.md
@@ -1,31 +1,5 @@
 # @scalar/agent-chat
 
-## 0.5.17
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/workspace-store@0.34.3**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: nest description headings in the sidebar
-  - [#8242](https://github.com/scalar/scalar/pull/8242): chore: map themeId to slug and add default operation to drafts
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
-- **@scalar/components@0.19.9**
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: add optional chevron click handler for the sidebar
-
-- **@scalar/api-client@2.29.3**
-  - [#8225](https://github.com/scalar/scalar/pull/8225): fix: selecting multiply security schemes doesn't render Markdown in descriptions
-  - [#8227](https://github.com/scalar/scalar/pull/8227): fix: remove unnecessary property truncation in example generation
-
-- **@scalar/json-magic@0.11.5**
-
-- **@scalar/types@0.6.7**
-
 ## 0.5.16
 
 ### Patch Changes

--- a/packages/agent-chat/package.json
+++ b/packages/agent-chat/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/agent-chat"
   },
-  "version": "0.5.17",
+  "version": "0.5.16",
   "engines": {
     "node": ">=20"
   },

--- a/packages/api-client-react/CHANGELOG.md
+++ b/packages/api-client-react/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @scalar/api-client-react
 
-## 1.3.101
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/api-client@2.29.3**
-  - [#8225](https://github.com/scalar/scalar/pull/8225): fix: selecting multiply security schemes doesn't render Markdown in descriptions
-  - [#8227](https://github.com/scalar/scalar/pull/8227): fix: remove unnecessary property truncation in example generation
-
-- **@scalar/types@0.6.7**
-
 ## 1.3.100
 
 ### Patch Changes

--- a/packages/api-client-react/package.json
+++ b/packages/api-client-react/package.json
@@ -19,7 +19,7 @@
     "testing",
     "react"
   ],
-  "version": "1.3.101",
+  "version": "1.3.100",
   "engines": {
     "node": ">=20"
   },

--- a/packages/api-client/CHANGELOG.md
+++ b/packages/api-client/CHANGELOG.md
@@ -1,51 +1,5 @@
 # @scalar/api-client
 
-## 2.29.3
-
-### Patch Changes
-
-- [#8225](https://github.com/scalar/scalar/pull/8225): fix: selecting multiply security schemes doesn't render Markdown in descriptions
-- [#8227](https://github.com/scalar/scalar/pull/8227): fix: remove unnecessary property truncation in example generation
-
-#### Updated Dependencies
-
-- **@scalar/workspace-store@0.34.3**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: nest description headings in the sidebar
-  - [#8242](https://github.com/scalar/scalar/pull/8242): chore: map themeId to slug and add default operation to drafts
-
-- **@scalar/oas-utils@0.6.47**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8227](https://github.com/scalar/scalar/pull/8227): fix: remove unnecessary property truncation in example generation
-  - [#8242](https://github.com/scalar/scalar/pull/8242): chore: map themeId to slug and add default operation to drafts
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
-- **@scalar/components@0.19.9**
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: add optional chevron click handler for the sidebar
-
-- **@scalar/sidebar@0.7.40**
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: add optional chevron click handler for the sidebar
-
-- **@scalar/snippetz@0.6.16**
-  - [#8240](https://github.com/scalar/scalar/pull/8240): fix: duplicate http headers for PHP CURL
-
-- **@scalar/import@0.4.53**
-
-- **@scalar/json-magic@0.11.5**
-
-- **@scalar/object-utils@1.2.30**
-
-- **@scalar/openapi-parser@0.24.14**
-
-- **@scalar/postman-to-openapi@0.4.8**
-
-- **@scalar/types@0.6.7**
-
-- **@scalar/use-codemirror@0.13.44**
-
 ## 2.29.2
 
 ### Patch Changes

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -18,7 +18,7 @@
     "rest",
     "testing"
   ],
-  "version": "2.29.3",
+  "version": "2.29.2",
   "engines": {
     "node": ">=20"
   },

--- a/packages/api-reference-react/CHANGELOG.md
+++ b/packages/api-reference-react/CHANGELOG.md
@@ -1,21 +1,5 @@
 # @scalar/api-reference-react
 
-## 0.8.63
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/api-reference@1.45.0**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-  - [#8243](https://github.com/scalar/scalar/pull/8243): chore: correctly display header in classic layout
-  - [#8129](https://github.com/scalar/scalar/pull/8129): feat: always show the schema type
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: nest description headings in the sidebar
-  - [#8238](https://github.com/scalar/scalar/pull/8238): feat: add option to open first tag by default
-
-- **@scalar/types@0.6.7**
-
 ## 0.8.62
 
 ### Patch Changes

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -18,7 +18,7 @@
     "testing",
     "react"
   ],
-  "version": "0.8.63",
+  "version": "0.8.62",
   "engines": {
     "node": ">=20"
   },

--- a/packages/api-reference/CHANGELOG.md
+++ b/packages/api-reference/CHANGELOG.md
@@ -1,57 +1,5 @@
 # @scalar/api-reference
 
-## 1.45.0
-
-### Minor Changes
-
-- [#8238](https://github.com/scalar/scalar/pull/8238): feat: add option to open first tag by default
-
-### Patch Changes
-
-- [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-- [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-- [#8243](https://github.com/scalar/scalar/pull/8243): chore: correctly display header in classic layout
-- [#8129](https://github.com/scalar/scalar/pull/8129): feat: always show the schema type
-- [#8130](https://github.com/scalar/scalar/pull/8130): feat: nest description headings in the sidebar
-
-#### Updated Dependencies
-
-- **@scalar/workspace-store@0.34.3**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: nest description headings in the sidebar
-  - [#8242](https://github.com/scalar/scalar/pull/8242): chore: map themeId to slug and add default operation to drafts
-
-- **@scalar/oas-utils@0.6.47**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8227](https://github.com/scalar/scalar/pull/8227): fix: remove unnecessary property truncation in example generation
-  - [#8242](https://github.com/scalar/scalar/pull/8242): chore: map themeId to slug and add default operation to drafts
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
-- **@scalar/code-highlight@0.2.4**
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-
-- **@scalar/components@0.19.9**
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: add optional chevron click handler for the sidebar
-
-- **@scalar/api-client@2.29.3**
-  - [#8225](https://github.com/scalar/scalar/pull/8225): fix: selecting multiply security schemes doesn't render Markdown in descriptions
-  - [#8227](https://github.com/scalar/scalar/pull/8227): fix: remove unnecessary property truncation in example generation
-
-- **@scalar/sidebar@0.7.40**
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: add optional chevron click handler for the sidebar
-
-- **@scalar/snippetz@0.6.16**
-  - [#8240](https://github.com/scalar/scalar/pull/8240): fix: duplicate http headers for PHP CURL
-
-- **@scalar/agent-chat@0.5.17**
-
-- **@scalar/openapi-parser@0.24.14**
-
-- **@scalar/types@0.6.7**
-
 ## 1.44.25
 
 ### Patch Changes

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -20,7 +20,7 @@
     "vue",
     "vue3"
   ],
-  "version": "1.45.0",
+  "version": "1.44.25",
   "engines": {
     "node": ">=20"
   },

--- a/packages/code-highlight/CHANGELOG.md
+++ b/packages/code-highlight/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @scalar/code-highlight
 
-## 0.2.4
-
-### Patch Changes
-
-- [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -16,7 +16,7 @@
     "lowlight",
     "highlightjs"
   ],
-  "version": "0.2.4",
+  "version": "0.2.3",
   "engines": {
     "node": ">=20"
   },

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,25 +1,5 @@
 # @scalar/components
 
-## 0.19.9
-
-### Patch Changes
-
-- [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-- [#8130](https://github.com/scalar/scalar/pull/8130): feat: add optional chevron click handler for the sidebar
-
-#### Updated Dependencies
-
-- **@scalar/oas-utils@0.6.47**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8227](https://github.com/scalar/scalar/pull/8227): fix: remove unnecessary property truncation in example generation
-  - [#8242](https://github.com/scalar/scalar/pull/8242): chore: map themeId to slug and add default operation to drafts
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
-- **@scalar/code-highlight@0.2.4**
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-
 ## 0.19.8
 
 ### Patch Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/components"
   },
-  "version": "0.19.9",
+  "version": "0.19.8",
   "engines": {
     "node": ">=20"
   },

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @scalar/core
 
-## 0.3.42
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/types@0.6.7**
-
 ## 0.3.41
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/core"
   },
   "keywords": [],
-  "version": "0.3.42",
+  "version": "0.3.41",
   "engines": {
     "node": ">=20"
   },

--- a/packages/helpers/CHANGELOG.md
+++ b/packages/helpers/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @scalar/helpers
 
-## 0.2.16
-
-### Patch Changes
-
-- [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
 ## 0.2.15
 
 ### Patch Changes

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -14,7 +14,7 @@
     "helpers",
     "js"
   ],
-  "version": "0.2.16",
+  "version": "0.2.15",
   "engines": {
     "node": ">=20"
   },

--- a/packages/import/CHANGELOG.md
+++ b/packages/import/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/import
 
-## 0.4.53
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
 ## 0.4.52
 
 ### Patch Changes

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -16,7 +16,7 @@
     "postman",
     "scalar"
   ],
-  "version": "0.4.53",
+  "version": "0.4.52",
   "engines": {
     "node": ">=20"
   },

--- a/packages/json-magic/CHANGELOG.md
+++ b/packages/json-magic/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/json-magic
 
-## 0.11.5
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
 ## 0.11.4
 
 ### Patch Changes

--- a/packages/json-magic/package.json
+++ b/packages/json-magic/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/json-magic"
   },
-  "version": "0.11.5",
+  "version": "0.11.4",
   "engines": {
     "node": ">=20"
   },

--- a/packages/mock-server/CHANGELOG.md
+++ b/packages/mock-server/CHANGELOG.md
@@ -1,25 +1,5 @@
 # @scalar/mock-server
 
-## 0.8.42
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/oas-utils@0.6.47**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8227](https://github.com/scalar/scalar/pull/8227): fix: remove unnecessary property truncation in example generation
-  - [#8242](https://github.com/scalar/scalar/pull/8242): chore: map themeId to slug and add default operation to drafts
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
-- **@scalar/json-magic@0.11.5**
-
-- **@scalar/openapi-parser@0.24.14**
-
-- **@scalar/openapi-upgrader@0.1.8**
-
 ## 0.8.41
 
 ### Patch Changes

--- a/packages/mock-server/docker/CHANGELOG.md
+++ b/packages/mock-server/docker/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/mock-server-docker
 
-## 0.1.38
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/mock-server@0.8.42**
-
-- **@scalar/hono-api-reference@0.9.45**
-
 ## 0.1.37
 
 ### Patch Changes

--- a/packages/mock-server/docker/package.json
+++ b/packages/mock-server/docker/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/mock-server/docker"
   },
-  "version": "0.1.38",
+  "version": "0.1.37",
   "engines": {
     "node": ">=20"
   },

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -16,7 +16,7 @@
     "swagger",
     "cli"
   ],
-  "version": "0.8.42",
+  "version": "0.8.41",
   "engines": {
     "node": ">=20"
   },

--- a/packages/nextjs-openapi/CHANGELOG.md
+++ b/packages/nextjs-openapi/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/nextjs-openapi
 
-## 0.2.49
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/types@0.6.7**
-
-- **@scalar/nextjs-api-reference@0.9.23**
-
 ## 0.2.48
 
 ### Patch Changes

--- a/packages/nextjs-openapi/package.json
+++ b/packages/nextjs-openapi/package.json
@@ -16,7 +16,7 @@
     "scalar",
     "references"
   ],
-  "version": "0.2.49",
+  "version": "0.2.48",
   "engines": {
     "node": ">=20"
   },

--- a/packages/oas-utils/CHANGELOG.md
+++ b/packages/oas-utils/CHANGELOG.md
@@ -1,29 +1,5 @@
 # @scalar/oas-utils
 
-## 0.6.47
-
-### Patch Changes
-
-- [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-- [#8227](https://github.com/scalar/scalar/pull/8227): fix: remove unnecessary property truncation in example generation
-- [#8242](https://github.com/scalar/scalar/pull/8242): chore: map themeId to slug and add default operation to drafts
-
-#### Updated Dependencies
-
-- **@scalar/workspace-store@0.34.3**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: nest description headings in the sidebar
-  - [#8242](https://github.com/scalar/scalar/pull/8242): chore: map themeId to slug and add default operation to drafts
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
-- **@scalar/json-magic@0.11.5**
-
-- **@scalar/object-utils@1.2.30**
-
-- **@scalar/types@0.6.7**
-
 ## 0.6.46
 
 ### Patch Changes

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -16,7 +16,7 @@
     "specification",
     "yaml"
   ],
-  "version": "0.6.47",
+  "version": "0.6.46",
   "engines": {
     "node": ">=20"
   },

--- a/packages/object-utils/CHANGELOG.md
+++ b/packages/object-utils/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/object-utils
 
-## 1.2.30
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
 ## 1.2.29
 
 ### Patch Changes

--- a/packages/object-utils/package.json
+++ b/packages/object-utils/package.json
@@ -13,7 +13,7 @@
   "keywords": [
     "typescript object transforms"
   ],
-  "version": "1.2.30",
+  "version": "1.2.29",
   "engines": {
     "node": ">=20"
   },

--- a/packages/openapi-parser/CHANGELOG.md
+++ b/packages/openapi-parser/CHANGELOG.md
@@ -1,18 +1,5 @@
 # @scalar/openapi-parser
 
-## 0.24.14
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
-- **@scalar/json-magic@0.11.5**
-
-- **@scalar/openapi-upgrader@0.1.8**
-
 ## 0.24.13
 
 ### Patch Changes

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -17,7 +17,7 @@
     "parser",
     "typescript"
   ],
-  "version": "0.24.14",
+  "version": "0.24.13",
   "engines": {
     "node": ">=20"
   },

--- a/packages/openapi-to-markdown/CHANGELOG.md
+++ b/packages/openapi-to-markdown/CHANGELOG.md
@@ -1,29 +1,5 @@
 # @scalar/openapi-to-markdown
 
-## 0.3.50
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/oas-utils@0.6.47**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8227](https://github.com/scalar/scalar/pull/8227): fix: remove unnecessary property truncation in example generation
-  - [#8242](https://github.com/scalar/scalar/pull/8242): chore: map themeId to slug and add default operation to drafts
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
-- **@scalar/components@0.19.9**
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: add optional chevron click handler for the sidebar
-
-- **@scalar/openapi-parser@0.24.14**
-
-- **@scalar/types@0.6.7**
-
-- **@scalar/openapi-upgrader@0.1.8**
-
 ## 0.3.49
 
 ### Patch Changes

--- a/packages/openapi-to-markdown/package.json
+++ b/packages/openapi-to-markdown/package.json
@@ -16,7 +16,7 @@
     "llm",
     "swagger"
   ],
-  "version": "0.3.50",
+  "version": "0.3.49",
   "engines": {
     "node": ">=20"
   },

--- a/packages/postman-to-openapi/CHANGELOG.md
+++ b/packages/postman-to-openapi/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/postman-to-openapi
 
-## 0.4.8
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
 ## 0.4.7
 
 ### Patch Changes

--- a/packages/postman-to-openapi/package.json
+++ b/packages/postman-to-openapi/package.json
@@ -19,7 +19,7 @@
     "export",
     "scalar"
   ],
-  "version": "0.4.8",
+  "version": "0.4.7",
   "engines": {
     "node": ">=20"
   },

--- a/packages/pre-post-request-scripts/CHANGELOG.md
+++ b/packages/pre-post-request-scripts/CHANGELOG.md
@@ -1,20 +1,5 @@
 # @scalar/scripts
 
-## 0.2.3
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/oas-utils@0.6.47**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8227](https://github.com/scalar/scalar/pull/8227): fix: remove unnecessary property truncation in example generation
-  - [#8242](https://github.com/scalar/scalar/pull/8242): chore: map themeId to slug and add default operation to drafts
-
-- **@scalar/components@0.19.9**
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: add optional chevron click handler for the sidebar
-
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/pre-post-request-scripts/package.json
+++ b/packages/pre-post-request-scripts/package.json
@@ -19,7 +19,7 @@
     "post-response scripts",
     "api client"
   ],
-  "version": "0.2.3",
+  "version": "0.2.2",
   "private": true,
   "engines": {
     "node": ">=18"

--- a/packages/sidebar/CHANGELOG.md
+++ b/packages/sidebar/CHANGELOG.md
@@ -1,25 +1,5 @@
 # @scalar/sidebar
 
-## 0.7.40
-
-### Patch Changes
-
-- [#8130](https://github.com/scalar/scalar/pull/8130): feat: add optional chevron click handler for the sidebar
-
-#### Updated Dependencies
-
-- **@scalar/workspace-store@0.34.3**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: nest description headings in the sidebar
-  - [#8242](https://github.com/scalar/scalar/pull/8242): chore: map themeId to slug and add default operation to drafts
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
-- **@scalar/components@0.19.9**
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: add optional chevron click handler for the sidebar
-
 ## 0.7.39
 
 ### Patch Changes

--- a/packages/sidebar/package.json
+++ b/packages/sidebar/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/sidebar"
   },
-  "version": "0.7.40",
+  "version": "0.7.39",
   "engines": {
     "node": ">=20"
   },

--- a/packages/snippetz/CHANGELOG.md
+++ b/packages/snippetz/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/snippetz
 
-## 0.6.16
-
-### Patch Changes
-
-- [#8240](https://github.com/scalar/scalar/pull/8240): fix: duplicate http headers for PHP CURL
-
-#### Updated Dependencies
-
-- **@scalar/types@0.6.7**
-
 ## 0.6.15
 
 ### Patch Changes

--- a/packages/snippetz/package.json
+++ b/packages/snippetz/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "packages/snippetz"
   },
-  "version": "0.6.16",
+  "version": "0.6.15",
   "engines": {
     "node": ">=20"
   },

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/types
 
-## 0.6.7
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
 ## 0.6.6
 
 ### Patch Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,7 +16,7 @@
     "scalar",
     "references"
   ],
-  "version": "0.6.7",
+  "version": "0.6.6",
   "engines": {
     "node": ">=20"
   },

--- a/packages/use-codemirror/CHANGELOG.md
+++ b/packages/use-codemirror/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @scalar/use-codemirror
 
-## 0.13.44
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/components@0.19.9**
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: add optional chevron click handler for the sidebar
-
 ## 0.13.43
 
 ### Patch Changes

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -16,7 +16,7 @@
     "vue",
     "vue3"
   ],
-  "version": "0.13.44",
+  "version": "0.13.43",
   "engines": {
     "node": ">=20"
   },

--- a/packages/void-server/CHANGELOG.md
+++ b/packages/void-server/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @scalar/void-server
 
-## 2.3.9
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
 ## 2.3.8
 
 ### Patch Changes

--- a/packages/void-server/package.json
+++ b/packages/void-server/package.json
@@ -15,7 +15,7 @@
     "http testing",
     "hono"
   ],
-  "version": "2.3.9",
+  "version": "2.3.8",
   "engines": {
     "node": ">=20"
   },

--- a/packages/workspace-store/CHANGELOG.md
+++ b/packages/workspace-store/CHANGELOG.md
@@ -1,32 +1,5 @@
 # @scalar/workspace-store
 
-## 0.34.3
-
-### Patch Changes
-
-- [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-- [#8130](https://github.com/scalar/scalar/pull/8130): feat: nest description headings in the sidebar
-- [#8242](https://github.com/scalar/scalar/pull/8242): chore: map themeId to slug and add default operation to drafts
-
-#### Updated Dependencies
-
-- **@scalar/helpers@0.2.16**
-  - [#8233](https://github.com/scalar/scalar/pull/8233): fix: local storage migration script
-
-- **@scalar/code-highlight@0.2.4**
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-
-- **@scalar/snippetz@0.6.16**
-  - [#8240](https://github.com/scalar/scalar/pull/8240): fix: duplicate http headers for PHP CURL
-
-- **@scalar/json-magic@0.11.5**
-
-- **@scalar/object-utils@1.2.30**
-
-- **@scalar/types@0.6.7**
-
-- **@scalar/openapi-upgrader@0.1.8**
-
 ## 0.34.2
 
 ### Patch Changes

--- a/packages/workspace-store/package.json
+++ b/packages/workspace-store/package.json
@@ -16,7 +16,7 @@
     "openapi",
     "scalar"
   ],
-  "version": "0.34.3",
+  "version": "0.34.2",
   "engines": {
     "node": ">=18"
   },

--- a/projects/scalar-app/CHANGELOG.md
+++ b/projects/scalar-app/CHANGELOG.md
@@ -1,21 +1,5 @@
 # scalar-app
 
-## 0.1.294
-
-### Patch Changes
-
-#### Updated Dependencies
-
-- **@scalar/components@0.19.9**
-  - [#8226](https://github.com/scalar/scalar/pull/8226): feat: slugs for headings with nested content
-  - [#8130](https://github.com/scalar/scalar/pull/8130): feat: add optional chevron click handler for the sidebar
-
-- **@scalar/api-client@2.29.3**
-  - [#8225](https://github.com/scalar/scalar/pull/8225): fix: selecting multiply security schemes doesn't render Markdown in descriptions
-  - [#8227](https://github.com/scalar/scalar/pull/8227): fix: remove unnecessary property truncation in example generation
-
-- **@scalar/import@0.4.53**
-
 ## 0.1.293
 
 ### Patch Changes

--- a/projects/scalar-app/package.json
+++ b/projects/scalar-app/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/scalar/scalar.git",
     "directory": "projects/scalar-app"
   },
-  "version": "0.1.294",
+  "version": "0.1.293",
   "private": true,
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Reverts scalar/scalar#8236

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily metadata/release-management changes (versions, changelogs, and changeset files) with no functional code changes, so runtime risk is low; main risk is publishing/versioning confusion if merged incorrectly.
> 
> **Overview**
> This PR **reverts an automated release** by rolling back `package.json` version bumps and removing the newly-added top-of-file changelog entries across many packages and integrations.
> 
> It also restores a set of pending `.changeset/*.md` files for the underlying changes (e.g., local storage migration fix, heading slug/sidebar nesting improvements, schema type display, and a few client/snippet fixes) so they can be released via the normal Changesets flow later.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 733a5aaac707fd0c06ae2a09652e0ccc88273f77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->