### PR TITLE
test: fix flacky tests who was failing only locally

### DIFF
--- a/packages/api-reference/src/helpers/download.test.ts
+++ b/packages/api-reference/src/helpers/download.test.ts
@@ -1,35 +1,44 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { downloadDocument } from './download'
 
-describe('downloadDocument', () => {
-  // Mock URL.createObjectURL and URL.revokeObjectURL
-  const mockObjectUrl = 'blob:test'
-  const createObjectURL = vi.fn().mockReturnValue(mockObjectUrl)
-  const revokeObjectURL = vi.fn()
-
-  // Mock createElement and its methods
-  const mockDispatchEvent = vi.fn()
-  const mockLink = {
-    href: '',
-    download: '',
-    dispatchEvent: mockDispatchEvent,
-    remove: vi.fn(),
+/**
+ * Read UTF-8 text from a Blob in tests.
+ * jsdom's `blob.text()` / `new Response(blob).text()` can yield `"[object Blob]"`; `arrayBuffer` is reliable.
+ */
+const readBlobBody = async (blob: Blob) => {
+  if (typeof blob.arrayBuffer === 'function') {
+    const buffer = await blob.arrayBuffer()
+    return new TextDecoder().decode(buffer)
   }
-  const createElement = vi.fn().mockReturnValue(mockLink)
+  if (typeof blob.text === 'function') {
+    return blob.text()
+  }
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result))
+    reader.onerror = () => reject(reader.error)
+    reader.readAsText(blob)
+  })
+}
 
-  // Setup mocks before each test
+describe('downloadDocument', () => {
+  let createObjectURLSpy: ReturnType<typeof vi.spyOn>
+  let revokeObjectURLSpy: ReturnType<typeof vi.spyOn>
+  let createElementSpy: ReturnType<typeof vi.spyOn>
+  let dispatchEventSpy: ReturnType<typeof vi.spyOn>
+  let removeSpy: ReturnType<typeof vi.spyOn>
+
   beforeEach(() => {
-    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
-    vi.stubGlobal('document', { createElement })
-    vi.useFakeTimers()
+    createObjectURLSpy = vi.spyOn(URL, 'createObjectURL')
+    revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL')
+    createElementSpy = vi.spyOn(document, 'createElement')
+    dispatchEventSpy = vi.spyOn(EventTarget.prototype, 'dispatchEvent')
+    removeSpy = vi.spyOn(Element.prototype, 'remove')
   })
 
-  // Cleanup after each test
   afterEach(() => {
-    vi.unstubAllGlobals()
-    vi.useRealTimers()
-    vi.clearAllMocks()
+    vi.restoreAllMocks()
   })
 
   it('downloads JSON when format is explicitly set to json', async () => {
@@ -41,27 +50,25 @@ info:
     `
     await downloadDocument(yamlContent, 'scalar-galaxy', 'json')
 
-    // Should create a JSON blob
-    expect(createObjectURL).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'application/json',
-      }),
-    )
+    const blobArg = createObjectURLSpy.mock.calls[0]![0] as Blob
+    expect(blobArg.type).toBe('application/json')
 
-    // Should set correct filename
-    expect(mockLink.download).toBe('scalar-galaxy.json')
+    const link = createElementSpy.mock.results.at(-1)!.value as HTMLAnchorElement
+    expect(link.tagName.toLowerCase()).toBe('a')
+    expect(link.download).toBe('scalar-galaxy.json')
 
-    // Should trigger the download
-    expect(mockDispatchEvent).toHaveBeenCalledWith(
+    expect(dispatchEventSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'click',
       }),
     )
 
-    // Should cleanup
-    vi.runAllTimers()
-    expect(revokeObjectURL).toHaveBeenCalledWith(mockObjectUrl)
-    expect(mockLink.remove).toHaveBeenCalled()
+    assert(createObjectURLSpy.mock.results.length > 0)
+    const objectUrl = createObjectURLSpy.mock.results[0].value
+    assert(typeof objectUrl === 'string')
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith(objectUrl)
+    expect(removeSpy).toHaveBeenCalled()
   })
 
   it('downloads YAML when format is explicitly set to yaml', async () => {
@@ -75,15 +82,13 @@ info:
 
     await downloadDocument(jsonContent, 'scalar-galaxy', 'yaml')
 
-    // Should create a YAML blob
-    expect(createObjectURL).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'application/x-yaml',
-      }),
-    )
+    assert(createObjectURLSpy.mock.calls.length > 0)
+    const blobArg = createObjectURLSpy.mock.calls[0]![0]
+    assert(blobArg instanceof Blob)
+    expect(blobArg.type).toBe('application/x-yaml')
 
-    // Should set correct filename
-    expect(mockLink.download).toBe('scalar-galaxy.yaml')
+    const link = createElementSpy.mock.results.at(-1)!.value as HTMLAnchorElement
+    expect(link.download).toBe('scalar-galaxy.yaml')
   })
 
   it('defaults to JSON when no format is specified and content is JSON', async () => {
@@ -93,12 +98,11 @@ info:
 
     await downloadDocument(jsonContent, 'scalar-galaxy')
 
-    expect(createObjectURL).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'application/json',
-      }),
-    )
-    expect(mockLink.download).toBe('scalar-galaxy.json')
+    const blobArg = createObjectURLSpy.mock.calls[0]![0] as Blob
+    expect(blobArg.type).toBe('application/json')
+
+    const link = createElementSpy.mock.results.at(-1)!.value as HTMLAnchorElement
+    expect(link.download).toBe('scalar-galaxy.json')
   })
 
   it('defaults to YAML when no format is specified and content is YAML', async () => {
@@ -106,17 +110,17 @@ info:
 
     await downloadDocument(yamlContent, 'scalar-galaxy')
 
-    expect(createObjectURL).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'application/x-yaml',
-      }),
-    )
-    expect(mockLink.download).toBe('scalar-galaxy.yaml')
+    const blobArg = createObjectURLSpy.mock.calls[0]![0] as Blob
+    expect(blobArg.type).toBe('application/x-yaml')
+
+    const link = createElementSpy.mock.results.at(-1)!.value as HTMLAnchorElement
+    expect(link.download).toBe('scalar-galaxy.yaml')
   })
 
   it('uses default filename when none is provided', async () => {
     await downloadDocument('{"test": true}')
-    expect(mockLink.download).toBe('openapi.json')
+    const link = createElementSpy.mock.results.at(-1)!.value as HTMLAnchorElement
+    expect(link.download).toBe('openapi.json')
   })
 
   it('preserves YAML content verbatim when output format matches input format', async () => {
@@ -128,8 +132,8 @@ info:
 `
     await downloadDocument(yamlWithComments, 'scalar-galaxy', 'yaml')
 
-    const blob = createObjectURL.mock.calls[0]![0] as Blob
-    const text = await blob.text()
+    const blobArg = createObjectURLSpy.mock.calls.at(-1)![0] as Blob
+    const text = await readBlobBody(blobArg)
 
     expect(text).toBe(yamlWithComments)
   })
@@ -139,8 +143,8 @@ info:
 
     await downloadDocument(jsonContent, 'test')
 
-    const blob = createObjectURL.mock.calls[0]![0] as Blob
-    const text = await blob.text()
+    const blobArg = createObjectURLSpy.mock.calls.at(-1)![0] as Blob
+    const text = await readBlobBody(blobArg)
 
     expect(text).toBe(jsonContent)
   })


### PR DESCRIPTION
## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust mocking and async timing around `URL.createObjectURL` revocation; low risk beyond potential for masking regressions if assertions become less strict.
> 
> **Overview**
> Makes `downloadDocument` tests more reliable across environments by switching from `vi.stubGlobal`/fake timers to `vi.spyOn` against real `URL`/DOM APIs and restoring mocks via `vi.restoreAllMocks()`.
> 
> Adds a `readBlobBody` helper to read Blob contents via `arrayBuffer` (with fallbacks) and updates assertions to validate the generated Blob MIME type, anchor `download` filename, click dispatch, and delayed `revokeObjectURL`/element removal cleanup using a real timeout wait.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddd14224a329455a021d5bbedc8cf8595b67181d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->