### PR TITLE
feat(biome): add noGlobalDirnameFilename lint rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -113,6 +113,7 @@
         "noConstantCondition": "warn",
         "noEmptyCharacterClassInRegex": "warn",
         "noEmptyPattern": "warn",
+        "noGlobalDirnameFilename": "error",
         "noGlobalObjectCalls": "warn",
         "noInnerDeclarations": "warn",
         "noInvalidBuiltinInstantiation": "warn",

--- a/packages/json-magic/src/bundle/bundle.test.ts
+++ b/packages/json-magic/src/bundle/bundle.test.ts
@@ -1745,7 +1745,7 @@ describe('bundle', () => {
       const chunk1 = { a: 'a', b: 'b' }
       const chunk1Path = randomUUID()
 
-      await fs.writeFile(path.join(__dirname, chunk1Path), JSON.stringify(chunk1))
+      await fs.writeFile(path.join(import.meta.dirname, chunk1Path), JSON.stringify(chunk1))
 
       const input = {
         a: {
@@ -1753,9 +1753,9 @@ describe('bundle', () => {
         },
       }
 
-      await bundle(input, { origin: __filename, plugins: [fetchUrls(), readFiles()], treeShake: false })
+      await bundle(input, { origin: import.meta.filename, plugins: [fetchUrls(), readFiles()], treeShake: false })
 
-      await fs.rm(path.join(__dirname, chunk1Path))
+      await fs.rm(path.join(import.meta.dirname, chunk1Path))
 
       expect(input).toEqual({
         'x-ext': {
@@ -1776,8 +1776,8 @@ describe('bundle', () => {
       const chunk2 = { a: { '$ref': `./${chunk1Path}#` } }
       const chunk2Path = randomUUID()
 
-      await fs.writeFile(path.join(__dirname, chunk1Path), JSON.stringify(chunk1))
-      await fs.writeFile(path.join(__dirname, chunk2Path), JSON.stringify(chunk2))
+      await fs.writeFile(path.join(import.meta.dirname, chunk1Path), JSON.stringify(chunk1))
+      await fs.writeFile(path.join(import.meta.dirname, chunk2Path), JSON.stringify(chunk2))
 
       const input = {
         a: {
@@ -1785,10 +1785,10 @@ describe('bundle', () => {
         },
       }
 
-      await bundle(input, { origin: __filename, plugins: [fetchUrls(), readFiles()], treeShake: false })
+      await bundle(input, { origin: import.meta.filename, plugins: [fetchUrls(), readFiles()], treeShake: false })
 
-      await fs.rm(path.join(__dirname, chunk1Path))
-      await fs.rm(path.join(__dirname, chunk2Path))
+      await fs.rm(path.join(import.meta.dirname, chunk1Path))
+      await fs.rm(path.join(import.meta.dirname, chunk2Path))
 
       expect(input).toEqual({
         'x-ext': {
@@ -1818,11 +1818,11 @@ describe('bundle', () => {
       }
       const bName = randomUUID()
 
-      await fs.mkdir(path.join(__dirname, 'nested')).catch(() => {
+      await fs.mkdir(path.join(import.meta.dirname, 'nested')).catch(() => {
         return
       })
-      await fs.writeFile(path.join(__dirname, `nested/${bName}`), JSON.stringify(b))
-      await fs.writeFile(path.join(__dirname, `nested/${cName}`), JSON.stringify(c))
+      await fs.writeFile(path.join(import.meta.dirname, `nested/${bName}`), JSON.stringify(b))
+      await fs.writeFile(path.join(import.meta.dirname, `nested/${cName}`), JSON.stringify(c))
 
       const input = {
         a: {
@@ -1830,11 +1830,11 @@ describe('bundle', () => {
         },
       }
 
-      await bundle(input, { origin: __filename, plugins: [fetchUrls(), readFiles()], treeShake: false })
+      await bundle(input, { origin: import.meta.filename, plugins: [fetchUrls(), readFiles()], treeShake: false })
 
-      await fs.rm(path.join(__dirname, `./nested/${bName}`))
-      await fs.rm(path.join(__dirname, `./nested/${cName}`))
-      await fs.rmdir(path.join(__dirname, 'nested'))
+      await fs.rm(path.join(import.meta.dirname, `./nested/${bName}`))
+      await fs.rm(path.join(import.meta.dirname, `./nested/${cName}`))
+      await fs.rmdir(path.join(import.meta.dirname, 'nested'))
 
       expect(input).toEqual({
         'x-ext': {
@@ -1901,7 +1901,7 @@ describe('bundle', () => {
       const chunk1 = { a: 'a', b: 'b' }
       const chunk1Path = randomUUID()
 
-      await fs.writeFile(path.join(__dirname, chunk1Path), JSON.stringify(chunk1))
+      await fs.writeFile(path.join(import.meta.dirname, chunk1Path), JSON.stringify(chunk1))
 
       const input = {
         a: {
@@ -1909,9 +1909,14 @@ describe('bundle', () => {
         },
       }
 
-      await bundle(input, { origin: __filename, plugins: [fetchUrls(), readFiles()], treeShake: false, urlMap: true })
+      await bundle(input, {
+        origin: import.meta.filename,
+        plugins: [fetchUrls(), readFiles()],
+        treeShake: false,
+        urlMap: true,
+      })
 
-      await fs.rm(path.join(__dirname, chunk1Path))
+      await fs.rm(path.join(import.meta.dirname, chunk1Path))
 
       expect(input).toEqual({
         'a': {
@@ -1950,7 +1955,7 @@ describe('bundle', () => {
       const chunk1 = { a: 'a', b: 'b' }
       const chunk1Path = randomUUID()
 
-      await fs.writeFile(path.join(__dirname, chunk1Path), JSON.stringify(chunk1))
+      await fs.writeFile(path.join(import.meta.dirname, chunk1Path), JSON.stringify(chunk1))
 
       const input = JSON.stringify({
         a: {
@@ -1958,9 +1963,13 @@ describe('bundle', () => {
         },
       })
 
-      const result = await bundle(input, { origin: __filename, plugins: [readFiles(), parseJson()], treeShake: false })
+      const result = await bundle(input, {
+        origin: import.meta.filename,
+        plugins: [readFiles(), parseJson()],
+        treeShake: false,
+      })
 
-      await fs.rm(path.join(__dirname, chunk1Path))
+      await fs.rm(path.join(import.meta.dirname, chunk1Path))
 
       expect(result).toEqual({
         'x-ext': {
@@ -2007,7 +2016,7 @@ describe('bundle', () => {
       const chunk1 = { a: 'a', b: 'b' }
       const chunk1Path = randomUUID()
 
-      await fs.writeFile(path.join(__dirname, chunk1Path), YAML.stringify(chunk1))
+      await fs.writeFile(path.join(import.meta.dirname, chunk1Path), YAML.stringify(chunk1))
 
       const input = YAML.stringify({
         a: {
@@ -2015,9 +2024,13 @@ describe('bundle', () => {
         },
       })
 
-      const result = await bundle(input, { origin: __filename, plugins: [parseYaml(), readFiles()], treeShake: false })
+      const result = await bundle(input, {
+        origin: import.meta.filename,
+        plugins: [parseYaml(), readFiles()],
+        treeShake: false,
+      })
 
-      await fs.rm(path.join(__dirname, chunk1Path))
+      await fs.rm(path.join(import.meta.dirname, chunk1Path))
 
       expect(result).toEqual({
         'x-ext': {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Using `__dirname` and `__filename` in ESM code causes issues because these globals are not available in ES modules. This leads to runtime errors and inconsistent behavior across the codebase.

As discussed in Slack, we want to catch these usages automatically so developers are nudged to use the correct ESM alternatives: `import.meta.dirname` and `import.meta.filename`.

## Solution

Added the Biome lint rule `noGlobalDirnameFilename` with `error` severity to catch any usage of `__dirname` or `__filename` in the codebase. Biome will suggest the safe fix of replacing these with their `import.meta` equivalents.

Also fixed the existing violations in `packages/json-magic/src/bundle/bundle.test.ts` by replacing all `__dirname` usages with `import.meta.dirname` and `__filename` usages with `import.meta.filename`.

Reference: https://biomejs.dev/linter/rules/no-global-dirname-filename/

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed for config changes -->
- [x] I added tests. <!-- Existing tests pass -->
- [ ] I updated the documentation. <!-- Not applicable -->
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C04DLSW521X/p1773686362832789?thread_ts=1773686362.832789&cid=C04DLSW521X)

<div><a href="https://cursor.com/agents/bc-6156a269-e94d-55e6-b20b-4a284902870b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6156a269-e94d-55e6-b20b-4a284902870b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

