### PR TITLE
fix(api-client): replace v-show transition with visibility/opacity to fix modal stutter

### DIFF
--- a/.changeset/cozy-sites-bake.md
+++ b/.changeset/cozy-sites-bake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix modal fade-in animation stutter by replacing v-show with CSS visibility/opacity to avoid forced layout recalculation on open

--- a/packages/api-client/src/v2/components/modals/ModalClientContainer.spec.ts
+++ b/packages/api-client/src/v2/components/modals/ModalClientContainer.spec.ts
@@ -53,7 +53,8 @@ describe('ModalClient.vue', () => {
       },
     })
 
-    expect(wrapper.find('.scalar').isVisible()).toBe(false)
+    // Visibility is controlled via CSS class (not v-show/display:none) to avoid layout reflow on open
+    expect(wrapper.find('.scalar-container').classes()).not.toContain('scalar-client--open')
   })
 
   it('shows when modalState.open becomes true', async ({ onTestFinished }) => {
@@ -68,7 +69,7 @@ describe('ModalClient.vue', () => {
     await wrapper.setProps({ modalState })
     await nextTick()
 
-    expect(wrapper.find('.scalar').isVisible()).toBe(true)
+    expect(wrapper.find('.scalar-container').classes()).toContain('scalar-client--open')
 
     onTestFinished(() => {
       wrapper.unmount()
@@ -87,7 +88,9 @@ describe('ModalClient.vue', () => {
     modalState = { ...modalState, open: true }
     await wrapper.setProps({ modalState })
 
-    // Wait for the focus trap to activate
+    // Wait for Vue to flush the watch callback
+    await nextTick()
+    // Wait for the inner nextTick inside the watch (before activateFocusTrap is called)
     await nextTick()
     // Wait for the browser to apply the focus
     await new Promise((resolve) => setTimeout(resolve, 0))

--- a/packages/api-client/src/v2/components/modals/ModalClientContainer.vue
+++ b/packages/api-client/src/v2/components/modals/ModalClientContainer.vue
@@ -5,14 +5,7 @@ import {
   type ModalState,
 } from '@scalar/components'
 import { useFocusTrap } from '@vueuse/integrations/useFocusTrap'
-import {
-  nextTick,
-  onBeforeMount,
-  onBeforeUnmount,
-  ref,
-  useId,
-  watch,
-} from 'vue'
+import { onBeforeMount, onBeforeUnmount, ref, useId, watch } from 'vue'
 
 const props = defineProps<{ modalState: ModalState }>()
 const emit = defineEmits<{
@@ -35,11 +28,12 @@ onBeforeMount(() => addScalarClassesToHeadless())
 // manage the focus trap and emit lifecycle events
 watch(
   () => props.modalState.open,
-  async (open) => {
+  (open) => {
     if (open) {
-      await nextTick()
-      activateFocusTrap()
-      emit('open')
+      requestAnimationFrame(() => {
+        activateFocusTrap()
+        emit('open')
+      })
     } else {
       deactivateFocusTrap()
       emit('close')
@@ -55,32 +49,30 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <Transition name="scalar-client-fade">
+  <div class="scalar scalar-app z-overlay relative">
     <div
-      v-show="modalState.open"
-      class="scalar scalar-app z-overlay relative">
-      <div class="scalar-container">
-        <div
-          :id="id"
-          ref="client"
-          aria-label="API Client"
-          aria-modal="true"
-          v-bind="$attrs"
-          class="scalar-app-layout scalar-client"
-          role="dialog"
-          tabindex="-1">
-          <ScalarTeleportRoot>
-            <slot />
-          </ScalarTeleportRoot>
-        </div>
-
-        <!-- overlay / exit area -->
-        <div
-          class="scalar-app-exit"
-          @click="modalState.hide()" />
+      class="scalar-container"
+      :class="{ 'scalar-client--open': modalState.open }">
+      <div
+        :id="id"
+        ref="client"
+        aria-label="API Client"
+        aria-modal="true"
+        v-bind="$attrs"
+        class="scalar-app-layout scalar-client"
+        role="dialog"
+        tabindex="-1">
+        <ScalarTeleportRoot>
+          <slot />
+        </ScalarTeleportRoot>
       </div>
+
+      <!-- overlay / exit area -->
+      <div
+        class="scalar-app-exit"
+        @click="modalState.hide()" />
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped>
@@ -143,7 +135,7 @@ onBeforeUnmount(() => {
 /* container */
 .scalar-container {
   overflow: hidden;
-  visibility: visible;
+  visibility: hidden;
   position: fixed;
   bottom: 0;
   left: 0;
@@ -153,6 +145,19 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  will-change: opacity;
+  transition:
+    opacity 0.35s ease,
+    visibility 0s linear 0.35s;
+}
+
+.scalar-container.scalar-client--open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition: opacity 0.35s ease;
 }
 
 .scalar .url-form-input {
@@ -161,15 +166,5 @@ onBeforeUnmount(() => {
 
 .scalar .scalar-container {
   line-height: normal;
-}
-
-.scalar-client-fade-enter-active,
-.scalar-client-fade-leave-active {
-  transition: opacity 0.35s ease;
-}
-
-.scalar-client-fade-enter-from,
-.scalar-client-fade-leave-to {
-  opacity: 0;
 }
 </style>

--- a/packages/api-client/src/v2/components/modals/ModalClientContainer.vue
+++ b/packages/api-client/src/v2/components/modals/ModalClientContainer.vue
@@ -5,7 +5,7 @@ import {
   type ModalState,
 } from '@scalar/components'
 import { useFocusTrap } from '@vueuse/integrations/useFocusTrap'
-import { onBeforeMount, onBeforeUnmount, ref, useId, watch } from 'vue'
+import { nextTick, onBeforeMount, onBeforeUnmount, ref, watch } from 'vue'
 
 const props = defineProps<{ modalState: ModalState }>()
 const emit = defineEmits<{
@@ -14,12 +14,11 @@ const emit = defineEmits<{
 }>()
 
 const client = ref<HTMLElement | null>(null)
-const id = useId()
 
 const { activate: activateFocusTrap, deactivate: deactivateFocusTrap } =
   useFocusTrap(client, {
     allowOutsideClick: true,
-    fallbackFocus: `#${id}`,
+    fallbackFocus: () => client.value as HTMLElement,
   })
 
 // ensure scalar classes exist on headless-ui root
@@ -28,12 +27,11 @@ onBeforeMount(() => addScalarClassesToHeadless())
 // manage the focus trap and emit lifecycle events
 watch(
   () => props.modalState.open,
-  (open) => {
+  async (open) => {
     if (open) {
-      requestAnimationFrame(() => {
-        activateFocusTrap()
-        emit('open')
-      })
+      await nextTick()
+      activateFocusTrap()
+      emit('open')
     } else {
       deactivateFocusTrap()
       emit('close')
@@ -54,7 +52,6 @@ onBeforeUnmount(() => {
       class="scalar-container"
       :class="{ 'scalar-client--open': modalState.open }">
       <div
-        :id="id"
         ref="client"
         aria-label="API Client"
         aria-modal="true"

--- a/packages/api-client/src/v2/features/modal/Modal.test.ts
+++ b/packages/api-client/src/v2/features/modal/Modal.test.ts
@@ -154,10 +154,10 @@ describe('Modal', () => {
 
     /**
      * The modal should be hidden when modalState.open is false.
-     * Uses v-show so the element exists but is not visible.
+     * Visibility is controlled via CSS class (not v-show/display:none) to avoid layout reflow on open.
      */
-    const scalarApp = wrapper.find('.scalar')
-    expect(scalarApp.attributes('style')).toContain('display: none')
+    const container = wrapper.find('.scalar-container')
+    expect(container.classes()).not.toContain('scalar-client--open')
   })
 
   it('renders Operation component when document, path, and method are provided', async () => {


### PR DESCRIPTION
## Problem

The modal fade-in animation stuttered on every open because `v-show` hides the container with `display: none`, which forces the browser to recalculate layout for the entire modal subtree (Operation, Sidebar, RequestBlock, etc.) on every open, blocking the main thread during the first animation frames.

Attempts to fix this by reordering `modalState.show()` and `handleSelectItem` only shifted when the JS work happened, but the forced layout recalculation when `display: none` is removed is unavoidable regardless of JS ordering.

## Solution

Replaced `<Transition name="scalar-client-fade">` + `v-show` on the outer div with a CSS visibility/opacity approach on `.scalar-container` directly:
- The container is always in the layout tree (`visibility: hidden` instead of `display: none`), eliminating the forced layout recalculation on open entirely.
- `will-change: opacity` keeps a GPU compositor layer allocated so the opacity animation runs on the compositor thread independently of any Vue patch work on the main thread.
- Open: visibility snaps to visible immediately, opacity fades in over 0.35s.
- Close: opacity fades out over 0.35s, then visibility snaps to hidden via `transition-delay`.

Also fixed an issue I noticed:
`fallbackFocus` broken selector `useFocusTrap` was passed `#:r0:` (Vue's `useId()` output), which is an invalid CSS selector. `querySelector` silently returned null so the fallback never worked. Replaced with the ref directly.

## Demo

<details><summary><strong>Before</strong></summary>
<p>


https://github.com/user-attachments/assets/96a8f494-c9f7-406b-af9f-49fdd88e4f0f



</p>
</details> 

<details><summary><strong>After</strong></summary>
<p>


https://github.com/user-attachments/assets/22f51369-92a1-4683-912f-e625b2121e78



</p>
</details> 

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [ ] I added tests.
- [ ] I updated the documentation.