### PR TITLE
docs: fix invalid schema url

### DIFF
--- a/documentation/guides/docs/configuration/domains.md
+++ b/documentation/guides/docs/configuration/domains.md
@@ -26,7 +26,7 @@ The `customDomain` property allows you to use your own domain name. This feature
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "customDomain": "docs.example.com"

--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -32,7 +32,7 @@ The `navigation.header` array defines links that appear in the top navigation ba
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "navigation": {
     "header": [
@@ -87,7 +87,7 @@ The `navigation.sidebar` array defines links that appear at the bottom of the si
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "navigation": {
     "sidebar": [
@@ -123,7 +123,7 @@ The `navigation.tabs` array defines tabs that appear in the navigation area. Tab
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "navigation": {
     "tabs": [

--- a/documentation/guides/docs/configuration/site-config.md
+++ b/documentation/guides/docs/configuration/site-config.md
@@ -27,7 +27,7 @@ The `logo` property defines your site's logo displayed in the navigation. You ca
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "logo": "https://example.com/logo.svg"
@@ -42,7 +42,7 @@ For better visibility across themes, provide different logos for light and dark 
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "logo": {
@@ -68,7 +68,7 @@ The `theme` property sets a platform-defined theme for your documentation site.
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "theme": "purple"
@@ -89,7 +89,7 @@ The `layout` property controls global layout options that apply to all pages unl
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "layout": {
@@ -116,7 +116,7 @@ The `head` property allows you to inject custom elements into the HTML `<head>` 
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "head": {
@@ -257,7 +257,7 @@ The `footer` property allows you to add a custom footer to your documentation si
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "footer": {
@@ -286,7 +286,7 @@ Set up redirects to handle URL changes or aliases:
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "routing": {

--- a/documentation/guides/docs/content/assets.md
+++ b/documentation/guides/docs/content/assets.md
@@ -63,7 +63,7 @@ Assets can also be referenced in the `siteConfig.head` configuration for scripts
 
 ```json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "assetsDir": "docs/assets",
   "siteConfig": {
@@ -99,7 +99,7 @@ Here's a complete example showing how to configure assets and use them throughou
 
 ```json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "assetsDir": "docs/assets",
   "siteConfig": {

--- a/documentation/guides/docs/content/html-css-js.md
+++ b/documentation/guides/docs/content/html-css-js.md
@@ -184,7 +184,7 @@ The `scripts` array allows you to include custom JavaScript files in your docume
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "head": {
@@ -221,7 +221,7 @@ The `styles` array allows you to include custom CSS files to customize the appea
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "head": {
@@ -251,7 +251,7 @@ The `meta` array allows you to add meta tags for SEO, social sharing (Open Graph
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "head": {
@@ -350,7 +350,7 @@ The `links` array allows you to add link elements to the `<head>`, commonly used
 ```json
 // scalar.config.json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "head": {

--- a/documentation/migration/stoplight.md
+++ b/documentation/migration/stoplight.md
@@ -152,7 +152,7 @@ Copy and paste that chunk of JSON out of there, and make the following changes.
 
 ```json
 {
-  "$schema": "https://registry.scalar.com/@scalar/schemas/config
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
   "scalar": "2.0.0",
   "siteConfig": {
     "subdomain": "name-of-your-api"


### PR DESCRIPTION
oops

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that correct example JSON; no runtime or behavior impact.
> 
> **Overview**
> Fixes multiple documentation JSON snippets that had an invalid `$schema` value by adding the missing closing quote/comma to `https://registry.scalar.com/@scalar/schemas/config` (across configuration guides, content docs, and the Stoplight migration guide).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1a5cb8032069aad8628b496d913efa908069f5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->