### PR TITLE
fix(java): broken asset path generation

### DIFF
--- a/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/ScalarHtmlRenderer.java
+++ b/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/ScalarHtmlRenderer.java
@@ -82,6 +82,9 @@ public final class ScalarHtmlRenderer {
 
     /**
      * Builds the URL for the Scalar JavaScript bundle based on the base path.
+     * Uses only the last path segment so the relative URL resolves correctly
+     * when the page is at basePath (avoids duplicate segments for multi-segment
+     * paths) and when deployed behind a reverse proxy with a context path.
      *
      * @param basePath the base path
      * @return the relative path for the JavaScript bundle
@@ -93,7 +96,9 @@ public final class ScalarHtmlRenderer {
             path = path.substring(0, path.length() - 1);
         }
 
-        return "." + path + "/" + ScalarConstants.JS_FILENAME;
+        int lastSlash = path.lastIndexOf('/');
+        String lastSegment = lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
+        return lastSegment + "/" + ScalarConstants.JS_FILENAME;
     }
 
     /**

--- a/integrations/java/scalar-core/src/test/java/com/scalar/maven/core/ScalarHtmlRendererTest.java
+++ b/integrations/java/scalar-core/src/test/java/com/scalar/maven/core/ScalarHtmlRendererTest.java
@@ -29,7 +29,8 @@ class ScalarHtmlRendererTest {
                     .contains("<title>Scalar API Reference</title>")
                     .contains("<body>")
                     .contains("<div id=\"app\"></div>")
-                    .contains("Scalar.createApiReference('#app',");
+                    .contains("Scalar.createApiReference('#app',")
+                    .contains("src=\"scalar/scalar.js\"");
         }
 
         @Test
@@ -51,7 +52,18 @@ class ScalarHtmlRendererTest {
             String html = ScalarHtmlRenderer.render(properties);
             assertThat(html)
                     .isNotNull()
-                    .contains("/api/docs/scalar.js");
+                    .contains("src=\"docs/scalar.js\"");
+        }
+
+        @Test
+        @DisplayName("should render script URL with last path segment for context path deployment")
+        void shouldRenderScriptUrlWithLastSegmentForContextPath() throws IOException {
+            ScalarProperties properties = new ScalarProperties();
+            properties.setPath("/myapp/scalar-ui");
+            String html = ScalarHtmlRenderer.render(properties);
+            assertThat(html)
+                    .isNotNull()
+                    .contains("src=\"scalar-ui/scalar.js\"");
         }
 
         @Test
@@ -71,7 +83,7 @@ class ScalarHtmlRendererTest {
             String html = ScalarHtmlRenderer.render(properties);
             assertThat(html)
                     .isNotNull()
-                    .contains("/scalar/scalar.js");
+                    .contains("src=\"scalar/scalar.js\"");
         }
     }
 


### PR DESCRIPTION
I actually wanted to address issues in #8284, but forgot to push before merge.

Let me quickly ff with the fixes.

no changeset needed, the other PR had one

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the JS bundle URL is derived from `ScalarProperties.path`, which can affect static asset loading for existing deployments (especially multi-segment paths). Risk is moderate and localized to HTML/script URL generation with updated tests covering common path shapes.
> 
> **Overview**
> Fixes Scalar Java integration asset path generation by deriving the script bundle URL from **only the last segment** of `ScalarProperties.path`, preventing duplicate path segments and improving behavior behind reverse proxies/context paths.
> 
> Updates `ScalarHtmlRendererTest` assertions to match the new relative `src` output and adds coverage for a multi-segment context path case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f916fa26dba62ae95e98fc28329b829d2fe9d04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->