### PR TITLE
fix(api-client): send raw binary file bodies

### DIFF
--- a/.changeset/fuzzy-poets-pretend.md
+++ b/.changeset/fuzzy-poets-pretend.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix raw binary request bodies so uploaded files are sent correctly and code samples show file references.

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/build-request-body.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/build-request-body.test.ts
@@ -187,6 +187,25 @@ describe('buildRequestBody', () => {
     expect(formData.get('description')).toStrictEqual('Test file')
   })
 
+  it('returns File bodies for raw binary request examples', () => {
+    const mockFile = new File(['binary content'], 'payload.bin', { type: 'application/octet-stream' })
+    const requestBody = {
+      content: {
+        'application/octet-stream': {
+          examples: {
+            default: {
+              value: mockFile,
+            },
+          },
+        },
+      },
+    }
+
+    const result = buildRequestBody(requestBody, {}, 'default')
+
+    expect(result).toStrictEqual(mockFile)
+  })
+
   it('skips form entries with empty names and replaces environment variables in field names', () => {
     const requestBody = {
       content: {

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/build-request-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/build-request-body.ts
@@ -87,11 +87,18 @@ export const buildRequestBody = (
     return form
   }
 
+  const exampleValue =
+    example.value !== null && typeof example.value === 'object' ? unpackProxyObject(example.value) : example.value
+
+  if (exampleValue instanceof File) {
+    return exampleValue
+  }
+
   // Ensure we stringify the example value if it is an object
-  if (typeof example.value === 'object') {
-    return replaceEnvVariables(JSON.stringify(example.value), env)
+  if (typeof exampleValue === 'object') {
+    return replaceEnvVariables(JSON.stringify(exampleValue), env)
   }
 
   // Return binary or string values
-  return typeof example.value === 'string' ? replaceEnvVariables(example.value, env) : example.value
+  return typeof exampleValue === 'string' ? replaceEnvVariables(exampleValue, env) : exampleValue
 }

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
@@ -1042,6 +1042,29 @@ describe('processBody', () => {
   })
 
   describe('binary files', () => {
+    it('formats raw binary file examples as file references', () => {
+      const mockFile = new File(['binary content'], 'payload.bin', { type: 'application/octet-stream' })
+      const content = {
+        'application/octet-stream': {
+          examples: {
+            default: {
+              value: mockFile,
+            },
+          },
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'application/octet-stream',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'application/octet-stream',
+        text: '@payload.bin',
+      })
+    })
+
     it('extracts binary file examples', () => {
       const content = {
         'image/png': {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
@@ -69,6 +69,10 @@ const objectToFormParams = (obj: object | { name: string; value: string; isDisab
  */
 export const processBody = ({ requestBody, contentType, example }: ProcessBodyProps): PostData | undefined => {
   const _contentType = contentType || Object.keys(requestBody.content)[0] || ''
+  const formatBinaryFile = (file: File) => {
+    const unwrappedFile = unpackProxyObject(file)
+    return `@${unwrappedFile.name || 'filename'}`
+  }
 
   // Check if this is a form data content type
   const isFormData = _contentType === 'multipart/form-data' || _contentType === 'application/x-www-form-urlencoded'
@@ -81,23 +85,32 @@ export const processBody = ({ requestBody, contentType, example }: ProcessBodyPr
 
   // Return the provided top level example
   if (typeof _example !== 'undefined') {
-    if (isFormData && typeof _example === 'object' && _example !== null) {
+    const exampleValue = _example !== null && typeof _example === 'object' ? unpackProxyObject(_example) : _example
+
+    if (isFormData && typeof exampleValue === 'object' && exampleValue !== null) {
       return {
         mimeType: _contentType,
-        params: objectToFormParams(_example),
+        params: objectToFormParams(exampleValue),
       }
     }
 
-    if (isXml && typeof _example === 'object' && _example !== null) {
+    if (isXml && typeof exampleValue === 'object' && exampleValue !== null) {
       return {
         mimeType: _contentType,
-        text: json2xml(_example),
+        text: json2xml(exampleValue),
+      }
+    }
+
+    if (exampleValue instanceof File) {
+      return {
+        mimeType: _contentType,
+        text: formatBinaryFile(exampleValue),
       }
     }
 
     return {
       mimeType: _contentType,
-      text: typeof _example === 'string' ? _example : JSON.stringify(_example),
+      text: typeof exampleValue === 'string' ? exampleValue : JSON.stringify(exampleValue),
     }
   }
 


### PR DESCRIPTION
Fixes #8401.

## Summary

Raw binary request bodies selected in the v2 request body editor were being serialized as `{}`. That broke both the actual request body and the generated code samples for `application/octet-stream` style uploads.

## Changes

- return top-level `File` examples directly from the v2 request body builder
- serialize top-level raw binary `File` examples as `@filename` in HAR/code sample generation
- add focused regression coverage for both helper paths
- add a patch changeset for `@scalar/api-client`

## Testing

- `pnpm exec biome check packages/api-client/src/v2/blocks/operation-block/helpers/build-request-body.ts packages/api-client/src/v2/blocks/operation-block/helpers/build-request-body.test.ts packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts`
- `pnpm exec vitest run --config vite.config.ts src/v2/blocks/operation-block/helpers/build-request-body.test.ts src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts` (from `packages/api-client`)
