### PR TITLE
fix(api-reference): do not show the content switch button if there is no content keys

### DIFF
--- a/.changeset/jolly-states-strive.md
+++ b/.changeset/jolly-states-strive.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: hide content type switch when there is no content

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -42,9 +42,16 @@ const schema = computed<SchemaObject | null>(() =>
 )
 
 /** Response and params may both have content */
-const content = computed(() =>
-  'content' in parameter && parameter.content ? parameter.content : null,
-)
+const content = computed(() => {
+  if (!('content' in parameter) || !parameter.content) {
+    return null
+  }
+  const keys = Object.keys(parameter.content)
+  if (keys.length === 0) {
+    return null
+  }
+  return parameter.content
+})
 
 const selectedContentType = ref<string>(
   Object.keys(content.value || {})[0] ?? '',


### PR DESCRIPTION
We were still displaying the empty button to switch content even if there was no content. This PR fixes that problem.

<img width="1073" height="453" alt="image" src="https://github.com/user-attachments/assets/9ed75885-0f7f-40f6-8ecf-4124d1f16564" />


## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI logic change to treat empty `content` objects as absent, affecting when the content-type selector renders. Low risk, but could hide the selector in edge cases where content keys are populated asynchronously or incorrectly parsed.
> 
> **Overview**
> Prevents `ParameterListItem` from treating an empty `content` object as valid by returning `null` when `content` has no keys, which in turn stops rendering the content-type selector in that case.
> 
> Adds a patch changeset for `@scalar/api-reference` documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70de5968908eb92ed0b58211b1eebc3587c905c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->