### PR TITLE
chore(api-reference): patch not minor changeset

### DIFF
--- a/.changeset/real-areas-strive.md
+++ b/.changeset/real-areas-strive.md
@@ -1,5 +1,5 @@
 ---
-'@scalar/api-reference': minor
+'@scalar/api-reference': patch
 ---
 
 feat: add option to open first tag by default


### PR DESCRIPTION
not a minor, this should be a patch release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes release versioning metadata; no runtime or logic changes.
> 
> **Overview**
> Adjusts the release metadata for `@scalar/api-reference` by changing the changeset bump from **minor** to **patch**, keeping the same feature note (open first tag by default).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca37d9ff6ed5b5bad2116273aa0d89407321c348. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->