### PR TITLE
chore(rust): trigger release

### DIFF
--- a/.changeset/strict-zoos-mix.md
+++ b/.changeset/strict-zoos-mix.md
@@ -1,0 +1,5 @@
+---
+'scalar_api_reference': patch
+---
+
+fix: assets not published


### PR DESCRIPTION
fixes #8136


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a Changesets entry to trigger a patch release; no runtime code changes. Low risk aside from release/versioning impact.
> 
> **Overview**
> Adds a new Changesets file to publish a **patch** release of `scalar_api_reference`, noting a fix for assets not being published.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a72b281b4a5b2250e37d761a51d949ed40f1078a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->