### PR TITLE
fix(build-scripts): use forward slashes in package.json directory field on Windows

### DIFF
--- a/tooling/scripts/src/commands/packages/format.ts
+++ b/tooling/scripts/src/commands/packages/format.ts
@@ -150,7 +150,7 @@ async function formatPackage(filepath: string) {
   })
 
   // Repository URL
-  const directory = path.relative(root, path.dirname(filepath))
+  const directory = path.relative(root, path.dirname(filepath)).split(path.sep).join('/')
   // console.log(directory)
   formattedData['repository'] = {
     type: 'git',


### PR DESCRIPTION
## Problem

Running `pnpm script packages format` on Windows causes the `directory` field in all `package.json` files to be written with backslashes (e.g. `examples\\nextjs-api-reference`) instead of forward slashes. This happens because Node's `path.relative()` uses the OS native path separator, which is `\` on Windows.

This causes the lefthook `pre-commit` hook to reformat and re-stage every `package.json` in the repo on every commit when developing on Windows.

## Solution

Use `.split(path.sep).join('/')` to normalize the result of `path.relative()` to always use forward slashes, regardless of the OS it's run on.

```diff
-const directory = path.relative(root, path.dirname(filepath))
+const directory = path.relative(root, path.dirname(filepath)).split(path.sep).join('/')
```

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.