### PR TITLE
fix(components): alias in the build

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -15,7 +15,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "pnpm typegen:icons && vite build && vue-tsc -p tsconfig.build.json",
+    "build": "pnpm typegen:icons && vite build && vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:storybook": "storybook build",
     "clean:snapshots": "shx rm -rf \"**/snapshots\"",
     "dev": "storybook dev -p 5100 --ci",


### PR DESCRIPTION
there's an alias in the components build, let's add `tsc-alias` there too

> ❌ Found unresolved "@/..." alias imports in built declaration files:
> packages/components/dist/components/ScalarCombobox/filter-by-option-label.d.ts:1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the `@scalar/components` build pipeline to post-process emitted types/JS; behavior at runtime shouldn’t change, but build output paths/imports may differ.
> 
> **Overview**
> Fixes unresolved `@/...` path aliases in the `@scalar/components` build output by running `tsc-alias` after `vue-tsc` during `pnpm build`.
> 
> This ensures generated declaration files (and other TS outputs from the build config) have rewritten import paths instead of leaving alias-based imports in `dist`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44c7f170e589bf494bb5217e5ea63857ed3fb615. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->