### PR TITLE
fix(api-reference): honor default OAuth scopes on spec fallback

### DIFF
--- a/.changeset/empty-ligers-share.md
+++ b/.changeset/empty-ligers-share.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix auth default OAuth scope fallback

--- a/packages/api-reference/src/components/Content/Auth/helpers/get-default-security.test.ts
+++ b/packages/api-reference/src/components/Content/Auth/helpers/get-default-security.test.ts
@@ -230,6 +230,68 @@ describe('getDefaultSecurity', () => {
     expect(result).toEqual({ apiKeyAuth: [] })
   })
 
+  it('applies x-default-scopes when falling back to the first oauth2 security requirement', () => {
+    const securityRequirements: SecurityRequirementObject[] = [{ oauth2Auth: [] }]
+    const preferredSecurityScheme: AuthenticationConfiguration['preferredSecurityScheme'] = undefined
+    const securitySchemes: MergedSecuritySchemes = {
+      oauth2Auth: {
+        type: 'oauth2',
+        flows: {
+          authorizationCode: {
+            'x-usePkce': 'no',
+            'x-scalar-secret-client-id': 'test-client-id',
+            'x-scalar-secret-client-secret': 'test-client-secret',
+            'x-scalar-secret-redirect-uri': 'https://example.com/oauth/callback',
+            'x-scalar-secret-token': 'test-token',
+            refreshUrl: 'https://example.com/oauth/refresh',
+            authorizationUrl: 'https://example.com/oauth/authorize',
+            tokenUrl: 'https://example.com/oauth/token',
+            scopes: {
+              'openid': 'OpenID',
+              'email': 'Email',
+            },
+          },
+        },
+        'x-default-scopes': ['openid', 'email'],
+      } satisfies SecuritySchemeObjectSecret,
+    }
+
+    const result = getDefaultSecurity(securityRequirements, preferredSecurityScheme, securitySchemes)
+
+    expect(result).toEqual({ oauth2Auth: ['openid', 'email'] })
+  })
+
+  it('preserves explicit scopes from the first security requirement over x-default-scopes', () => {
+    const securityRequirements: SecurityRequirementObject[] = [{ oauth2Auth: ['openid'] }]
+    const preferredSecurityScheme: AuthenticationConfiguration['preferredSecurityScheme'] = undefined
+    const securitySchemes: MergedSecuritySchemes = {
+      oauth2Auth: {
+        type: 'oauth2',
+        flows: {
+          authorizationCode: {
+            'x-usePkce': 'no',
+            'x-scalar-secret-client-id': 'test-client-id',
+            'x-scalar-secret-client-secret': 'test-client-secret',
+            'x-scalar-secret-redirect-uri': 'https://example.com/oauth/callback',
+            'x-scalar-secret-token': 'test-token',
+            refreshUrl: 'https://example.com/oauth/refresh',
+            authorizationUrl: 'https://example.com/oauth/authorize',
+            tokenUrl: 'https://example.com/oauth/token',
+            scopes: {
+              'openid': 'OpenID',
+              'email': 'Email',
+            },
+          },
+        },
+        'x-default-scopes': ['openid', 'email'],
+      } satisfies SecuritySchemeObjectSecret,
+    }
+
+    const result = getDefaultSecurity(securityRequirements, preferredSecurityScheme, securitySchemes)
+
+    expect(result).toEqual({ oauth2Auth: ['openid'] })
+  })
+
   it('handles security scheme with $ref-value wrapper', () => {
     const securityRequirements: SecurityRequirementObject[] = []
     const preferredSecurityScheme: AuthenticationConfiguration['preferredSecurityScheme'] = ['oauth2Auth']

--- a/packages/api-reference/src/components/Content/Auth/helpers/get-default-security.ts
+++ b/packages/api-reference/src/components/Content/Auth/helpers/get-default-security.ts
@@ -20,6 +20,29 @@ export const getDefaultScopes = (scheme: SecuritySchemeObject | undefined): stri
 }
 
 /**
+ * Hydrates an existing security requirement with configured default scopes.
+ * Explicit scopes from the OpenAPI requirement take precedence over x-default-scopes.
+ */
+const hydrateSecurityRequirement = (
+  requirement: SecurityRequirementObject,
+  securitySchemes: MergedSecuritySchemes,
+): SecurityRequirementObject => {
+  const hydratedRequirement: SecurityRequirementObject = {}
+
+  for (const [schemeName, scopes] of Object.entries(unpackProxyObject(requirement, { depth: 1 }) ?? requirement)) {
+    if (Array.isArray(scopes) && scopes.length > 0) {
+      hydratedRequirement[schemeName] = scopes
+      continue
+    }
+
+    const scheme = getResolvedRef(securitySchemes[schemeName])
+    hydratedRequirement[schemeName] = getDefaultScopes(scheme)
+  }
+
+  return hydratedRequirement
+}
+
+/**
  * Processes a single scheme name and adds it to the accumulator with its default scopes.
  */
 const addSchemeToRequirement = (
@@ -79,7 +102,7 @@ export const getDefaultSecurity = (
 
   const firstRequirement = securityRequirements[0]
   if (firstRequirement) {
-    return unpackProxyObject(firstRequirement, { depth: 1 })
+    return hydrateSecurityRequirement(firstRequirement, securitySchemes)
   }
 
   return null


### PR DESCRIPTION
Fixes #8082.

## Summary

When Scalar falls back to the first OpenAPI security requirement, it was preserving the raw requirement scopes as-is. For OAuth2 schemes that usually meant an empty array, so `AddDefaultScopes` and flow-level `SelectedScopes` never showed up unless the same scheme was also configured as preferred.

## Changes

- hydrate the fallback security requirement with `x-default-scopes` for OAuth2 schemes
- preserve explicit scopes from the OpenAPI security requirement when they are already present
- add focused regression coverage for the non-preferred fallback path
- add a patch changeset for `@scalar/api-reference`

## Testing

- `pnpm exec biome check packages/api-reference/src/components/Content/Auth/helpers/get-default-security.ts packages/api-reference/src/components/Content/Auth/helpers/get-default-security.test.ts`
- `pnpm exec vitest run packages/api-reference/src/components/Content/Auth/helpers/get-default-security.test.ts`