### PR TITLE
chore(docs): update demo booking links to new form URL

### DIFF
--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -449,7 +449,7 @@ Here is an example of a group containing multiple links:
     "/demo": {
       "title": "Book a Demo",
       "icon": "phosphor/regular/monitor",
-      "url": "https://scalar.cal.com/scalar/chat-with-scalar",
+      "url": "https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a",
       "type": "link"
     }
   }

--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -142,7 +142,7 @@ Put your content where you want: in your repository, any folder, or the Scalar E
   </p>
   <div class="flex gap-2 mb-11">
     <a class="t-editor__button" href="https://dashboard.scalar.com/register">Get Started</a>
-    <a class="t-editor__button" href="https://scalar.cal.com/scalar/chat-with-scalar" target="_blank">Book a Demo</a>
+    <a class="t-editor__button" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a Demo</a>
   </div>
   <a class="expander-hover-link" href="https://discord.gg/scalar" target="_blank" aria-label="Join Scalar community on Discord">Community →</a>
   <a class="expander-hover-link" href="https://github.com/scalar/scalar" target="_blank" aria-label="View Scalar on GitHub">GitHub →</a>

--- a/documentation/guides/docs/starter-kit.md
+++ b/documentation/guides/docs/starter-kit.md
@@ -62,4 +62,4 @@ We are here to help:
 
 - [Email support@scalar.com](mailto:support@scalar.com)
 - [Chat with us on Discord](https://discord.gg/scalar)
-- [Schedule a call](https://scalar.cal.com/scalar/chat-with-scalar)
+- [Schedule a call](https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a)

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -7,7 +7,7 @@
   </p>
   <div class="flex gap-2">
     <a class="t-editor__button" href="https://dashboard.scalar.com/register">Get Started</a>
-    <a class="t-editor__button" href="https://scalar.cal.com/scalar/chat-with-scalar" target="_blank">Book a Demo</a>
+    <a class="t-editor__button" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a Demo</a>
   </div>
   <div class="stickers">
     <div class="draggable sticker-5">
@@ -355,7 +355,7 @@
   </p>
   <div class="flex gap-2 mb-11">
     <a class="t-editor__button" href="https://dashboard.scalar.com/register">Get Started</a>
-    <a class="t-editor__button" href="https://scalar.cal.com/scalar/chat-with-scalar" target="_blank">Book a Demo</a>
+    <a class="t-editor__button" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a Demo</a>
   </div>
   <a class="expander-hover-link" href="https://discord.gg/scalar" target="_blank" aria-label="Join Scalar community on Discord">Community →</a>
   <a class="expander-hover-link" href="https://github.com/scalar/scalar" target="_blank" aria-label="View Scalar on GitHub">GitHub →</a>

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -38,7 +38,7 @@
                 <b class="text-sm">Enterprise</b>
                 <p class="text-xl font-bold ">Custom Pricing</p>
                 <p class=" text-c-2 text-sm font-normal">* Custom pricing tailored to your API & business needs</p>
-                <a href="https://scalar.cal.com/scalar/chat-with-scalar" class="pricing-cta">Contact Sales</a>
+                <a href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" class="pricing-cta">Contact Sales</a>
               </div>
             </div>
           </header>
@@ -568,7 +568,7 @@
   </p>
   <div class="flex gap-2 mb-11">
     <a class="t-editor__button" href="https://dashboard.scalar.com/register">Get Started</a>
-    <a class="t-editor__button" href="https://scalar.cal.com/scalar/chat-with-scalar" target="_blank">Book a Demo</a>
+    <a class="t-editor__button" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a Demo</a>
   </div>
   <a class="expander-hover-link" href="https://discord.gg/scalar" target="_blank" aria-label="Join Scalar community on Discord">Community →</a>
   <a class="expander-hover-link" href="https://github.com/scalar/scalar" target="_blank" aria-label="View Scalar on GitHub">GitHub →</a>

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -104,7 +104,7 @@ All of this with just a couple clicks or a few API requests! You handle making y
   </p>
   <div class="flex gap-2 mb-11">
     <a class="t-editor__button" href="https://dashboard.scalar.com/register">Get Started</a>
-    <a class="t-editor__button" href="https://scalar.cal.com/scalar/chat-with-scalar" target="_blank">Book a Demo</a>
+    <a class="t-editor__button" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a Demo</a>
   </div>
   <a class="expander-hover-link" href="https://discord.gg/scalar" target="_blank" aria-label="Join Scalar community on Discord">Community →</a>
   <a class="expander-hover-link" href="https://github.com/scalar/scalar" target="_blank" aria-label="View Scalar on GitHub">GitHub →</a>

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -103,7 +103,7 @@ Once created, you will get redirected to the SDK Overview page where you can:
   </p>
   <div class="flex gap-2 mb-11">
     <a class="t-editor__button" href="https://dashboard.scalar.com/register">Get Started</a>
-    <a class="t-editor__button" href="https://scalar.cal.com/scalar/chat-with-scalar" target="_blank">Book a Demo</a>
+    <a class="t-editor__button" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a Demo</a>
   </div>
   <a class="expander-hover-link" href="https://discord.gg/scalar" target="_blank" aria-label="Join Scalar community on Discord">Community →</a>
   <a class="expander-hover-link" href="https://github.com/scalar/scalar" target="_blank" aria-label="View Scalar on GitHub">GitHub →</a>

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -2063,7 +2063,7 @@
               "/demo": {
                 "title": "Book a Demo",
                 "icon": "phosphor/regular/monitor",
-                "url": "https://scalar.cal.com/scalar/chat-with-scalar",
+                "url": "https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a",
                 "type": "link"
               }
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The demo booking links throughout the documentation use the old Cal.com URL (`https://scalar.cal.com/scalar/chat-with-scalar`) which needs to be updated to the new form URL.

## Solution

Updated all 10 occurrences of the old demo booking link to the new form URL (`https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a`).

**Files updated:**
- `scalar.config.json`
- `documentation/guides/sdks/getting-started.md`
- `documentation/guides/registry/getting-started.md`
- `documentation/guides/pricing.md` (2 occurrences)
- `documentation/guides/docs/getting-started.md`
- `documentation/guides/docs/configuration/navigation.md`
- `documentation/guides/docs/starter-kit.md`
- `documentation/guides/introduction.md` (2 occurrences)

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed for URL updates in documentation -->
- [ ] I added tests. <!-- N/A - simple URL replacement -->
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/D0939MF81M1/p1773862982361439?thread_ts=1773862982.361439&cid=D0939MF81M1)

<div><a href="https://cursor.com/agents/bc-7b75efe9-57a7-536b-bdcf-e1ceb0febed5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b75efe9-57a7-536b-bdcf-e1ceb0febed5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

