### PR TITLE
fix(postman-to-openapi): omit content for no-body statuses

### DIFF
--- a/.changeset/wise-cheetahs-warn.md
+++ b/.changeset/wise-cheetahs-warn.md
@@ -1,0 +1,5 @@
+---
+'@scalar/postman-to-openapi': patch
+---
+
+fix: omit response content for no-body status codes by default

--- a/packages/postman-to-openapi/src/convert.test.ts
+++ b/packages/postman-to-openapi/src/convert.test.ts
@@ -325,9 +325,6 @@ describe('convert', () => {
       },
       '204': {
         description: 'Invalid country code filter',
-        content: {
-          'application/json': {},
-        },
       },
     })
 

--- a/packages/postman-to-openapi/src/helpers/path-items.test.ts
+++ b/packages/postman-to-openapi/src/helpers/path-items.test.ts
@@ -615,9 +615,6 @@ describe('path-items', () => {
     const result = processItem(item, 'default', [], '', true)
     expect(result.paths['/languages']?.get?.responses?.['204']).toEqual({
       description: 'Invalid country code filter',
-      content: {
-        'application/json': {},
-      },
     })
   })
 

--- a/packages/postman-to-openapi/src/helpers/responses.test.ts
+++ b/packages/postman-to-openapi/src/helpers/responses.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { Item, Response } from '@/types'
 
@@ -297,9 +297,78 @@ describe('responses', () => {
 
     const result = extractResponses(responses)
 
-    expect(result?.['204']?.content?.['application/json']?.examples?.default).toEqual({
-      rawContent: '',
+    expect(result?.['204']?.content).toBeUndefined()
+  })
+
+  it('omits content for no-body status codes without body examples', () => {
+    const responses: Response[] = [
+      {
+        code: 101,
+        status: 'Switching Protocols',
+      },
+      {
+        code: 205,
+        status: 'Reset Content',
+      },
+      {
+        code: 304,
+        status: 'Not Modified',
+      },
+    ]
+
+    const result = extractResponses(responses)
+
+    expect(result?.['101']?.content).toBeUndefined()
+    expect(result?.['205']?.content).toBeUndefined()
+    expect(result?.['304']?.content).toBeUndefined()
+  })
+
+  it('omits content for no-body status codes extracted from test scripts', () => {
+    const responses: Response[] = []
+    const item: Item = {
+      name: 'No Body Status',
+      request: {
+        method: 'GET',
+        url: {
+          raw: 'https://example.com/resource',
+        },
+      },
+      event: [
+        {
+          listen: 'test',
+          script: {
+            exec: ['pm.response.to.have.status(204);', 'pm.response.to.have.status(304);'],
+          },
+        },
+      ],
+    }
+
+    const result = extractResponses(responses, item)
+
+    expect(result?.['204']?.content).toBeUndefined()
+    expect(result?.['304']?.content).toBeUndefined()
+  })
+
+  it('keeps content and logs warning when no-body status code has explicit body example', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const responses: Response[] = [
+      {
+        code: 204,
+        status: 'No Content',
+        body: '{"message": "actually has content"}',
+      },
+    ]
+
+    const result = extractResponses(responses)
+
+    expect(result?.['204']?.content?.['application/json']?.examples?.default).toStrictEqual({
+      message: 'actually has content',
     })
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[postman-to-openapi] Response 204 usually has no body, but Postman includes a body example. Keeping OpenAPI content.',
+    )
+
+    warnSpy.mockRestore()
   })
 
   it('handles array response body', () => {

--- a/packages/postman-to-openapi/src/helpers/responses.ts
+++ b/packages/postman-to-openapi/src/helpers/responses.ts
@@ -33,17 +33,31 @@ export function extractResponses(responses: Response[], item?: Item): OpenAPIV3_
   // Create a map of status codes to descriptions from responses
   const responseMap = responses.reduce((acc, response) => {
     const statusCode = response.code?.toString() || 'default'
+    const hasNoContentStatusCode = hasNoResponseBodyStatusCode(statusCode)
+    const hasExplicitBodyExample = response.body !== undefined && response.body !== null && response.body !== ''
+
+    if (hasNoContentStatusCode && hasExplicitBodyExample) {
+      console.warn(
+        `[postman-to-openapi] Response ${statusCode} usually has no body, but Postman includes a body example. Keeping OpenAPI content.`,
+      )
+    }
+
+    const content =
+      hasNoContentStatusCode && !hasExplicitBodyExample
+        ? undefined
+        : {
+            'application/json': {
+              schema: inferSchemaFromExample(response.body || ''),
+              examples: {
+                default: tryParseJson(response.body || ''),
+              },
+            },
+          }
+
     acc[statusCode] = {
       description: getResponseDescription(response, statusCode),
       headers: extractHeaders(response.header),
-      content: {
-        'application/json': {
-          schema: inferSchemaFromExample(response.body || ''),
-          examples: {
-            default: tryParseJson(response.body || ''),
-          },
-        },
-      },
+      ...(content ? { content } : {}),
     }
     return acc
   }, {} as OpenAPIV3_1.ResponsesObject)
@@ -52,11 +66,16 @@ export function extractResponses(responses: Response[], item?: Item): OpenAPIV3_
   statusCodes.forEach((code) => {
     const codeStr = code.toString()
     if (!responseMap[codeStr]) {
+      const hasNoContentStatusCode = hasNoResponseBodyStatusCode(codeStr)
       responseMap[codeStr] = {
         description: getDefaultResponseDescription(codeStr),
-        content: {
-          'application/json': {},
-        },
+        ...(!hasNoContentStatusCode
+          ? {
+              content: {
+                'application/json': {},
+              },
+            }
+          : {}),
       }
     }
   })
@@ -121,6 +140,16 @@ function isThreeDigitStatusCode(value: string): boolean {
   }
 
   return true
+}
+
+const hasNoResponseBodyStatusCode = (statusCode: string): boolean => {
+  const numericCode = Number(statusCode)
+
+  if (!Number.isInteger(numericCode)) {
+    return false
+  }
+
+  return (numericCode >= 100 && numericCode <= 199) || numericCode === 204 || numericCode === 205 || numericCode === 304
 }
 
 function extractHeaders(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`@scalar/postman-to-openapi` emitted `content: { "application/json": {} }` for response status codes that normally have no body (`1xx`, `204`, `205`, `304`), which made generated OpenAPI responses less accurate.

## Solution

- Added no-body status detection for `100-199`, `204`, `205`, and `304`.
- Omit `response.content` for those codes when no explicit Postman body example is present.
- If Postman includes an explicit body example for a no-body status code, keep `content` and log a warning explaining why content was preserved.
- Applied the same omission behavior to status codes extracted from Postman test scripts.
- Added unit tests for no-body status handling and warning behavior.

## Testing

- `pnpm vitest packages/postman-to-openapi/src/helpers/responses.test.ts --run`
- `pnpm --filter @scalar/postman-to-openapi test`
- `pnpm changeset status`
- `pnpm format`
- `pnpm knip` *(fails in this environment due to missing `@scalar/docusaurus/dist/index.js` while loading `integrations/docusaurus/playground/docusaurus.config.ts`)*

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82ecfe83-151b-4931-950e-6c3814fd1639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82ecfe83-151b-4931-950e-6c3814fd1639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

