### PR TITLE
fix(api-client): do not add Content-Type header when request has no body

### DIFF
--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-default-headers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-default-headers.ts
@@ -82,7 +82,8 @@ export const getDefaultHeaders = ({
   const requestBody = getResolvedRef(operation.requestBody)
 
   // Add Content-Type header only for methods that support a request body
-  if (canMethodHaveBody(method)) {
+  // and only when the operation actually defines a request body
+  if (canMethodHaveBody(method) && requestBody) {
     const contentType =
       requestBody?.['x-scalar-selected-content-type']?.[exampleKey] ??
       Object.keys(requestBody?.content ?? {})[0] ??


### PR DESCRIPTION
## What

Added a `requestBody` existence check before adding the `Content-Type` header to outgoing requests.

## Why

When an operation does not define a `requestBody` (e.g. a simple `DELETE` endpoint), the API client still adds `Content-Type: application/json` to the request. This causes servers like Fastify to reject the request with `FST_ERR_CTP_EMPTY_JSON_BODY`.

The existing check only verified whether the HTTP method *can* have a body (`canMethodHaveBody`), but not whether the operation actually *defines* one.

Reported in #8458. Previously reported in #3142, #2486, #4542.

## Changes

**File:** `packages/api-client/src/v2/blocks/request-block/helpers/get-default-headers.ts`

```diff
-  if (canMethodHaveBody(method)) {
+  if (canMethodHaveBody(method) && requestBody) {
```

`requestBody` is already resolved from the operation on the line above, so this is a minimal, safe addition.

## Behavior

| Method | requestBody defined | Content-Type added |
|--------|--------------------|--------------------|
| POST | Yes | ✅ Yes (unchanged) |
| PUT | Yes | ✅ Yes (unchanged) |
| DELETE | Yes | ✅ Yes (unchanged) |
| DELETE | **No** | ✅ **No (fixed)** |
| GET | N/A | ✅ No (unchanged) |

Fixes #8458