### PR TITLE
fix(api-client): prevent address bar text from hiding under fade overlay while typing

### DIFF
--- a/.changeset/wild-pears-relax.md
+++ b/.changeset/wild-pears-relax.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: prevent address bar text from hiding under fade overlay while typing

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -40,6 +40,7 @@ import type { HttpMethod as HttpMethodType } from '@scalar/helpers/http/http-met
 import { replaceEnvVariables } from '@scalar/helpers/regex/replace-variables'
 import { extractServerFromPath } from '@scalar/helpers/url/extract-server-from-path'
 import { ScalarIconCopy, ScalarIconWarningCircle } from '@scalar/icons'
+import { EditorView } from '@scalar/use-codemirror'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import type {
   ApiReferenceEvents,
@@ -97,6 +98,11 @@ const { percentage, startLoading, stopLoading, isLoading } =
 const style = computed(() => ({
   backgroundColor: `color-mix(in srgb, transparent 90%, ${REQUEST_METHODS[method].colorVar})`,
   transform: `translate3d(-${percentage.value}%,0,0)`,
+}))
+
+/** Keeps the cursor visible past the fade-right overlay while typing */
+const addressBarScrollMargins = EditorView.scrollMargins.of(() => ({
+  right: 24,
 }))
 
 const pathConflict = ref<string | null>(null)
@@ -412,6 +418,7 @@ defineExpose({
           disableTabIndent
           :emitOnBlur="false"
           :environment="environment"
+          :extensions="[addressBarScrollMargins]"
           importCurl
           :layout="layout"
           :modelValue="path"


### PR DESCRIPTION
**Summary**

Use CodeMirror's `EditorView.scrollMargins` to account for the `24px` fade-right overlay when auto-scrolling the cursor into view during typing


| Before | After |
| --- | ----------- |
| <img width="738" height="51" alt="image" src="https://github.com/user-attachments/assets/67528fa9-bc10-4588-a501-3117ca756942" /> | <img width="738" height="51" alt="image" src="https://github.com/user-attachments/assets/79bbb1e6-9a00-40f0-8422-1c2c7f6f6958" /> |

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts CodeMirror scrolling behavior in the address bar; minimal chance of regressions beyond cursor/scroll positioning.
> 
> **Overview**
> Fixes the address bar editor so the caret/text doesn’t auto-scroll under the right-side fade overlay while typing by adding a CodeMirror `EditorView.scrollMargins` extension (24px right margin) to the `CodeInput`.
> 
> Adds a changeset to release `@scalar/api-client` as a patch for this UI fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbe79f9330305114a4919d0cc5f2441b6ec6a493. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->