### PR TITLE
docs(agents): require pnpm format and pnpm knip before PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,14 @@ If your PR will cause a version bump for any package, add a changeset:
 pnpm changeset
 ```
 
+### Pre-PR command checklist
+
+After making code changes, run `pnpm format` before opening or updating a PR.
+
+```bash
+pnpm format
+```
+
 ## Visual Testing
 
 When making changes that affect the UI, **PRs must include visual artifacts** (screenshots and/or demo videos) demonstrating the visual impact. Most package dependencies trickle up into three main visual surfaces: `api-reference`, `api-client`, and `components`. Test your changes in whichever playground is relevant.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,10 +174,11 @@ pnpm changeset
 
 ### Pre-PR command checklist
 
-After making code changes, run `pnpm format` before opening or updating a PR.
+After making code changes, run `pnpm format` and `pnpm knip` before opening or updating a PR.
 
 ```bash
 pnpm format
+pnpm knip
 ```
 
 ## Visual Testing


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Agents can miss required maintenance checks after making edits, even when commands are listed in the guide.

## Solution

Add a dedicated **Pre-PR command checklist** section to `AGENTS.md` that explicitly requires running both `pnpm format` and `pnpm knip` before opening or updating a pull request.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa51e498-3432-4c1d-afb5-fd65dd364387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa51e498-3432-4c1d-afb5-fd65dd364387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

