### PR TITLE
chore: update aquasecurity/trivy-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -813,8 +813,7 @@ jobs:
   # Integration builds, tests, and publishes
 
   docker-build-scan:
-    # TODO: Enable before merge
-    # if: needs.check-changes.outputs.docker_changed == 'true'
+    if: needs.check-changes.outputs.docker_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
     needs: [build, check-changes]


### PR DESCRIPTION
ci is failing, let's see if an trivy update fixes it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump confined to the CI vulnerability scan step, though it may change scan behavior/output and could affect pipeline pass/fail.
> 
> **Overview**
> Updates the CI workflow’s Docker image vulnerability scan in `ci.yml` by bumping `aquasecurity/trivy-action` from `0.33.1` to `0.35.0` (new pinned commit), aiming to resolve current CI failures while keeping scan inputs and thresholds unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 339dcb2af542a7e108abe860f2dc2fce03b2dae3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->