### PR TITLE
fix(workspace-store): use path-level parameters in syncPathParameters

### DIFF
--- a/.changeset/itchy-pens-guess.md
+++ b/.changeset/itchy-pens-guess.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+consider path-level parameters in syncPathParameters instead of creating bare synthetic ones

--- a/packages/workspace-store/src/plugins/bundler/index.ts
+++ b/packages/workspace-store/src/plugins/bundler/index.ts
@@ -314,6 +314,19 @@ export const syncPathParameters = (): LifecyclePlugin => {
           },
         )
 
+        // Include path-item level path parameters as fallbacks for any that the operation does not declare.
+        // Without this, syncParametersForPathChange would create bare `{ name, in: 'path' }` params,
+        // losing description, schema, required, etc. from the path-item definition.
+        const pathItemParameters = 'parameters' in node && Array.isArray(node.parameters) ? node.parameters : []
+
+        for (const param of pathItemParameters) {
+          const resolved = getResolvedRef(param, context)
+
+          if (isObject(resolved) && resolved.in === 'path' && !pathParameters.find((p) => p.name === resolved.name)) {
+            pathParameters.push(resolved)
+          }
+        }
+
         // Sync path parameters using the same path for old and new
         // This ensures parameters match the current path string
         const syncedParameters = syncParametersForPathChange(pathString, pathString, pathParameters)


### PR DESCRIPTION
Consider path-level parameters in syncPathParameters instead of creating bare synthetic ones

## Problem

When a path parameter is defined at the path-item level and the operation does not redeclare it, `syncPathParameters` only looked at the operation's own parameters. It didn't find the path variable, so `syncParametersForPathChange` created a bare `{ name: 'id', in:  'path' }` losing all the metadata from the path-item definition.
                                                                                                                                                                                                                                                                                                                     
Example of openAPI specification to reproduce the problem : 

```yaml
openapi: 3.0.3
info:
  title: Users API
  version: 1.0.0

paths:
  /users/{userId}:
    parameters:
      - name: userId
        in: path
        required: true
        description: Unique user identifier
        schema:
          type: string
          format: uuid

    get:
      summary: Get a user
      operationId: getUser
      responses:
        '200':
          description: User found
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/User'
        '404':
          description: User not found

components:
  schemas:
    User:
      type: object
      properties:
        id:
          type: string
          format: uuid
        name:
          type: string
        email:
          type: string
          format: email
```

The parameter is displayed without description : https://sandbox.scalar.com/e/4Y3e2
<img width="1271" height="1059" alt="image" src="https://github.com/user-attachments/assets/9490a6da-6116-40cc-8ac2-cf0672557f8c" />


## Solution

During the bundle, before calling `syncParametersForPathChange`, we now also check the path-item's parameters array for any path parameters that the operation doesn't already declare. These resolved params are added to the list so `syncParametersForPathChange` finds them by name and preserves their config, instead of creating new bare ones.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.