### PR TITLE
docs: deployment configuration moved to the UI

### DIFF
--- a/documentation/guides/docs/deployment/automatic-deployment.md
+++ b/documentation/guides/docs/deployment/automatic-deployment.md
@@ -2,23 +2,7 @@
 
 Scalar Docs can automatically publish your documentation whenever changes are merged into your default branch (usually `main`).
 
-You can configure which branch triggers automatic deployments in the [Scalar Dashboard](https://dashboard.scalar.com).
-
-## Enable via Configuration
-
-Add the following to your `scalar.config.json`:
-
-```json
-{
-  "publishOnMerge": true
-}
-```
-
-That's it. From now on, every time you merge changes into your default branch, your documentation will be automatically published.
-
-## Enable via Dashboard
-
-You can also toggle this setting in the [Scalar Dashboard](https://dashboard.scalar.com) under your project settings.
+Enable automatic deployment and configure which branch triggers it in the [Scalar Dashboard](https://dashboard.scalar.com) under your project settings. Every time you merge changes into your default branch, your documentation will be automatically published.
 
 ## Other Deployment Options
 

--- a/documentation/guides/docs/deployment/preview-deployments.md
+++ b/documentation/guides/docs/deployment/preview-deployments.md
@@ -2,20 +2,16 @@
 
 Preview deployments allow you to see how your documentation changes will look before merging them into your main branch. When you open a pull request, Scalar Docs automatically creates a preview deployment and can post a comment with a link to preview your changes.
 
-## Enable via Configuration
+## Enable in the Dashboard
 
-Add the following to your `scalar.config.json`:
+Configure preview deployments and pull request comments in the [Scalar Dashboard](https://dashboard.scalar.com) under your project settings. You can:
 
-```json
-{
-  // automatically create a preview deployment for every pull request
-  "publishPreviews": true,
-  // automatically post a comment on your pull request with a direct link to the preview deployment
-  "pullRequestComments": true
-}
-```
+- Enable preview deployments for every pull request
+- Enable automatic comments on pull requests with a direct link to the preview
 
 ### GitHub Pull Request Comments for Preview Deployments
+
+When enabled in the Dashboard, Scalar posts a comment on each pull request with a direct link to the preview deployment:
 
 ![PR Comment](../../../assets/docs/pr-comment.png)
 

--- a/documentation/migration/api-hub.md
+++ b/documentation/migration/api-hub.md
@@ -49,7 +49,6 @@ To set this up, create a `scalar.config.json` file in your repository root:
 {
   "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
   "scalar": "2.0.0",
-  "publishOnMerge": true,
   "siteConfig": {
     "subdomain": "name-of-your-api"
   },
@@ -82,7 +81,7 @@ To set this up, create a `scalar.config.json` file in your repository root:
 }
 ```
 
-The `"publishOnMerge": true` setting tells Scalar to automatically publish your documentation when a branch is merged into your main branch.
+Configure automatic deployment (publish when a branch is merged into your main branch) in the [Scalar Dashboard](https://dashboard.scalar.com) under your project settings.
 
 ## How to migrate from API Hub Explore to Scalar
 

--- a/documentation/migration/stoplight.md
+++ b/documentation/migration/stoplight.md
@@ -87,7 +87,6 @@ Once the project is hooked up to Scalar, the next step is to set up the Scalar c
 {
   "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
   "scalar": "2.0.0",
-  "publishOnMerge": true,
   "siteConfig": {
     "subdomain": "name-of-your-api"
   },
@@ -120,7 +119,7 @@ Once the project is hooked up to Scalar, the next step is to set up the Scalar c
 }
 ```
 
-The `"publishOnMerge": true` tells Scalar to publish your documentation when a branch is merged into the selected branch, instead of anyone having to manually publish it.
+Configure automatic deployment (publish when a branch is merged into your selected branch) in the [Scalar Dashboard](https://dashboard.scalar.com) under your project settings.
 
 ![](../assets/migration/git-deployments.png)
 
@@ -155,7 +154,6 @@ Copy and paste that chunk of JSON out of there, and make the following changes.
 {
   "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
   "scalar": "2.0.0",
-  "publishOnMerge": true,
   "siteConfig": {
     "subdomain": "name-of-your-api"
   },
@@ -196,7 +194,7 @@ Copy and paste that chunk of JSON out of there, and make the following changes.
 > [!NOTE]
 > You can create more complex sidebars with nested pages and more. See this example [scalar.config.json](https://raw.githubusercontent.com/scalar/scalar/refs/heads/main/scalar.config.json) to see how it works.
 
-Commit this file off to the Git repo and push. If `"publishOnMerge": true,` has been added to the config file then a new entry under Deployments should appear, and when that's done we can go and see how it all looks.
+Commit this file and push. If automatic deployment is enabled in the [Scalar Dashboard](https://dashboard.scalar.com) under your project settings, a new entry under Deployments will appear once the branch is merged; when that is done you can see how it all looks.
 
 ## Step 4: Review The New Documentation
 

--- a/documentation/migration/zuplo.md
+++ b/documentation/migration/zuplo.md
@@ -164,7 +164,6 @@ If you're using GitHub Sync, create a `scalar.config.json` file in your reposito
 {
   "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
   "scalar": "2.0.0",
-  "publishOnMerge": true,
   "siteConfig": {
     "subdomain": "name-of-your-api"
   },
@@ -186,7 +185,7 @@ If you're using GitHub Sync, create a `scalar.config.json` file in your reposito
 }
 ```
 
-The `"publishOnMerge": true` setting tells Scalar to automatically publish your documentation when a branch is merged into your main branch.
+Configure automatic deployment (publish when a branch is merged into your main branch) in the [Scalar Dashboard](https://dashboard.scalar.com) under your project settings.
 
 ### Step 5: Migrate Custom Styling
 

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -5,10 +5,7 @@
     "title": "Scalar Documentation",
     "description": "Guides for Scalar, covering your favorite frameworks, languages and use cases."
   },
-  "publishOnMerge": true,
   "assetsDir": "documentation/assets",
-  "publishPreviews": true,
-  "pullRequestComments": true,
   "insertPageTitles": false,
   "siteConfig": {
     "subdomain": "scalar",


### PR DESCRIPTION
prreview deployments, PR comments, and automatic deployment are configured through the UI now :)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only updates that remove config-based deployment toggles and could only impact users following outdated setup steps.
> 
> **Overview**
> Deployment docs now direct users to enable **automatic deployments**, **preview deployments**, and **PR comments** via the Scalar Dashboard instead of `scalar.config.json` examples.
> 
> The repo’s `scalar.config.json` sample/config removes `publishOnMerge`, `publishPreviews`, and `pullRequestComments`, aligning config guidance with UI-managed settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 821e073d38e7a47b155715daa77c9d7bb6b3b103. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->