### PR TITLE
chore: clean up pnpm workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -108,30 +108,10 @@ ignoredBuiltDependencies:
   - workerd
 
 # Do not lower this value; add popular packages to minimumReleaseAgeExclude or wait before updating.
-minimumReleaseAge: 7200
-
-minimumReleaseAgeExclude:
-  - '@storybook/addon-docs'
-  - '@storybook/addon-links'
-  - '@storybook/builder-vite'
-  - '@storybook/csf-plugin'
-  - '@storybook/react-dom-shim'
-  - '@storybook/vue3'
-  - '@storybook/vue3-vite'
-  - '@sveltejs/kit'
-  - '@vitejs/plugin-react'
-  - knip
-  - next
-  - nuxt
-  - storybook
-  - turbo
-  - undici
-  - vite
-  - vitest
+minimumReleaseAge: 7200 # 5 days
 
 onlyBuiltDependencies:
   - '@nestjs/core'
-  - '@parcel/watcher'
   - '@swc/core'
   - '@tailwindcss/oxide'
   - lefthook


### PR DESCRIPTION
we don't need those `minimumReleaseAgeExclude` entries rn
we don't use the parcel watcher anymore

time to clean up

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change: removes `minimumReleaseAgeExclude` overrides and stops marking `@parcel/watcher` as an allowed built dependency, which may only affect dependency update cadence and install/build behavior.
> 
> **Overview**
> Cleans up `pnpm-workspace.yaml` by removing the `minimumReleaseAgeExclude` list and keeping a single `minimumReleaseAge: 7200` setting (now annotated as *5 days*).
> 
> Also drops `@parcel/watcher` from `onlyBuiltDependencies`, tightening which packages are allowed to run install-time build steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a4e9d7614431fb2e2290a656577ac7d76294040. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->