### PR TITLE
fix(workspace-store): resolve selected security schemes using selectedIndex

### DIFF
--- a/.changeset/strict-owls-rhyme.md
+++ b/.changeset/strict-owls-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: resolve selected security schemes using selectedIndex

--- a/packages/agent-chat/src/helpers.ts
+++ b/packages/agent-chat/src/helpers.ts
@@ -39,7 +39,7 @@ function getSecurityFromDocument(
     securityRequirements,
   )
 
-  return getSecuritySchemes(mergedSecurity, selectedSecurity.selectedSchemes)
+  return getSecuritySchemes(mergedSecurity, selectedSecurity.selectedSchemes[selectedSecurity.selectedIndex] ?? {})
 }
 
 /** Generate document settings from workspace store */

--- a/packages/api-reference/src/features/Operation/helpers/filter-selected-security.ts
+++ b/packages/api-reference/src/features/Operation/helpers/filter-selected-security.ts
@@ -41,13 +41,13 @@ export const filterSelectedSecurity = (
   // Lets check the selectedIndex first
   const selectedRequirement = selectedSecurity.selectedSchemes[selectedSecurity.selectedIndex]
   if (selectedRequirement && requirementSet.has(getKey(selectedRequirement))) {
-    return getSecuritySchemes(securitySchemes, [selectedRequirement])
+    return getSecuritySchemes(securitySchemes, selectedRequirement)
   }
 
   // Otherwise lets loop over all selected
   for (const selected of selectedSecurity.selectedSchemes) {
     if (requirementSet.has(getKey(selected))) {
-      return getSecuritySchemes(securitySchemes, [selected])
+      return getSecuritySchemes(securitySchemes, selected)
     }
   }
 
@@ -56,7 +56,7 @@ export const filterSelectedSecurity = (
    * we should show the first requirement of the operation to show auth is required
    */
   if (operation?.security?.length) {
-    return getSecuritySchemes(securitySchemes, securityRequirements.slice(0, 1))
+    return getSecuritySchemes(securitySchemes, securityRequirements[0] ?? {})
   }
 
   return []

--- a/packages/workspace-store/src/request-example/builder/build-request.test.ts
+++ b/packages/workspace-store/src/request-example/builder/build-request.test.ts
@@ -534,9 +534,7 @@ describe('buildRequest', () => {
     const { request } = buildRequest(
       createFactory({
         headers,
-        security: [
-          { in: 'header', name: 'X-Custom', value: 'from-security' },
-        ],
+        security: [{ in: 'header', name: 'X-Custom', value: 'from-security' }],
       }),
       { envVariables: {} },
     )

--- a/packages/workspace-store/src/request-example/builder/build-request.test.ts
+++ b/packages/workspace-store/src/request-example/builder/build-request.test.ts
@@ -495,4 +495,54 @@ describe('buildRequest', () => {
     expect(request.method).toBe('PATCH')
     expect(request.cache).toBe('no-store')
   })
+
+  it('appends multiple security headers with the same name instead of overwriting', () => {
+    const { request } = buildRequest(
+      createFactory({
+        security: [
+          { in: 'header', name: 'Authorization', format: 'bearer', value: 'token-a' },
+          { in: 'header', name: 'Authorization', format: 'bearer', value: 'token-b' },
+        ],
+      }),
+      { envVariables: {} },
+    )
+
+    const values = request.headers.get('Authorization')
+    expect(values).toContain('Bearer token-a')
+    expect(values).toContain('Bearer token-b')
+  })
+
+  it('appends multiple security query params with the same name instead of overwriting', () => {
+    const { request } = buildRequest(
+      createFactory({
+        security: [
+          { in: 'query', name: 'api_key', value: 'key-1' },
+          { in: 'query', name: 'api_key', value: 'key-2' },
+        ],
+      }),
+      { envVariables: {} },
+    )
+
+    const url = new URL(request.url)
+    expect(url.searchParams.getAll('api_key')).toStrictEqual(['key-1', 'key-2'])
+  })
+
+  it('preserves existing header values when appending security headers', () => {
+    const headers = new Headers()
+    headers.set('X-Custom', 'existing')
+
+    const { request } = buildRequest(
+      createFactory({
+        headers,
+        security: [
+          { in: 'header', name: 'X-Custom', value: 'from-security' },
+        ],
+      }),
+      { envVariables: {} },
+    )
+
+    const values = request.headers.get('X-Custom')
+    expect(values).toContain('existing')
+    expect(values).toContain('from-security')
+  })
 })

--- a/packages/workspace-store/src/request-example/builder/build-request.ts
+++ b/packages/workspace-store/src/request-example/builder/build-request.ts
@@ -98,12 +98,12 @@ export const buildRequest = (
 
       if (security.in === 'header') {
         // Set the header (use replaced header name so {{ env }} placeholders work)
-        headers.set(name, securityValue)
+        headers.append(name, securityValue)
         return
       }
 
       if (security.in === 'query') {
-        securityQueryParams.set(name, securityValue)
+        securityQueryParams.append(name, securityValue)
         return
       }
 

--- a/packages/workspace-store/src/request-example/context/get-request-example-context.test.ts
+++ b/packages/workspace-store/src/request-example/context/get-request-example-context.test.ts
@@ -1,5 +1,5 @@
 import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-import { describe, expect, it } from 'vitest'
+import { assert, describe, expect, it } from 'vitest'
 
 import { createWorkspaceStore } from '@/client'
 
@@ -132,5 +132,102 @@ describe('getRequestExampleContext', () => {
       value: 'CONFIG_TOKEN',
       'x-scalar-secret-token': 'STORE_TOKEN',
     })
+  })
+
+  it('resolves selectedSchemes using selectedIndex from the selected security', async () => {
+    const workspaceStore = createWorkspaceStore()
+    await workspaceStore.addDocument({
+      name: 'doc',
+      document: createMinimalDocument({
+        security: [{ apiKeyHeader: [] }],
+      }),
+    })
+
+    const result = getRequestExampleContext(workspaceStore, 'doc', {
+      path: '/pets',
+      method: 'get',
+      exampleName: 'default',
+    })
+
+    expect(result.ok).toBe(true)
+    assert(result.ok)
+
+    expect(result.data.security.selected.selectedIndex).toBe(0)
+    expect(result.data.security.selectedSchemes).toStrictEqual([
+      expect.objectContaining({
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'header',
+      }),
+    ])
+  })
+
+  it('returns empty selectedSchemes when selectedIndex is -1 (optional auth)', async () => {
+    const workspaceStore = createWorkspaceStore()
+    await workspaceStore.addDocument({
+      name: 'doc',
+      document: createMinimalDocument({
+        security: [{}],
+      }),
+    })
+
+    const result = getRequestExampleContext(workspaceStore, 'doc', {
+      path: '/pets',
+      method: 'get',
+      exampleName: 'default',
+    })
+
+    assert(result.ok)
+
+    expect(result.data.security.selected.selectedIndex).toBe(-1)
+    expect(result.data.security.selectedSchemes).toStrictEqual([])
+  })
+
+  it('resolves selectedSchemes from the correct index when multiple requirements exist', async () => {
+    const workspaceStore = createWorkspaceStore()
+    await workspaceStore.addDocument({
+      name: 'doc',
+      document: createMinimalDocument({
+        components: {
+          securitySchemes: {
+            apiKeyHeader: {
+              type: 'apiKey',
+              name: 'X-API-Key',
+              in: 'header',
+            },
+            bearerAuth: {
+              type: 'http',
+              scheme: 'bearer',
+            },
+          },
+        },
+        security: [{ apiKeyHeader: [] }, { bearerAuth: [] }],
+      }),
+    })
+
+    workspaceStore.auth.setAuthSelectedSchemas(
+      { type: 'document', documentName: 'doc' },
+      {
+        selectedIndex: 1,
+        selectedSchemes: [{ apiKeyHeader: [] }, { bearerAuth: [] }],
+      },
+    )
+
+    const result = getRequestExampleContext(workspaceStore, 'doc', {
+      path: '/pets',
+      method: 'get',
+      exampleName: 'default',
+    })
+
+    expect(result.ok).toBe(true)
+    assert(result.ok)
+
+    expect(result.data.security.selected.selectedIndex).toBe(1)
+    expect(result.data.security.selectedSchemes).toStrictEqual([
+      expect.objectContaining({
+        type: 'http',
+        scheme: 'bearer',
+      }),
+    ])
   })
 })

--- a/packages/workspace-store/src/request-example/context/get-request-example-context.ts
+++ b/packages/workspace-store/src/request-example/context/get-request-example-context.ts
@@ -151,7 +151,10 @@ export const getRequestExampleContext = (
   )
 
   /** The above selected requirements in scheme form */
-  const selectedSecuritySchemes = getSecuritySchemes(securitySchemes, selectedSecurity.selectedSchemes[selectedSecurity.selectedIndex] ?? {})
+  const selectedSecuritySchemes = getSecuritySchemes(
+    securitySchemes,
+    selectedSecurity.selectedSchemes[selectedSecurity.selectedIndex] ?? {},
+  )
 
   const serverMeta: ServerMeta =
     operation.servers != null ? { type: 'operation', path: path ?? '', method: method ?? 'get' } : { type: 'document' }

--- a/packages/workspace-store/src/request-example/context/get-request-example-context.ts
+++ b/packages/workspace-store/src/request-example/context/get-request-example-context.ts
@@ -151,7 +151,7 @@ export const getRequestExampleContext = (
   )
 
   /** The above selected requirements in scheme form */
-  const selectedSecuritySchemes = getSecuritySchemes(securitySchemes, selectedSecurity.selectedSchemes)
+  const selectedSecuritySchemes = getSecuritySchemes(securitySchemes, selectedSecurity.selectedSchemes[selectedSecurity.selectedIndex] ?? {})
 
   const serverMeta: ServerMeta =
     operation.servers != null ? { type: 'operation', path: path ?? '', method: method ?? 'get' } : { type: 'document' }

--- a/packages/workspace-store/src/request-example/context/security/get-security-schemes.test.ts
+++ b/packages/workspace-store/src/request-example/context/security/get-security-schemes.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MergedSecuritySchemes } from '@/request-example/context/security/merge-security'
+import type { SecurityRequirementObject } from '@/schemas/v3.1/strict/security-requirement'
+
+import { getSecuritySchemes } from './get-security-schemes'
+
+const createSchemes = (overrides: Partial<MergedSecuritySchemes> = {}): MergedSecuritySchemes => ({
+  apiKey: {
+    type: 'apiKey',
+    name: 'X-API-Key',
+    in: 'header',
+    'x-scalar-secret-token': 'secret-1',
+  },
+  bearerAuth: {
+    type: 'http',
+    scheme: 'bearer',
+    'x-scalar-secret-token': 'jwt-token',
+    'x-scalar-secret-username': '',
+    'x-scalar-secret-password': '',
+  },
+  ...overrides,
+})
+
+describe('get-security-schemes', () => {
+  it('resolves a single scheme from a security requirement', () => {
+    const schemes = createSchemes()
+    const selected: SecurityRequirementObject = { apiKey: [] }
+
+    const result = getSecuritySchemes(schemes, selected)
+
+    expect(result).toStrictEqual([schemes.apiKey])
+  })
+
+  it('resolves multiple schemes from a combined security requirement', () => {
+    const schemes = createSchemes()
+    const selected: SecurityRequirementObject = { apiKey: [], bearerAuth: [] }
+
+    const result = getSecuritySchemes(schemes, selected)
+
+    expect(result).toStrictEqual([schemes.apiKey, schemes.bearerAuth])
+  })
+
+  it('skips keys that do not exist in securitySchemes', () => {
+    const schemes = createSchemes()
+    const selected: SecurityRequirementObject = { nonExistent: [] }
+
+    const result = getSecuritySchemes(schemes, selected)
+
+    expect(result).toStrictEqual([])
+  })
+
+  it('returns an empty array for an empty security requirement', () => {
+    const schemes = createSchemes()
+    const selected: SecurityRequirementObject = {}
+
+    const result = getSecuritySchemes(schemes, selected)
+
+    expect(result).toStrictEqual([])
+  })
+
+  it('filters out missing schemes while keeping valid ones', () => {
+    const schemes = createSchemes()
+    const selected: SecurityRequirementObject = { apiKey: [], missing: [], bearerAuth: [] }
+
+    const result = getSecuritySchemes(schemes, selected)
+
+    expect(result).toStrictEqual([schemes.apiKey, schemes.bearerAuth])
+  })
+})

--- a/packages/workspace-store/src/request-example/context/security/get-security-schemes.ts
+++ b/packages/workspace-store/src/request-example/context/security/get-security-schemes.ts
@@ -11,15 +11,13 @@ import type { SecurityRequirementObject } from '@/schemas/v3.1/strict/security-r
  */
 export const getSecuritySchemes = (
   securitySchemes: MergedSecuritySchemes,
-  selectedSecurity: SecurityRequirementObject[],
+  selectedSecurity: SecurityRequirementObject,
 ): SecuritySchemeObjectSecret[] =>
-  selectedSecurity.flatMap((scheme) =>
-    objectKeys(scheme).flatMap((key) => {
+    objectKeys(selectedSecurity).flatMap((key) => {
       const scheme = getResolvedRef(securitySchemes?.[key])
       if (scheme) {
         return scheme
       }
 
       return []
-    }),
-  ) ?? []
+    })

--- a/packages/workspace-store/src/request-example/context/security/get-security-schemes.ts
+++ b/packages/workspace-store/src/request-example/context/security/get-security-schemes.ts
@@ -13,11 +13,11 @@ export const getSecuritySchemes = (
   securitySchemes: MergedSecuritySchemes,
   selectedSecurity: SecurityRequirementObject,
 ): SecuritySchemeObjectSecret[] =>
-    objectKeys(selectedSecurity).flatMap((key) => {
-      const scheme = getResolvedRef(securitySchemes?.[key])
-      if (scheme) {
-        return scheme
-      }
+  objectKeys(selectedSecurity).flatMap((key) => {
+    const scheme = getResolvedRef(securitySchemes?.[key])
+    if (scheme) {
+      return scheme
+    }
 
-      return []
-    })
+    return []
+  })


### PR DESCRIPTION
Fixes: #5629

## Summary

- Fix `getSecuritySchemes` to accept a single `SecurityRequirementObject` instead of the full array, and update `getRequestExampleContext` to pass only the actively selected requirement using `selectedIndex` — previously, all security requirements were flattened into `selectedSchemes`, ignoring which one the user actually selected.
- Change `buildRequest` to use `headers.append` / `securityQueryParams.append` instead of `.set` so that multiple security schemes with the same header or query parameter name are preserved rather than silently overwritten.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth selection and request construction paths; behavior changes could alter which credentials are applied and how repeated auth values are sent, though changes are targeted and covered by new tests.
> 
> **Overview**
> Fixes security scheme resolution to only hydrate the *actively selected* security requirement (via `selectedIndex`) instead of flattening all `selectedSchemes`, updating `getSecuritySchemes` to accept a single `SecurityRequirementObject` and adjusting call sites (`getRequestExampleContext`, API reference operation filtering, and agent-chat helpers).
> 
> Updates request example building to *append* security headers/query params (using `Headers.append` and `URLSearchParams.append`) so multiple auth schemes sharing the same name don’t overwrite each other, with added tests covering selected-index behavior and repeated header/query values. Includes a patch changeset for `@scalar/workspace-store`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2c1f84c8c921713ca6a68c08a139803897b8e43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->