### PR TITLE
fix(api-client): surface OAuth2 token endpoint error responses

### DIFF
--- a/.changeset/swift-tokens-surface.md
+++ b/.changeset/swift-tokens-surface.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: surface OAuth2 token endpoint error responses with RFC 6749 error_description

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
@@ -734,6 +734,19 @@ describe('oauth', () => {
       expect(error!.message).toBe('Token request failed: invalid_grant')
     })
 
+    it('should fall back to HTTP status when the error response body is not JSON', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: () => Promise.reject(new SyntaxError('Unexpected token')),
+      })
+
+      const [error, result] = await authorizeOauth2(scheme, 'clientCredentials', selectedScopes, mockServer, '')
+      expect(result).toBe(null)
+      expect(error).toBeInstanceOf(Error)
+      expect(error!.message).toBe('Token request failed: HTTP 503')
+    })
+
     it('should use custom token name when x-tokenName is specified', async () => {
       const flows = {
         clientCredentials: {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
@@ -96,6 +96,7 @@ describe('oauth', () => {
 
       // Mock the token exchange
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: accessToken }),
       })
 
@@ -137,6 +138,7 @@ describe('oauth', () => {
       mockWindow.location.href = `${flows.authorizationCode['x-scalar-secret-redirect-uri']}?code=${code}&state=${state}`
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: accessToken }),
       })
 
@@ -219,6 +221,7 @@ describe('oauth', () => {
       mockWindow.location.href = `https://callback.example.com?code=${code}&state=${state}`
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: accessToken }),
       })
 
@@ -266,6 +269,7 @@ describe('oauth', () => {
 
       // Mock the token exchange
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: accessToken }),
       })
 
@@ -377,6 +381,7 @@ describe('oauth', () => {
 
       // Mock the token exchange
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: accessToken }),
       })
 
@@ -454,6 +459,7 @@ describe('oauth', () => {
 
       // Mock the token exchange
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: accessToken }),
       })
 
@@ -499,6 +505,7 @@ describe('oauth', () => {
 
       // Mock the token exchange
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: accessToken }),
       })
 
@@ -563,6 +570,7 @@ describe('oauth', () => {
       mockWindow.location.href = `https://callback.example.com?code=${code}&state=${state}`
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: accessToken }),
       })
 
@@ -618,6 +626,7 @@ describe('oauth', () => {
 
       // Mock the token exchange
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: accessToken }),
       })
 
@@ -666,6 +675,7 @@ describe('oauth', () => {
 
     it('should handle successful client credentials flow', async () => {
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'access_token_123' }),
       })
 
@@ -694,6 +704,36 @@ describe('oauth', () => {
       expect(error!.message).toBe('Failed to get an access token. Please check your credentials.')
     })
 
+    it('should return the server error when the token endpoint responds with an HTTP error', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: () =>
+          Promise.resolve({
+            error: 'invalid_client',
+            error_description: 'Client authentication failed',
+          }),
+      })
+
+      const [error, result] = await authorizeOauth2(scheme, 'clientCredentials', selectedScopes, mockServer, '')
+      expect(result).toBe(null)
+      expect(error).toBeInstanceOf(Error)
+      expect(error!.message).toBe('Token request failed: Client authentication failed')
+    })
+
+    it('should fall back to the error code when error_description is absent', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ error: 'invalid_grant' }),
+      })
+
+      const [error, result] = await authorizeOauth2(scheme, 'clientCredentials', selectedScopes, mockServer, '')
+      expect(result).toBe(null)
+      expect(error).toBeInstanceOf(Error)
+      expect(error!.message).toBe('Token request failed: invalid_grant')
+    })
+
     it('should use custom token name when x-tokenName is specified', async () => {
       const flows = {
         clientCredentials: {
@@ -703,6 +743,7 @@ describe('oauth', () => {
       } satisfies OAuthFlowsObjectSecret
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ custom_access_token: 'custom_token_123' }),
       })
 
@@ -723,6 +764,7 @@ describe('oauth', () => {
       } satisfies OAuthFlowsObjectSecret
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'access_token_123' }),
       })
 
@@ -757,6 +799,7 @@ describe('oauth', () => {
       } satisfies OAuthFlowsObjectSecret
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'access_token_123' }),
       })
 
@@ -780,6 +823,7 @@ describe('oauth', () => {
       } satisfies OAuthFlowsObjectSecret
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'access_token_123' }),
       })
 
@@ -821,6 +865,7 @@ describe('oauth', () => {
       } satisfies OAuthFlowsObjectSecret
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'access_token_123' }),
       })
 
@@ -860,6 +905,7 @@ describe('oauth', () => {
       } satisfies OAuthFlowsObjectSecret
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'access_token_123' }),
       })
 
@@ -919,6 +965,7 @@ describe('oauth', () => {
       }
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: async () => ({ access_token: 'access_token_123' }),
       })
 
@@ -976,6 +1023,7 @@ describe('oauth', () => {
       const merged = mergeSecurity(securitySchemes, {}, workspaceStore.auth, documentSlug)
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: async () => ({ access_token: 'access_token_123' }),
       })
 
@@ -1114,6 +1162,7 @@ describe('oauth', () => {
     it('should handle successful password flow', async () => {
       // Mock fetch
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () =>
           Promise.resolve({
             access_token: 'access_token_123',
@@ -1159,6 +1208,7 @@ describe('oauth', () => {
       } satisfies OAuthFlowsObjectSecret
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'access_token_123' }),
       })
 
@@ -1192,6 +1242,7 @@ describe('oauth', () => {
       } satisfies OAuthFlowsObjectSecret
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () =>
           Promise.resolve({
             access_token: 'access_token_123',
@@ -1245,6 +1296,7 @@ describe('oauth', () => {
       } satisfies OAuthFlowsObjectSecret
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () =>
           Promise.resolve({
             access_token: 'access_token_123',
@@ -1296,6 +1348,7 @@ describe('oauth', () => {
       } satisfies OAuthFlowsObjectSecret
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () =>
           Promise.resolve({
             access_token: 'access_token_123',
@@ -1352,6 +1405,7 @@ describe('oauth', () => {
       })
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () =>
           Promise.resolve({
             access_token: 'access_token_123',
@@ -1409,6 +1463,7 @@ describe('oauth', () => {
       }
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'token_123' }),
       })
 
@@ -1443,6 +1498,7 @@ describe('oauth', () => {
       mockWindow.location.href = `${redirectUri}?code=auth_code_123&state=${state}`
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'token_prod' }),
       })
 
@@ -1495,6 +1551,7 @@ describe('oauth', () => {
         variables: { protocol: { default: 'https' }, path: { default: '' } },
       }
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'token_env' }),
       })
 

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
@@ -392,6 +392,12 @@ const authorizeServers = async (
     })
     const responseData = await resp.json()
 
+    if (!resp.ok) {
+      // OAuth2 error responses follow RFC 6749 §5.2
+      const detail = responseData?.error_description || responseData?.error || `HTTP ${resp.status}`
+      return [new Error(`Token request failed: ${detail}`), null]
+    }
+
     // Use custom token name if specified, otherwise default to access_token
     const tokenName = flow['x-tokenName'] || 'access_token'
     const accessToken = responseData[tokenName]

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
@@ -408,7 +408,7 @@ const authorizeServers = async (
 
     // Use custom token name if specified, otherwise default to access_token
     const tokenName = flow['x-tokenName'] || 'access_token'
-    const accessToken = responseData[tokenName]
+    const accessToken = responseData[tokenName] as string
     const refreshToken = responseData.refresh_token
 
     return [null, { accessToken, ...(typeof refreshToken === 'string' ? { refreshToken } : {}) }]

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
@@ -390,11 +390,19 @@ const authorizeServers = async (
       headers,
       body: formData,
     })
-    const responseData = await resp.json()
+    // Parse the body cautiously — some error responses (e.g. from proxies) are not JSON
+    let responseData: Record<string, unknown> = {}
+    try {
+      responseData = await resp.json()
+    } catch {
+      // Non-JSON body; fall through to the resp.ok check below
+    }
 
     if (!resp.ok) {
       // OAuth2 error responses follow RFC 6749 §5.2
-      const detail = responseData?.error_description || responseData?.error || `HTTP ${resp.status}`
+      const detail = (responseData?.error_description as string | undefined)
+        || (responseData?.error as string | undefined)
+        || `HTTP ${resp.status}`
       return [new Error(`Token request failed: ${detail}`), null]
     }
 

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -110,6 +110,7 @@ describe('oauth2', () => {
 
       // Mock the token exchange
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: accessToken }),
       })
 
@@ -190,6 +191,7 @@ describe('oauth2', () => {
       mockWindow.location.href = `https://callback.example.com?code=${code}&state=${state}`
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: accessToken }),
       })
 
@@ -237,6 +239,7 @@ describe('oauth2', () => {
 
       // Mock the token exchange
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: accessToken }),
       })
 
@@ -345,6 +348,7 @@ describe('oauth2', () => {
 
       // Mock the token exchange
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: accessToken }),
       })
 
@@ -397,6 +401,7 @@ describe('oauth2', () => {
 
     it('should handle successful client credentials flow', async () => {
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'access_token_123' }),
       })
 
@@ -427,6 +432,36 @@ describe('oauth2', () => {
       expect(error!.message).toBe('Failed to get an access token. Please check your credentials.')
     })
 
+    it('should return the server error when the token endpoint responds with an HTTP error', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: () =>
+          Promise.resolve({
+            error: 'invalid_client',
+            error_description: 'Client authentication failed',
+          }),
+      })
+
+      const [error, result] = await authorizeOauth2(flow, mockServer)
+      expect(result).toBe(null)
+      expect(error).toBeInstanceOf(Error)
+      expect(error!.message).toBe('Token request failed: Client authentication failed')
+    })
+
+    it('should fall back to the error code when error_description is absent', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ error: 'invalid_grant' }),
+      })
+
+      const [error, result] = await authorizeOauth2(flow, mockServer)
+      expect(result).toBe(null)
+      expect(error).toBeInstanceOf(Error)
+      expect(error!.message).toBe('Token request failed: invalid_grant')
+    })
+
     it('should use custom token name when x-tokenName is specified', async () => {
       const customFlow = {
         ...flow,
@@ -434,6 +469,7 @@ describe('oauth2', () => {
       } as const
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ custom_access_token: 'custom_token_123' }),
       })
 
@@ -452,6 +488,7 @@ describe('oauth2', () => {
       } as const
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'access_token_123' }),
       })
 
@@ -486,6 +523,7 @@ describe('oauth2', () => {
       } as const
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'access_token_123' }),
       })
 
@@ -507,6 +545,7 @@ describe('oauth2', () => {
       } as const
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'access_token_123' }),
       })
 
@@ -535,6 +574,7 @@ describe('oauth2', () => {
       } as const
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'access_token_123' }),
       })
 
@@ -650,6 +690,7 @@ describe('oauth2', () => {
     it('should handle successful password flow', async () => {
       // Mock fetch
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () =>
           Promise.resolve({
             access_token: 'access_token_123',
@@ -692,6 +733,7 @@ describe('oauth2', () => {
       } as const
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'access_token_123' }),
       })
 
@@ -725,6 +767,7 @@ describe('oauth2', () => {
       } as const
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () =>
           Promise.resolve({
             access_token: 'access_token_123',
@@ -762,6 +805,7 @@ describe('oauth2', () => {
       } as const
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () =>
           Promise.resolve({
             access_token: 'access_token_123',
@@ -813,6 +857,7 @@ describe('oauth2', () => {
       })
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () =>
           Promise.resolve({
             access_token: 'access_token_123',
@@ -910,6 +955,7 @@ describe('oauth2', () => {
       })
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'token_123' }),
       })
 
@@ -949,6 +995,7 @@ describe('oauth2', () => {
       mockWindow.location.href = `${redirectUri}?code=auth_code_123&state=${state}`
 
       global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ access_token: 'token_prod' }),
       })
 

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -462,6 +462,19 @@ describe('oauth2', () => {
       expect(error!.message).toBe('Token request failed: invalid_grant')
     })
 
+    it('should fall back to HTTP status when the error response body is not JSON', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: () => Promise.reject(new SyntaxError('Unexpected token')),
+      })
+
+      const [error, result] = await authorizeOauth2(flow, mockServer)
+      expect(result).toBe(null)
+      expect(error).toBeInstanceOf(Error)
+      expect(error!.message).toBe('Token request failed: HTTP 503')
+    })
+
     it('should use custom token name when x-tokenName is specified', async () => {
       const customFlow = {
         ...flow,

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -388,7 +388,7 @@ export const authorizeServers = async (
 
     // Use custom token name if specified, otherwise default to access_token
     const tokenName = flow['x-tokenName'] || 'access_token'
-    const accessToken = responseData[tokenName]
+    const accessToken = responseData[tokenName] as string | null
 
     return [null, accessToken]
   } catch {

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -370,11 +370,19 @@ export const authorizeServers = async (
       headers,
       body: formData,
     })
-    const responseData = await resp.json()
+    // Parse the body cautiously — some error responses (e.g. from proxies) are not JSON
+    let responseData: Record<string, unknown> = {}
+    try {
+      responseData = await resp.json()
+    } catch {
+      // Non-JSON body; fall through to the resp.ok check below
+    }
 
     if (!resp.ok) {
       // OAuth2 error responses follow RFC 6749 §5.2
-      const detail = responseData?.error_description || responseData?.error || `HTTP ${resp.status}`
+      const detail = (responseData?.error_description as string | undefined)
+        || (responseData?.error as string | undefined)
+        || `HTTP ${resp.status}`
       return [new Error(`Token request failed: ${detail}`), null]
     }
 

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -372,6 +372,12 @@ export const authorizeServers = async (
     })
     const responseData = await resp.json()
 
+    if (!resp.ok) {
+      // OAuth2 error responses follow RFC 6749 §5.2
+      const detail = responseData?.error_description || responseData?.error || `HTTP ${resp.status}`
+      return [new Error(`Token request failed: ${detail}`), null]
+    }
+
     // Use custom token name if specified, otherwise default to access_token
     const tokenName = flow['x-tokenName'] || 'access_token'
     const accessToken = responseData[tokenName]


### PR DESCRIPTION
## What

Noticed while debugging a Client Credentials setup with a wrong `client_secret` — the toast just said *"Failed to authorize"* with no hint about what went wrong. Traced it to `authorizeServers` in both `oauth2.ts` and the v2 `oauth.ts`: the fetch call never checks `resp.ok`, so when the token endpoint returns e.g. HTTP 401 with `{"error":"invalid_client","error_description":"Client authentication failed"}`, the body is parsed fine but `responseData.access_token` is `undefined`. The function returns `[null, undefined]` and the caller's fallback message kicks in.

Meanwhile `fetchOpenIDConnectDiscovery` in the same package already does the right thing:

```ts
if (!response.ok) {
  return [new Error(`Failed to fetch …: ${response.status} ${response.statusText}`), null]
}
```

## Fix

Added a `!resp.ok` check after `resp.json()` in both `authorizeServers` implementations. When the token server responds with an error status, the `error_description` (or `error` code, per RFC 6749 §5.2) is extracted from the parsed body and returned as the Error message. This way the user sees e.g. *"Token request failed: Client authentication failed"* instead of the generic fallback.

## Before / After

| | Before | After |
|---|---|---|
| Wrong `client_secret` | Toast: *"Failed to authorize"* | Toast: *"Token request failed: Client authentication failed"* |
| Expired auth code | Toast: *"Failed to authorize"* | Toast: *"Token request failed: invalid_grant"* |
| Network error | Toast: *"Failed to get an access token…"* | *(unchanged)* |

## Tests

- Updated all existing fetch mocks to include `ok: true` (they were missing it, which would have made them fail silently under the new check)
- Added 2 test cases per implementation (v1 + v2 = 4 total):
  - token endpoint returns 401 with `error_description` → error message includes the description
  - token endpoint returns 400 with only `error` code → error message falls back to the code
- All 31 v1 tests and 37 v2 tests pass