### PR TITLE
fix(api-client): clean up modal watchers on unmount

### DIFF
--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.test.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.test.ts
@@ -252,6 +252,37 @@ describe('createApiClientModal', () => {
     })
   })
 
+  it('stops modal watchers when app is unmounted', async () => {
+    const workspaceStore = await setupWorkspaceStore()
+
+    const modal = createApiClientModal({
+      el: mountElement,
+      workspaceStore,
+      mountOnInitialize: true,
+    })
+    createdApps.push(modal.app)
+
+    modal.open({
+      path: '/users',
+      method: 'get',
+      example: 'default',
+    })
+
+    await nextTick()
+
+    const documentSlug = workspaceStore.workspace['x-scalar-active-document']
+    const document = workspaceStore.workspace.documents[documentSlug || '']
+    expect(document).toBeDefined()
+
+    document!.info.title = 'Changed while open'
+
+    modal.app.unmount()
+    modal.modalState.open = false
+    await nextTick()
+
+    expect(workspaceStore.workspace.documents[documentSlug || '']?.info.title).toBe('Changed while open')
+  })
+
   it('drops document changes when modal closes, but preserves servers', async () => {
     const workspaceStore = await setupWorkspaceStore()
 

--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
@@ -130,13 +130,24 @@ export const createApiClientModal = ({
     return
   }
 
-  watch(
+  const stopModalOpenWatch = watch(
     () => modalState.open,
     (open) => (open ? handleModalOpen() : handleModalClose()),
   )
 
+  const dispose = (): void => {
+    stopModalOpenWatch()
+    sidebarState.dispose()
+  }
+
   // Use a unique id prefix to prevent collisions with other Vue apps on the page
   app.config.idPrefix = 'scalar-client'
+
+  const unmount = app.unmount.bind(app)
+  app.unmount = (): void => {
+    dispose()
+    unmount()
+  }
 
   /** Mount the modal to a given element. */
   const mount = (mountingEl: HTMLElement | null = el): void => {

--- a/packages/api-client/src/v2/features/modal/hooks/use-modal-sidebar.test.ts
+++ b/packages/api-client/src/v2/features/modal/hooks/use-modal-sidebar.test.ts
@@ -508,6 +508,52 @@ describe('use-modal-sidebar', () => {
     expect(state.isSelected(initialEntry!.id)).toBe(false)
   })
 
+  it('stops route synchronization when disposed', async () => {
+    const store = await createTestStore()
+    const documentSlug = computed<string | undefined>(() => 'test-doc')
+    const path = ref<string | undefined>('/users')
+    const method = ref<'get' | 'post' | undefined>('get')
+    const exampleName = ref<string | undefined>('default')
+
+    const { state, getEntryByLocation, dispose } = useModalSidebar({
+      workspaceStore: store,
+      documentSlug,
+      path: computed(() => path.value),
+      method: computed(() => method.value),
+      exampleName: computed(() => exampleName.value),
+      route: vi.fn(),
+    })
+
+    await waitForUpdates()
+
+    const initialEntry = getEntryByLocation({
+      document: 'test-doc',
+      path: '/users',
+      method: 'get',
+      example: 'default',
+    })
+
+    expect(initialEntry).toBeDefined()
+    expect(state.isSelected(initialEntry!.id)).toBe(true)
+
+    dispose()
+
+    path.value = '/pets'
+    method.value = 'get'
+    exampleName.value = undefined
+    await waitForUpdates()
+
+    const nextEntry = getEntryByLocation({
+      document: 'test-doc',
+      path: '/pets',
+      method: 'get',
+    })
+
+    expect(nextEntry).toBeDefined()
+    expect(state.isSelected(initialEntry!.id)).toBe(true)
+    expect(state.isSelected(nextEntry!.id)).toBe(false)
+  })
+
   it('resets selection when document is cleared', async () => {
     const store = await createTestStore()
     const documentSlug = ref<string | undefined>('test-doc')

--- a/packages/api-client/src/v2/features/modal/hooks/use-modal-sidebar.ts
+++ b/packages/api-client/src/v2/features/modal/hooks/use-modal-sidebar.ts
@@ -17,6 +17,8 @@ export type UseModalSidebarReturn = {
     method?: HttpMethod
     example?: string
   }) => TraversedEntry | undefined
+  /** Stops reactive syncing created by this composable. */
+  dispose: () => void
 }
 
 /**
@@ -171,7 +173,7 @@ export const useModalSidebar = ({
   }
 
   /** Keep the sidebar state in sync with the modal parameters */
-  watch(
+  const stopRouteSyncWatch = watch(
     [documentSlug, path, method, exampleName],
     ([newDocument, newPath, newMethod, newExample]) => {
       if (!newDocument) {
@@ -201,5 +203,6 @@ export const useModalSidebar = ({
     handleSelectItem,
     state,
     getEntryByLocation,
+    dispose: stopRouteSyncWatch,
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`test-packages (2, 3)` intermittently failed in CI with Vitest `EnvironmentTeardownError` (`Closing rpc while "onUserConsoleLog" was pending`) while all assertions were passing. The reported source was the modal helper test file.

The modal helper and sidebar composable both created `watch()` subscriptions outside component scope and never disposed them, so reactive/logging work could continue during worker teardown.

## Solution

- Added explicit disposal for sidebar route-sync watcher in `useModalSidebar()` via a returned `dispose()` function.
- Added explicit disposal for modal open/close watcher in `createApiClientModal()`.
- Wrapped `app.unmount()` in `createApiClientModal()` so teardown reliably stops both watchers before unmounting.
- Added regression tests to verify:
  - sidebar route syncing stops after `dispose()`
  - modal watchers stop after `app.unmount()`

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f38ab5f4-be17-4254-80ca-a36d65d3dde1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f38ab5f4-be17-4254-80ca-a36d65d3dde1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

