### PR TITLE
fix(api-client): improve registry sync and publish UX copy

### DIFF
--- a/.changeset/sixty-forks-think.md
+++ b/.changeset/sixty-forks-think.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): improve registry sync and save-before-sync UX

--- a/packages/api-client/src/v2/features/collection/DocumentCollection.test.ts
+++ b/packages/api-client/src/v2/features/collection/DocumentCollection.test.ts
@@ -180,6 +180,7 @@ describe('DocumentCollection', () => {
 
     const syncButton = wrapper.find('[data-testid="document-sync-button"]')
     expect(syncButton.exists()).toBe(true)
+    expect(syncButton.text()).toContain('Sync with Registry')
 
     await syncButton.trigger('click')
     await flushPromises()
@@ -234,5 +235,31 @@ describe('DocumentCollection', () => {
       name: 'test-document',
       document: registryDocument,
     })
+  })
+
+  it('does not continue sync when save fails in dirty-state modal', async () => {
+    const document = createMockDocument({
+      info: { title: 'Dirty API', version: '1.0.0' },
+      'x-scalar-original-source-url': 'https://example.com/openapi.yaml',
+      'x-scalar-is-dirty': true,
+    })
+
+    const { wrapper, workspaceStore } = await mountWithRouter(document)
+    workspaceStore.saveDocument = vi.fn().mockResolvedValue(false) as any
+
+    const syncButton = wrapper.find('[data-testid="document-sync-button"]')
+    await syncButton.trigger('click')
+    await flushPromises()
+
+    const saveAndContinueButton = [...globalThis.document.body.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Save and continue'),
+    )
+    expect(saveAndContinueButton).toBeDefined()
+
+    saveAndContinueButton?.dispatchEvent(new MouseEvent('click'))
+    await flushPromises()
+
+    expect(workspaceStore.saveDocument).toHaveBeenCalledWith('test-document')
+    expect(workspaceStore.rebaseDocument).not.toHaveBeenCalled()
   })
 })

--- a/packages/api-client/src/v2/features/collection/DocumentCollection.vue
+++ b/packages/api-client/src/v2/features/collection/DocumentCollection.vue
@@ -21,7 +21,7 @@ import {
   useModal,
 } from '@scalar/components'
 import {
-  ScalarIconCloudArrowDown,
+  ScalarIconArrowsClockwise,
   ScalarIconDownload,
   ScalarIconFloppyDisk,
   ScalarIconSpinner,
@@ -104,7 +104,11 @@ const downloadDocument = () => {
 }
 
 const handleSaveThenCloseDirtyModal = async () => {
-  await props.workspaceStore.saveDocument(props.documentSlug)
+  const isSaved = await props.workspaceStore.saveDocument(props.documentSlug)
+  if (!isSaved) {
+    toast('Could not save your changes. Please try saving again.', 'error')
+    return
+  }
   dirtyBeforeSyncModal.hide()
   await handleSyncFlow()
 }
@@ -169,10 +173,7 @@ const onSyncComplete = () => {
   syncModal.hide()
   isSyncInProgress.value = false
   // Display the toast to show that the sync is complete
-  toast(
-    'Your document has been rebased with the latest version from the source.',
-    'info',
-  )
+  toast('Document synced with Registry.', 'info')
   // Emit the event to notify other components that the sync is complete
   props.eventBus.emit('hooks:on:rebase:document:complete', {
     meta: {
@@ -340,7 +341,7 @@ const onSyncModalClose = () => {
             data-testid="document-sync-button"
             :disabled="isSyncInProgress"
             size="xs"
-            :title="'Pull the latest version from the document source and merge with your local copy. Save your changes first if you have unsaved edits.'"
+            :title="'Sync your local document with the Registry. This can pull remote updates and prepare your saved local edits for publish.'"
             type="button"
             variant="ghost"
             @click="handleSyncFlow">
@@ -348,12 +349,12 @@ const onSyncModalClose = () => {
               v-if="isSyncInProgress"
               class="size-3.5 animate-spin"
               size="sm" />
-            <ScalarIconCloudArrowDown
+            <ScalarIconArrowsClockwise
               v-else
               class="size-3.5"
               size="sm"
               thickness="1.5" />
-            <span>Sync from source</span>
+            <span>Sync with Registry</span>
           </ScalarButton>
         </div>
       </div>
@@ -388,7 +389,7 @@ const onSyncModalClose = () => {
     bodyClass="border-t-0 rounded-t-lg flex flex-col gap-5"
     size="xs"
     :state="dirtyBeforeSyncModal"
-    title="Sync requires saved document"
+    title="Save changes before syncing"
     @close="dirtyBeforeSyncModal.hide()">
     <div class="flex flex-col gap-5">
       <div class="flex gap-3">
@@ -403,7 +404,7 @@ const onSyncModalClose = () => {
           </p>
           <p class="text-c-2 text-sm leading-relaxed">
             Save your work to keep changes, or discard to revert to the last
-            saved version. Then you can sync with the source.
+            saved version. Then you can sync with the Registry.
           </p>
         </div>
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The document sync action in the API client still used pull-only language (`Sync from source`) even though this workflow is registry-oriented and effectively bidirectional around local and remote state. The save-before-sync path also continued into sync even if save failed, which could make the flow feel unreliable.

## Solution

- Renamed the action to `Sync with Registry`.
- Updated sync UX copy (tooltip, dirty-state modal title/body, completion toast) to align with registry sync/publish expectations.
- Updated the icon to a bidirectional sync icon (`ScalarIconArrowsClockwise`) to match the action semantics.
- Added a guard in the dirty-state flow so `Save and continue` only proceeds when `saveDocument` succeeds; otherwise an error toast is shown and sync is not started.
- Updated/extended `DocumentCollection` Vitest coverage for the new label and save-failure behavior.
- Added a patch changeset for `@scalar/api-client`.

## Visual

<a href="https://cursor.com/agents/bc-f35d0894-0f4a-40f9-bbca-b6d4085cb2cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdoc_5193_sync_registry_dirty_modal_demo.mp4"><img src="https://cursor.com/artifacts/c/art-b292f8e7-9d12-480d-931f-3248abe5d837" alt="doc_5193_sync_registry_dirty_modal_demo.mp4" /></a>
![Sync with Registry tooltip](https://cursor.com/artifacts/c/art-6719af5f-538c-4aa7-b07a-65739716c02a)
![Save changes before syncing modal](https://cursor.com/artifacts/c/art-eed2cb21-ea84-4111-8094-9a5e61bfecb9)

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Fixes DOC-5193
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f35d0894-0f4a-40f9-bbca-b6d4085cb2cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f35d0894-0f4a-40f9-bbca-b6d4085cb2cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

