### PR TITLE
chore: decrease `minimumReleaseAge` for pnpm

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,7 +15,7 @@
     {
       "description": "Keep this in sync with package.json minimumReleaseAge",
       "matchDatasources": ["npm"],
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "5 days"
     },
 
     {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -108,7 +108,8 @@ ignoredBuiltDependencies:
   - vue-demi
   - workerd
 
-minimumReleaseAge: 10080
+# Do not lower this value; add popular packages to minimumReleaseAgeExclude or wait before updating.
+minimumReleaseAge: 7200
 
 minimumReleaseAgeExclude:
   - '@astrojs/*'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Cursor agent tried to decrease this value to 0, so let's add a comment. But actually, we can increase it a bit I think.

## Solution

- Decreased `minimumReleaseAge` in `pnpm-workspace.yaml` from 10080 minutes (7 days) to 7200 minutes (5 days).
- Added a warning comment next to the `minimumReleaseAge` setting in `pnpm-workspace.yaml` to guide future adjustments.
- Updated the corresponding `minimumReleaseAge` in `.github/renovate.json` from "7 days" to "5 days" to ensure alignment between pnpm and Renovate configurations.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset.
- [ ] I added tests.
- [ ] I updated the documentation.

[Slack Thread](https://apidocumentation.slack.com/archives/D0AKUDSNVSB/p1773399744128879?thread_ts=1773399744.128879&cid=D0AKUDSNVSB)

<div><a href="https://cursor.com/agents/bc-d050e515-3528-507e-9740-9fbadfcb7e0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d050e515-3528-507e-9740-9fbadfcb7e0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->