### PR TITLE
fix(server-side-rendering): harden SSR hydration script serialization

### DIFF
--- a/.changeset/green-shrimps-build.md
+++ b/.changeset/green-shrimps-build.md
@@ -1,0 +1,5 @@
+---
+'@scalar/server-side-rendering': patch
+---
+
+fix(server-side-rendering): harden inline script serialization against injection

--- a/packages/server-side-rendering/src/ssr.test.ts
+++ b/packages/server-side-rendering/src/ssr.test.ts
@@ -113,6 +113,23 @@ describe('ssr', () => {
       expect(script).toContain('dark-mode')
       expect(script).not.toContain('localStorage')
     })
+
+    it('ignores non-boolean darkMode values and falls back to matchMedia', () => {
+      const script = generateBodyScript({ darkMode: 'true);window.__pwned=1;//' as unknown as boolean })
+
+      expect(script).toContain('matchMedia')
+      expect(script).not.toContain('window.__pwned=1')
+    })
+
+    it('ignores invalid forceDarkModeState values', () => {
+      const script = generateBodyScript({
+        forceDarkModeState: `dark');window.__pwned=2;//` as unknown as 'dark' | 'light',
+      })
+
+      expect(script).toContain('localStorage')
+      expect(script).toContain('matchMedia')
+      expect(script).not.toContain('window.__pwned=2')
+    })
   })
 
   describe('renderApiReference', () => {
@@ -216,7 +233,19 @@ describe('ssr', () => {
       expect(html).toContain('"url":"https://example.com/api.json"')
     })
 
-    it('preserves function properties in the hydration script', async () => {
+    it('prevents script breakout in hydration config serialization', async () => {
+      const html = await renderApiReference({
+        config: {
+          title: '</script><script>window.__pwned=1</script>',
+        },
+        css: '',
+      })
+
+      expect(html).not.toContain('</script><script>window.__pwned=1</script>')
+      expect(html).toContain('"title":"\\u003c/script\\u003e\\u003cscript\\u003ewindow.__pwned=1\\u003c/script\\u003e"')
+    })
+
+    it('drops function properties from hydration config serialization', async () => {
       const html = await renderApiReference({
         config: {
           url: 'https://example.com/api.json',
@@ -225,11 +254,13 @@ describe('ssr', () => {
         css: '',
       })
 
-      expect(html).toContain('"onLoaded": () => console.log')
-      expect(html).toContain('"url":"https://example.com/api.json"')
+      expect(html).toContain('Scalar.createApiReference')
+      expect(html).toContain('{"url":"https://example.com/api.json"}')
+      expect(html).not.toContain('onLoaded')
+      expect(html).not.toContain('console.log')
     })
 
-    it('serializes function-only configuration without invalid leading comma', async () => {
+    it('serializes function-only configuration as empty object', async () => {
       const html = await renderApiReference({
         config: {
           onLoaded: () => console.log('loaded'),
@@ -237,9 +268,7 @@ describe('ssr', () => {
         css: '',
       })
 
-      expect(html).toContain('Scalar.createApiReference')
-      expect(html).toContain('{"onLoaded": () => console.log("loaded")}')
-      expect(html).not.toContain('{, "onLoaded"')
+      expect(html).toContain("Scalar.createApiReference('#app', {})")
     })
   })
 

--- a/packages/server-side-rendering/src/ssr.ts
+++ b/packages/server-side-rendering/src/ssr.ts
@@ -17,6 +17,20 @@ function unwrapConfig(configuration: AnyApiReferenceConfiguration): Record<strin
   return (config ?? {}) as Record<string, unknown>
 }
 
+function parseForceDarkModeState(config: Record<string, unknown>): 'dark' | 'light' | null {
+  const forced = config.forceDarkModeState
+
+  if (forced === 'dark' || forced === 'light') {
+    return forced
+  }
+
+  return null
+}
+
+function parseDarkMode(config: Record<string, unknown>): boolean | null {
+  return typeof config.darkMode === 'boolean' ? config.darkMode : null
+}
+
 /**
  * Generate an inline script that detects the user's color mode preference
  * and applies the correct class to <body> before content paints.
@@ -33,8 +47,8 @@ function unwrapConfig(configuration: AnyApiReferenceConfiguration): Record<strin
  */
 export function generateBodyScript(configuration: AnyApiReferenceConfiguration): string {
   const config = unwrapConfig(configuration)
-  const forced = (config.forceDarkModeState as string | undefined) ?? null
-  const darkMode = (config.darkMode as boolean | undefined) ?? null
+  const forced = parseForceDarkModeState(config)
+  const darkMode = parseDarkMode(config)
 
   /** When forceDarkModeState is set, we do not need runtime detection at all. */
   if (forced) {
@@ -61,8 +75,8 @@ export function generateBodyScript(configuration: AnyApiReferenceConfiguration):
  */
 function getInitialBodyClass(configuration: AnyApiReferenceConfiguration): 'dark-mode' | 'light-mode' {
   const config = unwrapConfig(configuration)
-  const forced = (config.forceDarkModeState as string | undefined) ?? null
-  const darkMode = (config.darkMode as boolean | undefined) ?? null
+  const forced = parseForceDarkModeState(config)
+  const darkMode = parseDarkMode(config)
 
   if (forced) {
     return forced === 'dark' ? 'dark-mode' : 'light-mode'
@@ -128,39 +142,34 @@ function escapeHtmlAttribute(str: string): string {
   return escapeHtml(str).replace(/"/g, '&quot;').replace(/'/g, '&#39;')
 }
 
-/** Serialize an array that may contain functions. */
-function serializeArrayWithFunctions(arr: unknown[]): string {
-  return `[${arr.map((item) => (typeof item === 'function' ? item.toString() : JSON.stringify(item))).join(', ')}]`
+/**
+ * Escape a JSON string so it is safe to embed inside an inline script tag.
+ * This prevents user content from closing the script tag.
+ */
+function escapeJsonForInlineScript(json: string): string {
+  return json
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')
 }
 
 /**
- * Serialize a configuration object to a JavaScript expression string,
- * preserving function values (which JSON.stringify would silently drop).
+ * Serialize a configuration object to JSON for hydration.
+ * Function values are intentionally stripped because they cannot be safely
+ * represented in an inline script.
  */
 function serializeConfigToJs(config: Record<string, unknown>): string {
-  const jsonProps: Record<string, unknown> = {}
-  const functionProps: string[] = []
-
-  for (const [key, value] of Object.entries(config)) {
+  const jsonString = JSON.stringify(config, (_, value) => {
     if (typeof value === 'function') {
-      functionProps.push(`"${key}": ${value.toString()}`)
-    } else if (Array.isArray(value) && value.some((item) => typeof item === 'function')) {
-      functionProps.push(`"${key}": ${serializeArrayWithFunctions(value)}`)
-    } else {
-      jsonProps[key] = value
+      return undefined
     }
-  }
 
-  const jsonString = JSON.stringify(jsonProps)
+    return value
+  })
 
-  if (functionProps.length === 0) {
-    return jsonString
-  }
-
-  const jsonEntries = jsonString === '{}' ? '' : jsonString.slice(1, -1)
-  const functionEntries = functionProps.join(', ')
-
-  return `{${[jsonEntries, functionEntries].filter(Boolean).join(', ')}}`
+  return escapeJsonForInlineScript(jsonString)
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`@scalar/server-side-rendering` allowed unsafe values to flow into inline hydration scripts.

Specifically:
- config values containing `</script>` could break out of the hydration script tag
- non-boolean runtime values for `darkMode` and invalid values for `forceDarkModeState` could alter generated inline script logic
- function-valued config properties were serialized into executable inline script source

## Solution

- Added runtime parsing guards for `darkMode` and `forceDarkModeState` so only valid primitive values are used in inline script generation.
- Replaced function-preserving config serialization with JSON-only serialization that drops function values.
- Added explicit escaping for JSON embedded in inline scripts (`<`, `>`, `&`, U+2028, U+2029) to prevent script tag breakout.
- Added security-focused unit tests that cover the three identified findings and verify safe output behavior.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d06a275c-ac1b-440b-adac-3b4b96d3890c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d06a275c-ac1b-440b-adac-3b4b96d3890c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

