### PR TITLE
feat(component): don't add word breaks for the start of text

### DIFF
--- a/.changeset/floppy-canyons-heal.md
+++ b/.changeset/floppy-canyons-heal.md
@@ -1,0 +1,5 @@
+---
+'@scalar/sidebar': patch
+---
+
+fix(sidebar): treat examples labels as properties

--- a/.changeset/many-hoops-punch.md
+++ b/.changeset/many-hoops-punch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+feat(component): don't add word breaks for the start of text

--- a/packages/components/src/components/ScalarWrappingText/ScalarWrappingText.test.ts
+++ b/packages/components/src/components/ScalarWrappingText/ScalarWrappingText.test.ts
@@ -76,10 +76,7 @@ describe('ScalarWrappingText', () => {
       })
       const text = wrapper.text()
       expect(text).toBe('Long string that needs to wrap to multiple lines')
-      // Component always renders one <wbr> before each word segment
-      // When there are no matches, there's only one segment
-      const wbrCount = (wrapper.html().match(/<wbr>/g) || []).length
-      expect(wbrCount).toBe(1)
+      expect(wrapper.html()).not.toContain('<wbr>')
     })
 
     it('handles empty string', () => {
@@ -100,10 +97,7 @@ describe('ScalarWrappingText', () => {
       })
       const text = wrapper.text()
       expect(text).toBe('test')
-      // Component always renders one <wbr> before each word segment
-      // When there are no matches, there's only one segment
-      const wbrCount = (wrapper.html().match(/<wbr>/g) || []).length
-      expect(wbrCount).toBe(1)
+      expect(wrapper.html()).not.toContain('<wbr>')
     })
 
     it('handles PascalCase with default settings (should not wrap)', () => {
@@ -114,10 +108,7 @@ describe('ScalarWrappingText', () => {
       })
       const text = wrapper.text()
       expect(text).toBe('LongPascalCaseStringThatNeedsToWrapToMultipleLines')
-      // Component always renders one <wbr> before each word segment
-      // When there are no matches, there's only one segment
-      const wbrCount = (wrapper.html().match(/<wbr>/g) || []).length
-      expect(wbrCount).toBe(1)
+      expect(wrapper.html()).not.toContain('<wbr>')
     })
   })
 
@@ -186,10 +177,7 @@ describe('ScalarWrappingText', () => {
       })
       const text = wrapper.text()
       expect(text).toBe('PascalCase')
-      // Component always renders one <wbr> before each word segment
-      // When there are no matches, there's only one segment
-      const wbrCount = (wrapper.html().match(/<wbr>/g) || []).length
-      expect(wbrCount).toBe(1)
+      expect(wrapper.html()).not.toContain('<wbr>')
     })
 
     it('does not match underscores', () => {
@@ -201,10 +189,7 @@ describe('ScalarWrappingText', () => {
       })
       const text = wrapper.text()
       expect(text).toBe('snake_case')
-      // Component always renders one <wbr> before each word segment
-      // When there are no matches, there's only one segment
-      const wbrCount = (wrapper.html().match(/<wbr>/g) || []).length
-      expect(wbrCount).toBe(1)
+      expect(wrapper.html()).not.toContain('<wbr>')
     })
 
     it('does not match dots', () => {
@@ -215,9 +200,9 @@ describe('ScalarWrappingText', () => {
         },
       })
       const html = wrapper.html()
-      // Path preset matches dots, so this should have multiple segments
+      // Path preset matches dots: two segments, one <wbr> between them
       const wbrCount = (html.match(/<wbr>/g) || []).length
-      expect(wbrCount).toBeGreaterThan(1)
+      expect(wbrCount).toBe(1)
       const text = wrapper.text()
       expect(text).toBe('dot.separated')
     })
@@ -324,10 +309,7 @@ describe('ScalarWrappingText', () => {
       })
       const text = wrapper.text()
       expect(text).toBe('lowercase text')
-      // Component always renders one <wbr> before each word segment
-      // When there are no matches, there's only one segment
-      const wbrCount = (wrapper.html().match(/<wbr>/g) || []).length
-      expect(wbrCount).toBe(1)
+      expect(wrapper.html()).not.toContain('<wbr>')
     })
 
     it('does not match slashes', () => {
@@ -339,10 +321,7 @@ describe('ScalarWrappingText', () => {
       })
       const text = wrapper.text()
       expect(text).toBe('/api/user')
-      // Component always renders one <wbr> before each word segment
-      // When there are no matches, there's only one segment
-      const wbrCount = (wrapper.html().match(/<wbr>/g) || []).length
-      expect(wbrCount).toBe(1)
+      expect(wrapper.html()).not.toContain('<wbr>')
     })
   })
 
@@ -384,10 +363,7 @@ describe('ScalarWrappingText', () => {
       })
       const text = wrapper.text()
       expect(text).toBe('simple text')
-      // Component always renders one <wbr> before each word segment
-      // When there are no matches, there's only one segment
-      const wbrCount = (wrapper.html().match(/<wbr>/g) || []).length
-      expect(wbrCount).toBe(1)
+      expect(wrapper.html()).not.toContain('<wbr>')
     })
 
     it('handles empty regex pattern', () => {
@@ -399,10 +375,7 @@ describe('ScalarWrappingText', () => {
       })
       const text = wrapper.text()
       expect(text).toBe('/test/path')
-      // Component always renders one <wbr> before each word segment
-      // When there are no matches, there's only one segment
-      const wbrCount = (wrapper.html().match(/<wbr>/g) || []).length
-      expect(wbrCount).toBe(1)
+      expect(wrapper.html()).not.toContain('<wbr>')
     })
 
     it('overrides preset when regex is provided', () => {
@@ -416,10 +389,7 @@ describe('ScalarWrappingText', () => {
       const text = wrapper.text()
       expect(text).toBe('/api/user-profile')
       // Custom regex /\./g doesn't match anything in '/api/user-profile'
-      // Component always renders one <wbr> before each word segment
-      // When there are no matches, there's only one segment
-      const wbrCount = (wrapper.html().match(/<wbr>/g) || []).length
-      expect(wbrCount).toBe(1)
+      expect(wrapper.html()).not.toContain('<wbr>')
     })
 
     it('handles PascalCase with custom regex', () => {
@@ -473,7 +443,7 @@ describe('ScalarWrappingText', () => {
         },
       })
       const html = wrapper.html()
-      expect(html).toContain('<wbr>')
+      expect(html).not.toContain('<wbr>')
       expect(html).toContain('/')
     })
 
@@ -484,7 +454,7 @@ describe('ScalarWrappingText', () => {
         },
       })
       const html = wrapper.html()
-      expect(html).toContain('<wbr>')
+      expect(html).not.toContain('<wbr>')
       expect(html).toContain('-')
     })
 
@@ -530,7 +500,7 @@ describe('ScalarWrappingText', () => {
         },
       })
       const html = wrapper.html()
-      expect(html).toContain('<wbr>')
+      expect(html).not.toContain('<wbr>')
       expect(html).toContain('A')
     })
 
@@ -542,7 +512,7 @@ describe('ScalarWrappingText', () => {
         },
       })
       const html = wrapper.html()
-      expect(html).toContain('<wbr>')
+      expect(html).not.toContain('<wbr>')
       expect(html).toContain('_')
     })
 
@@ -554,7 +524,7 @@ describe('ScalarWrappingText', () => {
         },
       })
       const html = wrapper.html()
-      expect(html).toContain('<wbr>')
+      expect(html).not.toContain('<wbr>')
       expect(html).toContain('.')
     })
 
@@ -566,7 +536,7 @@ describe('ScalarWrappingText', () => {
         },
       })
       const html = wrapper.html()
-      expect(html).toContain('<wbr>')
+      expect(html).not.toContain('<wbr>')
       expect(html).toContain('-')
     })
   })

--- a/packages/components/src/components/ScalarWrappingText/ScalarWrappingText.vue
+++ b/packages/components/src/components/ScalarWrappingText/ScalarWrappingText.vue
@@ -45,6 +45,6 @@ const words = computed<string[]>(() => {
   <template
     v-for="(word, i) in words"
     :key="i">
-    <wbr />{{ word }}
+    <wbr v-if="i !== 0" />{{ word }}
   </template>
 </template>

--- a/packages/sidebar/src/components/SidebarItemLabel.vue
+++ b/packages/sidebar/src/components/SidebarItemLabel.vue
@@ -15,17 +15,15 @@ const { item } = defineProps<{
 }>()
 </script>
 <template>
-  <template v-if="item.type === 'model'">
-    <ScalarWrappingText
-      preset="property"
-      :text="item.title" />
-  </template>
-  <template v-else>
-    <ScalarWrappingText
-      :text="
-        operationTitleSource === 'path' && 'path' in item
-          ? (item.path as string)
-          : (item.title as string)
-      " />
-  </template>
+  <ScalarWrappingText
+    v-if="item.type === 'model' || item.type === 'example'"
+    preset="property"
+    :text="item.title" />
+  <ScalarWrappingText
+    v-else
+    :text="
+      operationTitleSource === 'path' && 'path' in item
+        ? (item.path as string)
+        : (item.title as string)
+    " />
 </template>


### PR DESCRIPTION
Previously we were adding a `<wbr>` at the start of ScalarWrappingText which could cause weird behavior if no other word break opportunities were found.

Before / After
<img width="1716" height="1288" alt="CleanShot 2026-04-10 at 13 43 03@2x" src="https://github.com/user-attachments/assets/4c90e8d2-654f-40a8-ae9d-78b92933f9d7" />
<img width="1716" height="1288" alt="CleanShot 2026-04-10 at 13 46 29@2x" src="https://github.com/user-attachments/assets/c7a9ec3a-21ff-4bea-a2c0-f0c8a8d773d0" />

Also set the sidebar to treat example labels as properties since that's what folks seem to sometimes have there.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
