### PR TITLE
chore(agent-chat): changeset

### DIFF
--- a/.changeset/fruity-fans-beam.md
+++ b/.changeset/fruity-fans-beam.md
@@ -1,0 +1,5 @@
+---
+'@scalar/agent-chat': patch
+---
+
+feat: make external urls configurable


### PR DESCRIPTION
we forgot to add a changeset here

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a Changesets metadata file to trigger a patch release; no runtime code or behavior is modified.
> 
> **Overview**
> Adds a Changesets entry (`.changeset/fruity-fans-beam.md`) marking `@scalar/agent-chat` for a **patch** release with the note "feat: make external urls configurable".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be6ab039dabc8c88172825596f6655fab3963b0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->