### PR TITLE
docs: pricing update

### DIFF
--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -47,13 +47,13 @@
             <header class="pricing-table-group-heading">Docs</header>
             <div class="pricing-table-row">
               <div class="pricing-table-column">Subdomains</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
+              <div class="pricing-table-column"></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
             </div>
             <div class="pricing-table-row">
               <div class="pricing-table-column">API References (OpenAPI)</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
+              <div class="pricing-table-column"></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
             </div>
@@ -65,7 +65,7 @@
             </div>
             <div class="pricing-table-row">
               <div class="pricing-table-column">Custom HTML/CSS/JS</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
+              <div class="pricing-table-column"></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
             </div>
@@ -490,6 +490,12 @@
               <div class="pricing-table-column">Dedicated Slack channel</div>
               <div class="pricing-table-column"></div>
               <div class="pricing-table-column"></div>
+              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
+            </div>
+            <div class="pricing-table-row">
+              <div class="pricing-table-column">Max APIs</div>
+              <div class="pricing-table-column">3</div>
+              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
             </div>
           </div>

--- a/documentation/migration/api-hub.md
+++ b/documentation/migration/api-hub.md
@@ -9,7 +9,7 @@ Scalar includes many of the same features as API Hub including:
 3. Custom domains, theming, and logos.
 4. A built-in, local-first API client to help developers and end users call endpoints and test  APIs.
 
-Beyond having a simpler name, Scalar is also [free to use forever](../guides/pricing.md) with fewer limits than API Hub. If you want custom domains, GitHub sync, and a few other features, our Pro plan starts at $72/mo (3-seat min).
+Beyond having a simpler name, Scalar is also [free to get started with](../guides/pricing.md), and our Pro plan starts at $72/mo (3-seat min). If you want custom domains, GitHub sync, and a few other features, check out the Pro plan.
 
 As a bonus, Scalar is also open source, meaning you can self-host it and view all of its code on [GitHub](https://github.com/scalar/scalar).
 

--- a/documentation/migration/stoplight.md
+++ b/documentation/migration/stoplight.md
@@ -11,7 +11,7 @@ For a long time Stoplight was the scrappy underdog, taking on confusing unafford
 
 On top of this, Scalar provides added benefits like:
 
-- **Flexible SaaS pricing.** Most of the features of Scalar can be used for free, and the Pro plan starts at $72/mo (3-seat min).
+- **Flexible SaaS pricing.** Scalar has a free tier to get started, and the Pro plan starts at $72/mo (3-seat min).
 - **Open Source.** Scalar is fully open source and can be self-hosted, something Stoplight phased out years ago.
 - **Built-in API client.** Scalar has also built an API client into the API reference, enabling users to send test requests straight from the docs.
 
@@ -45,7 +45,7 @@ With that in mind, let's look at how you can switch to a cheaper and better Open
 
 ## Step 1: Create a free Scalar account
 
-Scalar has a free tier, and you can get quite a lot done with it. No credit card needed or gimmick trials that are hard to cancel, just [register over here](https://dashboard.scalar.com/register).
+Scalar has a free tier, and you can get quite a lot done with it. No credit card needed, just [register over here](https://dashboard.scalar.com/register).
 
 ## Step 2: Introduce your OpenAPI to Scalar
 

--- a/documentation/migration/zuplo.md
+++ b/documentation/migration/zuplo.md
@@ -25,7 +25,7 @@ Scalar offers a more accessible entry point with a free tier and simpler pricing
 | Enterprise | custom pricing |  custom pricing  |
 
 - Scalar pricing is user-based (documentation platform), while Zuplo pricing is request-based (gateway usage)
-- Scalar has a generous free tier for documentation that doesn't depend on API traffic
+- Scalar has a free tier for getting started that doesn't depend on API traffic
 - For teams focused on documentation, Scalar provides predictable and often lower costs
 
 For detailed pricing information, visit [Scalar Pricing](../guides/pricing.md) and [Zuplo Pricing](https://zuplo.com/pricing).
@@ -143,7 +143,7 @@ If you have multiple OpenAPI files in Zuplo (split across different files), you'
 
 ### Step 2: Create a Scalar Account
 
-Scalar has a free tier, and you can get quite a lot done with it. No credit card needed or gimmick trials that are hard to cancel, just [register over here](https://dashboard.scalar.com/register).
+Scalar has a free tier, and you can get quite a lot done with it. No credit card needed, just [register over here](https://dashboard.scalar.com/register).
 
 ### Step 3: Upload OpenAPI Document
 


### PR DESCRIPTION
reflects the recent changes in the docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only updates that adjust pricing table entitlements/limits and refresh marketing copy; no runtime or API behavior changes.
> 
> **Overview**
> Updates the pricing guide to reflect revised Free-plan entitlements (removing checks for some Docs features) and adds a new `Max APIs` row/limit.
> 
> Refreshes pricing language across migration guides (`api-hub`, `stoplight`, `zuplo`) to describe a “free tier to get started” and simplifies the no-credit-card messaging while keeping Pro pricing consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eef02db45047e743784ed9fa4be0833330b3c8a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->