### PR TITLE
fix(rust): include scalar.js in packaged crate

### DIFF
--- a/integrations/rust/.gitignore
+++ b/integrations/rust/.gitignore
@@ -1,1 +1,2 @@
 target/
+ui/scalar.js

--- a/integrations/rust/Cargo.toml
+++ b/integrations/rust/Cargo.toml
@@ -7,7 +7,15 @@ license = "MIT"
 repository = "https://github.com/scalar/scalar"
 keywords = ["api", "documentation", "openapi", "swagger"]
 categories = ["web-programming", "development-tools"]
-exclude = ["package.json", "CHANGELOG.md"]
+include = [
+    "Cargo.toml",
+    "Cargo.lock",
+    "README.md",
+    "src/**/*",
+    "ui/index.html",
+    "ui/scalar.js",
+    "examples/**/*",
+]
 
 [dependencies]
 rust-embed = "8.11.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Rust integration can publish a crate without `ui/scalar.js`, which breaks the local `/scalar/scalar.js` asset route and reproduces issue #8464.

`cargo package` excludes gitignored files by default, so the generated JS asset was omitted from the published crate.

## Solution

- Keep `ui/scalar.js` ignored in Git (`integrations/rust/.gitignore`) so the built artifact is not committed.
- Add an explicit `include` list in `integrations/rust/Cargo.toml` and include `ui/scalar.js` so Cargo packages it even though it is gitignored.
- Keep package/CI changes minimal and focused on the packaging fix.
- Add a patch changeset for `scalar_api_reference` to trigger release.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a5f7193-6080-4090-a335-878ad223525c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a5f7193-6080-4090-a335-878ad223525c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

