### PR TITLE
chore: tweak changesets a bit

### DIFF
--- a/.changeset/flat-glasses-lick.md
+++ b/.changeset/flat-glasses-lick.md
@@ -1,5 +1,5 @@
 ---
-'@scalar/api-client': minor
+'@scalar/api-client': patch
 ---
 
 feat: support document download

--- a/.changeset/flat-rabbits-strive.md
+++ b/.changeset/flat-rabbits-strive.md
@@ -1,6 +1,7 @@
 ---
 '@scalar/api-reference': patch
 '@scalar/types': patch
+'@scalar/agent-chat': patch
 ---
 
-feat(api-reference): Add configurable API url for agent chat
+feat: make external urls configurable

--- a/.changeset/fruity-fans-beam.md
+++ b/.changeset/fruity-fans-beam.md
@@ -1,5 +1,0 @@
----
-'@scalar/agent-chat': patch
----
-
-feat: make external urls configurable

--- a/.changeset/tiny-snakes-heal.md
+++ b/.changeset/tiny-snakes-heal.md
@@ -3,4 +3,4 @@
 '@scalar/api-reference': patch
 ---
 
-fix request body code samples when switching anyOf or oneOf schemas
+fix: request body code samples when switching anyOf or oneOf schemas


### PR DESCRIPTION
just saw a few smaller things in the changesets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes Changesets metadata (version bump levels and messages) and removes a duplicate entry; no runtime code is modified.
> 
> **Overview**
> Updates Changesets to correct release metadata: downgrades `@scalar/api-client` from *minor* to *patch*, adds `@scalar/agent-chat` to the "external urls configurable" patch set, and removes a duplicate Changeset.
> 
> Also normalizes the wording of a fix entry to the `fix:` format.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3cd06534166224d9f75267584277fe90acf05ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->