### PR TITLE
docs: header link active style

### DIFF
--- a/documentation/assets/styles.css
+++ b/documentation/assets/styles.css
@@ -13,7 +13,6 @@
   font-size: var(--scalar-small);
   font-weight: normal;
   line-height: 18px;
-  color: var(--scalar-header-color-2, var(--scalar-color-2));
   height: auto;
 }
 


### PR DESCRIPTION
removes some CSS so we see the active state in the header link on scalar.com

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CSS removal limited to documentation header link styling; low chance of broader regressions beyond minor visual changes.
> 
> **Overview**
> Removes the default text `color` assignment for `.t-header .link`/`.t-header .group__label` in `documentation/assets/styles.css`, allowing other styles (e.g., active-state styling) to show through instead of being overridden.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c4e4efa02b8a9f78fa5a519380c4465bc686bb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->