### PR TITLE
fix(api-reference): set example z-index to context layer

### DIFF
--- a/.changeset/odd-lamps-design.md
+++ b/.changeset/odd-lamps-design.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): set example z-index to context layer

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
@@ -86,6 +86,8 @@ const multipleExamplesLabel = computed(() =>
 </template>
 
 <style scoped>
+@reference "../../../style.css";
+
 .property-example {
   display: flex;
   flex-direction: column;
@@ -152,7 +154,7 @@ const multipleExamplesLabel = computed(() =>
   flex-direction: column;
   gap: 3px;
   display: none;
-  z-index: 2;
+  @apply z-context;
 }
 .property-example:hover .property-example-value-list,
 .property-example:focus-within .property-example-value-list {


### PR DESCRIPTION
Fixes an edge case where the example is clipped by the sidebar.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
