### PR TITLE
fix(api-reference): support hash-prefixed basePath

### DIFF
--- a/.changeset/polite-boats-compete.md
+++ b/.changeset/polite-boats-compete.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix hash-prefixed basePath routing

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -68,7 +68,11 @@ import DocumentSelector from '@/features/multiple-documents/DocumentSelector.vue
 import SearchButton from '@/features/Search/components/SearchButton.vue'
 import { getSystemModePreference } from '@/helpers/color-mode'
 import { downloadDocument } from '@/helpers/download'
-import { getIdFromUrl, makeUrlFromId } from '@/helpers/id-routing'
+import {
+  getIdFromUrl,
+  makeUrlFromId,
+  matchesBasePath,
+} from '@/helpers/id-routing'
 import {
   scrollToLazy as _scrollToLazy,
   addToPriorityQueue,
@@ -202,9 +206,7 @@ if (typeof window !== 'undefined') {
 
   const initialId = getIdFromUrl(
     url,
-    basePaths.find(
-      (p) => p && url.pathname.startsWith(p.startsWith('/') ? p : `/${p}`),
-    ),
+    basePaths.find((p) => (p ? matchesBasePath(url, p) : false)),
     isMultiDocument.value ? undefined : activeSlug.value,
   )
   const documentSlug = initialId.split('/')[0]

--- a/packages/api-reference/src/helpers/id-routing.test.ts
+++ b/packages/api-reference/src/helpers/id-routing.test.ts
@@ -2,10 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   getIdFromHash,
+  getIdFromHashBasePath,
   getIdFromPath,
   getIdFromUrl,
   getSchemaParamsFromId,
   makeUrlFromId,
+  matchesBasePath,
   sanitizeBasePath,
 } from './id-routing'
 
@@ -449,6 +451,53 @@ describe('getIdFromPath', () => {
   })
 })
 
+describe('getIdFromHashBasePath', () => {
+  it('extracts id from a hash-prefixed basePath', () => {
+    const result = getIdFromHashBasePath(
+      'https://example.com/#/services/petstore/openapi/tag/pet/GET/pet/{petId}',
+      '#/services/petstore/openapi',
+      undefined,
+    )
+    expect(result).toBe('tag/pet/GET/pet/{petId}')
+  })
+
+  it('returns empty string when the hash only contains the basePath', () => {
+    const result = getIdFromHashBasePath(
+      'https://example.com/#/services/petstore/openapi',
+      '#/services/petstore/openapi',
+      undefined,
+    )
+    expect(result).toBe('')
+  })
+
+  it('applies slugPrefix when the hash-prefixed basePath matches', () => {
+    const result = getIdFromHashBasePath(
+      'https://example.com/#/services/petstore/openapi/users',
+      '#/services/petstore/openapi',
+      'doc',
+    )
+    expect(result).toBe('doc/users')
+  })
+})
+
+describe('matchesBasePath', () => {
+  it('matches pathname basePaths', () => {
+    expect(matchesBasePath('https://example.com/api/tag/users', 'api')).toBe(true)
+  })
+
+  it('matches hash-prefixed basePaths', () => {
+    expect(
+      matchesBasePath('https://example.com/#/services/petstore/openapi/tag/users', '#/services/petstore/openapi'),
+    ).toBe(true)
+  })
+
+  it('does not match unrelated hash-prefixed basePaths', () => {
+    expect(
+      matchesBasePath('https://example.com/#/services/other/openapi/tag/users', '#/services/petstore/openapi'),
+    ).toBe(false)
+  })
+})
+
 describe('getIdFromUrl', () => {
   it('uses hash routing when basePath is undefined', () => {
     const result = getIdFromUrl('https://example.com#tag/users', undefined, undefined)
@@ -457,6 +506,15 @@ describe('getIdFromUrl', () => {
 
   it('uses path routing when basePath is a string', () => {
     const result = getIdFromUrl('https://example.com/api/tag/users', 'api', undefined)
+    expect(result).toBe('tag/users')
+  })
+
+  it('uses hash-base routing when basePath starts with a hash', () => {
+    const result = getIdFromUrl(
+      'https://example.com/#/services/petstore/openapi/tag/users',
+      '#/services/petstore/openapi',
+      undefined,
+    )
     expect(result).toBe('tag/users')
   })
 
@@ -570,6 +628,19 @@ describe('makeUrlFromId', () => {
     const result = makeUrlFromId('tag/users', 'api', true)
     expect(result?.pathname).toBe('/api/tag/users')
     expect(result?.hash).toBe('')
+  })
+
+  it('uses hash-base routing when basePath starts with a hash', () => {
+    vi.stubGlobal('window', {
+      location: createLocationMock({
+        href: 'https://example.com/#/services/petstore/openapi',
+        hash: '#/services/petstore/openapi',
+      }) as Location,
+    })
+
+    const result = makeUrlFromId('tag/users', '#/services/petstore/openapi', true)
+    expect(result?.hash).toBe('#/services/petstore/openapi/tag/users')
+    expect(result?.pathname).toBe('/')
   })
 
   it('uses path routing with empty basePath', () => {

--- a/packages/api-reference/src/helpers/id-routing.ts
+++ b/packages/api-reference/src/helpers/id-routing.ts
@@ -2,13 +2,35 @@ export const sanitizeBasePath = (basePath: string) => {
   return basePath.replace(/^\/+|\/+$/g, '')
 }
 
+const isHashBasePath = (basePath: string) => basePath.startsWith('#')
+
+const sanitizeHashBasePath = (basePath: string) => {
+  return basePath.replace(/^#+/, '').replace(/\/+$/g, '')
+}
+
+const applySlugPrefix = (base: string, slugPrefix: string | undefined) => {
+  return slugPrefix ? `${slugPrefix}${base ? '/' : ''}${base}` : base
+}
+
+const stripBasePathPrefix = (value: string, basePath: string) => {
+  if (value === basePath) {
+    return ''
+  }
+
+  if (value.startsWith(`${basePath}/`)) {
+    return value.slice(basePath.length + 1)
+  }
+
+  return null
+}
+
 /** Extracts an element id from the hash when using hash routing */
 export const getIdFromHash = (location: string | URL, slugPrefix: string | undefined) => {
   const url = typeof location === 'string' ? new URL(location) : location
 
   const base = decodeURIComponent(url.hash.slice(1))
 
-  return slugPrefix ? `${slugPrefix}${base ? '/' : ''}${base}` : base
+  return applySlugPrefix(base, slugPrefix)
 }
 /** Extracts an element id from the path when using path routing */
 export const getIdFromPath = (location: string | URL, basePath: string, slugPrefix: string | undefined) => {
@@ -28,10 +50,44 @@ export const getIdFromPath = (location: string | URL, basePath: string, slugPref
   if (url.pathname.startsWith(basePathWithSlash)) {
     const remainder = url.pathname.slice(basePathWithSlash.length)
     const base = decodeURIComponent(remainder.startsWith('/') ? remainder.slice(1) : remainder)
-    return slugPrefix ? `${slugPrefix}${base ? '/' : ''}${base}` : base
+    return applySlugPrefix(base, slugPrefix)
   }
 
   return slugPrefix ?? ''
+}
+
+/** Extracts an element id from a hash-prefixed basePath */
+export const getIdFromHashBasePath = (location: string | URL, basePath: string, slugPrefix: string | undefined) => {
+  const url = typeof location === 'string' ? new URL(location) : location
+  const hash = decodeURIComponent(url.hash.slice(1))
+  const sanitized = sanitizeHashBasePath(basePath)
+
+  const remainder = stripBasePathPrefix(hash, sanitized)
+  if (remainder !== null) {
+    return applySlugPrefix(remainder, slugPrefix)
+  }
+
+  return slugPrefix ?? ''
+}
+
+/** Determines whether a URL matches the provided basePath. */
+export const matchesBasePath = (location: string | URL, basePath: string) => {
+  const url = typeof location === 'string' ? new URL(location) : location
+
+  if (isHashBasePath(basePath)) {
+    const hash = decodeURIComponent(url.hash)
+    return hash === basePath || hash.startsWith(`${basePath}/`)
+  }
+
+  const sanitized = sanitizeBasePath(basePath)
+  const basePathWithSlash = sanitized
+    ? `/${sanitized
+        .split('/')
+        .map((segment) => encodeURIComponent(segment))
+        .join('/')}`
+    : ''
+
+  return url.pathname === basePathWithSlash || url.pathname.startsWith(`${basePathWithSlash}/`)
 }
 
 /**
@@ -42,7 +98,13 @@ export const getIdFromPath = (location: string | URL, basePath: string, slugPref
  * @param slugPrefix - If the document slug is not expected in the URL then we must prefix it
  */
 export const getIdFromUrl = (url: string | URL, basePath: string | undefined, slugPrefix: string | undefined) => {
-  return typeof basePath === 'string' ? getIdFromPath(url, basePath, slugPrefix) : getIdFromHash(url, slugPrefix)
+  if (typeof basePath !== 'string') {
+    return getIdFromHash(url, slugPrefix)
+  }
+
+  return isHashBasePath(basePath)
+    ? getIdFromHashBasePath(url, basePath, slugPrefix)
+    : getIdFromPath(url, basePath, slugPrefix)
 }
 
 /**
@@ -80,8 +142,13 @@ export const makeUrlFromId = (_id: string, basePath: string | undefined, isMulti
   const url = new URL(window.location.href)
 
   if (typeof basePath === 'string') {
-    const base = sanitizeBasePath(basePath)
-    url.pathname = `${base}/${id}`
+    if (isHashBasePath(basePath)) {
+      const base = sanitizeHashBasePath(basePath)
+      url.hash = [base, id].filter(Boolean).join('/')
+    } else {
+      const base = sanitizeBasePath(basePath)
+      url.pathname = `${base}/${id}`
+    }
   } else {
     url.hash = id
   }


### PR DESCRIPTION
Fixes #5599.

## Summary

`pathRouting.basePath` values that included a hash fragment were treated as pathname routing, so Scalar URL generation encoded the `#` into the pathname instead of appending the generated anchor inside the existing hash route.

## Changes

- add hash-prefixed basePath support to the shared id-routing helpers
- preserve existing hash routes like `#/services/petstore/openapi` and append Scalar ids inside that hash instead of encoding `#` into the pathname
- update initial basePath matching in `ApiReference.vue` so multi-document setups can recognize hash-prefixed base paths on first load
- add focused regression coverage for hash-prefixed basePath matching, id extraction, and URL generation
- add a patch changeset for `@scalar/api-reference`

## Testing

- `pnpm exec biome check packages/api-reference/src/helpers/id-routing.ts packages/api-reference/src/helpers/id-routing.test.ts packages/api-reference/src/components/ApiReference.vue`
- `pnpm exec vitest run packages/api-reference/src/helpers/id-routing.test.ts`