### PR TITLE
fix(api-client): skip content type without request body

### DIFF
--- a/.changeset/orange-bulldogs-juggle.md
+++ b/.changeset/orange-bulldogs-juggle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix default content type headers for operations without request bodies

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-default-headers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-default-headers.test.ts
@@ -26,7 +26,7 @@ describe('get-default-headers', () => {
       expect(contentTypeHeader).toBeUndefined()
     })
 
-    it('adds Content-Type header for POST requests with default application/json', () => {
+    it('adds Content-Type header for POST requests when the request body defines one', () => {
       const operation: OperationObject = {
         requestBody: {
           content: {
@@ -325,7 +325,9 @@ describe('get-default-headers', () => {
       // Should still have Accept header, but no Content-Type since there's no requestBody
       expect(headers.length).toBeGreaterThan(0)
       const acceptHeader = headers.find((header) => header.name.toLowerCase() === 'accept')
+      const contentTypeHeader = headers.find((header) => header.name.toLowerCase() === 'content-type')
       expect(acceptHeader).toBeDefined()
+      expect(contentTypeHeader).toBeUndefined()
     })
 
     it('uses first content type when no selection is made', () => {
@@ -351,7 +353,7 @@ describe('get-default-headers', () => {
       expect(contentTypeHeader?.defaultValue).toBe('application/xml')
     })
 
-    it('handles empty content object', () => {
+    it('does not add Content-Type when the requestBody has no content types', () => {
       const operation: OperationObject = {
         requestBody: {
           content: {},
@@ -366,9 +368,30 @@ describe('get-default-headers', () => {
 
       const contentTypeHeader = headers.find((header) => header.name.toLowerCase() === 'content-type')
 
-      // Should fall back to default application/json
-      expect(contentTypeHeader).toBeDefined()
-      expect(contentTypeHeader?.defaultValue).toBe('application/json')
+      expect(contentTypeHeader).toBeUndefined()
+    })
+
+    it('does not add Content-Type for DELETE requests without a request body', () => {
+      const operation: OperationObject = {
+        responses: {
+          '200': {
+            description: 'Delete Success',
+            content: {
+              'application/json': {},
+            },
+          },
+        },
+      }
+
+      const headers = getDefaultHeaders({
+        method: 'delete',
+        operation,
+        exampleKey: 'example-1',
+      })
+
+      const contentTypeHeader = headers.find((header) => header.name.toLowerCase() === 'content-type')
+
+      expect(contentTypeHeader).toBeUndefined()
     })
   })
 })

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-default-headers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-default-headers.ts
@@ -8,9 +8,6 @@ import { isElectron } from '@/libs/electron'
 // eslint-disable-next-line no-undef
 const APP_VERSION = PACKAGE_VERSION
 
-/** Default Content-Type header value for requests with a body. */
-const DEFAULT_CONTENT_TYPE = 'application/json'
-
 /** Default Accept header value to accept all response types. */
 const DEFAULT_ACCEPT = '*/*'
 
@@ -45,8 +42,9 @@ const createDefaultHeader = (name: string, defaultValue: string, existingHeaders
  * Generates a list of default headers for an OpenAPI operation and HTTP method.
  *
  * This function intelligently adds standard HTTP headers based on the request context:
- * - Content-Type: Added only if the HTTP method supports a request body (POST, PUT, PATCH, etc.).
- *   Uses the selected content type from the operation or defaults to "application/json".
+ * - Content-Type: Added only if the HTTP method supports a request body and the OpenAPI operation
+ *   defines a request body content type. Uses the selected content type from the operation or the
+ *   first defined request body content type.
  * - Accept: Derived from the 2xx response content types in the spec (joined as a comma-separated list), falling back to a wildcard.
  * - User-Agent: Added in Electron environments (desktop app or proxy) to identify the client.
  *
@@ -82,14 +80,12 @@ export const getDefaultHeaders = ({
   const requestBody = getResolvedRef(operation.requestBody)
 
   // Add Content-Type header only for methods that support a request body
-  if (canMethodHaveBody(method)) {
+  if (canMethodHaveBody(method) && requestBody) {
     const contentType =
-      requestBody?.['x-scalar-selected-content-type']?.[exampleKey] ??
-      Object.keys(requestBody?.content ?? {})[0] ??
-      DEFAULT_CONTENT_TYPE
+      requestBody['x-scalar-selected-content-type']?.[exampleKey] ?? Object.keys(requestBody.content ?? {})[0]
 
-    // We never want to add a content type of 'none'
-    if (contentType !== 'none') {
+    // We never want to add a content type of 'none' or invent one when the schema defines no body.
+    if (contentType && contentType !== 'none') {
       headers.push(createDefaultHeader('Content-Type', contentType, existingHeaders))
     }
   }


### PR DESCRIPTION
Fixes #8458.

## Summary

Scalar was defaulting `Content-Type: application/json` for methods that can carry a body even when the operation does not define any request body. That leaked a request-body header into body-less operations like `DELETE`.

## Changes

- only add a default `Content-Type` when the operation actually defines request body content
- keep honoring the selected body content type when request body content exists
- add focused regression coverage for operations with no request body and empty request body content
- add a patch changeset for `@scalar/api-client`

## Testing

- `pnpm exec biome check packages/api-client/src/v2/blocks/request-block/helpers/get-default-headers.ts packages/api-client/src/v2/blocks/request-block/helpers/get-default-headers.test.ts .changeset/orange-bulldogs-juggle.md`
- `pnpm --dir packages/api-client exec vitest run src/v2/blocks/request-block/helpers/get-default-headers.test.ts`
