### PR TITLE
docs: update visual testing guide to embed artifacts in PR descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ pnpm changeset
 
 ## Visual Testing
 
-When making changes that affect the UI, **PRs must include screenshots** (ideally before and after) demonstrating the visual impact. Most package dependencies trickle up into three main visual surfaces: `api-reference`, `api-client`, and `components`. Test your changes in whichever playground is relevant.
+When making changes that affect the UI, **PRs must include visual artifacts** (screenshots and/or demo videos) demonstrating the visual impact. Most package dependencies trickle up into three main visual surfaces: `api-reference`, `api-client`, and `components`. Test your changes in whichever playground is relevant.
 
 ### Prerequisites
 
@@ -151,12 +151,45 @@ The `api-client` has multiple layouts (web, app, modal) — see its package `AGE
 | Code highlighting, snippets | `api-reference` | `api-client` |
 | Icons | `components` Storybook | `api-reference` |
 
-### Screenshot guidelines for PRs
+### Artifact guidelines for PRs
+
+When making UI changes, **PRs must include visual artifacts** (screenshots and videos) embedded directly in the PR description. Cursor Cloud Agents can post these artifacts to GitHub automatically.
+
+#### How it works
+
+1. **Save artifacts** to `/opt/cursor/artifacts/` with descriptive snake_case names (e.g. `screenshot_sidebar_before.png`, `demo_dark_mode_toggle.mp4`).
+2. **Reference artifacts in the PR description** using HTML tags with absolute file paths. The platform automatically uploads them and rewrites the paths to public URLs.
+
+```html
+<!-- Screenshots -->
+<img src="/opt/cursor/artifacts/screenshot_before.png" alt="Before change" />
+<img src="/opt/cursor/artifacts/screenshot_after.png" alt="After change" />
+
+<!-- Videos -->
+<video src="/opt/cursor/artifacts/demo_feature.mp4" controls></video>
+```
+
+3. **Use the `ManagePullRequest` tool** to create or update the PR with these references in the body.
+
+#### What to capture
 
 - Include **before and after** screenshots when modifying existing UI.
 - For new features, include screenshots showing the feature in context.
 - Use the playground that best demonstrates the change.
 - If the change affects multiple playgrounds, include screenshots from each.
+- For interactive changes (animations, state transitions, flows), record a **demo video** showing the feature working end-to-end.
+
+#### PR description format
+
+Add a `## Visual` section to the PR description with the artifacts:
+
+```markdown
+## Visual
+
+<img src="/opt/cursor/artifacts/screenshot_before.png" alt="Before" />
+<img src="/opt/cursor/artifacts/screenshot_after.png" alt="After" />
+<video src="/opt/cursor/artifacts/demo_feature.mp4" controls></video>
+```
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The visual testing guide in `AGENTS.md` only mentioned screenshots and did not instruct cloud agents to embed visual artifacts (screenshots and videos) directly into PR descriptions. Now that the "Allow posting artifacts to GitHub" setting is enabled in the Cursor Cloud Agents dashboard, agents should take advantage of this to make PR reviews faster.

## Solution

Updated the Visual Testing section in `AGENTS.md` to:

- Rename "Screenshot guidelines for PRs" to "Artifact guidelines for PRs" covering both screenshots and videos
- Add step-by-step instructions for saving artifacts to `/opt/cursor/artifacts/` and referencing them with HTML `<img>` / `<video>` tags in PR descriptions
- Add a recommended `## Visual` section format for PR descriptions
- Broaden the intro from screenshots-only to screenshots and/or demo videos

## Visual

Here is an example of artifacts embedded in a PR description, exactly as described in the updated guide:

**Screenshot** — Scalar API Reference playground (Galaxy spec):

![Scalar API Reference playground showing the Galaxy spec](https://cursor.com/artifacts/c/art-21c8d4fc-615e-491f-aefb-b187b472fd1e)

**Demo video** — navigating the sidebar, viewing an endpoint, and opening the Test Request modal:

<a href="https://cursor.com/agents/bc-8200d10e-df33-4a54-8524-a8f9d39bde6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_api_reference_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-0cd530f6-3f04-485f-8276-8c01acc2c939" alt="demo_api_reference_walkthrough.mp4" /></a>

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- not needed for docs-only change -->
- [ ] I added tests. <!-- not applicable for docs-only change -->
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8200d10e-df33-4a54-8524-a8f9d39bde6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8200d10e-df33-4a54-8524-a8f9d39bde6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

