### PR TITLE
feat(proxy-scalar-com): support streaming SSE responses

### DIFF
--- a/projects/proxy-scalar-com/main.go
+++ b/projects/proxy-scalar-com/main.go
@@ -131,6 +131,21 @@ type ProxyServer struct {
 	bypassCidr bool
 }
 
+type streamingResponseWriter struct {
+	writer  http.ResponseWriter
+	flusher http.Flusher
+}
+
+func (s streamingResponseWriter) Write(p []byte) (int, error) {
+	n, err := s.writer.Write(p)
+
+	if err == nil {
+		s.flusher.Flush()
+	}
+
+	return n, err
+}
+
 // NewProxyServer creates a new proxy server instance
 func NewProxyServer(bypassCidr bool) *ProxyServer {
 	dialer := &net.Dialer{Timeout: 10 * time.Second}
@@ -375,8 +390,22 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 	// Copy the status code from the proxied response
 	w.WriteHeader(resp.StatusCode)
 
+	responseWriter := io.Writer(w)
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+
+	// SSE streams require chunk flushing to deliver events progressively.
+	if strings.HasPrefix(contentType, "text/event-stream") {
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+			responseWriter = streamingResponseWriter{
+				writer:  w,
+				flusher: flusher,
+			}
+		}
+	}
+
 	// Copy the body
-	if _, err := io.Copy(w, resp.Body); err != nil {
+	if _, err := io.Copy(responseWriter, resp.Body); err != nil {
 		return err
 	}
 

--- a/projects/proxy-scalar-com/main_test.go
+++ b/projects/proxy-scalar-com/main_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bufio"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
@@ -551,6 +554,91 @@ func TestProxyBehavior(t *testing.T) {
 			t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
 		}
 	})
+}
+
+func readSSEEvent(reader *bufio.Reader) (string, error) {
+	lines := []string{}
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+
+		if line == "\n" {
+			return strings.Join(lines, ""), nil
+		}
+
+		lines = append(lines, line)
+	}
+}
+
+func TestSSEStreaming(t *testing.T) {
+	proxyServer := NewProxyServer(true)
+	const eventInterval = 350 * time.Millisecond
+
+	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("expected SSE handler response writer to support flushing")
+		}
+
+		for i := range 2 {
+			fmt.Fprintf(w, "data: event-%d\n\n", i+1)
+			flusher.Flush()
+			time.Sleep(eventInterval)
+		}
+	}))
+	defer targetServer.Close()
+
+	proxy := httptest.NewServer(corsMiddleware(http.HandlerFunc(proxyServer.handleRequest)))
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL + "/?scalar_url=" + url.QueryEscape(targetServer.URL))
+	if err != nil {
+		t.Fatalf("Expected proxy request to succeed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+
+	reader := bufio.NewReader(resp.Body)
+
+	firstStart := time.Now()
+	firstEvent, err := readSSEEvent(reader)
+	firstDuration := time.Since(firstStart)
+	if err != nil {
+		t.Fatalf("Expected first SSE event to be readable: %v", err)
+	}
+
+	if firstEvent != "data: event-1\n" {
+		t.Fatalf("Expected first SSE event to be %q, got %q", "data: event-1\n", firstEvent)
+	}
+
+	if firstDuration > 250*time.Millisecond {
+		t.Fatalf("Expected first SSE event to arrive quickly, took %s", firstDuration)
+	}
+
+	secondStart := time.Now()
+	secondEvent, err := readSSEEvent(reader)
+	secondDuration := time.Since(secondStart)
+	if err != nil {
+		t.Fatalf("Expected second SSE event to be readable: %v", err)
+	}
+
+	if secondEvent != "data: event-2\n" {
+		t.Fatalf("Expected second SSE event to be %q, got %q", "data: event-2\n", secondEvent)
+	}
+
+	if secondDuration < 200*time.Millisecond {
+		t.Fatalf("Expected second SSE event to arrive after stream delay, took %s", secondDuration)
+	}
 }
 
 func TestCidrPolicy(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`projects/proxy-scalar-com` did not guarantee progressive flushing for `text/event-stream` responses, so SSE events could be buffered and delivered late to browser clients.

## Solution

- Added SSE-aware streaming in the proxy response path: when upstream `Content-Type` starts with `text/event-stream`, the proxy now flushes headers immediately and flushes after each write chunk.
- Added a focused Go test (`TestSSEStreaming`) that spins up an SSE upstream server, proxies through `handleRequest`, and asserts event timing to verify true streaming behavior.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ede3a69-7329-42fd-8e57-32741f339624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ede3a69-7329-42fd-8e57-32741f339624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

