### PR TITLE
fix(api-reference): broken test for create search index

### DIFF
--- a/.changeset/fresh-geese-think.md
+++ b/.changeset/fresh-geese-think.md
@@ -1,5 +1,0 @@
----
-'@scalar/api-reference': patch
----
-
-fix: broken test for create search index


### PR DESCRIPTION
Not sure how this test passed in the PR but is broken now, but this fixes it

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change adjusting expectations for the operation `body` parameter map shape; no production logic changes.
> 
> **Overview**
> Fixes a broken `createSearchIndex` unit test by updating the expected operation `body` parameter map to no longer include empty `body`/`formData` arrays when indexing path-item parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2437ea41b4c5217107dd6b3bbffbb66dfe0337a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->