### PR TITLE
feat(ts-to-openapi): add nextjs openapi document generator

### DIFF
--- a/.changeset/fuzzy-crabs-brake.md
+++ b/.changeset/fuzzy-crabs-brake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/ts-to-openapi': minor
+---
+
+feat(ts-to-openapi): add Next.js API description document generator

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -241,7 +241,7 @@
     },
     "packages/ts-to-openapi": {
       "entry": ["src/index.ts"],
-      "ignoreFiles": ["test/fixtures/*"]
+      "ignoreFiles": ["test/fixtures/**"]
     },
     "packages/types": {
       "entry": [

--- a/packages/ts-to-openapi/README.MD
+++ b/packages/ts-to-openapi/README.MD
@@ -5,9 +5,34 @@
 [![License](https://img.shields.io/npm/l/%40scalar%type-to-openapi)](https://www.npmjs.com/package/@scalar/type-to-openapi)
 [![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
-This an extremely early version of a typescript type to OpenAPI document converter. The goal is to take types that one
-would normally use when developing an API and convert them to an OpenAPI document which will then be used to power the
-standalone Scalar API References.
+This package converts TypeScript route handlers and type annotations into an OpenAPI API description document.
 
-This package is not meant to be used directly, but will be the core technology behind framework specific integrations
-starting with Next.js.
+The current focus is Next.js App Router route handlers, where you can generate an OpenAPI 3.1 API description document
+from files in `app/api`.
+
+## Usage (Next.js)
+
+Create a script in your Next.js project:
+
+```ts
+import { generateNextJsOpenApiDocument } from '@scalar/ts-to-openapi'
+
+const document = generateNextJsOpenApiDocument({
+  cwd: process.cwd(),
+  apiDirectory: 'app/api',
+  info: {
+    title: 'My API',
+    version: '1.0.0',
+  },
+})
+
+console.log(JSON.stringify(document, null, 2))
+```
+
+## Exported APIs
+
+- `generateNextJsOpenApiDocument(options)` - Generate a full OpenAPI 3.1 API description document.
+- `getOpenApiPathFromNextJsRouteFile(routeFileName, apiDirectory)` - Convert a Next.js route file path to an OpenAPI path.
+- `getPathItemFromNextJsSourceFile(sourceFile, program)` - Build an OpenAPI path item from a route source file.
+- `getSchemaFromTypeNode(typeNode, program, fileNameResolver)` - Convert TypeScript type nodes to OpenAPI schemas.
+- `generateResponses(node, typeChecker)` - Derive OpenAPI responses from route handler returns.

--- a/packages/ts-to-openapi/src/index.ts
+++ b/packages/ts-to-openapi/src/index.ts
@@ -1,3 +1,9 @@
 export { getJSDocFromNode } from './js-doc'
+export {
+  generateNextJsOpenApiDocument,
+  getOpenApiPathFromNextJsRouteFile,
+  getPathItemFromNextJsSourceFile,
+} from './nextjs'
+export { collectTypeScriptFiles, createProgramFromFileSystem } from './program'
 export { generateResponses, getReturnStatements } from './responses'
 export { getSchemaFromTypeNode } from './type-nodes'

--- a/packages/ts-to-openapi/src/nextjs.test.ts
+++ b/packages/ts-to-openapi/src/nextjs.test.ts
@@ -1,0 +1,219 @@
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  generateNextJsOpenApiDocument,
+  getOpenApiPathFromNextJsRouteFile,
+  getPathItemFromNextJsSourceFile,
+} from './nextjs'
+import { createProgramFromFileSystem } from './program'
+
+describe('nextjs', () => {
+  const fixtureRoot = path.join(import.meta.dirname, '../test/fixtures/nextjs-app')
+  const apiDirectory = path.join(fixtureRoot, 'app/api')
+  const userRouteFile = path.join(apiDirectory, 'users/[id]/route.ts')
+
+  it('converts nextjs route file path into openapi path', () => {
+    const openApiPath = getOpenApiPathFromNextJsRouteFile(userRouteFile, apiDirectory)
+    expect(openApiPath).toBe('/users/{id}')
+  })
+
+  it('extracts path operations from a route source file', () => {
+    const program = createProgramFromFileSystem({ rootDirectory: apiDirectory })
+    const sourceFile = program.getSourceFile(userRouteFile)
+
+    expect(sourceFile).toBeDefined()
+    if (!sourceFile) {
+      return
+    }
+
+    const pathItem = getPathItemFromNextJsSourceFile(sourceFile, program)
+
+    expect(pathItem).toStrictEqual({
+      get: {
+        summary: 'Get user by id',
+        description: 'Returns user details by path parameter.',
+        parameters: [
+          {
+            in: 'path',
+            name: 'id',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'TODO: grab this from jsdoc and add a default',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    id: {
+                      type: 'string',
+                      example: 'user_1',
+                    },
+                    name: {
+                      type: 'string',
+                      example: 'Ada Lovelace',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      delete: {
+        summary: 'Delete user by id',
+        description: 'Deletes the user and returns no payload.',
+        parameters: [
+          {
+            in: 'path',
+            name: 'id',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+        responses: {
+          '204': {
+            description: 'TODO: grab this from jsdoc and add a default',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'null',
+                  example: null,
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+
+  it('generates an openapi document from nextjs api routes', () => {
+    const document = generateNextJsOpenApiDocument({
+      cwd: fixtureRoot,
+      info: {
+        title: 'Fixture API',
+        version: '1.2.3',
+      },
+      servers: [{ url: 'https://example.com' }],
+    })
+
+    expect(document).toStrictEqual({
+      openapi: '3.1.0',
+      info: {
+        title: 'Fixture API',
+        version: '1.2.3',
+        description: 'Generated from Next.js route handlers',
+        summary: undefined,
+        termsOfService: undefined,
+        contact: undefined,
+        license: undefined,
+      },
+      servers: [{ url: 'https://example.com' }],
+      paths: {
+        '/posts': {
+          post: {
+            summary: 'Create post',
+            description: 'use jsdoc tag to set the description',
+            responses: {
+              '201': {
+                description: 'TODO: grab this from jsdoc and add a default',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        ok: {
+                          type: 'boolean',
+                          example: true,
+                        },
+                        postId: {
+                          type: 'number',
+                          example: 10,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/users/{id}': {
+          get: {
+            summary: 'Get user by id',
+            description: 'Returns user details by path parameter.',
+            parameters: [
+              {
+                in: 'path',
+                name: 'id',
+                required: true,
+                schema: {
+                  type: 'string',
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'TODO: grab this from jsdoc and add a default',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: {
+                          type: 'string',
+                          example: 'user_1',
+                        },
+                        name: {
+                          type: 'string',
+                          example: 'Ada Lovelace',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          delete: {
+            summary: 'Delete user by id',
+            description: 'Deletes the user and returns no payload.',
+            parameters: [
+              {
+                in: 'path',
+                name: 'id',
+                required: true,
+                schema: {
+                  type: 'string',
+                },
+              },
+            ],
+            responses: {
+              '204': {
+                description: 'TODO: grab this from jsdoc and add a default',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'null',
+                      example: null,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+})

--- a/packages/ts-to-openapi/src/nextjs.ts
+++ b/packages/ts-to-openapi/src/nextjs.ts
@@ -182,7 +182,10 @@ export const getOpenApiPathFromNextJsRouteFile = (routeFileName: string, apiDire
 /**
  * Builds a path item object from a Next.js route source file.
  */
-export const getPathItemFromNextJsSourceFile = (sourceFile: SourceFile, program: Program): OpenAPIV3_1.PathItemObject => {
+export const getPathItemFromNextJsSourceFile = (
+  sourceFile: SourceFile,
+  program: Program,
+): OpenAPIV3_1.PathItemObject => {
   const pathItem: Record<string, OpenAPIV3_1.OperationObject> = {}
 
   sourceFile.statements.forEach((statement) => {
@@ -214,7 +217,12 @@ export const getPathItemFromNextJsSourceFile = (sourceFile: SourceFile, program:
 
         const bodyNode = getFunctionBody(declaration.initializer)
         const contextParameter = getFunctionContextParameter(declaration.initializer)
-        pathItem[method] = createOperationObject(statement, bodyNode, getPathParameters(contextParameter, program), program)
+        pathItem[method] = createOperationObject(
+          statement,
+          bodyNode,
+          getPathParameters(contextParameter, program),
+          program,
+        )
       })
     }
   })
@@ -222,7 +230,7 @@ export const getPathItemFromNextJsSourceFile = (sourceFile: SourceFile, program:
   return pathItem as OpenAPIV3_1.PathItemObject
 }
 
-export type GenerateNextJsOpenApiDocumentOptions = {
+type GenerateNextJsOpenApiDocumentOptions = {
   /** Root directory used to resolve `apiDirectory`. Defaults to `process.cwd()`. */
   cwd?: string
   /** App Router API directory containing route handlers. Defaults to `app/api`. */

--- a/packages/ts-to-openapi/src/nextjs.ts
+++ b/packages/ts-to-openapi/src/nextjs.ts
@@ -1,0 +1,281 @@
+import { existsSync } from 'node:fs'
+import { dirname, extname, join, relative, resolve } from 'node:path'
+
+import type { OpenAPIV3_1 } from 'openapi-types'
+import {
+  type Identifier,
+  type Node,
+  type ParameterDeclaration,
+  type Program,
+  type SourceFile,
+  isArrowFunction,
+  isFunctionDeclaration,
+  isFunctionExpression,
+  isIdentifier,
+  isVariableStatement,
+} from 'typescript'
+
+import { getJSDocFromNode } from './js-doc'
+import { collectTypeScriptFiles, createProgramFromFileSystem } from './program'
+import { generateResponses } from './responses'
+import { getSchemaFromTypeNode } from './type-nodes'
+import type { FileNameResolver } from './types'
+
+const HTTP_METHODS = new Set<OpenAPIV3_1.HttpMethods>(['get', 'post', 'put', 'patch', 'delete', 'head', 'options'])
+
+const DEFAULT_INFO_DESCRIPTION = 'Generated from Next.js route handlers'
+
+const normalizePath = (value: string): string => value.replaceAll('\\', '/')
+
+const isRouteHandlerFile = (fileName: string): boolean => /\/route\.tsx?$/.test(normalizePath(fileName))
+
+const resolveImportFileName: FileNameResolver = (sourceFileName: string, targetFileName: string): string => {
+  const sourceDirectory = dirname(sourceFileName)
+  const targetPath = join(sourceDirectory, targetFileName)
+
+  if (extname(targetFileName)) {
+    return targetPath
+  }
+
+  const candidates = [`${targetPath}.ts`, `${targetPath}.tsx`, `${targetPath}.d.ts`]
+  const fileName = candidates.find((candidate) => existsSync(candidate))
+
+  return fileName ?? `${targetPath}.ts`
+}
+
+const getHttpMethod = (identifier: Pick<Identifier, 'escapedText'> | undefined): OpenAPIV3_1.HttpMethods | null => {
+  const method = identifier?.escapedText?.toString().toLowerCase()
+  return method && HTTP_METHODS.has(method as OpenAPIV3_1.HttpMethods) ? (method as OpenAPIV3_1.HttpMethods) : null
+}
+
+const isSchemaObject = (
+  schema: OpenAPIV3_1.ReferenceObject | OpenAPIV3_1.SchemaObject | undefined,
+): schema is OpenAPIV3_1.SchemaObject => Boolean(schema) && !('$ref' in schema)
+
+const getFunctionBody = (node: Node | undefined): Node | undefined => {
+  if (!node) {
+    return undefined
+  }
+
+  if (isArrowFunction(node) || isFunctionExpression(node)) {
+    return node.body
+  }
+
+  return undefined
+}
+
+const getFunctionContextParameter = (node: Node | undefined): ParameterDeclaration | undefined => {
+  if (!node) {
+    return undefined
+  }
+
+  if (isArrowFunction(node) || isFunctionExpression(node)) {
+    return node.parameters[1]
+  }
+
+  return undefined
+}
+
+const getPathParameters = (node: ParameterDeclaration | undefined, program: Program): OpenAPIV3_1.ParameterObject[] => {
+  if (!node?.type) {
+    return []
+  }
+
+  const contextSchema = getSchemaFromTypeNode(node.type, program, resolveImportFileName)
+  const contextProperties =
+    contextSchema.type === 'object' && contextSchema.properties
+      ? (contextSchema.properties as Record<string, OpenAPIV3_1.ReferenceObject | OpenAPIV3_1.SchemaObject>)
+      : undefined
+  const paramsSchema = contextProperties?.params
+
+  if (!isSchemaObject(paramsSchema) || paramsSchema.type !== 'object' || !paramsSchema.properties) {
+    return []
+  }
+
+  return Object.entries(paramsSchema.properties).flatMap(([name, schema]) => {
+    if (!isSchemaObject(schema)) {
+      return []
+    }
+
+    return {
+      in: 'path',
+      name,
+      required: true,
+      schema,
+    } as OpenAPIV3_1.ParameterObject
+  })
+}
+
+const toOpenApiSegment = (segment: string): string | null => {
+  if (/^\(.+\)$/.test(segment)) {
+    return null
+  }
+
+  const optionalCatchAll = segment.match(/^\[\[\.\.\.([^\]]+)\]\]$/)
+  if (optionalCatchAll?.[1]) {
+    return `{${optionalCatchAll[1]}}`
+  }
+
+  const catchAll = segment.match(/^\[\.\.\.([^\]]+)\]$/)
+  if (catchAll?.[1]) {
+    return `{${catchAll[1]}}`
+  }
+
+  const dynamicSegment = segment.match(/^\[([^\]]+)\]$/)
+  if (dynamicSegment?.[1]) {
+    return `{${dynamicSegment[1]}}`
+  }
+
+  return segment
+}
+
+const createOperationObject = (
+  docsNode: Node,
+  bodyNode: Node | undefined,
+  parameters: OpenAPIV3_1.ParameterObject[],
+  program: Program,
+): OpenAPIV3_1.OperationObject => {
+  const { title, description } = getJSDocFromNode(docsNode)
+  const responses = generateResponses(bodyNode, program.getTypeChecker())
+  const operation: OpenAPIV3_1.OperationObject = {
+    responses: Object.keys(responses).length
+      ? responses
+      : {
+          default: {
+            description: 'No response body detected',
+          },
+        },
+  }
+
+  if (title) {
+    operation.summary = title
+  }
+  if (description) {
+    operation.description = description
+  }
+  if (parameters.length) {
+    operation.parameters = parameters
+  }
+
+  return operation
+}
+
+/**
+ * Converts a Next.js route file path into an OpenAPI path.
+ */
+export const getOpenApiPathFromNextJsRouteFile = (routeFileName: string, apiDirectory: string): string => {
+  const routeDirectory = dirname(resolve(routeFileName))
+  const apiRoot = resolve(apiDirectory)
+  const relativeDirectory = normalizePath(relative(apiRoot, routeDirectory))
+  const segments = relativeDirectory
+    .split('/')
+    .filter(Boolean)
+    .map(toOpenApiSegment)
+    .filter((segment): segment is string => Boolean(segment))
+
+  return segments.length ? `/${segments.join('/')}` : '/'
+}
+
+/**
+ * Builds a path item object from a Next.js route source file.
+ */
+export const getPathItemFromNextJsSourceFile = (sourceFile: SourceFile, program: Program): OpenAPIV3_1.PathItemObject => {
+  const pathItem: OpenAPIV3_1.PathItemObject = {}
+
+  sourceFile.statements.forEach((statement) => {
+    if (isFunctionDeclaration(statement) && statement.name) {
+      const method = getHttpMethod(statement.name)
+      if (!method) {
+        return
+      }
+
+      pathItem[method] = createOperationObject(
+        statement,
+        statement.body,
+        getPathParameters(statement.parameters[1], program),
+        program,
+      )
+      return
+    }
+
+    if (isVariableStatement(statement)) {
+      statement.declarationList.declarations.forEach((declaration) => {
+        if (!isIdentifier(declaration.name)) {
+          return
+        }
+
+        const method = getHttpMethod(declaration.name)
+        if (!method) {
+          return
+        }
+
+        const bodyNode = getFunctionBody(declaration.initializer)
+        const contextParameter = getFunctionContextParameter(declaration.initializer)
+        pathItem[method] = createOperationObject(statement, bodyNode, getPathParameters(contextParameter, program), program)
+      })
+    }
+  })
+
+  return pathItem
+}
+
+export type GenerateNextJsOpenApiDocumentOptions = {
+  /** Root directory used to resolve `apiDirectory`. Defaults to `process.cwd()`. */
+  cwd?: string
+  /** App Router API directory containing route handlers. Defaults to `app/api`. */
+  apiDirectory?: string
+  /** OpenAPI info object values. */
+  info?: Partial<OpenAPIV3_1.InfoObject>
+  /** Optional server definitions for the generated document. */
+  servers?: OpenAPIV3_1.ServerObject[]
+}
+
+/**
+ * Generates an OpenAPI 3.1 document from Next.js route handlers.
+ */
+export const generateNextJsOpenApiDocument = (
+  options: GenerateNextJsOpenApiDocumentOptions = {},
+): OpenAPIV3_1.Document => {
+  const cwd = resolve(options.cwd ?? process.cwd())
+  const apiDirectory = resolve(cwd, options.apiDirectory ?? 'app/api')
+  const allFiles = collectTypeScriptFiles(apiDirectory)
+  const routeFiles = allFiles.filter(isRouteHandlerFile)
+  const program = createProgramFromFileSystem({ rootDirectory: apiDirectory })
+  const infoOptions = options.info ?? {}
+  const info: OpenAPIV3_1.InfoObject = {
+    title: infoOptions.title ?? process.env.npm_package_name ?? 'Next.js API',
+    version: infoOptions.version ?? process.env.npm_package_version ?? '0.0.0',
+    description: infoOptions.description ?? DEFAULT_INFO_DESCRIPTION,
+    summary: infoOptions.summary,
+    termsOfService: infoOptions.termsOfService,
+    contact: infoOptions.contact,
+    license: infoOptions.license,
+  }
+
+  const paths = routeFiles.reduce<OpenAPIV3_1.PathsObject>((accumulator, routeFileName) => {
+    const sourceFile = program.getSourceFile(routeFileName)
+
+    if (!sourceFile) {
+      return accumulator
+    }
+
+    const path = getOpenApiPathFromNextJsRouteFile(routeFileName, apiDirectory)
+    const pathItem = getPathItemFromNextJsSourceFile(sourceFile, program)
+
+    if (!Object.keys(pathItem).length) {
+      return accumulator
+    }
+
+    return {
+      ...accumulator,
+      [path]: pathItem,
+    }
+  }, {})
+
+  return {
+    openapi: '3.1.0',
+    info,
+    paths,
+    ...(options.servers ? { servers: options.servers } : {}),
+  }
+}

--- a/packages/ts-to-openapi/src/nextjs.ts
+++ b/packages/ts-to-openapi/src/nextjs.ts
@@ -21,7 +21,10 @@ import { generateResponses } from './responses'
 import { getSchemaFromTypeNode } from './type-nodes'
 import type { FileNameResolver } from './types'
 
-const HTTP_METHODS = new Set<OpenAPIV3_1.HttpMethods>(['get', 'post', 'put', 'patch', 'delete', 'head', 'options'])
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'] as const
+
+const isHttpMethod = (value: string): value is OpenAPIV3_1.HttpMethods =>
+  (HTTP_METHODS as readonly string[]).includes(value)
 
 const DEFAULT_INFO_DESCRIPTION = 'Generated from Next.js route handlers'
 
@@ -45,12 +48,12 @@ const resolveImportFileName: FileNameResolver = (sourceFileName: string, targetF
 
 const getHttpMethod = (identifier: Pick<Identifier, 'escapedText'> | undefined): OpenAPIV3_1.HttpMethods | null => {
   const method = identifier?.escapedText?.toString().toLowerCase()
-  return method && HTTP_METHODS.has(method as OpenAPIV3_1.HttpMethods) ? (method as OpenAPIV3_1.HttpMethods) : null
+  return method && isHttpMethod(method) ? method : null
 }
 
 const isSchemaObject = (
   schema: OpenAPIV3_1.ReferenceObject | OpenAPIV3_1.SchemaObject | undefined,
-): schema is OpenAPIV3_1.SchemaObject => Boolean(schema) && !('$ref' in schema)
+): schema is OpenAPIV3_1.SchemaObject => schema !== undefined && typeof schema === 'object' && !('$ref' in schema)
 
 const getFunctionBody = (node: Node | undefined): Node | undefined => {
   if (!node) {
@@ -180,7 +183,7 @@ export const getOpenApiPathFromNextJsRouteFile = (routeFileName: string, apiDire
  * Builds a path item object from a Next.js route source file.
  */
 export const getPathItemFromNextJsSourceFile = (sourceFile: SourceFile, program: Program): OpenAPIV3_1.PathItemObject => {
-  const pathItem: OpenAPIV3_1.PathItemObject = {}
+  const pathItem: Record<string, OpenAPIV3_1.OperationObject> = {}
 
   sourceFile.statements.forEach((statement) => {
     if (isFunctionDeclaration(statement) && statement.name) {
@@ -216,7 +219,7 @@ export const getPathItemFromNextJsSourceFile = (sourceFile: SourceFile, program:
     }
   })
 
-  return pathItem
+  return pathItem as OpenAPIV3_1.PathItemObject
 }
 
 export type GenerateNextJsOpenApiDocumentOptions = {

--- a/packages/ts-to-openapi/src/program.ts
+++ b/packages/ts-to-openapi/src/program.ts
@@ -30,7 +30,7 @@ export const collectTypeScriptFiles = (directoryPath: string): string[] => {
   }
 }
 
-export type CreateProgramFromFileSystemOptions = {
+type CreateProgramFromFileSystemOptions = {
   rootDirectory: string
   target?: ScriptTarget
 }

--- a/packages/ts-to-openapi/src/program.ts
+++ b/packages/ts-to-openapi/src/program.ts
@@ -1,0 +1,47 @@
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { ScriptTarget, createProgram } from 'typescript'
+
+const isTypeScriptFile = (fileName: string): boolean => fileName.endsWith('.ts') || fileName.endsWith('.tsx')
+
+/**
+ * Recursively collects TypeScript files from a directory.
+ */
+export const collectTypeScriptFiles = (directoryPath: string): string[] => {
+  try {
+    const entries = readdirSync(directoryPath, { withFileTypes: true })
+
+    return entries.flatMap((entry) => {
+      const filePath = join(directoryPath, entry.name)
+
+      if (entry.isDirectory()) {
+        return collectTypeScriptFiles(filePath)
+      }
+
+      if (entry.isFile() && isTypeScriptFile(entry.name)) {
+        return [filePath]
+      }
+
+      return []
+    })
+  } catch {
+    return []
+  }
+}
+
+export type CreateProgramFromFileSystemOptions = {
+  rootDirectory: string
+  target?: ScriptTarget
+}
+
+/**
+ * Creates a TypeScript program from all `.ts` and `.tsx` files in a directory tree.
+ */
+export const createProgramFromFileSystem = ({
+  rootDirectory,
+  target = ScriptTarget.Latest,
+}: CreateProgramFromFileSystemOptions) => {
+  const files = collectTypeScriptFiles(rootDirectory)
+  return createProgram(files, { target })
+}

--- a/packages/ts-to-openapi/test/fixtures/nextjs-app/app/api/posts/route.ts
+++ b/packages/ts-to-openapi/test/fixtures/nextjs-app/app/api/posts/route.ts
@@ -1,0 +1,14 @@
+/**
+ * Create a post
+ *
+ * @summary Create post
+ */
+export async function POST() {
+  return Response.json(
+    {
+      ok: true,
+      postId: 10,
+    } as const,
+    { status: 201 } as const,
+  )
+}

--- a/packages/ts-to-openapi/test/fixtures/nextjs-app/app/api/users/[id]/route.ts
+++ b/packages/ts-to-openapi/test/fixtures/nextjs-app/app/api/users/[id]/route.ts
@@ -1,0 +1,28 @@
+import type { UserRouteContext } from './types'
+
+/**
+ * Get a single user
+ *
+ * Returns a user object for the provided route parameter.
+ * @summary Get user by id
+ * @description Returns user details by path parameter.
+ */
+export const GET = async (_request: Request, _context: UserRouteContext) => {
+  return Response.json(
+    {
+      id: 'user_1',
+      name: 'Ada Lovelace',
+    } as const,
+    { status: 200 } as const,
+  )
+}
+
+/**
+ * Delete a single user
+ *
+ * @summary Delete user by id
+ * @description Deletes the user and returns no payload.
+ */
+export async function DELETE(_request: Request, _context: UserRouteContext) {
+  return Response.json(null, { status: 204 } as const)
+}

--- a/packages/ts-to-openapi/test/fixtures/nextjs-app/app/api/users/[id]/types.ts
+++ b/packages/ts-to-openapi/test/fixtures/nextjs-app/app/api/users/[id]/types.ts
@@ -1,0 +1,5 @@
+export type UserRouteContext = {
+  params: {
+    id: string
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`@scalar/ts-to-openapi` only exposed low-level AST helpers. It did not provide a concrete package-level API to generate an OpenAPI API description document directly from Next.js App Router routes.

## Solution

- Added a new Next.js-focused generator API in `packages/ts-to-openapi/src/nextjs.ts`:
  - `generateNextJsOpenApiDocument(options)`
  - `getOpenApiPathFromNextJsRouteFile(routeFileName, apiDirectory)`
  - `getPathItemFromNextJsSourceFile(sourceFile, program)`
- Added reusable filesystem program helpers in `src/program.ts`.
- Exported the new APIs from `src/index.ts`.
- Added fixture-based tests covering route-path conversion, path-item generation, and full document generation.
- Updated package README usage/docs and added a changeset.
- Tightened TypeScript typings in the new Next.js generator implementation.
- Follow-up CI fix: applied Biome formatting and adjusted knip handling for nested test fixtures.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aeda2cb4-ba18-4587-9e60-52cf917855ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aeda2cb4-ba18-4587-9e60-52cf917855ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

