### PR TITLE
docs: scalar docs api reference config

### DIFF
--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -288,6 +288,36 @@ Fetch an OpenAPI document from a remote URL. The document is fetched on each pag
 - `flat` Shows a single level of links with a section title
 - `nested` Shows a sub-sidebar with breadcrumbs for deep navigation
 
+### API Reference configuration
+
+When you add an OpenAPI route (`type: "openapi"`) in your navigation, you can pass API Reference options by adding a `config` object. The same options supported by the [API Reference configuration](../../../configuration.md) (e.g. `authentication`, `theme`) can be used here.
+
+Example:
+
+```json
+// scalar.config.json
+"/api": {
+  "type": "openapi",
+  "title": "My API",
+  "url": "https://example.com/openapi.json",
+  "mode": "nested",
+  "config": {
+    "authentication": {
+      "preferredSecurityScheme": "httpBasic",
+      "securitySchemes": {
+        "httpBasic": {
+          "type": "http",
+          "scheme": "basic",
+          "username": "my-username"
+        }
+      }
+    }
+  }
+}
+```
+
+For all available options, see [Configuration](../../../configuration.md).
+
 ## Groups
 
 Groups allow you to organize related pages, API references, and links into collapsible sections in your navigation. They can be nested to create multi-level hierarchies.


### PR DESCRIPTION
shows how to add api reference config to the scalar.config.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime behavior or configuration schema changes.
> 
> **Overview**
> Updates the navigation configuration docs to explain that `openapi` routes can include a `config` object to pass through API Reference options (e.g. `authentication`, `theme`).
> 
> Adds an example `scalar.config.json` snippet showing per-route API Reference configuration and links readers to the main Configuration docs for the full option set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8cd895a61e7139be9009cee5f808fdf682d9195. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->