### PR TITLE
docs(blog): add 2025 OSS pledge blog post

### DIFF
--- a/documentation/blog/2026-04-11-oss-pledge.md
+++ b/documentation/blog/2026-04-11-oss-pledge.md
@@ -1,0 +1,17 @@
+# Scalar's 2025 Open Source Pledge
+
+## Apr 11th, 2026
+
+What is OSS Pledge?
+
+You can read more about it [here](https://osspledge.com/), but in short, it's paying Open Source maintainers. The minimum to participate is $2,000 per full-time employed developer per year.
+
+Open source is the foundation everything we build sits on. In **2025**, Scalar is made up of **10 developers** and contributed **$21,232** directly to open source maintainers -- **$2,123 per developer**.
+
+We sponsored the following maintainers and projects:
+
+[tiangolo](https://github.com/tiangolo) (FastAPI), [SaltyAom](https://github.com/SaltyAom) (ElysiaJS), [hey-api](https://github.com/hey-api), [litestar-org](https://github.com/litestar-org) (LiteStar), [colinhacks](https://github.com/colinhacks) (Zod), [daveshanley](https://github.com/daveshanley) (libopenapi), [mholt](https://github.com/mholt), [yusukebe](https://github.com/yusukebe) (Hono), [Aslemammad](https://github.com/Aslemammad), [pi0](https://github.com/pi0) (Nuxt / UnJS), [typst](https://github.com/typst), [MathurAditya724](https://github.com/MathurAditya724), [fuma-nama](https://github.com/fuma-nama), [thibaultleouay](https://github.com/thibaultleouay) (OpenStatus), [dmonad](https://github.com/dmonad) (Yjs), [marijnh](https://github.com/marijnh) (CodeMirror / ProseMirror), [LinusBorg](https://github.com/LinusBorg) (Vue.js)
+
+Most of us got into engineering through open source. We're glad to give back -- and we're proud to be members of the Open Source Pledge again in 2025.
+
+-- Marc, CEO & co-founder, Scalar

--- a/documentation/blog/2026-04-11-oss-pledge.md
+++ b/documentation/blog/2026-04-11-oss-pledge.md
@@ -10,7 +10,23 @@ Open source is the foundation everything we build sits on. In **2025**, Scalar i
 
 We sponsored the following maintainers and projects:
 
-[tiangolo](https://github.com/tiangolo) (FastAPI), [SaltyAom](https://github.com/SaltyAom) (ElysiaJS), [hey-api](https://github.com/hey-api), [litestar-org](https://github.com/litestar-org) (LiteStar), [colinhacks](https://github.com/colinhacks) (Zod), [daveshanley](https://github.com/daveshanley) (libopenapi), [mholt](https://github.com/mholt), [yusukebe](https://github.com/yusukebe) (Hono), [Aslemammad](https://github.com/Aslemammad), [pi0](https://github.com/pi0) (Nuxt / UnJS), [typst](https://github.com/typst), [MathurAditya724](https://github.com/MathurAditya724), [fuma-nama](https://github.com/fuma-nama), [thibaultleouay](https://github.com/thibaultleouay) (OpenStatus), [dmonad](https://github.com/dmonad) (Yjs), [marijnh](https://github.com/marijnh) (CodeMirror / ProseMirror), [LinusBorg](https://github.com/LinusBorg) (Vue.js)
+* [tiangolo](https://github.com/tiangolo) (FastAPI)
+* [SaltyAom](https://github.com/SaltyAom) (ElysiaJS)
+* [hey-api](https://github.com/hey-api)
+* [litestar-org](https://github.com/litestar-org) (LiteStar)
+* [colinhacks](https://github.com/colinhacks) (Zod)
+* [daveshanley](https://github.com/daveshanley) (libopenapi)
+* [mholt](https://github.com/mholt)
+* [yusukebe](https://github.com/yusukebe) (Hono)
+* [Aslemammad](https://github.com/Aslemammad)
+* [pi0](https://github.com/pi0) (Nuxt / UnJS)
+* [typst](https://github.com/typst)
+* [MathurAditya724](https://github.com/MathurAditya724)
+* [fuma-nama](https://github.com/fuma-nama)
+* [thibaultleouay](https://github.com/thibaultleouay) (OpenStatus)
+* [dmonad](https://github.com/dmonad) (Yjs)
+* [marijnh](https://github.com/marijnh) (CodeMirror / ProseMirror)
+* [LinusBorg](https://github.com/LinusBorg) (Vue.js)
 
 Most of us got into engineering through open source. We're glad to give back -- and we're proud to be members of the Open Source Pledge again in 2025.
 

--- a/documentation/blog/2026-04-11-oss-pledge.md
+++ b/documentation/blog/2026-04-11-oss-pledge.md
@@ -1,7 +1,5 @@
 # Scalar's 2025 Open Source Pledge
 
-## Apr 11th, 2026
-
 What is OSS Pledge?
 
 You can read more about it [here](https://osspledge.com/), but in short, it's paying Open Source maintainers. The minimum to participate is $2,000 per full-time employed developer per year.

--- a/documentation/blog/index.md
+++ b/documentation/blog/index.md
@@ -5,6 +5,13 @@
   Cards are built from YYYY-MM-DD-slug.md files in documentation/blog/.
   Descriptions are preserved between runs — new posts get auto-extracted text.
 -->
+:::scalar-card{title="Scalar's 2025 Open Source Pledge" href="./2026-04-11-oss-pledge.md"}
+
+Open source is the foundation everything we build sits on. In 2025, Scalar was made up of 10 developers and contributed $21,232 directly to open-source maintainers ($2,123 per developer).
+
+::scalar-fineprint[Apr 11, 2026]{}
+:::
+
 :::scalar-card{title="Too Long; Didn't Read; Used MCP" href="./2026-03-25-scalar-mcp-oauth.md"}
 
 Hey, it's 2026, who does even **read** the documentation for your API anymore. Just boot up a MCP based on your OpenAPI document (using Scalar), and share it with your users or your team[1].

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -2195,6 +2195,11 @@
                 "mode": "flat",
                 "title": "Posts",
                 "children": {
+                  "/2026-04-11-oss-pledge": {
+                    "type": "page",
+                    "title": "Scalar's 2025 Open Source Pledge",
+                    "filepath": "documentation/blog/2026-04-11-oss-pledge.md"
+                  },
                   "/2026-03-25-scalar-mcp-oauth": {
                     "type": "page",
                     "title": "Too Long; Didn't Read; Used MCP",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The 2025 Open Source Pledge blog announcement needed to be published as a new post, registered in the docs site navigation, and shown on the blog overview page.

## Solution

- Added a new blog post file at `documentation/blog/2026-04-11-oss-pledge.md` with the provided 2025 pledge copy.
- Added the new `/2026-04-11-oss-pledge` route to `scalar.config.json` under blog posts.
- Placed the "What is OSS Pledge?" section at the top of the post body as requested.
- Formatted the sponsored maintainer/project section as a Markdown bullet list for readability.
- Added a new card entry for the post at the top of `documentation/blog/index.md` so it appears in blog overview.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45a576d3-2db8-45d7-b4e2-e071da72f226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45a576d3-2db8-45d7-b4e2-e071da72f226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

