### PR TITLE
docs(AGENTS): refine ticket linking placement rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ When a **Linear ticket** ID (e.g. `DOC-5102`, `ENG-123`) or a **GitHub issue** n
 
 #### Linear tickets
 
-Include the Linear issue ID in the **PR branch name**, **PR title**, or **PR description** using a magic word. Linear's GitHub integration detects these and links the PR to the issue.
+Include the Linear issue ID in the **PR branch name** or **PR description** using a magic word. Linear's GitHub integration detects these and links the PR to the issue. Do **not** put the issue ID in the PR title — titles must follow the conventional commit format (e.g. `feat(api-reference): add my new feature`).
 
 **Closing magic words** (move the issue to Done when the PR merges):
 `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`
@@ -145,7 +145,7 @@ Use GitHub's closing keywords in the PR description to link and auto-close GitHu
 
 #### Where to place the link
 
-Add a `## Ticket` section near the top of the PR description:
+Add a `## Ticket` section at the bottom of the PR description:
 
 ```markdown
 ## Ticket


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The ticket linking instructions merged in #8648 allowed putting Linear issue IDs in PR titles (which conflicts with the conventional commit format requirement) and placed the `## Ticket` section near the top of the PR description instead of the bottom.

## Solution

- Removed **PR title** as a valid location for Linear issue IDs, with an explicit note that titles must follow conventional commit format.
- Changed the `## Ticket` section placement from "near the top" to "at the bottom" of the PR description.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- not needed for docs-only change -->
- [ ] I added tests. <!-- not applicable -->
- [x] I updated the documentation.

## Ticket

Part of DOC-5102

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-462e300b-9a2d-4e3e-ba6a-a3abf4a2e3d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-462e300b-9a2d-4e3e-ba6a-a3abf4a2e3d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

