### PR TITLE
Broken starter-kit link

### DIFF
--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -168,7 +168,7 @@ Put your content where you want: in your repository, any folder, or the Scalar E
         <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/deployment/cli"><scalar-icon src="phosphor/bold/terminal"></scalar-icon> CLI</a>
       </p>
       <p>
-        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/starter-kit"><scalar-icon src="phosphor/bold/rocket-launch"></scalar-icon> Starter Kit</a>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/configuration/starter-kit"><scalar-icon src="phosphor/bold/rocket-launch"></scalar-icon> Starter Kit</a>
       </p>
       <p>
         <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/configuration/themes"><scalar-icon src="phosphor/bold/palette"></scalar-icon> Themes</a>


### PR DESCRIPTION
## Problem

The `starter-kit` documentation page was moved into the `configuration` group in `scalar.config.json`, changing its URL from `/products/docs/starter-kit` to `/products/docs/configuration/starter-kit`. An existing hardcoded link in `getting-started.md` was not updated, resulting in a broken link.

## Solution

The hardcoded link in `getting-started.md` pointing to `/products/docs/starter-kit` was updated to the correct path: `/products/docs/configuration/starter-kit`.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a single hardcoded URL to prevent a broken link.
> 
> **Overview**
> Fixes a broken **Starter Kit** link in `documentation/guides/docs/getting-started.md` by updating the href from `/products/docs/starter-kit` to `/products/docs/configuration/starter-kit`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f23d2a7e0c377cb8692ea75d6db325c1548e6ee0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->