### PR TITLE
refactor(integrations): use @scalar/client-side-rendering

### DIFF
--- a/.changeset/fair-mangos-tickle.md
+++ b/.changeset/fair-mangos-tickle.md
@@ -1,0 +1,11 @@
+---
+'@scalar/astro': patch
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/hono-api-reference': patch
+'@scalar/nestjs-api-reference': patch
+'@scalar/nextjs-api-reference': patch
+'@scalar/sveltekit': patch
+---
+
+refactor: migrate integrations to client-side rendering package

--- a/integrations/astro/package.json
+++ b/integrations/astro/package.json
@@ -48,8 +48,7 @@
     "documentation": "https://scalar.com/products/api-references/integrations/astro"
   },
   "dependencies": {
-    "@scalar/client-side-rendering": "workspace:*",
-    "@scalar/types": "workspace:*"
+    "@scalar/client-side-rendering": "workspace:*"
   },
   "devDependencies": {
     "astro": "^4.0.0 || ^5.0.0"

--- a/integrations/astro/package.json
+++ b/integrations/astro/package.json
@@ -48,7 +48,8 @@
     "documentation": "https://scalar.com/products/api-references/integrations/astro"
   },
   "dependencies": {
-    "@scalar/core": "workspace:*"
+    "@scalar/client-side-rendering": "workspace:*",
+    "@scalar/types": "workspace:*"
   },
   "devDependencies": {
     "astro": "^4.0.0 || ^5.0.0"

--- a/integrations/astro/src/ScalarComponent.astro
+++ b/integrations/astro/src/ScalarComponent.astro
@@ -1,6 +1,5 @@
 ---
-import { renderApiReference } from '@scalar/client-side-rendering'
-import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
+import { renderApiReference, type HtmlRenderingConfiguration } from '@scalar/client-side-rendering'
 
 export interface Props {
   configuration: Partial<HtmlRenderingConfiguration>

--- a/integrations/astro/src/ScalarComponent.astro
+++ b/integrations/astro/src/ScalarComponent.astro
@@ -1,5 +1,6 @@
 ---
-import { getHtmlDocument, type HtmlRenderingConfiguration } from '@scalar/core/libs/html-rendering'
+import { renderApiReference } from '@scalar/client-side-rendering'
+import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
 
 export interface Props {
   configuration: Partial<HtmlRenderingConfiguration>
@@ -15,9 +16,15 @@ const DEFAULT_CONFIGURATION: Partial<HtmlRenderingConfiguration> = {
 
 const { configuration } = Astro.props
 
-const html = getHtmlDocument({
+const finalConfiguration = {
   ...DEFAULT_CONFIGURATION,
   ...configuration,
+}
+const { cdn, pageTitle, ...config } = finalConfiguration
+const html = renderApiReference({
+  config,
+  cdn,
+  pageTitle,
 })
 ---
 

--- a/integrations/express/package.json
+++ b/integrations/express/package.json
@@ -54,7 +54,8 @@
     "documentation": "https://scalar.com/products/api-references/integrations/express"
   },
   "dependencies": {
-    "@scalar/core": "workspace:*"
+    "@scalar/client-side-rendering": "workspace:*",
+    "@scalar/types": "workspace:*"
   },
   "devDependencies": {
     "@types/express": "catalog:*",

--- a/integrations/express/package.json
+++ b/integrations/express/package.json
@@ -54,8 +54,7 @@
     "documentation": "https://scalar.com/products/api-references/integrations/express"
   },
   "dependencies": {
-    "@scalar/client-side-rendering": "workspace:*",
-    "@scalar/types": "workspace:*"
+    "@scalar/client-side-rendering": "workspace:*"
   },
   "devDependencies": {
     "@types/express": "catalog:*",

--- a/integrations/express/src/apiReference.ts
+++ b/integrations/express/src/apiReference.ts
@@ -1,4 +1,4 @@
-import { getHtmlDocument } from '@scalar/core/libs/html-rendering'
+import { renderApiReference } from '@scalar/client-side-rendering'
 import type { RequestHandler } from 'express'
 
 import type { ApiReferenceConfiguration } from './types'
@@ -22,6 +22,7 @@ export function apiReference(givenConfiguration: Partial<ApiReferenceConfigurati
 
   // Respond with the HTML document
   return (_, res) => {
-    res.type('text/html').send(getHtmlDocument(configuration))
+    const { cdn, pageTitle, ...config } = configuration
+    res.type('text/html').send(renderApiReference({ config, pageTitle, cdn }))
   }
 }

--- a/integrations/express/src/types.ts
+++ b/integrations/express/src/types.ts
@@ -1,4 +1,4 @@
-import type { HtmlRenderingConfiguration } from '@scalar/core/libs/html-rendering'
+import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
 
 /**
  * The configuration for the Scalar API Reference for Express

--- a/integrations/express/src/types.ts
+++ b/integrations/express/src/types.ts
@@ -1,4 +1,4 @@
-import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
+import type { HtmlRenderingConfiguration } from '@scalar/client-side-rendering'
 
 /**
  * The configuration for the Scalar API Reference for Express

--- a/integrations/fastify/package.json
+++ b/integrations/fastify/package.json
@@ -64,7 +64,6 @@
     "@scalar/client-side-rendering": "workspace:*",
     "@scalar/openapi-parser": "workspace:*",
     "@scalar/openapi-types": "workspace:*",
-    "@scalar/types": "workspace:*",
     "fastify-plugin": "catalog:*",
     "github-slugger": "catalog:*"
   },

--- a/integrations/fastify/package.json
+++ b/integrations/fastify/package.json
@@ -61,9 +61,10 @@
     "documentation": "https://scalar.com/products/api-references/integrations/fastify"
   },
   "dependencies": {
-    "@scalar/core": "workspace:*",
+    "@scalar/client-side-rendering": "workspace:*",
     "@scalar/openapi-parser": "workspace:*",
     "@scalar/openapi-types": "workspace:*",
+    "@scalar/types": "workspace:*",
     "fastify-plugin": "catalog:*",
     "github-slugger": "catalog:*"
   },

--- a/integrations/fastify/src/fastifyApiReference.ts
+++ b/integrations/fastify/src/fastifyApiReference.ts
@@ -1,5 +1,5 @@
 /// <reference types="@fastify/swagger" />
-import { getHtmlDocument } from '@scalar/core/libs/html-rendering'
+import { renderApiReference } from '@scalar/client-side-rendering'
 import { normalize, toJson, toYaml } from '@scalar/openapi-parser'
 import type { OpenAPI } from '@scalar/openapi-types'
 import type { FastifyBaseLogger, FastifyTypeProviderDefault, RawServerDefault } from 'fastify'
@@ -226,13 +226,17 @@ const fastifyApiReference = fp<
         }
 
         // Respond with the HTML document
-        return reply.header('Content-Type', 'text/html; charset=utf-8').send(
-          getHtmlDocument({
-            // We're using the bundled JS here by default, but the user can pass a CDN URL.
-            cdn: RELATIVE_JAVASCRIPT_PATH,
-            ...configuration,
-          }),
-        )
+        const { cdn, pageTitle, ...config } = configuration
+        return reply
+          .header('Content-Type', 'text/html; charset=utf-8')
+          .send(
+            renderApiReference({
+              config,
+              // We're using the bundled JS here by default, but the user can pass a CDN URL.
+              cdn: cdn ?? RELATIVE_JAVASCRIPT_PATH,
+              pageTitle,
+            }),
+          )
       },
     })
 

--- a/integrations/fastify/src/fastifyApiReference.ts
+++ b/integrations/fastify/src/fastifyApiReference.ts
@@ -227,16 +227,14 @@ const fastifyApiReference = fp<
 
         // Respond with the HTML document
         const { cdn, pageTitle, ...config } = configuration
-        return reply
-          .header('Content-Type', 'text/html; charset=utf-8')
-          .send(
-            renderApiReference({
-              config,
-              // We're using the bundled JS here by default, but the user can pass a CDN URL.
-              cdn: cdn ?? RELATIVE_JAVASCRIPT_PATH,
-              pageTitle,
-            }),
-          )
+        return reply.header('Content-Type', 'text/html; charset=utf-8').send(
+          renderApiReference({
+            config,
+            // We're using the bundled JS here by default, but the user can pass a CDN URL.
+            cdn: cdn ?? RELATIVE_JAVASCRIPT_PATH,
+            pageTitle,
+          }),
+        )
       },
     })
 

--- a/integrations/fastify/src/types.ts
+++ b/integrations/fastify/src/types.ts
@@ -1,4 +1,4 @@
-import type { HtmlRenderingConfiguration } from '@scalar/core/libs/html-rendering'
+import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
 import type { onRequestHookHandler, preHandlerHookHandler } from 'fastify'
 
 /**

--- a/integrations/fastify/src/types.ts
+++ b/integrations/fastify/src/types.ts
@@ -1,4 +1,4 @@
-import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
+import type { HtmlRenderingConfiguration } from '@scalar/client-side-rendering'
 import type { onRequestHookHandler, preHandlerHookHandler } from 'fastify'
 
 /**

--- a/integrations/hono/package.json
+++ b/integrations/hono/package.json
@@ -52,8 +52,7 @@
     "documentation": "https://scalar.com/products/api-references/integrations/hono"
   },
   "dependencies": {
-    "@scalar/client-side-rendering": "workspace:*",
-    "@scalar/types": "workspace:*"
+    "@scalar/client-side-rendering": "workspace:*"
   },
   "devDependencies": {
     "@hono/node-server": "catalog:*",

--- a/integrations/hono/package.json
+++ b/integrations/hono/package.json
@@ -52,7 +52,8 @@
     "documentation": "https://scalar.com/products/api-references/integrations/hono"
   },
   "dependencies": {
-    "@scalar/core": "workspace:*"
+    "@scalar/client-side-rendering": "workspace:*",
+    "@scalar/types": "workspace:*"
   },
   "devDependencies": {
     "@hono/node-server": "catalog:*",

--- a/integrations/hono/src/scalar.ts
+++ b/integrations/hono/src/scalar.ts
@@ -1,4 +1,4 @@
-import { getHtmlDocument } from '@scalar/core/libs/html-rendering'
+import { renderApiReference } from '@scalar/client-side-rendering'
 import type { Context, Env, MiddlewareHandler } from 'hono'
 
 import type { ApiReferenceConfiguration } from './types'
@@ -89,6 +89,7 @@ export const Scalar = <E extends Env>(configOrResolver: Configuration<E>): Middl
     }
 
     // Respond with the HTML document
-    return c.html(getHtmlDocument(configuration, customTheme))
+    const { cdn, pageTitle, ...config } = configuration
+    return c.html(renderApiReference({ config, pageTitle, cdn }, customTheme))
   }
 }

--- a/integrations/hono/src/types.ts
+++ b/integrations/hono/src/types.ts
@@ -1,4 +1,4 @@
-import type { HtmlRenderingConfiguration } from '@scalar/core/libs/html-rendering'
+import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
 
 /**
  * The configuration for the Scalar API Reference for Hono

--- a/integrations/hono/src/types.ts
+++ b/integrations/hono/src/types.ts
@@ -1,4 +1,4 @@
-import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
+import type { HtmlRenderingConfiguration } from '@scalar/client-side-rendering'
 
 /**
  * The configuration for the Scalar API Reference for Hono

--- a/integrations/nestjs/package.json
+++ b/integrations/nestjs/package.json
@@ -64,7 +64,8 @@
     "documentation": "https://scalar.com/products/api-references/integrations/nestjs"
   },
   "dependencies": {
-    "@scalar/core": "workspace:*"
+    "@scalar/client-side-rendering": "workspace:*",
+    "@scalar/types": "workspace:*"
   },
   "devDependencies": {
     "@nestjs/common": "catalog:*",

--- a/integrations/nestjs/package.json
+++ b/integrations/nestjs/package.json
@@ -64,8 +64,7 @@
     "documentation": "https://scalar.com/products/api-references/integrations/nestjs"
   },
   "dependencies": {
-    "@scalar/client-side-rendering": "workspace:*",
-    "@scalar/types": "workspace:*"
+    "@scalar/client-side-rendering": "workspace:*"
   },
   "devDependencies": {
     "@nestjs/common": "catalog:*",

--- a/integrations/nestjs/src/nestJSApiReference.ts
+++ b/integrations/nestjs/src/nestJSApiReference.ts
@@ -1,6 +1,6 @@
 import type { ServerResponse } from 'node:http'
 
-import { getHtmlDocument } from '@scalar/core/libs/html-rendering'
+import { renderApiReference } from '@scalar/client-side-rendering'
 import type { Request, Response } from 'express'
 import type { FastifyRequest } from 'fastify'
 
@@ -91,7 +91,10 @@ export function apiReference(givenConfiguration: NestJSReferenceConfiguration) {
     ...givenConfiguration,
   }
 
-  const content = () => getHtmlDocument(configuration, customThemeCSS)
+  const content = () => {
+    const { cdn, pageTitle, ...config } = configuration
+    return renderApiReference({ config, pageTitle, cdn }, customThemeCSS)
+  }
 
   if (givenConfiguration.withFastify) {
     return (_req: FastifyRequest, res: ServerResponse) => {

--- a/integrations/nestjs/src/types.ts
+++ b/integrations/nestjs/src/types.ts
@@ -1,4 +1,4 @@
-import type { HtmlRenderingConfiguration } from '@scalar/core/libs/html-rendering'
+import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
 
 export type ApiReferenceOptions = Partial<HtmlRenderingConfiguration>
 

--- a/integrations/nestjs/src/types.ts
+++ b/integrations/nestjs/src/types.ts
@@ -1,4 +1,4 @@
-import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
+import type { HtmlRenderingConfiguration } from '@scalar/client-side-rendering'
 
 export type ApiReferenceOptions = Partial<HtmlRenderingConfiguration>
 

--- a/integrations/nextjs/package.json
+++ b/integrations/nextjs/package.json
@@ -56,8 +56,7 @@
     "documentation": "https://scalar.com/products/api-references/integrations/nextjs"
   },
   "dependencies": {
-    "@scalar/client-side-rendering": "workspace:*",
-    "@scalar/types": "workspace:*"
+    "@scalar/client-side-rendering": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "catalog:*",

--- a/integrations/nextjs/package.json
+++ b/integrations/nextjs/package.json
@@ -56,7 +56,8 @@
     "documentation": "https://scalar.com/products/api-references/integrations/nextjs"
   },
   "dependencies": {
-    "@scalar/core": "workspace:*"
+    "@scalar/client-side-rendering": "workspace:*",
+    "@scalar/types": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "catalog:*",

--- a/integrations/nextjs/src/ApiReference.ts
+++ b/integrations/nextjs/src/ApiReference.ts
@@ -1,4 +1,4 @@
-import { getHtmlDocument } from '@scalar/core/libs/html-rendering'
+import { renderApiReference } from '@scalar/client-side-rendering'
 
 import { customTheme } from './custom-theme'
 import type { ApiReferenceConfiguration } from './types'
@@ -26,7 +26,8 @@ export const ApiReference = (givenConfiguration: Partial<ApiReferenceConfigurati
   }
 
   return () => {
-    const referenceDocument = getHtmlDocument(configuration, customTheme)
+    const { cdn, pageTitle, ...config } = configuration
+    const referenceDocument = renderApiReference({ config, pageTitle, cdn }, customTheme)
     return new Response(referenceDocument, {
       status: 200,
       headers: { 'Content-Type': 'text/html' },

--- a/integrations/nextjs/src/types.ts
+++ b/integrations/nextjs/src/types.ts
@@ -1,4 +1,4 @@
-import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
+import type { HtmlRenderingConfiguration } from '@scalar/client-side-rendering'
 
 /**
  * The configuration for the Scalar API Reference for Next.js

--- a/integrations/nextjs/src/types.ts
+++ b/integrations/nextjs/src/types.ts
@@ -1,4 +1,4 @@
-import type { HtmlRenderingConfiguration } from '@scalar/core/libs/html-rendering'
+import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
 
 /**
  * The configuration for the Scalar API Reference for Next.js

--- a/integrations/nextjs/test/ApiReference.test.ts
+++ b/integrations/nextjs/test/ApiReference.test.ts
@@ -1,15 +1,15 @@
-import { getHtmlDocument } from '@scalar/core/libs/html-rendering'
+import { renderApiReference } from '@scalar/client-side-rendering'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ApiReference } from '../src/ApiReference'
 
-vi.mock('@scalar/core/libs/html-rendering', { spy: true })
+vi.mock('@scalar/client-side-rendering', { spy: true })
 vi.mock('../src/custom-theme', () => ({ customTheme: '___customTheme___' }))
 
-const getHtmlDocumentSpy = vi.mocked(getHtmlDocument)
+const renderApiReferenceSpy = vi.mocked(renderApiReference)
 
 beforeEach(() => {
-  getHtmlDocumentSpy.mockReset()
+  renderApiReferenceSpy.mockReset()
 })
 
 describe('ApiReference', () => {
@@ -19,7 +19,7 @@ describe('ApiReference', () => {
   })
 
   it('should return a Response with correct headers and body', async () => {
-    getHtmlDocumentSpy.mockReturnValueOnce('___HTMLDoc___')
+    renderApiReferenceSpy.mockReturnValueOnce('___HTMLDoc___')
 
     const handler = ApiReference({ title: 'Test API' })
     const response = handler()
@@ -28,12 +28,16 @@ describe('ApiReference', () => {
     expect(response.status).toBe(200)
     expect(response.headers.get('Content-Type')).toBe('text/html')
 
-    expect(getHtmlDocumentSpy).toHaveBeenCalledOnce()
-    expect(getHtmlDocumentSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        title: 'Test API',
-        _integration: 'nextjs', // default should be merged in
-      }),
+    expect(renderApiReferenceSpy).toHaveBeenCalledOnce()
+    expect(renderApiReferenceSpy).toHaveBeenCalledWith(
+      {
+        config: expect.objectContaining({
+          title: 'Test API',
+          _integration: 'nextjs', // default should be merged in
+        }),
+        cdn: undefined,
+        pageTitle: undefined,
+      },
       '___customTheme___',
     )
 

--- a/integrations/sveltekit/package.json
+++ b/integrations/sveltekit/package.json
@@ -64,8 +64,7 @@
   ],
   "svelte": "./dist/index.js",
   "dependencies": {
-    "@scalar/client-side-rendering": "workspace:*",
-    "@scalar/types": "workspace:*"
+    "@scalar/client-side-rendering": "workspace:*"
   },
   "devDependencies": {
     "@sveltejs/kit": "^2.57.1",

--- a/integrations/sveltekit/package.json
+++ b/integrations/sveltekit/package.json
@@ -64,7 +64,8 @@
   ],
   "svelte": "./dist/index.js",
   "dependencies": {
-    "@scalar/core": "workspace:*"
+    "@scalar/client-side-rendering": "workspace:*",
+    "@scalar/types": "workspace:*"
   },
   "devDependencies": {
     "@sveltejs/kit": "^2.57.1",

--- a/integrations/sveltekit/src/scalar-api-reference.ts
+++ b/integrations/sveltekit/src/scalar-api-reference.ts
@@ -1,4 +1,4 @@
-import { getHtmlDocument } from '@scalar/core/libs/html-rendering'
+import { renderApiReference } from '@scalar/client-side-rendering'
 
 import { customTheme } from './custom-theme.js'
 import type { ApiReferenceConfiguration } from './types.js'
@@ -23,7 +23,8 @@ export const ScalarApiReference = (givenConfiguration: Partial<ApiReferenceConfi
   }
 
   return () => {
-    const referenceDocument = getHtmlDocument(configuration, customTheme)
+    const { cdn, pageTitle, ...config } = configuration
+    const referenceDocument = renderApiReference({ config, pageTitle, cdn }, customTheme)
     return new Response(referenceDocument, {
       status: 200,
       headers: { 'Content-Type': 'text/html' },

--- a/integrations/sveltekit/src/types.ts
+++ b/integrations/sveltekit/src/types.ts
@@ -1,4 +1,4 @@
-import type { HtmlRenderingConfiguration } from '@scalar/core/libs/html-rendering'
+import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
 
 /**
  * The configuration for the Scalar API Reference for SvelteKit

--- a/integrations/sveltekit/src/types.ts
+++ b/integrations/sveltekit/src/types.ts
@@ -1,4 +1,4 @@
-import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
+import type { HtmlRenderingConfiguration } from '@scalar/client-side-rendering'
 
 /**
  * The configuration for the Scalar API Reference for SvelteKit

--- a/packages/client-side-rendering/src/html-rendering.ts
+++ b/packages/client-side-rendering/src/html-rendering.ts
@@ -1,4 +1,6 @@
-import type { AnyApiReferenceConfiguration } from '@scalar/types/api-reference'
+import type { AnyApiReferenceConfiguration, HtmlRenderingConfiguration } from '@scalar/types/api-reference'
+
+export type { AnyApiReferenceConfiguration, HtmlRenderingConfiguration }
 
 const DEFAULT_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
 

--- a/packages/client-side-rendering/src/index.ts
+++ b/packages/client-side-rendering/src/index.ts
@@ -1,1 +1,7 @@
-export { getConfiguration, getScriptTags, renderApiReference } from './html-rendering'
+export {
+  getConfiguration,
+  getScriptTags,
+  renderApiReference,
+  type AnyApiReferenceConfiguration,
+  type HtmlRenderingConfiguration,
+} from './html-rendering'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,7 +421,7 @@ importers:
         version: 7.2.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.4(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.27.2)(jest@29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@24.10.13)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.4(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.2)(jest@29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@24.10.13)(typescript@5.9.3)))(typescript@5.9.3)
       ts-loader:
         specifier: ^9.4.3
         version: 9.5.1(typescript@5.9.3)(webpack@5.103.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.27.2))
@@ -494,7 +494,7 @@ importers:
         version: 7.2.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.4(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.2)(jest@29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@24.10.13)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.4(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.27.2)(jest@29.7.0(@types/node@24.10.13)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@24.10.13)(typescript@5.9.3)))(typescript@5.9.3)
       ts-loader:
         specifier: ^9.4.3
         version: 9.5.1(typescript@5.9.3)(webpack@5.103.0(@swc/core@1.5.29(@swc/helpers@0.5.15))(esbuild@0.27.2))
@@ -741,9 +741,12 @@ importers:
 
   integrations/astro:
     dependencies:
-      '@scalar/core':
+      '@scalar/client-side-rendering':
         specifier: workspace:*
-        version: link:../../packages/core
+        version: link:../../packages/client-side-rendering
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../../packages/types
     devDependencies:
       astro:
         specifier: ^4.0.0 || ^5.0.0
@@ -852,9 +855,12 @@ importers:
 
   integrations/express:
     dependencies:
-      '@scalar/core':
+      '@scalar/client-side-rendering':
         specifier: workspace:*
-        version: link:../../packages/core
+        version: link:../../packages/client-side-rendering
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../../packages/types
     devDependencies:
       '@types/express':
         specifier: catalog:*
@@ -885,15 +891,18 @@ importers:
 
   integrations/fastify:
     dependencies:
-      '@scalar/core':
+      '@scalar/client-side-rendering':
         specifier: workspace:*
-        version: link:../../packages/core
+        version: link:../../packages/client-side-rendering
       '@scalar/openapi-parser':
         specifier: workspace:*
         version: link:../../packages/openapi-parser
       '@scalar/openapi-types':
         specifier: workspace:*
         version: link:../../packages/openapi-types
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       fastify-plugin:
         specifier: catalog:*
         version: 4.5.1
@@ -928,9 +937,12 @@ importers:
 
   integrations/hono:
     dependencies:
-      '@scalar/core':
+      '@scalar/client-side-rendering':
         specifier: workspace:*
-        version: link:../../packages/core
+        version: link:../../packages/client-side-rendering
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../../packages/types
     devDependencies:
       '@hono/node-server':
         specifier: catalog:*
@@ -963,9 +975,12 @@ importers:
 
   integrations/nestjs:
     dependencies:
-      '@scalar/core':
+      '@scalar/client-side-rendering':
         specifier: workspace:*
-        version: link:../../packages/core
+        version: link:../../packages/client-side-rendering
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../../packages/types
     devDependencies:
       '@nestjs/common':
         specifier: catalog:*
@@ -1006,9 +1021,12 @@ importers:
 
   integrations/nextjs:
     dependencies:
-      '@scalar/core':
+      '@scalar/client-side-rendering':
         specifier: workspace:*
-        version: link:../../packages/core
+        version: link:../../packages/client-side-rendering
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../../packages/types
     devDependencies:
       '@types/node':
         specifier: ^24.1.0
@@ -1082,9 +1100,12 @@ importers:
 
   integrations/sveltekit:
     dependencies:
-      '@scalar/core':
+      '@scalar/client-side-rendering':
         specifier: workspace:*
-        version: link:../../packages/core
+        version: link:../../packages/client-side-rendering
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../../packages/types
     devDependencies:
       '@sveltejs/kit':
         specifier: ^2.57.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -744,9 +744,6 @@ importers:
       '@scalar/client-side-rendering':
         specifier: workspace:*
         version: link:../../packages/client-side-rendering
-      '@scalar/types':
-        specifier: workspace:*
-        version: link:../../packages/types
     devDependencies:
       astro:
         specifier: ^4.0.0 || ^5.0.0
@@ -858,9 +855,6 @@ importers:
       '@scalar/client-side-rendering':
         specifier: workspace:*
         version: link:../../packages/client-side-rendering
-      '@scalar/types':
-        specifier: workspace:*
-        version: link:../../packages/types
     devDependencies:
       '@types/express':
         specifier: catalog:*
@@ -900,9 +894,6 @@ importers:
       '@scalar/openapi-types':
         specifier: workspace:*
         version: link:../../packages/openapi-types
-      '@scalar/types':
-        specifier: workspace:*
-        version: link:../../packages/types
       fastify-plugin:
         specifier: catalog:*
         version: 4.5.1
@@ -940,9 +931,6 @@ importers:
       '@scalar/client-side-rendering':
         specifier: workspace:*
         version: link:../../packages/client-side-rendering
-      '@scalar/types':
-        specifier: workspace:*
-        version: link:../../packages/types
     devDependencies:
       '@hono/node-server':
         specifier: catalog:*
@@ -978,9 +966,6 @@ importers:
       '@scalar/client-side-rendering':
         specifier: workspace:*
         version: link:../../packages/client-side-rendering
-      '@scalar/types':
-        specifier: workspace:*
-        version: link:../../packages/types
     devDependencies:
       '@nestjs/common':
         specifier: catalog:*
@@ -1024,9 +1009,6 @@ importers:
       '@scalar/client-side-rendering':
         specifier: workspace:*
         version: link:../../packages/client-side-rendering
-      '@scalar/types':
-        specifier: workspace:*
-        version: link:../../packages/types
     devDependencies:
       '@types/node':
         specifier: ^24.1.0
@@ -1103,9 +1085,6 @@ importers:
       '@scalar/client-side-rendering':
         specifier: workspace:*
         version: link:../../packages/client-side-rendering
-      '@scalar/types':
-        specifier: workspace:*
-        version: link:../../packages/types
     devDependencies:
       '@sveltejs/kit':
         specifier: ^2.57.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The integrations still depended on `@scalar/core/libs/html-rendering` for CDN-based HTML generation, even though that functionality now lives in `@scalar/client-side-rendering`.

## Solution

Migrated all integration usage of `@scalar/core/libs/html-rendering` to `@scalar/client-side-rendering` and made integration type usage one-package-only:

- Replaced `getHtmlDocument(...)` calls with `renderApiReference({ config, pageTitle, cdn }, customTheme?)` in:
  - `integrations/astro`
  - `integrations/express`
  - `integrations/fastify`
  - `integrations/hono`
  - `integrations/nestjs`
  - `integrations/nextjs`
  - `integrations/sveltekit`
- Re-exported `HtmlRenderingConfiguration` and `AnyApiReferenceConfiguration` from `@scalar/client-side-rendering`.
- Updated integrations to import `HtmlRenderingConfiguration` directly from `@scalar/client-side-rendering`.
- Removed direct `@scalar/types` dependency from the touched integrations so they only need `@scalar/client-side-rendering` for rendering + required config types.
- Updated integration package dependencies from `@scalar/core` to `@scalar/client-side-rendering`.
- Updated Next.js unit tests to mock/spy `renderApiReference` instead of `getHtmlDocument`.
- Added changeset for all touched integration packages.
- Synced `pnpm-lock.yaml` for frozen-lockfile CI installs.
- Applied Biome formatting to `integrations/fastify/src/fastifyApiReference.ts` to satisfy `format` CI.

## CI Follow-up

- Investigated failing `test-packages (3, 3)` log: failure is a timeout in `packages/api-reference/src/components/ApiReference.config.test.ts` (`alternative values and edge cases`) with no touched files from this PR in `packages/api-reference`.
- This looks unrelated/flaky relative to this integrations-only refactor branch.

## Testing

- ✅ `pnpm install --frozen-lockfile`
- ✅ `pnpm --filter @scalar/client-side-rendering types:check`
- ✅ `pnpm --filter @scalar/client-side-rendering build`
- ✅ `pnpm --filter @scalar/nextjs-api-reference test`
- ✅ `pnpm --filter @scalar/fastify-api-reference test`
- ✅ `pnpm --filter @scalar/nextjs-api-reference types:check && pnpm --filter @scalar/express-api-reference types:check && pnpm --filter @scalar/hono-api-reference types:check && pnpm --filter @scalar/nestjs-api-reference types:check`
- ✅ `pnpm format:check`
- ✅ `pnpm format`
- ✅ `pnpm changeset status`
- ⚠️ `pnpm --filter @scalar/sveltekit check` (package expects generated `.svelte-kit/tsconfig.json`, but this integration package does not include the config/bootstrap needed to generate it in this environment)
- ⚠️ `pnpm --filter @scalar/fastify-api-reference types:check` (pre-existing Fastify generic/type-provider mismatch errors in this package; unchanged by this refactor)
- ⚠️ `pnpm knip` (fails on unrelated missing built artifact in `integrations/docusaurus/playground`)

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b49cc860-6c01-455a-bc43-28824878a3ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b49cc860-6c01-455a-bc43-28824878a3ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

