### PR TITLE
refactor(api-reference): type window debug workspace dump

### DIFF
--- a/.changeset/quick-forks-retire.md
+++ b/.changeset/quick-forks-retire.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+refactor(api-reference): remove window debug ts-expect-error with explicit global typing

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -37,6 +37,7 @@ import type {
   TraversedEntry,
   TraversedTag,
 } from '@scalar/workspace-store/schemas/navigation'
+import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import { useScrollLock } from '@vueuse/core'
 import diff from 'microdiff'
 import {
@@ -91,6 +92,12 @@ import { AGENT_CONTEXT_SYMBOL, useAgent } from '@/hooks/use-agent'
 import { useIntersection } from '@/hooks/use-intersection'
 import { createPluginManager, PLUGIN_MANAGER_SYMBOL } from '@/plugins'
 import { persistencePlugin } from '@/plugins/persistance-plugin'
+
+declare global {
+  interface Window {
+    dataDumpWorkspace?: () => WorkspaceStore
+  }
+}
 
 const props = defineProps<{
   /**
@@ -441,7 +448,6 @@ const environment = computed(
 )
 
 if (typeof window !== 'undefined') {
-  // @ts-expect-error - For debugging purposes expose the store
   window.dataDumpWorkspace = () => workspaceStore
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`@scalar/api-reference` had a production `@ts-expect-error` in `ApiReference.vue` to attach `dataDumpWorkspace` onto `window` for debugging.

## Solution

- Added explicit global `Window` augmentation for `dataDumpWorkspace` using `WorkspaceStore`.
- Removed the `@ts-expect-error` and kept the debug behavior unchanged.
- Added a patch changeset for `@scalar/api-reference`.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c305adbb-84b8-4fd6-bd02-27d214f4a478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c305adbb-84b8-4fd6-bd02-27d214f4a478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

