### PR TITLE
feat(docs): add agent tab

### DIFF
--- a/documentation/assets/styles.css
+++ b/documentation/assets/styles.css
@@ -22,6 +22,27 @@
   color: var(--scalar-sidebar-color-1, var(--scalar-color-1));
 }
 
+/** Active state (matches sidebar active styling) */
+.t-header .link.active,
+.t-header .link.link--active,
+.t-header .link[aria-current="page"] {
+  color: var(--scalar-sidebar-color-active, var(--scalar-header-color-1, var(--scalar-color-1)));
+  font-weight: var(--scalar-sidebar-font-weight-active, var(--scalar-semibold));
+}
+
+/** Home link underline (first nav item) */
+.t-header .navigation .link:first-child {
+  position: relative;
+}
+
+.t-header .navigation .link:first-child::after {
+  content: "";
+  position: absolute;
+  bottom: -15px;
+  inset-inline: 8px 8px;
+  height: 1px;
+  background: currentColor;
+}
 /** __cta styles are for when we display the item as a button */
 .t-header .link.link__button {
   background: var(--scalar-button-1);
@@ -43,4 +64,13 @@
 
 .header .header-center {
   display: none;
+}
+
+/** Keep Home and Agent next to the logo; push Log in and Register to the right */
+.t-header .header-right {
+  flex: 1;
+  min-width: 0;
+}
+.t-header .navigation .link:nth-child(3) {
+  margin-left: auto;
 }

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -555,6 +555,18 @@
     "header": [
       {
         "type": "link",
+        "title": "Home",
+        "to": "/",
+        "class": "nav-left"
+      },
+      {
+        "type": "link",
+        "title": "Agent",
+        "to": "https://agent.scalar.com",
+        "class": "nav-left"
+      },
+      {
+        "type": "link",
         "title": "Log in",
         "to": "https://dashboard.scalar.com/login"
       },


### PR DESCRIPTION
## Problem

lets add agent tab!

<img width="1001" height="410" alt="image" src="https://github.com/user-attachments/assets/c41b10b5-0048-447b-a836-03faa46e2a42" />


## Solution

had to add our own css till we have tabs

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: docs-site navigation config and CSS-only header styling changes with no backend logic or data handling.
> 
> **Overview**
> Adds `Home` and `Agent` as new header navigation links in `scalar.config.json` alongside the existing auth links.
> 
> Updates `documentation/assets/styles.css` to style active header links, underline the first nav item, and adjust header flex layout so `Log in`/`Register` are pushed to the right.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0e779dae2156b6e6362c978721a79375f1b21c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->