### PR TITLE
fix(api-client): surface registry metadata on docs and collections

### DIFF
--- a/.changeset/hungry-kiwis-cheat.md
+++ b/.changeset/hungry-kiwis-cheat.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/agent-chat': patch
+---
+
+Surface registry metadata in collection and document UI by showing version and source tags, add a Saved Locally badge for local-only unsaved changes, disable watch mode controls/polling for registry documents, and show title with version in registry import lists.

--- a/packages/agent-chat/src/components/SearchPopover.vue
+++ b/packages/agent-chat/src/components/SearchPopover.vue
@@ -61,7 +61,8 @@ const searchOptions = computed(() =>
             v-if="option.logoUrl"
             class="searchItemLogo"
             :src="option.logoUrl" />
-          <span>{{ option.title }}</span>
+          <span class="searchItemTitle">{{ option.title }}</span>
+          <span class="searchItemVersion">v{{ option.currentVersion }}</span>
         </button>
       </template>
 
@@ -89,6 +90,22 @@ const searchOptions = computed(() =>
 
 .searchItem:hover {
   background: var(--scalar-background-2);
+}
+
+.searchItemTitle {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.searchItemVersion {
+  margin-left: auto;
+  border-radius: 9999px;
+  background: var(--scalar-background-3);
+  padding: 2px 6px;
+  font-size: var(--scalar-font-size-5);
+  color: var(--scalar-color-2);
 }
 
 .searchItemLogo {

--- a/packages/agent-chat/src/registry/add-documents-to-store.ts
+++ b/packages/agent-chat/src/registry/add-documents-to-store.ts
@@ -56,6 +56,13 @@ export const loadDocument = n.safeFn(
       {
         name: documentName,
         document,
+        meta: {
+          'x-scalar-registry-meta': {
+            namespace,
+            slug,
+          },
+          'x-scalar-watch-mode': false,
+        },
       },
       config,
     )

--- a/packages/agent-chat/src/views/Catalog/Catalog.vue
+++ b/packages/agent-chat/src/views/Catalog/Catalog.vue
@@ -69,7 +69,6 @@ const searchOptions = computed(() =>
           <div class="right">
             <div class="item-top">
               <span>{{ option.title }}</span>
-
               <span class="version">v{{ option.currentVersion }}</span>
             </div>
 
@@ -132,6 +131,7 @@ const searchOptions = computed(() =>
 .item-top {
   display: flex;
   gap: 10px;
+  align-items: center;
 }
 .version {
   background: var(--scalar-background-3);

--- a/packages/agent-chat/src/views/PromptForm.vue
+++ b/packages/agent-chat/src/views/PromptForm.vue
@@ -208,6 +208,7 @@ const chatError = useChatError()
               class="apiPillLogo"
               :src="document.logoUrl" />
             {{ document.title }}
+            <span class="apiPillVersion">v{{ document.currentVersion }}</span>
             <button
               v-if="document.removable"
               class="apiPillRemove"
@@ -359,6 +360,10 @@ const chatError = useChatError()
   z-index: 1;
   gap: 4px;
   user-select: none;
+}
+.apiPillVersion {
+  color: var(--scalar-color-3);
+  font-weight: var(--scalar-font-regular);
 }
 .apiPillLogo {
   width: 15px;

--- a/packages/api-client/src/v2/features/app/hooks/use-document-watcher.test.ts
+++ b/packages/api-client/src/v2/features/app/hooks/use-document-watcher.test.ts
@@ -159,4 +159,35 @@ describe('useDocumentWatcher', () => {
 
     expect(fn).toHaveBeenCalledTimes(3)
   })
+
+  it('does not poll registry documents even when watch mode is enabled', async () => {
+    const rebaseDocumentSpy = vi.fn()
+    const store = createWorkspaceStore()
+
+    await store.addDocument({
+      name: 'default',
+      url,
+      meta: {
+        'x-scalar-registry-meta': {
+          namespace: 'scalar',
+          slug: 'petstore',
+        },
+      },
+    })
+
+    const defaultDocument = store.workspace.documents['default']
+    assert(defaultDocument)
+    defaultDocument['x-scalar-watch-mode'] = true
+
+    store.rebaseDocument = rebaseDocumentSpy as typeof store.rebaseDocument
+
+    const initialTimeout = 200
+    useDocumentWatcher({ documentName: ref('default'), store, initialTimeout })
+    await nextTick()
+
+    await vi.advanceTimersByTimeAsync(initialTimeout * 4)
+    await vi.advanceTimersToNextTimerAsync()
+
+    expect(rebaseDocumentSpy).not.toHaveBeenCalled()
+  })
 })

--- a/packages/api-client/src/v2/features/app/hooks/use-document-watcher.ts
+++ b/packages/api-client/src/v2/features/app/hooks/use-document-watcher.ts
@@ -187,8 +187,12 @@ export const useDocumentWatcher = ({
    * Starts or stops polling based on these values.
    */
   watch(
-    [() => document.value?.['x-scalar-original-source-url'], () => document.value?.['x-scalar-watch-mode']],
-    ([sourceUrl, watchMode = false]) => {
+    [
+      () => document.value?.['x-scalar-original-source-url'],
+      () => document.value?.['x-scalar-watch-mode'],
+      () => document.value?.['x-scalar-registry-meta'],
+    ],
+    ([sourceUrl, watchMode = false, registryMeta]) => {
       const storeValue = toValue(store)
 
       // Clear timer if store is unavailable
@@ -200,7 +204,13 @@ export const useDocumentWatcher = ({
       // Clear any existing timer
       timerManager.clear()
 
-      // Stop polling if source URL is missing or watch mode is disabled
+      // Registry documents are synced externally and do not need local watch polling.
+      if (registryMeta) {
+        timeoutManager.reset()
+        return
+      }
+
+      // Stop polling if source URL is missing or watch mode is disabled.
       if (!sourceUrl || !watchMode) {
         timeoutManager.reset()
         return

--- a/packages/api-client/src/v2/features/collection/DocumentCollection.test.ts
+++ b/packages/api-client/src/v2/features/collection/DocumentCollection.test.ts
@@ -140,6 +140,46 @@ describe('DocumentCollection', () => {
     expect(routerView.exists()).toBe(true)
   })
 
+  it('shows document version tag when version is present', async () => {
+    const document = createMockDocument({
+      info: { title: 'Versioned API', version: '2.3.4' },
+    })
+
+    const { wrapper } = await mountWithRouter(document)
+    expect(wrapper.text()).toContain('v2.3.4')
+  })
+
+  it('shows Registry tag for registry-backed document', async () => {
+    const document = createMockDocument({
+      info: { title: 'Registry API', version: '1.0.0' },
+      'x-scalar-registry-meta': { namespace: 'team', slug: 'my-api' },
+    })
+
+    const { wrapper } = await mountWithRouter(document)
+    expect(wrapper.text()).toContain('Registry')
+  })
+
+  it('shows Saved Locally tag for dirty local document', async () => {
+    const document = createMockDocument({
+      info: { title: 'Local API', version: '1.0.0' },
+      'x-scalar-is-dirty': true,
+    })
+
+    const { wrapper } = await mountWithRouter(document)
+    expect(wrapper.text()).toContain('Saved Locally')
+  })
+
+  it('does not show Saved Locally tag for dirty registry document', async () => {
+    const document = createMockDocument({
+      info: { title: 'Registry API', version: '1.0.0' },
+      'x-scalar-is-dirty': true,
+      'x-scalar-registry-meta': { namespace: 'team', slug: 'my-api' },
+    })
+
+    const { wrapper } = await mountWithRouter(document)
+    expect(wrapper.text()).not.toContain('Saved Locally')
+  })
+
   it('handles icon update events correctly', async () => {
     const document = createMockDocument()
     const { wrapper, eventBus } = await mountWithRouter(document)

--- a/packages/api-client/src/v2/features/collection/DocumentCollection.vue
+++ b/packages/api-client/src/v2/features/collection/DocumentCollection.vue
@@ -73,8 +73,12 @@ const documentRegistryMeta = computed(
       | undefined,
 )
 
-const isRegistryDocument = computed(() => documentRegistryMeta.value !== undefined)
-const isDocumentSavedLocally = computed(() => isDocumentDirty.value && !isRegistryDocument.value)
+const isRegistryDocument = computed(
+  () => documentRegistryMeta.value !== undefined,
+)
+const isDocumentSavedLocally = computed(
+  () => isDocumentDirty.value && !isRegistryDocument.value,
+)
 
 /** Show Sync when the document has a source URL or registry meta (registry can be used if fetchRegistryDocument is set). */
 const canShowSyncButton = computed(

--- a/packages/api-client/src/v2/features/collection/DocumentCollection.vue
+++ b/packages/api-client/src/v2/features/collection/DocumentCollection.vue
@@ -46,6 +46,7 @@ const props = defineProps<RouteProps>()
 
 /** Snag the title from the info object */
 const title = computed(() => props.document?.info?.title ?? '')
+const version = computed(() => props.document?.info?.version?.trim() ?? '')
 
 /** Default to the folder icon */
 const icon = computed(
@@ -71,6 +72,9 @@ const documentRegistryMeta = computed(
       | { namespace: string; slug: string }
       | undefined,
 )
+
+const isRegistryDocument = computed(() => documentRegistryMeta.value !== undefined)
+const isDocumentSavedLocally = computed(() => isDocumentDirty.value && !isRegistryDocument.value)
 
 /** Show Sync when the document has a source URL or registry meta (registry can be used if fetchRegistryDocument is set). */
 const canShowSyncButton = computed(
@@ -294,7 +298,7 @@ const onSyncModalClose = () => {
           @discard="undoChanges"
           @save="saveChanges" />
         <div class="flex flex-row items-center justify-between gap-2">
-          <div class="flex min-w-0 items-center gap-2">
+          <div class="flex min-w-0 flex-wrap items-center gap-2">
             <IconSelector
               :modelValue="icon"
               placement="bottom-start"
@@ -320,6 +324,21 @@ const onSyncModalClose = () => {
                   (title) => eventBus.emit('document:update:info', { title })
                 " />
             </div>
+            <span
+              v-if="version"
+              class="bg-b-2 text-c-2 inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium">
+              v{{ version }}
+            </span>
+            <span
+              v-if="isRegistryDocument"
+              class="bg-b-2 text-c-2 inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium">
+              Registry
+            </span>
+            <span
+              v-if="isDocumentSavedLocally"
+              class="bg-b-2 text-c-2 inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium">
+              Saved Locally
+            </span>
           </div>
 
           <ScalarButton

--- a/packages/api-client/src/v2/features/collection/components/Settings.test.ts
+++ b/packages/api-client/src/v2/features/collection/components/Settings.test.ts
@@ -46,6 +46,7 @@ describe('Settings', () => {
       },
       'x-scalar-original-source-url': 'https://example.com/openapi.json',
       'x-scalar-watch-mode': true,
+      'x-scalar-registry-meta': undefined,
     })
 
     return {
@@ -119,7 +120,32 @@ describe('Settings', () => {
       expect(documentSettings.props('documentUrl')).toBe('https://api.example.com/spec.json')
       expect(documentSettings.props('title')).toBe('My API')
       expect(documentSettings.props('watchMode')).toBe(false)
+      expect(documentSettings.props('isRegistryDocument')).toBe(false)
       expect(documentSettings.props('isDraftDocument')).toBe(false)
+    })
+
+    it('passes registry state to DocumentSettings', () => {
+      const props = createDocumentProps({
+        document: {
+          openapi: '3.1.0',
+          info: {
+            title: 'Registry API',
+            description: 'Test description',
+            version: '1.0.0',
+          },
+          'x-scalar-original-source-url': 'https://api.example.com/spec.json',
+          'x-scalar-watch-mode': true,
+          'x-scalar-registry-meta': {
+            namespace: 'scalar',
+            slug: 'registry-api',
+          },
+          'x-scalar-original-document-hash': '123',
+        },
+      })
+      const wrapper = mount(Settings, { props })
+
+      const documentSettings = wrapper.findComponent({ name: 'DocumentSettings' })
+      expect(documentSettings.props('isRegistryDocument')).toBe(true)
     })
 
     it('marks DocumentSettings as draft when documentSlug is drafts', () => {

--- a/packages/api-client/src/v2/features/collection/components/Settings.vue
+++ b/packages/api-client/src/v2/features/collection/components/Settings.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { getActiveProxyUrl } from '@scalar/workspace-store/request-example'
 import type { ColorMode } from '@scalar/workspace-store/schemas/workspace'
+import { computed } from 'vue'
 
 import type { CollectionProps } from '@/v2/features/app/helpers/routes'
 import { CollectionSettings, DocumentSettings } from '@/v2/features/settings'
@@ -15,6 +16,10 @@ const {
   telemetry,
   onUpdateTelemetry,
 } = defineProps<CollectionProps>()
+
+const isRegistryDocument = computed(
+  () => document?.['x-scalar-registry-meta'] !== undefined,
+)
 
 const handleUpdateWatchMode = (watchMode: boolean) => {
   eventBus.emit('document:update:watch-mode', watchMode)
@@ -35,6 +40,7 @@ const handleUpdateColorMode = (colorMode: ColorMode) => {
   <DocumentSettings
     v-if="collectionType === 'document'"
     :documentUrl="document?.['x-scalar-original-source-url']"
+    :isRegistryDocument="isRegistryDocument"
     :isDraftDocument="documentSlug === 'drafts'"
     :title="document?.info.title ?? ''"
     :watchMode="document?.['x-scalar-watch-mode']"

--- a/packages/api-client/src/v2/features/settings/DocumentSettings.vue
+++ b/packages/api-client/src/v2/features/settings/DocumentSettings.vue
@@ -14,6 +14,8 @@ import Section from './components/Section.vue'
 const {
   documentUrl,
   watchMode,
+  isRegistryDocument = false,
+  version,
   title,
   isDraftDocument = false,
 } = defineProps<{
@@ -21,6 +23,10 @@ const {
   documentUrl?: string
   /** Watch mode status if also document url is provided */
   watchMode?: boolean
+  /** Whether this document was loaded from Scalar Registry */
+  isRegistryDocument?: boolean
+  /** Document version */
+  version?: string
   /** Document title */
   title: string
   /** Whether the document is a draft document */
@@ -62,7 +68,19 @@ const handleDocumentDelete = () => {
         <div
           class="bg-b-1 flex items-center justify-between gap-4 rounded-t-lg p-3">
           <div>
-            <h4>Watch Mode</h4>
+            <div class="flex items-center gap-2">
+              <h4>Watch Mode</h4>
+              <span
+                v-if="version"
+                class="bg-b-2 text-c-2 inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium">
+                v{{ version }}
+              </span>
+              <span
+                v-if="isRegistryDocument"
+                class="bg-b-2 text-c-2 inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium">
+                Registry
+              </span>
+            </div>
             <p class="text-c-2 mt-1">
               When enabled, the OpenAPI document will be polled for changes. The
               collection will be updated automatically.
@@ -70,7 +88,7 @@ const handleDocumentDelete = () => {
           </div>
           <ScalarToggle
             class="w-4"
-            :disabled="!documentUrl"
+            :disabled="!documentUrl || isRegistryDocument"
             :modelValue="watchMode ?? false"
             @update:modelValue="(value) => emit('update:watchMode', value)" />
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

It is hard to tell where loaded OpenAPI documents come from in the client surfaces, and registry-backed documents still exposed watch mode controls even though they are already synced externally.

## Solution

- Persist registry metadata (`x-scalar-registry-meta`) when adding registry documents from agent-chat so downstream client views can identify registry-backed documents.
- Surface source metadata in document/collection UI by adding version + `Registry` tags, and add a `Saved Locally` tag for dirty non-registry documents.
- Disable watch mode behavior for registry-backed documents:
  - disable the watch mode toggle in collection settings for registry documents,
  - skip polling entirely in `useDocumentWatcher` whenever registry metadata exists.
- Update registry import/listing flows to show title plus version in search/catalog rows and selected document pills.
- Add/update targeted tests for the new tags/props and registry watch-mode polling behavior.
- Add a changeset for `@scalar/api-client` and `@scalar/agent-chat`.
- Follow-up commit formats `DocumentCollection.vue` to satisfy CI formatting checks.

## Visual

![Document header showing version and Saved Locally tags](https://cursor.com/artifacts/c/art-1bfb7fc9-5a79-4cf5-b90e-f8e350ff1c5f)
<a href="https://cursor.com/agents/bc-64b53e0e-9ad9-4b64-86f7-b83ff972d13a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdoc_5192_api_client_metadata_tags_demo.mp4"><img src="https://cursor.com/artifacts/c/art-b8722b62-7977-44ae-8bc1-4cc024a04c18" alt="doc_5192_api_client_metadata_tags_demo.mp4" /></a>

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Fixes DOC-5192
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64b53e0e-9ad9-4b64-86f7-b83ff972d13a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64b53e0e-9ad9-4b64-86f7-b83ff972d13a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

