### PR TITLE
docs(changeset): invalid json body handling and add root document for bulk operation selection

### DIFF
--- a/.changeset/sweet-zebras-stay.md
+++ b/.changeset/sweet-zebras-stay.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/postman-to-openapi': patch
+---
+
+fix: invalid json body handling and add root document for bulk operation selection


### PR DESCRIPTION
Forgot to include a changeset...

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a Changesets metadata file; no runtime code changes, so functional risk is minimal.
> 
> **Overview**
> Adds a Changesets release note marking patch bumps for `@scalar/api-client` and `@scalar/postman-to-openapi`, documenting a fix for invalid JSON body handling and adding a root document for bulk operation selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a8aa36f82360adad01c3447090fd124f96a54d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->