### PR TITLE
fix(api-client): default-close auth when not required

### DIFF
--- a/.changeset/orange-dingos-smell.md
+++ b/.changeset/orange-dingos-smell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): default-close auth when not required

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.test.ts
@@ -95,7 +95,35 @@ describe('RequestBlock', () => {
     expect(wrapper.attributes('aria-label')).toBe('Request: Summary')
   })
 
-  it('shows Auth section in modal layout', () => {
+  it('shows Auth section opened in modal layout when security is required', () => {
+    const wrapper = mount(RequestBlock, {
+      props: {
+        ...defaultProps,
+        layout: 'modal',
+        securityRequirements: [{ a: [] }],
+        securitySchemes: {
+          a: {
+            type: 'apiKey',
+            'x-scalar-secret-token': '',
+            name: 'X-API-Key',
+            in: 'header',
+          },
+        },
+      },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    })
+
+    const auth = wrapper.findComponent(AuthSelector)
+    expect(auth.exists()).toBe(true)
+    expect(auth.isVisible()).toBe(true)
+    expect(auth.findComponent({ name: 'RequestAuthDataTable' }).isVisible()).toBe(true)
+  })
+
+  it('shows Auth section collapsed in modal layout when no security requirement is configured', () => {
     const wrapper = mount(RequestBlock, {
       props: {
         ...defaultProps,
@@ -119,6 +147,7 @@ describe('RequestBlock', () => {
     const auth = wrapper.findComponent(AuthSelector)
     expect(auth.exists()).toBe(true)
     expect(auth.isVisible()).toBe(true)
+    expect(auth.findComponent({ name: 'RequestAuthDataTable' }).exists()).toBe(false)
   })
 
   it('hides Auth section in modal layout when no security is configured', () => {

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
@@ -73,6 +73,7 @@ const {
   securityRequirements,
   securitySchemes,
   selectedClient,
+  selectedSecurity,
   selectedSecuritySchemes,
   server,
 } = defineProps<{
@@ -266,10 +267,19 @@ const filterIds = computed(
  * This keeps the UI clean when there are no authentication options available.
  */
 const isAuthHidden = computed(
+  () => layout === 'modal' && !Object.keys(securitySchemes ?? {}).length,
+)
+
+/**
+ * Keep auth available for unauthenticated operations, but collapse it by default
+ * in readonly modal layouts unless a requirement or manual selection exists.
+ */
+const isAuthDefaultOpen = computed(
   () =>
-    layout === 'modal' &&
-    !operation.security &&
-    !Object.keys(securitySchemes ?? {}).length,
+    layout !== 'modal' ||
+    Boolean(
+      securityRequirements?.length || selectedSecurity.selectedSchemes.length,
+    ),
 )
 
 /** Get a sensible placeholder for the request name input */
@@ -427,6 +437,7 @@ const updateOperationExtension = (
         v-show="isSectionVisible('Auth') && !isAuthHidden"
         :id="filterIds.Auth"
         :createAnySecurityScheme="layout !== 'modal'"
+        :defaultOpen="isAuthDefaultOpen"
         :environment
         :eventBus
         :meta="authMeta"

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/AuthSelector.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/AuthSelector.vue
@@ -41,6 +41,7 @@ const {
   environment,
   eventBus,
   createAnySecurityScheme = false,
+  defaultOpen = true,
   isStatic = false,
   meta,
   proxyUrl,
@@ -54,6 +55,8 @@ const {
   eventBus: WorkspaceEventBus
   /** Allows adding authentication which is not in the document */
   createAnySecurityScheme?: boolean
+  /** Whether the authentication disclosure should start expanded */
+  defaultOpen?: boolean
   /** Creates a static disclosure that cannot be collapsed */
   isStatic?: boolean
   meta: AuthMeta
@@ -207,6 +210,7 @@ defineExpose({
 <template>
   <CollapsibleSection
     class="group/params relative"
+    :defaultOpen
     :isStatic="isStatic"
     :itemCount="activeSchemeOptions.length"
     @update:modelValue="(open) => (isDisclosureOpen = open)">


### PR DESCRIPTION
Fixes #8046.

## Summary

When an operation has available security schemes but no effective `security` requirement, Scalar still needs to leave a path for manually adding auth. The issue in the modal request UI was that the Authentication section opened by default anyway, which made unauthenticated operations look like they required auth.

This change keeps the auth selector available, but defaults it to collapsed for modal operations with no security requirements. If auth is actually required or already selected, it still opens by default.

## Changes

- add a `defaultOpen` prop to the v2 auth selector disclosure
- default modal request auth to closed when there are security schemes but no operation/document security requirements
- keep the auth section hidden when no security schemes exist at all
- add focused request-block tests for required-vs-unauthenticated modal auth behavior
- add a patch changeset for `@scalar/api-client`

## Testing

- `pnpm exec biome check packages/api-client/src/v2/blocks/request-block/RequestBlock.vue packages/api-client/src/v2/blocks/request-block/RequestBlock.test.ts packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/AuthSelector.vue`
- `pnpm exec vitest run packages/api-client/src/v2/blocks/request-block/RequestBlock.test.ts packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/AuthSelector.test.ts`