### PR TITLE
docs: add ticket and issue linking instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,59 @@ fix(api-client): crashes when API returns null
 type (feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert)
 ```
 
+### Ticket and issue linking
+
+When a **Linear ticket** ID (e.g. `DOC-5102`, `ENG-123`) or a **GitHub issue** number/URL is provided in the prompt, instructions, or a related Slack thread, you **must** link it in the PR so that project-management integrations can track progress automatically.
+
+#### Linear tickets
+
+Include the Linear issue ID in the **PR branch name**, **PR title**, or **PR description** using a magic word. Linear's GitHub integration detects these and links the PR to the issue.
+
+**Closing magic words** (move the issue to Done when the PR merges):
+`close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`
+
+**Non-closing magic words** (link without auto-closing):
+`ref`, `refs`, `references`, `part of`, `related to`, `contributes to`, `toward`, `towards`
+
+Examples (in the PR description):
+
+```
+Fixes DOC-5102
+Part of ENG-123
+Resolves DOC-5102, ENG-456
+```
+
+You can also use the full Linear URL: `Fixes https://linear.app/scalar/issue/DOC-5102/title`.
+
+To link multiple issues, list them after the magic word separated by commas: `Fixes ENG-123, DES-5, ENG-256`.
+
+#### GitHub issues
+
+Use GitHub's closing keywords in the PR description to link and auto-close GitHub issues when the PR merges:
+
+`close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`
+
+| Scenario | Syntax | Example |
+|----------|--------|---------|
+| Same repository | `KEYWORD #ISSUE` | `Closes #42` |
+| Different repository | `KEYWORD OWNER/REPO#ISSUE` | `Fixes scalar/scalar#100` |
+| Multiple issues | Repeat full syntax | `Resolves #10, resolves #42` |
+
+#### Where to place the link
+
+Add a `## Ticket` section near the top of the PR description:
+
+```markdown
+## Ticket
+
+Fixes DOC-5102
+Closes #42
+```
+
+If both a Linear ticket and a GitHub issue are provided, include both.
+
+> **Tip:** Magic words must appear in the PR description (not in PR comments) for Linear to detect them. For GitHub issues, keywords work in both the PR description and commit messages.
+
 ### Changesets
 
 If your PR will cause a version bump for any package, add a changeset:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Ticket

Part of DOC-5102

## Problem

AI agents had no guidance on linking Linear tickets or GitHub issues in PRs. When a ticket ID (e.g. `DOC-5102`) or issue number was provided in the prompt or a related Slack thread, agents would ignore it, breaking the automatic project-management tracking that Linear and GitHub provide.

## Solution

Added a new **Ticket and issue linking** subsection under **PR Requirements** in `AGENTS.md` that instructs agents to:

- Detect Linear ticket IDs and GitHub issue references from prompts, instructions, or Slack threads
- Use Linear **magic words** (closing: `fixes`, `closes`, `resolves`, etc. and non-closing: `ref`, `part of`, `related to`, etc.) in the PR description to link to Linear issues
- Use GitHub **closing keywords** (`closes #42`, `fixes owner/repo#100`) to link and auto-close GitHub issues
- Place links in a `## Ticket` section near the top of the PR description
- Handle multiple tickets/issues when more than one is provided

Reference: https://linear.app/docs/github-integration

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- not needed for docs-only change -->
- [ ] I added tests. <!-- not applicable -->
- [x] I updated the documentation.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-462e300b-9a2d-4e3e-ba6a-a3abf4a2e3d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-462e300b-9a2d-4e3e-ba6a-a3abf4a2e3d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

