### PR TITLE
test(postman-to-openapi): verify info.name maps to OpenAPI title

### DIFF
--- a/packages/postman-to-openapi/src/convert.test.ts
+++ b/packages/postman-to-openapi/src/convert.test.ts
@@ -50,6 +50,26 @@ describe('fixtures', () => {
 })
 
 describe('convert', () => {
+  it('maps Postman info.name to OpenAPI info.title', () => {
+    const collection: PostmanCollection = {
+      info: {
+        _postman_id: '5ffe9376-4f10-4ae3-8a47-f7da1a6a02e6',
+        name: 'Hello World',
+        description: '## An Introduction To Our API',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+        _exporter_id: '24620900',
+        _collection_link:
+          'https://go.postman.co/collection/24621026-5ffe9376-4f10-4ae3-8a47-f7da1a6a02e6?source=collection_link',
+        version: '1.0.0',
+      },
+      item: [],
+    }
+
+    const result = convert(collection)
+
+    expect(result.info.title).toBe('Hello World')
+  })
+
   it('merges into an existing OpenAPI document', () => {
     const collection: PostmanCollection = {
       info: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A Postman collection import was reported to potentially drop the collection `info.name` when converting to OpenAPI, where it is expected to become `info.title`.

## Solution

Added a focused regression test in `packages/postman-to-openapi/src/convert.test.ts` using a real-world Postman `info` payload (`name: "Hello World"`).
The test asserts that conversion output sets `openapi.info.title` to that value.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e6d7ef4-c248-4973-8b56-685d1291f54c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e6d7ef4-c248-4973-8b56-685d1291f54c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

