### PR TITLE
refactor(api-reference): remove search hook @ts-expect-error

### DIFF
--- a/.changeset/small-pants-build.md
+++ b/.changeset/small-pants-build.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+refactor(api-reference): remove search index ts-expect-error by using typed collection access

--- a/packages/api-reference/src/features/Search/hooks/useSearchIndex.ts
+++ b/packages/api-reference/src/features/Search/hooks/useSearchIndex.ts
@@ -12,10 +12,12 @@ const MAX_SEARCH_RESULTS = 25
  * Creates the search index from an OpenAPI document.
  */
 export function useSearchIndex(document: MaybeRefOrGetter<OpenApiDocument | undefined>) {
+  const searchIndex = computed<FuseData[]>(() => createSearchIndex(toValue(document)))
+
   /** When the document changes we replace the search index */
   const fuse = computed(() => {
     const instance = createFuseInstance()
-    instance.setCollection(createSearchIndex(toValue(document)))
+    instance.setCollection(searchIndex.value)
     return instance
   })
 
@@ -28,11 +30,8 @@ export function useSearchIndex(document: MaybeRefOrGetter<OpenApiDocument | unde
       })
     }
 
-    // @ts-expect-error - _docs is a private property
-    const allEntries: FuseData[] = fuse.value._docs
-
     // Show a few entries as a placeholder
-    return allEntries.slice(0, MAX_SEARCH_RESULTS).map(
+    return searchIndex.value.slice(0, MAX_SEARCH_RESULTS).map(
       (item: FuseData, index: number) =>
         ({
           item,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

There are no literal `@ts-ignore` directives in `@scalar/api-reference`, but there is equivalent type-suppression debt in production search code: `@ts-expect-error` was used to access Fuse's private `_docs` property.

## Solution

- Added a typed `searchIndex` computed source (`FuseData[]`) in `useSearchIndex`.
- Reused that same typed collection for both `fuse.setCollection(...)` and placeholder results when the query is empty.
- Removed the `@ts-expect-error` that accessed Fuse private internals.
- Added a changeset for `@scalar/api-reference`.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c305adbb-84b8-4fd6-bd02-27d214f4a478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c305adbb-84b8-4fd6-bd02-27d214f4a478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

