### PR TITLE
fix(api-client): clean up web client header auth actions

### DIFF
--- a/.changeset/late-owls-bake.md
+++ b/.changeset/late-owls-bake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): add dashboard-style auth header for web layout

--- a/packages/api-client/src/v2/features/app/App.test.ts
+++ b/packages/api-client/src/v2/features/app/App.test.ts
@@ -136,4 +136,27 @@ describe('App', () => {
     expect(appState.document.value).toBeDefined()
     expect(appState.document.value?.info.title).toBe('Test Document')
   })
+
+  it('renders dashboard auth links in web layout header', async () => {
+    const { wrapper } = await setupApp('web')
+
+    const loginLink = wrapper.find('a[href="https://dashboard.scalar.com/login"]')
+    const registerLink = wrapper.find(
+      'a[href="https://dashboard.scalar.com/register"]',
+    )
+
+    expect(loginLink.exists()).toBe(true)
+    expect(registerLink.exists()).toBe(true)
+  })
+
+  it('does not render dashboard auth links in desktop layout', async () => {
+    const { wrapper } = await setupApp('desktop')
+
+    expect(
+      wrapper.find('a[href="https://dashboard.scalar.com/login"]').exists(),
+    ).toBe(false)
+    expect(
+      wrapper.find('a[href="https://dashboard.scalar.com/register"]').exists(),
+    ).toBe(false)
+  })
 })

--- a/packages/api-client/src/v2/features/app/App.test.ts
+++ b/packages/api-client/src/v2/features/app/App.test.ts
@@ -141,9 +141,7 @@ describe('App', () => {
     const { wrapper } = await setupApp('web')
 
     const loginLink = wrapper.find('a[href="https://dashboard.scalar.com/login"]')
-    const registerLink = wrapper.find(
-      'a[href="https://dashboard.scalar.com/register"]',
-    )
+    const registerLink = wrapper.find('a[href="https://dashboard.scalar.com/register"]')
 
     expect(loginLink.exists()).toBe(true)
     expect(registerLink.exists()).toBe(true)
@@ -152,11 +150,7 @@ describe('App', () => {
   it('does not render dashboard auth links in desktop layout', async () => {
     const { wrapper } = await setupApp('desktop')
 
-    expect(
-      wrapper.find('a[href="https://dashboard.scalar.com/login"]').exists(),
-    ).toBe(false)
-    expect(
-      wrapper.find('a[href="https://dashboard.scalar.com/register"]').exists(),
-    ).toBe(false)
+    expect(wrapper.find('a[href="https://dashboard.scalar.com/login"]').exists()).toBe(false)
+    expect(wrapper.find('a[href="https://dashboard.scalar.com/register"]').exists()).toBe(false)
   })
 })

--- a/packages/api-client/src/v2/features/app/App.vue
+++ b/packages/api-client/src/v2/features/app/App.vue
@@ -22,6 +22,7 @@ import { RouterView } from 'vue-router'
 import { SidebarToggle } from '@/v2/components/sidebar'
 import CreateWorkspaceModal from '@/v2/features/app/components/CreateWorkspaceModal.vue'
 import SplashScreen from '@/v2/features/app/components/SplashScreen.vue'
+import WebHeader from '@/v2/features/app/components/WebHeader.vue'
 import type { RouteProps } from '@/v2/features/app/helpers/routes'
 import { useDocumentWatcher } from '@/v2/features/app/hooks/use-document-watcher'
 import type { CommandPaletteState } from '@/v2/features/command-palette/hooks/use-command-palette-state'
@@ -174,8 +175,12 @@ const routerViewProps = computed<RouteProps>(() => {
       ">
       <div class="relative flex h-dvh w-dvw flex-1 flex-col">
         <SidebarToggle
+          v-if="layout !== 'web'"
           v-model="app.sidebar.isOpen.value"
           class="absolute top-4 left-3 z-[60] md:hidden" />
+        <WebHeader
+          v-if="layout === 'web'"
+          v-model:isSidebarOpen="app.sidebar.isOpen.value" />
         <div class="flex min-h-0 flex-1 flex-row">
           <!-- App sidebar -->
           <AppSidebar

--- a/packages/api-client/src/v2/features/app/components/WebHeader.vue
+++ b/packages/api-client/src/v2/features/app/components/WebHeader.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import {
+  ScalarHeader,
+  ScalarHeaderButton,
+  ScalarMenu,
+  ScalarMenuProducts,
+} from '@scalar/components'
+
+import { SidebarToggle } from '@/v2/components/sidebar'
+
+const isSidebarOpen = defineModel<boolean>('isSidebarOpen', {
+  required: true,
+})
+</script>
+<template>
+  <ScalarHeader class="z-30">
+    <template #start>
+      <SidebarToggle
+        v-model="isSidebarOpen"
+        class="md:hidden" />
+      <ScalarMenu>
+        <template #products>
+          <ScalarMenuProducts selected="client" />
+        </template>
+      </ScalarMenu>
+    </template>
+    <template #end>
+      <ScalarHeaderButton
+        is="a"
+        href="https://dashboard.scalar.com/login"
+        rel="noreferrer"
+        target="_blank">
+        Log in
+      </ScalarHeaderButton>
+      <ScalarHeaderButton
+        active
+        is="a"
+        href="https://dashboard.scalar.com/register"
+        rel="noreferrer"
+        target="_blank">
+        Register
+      </ScalarHeaderButton>
+    </template>
+  </ScalarHeader>
+</template>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The API Client web experience on `client.scalar.com` did not have a proper product-style header with auth actions, so it did not match the dashboard pattern.

## Solution

- Added a dedicated web-only header component in `@scalar/api-client` that uses the shared `ScalarHeader` + `ScalarMenu` pattern.
- Added `Log in` and `Register` actions linking to `https://dashboard.scalar.com/login` and `https://dashboard.scalar.com/register`.
- Rendered this header only for `layout === 'web'` in `App.vue`.
- Added app tests to assert auth links are present in web layout and absent in desktop layout.
- Added a patch changeset for `@scalar/api-client`.

## Visual

![Web layout header with Log in and Register](https://cursor.com/artifacts/c/art-ed8ae6cb-3f4d-42b8-82a7-62c62fe629fe)
![App layout without web auth header](https://cursor.com/artifacts/c/art-fbeaef9d-86c3-425f-892d-e9c5fd143ece)
![Dashboard login destination](https://cursor.com/artifacts/c/art-d4505a80-b39e-4693-bd28-ba9eef8ea1c1)
![Dashboard register destination](https://cursor.com/artifacts/c/art-63328b10-158f-41be-b45e-636633f76df7)
<a href="https://cursor.com/agents/bc-792f7b11-d630-43f1-84c8-ca2efd98d166/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdoc_5189_api_client_header_verified_demo.mp4"><img src="https://cursor.com/artifacts/c/art-5f1dacd6-11f0-432d-a9d0-863d2ecc51e9" alt="doc_5189_api_client_header_verified_demo.mp4" /></a>

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Fixes DOC-5189
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-792f7b11-d630-43f1-84c8-ca2efd98d166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-792f7b11-d630-43f1-84c8-ca2efd98d166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

