### PR TITLE
feat: don’t show dependency updates in changelogs

### DIFF
--- a/tooling/changelog-generator/src/formatter.test.ts
+++ b/tooling/changelog-generator/src/formatter.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { GitHubInfo } from '@/types'
 
-import { formatDependencyChange, formatDependencyHeader, formatReleaseLine } from './formatter'
+import { formatReleaseLine } from './formatter'
 
 describe('formatter helpers', () => {
   it('formats release line with PR link', () => {
@@ -70,55 +70,6 @@ describe('formatter helpers', () => {
         '  - `LoadingCompletionOptions`',
         '  - `MaybeElement`',
         '  - `ScalarComboBox#isGroup`',
-      ].join('\n'),
-    )
-  })
-
-  it('formats dependency header and change', () => {
-    expect(formatDependencyHeader('@scalar/api-reference', '1.2.3')).toBe('- **@scalar/api-reference@1.2.3**')
-
-    const githubInfo: GitHubInfo = {
-      pull: 10,
-      user: null,
-      links: {
-        commit: '',
-        pull: 'https://github.com/scalar/scalar/pull/10',
-        user: null,
-      },
-    }
-
-    expect(formatDependencyChange(githubInfo, 'Fixed things')).toBe(
-      '  - [#10](https://github.com/scalar/scalar/pull/10): Fixed things',
-    )
-    expect(formatDependencyChange(null, 'No PR')).toBe('  - No PR')
-  })
-
-  it('formats changelog entries with higher indent levels', () => {
-    const githubInfo: GitHubInfo = {
-      pull: 42,
-      user: null,
-      links: {
-        commit: '',
-        pull: 'https://github.com/scalar/scalar/pull/42',
-        user: null,
-      },
-    }
-
-    const description = [
-      'Update dependency internals',
-      '',
-      '- feat: improve caching',
-      '- fix: reduce bundle size',
-    ].join('\n')
-
-    const result = formatDependencyChange(githubInfo, description)
-
-    expect(result).toBe(
-      [
-        '  - [#42](https://github.com/scalar/scalar/pull/42): Update dependency internals',
-        '',
-        '    - feat: improve caching',
-        '    - fix: reduce bundle size',
       ].join('\n'),
     )
   })

--- a/tooling/changelog-generator/src/formatter.ts
+++ b/tooling/changelog-generator/src/formatter.ts
@@ -83,16 +83,3 @@ export function formatReleaseLine(changeset: NewChangesetWithCommit, githubInfo:
   const prLink = getPRLink(githubInfo)
   return formatChangelogEntry(changeset.summary, { prLink })
 }
-
-export function formatDependencyHeader(packageName: string, version: string): string {
-  return `- **${packageName}@${version}**`
-}
-
-export function formatDependencyChange(githubInfo: GitHubInfo | null, description: string): string {
-  if (startsWithPRLink(description)) {
-    return formatChangelogEntry(description, { indentLevel: 1 })
-  }
-
-  const prLink = getPRLink(githubInfo)
-  return formatChangelogEntry(description, { prLink, indentLevel: 1 })
-}

--- a/tooling/changelog-generator/src/index.test.ts
+++ b/tooling/changelog-generator/src/index.test.ts
@@ -38,17 +38,7 @@ describe('changelog functions', () => {
     expect(line).toBe('- [#42](https://github.com/scalar/scalar/pull/42): Add feature X')
   })
 
-  it('getDependencyReleaseLine groups dependency changes', async () => {
-    mockGetInfo.mockResolvedValue({
-      pull: 10,
-      user: null,
-      links: {
-        commit: '',
-        pull: 'https://github.com/scalar/scalar/pull/10',
-        user: null,
-      },
-    })
-
+  it('getDependencyReleaseLine always returns empty string', async () => {
     const changesets: Array<NewChangesetWithCommit> = [
       {
         id: '123',
@@ -67,13 +57,6 @@ describe('changelog functions', () => {
 
     const output = await changelogFunctions.getDependencyReleaseLine(changesets, deps, { repo: 'scalar/scalar' })
 
-    expect(output.trim()).toBe(
-      [
-        '#### Updated Dependencies',
-        '',
-        '- **@scalar/api-reference@1.0.1**',
-        '  - [#10](https://github.com/scalar/scalar/pull/10): Fix api ref',
-      ].join('\n'),
-    )
+    expect(output).toBe('')
   })
 })

--- a/tooling/changelog-generator/src/index.ts
+++ b/tooling/changelog-generator/src/index.ts
@@ -1,7 +1,7 @@
 import { getInfo } from '@changesets/get-github-info'
 import type { ChangelogFunctions } from '@changesets/types'
 
-import { formatDependencyChange, formatDependencyHeader, formatReleaseLine } from './formatter'
+import { formatReleaseLine } from './formatter'
 
 type Options = Partial<{ repo?: string }> | null
 
@@ -63,49 +63,9 @@ const changelogFunctions: ChangelogFunctions = {
     return formatReleaseLine(changeset, githubInfoWithPR)
   },
 
-  getDependencyReleaseLine: async (changesets, dependenciesUpdated, options: Options) => {
-    const repo = options?.repo
-    if (!repo) {
-      throw new Error('Please provide a `repo` option. It should be a string like "user/repo".')
-    }
-
-    if (dependenciesUpdated.length === 0) {
-      return ''
-    }
-
-    const lines: string[] = []
-    lines.push('#### Updated Dependencies')
-    lines.push('')
-
-    // Group dependencies by package name
-    for (const dependency of dependenciesUpdated) {
-      const packageName = dependency.name
-      const version = dependency.newVersion
-
-      lines.push(formatDependencyHeader(packageName, version))
-
-      // Find all changesets that affected this dependency
-      const relevantChangesets = changesets.filter((changeset) =>
-        changeset.releases.some((release) => release.name === packageName),
-      )
-
-      // Get GitHub info for each changeset and format the changes
-      for (const changeset of relevantChangesets) {
-        const githubInfo = changeset.commit
-          ? await getInfo({
-              repo,
-              commit: changeset.commit,
-            })
-          : null
-
-        const changeLine = formatDependencyChange(githubInfo, changeset.summary)
-        lines.push(changeLine)
-      }
-
-      lines.push('')
-    }
-
-    return lines.join('\n')
+  getDependencyReleaseLine: async (_changesets, _dependenciesUpdated, _options: Options) => {
+    // Skip dependency updates in changelog — they are noise
+    return await Promise.resolve('')
   },
 }
 


### PR DESCRIPTION
## Problem

so much noise, little value

<img width="749" height="809" alt="Screenshot 2026-03-17 at 15 19 13" src="https://github.com/user-attachments/assets/e2b720cd-0e04-451c-afe8-960d28e8c72a" />

## Solution

don't show dependency updates in the releases/changelogs

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limits changelog output by skipping dependency-update sections; main change is to release-note formatting rather than runtime behavior.
> 
> **Overview**
> Changelog generation now **omits dependency update entries**: `getDependencyReleaseLine` always returns an empty string, so dependency bumps no longer produce an “Updated Dependencies” section.
> 
> Removes the dependency-specific formatting helpers (`formatDependencyHeader`, `formatDependencyChange`) and updates tests to assert dependency release output is empty while keeping `formatReleaseLine` behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e7c929b2ad62a442a87dc9cd9e6819e77682d35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->