### PR TITLE
chore(site): add PostHog web tracking on scalar.com

### DIFF
--- a/documentation/assets/posthog.js
+++ b/documentation/assets/posthog.js
@@ -45,6 +45,5 @@
 window.posthog.init('phc_3elIjSOvGOo5aEwg6krzIY9IcQiRubsBtglOXsQ4Uu4', {
   api_host: 'https://magic.scalar.com',
   ui_host: 'https://us.posthog.com',
-  defaults: '2026-01-30',
-  person_profiles: 'identified_only',
+  defaults: '2025-11-30',
 })

--- a/documentation/assets/posthog.js
+++ b/documentation/assets/posthog.js
@@ -1,0 +1,50 @@
+/* PostHog Analytics */
+!(function (t, e) {
+  var o, n, p, r
+  e.__SV ||
+    (window.posthog && window.posthog.__loaded) ||
+    ((window.posthog = e),
+    (e._i = []),
+    (e.init = function (i, s, a) {
+      function g(t, e) {
+        var o = e.split('.')
+        2 == o.length && ((t = t[o[0]]), (e = o[1]))
+        t[e] = function () {
+          t.push([e].concat(Array.prototype.slice.call(arguments, 0)))
+        }
+      }
+      ;(p = t.createElement('script')).type = 'text/javascript'
+      p.crossOrigin = 'anonymous'
+      p.async = !0
+      p.src = s.api_host.replace('.i.posthog.com', '-assets.i.posthog.com') + '/static/array.js'
+      ;(r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r)
+      var u = e
+      for (
+        void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
+          (u.people = u.people || []),
+          (u.toString = function (t) {
+            var e = 'posthog'
+            return 'posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e
+          }),
+          (u.people.toString = function () {
+            return u.toString(1) + '.people (stub)'
+          }),
+          o = 'Ii init Di qi Sr Bi Zi Pi capture calculateEventProperties Yi register register_once register_for_session unregister unregister_for_session Xi getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync Ji identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty Wi Vi createPersonProfile setInternalOrTestUser Gi Fi tn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing $i debug Tr Ui getPageViewId captureTraceFeedback captureTraceMetric Ri'.split(
+            ' ',
+          ),
+          n = 0;
+        n < o.length;
+        n++
+      )
+        g(u, o[n])
+      e._i.push([i, s, a])
+    }),
+    (e.__SV = 1))
+})(document, window.posthog || [])
+
+window.posthog.init('phc_3elIjSOvGOo5aEwg6krzIY9IcQiRubsBtglOXsQ4Uu4', {
+  api_host: 'https://magic.scalar.com',
+  ui_host: 'https://us.posthog.com',
+  defaults: '2026-01-30',
+  person_profiles: 'identified_only',
+})

--- a/documentation/assets/posthog.js
+++ b/documentation/assets/posthog.js
@@ -21,17 +21,18 @@
       var u = e
       for (
         void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
-          (u.people = u.people || []),
-          (u.toString = function (t) {
+          u.people = u.people || [],
+          u.toString = function (t) {
             var e = 'posthog'
             return 'posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e
-          }),
-          (u.people.toString = function () {
+          },
+          u.people.toString = function () {
             return u.toString(1) + '.people (stub)'
-          }),
-          o = 'Ii init Di qi Sr Bi Zi Pi capture calculateEventProperties Yi register register_once register_for_session unregister unregister_for_session Xi getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync Ji identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty Wi Vi createPersonProfile setInternalOrTestUser Gi Fi tn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing $i debug Tr Ui getPageViewId captureTraceFeedback captureTraceMetric Ri'.split(
-            ' ',
-          ),
+          },
+          o =
+            'Ii init Di qi Sr Bi Zi Pi capture calculateEventProperties Yi register register_once register_for_session unregister unregister_for_session Xi getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync Ji identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty Wi Vi createPersonProfile setInternalOrTestUser Gi Fi tn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing $i debug Tr Ui getPageViewId captureTraceFeedback captureTraceMetric Ri'.split(
+              ' ',
+            ),
           n = 0;
         n < o.length;
         n++

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -19,6 +19,7 @@
     // Referenced in scalar.config.json
     "documentation/assets/landing.js",
     "documentation/assets/fathom.js",
+    "documentation/assets/posthog.js",
     "documentation/assets/apollo.js",
     "documentation/assets/enterprise-contact-form.js"
   ],

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -19,6 +19,9 @@
           "path": "documentation/assets/fathom.js"
         },
         {
+          "path": "documentation/assets/posthog.js"
+        },
+        {
           "path": "documentation/assets/apollo.js"
         },
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`scalar.com` currently includes Fathom analytics but does not load PostHog tracking.

## Solution

- Add `documentation/assets/posthog.js` with the PostHog bootstrap loader.
- Register `documentation/assets/posthog.js` in `scalar.config.json` under `siteConfig.head.scripts` so it loads alongside existing analytics scripts.
- Update PostHog init config to use `defaults: '2025-11-30'` and remove `person_profiles`.
- Format the PostHog asset with Biome and add `documentation/assets/posthog.js` to `knip.jsonc` `ignoreFiles` (same pattern as the other `documentation/assets/*.js` files referenced by config).

## Validation

- `pnpm format:check` passes after formatting fix.
- `pnpm lint:knip` no longer reports `documentation/assets/posthog.js`; remaining failures are pre-existing unresolved imports in Nuxt files (`integrations/nuxt/src/runtime/components/ScalarApiReference.vue`, `integrations/nuxt/src/runtime/pages/ScalarPage.vue`).

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. (Not required for this root config/assets-only change.)
- [ ] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b7404a8-3b51-4a04-b13c-bf37cd76ebe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b7404a8-3b51-4a04-b13c-bf37cd76ebe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

