### PR TITLE
fix(api-client): revert support header for web layout

### DIFF
--- a/.changeset/tender-garlics-decide.md
+++ b/.changeset/tender-garlics-decide.md
@@ -1,5 +1,0 @@
----
-'@scalar/api-client': patch
----
-
-feat(api-client): support header for web layout

--- a/packages/api-client/playground/web/index.html
+++ b/packages/api-client/playground/web/index.html
@@ -10,30 +10,8 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0" />
     <title>Scalar API Client Web</title>
-    <style>
-      html,
-      body {
-        height: 100dvh;
-        overflow: hidden;
-      }
-      body {
-        display: grid;
-        grid-template-rows: var(--scalar-header-height) 1fr;
-      }
-      body > header {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-      #scalar-client,
-      #scalar-client > main {
-        display: grid;
-        min-height: 0;
-      }
-    </style>
   </head>
   <body class="scalar-app">
-    <header class="h-header border-b">Header / Menu Go Here</header>
     <div
       id="scalar-client"
       class="scalar-client"></div>

--- a/packages/api-client/src/v2/components/sidebar/Sidebar.vue
+++ b/packages/api-client/src/v2/components/sidebar/Sidebar.vue
@@ -122,9 +122,7 @@ const handleSelectItem = (id: string) => {
           <div
             class="bg-sidebar-b-1 z-1 flex flex-col gap-1.5 px-3 pb-1.5"
             :class="{ 'max-md:pt-12': layout !== 'modal' }">
-            <div
-              v-if="layout !== 'web'"
-              class="flex items-center justify-between">
+            <div class="flex items-center justify-between">
               <!-- Desktop gets the workspace menu here  -->
               <SidebarMenu
                 v-if="layout !== 'modal'"
@@ -149,9 +147,9 @@ const handleSelectItem = (id: string) => {
             </div>
 
             <ScalarSidebarSearchInput
-              v-if="isSearchVisible || layout === 'web'"
+              v-if="isSearchVisible"
               v-model="query"
-              :autofocus="layout !== 'web'" />
+              autofocus />
           </div>
         </template>
 

--- a/packages/api-client/src/v2/features/app/App.vue
+++ b/packages/api-client/src/v2/features/app/App.vue
@@ -200,9 +200,7 @@ const routerViewProps = computed<RouteProps>(() => {
         app.workspace.activeWorkspace.value !== null &&
         !app.loading.value
       ">
-      <div
-        class="relative flex w-dvw flex-col"
-        :class="layout === 'web' ? 'min-h-0' : 'h-dvh'">
+      <div class="relative flex h-dvh w-dvw flex-1 flex-col">
         <SidebarToggle
           v-model="app.sidebar.isOpen.value"
           class="absolute top-4 left-3 z-[60] md:hidden" />
@@ -228,7 +226,7 @@ const routerViewProps = computed<RouteProps>(() => {
             </template>
           </AppSidebar>
 
-          <div class="flex min-h-0 flex-1 flex-col">
+          <div class="flex flex-1 flex-col">
             <!-- App Tabs -->
             <DesktopTabs
               v-if="layout === 'desktop'"


### PR DESCRIPTION
Reverts scalar/scalar#8867

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a revert of UI layout and conditional rendering; minimal logic changes and no security/data-path impact.
> 
> **Overview**
> Reverts the prior "web header" layout work in `@scalar/api-client`.
> 
> The web playground `index.html` drops the injected header placeholder and the associated full-height grid CSS.
> 
> In the client UI, the sidebar header no longer has web-specific conditions: the search input is no longer forced visible on `layout === 'web'` (it only appears when toggled), and `App.vue` reverts the main container sizing classes back to a fixed `h-dvh` layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4600acdef941fae9588eb069ff02f5973d162f11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->