### PR TITLE
fix(api-client): flaky modal test

### DIFF
--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.test.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.test.ts
@@ -1,4 +1,5 @@
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
+import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { enableAutoUnmount, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -37,6 +38,9 @@ const createTestDocument = (overrides: Partial<OpenApiDocument> = {}): OpenApiDo
   },
   ...overrides,
 })
+
+/** Creates an event bus with debug disabled to prevent pending setTimeout in tests */
+const createTestEventBus = () => createWorkspaceEventBus({ debug: false })
 
 /** Sets up a workspace store with a test document */
 const setupWorkspaceStore = async () => {
@@ -83,6 +87,7 @@ describe('createApiClientModal', () => {
       el: mountElement,
       workspaceStore,
       mountOnInitialize: true,
+      eventBus: createTestEventBus(),
     })
     createdApps.push(modal.app)
 
@@ -99,6 +104,7 @@ describe('createApiClientModal', () => {
       el: mountElement,
       workspaceStore,
       mountOnInitialize: false,
+      eventBus: createTestEventBus(),
     })
     createdApps.push(modal.app)
 
@@ -115,6 +121,7 @@ describe('createApiClientModal', () => {
       el: mountElement,
       workspaceStore,
       mountOnInitialize: true,
+      eventBus: createTestEventBus(),
     })
     createdApps.push(modal.app)
 
@@ -189,6 +196,7 @@ describe('createApiClientModal', () => {
       workspaceStore: store,
       mountOnInitialize: true,
       options,
+      eventBus: createTestEventBus(),
     })
     createdApps.push(modal.app)
 
@@ -259,6 +267,7 @@ describe('createApiClientModal', () => {
       el: mountElement,
       workspaceStore,
       mountOnInitialize: true,
+      eventBus: createTestEventBus(),
     })
     createdApps.push(modal.app)
 
@@ -307,6 +316,7 @@ describe('createApiClientModal', () => {
       el: mountElement,
       workspaceStore,
       mountOnInitialize: true,
+      eventBus: createTestEventBus(),
     })
     createdApps.push(modal.app)
 
@@ -373,6 +383,7 @@ describe('createApiClientModal', () => {
       el: mountElement,
       workspaceStore,
       mountOnInitialize: true,
+      eventBus: createTestEventBus(),
     })
     createdApps.push(modal.app)
 
@@ -419,6 +430,7 @@ describe('createApiClientModal', () => {
       el: mountElement,
       workspaceStore,
       mountOnInitialize: true,
+      eventBus: createTestEventBus(),
     })
     createdApps.push(modal.app)
 


### PR DESCRIPTION
The test file `packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.test.ts` causes a flaky Vitest error:

> EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending

`createWorkspaceEventBus` batches debug logs with a 500ms setTimeout. When import.meta.env.DEV is true (in tests), the event bus queues console.log calls via setTimeout(flushLogs, 500). If the test environment tears down before this timeout fires, Vitest's RPC connection closes while it's still tracking the pending console operation.      

**Fix**

Pass a pre-created event bus with debug: false to `createApiClientModal` in each test, suppressing the debug logging that causes the pending timeout. The `createApiClientModal` function already accepts an optional eventBus parameter.

@DemonHa there's probably a smarter solution, wdyt?