### PR TITLE
docs: `project publish --github`

### DIFF
--- a/documentation/guides/docs/deployment/cli.md
+++ b/documentation/guides/docs/deployment/cli.md
@@ -6,7 +6,7 @@ Publish your Scalar Docs project using the Scalar CLI. The CLI uploads your proj
 
 `scalar project publish` supports two ways to deploy:
 
-- **Default (no flag):** The CLI uploads your project configuration and content from your local machine to Scalar. What you have on disk is what gets deployed.
+- **Default:** The CLI uploads your project configuration and content from your local machine to Scalar. What you have on disk is what gets deployed.
 - **With `--github`:** Use only when your Scalar Docs project is connected to a GitHub repository. Scalar pulls the files from GitHub and deploys that. Local changes are ignored. Use this to trigger a deploy from the linked repository.
 
 ## Installation


### PR DESCRIPTION
adds some blurb about the new `--github` flag for `project publish`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update that clarifies publish behavior and adds a new option entry; no runtime or security-impacting code changes.
> 
> **Overview**
> Adds a **Deployment modes** section to the CLI deployment guide explaining the difference between default `scalar project publish` (uploads local files) and `scalar project publish --github` (deploys from the linked GitHub repo and ignores local changes).
> 
> Reworks the **Publishing** section to split local vs GitHub publishing, adds an example command for `--github`, and updates the options table and guidance text to include/describe the new `--github` flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e49167bcdc5e691fa8c7838ca81e0170958d037. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->