### PR TITLE
fix(dev): use cross-env for Windows compatible dev commands

### DIFF
--- a/projects/proxy-scalar-com/package.json
+++ b/projects/proxy-scalar-com/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "go build main.go",
-    "dev": "ENV=dev PORT=5051 go run main.go",
+    "dev": "cross-env ENV=dev PORT=5051 go run main.go",
     "docker:build": "docker build -t scalar-proxy-server .",
     "docker:run": "pnpm docker:build && docker run --env ENV=dev -p 5051:9033 scalar-proxy-server",
     "lint:check": "go fmt ./main.go",

--- a/tooling/scripts/src/commands/run.ts
+++ b/tooling/scripts/src/commands/run.ts
@@ -8,12 +8,12 @@ run.addCommand(
   new Command('test-servers').description('Run the test servers').action(async () => {
     const { result } = concurrently([
       {
-        command: 'CI=1 pnpm --filter @scalar/void-server dev',
+        command: 'cross-env CI=1 pnpm --filter @scalar/void-server dev',
         name: 'void-server',
         prefixColor: 'blue',
       },
       {
-        command: 'CI=1 pnpm --filter proxy-scalar-com dev',
+        command: 'cross-env CI=1 pnpm --filter proxy-scalar-com dev',
         name: 'proxy-server',
         prefixColor: 'cyan',
       },


### PR DESCRIPTION
## Problem

Some development commands currently rely on Unix-style inline environment variable assignment, for example:

- `CI=1 pnpm --filter @scalar/void-server dev`
- `CI=1 pnpm --filter proxy-scalar-com dev`
- `ENV=dev PORT=5051 go run main.go`

As a result, these dev commands will fail when running the local development workflow on Windows.

## Solution

Replace inline environment variable assignment with `cross-env` in the affected scripts so the commands behave consistently across Windows, Linux, and macOS.

Many other scripts already use `cross-env`, so this appears the be the intended solution.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset.
- [ ] I added tests.
- [ ] I updated the documentation.