### PR TITLE
chore: update aquasecurity/trivy-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -846,7 +846,7 @@ jobs:
           tags: scalarapi/api-reference:latest
 
       - name: Scan for vulnerabilities
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: 'image'
           image-ref: 'scalarapi/api-reference:latest'


### PR DESCRIPTION
ci failing

let's see if the update fixes it