### PR TITLE
feat(postman-to-openapi): evaluate script

### DIFF
--- a/packages/postman-to-openapi/package.json
+++ b/packages/postman-to-openapi/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
+    "evaluate": "tsx ./scripts/evaluate/run.ts",
     "generate:textures": "tsx ./scripts/generate-textures.ts",
     "test": "vitest --run",
     "types:check": "tsc --noEmit"
@@ -48,6 +49,7 @@
     "@scalar/openapi-types": "workspace:*"
   },
   "devDependencies": {
+    "@scalar/openapi-parser": "workspace:*",
     "@types/node": "catalog:*",
     "vite": "catalog:*"
   }

--- a/packages/postman-to-openapi/scripts/evaluate/README.md
+++ b/packages/postman-to-openapi/scripts/evaluate/README.md
@@ -1,0 +1,68 @@
+# Postman → OpenAPI evaluation harness
+
+A loop for regularly checking how well `@scalar/postman-to-openapi` handles real-world Postman collections. A runner script does the conversion and records structural metrics. A coding agent (or a human) then reads those results, rates the output against [`RUBRIC.md`](./RUBRIC.md), and files improvement ideas as individual markdown files.
+
+## Layout
+
+Everything under `fixtures/evaluate/` is git-ignored (the package's `.gitignore` already excludes `fixtures/`):
+
+```
+packages/postman-to-openapi/
+├── scripts/evaluate/
+│   ├── run.ts         # runner (committed)
+│   ├── README.md      # this file (committed)
+│   └── RUBRIC.md      # rating criteria (committed)
+└── fixtures/evaluate/
+    ├── input/         # ← drop .json Postman collections here
+    ├── output/        # generated OpenAPI, one file per input
+    ├── reports/       # run-<timestamp>.json + report.md
+    └── ideas/         # one markdown file per distinct improvement idea
+```
+
+## Running it
+
+```bash
+# 1. Drop Postman collection JSON files into fixtures/evaluate/input/
+# 2. From the repo root:
+pnpm --filter @scalar/postman-to-openapi evaluate
+```
+
+The runner:
+
+- iterates every `.json` file in `fixtures/evaluate/input/`,
+- calls `convert()` on each one (catching errors per-file so one bad collection does not abort the run),
+- writes the resulting OpenAPI document to `fixtures/evaluate/output/<name>.json`,
+- runs `@scalar/openapi-parser` `validate()` against each output,
+- records structural metrics for both the input (request count, auth types, body modes, …) and the output (paths, operations, security schemes, response examples, …),
+- writes a machine-readable `fixtures/evaluate/reports/run-<timestamp>.json` summarising the whole run,
+- prints a compact pass/fail table to stdout.
+
+## Agent review loop
+
+After a run, ask the coding agent (Claude Code) to review the results:
+
+> "Review the latest evaluate run in `packages/postman-to-openapi/fixtures/evaluate/` and update the report + ideas."
+
+The agent then:
+
+1. Reads the newest `fixtures/evaluate/reports/run-*.json`.
+2. For each result, opens the input collection and — for successful conversions — the generated OpenAPI output, scoring it against each dimension in [`RUBRIC.md`](./RUBRIC.md) (1-5 with a short note).
+3. Writes `fixtures/evaluate/reports/report.md`:
+   - top-level summary table (collection × dimension scores),
+   - narrative notes per collection,
+   - aggregated patterns at the bottom.
+4. For each distinct issue found, creates or updates `fixtures/evaluate/ideas/<kebab-slug>.md` containing:
+   - problem statement,
+   - evidence (which collections exhibit it, with small excerpts),
+   - suggested fix direction,
+   - rough effort estimate.
+
+   If an idea file with the same root cause already exists, the agent appends new evidence to it rather than creating a duplicate.
+
+## Adding to the input set
+
+Postman collections often contain real URLs, tokens, or internal API details. Keep them out of git — this harness never commits anything under `fixtures/`. When sharing a finding externally, reference the redacted excerpt inside the idea file, not the raw collection.
+
+## Re-running after converter changes
+
+Because `run.ts` imports `convert` from `../../src/index` (not the built `dist/`), any local change to the converter is reflected on the next `evaluate` run with no rebuild required.

--- a/packages/postman-to-openapi/scripts/evaluate/RUBRIC.md
+++ b/packages/postman-to-openapi/scripts/evaluate/RUBRIC.md
@@ -1,0 +1,99 @@
+# Evaluation rubric
+
+Score each dimension **1-5** with a short note grounded in specifics from the input and output files. Lower scores mean higher-priority issues — they should produce an entry in `fixtures/evaluate/ideas/`.
+
+| Score | Meaning |
+| ----- | ------- |
+| 5     | Complete and correct. No observable gap vs. the Postman source. |
+| 4     | Minor cosmetic or edge-case gap. Usable as-is. |
+| 3     | Noticeable gap that a consumer of the OpenAPI would work around. |
+| 2     | Significant loss of information or incorrect structure. |
+| 1     | Broken or missing entirely. |
+| —     | N/A — the input does not exercise this dimension. |
+
+## Dimensions
+
+### 1. Conversion success
+Did `convert()` return a document, or did it throw? For thrown errors, capture the error name and message verbatim from the run report. A throw is always a 1.
+
+### 2. Description validity
+Did `@scalar/openapi-parser` `validate()` accept the output against the OpenAPI Specification? Invalid description documents are at most a 2; list the top few validation errors in the report.
+
+### 3. Request coverage
+Count of Postman requests vs. resulting OpenAPI operations. A 5 means every request became an operation with the correct method. A 3 means several requests were dropped or merged incorrectly.
+
+### 4. Path & parameters
+- Does the path template match the Postman URL (including `{placeholder}` path params)?
+- Are query parameters represented under `parameters` with sensible schemas?
+- Are request-level headers preserved as `header` parameters (ignoring purely transport-level ones like `Host`, `Content-Length`)?
+
+### 5. Auth fidelity
+Postman supports auth at the collection, folder, and request level. A 5 means:
+- collection-level auth → `security` + `components.securitySchemes`,
+- folder/request overrides → per-operation `security`,
+- auth type translated (bearer → `http bearer`, apikey → `apiKey`, basic → `http basic`, oauth2 → `oauth2`, …).
+
+### 6. Body fidelity
+- `raw` JSON → `application/json` with inferred schema.
+- `raw` GraphQL → `application/json` with `query`/`variables` fields.
+- `formdata` → `multipart/form-data` with per-field type (`text`/`file`).
+- `urlencoded` → `application/x-www-form-urlencoded`.
+- `file` → `application/octet-stream` or appropriate binary media type.
+
+### 7. Response fidelity
+Saved Postman example responses should become OpenAPI response entries with:
+- correct status code (from `code`),
+- correct media type (inferred from `Content-Type` header or response body shape),
+- example payload preserved,
+- schema inferred from the example when possible.
+
+### 8. Metadata
+- `info.title`, `info.description`, `info.version` sourced from the Postman `info` block.
+- Folders translated to `tags` with descriptions.
+- `operationId` present and unique across the document.
+
+### 9. Servers
+- Base URL extracted once per distinct host, not duplicated per path.
+- Path templates relative to the server URL, not absolute (no leaked hostnames inside `paths`).
+- Multi-host collections produce multiple `servers` entries.
+
+### 10. Faithfulness
+Output should not invent fields that are not grounded in the Postman input. Watch for:
+- fabricated `description` text,
+- guessed `example` values,
+- security schemes that the collection never used,
+- operation tags with no corresponding folder.
+
+## Reporting format
+
+In `fixtures/evaluate/reports/report.md`, produce a table like:
+
+```
+| collection        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | notes |
+| ----------------- | - | - | - | - | - | - | - | - | - | -- | ----- |
+| stripe-public.json| 5 | 5 | 4 | 4 | 3 | 3 | 2 | 4 | 5 | 4  | see #12, #15 |
+```
+
+Follow the table with short per-collection sections calling out the evidence behind each score. At the bottom, summarise the top three most impactful patterns observed across the set.
+
+## Idea files
+
+For each distinct root cause that produced a sub-4 score in any collection, add or update `fixtures/evaluate/ideas/<kebab-slug>.md` using this shape:
+
+```markdown
+# <short title>
+
+**Dimension:** <rubric dimension(s)>
+**Severity:** low | medium | high
+**Effort:** small | medium | large
+
+## Problem
+<what breaks, in 1-2 sentences>
+
+## Evidence
+- `stripe-public.json` — <excerpt + pointer>
+- `twilio.json` — <excerpt + pointer>
+
+## Suggested direction
+<sketch of a fix, referencing relevant files in packages/postman-to-openapi/src/>
+```

--- a/packages/postman-to-openapi/scripts/evaluate/run.ts
+++ b/packages/postman-to-openapi/scripts/evaluate/run.ts
@@ -1,0 +1,335 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import { type ErrorObject, validate } from '@scalar/openapi-parser'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
+import { convert } from '../../src/index'
+import type { Item, ItemGroup, PostmanCollection, Request, RequestBody } from '../../src/types'
+
+const PACKAGE_ROOT = path.resolve(import.meta.dirname, '../..')
+const INPUT_DIR = path.join(PACKAGE_ROOT, 'fixtures/evaluate/input')
+const OUTPUT_DIR = path.join(PACKAGE_ROOT, 'fixtures/evaluate/output')
+const REPORTS_DIR = path.join(PACKAGE_ROOT, 'fixtures/evaluate/reports')
+const IDEAS_DIR = path.join(PACKAGE_ROOT, 'fixtures/evaluate/ideas')
+
+type ConversionError = {
+  name: string
+  message: string
+  stack?: string
+}
+
+type ValidationReport = {
+  valid: boolean
+  errors: Array<{ message: string; path?: string }>
+}
+
+type InputMetrics = {
+  requestCount: number
+  folderCount: number
+  authTypes: string[]
+  bodyModes: string[]
+  responseExampleCount: number
+  variableCount: number
+}
+
+type OutputMetrics = {
+  pathCount: number
+  operationCount: number
+  serverCount: number
+  securitySchemes: string[]
+  operationsWithSecurity: number
+  componentsSchemaCount: number
+  responseExampleCount: number
+  tagCount: number
+  operationIdCount: number
+}
+
+type Result = {
+  file: string
+  status: 'success' | 'error'
+  error: ConversionError | null
+  validation: ValidationReport | null
+  input: InputMetrics | null
+  output: OutputMetrics | null
+  outputPath: string | null
+}
+
+type RunReport = {
+  runAt: string
+  inputDir: string
+  outputDir: string
+  totals: {
+    total: number
+    converted: number
+    validated: number
+    failed: number
+  }
+  results: Result[]
+}
+
+const isItemGroup = (entry: Item | ItemGroup): entry is ItemGroup => Array.isArray((entry as ItemGroup).item)
+
+const pushUnique = (list: string[], value: string | undefined | null) => {
+  if (value && !list.includes(value)) {
+    list.push(value)
+  }
+}
+
+const collectInputMetrics = (collection: PostmanCollection): InputMetrics => {
+  const metrics: InputMetrics = {
+    requestCount: 0,
+    folderCount: 0,
+    authTypes: [],
+    bodyModes: [],
+    responseExampleCount: 0,
+    variableCount: collection.variable?.length ?? 0,
+  }
+
+  pushUnique(metrics.authTypes, collection.auth?.type)
+
+  const walk = (entries: (Item | ItemGroup)[] | undefined) => {
+    if (!Array.isArray(entries)) {
+      return
+    }
+    for (const entry of entries) {
+      if (isItemGroup(entry)) {
+        metrics.folderCount += 1
+        pushUnique(metrics.authTypes, entry.auth?.type)
+        walk(entry.item)
+        continue
+      }
+
+      metrics.requestCount += 1
+      metrics.responseExampleCount += entry.response?.length ?? 0
+
+      const request: Request | undefined = entry.request
+      if (request && typeof request !== 'string') {
+        pushUnique(metrics.authTypes, request.auth?.type)
+        const body: RequestBody | null | undefined = request.body
+        pushUnique(metrics.bodyModes, body?.mode)
+      }
+    }
+  }
+
+  walk(collection.item)
+  return metrics
+}
+
+const collectOutputMetrics = (document: OpenAPIV3_1.Document): OutputMetrics => {
+  const metrics: OutputMetrics = {
+    pathCount: 0,
+    operationCount: 0,
+    serverCount: document.servers?.length ?? 0,
+    securitySchemes: Object.keys(document.components?.securitySchemes ?? {}),
+    operationsWithSecurity: 0,
+    componentsSchemaCount: Object.keys(document.components?.schemas ?? {}).length,
+    responseExampleCount: 0,
+    tagCount: document.tags?.length ?? 0,
+    operationIdCount: 0,
+  }
+
+  const methods: OpenAPIV3_1.HttpMethods[] = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']
+  const paths = document.paths ?? {}
+
+  for (const [, pathItem] of Object.entries(paths)) {
+    if (!pathItem) {
+      continue
+    }
+    metrics.pathCount += 1
+
+    for (const method of methods) {
+      const operation = pathItem[method]
+      if (!operation) {
+        continue
+      }
+      metrics.operationCount += 1
+      if (operation.operationId) {
+        metrics.operationIdCount += 1
+      }
+      if (operation.security?.length) {
+        metrics.operationsWithSecurity += 1
+      }
+
+      for (const response of Object.values(operation.responses ?? {})) {
+        const content = (response as OpenAPIV3_1.ResponseObject).content ?? {}
+        for (const media of Object.values(content)) {
+          const examples = (media as OpenAPIV3_1.MediaTypeObject).examples
+          if (examples) {
+            metrics.responseExampleCount += Object.keys(examples).length
+          } else if ((media as OpenAPIV3_1.MediaTypeObject).example !== undefined) {
+            metrics.responseExampleCount += 1
+          }
+        }
+      }
+    }
+  }
+
+  return metrics
+}
+
+const toConversionError = (error: unknown): ConversionError => {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message, stack: error.stack }
+  }
+  return { name: 'UnknownError', message: String(error) }
+}
+
+const runValidation = async (document: OpenAPIV3_1.Document): Promise<ValidationReport> => {
+  try {
+    const result = await validate(document)
+    return {
+      valid: result.valid,
+      errors: (result.errors ?? []).map((entry: ErrorObject) => ({
+        message: entry.message ?? 'Unknown error',
+        path: 'path' in entry && typeof entry.path === 'string' ? entry.path : undefined,
+      })),
+    }
+  } catch (error) {
+    return { valid: false, errors: [{ message: toConversionError(error).message }] }
+  }
+}
+
+const ensureDir = async (dir: string) => {
+  await fs.mkdir(dir, { recursive: true })
+}
+
+const listInputs = async (): Promise<string[]> => {
+  try {
+    const entries = await fs.readdir(INPUT_DIR)
+    return entries.filter((name) => name.toLowerCase().endsWith('.json')).sort()
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return []
+    }
+    throw error
+  }
+}
+
+const processFile = async (fileName: string): Promise<Result> => {
+  const inputPath = path.join(INPUT_DIR, fileName)
+  const raw = await fs.readFile(inputPath, 'utf8')
+
+  let collection: PostmanCollection
+  try {
+    collection = JSON.parse(raw) as PostmanCollection
+  } catch (error) {
+    return {
+      file: fileName,
+      status: 'error',
+      error: { ...toConversionError(error), name: 'InputJsonParseError' },
+      validation: null,
+      input: null,
+      output: null,
+      outputPath: null,
+    }
+  }
+
+  const input = collectInputMetrics(collection)
+
+  let document: OpenAPIV3_1.Document
+  try {
+    document = convert(collection)
+  } catch (error) {
+    return {
+      file: fileName,
+      status: 'error',
+      error: toConversionError(error),
+      validation: null,
+      input,
+      output: null,
+      outputPath: null,
+    }
+  }
+
+  const outputPath = path.join(OUTPUT_DIR, fileName)
+  await fs.writeFile(outputPath, `${JSON.stringify(document, null, 2)}\n`)
+
+  const validation = await runValidation(document)
+  const output = collectOutputMetrics(document)
+
+  return {
+    file: fileName,
+    status: 'success',
+    error: null,
+    validation,
+    input,
+    output,
+    outputPath: path.relative(PACKAGE_ROOT, outputPath),
+  }
+}
+
+const formatTable = (results: Result[]): string => {
+  const rows: string[][] = [['file', 'status', 'valid', 'reqs→ops', 'schemes', 'examples']]
+  for (const result of results) {
+    const reqs = result.input?.requestCount ?? '-'
+    const ops = result.output?.operationCount ?? '-'
+    const schemes = result.output?.securitySchemes.length ?? '-'
+    const examples = result.output?.responseExampleCount ?? '-'
+    rows.push([
+      result.file,
+      result.status,
+      result.validation ? (result.validation.valid ? 'yes' : 'no') : '-',
+      `${reqs}→${ops}`,
+      String(schemes),
+      String(examples),
+    ])
+  }
+
+  const widths = rows[0].map((_, column) => Math.max(...rows.map((row) => row[column].length)))
+  return rows.map((row) => row.map((cell, column) => cell.padEnd(widths[column])).join('  ')).join('\n')
+}
+
+const main = async () => {
+  const files = await listInputs()
+
+  if (files.length === 0) {
+    console.log(`No Postman collections found in ${path.relative(PACKAGE_ROOT, INPUT_DIR)}/`)
+    console.log('Drop one or more .json collections into that folder and re-run.')
+    return
+  }
+
+  await ensureDir(OUTPUT_DIR)
+  await ensureDir(REPORTS_DIR)
+  await ensureDir(IDEAS_DIR)
+
+  console.log(`Evaluating ${files.length} collection${files.length === 1 ? '' : 's'}...`)
+
+  const results: Result[] = []
+  for (const file of files) {
+    process.stdout.write(`  • ${file} ... `)
+    const result = await processFile(file)
+    results.push(result)
+    if (result.status === 'success') {
+      console.log(result.validation?.valid ? 'ok' : 'ok (invalid document)')
+    } else {
+      console.log(`failed (${result.error?.name})`)
+    }
+  }
+
+  const runAt = new Date().toISOString()
+  const report: RunReport = {
+    runAt,
+    inputDir: path.relative(PACKAGE_ROOT, INPUT_DIR),
+    outputDir: path.relative(PACKAGE_ROOT, OUTPUT_DIR),
+    totals: {
+      total: results.length,
+      converted: results.filter((r) => r.status === 'success').length,
+      validated: results.filter((r) => r.validation?.valid).length,
+      failed: results.filter((r) => r.status === 'error').length,
+    },
+    results,
+  }
+
+  const reportFileName = `run-${runAt.replace(/[:.]/g, '-')}.json`
+  const reportPath = path.join(REPORTS_DIR, reportFileName)
+  await fs.writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`)
+
+  console.log('')
+  console.log(formatTable(results))
+  console.log('')
+  console.log(`Report: ${path.relative(PACKAGE_ROOT, reportPath)}`)
+  console.log(`Outputs: ${path.relative(PACKAGE_ROOT, OUTPUT_DIR)}/`)
+}
+
+await main()

--- a/packages/postman-to-openapi/scripts/evaluate/run.ts
+++ b/packages/postman-to-openapi/scripts/evaluate/run.ts
@@ -175,6 +175,16 @@ const toConversionError = (error: unknown): ConversionError => {
   return { name: 'UnknownError', message: String(error) }
 }
 
+const formatErrorPath = (pathValue: ErrorObject['path'] | string | undefined): string | undefined => {
+  if (Array.isArray(pathValue)) {
+    return pathValue.join('.')
+  }
+  if (typeof pathValue === 'string') {
+    return pathValue
+  }
+  return undefined
+}
+
 const runValidation = async (document: OpenAPIV3_1.Document): Promise<ValidationReport> => {
   try {
     const result = await validate(document)
@@ -182,7 +192,7 @@ const runValidation = async (document: OpenAPIV3_1.Document): Promise<Validation
       valid: result.valid,
       errors: (result.errors ?? []).map((entry: ErrorObject) => ({
         message: entry.message ?? 'Unknown error',
-        path: 'path' in entry && typeof entry.path === 'string' ? entry.path : undefined,
+        path: formatErrorPath(entry.path),
       })),
     }
   } catch (error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2101,6 +2101,9 @@ importers:
         specifier: workspace:*
         version: link:../openapi-types
     devDependencies:
+      '@scalar/openapi-parser':
+        specifier: workspace:*
+        version: link:../openapi-parser
       '@types/node':
         specifier: ^24.1.0
         version: 24.10.13


### PR DESCRIPTION
I needed a way to evaluate the quality of the @scalar/postman-to-openapi output quickly, and I needed this a few times in the past already.

So I’ve added this evaluate script (or harness) where you can just drop a few files, they are converted, LLMs can analyze them quickly and generate ideas to improve the converter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new developer-only `evaluate` script and dev dependency; it doesn’t change runtime conversion logic, but it does introduce new tooling that reads/writes local fixture data and may need maintenance as types/APIs evolve.
> 
> **Overview**
> Adds a new `pnpm evaluate` harness in `packages/postman-to-openapi` that scans `fixtures/evaluate/input` for Postman collections, runs `convert()` per file (error-isolated), writes generated OpenAPI JSON outputs, and validates them via `@scalar/openapi-parser`.
> 
> The runner records input/output structural metrics and emits a timestamped machine-readable report plus a compact stdout summary table, alongside new documentation (`scripts/evaluate/README.md`, `RUBRIC.md`) describing a reviewer/agent loop and scoring rubric. Package wiring is updated with an `evaluate` script and a new dev dependency on `@scalar/openapi-parser`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49438cbc2b661e91d03dfbf64c5ecec7cb79fba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->