### PR TITLE
test(api-reference): verify built css does not contain deep selectors

### DIFF
--- a/packages/api-reference/src/dist.test.ts
+++ b/packages/api-reference/src/dist.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import builtCss from '../dist/style.css?raw'
+
+describe('dist', () => {
+  it('does not include Vue deep selectors in built css', () => {
+    expect(builtCss).not.toContain(':deep')
+  })
+})


### PR DESCRIPTION
## Problem

`@scalar/api-reference` uses Vue `:deep(...)` selectors in source styles, but those selectors should not survive in the built CSS output. If `:deep` leaks into the published stylesheet, Bun can crash as described in #8044.

## Solution

- add a regression test for the built `@scalar/api-reference` stylesheet
- verify the generated CSS does not contain `:deep`

## Validation

- `pnpm --filter @scalar/build-tooling build`
- `pnpm --filter @scalar/themes build`
- `pnpm --filter @scalar/api-reference build:default`
- `pnpm exec biome check --diagnostic-level=error packages/api-reference/src/dist.test.ts`
- `pnpm exec vitest run packages/api-reference/src/dist.test.ts`

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

Fixes #8044
