### PR TITLE
fix(helpers): preserve special characters in query parameters

### DIFF
--- a/packages/helpers/src/url/merge-urls.test.ts
+++ b/packages/helpers/src/url/merge-urls.test.ts
@@ -3,7 +3,47 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import { combineUrlAndPath, mergeSearchParams, mergeUrls } from './merge-urls'
+import { combineUrlAndPath, mergeSearchParams, mergeUrls, searchParamsToString } from './merge-urls'
+
+describe('searchParamsToString', () => {
+  it('preserves colons in values', () => {
+    const params = new URLSearchParams('sort=name:asc')
+    expect(searchParamsToString(params)).toBe('sort=name:asc')
+  })
+
+  it('preserves special characters like @ and #', () => {
+    const params = new URLSearchParams('email=user@example.com&hash=test#123')
+    expect(searchParamsToString(params)).toBe('email=user@example.com&hash=test#123')
+  })
+
+  it('encodes ampersands and equals signs', () => {
+    const params = new URLSearchParams('filter=a=b&test=c&d')
+    expect(searchParamsToString(params)).toBe('filter=a%3Db&test=c%26d')
+  })
+
+  it('encodes spaces as plus signs', () => {
+    const params = new URLSearchParams('q=hello world')
+    expect(searchParamsToString(params)).toBe('q=hello+world')
+  })
+
+  it('encodes percent signs to prevent double-encoding', () => {
+    const params = new URLSearchParams('value=100%')
+    expect(searchParamsToString(params)).toBe('value=100%25')
+  })
+
+  it('handles multiple values for same key', () => {
+    const params = new URLSearchParams([
+      ['tag', 'a:b'],
+      ['tag', 'c:d'],
+    ])
+    expect(searchParamsToString(params)).toBe('tag=a:b&tag=c:d')
+  })
+
+  it('handles empty params', () => {
+    const params = new URLSearchParams()
+    expect(searchParamsToString(params)).toBe('')
+  })
+})
 
 describe('mergeSearchParams', () => {
   it('merges basic params from different sources', () => {
@@ -220,6 +260,18 @@ describe('mergeUrls', () => {
       ])
       const result = mergeUrls('https://api.example.com?a=1', '/users?b=2', params)
       expect(result).toBe('https://api.example.com/users?a=1&b=2&c=3&d=4')
+    })
+
+    it('preserves colons in query parameters', () => {
+      const params = new URLSearchParams('sort=name:asc')
+      const result = mergeUrls('https://api.example.com', '/users', params)
+      expect(result).toBe('https://api.example.com/users?sort=name:asc')
+    })
+
+    it('preserves special characters like @ in query parameters', () => {
+      const params = new URLSearchParams('email=user@example.com')
+      const result = mergeUrls('https://api.example.com', '/users', params)
+      expect(result).toBe('https://api.example.com/users?email=user@example.com')
     })
 
     it('handles special characters in parameters', () => {

--- a/packages/helpers/src/url/merge-urls.ts
+++ b/packages/helpers/src/url/merge-urls.ts
@@ -3,6 +3,51 @@ import { isRelativePath } from './is-relative-path'
 import { ensureProtocol } from './ensure-protocol'
 
 /**
+ * Encodes a query parameter value for use in a URL.
+ * Unlike encodeURIComponent, this preserves characters like `:`, `@`, `#`, `$`, etc.
+ * that are commonly used in API query parameters and shouldn't be encoded.
+ *
+ * Based on RFC 3986, we only encode characters that are definitely unsafe in query values:
+ * - Space becomes +
+ * - % is encoded to prevent double-encoding issues
+ * - & and = are encoded as they are query string delimiters
+ * - [ and ] are encoded for compatibility
+ */
+const encodeQueryParamValue = (value: string): string => {
+  return value
+    .replace(/%/g, '%25') // Encode % first to avoid double-encoding
+    .replace(/&/g, '%26') // & is a query string delimiter
+    .replace(/=/g, '%3D') // = is a query string delimiter
+    .replace(/\[/g, '%5B') // [ can cause issues
+    .replace(/\]/g, '%5D') // ] can cause issues
+    .replace(/ /g, '+') // Space becomes +
+}
+
+/**
+ * Decodes a query parameter value.
+ */
+const decodeQueryParamValue = (value: string): string => {
+  return value.replace(/\+/g, ' ')
+}
+
+/**
+ * Converts URLSearchParams to a query string without over-encoding special characters.
+ * This preserves characters like `:`, `@`, `#` that are valid in query values but
+ * would be encoded by the standard URLSearchParams.toString().
+ */
+export const searchParamsToString = (params: URLSearchParams): string => {
+  const pairs: string[] = []
+
+  for (const [key, value] of params) {
+    const encodedKey = encodeQueryParamValue(key)
+    const encodedValue = encodeQueryParamValue(value)
+    pairs.push(`${encodedKey}=${encodedValue}`)
+  }
+
+  return pairs.join('&')
+}
+
+/**
  * Merges multiple URLSearchParams objects, preserving multiple values per param
  * within each source, but later sources overwrite earlier ones completely
  * This should de-dupe our query params while allowing multiple keys for "arrays"
@@ -86,8 +131,8 @@ export const mergeUrls = (
     // Merge all search params
     const mergedSearchParams = mergeSearchParams(baseParams, pathParams, urlParams)
 
-    // Build the final URL
-    const search = mergedSearchParams.toString()
+    // Build the final URL using our custom toString to avoid over-encoding
+    const search = searchParamsToString(mergedSearchParams)
     return search ? `${mergedUrl}?${search}` : mergedUrl
   }
   if (path) {


### PR DESCRIPTION
## Problem

Query parameters with special characters like <code>:</code> were being incorrectly URL-encoded. For example, <code>sort=name:asc</code> was being sent as <code>sort=name%3Aasc</code>, which caused backend validation errors.

Fixes #8492

## Solution

Introduced a custom <code>searchParamsToString()</code> function that:
- Preserves commonly used special characters (<code>:</code>, <code>@</code>, <code>#</code>, etc.) that are valid in query values per RFC 3986
- Only encodes characters that are truly problematic in query strings (<code>&amp;</code>, <code>=</code>, <code>%</code>, brackets, and spaces)
- Prevents double-encoding by handling <code>%</code> first

## Changes

- Added <code>encodeQueryParamValue()</code> helper with selective encoding
- Added <code>searchParamsToString()</code> export for converting URLSearchParams without over-encoding
- Updated <code>mergeUrls()</code> to use the new function
- Added comprehensive tests for the new functionality

## Testing

- Added tests for <code>searchParamsToString()</code> covering colons, @ symbols, special characters, encoding of delimiters, and spaces
- Added tests in <code>mergeUrls()</code> for query parameters with colons and special characters
- All existing tests continue to pass