### PR TITLE
fix(docs): make our h1 more clear

### DIFF
--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -1,10 +1,9 @@
 <div class="flex flex-col gap-3 hero small-test">
   <scalar-heading level="2" slug="introduction" class="text-balance">
-    A modern API platform built for the OpenAPI™ standard.
+    Industry leading Developer Docs, SDKs & API Registry
   </scalar-heading>
   <p>
-    Industry leading Developer Docs, SDKs, API Client & Registry that your APIs
-    deserve
+    Purpose-built for the OpenAPI™ standard
   </p>
   <div class="flex gap-2">
     <a class="t-editor__button" href="https://dashboard.scalar.com/register">Get Started</a>


### PR DESCRIPTION
Before // After
<img width="1512" height="414" alt="image" src="https://github.com/user-attachments/assets/fe9179f5-9103-4099-93fc-12b35f5ab184" />

<img width="1503" height="369" alt="image" src="https://github.com/user-attachments/assets/1054db43-49ca-48f2-8c1a-bd347951c40f" />


## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only change limited to the introduction page hero text; no functional or behavioral impact.
> 
> **Overview**
> Updates `documentation/guides/introduction.md` hero messaging by replacing the headline with “Industry leading Developer Docs, SDKs & API Registry” and simplifying the supporting line to “Purpose-built for the OpenAPI™ standard” to make the page’s primary value proposition clearer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6a48db85b79ff036cce57c85c8ea3c9570bec3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->