### PR TITLE
docs: update mcp page

### DIFF
--- a/documentation/guides/agent/mcp.md
+++ b/documentation/guides/agent/mcp.md
@@ -1,39 +1,65 @@
-# MCP
+# MCP Servers
 
-Scalar lets you build an MCP (Model Context Protocol) server from your OpenAPI document. You choose which endpoints to expose, configure how each one behaves, and connect it to any compatible AI client.
+Spin up MCP Servers ([Model Context Protocol](https://modelcontextprotocol.io/)) from your OpenAPI documents with Scalar.
 
-## Using an MCP
+You choose which endpoints to expose (and which not), configure how each one behaves, and connect it to your LLM or AI Agent (Claude, Cursor, etc.).
 
-To connect an MCP to an AI client:
+## Create a MCP Server
 
-1. Create an MCP in the [Scalar dashboard](https://dashboard.scalar.com)
-2. Configure your tools — add the endpoints you want to expose
-3. Create an installation and an API key
-4. Copy the installation URL and API key and add them to your MCP client
+Create a new MCP Server for your API in under a minute (I promise):
 
-The exact steps for adding an MCP server depend on your client — refer to its documentation for details.
+1. Open the [Scalar Dashboard](https://dashboard.scalar.com) and go to *MCP*.
+2. Create an MCP Server.
+3. Configure your tools, select your API and decide which endpoints to expose.
+4. Create an installation.
+5. Authenticate with your API.
+6. Write the installation URL on a napkin, you'll need it sooner or later.
+
+Your MCP Server is ready to be used.
+
+## Connect to your MCP Server
+
+1. Create a personal access token under [Account > API Keys](https://dashboard.scalar.com/account).
+2. Got the MCP Server installation URL (see above)? That's good.
+3. Pass the installation URL and Personal Access Token to your LLM.
+
+The exact steps for adding an MCP server depend on your client, refer to its documentation for details. Here's how you would do that with Claude:
+
+### Claude Code
+
+For Claude Code, you can run the following command in your terminal to add and test the MCP:
+
+```bash
+claude mcp add \
+  YOUR_MCP_SERVER_NAME \
+  https://api.scalar.com/vector/mcp/YOUR_MCP_SERVER_ID \
+  --header "Authorization: YOUR_PERSONAL_ACCESS_TOKEN" \
+  --transport http
+```
 
 ## Tools
 
-Tools are the individual capabilities your MCP exposes. Each tool maps to an operation (endpoint) in your OpenAPI document.
+Tools are the individual capabilities your MCP exposes. Each tool maps to an operation (endpoint) in your OpenAPI document. To configure your tools:
 
-To configure your tools, go to your API doc page under Registry in the Scalar dashboard, scroll to **Agent Settings**, and click **Configure Tools**. From there you can add or remove endpoints and configure how each one behaves:
-
-<br>
-
-![](./configure-mcp-tools.png)
+1. Open the [Scalar Dashboard](https://dashboard.scalar.com) and go to *Registry*
+2. Select your API
+3. Scroll to MCP, and click on "Configure Tools"
 
 <br>
 
-| Mode | Description |
-| ---- | ----------- |
-| Search | Exposes the endpoint for lookup only — no real API calls are made |
-| Execute | Makes real, authenticated requests to your API |
+![UI to enable/disable endpoints for your MCP server](./configure-mcp-tools.png)
+
+<br>
+
+| Mode    | Description                                                            |
+| ------- | ---------------------------------------------------------------------- |
+| Search  | Exposes the endpoint for lookup only (no requests are sent to your AP) |
+| Execute | Makes real, authenticated requests to your API                         |
 
 ## API Authentication
 
-Authentication is configured per installation in the Scalar dashboard. This lets your MCP make authenticated requests to your API without exposing credentials to the client.
+Authentication is configured per installation in the [Scalar Dashboard](https://dashboard.scalar.com). This lets your MCP Server make authenticated requests to your API without exposing credentials to the client.
 
 <br>
 
-![](./configure-authentication.png)
+![UI to configure authentication for your API](./configure-authentication.png)

--- a/documentation/guides/agent/sdk.md
+++ b/documentation/guides/agent/sdk.md
@@ -22,7 +22,7 @@ bun i @scalar/agent
 
 ### Personal Access Token
 
-You can create a personal access token in the [Scalar dashboard](https://dashboard.scalar.com/account) under **Account > API Keys**.
+You can create a personal access token in the [Dashboard](https://dashboard.scalar.com/account) under **Account > API Keys**.
 
 ### Setup
 

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -21,8 +21,9 @@
 To first access the Registry you need to [create an account](https://dashboard.scalar.com/register) or [sign in](https://dashboard.scalar.com/login).
 
 Once authenticated you will see your dashboard, you have two options to interface with the Registry:
-- [Scalar dashboard](https://dashboard.scalar.com)
-- [Scalar CLI](cli.md)
+
+- [Dashboard](https://dashboard.scalar.com)
+- [CLI](cli.md)
 - [GitHub Actions](github-actions.md)
 
 <div class="mt-6">

--- a/documentation/guides/sso/getting-started.md
+++ b/documentation/guides/sso/getting-started.md
@@ -46,7 +46,7 @@ After creating the application, assign the users and groups that should have acc
 
 Before configuring SAML settings in your IdP, create a new SSO connection in Scalar:
 
-1. Navigate to [Team > Security](https://dashboard.scalar.com/team/security) in your Scalar dashboard
+1. Navigate to [Team > Security](https://dashboard.scalar.com/team/security) in your Scalar Dashboard
 2. Under **Advanced Security**, enable **Single Sign-On**
 3. Click **Setup Connection** to create a new SSO connection
 


### PR DESCRIPTION
tested mcp servers, updated the docs page a bit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only edits (wording, formatting, and updated setup steps) with no product or runtime code changes.
> 
> **Overview**
> Updates the `MCP Servers` guide to reflect the current Scalar workflow, including a clearer step-by-step for creating an MCP server/installation, using a Personal Access Token, and a concrete `claude mcp add` example command.
> 
> Also tweaks related docs for consistency/clarity (e.g., “Scalar Dashboard” wording, “Dashboard” link text) and fixes minor formatting in the Registry getting-started page’s interface options list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93f441935b90fe0296e9290d251d5306fce4648c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->