### PR TITLE
docs: api client

### DIFF
--- a/documentation/guides/app/community.md
+++ b/documentation/guides/app/community.md
@@ -10,7 +10,7 @@ Join the Scalar Discord to chat with the team and other users. It is the fastest
 
 ## GitHub
 
-The entire source code for the API Client (and all other Scalar products) is available on GitHub under the MIT license.
+The entire source code for the API Client package is available on GitHub under the MIT license.
 
 - [Browse the repository](https://github.com/scalar/scalar)
 - [Report a bug](https://github.com/scalar/scalar/issues/new/choose)

--- a/documentation/guides/app/community.md
+++ b/documentation/guides/app/community.md
@@ -1,0 +1,19 @@
+# Community
+
+The Scalar API Client is fully open-source and built together with the community. Whether you want to report a bug, request a feature, or just hang out with other API nerds, here is where to find us.
+
+## Discord
+
+Join the Scalar Discord to chat with the team and other users. It is the fastest way to get help, share feedback, or discuss ideas.
+
+[Join the Discord](https://discord.gg/scalar)
+
+## GitHub
+
+The entire source code for the API Client (and all other Scalar products) is available on GitHub under the MIT license.
+
+- [Browse the repository](https://github.com/scalar/scalar)
+- [Report a bug](https://github.com/scalar/scalar/issues/new/choose)
+- [Request a feature](https://github.com/scalar/scalar/issues/new/choose)
+
+Contributions are welcome. If you want to fix something or add a feature, open a pull request and the team will review it.

--- a/documentation/guides/app/community.md
+++ b/documentation/guides/app/community.md
@@ -1,6 +1,6 @@
 # Community
 
-The Scalar API Client is fully open-source and built together with the community. Whether you want to report a bug, request a feature, or just hang out with other API nerds, here is where to find us.
+The Scalar API Client is fully open-source and built together with the community. Whether you want to report a bug, request a feature, or just hang out with other API nerds, this is where you can find us.
 
 ## Discord
 

--- a/documentation/guides/app/download.md
+++ b/documentation/guides/app/download.md
@@ -1,0 +1,14 @@
+# Download
+
+The Scalar API Client is available for Windows, macOS, Linux, and [in the browser](https://client.scalar.com).
+
+## Desktop
+
+- [macOS (Universal Installer)](https://download.scalar.com/mac/installer/universal)
+- [Windows](https://download.scalar.com/windows/msi/x64)
+- [Linux (AppImage x64)](https://download.scalar.com/linux/appImage/x64)
+- [Linux (Debian x64)](https://download.scalar.com/linux/deb/x64)
+
+## Browser
+
+No installation required. Open [client.scalar.com](https://client.scalar.com) and start testing your APIs right away.

--- a/documentation/guides/app/getting-started.md
+++ b/documentation/guides/app/getting-started.md
@@ -1,12 +1,23 @@
 # API Client
 
-Our Postman-like API Client, based on the OpenAPI standard.
+A modern, open-source API client built on the OpenAPI standard. Send requests, organize collections, and test your APIs – all from a beautiful, offline-first interface available on every platform.
 
-Available for Windows, macOS, Linux and [in the browser](https://client.scalar.com).
+## Features
 
-* [Windows](https://download.scalar.com/windows/msi/x64)
-* [macOS (Universal Installer)](https://download.scalar.com/mac/installer/universal)
-* [Linux (AppImage x64)](https://download.scalar.com/linux/appImage/x64)
-* [Linux (Debian x64)](https://download.scalar.com/linux/deb/x64)
+- **Offline-first:** Works without an internet connection, your data stays on your device
+- **Sync your local API:** Connect to APIs running on localhost during development
+- **OpenAPI by Heart:** Import OpenAPI descriptions to auto-generate requests and documentation
+- **Collaborate with Others:** Share collections and environments with your team
+- **No Vendor Lock-In:** Fully open-source, your data is always yours
+- **Linux, Windows, macOS:** Native apps for every platform, plus a [browser version](https://client.scalar.com)
 
+## Get Started
 
+[Download the app](/products/api-client/download) for your platform, or try it instantly in the [browser](https://client.scalar.com).
+
+Once installed, you can:
+
+1. **Send a request:** Enter a URL, select an HTTP method, and click Send
+2. **Import an OpenAPI file:** Drag and drop your OpenAPI description to generate a complete collection
+3. **Watch OpenAPI files for changes:** When you update your OpenAPI document on your machine, the app will detect changes and automatically sync your collections and requests
+4. **Write tests:** Add [post-response scripts](/products/api-client/testing) to automatically validate API responses

--- a/documentation/guides/app/import.md
+++ b/documentation/guides/app/import.md
@@ -1,0 +1,41 @@
+# Import
+
+The API Client supports several formats to get your API collections into the app. To import, click **Add Item** (⌘ K) and select **Import from OpenAPI/Swagger/Postman/cURL**.
+
+## Formats
+
+### OpenAPI 3.x
+
+The native format used internally by the API Client. OpenAPI descriptions can be auto-generated from your codebase or hand-written. Both JSON and YAML are supported.
+
+This is the recommended format. All features of the API Client, including environments, authentication schemes, and server configuration, map directly to the OpenAPI specification.
+
+### Swagger 2.0
+
+Swagger 2.0 files are automatically upgraded to OpenAPI 3.1 on import. You do not need to convert them beforehand.
+
+### Postman Collections
+
+Import Postman Collection files (v2.0 / v2.1) as a one-off import. Requests, folders, and basic authentication settings are converted to an OpenAPI-based collection.
+
+### cURL
+
+Paste a cURL command to create a single request. The API Client parses the method, URL, headers, and body from the command.
+
+```bash
+curl -X POST https://api.example.com/users \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Jane"}'
+```
+
+## Sources
+
+You can import from different sources:
+
+- **URL** — Provide a link to a hosted OpenAPI document. The API Client fetches and imports it directly.
+- **File** — Drag and drop a local file, or browse to select one from your file system.
+- **Development environment** — Point to your local development server to sync with an API running on localhost.
+
+## Start from scratch
+
+You do not need to import anything to get started. Create an empty collection and add requests manually as you go.

--- a/documentation/guides/app/import.md
+++ b/documentation/guides/app/import.md
@@ -1,6 +1,6 @@
 # Import
 
-The API Client supports several formats to get your API collections into the app. To import, click **Add Item** (⌘ K) and select **Import from OpenAPI/Swagger/Postman/cURL**.
+The API Client supports several formats to get your API collections into the app. To import, click **Add Item** (⌘ K or Control K) and select **Import from OpenAPI/Swagger/Postman/cURL**.
 
 ## Formats
 

--- a/documentation/guides/app/keyboard-shortcuts.md
+++ b/documentation/guides/app/keyboard-shortcuts.md
@@ -2,7 +2,7 @@
 
 The API Client supports keyboard shortcuts to speed up your workflow. On macOS, shortcuts use ⌘ (Cmd). On Windows and Linux, use Ctrl instead.
 
-## General
+## Browser & Desktop App
 
 | Shortcut | Action |
 | --- | --- |
@@ -25,10 +25,3 @@ These shortcuts are available in the desktop app.
 | ⌘ 9 | Jump to last tab |
 | ⌘ ⌥ ← | Previous tab |
 | ⌘ ⌥ → | Next tab |
-
-### Other
-
-| Shortcut | Action |
-| --- | --- |
-| ⌘ N | Open command palette |
-| ⌘ F | Focus search |

--- a/documentation/guides/app/keyboard-shortcuts.md
+++ b/documentation/guides/app/keyboard-shortcuts.md
@@ -1,0 +1,34 @@
+# Keyboard Shortcuts
+
+The API Client supports keyboard shortcuts to speed up your workflow. On macOS, shortcuts use ⌘ (Cmd). On Windows and Linux, use Ctrl instead.
+
+## General
+
+| Shortcut | Action |
+| --- | --- |
+| ⌘ Enter | Send request |
+| ⌘ K | Open command palette |
+| ⌘ B | Toggle sidebar |
+| ⌘ L | Focus address bar |
+| Escape | Close modal |
+
+## Desktop Only
+
+These shortcuts are available in the desktop app.
+
+### Tabs
+
+| Shortcut | Action |
+| --- | --- |
+| ⌘ T | New tab |
+| ⌘ 1–8 | Jump to tab 1–8 |
+| ⌘ 9 | Jump to last tab |
+| ⌘ ⌥ ← | Previous tab |
+| ⌘ ⌥ → | Next tab |
+
+### Other
+
+| Shortcut | Action |
+| --- | --- |
+| ⌘ N | Open command palette |
+| ⌘ F | Focus search |

--- a/documentation/guides/app/scripts.md
+++ b/documentation/guides/app/scripts.md
@@ -23,16 +23,6 @@ pm.request.headers.add({
 })
 ```
 
-### Generate an auth token
-
-```js
-const token = 'Bearer ' + pm.environment.get('api_key')
-pm.request.headers.add({
-  key: 'Authorization',
-  value: token
-})
-```
-
 ### Set variables for post-response scripts
 
 Variables set in a pre-request script persist into the post-response script for the same request.
@@ -111,4 +101,4 @@ x-pre-request: |-
   })
 ```
 
-See the [OpenAPI extensions reference](/openapi#x-pre-request) for more details.
+See the [OpenAPI extensions reference](../../openapi.md#x-pre-request) for more details.

--- a/documentation/guides/app/scripts.md
+++ b/documentation/guides/app/scripts.md
@@ -1,0 +1,114 @@
+# Scripts
+
+Pre-request scripts run before a request is sent. Use them to set variables, add headers, generate dynamic values, or prepare authentication tokens.
+
+Scripts use the same Postman-compatible `pm` API as [post-response scripts](/products/api-client/testing). They run in the official [Postman Sandbox](https://github.com/postmanlabs/postman-sandbox) runtime.
+
+## Examples
+
+### Set an environment variable
+
+```js
+pm.environment.set('timestamp', new Date().toISOString())
+```
+
+The variable is available in the request URL, headers, and body as `{{timestamp}}`, and in post-response scripts via `pm.environment.get('timestamp')`.
+
+### Add a header
+
+```js
+pm.request.headers.add({
+  key: 'X-Request-Id',
+  value: 'req-' + Date.now()
+})
+```
+
+### Generate an auth token
+
+```js
+const token = 'Bearer ' + pm.environment.get('api_key')
+pm.request.headers.add({
+  key: 'Authorization',
+  value: token
+})
+```
+
+### Set variables for post-response scripts
+
+Variables set in a pre-request script persist into the post-response script for the same request.
+
+```js
+pm.globals.set('requestStartTime', Date.now())
+```
+
+Then in the post-response script:
+
+```js
+pm.test("Request completed quickly", () => {
+  const start = pm.globals.get('requestStartTime')
+  const duration = Date.now() - start
+  pm.expect(duration).to.be.below(2000)
+})
+```
+
+## pm.request
+
+The `pm.request` object represents the request that is about to be sent. Changes to headers and method are applied to the actual request.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `pm.request.method` | string | HTTP method (GET, POST, etc.) |
+| `pm.request.url` | Url | Request URL |
+| `pm.request.headers` | HeaderList | Request headers |
+| `pm.request.body` | RequestBody | Request body |
+
+### Modifying headers
+
+```js
+// Add a header
+pm.request.headers.add({ key: 'X-Custom', value: 'value' })
+
+// Remove a header
+pm.request.headers.remove('X-Custom')
+```
+
+### Modifying the method
+
+```js
+pm.request.method = 'POST'
+```
+
+## Adding Scripts to OpenAPI Documents
+
+Add pre-request scripts to your OpenAPI description using the `x-pre-request` extension. Scripts can be set at the operation level, the document level, or both. When both are present, the document-level script runs first.
+
+### Operation level
+
+```yaml
+openapi: 3.1.0
+info:
+  title: Example
+  version: 1.0
+paths:
+  '/users':
+    get:
+      summary: Get all users
+      x-pre-request: |-
+        pm.environment.set('timestamp', new Date().toISOString())
+```
+
+### Document level
+
+```yaml
+openapi: 3.1.0
+info:
+  title: Example
+  version: 1.0
+x-pre-request: |-
+  pm.request.headers.add({
+    key: 'X-Request-Id',
+    value: 'req-' + Date.now()
+  })
+```
+
+See the [OpenAPI extensions reference](/openapi#x-pre-request) for more details.

--- a/documentation/guides/app/testing.md
+++ b/documentation/guides/app/testing.md
@@ -1,0 +1,304 @@
+# Testing
+
+Write post-response scripts to automatically validate API responses. Scripts use a Postman-compatible syntax, so if you have used Postman before, you will feel right at home.
+
+## Examples
+
+### Check the status code
+
+```js
+pm.test("Status code is 200", () => {
+  pm.response.to.have.status(200)
+})
+```
+
+### Check JSON response
+
+```js
+pm.test("Response is valid JSON", () => {
+  const responseData = pm.response.json()
+  pm.expect(responseData).to.be.an('object')
+})
+```
+
+### Check response headers
+
+```js
+pm.test("Content-Type header is present", () => {
+  pm.response.to.have.header('Content-Type')
+})
+```
+
+### Validate JSON schema
+
+```js
+pm.test("Response matches schema", () => {
+  const schema = {
+    type: 'object',
+    required: ['id', 'name'],
+    properties: {
+      id: { type: 'number' },
+      name: { type: 'string' }
+    }
+  }
+  pm.response.to.have.jsonSchema(schema)
+})
+```
+
+### Check response body
+
+```js
+pm.test("Response body contains string", () => {
+  pm.expect(pm.response.text()).to.include('success')
+})
+```
+
+### Successful POST request
+
+```js
+pm.test("Successful POST request", () => {
+  pm.expect(pm.response.code).to.be.oneOf([201, 202])
+})
+```
+
+### Negate an assertion
+
+```js
+pm.test("Response is not an error", () => {
+  pm.expect(pm.response.code).to.not.be.oneOf([400, 500])
+  pm.expect(pm.response.json()).to.not.have.property('error')
+})
+```
+
+### Check header value
+
+```js
+pm.test("Content-Type is JSON", () => {
+  pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json')
+})
+```
+
+### Multiple assertions
+
+```js
+pm.test("Response has all properties", () => {
+  const data = pm.response.json()
+  pm.expect(data.type).to.eql('vip')
+  pm.expect(data.name).to.be.a('string')
+  pm.expect(data.id).to.have.lengthOf(1)
+})
+```
+
+### Assert data types
+
+```js
+pm.test("Response data types are correct", () => {
+  const data = pm.response.json()
+  pm.expect(data).to.be.an('object')
+  pm.expect(data.name).to.be.a('string')
+  pm.expect(data.age).to.be.a('number')
+  pm.expect(data.hobbies).to.be.an('array')
+})
+```
+
+### Check object containment
+
+```js
+pm.test("Response contains expected object", () => {
+  const expected = { created: true, errors: [] }
+  pm.expect(pm.response.json()).to.deep.include(expected)
+})
+```
+
+## Adding Scripts to OpenAPI Documents
+
+You can add post-response scripts directly to your OpenAPI description using the `x-post-response` extension. When the API Client imports the document, scripts are automatically attached to the corresponding operations.
+
+```yaml
+openapi: 3.1.0
+info:
+  title: Example
+  version: 1.0
+paths:
+  '/planets':
+    get:
+      summary: Get all planets
+      x-post-response: |-
+        pm.test("Status code is 200", () => {
+          pm.response.to.have.status(200)
+        })
+```
+
+See the [OpenAPI extensions reference](/openapi#x-post-response) for more examples.
+
+## Reference
+
+Scripts run in the official [Postman Sandbox](https://github.com/postmanlabs/postman-sandbox) runtime, so the full `pm` API is available.
+
+### pm.test(name, callback)
+
+Define a named test. The test passes if the callback executes without throwing an error. Returns the `pm` object, so calls can be chained.
+
+```js
+pm.test("response is okay to process", () => {
+  pm.response.to.not.be.error
+  pm.response.to.have.jsonBody('data')
+})
+```
+
+Async tests are supported by accepting a `done` callback:
+
+```js
+pm.test("async test", (done) => {
+  setTimeout(() => {
+    pm.expect(pm.response.code).to.equal(200)
+    done()
+  }, 1500)
+})
+```
+
+Skip a test with `pm.test.skip`:
+
+```js
+pm.test.skip("not yet implemented", () => {
+  // this test will not run
+})
+```
+
+### pm.expect(value)
+
+Create an assertion on a value. Uses [Chai BDD](https://www.chaijs.com/api/bdd/) syntax, so all Chai chains are supported.
+
+#### Equality
+
+```js
+pm.expect(value).to.equal('exact match')    // strict equality (===)
+pm.expect(value).to.eql({ id: 1 })          // deep equality
+```
+
+#### Type checks
+
+```js
+pm.expect(value).to.be.a('string')
+pm.expect(value).to.be.an('object')
+pm.expect(value).to.be.true
+pm.expect(value).to.be.false
+pm.expect(value).to.be.null
+pm.expect(value).to.be.undefined
+pm.expect(value).to.be.empty
+pm.expect(value).to.be.ok               // truthy
+```
+
+#### Numbers
+
+```js
+pm.expect(count).to.be.above(5)
+pm.expect(count).to.be.below(100)
+pm.expect(count).to.be.at.least(1)
+pm.expect(count).to.be.at.most(50)
+pm.expect(count).to.be.within(1, 100)
+```
+
+#### Strings and arrays
+
+```js
+pm.expect(text).to.include('success')
+pm.expect(text).to.match(/^hello/)
+pm.expect(list).to.have.lengthOf(3)
+pm.expect(list).to.have.members([1, 2, 3])
+pm.expect(value).to.be.oneOf([200, 201])
+```
+
+#### Objects
+
+```js
+pm.expect(obj).to.have.property('name')
+pm.expect(obj).to.have.property('name', 'Earth')
+pm.expect(obj).to.have.keys(['id', 'name'])
+pm.expect(obj).to.have.nested.property('data.items[0].id')
+pm.expect(obj).to.deep.include({ id: 1 })
+```
+
+#### Negation
+
+Add `.not` to negate any assertion:
+
+```js
+pm.expect(value).to.not.equal('error')
+pm.expect(list).to.not.be.empty
+```
+
+### pm.response
+
+Access the response object inside your scripts.
+
+#### Properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `pm.response.code` | number | HTTP status code |
+| `pm.response.status` | string | HTTP status text |
+| `pm.response.headers` | HeaderList | Response headers |
+| `pm.response.responseTime` | number | Time to receive the response in milliseconds |
+| `pm.response.responseSize` | number | Size of the response in bytes |
+
+#### Methods
+
+| Method | Returns | Description |
+| --- | --- | --- |
+| `pm.response.text()` | string | Response body as a string |
+| `pm.response.json()` | object | Parse the response body as JSON |
+
+#### Response assertions
+
+Assert directly on `pm.response` using `.to.have` and `.to.be` chains:
+
+```js
+// Status
+pm.response.to.have.status(200)
+pm.response.to.have.status('OK')
+
+// Headers
+pm.response.to.have.header('Content-Type')
+pm.response.to.have.header('Content-Type', 'application/json')
+
+// Body
+pm.response.to.have.jsonBody('data')
+pm.response.to.have.jsonBody('data', { id: 1 })
+
+// JSON Schema validation
+pm.response.to.have.jsonSchema({
+  type: 'object',
+  required: ['id'],
+  properties: { id: { type: 'number' } }
+})
+
+// Status classes
+pm.response.to.be.ok           // 2xx
+pm.response.to.be.error        // 4xx or 5xx
+pm.response.to.not.be.error
+
+// Negation
+pm.response.to.not.have.status(404)
+```
+
+### Variables
+
+Read and write variables at different scopes. All scopes support `.get(name)` and `.set(name, value)`.
+
+| Scope | Description |
+| --- | --- |
+| `pm.variables` | Local to the current script |
+| `pm.environment` | Tied to the active environment |
+| `pm.collectionVariables` | Shared across the collection |
+| `pm.globals` | Available everywhere |
+
+```js
+// Read a variable
+const token = pm.environment.get('auth_token')
+
+// Write a variable
+pm.environment.set('auth_token', 'new-value')
+```
+
+Variables resolve in order: local > environment > collection > global.

--- a/documentation/openapi.md
+++ b/documentation/openapi.md
@@ -382,3 +382,45 @@ info:
 +    source: |-
 +      npm install @your-awesome-company/sdk
 ```
+
+## x-post-response
+
+Add post-response scripts to operations to automatically validate API responses. Scripts use a Postman-compatible syntax and run after each request in the [API Client](/products/api-client/testing).
+
+```diff
+openapi: 3.1.0
+info:
+  title: Example
+  version: 1.0
+paths:
+  '/planets':
+    get:
+      summary: Get all planets
++      x-post-response: |-
++        pm.test("Status code is 200", () => {
++          pm.response.to.have.status(200)
++        })
+```
+
+You can add multiple assertions in a single script:
+
+```diff
+openapi: 3.1.0
+info:
+  title: Example
+  version: 1.0
+paths:
+  '/planets':
+    post:
+      summary: Create a planet
++      x-post-response: |-
++        pm.test("Returns 201", () => {
++          pm.expect(pm.response.code).to.be.oneOf([201, 202])
++        })
++        pm.test("Response is valid JSON", () => {
++          const data = pm.response.json()
++          pm.expect(data).to.be.an('object')
++        })
+```
+
+See [Testing in the API Client](/products/api-client/testing) for all available assertions and the full `pm` API reference.

--- a/documentation/openapi.md
+++ b/documentation/openapi.md
@@ -383,6 +383,41 @@ info:
 +      npm install @your-awesome-company/sdk
 ```
 
+## x-pre-request
+
+Add pre-request scripts to operations or at the document level. Scripts run before the request is sent and can modify headers, set variables, or prepare authentication. See [Scripts in the API Client](/products/api-client/scripts) for the full guide.
+
+On an operation:
+
+```diff
+openapi: 3.1.0
+info:
+  title: Example
+  version: 1.0
+paths:
+  '/users':
+    get:
+      summary: Get all users
++      x-pre-request: |-
++        pm.environment.set('timestamp', new Date().toISOString())
+```
+
+On the document (runs before every operation):
+
+```diff
+openapi: 3.1.0
+info:
+  title: Example
+  version: 1.0
++x-pre-request: |-
++  pm.request.headers.add({
++    key: 'X-Request-Id',
++    value: 'req-' + Date.now()
++  })
+```
+
+When both document-level and operation-level scripts are present, the document-level script runs first.
+
 ## x-post-response
 
 Add post-response scripts to operations to automatically validate API responses. Scripts use a Postman-compatible syntax and run after each request in the [API Client](/products/api-client/testing).

--- a/packages/pre-post-request-scripts/src/consts/example-scripts.ts
+++ b/packages/pre-post-request-scripts/src/consts/example-scripts.ts
@@ -93,4 +93,42 @@ export const EXAMPLE_SCRIPTS: ExampleScript[] = [
       body: { success: true },
     },
   },
+  {
+    title: 'Check header value',
+    script: `pm.test("Content-Type is JSON", () => {
+  pm.expect(pm.response.headers.get('Content-Type')).to.include('application/json')
+})`,
+    mockResponse: {
+      status: 200,
+      body: { success: true },
+      headers: { 'Content-Type': 'application/json' },
+    },
+  },
+  {
+    title: 'Assert data types',
+    script: `pm.test("Response data types are correct", () => {
+  const data = pm.response.json()
+  pm.expect(data).to.be.an('object')
+  pm.expect(data.name).to.be.a('string')
+  pm.expect(data.age).to.be.a('number')
+  pm.expect(data.hobbies).to.be.an('array')
+})`,
+    mockResponse: {
+      status: 200,
+      body: { name: 'Jane', age: 23, hobbies: ['reading'] },
+      headers: { 'Content-Type': 'application/json' },
+    },
+  },
+  {
+    title: 'Check object containment',
+    script: `pm.test("Response contains expected object", () => {
+  const expected = { created: true, errors: [] }
+  pm.expect(pm.response.json()).to.deep.include(expected)
+})`,
+    mockResponse: {
+      status: 200,
+      body: { created: true, errors: [], id: 42 },
+      headers: { 'Content-Type': 'application/json' },
+    },
+  },
 ]

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -143,7 +143,7 @@
         },
         {
           "from": "/download",
-          "to": "/products/api-client/getting-started"
+          "to": "/products/api-client/download"
         },
         {
           "from": "/scalar/introduction",
@@ -543,7 +543,7 @@
         },
         {
           "from": "/download",
-          "to": "/products/api-client/getting-started"
+          "to": "/products/api-client/download"
         },
         {
           "from": "/terms-and-conditions",
@@ -1836,7 +1836,7 @@
                     "filepath": "documentation/guides/app/getting-started.md",
                     "type": "page",
                     "title": "Getting Started",
-                    "description": "Download and start testing APIs with the most beautiful API client built for developers who love great tools.",
+                    "description": "A modern, open-source API client built on the OpenAPI standard with offline-first design and cross-platform support.",
                     "head": {
                       "links": [
                         {
@@ -1847,7 +1847,7 @@
                       "meta": [
                         {
                           "name": "description",
-                          "content": "Download and start testing APIs with the most beautiful API client built for developers who love great tools."
+                          "content": "A modern, open-source API client built on the OpenAPI standard with offline-first design and cross-platform support."
                         },
                         {
                           "property": "og:title",
@@ -1855,7 +1855,71 @@
                         },
                         {
                           "property": "og:description",
-                          "content": "Download and start testing APIs with the most beautiful API client built for developers who love great tools."
+                          "content": "A modern, open-source API client built on the OpenAPI standard with offline-first design and cross-platform support."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
+                  "download": {
+                    "filepath": "documentation/guides/app/download.md",
+                    "type": "page",
+                    "title": "Download",
+                    "description": "Download the Scalar API Client for Windows, macOS, or Linux, or use it in the browser.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/products/api-client/download"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Download the Scalar API Client for Windows, macOS, or Linux, or use it in the browser."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "Download API Client - Windows, macOS, Linux"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "Download the Scalar API Client for Windows, macOS, or Linux, or use it in the browser."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
+                  "testing": {
+                    "filepath": "documentation/guides/app/testing.md",
+                    "type": "page",
+                    "title": "Testing",
+                    "description": "Write post-response scripts to automatically validate API responses with Postman-compatible syntax.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/products/api-client/testing"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Write post-response scripts to automatically validate API responses with Postman-compatible syntax."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "API Testing Scripts - Validate Responses Automatically"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "Write post-response scripts to automatically validate API responses with Postman-compatible syntax."
                         },
                         {
                           "name": "robots",

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1927,6 +1927,38 @@
                         }
                       ]
                     }
+                  },
+                  "import": {
+                    "filepath": "documentation/guides/app/import.md",
+                    "type": "page",
+                    "title": "Import",
+                    "description": "Import API collections from OpenAPI, Swagger 2.0, Postman, or cURL into the Scalar API Client.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/products/api-client/import"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Import API collections from OpenAPI, Swagger 2.0, Postman, or cURL into the Scalar API Client."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "Import APIs - OpenAPI, Swagger, Postman, cURL"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "Import API collections from OpenAPI, Swagger 2.0, Postman, or cURL into the Scalar API Client."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
                   }
                 }
               }

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1896,30 +1896,30 @@
                       ]
                     }
                   },
-                  "testing": {
-                    "filepath": "documentation/guides/app/testing.md",
+                  "import": {
+                    "filepath": "documentation/guides/app/import.md",
                     "type": "page",
-                    "title": "Testing",
-                    "description": "Write post-response scripts to automatically validate API responses with Postman-compatible syntax.",
+                    "title": "Import",
+                    "description": "Import API collections from OpenAPI, Swagger 2.0, Postman, or cURL into the Scalar API Client.",
                     "head": {
                       "links": [
                         {
                           "rel": "canonical",
-                          "href": "https://scalar.com/products/api-client/testing"
+                          "href": "https://scalar.com/products/api-client/import"
                         }
                       ],
                       "meta": [
                         {
                           "name": "description",
-                          "content": "Write post-response scripts to automatically validate API responses with Postman-compatible syntax."
+                          "content": "Import API collections from OpenAPI, Swagger 2.0, Postman, or cURL into the Scalar API Client."
                         },
                         {
                           "property": "og:title",
-                          "content": "API Testing Scripts - Validate Responses Automatically"
+                          "content": "Import APIs - OpenAPI, Swagger, Postman, cURL"
                         },
                         {
                           "property": "og:description",
-                          "content": "Write post-response scripts to automatically validate API responses with Postman-compatible syntax."
+                          "content": "Import API collections from OpenAPI, Swagger 2.0, Postman, or cURL into the Scalar API Client."
                         },
                         {
                           "name": "robots",
@@ -1960,62 +1960,30 @@
                       ]
                     }
                   },
-                  "import": {
-                    "filepath": "documentation/guides/app/import.md",
+                  "testing": {
+                    "filepath": "documentation/guides/app/testing.md",
                     "type": "page",
-                    "title": "Import",
-                    "description": "Import API collections from OpenAPI, Swagger 2.0, Postman, or cURL into the Scalar API Client.",
+                    "title": "Testing",
+                    "description": "Write post-response scripts to automatically validate API responses with Postman-compatible syntax.",
                     "head": {
                       "links": [
                         {
                           "rel": "canonical",
-                          "href": "https://scalar.com/products/api-client/import"
+                          "href": "https://scalar.com/products/api-client/testing"
                         }
                       ],
                       "meta": [
                         {
                           "name": "description",
-                          "content": "Import API collections from OpenAPI, Swagger 2.0, Postman, or cURL into the Scalar API Client."
+                          "content": "Write post-response scripts to automatically validate API responses with Postman-compatible syntax."
                         },
                         {
                           "property": "og:title",
-                          "content": "Import APIs - OpenAPI, Swagger, Postman, cURL"
+                          "content": "API Testing Scripts - Validate Responses Automatically"
                         },
                         {
                           "property": "og:description",
-                          "content": "Import API collections from OpenAPI, Swagger 2.0, Postman, or cURL into the Scalar API Client."
-                        },
-                        {
-                          "name": "robots",
-                          "content": "index, follow"
-                        }
-                      ]
-                    }
-                  },
-                  "community": {
-                    "filepath": "documentation/guides/app/community.md",
-                    "type": "page",
-                    "title": "Community",
-                    "description": "Join the Scalar community on Discord and GitHub. The API Client is fully open-source.",
-                    "head": {
-                      "links": [
-                        {
-                          "rel": "canonical",
-                          "href": "https://scalar.com/products/api-client/community"
-                        }
-                      ],
-                      "meta": [
-                        {
-                          "name": "description",
-                          "content": "Join the Scalar community on Discord and GitHub. The API Client is fully open-source."
-                        },
-                        {
-                          "property": "og:title",
-                          "content": "Community - Discord, GitHub, Open Source"
-                        },
-                        {
-                          "property": "og:description",
-                          "content": "Join the Scalar community on Discord and GitHub. The API Client is fully open-source."
+                          "content": "Write post-response scripts to automatically validate API responses with Postman-compatible syntax."
                         },
                         {
                           "name": "robots",
@@ -2048,6 +2016,38 @@
                         {
                           "property": "og:description",
                           "content": "Keyboard shortcuts for the Scalar API Client on macOS, Windows, and Linux."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
+                  "community": {
+                    "filepath": "documentation/guides/app/community.md",
+                    "type": "page",
+                    "title": "Community",
+                    "description": "Join the Scalar community on Discord and GitHub. The API Client is fully open-source.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/products/api-client/community"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Join the Scalar community on Discord and GitHub. The API Client is fully open-source."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "Community - Discord, GitHub, Open Source"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "Join the Scalar community on Discord and GitHub. The API Client is fully open-source."
                         },
                         {
                           "name": "robots",

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1928,6 +1928,38 @@
                       ]
                     }
                   },
+                  "scripts": {
+                    "filepath": "documentation/guides/app/scripts.md",
+                    "type": "page",
+                    "title": "Scripts",
+                    "description": "Write pre-request scripts to set variables, modify headers, and prepare authentication before sending API requests.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/products/api-client/scripts"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Write pre-request scripts to set variables, modify headers, and prepare authentication before sending API requests."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "Pre-Request Scripts - Scalar API Client"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "Write pre-request scripts to set variables, modify headers, and prepare authentication before sending API requests."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
                   "import": {
                     "filepath": "documentation/guides/app/import.md",
                     "type": "page",
@@ -1952,6 +1984,70 @@
                         {
                           "property": "og:description",
                           "content": "Import API collections from OpenAPI, Swagger 2.0, Postman, or cURL into the Scalar API Client."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
+                  "community": {
+                    "filepath": "documentation/guides/app/community.md",
+                    "type": "page",
+                    "title": "Community",
+                    "description": "Join the Scalar community on Discord and GitHub. The API Client is fully open-source.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/products/api-client/community"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Join the Scalar community on Discord and GitHub. The API Client is fully open-source."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "Community - Discord, GitHub, Open Source"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "Join the Scalar community on Discord and GitHub. The API Client is fully open-source."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
+                  "keyboard-shortcuts": {
+                    "filepath": "documentation/guides/app/keyboard-shortcuts.md",
+                    "type": "page",
+                    "title": "Keyboard Shortcuts",
+                    "description": "Keyboard shortcuts for the Scalar API Client on macOS, Windows, and Linux.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/products/api-client/keyboard-shortcuts"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Keyboard shortcuts for the Scalar API Client on macOS, Windows, and Linux."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "Keyboard Shortcuts - Scalar API Client"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "Keyboard shortcuts for the Scalar API Client on macOS, Windows, and Linux."
                         },
                         {
                           "name": "robots",


### PR DESCRIPTION
before: got no docs for the api client
after: got docs for the api client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds documentation content and site navigation/redirect updates; risk is limited to potential broken links/SEO metadata issues if routes are misconfigured.
> 
> **Overview**
> Adds a new API Client docs section with dedicated pages for **Download**, **Import**, **Scripts** (pre-request), **Testing** (post-response), **Keyboard Shortcuts**, and **Community**, and expands `getting-started.md` from a download list into a feature/quickstart guide.
> 
> Updates `scalar.config.json` to include these pages in navigation (with canonical/meta tags) and changes the `/download` redirect to land on `/products/api-client/download`.
> 
> Extends `documentation/openapi.md` to document `x-pre-request` and `x-post-response` extensions, and adds additional post-response example scripts in `EXAMPLE_SCRIPTS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e163daa76efda99726400515f91945b15f1f0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->