### PR TITLE
docs(components): add component scaffolding instructions to AGENTS.md

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -225,7 +225,7 @@ test.describe('ScalarExample', () => {
 })
 ```
 
-Add `colorModes: ['light', 'dark']` in `test.use()` to capture both themes. Use `page.getByRole(...)` to interact with the component before taking additional snapshots (e.g., hover states).
+Add `colorModes: ['light', 'dark']` in `test.use()` when the component has theme-dependent styling that warrants separate snapshots. Use `page.getByRole(...)` to interact with the component before taking additional snapshots (e.g., hover states).
 
 ### 9. Define types (`types.ts`) — when needed
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Agents (and developers) working in `@scalar/components` had no documented guide for how to scaffold a new component. The existing `AGENTS.md` covered visual testing and Storybook, but not the step-by-step process for creating a component from scratch.

## Solution

Added a comprehensive **"Scaffolding a New Component"** section to `packages/components/AGENTS.md` that covers:

1. Directory structure and naming conventions
2. Required vs optional files
3. The two-script-block Vue component pattern (JSDoc + `<script setup>`)
4. `useBindCx` / `cva` class merging conventions
5. Barrel export (`index.ts`) patterns for components, subcomponents, composables, and types
6. Registering the component in the package entry (`src/index.ts`)
7. Storybook story conventions (`@storybook/vue3-vite`, `satisfies Meta`, `autodocs`)
8. Unit test conventions (Vitest + `@vue/test-utils`)
9. Visual snapshot test conventions (Playwright `@test/helpers`)
10. `types.ts` and `constants.ts` patterns

All examples are derived from real components in the codebase (ScalarButton, ScalarCard, ScalarListbox, ScalarTooltip, etc.) to ensure accuracy.

Includes a quick-reference checklist at the end.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- docs-only, no version bump needed -->
- [ ] I added tests. <!-- docs-only change -->
- [x] I updated the documentation.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b71961ea-15df-4cef-92ae-03a7c53907ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b71961ea-15df-4cef-92ae-03a7c53907ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

