### PR TITLE
fix(api-client): unblock SSE response streaming

### DIFF
--- a/.changeset/flat-hotels-kiss.md
+++ b/.changeset/flat-hotels-kiss.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix server-sent event requests getting stuck in a loading state by returning the stream reader without waiting for the full response body.

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -1348,6 +1348,62 @@ describe('create-request-operation', () => {
 
       expect(chunks).toEqual(['chunk 1', 'chunk 2'])
     })
+
+    it('returns a stream reader without waiting for the full SSE response body', async () => {
+      const encoder = new TextEncoder()
+      let streamController: ReadableStreamDefaultController<Uint8Array> | null = null
+
+      const streamingBody = new ReadableStream<Uint8Array>({
+        start(controller) {
+          streamController = controller
+          controller.enqueue(encoder.encode('data: hello\n\n'))
+        },
+      })
+
+      globalFetchSpy.mockResolvedValueOnce(
+        new Response(streamingBody, {
+          status: 200,
+          headers: new Headers({
+            'content-type': 'text/event-stream',
+          }),
+        }),
+      )
+
+      const [error, requestOperation] = createRequestOperation({
+        ...createRequestPayload({
+          serverPayload: { url: VOID_URL },
+        }),
+      })
+
+      if (error) {
+        throw error
+      }
+
+      const sendRequestResult = await Promise.race([
+        requestOperation.sendRequest().then((value) => ({ type: 'result' as const, value })),
+        new Promise<{ type: 'timeout' }>((resolve) => {
+          setTimeout(() => resolve({ type: 'timeout' }), 300)
+        }),
+      ])
+
+      expect(sendRequestResult.type).toBe('result')
+      if (sendRequestResult.type !== 'result') {
+        throw new Error('sendRequest timed out for SSE response')
+      }
+
+      const [requestError, result] = sendRequestResult.value
+      expect(requestError).toBe(null)
+      if (!result || !('reader' in result.response)) {
+        throw new Error('No reader')
+      }
+
+      const firstChunk = await result.response.reader.read()
+      expect(firstChunk.done).toBe(false)
+      expect(new TextDecoder().decode(firstChunk.value)).toBe('data: hello\n\n')
+
+      await result.response.reader.cancel()
+      streamController?.close()
+    })
   })
 
   it('executes onBeforeRequest hook when plugin manager is provided', async () => {

--- a/packages/api-client/src/libs/send-request/create-request-operation.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.ts
@@ -216,14 +216,7 @@ export const createRequestOperation = ({
 
         const duration = Date.now() - startTime
 
-        // Clone the response before reading it
-        const responseToRead = response.clone()
-
         const responseHeaders = normalizeHeaders(response.headers, shouldUseProxy(proxyUrl, url))
-        const responseType = response.headers.get('content-type') ?? 'text/plain;charset=UTF-8'
-
-        const arrayBuffer = await responseToRead.arrayBuffer()
-        const responseData = decodeBuffer(arrayBuffer, responseType)
 
         // Create a new response with the statusText
         const clonedResponse = response.clone()
@@ -270,6 +263,12 @@ export const createRequestOperation = ({
             },
           ]
         }
+
+        // Clone the response before reading it
+        const responseToRead = response.clone()
+        const responseType = response.headers.get('content-type') ?? 'text/plain;charset=UTF-8'
+        const arrayBuffer = await responseToRead.arrayBuffer()
+        const responseData = decodeBuffer(arrayBuffer, responseType)
 
         return [
           null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

SSE requests in `@scalar/api-client` could get stuck in an infinite loading state. This was reported in DOC-5176 when sending requests to `https://void.scalar.com/stream`.

## Solution

- moved non-streaming body decoding (`arrayBuffer()` + `decodeBuffer`) to run only for non-streaming responses
- return the `ReadableStream` reader immediately for `text/event-stream` responses so the UI can consume chunks live
- added a regression test that asserts `sendRequest()` resolves promptly for SSE and yields a reader without waiting for stream completion
- added a patch changeset for `@scalar/api-client`

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Fixes DOC-5176
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07RNPTKCB1/p1776091921994419?thread_ts=1776091921.994419&cid=C07RNPTKCB1)

<div><a href="https://cursor.com/agents/bc-a7bf7d1a-781f-5cfa-90ed-94123e546339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7bf7d1a-781f-5cfa-90ed-94123e546339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

