### PR TITLE
docs(scalar-config): add colorScheme and search configuration documentation

### DIFF
--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -206,10 +206,38 @@ Pages support layout configuration to customize how they are displayed:
 }
 ```
 
-| Option    | Type      | Default | Description                            |
-| --------- | --------- | ------- | -------------------------------------- |
-| `toc`     | `boolean` | `true`  | Whether to show the table of contents  |
-| `sidebar` | `boolean` | `true`  | Whether to show the sidebar navigation |
+| Option        | Type      | Default | Description                              |
+| ------------- | --------- | ------- | ---------------------------------------- |
+| `toc`         | `boolean` | `true`  | Whether to show the table of contents    |
+| `sidebar`     | `boolean` | `true`  | Whether to show the sidebar navigation   |
+| `tabs`        | `boolean` | `true`  | Whether to show the navigation tabs      |
+| `header`      | `boolean` | `true`  | Whether to show the header               |
+| `pageTitle`   | `boolean` | `true`  | Whether to show the page title           |
+| `pageActions` | `boolean` | `true`  | Whether to show page actions             |
+| `search`      | `object`  | —       | Search configuration for this page       |
+
+### Search Options
+
+You can configure the search behavior on a per-page basis:
+
+```json
+"/api-reference": {
+  "type": "page",
+  "title": "API Reference",
+  "filepath": "docs/api-reference.md",
+  "layout": {
+    "search": {
+      "enabled": true,
+      "position": "sidebar"
+    }
+  }
+}
+```
+
+| Option     | Type                      | Default    | Description                             |
+| ---------- | ------------------------- | ---------- | --------------------------------------- |
+| `enabled`  | `boolean`                 | `true`     | Enable or disable search for this page  |
+| `position` | `"header" \| "sidebar"`  | `"header"` | The position of the search bar          |
 
 ### Example with All Options
 

--- a/documentation/guides/docs/configuration/scalar.config.json.md
+++ b/documentation/guides/docs/configuration/scalar.config.json.md
@@ -118,13 +118,15 @@ Configure your site's domain, appearance, and custom assets:
 
 #### siteConfig properties
 
-| Property  | Type     | Description                                                                                                                 |
-| --------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `theme`   | `string` | Visual theme (`default`, `alternate`, `moon`, `purple`, `solarized`, `bluePlanet`, `deepSpace`, `saturn`, `kepler`, `mars`) |
-| `logo`    | `object` | Logo URLs for dark and light modes                                                                                          |
-| `head`    | `object` | Custom scripts, styles, meta tags, and links                                                                                |
-| `routing` | `object` | URL redirects configuration                                                                                                 |
-| `subpath` | `string` | URL subpath for multi-project deployments (e.g., `/guides`, `/api`)                                                         |
+| Property      | Type     | Description                                                                                                                 |
+| ------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `theme`       | `string` | Visual theme (`default`, `alternate`, `moon`, `purple`, `solarized`, `bluePlanet`, `deepSpace`, `saturn`, `kepler`, `mars`) |
+| `logo`        | `object` | Logo URLs for dark and light modes                                                                                          |
+| `head`        | `object` | Custom scripts, styles, meta tags, and links                                                                                |
+| `routing`     | `object` | URL redirects configuration                                                                                                 |
+| `subpath`     | `string` | URL subpath for multi-project deployments (e.g., `/guides`, `/api`)                                                         |
+| `colorScheme` | `object` | Light/dark mode appearance settings. See [Site](site-config.md#color-scheme)                                                |
+| `layout`      | `object` | Global layout options including search configuration. See [Site](site-config.md#layout)                                     |
 
 ### navigation
 

--- a/documentation/guides/docs/configuration/site-config.md
+++ b/documentation/guides/docs/configuration/site-config.md
@@ -82,6 +82,87 @@ The `theme` property sets a platform-defined theme for your documentation site.
 | -------- | -------- | -------- | --------------------------------- |
 | `theme`  | `string` | No       | Slug for a platform-defined theme |
 
+## Color Scheme
+
+The `colorScheme` property controls the light/dark mode appearance and toggle behavior for your documentation site.
+
+```json
+// scalar.config.json
+{
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
+  "scalar": "2.0.0",
+  "siteConfig": {
+    "colorScheme": {
+      "default": "system",
+      "showToggle": true
+    }
+  }
+}
+```
+
+### Properties
+
+| Property     | Type                             | Default    | Description                                |
+| ------------ | -------------------------------- | ---------- | ------------------------------------------ |
+| `default`    | `"light" \| "dark" \| "system"` | `"system"` | Default color scheme on page load          |
+| `showToggle` | `boolean`                        | `true`     | Whether to show the color scheme toggle    |
+
+### Examples
+
+#### Force Light Mode
+
+Force your documentation to always display in light mode without a toggle:
+
+```json
+// scalar.config.json
+{
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
+  "scalar": "2.0.0",
+  "siteConfig": {
+    "colorScheme": {
+      "default": "light",
+      "showToggle": false
+    }
+  }
+}
+```
+
+#### Force Dark Mode
+
+Force your documentation to always display in dark mode without a toggle:
+
+```json
+// scalar.config.json
+{
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
+  "scalar": "2.0.0",
+  "siteConfig": {
+    "colorScheme": {
+      "default": "dark",
+      "showToggle": false
+    }
+  }
+}
+```
+
+#### System Preference with Toggle
+
+Respect the user's system preference while allowing them to override it:
+
+```json
+// scalar.config.json
+{
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
+  "scalar": "2.0.0",
+  "siteConfig": {
+    "colorScheme": {
+      "default": "system",
+      "showToggle": true
+    }
+  }
+}
+```
+
 ## Layout
 
 The `layout` property controls global layout options that apply to all pages unless overridden at the page level.
@@ -94,7 +175,13 @@ The `layout` property controls global layout options that apply to all pages unl
   "siteConfig": {
     "layout": {
       "toc": true,
-      "header": true
+      "header": true,
+      "pageTitle": true,
+      "pageActions": true,
+      "search": {
+        "enabled": true,
+        "position": "header"
+      }
     }
   }
 }
@@ -102,10 +189,56 @@ The `layout` property controls global layout options that apply to all pages unl
 
 ### Properties
 
-| Property | Type      | Default | Description                                    |
-| -------- | --------- | ------- | ---------------------------------------------- |
-| `toc`    | `boolean` | `true`  | Whether to show the table of contents globally |
-| `header` | `boolean` | `true`  | Whether to show the header globally            |
+| Property      | Type      | Default  | Description                                    |
+| ------------- | --------- | -------- | ---------------------------------------------- |
+| `toc`         | `boolean` | `true`   | Whether to show the table of contents globally |
+| `header`      | `boolean` | `true`   | Whether to show the header globally            |
+| `pageTitle`   | `boolean` | `true`   | Whether to show page titles globally           |
+| `pageActions` | `boolean` | `true`   | Whether to show page actions globally          |
+| `search`      | `object`  | —        | Search bar configuration                       |
+
+### Search Configuration
+
+The `search` object within `layout` controls the global search behavior.
+
+| Property   | Type                        | Default    | Description                           |
+| ---------- | --------------------------- | ---------- | ------------------------------------- |
+| `enabled`  | `boolean`                   | `true`     | Enable or disable search globally     |
+| `position` | `"header" \| "sidebar"`    | `"header"` | Where to display the search bar       |
+
+#### Disable Search
+
+```json
+// scalar.config.json
+{
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
+  "scalar": "2.0.0",
+  "siteConfig": {
+    "layout": {
+      "search": {
+        "enabled": false
+      }
+    }
+  }
+}
+```
+
+#### Move Search to Sidebar
+
+```json
+// scalar.config.json
+{
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
+  "scalar": "2.0.0",
+  "siteConfig": {
+    "layout": {
+      "search": {
+        "position": "sidebar"
+      }
+    }
+  }
+}
+```
 
 ## Head
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The new `colorScheme` and `search` configuration options in `scalar.config.json` (shipped in PRs #4288 and #4290 in scalar-org) were missing documentation on scalar.com. Enterprise customers like People Data Labs need this documentation to configure their docs properly.

## Solution

Added comprehensive documentation for the new config options:

- **Color Scheme Configuration** (`siteConfig.colorScheme`):
  - `default`: Control initial color scheme (`"light"`, `"dark"`, or `"system"`)
  - `showToggle`: Show/hide the color scheme toggle

- **Search Configuration** (`siteConfig.layout.search`):
  - `enabled`: Enable or disable search globally
  - `position`: Position search in `"header"` or `"sidebar"`

- **Additional Layout Options**:
  - `pageTitle`: Show/hide page titles globally
  - `pageActions`: Show/hide page actions globally

Also updated:
- `navigation.md` with page-level layout and search options
- `scalar.config.json.md` reference table with links to the new sections

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed for docs-only changes -->
- [ ] I added tests. <!-- Not applicable for documentation -->
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07SL9L6SJ0/p1774269931509889?thread_ts=1774269931.509889&cid=C07SL9L6SJ0)

<div><a href="https://cursor.com/agents/bc-1cd5d9dd-8ab9-59cb-a9e8-8e6f93c25689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cd5d9dd-8ab9-59cb-a9e8-8e6f93c25689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

