### PR TITLE
fix(api-client): preselect upload content type

### DIFF
--- a/.changeset/curly-pigs-rush.md
+++ b/.changeset/curly-pigs-rush.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix legacy request body uploads to honor preselected content types

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts
@@ -84,6 +84,37 @@ describe('RequestBody.vue', () => {
     expect(wrapper.findComponent({ name: 'ScalarListbox' }).text()).toContain('Multipart Form')
   })
 
+  it('uses the selected request body content type for the current example', () => {
+    mockActiveExample.name = 'Upload'
+    mockActiveExample.body = {
+      activeBody: 'raw',
+    }
+
+    mockOperation.requestBody = {
+      content: {
+        'application/json': {},
+        'multipart/form-data': {},
+      },
+      'x-scalar-selected-content-type': {
+        Upload: 'multipart/form-data',
+      },
+    } as any
+
+    const wrapper = mount(RequestBody, props)
+
+    expect(wrapper.findComponent({ name: 'ScalarListbox' }).text()).toContain('Multipart Form')
+    expect(mockRequestExampleMutators.edit).toHaveBeenCalledWith('mockExampleUid', 'body.formData', {
+      encoding: 'form-data',
+      value: [
+        {
+          enabled: false,
+          key: '',
+          value: '',
+        },
+      ],
+    })
+  })
+
   it('renders with url encoded form', () => {
     mockActiveExample.body = {
       activeBody: 'formData',

--- a/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestBody.vue
@@ -57,6 +57,46 @@ const contentTypes = {
 } as const
 type ContentType = keyof typeof contentTypes
 
+const getContentTypeOptionId = (contentType?: string | null): ContentType => {
+  if (!contentType) {
+    return 'none'
+  }
+
+  if (contentType === 'multipart/form-data') {
+    return 'multipartForm'
+  }
+
+  if (contentType === 'application/x-www-form-urlencoded') {
+    return 'formUrlEncoded'
+  }
+
+  if (contentType === 'application/octet-stream') {
+    return 'binaryFile'
+  }
+
+  if (contentType.includes('/json') || contentType.endsWith('+json')) {
+    return 'json'
+  }
+
+  if (contentType.includes('/xml') || contentType.endsWith('+xml')) {
+    return 'xml'
+  }
+
+  if (contentType.includes('/yaml') || contentType.includes('/yml')) {
+    return 'yaml'
+  }
+
+  if (contentType.includes('/edn')) {
+    return 'edn'
+  }
+
+  if (contentType.startsWith('text/') || contentType.includes('/html')) {
+    return 'other'
+  }
+
+  return 'none'
+}
+
 /** Convert content types to options for the dropdown */
 const contentTypeOptions = (
   Object.entries(contentTypes) as Entries<typeof contentTypes>
@@ -87,10 +127,11 @@ const activeExampleContentType = computed(() => {
     return raw.encoding
   }
 
-  // Set content type from request if present
-  const contentType = Object.keys(operation.requestBody?.content || {})[0]
+  const selectedContentType =
+    operation.requestBody?.['x-scalar-selected-content-type']?.[example.name] ??
+    Object.keys(operation.requestBody?.content || {})[0]
 
-  return contentType || 'none'
+  return getContentTypeOptionId(selectedContentType)
 })
 /** Selected ref from options above */
 const selectedContentType = computed({


### PR DESCRIPTION
Fixes #5417.

## Summary

Legacy request body uploads could ignore preselected request-body content types and render the body dropdown as `None`.

## Changes

- normalize request body MIME types into the legacy dropdown option ids
- prefer `x-scalar-selected-content-type` for the current example when present
- add a focused regression test for multipart upload preselection
- add a patch changeset for `@scalar/api-client`

## Testing

- `pnpm exec biome check packages/api-client/src/views/Request/RequestSection/RequestBody.vue packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts`
- `pnpm exec vitest run packages/api-client/src/views/Request/RequestSection/RequestBody.test.ts`