### PR TITLE
docs(scalar-docs): ask ai

### DIFF
--- a/documentation/guides/docs/configuration/ask-ai.md
+++ b/documentation/guides/docs/configuration/ask-ai.md
@@ -1,0 +1,53 @@
+# Ask AI
+
+Ask AI adds an AI-powered assistant to your documentation site. The assistant searches across all your docs content, combines information from multiple pages, and returns a short, accurate answer.
+
+Ask AI is enabled by default for all Scalar Docs projects. No setup required.
+
+## How it works
+
+When a user asks a question, Ask AI searches through all your published documentation. It can combine information from multiple sources to give a complete answer, even when the answer spans several pages.
+
+## MCP integration
+
+You can connect your docs AI to LLMs like Cursor, Claude Code, Windsurf, and other tools that support Model Context Protocol (MCP). This gives the LLM the full context of your documentation, so it can answer questions about your API and product without you copy-pasting docs into the chat.
+
+Just add /mcp to your Scalar Docs domain.
+
+### Cursor
+
+Add the following to your `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "scalar-docs": {
+      "url": "https://<your-domain>/mcp"
+    }
+  }
+}
+```
+
+### Claude Code
+
+Add the MCP server to your Claude Code configuration:
+
+```sh
+claude mcp add scalar-docs https://<your-domain>/mcp
+```
+
+### Other MCP clients
+
+Any MCP-compatible client can connect to your docs AI. Point it to:
+
+```
+https://<your-domain>/mcp
+```
+
+## Configuration
+
+You can configure Ask AI in the [Scalar Dashboard](https://dashboard.scalar.com). Navigate to your Docs project and open the settings to enable or disable the feature, or to adjust its behavior.
+
+## Usage tracking
+
+Track how users interact with Ask AI in the [Scalar Dashboard](https://dashboard.scalar.com). The dashboard shows the number of conversations, common questions, and usage trends over time.

--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -93,7 +93,7 @@
     <div class="feature-item">
       <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-blue">
         <scalar-icon src="phosphor/bold/headset"></scalar-icon>
-        LLM-chat for your API
+        Ask AI
       </b>
     </div>
     <div class="feature-item">
@@ -175,6 +175,9 @@ Put your content where you want: in your repository, any folder, or the Scalar E
       </p>
       <p>
         <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/configuration/private-docs"><scalar-icon src="phosphor/bold/users"></scalar-icon> Private Docs</a>
+      </p>
+      <p>
+        <a class="flex items-center gap-1.5 font-medium text-c-2 hover:bg-b-2 rounded px-2 p-1" href="/products/docs/configuration/ask-ai"><scalar-icon src="phosphor/bold/headset"></scalar-icon> Ask AI</a>
       </p>
       <p class="mt-3 mb-1 pl-2">
         <b class="font-medium">Community</b>

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -847,6 +847,30 @@
                           ]
                         }
                       },
+                      "ask-ai": {
+                        "title": "Ask AI",
+                        "type": "page",
+                        "filepath": "documentation/guides/docs/configuration/ask-ai.md",
+                        "description": "AI-powered assistant that answers questions using your documentation content, with MCP integration for LLMs.",
+                        "head": {
+                          "links": [
+                            {
+                              "rel": "canonical",
+                              "href": "https://scalar.com/products/docs/configuration/ask-ai"
+                            }
+                          ],
+                          "meta": [
+                            {
+                              "name": "description",
+                              "content": "AI-powered assistant that answers questions using your documentation content, with MCP integration for LLMs."
+                            },
+                            {
+                              "name": "robots",
+                              "content": "index, follow"
+                            }
+                          ]
+                        }
+                      },
                       "private-docs": {
                         "title": "Private Docs",
                         "filepath": "documentation/guides/docs/configuration/private-docs.md",


### PR DESCRIPTION
adds an "ask ai" page to the scalar docs documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new page and navigation entries; main risk is broken links or misconfigured route metadata.
> 
> **Overview**
> Documents the **`Ask AI`** feature by adding a new `documentation/guides/docs/configuration/ask-ai.md` page, including MCP client connection examples (e.g., Cursor and Claude Code).
> 
> Updates the Docs getting-started page and `scalar.config.json` navigation/routes to surface `Ask AI` as a configuration page with canonical URL and SEO metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78f3d3f966c7407a08d7a7ead6b9627f9a268305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->