### PR TITLE
chore(examples-web): remove invalid preview tiles

### DIFF
--- a/examples/web/src/pages/StartPage.vue
+++ b/examples/web/src/pages/StartPage.vue
@@ -2,8 +2,6 @@
 import '@scalar/themes/style.css'
 
 import PageLink from '../components/PageLink.vue'
-
-const inDevelopment = import.meta.env.DEV
 </script>
 <template>
   <div class="main">
@@ -46,106 +44,6 @@ const inDevelopment = import.meta.env.DEV
         <template #title>API Reference with Path Routing</template>
         <template #description>
           Standalone API Reference with path routing instead of hash routing
-        </template>
-      </PageLink>
-    </div>
-    <h1>Examples</h1>
-    <div class="page-links">
-      <PageLink href="http://localhost:5065">
-        <template #title>Client V2</template>
-        <template #description>@scalar/api-client</template>
-      </PageLink>
-      <PageLink href="http://localhost:5062/json">
-        <template #title>Nuxt</template>
-        <template #description>@scalar/nuxt</template>
-      </PageLink>
-      <PageLink href="http://localhost:5066/api/openapi">
-        <template #title>Next.js</template>
-        <template #description>@scalar/nuxtjs-openapi</template>
-      </PageLink>
-      <PageLink href="http://localhost:5063/yaml-url">
-        <template #title>Docusaurus</template>
-        <template #description>@scalar/docusaurus</template>
-      </PageLink>
-      <PageLink
-        :href="
-          inDevelopment
-            ? 'http://localhost:5058'
-            : 'https://scalar-example-next-js-p6gnzjpyuq-uc.a.run.app'
-        ">
-        <template #title>Next.js</template>
-        <template #description>@scalar/nextjs-api-reference</template>
-      </PageLink>
-      <PageLink
-        :href="
-          inDevelopment
-            ? 'http://localhost:5059'
-            : 'https://scalar-example-react-p6gnzjpyuq-uc.a.run.app'
-        ">
-        <template #title>React</template>
-        <template #description>@scalar/api-reference</template>
-      </PageLink>
-      <PageLink
-        :href="
-          inDevelopment
-            ? 'http://localhost:5053'
-            : 'https://scalar-example-fastify-p6gnzjpyuq-uc.a.run.app/reference'
-        ">
-        <template #title>Fastify</template>
-        <template #description>@scalar/fastify-api-reference</template>
-      </PageLink>
-      <PageLink
-        :href="
-          inDevelopment
-            ? 'http://localhost:5054'
-            : 'https://scalar-example-hono-p6gnzjpyuq-uc.a.run.app'
-        ">
-        <template #title>Hono</template>
-        <template #description>@scalar/hono-api-reference</template>
-      </PageLink>
-      <PageLink
-        :href="
-          inDevelopment
-            ? 'http://localhost:5055'
-            : 'https://scalar-example-express-p6gnzjpyuq-uc.a.run.app'
-        ">
-        <template #title>Express</template>
-        <template #description>@scalar/express-api-reference</template>
-      </PageLink>
-      <PageLink
-        :href="
-          inDevelopment
-            ? 'http://localhost:5056'
-            : 'https://scalar-example-nest-js-p6gnzjpyuq-uc.a.run.app'
-        ">
-        <template #title>NestJS (Express)</template>
-        <template #description>@scalar/nestjs-api-reference</template>
-      </PageLink>
-      <PageLink
-        :href="
-          inDevelopment
-            ? 'http://localhost:5057'
-            : 'https://scalar-example-nest-js-fastify-p6gnzjpyuq-uc.a.run.app'
-        ">
-        <template #title>NestJS (Fastify)</template>
-        <template #description>@scalar/nestjs-api-reference</template>
-      </PageLink>
-    </div>
-    <h1>@scalar/components</h1>
-    <div class="page-links">
-      <PageLink href="http://localhost:5100">
-        <template #title>Components</template>
-        <template #description>
-          The design system we're using throughout our packages.
-        </template>
-      </PageLink>
-    </div>
-    <h1>@scalar/draggable</h1>
-    <div class="page-links">
-      <PageLink href="http://localhost:5064">
-        <template #title>Draggable</template>
-        <template #description>
-          Light vue wrapper around html5 drag and drop
         </template>
       </PageLink>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`examples/web` included tiles that target localhost or stale preview URLs. This page is used for PR previews, so those links appear broken and add noise.

## Solution

- Removed the external tile groups from `examples/web/src/pages/StartPage.vue`.
- Kept only internal `@scalar/api-reference` routes that are always available in the preview app.
- Removed the now-unused `inDevelopment` variable.

## Visual

<a href="https://cursor.com/agents/bc-213e2038-3c89-4885-9323-282e2eabe408/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexamples_web_tiles_cleanup_demo.mp4"><img src="https://cursor.com/artifacts/c/art-edafdb37-46fa-4efa-a636-815cd2469834" alt="examples_web_tiles_cleanup_demo.mp4" /></a>
![examples web start page with only four api-reference tiles](https://cursor.com/artifacts/c/art-c13cde35-f4f3-411d-96ae-eac03c8097e3)

## Testing

- `pnpm --filter @scalar-examples/web types:check` (pass)
- Manual browser walkthrough on `http://localhost:5173` (pass): verified only 4 internal tiles remain and each route loads.
- `pnpm --filter @scalar-examples/web lint:check` (fails due to pre-existing errors in `src/components/MonacoEditor.vue`, unrelated to this change).

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-213e2038-3c89-4885-9323-282e2eabe408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-213e2038-3c89-4885-9323-282e2eabe408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

