### PR TITLE
fix(api-reference): preserve exploded array query params in test requests

### DIFF
--- a/.changeset/cuddly-tools-hug.md
+++ b/.changeset/cuddly-tools-hug.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-reference': patch
+---
+
+fix test requests so exploded array query parameters keep all values instead of collapsing to the last one

--- a/packages/workspace-store/src/request-example/builder/build-request.test.ts
+++ b/packages/workspace-store/src/request-example/builder/build-request.test.ts
@@ -227,6 +227,20 @@ describe('buildRequest', () => {
     expect(new URL(request.url).searchParams.get('sort')).toBe('name')
   })
 
+  it('preserves repeated query parameters when building the request URL', () => {
+    const query = new URLSearchParams()
+    query.append('bbox', '13')
+    query.append('bbox', '48')
+    query.append('bbox', '18')
+    query.append('bbox', '52')
+
+    const { request } = buildRequest(createFactory({ query }), {
+      envVariables: {},
+    })
+
+    expect(new URL(request.url).searchParams.getAll('bbox')).toEqual(['13', '48', '18', '52'])
+  })
+
   it('encodes path variables after env substitution and substitutes them into the path', () => {
     const { request } = buildRequest(
       createFactory({

--- a/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.test.ts
+++ b/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.test.ts
@@ -76,6 +76,19 @@ describe('resolve-request-factory-url', () => {
     expect(result).toBe('https://api.example.com/v1/users?page=1&limit=10')
   })
 
+  it('preserves repeated query parameters for exploded arrays', () => {
+    const query = new URLSearchParams()
+    query.append('bbox', '13')
+    query.append('bbox', '48')
+    query.append('bbox', '18')
+    query.append('bbox', '52')
+
+    const request = createRequestFactory({ query })
+    const result = resolveRequestFactoryUrl(request, defaultOptions)
+
+    expect(result).toBe('https://api.example.com/v1/users?bbox=13&bbox=48&bbox=18&bbox=52')
+  })
+
   it('adds security query parameters from options.securityQueryParams', () => {
     const securityQueryParams = new URLSearchParams()
     securityQueryParams.set('api_key', 'secret123')

--- a/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.ts
+++ b/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.ts
@@ -1,5 +1,5 @@
 import { replaceEnvVariables, replacePathVariables } from '@scalar/helpers/regex/replace-variables'
-import { mergeUrls } from '@scalar/helpers/url/merge-urls'
+import { mergeSearchParams, mergeUrls } from '@scalar/helpers/url/merge-urls'
 
 import type { RequestFactory } from '@/request-example/builder/request-factory'
 
@@ -27,15 +27,17 @@ export const resolveRequestFactoryUrl = (
   const urlBase = globalThis.window?.location?.origin ?? 'http://localhost:3000'
   const url = new URL(mergedUrl, urlBase)
 
-  // Merge in operation query params
+  const operationQueryParams = new URLSearchParams()
   for (const [key, value] of request.query.entries()) {
-    url.searchParams.set(replaceEnvVariables(key, variables), replaceEnvVariables(value, variables))
+    operationQueryParams.append(replaceEnvVariables(key, variables), replaceEnvVariables(value, variables))
   }
 
-  // Merge in security query params
+  const securityQueryParams = new URLSearchParams()
   for (const [key, value] of options.securityQueryParams.entries()) {
-    url.searchParams.set(key, value)
+    securityQueryParams.append(key, value)
   }
+
+  url.search = mergeSearchParams(url.searchParams, operationQueryParams, securityQueryParams).toString()
 
   return url.toString()
 }


### PR DESCRIPTION
## Problem

API Reference `Test Request` was collapsing exploded query array params to the last value. In the issue repro, `bbox` should be sent as repeated query params, but the web request ended up with only the final entry.

## Solution

I fixed the request URL builder in `@scalar/workspace-store` so repeated query keys are preserved instead of overwritten during URL resolution.

I also added regression tests for the repeated `bbox` query-param case.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.


## Fixes

https://github.com/scalar/scalar/issues/8789