### PR TITLE
Package benchmark exclusion

### DIFF
--- a/packages/helpers/src/markdown/get-markdown-headings.ts
+++ b/packages/helpers/src/markdown/get-markdown-headings.ts
@@ -22,11 +22,8 @@ function stripInlineMarkdown(text: string): string {
       .replace(/`([^`]+)`/g, '$1')
       // HTML tags
       .replace(/<[^>]+>/g, '')
-<<<<<<< cursor/package-benchmark-exclusion-5ab5
-=======
       // Remove any remaining angle brackets to avoid partial/malformed HTML fragments
       .replace(/[<>]/g, '')
->>>>>>> geoff/reduce-bundle
       .trim()
   )
 }


### PR DESCRIPTION
## Problem

The `@scalar/helpers` package's `tsconfig.build.json` did not exclude benchmark files (`**/*.bench.ts`), causing them to be compiled into the `dist` directory and included in the published npm package. This added unnecessary bytes to the package and exposed an importable entry point that would fail at runtime due to a dependency on `vitest` (a devDependency).

## Solution

Updated `packages/helpers/tsconfig.build.json` to explicitly exclude `**/*.bench.ts` files from the build output, aligning with how other packages in the monorepo (e.g., `@scalar/api-reference`) handle benchmark files.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset.
- [ ] I added tests.
- [ ] I updated the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build config change is low risk, but the PR currently introduces unresolved merge-conflict markers in `get-markdown-headings.ts` that would break compilation and potentially affect markdown heading extraction if merged incorrectly.
> 
> **Overview**
> Updates `@scalar/helpers` build config to **exclude `**/*.bench.ts`** from `tsconfig.build.json`, preventing benchmark sources from being emitted into `dist`/published.
> 
> The PR also contains an **unresolved merge conflict** in `get-markdown-headings.ts` around additional angle-bracket stripping, which must be resolved before merge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3cd2f1fee1d231fa4fdebd4dbd4e4273aefcafd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->