### PR TITLE
fix(docs): remove email domain access control checkmark from free tier

### DIFF
--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -71,7 +71,7 @@
             </div>
             <div class="pricing-table-row">
               <div class="pricing-table-column">Email Domain Access Control</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
+              <div class="pricing-table-column"></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The pricing table on the dashboard shows a checkmark for "Email Domain Access Control" in the Free tier column. Since Free users cannot publish, having this checkmark is misleading - they won't be able to use email domain access control anyway.

This was identified by Brynn in the Slack thread and confirmed by Marc to be removed.

## Solution

Removed the checkmark icon from the Free tier column for "Email Domain Access Control" in the pricing table (`documentation/guides/pricing.md`). The feature still shows checkmarks for Pro and Enterprise tiers.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed - docs only change -->
- [ ] I added tests. <!-- Not applicable - docs only change -->
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07TEEPG2JX/p1773753753603359?thread_ts=1773753753.603359&cid=C07TEEPG2JX)

<div><a href="https://cursor.com/agents/bc-fee95765-eeb7-528d-a296-f445d088cc5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fee95765-eeb7-528d-a296-f445d088cc5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

