### PR TITLE
fix(api-client): invalid `json` body handling and add root document for bulk operation selection

### DIFF
--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportPostman.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportPostman.vue
@@ -30,7 +30,6 @@ import {
   applyPostmanRequestSelectionChange,
   buildPostmanRequestTree,
   countPostmanRequestLeaves,
-  pathKey,
   pathKeysToRequestIndexPaths,
   type PostmanTreeNode,
 } from '@/v2/features/command-palette/helpers/postman-request-tree'
@@ -105,6 +104,14 @@ const onPostmanFolderSelectionChange = (
     selected,
   )
 }
+
+/** Wraps all top-level nodes in a single root folder so the tree row handles select-all. */
+const rootTreeNode = computed<PostmanTreeNode>(() => ({
+  path: [],
+  name: postmanDocumentDetails.value?.title ?? 'Collection',
+  isFolder: true,
+  children: postmanRequestTree.value,
+}))
 
 const collisionsPathKeys = computed(() => {
   return getCollidingPostmanRequestPathKeys(
@@ -222,11 +229,9 @@ const handleImport = async (): Promise<void> => {
         <!-- Tree picker slot -->
         <template #treePicker>
           <PostmanRequestTreeRow
-            v-for="node in postmanRequestTree"
-            :key="pathKey(node.path)"
             :collisionPathKeys="collisionsPathKeys"
             :mergeSamePathAndMethod="mergeSamePathAndMethod"
-            :node="node"
+            :node="rootTreeNode"
             :selectedKeys="importPathKeys"
             @folderSelectionChange="onPostmanFolderSelectionChange"
             @requestSelectionChange="onPostmanRequestSelectionChange" />

--- a/packages/api-client/src/v2/features/command-palette/components/PostmanImportPreview.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/PostmanImportPreview.vue
@@ -132,7 +132,7 @@ const onImportDestinationChange = (option: ScalarListboxOption): void => {
         </div>
       </div>
     </div>
-    <div class="max-h-[300px] overflow-y-auto">
+    <div class="h-[300px] overflow-y-auto">
       <slots.treePicker />
     </div>
 

--- a/packages/postman-to-openapi/src/helpers/path-items.test.ts
+++ b/packages/postman-to-openapi/src/helpers/path-items.test.ts
@@ -373,6 +373,11 @@ describe('path-items', () => {
         body: {
           mode: 'raw',
           raw: '{"name": "John", "email": "john@example.com"}',
+          options: {
+            raw: {
+              language: 'json',
+            },
+          },
         },
       },
     }
@@ -436,6 +441,11 @@ describe('path-items', () => {
         body: {
           mode: 'raw',
           raw: '{}',
+          options: {
+            raw: {
+              language: 'json',
+            },
+          },
         },
       },
     }
@@ -471,8 +481,8 @@ describe('path-items', () => {
     expect(result.paths['/bedrock']?.get?.requestBody).toBeDefined()
     expect(result.paths['/bedrock']?.get?.requestBody?.content?.['application/json']).toBeDefined()
     const example = result.paths['/bedrock']?.get?.requestBody?.content?.['application/json']?.examples?.default
-      ?.value as any
-    expect(example?.data?.modelId).toBe('mistral.mistral-7b-instruct-v0:2')
+      ?.value as string
+    expect(example).toBe('{"data": {"modelId": "mistral.mistral-7b-instruct-v0:2"}}')
   })
 
   it('does not add requestBody when body is empty', () => {

--- a/packages/postman-to-openapi/src/helpers/request-body.test.ts
+++ b/packages/postman-to-openapi/src/helpers/request-body.test.ts
@@ -5,10 +5,15 @@ import type { RequestBody } from '@/types'
 import { extractRequestBody } from './request-body'
 
 describe('request-body', () => {
-  it('extracts raw JSON body', () => {
+  it('extracts raw JSON body when language is json', () => {
     const body: RequestBody = {
       mode: 'raw',
       raw: '{"name": "John", "age": 30}',
+      options: {
+        raw: {
+          language: 'json',
+        },
+      },
     }
 
     const result = extractRequestBody(body, 'default')
@@ -21,11 +26,28 @@ describe('request-body', () => {
           },
           examples: {
             default: {
-              value: {
-                name: 'John',
-                age: 30,
-              },
+              value: '{"name": "John", "age": 30}',
             },
+          },
+        },
+      },
+    })
+  })
+
+  it('treats raw JSON as text/plain when language is not set', () => {
+    const body: RequestBody = {
+      mode: 'raw',
+      raw: '{"name": "John", "age": 30}',
+    }
+
+    const result = extractRequestBody(body, 'default')
+
+    expect(result).toEqual({
+      content: {
+        'text/plain': {
+          schema: {
+            type: 'string',
+            examples: ['{"name": "John", "age": 30}'],
           },
         },
       },
@@ -201,24 +223,8 @@ describe('request-body', () => {
     })
   })
 
-  it('handles complex nested JSON', () => {
-    const body: RequestBody = {
-      mode: 'raw',
-      raw: JSON.stringify({
-        user: {
-          name: 'John',
-          address: {
-            street: '123 Main St',
-            city: 'New York',
-          },
-        },
-        tags: ['admin', 'user'],
-      }),
-    }
-
-    const result = extractRequestBody(body, 'default')
-
-    expect(result.content?.['application/json']?.examples?.default?.value).toEqual({
+  it('handles complex nested JSON when language is json', () => {
+    const raw = JSON.stringify({
       user: {
         name: 'John',
         address: {
@@ -228,9 +234,23 @@ describe('request-body', () => {
       },
       tags: ['admin', 'user'],
     })
+
+    const body: RequestBody = {
+      mode: 'raw',
+      raw,
+      options: {
+        raw: {
+          language: 'json',
+        },
+      },
+    }
+
+    const result = extractRequestBody(body, 'default')
+
+    expect(result.content?.['application/json']?.examples?.default?.value).toBe(raw)
   })
 
-  it('creates JSON schema placeholder when body has variables with JSON language', () => {
+  it('keeps variable placeholders as raw string value when language is json', () => {
     const body: RequestBody = {
       mode: 'raw',
       raw: '{{bodyData}}',
@@ -243,9 +263,20 @@ describe('request-body', () => {
 
     const result = extractRequestBody(body, 'default')
 
-    expect(result.content?.['application/json']).toBeDefined()
-    expect(result.content?.['application/json']?.schema?.type).toBe('object')
-    expect(result.content?.['application/json']?.schema?.description).toBe('Body data set via pre-request script')
+    expect(result).toEqual({
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+          },
+          examples: {
+            default: {
+              value: '{{bodyData}}',
+            },
+          },
+        },
+      },
+    })
   })
 
   it('handles body with variables but non-JSON language', () => {
@@ -330,10 +361,35 @@ describe('request-body', () => {
     expect(property?.description).toBe('User name')
   })
 
-  it('handles JSON null as valid JSON body', () => {
+  it('treats literal null as text/plain when language is not json', () => {
     const body: RequestBody = {
       mode: 'raw',
       raw: 'null',
+    }
+
+    const result = extractRequestBody(body, 'default')
+
+    expect(result).toEqual({
+      content: {
+        'text/plain': {
+          schema: {
+            type: 'string',
+            examples: ['null'],
+          },
+        },
+      },
+    })
+  })
+
+  it('treats literal null as application/json when language is json', () => {
+    const body: RequestBody = {
+      mode: 'raw',
+      raw: 'null',
+      options: {
+        raw: {
+          language: 'json',
+        },
+      },
     }
 
     const result = extractRequestBody(body, 'default')
@@ -346,7 +402,7 @@ describe('request-body', () => {
           },
           examples: {
             default: {
-              value: null,
+              value: 'null',
             },
           },
         },

--- a/packages/postman-to-openapi/src/helpers/request-body.ts
+++ b/packages/postman-to-openapi/src/helpers/request-body.ts
@@ -36,22 +36,8 @@ function handleRawBody(body: RequestBody, requestBody: OpenAPIV3_1.RequestBodyOb
   const rawBody = body.raw || ''
   const isJsonLanguage = body.options?.raw?.language === 'json'
 
-  // Check if body contains Postman variables (like {{bodyData}})
-  const hasVariables = /\{\{[\w-]+\}\}/.test(rawBody)
-
-  // Try parsing the raw body as JSON
-  // We use a boolean flag because `null` is a valid JSON value
-  let jsonBody: unknown
-  let isJsonBody = false
-  try {
-    jsonBody = JSON.parse(rawBody)
-    isJsonBody = true
-  } catch {
-    // Parsing failed - will handle below
-  }
-
   // If we have valid JSON, use it
-  if (isJsonBody) {
+  if (isJsonLanguage) {
     requestBody.content = {
       'application/json': {
         schema: {
@@ -59,22 +45,8 @@ function handleRawBody(body: RequestBody, requestBody: OpenAPIV3_1.RequestBodyOb
         },
         examples: {
           [exampleName]: {
-            value: jsonBody,
+            value: rawBody,
           },
-        },
-      },
-    }
-    return
-  }
-
-  // If we have variables and JSON language but could not parse JSON,
-  // create a JSON schema placeholder
-  if (hasVariables && isJsonLanguage) {
-    requestBody.content = {
-      'application/json': {
-        schema: {
-          type: 'object',
-          description: 'Body data set via pre-request script',
         },
       },
     }


### PR DESCRIPTION
This PR addresses two issues:

- **Fix invalid JSON body parsing**  
  Previously, when the raw body was set to JSON but contained invalid JSON (e.g. variables), it would incorrectly default to an empty object.  
  This change ensures that invalid JSON is no longer silently converted, preserving the original value instead of producing misleading data.

- **Add root document to tree import**  
  Introduces a root document node in the import tree, allowing users to easily select or deselect all operations at once.

## Notes
- Prevents unintended data loss when working with dynamic or variable-based request bodies  
- Improves UX when importing large API definitions by enabling bulk selection

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-body conversion semantics (content-type and example shape) for imported Postman collections, which may affect downstream generated OpenAPI output and merging behavior.
> 
> **Overview**
> Fixes Postman-to-OpenAPI conversion for `body.mode === 'raw'` so `application/json` is only emitted when Postman marks the raw body language as `json`, and the example value is preserved as the original raw string (including variables like `{{...}}`) instead of being JSON-parsed/coerced.
> 
> Improves the Postman import picker UX by wrapping all top-level request nodes in a computed root folder (enabling select/deselect-all via the existing folder selection logic) and constrains the preview tree container to a fixed `300px` height. Tests were updated/added to reflect the new raw-body behavior and example expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d88b22aac48f62e26209432e10cc12d02d8b7ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->