### PR TITLE
fix(server-side-rendering): serialize functions for hydration

### DIFF
--- a/.changeset/fair-lobsters-turn.md
+++ b/.changeset/fair-lobsters-turn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/server-side-rendering': patch
+---
+
+Preserve top-level function config values in SSR hydration output and throw when nested functions cannot be serialized safely.

--- a/.changeset/soft-pears-protect.md
+++ b/.changeset/soft-pears-protect.md
@@ -1,0 +1,5 @@
+---
+'@scalar/server-side-rendering': patch
+---
+
+fix(server-side-rendering): escape dynamic hydration property keys

--- a/packages/server-side-rendering/src/ssr.test.ts
+++ b/packages/server-side-rendering/src/ssr.test.ts
@@ -1,7 +1,13 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from 'vitest'
 
-import { generateBodyScript, getJsAsset, renderApiReference, renderApiReferenceToString } from './ssr'
+import {
+  generateBodyScript,
+  getJsAsset,
+  renderApiReference,
+  renderApiReferenceToString,
+  serializeConfigToJs,
+} from './ssr'
 
 describe('ssr', () => {
   describe('renderApiReferenceToString', () => {
@@ -273,63 +279,54 @@ describe('ssr', () => {
       expect(html).not.toContain('{,')
     })
 
-    it('preserves top-level arrays containing functions in hydration config serialization', async () => {
-      const html = await renderApiReference({
-        config: {
-          theme: 'kepler',
-          hooks: [
-            () => 'ready',
-            {
-              label: 'stable',
-            },
-          ],
-        },
-        css: '',
+    it('preserves top-level arrays containing functions in hydration config serialization', () => {
+      const result = serializeConfigToJs({
+        theme: 'kepler',
+        hooks: [
+          () => 'ready',
+          {
+            label: 'stable',
+          },
+        ],
       })
 
-      expect(html).toContain('"theme": "kepler"')
-      expect(html).toContain('"hooks": [() => "ready", {"label":"stable"}]')
+      expect(result).toContain('"theme": "kepler"')
+      expect(result).toContain('"hooks": [() => "ready", {"label":"stable"}]')
     })
 
-    it('escapes script-breaking sequences in serialized function properties', async () => {
+    it('escapes script-breaking sequences in serialized function properties', () => {
       // Arrow function whose source contains a </script> payload
       const maliciousFn = () => '</script><script>window.__pwned=3</script>'
-      const html = await renderApiReference({
-        config: {
-          onLoaded: maliciousFn,
-        },
-        css: '',
+      const result = serializeConfigToJs({
+        onLoaded: maliciousFn,
       })
 
-      expect(html).not.toContain('</script><script>window.__pwned=3</script>')
-      expect(html).toContain('<\\/script>')
+      expect(result).not.toContain('</script><script>window.__pwned=3</script>')
+      expect(result).toContain('<\\/script>')
     })
 
-    it('escapes script-breaking sequences in serialized array functions', async () => {
+    it('escapes script-breaking sequences in serialized array functions', () => {
       // Arrow function whose source contains a </script> payload
       const maliciousFn = () => '</script><script>window.__pwned=4</script>'
-      const html = await renderApiReference({
-        config: {
-          hooks: [maliciousFn],
-        },
-        css: '',
+      const result = serializeConfigToJs({
+        hooks: [maliciousFn],
       })
 
-      expect(html).not.toContain('</script><script>window.__pwned=4</script>')
-      expect(html).toContain('<\\/script>')
+      expect(result).not.toContain('</script><script>window.__pwned=4</script>')
+      expect(result).toContain('<\\/script>')
     })
 
     it('throws when nested functions would be dropped during hydration serialization', async () => {
       await expect(
         renderApiReference({
           config: {
-            meta: {
+            metaData: {
               onLoaded: () => console.log('loaded'),
             },
           },
           css: '',
         }),
-      ).rejects.toThrow('Cannot serialize function at "meta.onLoaded" for SSR hydration.')
+      ).rejects.toThrow('Cannot serialize function at "metaData.onLoaded" for SSR hydration.')
     })
   })
 

--- a/packages/server-side-rendering/src/ssr.test.ts
+++ b/packages/server-side-rendering/src/ssr.test.ts
@@ -316,6 +316,38 @@ describe('ssr', () => {
       expect(result).toContain('<\\/script>')
     })
 
+    it('escapes dangerous characters in function property keys', () => {
+      const maliciousKey = 'on"Loaded</script><script>window.__pwned=5</script>'
+      const result = serializeConfigToJs({
+        [maliciousKey]: () => 'safe',
+      })
+
+      expect(result).not.toContain(`"${maliciousKey}"`)
+      expect(result).not.toContain('</script><script>window.__pwned=5</script>')
+      expect(result).toContain(
+        '"on\\"Loaded\\u003c/script\\u003e\\u003cscript\\u003ewindow.__pwned=5\\u003c/script\\u003e"',
+      )
+      const hydratedConfig = new Function(`return (${result})`)() as Record<string, unknown>
+      expect(typeof hydratedConfig[maliciousKey]).toBe('function')
+      expect((hydratedConfig[maliciousKey] as () => string)()).toBe('safe')
+    })
+
+    it('escapes dangerous characters in array property keys', () => {
+      const maliciousKey = 'hooks"</script><script>window.__pwned=6</script>'
+      const result = serializeConfigToJs({
+        [maliciousKey]: [() => 'safe'],
+      })
+
+      expect(result).not.toContain(`"${maliciousKey}"`)
+      expect(result).not.toContain('</script><script>window.__pwned=6</script>')
+      expect(result).toContain(
+        '"hooks\\"\\u003c/script\\u003e\\u003cscript\\u003ewindow.__pwned=6\\u003c/script\\u003e"',
+      )
+      const hydratedConfig = new Function(`return (${result})`)() as Record<string, unknown>
+      expect(Array.isArray(hydratedConfig[maliciousKey])).toBe(true)
+      expect(((hydratedConfig[maliciousKey] as unknown[])[0] as () => string)()).toBe('safe')
+    })
+
     it('throws when nested functions would be dropped during hydration serialization', async () => {
       await expect(
         renderApiReference({

--- a/packages/server-side-rendering/src/ssr.test.ts
+++ b/packages/server-side-rendering/src/ssr.test.ts
@@ -291,6 +291,34 @@ describe('ssr', () => {
       expect(html).toContain('"hooks": [() => "ready", {"label":"stable"}]')
     })
 
+    it('escapes script-breaking sequences in serialized function properties', async () => {
+      // Arrow function whose source contains a </script> payload
+      const maliciousFn = () => '</script><script>window.__pwned=3</script>'
+      const html = await renderApiReference({
+        config: {
+          onLoaded: maliciousFn,
+        },
+        css: '',
+      })
+
+      expect(html).not.toContain('</script><script>window.__pwned=3</script>')
+      expect(html).toContain('<\\/script>')
+    })
+
+    it('escapes script-breaking sequences in serialized array functions', async () => {
+      // Arrow function whose source contains a </script> payload
+      const maliciousFn = () => '</script><script>window.__pwned=4</script>'
+      const html = await renderApiReference({
+        config: {
+          hooks: [maliciousFn],
+        },
+        css: '',
+      })
+
+      expect(html).not.toContain('</script><script>window.__pwned=4</script>')
+      expect(html).toContain('<\\/script>')
+    })
+
     it('throws when nested functions would be dropped during hydration serialization', async () => {
       await expect(
         renderApiReference({

--- a/packages/server-side-rendering/src/ssr.test.ts
+++ b/packages/server-side-rendering/src/ssr.test.ts
@@ -230,7 +230,7 @@ describe('ssr', () => {
     it('serializes configuration into the hydration script', async () => {
       const html = await renderApiReference({ config: { url: 'https://example.com/api.json' }, css: '' })
 
-      expect(html).toContain('"url":"https://example.com/api.json"')
+      expect(html).toContain('"url": "https://example.com/api.json"')
     })
 
     it('prevents script breakout in hydration config serialization', async () => {
@@ -242,10 +242,12 @@ describe('ssr', () => {
       })
 
       expect(html).not.toContain('</script><script>window.__pwned=1</script>')
-      expect(html).toContain('"title":"\\u003c/script\\u003e\\u003cscript\\u003ewindow.__pwned=1\\u003c/script\\u003e"')
+      expect(html).toContain(
+        '"title": "\\u003c/script\\u003e\\u003cscript\\u003ewindow.__pwned=1\\u003c/script\\u003e"',
+      )
     })
 
-    it('drops function properties from hydration config serialization', async () => {
+    it('preserves top-level function properties in hydration config serialization', async () => {
       const html = await renderApiReference({
         config: {
           url: 'https://example.com/api.json',
@@ -255,12 +257,11 @@ describe('ssr', () => {
       })
 
       expect(html).toContain('Scalar.createApiReference')
-      expect(html).toContain('{"url":"https://example.com/api.json"}')
-      expect(html).not.toContain('onLoaded')
-      expect(html).not.toContain('console.log')
+      expect(html).toContain('"url": "https://example.com/api.json"')
+      expect(html).toContain('"onLoaded": () => console.log("loaded")')
     })
 
-    it('serializes function-only configuration as empty object', async () => {
+    it('serializes function-only configuration as a valid object literal', async () => {
       const html = await renderApiReference({
         config: {
           onLoaded: () => console.log('loaded'),
@@ -268,7 +269,39 @@ describe('ssr', () => {
         css: '',
       })
 
-      expect(html).toContain("Scalar.createApiReference('#app', {})")
+      expect(html).toContain('"onLoaded": () => console.log("loaded")')
+      expect(html).not.toContain('{,')
+    })
+
+    it('preserves top-level arrays containing functions in hydration config serialization', async () => {
+      const html = await renderApiReference({
+        config: {
+          theme: 'kepler',
+          hooks: [
+            () => 'ready',
+            {
+              label: 'stable',
+            },
+          ],
+        },
+        css: '',
+      })
+
+      expect(html).toContain('"theme": "kepler"')
+      expect(html).toContain('"hooks": [() => "ready", {"label":"stable"}]')
+    })
+
+    it('throws when nested functions would be dropped during hydration serialization', async () => {
+      await expect(
+        renderApiReference({
+          config: {
+            meta: {
+              onLoaded: () => console.log('loaded'),
+            },
+          },
+          css: '',
+        }),
+      ).rejects.toThrow('Cannot serialize function at "meta.onLoaded" for SSR hydration.')
     })
   })
 

--- a/packages/server-side-rendering/src/ssr.ts
+++ b/packages/server-side-rendering/src/ssr.ts
@@ -177,21 +177,112 @@ function escapeJsonForInlineScript(json: string): string {
     .replace(/\u2029/g, '\\u2029')
 }
 
+/** Add consistent indentation to multiline strings embedded in HTML output. */
+const addIndent = (str: string, spaces: number = 2, initialIndent: boolean = false): string => {
+  const indent = ' '.repeat(spaces)
+  const lines = str.split('\n')
+
+  return lines
+    .map((line, index) => {
+      if (index === 0 && !initialIndent) {
+        return line
+      }
+
+      return `${indent}${line}`
+    })
+    .join('\n')
+}
+
 /**
- * Serialize a configuration object to JSON for hydration.
- * Function values are intentionally stripped because they cannot be safely
- * represented in an inline script.
+ * Reject function values that would otherwise be silently dropped by JSON.stringify.
+ * SSR only supports top-level function props and top-level arrays containing functions,
+ * matching the client-side renderer behavior.
+ */
+const assertNoNestedFunctions = (value: unknown, path: string): void => {
+  if (typeof value === 'function') {
+    throw new Error(
+      `Cannot serialize function at "${path}" for SSR hydration. ` +
+        'Only top-level function properties and top-level arrays containing functions are supported.',
+    )
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoNestedFunctions(item, `${path}[${index}]`))
+    return
+  }
+
+  if (value && typeof value === 'object') {
+    Object.entries(value).forEach(([key, nestedValue]) => assertNoNestedFunctions(nestedValue, `${path}.${key}`))
+  }
+}
+
+const serializeJsonValue = (value: unknown): string => escapeJsonForInlineScript(JSON.stringify(value))
+
+const serializeJsonObject = (value: Record<string, unknown>): string =>
+  escapeJsonForInlineScript(JSON.stringify(value, null, 2))
+
+const serializeArrayWithFunctions = (value: unknown[], path: string): string => {
+  return `[${value
+    .map((item, index) => {
+      if (typeof item === 'function') {
+        return item.toString()
+      }
+
+      assertNoNestedFunctions(item, `${path}[${index}]`)
+      return serializeJsonValue(item)
+    })
+    .join(', ')}]`
+}
+
+const serializeFunctionProperty = (key: string, value: Function): string => `"${key}": ${value.toString()}`
+
+const serializeArrayProperty = (key: string, value: unknown[]): string =>
+  `"${key}": ${serializeArrayWithFunctions(value, key)}`
+
+const mergeSerializedProperties = (jsonObjectLiteral: string, dynamicProperties: string[]): string => {
+  const formattedDynamicProperties = addIndent(dynamicProperties.join(',\n'), 8, true)
+
+  if (jsonObjectLiteral === '{}') {
+    return `{\n${formattedDynamicProperties}\n      }`
+  }
+
+  const jsonWithoutClosingBrace = jsonObjectLiteral.split('\n').slice(0, -1).join('\n')
+  return `${jsonWithoutClosingBrace},\n${formattedDynamicProperties}\n      }`
+}
+
+/**
+ * Serialize a configuration object to a JavaScript object literal for hydration.
+ * Top-level function props and top-level arrays containing functions are preserved
+ * to match the client-side renderer behavior.
  */
 function serializeConfigToJs(config: Record<string, unknown>): string {
-  const jsonString = JSON.stringify(config, (_, value) => {
+  const restConfig = { ...config }
+  const dynamicProperties: string[] = []
+
+  Object.entries(config).forEach(([key, value]) => {
     if (typeof value === 'function') {
-      return undefined
+      dynamicProperties.push(serializeFunctionProperty(key, value))
+      delete restConfig[key]
+      return
     }
 
-    return value
+    if (Array.isArray(value) && value.some((item) => typeof item === 'function')) {
+      dynamicProperties.push(serializeArrayProperty(key, value))
+      delete restConfig[key]
+      return
+    }
+
+    assertNoNestedFunctions(value, key)
   })
 
-  return escapeJsonForInlineScript(jsonString)
+  const jsonString = serializeJsonObject(restConfig)
+  const indentedJsonString = addIndent(jsonString, 6)
+
+  if (dynamicProperties.length === 0) {
+    return indentedJsonString
+  }
+
+  return mergeSerializedProperties(indentedJsonString, dynamicProperties)
 }
 
 /**

--- a/packages/server-side-rendering/src/ssr.ts
+++ b/packages/server-side-rendering/src/ssr.ts
@@ -240,6 +240,8 @@ const serializeJsonValue = (value: unknown): string => escapeJsonForInlineScript
 const serializeJsonObject = (value: Record<string, unknown>): string =>
   escapeJsonForInlineScript(JSON.stringify(value, null, 2))
 
+const serializePropertyKey = (key: string): string => escapeJsonForInlineScript(JSON.stringify(key))
+
 const serializeArrayWithFunctions = (value: unknown[], path: string): string => {
   return `[${value
     .map((item, index) => {
@@ -254,10 +256,10 @@ const serializeArrayWithFunctions = (value: unknown[], path: string): string => 
 }
 
 const serializeFunctionProperty = (key: string, value: Function): string =>
-  `"${key}": ${escapeFunctionSourceForInlineScript(value.toString())}`
+  `${serializePropertyKey(key)}: ${escapeFunctionSourceForInlineScript(value.toString())}`
 
 const serializeArrayProperty = (key: string, value: unknown[]): string =>
-  `"${key}": ${serializeArrayWithFunctions(value, key)}`
+  `${serializePropertyKey(key)}: ${serializeArrayWithFunctions(value, key)}`
 
 const mergeSerializedProperties = (jsonObjectLiteral: string, dynamicProperties: string[]): string => {
   const formattedDynamicProperties = addIndent(dynamicProperties.join(',\n'), 8, true)

--- a/packages/server-side-rendering/src/ssr.ts
+++ b/packages/server-side-rendering/src/ssr.ts
@@ -275,7 +275,7 @@ const mergeSerializedProperties = (jsonObjectLiteral: string, dynamicProperties:
  * Top-level function props and top-level arrays containing functions are preserved
  * to match the client-side renderer behavior.
  */
-function serializeConfigToJs(config: Record<string, unknown>): string {
+export function serializeConfigToJs(config: Record<string, unknown>): string {
   const restConfig = { ...config }
   const dynamicProperties: string[] = []
 

--- a/packages/server-side-rendering/src/ssr.ts
+++ b/packages/server-side-rendering/src/ssr.ts
@@ -177,6 +177,25 @@ function escapeJsonForInlineScript(json: string): string {
     .replace(/\u2029/g, '\\u2029')
 }
 
+/**
+ * Escape a function's source code so it is safe to embed inside an inline script tag.
+ *
+ * Unlike escapeJsonForInlineScript (which escapes all `<` and `>`), this only neutralizes
+ * sequences that could break out of a `<script>` block or open an HTML comment:
+ * - `</` (case-insensitive closing tags, e.g. `</script>`)
+ * - `<!--` (HTML comment open)
+ * - U+2028 / U+2029 (line/paragraph separators, invalid in JS source outside strings)
+ *
+ * This preserves JS syntax like `=>`, `<`, `>`, and `>=`.
+ */
+function escapeFunctionSourceForInlineScript(source: string): string {
+  return source
+    .replace(/<\//g, '<\\/')
+    .replace(/<!--/g, '<\\!--')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')
+}
+
 /** Add consistent indentation to multiline strings embedded in HTML output. */
 const addIndent = (str: string, spaces: number = 2, initialIndent: boolean = false): string => {
   const indent = ' '.repeat(spaces)
@@ -225,7 +244,7 @@ const serializeArrayWithFunctions = (value: unknown[], path: string): string => 
   return `[${value
     .map((item, index) => {
       if (typeof item === 'function') {
-        return item.toString()
+        return escapeFunctionSourceForInlineScript(item.toString())
       }
 
       assertNoNestedFunctions(item, `${path}[${index}]`)
@@ -234,7 +253,8 @@ const serializeArrayWithFunctions = (value: unknown[], path: string): string => 
     .join(', ')}]`
 }
 
-const serializeFunctionProperty = (key: string, value: Function): string => `"${key}": ${value.toString()}`
+const serializeFunctionProperty = (key: string, value: Function): string =>
+  `"${key}": ${escapeFunctionSourceForInlineScript(value.toString())}`
 
 const serializeArrayProperty = (key: string, value: unknown[]): string =>
   `"${key}": ${serializeArrayWithFunctions(value, key)}`


### PR DESCRIPTION
## Summary
- preserve top-level function config values in SSR hydration output to match client-side rendering
- throw when nested functions cannot be serialized safely instead of silently dropping them
- refactor SSR hydration serialization helpers for clearer formatting and indentation handling

## Testing
- pnpm --filter @scalar/server-side-rendering test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches inline hydration script generation and function serialization, which is XSS-sensitive and could impact SSR hydration if escaping or formatting is incorrect. Scope is contained and covered by new tests, but the output format/behavior changes may affect consumers relying on previous function-stripping behavior.
> 
> **Overview**
> SSR hydration config serialization now emits a JS object literal that **preserves top-level function properties** and **top-level arrays containing functions**, instead of stripping them, to better match client behavior.
> 
> The serializer was refactored into helpers that (1) escape function source to prevent `<script>` breakouts, (2) escape/quote dynamic property keys, and (3) **throw** when nested functions are encountered rather than silently dropping them. Tests were expanded to cover these new behaviors and injection edge cases, and changesets bump `@scalar/server-side-rendering` with patch releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d03aaef2c5127402953e1de27b285c3a88b52416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->