### PR TITLE
feat(api-client): support header for web layout

### DIFF
--- a/.changeset/tender-garlics-decide.md
+++ b/.changeset/tender-garlics-decide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat(api-client): support header for web layout

--- a/packages/api-client/playground/web/index.html
+++ b/packages/api-client/playground/web/index.html
@@ -10,8 +10,30 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0" />
     <title>Scalar API Client Web</title>
+    <style>
+      html,
+      body {
+        height: 100dvh;
+        overflow: hidden;
+      }
+      body {
+        display: grid;
+        grid-template-rows: var(--scalar-header-height) 1fr;
+      }
+      body > header {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      #scalar-client,
+      #scalar-client > main {
+        display: grid;
+        min-height: 0;
+      }
+    </style>
   </head>
   <body class="scalar-app">
+    <header class="h-header border-b">Header / Menu Go Here</header>
     <div
       id="scalar-client"
       class="scalar-client"></div>

--- a/packages/api-client/src/v2/components/sidebar/Sidebar.vue
+++ b/packages/api-client/src/v2/components/sidebar/Sidebar.vue
@@ -122,7 +122,9 @@ const handleSelectItem = (id: string) => {
           <div
             class="bg-sidebar-b-1 z-1 flex flex-col gap-1.5 px-3 pb-1.5"
             :class="{ 'max-md:pt-12': layout !== 'modal' }">
-            <div class="flex items-center justify-between">
+            <div
+              v-if="layout !== 'web'"
+              class="flex items-center justify-between">
               <!-- Desktop gets the workspace menu here  -->
               <SidebarMenu
                 v-if="layout !== 'modal'"
@@ -147,9 +149,9 @@ const handleSelectItem = (id: string) => {
             </div>
 
             <ScalarSidebarSearchInput
-              v-if="isSearchVisible"
+              v-if="isSearchVisible || layout === 'web'"
               v-model="query"
-              autofocus />
+              :autofocus="layout !== 'web'" />
           </div>
         </template>
 

--- a/packages/api-client/src/v2/features/app/App.vue
+++ b/packages/api-client/src/v2/features/app/App.vue
@@ -172,7 +172,9 @@ const routerViewProps = computed<RouteProps>(() => {
         app.workspace.activeWorkspace.value !== null &&
         !app.loading.value
       ">
-      <div class="relative flex h-dvh w-dvw flex-1 flex-col">
+      <div
+        class="relative flex w-dvw flex-col"
+        :class="layout === 'web' ? 'min-h-0' : 'h-dvh'">
         <SidebarToggle
           v-model="app.sidebar.isOpen.value"
           class="absolute top-4 left-3 z-[60] md:hidden" />
@@ -198,7 +200,7 @@ const routerViewProps = computed<RouteProps>(() => {
             </template>
           </AppSidebar>
 
-          <div class="flex flex-1 flex-col">
+          <div class="flex min-h-0 flex-1 flex-col">
             <!-- App Tabs -->
             <DesktopTabs
               v-if="layout === 'desktop'"


### PR DESCRIPTION
Updates the client to support a header in the web layout.

- Hides app menu for the web layout
- Makes the search always visible on web
- Fixes some layout issues

<img width="3194" height="1958" alt="CleanShot 2026-04-15 at 23 10 19@2x" src="https://github.com/user-attachments/assets/e8600ef1-f58f-4241-aa41-467723bcf142" />


## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
