### PR TITLE
test: root test script to run package tests recursively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
           args=()
           for i in "${!dirs[@]}"; do
             if (( i % ${{ matrix.shard-total }} == ${{ matrix.shard-index }} - 1 )); then
-              args+=(--filter "./${dirs[$i]%/}/**")
+              args+=(--filter "./${dirs[$i]%/}")
             fi
           done
           pnpm turbo "${args[@]}" test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,16 @@ jobs:
         run: pnpm script run test-servers & pnpm script wait -p 5051 5052
         timeout-minutes: 1
       - name: Run tests
-        run: pnpm vitest --project 'packages/*' --run --silent --shard=${{ matrix.shard-index }}/${{ matrix.shard-total }}
+        run: |
+          args=()
+          i=0
+          for dir in packages/*/; do
+            if (( i % ${{ matrix.shard-total }} == ${{ matrix.shard-index }} - 1 )); then
+              args+=(--filter "./${dir%/}/**")
+            fi
+            ((i++))
+          done
+          turbo "${args[@]}" test
 
   test-integrations:
     needs: [build]
@@ -268,7 +277,7 @@ jobs:
         with:
           packages: './integrations/**'
       - name: Run tests
-        run: pnpm vitest --project 'integrations/*' --run --silent
+        run: turbo --filter './integrations/**' test
         # For now we will integrate the E2E tests with the integrations tests as they are quite fast and this avoids another job.
       - name: Run e2e tests
         run: pnpm --filter @scalar/nuxt test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,10 @@ jobs:
               args+=(--filter "./${dirs[$i]%/}")
             fi
           done
+          if [ ${#args[@]} -eq 0 ]; then
+            echo "No packages assigned to this shard, skipping."
+            exit 0
+          fi
           pnpm turbo "${args[@]}" test
 
   test-integrations:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
         run: pnpm script run test-servers & pnpm script wait -p 5051 5052
         timeout-minutes: 1
       - name: Run tests
-        run: pnpm vitest packages/* --silent --shard=${{ matrix.shard-index }}/${{ matrix.shard-total }}
+        run: pnpm vitest --project 'packages/*' --run --silent --shard=${{ matrix.shard-index }}/${{ matrix.shard-total }}
 
   test-integrations:
     needs: [build]
@@ -268,7 +268,7 @@ jobs:
         with:
           packages: './integrations/**'
       - name: Run tests
-        run: pnpm vitest integrations/* --silent
+        run: pnpm vitest --project 'integrations/*' --run --silent
         # For now we will integrate the E2E tests with the integrations tests as they are quite fast and this avoids another job.
       - name: Run e2e tests
         run: pnpm --filter @scalar/nuxt test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,13 +245,17 @@ jobs:
         timeout-minutes: 1
       - name: Run tests
         run: |
-          args=()
-          i=0
+          dirs=()
           for dir in packages/*/; do
-            if (( i % ${{ matrix.shard-total }} == ${{ matrix.shard-index }} - 1 )); then
-              args+=(--filter "./${dir%/}/**")
+            if grep -q '"test"' "${dir}package.json" 2>/dev/null; then
+              dirs+=("$dir")
             fi
-            ((i++))
+          done
+          args=()
+          for i in "${!dirs[@]}"; do
+            if (( i % ${{ matrix.shard-total }} == ${{ matrix.shard-index }} - 1 )); then
+              args+=(--filter "./${dirs[$i]%/}/**")
+            fi
           done
           turbo "${args[@]}" test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
               args+=(--filter "./${dirs[$i]%/}/**")
             fi
           done
-          turbo "${args[@]}" test
+          pnpm turbo "${args[@]}" test
 
   test-integrations:
     needs: [build]
@@ -281,7 +281,7 @@ jobs:
         with:
           packages: './integrations/**'
       - name: Run tests
-        run: turbo --filter './integrations/**' test
+        run: pnpm turbo --filter './integrations/**' test
         # For now we will integrate the E2E tests with the integrations tests as they are quite fast and this avoids another job.
       - name: Run e2e tests
         run: pnpm --filter @scalar/nuxt test:e2e

--- a/integrations/docusaurus/package.json
+++ b/integrations/docusaurus/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "shx rm -Rf ./dist ./tsconfig.build.tsbuildinfo && tsc -p tsconfig.build.json && postcss src/theme.css -o dist/theme.css",
     "dev": "docusaurus start playground --port=5063 --no-open",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit --skipLibCheck"
   },
   "main": "./dist/index.js",

--- a/integrations/dotnet/aspire/package.json
+++ b/integrations/dotnet/aspire/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build:docker": "docker build --no-cache -t scalarapi/aspire-api-reference:latest -f src/Scalar.Aspire.Service/Dockerfile ../",
     "copy:standalone": "shx cp ../../../packages/api-reference/dist/browser/standalone.js ./src/Scalar.Aspire.Service/wwwroot/scalar.js",
-    "test": "vitest"
+    "test": "vitest --run"
   },
   "dependencies": {
     "@scalar/api-reference": "workspace:*",

--- a/integrations/dotnet/aspnetcore/package.json
+++ b/integrations/dotnet/aspnetcore/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "compress": "cd ./src/Scalar.AspNetCore/StaticAssets && gzip --keep --verbose --force scalar.js scalar.aspnetcore.js favicon.svg",
     "copy:standalone": "shx cp ../../../packages/api-reference/dist/browser/standalone.js ./src/Scalar.AspNetCore/StaticAssets/scalar.js",
-    "test": "vitest"
+    "test": "vitest --run"
   },
   "readme": {
     "title": "Scalar API Reference for ASP.NET Core",

--- a/integrations/dotnet/shared/package.json
+++ b/integrations/dotnet/shared/package.json
@@ -15,7 +15,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "test": "vitest"
+    "test": "vitest --run"
   },
   "devDependencies": {
     "@scalar/snippetz": "workspace:*"

--- a/integrations/express/package.json
+++ b/integrations/express/package.json
@@ -20,7 +20,7 @@
     "dev": "tsx watch playground/index.ts",
     "docker:build": "docker build --build-arg BASE_IMAGE=scalar-base -t express-api-reference -f Dockerfile .",
     "docker:run": "docker run -p 5055:5055 express-api-reference",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/integrations/fastify/package.json
+++ b/integrations/fastify/package.json
@@ -27,7 +27,7 @@
     "dev": "tsx watch playground/index.ts",
     "docker:build": "docker build --build-arg BASE_IMAGE=scalar-base -t fastify-api-reference -f Dockerfile .",
     "docker:run": "docker run -p 5053:5053 fastify-api-reference",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/integrations/fastify/src/fastifyApiReference.test.ts
+++ b/integrations/fastify/src/fastifyApiReference.test.ts
@@ -18,7 +18,6 @@ const authOptions: FastifyBasicAuthOptions = {
   authenticate: true,
 }
 
-
 function basicAuthEncode(username: string, password: string) {
   return 'Basic ' + Buffer.from(username + ':' + password).toString('base64')
 }
@@ -42,7 +41,7 @@ function exampleDocument() {
 
 describe('fastifyApiReference', () => {
   let fastify: ReturnType<typeof Fastify>
-  
+
   afterEach(async () => {
     if (fastify) {
       await fastify.close()

--- a/integrations/fastify/src/fastifyApiReference.test.ts
+++ b/integrations/fastify/src/fastifyApiReference.test.ts
@@ -2,7 +2,7 @@ import FastifyBasicAuth, { type FastifyBasicAuthOptions } from '@fastify/basic-a
 import fastifySwagger from '@fastify/swagger'
 import type { OpenAPI } from '@scalar/openapi-types'
 import Fastify, { type FastifyPluginAsync } from 'fastify'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import YAML from 'yaml'
 
 import fastifyApiReference from './index'
@@ -17,6 +17,7 @@ const authOptions: FastifyBasicAuthOptions = {
   },
   authenticate: true,
 }
+
 
 function basicAuthEncode(username: string, password: string) {
   return 'Basic ' + Buffer.from(username + ':' + password).toString('base64')
@@ -40,8 +41,16 @@ function exampleDocument() {
 }
 
 describe('fastifyApiReference', () => {
+  let fastify: ReturnType<typeof Fastify>
+  
+  afterEach(async () => {
+    if (fastify) {
+      await fastify.close()
+    }
+  })
+
   it('returns 200 OK for the HTML and redirects to the route with a trailing slash', async () => {
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
     })
 
@@ -63,7 +72,7 @@ describe('fastifyApiReference', () => {
   })
 
   it('returns 200 OK for the HTML and redirects to the route with a trailing slash (ignoreTrailingSlash: true)', async () => {
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
       ignoreTrailingSlash: true,
     })
@@ -95,7 +104,7 @@ describe('fastifyApiReference', () => {
       })
     }
 
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
     })
 
@@ -114,7 +123,7 @@ describe('fastifyApiReference', () => {
   })
 
   it('works with ignoreTrailingSlash', async () => {
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
       ignoreTrailingSlash: true,
     })
@@ -132,7 +141,7 @@ describe('fastifyApiReference', () => {
   })
 
   it('hasPlugin(fastifyApiReference) returns true', async () => {
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
     })
 
@@ -147,7 +156,7 @@ describe('fastifyApiReference', () => {
   })
 
   it('no fastify-html exposed', async () => {
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
     })
 
@@ -158,12 +167,11 @@ describe('fastifyApiReference', () => {
       },
     })
 
-    // @ts-expect-error
-    expect(fastify.html).toEqual(undefined)
+    expect(fastify.html).toBeUndefined()
   })
 
   it('the routePrefix is optional', async () => {
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
     })
 
@@ -201,7 +209,7 @@ describe('fastifyApiReference', () => {
       ] as const)('on the $endpointConfig endpoint', ({ json, yaml }) => {
         beforeEach<LocalTestContext>(async (context) => {
           const spec = exampleDocument()
-          const fastify = Fastify({
+          fastify = Fastify({
             logger: false,
           })
           const openApiDocumentEndpoints = {
@@ -287,7 +295,7 @@ describe('fastifyApiReference', () => {
   })
 
   it('has the JS url', async () => {
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
     })
 
@@ -315,7 +323,7 @@ describe('fastifyApiReference', () => {
       { expectedUrl: urlExt, specProvidedVia: 'url: urlExt' },
     ] as const)('when spec is provided via $specProvidedVia', async ({ expectedUrl, specProvidedVia }) => {
       const spec = exampleDocument()
-      const fastify = Fastify({
+      fastify = Fastify({
         logger: false,
       })
 
@@ -358,7 +366,7 @@ describe('fastifyApiReference', () => {
   })
 
   it('has the default title', async () => {
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
     })
 
@@ -375,7 +383,7 @@ describe('fastifyApiReference', () => {
   })
 
   it('has the correct content type', async () => {
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
     })
 
@@ -393,7 +401,7 @@ describe('fastifyApiReference', () => {
   })
 
   it('returns 401 Unauthorized for requests without authentication', async () => {
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
     })
     await fastify.register(FastifyBasicAuth, authOptions)
@@ -416,7 +424,7 @@ describe('fastifyApiReference', () => {
   })
 
   it('returns 200 OK for requests with authentication', async () => {
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
     })
     await fastify.register(FastifyBasicAuth, authOptions)
@@ -449,11 +457,11 @@ describe('fastifyApiReference', () => {
   it('respects logLevel configuration for routes', async () => {
     const loggedRequests: string[] = []
 
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: {
         level: 'info',
         serializers: {
-          req(request) {
+          req(request: { method: string; url: string }) {
             loggedRequests.push(`${request.method} ${request.url}`)
 
             return {
@@ -484,7 +492,7 @@ describe('fastifyApiReference', () => {
   })
 
   it('does not fail when registered without specSource configuration', async () => {
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
     })
 
@@ -504,7 +512,7 @@ describe('fastifyApiReference', () => {
   })
 
   it('serves Scalar UI when only sources option is provided', async () => {
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
     })
 

--- a/integrations/fastify/src/fastifyApiReference.ts
+++ b/integrations/fastify/src/fastifyApiReference.ts
@@ -1,3 +1,4 @@
+/// <reference types="@fastify/swagger" />
 import { getHtmlDocument } from '@scalar/core/libs/html-rendering'
 import { normalize, toJson, toYaml } from '@scalar/openapi-parser'
 import type { OpenAPI } from '@scalar/openapi-types'

--- a/integrations/fastify/src/proxy.test.ts
+++ b/integrations/fastify/src/proxy.test.ts
@@ -16,6 +16,7 @@ describe('fastifyApiReference', () => {
   it('returns 200 OK for the HTML', async () => {
     origin = Fastify({
       logger: false,
+      forceCloseConnections: true,
     })
 
     await origin.register(Scalar, {
@@ -32,6 +33,7 @@ describe('fastifyApiReference', () => {
 
     proxy = Fastify({
       logger: false,
+      forceCloseConnections: true,
     })
 
     await proxy.register(HttpProxy, {

--- a/integrations/fastify/src/proxy.test.ts
+++ b/integrations/fastify/src/proxy.test.ts
@@ -1,13 +1,20 @@
 import HttpProxy from '@fastify/http-proxy'
 import Fastify from 'fastify'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import Scalar from './index'
 
 describe('fastifyApiReference', () => {
+  let origin: ReturnType<typeof Fastify>
+  let proxy: ReturnType<typeof Fastify>
+
+  afterEach(async () => {
+    await proxy?.close()
+    await origin?.close()
+  })
+
   it('returns 200 OK for the HTML', async () => {
-    // Origin
-    const origin = Fastify({
+    origin = Fastify({
       logger: false,
     })
 
@@ -23,8 +30,7 @@ describe('fastifyApiReference', () => {
 
     expect(originResponse.status).toBe(200)
 
-    // Proxy
-    const proxy = Fastify({
+    proxy = Fastify({
       logger: false,
     })
 

--- a/integrations/fastify/test/exports.test.ts
+++ b/integrations/fastify/test/exports.test.ts
@@ -1,9 +1,15 @@
 import Fastify from 'fastify'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 describe('exports', () => {
+  let fastify: ReturnType<typeof Fastify>
+
+  afterEach(async () => {
+    await fastify?.close()
+  })
+
   it('ESM export', async () => {
-    const fastify = Fastify({
+    fastify = Fastify({
       logger: false,
     })
 

--- a/integrations/fastify/tsconfig.build.json
+++ b/integrations/fastify/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src"],
+  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "skipLibCheck": true,
     "declaration": true,

--- a/integrations/hono/package.json
+++ b/integrations/hono/package.json
@@ -19,7 +19,7 @@
     "dev": "tsx watch playground/index.ts",
     "docker:build": "docker buildx build --platform=linux/amd64 -t scalar-hono-reference --build-arg=\"BASE_IMAGE=scalar-base\" .",
     "docker:run": "docker run -t scalar-hono-reference",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/integrations/nestjs/package.json
+++ b/integrations/nestjs/package.json
@@ -26,7 +26,7 @@
     "docker:run-fastify": "docker run -p 5057:5057 nestjs-api-reference-fastify",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/integrations/nextjs/package.json
+++ b/integrations/nextjs/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "pnpm types:check && pnpm build-only",
     "build-only": "vite build",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit --skipLibCheck"
   },
   "type": "module",

--- a/integrations/nuxt/package.json
+++ b/integrations/nuxt/package.json
@@ -29,7 +29,7 @@
     "dev": "pnpm dev:prepare && nuxi dev playground",
     "dev:build": "nuxi build playground",
     "dev:prepare": "nuxi prepare && nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
-    "test": "vitest",
+    "test": "vitest --run",
     "test:e2e": "playwright test",
     "types:check": "NUXT_TELEMETRY_DISABLED=true nuxi typecheck"
   },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lint:markdown": "remark --frail .",
     "lint:knip": "cross-env NODE_ENV=test knip",
     "lint:fix": "biome lint --write && pnpm eslint \"**/*.vue\" --fix",
-    "test": "vitest",
+    "test": "turbo --filter './packages/**' --filter './integrations/**' --filter './projects/**' --filter './tooling/**' test",
     "types:check": "turbo types:check",
     "types:check:raw": "pnpm run -r --parallel types:check",
     "types:build": "turbo types:build",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -29,7 +29,7 @@
     "playground:v2:modal": "vite ./playground/v2/modal -c ./vite.config.ts",
     "playground:v2:web": "vite ./playground/v2/web -c ./vite.config.ts",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest --run",
     "test:benchmark": "vitest bench",
     "test:benchmark:compare": "vitest bench --compare test-results/test-benchmark.json",
     "test:benchmark:save": "vitest bench --outputJson test-results/test-benchmark.json",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -32,7 +32,7 @@
     "dev:standalone": "vite -c vite.standalone.config.ts",
     "playground:esm": "vite ./playground/esm -c ./playground/esm/vite.config.ts",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest --run",
     "test:benchmark": "vitest bench",
     "test:benchmark:compare": "vitest bench --compare test-results/test-benchmark.json",
     "test:benchmark:save": "vitest bench --outputJson test-results/test-benchmark.json",

--- a/packages/client-side-rendering/package.json
+++ b/packages/client-side-rendering/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && shx cp -r src/css dist/css",
     "dev": "vite",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,7 +23,7 @@
     "lint:check": "pnpm lint:icons",
     "lint:icons": "svglint src/components/ScalarIcon/icons/*.svg --config src/components/ScalarIcon/.svglintrc.js",
     "preview": "vite preview --outDir storybook-static -c test/vite.config.ts 1>&2",
-    "test": "vitest",
+    "test": "vitest --run",
     "test:e2e": "PW_TEST_CONNECT_WS_ENDPOINT=ws://127.0.0.1:5001/ playwright test",
     "test:e2e:ci": "CI=1 playwright test",
     "test:e2e:update": "pnpm test:e2e --update-snapshots",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/draggable/package.json
+++ b/packages/draggable/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "vite build && vue-tsc -p tsconfig.build.json",
     "dev": "vite ./playground -c ./vite.config.ts",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "vue-tsc --noEmit"
   },
   "type": "module",

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -24,7 +24,7 @@
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && tsx scripts/post-build.ts",
     "dev": "pnpx @scalar/cli document serve ./src/documents/3.1.yaml --watch",
     "dev:live": "cd src/documents && pnpx http-server --cors",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit",
     "validate": "bash scripts/validate.sh"
   },

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -19,7 +19,7 @@
     "generate:icons": "tsx ./scripts/generate-icons.ts",
     "lint:check": "pnpm lint:icons",
     "lint:icons": "svglint src/library/icons/*.svg --config src/library/.svglintrc.js",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "vue-tsc --noEmit"
   },
   "type": "module",

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "dev": "tsx watch playground/index.ts",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/json-magic/package.json
+++ b/packages/json-magic/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/mock-server/docker/package.json
+++ b/packages/mock-server/docker/package.json
@@ -21,7 +21,7 @@
     "docker:run": "docker run -v ./documents:/docs:ro -p 3000:3000 --rm --init scalarapi/mock-server",
     "docker:run:env": "docker run -e OPENAPI_DOCUMENT=\"$(cat ./documents/example.yaml)\" -p 3000:3000 --rm --init scalarapi/mock-server",
     "docker:run:url": "docker run -p 3000:3000 --rm --init scalarapi/mock-server --url https://raw.githubusercontent.com/OAI/OpenAPI-Specification/refs/heads/main/_archive_/schemas/v3.0/pass/petstore.yaml",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/object-utils/package.json
+++ b/packages/object-utils/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "NODE_OPTIONS=--max_old_space_size=8192 vitest",
+    "test": "NODE_OPTIONS=--max_old_space_size=8192 vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/openapi-to-markdown/package.json
+++ b/packages/openapi-to-markdown/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "vite build && vue-tsc -p tsconfig.build.json",
     "dev": "tsx watch playground/index.ts",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "vue-tsc --noEmit"
   },
   "type": "module",

--- a/packages/openapi-types/package.json
+++ b/packages/openapi-types/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/openapi-upgrader/package.json
+++ b/packages/openapi-upgrader/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/postman-to-openapi/package.json
+++ b/packages/postman-to-openapi/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "generate:textures": "tsx ./scripts/generate-textures.ts",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/pre-post-request-scripts/package.json
+++ b/packages/pre-post-request-scripts/package.json
@@ -27,7 +27,7 @@
     "build": "vite build && vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "dev": "vite",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "vue-tsc --noEmit"
   },
   "type": "module",

--- a/packages/react-renderer/package.json
+++ b/packages/react-renderer/package.json
@@ -24,7 +24,7 @@
     "build": "vite build && vue-tsc -p tsconfig.build.json",
     "dev": "vite",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "vue-tsc --noEmit"
   },
   "type": "module",

--- a/packages/server-side-rendering/package.json
+++ b/packages/server-side-rendering/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "vite build",
     "dev": "tsx playground/server.ts",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/sidebar/package.json
+++ b/packages/sidebar/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "vite build && vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "dev": "vite ./playground -c ./vite.config.ts",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "vue-tsc --noEmit"
   },
   "type": "module",

--- a/packages/snippetz/package.json
+++ b/packages/snippetz/package.json
@@ -19,7 +19,7 @@
     "generate:java-enums": "tsx scripts/generate-java-enums.ts",
     "generate:markdown-docs": "tsx scripts/generate-markdown-docs.ts",
     "postbuild": "pnpm generate:dotnet-enums && pnpm generate:java-enums && pnpm generate:markdown-docs",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/ts-to-openapi/package.json
+++ b/packages/ts-to-openapi/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/use-codemirror/package.json
+++ b/packages/use-codemirror/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "dev": "vite .",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "vue-tsc --noEmit"
   },
   "type": "module",

--- a/packages/use-hooks/package.json
+++ b/packages/use-hooks/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "vue-tsc --noEmit"
   },
   "type": "module",

--- a/packages/use-toasts/package.json
+++ b/packages/use-toasts/package.json
@@ -25,7 +25,7 @@
     "build": "vite build && vue-tsc -p tsconfig.build.json",
     "dev": "vite",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "vue-tsc --noEmit"
   },
   "type": "module",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "dev": "tsx playground/index.ts",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/void-server/package.json
+++ b/packages/void-server/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "dev": "tsx playground/index.ts",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/packages/workspace-store/package.json
+++ b/packages/workspace-store/package.json
@@ -24,7 +24,7 @@
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "generate-json-schemas": "tsx ./scripts/generate-json-schemas.ts",
     "generate-openapi-types": "tsx ./scripts/generate-openapi-types.ts",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/projects/galaxy-scalar-com/package.json
+++ b/projects/galaxy-scalar-com/package.json
@@ -26,7 +26,7 @@
     "copy:standalone": "LOCAL_JS_BUNDLE=true shx cp ../../packages/api-reference/dist/browser/standalone.js ./src/scalar.js",
     "dev": "tsx watch src/index.ts",
     "dev:local": "pnpm copy:standalone && LOCAL_JS_BUNDLE=true tsx watch src/index.ts",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "type": "module",

--- a/tooling/changelog-generator/package.json
+++ b/tooling/changelog-generator/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "test": "vitest",
+    "test": "vitest --run",
     "types:check": "tsc --noEmit"
   },
   "dependencies": {

--- a/tooling/scripts/package.json
+++ b/tooling/scripts/package.json
@@ -4,7 +4,7 @@
   "description": "Scalar OSS Scripts. Packaged for easy dependency installation.",
   "scripts": {
     "start": "tsx src/cli.ts",
-    "test": "vitest ."
+    "test": "vitest --run ."
   },
   "type": "module",
   "keywords": [],

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,10 @@
       "outputs": ["dist/**", "storybook-static/**", ".output", ".nuxt", ".next", "build", "target/**"],
       "dependsOn": ["^build"]
     },
+    "test": {
+      "dependsOn": ["^build"],
+      "cache": false
+    },
     "types:check": {
       "dependsOn": ["build"]
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    projects: ['integrations/*', 'packages/*', 'projects/*', 'tooling/*'],
+    passWithNoTests: true,
+    watch: false,
   },
 })


### PR DESCRIPTION
Previously, the top-level `test` script was running Vitest from the repository root using the root configuration. This was incorrect and caused issues when:

- Running tests from individual packages
- Running tests from the repository root

This was also skipping tests from the go packages

This PR fixes that behavior by updating the root `test` script to execute each package’s test script recursively instead. This ensures that every package runs tests with its own local Vitest configuration, making test execution consistent across the monorepo.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly test/CI infrastructure changes, but the new Turbo filtering/sharding logic could unintentionally skip some package tests or alter execution order in CI.
> 
> **Overview**
> Switches the monorepo’s test runner from root-level `vitest` discovery to **Turbo-driven per-package `test` scripts**, updating the root `test` script and CI workflows (including sharded `test-packages`) to only run packages that declare a `test` script.
> 
> Standardizes package `test` scripts to `vitest --run` and updates `vitest.config.ts` for CI-friendly behavior (`watch: false`, `passWithNoTests: true`). Also hardens `@scalar/fastify-api-reference` tests/build by ensuring Fastify instances are closed after tests, excluding `*.test.ts` from `tsconfig.build.json`, and adding a `/// <reference types="@fastify/swagger" />` to satisfy type expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87c46bf10a8e3c0ffa9202ef8d9d906592c72129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->