### PR TITLE
fix: knip warnings

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -21,7 +21,9 @@
     "documentation/assets/fathom.js",
     "documentation/assets/posthog.js",
     "documentation/assets/apollo.js",
-    "documentation/assets/enterprise-contact-form.js"
+    "documentation/assets/enterprise-contact-form.js",
+    // Generated Docusaurus build directory
+    "integrations/docusaurus/playground/.docusaurus/**"
   ],
   "ignore": [
     // We will use this in the future, just removed it from the workspace store for now
@@ -170,15 +172,7 @@
       "ignoreFiles": ["playground/next.config.js"]
     },
     "packages/oas-utils": {
-      "entry": [
-        "src/entities/*/index.ts",
-        "src/helpers/index.ts",
-        "src/helpers/security/index.ts",
-        "src/migrations/index.ts",
-        "src/spec-getters/index.ts",
-        "src/transforms/index.ts"
-      ],
-      "ignoreDependencies": ["@scalar/openapi-types"]
+      "entry": ["src/helpers/index.ts", "src/migrations/index.ts"]
     },
     "packages/object-utils": {
       "entry": ["src/*/index.ts"]


### PR DESCRIPTION
```

Unused files (4)

integrations/docusaurus/playground/.docusaurus/client-modules.js
integrations/docusaurus/playground/.docusaurus/docusaurus.config.mjs
integrations/docusaurus/playground/.docusaurus/registry.js
integrations/docusaurus/playground/.docusaurus/routes.js

Configuration hints (5)

@scalar/openapi-types          packages/oas-utils  knip.jsonc  Remove from ignoreDependencies
src/entities/*/index.ts        packages/oas-utils  knip.jsonc  Refine entry pattern (no matches)
src/helpers/security/index.ts  packages/oas-utils  knip.jsonc  Refine entry pattern (no matches)
src/spec-getters/index.ts      packages/oas-utils  knip.jsonc  Refine entry pattern (no matches)
src/transforms/index.ts        packages/oas-utils  knip.jsonc  Refine entry pattern (no matches)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to static Knip configuration (ignored paths and workspace entry globs) and do not affect runtime code.
> 
> **Overview**
> Reduces Knip noise by adding the generated Docusaurus build output (`integrations/docusaurus/playground/.docusaurus/**`) to `ignoreFiles`.
> 
> Refines the `packages/oas-utils` workspace config by removing entry globs that had no matches and dropping the now-unneeded `@scalar/openapi-types` `ignoreDependencies`, leaving only `src/helpers/index.ts` and `src/migrations/index.ts` as entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf7be8f3b7c7373efee83e4f6b1f9cd26de8e62d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->