### PR TITLE
refactor(api-client-react): migrate React provider to api-client v2 modal

### DIFF
--- a/.changeset/blue-rivers-cook.md
+++ b/.changeset/blue-rivers-cook.md
@@ -1,5 +1,5 @@
 ---
-'@scalar/api-client-react': patch
+'@scalar/api-client-react': minor
 ---
 
 refactor: migrate the React modal provider to the `@scalar/api-client` v2 modal and workspace-store flow

--- a/.changeset/blue-rivers-cook.md
+++ b/.changeset/blue-rivers-cook.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client-react': patch
+---
+
+refactor: migrate the React modal provider to the `@scalar/api-client` v2 modal and workspace-store flow

--- a/packages/api-client-react/package.json
+++ b/packages/api-client-react/package.json
@@ -50,7 +50,8 @@
   ],
   "dependencies": {
     "@scalar/api-client": "workspace:*",
-    "@scalar/types": "workspace:*"
+    "@scalar/types": "workspace:*",
+    "@scalar/workspace-store": "workspace:*"
   },
   "devDependencies": {
     "@scalar/build-tooling": "workspace:*",

--- a/packages/api-client-react/playground/App.tsx
+++ b/packages/api-client-react/playground/App.tsx
@@ -1,4 +1,4 @@
-import type { OpenClientPayload } from '@scalar/api-client/libs'
+import type { OpenClientPayload } from '../src'
 
 import { useApiClientModal } from '../src/ApiClientModalProvider'
 import '../src/style.css'

--- a/packages/api-client-react/src/ApiClientModalProvider.tsx
+++ b/packages/api-client-react/src/ApiClientModalProvider.tsx
@@ -67,9 +67,7 @@ type ResolvedDocumentInput = {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null
 
-const resolveDocumentInput = async (
-  configuration: Partial<ApiClientConfiguration>,
-): Promise<ResolvedDocumentInput | null> => {
+const resolveDocumentInput = (configuration: Partial<ApiClientConfiguration>): ResolvedDocumentInput | null => {
   const url = configuration.url ?? configuration.spec?.url
   if (url) {
     return { url }
@@ -119,12 +117,25 @@ const toRoutePayload = (payload?: OpenClientPayload) => {
     return undefined
   }
 
-  return {
+  const routePayload: {
+    path: string
+    method: HttpMethod
+    example?: string
+    documentSlug?: string
+  } = {
     path: payload.path,
     method,
-    example: payload.example,
-    documentSlug: payload.documentSlug,
   }
+
+  if (payload.example) {
+    routePayload.example = payload.example
+  }
+
+  if (payload.documentSlug) {
+    routePayload.documentSlug = payload.documentSlug
+  }
+
+  return routePayload
 }
 
 /**
@@ -169,7 +180,7 @@ export const ApiClientModalProvider = ({ children, initialRequest, configuration
         },
       })
 
-      const resolvedDocumentInput = await resolveDocumentInput(currentConfiguration)
+      const resolvedDocumentInput = resolveDocumentInput(currentConfiguration)
       if (!resolvedDocumentInput) {
         console.error(
           '[@scalar/api-client-react] Please provide an OpenAPI source through configuration.url or configuration.content.',

--- a/packages/api-client-react/src/ApiClientModalProvider.tsx
+++ b/packages/api-client-react/src/ApiClientModalProvider.tsx
@@ -28,7 +28,7 @@ type RequestUidPayload = {
 
 export type OpenClientPayload = RoutePayload | RequestUidPayload
 
-export type ApiClient = Omit<V2ApiClientModal, 'open' | 'route'> & {
+type ApiClient = Omit<V2ApiClientModal, 'open' | 'route'> & {
   open: (payload?: OpenClientPayload) => void
   route: (payload: OpenClientPayload) => void
 }
@@ -45,27 +45,19 @@ type Props = PropsWithChildren<{
 /** Hack: this is strictly to prevent creation of extra clients as the store lags a bit */
 const clientDict: Record<string, ApiClient> = {}
 
-const HTTP_METHODS = new Set<HttpMethod>([
-  'get',
-  'post',
-  'put',
-  'delete',
-  'patch',
-  'head',
-  'options',
-  'trace',
-])
+const HTTP_METHODS = new Set<HttpMethod>(['get', 'post', 'put', 'delete', 'patch', 'head', 'options', 'trace'])
 
 const isHttpMethod = (value: string): value is HttpMethod => HTTP_METHODS.has(value as HttpMethod)
 
-type ResolvedDocumentInput = {
-  url: string
-} | {
-  document: Record<string, unknown>
-}
+type ResolvedDocumentInput =
+  | {
+      url: string
+    }
+  | {
+      document: Record<string, unknown>
+    }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
 
 const resolveDocumentInput = (configuration: Partial<ApiClientConfiguration>): ResolvedDocumentInput | null => {
   const url = configuration.url ?? configuration.spec?.url

--- a/packages/api-client-react/src/ApiClientModalProvider.tsx
+++ b/packages/api-client-react/src/ApiClientModalProvider.tsx
@@ -1,16 +1,37 @@
 'use client'
 
-import type { ApiClient } from '@scalar/api-client/layouts/Modal'
-import type { OpenClientPayload } from '@scalar/api-client/libs'
+import type { ApiClientModal as V2ApiClientModal } from '@scalar/api-client/v2/features/modal'
 import type { ApiClientConfiguration } from '@scalar/types/api-reference'
+import type { WorkspaceDocumentInput } from '@scalar/workspace-store/client'
 import type { PropsWithChildren } from 'react'
 import { createContext, useContext, useEffect, useRef, useSyncExternalStore } from 'react'
-
-export type { OpenClientPayload }
 
 import { clientStore } from './client-store'
 
 import './style.css'
+
+type HttpMethod = 'get' | 'post' | 'put' | 'delete' | 'patch' | 'head' | 'options' | 'trace'
+
+type RoutePayload = {
+  path: string
+  method: HttpMethod | Uppercase<HttpMethod>
+  example?: string
+  documentSlug?: string
+  _source?: 'api-reference' | 'gitbook'
+}
+
+type RequestUidPayload = {
+  requestUid: string
+  path?: never
+  method?: never
+}
+
+export type OpenClientPayload = RoutePayload | RequestUidPayload
+
+export type ApiClient = Omit<V2ApiClientModal, 'open' | 'route'> & {
+  open: (payload?: OpenClientPayload) => void
+  route: (payload: OpenClientPayload) => void
+}
 
 const ApiClientModalContext = createContext<ApiClient | null>(null)
 
@@ -21,11 +42,90 @@ type Props = PropsWithChildren<{
   configuration?: Partial<ApiClientConfiguration>
 }>
 
-/** Ensures we only load createClient once */
-let isLoading = false
-
 /** Hack: this is strictly to prevent creation of extra clients as the store lags a bit */
 const clientDict: Record<string, ApiClient> = {}
+
+const HTTP_METHODS = new Set<HttpMethod>([
+  'get',
+  'post',
+  'put',
+  'delete',
+  'patch',
+  'head',
+  'options',
+  'trace',
+])
+
+const isHttpMethod = (value: string): value is HttpMethod => HTTP_METHODS.has(value as HttpMethod)
+
+type ResolvedDocumentInput = {
+  url: string
+} | {
+  document: Record<string, unknown>
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const resolveDocumentInput = async (
+  configuration: Partial<ApiClientConfiguration>,
+): Promise<ResolvedDocumentInput | null> => {
+  const url = configuration.url ?? configuration.spec?.url
+  if (url) {
+    return { url }
+  }
+
+  const rawContent = configuration.content ?? configuration.spec?.content
+  const content = typeof rawContent === 'function' ? rawContent() : rawContent
+
+  if (isRecord(content)) {
+    return { document: content }
+  }
+
+  if (typeof content === 'string') {
+    try {
+      const parsed = JSON.parse(content)
+      return isRecord(parsed) ? { document: parsed } : null
+    } catch {
+      console.error(
+        '[@scalar/api-client-react] String OpenAPI documents must be valid JSON when used with the v2 modal.',
+      )
+    }
+  }
+
+  return null
+}
+
+const mapModalOptions = (configuration: Partial<ApiClientConfiguration>) => ({
+  authentication: configuration.authentication,
+  baseServerURL: configuration.baseServerURL,
+  hideClientButton: configuration.hideClientButton,
+  servers: configuration.servers,
+})
+
+const toRoutePayload = (payload?: OpenClientPayload) => {
+  if (!payload) {
+    return undefined
+  }
+
+  if ('requestUid' in payload) {
+    console.warn('[@scalar/api-client-react] requestUid routing is no longer supported in the v2 modal.')
+    return undefined
+  }
+
+  const method = payload.method.toLowerCase()
+  if (!isHttpMethod(method)) {
+    console.warn('[@scalar/api-client-react] Invalid HTTP method provided for modal routing.', payload.method)
+    return undefined
+  }
+
+  return {
+    path: payload.path,
+    method,
+    example: payload.example,
+    documentSlug: payload.documentSlug,
+  }
+}
 
 /**
  * Api Client Modal React
@@ -34,58 +134,109 @@ const clientDict: Record<string, ApiClient> = {}
  * Rebuilt to support multiple instances when using a unique spec.url
  */
 export const ApiClientModalProvider = ({ children, initialRequest, configuration = {} }: Props) => {
-  const key = configuration.spec?.url || 'default'
+  const key = configuration.slug ?? configuration.url ?? configuration.spec?.url ?? 'default'
   const el = useRef<HTMLDivElement | null>(null)
+  const configurationRef = useRef(configuration)
 
   const state = useSyncExternalStore(clientStore.subscribe, clientStore.getSnapshot, clientStore.getSnapshot)
 
-  // Lazyload the js to create the client, but we only wanna call this once
   useEffect(() => {
-    const loadApiClientJs = async () => {
-      isLoading = true
-      const { createApiClientModal } = await import('@scalar/api-client/layouts/Modal')
-      clientStore.setCreateClient(createApiClientModal)
-    }
-    if (!isLoading) {
-      void loadApiClientJs()
-    }
-  }, [])
+    configurationRef.current = configuration
+  }, [configuration])
 
   useEffect(() => {
-    if (!el.current || !state.createClient || clientDict[key]) {
-      return () => null
-    }
+    let isMounted = true
+    let createdClient: ApiClient | null = null
 
-    // Check for cached client first
-    const { client: _client } = state.createClient({
-      el: el.current,
-      configuration,
-    })
-
-    const updateConfig = async () => {
-      await _client.updateConfig(configuration!)
-      if (initialRequest) {
-        _client.route(initialRequest)
+    const mountClient = async () => {
+      if (!el.current || clientStore.getSnapshot().clientDict[key]) {
+        return
       }
+
+      const [{ createApiClientModal }, { createWorkspaceStore }] = await Promise.all([
+        import('@scalar/api-client/v2/features/modal'),
+        import('@scalar/workspace-store/client'),
+      ])
+
+      if (!isMounted || !el.current || clientStore.getSnapshot().clientDict[key]) {
+        return
+      }
+
+      const currentConfiguration = configurationRef.current
+      const workspaceStore = createWorkspaceStore({
+        meta: {
+          'x-scalar-active-proxy': currentConfiguration.proxyUrl,
+        },
+      })
+
+      const resolvedDocumentInput = await resolveDocumentInput(currentConfiguration)
+      if (!resolvedDocumentInput) {
+        console.error(
+          '[@scalar/api-client-react] Please provide an OpenAPI source through configuration.url or configuration.content.',
+        )
+        return
+      }
+
+      const documentName = currentConfiguration.slug ?? key
+      const hasDocument = await workspaceStore.addDocument({
+        name: documentName,
+        ...resolvedDocumentInput,
+      } satisfies WorkspaceDocumentInput)
+
+      if (!hasDocument) {
+        console.error('[@scalar/api-client-react] Failed to load the configured OpenAPI document.')
+        return
+      }
+
+      workspaceStore.update('x-scalar-active-document', documentName)
+
+      const modalClient = createApiClientModal({
+        el: el.current,
+        workspaceStore,
+        options: mapModalOptions(currentConfiguration),
+      })
+
+      const client: ApiClient = {
+        ...modalClient,
+        open: (payload?: OpenClientPayload) => modalClient.open(toRoutePayload(payload)),
+        route: (payload: OpenClientPayload) => {
+          const routePayload = toRoutePayload(payload)
+          if (routePayload) {
+            modalClient.route(routePayload)
+          }
+        },
+      }
+
+      clientStore.addClient(key, client)
+      clientDict[key] = client
+      createdClient = client
     }
 
-    // Add the client to the store and dict
-    clientStore.addClient(key, _client)
-    clientDict[key] = _client
+    void mountClient()
 
-    // We update the config as we are using the sync version
-    void updateConfig()
-
-    // Ensure we unmount the vue app on unmount
     return () => {
-      _client.app.unmount()
+      isMounted = false
+      if (!createdClient) {
+        return
+      }
+
+      createdClient.app.unmount()
       clientStore.removeClient(key)
       delete clientDict[key]
     }
-  }, [el.current, state.createClient])
+  }, [key])
+
+  const client = (state.clientDict[key] as ApiClient | undefined) ?? null
+
+  useEffect(() => {
+    if (!client || !initialRequest) {
+      return
+    }
+    client.route(initialRequest)
+  }, [client, initialRequest])
 
   return (
-    <ApiClientModalContext.Provider value={state.clientDict[key] ?? null}>
+    <ApiClientModalContext.Provider value={client}>
       <div
         className="scalar-app"
         ref={el}

--- a/packages/api-client-react/src/client-store.ts
+++ b/packages/api-client-react/src/client-store.ts
@@ -1,4 +1,8 @@
-import type { ApiClient, createApiClientModal } from '@scalar/api-client/layouts/Modal'
+type ModalClient = {
+  app: {
+    unmount: () => void
+  }
+}
 
 // These are required for the vue bundler version
 globalThis.__VUE_OPTIONS_API__ = true
@@ -7,8 +11,7 @@ globalThis.__VUE_PROD_DEVTOOLS__ = false
 
 /** Client state */
 let state = {
-  createClient: null as typeof createApiClientModal | null,
-  clientDict: {} as Record<string, ApiClient>,
+  clientDict: {} as Record<string, ModalClient>,
 }
 
 /** Set of listener functions to be called when state changes */
@@ -26,14 +29,8 @@ const getSnapshot = () => state
 /** Trigger all listeners */
 const emit = () => listeners.forEach((listener) => listener())
 
-/** Set the create client state */
-const setCreateClient = (clientFactory: typeof createApiClientModal) => {
-  state = { ...state, createClient: clientFactory }
-  emit()
-}
-
 /** Add a client to the client dict */
-const addClient = (url: string, client: ApiClient) => {
+const addClient = (url: string, client: ModalClient) => {
   state = { ...state, clientDict: { ...state.clientDict, [url]: client } }
   emit()
 }
@@ -48,7 +45,6 @@ const removeClient = (url: string) => {
 export const clientStore = {
   getSnapshot,
   subscribe,
-  setCreateClient,
   addClient,
   removeClient,
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,7 +541,7 @@ importers:
         version: link:../../integrations/nuxt
       nuxt:
         specifier: 3.19.0 || ^3.19.2
-        version: 3.19.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.26)(db0@0.3.2)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.7.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.0)
+        version: 3.19.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.26)(db0@0.3.2)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.7.0)(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.0)
 
   examples/react:
     dependencies:
@@ -1119,7 +1119,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: ^4.0.0
-        version: 4.1.2(magicast@0.5.1)
+        version: 4.1.2(magicast@0.3.5)
       '@scalar/api-client':
         specifier: workspace:*
         version: link:../../packages/api-client
@@ -1138,7 +1138,7 @@ importers:
     devDependencies:
       '@nuxt/module-builder':
         specifier: ^1.0.1
-        version: 1.0.1(@nuxt/cli@3.28.0(magicast@0.5.1))(@vue/compiler-core@3.5.26)(esbuild@0.27.2)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.26(typescript@5.9.3))
+        version: 1.0.1(@nuxt/cli@3.28.0(magicast@0.3.5))(@vue/compiler-core@3.5.26)(esbuild@0.27.2)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.26(typescript@5.9.3))
       '@types/node':
         specifier: ^24.1.0
         version: 24.10.13
@@ -1147,7 +1147,7 @@ importers:
         version: 7.0.3
       nuxt:
         specifier: ^4.1.0
-        version: 4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.26)(db0@0.3.2)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.7.0)(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.0)
+        version: 4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.26)(db0@0.3.2)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.7.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.0)
       vitest:
         specifier: catalog:*
         version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0)
@@ -1460,6 +1460,9 @@ importers:
       '@scalar/types':
         specifier: workspace:*
         version: link:../types
+      '@scalar/workspace-store':
+        specifier: workspace:*
+        version: link:../workspace-store
     devDependencies:
       '@scalar/build-tooling':
         specifier: workspace:*
@@ -21260,9 +21263,9 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/kit@3.19.2(magicast@0.3.5)':
+  '@nuxt/kit@3.19.2(magicast@0.5.1)':
     dependencies:
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.1)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -21340,9 +21343,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/kit@4.1.2(magicast@0.5.1)':
+  '@nuxt/kit@4.1.2(magicast@0.3.5)':
     dependencies:
-      c12: 3.3.3(magicast@0.5.1)
+      c12: 3.3.3(magicast@0.3.5)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -21367,9 +21370,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/module-builder@1.0.1(@nuxt/cli@3.28.0(magicast@0.5.1))(@vue/compiler-core@3.5.26)(esbuild@0.27.2)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.26(typescript@5.9.3))':
+  '@nuxt/module-builder@1.0.1(@nuxt/cli@3.28.0(magicast@0.3.5))(@vue/compiler-core@3.5.26)(esbuild@0.27.2)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.26(typescript@5.9.3))':
     dependencies:
-      '@nuxt/cli': 3.28.0(magicast@0.5.1)
+      '@nuxt/cli': 3.28.0(magicast@0.3.5)
       citty: 0.1.6
       consola: 3.4.2
       defu: 6.1.4
@@ -21448,9 +21451,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/vite-builder@3.19.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vue-tsc@3.2.4(typescript@5.9.3))(vue@3.5.26(typescript@5.9.3))(yaml@2.8.0)':
+  '@nuxt/vite-builder@3.19.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vue-tsc@3.2.4(typescript@5.9.3))(vue@3.5.26(typescript@5.9.3))(yaml@2.8.0)':
     dependencies:
-      '@nuxt/kit': 3.19.2(magicast@0.3.5)
+      '@nuxt/kit': 3.19.2(magicast@0.5.1)
       '@rollup/plugin-replace': 6.0.2(rollup@4.50.2)
       '@vitejs/plugin-vue': 6.0.3(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue@3.5.26(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 5.1.3(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue@3.5.26(typescript@5.9.3))
@@ -21508,9 +21511,9 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.26(typescript@5.9.3))(yaml@2.8.0)':
+  '@nuxt/vite-builder@4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.26(typescript@5.9.3))(yaml@2.8.0)':
     dependencies:
-      '@nuxt/kit': 4.1.2(magicast@0.5.1)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.2(rollup@4.50.2)
       '@vitejs/plugin-vue': 6.0.3(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue@3.5.26(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 5.1.3(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue@3.5.26(typescript@5.9.3))
@@ -29565,18 +29568,18 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.103.0(webpack-cli@5.1.4)
 
-  nuxt@3.19.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.26)(db0@0.3.2)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.7.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.0):
+  nuxt@3.19.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.26)(db0@0.3.2)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.7.0)(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.0):
     dependencies:
-      '@nuxt/cli': 3.28.0(magicast@0.3.5)
+      '@nuxt/cli': 3.28.0(magicast@0.5.1)
       '@nuxt/devalue': 2.0.2
       '@nuxt/devtools': 2.7.0(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue@3.5.26(typescript@5.9.3))
-      '@nuxt/kit': 3.19.2(magicast@0.3.5)
+      '@nuxt/kit': 3.19.2(magicast@0.5.1)
       '@nuxt/schema': 3.19.2
-      '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
-      '@nuxt/vite-builder': 3.19.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vue-tsc@3.2.4(typescript@5.9.3))(vue@3.5.26(typescript@5.9.3))(yaml@2.8.0)
+      '@nuxt/telemetry': 2.6.6(magicast@0.5.1)
+      '@nuxt/vite-builder': 3.19.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vue-tsc@3.2.4(typescript@5.9.3))(vue@3.5.26(typescript@5.9.3))(yaml@2.8.0)
       '@unhead/vue': 2.1.4(vue@3.5.26(typescript@5.9.3))
       '@vue/shared': 3.5.26
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.1)
       chokidar: 4.0.3
       compatx: 0.2.0
       consola: 3.4.2
@@ -29688,18 +29691,18 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.26)(db0@0.3.2)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.7.0)(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.0):
+  nuxt@4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.26)(db0@0.3.2)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.7.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.0):
     dependencies:
-      '@nuxt/cli': 3.28.0(magicast@0.5.1)
+      '@nuxt/cli': 3.28.0(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
       '@nuxt/devtools': 2.7.0(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.31.2)(tsx@4.19.1)(yaml@2.8.0))(vue@3.5.26(typescript@5.9.3))
-      '@nuxt/kit': 4.1.2(magicast@0.5.1)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       '@nuxt/schema': 4.1.2
-      '@nuxt/telemetry': 2.6.6(magicast@0.5.1)
-      '@nuxt/vite-builder': 4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.26(typescript@5.9.3))(yaml@2.8.0)
+      '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
+      '@nuxt/vite-builder': 4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.50.2)(terser@5.31.2)(tsx@4.19.1)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.26(typescript@5.9.3))(yaml@2.8.0)
       '@unhead/vue': 2.1.4(vue@3.5.26(typescript@5.9.3))
       '@vue/shared': 3.5.26
-      c12: 3.3.3(magicast@0.5.1)
+      c12: 3.3.3(magicast@0.3.5)
       chokidar: 4.0.3
       compatx: 0.2.0
       consola: 3.4.2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`@scalar/api-client-react` was still wired to legacy `@scalar/api-client` modal internals (`layouts/Modal` + `libs` types) instead of the v2 modal stack. That made the React wrapper lag behind current API client behavior and internal architecture.

## Solution

- Migrated the React provider to lazy-load and instantiate the v2 modal from `@scalar/api-client/v2/features/modal`.
- Added a v2 workspace store setup flow (`@scalar/workspace-store/client`) to load the configured OpenAPI document before creating the modal.
- Added a compatibility layer for `open`/`route` payloads so existing React usage can continue passing path+method payloads (including uppercase methods).
- Fixed routed opens by omitting undefined `documentSlug` from payloads, so operations correctly load when opening from different provider instances.
- Added a changeset for `@scalar/api-client-react`.
- Fixed follow-up CI issues by applying Biome formatting to `ApiClientModalProvider.tsx` and making the internal `ApiClient` type non-exported to satisfy `knip`.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ad54522-7963-4c64-8801-162fe6762a2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ad54522-7963-4c64-8801-162fe6762a2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

