### PR TITLE
fix(api-client): Add support for text/json media type

### DIFF
--- a/.changeset/deep-jeans-like.md
+++ b/.changeset/deep-jeans-like.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Add support for `text/json` media type

--- a/packages/api-client/src/views/Request/consts/mediaTypes.ts
+++ b/packages/api-client/src/views/Request/consts/mediaTypes.ts
@@ -108,6 +108,7 @@ export const mediaTypes: { [type: string]: MediaConfig | undefined } = {
     preview: 'object',
   },
   'text/javascript': { extension: '.js', raw: true },
+  'text/json': { extension: '.json', raw: true, language: 'json' },
   'text/plain': { extension: '.txt', raw: true },
   'text/xml': { extension: '.xml', raw: true, language: 'xml' },
   'text/yaml': { extension: '.yaml', raw: true, language: 'yaml' },


### PR DESCRIPTION
## Problem

Some weirdos (me) use `content-type: text/json` instead of `application/json`.  
Because of that, in the response it doesn't show the json tree, instead is just says "Binary file".

<img width="1920" height="1046" alt="image" src="https://github.com/user-attachments/assets/d6f89cf1-482f-47e0-853f-4ad4c166e7f5" />


## Solution

Of course I can just update headers to `application/json`. And I did it. But why not make life easier for future users?

## Checklist

- [X] I explained why the change is needed.
- [X] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

---

To be honest, I didn't manage to run any build scripts in my IDE. Maybe because all scripts are not made for Windows. So this is blind pull request, but I'm 100% sure that will work!

Thank you