### PR TITLE
fix(api-reference): render direct download as source anchor link

### DIFF
--- a/.changeset/funny-coats-share.md
+++ b/.changeset/funny-coats-share.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: render `documentDownloadType: "direct"` as a direct anchor link to the source URL

--- a/packages/api-reference/src/blocks/scalar-info-block/components/DownloadLink.test.ts
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/DownloadLink.test.ts
@@ -40,6 +40,7 @@ describe('DownloadLink', () => {
       props: {
         eventBus: mockEventBus,
         documentDownloadType: config.value.documentDownloadType,
+        documentDownloadUrl: 'https://example.com/openapi.json',
         ...props,
       },
     })
@@ -144,6 +145,30 @@ describe('DownloadLink', () => {
       // Click YAML button
       await buttons[1]?.trigger('click')
       expect(mockEventBus.emit).toHaveBeenCalledWith('ui:download:document', { format: 'yaml' })
+    })
+  })
+
+  describe('Direct download type', () => {
+    it('renders direct link when documentDownloadType is direct', () => {
+      const wrapper = createWrapper({ documentDownloadType: 'direct' })
+
+      const link = wrapper.find('a.download-button')
+      expect(link.exists()).toBe(true)
+      expect(link.attributes('href')).toBe('https://example.com/openapi.json')
+      expect(link.attributes('target')).toBe('_blank')
+    })
+
+    it('does not emit download event when documentDownloadType is direct', async () => {
+      const wrapper = createWrapper({ documentDownloadType: 'direct' })
+
+      await wrapper.find('a.download-button').trigger('click')
+      expect(mockEventBus.emit).not.toHaveBeenCalled()
+    })
+
+    it('does not render container for direct mode when url is missing', () => {
+      const wrapper = createWrapper({ documentDownloadType: 'direct' }, { documentDownloadUrl: undefined })
+
+      expect(wrapper.find('.download-container').exists()).toBe(false)
     })
   })
 

--- a/packages/api-reference/src/blocks/scalar-info-block/components/DownloadLink.vue
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/DownloadLink.vue
@@ -4,11 +4,13 @@ import { type WorkspaceEventBus } from '@scalar/workspace-store/events'
 
 import Badge from '@/components/Badge/Badge.vue'
 
-const { eventBus, documentDownloadType } = defineProps<{
+const { eventBus, documentDownloadType, documentDownloadUrl } = defineProps<{
   /** The document download type. */
   documentDownloadType: ApiReferenceConfiguration['documentDownloadType']
   /** The event bus for the handling all events. */
   eventBus: WorkspaceEventBus
+  /** Source URL used for direct download link mode. */
+  documentDownloadUrl?: string
 }>()
 
 // The id is retrieved at the layout level.
@@ -18,26 +20,31 @@ const handleDownloadClick = (format: 'json' | 'yaml' | 'direct') => {
 </script>
 <template>
   <div
-    v-if="['yaml', 'json', 'both', 'direct'].includes(documentDownloadType)"
+    v-if="
+      ['yaml', 'json', 'both'].includes(documentDownloadType) ||
+      (documentDownloadType === 'direct' && !!documentDownloadUrl)
+    "
     class="download-container group"
     :class="{
       'download-both': documentDownloadType === 'both',
     }">
+    <!-- Direct URL -->
+    <a
+      v-if="documentDownloadType === 'direct' && documentDownloadUrl"
+      class="download-button"
+      :href="documentDownloadUrl"
+      rel="noopener noreferrer"
+      target="_blank">
+      <span> Download OpenAPI Document </span>
+      <Badge class="extension hidden group-hover:flex">json</Badge>
+    </a>
+
     <!-- JSON  -->
     <button
-      v-if="
-        documentDownloadType === 'json' ||
-        documentDownloadType === 'both' ||
-        documentDownloadType === 'direct'
-      "
+      v-if="documentDownloadType === 'json' || documentDownloadType === 'both'"
       class="download-button"
       type="button"
-      @click.prevent="
-        () =>
-          handleDownloadClick(
-            documentDownloadType === 'direct' ? 'direct' : 'json',
-          )
-      ">
+      @click.prevent="() => handleDownloadClick('json')">
       <span> Download OpenAPI Document </span>
       <Badge class="extension hidden group-hover:flex">json</Badge>
     </button>

--- a/packages/api-reference/src/blocks/scalar-info-block/components/InfoBlock.vue
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/InfoBlock.vue
@@ -18,6 +18,7 @@ const {
   layout,
   eventBus,
   documentDownloadType = 'both',
+  documentDownloadUrl,
 } = defineProps<{
   /** Optional unique identifier for the info block. */
   id?: string
@@ -39,6 +40,8 @@ const {
   layout?: 'modern' | 'classic'
   /** The document download type. */
   documentDownloadType?: ApiReferenceConfiguration['documentDownloadType']
+  /** The source URL used when documentDownloadType is `direct`. */
+  documentDownloadUrl?: string
 }>()
 
 /**
@@ -69,6 +72,7 @@ const introCardsSlot = computed(() =>
     <template #download-link>
       <DownloadLink
         :documentDownloadType
+        :documentDownloadUrl
         :eventBus />
     </template>
   </IntroductionLayout>

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -105,6 +105,7 @@ const securitySchemes = computed(() =>
       <InfoBlock
         :id="infoSectionId"
         :documentDownloadType="options.documentDownloadType"
+        :documentDownloadUrl="document?.['x-scalar-original-source-url']"
         :documentExtensions
         :eventBus
         :externalDocs="document?.externalDocs"


### PR DESCRIPTION
## Problem

`documentDownloadType: 'direct'` currently renders the same button flow as JSON download, which triggers an event that fetches and downloads the spec. This does not match the documented behavior for `direct`, which says it should render a regular link to the configured source URL.

Fixes #8378.

## Solution

- Pass the document source URL (`x-scalar-original-source-url`) into the info block download component.
- Render an `<a href="..." target="_blank">` for `documentDownloadType: 'direct'` instead of a `<button>`.
- Keep existing button behavior for `json`, `yaml`, and `both`.
- Add tests covering direct-link rendering, no event emission for direct mode, and hidden state when no direct URL is available.
- Add a changeset for `@scalar/api-reference`.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

## Validation

- `pnpm exec eslint --no-warn-ignored packages/api-reference/src/blocks/scalar-info-block/components/DownloadLink.vue packages/api-reference/src/blocks/scalar-info-block/components/InfoBlock.vue packages/api-reference/src/components/Content/Content.vue`
- Attempted: `pnpm vitest run packages/api-reference/src/blocks/scalar-info-block/components/DownloadLink.test.ts packages/api-reference/src/blocks/scalar-info-block/components/InfoBlock.test.ts` (blocked in this environment by unresolved `@scalar/build-tooling` project config resolution during Vitest multi-project startup).
