### PR TITLE
docs(docs): add showInSidebar documentation for hidden pages

### DIFF
--- a/.agents/skills/scalar-docs/SKILL.md
+++ b/.agents/skills/scalar-docs/SKILL.md
@@ -128,11 +128,14 @@ Markdown/MDX content from a file:
   "filepath": "docs/getting-started.md",
   "description": "Optional SEO description",
   "icon": "phosphor/regular/rocket",
+  "showInSidebar": true,
   "layout": { "toc": true, "sidebar": true }
 }
 ```
 
 Layout: `toc` (default `true`), `sidebar` (default `true`).
+
+**Hidden pages:** Set `showInSidebar: false` to hide a page from the sidebar while keeping it accessible via its direct URL.
 
 #### OpenAPI (`type: "openapi"`)
 

--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -180,14 +180,30 @@ Pages render markdown content from files in your repository. They are the most c
 
 ### Properties
 
-| Property      | Type     | Required | Description                         |
-| ------------- | -------- | -------- | ----------------------------------- |
-| `type`        | `"page"` | Yes      | Must be `"page"`                    |
-| `title`       | `string` | No       | The display text in the navigation  |
-| `filepath`    | `string` | Yes      | Relative path to the markdown file  |
-| `description` | `string` | No       | A description for SEO and metadata  |
-| `icon`        | `string` | No       | An icon to display next to the page |
-| `layout`      | `object` | No       | Layout configuration options        |
+| Property        | Type      | Required | Description                                               |
+| --------------- | --------- | -------- | --------------------------------------------------------- |
+| `type`          | `"page"`  | Yes      | Must be `"page"`                                          |
+| `title`         | `string`  | No       | The display text in the navigation                        |
+| `filepath`      | `string`  | Yes      | Relative path to the markdown file                        |
+| `description`   | `string`  | No       | A description for SEO and metadata                        |
+| `icon`          | `string`  | No       | An icon to display next to the page                       |
+| `showInSidebar` | `boolean` | No       | Whether to show the page in the sidebar (defaults `true`) |
+| `layout`        | `object`  | No       | Layout configuration options                              |
+
+### Hidden pages
+
+Set `showInSidebar` to `false` to hide a page from the sidebar navigation while keeping it accessible via its direct URL. This is useful for special pages like landing pages, promotional content, or forms that should not clutter the main navigation.
+
+```json
+"/enterprise": {
+  "type": "page",
+  "title": "Enterprise",
+  "filepath": "docs/enterprise.md",
+  "showInSidebar": false
+}
+```
+
+Users can still navigate to `/enterprise` directly, but the page will not appear in the sidebar. To make a page visible in the sidebar again, remove the `showInSidebar` property or set it to `true`.
 
 ### Layout Options
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `showInSidebar` property for page routes in `scalar.config.json` was undocumented. Users had no way to discover this feature for hiding pages from the sidebar while keeping them accessible via direct URL.

## Solution

Added documentation for the `showInSidebar` property in two places:

1. **`documentation/guides/docs/configuration/navigation.md`**:
   - Added `showInSidebar` to the Pages properties table
   - Added a new "Hidden pages" section with explanation and example

2. **`.agents/skills/scalar-docs/SKILL.md`**:
   - Updated the Page route type example to include `showInSidebar`
   - Added a note about hidden pages

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed for documentation-only changes -->
- [ ] I added tests. <!-- Not applicable for documentation -->
- [x] I updated the documentation.

## Ticket

Fixes DOC-5202
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07SL9L6SJ0/p1776388624207709?thread_ts=1776388624.207709&cid=C07SL9L6SJ0)

<div><a href="https://cursor.com/agents/bc-6e270623-356c-5c04-9034-537570af775f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e270623-356c-5c04-9034-537570af775f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

