### PR TITLE
docs(aspire): add failed-start troubleshooting for AppHost

### DIFF
--- a/documentation/integrations/aspire.md
+++ b/documentation/integrations/aspire.md
@@ -332,6 +332,25 @@ scalar.WithApiReference(bookService, async (options, cancellationToken) =>
 
 ## Common Pitfalls
 
+### Scalar resource shows "Failed to start"
+
+When you use `AddScalarApiReference()`, Aspire runs Scalar as a **container resource** (`scalarapi/aspire-api-reference`).
+If your other resources are .NET projects, they can still run while only Scalar fails.
+
+In that state, changing OpenAPI route patterns (`OpenApiRoutePattern`, `AddDocument(..., routePattern: ...)`) does not help because the Scalar container has not started yet.
+
+Troubleshooting checklist:
+
+1. Confirm a container runtime is installed and running:
+   - Docker: `docker info`
+   - Podman: `podman info`
+2. Confirm the Scalar image can be pulled:
+   - `docker pull scalarapi/aspire-api-reference:latest`
+3. Check **AppHost** logs (not just Scalar resource logs) for container runtime or image pull errors.
+4. If your environment blocks Docker Hub access (proxy/firewall/rate limit), allow access or mirror the image.
+
+If your environment cannot run container resources, use `app.MapScalarApiReference()` directly inside your ASP.NET Core API as a fallback.
+
 ### YARP Integration Issues
 
 When using YARP (`Aspire.Hosting.Yarp`), you may encounter proxy routing conflicts. Here are two solutions:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users can see a `failed to start` state for the Scalar Aspire resource in AppHost and assume OpenAPI route-pattern configuration is the cause. Existing docs do not clearly explain that this failure usually happens before Scalar reads those options.

## Solution

- Added a new **Common Pitfalls** subsection in the Aspire docs for `Scalar resource shows "Failed to start"`.
- Clarified that `AddScalarApiReference()` runs Scalar as a container resource.
- Added a concrete troubleshooting checklist for runtime/image/AppHost log validation.
- Added a fallback recommendation (`app.MapScalarApiReference()`) for environments that cannot run container resources.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.

## Ticket

Refs https://github.com/scalar/scalar/discussions/8878
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9df85f4-a2de-4ff0-abdb-8f4b1d4a6b59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9df85f4-a2de-4ff0-abdb-8f4b1d4a6b59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

