### PR TITLE
fix(postman-to-openapi): use status-aware response descriptions

### DIFF
--- a/.changeset/thin-zebras-smash.md
+++ b/.changeset/thin-zebras-smash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/postman-to-openapi': patch
+---
+
+fix postman-to-openapi response descriptions to use status-aware defaults and parse named examples

--- a/packages/postman-to-openapi/src/convert.test.ts
+++ b/packages/postman-to-openapi/src/convert.test.ts
@@ -6,6 +6,22 @@ import type { PostmanCollection } from './types'
 
 const BUCKET_NAME = 'scalar-test-fixtures'
 const BUCKET_URL = `https://storage.googleapis.com/${BUCKET_NAME}`
+const DEFAULT_RESPONSE_DESCRIPTIONS: Record<string, string> = {
+  200: 'OK',
+  201: 'Created',
+  202: 'Accepted',
+  204: 'No content',
+  301: 'Moved permanently',
+  400: 'Bad request',
+  401: 'Unauthorized',
+  403: 'Forbidden',
+  404: 'Not found',
+  409: 'Conflict',
+  422: 'Unprocessable entity',
+  500: 'Internal server error',
+  default: 'Default response',
+}
+const OPERATION_KEYS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const
 const FIXTURES = [
   'SimplePost',
   'NoVersion',
@@ -45,9 +61,40 @@ describe('fixtures', () => {
     const output = await fetch(`${BUCKET_URL}/packages/postman-to-openapi/output/${file}.json`)
     const openapi = await output.json()
 
-    expect(convert(postman)).toEqual(openapi)
+    const normalizedOpenApi = normalizeFixtureResponseDescriptions(openapi as OpenAPIV3_1.Document)
+    expect(convert(postman)).toEqual(normalizedOpenApi)
   })
 })
+
+function normalizeFixtureResponseDescriptions(document: OpenAPIV3_1.Document): OpenAPIV3_1.Document {
+  const normalizedDocument = structuredClone(document)
+
+  for (const pathItem of Object.values(normalizedDocument.paths ?? {})) {
+    if (!pathItem) {
+      continue
+    }
+
+    for (const key of OPERATION_KEYS) {
+      const operation = pathItem[key]
+      if (!operation) {
+        continue
+      }
+
+      for (const [statusCode, response] of Object.entries(operation.responses ?? {})) {
+        if (!response || '$ref' in response || response.description !== 'Successful response') {
+          continue
+        }
+
+        response.description =
+          DEFAULT_RESPONSE_DESCRIPTIONS[statusCode] ??
+          DEFAULT_RESPONSE_DESCRIPTIONS.default ??
+          'Default response'
+      }
+    }
+  }
+
+  return normalizedDocument
+}
 
 describe('convert', () => {
   it('merges into an existing OpenAPI document', () => {

--- a/packages/postman-to-openapi/src/convert.test.ts
+++ b/packages/postman-to-openapi/src/convert.test.ts
@@ -86,9 +86,7 @@ function normalizeFixtureResponseDescriptions(document: OpenAPIV3_1.Document): O
         }
 
         response.description =
-          DEFAULT_RESPONSE_DESCRIPTIONS[statusCode] ??
-          DEFAULT_RESPONSE_DESCRIPTIONS.default ??
-          'Default response'
+          DEFAULT_RESPONSE_DESCRIPTIONS[statusCode] ?? DEFAULT_RESPONSE_DESCRIPTIONS.default ?? 'Default response'
       }
     }
   }

--- a/packages/postman-to-openapi/src/helpers/responses.test.ts
+++ b/packages/postman-to-openapi/src/helpers/responses.test.ts
@@ -38,7 +38,63 @@ describe('responses', () => {
 
     const result = extractResponses(responses)
 
-    expect(result?.['200']?.description).toBe('Successful response')
+    expect(result?.['200']?.description).toBe('OK')
+  })
+
+  it('uses status-aware default description when status is missing for error responses', () => {
+    const responses: Response[] = [
+      {
+        code: 404,
+        body: '{"error": "Language not found"}',
+      },
+    ]
+
+    const result = extractResponses(responses)
+
+    expect(result?.['404']?.description).toBe('Not found')
+  })
+
+  it('uses default fallback description for unknown status codes', () => {
+    const responses: Response[] = [
+      {
+        code: 418,
+        body: '{"message": "I am a teapot"}',
+      },
+    ]
+
+    const result = extractResponses(responses)
+
+    expect(result?.['418']?.description).toBe('Default response')
+  })
+
+  it('prefers response name description when using "<code> - <description>" format', () => {
+    const responses: Response[] = [
+      {
+        name: '404 - Language not found',
+        code: 404,
+        status: 'Not Found',
+        body: '{"error": "Language not found"}',
+      },
+    ]
+
+    const result = extractResponses(responses)
+
+    expect(result?.['404']?.description).toBe('Language not found')
+  })
+
+  it('does not use response name description when code does not match', () => {
+    const responses: Response[] = [
+      {
+        name: '404 - Language not found',
+        code: 401,
+        status: 'Unauthorized',
+        body: '{"error": "Unauthorized"}',
+      },
+    ]
+
+    const result = extractResponses(responses)
+
+    expect(result?.['401']?.description).toBe('Unauthorized')
   })
 
   it('infers schema from JSON body', () => {
@@ -172,7 +228,7 @@ describe('responses', () => {
     const result = extractResponses(responses, item)
 
     expect(result?.['201']).toBeDefined()
-    expect(result?.['201']?.description).toBe('Successful response')
+    expect(result?.['201']?.description).toBe('Created')
   })
 
   it('does not override existing response when adding from tests', () => {

--- a/packages/postman-to-openapi/src/helpers/responses.ts
+++ b/packages/postman-to-openapi/src/helpers/responses.ts
@@ -103,7 +103,7 @@ function extractDescriptionFromName(name: string | undefined, statusCode: string
 }
 
 function getDefaultResponseDescription(statusCode: string): string {
-  return DEFAULT_RESPONSE_DESCRIPTIONS[statusCode] || DEFAULT_RESPONSE_DESCRIPTIONS.default
+  return DEFAULT_RESPONSE_DESCRIPTIONS[statusCode] ?? DEFAULT_RESPONSE_DESCRIPTIONS.default ?? 'Default response'
 }
 
 function extractHeaders(

--- a/packages/postman-to-openapi/src/helpers/responses.ts
+++ b/packages/postman-to-openapi/src/helpers/responses.ts
@@ -21,8 +21,6 @@ const DEFAULT_RESPONSE_DESCRIPTIONS: Record<string, string> = {
   default: 'Default response',
 }
 
-const STATUS_DESCRIPTION_PATTERN = /^(\d{3})\s*-\s*(.+)$/
-
 /**
  * Extracts and converts Postman response objects to OpenAPI response objects.
  * Processes response status codes, descriptions, headers, and body content,
@@ -88,14 +86,19 @@ function extractDescriptionFromName(name: string | undefined, statusCode: string
     return undefined
   }
 
-  const match = STATUS_DESCRIPTION_PATTERN.exec(name.trim())
-  if (!match) {
+  const trimmedName = name.trim()
+  const separatorIndex = trimmedName.indexOf('-')
+  if (separatorIndex < 0) {
     return undefined
   }
 
-  const code = match.at(1)
-  const description = match.at(2)?.trim()
-  if (code !== statusCode || !description) {
+  const code = trimmedName.slice(0, separatorIndex).trim()
+  if (!isThreeDigitStatusCode(code) || code !== statusCode) {
+    return undefined
+  }
+
+  const description = trimmedName.slice(separatorIndex + 1).trim()
+  if (!description) {
     return undefined
   }
 
@@ -104,6 +107,20 @@ function extractDescriptionFromName(name: string | undefined, statusCode: string
 
 function getDefaultResponseDescription(statusCode: string): string {
   return DEFAULT_RESPONSE_DESCRIPTIONS[statusCode] ?? DEFAULT_RESPONSE_DESCRIPTIONS.default ?? 'Default response'
+}
+
+function isThreeDigitStatusCode(value: string): boolean {
+  if (value.length !== 3) {
+    return false
+  }
+
+  for (const character of value) {
+    if (character < '0' || character > '9') {
+      return false
+    }
+  }
+
+  return true
 }
 
 function extractHeaders(

--- a/packages/postman-to-openapi/src/helpers/responses.ts
+++ b/packages/postman-to-openapi/src/helpers/responses.ts
@@ -5,6 +5,24 @@ import type { HeaderList, Item, Response } from '@/types'
 import { inferSchemaFromExample } from './schemas'
 import { extractStatusCodesFromTests } from './status-codes'
 
+const DEFAULT_RESPONSE_DESCRIPTIONS: Record<string, string> = {
+  200: 'OK',
+  201: 'Created',
+  202: 'Accepted',
+  204: 'No content',
+  301: 'Moved permanently',
+  400: 'Bad request',
+  401: 'Unauthorized',
+  403: 'Forbidden',
+  404: 'Not found',
+  409: 'Conflict',
+  422: 'Unprocessable entity',
+  500: 'Internal server error',
+  default: 'Default response',
+}
+
+const STATUS_DESCRIPTION_PATTERN = /^(\d{3})\s*-\s*(.+)$/
+
 /**
  * Extracts and converts Postman response objects to OpenAPI response objects.
  * Processes response status codes, descriptions, headers, and body content,
@@ -18,7 +36,7 @@ export function extractResponses(responses: Response[], item?: Item): OpenAPIV3_
   const responseMap = responses.reduce((acc, response) => {
     const statusCode = response.code?.toString() || 'default'
     acc[statusCode] = {
-      description: response.status || 'Successful response',
+      description: getResponseDescription(response, statusCode),
       headers: extractHeaders(response.header),
       content: {
         'application/json': {
@@ -37,7 +55,7 @@ export function extractResponses(responses: Response[], item?: Item): OpenAPIV3_
     const codeStr = code.toString()
     if (!responseMap[codeStr]) {
       responseMap[codeStr] = {
-        description: 'Successful response',
+        description: getDefaultResponseDescription(codeStr),
         content: {
           'application/json': {},
         },
@@ -50,6 +68,42 @@ export function extractResponses(responses: Response[], item?: Item): OpenAPIV3_
   }
 
   return responseMap
+}
+
+function getResponseDescription(response: Response, statusCode: string): string {
+  const descriptionFromName = extractDescriptionFromName(response.name, statusCode)
+  if (descriptionFromName) {
+    return descriptionFromName
+  }
+
+  if (response.status) {
+    return response.status
+  }
+
+  return getDefaultResponseDescription(statusCode)
+}
+
+function extractDescriptionFromName(name: string | undefined, statusCode: string): string | undefined {
+  if (!name) {
+    return undefined
+  }
+
+  const match = STATUS_DESCRIPTION_PATTERN.exec(name.trim())
+  if (!match) {
+    return undefined
+  }
+
+  const code = match.at(1)
+  const description = match.at(2)?.trim()
+  if (code !== statusCode || !description) {
+    return undefined
+  }
+
+  return description
+}
+
+function getDefaultResponseDescription(statusCode: string): string {
+  return DEFAULT_RESPONSE_DESCRIPTIONS[statusCode] || DEFAULT_RESPONSE_DESCRIPTIONS.default
 }
 
 function extractHeaders(

--- a/packages/postman-to-openapi/src/types.ts
+++ b/packages/postman-to-openapi/src/types.ts
@@ -204,6 +204,7 @@ export type FormParameter =
 
 export type Response = {
   id?: string
+  name?: string
   originalRequest?: Request
   responseTime?: string | number | null
   timings?: object | null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Postman-to-OpenAPI response descriptions were always emitted as `Successful response` when no explicit `status` field was present, which produced misleading output for non-2xx status codes like 401/404/409.

## Solution

- Added a status-aware default description map in `responses.ts` (e.g. `401 -> Unauthorized`, `404 -> Not found`, `204 -> No content`, with `default -> Default response`).
- Replaced hardcoded fallback strings with helper-based defaults for both regular responses and status codes inferred from Postman test scripts.
- Added support for response names in the format `"<code> - <description>"` and prefer that parsed description when the code matches the response status (e.g. `"404 - Language not found" -> "Language not found"`).
- Extended `Response` type with optional `name` to support this parsing.
- Added/updated unit tests in `responses.test.ts` for status-aware fallbacks, unknown code fallback, name-based description precedence, and mismatched code behavior.
- Added a changeset for `@scalar/postman-to-openapi` patch bump.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe043566-6137-4911-ba23-e1471a49efb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe043566-6137-4911-ba23-e1471a49efb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

