### PR TITLE
build(agent-chat, code-highlight): replace cp with shx cp in package build scripts

### DIFF
--- a/packages/agent-chat/package.json
+++ b/packages/agent-chat/package.json
@@ -15,7 +15,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "vite build && vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && cp package.json dist",
+    "build": "vite build && vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && shx cp package.json dist",
     "build:watch": "vite build --watch",
     "playground": "cd playground && vite",
     "types:check": "vue-tsc --noEmit"

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -21,7 +21,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && cp -r src/css dist/css",
+    "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && shx cp -r src/css dist/css",
     "dev": "vite",
     "test": "vitest",
     "types:check": "tsc --noEmit"


### PR DESCRIPTION
## Problem

The `agent-chat` and `code-highlight` package build scripts use the Unix `cp` command to copy build artifacts into `dist`.

This works in Unix-like environments, but can fail on Windows where `cp` is not available by default.

## Solution

Replace `cp` with `shx cp` in the affected package `build` scripts:
- `packages/agent-chat/package.json`
- `packages/code-highlight/package.json`

Many other scripts already use `shx`, so this appears the be the intended solution.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset.
- [ ] I added tests.
- [ ] I updated the documentation.
