### PR TITLE
fix(void-server): set stream endpoint SSE content type

### DIFF
--- a/.changeset/thick-tips-cough.md
+++ b/.changeset/thick-tips-cough.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+fix stream endpoint headers for server-sent events

--- a/packages/void-server/src/create-void-server.test.ts
+++ b/packages/void-server/src/create-void-server.test.ts
@@ -375,6 +375,15 @@ describe('createVoidServer', () => {
     expect(response.headers.get('Content-Type')).toContain('text/html')
   })
 
+  it('returns an SSE content type for /stream', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/stream')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toContain('text/event-stream')
+  })
+
   it('includes security headers in responses', async () => {
     const server = await createVoidServer()
 

--- a/packages/void-server/src/utils/create-stream-response.ts
+++ b/packages/void-server/src/utils/create-stream-response.ts
@@ -2,6 +2,10 @@ import type { Context } from 'hono'
 import { stream } from 'hono/streaming'
 
 export function createStreamResponse(c: Context) {
+  c.header('Content-Type', 'text/event-stream')
+  c.header('Cache-Control', 'no-cache')
+  c.header('Connection', 'keep-alive')
+
   return stream(c, async (s) => {
     while (true) {
       s.write('data: ping\n')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`@scalar/void-server` exposes `/stream` for server-sent events, but there was no test asserting the response MIME type and the endpoint was missing the SSE `Content-Type` header.

## Solution

- Added a focused test in `packages/void-server/src/create-void-server.test.ts` that requests `/stream` and asserts the response includes `Content-Type: text/event-stream`.
- Updated `packages/void-server/src/utils/create-stream-response.ts` to set SSE headers:
  - `Content-Type: text/event-stream`
  - `Cache-Control: no-cache`
  - `Connection: keep-alive`
- Added a changeset for `@scalar/void-server` patch release.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36858a0b-59fc-475d-a4c0-3e34fd856023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36858a0b-59fc-475d-a4c0-3e34fd856023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

