### PR TITLE
feat(api-reference): show explicit no-content response tabs

### DIFF
--- a/.changeset/bright-clocks-share.md
+++ b/.changeset/bright-clocks-share.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat(api-reference): show explicit no-content response tabs for defined response keys

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.test.ts
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.test.ts
@@ -709,4 +709,80 @@ describe('ExampleResponses', () => {
     expect(wrapper.text()).toContain('New Single Example')
     expect(wrapper.text()).not.toContain('Example 2')
   })
+
+  it('renders explicit 204 response tab and shows No Body', () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '204': {
+            description: 'No Content',
+          },
+        },
+      },
+    })
+
+    const tabs = wrapper.findAllComponents({ name: 'ExampleResponseTab' })
+    expect(tabs.length).toBe(1)
+    expect(tabs[0]?.text()).toContain('204')
+    expect(wrapper.text()).toContain('No Body')
+  })
+
+  it('renders both contentful and explicit no-content responses', async () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'Success response',
+            content: {
+              'application/json': {
+                examples: {
+                  example1: { value: { status: 'success' } },
+                },
+              },
+            },
+          },
+          '204': {
+            description: 'No Content',
+          },
+        },
+      },
+    })
+
+    const tabs = wrapper.findAllComponents({ name: 'ExampleResponseTab' })
+    expect(tabs.length).toBe(2)
+    expect(tabs[0]?.text()).toContain('200')
+    expect(tabs[1]?.text()).toContain('204')
+
+    await tabs[1]?.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('No Body')
+  })
+
+  it('does not render tabs for non-response keys', () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'Success response',
+            content: {
+              'application/json': {
+                examples: {
+                  example1: { value: { status: 'success' } },
+                },
+              },
+            },
+          },
+          'x-internal': {
+            description: 'Internal metadata',
+          },
+        },
+      },
+    })
+
+    const tabs = wrapper.findAllComponents({ name: 'ExampleResponseTab' })
+    expect(tabs.length).toBe(1)
+    expect(tabs[0]?.text()).toContain('200')
+    expect(wrapper.text()).not.toContain('x-internal')
+  })
 })

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.test.ts
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.test.ts
@@ -773,7 +773,7 @@ describe('ExampleResponses', () => {
               },
             },
           },
-          'x-internal': {
+          metadata: {
             description: 'Internal metadata',
           },
         },
@@ -783,6 +783,6 @@ describe('ExampleResponses', () => {
     const tabs = wrapper.findAllComponents({ name: 'ExampleResponseTab' })
     expect(tabs.length).toBe(1)
     expect(tabs[0]?.text()).toContain('200')
-    expect(wrapper.text()).not.toContain('x-internal')
+    expect(wrapper.text()).not.toContain('metadata')
   })
 })

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.vue
@@ -48,10 +48,10 @@ const orderedStatusCodes = computed<string[]>(() =>
   Object.keys(responses ?? {}).sort(),
 )
 
-// Filter to only status codes that have response content
+// Filter to only valid response keys that should render in the example responses panel
 const statusCodesWithContent = computed<string[]>(() =>
   orderedStatusCodes.value.filter((statusCode) =>
-    hasResponseContent(getResolvedRef(responses?.[statusCode])),
+    hasResponseContent(getResolvedRef(responses?.[statusCode]), statusCode),
   ),
 )
 

--- a/packages/api-reference/src/features/example-responses/has-response-content.test.ts
+++ b/packages/api-reference/src/features/example-responses/has-response-content.test.ts
@@ -12,6 +12,38 @@ describe('has-response-content', () => {
       expect(hasResponseContent({ description: 'Empty response' })).toBe(false)
     })
 
+    it('returns true for explicit 204 with no body content', () => {
+      expect(hasResponseContent({ description: 'No content response' }, '204')).toBe(true)
+    })
+
+    it('returns true for explicit default with no body content', () => {
+      expect(hasResponseContent({ description: 'Default response' }, 'default')).toBe(true)
+    })
+
+    it('returns true for explicit range status code with no body content', () => {
+      expect(hasResponseContent({ description: '2XX response' }, '2XX')).toBe(true)
+    })
+
+    it('returns false for non-response keys', () => {
+      expect(
+        hasResponseContent(
+          {
+            description: 'Invalid response key',
+            content: {
+              'application/json': {
+                schema: { type: 'object' },
+              },
+            },
+          },
+          'x-internal',
+        ),
+      ).toBe(false)
+    })
+
+    it('returns false for valid response key with undefined response', () => {
+      expect(hasResponseContent(undefined, '204')).toBe(false)
+    })
+
     it('returns false for response with empty content', () => {
       expect(
         hasResponseContent({

--- a/packages/api-reference/src/features/example-responses/has-response-content.ts
+++ b/packages/api-reference/src/features/example-responses/has-response-content.ts
@@ -21,11 +21,23 @@ function hasMediaTypeContent(mediaType: MediaTypeObject | undefined): boolean {
   return hasSchema || hasExample || hasExamples
 }
 
+function isResponseKey(responseKey: string): boolean {
+  return responseKey === 'default' || /^[1-5][0-9]{2}$/.test(responseKey) || /^[1-5]XX$/.test(responseKey)
+}
+
 /**
  * Checks if a response object has body content (schema, example, or examples).
  * Looks through common media types in priority order.
  */
-export function hasResponseContent(response: ResponseObject | undefined): boolean {
+export function hasResponseContent(response: ResponseObject | undefined, responseKey?: string): boolean {
+  if (responseKey !== undefined) {
+    if (!isResponseKey(responseKey)) {
+      return false
+    }
+
+    return Boolean(response)
+  }
+
   const normalizedContent = normalizeMimeTypeObject(response?.content)
   const keys = getObjectKeys(normalizedContent ?? {})
 


### PR DESCRIPTION
## Summary
- show explicitly defined response keys in Example Responses tabs even when there is no body content
- include `204`/`default`/range keys (for example `2XX`) when present in the operation `responses`
- keep existing behavior for rendering body content and empty-state (`No Body`)
- ignore non-response keys (for example `x-*`) in tab rendering

## Changes
- updated response filter helper to accept an optional response key and validate valid OpenAPI response keys
- wired key-aware filtering in `ExampleResponses.vue`
- added helper tests for explicit no-content response keys and invalid keys
- added component tests for explicit `204` rendering, mixed contentful/no-content tabs, and non-response key exclusion

Refs discussion: https://github.com/scalar/scalar/discussions/8264
