### PR TITLE
fix(workspace-store): check for `'null'` origin on base url

### DIFF
--- a/.changeset/plain-monkeys-talk.md
+++ b/.changeset/plain-monkeys-talk.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: Allows sending requests when scalar is framed in srcdoc

--- a/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.test.ts
+++ b/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi, afterEach } from 'vitest'
 
 import type { RequestFactory } from './request-factory'
 import { resolveRequestFactoryUrl } from './resolve-request-factory-url'
@@ -24,7 +24,20 @@ const createRequestFactory = (overrides: Partial<RequestFactory> = {}): RequestF
 const defaultOptions = { envVariables: {}, securityQueryParams: new URLSearchParams() }
 
 describe('resolve-request-factory-url', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('returns a simple URL from baseUrl and path', () => {
+    const request = createRequestFactory()
+    const result = resolveRequestFactoryUrl(request, defaultOptions)
+
+    expect(result).toBe('https://api.example.com/v1/users')
+  })
+
+  it('returns a simple URL from baseUrl and path when in iframe srcdoc', () => {
+    vi.stubGlobal('window', { location: { origin: 'null', href:'about:srcdoc', protocol: 'about:', pathname: 'srcdoc' } })
+
     const request = createRequestFactory()
     const result = resolveRequestFactoryUrl(request, defaultOptions)
 

--- a/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.test.ts
+++ b/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, afterEach } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { RequestFactory } from './request-factory'
 import { resolveRequestFactoryUrl } from './resolve-request-factory-url'
@@ -36,7 +36,15 @@ describe('resolve-request-factory-url', () => {
   })
 
   it('returns a simple URL from baseUrl and path when in iframe srcdoc', () => {
-    vi.stubGlobal('window', { location: { origin: 'null', href:'about:srcdoc', protocol: 'about:', pathname: 'srcdoc' } })
+    vi.stubGlobal('window', {
+      location: {
+        // Yep, JS returns 'null' as a string for origin when in iframe srcdoc
+        origin: 'null',
+        href: 'about:srcdoc',
+        protocol: 'about:',
+        pathname: 'srcdoc',
+      },
+    })
 
     const request = createRequestFactory()
     const result = resolveRequestFactoryUrl(request, defaultOptions)

--- a/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.ts
+++ b/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.ts
@@ -27,7 +27,7 @@ export const resolveRequestFactoryUrl = (
   const baseUrl = replaceEnvVariables(request.baseUrl, variables)
   const path = replacePathVariables(request.path.raw, pathVariables)
   const mergedUrl = mergeUrls(baseUrl, path)
-  const urlBase = globalThis.window?.location?.origin ?? 'http://localhost:3000'
+  const urlBase = (!globalThis.window?.location?.origin || globalThis.window.location.origin === 'null') ? 'http://localhost:3000' : globalThis.window.location.origin
   const url = new URL(mergedUrl, urlBase)
 
   const operationQueryParams = new URLSearchParams()

--- a/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.ts
+++ b/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.ts
@@ -27,7 +27,11 @@ export const resolveRequestFactoryUrl = (
   const baseUrl = replaceEnvVariables(request.baseUrl, variables)
   const path = replacePathVariables(request.path.raw, pathVariables)
   const mergedUrl = mergeUrls(baseUrl, path)
-  const urlBase = (!globalThis.window?.location?.origin || globalThis.window.location.origin === 'null') ? 'http://localhost:3000' : globalThis.window.location.origin
+  // When rendered inside an iframe with srcdoc, the browser reports
+  // window.location.origin as the string "null" instead of a real origin.
+  // Fall back to localhost so relative URLs can still be resolved.
+  const origin = globalThis.window?.location?.origin
+  const urlBase = origin && origin !== 'null' ? origin : 'http://localhost:3000'
   const url = new URL(mergedUrl, urlBase)
 
   const operationQueryParams = new URLSearchParams()


### PR DESCRIPTION
## Problem

Fixes https://github.com/scalar/scalar/issues/8851

Allows sending requests when scalar is framed in srcdoc

## Solution

Added a string 'null' check and if true, use localhost as the base for the url

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
