### PR TITLE
feat(api-reference): error messages on localhost

### DIFF
--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -61,6 +61,7 @@ import ClassicHeader from '@/components/ClassicHeader.vue'
 import Content from '@/components/Content/Content.vue'
 import MobileHeader from '@/components/MobileHeader.vue'
 import { DeveloperTools } from '@/features/developer-tools'
+import DocumentErrors from '@/features/developer-tools/components/DocumentErrors.vue'
 import DocumentSelector from '@/features/multiple-documents/DocumentSelector.vue'
 import SearchButton from '@/features/Search/components/SearchButton.vue'
 import { getSystemModePreference } from '@/helpers/color-mode'
@@ -1106,6 +1107,7 @@ const showMCPButton = computed(() => {
       <div ref="modal" />
     </div>
     <ScalarToasts />
+    <DocumentErrors :errors="workspaceStore.documentErrors" />
   </div>
 </template>
 

--- a/packages/api-reference/src/features/developer-tools/components/DocumentErrors.vue
+++ b/packages/api-reference/src/features/developer-tools/components/DocumentErrors.vue
@@ -165,10 +165,6 @@ const hasErrors = computed(() => errorCount.value > 0 && !dismissed.value)
   border-left-color: var(--scalar-color-red);
 }
 
-.document-error-item:has([data-type='parse']) {
-  border-left-color: var(--scalar-color-orange);
-}
-
 .document-error-item:has([data-type='validation']) {
   border-left-color: var(--scalar-color-yellow);
 }
@@ -185,11 +181,6 @@ const hasErrors = computed(() => errorCount.value > 0 && !dismissed.value)
 .document-error-badge[data-type='fetch'] {
   background: color-mix(in srgb, var(--scalar-color-red), transparent 90%);
   color: var(--scalar-color-red);
-}
-
-.document-error-badge[data-type='parse'] {
-  background: color-mix(in srgb, var(--scalar-color-orange), transparent 90%);
-  color: var(--scalar-color-orange);
 }
 
 .document-error-badge[data-type='validation'] {

--- a/packages/api-reference/src/features/developer-tools/components/DocumentErrors.vue
+++ b/packages/api-reference/src/features/developer-tools/components/DocumentErrors.vue
@@ -1,0 +1,220 @@
+<script lang="ts" setup>
+import type { DocumentError } from '@scalar/workspace-store/client'
+import { computed, ref } from 'vue'
+
+const { errors } = defineProps<{
+  errors: Record<string, DocumentError[]>
+}>()
+
+const dismissed = ref(false)
+
+const allErrors = computed(() => Object.entries(errors))
+
+const errorCount = computed(() =>
+  allErrors.value.reduce((sum, [, errs]) => sum + errs.length, 0),
+)
+
+const hasErrors = computed(() => errorCount.value > 0 && !dismissed.value)
+</script>
+<template>
+  <Teleport to="body">
+    <div
+      v-if="hasErrors"
+      class="document-error-overlay">
+      <div class="document-error-container custom-scroll">
+        <div class="document-error-header">
+          <div class="document-error-title">
+            <span class="document-error-icon">&#x26A0;</span>
+            {{ errorCount }} document
+            {{ errorCount === 1 ? 'error' : 'errors' }}
+          </div>
+          <button
+            class="document-error-dismiss"
+            type="button"
+            @click="dismissed = true">
+            &#x2715;
+          </button>
+        </div>
+        <div class="document-error-body">
+          <div
+            v-for="[docName, docErrors] in allErrors"
+            :key="docName"
+            class="document-error-group">
+            <h4 class="document-error-group-title">{{ docName }}</h4>
+            <ul class="document-error-list">
+              <li
+                v-for="(error, index) in docErrors"
+                :key="index"
+                class="document-error-item">
+                <span
+                  class="document-error-badge"
+                  :data-type="error.type">
+                  {{ error.type }}
+                </span>
+                <div class="document-error-detail">
+                  <p class="document-error-message">{{ error.message }}</p>
+                  <code
+                    v-if="error.path"
+                    class="document-error-path">
+                    #{{ error.path }}
+                  </code>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+<style scoped>
+.document-error-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--scalar-background-1) 80%, transparent);
+  font-family: var(--scalar-font);
+}
+
+.document-error-container {
+  background: var(--scalar-background-2);
+  color: var(--scalar-color-1);
+  border-radius: var(--scalar-radius-lg);
+  width: min(90vw, 800px);
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.document-error-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--scalar-border-color);
+  position: sticky;
+  top: 0;
+  background: var(--scalar-background-2);
+  border-radius: var(--scalar-radius-lg) var(--scalar-radius-lg) 0 0;
+}
+
+.document-error-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--scalar-heading-3);
+  font-weight: var(--scalar-semibold);
+  color: var(--scalar-color-red);
+}
+
+.document-error-icon {
+  font-size: var(--scalar-heading-3);
+}
+
+.document-error-dismiss {
+  background: none;
+  border: none;
+  color: var(--scalar-color-2);
+  font-size: var(--scalar-small);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--scalar-radius);
+  line-height: 1;
+}
+
+.document-error-dismiss:hover {
+  color: var(--scalar-color-1);
+  background: var(--scalar-background-3);
+}
+
+.document-error-body {
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.document-error-group-title {
+  color: var(--scalar-color-3);
+  margin: 0 0 8px;
+  font-weight: var(--scalar-regular);
+}
+
+.document-error-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.document-error-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--scalar-background-3);
+  border-radius: var(--scalar-radius-lg);
+  border-left: 3px solid var(--scalar-border-color);
+}
+
+.document-error-item:has([data-type='fetch']) {
+  border-left-color: var(--scalar-color-red);
+}
+
+.document-error-item:has([data-type='parse']) {
+  border-left-color: var(--scalar-color-orange);
+}
+
+.document-error-item:has([data-type='validation']) {
+  border-left-color: var(--scalar-color-yellow);
+}
+
+.document-error-badge {
+  flex-shrink: 0;
+  font-size: var(--scalar-micro);
+  padding: 2px 5px;
+  border-radius: var(--scalar-radius);
+  text-transform: uppercase;
+  margin-top: 1px;
+}
+
+.document-error-badge[data-type='fetch'] {
+  background: color-mix(in srgb, var(--scalar-color-red), transparent 90%);
+  color: var(--scalar-color-red);
+}
+
+.document-error-badge[data-type='parse'] {
+  background: color-mix(in srgb, var(--scalar-color-orange), transparent 90%);
+  color: var(--scalar-color-orange);
+}
+
+.document-error-badge[data-type='validation'] {
+  background: color-mix(in srgb, var(--scalar-color-yellow), transparent 90%);
+  color: var(--scalar-color-yellow);
+}
+
+.document-error-detail {
+  min-width: 0;
+  flex: 1;
+}
+
+.document-error-message {
+  margin: 0;
+  font-size: var(--scalar-small);
+  line-height: 1.5;
+  word-break: break-word;
+  color: var(--scalar-color-1);
+}
+
+.document-error-path {
+  display: block;
+  margin-top: 6px;
+  font-size: var(--scalar-small);
+  color: var(--scalar-color-2);
+  font-family: var(--scalar-font-code);
+}
+</style>

--- a/packages/json-magic/src/bundle/bundle.ts
+++ b/packages/json-magic/src/bundle/bundle.ts
@@ -33,7 +33,7 @@ export function isLocalRef(value: string): boolean {
   return value.startsWith('#')
 }
 
-export type ResolveResult = { ok: true; data: unknown; raw: string } | { ok: false }
+export type ResolveResult = { ok: true; data: unknown; raw: string } | { ok: false; error?: string }
 
 /**
  * Resolves a string by finding and executing the appropriate plugin.

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/index.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/index.ts
@@ -74,11 +74,13 @@ export async function fetchUrl(
     console.warn(`[WARN] Fetch failed with status ${result.status} ${result.statusText} for URL: ${url}`)
     return {
       ok: false,
+      error: `Fetch failed with status ${result.status} ${result.statusText} for URL: ${url}`,
     }
-  } catch {
+  } catch (e) {
     console.warn(`[WARN] Failed to parse JSON/YAML from URL: ${url}`)
     return {
       ok: false,
+      error: `Failed to fetch from URL: ${url}${e instanceof Error ? ` (${e.message})` : ''}`,
     }
   }
 }

--- a/packages/json-magic/src/bundle/plugins/parse-json/index.ts
+++ b/packages/json-magic/src/bundle/plugins/parse-json/index.ts
@@ -22,9 +22,10 @@ export function parseJson(): LoaderPlugin {
           data: JSON.parse(value),
           raw: value,
         })
-      } catch {
+      } catch (e) {
         return Promise.resolve({
           ok: false,
+          error: `Invalid JSON: ${e instanceof Error ? e.message : 'unknown parse error'}`,
         })
       }
     },

--- a/packages/json-magic/src/bundle/plugins/parse-yaml/index.ts
+++ b/packages/json-magic/src/bundle/plugins/parse-yaml/index.ts
@@ -24,9 +24,10 @@ export function parseYaml(): LoaderPlugin {
           data: YAML.parse(value, { merge: true, maxAliasCount: 10000 }),
           raw: value,
         })
-      } catch {
+      } catch (e) {
         return Promise.resolve({
           ok: false,
+          error: `Invalid YAML: ${e instanceof Error ? e.message : 'unknown parse error'}`,
         })
       }
     },

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -111,7 +111,7 @@ export type ObjectDoc = {
 export type WorkspaceDocumentInput = UrlDoc | ObjectDoc | FileDoc
 
 /** The category of a document error */
-export type DocumentErrorType = 'fetch' | 'parse' | 'validation'
+export type DocumentErrorType = 'fetch' | 'validation'
 
 /** An error or warning encountered while loading or validating a document */
 export type DocumentError = {
@@ -1056,7 +1056,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
 
         documentErrors[name] = [
           {
-            type: 'parse',
+            type: 'fetch',
             message: `Response data is not a valid object for document '${name}'`,
           },
         ]

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -110,6 +110,17 @@ export type ObjectDoc = {
  */
 export type WorkspaceDocumentInput = UrlDoc | ObjectDoc | FileDoc
 
+/** The category of a document error */
+export type DocumentErrorType = 'fetch' | 'parse' | 'validation'
+
+/** An error or warning encountered while loading or validating a document */
+export type DocumentError = {
+  type: DocumentErrorType
+  message: string
+  /** JSON pointer path to the invalid value (for validation errors) */
+  path?: string
+}
+
 /**
  * Resolves a workspace document from various input sources (URL, local file, or direct document object).
  *
@@ -213,6 +224,10 @@ export type WorkspaceStore = {
    * The auth store for the workspace
    */
   readonly auth: AuthStore
+  /**
+   * Document errors keyed by document name, populated during loading and validation
+   */
+  readonly documentErrors: Record<string, DocumentError[]>
   /**
    * Returns the reactive workspace object with an additional activeDocument getter
    */
@@ -793,6 +808,9 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     },
   )
 
+  /** Reactive map of document errors keyed by document name */
+  const documentErrors: Record<string, DocumentError[]> = reactive({})
+
   /**
    * This store is used to track the history of requests and responses for documents and operations.
    */
@@ -966,6 +984,16 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
           value: error.value,
         })),
       )
+
+      // Store validation errors for devtools display (cap at 100)
+      documentErrors[name] = validationErrors.slice(0, 100).map((error) => ({
+        type: 'validation' as const,
+        message: error.message,
+        path: error.path,
+      }))
+    } else {
+      // Clear any previous errors on successful validation
+      delete documentErrors[name]
     }
 
     // Skip navigation generation if the document already has a server-side generated navigation structure
@@ -1003,6 +1031,13 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       if (!resolve.ok) {
         console.error(`Failed to fetch document '${name}': request was not successful`)
 
+        documentErrors[name] = [
+          {
+            type: 'fetch',
+            message: resolve.error ?? `Document '${name}' could not be loaded`,
+          },
+        ]
+
         workspace.documents[name] = {
           ...meta,
           openapi: '3.1.0',
@@ -1018,6 +1053,13 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
 
       if (!isObject(resolve.data)) {
         console.error(`Failed to load document '${name}': response data is not a valid object`)
+
+        documentErrors[name] = [
+          {
+            type: 'parse',
+            message: `Response data is not a valid object for document '${name}'`,
+          },
+        ]
 
         workspace.documents[name] = {
           ...meta,
@@ -1174,6 +1216,9 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     get auth() {
       return auth
     },
+    get documentErrors() {
+      return documentErrors
+    },
     update(key, value) {
       preventPollution(key)
       Object.assign(workspace, { [key]: value })
@@ -1262,6 +1307,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       delete intermediateDocuments[documentName]
       delete overrides[documentName]
       delete extraDocumentConfigurations[documentName]
+      delete documentErrors[documentName]
       history.clearDocumentHistory(documentName)
       auth.clearDocumentAuth(documentName)
 


### PR DESCRIPTION
## Problem

errors only show up in the browser console

## Solution

not really happy with it yet, but it's something:
shows error messages (when on localhost)

## Preview

<img width="1318" height="760" alt="Screenshot 2026-04-01 at 14 57 41" src="https://github.com/user-attachments/assets/41175093-f2ed-4438-b6c2-6062f45839c0" />

<img width="1302" height="763" alt="Screenshot 2026-04-01 at 14 57 17" src="https://github.com/user-attachments/assets/76930e65-3c54-486b-8e7a-d9be3da224ee" />

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
