### PR TITLE
docs(blog): update Open Source Pledge naming and URL

### DIFF
--- a/documentation/blog/2026-04-11-oss-pledge.md
+++ b/documentation/blog/2026-04-11-oss-pledge.md
@@ -1,8 +1,8 @@
 # Scalar's 2025 Open Source Pledge
 
-What is OSS Pledge?
+What is Open Source Pledge?
 
-You can read more about it [here](https://osspledge.com/), but in short, it's paying Open Source maintainers. The minimum to participate is $2,000 per full-time employed developer per year.
+You can read more about it [here](https://opensourcepledge.com/), but in short, it's paying Open Source maintainers. The minimum to participate is $2,000 per full-time employed developer per year.
 
 Open source is the foundation everything we build sits on. In **2025**, Scalar is made up of **10 developers** and contributed **$21,232** directly to open source maintainers -- **$2,123 per developer**.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The new Open Source Pledge blog post still used the old naming (`OSS Pledge`) and old URL (`osspledge.com`) in a couple of places.

## Solution

Updated the new blog post to use the requested naming and link:

- `OSS Pledge` → `Open Source Pledge`
- `https://osspledge.com/` → `https://opensourcepledge.com/`

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbca8ee4-05d0-41b0-94d8-b63d24301ca5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbca8ee4-05d0-41b0-94d8-b63d24301ca5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

