### PR TITLE
test(proxy-scalar-com): cover self-proxy scalar_url behavior

### DIFF
--- a/projects/proxy-scalar-com/main_test.go
+++ b/projects/proxy-scalar-com/main_test.go
@@ -366,6 +366,39 @@ func TestProxyBehavior(t *testing.T) {
 		}
 	})
 
+	t.Run("Handles nested scalar_url chain pointing back to proxy without looping", func(t *testing.T) {
+		selfProxyServer := httptest.NewServer(http.HandlerFunc(proxyServer.handleRequest))
+		defer selfProxyServer.Close()
+
+		nestedTarget := selfProxyServer.URL
+		for range 3 {
+			nestedTarget = selfProxyServer.URL + "/?scalar_url=" + url.QueryEscape(nestedTarget)
+		}
+
+		client := &http.Client{Timeout: 2 * time.Second}
+		proxyRequestURL := selfProxyServer.URL + "/?scalar_url=" + url.QueryEscape(nestedTarget)
+		resp, err := client.Get(proxyRequestURL)
+
+		if err != nil {
+			t.Fatalf("Expected nested request chain to complete without loop, got error: %v", err)
+		}
+
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("Failed to read response body: %v", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+		}
+
+		if len(body) == 0 {
+			t.Error("Expected non-empty response body")
+		}
+	})
+
 	t.Run("Copies non-CORS headers from response", func(t *testing.T) {
 		server := setupTestServer(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("X-Custom-Header", "custom-value")

--- a/projects/proxy-scalar-com/main_test.go
+++ b/projects/proxy-scalar-com/main_test.go
@@ -4,7 +4,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
+	"time"
 )
 
 // Common test setup
@@ -333,6 +335,34 @@ func TestProxyBehavior(t *testing.T) {
 
 		if w.Code != http.StatusServiceUnavailable {
 			t.Errorf("Expected status code %d, got %d", http.StatusServiceUnavailable, w.Code)
+		}
+	})
+
+	t.Run("Handles scalar_url set to proxy root without looping", func(t *testing.T) {
+		selfProxyServer := httptest.NewServer(http.HandlerFunc(proxyServer.handleRequest))
+		defer selfProxyServer.Close()
+
+		client := &http.Client{Timeout: 2 * time.Second}
+		proxyRequestURL := selfProxyServer.URL + "/?scalar_url=" + url.QueryEscape(selfProxyServer.URL)
+		resp, err := client.Get(proxyRequestURL)
+
+		if err != nil {
+			t.Fatalf("Expected request to complete without loop, got error: %v", err)
+		}
+
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("Failed to read response body: %v", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+		}
+
+		if len(body) == 0 {
+			t.Error("Expected non-empty response body")
 		}
 	})
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`projects/proxy-scalar-com` did not have explicit coverage for self-referential `scalar_url` requests, including deeper nested chains where a proxied URL itself includes another proxied URL.

## Solution

Added two focused regression tests:

1. Proxy root URL passed as `scalar_url`.
2. A nested self-referential `scalar_url` chain (multiple levels deep) pointing back to the proxy.

Both assert requests complete quickly and return successful, non-empty responses.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- not needed: test-only change in projects/* -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-833af12c-eea7-4d85-b786-a7cbdd3b6bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-833af12c-eea7-4d85-b786-a7cbdd3b6bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

