### PR TITLE
fix(api-client): allow body on get 

### DIFF
--- a/.changeset/cute-pillows-punch.md
+++ b/.changeset/cute-pillows-punch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': patch
+---
+
+feat: allow body on get

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/har-to-fetch-request.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/har-to-fetch-request.test.ts
@@ -1,3 +1,4 @@
+import { X_SCALAR_ORIGINAL_METHOD } from '@scalar/helpers/http/safe-request'
 import type { HarRequest } from '@scalar/snippetz'
 import { describe, expect, it } from 'vitest'
 
@@ -551,5 +552,33 @@ describe('harToFetchRequest', () => {
 
     const bodyText = await request.text()
     expect(bodyText).toBe('tag=javascript&tag=typescript&tag=vue')
+  })
+
+  it('rewrites GET-with-body to POST plus the original-method sentinel header', async () => {
+    // Replays of Electron history can include a GET with a body. The Fetch spec
+    // forbids that, so createSafeRequest swaps the method and stashes the
+    // original in a sentinel header.
+    const jsonBody = JSON.stringify({ filter: 'active' })
+    const harRequest: HarRequest = {
+      method: 'GET',
+      url: 'https://api.example.com/search',
+      httpVersion: 'HTTP/1.1',
+      headers: [{ name: 'Content-Type', value: 'application/json' }],
+      queryString: [],
+      cookies: [],
+      postData: {
+        mimeType: 'application/json',
+        text: jsonBody,
+      },
+      headersSize: -1,
+      bodySize: -1,
+    }
+
+    const request = harToFetchRequest({ harRequest })
+
+    expect(request.method).toBe('POST')
+    expect(request.headers.get(X_SCALAR_ORIGINAL_METHOD)).toBe('GET')
+    expect(request.headers.get('Content-Type')).toBe('application/json')
+    await expect(request.text()).resolves.toBe(jsonBody)
   })
 })

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/har-to-fetch-request.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/har-to-fetch-request.ts
@@ -1,3 +1,4 @@
+import { createSafeRequest } from '@scalar/helpers/http/safe-request'
 import type { HarRequest } from '@scalar/snippetz'
 
 type HarToFetchRequestProps = {
@@ -43,7 +44,9 @@ export const harToFetchRequest = ({ harRequest }: HarToFetchRequestProps): Reque
   const headers = buildHeaders(harRequest)
   const body = buildBody(harRequest.postData)
 
-  return new Request(harRequest.url, {
+  // Use createSafeRequest so replayed history entries with a GET/HEAD body
+  // (allowed in Electron) do not trip the Fetch spec restriction.
+  return createSafeRequest(harRequest.url, {
     method: harRequest.method,
     headers,
     body,

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ClientPlugin } from '@scalar/oas-utils/helpers'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { sendRequest } from './send-request'
 
@@ -94,7 +94,7 @@ describe('sendRequest', () => {
     expect(result.response.status).toBe(200)
     expect(result.response.headers).toBeDefined()
     expect(result.response.duration).toBeGreaterThanOrEqual(0)
-    expect(result.response.method).toBe('GET')
+    expect(result.response.method).toBe('get')
     expect(result.response.path).toBe('/')
     expect(result.timestamp).toBeGreaterThan(0)
   })
@@ -130,7 +130,7 @@ describe('sendRequest', () => {
     if (!result || !('data' in result.response)) {
       throw new Error('No data')
     }
-    expect(result.response.method).toBe('POST')
+    expect(result.response.method).toBe('post')
     expect(JSON.parse(result.response.data as string)).toMatchObject({
       method: 'POST',
       body: { test: 'data' },

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.ts
@@ -2,16 +2,17 @@ import { ERRORS, type ErrorResponse, normalizeError } from '@scalar/helpers/erro
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import { httpStatusCodes } from '@scalar/helpers/http/http-status-codes'
 import { normalizeHeaders } from '@scalar/helpers/http/normalize-headers'
+import { getOriginalMethod } from '@scalar/helpers/http/safe-request'
 import type { ClientPlugin } from '@scalar/oas-utils/helpers'
 import cookie from 'cookie'
 import { parseSetCookie } from 'set-cookie-parser'
 
 import { getCookieHeaderKeys } from '@/v2/blocks/operation-block/helpers/get-cookie-header-keys'
+import { resolveResponseBodyHandler } from '@/v2/blocks/response-block/helpers/resolve-response-body-handler'
 import {
   resolveResponseContentType,
   resolveResponseMimeType,
 } from '@/v2/blocks/response-block/helpers/resolve-response-content-type'
-import { resolveResponseBodyHandler } from '@/v2/blocks/response-block/helpers/resolve-response-body-handler'
 
 import { decodeBuffer } from './decode-buffer'
 
@@ -93,7 +94,9 @@ export const sendRequest = async ({
     const responseUrl = new URL(response.url)
     const fullPath = responseUrl.pathname + responseUrl.search
     const statusText = response.statusText || httpStatusCodes[response.status]?.name || ''
-    const method = request.method as HttpMethod
+    // Honor the sentinel header from createSafeRequest so the response panel
+    // shows the original method (for example, GET-with-body in Electron).
+    const method = getOriginalMethod(request)
     const shouldSkipBody = NO_BODY_STATUS_CODES.includes(response.status)
 
     /**

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.ts
@@ -2,7 +2,7 @@ import { ERRORS, type ErrorResponse, normalizeError } from '@scalar/helpers/erro
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import { httpStatusCodes } from '@scalar/helpers/http/http-status-codes'
 import { normalizeHeaders } from '@scalar/helpers/http/normalize-headers'
-import { getOriginalMethod } from '@scalar/helpers/http/safe-request'
+import { X_SCALAR_ORIGINAL_METHOD, getOriginalMethod } from '@scalar/helpers/http/safe-request'
 import type { ClientPlugin } from '@scalar/oas-utils/helpers'
 import cookie from 'cookie'
 import { parseSetCookie } from 'set-cookie-parser'
@@ -94,10 +94,15 @@ export const sendRequest = async ({
     const responseUrl = new URL(response.url)
     const fullPath = responseUrl.pathname + responseUrl.search
     const statusText = response.statusText || httpStatusCodes[response.status]?.name || ''
+
     // Honor the sentinel header from createSafeRequest so the response panel
     // shows the original method (for example, GET-with-body in Electron).
     const method = getOriginalMethod(request)
     const shouldSkipBody = NO_BODY_STATUS_CODES.includes(response.status)
+
+    // Delete our special request headers
+    request.headers.delete(X_SCALAR_ORIGINAL_METHOD)
+    request.headers.delete(CUSTOM_COOKIE_HEADER)
 
     /**
      * Handle server-sent event streams separately.

--- a/packages/helpers/src/http/can-method-have-body.test.ts
+++ b/packages/helpers/src/http/can-method-have-body.test.ts
@@ -1,8 +1,24 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { canMethodHaveBody } from './can-method-have-body'
 import type { HttpMethod } from './http-methods'
 
+vi.mock('@/general/is-electron', () => ({
+  isElectron: vi.fn(() => false),
+}))
+
+const { isElectron } = await import('@/general/is-electron')
+const mockedIsElectron = vi.mocked(isElectron)
+
 describe('can-method-have-body', () => {
+  beforeEach(() => {
+    mockedIsElectron.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   describe('HTTP methods with body support', () => {
     it.each(['post', 'put', 'patch', 'delete'] as const)('returns true for %s method', (method) => {
       expect(canMethodHaveBody(method)).toBe(true)
@@ -31,11 +47,28 @@ describe('can-method-have-body', () => {
     })
   })
 
+  describe('Electron environment', () => {
+    beforeEach(() => {
+      mockedIsElectron.mockReturnValue(true)
+    })
+
+    it.each(['get', 'GET', 'Get'] as const)('returns true for %s method in Electron', (method) => {
+      expect(canMethodHaveBody(method as HttpMethod)).toBe(true)
+    })
+
+    it.each(['post', 'put', 'patch', 'delete'] as const)('still returns true for %s method in Electron', (method) => {
+      expect(canMethodHaveBody(method)).toBe(true)
+    })
+
+    it.each(['head', 'options', 'trace'] as const)('returns false for %s method in Electron', (method) => {
+      expect(canMethodHaveBody(method)).toBe(false)
+    })
+  })
+
   describe('type narrowing', () => {
     it('narrows type to BodyMethod when true is returned', () => {
       const method: HttpMethod = 'post'
       if (canMethodHaveBody(method)) {
-        // TypeScript should know that method is now BodyMethod
         expect(method).toBe('post')
       }
     })
@@ -43,7 +76,6 @@ describe('can-method-have-body', () => {
     it('preserves original type when false is returned', () => {
       const method: HttpMethod = 'get'
       if (!canMethodHaveBody(method)) {
-        // TypeScript should know that method is still HttpMethod
         expect(method).toBe('get')
       }
     })

--- a/packages/helpers/src/http/can-method-have-body.test.ts
+++ b/packages/helpers/src/http/can-method-have-body.test.ts
@@ -65,18 +65,14 @@ describe('can-method-have-body', () => {
     })
   })
 
-  describe('type narrowing', () => {
-    it('narrows type to BodyMethod when true is returned', () => {
-      const method: HttpMethod = 'post'
-      if (canMethodHaveBody(method)) {
-        expect(method).toBe('post')
-      }
-    })
-
-    it('preserves original type when false is returned', () => {
+  describe('return type', () => {
+    it('returns a plain boolean so the original HttpMethod type is preserved in both branches', () => {
       const method: HttpMethod = 'get'
-      if (!canMethodHaveBody(method)) {
-        expect(method).toBe('get')
+
+      if (canMethodHaveBody(method)) {
+        expect<HttpMethod>(method).toBe('get')
+      } else {
+        expect<HttpMethod>(method).toBe('get')
       }
     })
   })

--- a/packages/helpers/src/http/can-method-have-body.ts
+++ b/packages/helpers/src/http/can-method-have-body.ts
@@ -1,9 +1,27 @@
+import { isElectron } from '@/general/is-electron'
+
 import type { HttpMethod } from './http-methods'
 
 /** HTTP Methods which can have a body */
-const BODY_METHODS = ['post', 'put', 'patch', 'get', 'delete'] as const satisfies HttpMethod[]
+const BODY_METHODS = ['post', 'put', 'patch', 'delete'] as const satisfies HttpMethod[]
 type BodyMethod = (typeof BODY_METHODS)[number]
 
-/** Makes a check to see if this method CAN have a body */
-export const canMethodHaveBody = (method: HttpMethod): method is BodyMethod =>
-  BODY_METHODS.includes(method.toLowerCase() as BodyMethod)
+/** HTTP Methods which can have a body when running in Electron, where the fetch implementation allows bodies on GET. */
+const ELECTRON_BODY_METHODS = [...BODY_METHODS, 'get'] as const satisfies HttpMethod[]
+type ElectronBodyMethod = (typeof ELECTRON_BODY_METHODS)[number]
+
+/**
+ * Makes a check to see if this method CAN have a body.
+ *
+ * When running inside Electron, GET requests are also allowed to have a body because the underlying
+ * undici implementation does not reject it, which matches the behavior users expect from desktop API clients.
+ */
+export const canMethodHaveBody = (method: HttpMethod): method is BodyMethod | ElectronBodyMethod => {
+  const normalized = method.toLowerCase() as ElectronBodyMethod
+
+  if (isElectron()) {
+    return ELECTRON_BODY_METHODS.includes(normalized)
+  }
+
+  return BODY_METHODS.includes(normalized as BodyMethod)
+}

--- a/packages/helpers/src/http/can-method-have-body.ts
+++ b/packages/helpers/src/http/can-method-have-body.ts
@@ -15,8 +15,13 @@ type ElectronBodyMethod = (typeof ELECTRON_BODY_METHODS)[number]
  *
  * When running inside Electron, GET requests are also allowed to have a body because the underlying
  * undici implementation does not reject it, which matches the behavior users expect from desktop API clients.
+ *
+ * Note: this intentionally returns `boolean` rather than a type predicate. The result depends on the
+ * runtime environment (browser vs. Electron), so no single static predicate can soundly narrow the
+ * input type across both branches — narrowing out `'get'` in the false branch would be incorrect in
+ * Electron, and narrowing it in would be incorrect in the browser.
  */
-export const canMethodHaveBody = (method: HttpMethod): method is BodyMethod | ElectronBodyMethod => {
+export const canMethodHaveBody = (method: HttpMethod): boolean => {
   const normalized = method.toLowerCase() as ElectronBodyMethod
 
   if (isElectron()) {

--- a/packages/helpers/src/http/can-method-have-body.ts
+++ b/packages/helpers/src/http/can-method-have-body.ts
@@ -1,7 +1,7 @@
 import type { HttpMethod } from './http-methods'
 
 /** HTTP Methods which can have a body */
-const BODY_METHODS = ['post', 'put', 'patch', 'delete'] as const satisfies HttpMethod[]
+const BODY_METHODS = ['post', 'put', 'patch', 'get', 'delete'] as const satisfies HttpMethod[]
 type BodyMethod = (typeof BODY_METHODS)[number]
 
 /** Makes a check to see if this method CAN have a body */

--- a/packages/helpers/src/http/safe-request.test.ts
+++ b/packages/helpers/src/http/safe-request.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+
+import { X_SCALAR_ORIGINAL_METHOD, createSafeRequest, getOriginalMethod } from './safe-request'
+
+describe('safe-request', () => {
+  describe('createSafeRequest', () => {
+    it('builds a normal GET request when no body is provided', () => {
+      const request = createSafeRequest('https://example.com', { method: 'GET' })
+
+      expect(request.method).toBe('GET')
+      expect(request.headers.has(X_SCALAR_ORIGINAL_METHOD)).toBe(false)
+    })
+
+    it('uppercases the method even when no rewrite is needed', () => {
+      const request = createSafeRequest('https://example.com', { method: 'patch', body: '{}' })
+
+      expect(request.method).toBe('PATCH')
+      expect(request.headers.has(X_SCALAR_ORIGINAL_METHOD)).toBe(false)
+    })
+
+    it.each(['GET', 'HEAD', 'get', 'head'] as const)(
+      'rewrites %s with body to POST + sentinel header',
+      async (method) => {
+        const request = createSafeRequest('https://example.com', {
+          method,
+          body: 'payload',
+        })
+
+        expect(request.method).toBe('POST')
+        expect(request.headers.get(X_SCALAR_ORIGINAL_METHOD)).toBe(method.toUpperCase())
+        await expect(request.text()).resolves.toBe('payload')
+      },
+    )
+
+    it('preserves caller-provided headers when rewriting', () => {
+      const request = createSafeRequest('https://example.com', {
+        method: 'GET',
+        body: '{}',
+        headers: { 'content-type': 'application/json' },
+      })
+
+      expect(request.headers.get('content-type')).toBe('application/json')
+      expect(request.headers.get(X_SCALAR_ORIGINAL_METHOD)).toBe('GET')
+    })
+
+    it('keeps POST/PUT/PATCH/DELETE bodies untouched', async () => {
+      const request = createSafeRequest('https://example.com', { method: 'POST', body: 'payload' })
+
+      expect(request.method).toBe('POST')
+      expect(request.headers.has(X_SCALAR_ORIGINAL_METHOD)).toBe(false)
+      await expect(request.text()).resolves.toBe('payload')
+    })
+
+    it('does not rewrite GET when body is null', () => {
+      const request = createSafeRequest('https://example.com', { method: 'GET', body: null })
+
+      expect(request.method).toBe('GET')
+      expect(request.headers.has(X_SCALAR_ORIGINAL_METHOD)).toBe(false)
+    })
+
+    it('defaults to GET when no method is provided', () => {
+      const request = createSafeRequest('https://example.com')
+
+      expect(request.method).toBe('GET')
+    })
+  })
+
+  describe('getOriginalMethod', () => {
+    it('returns the request method when no sentinel header is set', () => {
+      const request = new Request('https://example.com', { method: 'POST', body: '{}' })
+
+      expect(getOriginalMethod(request)).toBe('post')
+    })
+
+    it('returns the sentinel value when present', () => {
+      const request = createSafeRequest('https://example.com', { method: 'GET', body: '{}' })
+
+      expect(getOriginalMethod(request)).toBe('get')
+    })
+
+    it('lowercases the resolved method', () => {
+      const request = new Request('https://example.com', {
+        method: 'POST',
+        body: '{}',
+        headers: { [X_SCALAR_ORIGINAL_METHOD]: 'HEAD' },
+      })
+
+      expect(getOriginalMethod(request)).toBe('head')
+    })
+  })
+})

--- a/packages/helpers/src/http/safe-request.ts
+++ b/packages/helpers/src/http/safe-request.ts
@@ -8,9 +8,6 @@ import type { HttpMethod } from './http-methods'
  */
 export const X_SCALAR_ORIGINAL_METHOD = 'x-scalar-original-method'
 
-/** Methods that the Fetch spec forbids from carrying a body. */
-const BODYLESS_METHODS = new Set(['GET', 'HEAD'])
-
 const hasBody = (body: BodyInit | null | undefined): boolean => body !== null && body !== undefined
 
 /**
@@ -28,14 +25,14 @@ const hasBody = (body: BodyInit | null | undefined): boolean => body !== null &&
 export const createSafeRequest = (input: RequestInfo | URL, init: RequestInit = {}): Request => {
   const method = (init.method ?? 'GET').toUpperCase()
 
-  if (!BODYLESS_METHODS.has(method) || !hasBody(init.body)) {
-    return new Request(input, { ...init, method })
+  // For get with body
+  if (method === 'GET' && hasBody(init.body)) {
+    const headers = new Headers(init.headers)
+    headers.set(X_SCALAR_ORIGINAL_METHOD, method)
+    return new Request(input, { ...init, method: 'POST', headers })
   }
 
-  const headers = new Headers(init.headers)
-  headers.set(X_SCALAR_ORIGINAL_METHOD, method)
-
-  return new Request(input, { ...init, method: 'POST', headers })
+  return new Request(input, { ...init, method })
 }
 
 /**

--- a/packages/helpers/src/http/safe-request.ts
+++ b/packages/helpers/src/http/safe-request.ts
@@ -1,0 +1,50 @@
+import type { HttpMethod } from './http-methods'
+
+/**
+ * Sentinel header used to ferry GET/HEAD requests with bodies past the Fetch
+ * spec restriction enforced by `new Request()` and `fetch()`. The receiving
+ * side (for example, the Electron fetch shim) strips this header and reverts
+ * the method back to the original before dispatching the underlying request.
+ */
+export const X_SCALAR_ORIGINAL_METHOD = 'x-scalar-original-method'
+
+/** Methods that the Fetch spec forbids from carrying a body. */
+const BODYLESS_METHODS = new Set(['GET', 'HEAD'])
+
+const hasBody = (body: BodyInit | null | undefined): boolean => body !== null && body !== undefined
+
+/**
+ * Drop-in replacement for `new Request()` that transparently routes
+ * GET/HEAD-with-body around the Fetch spec restriction.
+ *
+ * When the caller asks for a GET or HEAD request with a non-null body, the
+ * underlying `Request` is constructed as a POST and the original method is
+ * preserved in the {@link X_SCALAR_ORIGINAL_METHOD} header. Use
+ * {@link getOriginalMethod} on the receiving side to recover the user-facing
+ * method.
+ *
+ * In every other case this behaves exactly like `new Request()`.
+ */
+export const createSafeRequest = (input: RequestInfo | URL, init: RequestInit = {}): Request => {
+  const method = (init.method ?? 'GET').toUpperCase()
+
+  if (!BODYLESS_METHODS.has(method) || !hasBody(init.body)) {
+    return new Request(input, { ...init, method })
+  }
+
+  const headers = new Headers(init.headers)
+  headers.set(X_SCALAR_ORIGINAL_METHOD, method)
+
+  return new Request(input, { ...init, method: 'POST', headers })
+}
+
+/**
+ * Returns the user-facing HTTP method for a request, honoring the
+ * {@link X_SCALAR_ORIGINAL_METHOD} sentinel header when present.
+ *
+ * Pair this with {@link createSafeRequest} so consumers see the method the
+ * caller actually intended, even when the underlying `Request` was rewritten
+ * to satisfy the Fetch spec.
+ */
+export const getOriginalMethod = (request: Request): HttpMethod =>
+  (request.headers.get(X_SCALAR_ORIGINAL_METHOD) ?? request.method).toLowerCase() as HttpMethod

--- a/packages/helpers/src/http/safe-request.ts
+++ b/packages/helpers/src/http/safe-request.ts
@@ -8,6 +8,7 @@ import type { HttpMethod } from './http-methods'
  */
 export const X_SCALAR_ORIGINAL_METHOD = 'x-scalar-original-method'
 
+const METHODS_WITHOUT_BODY = new Set(['GET', 'HEAD'])
 const hasBody = (body: BodyInit | null | undefined): boolean => body !== null && body !== undefined
 
 /**
@@ -25,8 +26,8 @@ const hasBody = (body: BodyInit | null | undefined): boolean => body !== null &&
 export const createSafeRequest = (input: RequestInfo | URL, init: RequestInit = {}): Request => {
   const method = (init.method ?? 'GET').toUpperCase()
 
-  // For get with body
-  if (method === 'GET' && hasBody(init.body)) {
+  // For get/head with body
+  if (METHODS_WITHOUT_BODY.has(method) && hasBody(init.body)) {
     const headers = new Headers(init.headers)
     headers.set(X_SCALAR_ORIGINAL_METHOD, method)
     return new Request(input, { ...init, method: 'POST', headers })

--- a/packages/workspace-store/src/request-example/builder/build-request.test.ts
+++ b/packages/workspace-store/src/request-example/builder/build-request.test.ts
@@ -1,3 +1,4 @@
+import { X_SCALAR_ORIGINAL_METHOD } from '@scalar/helpers/http/safe-request'
 import { encode as encodeBase64 } from 'js-base64'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -494,5 +495,22 @@ describe('buildRequest', () => {
 
     expect(request.method).toBe('PATCH')
     expect(request.cache).toBe('no-store')
+  })
+
+  it('rewrites GET-with-body to POST and stores the original method in a sentinel header', async () => {
+    // The Fetch spec rejects GET requests with a body, but Electron lets the
+    // underlying transport carry one. createSafeRequest swaps the method so
+    // `new Request()` does not throw, and the receiving side reverts it.
+    const { request } = buildRequest(
+      createFactory({
+        method: 'get',
+        body: { mode: 'raw', value: '{"q":"test"}' },
+      }),
+      { envVariables: {} },
+    )
+
+    expect(request.method).toBe('POST')
+    expect(request.headers.get(X_SCALAR_ORIGINAL_METHOD)).toBe('GET')
+    await expect(request.text()).resolves.toBe('{"q":"test"}')
   })
 })

--- a/packages/workspace-store/src/request-example/builder/build-request.ts
+++ b/packages/workspace-store/src/request-example/builder/build-request.ts
@@ -1,3 +1,4 @@
+import { createSafeRequest } from '@scalar/helpers/http/safe-request'
 import { replaceEnvVariables } from '@scalar/helpers/regex/replace-variables'
 import { redirectToProxy, shouldUseProxy } from '@scalar/helpers/url/redirect-to-proxy'
 import { encode as encodeBase64 } from 'js-base64'
@@ -5,8 +6,8 @@ import { encode as encodeBase64 } from 'js-base64'
 import { buildRequestCookieHeader } from '@/request-example/builder/header/build-request-cookie-header'
 import { applyAllowReservedToUrl } from '@/request-example/builder/helpers/apply-allow-reserved-to-url'
 import type { RequestFactory } from '@/request-example/builder/request-factory'
-import { contextFunctions, isContextFunctionName } from '@/request-example/functions'
 import { resolveRequestFactoryUrl } from '@/request-example/builder/resolve-request-factory-url'
+import { contextFunctions, isContextFunctionName } from '@/request-example/functions'
 import type { XScalarCookie } from '@/schemas/extensions/general/x-scalar-cookies'
 
 export const buildRequest = (
@@ -151,8 +152,15 @@ export const buildRequest = (
   const finalUrl = isUsingProxy ? redirectToProxy(request.proxyUrl, encodedUrl) : encodedUrl
 
   return {
-    /** Create a new request object with the replaced values ready to be sent to the server */
-    request: new Request(finalUrl, {
+    /**
+     * Create a new request object with the replaced values ready to be sent to the server.
+     *
+     * Uses {@link createSafeRequest} so that GET/HEAD requests with a body (allowed in
+     * Electron via {@link canMethodHaveBody}) bypass the Fetch spec restriction by being
+     * dispatched as POST plus an `x-scalar-original-method` header. The Electron fetch
+     * shim reverts the method before sending the underlying request.
+     */
+    request: createSafeRequest(finalUrl, {
       /**
        * Ensure that all methods are uppercased (though only needed for patch)
        *


### PR DESCRIPTION
## Problem

We disallow body on get as it doesn't work in the browser. We also create a new Request a few places which doesn't allow this.

## Solution

Instead we create a safeRequest with a special header when using get with a body. This will then be read on the electron side and piped through undici instead.

TBH im not a fan of this, maybe we can just use harRequest everywhere and just convert it back to a fetch payload right before sending.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how requests are constructed and how the displayed HTTP method is derived, introducing a sentinel header + method rewrite path that could affect request semantics and intermediaries if the header isn’t stripped as expected.
> 
> **Overview**
> Enables replaying/sending *GET-with-body* requests in Electron without violating the Fetch spec by introducing `createSafeRequest` (rewrites GET-with-body to POST and stores the intended method in `x-scalar-original-method`).
> 
> Request construction paths (`buildRequest`, `harToFetchRequest`) now use `createSafeRequest`, and response metadata in `sendRequest` uses `getOriginalMethod` so the UI reports the user-intended method even when the underlying `Request` was rewritten. Adds/updates tests around Electron-specific body support and the rewrite/sentinel behavior, plus a patch changeset for `@scalar/helpers`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 311687ce23a05043ec655d17bf2fcd7a81538068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->