### PR TITLE
fix(api-client): encode path params in snippet HAR URLs

### DIFF
--- a/.changeset/small-hornets-turn.md
+++ b/.changeset/small-hornets-turn.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+fix code snippet HAR request URL generation to URL-encode substituted path parameter values, matching request sending behavior.

--- a/packages/api-client/src/views/Components/CodeSnippet/helpers/get-har-request.test.ts
+++ b/packages/api-client/src/views/Components/CodeSnippet/helpers/get-har-request.test.ts
@@ -157,4 +157,32 @@ describe('getHarRequest', () => {
     const result = getHarRequest({ operation, server, example, environment })
     expect(result.url).toBe('https://api.prod.com/v2/users/42')
   })
+
+  it('encodes path parameter values in snippet URL generation', () => {
+    const operation = operationSchema.parse({
+      method: 'get',
+      path: '/files/{{filePath}}',
+    })
+    const server = serverSchema.parse({
+      url: 'https://api.example.com/{version}',
+      variables: {
+        version: { default: 'v1' },
+      },
+    })
+    const example = requestExampleSchema.parse({
+      parameters: {
+        path: [
+          { key: 'filePath', value: 'folder/sub folder.txt', enabled: true },
+          { key: 'version', value: 'v2/beta', enabled: true },
+        ],
+        headers: [],
+        cookies: [],
+        query: [],
+      },
+    })
+
+    const result = getHarRequest({ operation, server, example })
+
+    expect(result.url).toBe('https://api.example.com/v2%2Fbeta/files/folder%2Fsub%20folder.txt')
+  })
 })

--- a/packages/api-client/src/views/Components/CodeSnippet/helpers/get-har-request.ts
+++ b/packages/api-client/src/views/Components/CodeSnippet/helpers/get-har-request.ts
@@ -34,13 +34,20 @@ export const getHarRequest = ({
       ? Object.fromEntries(environment.map((v: any) => [v.key, v.value]))
       : environment || {}
 
+  const encodedPathVars = (example?.parameters?.path ?? []).reduce<Record<string, string>>((vars, param) => {
+    if (param.enabled) {
+      const substitutedValue = replaceTemplateVariables(param.value, env)
+      vars[param.key] = encodeURIComponent(substitutedValue)
+    }
+    return vars
+  }, {})
+
   const serverString = (() => {
     if (server?.url && (REGEX.VARIABLES.test(server.url) || REGEX.PATH.test(server.url))) {
       const serverParams = Object.entries(server?.variables || {}).reduce<Record<string, string>>(
         (acc, [key, variable]) => {
-          const pathParamValue = example?.parameters?.path.find((p) => p.enabled && p.key === key)?.value
-          if (pathParamValue) {
-            acc[key] = replaceTemplateVariables(pathParamValue, env)
+          if (encodedPathVars[key]) {
+            acc[key] = encodedPathVars[key]
           } else if (variable.default) {
             acc[key] = replaceTemplateVariables(variable.default, env)
           }
@@ -56,13 +63,7 @@ export const getHarRequest = ({
   const pathString = (() => {
     const path = operation?.path ?? '/'
     if (path && (REGEX.VARIABLES.test(path) || REGEX.PATH.test(path))) {
-      const pathVars = (example?.parameters?.path ?? []).reduce<Record<string, string>>((vars, param) => {
-        if (param.enabled) {
-          vars[param.key] = replaceTemplateVariables(param.value, env)
-        }
-        return vars
-      }, {})
-      return replaceTemplateVariables(replaceTemplateVariables(path, env), pathVars)
+      return replaceTemplateVariables(replaceTemplateVariables(path, env), encodedPathVars)
     }
     return path
   })()


### PR DESCRIPTION
## Problem

`getHarRequest` was substituting path parameters into snippet URLs without URL-encoding them, while request sending already URL-encodes path parameter values. This causes mismatch for wildcard-like path values (for example values containing `/`) between the request URL in the client and generated code snippets.

Fixes #8373.

## Solution

- Build a shared `encodedPathVars` map in `getHarRequest` by substituting env vars and then applying `encodeURIComponent` to enabled path parameters.
- Reuse `encodedPathVars` for both operation path replacement and server variable replacement to match request-building behavior.
- Add a focused test covering encoded substitution in both `{version}` server variables and `{{filePath}}` operation path variables.
- Add a changeset for `@scalar/api-client`.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

## Validation

- `pnpm exec eslint --no-warn-ignored packages/api-client/src/views/Components/CodeSnippet/helpers/get-har-request.ts packages/api-client/src/views/Components/CodeSnippet/helpers/get-har-request.test.ts`
- `pnpm test packages/api-client/src/views/Components/CodeSnippet/helpers/get-har-request.test.ts`
