### PR TITLE
perf(api-reference): lazy-load CodeMirror and api-client modal chunks

### DIFF
--- a/.changeset/late-corners-lead.md
+++ b/.changeset/late-corners-lead.md
@@ -1,0 +1,6 @@
+---
+'@scalar/use-codemirror': patch
+'@scalar/api-reference': patch
+---
+
+lazy-load @codemirror/\* behind a dynamic import boundary

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -188,6 +188,11 @@
       "import": "./dist/v2/features/settings/index.js",
       "types": "./dist/v2/features/settings/index.d.ts",
       "default": "./dist/v2/features/settings/index.js"
+    },
+    "./v2/workspace-events": {
+      "import": "./dist/v2/workspace-events.js",
+      "types": "./dist/v2/workspace-events.d.ts",
+      "default": "./dist/v2/workspace-events.js"
     }
   },
   "files": [

--- a/packages/api-client/src/v2/workspace-events.ts
+++ b/packages/api-client/src/v2/workspace-events.ts
@@ -42,6 +42,14 @@ const withHook = <T extends keyof ApiReferenceEvents>(
 }
 
 /**
+ * Tracks which event buses have already had workspace event handlers registered.
+ *
+ * Prevents double registration when both the reference page and the modal call
+ * initializeWorkspaceEventHandlers with the same event bus.
+ */
+const _initializedBuses = new WeakSet<WorkspaceEventBus>()
+
+/**
  * Initializes all Workspace Event Handlers by subscribing eventBus listeners
  * to each relevant mutator operation. Hooks are used for before/after execution.
  *
@@ -58,6 +66,10 @@ export function initializeWorkspaceEventHandlers({
   store: Ref<WorkspaceStore | null>
   hooks: Hooks
 }) {
+  if (_initializedBuses.has(eventBus)) {
+    return
+  }
+  _initializedBuses.add(eventBus)
   // Generate all client mutators for the current workspace store
   const mutators = computed(() => generateClientMutators(store.value))
 

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -125,6 +125,7 @@
     "@playwright/test": "catalog:*",
     "@scalar/core": "workspace:*",
     "@scalar/galaxy": "workspace:*",
+    "@scalar/use-codemirror": "workspace:*",
     "@tailwindcss/vite": "catalog:*",
     "@vitejs/plugin-vue": "catalog:*",
     "@vue/server-renderer": "^3.5.30",

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { provideUseId } from '@headlessui/vue'
 import { OpenApiClientButton } from '@scalar/api-client/v2/blocks/operation-block'
-import {
-  createApiClientModal,
-  type ApiClientModal,
-} from '@scalar/api-client/v2/features/modal'
+import type * as ApiClientModalModule from '@scalar/api-client/v2/features/modal'
+import type { ApiClientModal } from '@scalar/api-client/v2/features/modal'
 import {
   addScalarClassesToHeadless,
   ScalarColorModeToggleButton,
@@ -43,7 +41,6 @@ import {
   computed,
   onBeforeMount,
   onBeforeUnmount,
-  onMounted,
   onServerPrefetch,
   provide,
   ref,
@@ -723,12 +720,40 @@ provide(AGENT_CONTEXT_SYMBOL, agent)
 // --------------------------------------------------------------------------- */
 // Api Client Modal
 
-// Setup the ApiClient on mount
 const modal = useTemplateRef<HTMLElement>('modal')
 const apiClient = ref<ApiClientModal | null>(null)
-onMounted(() => {
+
+/**
+ * Singleton promise for the api-client modal module.
+ *
+ * Keeping it outside the component ensures that if multiple ApiReference
+ * instances are on the same page the module is only fetched once.
+ */
+let _modalModulePromise: Promise<typeof ApiClientModalModule> | null = null
+
+/** Start fetching the api-client chunk without blocking the caller. */
+const loadModalModule = () => {
+  if (!_modalModulePromise) {
+    _modalModulePromise = import('@scalar/api-client/v2/features/modal')
+  }
+  return _modalModulePromise
+}
+
+/** Create and mount the modal if it has not been created yet. */
+const ensureModalCreated = async (): Promise<ApiClientModal | null> => {
+  if (apiClient.value) {
+    return apiClient.value
+  }
+
   if (!modal.value) {
-    return
+    return null
+  }
+
+  const { createApiClientModal } = await loadModalModule()
+
+  // Guard against concurrent calls racing to create the modal
+  if (apiClient.value) {
+    return apiClient.value
   }
 
   apiClient.value = createApiClientModal({
@@ -738,8 +763,56 @@ onMounted(() => {
     options: mergedConfig,
     plugins: mapConfigPlugins(mergedConfig, environment),
   })
+
+  return apiClient.value
+}
+
+/**
+ * Preload the api-client modal module when the spec declares environments.
+ *
+ * When `x-scalar-environments` is present the user is very likely to open the
+ * test-request panel (they have variables to fill in), so we fetch the chunk
+ * in the background while they read the docs. This way CodeMirror is already
+ * cached by the time they click "Test Request" and there is no perceptible
+ * loading delay.
+ *
+ * When no environments are configured the chunk is deferred until the user
+ * actually opens the panel for the first time.
+ */
+watch(
+  () => clientStore.workspace.activeDocument?.['x-scalar-environments'],
+  (envs) => {
+    if (envs && Object.keys(envs).length > 0) {
+      loadModalModule()
+    }
+  },
+  { immediate: true },
+)
+
+/**
+ * Intercept the first `ui:open:client-modal` event so the modal can be
+ * created lazily. Once the modal exists its own `initializeModalEvents`
+ * handler takes over for all subsequent events.
+ */
+let _unsubscribeInterceptor: (() => void) | null = null
+_unsubscribeInterceptor = eventBus.on('ui:open:client-modal', (payload) => {
+  // If the modal already exists this interceptor is stale
+  if (apiClient.value) {
+    _unsubscribeInterceptor?.()
+    _unsubscribeInterceptor = null
+    return
+  }
+
+  void ensureModalCreated().then(() => {
+    _unsubscribeInterceptor?.()
+    _unsubscribeInterceptor = null
+    eventBus.emit('ui:open:client-modal', payload)
+  })
 })
+
 onBeforeUnmount(() => {
+  _unsubscribeInterceptor?.()
+  _unsubscribeInterceptor = null
   apiClient.value?.app.unmount()
 })
 

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -3,6 +3,7 @@ import { provideUseId } from '@headlessui/vue'
 import { OpenApiClientButton } from '@scalar/api-client/v2/blocks/operation-block'
 import type * as ApiClientModalModule from '@scalar/api-client/v2/features/modal'
 import type { ApiClientModal } from '@scalar/api-client/v2/features/modal'
+import { initializeWorkspaceEventHandlers } from '@scalar/api-client/v2/workspace-events'
 import {
   addScalarClassesToHeadless,
   ScalarColorModeToggleButton,
@@ -41,6 +42,7 @@ import {
   computed,
   onBeforeMount,
   onBeforeUnmount,
+  onMounted,
   onServerPrefetch,
   provide,
   ref,
@@ -722,6 +724,18 @@ provide(AGENT_CONTEXT_SYMBOL, agent)
 
 const modal = useTemplateRef<HTMLElement>('modal')
 const apiClient = ref<ApiClientModal | null>(null)
+
+/**
+ * Register workspace event handlers (auth, client selection, server updates, etc.)
+ * eagerly so they are available immediately, before the modal is ever opened.
+ */
+onMounted(() => {
+  initializeWorkspaceEventHandlers({
+    eventBus,
+    store: ref(clientStore),
+    hooks: {},
+  })
+})
 
 /**
  * Singleton promise for the api-client modal module.

--- a/packages/api-reference/src/vitest.setup.ts
+++ b/packages/api-reference/src/vitest.setup.ts
@@ -7,7 +7,8 @@ import {
   isConsoleWarnEnabled,
   resetConsoleSpies,
 } from '@scalar/helpers/testing/console-spies'
-import { afterEach, expect, vi } from 'vitest'
+import { preloadCodeMirror } from '@scalar/use-codemirror'
+import { afterEach, beforeAll, expect, vi } from 'vitest'
 
 import { createPluginManager } from '@/plugins/plugin-manager'
 
@@ -15,6 +16,16 @@ import { createPluginManager } from '@/plugins/plugin-manager'
 vi.mock('@/plugins/hooks/usePluginManager', () => ({
   usePluginManager: vi.fn(() => createPluginManager({})),
 }))
+
+/**
+ * Eagerly load the CodeMirror setup module so that the dynamic import inside
+ * useCodeMirror resolves from cache during tests. Without this, the import
+ * fires during component mount but resolves after the test environment tears
+ * down.
+ */
+beforeAll(async () => {
+  await preloadCodeMirror()
+})
 
 afterEach(() => {
   /**

--- a/packages/use-codemirror/src/hooks/codemirror-setup.ts
+++ b/packages/use-codemirror/src/hooks/codemirror-setup.ts
@@ -1,0 +1,342 @@
+/**
+ * CodeMirror setup, dynamically imported to create a code-split boundary.
+ *
+ * This file is NEVER imported statically. All callers use `import('./codemirror-setup')`.
+ * Keeping all heavy `@codemirror/*` imports here means they live in a separate chunk.
+ *
+ * @see useCodeMirror.ts for the public hook that lazy-loads this file.
+ */
+
+import { autocompletion, closeBrackets, closeBracketsKeymap, completionKeymap } from '@codemirror/autocomplete'
+import { history, historyKeymap, indentWithTab, insertNewline } from '@codemirror/commands'
+import { css } from '@codemirror/lang-css'
+import { html } from '@codemirror/lang-html'
+import { json } from '@codemirror/lang-json'
+import { xml } from '@codemirror/lang-xml'
+import { yaml } from '@codemirror/lang-yaml'
+import {
+  type LanguageSupport,
+  type StreamLanguage,
+  bracketMatching,
+  defaultHighlightStyle,
+  foldGutter,
+  indentOnInput,
+  syntaxHighlighting,
+} from '@codemirror/language'
+import { type Diagnostic, linter } from '@codemirror/lint'
+import { StateEffect } from '@codemirror/state'
+import {
+  EditorView,
+  type KeyBinding,
+  highlightSpecialChars,
+  keymap,
+  lineNumbers as lineNumbersExtension,
+  placeholder as placeholderExtension,
+} from '@codemirror/view'
+
+import { customTheme } from '../themes'
+import type { CodeMirrorLanguage } from '../types'
+import { variables } from './variables'
+
+export { EditorView, StateEffect }
+
+const CHEVRON_DOWN =
+  '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m18 10-6 6-6-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>'
+const CHEVRON_RIGHT =
+  '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m9 18 6-6-6-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>'
+
+/**
+ * This was an insane bug that only exists in chrome
+ *
+ * Found these issues which may be related, it says che chrome one is fixed, they possibly had a regression?
+ *
+ * @see https://issues.chromium.org/issues/375711382
+ * @see https://discuss.codemirror.net/t/experimental-support-for-editcontext/8144
+ * @see https://github.com/codemirror/dev/issues/1458
+ */
+// @ts-expect-error this is the workaround suggested by codemirror
+EditorView.EDIT_CONTEXT = false
+
+const languageExtensions: {
+  [lang in CodeMirrorLanguage]: () => LanguageSupport | StreamLanguage<any>
+} = {
+  html: html,
+  json: json,
+  yaml: yaml,
+  css: css,
+  xml: xml,
+}
+
+const selectAllKeyBinding: KeyBinding = {
+  key: 'Mod-a',
+  run: (view) => {
+    // Select the entire content
+    view.dispatch({
+      selection: { anchor: 0, head: view.state.doc.length },
+      scrollIntoView: false,
+    })
+    return true
+  },
+}
+
+/** Generate the list of extensions from parameters */
+export const getCodeMirrorExtensions = ({
+  onChange,
+  onBlur,
+  onFocus,
+  provider,
+  language,
+  classes = [],
+  readOnly = false,
+  lineNumbers = false,
+  withVariables = false,
+  forceFoldGutter = false,
+  disableEnter = false,
+  disableCloseBrackets = false,
+  disableTabIndent = false,
+  withoutTheme = false,
+  lint = false,
+  additionalExtensions = [],
+  placeholder,
+}: {
+  classes?: string[]
+  language?: CodeMirrorLanguage
+  readOnly?: boolean
+  lineNumbers?: boolean
+  disableCloseBrackets?: boolean
+  disableTabIndent?: boolean
+  withVariables?: boolean
+  disableEnter?: boolean
+  forceFoldGutter?: boolean
+  onChange?: (val: string) => void
+  onFocus?: (val: string, event: FocusEvent) => void
+  onBlur?: (val: string, event: FocusEvent) => void
+  withoutTheme?: boolean
+  provider: import('@codemirror/state').Extension | null
+  lint?: boolean
+  additionalExtensions?: import('@codemirror/state').Extension[]
+  placeholder?: string
+}): import('@codemirror/state').Extension[] => {
+  const extensions: import('@codemirror/state').Extension[] = [
+    highlightSpecialChars(),
+    history(),
+    keymap.of(historyKeymap),
+    syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+    EditorView.theme({
+      '.cm-line': {
+        lineHeight: '22px',
+        padding: '0 2px 0 4px',
+      },
+      '.cm-gutterElement': {
+        lineHeight: '22px',
+      },
+      '.cm-tooltip': {
+        background: 'var(--scalar-background-1)',
+        border: '1px solid var(--scalar-border-color)',
+        borderRadius: 'var(--scalar-radius)',
+        boxShadow: 'var(--scalar-shadow-2)',
+        fontSize: '12px',
+        overflow: 'hidden',
+      },
+      '.cm-tooltip-autocomplete ul': {
+        padding: '6px',
+      },
+      '.cm-tooltip-autocomplete ul li': {
+        padding: '3px 6px',
+        color: 'var(--scalar-color-1)',
+        borderRadius: '3px',
+      },
+      '.cm-tooltip-autocomplete ul li[aria-selected]': {
+        background: 'var(--scalar-background-2)',
+        color: 'var(--scalar-color-1)',
+      },
+      '.cm-tooltip-autocomplete ul li:hover': {
+        background: 'var(--scalar-background-3)',
+        color: 'var(--scalar-color-1)',
+      },
+      '.cm-completionLabel': {
+        color: 'var(--scalar-color-1)',
+      },
+      '.cm-completionDetail': {
+        color: 'var(--scalar-color-3)',
+      },
+      '.cm-tooltip-lint': {
+        backgroundColor: 'var(--scalar-background-1)',
+      },
+      '.cm-diagnostic-error': {
+        borderLeft: '0',
+        color: '#dc1b19',
+      },
+      '.cm-foldPlaceholder': {
+        background: 'var(--scalar-background-1)',
+        border: 'none',
+        fontFamily: 'var(--scalar-font)',
+      },
+    }),
+    // Listen to updates
+    EditorView.updateListener.of((v) => {
+      if (!v.docChanged) {
+        return
+      }
+      onChange?.(v.state.doc.toString())
+    }),
+    EditorView.domEventHandlers({
+      blur: (event, view) => {
+        onBlur?.(view.state.doc.toString(), event)
+      },
+      focus: (event, view) => {
+        onFocus?.(view.state.doc.toString(), event)
+      },
+    }),
+    // Add Classes
+    EditorView.editorAttributes.of({ class: classes.join(' ') }),
+    ...additionalExtensions,
+  ]
+
+  // Enable the provider
+  if (provider) {
+    extensions.push(provider)
+  }
+
+  // Add the theme as needed
+  if (!withoutTheme) {
+    extensions.push(customTheme)
+  }
+
+  // Read only
+  if (readOnly) {
+    extensions.push(EditorView.editable.of(false))
+  } else {
+    extensions.push(
+      indentOnInput(),
+      bracketMatching(),
+      autocompletion(),
+      keymap.of([...completionKeymap, selectAllKeyBinding]),
+      bracketMatching(),
+    )
+
+    if (!disableCloseBrackets) {
+      extensions.push(closeBrackets(), keymap.of([...closeBracketsKeymap]))
+    }
+
+    if (disableTabIndent) {
+      extensions.push(
+        keymap.of([
+          {
+            key: 'Tab',
+            run: () => false, // Prevent default Tab behavior
+            shift: () => false, // Prevent default Shift+Tab behavior
+          },
+        ]),
+      )
+    } else {
+      extensions.push(keymap.of([indentWithTab]))
+    }
+  }
+
+  // Add placeholder extension if placeholder is provided
+  if (placeholder) {
+    extensions.push(placeholderExtension(placeholder))
+  }
+
+  // Line numbers
+  if (lineNumbers) {
+    extensions.push(lineNumbersExtension())
+  }
+
+  if (forceFoldGutter) {
+    extensions.push(
+      foldGutter({
+        markerDOM: (open) => {
+          const icon = document.createElement('div')
+          icon.classList.add('cm-foldMarker')
+          icon.innerHTML = open ? CHEVRON_DOWN : CHEVRON_RIGHT
+          return icon
+        },
+      }),
+    )
+  }
+
+  // Syntax highlighting
+  if (language && languageExtensions[language]) {
+    extensions.push(languageExtensions[language]())
+    if (!forceFoldGutter) {
+      extensions.push(
+        foldGutter({
+          markerDOM: (open) => {
+            const icon = document.createElement('div')
+            icon.classList.add('cm-foldMarker')
+            icon.innerHTML = open ? CHEVRON_DOWN : CHEVRON_RIGHT
+            return icon
+          },
+        }),
+      )
+    }
+  }
+
+  // JSON Linter
+  if (lint && language === 'json') {
+    const jsonLinter = linter((view) => {
+      const diagnostics: Diagnostic[] = []
+      const content = view.state.doc.toString()
+      if (content.trim()) {
+        try {
+          JSON.parse(content)
+        } catch (e) {
+          if (e instanceof Error) {
+            diagnostics.push({
+              from: 0,
+              to: view.state.doc.length,
+              severity: 'error',
+              message: e.message,
+            })
+          }
+        }
+      }
+      return diagnostics
+    })
+    extensions.push(jsonLinter)
+  }
+
+  // Highlight variables
+  if (withVariables) {
+    extensions.push(variables())
+  }
+
+  if (disableEnter) {
+    extensions.push(
+      keymap.of([
+        {
+          key: 'Enter',
+          run: () => {
+            return true
+          },
+        },
+        {
+          key: 'Ctrl-Enter',
+          mac: 'Cmd-Enter',
+          run: () => {
+            return true
+          },
+        },
+        {
+          key: 'Shift-Enter',
+          run: () => {
+            return true
+          },
+        },
+      ]),
+    )
+  } else {
+    extensions.push(
+      keymap.of([
+        {
+          key: 'Enter',
+          run: insertNewline,
+        },
+      ]),
+    )
+  }
+
+  return extensions
+}

--- a/packages/use-codemirror/src/hooks/useCodeMirror.test.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.test.ts
@@ -1,34 +1,44 @@
 // @vitest-environment jsdom
 import { EditorView } from '@codemirror/view'
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 import { ref } from 'vue'
 
-import { useCodeMirror } from '../hooks/useCodeMirror'
+import { preloadCodeMirror, useCodeMirror } from '../hooks/useCodeMirror'
+
+/**
+ * Eagerly load the CodeMirror setup module so that the dynamic import inside
+ * useCodeMirror resolves from cache during tests.
+ */
+beforeAll(async () => {
+  await preloadCodeMirror()
+})
 
 describe('useCodeMirror', () => {
-  it('should initialize with basic configuration', () => {
+  it('should initialize with basic configuration', async () => {
     const codeMirrorRef = ref(document.createElement('div'))
     const { codeMirror } = useCodeMirror({
       codeMirrorRef,
       content: '',
       language: undefined,
     })
+    await Promise.resolve()
     expect(codeMirror.value).not.toBeNull()
   })
 
-  it('should update content when content prop changes', () => {
+  it('should update content when content prop changes', async () => {
     const codeMirrorRef = ref(document.createElement('div'))
     const { codeMirror, setCodeMirrorContent } = useCodeMirror({
       codeMirrorRef,
       content: 'initial',
       language: undefined,
     })
+    await Promise.resolve()
 
     setCodeMirrorContent('updated content')
     expect(codeMirror.value?.state.doc.toString()).toBe('updated content')
   })
 
-  it('should handle read-only mode', () => {
+  it('should handle read-only mode', async () => {
     const codeMirrorRef = ref(document.createElement('div'))
     const { codeMirror } = useCodeMirror({
       codeMirrorRef,
@@ -36,22 +46,24 @@ describe('useCodeMirror', () => {
       language: undefined,
       readOnly: true,
     })
+    await Promise.resolve()
 
     expect(codeMirror.value?.state.facet(EditorView.editable)).toBe(false)
   })
 
-  it('should support different languages', () => {
+  it('should support different languages', async () => {
     const codeMirrorRef = ref(document.createElement('div'))
     const { codeMirror } = useCodeMirror({
       codeMirrorRef,
       content: '{"test": "json"}',
       language: 'json',
     })
+    await Promise.resolve()
 
     expect(codeMirror.value).not.toBeNull()
   })
 
-  it('should trigger onChange callback', () => {
+  it('should trigger onChange callback', async () => {
     let changedContent = ''
     const codeMirrorRef = ref(document.createElement('div'))
     const { setCodeMirrorContent } = useCodeMirror({
@@ -62,12 +74,13 @@ describe('useCodeMirror', () => {
         changedContent = content
       },
     })
+    await Promise.resolve()
 
     setCodeMirrorContent('new content')
     expect(changedContent).toBe('new content')
   })
 
-  it('should handle placeholder text', () => {
+  it('should handle placeholder text', async () => {
     const codeMirrorRef = ref(document.createElement('div'))
     const { codeMirror } = useCodeMirror({
       codeMirrorRef,
@@ -75,7 +88,9 @@ describe('useCodeMirror', () => {
       language: undefined,
       placeholder: 'Type something...',
     })
+    await Promise.resolve()
 
-    expect(codeMirror.value?.dom.querySelector('.cm-placeholder')).not.toBeNull()
+    expect(codeMirror.value).not.toBeNull()
+    expect(codeMirror.value!.dom.querySelector('.cm-placeholder')).not.toBeNull()
   })
 })

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -1,51 +1,43 @@
-import { autocompletion, closeBrackets, closeBracketsKeymap, completionKeymap } from '@codemirror/autocomplete'
-import { history, historyKeymap, indentWithTab, insertNewline } from '@codemirror/commands'
-import { css } from '@codemirror/lang-css'
-import { html } from '@codemirror/lang-html'
-import { json } from '@codemirror/lang-json'
-import { xml } from '@codemirror/lang-xml'
-import { yaml } from '@codemirror/lang-yaml'
-import {
-  type LanguageSupport,
-  type StreamLanguage,
-  bracketMatching,
-  defaultHighlightStyle,
-  foldGutter,
-  indentOnInput,
-  syntaxHighlighting,
-} from '@codemirror/language'
-import { type Diagnostic, linter } from '@codemirror/lint'
-import { type Extension, StateEffect } from '@codemirror/state'
-import {
-  EditorView,
-  type KeyBinding,
-  highlightSpecialChars,
-  keymap,
-  lineNumbers as lineNumbersExtension,
-  placeholder as placeholderExtension,
-} from '@codemirror/view'
+import type { Extension } from '@codemirror/state'
+import type { EditorView } from '@codemirror/view'
 import { type MaybeRefOrGetter, type Ref, computed, onBeforeUnmount, ref, toValue, watch } from 'vue'
 
-const CHEVRON_DOWN =
-  '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m18 10-6 6-6-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>'
-const CHEVRON_RIGHT =
-  '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m9 18 6-6-6-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>'
-
-import { customTheme } from '../themes'
 import type { CodeMirrorLanguage } from '../types'
-import { variables } from './variables'
 
 /**
- * This was an insane bug that only exists in chrome
+ * Cached reference to the lazily-loaded CodeMirror setup module.
  *
- * Found these issues which may be related, it says che chrome one is fixed, they possibly had a regression?
+ * Declared at module level so it is shared across all hook instances
  *
- * @see https://issues.chromium.org/issues/375711382
- * @see https://discuss.codemirror.net/t/experimental-support-for-editcontext/8144
- * @see https://github.com/codemirror/dev/issues/1458
+ * The heavy CodeMirror packages are only downloaded once regardless of
+ * how many editors are on the page.
  */
-// @ts-expect-error this is the workaround suggested by codemirror
-EditorView.EDIT_CONTEXT = false
+let _setup: typeof import('./codemirror-setup') | null = null
+let _setupPromise: Promise<typeof import('./codemirror-setup')> | null = null
+
+/** Load the CodeMirror setup module, caching the result. */
+const loadSetup = (): Promise<typeof import('./codemirror-setup')> => {
+  if (_setup) {
+    return Promise.resolve(_setup)
+  }
+  if (!_setupPromise) {
+    _setupPromise = import('./codemirror-setup').then((m) => {
+      _setup = m
+      return m
+    })
+  }
+  return _setupPromise
+}
+
+/**
+ * Prefetch the CodeMirror chunk without blocking.
+ *
+ * Call this as early as possible when you know a CodeMirror editor will be
+ * needed soon, for example, when detecting `x-scalar-environments` in a
+ * loaded OpenAPI document. The browser will start downloading the chunk in
+ * the background so it is already cached by the time the first editor mounts.
+ */
+export const preloadCodeMirror = (): Promise<void> => loadSetup().then(() => undefined)
 
 type BaseParameters = {
   /** Element Ref to mount codemirror to */
@@ -94,18 +86,6 @@ const hasProvider = (
   content?: MaybeRefOrGetter<string | undefined>
   provider: MaybeRefOrGetter<Extension>
 } => 'provider' in params && !!toValue(params.provider)
-
-const selectAllKeyBinding: KeyBinding = {
-  key: 'Mod-a',
-  run: (view) => {
-    // Select the entire content
-    view.dispatch({
-      selection: { anchor: 0, head: view.state.doc.length },
-      scrollIntoView: false,
-    })
-    return true
-  },
-}
 
 /** Reactive CodeMirror Integration */
 export const useCodeMirror = (
@@ -159,39 +139,58 @@ export const useCodeMirror = (
     placeholder: toValue(params.placeholder),
   }))
 
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Mount (or remount) the CodeMirror editor.
+   *
+   * Lazily loads the CodeMirror setup chunk on the first call. Subsequent
+   * calls reuse the already-loaded module synchronously.
+   */
+  const mountCodeMirror = async (): Promise<void> => {
+    // Capture the current target before awaiting so we can bail out if the
+    // ref changed while the chunk was loading (e.g. the component unmounted).
+    const mountTarget = params.codeMirrorRef.value
+    if (!mountTarget) {
+      return
+    }
+
+    const setup = await loadSetup()
+
+    // Bail out if the ref changed or the element was removed from the DOM.
+    if (params.codeMirrorRef.value !== mountTarget || !mountTarget.isConnected) {
+      return
+    }
+
+    const provider = hasProvider(params) ? toValue(params.provider) : null
+    const extensions = setup.getCodeMirrorExtensions({
+      ...extensionConfig.value,
+      provider,
+    })
+
+    codeMirror.value = new setup.EditorView({
+      parent: mountTarget,
+      extensions,
+    })
+
+    // Set the initial content if a provider is not in use
+    if (!hasProvider(params)) {
+      setCodeMirrorContent(toValue(params.content))
+    }
+  }
+
   // Unmounts CodeMirror if it's mounted already, and mounts CodeMirror, if the given ref exists.
   watch(
     params.codeMirrorRef,
     () => {
       codeMirror.value?.destroy()
-      mountCodeMirror()
+      void mountCodeMirror()
     },
     { immediate: true },
   )
 
   // Cleanup codemirror
   onBeforeUnmount(() => codeMirror.value?.destroy())
-
-  // Initializes CodeMirror.
-  function mountCodeMirror() {
-    if (params.codeMirrorRef.value) {
-      const provider = hasProvider(params) ? toValue(params.provider) : null
-      const extensions = getCodeMirrorExtensions({
-        ...extensionConfig.value,
-        provider,
-      })
-
-      codeMirror.value = new EditorView({
-        parent: params.codeMirrorRef.value,
-        extensions,
-      })
-
-      // Set the initial content if a provider is not in use
-      if (!hasProvider(params)) {
-        setCodeMirrorContent(toValue(params.content))
-      }
-    }
-  }
 
   // ---------------------------------------------------------------------------
 
@@ -201,29 +200,33 @@ export const useCodeMirror = (
     () => {
       if (hasProvider(params)) {
         codeMirror.value?.destroy()
-        mountCodeMirror()
+        void mountCodeMirror()
       }
     },
   )
 
-  // Update the extensions whenever parameters changes
+  // Update the extensions whenever parameters change.
+  // Uses the cached setup module — if the editor is not yet mounted (setup
+  // not loaded) `codeMirror.value` will be null and we return early. Once
+  // the editor is mounted the setup is guaranteed to be in the cache.
   watch(
     extensionConfig,
     () => {
-      if (!codeMirror.value) {
+      const setup = _setup
+      if (!codeMirror.value || !setup) {
         return
       }
       // If a provider is
 
       const provider = hasProvider(params) ? toValue(params.provider) : null
-      const extensions = getCodeMirrorExtensions({
+      const extensions = setup.getCodeMirrorExtensions({
         ...extensionConfig.value,
         provider,
       })
 
       requestAnimationFrame(() => {
         codeMirror.value?.dispatch({
-          effects: StateEffect.reconfigure.of(extensions),
+          effects: setup.StateEffect.reconfigure.of(extensions),
         })
       })
     },
@@ -252,278 +255,4 @@ export const useCodeMirror = (
     /** Codemirror instance */
     codeMirror,
   }
-}
-
-// ---------------------------------------------------------------------------
-
-const languageExtensions: {
-  [lang in CodeMirrorLanguage]: () => LanguageSupport | StreamLanguage<any>
-} = {
-  html: html,
-  json: json,
-  yaml: yaml,
-  css: css,
-  xml: xml,
-}
-
-/** Generate  the list of extension from parameters */
-function getCodeMirrorExtensions({
-  onChange,
-  onBlur,
-  onFocus,
-  provider,
-  language,
-  classes = [],
-  readOnly = false,
-  lineNumbers = false,
-  withVariables = false,
-  forceFoldGutter = false,
-  disableEnter = false,
-  disableCloseBrackets = false,
-  disableTabIndent = false,
-  withoutTheme = false,
-  lint = false,
-  additionalExtensions = [],
-  placeholder,
-}: {
-  classes?: string[]
-  language?: CodeMirrorLanguage
-  readOnly?: boolean
-  lineNumbers?: boolean
-  disableCloseBrackets?: boolean
-  disableTabIndent?: boolean
-  withVariables?: boolean
-  disableEnter?: boolean
-  forceFoldGutter?: boolean
-  onChange?: (val: string) => void
-  onFocus?: (val: string, event: FocusEvent) => void
-  onBlur?: (val: string, event: FocusEvent) => void
-  withoutTheme?: boolean
-  provider: Extension | null
-  lint?: boolean
-  additionalExtensions?: Extension[]
-  placeholder?: string
-}) {
-  const extensions: Extension[] = [
-    highlightSpecialChars(),
-    history(),
-    keymap.of(historyKeymap),
-    syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
-    EditorView.theme({
-      '.cm-line': {
-        lineHeight: '22px',
-        padding: '0 2px 0 4px',
-      },
-      '.cm-gutterElement': {
-        lineHeight: '22px',
-      },
-      '.cm-tooltip': {
-        background: 'var(--scalar-background-1)',
-        border: '1px solid var(--scalar-border-color)',
-        borderRadius: 'var(--scalar-radius)',
-        boxShadow: 'var(--scalar-shadow-2)',
-        fontSize: '12px',
-        overflow: 'hidden',
-      },
-      '.cm-tooltip-autocomplete ul': {
-        padding: '6px',
-      },
-      '.cm-tooltip-autocomplete ul li': {
-        padding: '3px 6px',
-        color: 'var(--scalar-color-1)',
-        borderRadius: '3px',
-      },
-      '.cm-tooltip-autocomplete ul li[aria-selected]': {
-        background: 'var(--scalar-background-2)',
-        color: 'var(--scalar-color-1)',
-      },
-      '.cm-tooltip-autocomplete ul li:hover': {
-        background: 'var(--scalar-background-3)',
-        color: 'var(--scalar-color-1)',
-      },
-      '.cm-completionLabel': {
-        color: 'var(--scalar-color-1)',
-      },
-      '.cm-completionDetail': {
-        color: 'var(--scalar-color-3)',
-      },
-      '.cm-tooltip-lint': {
-        backgroundColor: 'var(--scalar-background-1)',
-      },
-      '.cm-diagnostic-error': {
-        borderLeft: '0',
-        color: '#dc1b19',
-      },
-      '.cm-foldPlaceholder': {
-        background: 'var(--scalar-background-1)',
-        border: 'none',
-        fontFamily: 'var(--scalar-font)',
-      },
-    }),
-    // Listen to updates
-    EditorView.updateListener.of((v) => {
-      if (!v.docChanged) {
-        return
-      }
-      onChange?.(v.state.doc.toString())
-    }),
-    EditorView.domEventHandlers({
-      blur: (event, view) => {
-        onBlur?.(view.state.doc.toString(), event)
-      },
-      focus: (event, view) => {
-        onFocus?.(view.state.doc.toString(), event)
-      },
-    }),
-    // Add Classes
-    EditorView.editorAttributes.of({ class: classes.join(' ') }),
-    ...additionalExtensions,
-  ]
-
-  // Enable the provider
-  if (provider) {
-    extensions.push(provider)
-  }
-
-  // Add the theme as needed
-  if (!withoutTheme) {
-    extensions.push(customTheme)
-  }
-
-  // Read only
-  if (readOnly) {
-    extensions.push(EditorView.editable.of(false))
-  } else {
-    extensions.push(
-      indentOnInput(),
-      bracketMatching(),
-      autocompletion(),
-      keymap.of([...completionKeymap, selectAllKeyBinding]),
-      bracketMatching(),
-    )
-
-    if (!disableCloseBrackets) {
-      extensions.push(closeBrackets(), keymap.of([...closeBracketsKeymap]))
-    }
-
-    if (disableTabIndent) {
-      extensions.push(
-        keymap.of([
-          {
-            key: 'Tab',
-            run: () => false, // Prevent default Tab behavior
-            shift: () => false, // Prevent default Shift+Tab behavior
-          },
-        ]),
-      )
-    } else {
-      extensions.push(keymap.of([indentWithTab]))
-    }
-  }
-
-  // Add placeholder extension if placeholder is provided
-  if (placeholder) {
-    extensions.push(placeholderExtension(placeholder))
-  }
-
-  // Line numbers
-  if (lineNumbers) {
-    extensions.push(lineNumbersExtension())
-  }
-
-  if (forceFoldGutter) {
-    extensions.push(
-      foldGutter({
-        markerDOM: (open) => {
-          const icon = document.createElement('div')
-          icon.classList.add('cm-foldMarker')
-          icon.innerHTML = open ? CHEVRON_DOWN : CHEVRON_RIGHT
-          return icon
-        },
-      }),
-    )
-  }
-
-  // Syntax highlighting
-  if (language && languageExtensions[language]) {
-    extensions.push(languageExtensions[language]())
-    if (!forceFoldGutter) {
-      extensions.push(
-        foldGutter({
-          markerDOM: (open) => {
-            const icon = document.createElement('div')
-            icon.classList.add('cm-foldMarker')
-            icon.innerHTML = open ? CHEVRON_DOWN : CHEVRON_RIGHT
-            return icon
-          },
-        }),
-      )
-    }
-  }
-
-  // JSON Linter
-  if (lint && language === 'json') {
-    const jsonLinter = linter((view) => {
-      const diagnostics: Diagnostic[] = []
-      const content = view.state.doc.toString()
-      if (content.trim()) {
-        try {
-          JSON.parse(content)
-        } catch (e) {
-          if (e instanceof Error) {
-            diagnostics.push({
-              from: 0,
-              to: view.state.doc.length,
-              severity: 'error',
-              message: e.message,
-            })
-          }
-        }
-      }
-      return diagnostics
-    })
-    extensions.push(jsonLinter)
-  }
-
-  // Highlight variables
-  if (withVariables) {
-    extensions.push(variables())
-  }
-
-  if (disableEnter) {
-    extensions.push(
-      keymap.of([
-        {
-          key: 'Enter',
-          run: () => {
-            return true
-          },
-        },
-        {
-          key: 'Ctrl-Enter',
-          mac: 'Cmd-Enter',
-          run: () => {
-            return true
-          },
-        },
-        {
-          key: 'Shift-Enter',
-          run: () => {
-            return true
-          },
-        },
-      ]),
-    )
-  } else {
-    extensions.push(
-      keymap.of([
-        {
-          key: 'Enter',
-          run: insertNewline,
-        },
-      ]),
-    )
-  }
-
-  return extensions
 }

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -157,8 +157,9 @@ export const useCodeMirror = (
 
     const setup = await loadSetup()
 
-    // Bail out if the ref changed or the element was removed from the DOM.
-    if (params.codeMirrorRef.value !== mountTarget || !mountTarget.isConnected) {
+    // Bail out if the ref changed while the chunk was loading (e.g. the component
+    // unmounted). Vue sets template refs to null on unmount, so this covers that case.
+    if (params.codeMirrorRef.value !== mountTarget) {
       return
     }
 

--- a/packages/use-codemirror/src/index.ts
+++ b/packages/use-codemirror/src/index.ts
@@ -16,6 +16,7 @@ export { colorPicker } from '@replit/codemirror-css-color-picker'
 
 export {
   type UseCodeMirrorParameters,
+  preloadCodeMirror,
   useCodeMirror,
 } from './hooks/useCodeMirror'
 export { useDropdown } from './hooks/useDropdown'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1462,6 +1462,9 @@ importers:
       '@scalar/galaxy':
         specifier: workspace:*
         version: link:../galaxy
+      '@scalar/use-codemirror':
+        specifier: workspace:*
+        version: link:../use-codemirror
       '@tailwindcss/vite':
         specifier: catalog:*
         version: 4.2.1(vite@8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))


### PR DESCRIPTION
## Problem

For #8829 / codemirror.

Every page that uses `@scalar/api-reference` downloads all `@codemirror/*` packages on first load, even when the spec has no `x-scalar-environments` and the user never opens the request panel.

CodeMirror is heavy (~300 kB minified), and it blocks TTI for the majority of read-only documentation pages.

## Solution

Two independent code-split boundaries were introduced:

#### `@scalar/use-codemirror`

All `@codemirror/*` imports were moved from `useCodeMirror.ts` into a new `codemirror-setup.ts` file that is never imported statically. `useCodeMirror` now calls `import('./codemirror-setup')` on first mount, caching the result in a module-level singleton so the chunk is fetched at most once regardless of how many editors are on the page.

`preloadCodeMirror()` is exported for call sites that want to start fetching the chunk early without blocking.

#### `ApiReference.vue`

`createApiClientModal` is no longer statically imported. The modal chunk is fetched lazily on the first `ui:open:client-modal` event.

Additionally, if the parsed spec contains `x-scalar-environments`, the modal chunk begins prefetching immediately after spec load so it is already in cache before the user clicks "Test Request".

**Tests**

The `vitest.setup.ts` for `api-reference` calls `await preloadCodeMirror()` in a `beforeAll` so the module is fully resolved before any test mounts a component. Without this, the dynamic import fires during mount but resolves after the test environment tears down (`EnvironmentTeardownError`).

**ESM Playground Results**
- Before `index.js`
  - `1,191.81 kB │ gzip: 376.94 kB`
- After `index.js`
  - `922.07 kB │ gzip: 276.64 kB`

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [ ] I added tests.
- [ ] I updated the documentation.

---

Notes:

This is more of a PoC than anything else. I am confident in the solution, but like I mentioned in that discussion, I am not sure if this is semantically correct for this codebase. Scalar is very large and somewhat overwhelming. These somewhat "free" gains are nice though.

This might also require changes to the documentation.