### PR TITLE
fix(api-client): improve sidebar menu and drag regions

### DIFF
--- a/.changeset/silly-rockets-wink.md
+++ b/.changeset/silly-rockets-wink.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): apply ScalarMenuLink is prop correctly

--- a/.changeset/slow-tables-dig.md
+++ b/.changeset/slow-tables-dig.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): improve drag regions

--- a/packages/api-client/src/v2/components/sidebar/Sidebar.vue
+++ b/packages/api-client/src/v2/components/sidebar/Sidebar.vue
@@ -153,9 +153,8 @@ const handleSelectItem = (id: string) => {
           </div>
         </template>
 
-        <!-- drag region (macos) -->
         <template #spacer>
-          <div class="mac:app-drag-region flex-1"></div>
+          <div class="flex-1"></div>
         </template>
 
         <template

--- a/packages/api-client/src/v2/features/app/components/DesktopTab.vue
+++ b/packages/api-client/src/v2/features/app/components/DesktopTab.vue
@@ -88,9 +88,10 @@ const handleClose = (event: MouseEvent): void => {
         placement="bottom">
         <!-- Main tab container - clickable area to activate the tab -->
         <div
-          class="app-no-drag-region"
           :class="[
-            isSingleTab ? 'nav-single-tab' : 'nav-item',
+            isSingleTab
+              ? 'nav-single-tab mac:app-drag-region'
+              : 'nav-item app-no-drag-region',
             { 'nav-item__active': active && !isSingleTab },
           ]"
           @click="!isSingleTab && emit('click')">

--- a/packages/components/src/components/ScalarMenu/ScalarMenu.test.ts
+++ b/packages/components/src/components/ScalarMenu/ScalarMenu.test.ts
@@ -2,30 +2,151 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import { defineComponent } from 'vue'
 
-import { ScalarMenu, ScalarMenuLink } from './'
+import { ScalarMenu } from './'
+
+/** Radix sets aria-expanded on the menu trigger */
+const triggerSelector = 'button[aria-expanded]'
+
+const trigger = (wrapper: ReturnType<typeof mount>) => wrapper.get(triggerSelector)
 
 describe('ScalarMenu', () => {
-  it('renders properly', () => {
-    const wrapper = mount(ScalarMenu)
-    expect(wrapper.find('input')).toBeDefined()
+  it('exposes Open Menu as the default trigger label while closed', () => {
+    const wrapper = mount(ScalarMenu, { attachTo: document.body })
+    try {
+      expect(wrapper.text()).toMatch(/Open Menu/)
+      expect(trigger(wrapper).attributes('aria-expanded')).toBe('false')
+    } finally {
+      wrapper.unmount()
+    }
   })
-})
 
-describe('ScalarMenuLink', () => {
-  const MockMenu = defineComponent({
-    components: { ScalarMenu, ScalarMenuLink },
-    template: `
+  it('shows default product entries after the trigger opens the menu', async () => {
+    const wrapper = mount(ScalarMenu, { attachTo: document.body })
+    try {
+      await trigger(wrapper).trigger('click')
+      expect(wrapper.text()).toContain('Dashboard')
+      expect(wrapper.text()).toContain('Client')
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('marks the trigger closed after the trigger toggles the menu again', async () => {
+    const wrapper = mount(ScalarMenu, { attachTo: document.body })
+    try {
+      const t = trigger(wrapper)
+      await t.trigger('click')
+      expect(t.attributes('aria-expanded')).toBe('true')
+      await t.trigger('click')
+      expect(t.attributes('aria-expanded')).toBe('false')
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('closes when the products slot invokes close', async () => {
+    const WithSlot = defineComponent({
+      components: { ScalarMenu },
+      template: `
 <ScalarMenu>
-  <template #sections>
-    <ScalarMenuLink data-testid="menu-link">My Link</ScalarMenuLink>
+  <template #products="{ close }">
+    <button data-testid="products-close" type="button" @click="close">Close</button>
   </template>
 </ScalarMenu>`,
+    })
+    const wrapper = mount(WithSlot, { attachTo: document.body })
+    try {
+      await trigger(wrapper).trigger('click')
+      await wrapper.get('[data-testid="products-close"]').trigger('click')
+      expect(trigger(wrapper).attributes('aria-expanded')).toBe('false')
+    } finally {
+      wrapper.unmount()
+    }
   })
 
-  it('renders an anchor tag', async () => {
-    const wrapper = mount(MockMenu, { attachTo: document.body })
+  it('renders profile slot content inside the open panel', async () => {
+    const WithProfile = defineComponent({
+      components: { ScalarMenu },
+      template: `
+<ScalarMenu>
+  <template #profile>
+    <p data-testid="profile-slot">Workspace</p>
+  </template>
+</ScalarMenu>`,
+    })
+    const wrapper = mount(WithProfile, { attachTo: document.body })
+    try {
+      await trigger(wrapper).trigger('click')
+      expect(wrapper.get('[data-testid="profile-slot"]').text()).toContain('Workspace')
+    } finally {
+      wrapper.unmount()
+    }
+  })
 
-    await wrapper.find('button[aria-expanded=false]').trigger('click')
-    expect(wrapper.find('a[data-testid="menu-link"]').exists()).toBeTruthy()
+  it('renders the logo slot inside the trigger', () => {
+    const WithLogo = defineComponent({
+      components: { ScalarMenu },
+      template: `
+<ScalarMenu>
+  <template #logo>
+    <span data-testid="custom-logo">CL</span>
+  </template>
+</ScalarMenu>`,
+    })
+    const wrapper = mount(WithLogo, { attachTo: document.body })
+    try {
+      expect(wrapper.get('[data-testid="custom-logo"]').text()).toBe('CL')
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('uses the label slot for the trigger screen reader text', () => {
+    const WithLabel = defineComponent({
+      components: { ScalarMenu },
+      template: `
+<ScalarMenu>
+  <template #label>Custom menu label</template>
+</ScalarMenu>`,
+    })
+    const wrapper = mount(WithLabel, { attachTo: document.body })
+    try {
+      expect(wrapper.text()).toMatch(/Custom menu label/)
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('replaces default sections when the sections slot is provided', async () => {
+    const WithSections = defineComponent({
+      components: { ScalarMenu },
+      template: `
+<ScalarMenu>
+  <template #sections>
+    <div data-testid="custom-sections">Only custom sections</div>
+  </template>
+</ScalarMenu>`,
+    })
+    const wrapper = mount(WithSections, { attachTo: document.body })
+    try {
+      await trigger(wrapper).trigger('click')
+      expect(wrapper.get('[data-testid="custom-sections"]').text()).toContain('Only custom sections')
+      expect(wrapper.text()).not.toContain('Terms & Conditions')
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('forwards fallthrough attributes to the menu surface', async () => {
+    const wrapper = mount(ScalarMenu, {
+      attachTo: document.body,
+      attrs: { 'data-testid': 'menu-surface' },
+    })
+    try {
+      await trigger(wrapper).trigger('click')
+      expect(wrapper.find('[data-testid="menu-surface"]').exists()).toBe(true)
+    } finally {
+      wrapper.unmount()
+    }
   })
 })

--- a/packages/components/src/components/ScalarMenu/ScalarMenuLink.test.ts
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuLink.test.ts
@@ -1,0 +1,54 @@
+import { mount } from '@vue/test-utils'
+import { DropdownMenu } from 'radix-vue/namespaced'
+import { describe, expect, it } from 'vitest'
+import { defineComponent } from 'vue'
+
+import { ScalarMenu, ScalarMenuLink } from './'
+
+const menuWithLink = (attrs: Record<string, unknown> = {}, slotText = 'My Link') =>
+  defineComponent({
+    components: { ScalarMenu, ScalarMenuLink },
+    setup() {
+      return { attrs, slotText }
+    },
+    template: `
+<ScalarMenu>
+  <template #sections>
+    <ScalarMenuLink data-testid="menu-link" v-bind="attrs">{{ slotText }}</ScalarMenuLink>
+  </template>
+</ScalarMenu>`,
+  })
+
+describe('ScalarMenuLink', () => {
+  it('renders an anchor tag by default', async () => {
+    const wrapper = mount(menuWithLink(), { attachTo: document.body })
+
+    await wrapper.find('button[aria-expanded=false]').trigger('click')
+
+    const link = wrapper.get('[data-testid="menu-link"]')
+    expect(link.element.tagName).toBe('A')
+    expect(link.attributes('role')).toBe('menuitem')
+
+    const items = wrapper.findAllComponents(DropdownMenu.Item)
+    expect(items.some((c) => c.find('[data-testid="menu-link"]').exists())).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('renders DropdownMenu.Item while changing the DOM tag with is', async () => {
+    const wrapper = mount(menuWithLink({ is: 'button' }), {
+      attachTo: document.body,
+    })
+
+    await wrapper.find('button[aria-expanded=false]').trigger('click')
+
+    const link = wrapper.get('[data-testid="menu-link"]')
+    expect(link.element.tagName).toBe('BUTTON')
+    expect(link.attributes('role')).toBe('menuitem')
+
+    const items = wrapper.findAllComponents(DropdownMenu.Item)
+    expect(items.some((c) => c.find('[data-testid="menu-link"]').exists())).toBe(true)
+
+    wrapper.unmount()
+  })
+})

--- a/packages/components/src/components/ScalarMenu/ScalarMenuLink.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuLink.vue
@@ -26,6 +26,7 @@ const { is = 'a' } = defineProps<{
   is?: string | Component
   icon?: Icon | ScalarIconComponent
   strong?: boolean
+  submenu?: boolean
 }>()
 
 const { cx } = useBindCx()
@@ -34,7 +35,7 @@ defineOptions({ inheritAttrs: false })
 <template>
   <ScalarDropdownButton
     v-bind="cx('flex items-center')"
-    :is="DropdownMenu.Item"
+    :is="submenu ? DropdownMenu.SubTrigger : DropdownMenu.Item"
     :as="is">
     <ScalarIconLegacyAdapter
       v-if="icon"

--- a/packages/components/src/components/ScalarMenu/ScalarMenuLink.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuLink.vue
@@ -22,7 +22,7 @@ import type { Component } from 'vue'
 import { ScalarDropdownButton } from '../ScalarDropdown'
 import { type Icon, ScalarIconLegacyAdapter } from '../ScalarIcon'
 
-const { is = DropdownMenu.Item } = defineProps<{
+const { is = 'a' } = defineProps<{
   is?: string | Component
   icon?: Icon | ScalarIconComponent
   strong?: boolean
@@ -34,13 +34,13 @@ defineOptions({ inheritAttrs: false })
 <template>
   <ScalarDropdownButton
     v-bind="cx('flex items-center')"
-    :is="is"
-    as="a">
+    :is="DropdownMenu.Item"
+    :as="is">
     <ScalarIconLegacyAdapter
       v-if="icon"
       :class="[
         strong ? 'text-c-1' : 'text-c-2',
-        typeof icon === 'string' ? 'size-3' : 'size-3.5 -mx-0.25',
+        typeof icon === 'string' ? 'size-3' : 'size-3.5 -mx-px',
       ]"
       :icon="icon"
       :thickness="strong ? '2.5' : '2'"

--- a/packages/components/src/components/ScalarMenu/ScalarMenuTeamPicker.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuTeamPicker.vue
@@ -56,12 +56,12 @@ defineOptions({ inheritAttrs: false })
 <template>
   <DropdownMenu.Sub>
     <ScalarMenuLink
-      :is="DropdownMenu.SubTrigger"
       :icon="ScalarIconUserSwitch"
+      submenu
       v-bind="$attrs">
       <div>Change team</div>
       <ScalarIconCaretRight
-        class="ml-auto text-c-2 -mr-0.25 size-3"
+        class="ml-auto text-c-2 -mr-px size-3"
         weight="bold" />
     </ScalarMenuLink>
     <DropdownMenu.Portal>

--- a/packages/components/src/components/ScalarMenu/ScalarMenuWorkspacePicker.vue
+++ b/packages/components/src/components/ScalarMenu/ScalarMenuWorkspacePicker.vue
@@ -49,12 +49,12 @@ defineOptions({ inheritAttrs: false })
 <template>
   <DropdownMenu.Sub>
     <ScalarMenuLink
-      :is="DropdownMenu.SubTrigger"
       :icon="ScalarIconSwap"
+      submenu
       v-bind="$attrs">
       <div>Change workspace</div>
       <ScalarIconCaretRight
-        class="ml-auto text-c-2 -mr-0.25 size-3"
+        class="ml-auto text-c-2 -mr-px size-3"
         weight="bold" />
     </ScalarMenuLink>
 


### PR DESCRIPTION
We were setting a drag region in the sidebar below the items which was interfering with the sidebar menu. This PR:

- Removes the sidebar drag region (it was a little confusing anyway)
- Makes it so you can drag the top tab if you only have one tab open
- Fixes ScalarMenu so the buttons are semantically correct

Before:

https://github.com/user-attachments/assets/85f24c27-84dd-4e25-9cb3-1dfecc92770c

After:

https://github.com/user-attachments/assets/4e599311-4f6e-4a79-86c0-b29b0a40edab

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
