### PR TITLE
fix: config serialization invalid JS

### DIFF
--- a/packages/client-side-rendering/src/html-rendering.test.ts
+++ b/packages/client-side-rendering/src/html-rendering.test.ts
@@ -225,6 +225,17 @@ describe('html-rendering', () => {
       expect(tags).toContain('"onLoaded": () => console.log("loaded")')
     })
 
+    it('serializes function-only configuration without invalid leading comma', () => {
+      const config = {
+        onLoaded: () => console.log('loaded'),
+      }
+
+      const tags = getScriptTags(config, 'https://example.com/script.js')
+
+      expect(tags).toContain('"onLoaded": () => console.log("loaded")')
+      expect(tags).not.toContain('{,')
+    })
+
     it('preserves plugins array containing functions', () => {
       const mockPlugin = () => ({
         name: 'test-plugin',

--- a/packages/client-side-rendering/src/html-rendering.ts
+++ b/packages/client-side-rendering/src/html-rendering.ts
@@ -124,7 +124,10 @@ export function getScriptTags(configuration: Record<string, unknown>, cdn?: stri
     .join('\n')
     .replace(/\s*}$/, '') // Remove the closing brace and any whitespace before it
 
-  const functionPropsString = functionProps.length ? `,\n        ${functionProps.join(',\n        ')}\n      }` : '}'
+  const hasJsonProps = Object.keys(restConfig).length > 0
+  const functionPropsString = functionProps.length
+    ? `${hasJsonProps ? ',' : ''}\n        ${functionProps.join(',\n        ')}\n      }`
+    : '}'
 
   return `
     <!-- Load the Script -->

--- a/packages/server-side-rendering/src/ssr.test.ts
+++ b/packages/server-side-rendering/src/ssr.test.ts
@@ -187,6 +187,18 @@ describe('ssr', () => {
       expect(html).toContain('"onLoaded": () => console.log')
       expect(html).toContain('"url":"https://example.com/api.json"')
     })
+
+    it('serializes function-only configuration without invalid leading comma', async () => {
+      const html = await renderApiReference({
+        config: {
+          onLoaded: () => console.log('loaded'),
+        },
+        css: '',
+      })
+
+      expect(html).toContain('"onLoaded": () => console.log')
+      expect(html).not.toContain('{,')
+    })
   })
 
   describe('getJsAsset', () => {

--- a/packages/server-side-rendering/src/ssr.ts
+++ b/packages/server-side-rendering/src/ssr.ts
@@ -126,6 +126,10 @@ function serializeConfigToJs(config: Record<string, unknown>): string {
     return jsonString
   }
 
+  if (jsonString === '{}') {
+    return `{${functionProps.join(', ')}}`
+  }
+
   // Merge: remove trailing } from JSON, append function props
   return `${jsonString.slice(0, -1)}, ${functionProps.join(', ')}}`
 }


### PR DESCRIPTION
## Problem

When a configuration object contains only function-typed properties, the serialization logic in both `server-side-rendering` and `client-side-rendering` incorrectly processes the empty JSON part. This results in an invalid JavaScript syntax like `{,"onLoaded": ...}` in the generated script, causing a client-side runtime error.

## Solution

The serialization logic in `serializeConfigToJs` (server-side) and `getScriptTags` (client-side) has been updated to correctly handle cases where `jsonProps` (non-function properties) is an empty object. This ensures that the generated JavaScript for the config object maintains valid syntax, preventing the leading comma issue.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix that only adjusts config-to-JS string serialization for a specific edge case (function-only configs) and adds targeted tests; main impact is on generated HTML/JS output formatting.
> 
> **Overview**
> Fixes config serialization in both **client-side** (`getScriptTags`) and **server-side** (`serializeConfigToJs`) rendering so configurations containing *only function properties* no longer produce invalid JS like `{,"onLoaded": ...}`.
> 
> Adds regression tests in both packages to ensure function-only configs serialize without a leading comma while still preserving function-valued fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a44ffdcbaa2a5b78384d744ddbe46158a5a810ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->