### PR TITLE
fix(docs): reduce footer bottom padding to remove extra whitespace

### DIFF
--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -570,7 +570,7 @@ Put your content where you want: in your repository, any folder, or the Scalar E
     overflow: hidden;
     background: var(--scalar-background-2);
     padding-inline: 20px;
-    padding-bottom: 200px;
+    padding-bottom: 100px;
     margin-top: 100px;
   }
   .footer-animation {

--- a/documentation/guides/enterprise/enterprise.md
+++ b/documentation/guides/enterprise/enterprise.md
@@ -731,7 +731,7 @@ Validate contracts early so exploration and testing stay tied to the same API de
     overflow: hidden;
     background: var(--scalar-background-2);
     padding-inline: 20px;
-    padding-bottom: 200px;
+    padding-bottom: 100px;
     margin-top: 100px;
   }
   .footer-animation {

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -827,7 +827,7 @@
     overflow: hidden;
     background: var(--scalar-background-2);
     padding-inline: 20px;
-    padding-bottom: 200px;
+    padding-bottom: 100px;
     margin-top: 100px;
   }
   .footer-animation {

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -1038,7 +1038,7 @@ h4.t-editor__heading {
     position: relative;
     overflow: hidden;
     background: var(--scalar-background-2);
-    padding-bottom: 200px;
+    padding-bottom: 100px;
     margin-top: 100px;
   }
   .footer-animation svg {

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -519,7 +519,7 @@ All of this with just a couple clicks or a few API requests! You handle making y
     overflow: hidden;
     background: var(--scalar-background-2);
     padding-inline: 20px;
-    padding-bottom: 200px;
+    padding-bottom: 100px;
     margin-top: 100px;
   }
   .footer-animation {

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -523,7 +523,7 @@ Once created, you will get redirected to the SDK Overview page where you can:
     overflow: hidden;
     background: var(--scalar-background-2);
     padding-inline: 20px;
-    padding-bottom: 200px;
+    padding-bottom: 100px;
     margin-top: 100px;
   }
   .footer-animation {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The footer on the Getting Started page (and other landing pages) has extra whitespace/padding at the bottom. This was reported in the Slack thread by Marc.

The footer CSS had `padding-bottom: 200px` which was intended to provide space for the footer animation SVG, but this created excessive visible whitespace below the footer content.

## Solution

Reduced the `padding-bottom` from `200px` to `100px` on the footer sections across all affected documentation pages:

- `documentation/guides/docs/getting-started.md`
- `documentation/guides/sdks/getting-started.md`
- `documentation/guides/registry/getting-started.md`
- `documentation/guides/enterprise/enterprise.md`
- `documentation/guides/introduction.md`
- `documentation/guides/pricing.md`

This removes 100px of extra whitespace while still maintaining adequate space for the footer animation SVG.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not required for documentation-only changes -->
- [ ] I added tests. <!-- Not applicable for CSS changes in markdown files -->
- [ ] I updated the documentation. <!-- This IS the documentation fix -->

## Ticket

Fixes DOC-5174
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07SL9L6SJ0/p1776012488407739?thread_ts=1776012488.407739&cid=C07SL9L6SJ0)

<div><a href="https://cursor.com/agents/bc-6e534e14-faed-5815-b29a-ad32b87b3b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e534e14-faed-5815-b29a-ad32b87b3b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

