### PR TITLE
feat(snippetz): code splitting

### DIFF
--- a/.changeset/silly-pears-rush.md
+++ b/.changeset/silly-pears-rush.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': major
+---
+
+feat!: lazy load plugins

--- a/packages/api-client/src/libs/snippetz-instance.ts
+++ b/packages/api-client/src/libs/snippetz-instance.ts
@@ -1,0 +1,8 @@
+import { snippetz } from '@scalar/snippetz'
+import { allPlugins } from '@scalar/snippetz/clients'
+
+/**
+ * Shared snippetz instance with all plugins loaded eagerly.
+ * Re-use this instead of creating new instances per component.
+ */
+export const snippetzInstance = snippetz(allPlugins)

--- a/packages/api-client/src/libs/snippetz-instance.ts
+++ b/packages/api-client/src/libs/snippetz-instance.ts
@@ -1,8 +1,8 @@
 import { snippetz } from '@scalar/snippetz'
-import { allPlugins } from '@scalar/snippetz/clients'
+import { plugins } from '@scalar/snippetz/clients'
 
 /**
  * Shared snippetz instance with all plugins loaded eagerly.
  * Re-use this instead of creating new instances per component.
  */
-export const snippetzInstance = snippetz(allPlugins)
+export const snippetzInstance = snippetz(plugins)

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -104,6 +104,7 @@ import ViewLayout from '@/components/ViewLayout/ViewLayout.vue'
 import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
 import type { ClientLayout } from '@/hooks'
 import { ERRORS } from '@/libs/errors'
+import { snippetzInstance } from '@/libs/snippetz-instance'
 import { buildRequest } from '@/v2/blocks/operation-block/helpers/build-request'
 import { getSecuritySchemes } from '@/v2/blocks/operation-block/helpers/build-request-security'
 import { harToFetchRequest } from '@/v2/blocks/operation-block/helpers/har-to-fetch-request'
@@ -148,7 +149,9 @@ const {
 } = defineProps<OperationBlockProps>()
 
 /** Hoist up client generation so it doesn't get re-generated on every operation */
-const clientOptions = computed(() => generateClientOptions(httpClients))
+const clientOptions = computed(() =>
+  generateClientOptions(snippetzInstance, httpClients),
+)
 
 /** Compute what the security requirements should be for an operation */
 const securityRequirements = computed(() =>

--- a/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.vue
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.vue
@@ -134,9 +134,11 @@ import {
   ref,
   useId,
   watch,
+  watchEffect,
   type ComponentPublicInstance,
 } from 'vue'
 
+import { snippetzInstance } from '@/libs/snippetz-instance'
 import HttpMethod from '@/v2/blocks/operation-code-sample/components/HttpMethod.vue'
 import { findClient } from '@/v2/blocks/operation-code-sample/helpers/find-client'
 import { getClients } from '@/v2/blocks/operation-code-sample/helpers/get-clients'
@@ -236,12 +238,16 @@ const webhookHar = computed(() => {
 })
 
 /** Generate the code snippet for the selected example */
-const generatedCode = computed<string>(() => {
+const generatedCode = ref('')
+
+watchEffect(async () => {
   if (isWebhook) {
-    return webhookHar.value?.postData?.text ?? ''
+    generatedCode.value = webhookHar.value?.postData?.text ?? ''
+    return
   }
 
-  return generateCodeSnippet({
+  generatedCode.value = await generateCodeSnippet({
+    snippetzInstance,
     includeDefaultHeaders: integration === 'client',
     clientId: localSelectedClient.value?.id,
     customCodeSamples: customCodeSamples.value,

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-client-options.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-client-options.test.ts
@@ -1,13 +1,16 @@
 import type { XCodeSample } from '@scalar/openapi-types/schemas/extensions'
-import { AVAILABLE_CLIENTS } from '@scalar/snippetz'
+import { AVAILABLE_CLIENTS, snippetz } from '@scalar/snippetz'
+import { allPlugins } from '@scalar/snippetz/clients'
 import { describe, expect, it } from 'vitest'
 
 import { generateClientOptions, generateCustomId } from './generate-client-options'
 
+const s = snippetz(allPlugins)
+
 describe('generateClientOptions', () => {
   describe('with all clients allowed', () => {
     it('returns all available clients grouped by target', () => {
-      const result = generateClientOptions(AVAILABLE_CLIENTS)
+      const result = generateClientOptions(s, AVAILABLE_CLIENTS)
 
       expect(result).toHaveLength(21)
       expect(result.map((group) => group.label)).toEqual([
@@ -36,7 +39,7 @@ describe('generateClientOptions', () => {
     })
 
     it('structures each group correctly', () => {
-      const result = generateClientOptions(AVAILABLE_CLIENTS)
+      const result = generateClientOptions(s, AVAILABLE_CLIENTS)
 
       expect(result[0]).toEqual({
         label: 'C',
@@ -55,7 +58,7 @@ describe('generateClientOptions', () => {
     })
 
     it('returns 39 total client options', () => {
-      const result = generateClientOptions(AVAILABLE_CLIENTS)
+      const result = generateClientOptions(s, AVAILABLE_CLIENTS)
       const allOptions = result.flatMap((group) => group.options)
 
       expect(allOptions).toHaveLength(39)
@@ -64,7 +67,7 @@ describe('generateClientOptions', () => {
 
   describe('with subset of clients allowed', () => {
     it('includes only allowed clients', () => {
-      const result = generateClientOptions(['js/fetch', 'js/axios', 'node/fetch', 'python/requests'])
+      const result = generateClientOptions(s, ['js/fetch', 'js/axios', 'node/fetch', 'python/requests'])
 
       expect(result).toHaveLength(3)
       expect(result.map((group) => group.label)).toEqual(['JavaScript', 'Node.js', 'Python'])
@@ -83,7 +86,7 @@ describe('generateClientOptions', () => {
     })
 
     it('excludes clients not in the allowed list', () => {
-      const result = generateClientOptions(['js/fetch', 'js/axios'])
+      const result = generateClientOptions(s, ['js/fetch', 'js/axios'])
 
       const jsGroup = result.find((group) => group.label === 'JavaScript')
       const clientIds = jsGroup?.options.map((option) => option.id) ?? []
@@ -94,7 +97,7 @@ describe('generateClientOptions', () => {
     })
 
     it('filters out groups with no allowed clients', () => {
-      const result = generateClientOptions(['js/fetch', 'python/requests'])
+      const result = generateClientOptions(s, ['js/fetch', 'python/requests'])
 
       expect(result.map((group) => group.label)).not.toContain('Node.js')
       expect(result.map((group) => group.label)).not.toContain('Ruby')
@@ -104,7 +107,7 @@ describe('generateClientOptions', () => {
 
   describe('with empty allowed list', () => {
     it('returns empty array', () => {
-      const result = generateClientOptions([])
+      const result = generateClientOptions(s, [])
 
       expect(result).toEqual([])
     })
@@ -112,7 +115,7 @@ describe('generateClientOptions', () => {
 
   describe('curl special handling', () => {
     it('sets lang to "curl" for curl client', () => {
-      const result = generateClientOptions(['shell/curl'])
+      const result = generateClientOptions(s, ['shell/curl'])
 
       const shellGroup = result.find((group) => group.label === 'Shell')
       const curlOption = shellGroup?.options.find((option) => option.id === 'shell/curl')
@@ -121,7 +124,7 @@ describe('generateClientOptions', () => {
     })
 
     it('sets lang to group key for non-curl clients', () => {
-      const result = generateClientOptions(['js/fetch'])
+      const result = generateClientOptions(s, ['js/fetch'])
 
       const jsGroup = result.find((group) => group.label === 'JavaScript')
       const fetchOption = jsGroup?.options.find((option) => option.id === 'js/fetch')
@@ -130,7 +133,7 @@ describe('generateClientOptions', () => {
     })
 
     it('sets lang to group key for other shell clients', () => {
-      const result = generateClientOptions(['shell/httpie', 'shell/wget'])
+      const result = generateClientOptions(s, ['shell/httpie', 'shell/wget'])
 
       const shellGroup = result.find((group) => group.label === 'Shell')
       const httpieOption = shellGroup?.options.find((option) => option.id === 'shell/httpie')
@@ -143,7 +146,7 @@ describe('generateClientOptions', () => {
 
   describe('option structure', () => {
     it('includes all required fields for each option', () => {
-      const result = generateClientOptions(['js/fetch'])
+      const result = generateClientOptions(s, ['js/fetch'])
 
       const jsGroup = result[0]
       expect(jsGroup).toBeDefined()
@@ -159,7 +162,7 @@ describe('generateClientOptions', () => {
     })
 
     it('formats titles correctly', () => {
-      const result = generateClientOptions(['js/fetch', 'python/requests', 'node/axios'])
+      const result = generateClientOptions(s, ['js/fetch', 'python/requests', 'node/axios'])
 
       const allOptions = result.flatMap((group) => group.options)
 
@@ -171,7 +174,7 @@ describe('generateClientOptions', () => {
 
   describe('multiple clients from same target', () => {
     it('groups multiple JavaScript clients together', () => {
-      const result = generateClientOptions(['js/fetch', 'js/axios', 'js/ofetch'])
+      const result = generateClientOptions(s, ['js/fetch', 'js/axios', 'js/ofetch'])
 
       expect(result).toHaveLength(1)
       const jsGroup = result[0]
@@ -182,7 +185,7 @@ describe('generateClientOptions', () => {
     })
 
     it('groups multiple Node.js clients together', () => {
-      const result = generateClientOptions(['node/fetch', 'node/axios', 'node/undici', 'node/ofetch'])
+      const result = generateClientOptions(s, ['node/fetch', 'node/axios', 'node/undici', 'node/ofetch'])
 
       expect(result).toHaveLength(1)
       const nodeGroup = result[0]
@@ -194,7 +197,7 @@ describe('generateClientOptions', () => {
 
   describe('edge cases', () => {
     it('handles single client', () => {
-      const result = generateClientOptions(['js/fetch'])
+      const result = generateClientOptions(s, ['js/fetch'])
 
       expect(result).toHaveLength(1)
       const group = result[0]
@@ -203,7 +206,7 @@ describe('generateClientOptions', () => {
     })
 
     it('handles clients from many different targets', () => {
-      const result = generateClientOptions([
+      const result = generateClientOptions(s, [
         'c/libcurl',
         'go/native',
         'java/unirest',
@@ -217,8 +220,8 @@ describe('generateClientOptions', () => {
     })
 
     it('maintains consistent ordering', () => {
-      const result1 = generateClientOptions(['python/requests', 'js/fetch', 'node/axios'])
-      const result2 = generateClientOptions(['node/axios', 'js/fetch', 'python/requests'])
+      const result1 = generateClientOptions(s, ['python/requests', 'js/fetch', 'node/axios'])
+      const result2 = generateClientOptions(s, ['node/axios', 'js/fetch', 'python/requests'])
 
       expect(result1.map((g) => g.label)).toEqual(result2.map((g) => g.label))
     })

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-client-options.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-client-options.test.ts
@@ -1,11 +1,11 @@
 import type { XCodeSample } from '@scalar/openapi-types/schemas/extensions'
 import { AVAILABLE_CLIENTS, snippetz } from '@scalar/snippetz'
-import { allPlugins } from '@scalar/snippetz/clients'
+import { plugins } from '@scalar/snippetz/clients'
 import { describe, expect, it } from 'vitest'
 
 import { generateClientOptions, generateCustomId } from './generate-client-options'
 
-const s = snippetz(allPlugins)
+const s = snippetz(plugins)
 
 describe('generateClientOptions', () => {
   describe('with all clients allowed', () => {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-client-options.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-client-options.ts
@@ -1,4 +1,4 @@
-import { AVAILABLE_CLIENTS, type AvailableClients, snippetz } from '@scalar/snippetz'
+import { AVAILABLE_CLIENTS, type AvailableClients, type Snippetz } from '@scalar/snippetz'
 import type { XCodeSample } from '@scalar/workspace-store/schemas/extensions/operation'
 import { capitalize } from 'vue'
 
@@ -13,45 +13,47 @@ export const generateCustomId = (example: XCodeSample): CustomCodeSampleId => `c
 /**
  * Generate client options for the request example block by filtering by allowed clients
  *
+ * @param snippetzInstance - The configured snippetz instance to read clients from
  * @param allowedClients - The list of allowed clients to include in the options
  * @returns A list of client option groups
  */
-export const generateClientOptions = (allowedClients: AvailableClients = AVAILABLE_CLIENTS): ClientOptionGroup[] => {
+export const generateClientOptions = (
+  snippetzInstance: Snippetz,
+  allowedClients: AvailableClients = AVAILABLE_CLIENTS,
+): ClientOptionGroup[] => {
   /** Create set of allowlist for quicker lookups */
   const allowedClientsSet = new Set(allowedClients)
 
-  const options = snippetz()
-    .clients()
-    .flatMap((group) => {
-      const options = group.clients.flatMap((plugin) => {
-        const id = `${group.key}/${plugin.client}` as AvailableClients[number]
+  const options = snippetzInstance.clients().flatMap((group) => {
+    const options = group.clients.flatMap((plugin) => {
+      const id = `${group.key}/${plugin.client}` as AvailableClients[number]
 
-        // If the client is not allowed, skip it
-        if (!allowedClientsSet.has(id)) {
-          return []
-        }
-
-        return {
-          id,
-          lang: plugin.client === 'curl' ? ('curl' as const) : group.key,
-          title: `${capitalize(group.title)} ${plugin.title}`,
-          label: plugin.title,
-          targetKey: group.key,
-          targetTitle: group.title,
-          clientKey: plugin.client,
-        }
-      })
-
-      // If no clients are allowed, skip this group
-      if (options.length === 0) {
+      // If the client is not allowed, skip it
+      if (!allowedClientsSet.has(id)) {
         return []
       }
 
       return {
-        label: group.title,
-        options,
+        id,
+        lang: plugin.client === 'curl' ? ('curl' as const) : group.key,
+        title: `${capitalize(group.title)} ${plugin.title}`,
+        label: plugin.title,
+        targetKey: group.key,
+        targetTitle: group.title,
+        clientKey: plugin.client,
       }
     })
+
+    // If no clients are allowed, skip this group
+    if (options.length === 0) {
+      return []
+    }
+
+    return {
+      label: group.title,
+      options,
+    }
+  })
 
   return options
 }

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-code-snippet.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-code-snippet.test.ts
@@ -1,10 +1,14 @@
 import type { AvailableClient } from '@scalar/snippetz'
+import { snippetz } from '@scalar/snippetz'
+import { allPlugins } from '@scalar/snippetz/clients'
 import type { XCodeSample } from '@scalar/workspace-store/schemas/extensions/operation'
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { consoleErrorSpy } from '@test/vitest.setup'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { generateCodeSnippet } from './generate-code-snippet'
+
+const s = snippetz(allPlugins)
 
 describe('generateCodeSnippet', () => {
   const mockOperation: OperationObject = {
@@ -18,6 +22,7 @@ describe('generateCodeSnippet', () => {
   const mockServer = { url: 'https://api.example.com' }
 
   const baseParams = {
+    snippetzInstance: s,
     operation: mockOperation,
     method: 'get' as const,
     path: '/users',
@@ -32,8 +37,8 @@ describe('generateCodeSnippet', () => {
     vi.clearAllMocks()
   })
 
-  it('returns empty string when clientId is undefined', () => {
-    const result = generateCodeSnippet({
+  it('returns empty string when clientId is undefined', async () => {
+    const result = await generateCodeSnippet({
       ...baseParams,
       clientId: undefined,
     })
@@ -41,8 +46,8 @@ describe('generateCodeSnippet', () => {
     expect(result).toBe('')
   })
 
-  it('returns generated code snippet when successful', () => {
-    const result = generateCodeSnippet({
+  it('returns generated code snippet when successful', async () => {
+    const result = await generateCodeSnippet({
       ...baseParams,
       clientId: 'js/fetch',
       path: '/users/{userId}',
@@ -51,7 +56,7 @@ describe('generateCodeSnippet', () => {
     expect(result).toBe("fetch('https://api.example.com/users/{userId}')")
   })
 
-  it('returns custom code sample source when clientId starts with "custom"', () => {
+  it('returns custom code sample source when clientId starts with "custom"', async () => {
     const customCodeSamples: XCodeSample[] = [
       {
         lang: 'python',
@@ -65,7 +70,7 @@ describe('generateCodeSnippet', () => {
       },
     ]
 
-    const result = generateCodeSnippet({
+    const result = await generateCodeSnippet({
       ...baseParams,
       clientId: 'custom/python',
       customCodeSamples,
@@ -74,7 +79,7 @@ describe('generateCodeSnippet', () => {
     expect(result).toBe('import requests\nresponse = requests.get("https://api.example.com")')
   })
 
-  it('returns "Custom example not found" when custom clientId does not match any custom code sample', () => {
+  it('returns "Custom example not found" when custom clientId does not match any custom code sample', async () => {
     const customCodeSamples: XCodeSample[] = [
       {
         lang: 'python',
@@ -83,7 +88,7 @@ describe('generateCodeSnippet', () => {
       },
     ]
 
-    const result = generateCodeSnippet({
+    const result = await generateCodeSnippet({
       ...baseParams,
       clientId: 'custom/ruby',
       customCodeSamples,
@@ -92,13 +97,13 @@ describe('generateCodeSnippet', () => {
     expect(result).toBe('Custom example not found')
   })
 
-  it('returns error message when getSnippet fails', () => {
+  it('returns error message when getSnippet fails', async () => {
     // Mock console.error to suppress expected error output
     consoleErrorSpy.mockImplementation(() => {
       // Intentionally empty to suppress console output
     })
 
-    const result = generateCodeSnippet({
+    const result = await generateCodeSnippet({
       ...baseParams,
       clientId: 'js/fetch',
       // @ts-expect-error - testing undefined
@@ -109,8 +114,8 @@ describe('generateCodeSnippet', () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith('[generateCodeSnippet]', expect.any(Error))
   })
 
-  it('generates code snippet with request body and content type', () => {
-    const code = generateCodeSnippet({
+  it('generates code snippet with request body and content type', async () => {
+    const code = await generateCodeSnippet({
       ...baseParams,
       clientId: 'python/requests',
       operation: {
@@ -146,8 +151,8 @@ describe('generateCodeSnippet', () => {
 )`)
   })
 
-  it('generates code snippet with different client formats', () => {
-    const code = generateCodeSnippet({
+  it('generates code snippet with different client formats', async () => {
+    const code = await generateCodeSnippet({
       ...baseParams,
       clientId: 'node/axios',
     })
@@ -164,7 +169,7 @@ try {
 }`)
   })
 
-  it('processes different clientId formats without errors', () => {
+  it('processes different clientId formats without errors', async () => {
     const testCases: Array<{ input: AvailableClient; expectedClient: string }> = [
       { input: 'js/fetch', expectedClient: 'fetch' },
       { input: 'python/requests', expectedClient: 'requests' },
@@ -172,24 +177,24 @@ try {
       { input: 'shell/curl', expectedClient: 'curl' },
     ]
 
-    testCases.forEach(({ input, expectedClient }) => {
-      const result = generateCodeSnippet({
+    for (const { input, expectedClient } of testCases) {
+      const result = await generateCodeSnippet({
         ...baseParams,
         clientId: input,
         path: '/test',
       })
 
       expect(result).toContain(expectedClient)
-    })
+    }
   })
 
-  it('returns error message and logs error when exception is thrown', () => {
+  it('returns error message and logs error when exception is thrown', async () => {
     // Mock console.error to suppress expected error output
     consoleErrorSpy.mockImplementation(() => {
       // Intentionally empty to suppress console output
     })
 
-    const result = generateCodeSnippet({
+    const result = await generateCodeSnippet({
       ...baseParams,
       clientId: 'js/fetch',
       // @ts-expect-error - testing invalid input

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-code-snippet.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-code-snippet.test.ts
@@ -1,6 +1,6 @@
 import type { AvailableClient } from '@scalar/snippetz'
 import { snippetz } from '@scalar/snippetz'
-import { allPlugins } from '@scalar/snippetz/clients'
+import { plugins } from '@scalar/snippetz/clients'
 import type { XCodeSample } from '@scalar/workspace-store/schemas/extensions/operation'
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { consoleErrorSpy } from '@test/vitest.setup'
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { generateCodeSnippet } from './generate-code-snippet'
 
-const s = snippetz(allPlugins)
+const s = snippetz(plugins)
 
 describe('generateCodeSnippet', () => {
   const mockOperation: OperationObject = {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-code-snippet.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-code-snippet.ts
@@ -1,5 +1,5 @@
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
-import type { AvailableClient, ClientId, TargetId } from '@scalar/snippetz'
+import type { AvailableClient, ClientId, Snippetz, TargetId } from '@scalar/snippetz'
 import type { XScalarCookie } from '@scalar/workspace-store/schemas/extensions/general/x-scalar-cookies'
 import type { XCodeSample } from '@scalar/workspace-store/schemas/extensions/operation'
 import type { OperationObject, ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
@@ -11,6 +11,8 @@ import { getSnippet } from '@/views/Components/CodeSnippet/helpers/get-snippet'
 import { type CustomCodeSampleId, generateCustomId } from './generate-client-options'
 
 type GenerateCodeSnippetProps = {
+  /** The configured snippetz instance to use for code generation. */
+  snippetzInstance: Snippetz
   /** The selected client/language for code generation (e.g., 'node/fetch') or a custom code sample ID. */
   clientId: AvailableClient | CustomCodeSampleId | undefined
   /** The Content-Type header value for the request body (e.g., 'application/json'). */
@@ -36,7 +38,8 @@ type GenerateCodeSnippetProps = {
 }
 
 /** Generate the code snippet for the selected example OR operation */
-export const generateCodeSnippet = ({
+export const generateCodeSnippet = async ({
+  snippetzInstance,
   clientId,
   customCodeSamples,
   includeDefaultHeaders = false,
@@ -48,7 +51,7 @@ export const generateCodeSnippet = ({
   server,
   securitySchemes,
   globalCookies,
-}: GenerateCodeSnippetProps): string => {
+}: GenerateCodeSnippetProps): Promise<string> => {
   try {
     if (!clientId) {
       return ''
@@ -76,7 +79,7 @@ export const generateCodeSnippet = ({
 
     const [targetKey, clientKey] = clientId.split('/') as [TargetId, ClientId<TargetId>]
 
-    const [error, payload] = getSnippet(targetKey, clientKey, harRequest)
+    const [error, payload] = await getSnippet(snippetzInstance, targetKey, clientKey, harRequest)
     if (error) {
       console.error('[generateCodeSnippet]', error)
       return error.message ?? 'Error generating code snippet'

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestCodeSnippet.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestCodeSnippet.vue
@@ -7,8 +7,9 @@ import {
 } from '@scalar/components'
 import { ScalarIconCaretDown } from '@scalar/icons'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, watchEffect } from 'vue'
 
+import { snippetzInstance } from '@/libs/snippetz-instance'
 import {
   findClient,
   type ClientOption,
@@ -78,8 +79,11 @@ const handleClientChange = (option: ClientOption | undefined) => {
 }
 
 /** Generate the code snippet for the selected example */
-const generatedCode = computed<string>(() =>
-  generateCodeSnippet({
+const generatedCode = ref('')
+
+watchEffect(async () => {
+  generatedCode.value = await generateCodeSnippet({
+    snippetzInstance,
     clientId: localSelectedClient.value?.id,
     customCodeSamples: customCodeSamples.value,
     operation,
@@ -91,8 +95,8 @@ const generatedCode = computed<string>(() =>
     example: selectedExample,
     globalCookies,
     includeDefaultHeaders: integration === 'client',
-  }),
-)
+  })
+})
 
 /** Check if there are any clients available (built-in or custom code samples) */
 const hasClients = computed(() =>

--- a/packages/api-client/src/views/Components/CodeSnippet/CodeSnippet.vue
+++ b/packages/api-client/src/views/Components/CodeSnippet/CodeSnippet.vue
@@ -9,9 +9,10 @@ import type {
 import { isDefined } from '@scalar/oas-utils/helpers'
 import type { ClientId, TargetId } from '@scalar/snippetz'
 import { encode } from 'js-base64'
-import { computed } from 'vue'
+import { computed, ref, watchEffect } from 'vue'
 
 import type { EnvVariables } from '@/libs/env-helpers'
+import { snippetzInstance } from '@/libs/snippetz-instance'
 import { getHarRequest, getSnippet } from '@/views/Components/CodeSnippet'
 
 const {
@@ -56,7 +57,12 @@ const secretCredentials = computed(() =>
 )
 
 /** Generated code example */
-const content = computed(() => {
+const content = ref<{ error: Error | null; payload: string | null }>({
+  error: null,
+  payload: null,
+})
+
+watchEffect(async () => {
   const harRequest = getHarRequest({
     operation,
     example,
@@ -65,8 +71,13 @@ const content = computed(() => {
     environment,
   })
 
-  const [error, payload] = getSnippet(target, client, harRequest)
-  return { error, payload }
+  const [error, payload] = await getSnippet(
+    snippetzInstance,
+    target,
+    client,
+    harRequest,
+  )
+  content.value = { error, payload }
 })
 
 /** CodeMirror syntax highlighting language */

--- a/packages/api-client/src/views/Components/CodeSnippet/helpers/get-snippet.test.ts
+++ b/packages/api-client/src/views/Components/CodeSnippet/helpers/get-snippet.test.ts
@@ -7,12 +7,15 @@ import {
   securitySchemeSchema,
   serverSchema,
 } from '@scalar/oas-utils/entities/spec'
-import { AVAILABLE_CLIENTS, type ClientId, type TargetId } from '@scalar/snippetz'
+import { AVAILABLE_CLIENTS, type ClientId, type TargetId, snippetz } from '@scalar/snippetz'
+import { allPlugins } from '@scalar/snippetz/clients'
 import { describe, expect, it } from 'vitest'
 
 import { getHarRequest } from '@/views/Components/CodeSnippet/helpers/get-har-request'
 
 import { getSnippet } from './get-snippet'
+
+const s = snippetz(allPlugins)
 
 describe('getSnippet', () => {
   // Helper functions to create fresh instances
@@ -48,8 +51,9 @@ describe('getSnippet', () => {
       ...overrides,
     })
 
-  it('generates a basic shell/curl example (httpsnippet-lite)', () => {
-    const [error, result] = getSnippet(
+  it('generates a basic shell/curl example (httpsnippet-lite)', async () => {
+    const [error, result] = await getSnippet(
+      s,
       'shell',
       'curl',
       getHarRequest({
@@ -63,8 +67,9 @@ describe('getSnippet', () => {
     expect(result).toEqual('curl https://example.com/users')
   })
 
-  it('generates a basic node/undici example (@scalar/snippetz)', () => {
-    const [error, result] = getSnippet(
+  it('generates a basic node/undici example (@scalar/snippetz)', async () => {
+    const [error, result] = await getSnippet(
+      s,
       'node',
       'undici',
       getHarRequest({
@@ -82,8 +87,9 @@ describe('getSnippet', () => {
     `)
   })
 
-  it('generates a basic javascript/jquery example (httpsnippet-lite)', () => {
-    const [error, result] = getSnippet(
+  it('generates a basic javascript/jquery example (httpsnippet-lite)', async () => {
+    const [error, result] = await getSnippet(
+      s,
       'javascript',
       'jquery',
       getHarRequest({
@@ -109,8 +115,9 @@ describe('getSnippet', () => {
     `)
   })
 
-  it('returns an empty string if passed rubbish', () => {
-    const [error, result] = getSnippet(
+  it('returns an empty string if passed rubbish', async () => {
+    const [error, result] = await getSnippet(
+      s,
       'javascript',
       'invalid-client' as any,
       getHarRequest({
@@ -124,7 +131,7 @@ describe('getSnippet', () => {
     expect(result).toBeNull()
   })
 
-  it('shows the original path before variable replacement', () => {
+  it('shows the original path before variable replacement', async () => {
     const server = createServer({
       url: '{protocol}://void.scalar.com/{path}',
       description: 'Responds with your request data',
@@ -139,7 +146,8 @@ describe('getSnippet', () => {
       },
     })
 
-    const [error, result] = getSnippet(
+    const [error, result] = await getSnippet(
+      s,
       'javascript',
       'fetch',
       getHarRequest({
@@ -153,7 +161,7 @@ describe('getSnippet', () => {
     expect(result).toEqual(`fetch('https://void.scalar.com/{path}/users')`)
   })
 
-  it('should show the accept header if its not */*', () => {
+  it('should show the accept header if its not */*', async () => {
     const example = createExample()
     example.parameters.headers.push({
       key: 'Accept',
@@ -161,7 +169,8 @@ describe('getSnippet', () => {
       enabled: true,
     })
 
-    const [error, result] = getSnippet(
+    const [error, result] = await getSnippet(
+      s,
       'javascript',
       'fetch',
       getHarRequest({
@@ -188,6 +197,7 @@ describe('getSnippet', () => {
     })
 
     const [error, result] = await getSnippet(
+      s,
       'javascript',
       'fetch',
       getHarRequest({
@@ -205,7 +215,7 @@ describe('getSnippet', () => {
 })`)
   })
 
-  it('should show the headers', () => {
+  it('should show the headers', async () => {
     const example = createExample()
     example.parameters.headers.push({
       key: 'x-scalar-token',
@@ -213,7 +223,8 @@ describe('getSnippet', () => {
       enabled: true,
     })
 
-    const [error, result] = getSnippet(
+    const [error, result] = await getSnippet(
+      s,
       'javascript',
       'fetch',
       getHarRequest({
@@ -231,7 +242,7 @@ describe('getSnippet', () => {
 })`)
   })
 
-  it('should show the query parameters', () => {
+  it('should show the query parameters', async () => {
     const example = createExample()
     example.parameters.query.push({
       key: 'query-param',
@@ -239,7 +250,8 @@ describe('getSnippet', () => {
       enabled: true,
     })
 
-    const [error, result] = getSnippet(
+    const [error, result] = await getSnippet(
+      s,
       'javascript',
       'fetch',
       getHarRequest({
@@ -253,8 +265,9 @@ describe('getSnippet', () => {
     expect(result).toEqual(`fetch('https://example.com/users?query-param=query-value')`)
   })
 
-  it('should show the security headers, cookies and query', () => {
-    const [error, result] = getSnippet(
+  it('should show the security headers, cookies and query', async () => {
+    const [error, result] = await getSnippet(
+      s,
       'javascript',
       'fetch',
       getHarRequest({
@@ -301,8 +314,9 @@ describe('getSnippet', () => {
     `)
   })
 
-  it('should include the invalid url', () => {
-    const [error, result] = getSnippet(
+  it('should include the invalid url', async () => {
+    const [error, result] = await getSnippet(
+      s,
       'c',
       'libcurl',
       getHarRequest({
@@ -324,10 +338,11 @@ describe('getSnippet', () => {
 
   describe('it should generate a snipped without a proper URL for every client', () => {
     AVAILABLE_CLIENTS.forEach((id) => {
-      it(id, () => {
+      it(id, async () => {
         const operation = createOperation({ path: '/super-secret-path' })
         const [target, client] = id.split('/') as [TargetId, ClientId<TargetId>]
-        const [error, result] = getSnippet(
+        const [error, result] = await getSnippet(
+          s,
           target,
           client,
           getHarRequest({

--- a/packages/api-client/src/views/Components/CodeSnippet/helpers/get-snippet.test.ts
+++ b/packages/api-client/src/views/Components/CodeSnippet/helpers/get-snippet.test.ts
@@ -8,14 +8,14 @@ import {
   serverSchema,
 } from '@scalar/oas-utils/entities/spec'
 import { AVAILABLE_CLIENTS, type ClientId, type TargetId, snippetz } from '@scalar/snippetz'
-import { allPlugins } from '@scalar/snippetz/clients'
+import { plugins } from '@scalar/snippetz/clients'
 import { describe, expect, it } from 'vitest'
 
 import { getHarRequest } from '@/views/Components/CodeSnippet/helpers/get-har-request'
 
 import { getSnippet } from './get-snippet'
 
-const s = snippetz(allPlugins)
+const s = snippetz(plugins)
 
 describe('getSnippet', () => {
   // Helper functions to create fresh instances

--- a/packages/api-client/src/views/Components/CodeSnippet/helpers/get-snippet.ts
+++ b/packages/api-client/src/views/Components/CodeSnippet/helpers/get-snippet.ts
@@ -1,4 +1,4 @@
-import { type ClientId, type TargetId, snippetz } from '@scalar/snippetz'
+import type { ClientId, Snippetz, TargetId } from '@scalar/snippetz'
 import type { Request as HarRequest } from 'har-format'
 
 import type { ErrorResponse } from '@/libs/errors'
@@ -9,11 +9,12 @@ const INVALID_URLS_PREFIX = 'ws://replace.me'
 /**
  * Returns a code example for given operation
  */
-export const getSnippet = <T extends TargetId>(
+export const getSnippet = async <T extends TargetId>(
+  s: Snippetz,
   target: T | 'javascript',
   client: ClientId<T>,
   harRequest: HarRequest,
-): ErrorResponse<string> => {
+): Promise<ErrorResponse<string>> => {
   try {
     if (!harRequest.url) {
       return [new Error('Please enter a URL to see a code snippet'), null]
@@ -41,8 +42,8 @@ export const getSnippet = <T extends TargetId>(
     // TODO: Fix this, use js (instead of javascript) everywhere
     const snippetzTargetKey = target.replace('javascript', 'js') as TargetId
 
-    if (snippetz().hasPlugin(snippetzTargetKey, client)) {
-      const payload = snippetz().print(snippetzTargetKey, client as ClientId<TargetId>, harRequest)
+    if (s.hasPlugin(snippetzTargetKey, client)) {
+      const payload = await s.print(snippetzTargetKey, client as ClientId<TargetId>, harRequest)
       if (!payload) {
         return [new Error('Error generating snippet'), null]
       }

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.test.ts
@@ -21,9 +21,9 @@ vi.mock('@/store', () => ({
   useWorkspace: vi.fn(),
 }))
 
-// Mock the snippetz library
-vi.mock('@scalar/snippetz', () => ({
-  snippetz: () => ({
+// Mock the snippetz instance
+vi.mock('@/libs/snippetz-instance', () => ({
+  snippetzInstance: {
     clients: () => [
       {
         key: 'js',
@@ -39,7 +39,10 @@ vi.mock('@scalar/snippetz', () => ({
         clients: [{ client: 'curl', title: 'Curl' }],
       },
     ],
-  }),
+    print: async () => '// generated code',
+    hasPlugin: () => true,
+    plugins: () => [],
+  },
 }))
 
 // Mock the operation

--- a/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestCodeExample.vue
@@ -14,13 +14,14 @@ import type {
   Server,
 } from '@scalar/oas-utils/entities/spec'
 import type { Workspace } from '@scalar/oas-utils/entities/workspace'
-import { snippetz, type ClientId, type TargetId } from '@scalar/snippetz'
+import type { ClientId, TargetId } from '@scalar/snippetz'
 import { computed, ref } from 'vue'
 
 import DataTable from '@/components/DataTable/DataTable.vue'
 import DataTableRow from '@/components/DataTable/DataTableRow.vue'
 import ViewLayoutCollapse from '@/components/ViewLayout/ViewLayoutCollapse.vue'
 import type { EnvVariables } from '@/libs/env-helpers'
+import { snippetzInstance } from '@/libs/snippetz-instance'
 import { useWorkspace } from '@/store'
 import { CodeSnippet } from '@/views/Components/CodeSnippet'
 
@@ -97,18 +98,16 @@ const snippets = computed(() => {
   const dict: Record<string, string> = {}
 
   // Get the built-in snippets
-  const builtInOptions = snippetz()
-    .clients()
-    .map((group) => ({
-      label: group.title,
-      options: group.clients.map((plugin) => {
-        dict[`${group.key},${plugin.client}`] = plugin.title
-        return {
-          id: `${group.key},${plugin.client}`,
-          label: plugin.title,
-        }
-      }),
-    }))
+  const builtInOptions = snippetzInstance.clients().map((group) => ({
+    label: group.title,
+    options: group.clients.map((plugin) => {
+      dict[`${group.key},${plugin.client}`] = plugin.title
+      return {
+        id: `${group.key},${plugin.client}`,
+        label: plugin.title,
+      }
+    }),
+  }))
 
   // Get any custom code samples from x-codeSamples
   const customExamples = (

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { snippetzInstance } from '@scalar/api-client/libs/snippetz-instance'
 import { generateClientOptions } from '@scalar/api-client/v2/blocks/operation-code-sample'
 import { mergeSecurity } from '@scalar/api-client/v2/blocks/scalar-auth-selector-block'
 import { mapHiddenClientsConfig } from '@scalar/api-client/v2/features/modal'
@@ -62,7 +63,10 @@ const { document, items, environment, eventBus, options, authStore } =
 
 /** Generate all client options so that it can be shared between the top client picker and the operations */
 const clientOptions = computed(() =>
-  generateClientOptions(mapHiddenClientsConfig(options.hiddenClients)),
+  generateClientOptions(
+    snippetzInstance,
+    mapHiddenClientsConfig(options.hiddenClients),
+  ),
 )
 
 /** Computed property to get all OpenAPI extension fields from the root document object */

--- a/packages/snippetz/README.md
+++ b/packages/snippetz/README.md
@@ -17,8 +17,11 @@ npm install @scalar/snippetz
 
 ```ts
 import { snippetz } from '@scalar/snippetz'
+import { plugins } from '@scalar/snippetz/clients'
 
-const snippet = snippetz().print('node', 'undici', {
+const generator = snippetz(plugins)
+
+const snippet = await generator.print('node', 'undici', {
   url: 'https://example.com',
 })
 
@@ -33,12 +36,16 @@ const snippet = snippetz().print('node', 'undici', {
 
 ## API
 
+Create a configured instance by passing a plugin set (see [Plugin loading](#plugin-loading) below), then use its methods.
+
 ### Get all plugins
 
 ```ts
 import { snippetz } from '@scalar/snippetz'
+import { plugins } from '@scalar/snippetz/clients'
 
-const snippet = snippetz().plugins()
+const generator = snippetz(plugins)
+const plugins = generator.plugins()
 
 /* Output */
 
@@ -54,17 +61,56 @@ const snippet = snippetz().plugins()
 
 ```ts
 import { snippetz } from '@scalar/snippetz'
+import { plugins } from '@scalar/snippetz/clients'
 
-const snippet = snippetz().hasPlugin('node', 'undici')
+const generator = snippetz(plugins)
+const hasIt = generator.hasPlugin('node', 'undici')
 
 /* Output */
 
 // true
 ```
 
+### Plugin loading
+
+You control what gets bundled by choosing which plugins to pass to `snippetz()`:
+
+### Eager (all upfront)
+
+Loads every plugin at once.
+
+```ts
+import { plugins } from '@scalar/snippetz/clients'
+
+const generator = snippetz(plugins)
+```
+
+### Lazy (on-demand)
+
+```ts
+import { plugins } from '@scalar/snippetz/clients/lazy'
+
+const generator = snippetz(plugins)
+
+// generator.clients() works immediately
+
+// await generator.print(...) loads the chosen plugin when first used
+```
+
+### Selective (small bundle)
+
+Only selected plugins are bundled.
+
+```ts
+import { shellCurl } from '@scalar/snippetz/plugins/shell/curl'
+import { jsFetch } from '@scalar/snippetz/plugins/js/fetch'
+
+const generator = snippetz([shellCurl, jsFetch])
+```
+
 ### Lean usage
 
-You can also just use one specific plugin to keep your bundle size small.
+You can use a single plugin to keep your bundle size small. Either pass one plugin to the instance or call the plugin’s `generate()` directly:
 
 ```ts
 import { nodeUndici } from '@scalar/snippetz/plugins/node/undici'
@@ -73,14 +119,20 @@ const result = nodeUndici.generate({
   url: 'https://example.com',
 })
 
-console.log(source)
+console.log(result)
 
 // import { request } from 'undici'
-
+//
 // const { statusCode, body } = await request(
-//   'url': 'https://example.com',
+//   'https://example.com',
 // )
 ```
+
+With an instance: `const generator = snippetz([nodeUndici])` then `await generator.print('node', 'undici', request)`.
+
+## Playground
+
+Run `pnpm dev` in this package to try Snippetz in the Vue playground.
 
 ## Community
 

--- a/packages/snippetz/package.json
+++ b/packages/snippetz/package.json
@@ -15,12 +15,15 @@
   },
   "scripts": {
     "build": "scalar-build-esbuild",
+    "build:playground": "vite build playground",
+    "dev": "vite playground",
     "generate:dotnet-enums": "vite-node scripts/generate-dotnet-enums.ts",
     "generate:java-enums": "vite-node scripts/generate-java-enums.ts",
     "generate:markdown-docs": "vite-node scripts/generate-markdown-docs.ts",
     "lint:check": "scalar-lint-check",
     "lint:fix": "scalar-lint-fix",
     "postbuild": "pnpm generate:dotnet-enums && pnpm generate:java-enums && pnpm generate:markdown-docs",
+    "preview:playground": "vite preview playground",
     "test": "vitest",
     "types:build": "scalar-types-build",
     "types:check": "scalar-types-check"
@@ -38,6 +41,11 @@
       "import": "./dist/clients/index.js",
       "types": "./dist/clients/index.d.ts",
       "default": "./dist/clients/index.js"
+    },
+    "./clients/lazy": {
+      "import": "./dist/clients/lazy/index.js",
+      "types": "./dist/clients/lazy/index.d.ts",
+      "default": "./dist/clients/lazy/index.js"
     },
     "./plugins/c/libcurl": {
       "import": "./dist/plugins/c/libcurl/index.js",
@@ -247,6 +255,8 @@
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",
     "@types/stringify-object": "^4.0.5",
-    "vite": "catalog:*"
+    "@vitejs/plugin-vue": "catalog:*",
+    "vite": "catalog:*",
+    "vue": "catalog:*"
   }
 }

--- a/packages/snippetz/playground/index.html
+++ b/packages/snippetz/playground/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0" />
+    <title>Snippetz Playground</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/snippetz/playground/src/App.vue
+++ b/packages/snippetz/playground/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { snippetz } from '@scalar/snippetz'
-import { allPlugins as lazyPlugins } from '@scalar/snippetz/clients/lazy'
+import { plugins as lazyPlugins } from '@scalar/snippetz/clients/lazy'
 import { computed, ref, watchEffect } from 'vue'
 
 const selectedClient = ref('shell/curl')

--- a/packages/snippetz/playground/src/App.vue
+++ b/packages/snippetz/playground/src/App.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { snippetz } from '@scalar/snippetz'
+import { allPlugins as lazyPlugins } from '@scalar/snippetz/clients/lazy'
+import { computed, ref, watchEffect } from 'vue'
+
+const selectedClient = ref('shell/curl')
+const generatedCode = ref('')
+const isLoading = ref(false)
+
+/** Tracks which lazy plugins have had their generator invoked */
+const loadedPlugins = ref(new Set<string>())
+
+const instance = snippetz(lazyPlugins)
+
+/** All available client IDs */
+const availableClients = computed(() =>
+  instance.plugins().map((p) => `${p.target}/${p.client}`),
+)
+
+/** Generate the code snippet when the selected client changes */
+watchEffect(async () => {
+  const [target, client] = selectedClient.value.split('/') as [string, string]
+
+  isLoading.value = true
+  const result = await instance.print(target as any, client as any, {
+    url: 'https://example.com/api/users',
+    method: 'POST',
+    headers: [{ name: 'Content-Type', value: 'application/json' }],
+    postData: {
+      mimeType: 'application/json',
+      text: JSON.stringify({ name: 'John Doe', email: 'john@example.com' }),
+    },
+  })
+  isLoading.value = false
+  generatedCode.value = result ?? 'No output'
+
+  if (result) {
+    loadedPlugins.value.add(selectedClient.value)
+  }
+})
+</script>
+
+<template>
+  <div class="min-h-screen bg-gray-50 p-8 font-sans">
+    <h1 class="mb-6 text-2xl font-bold">Scalar Snippetz</h1>
+
+    <!-- Available plugins -->
+    <div class="mb-6">
+      <h2 class="mb-2 text-sm font-semibold text-gray-600">
+        Plugins ({{ availableClients.length }})
+      </h2>
+      <div class="flex flex-wrap gap-1.5">
+        <span
+          v-for="id in availableClients"
+          :key="id"
+          class="cursor-pointer rounded-full px-2 py-0.5 font-mono text-xs"
+          :class="
+            id === selectedClient
+              ? 'bg-blue-100 text-blue-800 ring-2 ring-blue-400'
+              : loadedPlugins.has(id)
+                ? 'bg-green-100 text-green-800 hover:bg-green-200'
+                : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+          "
+          @click="selectedClient = id">
+          {{ id }}
+        </span>
+      </div>
+    </div>
+
+    <!-- Generated code -->
+    <div class="relative">
+      <div
+        v-if="isLoading"
+        class="absolute top-2 right-2 text-xs text-gray-400">
+        Loading...
+      </div>
+      <pre
+        class="overflow-x-auto rounded-lg bg-gray-900 p-4 font-mono text-sm whitespace-pre-wrap text-green-300"
+        >{{ generatedCode }}</pre
+      >
+    </div>
+  </div>
+</template>

--- a/packages/snippetz/playground/src/main.ts
+++ b/packages/snippetz/playground/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/packages/snippetz/playground/tsconfig.json
+++ b/packages/snippetz/playground/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "paths": {
+      "@scalar/snippetz": ["../src/index.ts"],
+      "@scalar/snippetz/clients": ["../src/clients/index.ts"],
+      "@scalar/snippetz/clients/lazy": ["../src/clients/lazy/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}

--- a/packages/snippetz/playground/vite.config.ts
+++ b/packages/snippetz/playground/vite.config.ts
@@ -1,0 +1,18 @@
+import { resolve } from 'node:path'
+
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: [
+      // Most specific first so Vite does not prefix-match the shorter alias
+      { find: '@scalar/snippetz/clients/lazy', replacement: resolve(__dirname, '../src/clients/lazy/index.ts') },
+      { find: '@scalar/snippetz/clients', replacement: resolve(__dirname, '../src/clients/index.ts') },
+      { find: '@scalar/snippetz', replacement: resolve(__dirname, '../src/index.ts') },
+      // The snippetz source uses `@/` as a path alias for `src/`
+      { find: /^@\//, replacement: resolve(__dirname, '../src') + '/' },
+    ],
+  },
+})

--- a/packages/snippetz/src/clients/index.ts
+++ b/packages/snippetz/src/clients/index.ts
@@ -1,4 +1,4 @@
-import type { Target } from '@scalar/types/snippetz'
+import type { Plugin, Target } from '@scalar/types/snippetz'
 
 import { cLibcurl } from '@/plugins/c/libcurl'
 import { clojureCljhttp } from '@/plugins/clojure/clj_http'
@@ -169,4 +169,71 @@ export const clients: Target[] = [
     default: 'nsurlsession',
     clients: [swiftNsurlsession],
   },
+]
+
+/**
+ * Flat array of all plugins, ordered so the first plugin per target matches the default client.
+ * Pass this to `snippetz(allPlugins)` to load everything eagerly.
+ */
+export const allPlugins: Plugin[] = [
+  // C
+  cLibcurl,
+  // C#  (default: restsharp)
+  csharpRestsharp,
+  csharpHttpclient,
+  // Clojure
+  clojureCljhttp,
+  // Dart
+  dartHttp,
+  // F#
+  fsharpHttpclient,
+  // Go
+  goNative,
+  // HTTP
+  httpHttp11,
+  // Java (default: unirest)
+  javaUnirest,
+  javaAsynchttp,
+  javaNethttp,
+  javaOkhttp,
+  // JavaScript (default: fetch)
+  jsFetch,
+  jsAxios,
+  jsOfetch,
+  jsJquery,
+  jsXhr,
+  // Kotlin
+  kotlinOkhttp,
+  // Node.js (default: fetch)
+  nodeFetch,
+  nodeAxios,
+  nodeOfetch,
+  nodeUndici,
+  // Objective-C
+  objcNsurlsession,
+  // OCaml
+  ocamlCohttp,
+  // PHP (default: curl)
+  phpCurl,
+  phpGuzzle,
+  // PowerShell (default: webrequest)
+  powershellWebrequest,
+  powershellRestmethod,
+  // Python (default: python3)
+  pythonPython3,
+  pythonRequests,
+  pythonHttpxSync,
+  pythonHttpxAsync,
+  // R
+  rHttr,
+  // Ruby
+  rubyNative,
+  // Rust
+  rustReqwest,
+  // Shell (default: curl)
+  shellCurl,
+  shellWget,
+  shellHttpie,
+  // Swift
+  swiftNsurlsession,
 ]

--- a/packages/snippetz/src/clients/index.ts
+++ b/packages/snippetz/src/clients/index.ts
@@ -173,9 +173,9 @@ export const clients: Target[] = [
 
 /**
  * Flat array of all plugins, ordered so the first plugin per target matches the default client.
- * Pass this to `snippetz(allPlugins)` to load everything eagerly.
+ * Pass this to `snippetz(plugins)` to load everything eagerly.
  */
-export const allPlugins: Plugin[] = [
+export const plugins: Plugin[] = [
   // C
   cLibcurl,
   // C#  (default: restsharp)

--- a/packages/snippetz/src/clients/lazy/index.ts
+++ b/packages/snippetz/src/clients/lazy/index.ts
@@ -7,9 +7,9 @@ import type { Plugin } from '@scalar/types/snippetz'
  * plus thin async `generate()` wrappers that call `import()` on first use.
  * Bundlers like Vite will code-split each dynamic import into a separate chunk.
  *
- * Pass this to `snippetz(allPlugins)` for the "metadata upfront, code on demand" pattern.
+ * Pass this to `snippetz(plugins)` for the "metadata upfront, code on demand" pattern.
  */
-export const allPlugins: Plugin[] = [
+export const plugins: Plugin[] = [
   // C
   {
     target: 'c',

--- a/packages/snippetz/src/clients/lazy/index.ts
+++ b/packages/snippetz/src/clients/lazy/index.ts
@@ -1,0 +1,424 @@
+import type { Plugin } from '@scalar/types/snippetz'
+
+/**
+ * All plugins with lazy-loaded generators.
+ *
+ * This module is ~2-3KB — it contains only metadata (target, targetTitle, client, title)
+ * plus thin async `generate()` wrappers that call `import()` on first use.
+ * Bundlers like Vite will code-split each dynamic import into a separate chunk.
+ *
+ * Pass this to `snippetz(allPlugins)` for the "metadata upfront, code on demand" pattern.
+ */
+export const allPlugins: Plugin[] = [
+  // C
+  {
+    target: 'c',
+    targetTitle: 'C',
+    client: 'libcurl',
+    title: 'Libcurl',
+    async generate(request, config) {
+      const { cLibcurl } = await import('../../plugins/c/libcurl/index.js')
+      return cLibcurl.generate(request, config)
+    },
+  },
+  // C# (default: restsharp)
+  {
+    target: 'csharp',
+    targetTitle: 'C#',
+    client: 'restsharp',
+    title: 'RestSharp',
+    async generate(request, config) {
+      const { csharpRestsharp } = await import('../../plugins/csharp/restsharp/index.js')
+      return csharpRestsharp.generate(request, config)
+    },
+  },
+  {
+    target: 'csharp',
+    targetTitle: 'C#',
+    client: 'httpclient',
+    title: 'HttpClient',
+    async generate(request, config) {
+      const { csharpHttpclient } = await import('../../plugins/csharp/httpclient/index.js')
+      return csharpHttpclient.generate(request, config)
+    },
+  },
+  // Clojure
+  {
+    target: 'clojure',
+    targetTitle: 'Clojure',
+    client: 'clj_http',
+    title: 'clj-http',
+    async generate(request, config) {
+      const { clojureCljhttp } = await import('../../plugins/clojure/clj_http/index.js')
+      return clojureCljhttp.generate(request, config)
+    },
+  },
+  // Dart
+  {
+    target: 'dart',
+    targetTitle: 'Dart',
+    client: 'http',
+    title: 'Http',
+    async generate(request, config) {
+      const { dartHttp } = await import('../../plugins/dart/http/index.js')
+      return dartHttp.generate(request, config)
+    },
+  },
+  // F#
+  {
+    target: 'fsharp',
+    targetTitle: 'F#',
+    client: 'httpclient',
+    title: 'HttpClient',
+    async generate(request, config) {
+      const { fsharpHttpclient } = await import('../../plugins/fsharp/httpclient/index.js')
+      return fsharpHttpclient.generate(request, config)
+    },
+  },
+  // Go
+  {
+    target: 'go',
+    targetTitle: 'Go',
+    client: 'native',
+    title: 'NewRequest',
+    async generate(request, config) {
+      const { goNative } = await import('../../plugins/go/native/index.js')
+      return goNative.generate(request, config)
+    },
+  },
+  // HTTP
+  {
+    target: 'http',
+    targetTitle: 'HTTP',
+    client: 'http1.1',
+    title: 'HTTP/1.1',
+    async generate(request, config) {
+      const { httpHttp11 } = await import('../../plugins/http/http11/index.js')
+      return httpHttp11.generate(request, config)
+    },
+  },
+  // Java (default: unirest)
+  {
+    target: 'java',
+    targetTitle: 'Java',
+    client: 'unirest',
+    title: 'Unirest',
+    async generate(request, config) {
+      const { javaUnirest } = await import('../../plugins/java/unirest/index.js')
+      return javaUnirest.generate(request, config)
+    },
+  },
+  {
+    target: 'java',
+    targetTitle: 'Java',
+    client: 'asynchttp',
+    title: 'AsyncHttp',
+    async generate(request, config) {
+      const { javaAsynchttp } = await import('../../plugins/java/asynchttp/index.js')
+      return javaAsynchttp.generate(request, config)
+    },
+  },
+  {
+    target: 'java',
+    targetTitle: 'Java',
+    client: 'nethttp',
+    title: 'java.net.http',
+    async generate(request, config) {
+      const { javaNethttp } = await import('../../plugins/java/nethttp/index.js')
+      return javaNethttp.generate(request, config)
+    },
+  },
+  {
+    target: 'java',
+    targetTitle: 'Java',
+    client: 'okhttp',
+    title: 'OkHttp',
+    async generate(request, config) {
+      const { javaOkhttp } = await import('../../plugins/java/okhttp/index.js')
+      return javaOkhttp.generate(request, config)
+    },
+  },
+  // JavaScript (default: fetch)
+  {
+    target: 'js',
+    targetTitle: 'JavaScript',
+    client: 'fetch',
+    title: 'Fetch',
+    async generate(request, config) {
+      const { jsFetch } = await import('../../plugins/js/fetch/index.js')
+      return jsFetch.generate(request, config)
+    },
+  },
+  {
+    target: 'js',
+    targetTitle: 'JavaScript',
+    client: 'axios',
+    title: 'Axios',
+    async generate(request, config) {
+      const { jsAxios } = await import('../../plugins/js/axios/index.js')
+      return jsAxios.generate(request, config)
+    },
+  },
+  {
+    target: 'js',
+    targetTitle: 'JavaScript',
+    client: 'ofetch',
+    title: 'ofetch',
+    async generate(request, config) {
+      const { jsOfetch } = await import('../../plugins/js/ofetch/index.js')
+      return jsOfetch.generate(request, config)
+    },
+  },
+  {
+    target: 'js',
+    targetTitle: 'JavaScript',
+    client: 'jquery',
+    title: 'jQuery',
+    async generate(request, config) {
+      const { jsJquery } = await import('../../plugins/js/jquery/index.js')
+      return jsJquery.generate(request, config)
+    },
+  },
+  {
+    target: 'js',
+    targetTitle: 'JavaScript',
+    client: 'xhr',
+    title: 'XHR',
+    async generate(request, config) {
+      const { jsXhr } = await import('../../plugins/js/xhr/index.js')
+      return jsXhr.generate(request, config)
+    },
+  },
+  // Kotlin
+  {
+    target: 'kotlin',
+    targetTitle: 'Kotlin',
+    client: 'okhttp',
+    title: 'OkHttp',
+    async generate(request, config) {
+      const { kotlinOkhttp } = await import('../../plugins/kotlin/okhttp/index.js')
+      return kotlinOkhttp.generate(request, config)
+    },
+  },
+  // Node.js (default: fetch)
+  {
+    target: 'node',
+    targetTitle: 'Node.js',
+    client: 'fetch',
+    title: 'Fetch',
+    async generate(request, config) {
+      const { nodeFetch } = await import('../../plugins/node/fetch/index.js')
+      return nodeFetch.generate(request, config)
+    },
+  },
+  {
+    target: 'node',
+    targetTitle: 'Node.js',
+    client: 'axios',
+    title: 'Axios',
+    async generate(request, config) {
+      const { nodeAxios } = await import('../../plugins/node/axios/index.js')
+      return nodeAxios.generate(request, config)
+    },
+  },
+  {
+    target: 'node',
+    targetTitle: 'Node.js',
+    client: 'ofetch',
+    title: 'ofetch',
+    async generate(request, config) {
+      const { nodeOfetch } = await import('../../plugins/node/ofetch/index.js')
+      return nodeOfetch.generate(request, config)
+    },
+  },
+  {
+    target: 'node',
+    targetTitle: 'Node.js',
+    client: 'undici',
+    title: 'undici',
+    async generate(request, config) {
+      const { nodeUndici } = await import('../../plugins/node/undici/index.js')
+      return nodeUndici.generate(request, config)
+    },
+  },
+  // Objective-C
+  {
+    target: 'objc',
+    targetTitle: 'Objective-C',
+    client: 'nsurlsession',
+    title: 'NSURLSession',
+    async generate(request, config) {
+      const { objcNsurlsession } = await import('../../plugins/objc/nsurlsession/index.js')
+      return objcNsurlsession.generate(request, config)
+    },
+  },
+  // OCaml
+  {
+    target: 'ocaml',
+    targetTitle: 'OCaml',
+    client: 'cohttp',
+    title: 'Cohttp',
+    async generate(request, config) {
+      const { ocamlCohttp } = await import('../../plugins/ocaml/cohttp/index.js')
+      return ocamlCohttp.generate(request, config)
+    },
+  },
+  // PHP (default: curl)
+  {
+    target: 'php',
+    targetTitle: 'PHP',
+    client: 'curl',
+    title: 'cURL',
+    async generate(request, config) {
+      const { phpCurl } = await import('../../plugins/php/curl/index.js')
+      return phpCurl.generate(request, config)
+    },
+  },
+  {
+    target: 'php',
+    targetTitle: 'PHP',
+    client: 'guzzle',
+    title: 'Guzzle',
+    async generate(request, config) {
+      const { phpGuzzle } = await import('../../plugins/php/guzzle/index.js')
+      return phpGuzzle.generate(request, config)
+    },
+  },
+  // PowerShell (default: webrequest)
+  {
+    target: 'powershell',
+    targetTitle: 'PowerShell',
+    client: 'webrequest',
+    title: 'Invoke-WebRequest',
+    async generate(request, config) {
+      const { powershellWebrequest } = await import('../../plugins/powershell/webrequest/index.js')
+      return powershellWebrequest.generate(request, config)
+    },
+  },
+  {
+    target: 'powershell',
+    targetTitle: 'PowerShell',
+    client: 'restmethod',
+    title: 'Invoke-RestMethod',
+    async generate(request, config) {
+      const { powershellRestmethod } = await import('../../plugins/powershell/restmethod/index.js')
+      return powershellRestmethod.generate(request, config)
+    },
+  },
+  // Python (default: python3)
+  {
+    target: 'python',
+    targetTitle: 'Python',
+    client: 'python3',
+    title: 'http.client',
+    async generate(request, config) {
+      const { pythonPython3 } = await import('../../plugins/python/python3/index.js')
+      return pythonPython3.generate(request, config)
+    },
+  },
+  {
+    target: 'python',
+    targetTitle: 'Python',
+    client: 'requests',
+    title: 'Requests',
+    async generate(request, config) {
+      const { pythonRequests } = await import('../../plugins/python/requests/index.js')
+      return pythonRequests.generate(request, config)
+    },
+  },
+  {
+    target: 'python',
+    targetTitle: 'Python',
+    client: 'httpx_sync',
+    title: 'HTTPX (Sync)',
+    async generate(request, config) {
+      const { pythonHttpxSync } = await import('../../plugins/python/httpx/index.js')
+      return pythonHttpxSync.generate(request, config)
+    },
+  },
+  {
+    target: 'python',
+    targetTitle: 'Python',
+    client: 'httpx_async',
+    title: 'HTTPX (Async)',
+    async generate(request, config) {
+      const { pythonHttpxAsync } = await import('../../plugins/python/httpx/index.js')
+      return pythonHttpxAsync.generate(request, config)
+    },
+  },
+  // R
+  {
+    target: 'r',
+    targetTitle: 'R',
+    client: 'httr',
+    title: 'httr',
+    async generate(request, config) {
+      const { rHttr } = await import('../../plugins/r/httr/index.js')
+      return rHttr.generate(request, config)
+    },
+  },
+  // Ruby
+  {
+    target: 'ruby',
+    targetTitle: 'Ruby',
+    client: 'native',
+    title: 'net::http',
+    async generate(request, config) {
+      const { rubyNative } = await import('../../plugins/ruby/native/index.js')
+      return rubyNative.generate(request, config)
+    },
+  },
+  // Rust
+  {
+    target: 'rust',
+    targetTitle: 'Rust',
+    client: 'reqwest',
+    title: 'reqwest',
+    async generate(request, config) {
+      const { rustReqwest } = await import('../../plugins/rust/reqwest/index.js')
+      return rustReqwest.generate(request, config)
+    },
+  },
+  // Shell (default: curl)
+  {
+    target: 'shell',
+    targetTitle: 'Shell',
+    client: 'curl',
+    title: 'Curl',
+    async generate(request, config) {
+      const { shellCurl } = await import('../../plugins/shell/curl/index.js')
+      return shellCurl.generate(request, config)
+    },
+  },
+  {
+    target: 'shell',
+    targetTitle: 'Shell',
+    client: 'wget',
+    title: 'Wget',
+    async generate(request, config) {
+      const { shellWget } = await import('../../plugins/shell/wget/index.js')
+      return shellWget.generate(request, config)
+    },
+  },
+  {
+    target: 'shell',
+    targetTitle: 'Shell',
+    client: 'httpie',
+    title: 'HTTPie',
+    async generate(request, config) {
+      const { shellHttpie } = await import('../../plugins/shell/httpie/index.js')
+      return shellHttpie.generate(request, config)
+    },
+  },
+  // Swift
+  {
+    target: 'swift',
+    targetTitle: 'Swift',
+    client: 'nsurlsession',
+    title: 'NSURLSession',
+    async generate(request, config) {
+      const { swiftNsurlsession } = await import('../../plugins/swift/nsurlsession/index.js')
+      return swiftNsurlsession.generate(request, config)
+    },
+  },
+]

--- a/packages/snippetz/src/index.ts
+++ b/packages/snippetz/src/index.ts
@@ -12,4 +12,4 @@ export {
   type TargetId,
 } from '@scalar/types/snippetz'
 
-export { snippetz } from './snippetz'
+export { type Snippetz, snippetz } from './snippetz'

--- a/packages/snippetz/src/plugins/c/libcurl/libcurl.ts
+++ b/packages/snippetz/src/plugins/c/libcurl/libcurl.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const cLibcurl: Plugin = {
   target: 'c',
+  targetTitle: 'C',
   client: 'libcurl',
   title: 'Libcurl',
   generate(request) {

--- a/packages/snippetz/src/plugins/clojure/clj_http/clj_http.ts
+++ b/packages/snippetz/src/plugins/clojure/clj_http/clj_http.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const clojureCljhttp: Plugin = {
   target: 'clojure',
+  targetTitle: 'Clojure',
   client: 'clj_http',
   title: 'clj-http',
   generate(request) {

--- a/packages/snippetz/src/plugins/csharp/httpclient/httpclient.test.ts
+++ b/packages/snippetz/src/plugins/csharp/httpclient/httpclient.test.ts
@@ -318,8 +318,8 @@ request.Content = content;
 using var response = await client.SendAsync(request);`)
   })
 
-  it('handles duplicate headers by keeping the last value', () => {
-    const result = csharpHttpclient.generate({
+  it('handles duplicate headers by keeping the last value', async () => {
+    const result = await csharpHttpclient.generate({
       url: 'https://example.com',
       headers: [
         { name: 'X-Custom', value: 'value1' },

--- a/packages/snippetz/src/plugins/csharp/httpclient/httpclient.ts
+++ b/packages/snippetz/src/plugins/csharp/httpclient/httpclient.ts
@@ -8,6 +8,7 @@ import { createSearchParams } from '@/libs/http'
  */
 export const csharpHttpclient: Plugin = {
   target: 'csharp',
+  targetTitle: 'C#',
   client: 'httpclient',
   title: 'HttpClient',
   generate(request, configuration) {

--- a/packages/snippetz/src/plugins/csharp/restsharp/restsharp.ts
+++ b/packages/snippetz/src/plugins/csharp/restsharp/restsharp.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const csharpRestsharp: Plugin = {
   target: 'csharp',
+  targetTitle: 'C#',
   client: 'restsharp',
   title: 'RestSharp',
   generate(request) {

--- a/packages/snippetz/src/plugins/dart/http/http.ts
+++ b/packages/snippetz/src/plugins/dart/http/http.ts
@@ -5,6 +5,7 @@ import type { Plugin } from '@scalar/types/snippetz'
  */
 export const dartHttp: Plugin = {
   target: 'dart',
+  targetTitle: 'Dart',
   client: 'http',
   title: 'Http',
   generate(request, options?: { auth?: { username: string; password: string } }) {

--- a/packages/snippetz/src/plugins/fsharp/httpclient/httpclient.ts
+++ b/packages/snippetz/src/plugins/fsharp/httpclient/httpclient.ts
@@ -5,6 +5,7 @@ import type { Plugin } from '@scalar/types/snippetz'
  */
 export const fsharpHttpclient: Plugin = {
   target: 'fsharp',
+  targetTitle: 'F#',
   client: 'httpclient',
   title: 'HttpClient',
   generate: (request, _) => {

--- a/packages/snippetz/src/plugins/go/native/native.ts
+++ b/packages/snippetz/src/plugins/go/native/native.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const goNative: Plugin = {
   target: 'go',
+  targetTitle: 'Go',
   client: 'native',
   title: 'NewRequest',
   generate(request) {

--- a/packages/snippetz/src/plugins/http/http11/http11.ts
+++ b/packages/snippetz/src/plugins/http/http11/http11.ts
@@ -5,6 +5,7 @@ import type { Plugin } from '@scalar/types/snippetz'
  */
 export const httpHttp11: Plugin = {
   target: 'http',
+  targetTitle: 'HTTP',
   client: 'http1.1',
   title: 'HTTP/1.1',
   generate(request) {

--- a/packages/snippetz/src/plugins/java/asynchttp/asynchttp.ts
+++ b/packages/snippetz/src/plugins/java/asynchttp/asynchttp.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const javaAsynchttp: Plugin = {
   target: 'java',
+  targetTitle: 'Java',
   client: 'asynchttp',
   title: 'AsyncHttp',
   generate(request) {

--- a/packages/snippetz/src/plugins/java/nethttp/nethttp.ts
+++ b/packages/snippetz/src/plugins/java/nethttp/nethttp.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const javaNethttp: Plugin = {
   target: 'java',
+  targetTitle: 'Java',
   client: 'nethttp',
   title: 'java.net.http',
   generate(request) {

--- a/packages/snippetz/src/plugins/java/okhttp/okhttp.ts
+++ b/packages/snippetz/src/plugins/java/okhttp/okhttp.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const javaOkhttp: Plugin = {
   target: 'java',
+  targetTitle: 'Java',
   client: 'okhttp',
   title: 'OkHttp',
   generate(request) {

--- a/packages/snippetz/src/plugins/java/unirest/unirest.ts
+++ b/packages/snippetz/src/plugins/java/unirest/unirest.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const javaUnirest: Plugin = {
   target: 'java',
+  targetTitle: 'Java',
   client: 'unirest',
   title: 'Unirest',
   generate(request) {

--- a/packages/snippetz/src/plugins/js/axios/axios.ts
+++ b/packages/snippetz/src/plugins/js/axios/axios.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const jsAxios: Plugin = {
   target: 'js',
+  targetTitle: 'JavaScript',
   client: 'axios',
   title: 'Axios',
   generate(request) {

--- a/packages/snippetz/src/plugins/js/fetch/fetch.ts
+++ b/packages/snippetz/src/plugins/js/fetch/fetch.ts
@@ -8,6 +8,7 @@ import { Raw, objectToString } from '@/libs/javascript'
  */
 export const jsFetch: Plugin = {
   target: 'js',
+  targetTitle: 'JavaScript',
   client: 'fetch',
   title: 'Fetch',
   generate(request) {

--- a/packages/snippetz/src/plugins/js/jquery/jquery.ts
+++ b/packages/snippetz/src/plugins/js/jquery/jquery.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const jsJquery: Plugin = {
   target: 'js',
+  targetTitle: 'JavaScript',
   client: 'jquery',
   title: 'jQuery',
   generate(request) {

--- a/packages/snippetz/src/plugins/js/ofetch/ofetch.ts
+++ b/packages/snippetz/src/plugins/js/ofetch/ofetch.ts
@@ -7,6 +7,7 @@ import { objectToString } from '@/libs/javascript'
  */
 export const jsOfetch: Plugin = {
   target: 'js',
+  targetTitle: 'JavaScript',
   client: 'ofetch',
   title: 'ofetch',
   generate(request) {

--- a/packages/snippetz/src/plugins/js/xhr/xhr.ts
+++ b/packages/snippetz/src/plugins/js/xhr/xhr.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const jsXhr: Plugin = {
   target: 'js',
+  targetTitle: 'JavaScript',
   client: 'xhr',
   title: 'XHR',
   generate(request) {

--- a/packages/snippetz/src/plugins/kotlin/okhttp/okhttp.ts
+++ b/packages/snippetz/src/plugins/kotlin/okhttp/okhttp.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const kotlinOkhttp: Plugin = {
   target: 'kotlin',
+  targetTitle: 'Kotlin',
   client: 'okhttp',
   title: 'OkHttp',
   generate(request) {

--- a/packages/snippetz/src/plugins/node/axios/axios.ts
+++ b/packages/snippetz/src/plugins/node/axios/axios.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const nodeAxios: Plugin = {
   target: 'node',
+  targetTitle: 'Node.js',
   client: 'axios',
   title: 'Axios',
   generate(request) {

--- a/packages/snippetz/src/plugins/node/fetch/fetch.ts
+++ b/packages/snippetz/src/plugins/node/fetch/fetch.ts
@@ -8,6 +8,7 @@ import { Raw, objectToString } from '@/libs/javascript'
  */
 export const nodeFetch: Plugin = {
   target: 'node',
+  targetTitle: 'Node.js',
   client: 'fetch',
   title: 'Fetch',
   generate(request) {

--- a/packages/snippetz/src/plugins/node/ofetch/ofetch.ts
+++ b/packages/snippetz/src/plugins/node/ofetch/ofetch.ts
@@ -7,6 +7,7 @@ import { objectToString } from '@/libs/javascript'
  */
 export const nodeOfetch: Plugin = {
   target: 'node',
+  targetTitle: 'Node.js',
   client: 'ofetch',
   title: 'ofetch',
   generate(request) {

--- a/packages/snippetz/src/plugins/node/undici/undici.ts
+++ b/packages/snippetz/src/plugins/node/undici/undici.ts
@@ -8,6 +8,7 @@ import { Raw, objectToString } from '@/libs/javascript'
  */
 export const nodeUndici: Plugin = {
   target: 'node',
+  targetTitle: 'Node.js',
   client: 'undici',
   title: 'undici',
   generate(request) {

--- a/packages/snippetz/src/plugins/objc/nsurlsession/nsurlsession.ts
+++ b/packages/snippetz/src/plugins/objc/nsurlsession/nsurlsession.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const objcNsurlsession: Plugin = {
   target: 'objc',
+  targetTitle: 'Objective-C',
   client: 'nsurlsession',
   title: 'NSURLSession',
   generate(request) {

--- a/packages/snippetz/src/plugins/ocaml/cohttp/cohttp.ts
+++ b/packages/snippetz/src/plugins/ocaml/cohttp/cohttp.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const ocamlCohttp: Plugin = {
   target: 'ocaml',
+  targetTitle: 'OCaml',
   client: 'cohttp',
   title: 'Cohttp',
   generate(request) {

--- a/packages/snippetz/src/plugins/php/curl/curl.test.ts
+++ b/packages/snippetz/src/plugins/php/curl/curl.test.ts
@@ -575,8 +575,8 @@ curl_exec($ch);
 curl_close($ch);`)
   })
 
-  it('does not duplicate CURLOPT_HTTPHEADER when headers and form-urlencoded body both set Content-Type', () => {
-    const result = phpCurl.generate({
+  it('does not duplicate CURLOPT_HTTPHEADER when headers and form-urlencoded body both set Content-Type', async () => {
+    const result = await phpCurl.generate({
       url: 'https://example.com/register',
       method: 'POST',
       headers: [
@@ -610,8 +610,8 @@ curl_exec($ch);
 curl_close($ch);`)
   })
 
-  it('does not duplicate CURLOPT_HTTPHEADER with custom headers and form-urlencoded body', () => {
-    const result = phpCurl.generate({
+  it('does not duplicate CURLOPT_HTTPHEADER with custom headers and form-urlencoded body', async () => {
+    const result = await phpCurl.generate({
       url: 'https://example.com',
       method: 'POST',
       headers: [

--- a/packages/snippetz/src/plugins/php/curl/curl.ts
+++ b/packages/snippetz/src/plugins/php/curl/curl.ts
@@ -7,6 +7,7 @@ import { objectToString } from '@/libs/php'
  */
 export const phpCurl: Plugin = {
   target: 'php',
+  targetTitle: 'PHP',
   client: 'curl',
   title: 'cURL',
   generate(request, configuration) {

--- a/packages/snippetz/src/plugins/php/guzzle/guzzle.ts
+++ b/packages/snippetz/src/plugins/php/guzzle/guzzle.ts
@@ -7,6 +7,7 @@ import { Raw, objectToString } from '@/libs/php'
  */
 export const phpGuzzle: Plugin = {
   target: 'php',
+  targetTitle: 'PHP',
   client: 'guzzle',
   title: 'Guzzle',
   generate(request, configuration) {

--- a/packages/snippetz/src/plugins/powershell/restmethod/restmethod.ts
+++ b/packages/snippetz/src/plugins/powershell/restmethod/restmethod.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const powershellRestmethod: Plugin = {
   target: 'powershell',
+  targetTitle: 'PowerShell',
   client: 'restmethod',
   title: 'Invoke-RestMethod',
   generate(request) {

--- a/packages/snippetz/src/plugins/powershell/webrequest/webrequest.ts
+++ b/packages/snippetz/src/plugins/powershell/webrequest/webrequest.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const powershellWebrequest: Plugin = {
   target: 'powershell',
+  targetTitle: 'PowerShell',
   client: 'webrequest',
   title: 'Invoke-WebRequest',
   generate(request) {

--- a/packages/snippetz/src/plugins/python/httpx/async.ts
+++ b/packages/snippetz/src/plugins/python/httpx/async.ts
@@ -7,6 +7,7 @@ import { requestsLikeGenerate } from '@/plugins/python/requestsLike'
  */
 export const pythonHttpxAsync: Plugin = {
   target: 'python',
+  targetTitle: 'Python',
   client: 'httpx_async',
   title: 'HTTPX (Async)',
   generate(request, configuration) {

--- a/packages/snippetz/src/plugins/python/httpx/sync.ts
+++ b/packages/snippetz/src/plugins/python/httpx/sync.ts
@@ -7,6 +7,7 @@ import { requestsLikeGenerate } from '@/plugins/python/requestsLike'
  */
 export const pythonHttpxSync: Plugin = {
   target: 'python',
+  targetTitle: 'Python',
   client: 'httpx_sync',
   title: 'HTTPX (Sync)',
   generate(request, configuration) {

--- a/packages/snippetz/src/plugins/python/python3/python3.ts
+++ b/packages/snippetz/src/plugins/python/python3/python3.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const pythonPython3: Plugin = {
   target: 'python',
+  targetTitle: 'Python',
   client: 'python3',
   title: 'http.client',
   generate(request) {

--- a/packages/snippetz/src/plugins/python/requests/requests.ts
+++ b/packages/snippetz/src/plugins/python/requests/requests.ts
@@ -7,6 +7,7 @@ import { requestsLikeGenerate } from '@/plugins/python/requestsLike'
  */
 export const pythonRequests: Plugin = {
   target: 'python',
+  targetTitle: 'Python',
   client: 'requests',
   title: 'Requests',
   generate(request, configuration) {

--- a/packages/snippetz/src/plugins/r/httr/httr.ts
+++ b/packages/snippetz/src/plugins/r/httr/httr.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const rHttr: Plugin = {
   target: 'r',
+  targetTitle: 'R',
   client: 'httr',
   title: 'httr',
   generate(request) {

--- a/packages/snippetz/src/plugins/ruby/native/native.ts
+++ b/packages/snippetz/src/plugins/ruby/native/native.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const rubyNative: Plugin = {
   target: 'ruby',
+  targetTitle: 'Ruby',
   client: 'native',
   title: 'net::http',
   generate(request) {

--- a/packages/snippetz/src/plugins/rust/reqwest/reqwest.ts
+++ b/packages/snippetz/src/plugins/rust/reqwest/reqwest.ts
@@ -8,6 +8,7 @@ import { createChain, formatJson, indent, wrapInDoubleQuotes } from '@/libs/rust
  */
 export const rustReqwest: Plugin = {
   target: 'rust',
+  targetTitle: 'Rust',
   client: 'reqwest',
   title: 'reqwest',
   generate(request, options?: { auth?: { username: string; password: string } }) {

--- a/packages/snippetz/src/plugins/shell/curl/curl.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.ts
@@ -7,6 +7,7 @@ import { escapeSingleQuotes } from '@/libs/shell'
  */
 export const shellCurl: Plugin = {
   target: 'shell',
+  targetTitle: 'Shell',
   client: 'curl',
   title: 'Curl',
   generate(request, configuration) {

--- a/packages/snippetz/src/plugins/shell/httpie/httpie.ts
+++ b/packages/snippetz/src/plugins/shell/httpie/httpie.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const shellHttpie: Plugin = {
   target: 'shell',
+  targetTitle: 'Shell',
   client: 'httpie',
   title: 'HTTPie',
   generate(request) {

--- a/packages/snippetz/src/plugins/shell/wget/wget.ts
+++ b/packages/snippetz/src/plugins/shell/wget/wget.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const shellWget: Plugin = {
   target: 'shell',
+  targetTitle: 'Shell',
   client: 'wget',
   title: 'Wget',
   generate(request) {

--- a/packages/snippetz/src/plugins/swift/nsurlsession/nsurlsession.ts
+++ b/packages/snippetz/src/plugins/swift/nsurlsession/nsurlsession.ts
@@ -8,6 +8,7 @@ import { convertWithHttpSnippetLite } from '@/utils/convertWithHttpSnippetLite'
  */
 export const swiftNsurlsession: Plugin = {
   target: 'swift',
+  targetTitle: 'Swift',
   client: 'nsurlsession',
   title: 'NSURLSession',
   generate(request) {

--- a/packages/snippetz/src/snippetz.test.ts
+++ b/packages/snippetz/src/snippetz.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { allPlugins } from './clients'
-import { allPlugins as lazyPlugins } from './clients/lazy'
+import { plugins } from './clients'
+import { plugins as lazyPlugins } from './clients/lazy'
 import { snippetz } from './snippetz'
 
 describe('snippetz', () => {
   it('generates code for undici with all plugins', async () => {
-    const snippet = await snippetz(allPlugins).print('node', 'undici', {
+    const snippet = await snippetz(plugins).print('node', 'undici', {
       url: 'https://example.com',
     })
 
@@ -43,7 +43,7 @@ describe('snippetz', () => {
   })
 
   it('builds clients list from registered plugins', () => {
-    expect(snippetz(allPlugins).clients()).toEqual(
+    expect(snippetz(plugins).clients()).toEqual(
       expect.arrayContaining([
         {
           key: 'node',
@@ -91,7 +91,7 @@ describe('snippetz', () => {
 
 describe('plugins', () => {
   it('returns all registered plugin identifiers', () => {
-    const result = snippetz(allPlugins).plugins()
+    const result = snippetz(plugins).plugins()
 
     expect(result).toEqual(
       expect.arrayContaining([
@@ -114,13 +114,13 @@ describe('plugins', () => {
 
 describe('hasPlugin', () => {
   it('returns true if it has the plugin', () => {
-    const result = snippetz(allPlugins).hasPlugin('node', 'undici')
+    const result = snippetz(plugins).hasPlugin('node', 'undici')
 
     expect(result).toBe(true)
   })
 
   it('returns false if it does not know the plugin', () => {
-    const result = snippetz(allPlugins).hasPlugin('node', 'fantasy')
+    const result = snippetz(plugins).hasPlugin('node', 'fantasy')
 
     expect(result).toBe(false)
   })

--- a/packages/snippetz/src/snippetz.test.ts
+++ b/packages/snippetz/src/snippetz.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
+import { allPlugins } from './clients'
+import { allPlugins as lazyPlugins } from './clients/lazy'
 import { snippetz } from './snippetz'
 
 describe('snippetz', () => {
-  it('returns code for undici', () => {
-    const snippet = snippetz().print('node', 'undici', {
+  it('generates code for undici with all plugins', async () => {
+    const snippet = await snippetz(allPlugins).print('node', 'undici', {
       url: 'https://example.com',
     })
 
@@ -15,8 +17,33 @@ describe('snippetz', () => {
     `)
   })
 
-  it('loads some clients by default', () => {
-    expect(snippetz().clients()).toEqual(
+  it('generates code with a subset of plugins', async () => {
+    const { shellCurl } = await import('./plugins/shell/curl')
+    const { nodeUndici } = await import('./plugins/node/undici')
+
+    const s = snippetz([shellCurl, nodeUndici])
+
+    const snippet = await s.print('shell', 'curl', {
+      url: 'https://example.com',
+    })
+
+    expect(snippet).toContain('curl')
+    expect(snippet).toContain('https://example.com')
+  })
+
+  it('returns undefined for unregistered plugins', async () => {
+    const { shellCurl } = await import('./plugins/shell/curl')
+    const s = snippetz([shellCurl])
+
+    const result = await s.print('node', 'undici', {
+      url: 'https://example.com',
+    })
+
+    expect(result).toBeUndefined()
+  })
+
+  it('builds clients list from registered plugins', () => {
+    expect(snippetz(allPlugins).clients()).toEqual(
       expect.arrayContaining([
         {
           key: 'node',
@@ -50,11 +77,21 @@ describe('snippetz', () => {
       ]),
     )
   })
+
+  it('only shows registered plugins in clients()', async () => {
+    const { shellCurl } = await import('./plugins/shell/curl')
+    const s = snippetz([shellCurl])
+
+    const targets = s.clients()
+    expect(targets).toHaveLength(1)
+    expect(targets[0]?.key).toBe('shell')
+    expect(targets[0]?.clients).toHaveLength(1)
+  })
 })
 
 describe('plugins', () => {
-  it('returns true if it has the plugin', () => {
-    const result = snippetz().plugins()
+  it('returns all registered plugin identifiers', () => {
+    const result = snippetz(allPlugins).plugins()
 
     expect(result).toEqual(
       expect.arrayContaining([
@@ -77,14 +114,36 @@ describe('plugins', () => {
 
 describe('hasPlugin', () => {
   it('returns true if it has the plugin', () => {
-    const result = snippetz().hasPlugin('node', 'undici')
+    const result = snippetz(allPlugins).hasPlugin('node', 'undici')
 
     expect(result).toBe(true)
   })
 
-  it("returns false if it doesn't know the plugin", () => {
-    const result = snippetz().hasPlugin('node', 'fantasy')
+  it('returns false if it does not know the plugin', () => {
+    const result = snippetz(allPlugins).hasPlugin('node', 'fantasy')
 
     expect(result).toBe(false)
+  })
+})
+
+describe('lazy plugins', () => {
+  it('generates code on demand via lazy plugins', async () => {
+    const s = snippetz(lazyPlugins)
+
+    const snippet = await s.print('shell', 'curl', {
+      url: 'https://example.com',
+    })
+
+    expect(snippet).toContain('curl')
+    expect(snippet).toContain('https://example.com')
+  })
+
+  it('provides clients metadata immediately', () => {
+    const s = snippetz(lazyPlugins)
+    const targets = s.clients()
+
+    expect(targets.length).toBeGreaterThan(0)
+    expect(targets.find((t) => t.key === 'shell')).toBeDefined()
+    expect(targets.find((t) => t.key === 'node')).toBeDefined()
   })
 })

--- a/packages/snippetz/src/snippetz.ts
+++ b/packages/snippetz/src/snippetz.ts
@@ -11,8 +11,8 @@ export type Snippetz = ReturnType<typeof snippetz>
  *
  * Consumers control what gets bundled by choosing which plugins to pass in:
  * - A hand-picked subset for minimal bundles
- * - `allPlugins` from `@scalar/snippetz/clients` for everything upfront
- * - `allPlugins` from `@scalar/snippetz/clients/lazy` for metadata-only with on-demand loading
+ * - `plugins` from `@scalar/snippetz/clients` for everything upfront
+ * - `plugins` from `@scalar/snippetz/clients/lazy` for metadata-only with on-demand loading
  */
 export function snippetz(plugins: Plugin[]) {
   function findPlugin<T extends TargetId>(target: T | string, client: ClientId<T> | string): Plugin | undefined {

--- a/packages/snippetz/src/snippetz.ts
+++ b/packages/snippetz/src/snippetz.ts
@@ -1,32 +1,87 @@
-import type { ClientId, HarRequest, TargetId } from '@scalar/types/snippetz'
-
-import { clients } from '@/clients'
+import type { ClientId, HarRequest, Plugin, PluginConfiguration, Target, TargetId } from '@scalar/types/snippetz'
 
 /**
- * Generate code examples for HAR requests
+ * The return type of the snippetz() factory function.
+ * Useful for passing a configured instance around without coupling to the plugin list.
  */
-export function snippetz() {
-  function findPlugin<T extends TargetId>(target: T | string, client: ClientId<T> | string) {
-    return clients.find(({ key }) => key === target)?.clients.find((plugin) => plugin.client === client)
+export type Snippetz = ReturnType<typeof snippetz>
+
+/**
+ * Create a code snippet generator from the given set of plugins.
+ *
+ * Consumers control what gets bundled by choosing which plugins to pass in:
+ * - A hand-picked subset for minimal bundles
+ * - `allPlugins` from `@scalar/snippetz/clients` for everything upfront
+ * - `allPlugins` from `@scalar/snippetz/clients/lazy` for metadata-only with on-demand loading
+ */
+export function snippetz(plugins: Plugin[]) {
+  function findPlugin<T extends TargetId>(target: T | string, client: ClientId<T> | string): Plugin | undefined {
+    return plugins.find((p) => p.target === target && p.client === client)
   }
 
   return {
-    print<T extends TargetId>(target: T, client: ClientId<T>, request: Partial<HarRequest>) {
-      return findPlugin(target, client)?.generate(request)
+    /**
+     * Generate a code snippet for the given target/client pair.
+     * Returns a Promise because lazy plugins load their generator on demand.
+     */
+    async print<T extends TargetId>(
+      target: T,
+      client: ClientId<T>,
+      request: Partial<HarRequest>,
+      configuration?: PluginConfiguration,
+    ): Promise<string | undefined> {
+      const plugin = findPlugin(target, client)
+      if (!plugin) {
+        return undefined
+      }
+      return await plugin.generate(request, configuration)
     },
-    clients() {
-      return clients
+
+    /**
+     * Build the grouped Target[] list dynamically from the registered plugins.
+     * The first plugin registered for each target becomes the default client.
+     */
+    clients(): Target[] {
+      const targetMap = new Map<
+        string,
+        { key: TargetId; title: string; defaultClient: ClientId<TargetId>; clients: Plugin[] }
+      >()
+
+      for (const plugin of plugins) {
+        const existing = targetMap.get(plugin.target)
+        if (existing) {
+          existing.clients.push(plugin)
+        } else {
+          targetMap.set(plugin.target, {
+            key: plugin.target,
+            title: plugin.targetTitle,
+            defaultClient: plugin.client,
+            clients: [plugin],
+          })
+        }
+      }
+
+      return Array.from(targetMap.values()).map(({ key, title, defaultClient, clients }) => ({
+        key,
+        title,
+        default: defaultClient,
+        clients,
+      })) as Target[]
     },
-    plugins() {
-      return clients.flatMap(({ key, clients }) =>
-        clients.map((plugin) => ({
-          target: key,
-          client: plugin.client,
-        })),
-      )
+
+    /**
+     * Returns a flat list of all registered plugin identifiers.
+     */
+    plugins(): Array<{ target: TargetId; client: ClientId<TargetId> }> {
+      return plugins.map((p) => ({
+        target: p.target,
+        client: p.client,
+      }))
     },
+
     findPlugin,
-    hasPlugin<T extends TargetId>(target: T | string, client: ClientId<T> | string) {
+
+    hasPlugin<T extends TargetId>(target: T | string, client: ClientId<T> | string): boolean {
       return Boolean(findPlugin(target, client))
     },
   }

--- a/packages/types/src/snippetz/snippetz.ts
+++ b/packages/types/src/snippetz/snippetz.ts
@@ -107,12 +107,14 @@ export type Target = {
 export type Plugin = {
   /** The language or environment this plugin targets. */
   target: TargetId
+  /** Human-readable name for the target (e.g. "Node.js", "Shell"). */
+  targetTitle: string
   /** The identifier of the HTTP client within the target. */
   client: ClientId<TargetId>
   /** Human-readable name for the client. */
   title: string
-  /** Generates source code for the given HTTP request. */
-  generate: (request?: Partial<HarRequest>, configuration?: PluginConfiguration) => string
+  /** Generates source code for the given HTTP request. May be async for lazy-loaded plugins. */
+  generate: (request?: Partial<HarRequest>, configuration?: PluginConfiguration) => string | Promise<string>
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2503,9 +2503,15 @@ importers:
       '@types/stringify-object':
         specifier: ^4.0.5
         version: 4.0.5
+      '@vitejs/plugin-vue':
+        specifier: catalog:*
+        version: 6.0.3(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue@3.5.26(typescript@5.9.3))
       vite:
         specifier: catalog:*
         version: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
+      vue:
+        specifier: catalog:*
+        version: 3.5.26(typescript@5.9.3)
 
   packages/themes:
     dependencies:
@@ -17132,6 +17138,36 @@ packages:
   tsyringe@4.10.0:
     resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
     engines: {node: '>= 6.0.0'}
+
+  turbo-darwin-64@2.8.11:
+    resolution: {integrity: sha512-XKaCWaz4OCt77oYYvGCIRpvYD4c/aNaKjRkUpv+e8rN3RZb+5Xsyew4yRO+gaHdMIUhQznXNXfHlhs+/p7lIhA==}
+    cpu: [x64]
+    os: [darwin]
+
+  turbo-darwin-arm64@2.8.11:
+    resolution: {integrity: sha512-VvynLHGUNvQ9k7GZjRPSsRcK4VkioTfFb7O7liAk4nHKjEcMdls7GqxzjVWgJiKz3hWmQGaP9hRa9UUnhVWCxA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  turbo-linux-64@2.8.11:
+    resolution: {integrity: sha512-cbSn37dcm+EmkQ7DD0euy7xV7o2el4GAOr1XujvkAyKjjNvQ+6QIUeDgQcwAx3D17zPpDvfDMJY2dLQadWnkmQ==}
+    cpu: [x64]
+    os: [linux]
+
+  turbo-linux-arm64@2.8.11:
+    resolution: {integrity: sha512-+trymp2s2aBrhS04l6qFxcExzZ8ffndevuUB9c5RCeqsVpZeiWuGQlWNm5XjOmzoMayxRARZ5ma7yiWbGMiLqQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  turbo-windows-64@2.8.11:
+    resolution: {integrity: sha512-3kJjFSM4yw1n9Uzmi+XkAUgCae19l/bH6RJ442xo7mnZm0tpOjo33F+FYHoSVpIWVMd0HG0LDccyafPSdylQbA==}
+    cpu: [x64]
+    os: [win32]
+
+  turbo-windows-arm64@2.8.11:
+    resolution: {integrity: sha512-JOM4uF2vuLsJUvibdR6X9QqdZr6BhC6Nhlrw4LKFPsXZZI/9HHLoqAiYRpE4MuzIwldCH/jVySnWXrI1SKto0g==}
+    cpu: [arm64]
+    os: [win32]
 
   turbo@2.8.11:
     resolution: {integrity: sha512-H+rwSHHPLoyPOSoHdmI1zY0zy0GGj1Dmr7SeJW+nZiWLz2nex8EJ+fkdVabxXFMNEux+aywI4Sae8EqhmnOv4A==}
@@ -36136,7 +36172,32 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  turbo@2.8.11: {}
+  turbo-darwin-64@2.8.11:
+    optional: true
+
+  turbo-darwin-arm64@2.8.11:
+    optional: true
+
+  turbo-linux-64@2.8.11:
+    optional: true
+
+  turbo-linux-arm64@2.8.11:
+    optional: true
+
+  turbo-windows-64@2.8.11:
+    optional: true
+
+  turbo-windows-arm64@2.8.11:
+    optional: true
+
+  turbo@2.8.11:
+    optionalDependencies:
+      turbo-darwin-64: 2.8.11
+      turbo-darwin-arm64: 2.8.11
+      turbo-linux-64: 2.8.11
+      turbo-linux-arm64: 2.8.11
+      turbo-windows-64: 2.8.11
+      turbo-windows-arm64: 2.8.11
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## Problem

The whole `@scalar/snippetz` package has 440 kb, though for our use case we only need a single plugin until the users selects another plugin, and probably no one ever needs all plugins loaded.

## Solution

This PR refactors the library to allow lazy loading plugins:

https://github.com/user-attachments/assets/5c8aacca-04b1-42f1-aa69-41b681dcabff

Unfortunately, the main distribution way for `@scalar/api-reference` is to just bundle everything together, so we won't see an immediate benefit. We'd need to switch to an ESM CDN as the main distribution (I’ll try that again asap).

I made this a major release, and I think I’ll add a bit more to the PR for the v1. So just a draft for now.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
