### PR TITLE
Bundler $ref name resolution

### DIFF
--- a/packages/workspace-store/src/plugins/bundler/index.ts
+++ b/packages/workspace-store/src/plugins/bundler/index.ts
@@ -324,14 +324,16 @@ export const syncPathParameters = (): LifecyclePlugin => {
         const pathItemParameters = 'parameters' in node && Array.isArray(node.parameters) ? node.parameters : []
 
         const pathItemPathParameters = pathItemParameters.filter((param): param is MinimalParameterObject => {
-          if (!isPathParameterNode(param)) {
+          const resolved = getResolvedRef(param, context)
+
+          if (!isPathParameterNode(resolved)) {
             return false
           }
 
-          const result = !existingPathParameters.has(param.name)
+          const result = !existingPathParameters.has(resolved.name)
 
           if (result) {
-            existingPathParameters.add(param.name)
+            existingPathParameters.add(resolved.name)
           }
 
           return result


### PR DESCRIPTION
## Problem

The deduplication logic for OpenAPI path parameters incorrectly used the `name` property of unresolved `$ref` objects, which is `undefined`. This led to `$ref` parameters not being properly matched or being incorrectly filtered out, resulting in the loss of their original `$ref` structure and replacement with generic placeholders.

## Solution

The parameter object is now resolved using `getResolvedRef` before its `name` property is accessed for deduplication. This ensures that the correct, resolved parameter name is used, allowing `$ref` parameters to be accurately deduplicated and preserved.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches OpenAPI parameter syncing/deduplication logic; small change but can alter bundled specs for APIs using `$ref` parameters, so regressions would show up as missing/changed parameter definitions.
> 
> **Overview**
> Fixes `syncPathParameters` so path-item `parameters` that are `$ref`s are resolved via `getResolvedRef` before reading `name` during deduplication.
> 
> This prevents referenced path parameters from being treated as `undefined`/distinct and avoids them being dropped and replaced with generic `{ name, in: 'path' }` placeholders when syncing path params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bff51dded7d7c740f7f8acad74fe2cade3174474. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->