### PR TITLE
docs: use scalar config schema from the registry

### DIFF
--- a/documentation/guides/docs/configuration/domains.md
+++ b/documentation/guides/docs/configuration/domains.md
@@ -9,7 +9,7 @@ The `subdomain` property provides a free domain at `https://<subdomain>.apidocum
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "subdomain": "your-docs"
@@ -26,7 +26,7 @@ The `customDomain` property allows you to use your own domain name. This feature
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "siteConfig": {
     "customDomain": "docs.example.com"

--- a/documentation/guides/docs/configuration/migration.md
+++ b/documentation/guides/docs/configuration/migration.md
@@ -44,7 +44,7 @@ For Scalar Docs 2.0 we still use the `scalar.config.json`, but the structure cha
 ```json
 // scalar.config.json (Scalar Docs 2.0)
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "info": {
     // …

--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -9,7 +9,7 @@ All navigation is configured within the `navigation.routes` object in your `scal
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "navigation": {
     "routes": {
@@ -32,7 +32,7 @@ The `navigation.header` array defines links that appear in the top navigation ba
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "navigation": {
     "header": [
@@ -77,7 +77,7 @@ The `navigation.sidebar` array defines links that appear at the bottom of the si
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "navigation": {
     "sidebar": [
@@ -113,7 +113,7 @@ The `navigation.tabs` array defines tabs that appear in the navigation area. Tab
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "navigation": {
     "tabs": [

--- a/documentation/guides/docs/configuration/redirects.md
+++ b/documentation/guides/docs/configuration/redirects.md
@@ -8,7 +8,7 @@ Redirects are configured in your `scalar.config.json` file under the `siteConfig
 
 ```json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "routing": {

--- a/documentation/guides/docs/configuration/site-config.md
+++ b/documentation/guides/docs/configuration/site-config.md
@@ -9,7 +9,7 @@ All site settings are configured within the `siteConfig` object in your `scalar.
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "logo": "https://example.com/logo.svg",
@@ -27,7 +27,7 @@ The `logo` property defines your site's logo displayed in the navigation. You ca
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "siteConfig": {
     "logo": "https://example.com/logo.svg"
@@ -42,7 +42,7 @@ For better visibility across themes, provide different logos for light and dark 
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "siteConfig": {
     "logo": {
@@ -68,7 +68,7 @@ The `theme` property sets a platform-defined theme for your documentation site.
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "siteConfig": {
     "theme": "purple"
@@ -89,7 +89,7 @@ The `layout` property controls global layout options that apply to all pages unl
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "siteConfig": {
     "layout": {
@@ -116,7 +116,7 @@ The `head` property allows you to inject custom elements into the HTML `<head>` 
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "siteConfig": {
     "head": {
@@ -257,7 +257,7 @@ The `footer` property allows you to add a custom footer to your documentation si
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "siteConfig": {
     "footer": {
@@ -286,7 +286,7 @@ Set up redirects to handle URL changes or aliases:
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "siteConfig": {
     "routing": {

--- a/documentation/guides/docs/configuration/themes.md
+++ b/documentation/guides/docs/configuration/themes.md
@@ -9,7 +9,7 @@ Set the theme in the `siteConfig` object of your `scalar.config.json` file:
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "theme": "purple"

--- a/documentation/guides/docs/content/assets.md
+++ b/documentation/guides/docs/content/assets.md
@@ -7,7 +7,7 @@ The `assetsDir` configuration allows you to specify a folder containing custom a
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "assetsDir": "docs/assets",
   "navigation": {
@@ -63,7 +63,7 @@ Assets can also be referenced in the `siteConfig.head` configuration for scripts
 
 ```json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "assetsDir": "docs/assets",
   "siteConfig": {
@@ -99,7 +99,7 @@ Here's a complete example showing how to configure assets and use them throughou
 
 ```json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "assetsDir": "docs/assets",
   "siteConfig": {

--- a/documentation/guides/docs/content/html-css-js.md
+++ b/documentation/guides/docs/content/html-css-js.md
@@ -144,7 +144,7 @@ All head configuration is done within the `siteConfig.head` object in your `scal
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "head": {
@@ -184,7 +184,7 @@ The `scripts` array allows you to include custom JavaScript files in your docume
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "siteConfig": {
     "head": {
@@ -221,7 +221,7 @@ The `styles` array allows you to include custom CSS files to customize the appea
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "siteConfig": {
     "head": {
@@ -251,7 +251,7 @@ The `meta` array allows you to add meta tags for SEO, social sharing (Open Graph
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "siteConfig": {
     "head": {
@@ -350,7 +350,7 @@ The `links` array allows you to add link elements to the `<head>`, commonly used
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "siteConfig": {
     "head": {

--- a/documentation/guides/docs/content/mdx.mdx
+++ b/documentation/guides/docs/content/mdx.mdx
@@ -13,7 +13,7 @@ Reference MDX files the same way as Markdown files:
 ```json
 // scalar.config.json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "navigation": {
     "routes": {

--- a/documentation/migration/api-hub.md
+++ b/documentation/migration/api-hub.md
@@ -47,7 +47,7 @@ To set this up, create a `scalar.config.json` file in your repository root:
 
 ```json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "subdomain": "name-of-your-api"

--- a/documentation/migration/stoplight.md
+++ b/documentation/migration/stoplight.md
@@ -85,7 +85,7 @@ Once the project is hooked up to Scalar, the next step is to set up the Scalar c
 
 ```json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "subdomain": "name-of-your-api"
@@ -152,7 +152,7 @@ Copy and paste that chunk of JSON out of there, and make the following changes.
 
 ```json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config
   "scalar": "2.0.0",
   "siteConfig": {
     "subdomain": "name-of-your-api"

--- a/documentation/migration/zuplo.md
+++ b/documentation/migration/zuplo.md
@@ -162,7 +162,7 @@ If you're using GitHub Sync, create a `scalar.config.json` file in your reposito
 
 ```json
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "subdomain": "name-of-your-api"

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://cdn.scalar.com/schema/scalar-config-next.json",
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "info": {
     "title": "Scalar Documentation",


### PR DESCRIPTION
let's use the config schema from our registry, not from the CDN :)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 9bc6854d9a7c5a090588f375d64c3cef539c6cae. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->