### PR TITLE
feat(aspire): add optional endpointName to WithApiReferenceFeat/endpoint name

### DIFF
--- a/.changeset/icy-ibis-talk.md
+++ b/.changeset/icy-ibis-talk.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspire': patch
+---
+
+feat(aspire): add optional endpointName to WithApiReference

--- a/documentation/integrations/aspire.md
+++ b/documentation/integrations/aspire.md
@@ -152,6 +152,27 @@ scalar.WithApiReference(
     });
 ```
 
+### Scoping Service Discovery Endpoints
+
+By default, `WithApiReference` exposes **all** endpoints of a service to Aspire service discovery. This injects one `services__{resourceName}__{scheme}__{index}` environment variable per endpoint into the Scalar container (e.g., `services__book-service__http__0` and `services__book-service__https__0`).
+
+Use the optional `endpointName` parameter to restrict discovery to a single named endpoint:
+
+```csharp
+// Only expose the "https" endpoint for service discovery
+scalar.WithApiReference(bookService, endpointName: "https");
+```
+
+When `endpointName` is provided, only that endpoint is registered, so the Scalar container receives a single `services__book-service__https__0` variable and the HTTP endpoint is not injected. This is useful when a service has both HTTP and HTTPS endpoints and you want Scalar to communicate exclusively over HTTPS.
+
+The same parameter is available on the file-based overload:
+
+```csharp
+scalar.WithApiReference(bookService, new FileInfo("openapi.yaml"), endpointName: "https");
+```
+
+> **Note**: `endpointName` affects only the `services__*` environment variables injected for Aspire service discovery. It does not change the source URL of the OpenAPI document.
+
 ### Advanced: Base document URL
 
 `WithBaseDocumentUrl(ReferenceExpression?)` controls the base URL used to resolve the OpenAPI document URL. For static files, the integration sets this internally so the document is loaded from the route pattern `/openapi/{resourceName}/{filename}` (or `/openapi/{folderPath}/{filename}` when `folderPath` is specified). You can override it for custom setups—for example, use `ReferenceExpression.Empty` so the document URL is the route pattern as-is, or pass a different expression to resolve at startup when endpoints are known.

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/Extensions/ResourceBuilderExtensions.cs
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/Extensions/ResourceBuilderExtensions.cs
@@ -13,17 +13,24 @@ public static class ResourceBuilderExtensions
     /// </summary>
     /// <param name="builder">The Scalar resource builder.</param>
     /// <param name="resourceBuilder">The resource builder that provides the OpenAPI document.</param>
+    /// <param name="endpointName">
+    /// Optional name of the endpoint to expose via service discovery.
+    /// When provided, only the endpoint with that name is used, injecting a single
+    /// <c>services__{resourceName}__{scheme}__{index}</c> environment variable into the Scalar container,
+    /// where <c>scheme</c> is the URI scheme of the named endpoint (e.g., <c>https</c>).
+    /// When <see langword="null"/> (default), all endpoints are exposed.
+    /// </param>
     /// <param name="configureOptions">Optional action to configure <see cref="ScalarOptions"/> for this service.</param>
     /// <returns>The resource builder for the <see cref="ScalarResource"/>.</returns>
     public static IResourceBuilder<ScalarResource> WithApiReference(
         this IResourceBuilder<ScalarResource> builder,
         IResourceBuilder<IResourceWithServiceDiscovery> resourceBuilder,
-        Action<ScalarOptions>? configureOptions = null) => builder.WithApiReference(resourceBuilder, (options, _) =>
+        string? endpointName = null,
+        Action<ScalarOptions>? configureOptions = null) => builder.WithApiReference(resourceBuilder, endpointName, (options, _) =>
     {
         configureOptions?.Invoke(options);
         return Task.CompletedTask;
     });
-
 
     /// <summary>
     /// Adds an OpenAPI reference to the Scalar resource from another resource with service discovery.
@@ -35,6 +42,27 @@ public static class ResourceBuilderExtensions
     public static IResourceBuilder<ScalarResource> WithApiReference(
         this IResourceBuilder<ScalarResource> builder,
         IResourceBuilder<IResourceWithServiceDiscovery> resourceBuilder,
+        Func<ScalarOptions, CancellationToken, Task> configureOptions) =>
+        builder.WithApiReference(resourceBuilder, null, configureOptions);
+
+    /// <summary>
+    /// Adds an OpenAPI reference to the Scalar resource from another resource with service discovery.
+    /// </summary>
+    /// <param name="builder">The Scalar resource builder.</param>
+    /// <param name="resourceBuilder">The resource builder that provides the OpenAPI document.</param>
+    /// <param name="endpointName">
+    /// Optional name of the endpoint to expose via service discovery.
+    /// When provided, only the endpoint with that name is used, injecting a single
+    /// <c>services__{resourceName}__{scheme}__{index}</c> environment variable into the Scalar container,
+    /// where <c>scheme</c> is the URI scheme of the named endpoint (e.g., <c>https</c>).
+    /// When <see langword="null"/> (default), all endpoints are exposed.
+    /// </param>
+    /// <param name="configureOptions">Action to configure <see cref="ScalarOptions"/> for this service asynchronously.</param>
+    /// <returns>The resource builder for the <see cref="ScalarResource"/>.</returns>
+    public static IResourceBuilder<ScalarResource> WithApiReference(
+        this IResourceBuilder<ScalarResource> builder,
+        IResourceBuilder<IResourceWithServiceDiscovery> resourceBuilder,
+        string? endpointName,
         Func<ScalarOptions, CancellationToken, Task> configureOptions)
     {
         // Create the expression at build time so the annotation owns it from the start.
@@ -42,17 +70,21 @@ public static class ResourceBuilderExtensions
         var endpointExpression = new ResourceBaseUrlExpression(resourceBuilder.Resource);
         var baseDocumentUrl = ReferenceExpression.Create($"{endpointExpression}");
 
-        return builder
-            .WithReference(resourceBuilder)
-            .WithAnnotation(new ScalarAnnotation(resourceBuilder.Resource, async (options, ct) =>
-            {
-                await configureOptions(options, ct);
+        // GetEndpoint filters service-discovery to the named endpoint only.
+        // WithReference(resource, alias) would rename the resource in discovery keys — not what we want.
+        var refBuilder = endpointName is not null
+            ? builder.WithReference(resourceBuilder.GetEndpoint(endpointName))
+            : builder.WithReference(resourceBuilder);
 
-                // Configure after the user's callback so DefaultProxy and PreferHttpsEndpoint are final.
-                endpointExpression.Configure(
-                    ((ScalarAspireOptions)options).DefaultProxy,
-                    options.PreferHttpsEndpoint);
-            }, BaseDocumentUrl: baseDocumentUrl));
+        return refBuilder.WithAnnotation(new ScalarAnnotation(resourceBuilder.Resource, async (options, ct) =>
+        {
+            await configureOptions(options, ct);
+
+            // Configure after the user's callback so DefaultProxy and PreferHttpsEndpoint are final.
+            endpointExpression.Configure(
+                ((ScalarAspireOptions)options).DefaultProxy,
+                options.PreferHttpsEndpoint);
+        }, BaseDocumentUrl: baseDocumentUrl));
     }
 
     /// <summary>
@@ -70,6 +102,13 @@ public static class ResourceBuilderExtensions
     /// serving the file at <c>/openapi/{resourceName}/{filename}</c>.
     /// Use an explicit value to override the default folder or to avoid name collisions.
     /// </param>
+    /// <param name="endpointName">
+    /// Optional name of the endpoint to expose via service discovery.
+    /// When provided, only the endpoint with that name is used, injecting a single
+    /// <c>services__{resourceName}__{scheme}__{index}</c> environment variable into the Scalar container,
+    /// where <c>scheme</c> is the URI scheme of the named endpoint (e.g., <c>https</c>).
+    /// When <see langword="null"/> (default), all endpoints are exposed.
+    /// </param>
     /// <param name="configureOptions">Optional action to configure <see cref="ScalarOptions"/> for this document.</param>
     /// <returns>The resource builder for the <see cref="ScalarResource"/>.</returns>
     public static IResourceBuilder<ScalarResource> WithApiReference(
@@ -77,8 +116,9 @@ public static class ResourceBuilderExtensions
         IResourceBuilder<IResourceWithServiceDiscovery> resourceBuilder,
         FileInfo openApiFile,
         string? folderPath = null,
+        string? endpointName = null,
         Action<ScalarOptions>? configureOptions = null) =>
-        builder.WithApiReference(resourceBuilder, openApiFile, folderPath, (options, _) =>
+        builder.WithApiReference(resourceBuilder, openApiFile, folderPath, endpointName, (options, _) =>
         {
             configureOptions?.Invoke(options);
             return Task.CompletedTask;
@@ -106,18 +146,56 @@ public static class ResourceBuilderExtensions
         IResourceBuilder<IResourceWithServiceDiscovery> resourceBuilder,
         FileInfo openApiFile,
         string? folderPath,
+        Func<ScalarOptions, CancellationToken, Task> configureOptions) =>
+        builder.WithApiReference(resourceBuilder, openApiFile, folderPath, null, configureOptions);
+
+    /// <summary>
+    /// Adds a static OpenAPI document to the Scalar resource for a given service.
+    /// Use this overload when the service does not expose a live OpenAPI endpoint.
+    /// The file is mounted into the Scalar container and served at <c>/openapi/{folderPath}/{filename}</c>.
+    /// </summary>
+    /// <param name="builder">The Scalar resource builder.</param>
+    /// <param name="resourceBuilder">The resource builder for the service. Used to configure the API server URL for the "Try It" feature.</param>
+    /// <param name="openApiFile">The local OpenAPI document file to serve.</param>
+    /// <param name="folderPath">
+    /// Optional sub-folder path (relative to <c>/openapi</c>) where the file is mounted inside the Scalar container.
+    /// When provided, the file is served at <c>/openapi/{folderPath}/{filename}</c>.
+    /// When <see langword="null"/> (default), the resource name (<see cref="IResource.Name"/>) is used as the folder,
+    /// serving the file at <c>/openapi/{resourceName}/{filename}</c>.
+    /// Use an explicit value to override the default folder or to avoid name collisions.
+    /// </param>
+    /// <param name="endpointName">
+    /// Optional name of the endpoint to expose via service discovery.
+    /// When provided, only the endpoint with that name is used, injecting a single
+    /// <c>services__{resourceName}__{scheme}__{index}</c> environment variable into the Scalar container,
+    /// where <c>scheme</c> is the URI scheme of the named endpoint (e.g., <c>https</c>).
+    /// When <see langword="null"/> (default), all endpoints are exposed.
+    /// </param>
+    /// <param name="configureOptions">Action to configure <see cref="ScalarOptions"/> for this document asynchronously.</param>
+    /// <returns>The resource builder for the <see cref="ScalarResource"/>.</returns>
+    public static IResourceBuilder<ScalarResource> WithApiReference(
+        this IResourceBuilder<ScalarResource> builder,
+        IResourceBuilder<IResourceWithServiceDiscovery> resourceBuilder,
+        FileInfo openApiFile,
+        string? folderPath,
+        string? endpointName,
         Func<ScalarOptions, CancellationToken, Task> configureOptions)
     {
         // The OpenAPI document is served from the Scalar container's static file endpoint,
         // so BaseDocumentUrl = Empty signals to the configurator to use the route pattern as-is.
         // A separate endpointExpression is still needed inside the callback so that DefaultProxy
-        // and PreferHttpsEndpoint are picked up for any downstream use (e.g., servers).
+        // and PreferHttpsEndpoint are picked up for the servers list (the "Try It" feature).
         var endpointExpression = new ResourceBaseUrlExpression(resourceBuilder.Resource);
         var folder = string.IsNullOrEmpty(folderPath) ? resourceBuilder.Resource.Name : folderPath.Trim('/');
         var containerPath = $"{StaticFilesEndpoint}/{folder}/{openApiFile.Name}";
 
-        return builder
-            .WithReference(resourceBuilder)
+        // GetEndpoint filters service-discovery to the named endpoint only.
+        // WithReference(resource, alias) would rename the resource in discovery keys — not what we want.
+        var refBuilder = endpointName is not null
+            ? builder.WithReference(resourceBuilder.GetEndpoint(endpointName))
+            : builder.WithReference(resourceBuilder);
+
+        return refBuilder
             .WithBindMount(openApiFile.FullName, containerPath, isReadOnly: true)
             .WithAnnotation(new ScalarAnnotation(resourceBuilder.Resource, async (options, ct) =>
             {

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/ResourceBaseUrlExpression.cs
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/ResourceBaseUrlExpression.cs
@@ -54,20 +54,20 @@ internal sealed class ResourceBaseUrlExpression(IResource resource) : IValueProv
         var shouldUseHttps = (!httpAvailable || _preferHttps) && httpsAvailable;
         var scheme = shouldUseHttps ? "https" : "http";
 
-        string url;
+        string result;
         if (_defaultProxy)
         {
             // Service-discovery mode: use the resource name as the hostname.
-            url = $"{scheme}://{resource.Name}";
+            result = $"{scheme}://{resource.Name}";
         }
         else
         {
             var endpoint = endpoints.FirstOrDefault(e => e.UriScheme == scheme)
                            ?? throw new InvalidOperationException(
                                $"No endpoint found for resource '{resource.Name}' with URI scheme '{scheme}'.");
-            url = $"{scheme}://{endpoint.TargetHost}:{endpoint.TargetPort ?? endpoint.Port}";
+            result = $"{scheme}://{endpoint.TargetHost}:{endpoint.TargetPort ?? endpoint.Port}";
         }
 
-        return ValueTask.FromResult<string?>(url);
+        return ValueTask.FromResult<string?>(result);
     }
 }

--- a/integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/ScalarResourceConfiguratorTests.cs
+++ b/integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/ScalarResourceConfiguratorTests.cs
@@ -377,4 +377,145 @@ public class ScalarResourceConfiguratorTests
         var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(raw));
         JsonDocument.Parse(decoded).RootElement.ValueKind.Should().Be(JsonValueKind.Array);
     }
+
+    // ---------------------------------------------------------------------------
+    // Service-discovery environment variable tests
+    //
+    // WithApiReference forwards endpointName to Aspire's WithReference, which injects
+    // services__{resourceName}__{scheme}__{index} environment variables into the Scalar container.
+    // These tests verify the correct endpoints are exposed for a given endpointName value.
+    // ---------------------------------------------------------------------------
+
+    // ContainerResource alone does not implement IResourceWithServiceDiscovery, which is the
+    // constraint on WithApiReference. This minimal subclass satisfies that constraint without
+    // requiring project metadata or DCP infrastructure.
+    private sealed class TestApiResource(string name) : ContainerResource(name), IResourceWithServiceDiscovery;
+
+    // Minimal IResourceBuilder<T> that supports annotation mutations only. This is all that
+    // WithReference and WithApiReference need — neither accesses ApplicationBuilder during setup.
+    private sealed class MinimalResourceBuilder<T>(T resource) : IResourceBuilder<T> where T : IResource
+    {
+        public T Resource { get; } = resource;
+
+        public IDistributedApplicationBuilder ApplicationBuilder =>
+            throw new NotSupportedException("ApplicationBuilder is not available in minimal tests.");
+
+        public IResourceBuilder<T> WithAnnotation<TAnnotation>(
+            TAnnotation annotation,
+            ResourceAnnotationMutationBehavior behavior = ResourceAnnotationMutationBehavior.Append)
+            where TAnnotation : IResourceAnnotation
+        {
+            if (behavior == ResourceAnnotationMutationBehavior.Replace)
+            {
+                var toRemove = Resource.Annotations.OfType<TAnnotation>().ToList();
+                foreach (var a in toRemove)
+                {
+                    Resource.Annotations.Remove(a);
+                }
+            }
+
+            Resource.Annotations.Add(annotation);
+            return this;
+        }
+    }
+
+    // Invokes all EnvironmentCallbackAnnotation instances on the resource and resolves IValueProvider
+    // values (such as EndpointReference) to strings. Replicates what Aspire's internal
+    // EnvironmentVariableEvaluator does, without the dependency on Aspire's test infrastructure.
+    private static async Task<Dictionary<string, string>> GetServiceDiscoveryEnvVarsAsync(IResource resource)
+    {
+        var executionContext = new DistributedApplicationExecutionContext(
+            new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run)
+            {
+                ServiceProvider = new ServiceCollection().BuildServiceProvider()
+            });
+
+        var envVars = new Dictionary<string, object>();
+        var callbackContext = new EnvironmentCallbackContext(executionContext, resource, envVars);
+
+        foreach (var annotation in resource.Annotations.OfType<EnvironmentCallbackAnnotation>())
+        {
+            await annotation.Callback(callbackContext);
+        }
+
+        var result = new Dictionary<string, string>();
+        foreach (var (key, value) in envVars)
+        {
+            result[key] = value switch
+            {
+                string s => s,
+                IValueProvider vp => await vp.GetValueAsync() ?? string.Empty,
+                _ => value.ToString() ?? string.Empty
+            };
+        }
+
+        return result;
+    }
+
+    // Creates a TestApiResource with http (port 5000) and https (port 5001) endpoints that have
+    // AllocatedEndpoints set so EndpointReference.GetValueAsync() resolves without a live runtime.
+    private static MinimalResourceBuilder<TestApiResource> BuildTestApiResource()
+    {
+        var apiResource = new TestApiResource(ApiResourceName);
+        var httpEndpoint = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http", targetPort: 5000) { Port = 5000 };
+        var httpsEndpoint = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "https", name: "https", targetPort: 5001) { Port = 5001 };
+        httpEndpoint.AllocatedEndpoint = new AllocatedEndpoint(httpEndpoint, "localhost", 5000);
+        httpsEndpoint.AllocatedEndpoint = new AllocatedEndpoint(httpsEndpoint, "localhost", 5001);
+        apiResource.Annotations.Add(httpEndpoint);
+        apiResource.Annotations.Add(httpsEndpoint);
+        return new MinimalResourceBuilder<TestApiResource>(apiResource);
+    }
+
+    [Fact]
+    public async Task WithApiReference_NoEndpointName_ExposesAllEndpointsForServiceDiscovery()
+    {
+        var apiBuilder = BuildTestApiResource();
+        var scalarResource = new ScalarResource(ScalarResourceName);
+        var scalarBuilder = new MinimalResourceBuilder<ScalarResource>(scalarResource);
+
+        scalarBuilder.WithApiReference(apiBuilder);
+
+        var envVars = await GetServiceDiscoveryEnvVarsAsync(scalarResource);
+
+        // Both endpoints are injected when no endpointName is specified.
+        envVars.Should().ContainKey("services__my-api__https__0")
+            .WhoseValue.Should().Be("https://localhost:5001");
+        envVars.Should().ContainKey("services__my-api__http__0")
+            .WhoseValue.Should().Be("http://localhost:5000");
+    }
+
+    [Fact]
+    public async Task WithApiReference_WithEndpointName_ExposesOnlyNamedEndpointForServiceDiscovery()
+    {
+        var apiBuilder = BuildTestApiResource();
+        var scalarResource = new ScalarResource(ScalarResourceName);
+        var scalarBuilder = new MinimalResourceBuilder<ScalarResource>(scalarResource);
+
+        // endpointName: "https" filters service-discovery to only the https endpoint.
+        scalarBuilder.WithApiReference(apiBuilder, endpointName: "https");
+
+        var envVars = await GetServiceDiscoveryEnvVarsAsync(scalarResource);
+
+        envVars.Should().ContainKey("services__my-api__https__0")
+            .WhoseValue.Should().Be("https://localhost:5001");
+        envVars.Should().NotContainKey("services__my-api__http__0");
+    }
+
+    [Fact]
+    public async Task WithApiReference_FileOverload_WithEndpointName_ExposesOnlyNamedEndpoint()
+    {
+        // The file overload also forwards endpointName to WithReference, so the same filtering applies.
+        var apiBuilder = BuildTestApiResource();
+        var scalarResource = new ScalarResource(ScalarResourceName);
+        var scalarBuilder = new MinimalResourceBuilder<ScalarResource>(scalarResource);
+
+        // FileInfo path does not need to exist — no disk I/O occurs during env var resolution.
+        scalarBuilder.WithApiReference(apiBuilder, new FileInfo("openapi.json"), endpointName: "https");
+
+        var envVars = await GetServiceDiscoveryEnvVarsAsync(scalarResource);
+
+        envVars.Should().ContainKey("services__my-api__https__0")
+            .WhoseValue.Should().Be("https://localhost:5001");
+        envVars.Should().NotContainKey("services__my-api__http__0");
+    }
 }

--- a/integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/ScalarResourceConfiguratorTests.cs
+++ b/integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/ScalarResourceConfiguratorTests.cs
@@ -422,7 +422,7 @@ public class ScalarResourceConfiguratorTests
     // Invokes all EnvironmentCallbackAnnotation instances on the resource and resolves IValueProvider
     // values (such as EndpointReference) to strings. Replicates what Aspire's internal
     // EnvironmentVariableEvaluator does, without the dependency on Aspire's test infrastructure.
-    private static async Task<Dictionary<string, string>> GetServiceDiscoveryEnvVarsAsync(IResource resource)
+    private static async Task<Dictionary<string, string>> GetServiceDiscoveryEnvVarsAsync(ScalarResource resource)
     {
         var executionContext = new DistributedApplicationExecutionContext(
             new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run)


### PR DESCRIPTION
## Problem

When a resource has more that one endpoint, it's not guaranteed that the first one is the one exposing the API.

## Solution

 Adds an optional `endpointName` parameter to all `WithApiReference`
 overloads. When provided, only the endpoint with that name is registered
 for Aspire service discovery, injecting a single
 `services__{resourceName}__{scheme}__{index}` environment variable
 instead of one per endpoint.

 Uses `resourceBuilder.GetEndpoint(endpointName)` internally rather than
 `WithReference(resource, alias)`, which in Aspire 13.1.0 would rename
 the resource in discovery keys rather than filter endpoints.

 Backward-compatible `Func<ScalarOptions, CancellationToken, Task>`
 overloads (without `endpointName`) are preserved as delegates to the new
 core overloads.

 Adds three tests to `ScalarResourceConfiguratorTests` covering:
 - no `endpointName` → all endpoints exposed
 - `endpointName: "https"` → only the https endpoint exposed
 - file overload with `endpointName` → same filtering behavior

## Checklist

- [X] I explained why the change is needed.
- [X] I added a changeset. <!-- pnpm changeset -->
- [X] I added tests.
- [X] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
