### PR TITLE
feat: AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,30 @@ projects/           # Supporting projects (e.g. proxy-scalar-com)
 - **Branch naming**: `claude/feature-description`, `claude/fix-description`
 - **Commits**: Conventional commits, present tense, scope when relevant
 
+## PR Requirements
+
+### Semantic PR titles
+
+PR titles must follow `type(scope): subject`:
+
+```
+fix(api-client): crashes when API returns null
+^   ^            ^
+|   |            subject
+|   package scope
+type (feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert)
+```
+
+### Changesets
+
+If your PR will cause a version bump for any package, add a changeset:
+
+```bash
+pnpm changeset
+```
+
 ## Further Reading
 
+- [CONTRIBUTING.md](./CONTRIBUTING.md) – PR requirements, changesets, auto-generated files
 - [CLAUDE.md](./CLAUDE.md) – Full development guide, Vue/TS conventions, testing
 - [.cursor/rules/cloud-agents-starter-skill.mdc](./.cursor/rules/cloud-agents-starter-skill.mdc) – Runbook for CI parity and test servers


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The project lacked a dedicated documentation file (`AGENTS.md`) tailored specifically for AI coding agents, leading to a potential gap in guiding their understanding and interaction with the codebase.

## Solution

A new `AGENTS.md` file has been created to serve as a quick reference guide for AI coding agents. It covers essential topics such as:

- Project overview (Vue 3 + TypeScript monorepo, tech stack)
- Prerequisites (Node.js v24, pnpm)
- Setup instructions (`pnpm install`, `pnpm build:packages`)
- Common commands (build, test, lint, format, type check)
- Development and test server setup
- Directory structure (`packages/`, `integrations/`, `examples/`)
- Code conventions (Vue, TypeScript, naming, test layout)
- Testing methodologies (Vitest, Playwright, integration tests)
- Git workflow (branch naming, commit style)
- References to `CLAUDE.md` and cloud agents starter skill

This file is intended to complement `CLAUDE.md`, which remains the main development guide.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<div><a href="https://cursor.com/agents/bc-3d3ca717-7888-45fa-817e-390adcf38e3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d3ca717-7888-45fa-817e-390adcf38e3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->