### PR TITLE
docs: show changelogs for mock-server and openapi-upgrader

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1718,6 +1718,11 @@
                     "title": "Data Seeding",
                     "filepath": "documentation/guides/mock-server/data-seeding.md",
                     "type": "page"
+                  },
+                  "changelog": {
+                    "title": "Changelog",
+                    "filepath": "packages/mock-server/CHANGELOG.md",
+                    "type": "page"
                   }
                 }
               }
@@ -1808,6 +1813,11 @@
                         }
                       ]
                     }
+                  },
+                  "changelog": {
+                    "title": "Changelog",
+                    "filepath": "packages/openapi-upgrader/CHANGELOG.md",
+                    "type": "page"
                   }
                 }
               },


### PR DESCRIPTION
let's show those two changelogs in the docs, too
we have them anyway :)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds two new navigation entries pointing at existing `CHANGELOG.md` files.
> 
> **Overview**
> Exposes package changelogs in the public docs navigation by adding new `changelog` pages under **Mock Server** and **OpenAPI Upgrader**, each rendering the corresponding `packages/*/CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0f3949d94db25c43e372635629e67435085ec59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->