### PR TITLE
docs: clarify registry updates trigger docs republish

### DIFF
--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -270,6 +270,8 @@ scalar registry publish ./openapi.yaml \
 }
 ```
 
+When someone updates that OpenAPI document in the Registry, Scalar republishes any connected Docs project that references it. This keeps your API documentation up to date automatically.
+
 ### 3. URL
 
 Fetch an OpenAPI document from a remote URL. The document is fetched on each page load, keeping your documentation in sync with your live API:

--- a/documentation/guides/docs/deployment/automatic-deployment.md
+++ b/documentation/guides/docs/deployment/automatic-deployment.md
@@ -4,6 +4,8 @@ Docs can automatically publish your documentation whenever changes are merged in
 
 Enable automatic deployment and configure which branch triggers it in the [Scalar Dashboard](https://dashboard.scalar.com) under your project settings. Every time you merge changes into your default branch, your documentation will be automatically published.
 
+If your Docs project references an OpenAPI document from the Registry, updating that Registry document also triggers the Docs project to publish again. Once your document is in the Registry, your documentation stays up to date automatically.
+
 ## Other Deployment Options
 
 Looking for more control over your deployment process?


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The documentation did not clearly explain what happens to a Scalar Docs project when an OpenAPI document in the Registry is updated.

## Solution

Added explicit wording in Docs deployment and navigation guides that updating a Registry document triggers connected Docs projects to publish again, keeping API documentation up to date.

Validated markdown formatting for updated files with Prettier.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54246e9d-0e5e-4df8-a0e3-5c7cad657661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54246e9d-0e5e-4df8-a0e3-5c7cad657661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

