### PR TITLE
fix(api-reference): hide response tabs without body content

### DIFF
--- a/.changeset/happy-buttons-dance.md
+++ b/.changeset/happy-buttons-dance.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+feat: hide response tabs without body content

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.test.ts
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.test.ts
@@ -710,7 +710,7 @@ describe('ExampleResponses', () => {
     expect(wrapper.text()).not.toContain('Example 2')
   })
 
-  it('renders explicit 204 response tab and shows No Body', () => {
+  it('does not render explicit 204 response', () => {
     const wrapper = mount(ExampleResponses, {
       props: {
         responses: {
@@ -722,12 +722,10 @@ describe('ExampleResponses', () => {
     })
 
     const tabs = wrapper.findAllComponents({ name: 'ExampleResponseTab' })
-    expect(tabs.length).toBe(1)
-    expect(tabs[0]?.text()).toContain('204')
-    expect(wrapper.text()).toContain('No Body')
+    expect(tabs.length).toBe(0)
   })
 
-  it('renders both contentful and explicit no-content responses', async () => {
+  it('renders only contentful responses', () => {
     const wrapper = mount(ExampleResponses, {
       props: {
         responses: {
@@ -749,14 +747,8 @@ describe('ExampleResponses', () => {
     })
 
     const tabs = wrapper.findAllComponents({ name: 'ExampleResponseTab' })
-    expect(tabs.length).toBe(2)
+    expect(tabs.length).toBe(1)
     expect(tabs[0]?.text()).toContain('200')
-    expect(tabs[1]?.text()).toContain('204')
-
-    await tabs[1]?.trigger('click')
-    await wrapper.vm.$nextTick()
-
-    expect(wrapper.text()).toContain('No Body')
   })
 
   it('does not render tabs for non-response keys', () => {

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.vue
@@ -47,7 +47,7 @@ const orderedStatusCodes = computed<string[]>(() =>
 // Filter to only valid response keys that should render in the example responses panel
 const statusCodesWithContent = computed<string[]>(() =>
   orderedStatusCodes.value.filter((statusCode) =>
-    hasResponseContent(getResolvedRef(responses?.[statusCode]), statusCode),
+    hasResponseContent(getResolvedRef(responses?.[statusCode])),
   ),
 )
 

--- a/packages/api-reference/src/features/example-responses/has-response-content.test.ts
+++ b/packages/api-reference/src/features/example-responses/has-response-content.test.ts
@@ -1,8 +1,77 @@
 import { describe, expect, it } from 'vitest'
 
-import { hasResponseContent } from './has-response-content'
+import { hasMediaTypeContent, hasResponseContent } from './has-response-content'
 
 describe('has-response-content', () => {
+  describe('hasMediaTypeContent', () => {
+    it('returns false for undefined', () => {
+      expect(hasMediaTypeContent(undefined)).toBe(false)
+    })
+
+    it('returns false for empty media type object', () => {
+      expect(hasMediaTypeContent({})).toBe(false)
+    })
+
+    it('returns true for media type with schema', () => {
+      expect(hasMediaTypeContent({ schema: { type: 'object' } })).toBe(true)
+    })
+
+    it('returns true for media type with example object', () => {
+      expect(hasMediaTypeContent({ example: { message: 'Hello' } })).toBe(true)
+    })
+
+    it('returns true for media type with examples', () => {
+      expect(
+        hasMediaTypeContent({
+          examples: {
+            example1: { value: { message: 'Hello' } },
+          },
+        }),
+      ).toBe(true)
+    })
+
+    it('returns true for media type with schema and example', () => {
+      expect(
+        hasMediaTypeContent({
+          schema: { type: 'object' },
+          example: { message: 'Hello' },
+        }),
+      ).toBe(true)
+    })
+
+    it('returns false for media type with only encoding', () => {
+      expect(
+        hasMediaTypeContent({
+          encoding: { field: { contentType: 'text/plain' } },
+        }),
+      ).toBe(false)
+    })
+
+    it('returns false for null example', () => {
+      expect(hasMediaTypeContent({ example: null })).toBe(false)
+    })
+
+    it('returns true for falsy example value 0', () => {
+      expect(hasMediaTypeContent({ example: 0 })).toBe(true)
+    })
+
+    it('returns true for falsy example value false', () => {
+      expect(hasMediaTypeContent({ example: false })).toBe(true)
+    })
+
+    it('returns true for falsy example value empty string', () => {
+      expect(hasMediaTypeContent({ example: '' })).toBe(true)
+    })
+
+    it('returns true for example with empty array', () => {
+      expect(hasMediaTypeContent({ example: [] })).toBe(true)
+    })
+
+    it('returns true for example with empty object', () => {
+      expect(hasMediaTypeContent({ example: {} })).toBe(true)
+    })
+  })
+
   describe('hasResponseContent', () => {
     it('returns false for undefined', () => {
       expect(hasResponseContent(undefined)).toBe(false)
@@ -12,36 +81,8 @@ describe('has-response-content', () => {
       expect(hasResponseContent({ description: 'Empty response' })).toBe(false)
     })
 
-    it('returns true for explicit 204 with no body content', () => {
-      expect(hasResponseContent({ description: 'No content response' }, '204')).toBe(true)
-    })
-
-    it('returns true for explicit default with no body content', () => {
-      expect(hasResponseContent({ description: 'Default response' }, 'default')).toBe(true)
-    })
-
-    it('returns true for explicit range status code with no body content', () => {
-      expect(hasResponseContent({ description: '2XX response' }, '2XX')).toBe(true)
-    })
-
-    it('returns false for non-response keys', () => {
-      expect(
-        hasResponseContent(
-          {
-            description: 'Invalid response key',
-            content: {
-              'application/json': {
-                schema: { type: 'object' },
-              },
-            },
-          },
-          'x-internal',
-        ),
-      ).toBe(false)
-    })
-
-    it('returns false for valid response key with undefined response', () => {
-      expect(hasResponseContent(undefined, '204')).toBe(false)
+    it('returns false for response with only description (no body content)', () => {
+      expect(hasResponseContent({ description: 'No content response', content: {} })).toBe(false)
     })
 
     it('returns false for response with empty content', () => {

--- a/packages/api-reference/src/features/example-responses/has-response-content.ts
+++ b/packages/api-reference/src/features/example-responses/has-response-content.ts
@@ -1,4 +1,5 @@
-import { getObjectKeys, normalizeMimeTypeObject } from '@scalar/oas-utils/helpers'
+import { getObjectKeys } from '@scalar/oas-utils/helpers'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { MediaTypeObject, ResponseObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
 /**
@@ -9,7 +10,7 @@ import type { MediaTypeObject, ResponseObject } from '@scalar/workspace-store/sc
  * like `0`, `false`, and `""` are valid JSON examples that should be displayed.
  * We still treat `null` as "no content" since it explicitly indicates absence.
  */
-function hasMediaTypeContent(mediaType: MediaTypeObject | undefined): boolean {
+export function hasMediaTypeContent(mediaType: MediaTypeObject | undefined): boolean {
   if (!mediaType) {
     return false
   }
@@ -21,33 +22,18 @@ function hasMediaTypeContent(mediaType: MediaTypeObject | undefined): boolean {
   return hasSchema || hasExample || hasExamples
 }
 
-function isResponseKey(responseKey: string): boolean {
-  return responseKey === 'default' || /^[1-5][0-9]{2}$/.test(responseKey) || /^[1-5]XX$/.test(responseKey)
-}
-
 /**
  * Checks if a response object has body content (schema, example, or examples).
  * Looks through common media types in priority order.
+ *
+ * Responses with only a description (no content) are considered empty and will return false.
  */
-export function hasResponseContent(response: ResponseObject | undefined, responseKey?: string): boolean {
-  if (responseKey !== undefined) {
-    if (!isResponseKey(responseKey)) {
-      return false
-    }
-
-    return Boolean(response)
+export function hasResponseContent(response: ResponseObject | undefined): boolean {
+  const content = response?.content
+  if (!content) {
+    return false
   }
 
-  const normalizedContent = normalizeMimeTypeObject(response?.content)
-  const keys = getObjectKeys(normalizedContent ?? {})
-
-  const mediaType =
-    normalizedContent?.['application/json'] ??
-    normalizedContent?.['application/xml'] ??
-    normalizedContent?.['text/plain'] ??
-    normalizedContent?.['text/html'] ??
-    normalizedContent?.['*/*'] ??
-    normalizedContent?.[keys[0] ?? '']
-
-  return hasMediaTypeContent(mediaType)
+  const keys = getObjectKeys(content)
+  return keys.some((key) => hasMediaTypeContent(getResolvedRef(content[key])))
 }


### PR DESCRIPTION
Fixes: #4302

## Summary

- Hide response tabs (like 204 No Content) that have only a description but no actual body content (schema, example, or examples)
- Simplify `hasResponseContent` to check all media types for content instead of special-casing certain status codes
- Export `hasMediaTypeContent` for direct use and add comprehensive tests for it

| Before      | After |
| ----------- | ----------- |
| <img width="728" height="284" alt="image" src="https://github.com/user-attachments/assets/5ef5d1f0-40e5-4fc1-be33-b9038d2ea322" />       | <img width="728" height="284" alt="image" src="https://github.com/user-attachments/assets/1a81a996-d02e-492f-ab0e-edcb8cb38b3f" />      | 

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
