### PR TITLE
fix(api-client-react): config is not reactive

### DIFF
--- a/.changeset/fast-moose-visit.md
+++ b/.changeset/fast-moose-visit.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client-react': patch
+'@scalar/api-client': patch
+---
+
+feat: allow updating the proxyUrl and make options reactive in api-client

--- a/packages/api-client-react/README.md
+++ b/packages/api-client-react/README.md
@@ -46,10 +46,20 @@ export const OpenButton = () => {
 
 ### Options
 
-| Option | Type | Description |
-|---|---|---|
-| `configuration.url` | `string` | URL of an OpenAPI document to load |
-| `configuration.content` | `Record<string, unknown>` | Inline OpenAPI document object |
+For the complete list of configuration options, see the [Scalar configuration docs](https://scalar.com/products/api-references/configuration).
+
+| Option | Description |
+|---|---|
+| `configuration.url` | [Required] Pass the URL of an OpenAPI document (JSON or YAML). |
+| `configuration.proxyUrl` | Use a proxy URL to send requests to other origins when CORS blocks direct browser requests. |
+| `configuration.authentication` | Prefill authentication credentials and default security scheme behavior for users. |
+| `configuration.baseServerURL` | Prefix all relative servers with a base URL. |
+| `configuration.hideClientButton` | Whether to hide the client button from the reference sidebar and modal. |
+| `configuration.hiddenClients` | Control which HTTP code-example clients are shown; pass `[]` to show all clients. |
+| `configuration.oauth2RedirectUri` | Set the default OAuth 2.0 redirect URI for authorization code and implicit flows. |
+| `configuration.servers` | Pass a list of servers to override the servers in your OpenAPI document. |
+
+<!-- | `configuration.content` | `Record<string, unknown>` | Inline OpenAPI document object | -->
 
 ### Routing to a specific request
 

--- a/packages/api-client-react/package.json
+++ b/packages/api-client-react/package.json
@@ -46,7 +46,6 @@
   ],
   "dependencies": {
     "@scalar/api-client": "workspace:*",
-    "@scalar/types": "workspace:*",
     "@scalar/workspace-store": "workspace:*"
   },
   "devDependencies": {

--- a/packages/api-client-react/package.json
+++ b/packages/api-client-react/package.json
@@ -46,6 +46,7 @@
   ],
   "dependencies": {
     "@scalar/api-client": "workspace:*",
+    "@scalar/helpers": "workspace:*",
     "@scalar/workspace-store": "workspace:*"
   },
   "devDependencies": {

--- a/packages/api-client-react/playground/App.tsx
+++ b/packages/api-client-react/playground/App.tsx
@@ -7,7 +7,7 @@ const GALAXY_URL = 'https://registry.scalar.com/@scalar/apis/galaxy?format=json'
 
 export const App = ({ initialRequest, url = GALAXY_URL }: { initialRequest: RoutePayload; url?: string }) => {
   const client = useApiClient({
-    configuration: { url },
+    configuration: { url, proxyUrl: 'https://proxy.scalar.com' },
   })
 
   return <button onClick={() => client?.open(initialRequest)}>Click me to open the Api Client</button>

--- a/packages/api-client-react/src/lazy-load.ts
+++ b/packages/api-client-react/src/lazy-load.ts
@@ -1,4 +1,4 @@
-import type { ApiClientConfiguration } from '@scalar/types/api-reference'
+import type { ApiClientModalOptions } from '@scalar/api-client/v2/features/modal'
 
 /**
  * Creates a lazy singleton getter: the factory runs at most once, caches the resulting promise,
@@ -39,11 +39,11 @@ export const getWorkspaceEventBusSingleton = makeLazySingleton(() =>
  * Lazily creates the singleton Vue app, mounts it as the last child of document.body,
  * and returns the controller. Subsequent calls return the same promise.
  *
- * Only modal-level options (e.g. `proxyUrl`) are accepted here. Document-specific fields
+ * Only modal-supported options are accepted here. Document-specific fields
  * (`url`, `content`) must be registered via `workspaceStore.addDocument` after the client
  * is ready — they are not part of the modal constructor.
  */
-export const getOrCreateApiClient = makeLazySingleton(async (options: Partial<ApiClientConfiguration> = {}) => {
+export const getOrCreateApiClient = makeLazySingleton(async (options: ApiClientModalOptions = {}) => {
   const el = document.createElement('div')
   el.className = 'scalar-app'
   document.body.appendChild(el)

--- a/packages/api-client-react/src/use-api-client.test.ts
+++ b/packages/api-client-react/src/use-api-client.test.ts
@@ -1,6 +1,8 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ApiClientConfigurationReact } from './use-api-client'
+
 // Mock the style import so it doesn't fail in jsdom
 vi.mock('./style.css', () => ({}))
 
@@ -508,15 +510,19 @@ describe('use-api-client', () => {
 
   it('calls updateOptions when configuration changes', async () => {
     const { useApiClient } = await import('./use-api-client')
-    const { rerender } = renderHook(({ config }) => useApiClient({ configuration: config }), {
-      initialProps: {
-        config: {
-          authentication: {
-            preferredSecurityScheme: 'bearerAuth',
-          },
+    const initialProps: { config: ApiClientConfigurationReact } = {
+      config: {
+        authentication: {
+          preferredSecurityScheme: 'bearerAuth',
         },
       },
-    })
+    }
+    const { rerender } = renderHook(
+      ({ config }: { config: ApiClientConfigurationReact }) => useApiClient({ configuration: config }),
+      {
+        initialProps,
+      },
+    )
 
     await waitFor(() => expect(mockApiClient.updateOptions).toHaveBeenCalled())
 

--- a/packages/api-client-react/src/use-api-client.test.ts
+++ b/packages/api-client-react/src/use-api-client.test.ts
@@ -55,14 +55,14 @@ describe('use-api-client', () => {
     vi.mocked(getOrCreateApiClient).mockReturnValue(new Promise(() => {}))
 
     const { useApiClient } = await import('./use-api-client')
-    const { result } = renderHook(() => useApiClient())
+    const { result } = renderHook(() => useApiClient({ configuration: { url: '' } }))
 
     expect(result.current).toBeUndefined()
   })
 
   it('returns the client after the async initialization resolves', async () => {
     const { useApiClient } = await import('./use-api-client')
-    const { result } = renderHook(() => useApiClient())
+    const { result } = renderHook(() => useApiClient({ configuration: { url: '' } }))
 
     await waitFor(() => expect(result.current).not.toBeUndefined())
 
@@ -72,7 +72,7 @@ describe('use-api-client', () => {
 
   it('spreads all apiClient properties onto the returned object', async () => {
     const { useApiClient } = await import('./use-api-client')
-    const { result } = renderHook(() => useApiClient())
+    const { result } = renderHook(() => useApiClient({ configuration: { url: '' } }))
 
     await waitFor(() => expect(result.current).not.toBeUndefined())
 
@@ -100,12 +100,12 @@ describe('use-api-client', () => {
     })
   })
 
-  it('uses the content title as documentSlug when url is not provided', async () => {
+  it('uses "default" as documentSlug when url is an empty string', async () => {
     const { useApiClient } = await import('./use-api-client')
     const { result } = renderHook(() =>
       useApiClient({
         configuration: {
-          content: { info: { title: 'My API' } },
+          url: '',
         },
       }),
     )
@@ -117,15 +117,15 @@ describe('use-api-client', () => {
     })
 
     expect(mockApiClient.open).toHaveBeenCalledWith({
-      documentSlug: 'My API',
+      documentSlug: 'default',
       path: '/users',
       method: 'get',
     })
   })
 
-  it('uses "default" as documentSlug when neither url nor content title is provided', async () => {
+  it('uses "default" as documentSlug when url is empty', async () => {
     const { useApiClient } = await import('./use-api-client')
-    const { result } = renderHook(() => useApiClient({ configuration: {} }))
+    const { result } = renderHook(() => useApiClient({ configuration: { url: '' } }))
 
     await waitFor(() => expect(result.current).not.toBeUndefined())
 
@@ -152,30 +152,9 @@ describe('use-api-client', () => {
     })
   })
 
-  it('calls workspaceStore.addDocument with inline content when content is configured', async () => {
-    const inlineContent = { info: { title: 'My API' }, paths: {} }
+  it('calls workspaceStore.addDocument with "default" slug when url is empty', async () => {
     const { useApiClient } = await import('./use-api-client')
-    renderHook(() => useApiClient({ configuration: { content: inlineContent } }))
-
-    await waitFor(() => expect(mockWorkspaceStore.addDocument).toHaveBeenCalled())
-
-    expect(mockWorkspaceStore.addDocument).toHaveBeenCalledWith({
-      name: 'My API',
-      document: inlineContent,
-    })
-  })
-
-  it('does not call addDocument when no configuration is provided', async () => {
-    const { useApiClient } = await import('./use-api-client')
-    renderHook(() => useApiClient())
-
-    // Give the effect time to run
-    await waitFor(() => expect(mockWorkspaceStore.addDocument).not.toHaveBeenCalled())
-  })
-
-  it('calls addDocument with "default" slug when configuration has no url or content', async () => {
-    const { useApiClient } = await import('./use-api-client')
-    renderHook(() => useApiClient({ configuration: {} }))
+    renderHook(() => useApiClient({ configuration: { url: '' } }))
 
     await waitFor(() => expect(mockWorkspaceStore.addDocument).toHaveBeenCalled())
 
@@ -185,7 +164,26 @@ describe('use-api-client', () => {
     })
   })
 
-  it('uses "default" slug when url changes to empty configuration', async () => {
+  it('calls addDocument with "default" when configuration url is empty', async () => {
+    const { useApiClient } = await import('./use-api-client')
+    renderHook(() => useApiClient({ configuration: { url: '' } }))
+
+    await waitFor(() => expect(mockWorkspaceStore.addDocument).toHaveBeenCalledWith({ name: 'default', url: '' }))
+  })
+
+  it('calls addDocument with "default" slug when configuration has no url or content', async () => {
+    const { useApiClient } = await import('./use-api-client')
+    renderHook(() => useApiClient({ configuration: { url: '' } }))
+
+    await waitFor(() => expect(mockWorkspaceStore.addDocument).toHaveBeenCalled())
+
+    expect(mockWorkspaceStore.addDocument).toHaveBeenCalledWith({
+      name: 'default',
+      url: '',
+    })
+  })
+
+  it('uses "default" slug when url changes to empty string', async () => {
     vi.resetModules()
 
     const { getOrCreateApiClient } = await import('./lazy-load')
@@ -198,13 +196,13 @@ describe('use-api-client', () => {
 
     // Start with a valid url so client is initialized
     const { rerender } = renderHook(({ config }) => useApiClient({ configuration: config }), {
-      initialProps: { config: { url: 'https://api.example.com/v1.json' } as Record<string, unknown> },
+      initialProps: { config: { url: 'https://api.example.com/v1.json' } },
     })
 
     await waitFor(() => expect(mockWorkspaceStore.addDocument).toHaveBeenCalledTimes(1))
 
-    // Re-render with an empty configuration — the second useEffect falls back to 'default'
-    rerender({ config: {} })
+    // Re-render with an empty url — the second useEffect falls back to 'default'
+    rerender({ config: { url: '' } })
 
     await waitFor(() => expect(mockWorkspaceStore.addDocument).toHaveBeenCalledTimes(2))
 
@@ -323,7 +321,7 @@ describe('use-api-client', () => {
     vi.mocked(getOrCreateApiClient).mockReturnValue(pendingPromise as any)
 
     const { useApiClient } = await import('./use-api-client')
-    const { result, unmount } = renderHook(() => useApiClient())
+    const { result, unmount } = renderHook(() => useApiClient({ configuration: { url: '' } }))
 
     expect(result.current).toBeUndefined()
 
@@ -354,8 +352,8 @@ describe('use-api-client', () => {
     vi.mocked(getOrCreateApiClient).mockReturnValue(pendingPromise as any)
 
     const { useApiClient } = await import('./use-api-client')
-    const firstConsumer = renderHook(() => useApiClient())
-    const secondConsumer = renderHook(() => useApiClient())
+    const firstConsumer = renderHook(() => useApiClient({ configuration: { url: '' } }))
+    const secondConsumer = renderHook(() => useApiClient({ configuration: { url: '' } }))
 
     expect(firstConsumer.result.current).toBeUndefined()
     expect(secondConsumer.result.current).toBeUndefined()
@@ -449,14 +447,14 @@ describe('use-api-client', () => {
     vi.mocked(getOrCreateApiClient).mockReturnValue(new Promise(() => {}))
 
     const { useApiClient } = await import('./use-api-client')
-    const { result } = renderHook(() => useApiClient())
+    const { result } = renderHook(() => useApiClient({ configuration: { url: '' } }))
 
     // Client is undefined, so open should not throw
     expect(result.current).toBeUndefined()
     // Calling open on undefined would normally throw — the hook returns undefined so callers guard it
   })
 
-  it('strips url and content and forwards only supported modal options', async () => {
+  it('strips url and forwards only supported modal options', async () => {
     const { getOrCreateApiClient } = await import('./lazy-load')
     const { useApiClient } = await import('./use-api-client')
 
@@ -464,7 +462,6 @@ describe('use-api-client', () => {
       useApiClient({
         configuration: {
           url: 'https://api.example.com/openapi.json',
-          content: { info: { title: 'My API' } },
           authentication: {
             preferredSecurityScheme: 'bearerAuth',
           },
@@ -477,7 +474,6 @@ describe('use-api-client', () => {
 
     const calledWith = vi.mocked(getOrCreateApiClient).mock.calls[0]![0]
     expect(calledWith).not.toHaveProperty('url')
-    expect(calledWith).not.toHaveProperty('content')
     expect(calledWith).toMatchObject({
       authentication: { preferredSecurityScheme: 'bearerAuth' },
       baseServerURL: 'https://proxy.example.com',
@@ -490,6 +486,7 @@ describe('use-api-client', () => {
     renderHook(() =>
       useApiClient({
         configuration: {
+          url: 'https://api.example.com/openapi.json',
           authentication: {
             preferredSecurityScheme: 'bearerAuth',
           },
@@ -515,6 +512,7 @@ describe('use-api-client', () => {
     const { useApiClient } = await import('./use-api-client')
     const initialProps: { config: ApiClientConfigurationReact } = {
       config: {
+        url: 'https://api.example.com/openapi.json',
         authentication: {
           preferredSecurityScheme: 'bearerAuth',
         },
@@ -531,6 +529,7 @@ describe('use-api-client', () => {
 
     rerender({
       config: {
+        url: 'https://api.example.com/openapi.json',
         authentication: {
           preferredSecurityScheme: 'apiKey',
         },
@@ -585,6 +584,7 @@ describe('use-api-client', () => {
     const { useApiClient } = await import('./use-api-client')
     const initialProps: { config: ApiClientConfigurationReact } = {
       config: {
+        url: 'https://api.example.com/openapi.json',
         proxyUrl: 'https://proxy.example.com',
       },
     }
@@ -604,7 +604,7 @@ describe('use-api-client', () => {
       ),
     )
 
-    rerender({ config: {} })
+    rerender({ config: { url: 'https://api.example.com/openapi.json' } })
 
     await waitFor(() => expect(mockApiClient.updateOptions).toHaveBeenLastCalledWith({}, true))
   })

--- a/packages/api-client-react/src/use-api-client.test.ts
+++ b/packages/api-client-react/src/use-api-client.test.ts
@@ -580,6 +580,40 @@ describe('use-api-client', () => {
     expect(mockApiClient.updateOptions).toHaveBeenCalledTimes(callsAfterInitialRender)
   })
 
+  it('does not call updateOptions again when nested modal options are recreated with the same values', async () => {
+    const { useApiClient } = await import('./use-api-client')
+    const initialProps: { config: ApiClientConfigurationReact } = {
+      config: {
+        url: 'https://api.example.com/openapi.json',
+        authentication: {
+          preferredSecurityScheme: 'bearerAuth',
+        },
+      },
+    }
+    const { rerender } = renderHook(
+      ({ config }: { config: ApiClientConfigurationReact }) => useApiClient({ configuration: config }),
+      {
+        initialProps,
+      },
+    )
+
+    await waitFor(() => expect(mockApiClient.updateOptions).toHaveBeenCalled())
+    const callsAfterInitialRender = mockApiClient.updateOptions.mock.calls.length
+
+    act(() => {
+      rerender({
+        config: {
+          url: 'https://api.example.com/openapi.json',
+          authentication: {
+            preferredSecurityScheme: 'bearerAuth',
+          },
+        },
+      })
+    })
+
+    expect(mockApiClient.updateOptions).toHaveBeenCalledTimes(callsAfterInitialRender)
+  })
+
   it('overwrites modal options when configuration keys are removed', async () => {
     const { useApiClient } = await import('./use-api-client')
     const initialProps: { config: ApiClientConfigurationReact } = {

--- a/packages/api-client-react/src/use-api-client.test.ts
+++ b/packages/api-client-react/src/use-api-client.test.ts
@@ -8,15 +8,20 @@ vi.mock('./style.css', () => ({}))
 vi.mock('./lazy-load', () => ({
   getOrCreateApiClient: vi.fn(),
 }))
+vi.mock('@scalar/api-client/v2/blocks/operation-code-sample', () => ({
+  isClient: vi.fn(() => true),
+}))
 
 const makeWorkspaceStore = () => ({
   addDocument: vi.fn().mockResolvedValue(undefined),
+  update: vi.fn(),
 })
 
 const makeApiClient = () => ({
   open: vi.fn(),
   route: vi.fn(),
   mount: vi.fn(),
+  updateOptions: vi.fn(),
   modalState: { open: false },
   app: {} as any,
 })
@@ -333,6 +338,109 @@ describe('use-api-client', () => {
     expect(result.current).toBeUndefined()
   })
 
+  it('resolves client state for multiple hook consumers from the same pending initialization', async () => {
+    vi.resetModules()
+
+    let resolveClient!: (value: any) => void
+    const pendingPromise = new Promise<
+      { apiClient: typeof mockApiClient; workspaceStore: typeof mockWorkspaceStore } | undefined
+    >((resolve) => {
+      resolveClient = resolve
+    })
+
+    const { getOrCreateApiClient } = await import('./lazy-load')
+    vi.mocked(getOrCreateApiClient).mockReturnValue(pendingPromise as any)
+
+    const { useApiClient } = await import('./use-api-client')
+    const firstConsumer = renderHook(() => useApiClient())
+    const secondConsumer = renderHook(() => useApiClient())
+
+    expect(firstConsumer.result.current).toBeUndefined()
+    expect(secondConsumer.result.current).toBeUndefined()
+
+    await act(async () => {
+      resolveClient({ apiClient: mockApiClient, workspaceStore: mockWorkspaceStore })
+      await pendingPromise
+    })
+
+    await waitFor(() => {
+      expect(firstConsumer.result.current).not.toBeUndefined()
+      expect(secondConsumer.result.current).not.toBeUndefined()
+    })
+
+    expect(firstConsumer.result.current?.route).toBe(mockApiClient.route)
+    expect(secondConsumer.result.current?.route).toBe(mockApiClient.route)
+  })
+
+  it('keeps documentSlug reactive and isolated across multiple hook consumers', async () => {
+    vi.resetModules()
+
+    const { getOrCreateApiClient } = await import('./lazy-load')
+    vi.mocked(getOrCreateApiClient).mockResolvedValue({
+      apiClient: mockApiClient as any,
+      workspaceStore: mockWorkspaceStore as any,
+    })
+
+    const { useApiClient } = await import('./use-api-client')
+
+    const firstConsumer = renderHook(({ config }) => useApiClient({ configuration: config }), {
+      initialProps: { config: { url: 'https://api.example.com/first-v1.json' } },
+    })
+    const secondConsumer = renderHook(({ config }) => useApiClient({ configuration: config }), {
+      initialProps: { config: { url: 'https://api.example.com/second-v1.json' } },
+    })
+
+    await waitFor(() => {
+      expect(firstConsumer.result.current).not.toBeUndefined()
+      expect(secondConsumer.result.current).not.toBeUndefined()
+    })
+
+    act(() => {
+      firstConsumer.result.current?.open({ path: '/first', method: 'get' })
+    })
+    expect(mockApiClient.open).toHaveBeenLastCalledWith({
+      documentSlug: 'https://api.example.com/first-v1.json',
+      path: '/first',
+      method: 'get',
+    })
+
+    act(() => {
+      secondConsumer.result.current?.open({ path: '/second', method: 'get' })
+    })
+    expect(mockApiClient.open).toHaveBeenLastCalledWith({
+      documentSlug: 'https://api.example.com/second-v1.json',
+      path: '/second',
+      method: 'get',
+    })
+
+    firstConsumer.rerender({ config: { url: 'https://api.example.com/first-v2.json' } })
+
+    await waitFor(() =>
+      expect(mockWorkspaceStore.addDocument).toHaveBeenCalledWith({
+        name: 'https://api.example.com/first-v2.json',
+        url: 'https://api.example.com/first-v2.json',
+      }),
+    )
+
+    act(() => {
+      firstConsumer.result.current?.open({ path: '/first', method: 'get' })
+    })
+    expect(mockApiClient.open).toHaveBeenLastCalledWith({
+      documentSlug: 'https://api.example.com/first-v2.json',
+      path: '/first',
+      method: 'get',
+    })
+
+    act(() => {
+      secondConsumer.result.current?.open({ path: '/second', method: 'get' })
+    })
+    expect(mockApiClient.open).toHaveBeenLastCalledWith({
+      documentSlug: 'https://api.example.com/second-v1.json',
+      path: '/second',
+      method: 'get',
+    })
+  })
+
   it('open is a no-op when client is not yet initialized', async () => {
     const { getOrCreateApiClient } = await import('./lazy-load')
     // biome-ignore lint/suspicious/noEmptyBlockStatements: intentionally never-resolving promise
@@ -346,7 +454,7 @@ describe('use-api-client', () => {
     // Calling open on undefined would normally throw — the hook returns undefined so callers guard it
   })
 
-  it('strips url and content from the options passed to getOrCreateApiClient', async () => {
+  it('strips url and content and forwards only supported modal options', async () => {
     const { getOrCreateApiClient } = await import('./lazy-load')
     const { useApiClient } = await import('./use-api-client')
 
@@ -355,7 +463,10 @@ describe('use-api-client', () => {
         configuration: {
           url: 'https://api.example.com/openapi.json',
           content: { info: { title: 'My API' } },
-          proxyUrl: 'https://proxy.example.com',
+          authentication: {
+            preferredSecurityScheme: 'bearerAuth',
+          },
+          baseServerURL: 'https://proxy.example.com',
         },
       }),
     )
@@ -365,7 +476,67 @@ describe('use-api-client', () => {
     const calledWith = vi.mocked(getOrCreateApiClient).mock.calls[0]![0]
     expect(calledWith).not.toHaveProperty('url')
     expect(calledWith).not.toHaveProperty('content')
-    expect(calledWith).toMatchObject({ proxyUrl: 'https://proxy.example.com' })
+    expect(calledWith).toMatchObject({
+      authentication: { preferredSecurityScheme: 'bearerAuth' },
+      baseServerURL: 'https://proxy.example.com',
+    })
+  })
+
+  it('calls updateOptions during initial setup', async () => {
+    const { useApiClient } = await import('./use-api-client')
+
+    renderHook(() =>
+      useApiClient({
+        configuration: {
+          authentication: {
+            preferredSecurityScheme: 'bearerAuth',
+          },
+          baseServerURL: 'https://proxy.example.com',
+        },
+      }),
+    )
+
+    await waitFor(() =>
+      expect(mockApiClient.updateOptions).toHaveBeenCalledWith({
+        authentication: {
+          preferredSecurityScheme: 'bearerAuth',
+        },
+        baseServerURL: 'https://proxy.example.com',
+      }),
+    )
+  })
+
+  it('calls updateOptions when configuration changes', async () => {
+    const { useApiClient } = await import('./use-api-client')
+    const { rerender } = renderHook(({ config }) => useApiClient({ configuration: config }), {
+      initialProps: {
+        config: {
+          authentication: {
+            preferredSecurityScheme: 'bearerAuth',
+          },
+        },
+      },
+    })
+
+    await waitFor(() => expect(mockApiClient.updateOptions).toHaveBeenCalled())
+
+    rerender({
+      config: {
+        authentication: {
+          preferredSecurityScheme: 'apiKey',
+        },
+        baseServerURL: 'https://proxy.example.com',
+      },
+    })
+
+    await waitFor(() =>
+      expect(mockApiClient.updateOptions).toHaveBeenLastCalledWith({
+        authentication: {
+          preferredSecurityScheme: 'apiKey',
+        },
+        baseServerURL: 'https://proxy.example.com',
+      }),
+    )
   })
 
   it('sets Vue globals on module load', async () => {

--- a/packages/api-client-react/src/use-api-client.test.ts
+++ b/packages/api-client-react/src/use-api-client.test.ts
@@ -551,16 +551,47 @@ describe('use-api-client', () => {
     )
   })
 
-  it('overwrites modal options when configuration keys are removed', async () => {
+  it('does not call updateOptions again when an inline configuration object keeps the same values', async () => {
     const { useApiClient } = await import('./use-api-client')
+    const initialProps: { config: ApiClientConfigurationReact } = {
+      config: {
+        url: 'https://api.example.com/openapi.json',
+        proxyUrl: 'https://proxy.example.com',
+      },
+    }
     const { rerender } = renderHook(
       ({ config }: { config: ApiClientConfigurationReact }) => useApiClient({ configuration: config }),
       {
-        initialProps: {
-          config: {
-            proxyUrl: 'https://proxy.example.com',
-          },
+        initialProps,
+      },
+    )
+
+    await waitFor(() => expect(mockApiClient.updateOptions).toHaveBeenCalled())
+    const callsAfterInitialRender = mockApiClient.updateOptions.mock.calls.length
+
+    act(() => {
+      rerender({
+        config: {
+          url: 'https://api.example.com/openapi.json',
+          proxyUrl: 'https://proxy.example.com',
         },
+      })
+    })
+
+    expect(mockApiClient.updateOptions).toHaveBeenCalledTimes(callsAfterInitialRender)
+  })
+
+  it('overwrites modal options when configuration keys are removed', async () => {
+    const { useApiClient } = await import('./use-api-client')
+    const initialProps: { config: ApiClientConfigurationReact } = {
+      config: {
+        proxyUrl: 'https://proxy.example.com',
+      },
+    }
+    const { rerender } = renderHook(
+      ({ config }: { config: ApiClientConfigurationReact }) => useApiClient({ configuration: config }),
+      {
+        initialProps,
       },
     )
 

--- a/packages/api-client-react/src/use-api-client.test.ts
+++ b/packages/api-client-react/src/use-api-client.test.ts
@@ -499,12 +499,15 @@ describe('use-api-client', () => {
     )
 
     await waitFor(() =>
-      expect(mockApiClient.updateOptions).toHaveBeenCalledWith({
-        authentication: {
-          preferredSecurityScheme: 'bearerAuth',
+      expect(mockApiClient.updateOptions).toHaveBeenCalledWith(
+        {
+          authentication: {
+            preferredSecurityScheme: 'bearerAuth',
+          },
+          baseServerURL: 'https://proxy.example.com',
         },
-        baseServerURL: 'https://proxy.example.com',
-      }),
+        true,
+      ),
     )
   })
 
@@ -536,13 +539,43 @@ describe('use-api-client', () => {
     })
 
     await waitFor(() =>
-      expect(mockApiClient.updateOptions).toHaveBeenLastCalledWith({
-        authentication: {
-          preferredSecurityScheme: 'apiKey',
+      expect(mockApiClient.updateOptions).toHaveBeenLastCalledWith(
+        {
+          authentication: {
+            preferredSecurityScheme: 'apiKey',
+          },
+          baseServerURL: 'https://proxy.example.com',
         },
-        baseServerURL: 'https://proxy.example.com',
-      }),
+        true,
+      ),
     )
+  })
+
+  it('overwrites modal options when configuration keys are removed', async () => {
+    const { useApiClient } = await import('./use-api-client')
+    const { rerender } = renderHook(
+      ({ config }: { config: ApiClientConfigurationReact }) => useApiClient({ configuration: config }),
+      {
+        initialProps: {
+          config: {
+            proxyUrl: 'https://proxy.example.com',
+          },
+        },
+      },
+    )
+
+    await waitFor(() =>
+      expect(mockApiClient.updateOptions).toHaveBeenCalledWith(
+        {
+          proxyUrl: 'https://proxy.example.com',
+        },
+        true,
+      ),
+    )
+
+    rerender({ config: {} })
+
+    await waitFor(() => expect(mockApiClient.updateOptions).toHaveBeenLastCalledWith({}, true))
   })
 
   it('sets Vue globals on module load', async () => {

--- a/packages/api-client-react/src/use-api-client.ts
+++ b/packages/api-client-react/src/use-api-client.ts
@@ -1,7 +1,6 @@
 'use client'
 
-import type { ApiClientModal, RoutePayload } from '@scalar/api-client/v2/features/modal'
-import type { ApiClientConfiguration } from '@scalar/types/api-reference'
+import type { ApiClientModal, ApiClientModalOptions, RoutePayload } from '@scalar/api-client/v2/features/modal'
 import { useEffect, useState } from 'react'
 
 import './style.css'
@@ -14,10 +13,10 @@ globalThis.__VUE_OPTIONS_API__ = true
 globalThis.__VUE_PROD_HYDRATION_MISMATCH_DETAILS__ = true
 globalThis.__VUE_PROD_DEVTOOLS__ = false
 
-/** We don't really need all of the content types so we just accept an object instead */
-export type ApiClientConfigurationReact = Partial<
-  Omit<ApiClientConfiguration, 'content' | 'url'> & { content?: Record<string, unknown>; url?: string }
->
+export type ApiClientConfigurationReact = ApiClientModalOptions & {
+  content?: Record<string, unknown>
+  url?: string
+}
 
 export type UseApiClientModalProps = {
   /** Configuration for the Api Client (url or inline content) */
@@ -65,6 +64,9 @@ export const useApiClient = ({
       // preventing a render where `client` is set but `documentSlug` is still ''.
       const slug = url || (content as { info?: { title?: string } })?.info?.title || ''
 
+      // Keep singleton modal options in sync even when the client already exists.
+      _client.apiClient.updateOptions(modalOptions)
+
       setClient(_client.apiClient)
       setWorkspaceStore(_client.workspaceStore)
       setDocumentSlug(slug)
@@ -84,9 +86,16 @@ export const useApiClient = ({
     // Only run once per mount
   }, [])
 
-  // When url or content changes after the client is already mounted, register the new document
+  // Keep modal options in sync and register a new document when configuration changes.
   useEffect(() => {
-    if (!client || !configuration || !workspaceStore) {
+    if (!client || !workspaceStore) {
+      return
+    }
+
+    const { ...modalOptions } = configuration ?? {}
+    client.updateOptions(modalOptions)
+
+    if (!configuration) {
       return
     }
 
@@ -103,7 +112,7 @@ export const useApiClient = ({
         ? { name: slug, document: configuration.content }
         : { name: slug, url: configuration.url ?? '' },
     )
-  }, [client, configuration?.url, configuration?.content, workspaceStore])
+  }, [client, configuration, workspaceStore])
 
   return client
     ? {

--- a/packages/api-client-react/src/use-api-client.ts
+++ b/packages/api-client-react/src/use-api-client.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import type { ApiClientModal, ApiClientModalOptions, RoutePayload } from '@scalar/api-client/v2/features/modal'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import './style.css'
 
@@ -14,17 +14,35 @@ globalThis.__VUE_PROD_HYDRATION_MISMATCH_DETAILS__ = true
 globalThis.__VUE_PROD_DEVTOOLS__ = false
 
 export type ApiClientConfigurationReact = ApiClientModalOptions & {
-  content?: Record<string, unknown>
-  url?: string
+  // content?: Record<string, unknown>
+  url: string
 }
 
 export type UseApiClientModalProps = {
   /** Configuration for the Api Client (url or inline content) */
-  configuration?: ApiClientConfigurationReact
+  configuration: ApiClientConfigurationReact
 }
 
 /** Tracks which documents are/have been loaded so we dont duplicate */
-const documentDict: Record<string, true> = {}
+const documentSet = new Set<string>()
+
+const hasModalOptionsChanged = (
+  previousOptions: ApiClientModalOptions | undefined,
+  nextOptions: ApiClientModalOptions,
+): boolean => {
+  if (!previousOptions) {
+    return true
+  }
+
+  const previousKeys = Object.keys(previousOptions) as Array<keyof ApiClientModalOptions>
+  const nextKeys = Object.keys(nextOptions) as Array<keyof ApiClientModalOptions>
+
+  if (previousKeys.length !== nextKeys.length) {
+    return true
+  }
+
+  return nextKeys.some((key) => !Object.is(previousOptions[key], nextOptions[key]))
+}
 
 /**
  * Returns the singleton Api Client
@@ -38,22 +56,20 @@ const documentDict: Record<string, true> = {}
  */
 export const useApiClient = ({
   configuration,
-}: UseApiClientModalProps = {}):
-  | (Omit<ApiClientModal, 'open'> & { open: (payload: RoutePayload) => void })
-  | undefined => {
+}: UseApiClientModalProps): (Omit<ApiClientModal, 'open'> & { open: (payload: RoutePayload) => void }) | undefined => {
   const [client, setClient] = useState<ApiClientModal | undefined>(undefined)
   const [workspaceStore, setWorkspaceStore] = useState<WorkspaceStore | undefined>(undefined)
-  const [documentSlug, setDocumentSlug] = useState('')
+  const documentSlugRef = useRef('')
+  const previousModalOptionsRef = useRef<ApiClientModalOptions | undefined>(undefined)
 
   /** Small wrapper to set the documentSlug */
-  const open = (payload: RoutePayload) => client?.open({ documentSlug, ...payload })
+  const open = (payload: RoutePayload) => client?.open({ documentSlug: documentSlugRef.current, ...payload })
 
   useEffect(() => {
     let cancelled = false
 
     // Strip document-specific fields before passing to the modal constructor.
-    // `url` and `content` are registered separately via workspaceStore.addDocument.
-    const { url, content, ...modalOptions } = configuration ?? {}
+    const { url, ...modalOptions } = configuration
 
     void getOrCreateApiClient(modalOptions)?.then((_client) => {
       if (cancelled || !_client) {
@@ -62,21 +78,20 @@ export const useApiClient = ({
 
       // Compute the slug here so we can batch all three state updates into one render,
       // preventing a render where `client` is set but `documentSlug` is still ''.
-      const slug = url || (content as { info?: { title?: string } })?.info?.title || ''
+      const slug = url || ''
 
       // React always provides the complete modal option set for this hook instance,
       // so we overwrite to clear options removed by consumers.
       _client.apiClient.updateOptions(modalOptions, true)
+      previousModalOptionsRef.current = modalOptions
 
       setClient(_client.apiClient)
       setWorkspaceStore(_client.workspaceStore)
-      setDocumentSlug(slug)
+      documentSlugRef.current = slug
 
-      if (slug && !documentDict[slug]) {
-        documentDict[slug] = true
-        void _client.workspaceStore.addDocument(
-          content ? { name: slug, document: content } : { name: slug, url: url ?? '' },
-        )
+      if (slug && !documentSet.has(slug)) {
+        documentSet.add(slug)
+        void _client.workspaceStore.addDocument({ name: slug, url })
       }
     })
 
@@ -87,33 +102,37 @@ export const useApiClient = ({
     // Only run once per mount
   }, [])
 
-  // Keep modal options in sync and register a new document when configuration changes.
+  // Register new document when we detect the url has changed
   useEffect(() => {
     if (!client || !workspaceStore) {
       return
     }
 
-    const { url: _, content: __, ...modalOptions } = configuration ?? {}
+    const slug = configuration.url || 'default'
+    documentSlugRef.current = slug
+
+    if (documentSet.has(slug)) {
+      return
+    }
+    documentSet.add(slug)
+
+    void workspaceStore.addDocument({ name: slug, url: configuration.url })
+  }, [client, configuration.url, workspaceStore])
+
+  // Update the modal options when the configuration changes
+  useEffect(() => {
+    if (!client || !configuration) {
+      return
+    }
+
+    const { url: _, ...modalOptions } = configuration
+    if (!hasModalOptionsChanged(previousModalOptionsRef.current, modalOptions)) {
+      return
+    }
+
     client.updateOptions(modalOptions, true)
-
-    if (!configuration) {
-      return
-    }
-
-    const slug = configuration.url || (configuration.content as { info?: { title?: string } })?.info?.title || 'default'
-    setDocumentSlug(slug)
-
-    if (documentDict[slug]) {
-      return
-    }
-    documentDict[slug] = true
-
-    void workspaceStore.addDocument(
-      configuration.content
-        ? { name: slug, document: configuration.content }
-        : { name: slug, url: configuration.url ?? '' },
-    )
-  }, [client, configuration, workspaceStore])
+    previousModalOptionsRef.current = modalOptions
+  }, [client, configuration])
 
   return client
     ? {

--- a/packages/api-client-react/src/use-api-client.ts
+++ b/packages/api-client-react/src/use-api-client.ts
@@ -64,8 +64,9 @@ export const useApiClient = ({
       // preventing a render where `client` is set but `documentSlug` is still ''.
       const slug = url || (content as { info?: { title?: string } })?.info?.title || ''
 
-      // Keep singleton modal options in sync even when the client already exists.
-      _client.apiClient.updateOptions(modalOptions)
+      // React always provides the complete modal option set for this hook instance,
+      // so we overwrite to clear options removed by consumers.
+      _client.apiClient.updateOptions(modalOptions, true)
 
       setClient(_client.apiClient)
       setWorkspaceStore(_client.workspaceStore)
@@ -93,7 +94,7 @@ export const useApiClient = ({
     }
 
     const { url: _, content: __, ...modalOptions } = configuration ?? {}
-    client.updateOptions(modalOptions)
+    client.updateOptions(modalOptions, true)
 
     if (!configuration) {
       return

--- a/packages/api-client-react/src/use-api-client.ts
+++ b/packages/api-client-react/src/use-api-client.ts
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import './style.css'
 
+import { isObjectEqual } from '@scalar/helpers/object/is-object-equal'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 
 import { getOrCreateApiClient } from './lazy-load'
@@ -25,24 +26,6 @@ export type UseApiClientModalProps = {
 
 /** Tracks which documents are/have been loaded so we dont duplicate */
 const documentSet = new Set<string>()
-
-const hasModalOptionsChanged = (
-  previousOptions: ApiClientModalOptions | undefined,
-  nextOptions: ApiClientModalOptions,
-): boolean => {
-  if (!previousOptions) {
-    return true
-  }
-
-  const previousKeys = Object.keys(previousOptions) as Array<keyof ApiClientModalOptions>
-  const nextKeys = Object.keys(nextOptions) as Array<keyof ApiClientModalOptions>
-
-  if (previousKeys.length !== nextKeys.length) {
-    return true
-  }
-
-  return nextKeys.some((key) => !Object.is(previousOptions[key], nextOptions[key]))
-}
 
 /**
  * Returns the singleton Api Client
@@ -126,7 +109,7 @@ export const useApiClient = ({
     }
 
     const { url: _, ...modalOptions } = configuration
-    if (!hasModalOptionsChanged(previousModalOptionsRef.current, modalOptions)) {
+    if (isObjectEqual(previousModalOptionsRef.current, modalOptions)) {
       return
     }
 

--- a/packages/api-client-react/src/use-api-client.ts
+++ b/packages/api-client-react/src/use-api-client.ts
@@ -92,7 +92,7 @@ export const useApiClient = ({
       return
     }
 
-    const { ...modalOptions } = configuration ?? {}
+    const { url: _, content: __, ...modalOptions } = configuration ?? {}
     client.updateOptions(modalOptions)
 
     if (!configuration) {

--- a/packages/api-client/src/v2/features/modal/Modal.test.ts
+++ b/packages/api-client/src/v2/features/modal/Modal.test.ts
@@ -9,6 +9,7 @@ import 'fake-indexeddb/auto'
 
 import { mockEventBus } from '@/v2/helpers/test-utils'
 
+import type { ApiClientModalOptions, ApiClientModalOptionsRef } from './helpers/types'
 import { useModalSidebar } from './hooks/use-modal-sidebar'
 import Modal from './Modal.vue'
 
@@ -34,6 +35,8 @@ const getDocument = (overrides: Partial<OpenApiDocument> = {}): OpenApiDocument 
   'x-scalar-original-document-hash': 'test-hash',
   ...overrides,
 })
+
+const createModalOptions = (options: ApiClientModalOptions = {}): ApiClientModalOptionsRef => ref(options)
 
 /**
  * Creates a complete modal props setup for testing.
@@ -92,7 +95,7 @@ const createModalProps = async (documentOverrides: Partial<OpenApiDocument> = {}
       document,
       path: computed(() => path.value),
       method: computed(() => method.value),
-      options: {},
+      options: createModalOptions(),
       plugins: [],
       exampleName: computed(() => exampleName.value),
       requestBodyCompositionSelection,
@@ -197,7 +200,7 @@ describe('Modal', () => {
         document: emptyDocument,
         path: computed(() => undefined),
         method: computed(() => undefined),
-        options: {},
+        options: createModalOptions(),
         plugins: [],
         exampleName: computed(() => undefined),
         requestBodyCompositionSelection,
@@ -428,7 +431,7 @@ describe('Modal', () => {
     const wrapperWithHidden = mount(Modal, {
       props: {
         ...baseProps,
-        options: { hideClientButton: true },
+        options: createModalOptions({ hideClientButton: true }),
       },
       attachTo: '#scalar-modal-test',
     })
@@ -448,7 +451,7 @@ describe('Modal', () => {
     const wrapperWithShown = mount(Modal, {
       props: {
         ...baseProps,
-        options: { hideClientButton: false },
+        options: createModalOptions({ hideClientButton: false }),
       },
       attachTo: '#scalar-modal-test',
     })
@@ -467,7 +470,7 @@ describe('Modal', () => {
     const wrapperWithDefault = mount(Modal, {
       props: {
         ...baseProps,
-        options: {},
+        options: createModalOptions(),
       },
       attachTo: '#scalar-modal-test',
     })

--- a/packages/api-client/src/v2/features/modal/Modal.vue
+++ b/packages/api-client/src/v2/features/modal/Modal.vue
@@ -66,6 +66,7 @@ import {
 
 import ModalClientContainer from '@/v2/components/modals/ModalClientContainer.vue'
 import { Sidebar, SidebarToggle } from '@/v2/components/sidebar'
+import type { ApiClientModalOptionsRef } from '@/v2/features/modal/helpers/types'
 import { type UseModalSidebarReturn } from '@/v2/features/modal/hooks/use-modal-sidebar'
 import { initializeModalEvents } from '@/v2/features/modal/modal-events'
 import Operation from '@/v2/features/operation/Operation.vue'
@@ -81,7 +82,9 @@ const {
   requestBodyCompositionSelection,
   sidebarState,
   workspaceStore,
-} = defineProps<ModalProps>()
+} = defineProps<
+  Omit<ModalProps, 'options'> & { options: ApiClientModalOptionsRef }
+>()
 
 const activeWorkspace: ScalarListboxOption = {
   label: 'default',

--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.test.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.test.ts
@@ -300,6 +300,285 @@ describe('createApiClientModal', () => {
     })
   })
 
+  it('reacts when the options ref value is replaced', async () => {
+    const store = createWorkspaceStore()
+    await store.addDocument({
+      name: 'test-doc',
+      document: createTestDocument({
+        components: {
+          securitySchemes: {
+            apiKey: {
+              type: 'apiKey',
+              name: 'X-API-Key',
+              in: 'header',
+            },
+          },
+        },
+      }),
+    })
+    store.update('x-scalar-active-document', 'test-doc')
+
+    const options = ref({
+      authentication: {
+        securitySchemes: {
+          oauth2: {
+            type: 'oauth2' as const,
+            flows: {
+              authorizationCode: {
+                authorizationUrl: 'https://example.com/oauth/authorize',
+                tokenUrl: 'https://example.com/oauth/token',
+                scopes: {
+                  'read:users': 'Read user data',
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const modal = createApiClientModal({
+      el: mountElement,
+      workspaceStore: store,
+      mountOnInitialize: true,
+      options,
+      eventBus: createTestEventBus(),
+    })
+    createdApps.push(modal.app)
+
+    modal.open({
+      path: '/users',
+      method: 'get',
+      example: 'default',
+    })
+
+    await nextTick()
+
+    const wrapper = mount(Modal, {
+      attachTo: mountElement,
+      props: modal.app._instance?.props as ModalProps,
+    })
+    const operationBlock = wrapper.findComponent({ name: 'OperationBlock' })
+    expect(operationBlock.exists()).toBe(true)
+
+    options.value = {
+      authentication: {
+        securitySchemes: {
+          oauth2: {
+            type: 'oauth2',
+            flows: {
+              authorizationCode: {
+                authorizationUrl: 'https://updated-auth.test',
+                tokenUrl: 'https://updated-token.test',
+                scopes: {
+                  'read:users': 'Read user data',
+                  'write:users': 'Write user data',
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+    await nextTick()
+
+    expect(operationBlock.props('securitySchemes').oauth2).toMatchObject({
+      flows: {
+        authorizationCode: {
+          authorizationUrl: 'https://updated-auth.test',
+          tokenUrl: 'https://updated-token.test',
+          scopes: {
+            'read:users': 'Read user data',
+            'write:users': 'Write user data',
+          },
+        },
+      },
+    })
+  })
+
+  it('reacts when updateOptions merges new authentication settings', async () => {
+    const store = createWorkspaceStore()
+    await store.addDocument({
+      name: 'test-doc',
+      document: createTestDocument(),
+    })
+    store.update('x-scalar-active-document', 'test-doc')
+
+    const modal = createApiClientModal({
+      el: mountElement,
+      workspaceStore: store,
+      mountOnInitialize: true,
+      options: {
+        authentication: {
+          securitySchemes: {
+            oauth2: {
+              type: 'oauth2',
+              flows: {
+                authorizationCode: {
+                  authorizationUrl: 'https://initial-auth.test',
+                  tokenUrl: 'https://initial-token.test',
+                  scopes: {
+                    'read:users': 'Read user data',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      eventBus: createTestEventBus(),
+    })
+    createdApps.push(modal.app)
+
+    modal.open({
+      path: '/users',
+      method: 'get',
+      example: 'default',
+    })
+    await nextTick()
+
+    const wrapper = mount(Modal, {
+      attachTo: mountElement,
+      props: modal.app._instance?.props as ModalProps,
+    })
+    const operationBlock = wrapper.findComponent({ name: 'OperationBlock' })
+    expect(operationBlock.exists()).toBe(true)
+
+    expect(operationBlock.props('securitySchemes').oauth2).toMatchObject({
+      flows: {
+        authorizationCode: {
+          authorizationUrl: 'https://initial-auth.test',
+        },
+      },
+    })
+
+    modal.updateOptions({
+      authentication: {
+        securitySchemes: {
+          oauth2: {
+            type: 'oauth2',
+            flows: {
+              authorizationCode: {
+                authorizationUrl: 'https://merged-auth.test',
+                tokenUrl: 'https://merged-token.test',
+                scopes: {
+                  'read:users': 'Read user data',
+                  'write:users': 'Write user data',
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+    await nextTick()
+
+    expect(operationBlock.props('securitySchemes').oauth2).toMatchObject({
+      flows: {
+        authorizationCode: {
+          authorizationUrl: 'https://merged-auth.test',
+          tokenUrl: 'https://merged-token.test',
+          scopes: {
+            'read:users': 'Read user data',
+            'write:users': 'Write user data',
+          },
+        },
+      },
+    })
+  })
+
+  it('reacts when updateOptions overwrites previous authentication settings', async () => {
+    const store = createWorkspaceStore()
+    await store.addDocument({
+      name: 'test-doc',
+      document: createTestDocument(),
+    })
+    store.update('x-scalar-active-document', 'test-doc')
+
+    const modal = createApiClientModal({
+      el: mountElement,
+      workspaceStore: store,
+      mountOnInitialize: true,
+      options: {
+        authentication: {
+          securitySchemes: {
+            oauth2: {
+              type: 'oauth2',
+              flows: {
+                authorizationCode: {
+                  authorizationUrl: 'https://initial-auth.test',
+                  tokenUrl: 'https://initial-token.test',
+                  scopes: {
+                    'read:users': 'Read user data',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      eventBus: createTestEventBus(),
+    })
+    createdApps.push(modal.app)
+
+    modal.open({
+      path: '/users',
+      method: 'get',
+      example: 'default',
+    })
+    await nextTick()
+
+    const wrapper = mount(Modal, {
+      attachTo: mountElement,
+      props: modal.app._instance?.props as ModalProps,
+    })
+    const operationBlock = wrapper.findComponent({ name: 'OperationBlock' })
+    expect(operationBlock.exists()).toBe(true)
+
+    expect(operationBlock.props('securitySchemes').oauth2).toMatchObject({
+      flows: {
+        authorizationCode: {
+          authorizationUrl: 'https://initial-auth.test',
+        },
+      },
+    })
+
+    modal.updateOptions(
+      {
+        authentication: {
+          securitySchemes: {
+            oauth2: {
+              type: 'oauth2',
+              flows: {
+                authorizationCode: {
+                  authorizationUrl: 'https://overwrite-auth.test',
+                  tokenUrl: 'https://overwrite-token.test',
+                  scopes: {
+                    'admin:users': 'Admin users',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      true,
+    )
+    await nextTick()
+
+    expect(operationBlock.props('securitySchemes').oauth2).toMatchObject({
+      flows: {
+        authorizationCode: {
+          authorizationUrl: 'https://overwrite-auth.test',
+          tokenUrl: 'https://overwrite-token.test',
+          scopes: {
+            'admin:users': 'Admin users',
+          },
+        },
+      },
+    })
+  })
+
   it('keeps the changes when the modal closes', async () => {
     const workspaceStore = await setupWorkspaceStore()
 

--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.test.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.test.ts
@@ -4,7 +4,7 @@ import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/stric
 import { enableAutoUnmount, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
-import { nextTick, ref } from 'vue'
+import { nextTick, ref, toValue } from 'vue'
 
 import 'fake-indexeddb/auto'
 
@@ -13,6 +13,7 @@ import { deepClone } from '@scalar/workspace-store/helpers/deep-clone'
 import Modal, { type ModalProps } from '@/v2/features/modal/Modal.vue'
 
 import { createApiClientModal } from './create-api-client-modal'
+import type { ApiClientModalOptions, ApiClientModalOptionsRef } from './types'
 
 enableAutoUnmount(afterEach)
 
@@ -59,6 +60,12 @@ describe('createApiClientModal', () => {
   let mountElement: HTMLElement
   /** Track Vue apps created in tests to ensure proper cleanup */
   const createdApps: App[] = []
+  type MountedModalProps = Omit<ModalProps, 'options'> & {
+    options: ApiClientModalOptionsRef
+  }
+
+  /** Accesses the root props passed to the modal app instance */
+  const getModalProps = (app: App) => app._props as unknown as MountedModalProps
 
   beforeEach(() => {
     // Create a DOM element for mounting.
@@ -93,9 +100,10 @@ describe('createApiClientModal', () => {
     })
     createdApps.push(modal.app)
 
+    await nextTick()
+
     // The modal should be mounted immediately when mountOnInitialize is true.
     expect(modal.app).toBeDefined()
-    expect(modal.app._instance).not.toBeNull()
     expect(mountElement.innerHTML).not.toBe('')
   })
 
@@ -141,7 +149,7 @@ describe('createApiClientModal', () => {
 
     const wrapper = mount(Modal, {
       attachTo: mountElement,
-      props: modal.app._instance?.props as ModalProps,
+      props: getModalProps(modal.app),
     })
 
     const operationBlock = wrapper.findComponent({ name: 'OperationBlock' })
@@ -178,7 +186,7 @@ describe('createApiClientModal', () => {
 
     const wrapper = mount(Modal, {
       attachTo: mountElement,
-      props: modal.app._instance?.props as ModalProps,
+      props: getModalProps(modal.app),
     })
 
     const operationBlock = wrapper.findComponent({ name: 'OperationBlock' })
@@ -211,7 +219,7 @@ describe('createApiClientModal', () => {
     })
     store.update('x-scalar-active-document', 'test-doc')
 
-    const options = ref({
+    const options = ref<ApiClientModalOptions>({
       authentication: {
         securitySchemes: {
           oauth2: {
@@ -250,7 +258,7 @@ describe('createApiClientModal', () => {
 
     const wrapper = mount(Modal, {
       attachTo: mountElement,
-      props: modal.app._instance?.props as ModalProps,
+      props: getModalProps(modal.app),
     })
 
     const operationBlock = wrapper.findComponent({ name: 'OperationBlock' })
@@ -288,9 +296,16 @@ describe('createApiClientModal', () => {
       },
     })
 
-    // Now lets check the reactivity
-    options.value.authentication.securitySchemes.oauth2.flows.authorizationCode.authorizationUrl =
-      'https://new-auth.test'
+    // Verify the options ref is reactive when mutated in place.
+    const oauth2Scheme = options.value.authentication?.securitySchemes?.oauth2 as {
+      flows: {
+        authorizationCode: {
+          authorizationUrl: string
+        }
+      }
+    }
+    expect(oauth2Scheme).toBeDefined()
+    oauth2Scheme.flows.authorizationCode.authorizationUrl = 'https://new-auth.test'
     await nextTick()
     expect(operationBlock.props('securitySchemes')).toHaveProperty('oauth2')
     expect(operationBlock.props('securitySchemes').oauth2).toMatchObject({
@@ -318,7 +333,7 @@ describe('createApiClientModal', () => {
     })
     store.update('x-scalar-active-document', 'test-doc')
 
-    const options = ref({
+    const options = ref<ApiClientModalOptions>({
       authentication: {
         securitySchemes: {
           oauth2: {
@@ -356,7 +371,7 @@ describe('createApiClientModal', () => {
 
     const wrapper = mount(Modal, {
       attachTo: mountElement,
-      props: modal.app._instance?.props as ModalProps,
+      props: getModalProps(modal.app),
     })
     const operationBlock = wrapper.findComponent({ name: 'OperationBlock' })
     expect(operationBlock.exists()).toBe(true)
@@ -390,6 +405,18 @@ describe('createApiClientModal', () => {
           scopes: {
             'read:users': 'Read user data',
             'write:users': 'Write user data',
+          },
+        },
+      },
+    })
+
+    // Also verify the same update flows through the root options prop.
+    expect(toValue(getModalProps(modal.app).options).authentication?.securitySchemes).toMatchObject({
+      oauth2: {
+        flows: {
+          authorizationCode: {
+            authorizationUrl: 'https://updated-auth.test',
+            tokenUrl: 'https://updated-token.test',
           },
         },
       },
@@ -439,7 +466,7 @@ describe('createApiClientModal', () => {
 
     const wrapper = mount(Modal, {
       attachTo: mountElement,
-      props: modal.app._instance?.props as ModalProps,
+      props: getModalProps(modal.app),
     })
     const operationBlock = wrapper.findComponent({ name: 'OperationBlock' })
     expect(operationBlock.exists()).toBe(true)
@@ -481,6 +508,16 @@ describe('createApiClientModal', () => {
           scopes: {
             'read:users': 'Read user data',
             'write:users': 'Write user data',
+          },
+        },
+      },
+    })
+    expect(toValue(getModalProps(modal.app).options).authentication?.securitySchemes).toMatchObject({
+      oauth2: {
+        flows: {
+          authorizationCode: {
+            authorizationUrl: 'https://merged-auth.test',
+            tokenUrl: 'https://merged-token.test',
           },
         },
       },
@@ -530,7 +567,7 @@ describe('createApiClientModal', () => {
 
     const wrapper = mount(Modal, {
       attachTo: mountElement,
-      props: modal.app._instance?.props as ModalProps,
+      props: getModalProps(modal.app),
     })
     const operationBlock = wrapper.findComponent({ name: 'OperationBlock' })
     expect(operationBlock.exists()).toBe(true)
@@ -573,6 +610,19 @@ describe('createApiClientModal', () => {
           tokenUrl: 'https://overwrite-token.test',
           scopes: {
             'admin:users': 'Admin users',
+          },
+        },
+      },
+    })
+    expect(toValue(getModalProps(modal.app).options).authentication?.securitySchemes).toMatchObject({
+      oauth2: {
+        flows: {
+          authorizationCode: {
+            authorizationUrl: 'https://overwrite-auth.test',
+            tokenUrl: 'https://overwrite-token.test',
+            scopes: {
+              'admin:users': 'Admin users',
+            },
           },
         },
       },

--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
@@ -2,14 +2,14 @@ import { type ModalState, useModal } from '@scalar/components'
 import type { ClientPlugin } from '@scalar/oas-utils/helpers'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import { type WorkspaceEventBus, createWorkspaceEventBus } from '@scalar/workspace-store/events'
-import { type App, computed, createApp, isRef, reactive, ref, toValue, watch } from 'vue'
+import { type App, type MaybeRefOrGetter, computed, createApp, isRef, reactive, ref, toValue, watch } from 'vue'
 
 import {
   type DefaultEntities,
   type RoutePayload,
   resolveRouteParameters,
 } from '@/v2/features/modal/helpers/resolve-route-parameters'
-import type { ApiClientModalOptionsRef } from '@/v2/features/modal/helpers/types'
+import type { ApiClientModalOptions, ApiClientModalOptionsRef } from '@/v2/features/modal/helpers/types'
 import { useModalSidebar } from '@/v2/features/modal/hooks/use-modal-sidebar'
 import Modal, { type ModalProps } from '@/v2/features/modal/Modal.vue'
 
@@ -28,7 +28,7 @@ type CreateApiClientModalOptions = {
   /** Api client plugins to include in the modal */
   plugins?: ClientPlugin[]
   /** Subset of the configuration options for the modal, if you want it to be reactive ensure its a ref */
-  options?: ModalProps['options']
+  options?: MaybeRefOrGetter<ApiClientModalOptions>
 }
 
 export type ApiClientModal = {
@@ -36,6 +36,7 @@ export type ApiClientModal = {
   open: (payload?: RoutePayload) => void
   mount: (mountingEl: HTMLElement | null) => void
   route: (payload: RoutePayload) => void
+  updateOptions: (nextOptions: ApiClientModalOptions) => void
   modalState: ModalState
 }
 
@@ -106,7 +107,7 @@ export const createApiClientModal = ({
     requestBodyCompositionSelection,
     sidebarState,
     workspaceStore,
-    options,
+    options: optionsRef,
   } satisfies ModalProps)
 
   /** Restore the workspace store when the modal is closed. */
@@ -162,5 +163,19 @@ export const createApiClientModal = ({
     route,
     /** Controls the visibility of the modal. */
     modalState,
+    /**
+     * Merge new options into the current modal options.
+     *
+     * @param newOptions - The new options to merge into the current modal options.
+     * @param overwrite - Whether to overwrite the current modal options with the new options. If false, the new options will be merged with the current options.
+     */
+    updateOptions: (newOptions: ApiClientModalOptions, overwrite = false): void => {
+      optionsRef.value = overwrite
+        ? newOptions
+        : {
+            ...optionsRef.value,
+            ...newOptions,
+          }
+    },
   }
 }

--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
@@ -2,13 +2,14 @@ import { type ModalState, useModal } from '@scalar/components'
 import type { ClientPlugin } from '@scalar/oas-utils/helpers'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import { type WorkspaceEventBus, createWorkspaceEventBus } from '@scalar/workspace-store/events'
-import { type App, computed, createApp, reactive, ref, watch } from 'vue'
+import { type App, computed, createApp, isRef, reactive, ref, toValue, watch } from 'vue'
 
 import {
   type DefaultEntities,
   type RoutePayload,
   resolveRouteParameters,
 } from '@/v2/features/modal/helpers/resolve-route-parameters'
+import type { ApiClientModalOptionsRef } from '@/v2/features/modal/helpers/types'
 import { useModalSidebar } from '@/v2/features/modal/hooks/use-modal-sidebar'
 import Modal, { type ModalProps } from '@/v2/features/modal/Modal.vue'
 
@@ -55,6 +56,9 @@ export const createApiClientModal = ({
   options = {},
 }: CreateApiClientModalOptions): ApiClientModal => {
   const requestBodyCompositionSelection = ref<Record<string, number>>({})
+
+  /** This is to ensure that the options are a ref if they are not already, useful for react */
+  const optionsRef = (isRef(options) ? options : ref(toValue(options))) as ApiClientModalOptionsRef
 
   const defaultEntities: DefaultEntities = {
     path: 'default',
@@ -113,6 +117,13 @@ export const createApiClientModal = ({
   watch(
     () => modalState.open,
     (open) => (open ? null : handleModalClose()),
+  )
+
+  // Update the active proxy when the proxyUrl changes
+  watch(
+    () => toValue(optionsRef).proxyUrl,
+    (newProxyUrl) => workspaceStore.update('x-scalar-active-proxy', newProxyUrl),
+    { immediate: true },
   )
 
   // Use a unique id prefix to prevent collisions with other Vue apps on the page

--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
@@ -36,7 +36,7 @@ export type ApiClientModal = {
   open: (payload?: RoutePayload) => void
   mount: (mountingEl: HTMLElement | null) => void
   route: (payload: RoutePayload) => void
-  updateOptions: (nextOptions: ApiClientModalOptions) => void
+  updateOptions: (nextOptions: ApiClientModalOptions, overwrite?: boolean) => void
   modalState: ModalState
 }
 

--- a/packages/api-client/src/v2/features/modal/helpers/types.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/types.ts
@@ -1,0 +1,20 @@
+import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
+import type { Ref } from 'vue'
+
+/**
+ * Configuration options supported by the API Client modal constructor.
+ */
+export type ApiClientModalOptions = Partial<
+  Pick<
+    ApiReferenceConfigurationRaw,
+    | 'authentication'
+    | 'baseServerURL'
+    | 'hideClientButton'
+    | 'hiddenClients'
+    | 'oauth2RedirectUri'
+    | 'proxyUrl'
+    | 'servers'
+  >
+>
+
+export type ApiClientModalOptionsRef = Ref<ApiClientModalOptions>

--- a/packages/api-client/src/v2/features/modal/index.ts
+++ b/packages/api-client/src/v2/features/modal/index.ts
@@ -1,4 +1,5 @@
 export { type ApiClientModal, createApiClientModal } from './helpers/create-api-client-modal'
 export { mapHiddenClientsConfig } from './helpers/map-hidden-clients-config'
 export type { RoutePayload } from './helpers/resolve-route-parameters'
+export type { ApiClientModalOptions } from './helpers/types'
 export { initializeModalEvents } from './modal-events'

--- a/packages/api-client/src/v2/features/operation/Operation.vue
+++ b/packages/api-client/src/v2/features/operation/Operation.vue
@@ -22,7 +22,7 @@ import { OperationBlock } from '@/v2/blocks/operation-block'
 import { APP_VERSION } from '@/v2/constants'
 import type { RouteProps } from '@/v2/features/app/helpers/routes'
 import { mapHiddenClientsConfig } from '@/v2/features/modal/helpers/map-hidden-clients-config'
-import type { ModalProps } from '@/v2/features/modal/Modal.vue'
+import type { ApiClientModalOptionsRef } from '@/v2/features/modal/helpers/types'
 
 const {
   document,
@@ -39,7 +39,7 @@ const {
 } = defineProps<
   RouteProps & {
     /** Subset of config options for the modal */
-    options?: ModalProps['options']
+    options?: ApiClientModalOptionsRef
     /** Selected anyOf/oneOf request-body variants keyed by schema path */
     requestBodyCompositionSelection?: Record<string, number>
   }

--- a/packages/helpers/src/object/is-object-equal.test.ts
+++ b/packages/helpers/src/object/is-object-equal.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import { isObjectEqual } from './is-object-equal'
+
+describe('isObjectEqual', () => {
+  it('uses Object.is semantics for primitive edge cases', () => {
+    expect(isObjectEqual(Number.NaN, Number.NaN)).toBe(true)
+    expect(isObjectEqual(0, -0)).toBe(false)
+  })
+
+  it('returns false for different primitive values', () => {
+    expect(isObjectEqual('1', 1)).toBe(false)
+    expect(isObjectEqual(true, false)).toBe(false)
+  })
+
+  it('returns true for deeply equal nested objects', () => {
+    const left = {
+      id: 'user-1',
+      profile: {
+        name: 'Alice',
+        tags: ['admin', 'editor'],
+        meta: { active: true, retries: 0 },
+      },
+    }
+    const right = {
+      id: 'user-1',
+      profile: {
+        name: 'Alice',
+        tags: ['admin', 'editor'],
+        meta: { active: true, retries: 0 },
+      },
+    }
+
+    expect(isObjectEqual(left, right)).toBe(true)
+  })
+
+  it('returns false when a nested object value differs', () => {
+    const left = {
+      profile: {
+        meta: { active: true },
+      },
+    }
+    const right = {
+      profile: {
+        meta: { active: false },
+      },
+    }
+
+    expect(isObjectEqual(left, right)).toBe(false)
+  })
+
+  it('returns true for deeply equal arrays with nested values', () => {
+    const left = [1, { flags: [true, false] }, ['x', 'y']]
+    const right = [1, { flags: [true, false] }, ['x', 'y']]
+
+    expect(isObjectEqual(left, right)).toBe(true)
+  })
+
+  it('returns false for arrays with different lengths or ordering', () => {
+    expect(isObjectEqual([1, 2, 3], [1, 2])).toBe(false)
+    expect(isObjectEqual([1, 2, 3], [3, 2, 1])).toBe(false)
+  })
+
+  it('returns false when comparing an array to an object', () => {
+    expect(isObjectEqual([1, 2], { 0: 1, 1: 2, length: 2 })).toBe(false)
+  })
+
+  it('ignores inherited properties when checking equality', () => {
+    const proto = { inherited: 'value' }
+    const left = Object.create(proto) as Record<string, unknown>
+    const right = Object.create(proto) as Record<string, unknown>
+
+    left.own = 'same'
+    right.own = 'same'
+
+    expect(isObjectEqual(left, right)).toBe(true)
+  })
+
+  it('detects own-key count differences even when inherited values match', () => {
+    const proto = { role: 'admin' }
+    const left = { role: 'admin' }
+    const right = Object.create(proto)
+
+    expect(isObjectEqual(left, right)).toBe(false)
+  })
+
+  it('treats Date instances as equal when they have no own enumerable properties', () => {
+    const left = new Date('2020-01-01T00:00:00.000Z')
+    const right = new Date('2030-01-01T00:00:00.000Z')
+
+    expect(isObjectEqual(left, right)).toBe(true)
+  })
+})

--- a/packages/helpers/src/object/is-object-equal.ts
+++ b/packages/helpers/src/object/is-object-equal.ts
@@ -1,0 +1,63 @@
+import { isObjectLike } from '@/object/is-object'
+
+/**
+ * Compares two values with deep equality semantics.
+ *
+ * This utility is optimized for nested arrays and object-like values and uses
+ * `Object.is` for primitive and reference identity checks.
+ */
+export const isObjectEqual = (a: unknown, b: unknown): boolean => {
+  if (Object.is(a, b)) {
+    return true
+  }
+
+  if (!isObjectLike(a) || !isObjectLike(b)) {
+    return false
+  }
+
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) {
+      return false
+    }
+
+    for (let i = 0; i < a.length; i += 1) {
+      if (!isObjectEqual(a[i], b[i])) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  if (Array.isArray(b)) {
+    return false
+  }
+
+  const leftObject = a as Record<string, unknown>
+  const rightObject = b as Record<string, unknown>
+
+  // Count only own enumerable keys so inherited properties do not affect equality.
+  let leftCount = 0
+  for (const key in leftObject) {
+    if (!Object.hasOwn(leftObject, key)) {
+      continue
+    }
+
+    leftCount += 1
+
+    if (!Object.hasOwn(rightObject, key) || !isObjectEqual(leftObject[key], rightObject[key])) {
+      return false
+    }
+  }
+
+  let rightCount = 0
+  for (const key in rightObject) {
+    if (!Object.hasOwn(rightObject, key)) {
+      continue
+    }
+
+    rightCount += 1
+  }
+
+  return leftCount === rightCount
+}

--- a/packages/helpers/src/object/is-object.ts
+++ b/packages/helpers/src/object/is-object.ts
@@ -5,16 +5,17 @@
  * Differs from the previous isObject in that it returns false for Date,
  * RegExp, Error, Map, Set, WeakMap, WeakSet, Promise, and other non-plain objects.
  *
- * Examples:
- *   isObject({})                  // true
- *   isObject({ a: 1 })            // true
- *   isObject([])                  // false (Array)
- *   isObject(null)                // false
- *   isObject(123)                 // false
- *   isObject('string')            // false
- *   isObject(new Error('test'))   // false
- *   isObject(new Date())          // false
- *   isObject(Object.create(null)) // true
+ * | Value | Result |
+ * | :--- | :--- |
+ * | `isObject({})` | `true` |
+ * | `isObject({ a: 1 })` | `true` |
+ * | `isObject([])` | `false` (Array) |
+ * | `isObject(null)` | `false` |
+ * | `isObject(123)` | `false` |
+ * | `isObject('string')` | `false` |
+ * | `isObject(new Error('test'))` | `false` |
+ * | `isObject(new Date())` | `false` |
+ * | `isObject(Object.create(null))` | `true` |
  */
 export const isObject = (value: unknown): value is Record<string, unknown> => {
   if (value === null || typeof value !== 'object') {
@@ -24,3 +25,20 @@ export const isObject = (value: unknown): value is Record<string, unknown> => {
   const proto = Object.getPrototypeOf(value)
   return proto === Object.prototype || proto === null
 }
+
+/**
+ * A cheaper version of isObject if you do not care about arrays, errors, and dates.
+ *
+ * This helper is useful when you only need to guard against `null` and primitives.
+ *
+ * | Value | Result |
+ * | :--- | :--- |
+ * | `isObjectLike({})` | `true` |
+ * | `isObjectLike([])` | `true` (Array) |
+ * | `isObjectLike(new Date())` | `true` |
+ * | `isObjectLike(null)` | `false` |
+ * | `isObjectLike(123)` | `false` |
+ * | `isObjectLike('string')` | `false` |
+ */
+export const isObjectLike = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null

--- a/packages/oas-utils/src/migrations/migrate-to-indexdb.test.ts
+++ b/packages/oas-utils/src/migrations/migrate-to-indexdb.test.ts
@@ -251,6 +251,18 @@ describe('migrate-to-indexdb', () => {
     })
   })
 
+  describe('collection test helper defaults', () => {
+    it('defaults useCollectionSecurity to false to match the v-2.5.0 schema', () => {
+      const collection = collectionSchema.parse({
+        uid: 'collection-1',
+        openapi: '3.1.0',
+        info: { title: 'Test API', version: '1.0.0' },
+      })
+
+      expect(collection.useCollectionSecurity).toBe(false)
+    })
+  })
+
   describe('transformLegacyDataToWorkspace - Security Schemes', () => {
     it('should transform API key security schemes into document components and auth store', async () => {
       const scheme = securitySchemeSchema.parse({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1334,6 +1334,9 @@ importers:
       '@scalar/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@scalar/helpers':
+        specifier: workspace:*
+        version: link:../helpers
       '@scalar/workspace-store':
         specifier: workspace:*
         version: link:../workspace-store

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,7 +540,7 @@ importers:
         version: link:../../integrations/nuxt
       nuxt:
         specifier: ^3.20.2
-        version: 3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2)
+        version: 3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2)
 
   examples/react:
     dependencies:
@@ -1334,9 +1334,6 @@ importers:
       '@scalar/api-client':
         specifier: workspace:*
         version: link:../api-client
-      '@scalar/types':
-        specifier: workspace:*
-        version: link:../types
       '@scalar/workspace-store':
         specifier: workspace:*
         version: link:../workspace-store
@@ -20930,10 +20927,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@dxup/nuxt@0.4.0(magicast@0.5.2)(typescript@5.9.3)':
+  '@dxup/nuxt@0.4.0(magicast@0.5.1)(typescript@5.9.3)':
     dependencies:
       '@dxup/unimport': 0.1.2
-      '@nuxt/kit': 4.3.1(magicast@0.5.2)
+      '@nuxt/kit': 4.3.1(magicast@0.5.1)
       chokidar: 5.0.0
       pathe: 2.0.3
       tinyglobby: 0.2.15
@@ -22450,11 +22447,11 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/cli@3.34.0(@nuxt/schema@3.21.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)':
+  '@nuxt/cli@3.34.0(@nuxt/schema@3.21.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.1)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.1)(commander@13.1.0)
       '@clack/prompts': 1.1.0
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.5.1)
       citty: 0.2.1
       confbox: 0.2.4
       consola: 3.4.2
@@ -22672,9 +22669,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/kit@3.21.2(magicast@0.5.2)':
+  '@nuxt/kit@3.21.2(magicast@0.5.1)':
     dependencies:
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.5.1)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -22721,6 +22718,31 @@ snapshots:
       ufo: 1.6.1
       unctx: 2.4.1
       unimport: 5.2.0
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@nuxt/kit@4.3.1(magicast@0.5.1)':
+    dependencies:
+      c12: 3.3.3(magicast@0.5.1)
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.0.8
+      ignore: 7.0.5
+      jiti: 2.6.1
+      klona: 2.0.6
+      mlly: 1.8.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      rc9: 3.0.0
+      scule: 1.3.0
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ufo: 1.6.3
+      unctx: 2.5.0
       untyped: 2.0.0
     transitivePeerDependencies:
       - magicast
@@ -22773,10 +22795,10 @@ snapshots:
       - vue
       - vue-tsc
 
-  '@nuxt/nitro-server@3.21.2(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.2)(nuxt@3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2))(rolldown@1.0.0-rc.11)(typescript@5.9.3)':
+  '@nuxt/nitro-server@3.21.2(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.1)(nuxt@3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2))(rolldown@1.0.0-rc.11)(typescript@5.9.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 3.21.2(magicast@0.5.2)
+      '@nuxt/kit': 3.21.2(magicast@0.5.1)
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
       consola: 3.4.2
@@ -22791,7 +22813,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.1(@netlify/blobs@9.1.2)(rolldown@1.0.0-rc.11)
-      nuxt: 3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2)
+      nuxt: 3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2)
       ohash: 2.0.11
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -22875,18 +22897,18 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/telemetry@2.7.0(@nuxt/kit@3.21.2(magicast@0.5.2))':
+  '@nuxt/telemetry@2.7.0(@nuxt/kit@3.21.2(magicast@0.5.1))':
     dependencies:
-      '@nuxt/kit': 3.21.2(magicast@0.5.2)
+      '@nuxt/kit': 3.21.2(magicast@0.5.1)
       citty: 0.2.1
       consola: 3.4.2
       ofetch: 2.0.0-alpha.3
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/vite-builder@3.21.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(nuxt@3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.4(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)':
+  '@nuxt/vite-builder@3.21.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(nuxt@3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.4(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
-      '@nuxt/kit': 3.21.2(magicast@0.5.2)
+      '@nuxt/kit': 3.21.2(magicast@0.5.1)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
       '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 5.1.4(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
@@ -22903,7 +22925,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.1
       mocked-exports: 0.1.1
-      nuxt: 3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2)
+      nuxt: 3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -32041,19 +32063,19 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.103.0(esbuild@0.27.2)
 
-  nuxt@3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2):
+  nuxt@3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2):
     dependencies:
-      '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
-      '@nuxt/cli': 3.34.0(@nuxt/schema@3.21.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
+      '@dxup/nuxt': 0.4.0(magicast@0.5.1)(typescript@5.9.3)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@3.21.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.1)
       '@nuxt/devtools': 3.2.3(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      '@nuxt/kit': 3.21.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 3.21.2(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.2)(nuxt@3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2))(rolldown@1.0.0-rc.11)(typescript@5.9.3)
+      '@nuxt/kit': 3.21.2(magicast@0.5.1)
+      '@nuxt/nitro-server': 3.21.2(@netlify/blobs@9.1.2)(db0@0.3.4)(ioredis@5.10.0)(magicast@0.5.1)(nuxt@3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2))(rolldown@1.0.0-rc.11)(typescript@5.9.3)
       '@nuxt/schema': 3.21.2
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@3.21.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 3.21.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(nuxt@3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.4(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@3.21.2(magicast@0.5.1))
+      '@nuxt/vite-builder': 3.21.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(nuxt@3.21.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.4.1)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2))(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.11)(rollup@4.59.0))(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.4(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.5.1)
       chokidar: 5.0.0
       compatx: 0.2.0
       consola: 3.4.2
@@ -35895,7 +35917,7 @@ snapshots:
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.2
-      get-tsconfig: 4.13.0
+      get-tsconfig: 4.13.7
     optionalDependencies:
       fsevents: 2.3.3
     optional: true


### PR DESCRIPTION
## Problem

Setting config options like proxyUrl wasn't working.

## Solution

We added a watcher to set the proxyUrl but also added a ref which we can update with the `updateOptions` method from react. I know this doesn't cover all of the config options, but we will update those after the new schema stuff is in.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `useApiClient` and the Vue modal manage and react to configuration, including `proxyUrl` propagation into workspace state; mistakes could break request routing or option updates across consumers.
> 
> **Overview**
> Fixes React `useApiClient` configuration reactivity by separating document registration from modal options, tracking per-hook `documentSlug` via refs, and calling `updateOptions(..., true)` on init and whenever modal options change (with deep-equality guarding).
> 
> Extends the Vue modal API with `ApiClientModalOptions`/ref-based `options` and a new `updateOptions` method, plus a watcher that syncs `proxyUrl` into `x-scalar-active-proxy` so proxy changes take effect without remounting.
> 
> Adds a new `isObjectEqual` helper for deep comparisons, updates docs/playground, and expands test coverage around multi-consumer behavior and reactive option updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 393cda7f5f1534e10ae0d3330a3fede1a835dc4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->