### PR TITLE
fix(postman-to-openapi): unify equivalent path parameter variants

### DIFF
--- a/.changeset/real-apples-wave.md
+++ b/.changeset/real-apples-wave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/postman-to-openapi': patch
+---
+
+merge structurally equivalent paths that only differ by path parameter names and align path parameter definitions with the canonical path

--- a/packages/postman-to-openapi/src/convert.test.ts
+++ b/packages/postman-to-openapi/src/convert.test.ts
@@ -648,6 +648,7 @@ describe('convert', () => {
               request: {
                 method: 'GET',
                 url: 'https://api.scalar.com/applications/{{applicationId}}',
+                description: '| object | name | required |\n| --- | --- | --- |\n| path | applicationId | true |',
               },
             },
             {
@@ -655,6 +656,7 @@ describe('convert', () => {
               request: {
                 method: 'DELETE',
                 url: 'https://api.scalar.com/applications/{{fakeAppId}}',
+                description: '| object | name | required |\n| --- | --- | --- |\n| path | fakeAppId | true |',
               },
             },
           ],

--- a/packages/postman-to-openapi/src/convert.test.ts
+++ b/packages/postman-to-openapi/src/convert.test.ts
@@ -686,4 +686,50 @@ describe('convert', () => {
       },
     ])
   })
+
+  it('keeps server placement correct after path unification', () => {
+    const collection: PostmanCollection = {
+      info: {
+        name: 'Server placement with unified paths',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+      },
+      item: [
+        {
+          name: 'Get application by first variable',
+          request: {
+            method: 'GET',
+            url: 'https://api.example.com/applications/{{applicationId}}',
+          },
+        },
+        {
+          name: 'Get application by second variable',
+          request: {
+            method: 'GET',
+            url: 'https://api.example.com/applications/{{fakeAppId}}',
+          },
+        },
+        {
+          name: 'Get users from another server',
+          request: {
+            method: 'GET',
+            url: 'https://api.other.com/users',
+          },
+        },
+      ],
+    }
+
+    const result = convert(collection)
+
+    expect(result.servers).toBeUndefined()
+    expect(result.paths?.['/applications/{applicationId}']?.get?.servers).toEqual([
+      {
+        url: 'https://api.example.com',
+      },
+    ])
+    expect(result.paths?.['/users']?.get?.servers).toEqual([
+      {
+        url: 'https://api.other.com',
+      },
+    ])
+  })
 })

--- a/packages/postman-to-openapi/src/convert.test.ts
+++ b/packages/postman-to-openapi/src/convert.test.ts
@@ -583,4 +583,105 @@ describe('convert', () => {
       },
     ])
   })
+
+  it('unifies structurally equal paths using the most common path parameter name', () => {
+    const collection: PostmanCollection = {
+      info: {
+        name: 'Path canonicalization',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+      },
+      item: [
+        {
+          name: 'Get application',
+          request: {
+            method: 'GET',
+            url: 'https://api.scalar.com/applications/{{applicationId}}',
+          },
+        },
+        {
+          name: 'Delete application',
+          request: {
+            method: 'DELETE',
+            url: 'https://api.scalar.com/applications/{{applicationId2}}',
+          },
+        },
+        {
+          name: 'Error case with fake id',
+          request: {
+            method: 'GET',
+            url: 'https://api.scalar.com/applications/{{fakeAppId}}',
+            description: '| object | name | required |\n| --- | --- | --- |\n| path | fakeAppId | true |',
+          },
+        },
+      ],
+    }
+
+    const result = convert(collection, { mergeOperation: true })
+    const pathKeys = Object.keys(result.paths ?? {})
+    expect(pathKeys).toEqual(['/applications/{applicationId}'])
+
+    const mergedPath = result.paths?.['/applications/{applicationId}']
+    expect(mergedPath?.get).toBeDefined()
+    expect(mergedPath?.delete).toBeDefined()
+    expect(mergedPath?.get?.parameters).toEqual([
+      {
+        name: 'applicationId',
+        in: 'path',
+        required: true,
+        schema: { type: 'string' },
+      },
+    ])
+  })
+
+  it('prefers folder path-template hints when choosing canonical path parameter names', () => {
+    const collection: PostmanCollection = {
+      info: {
+        name: 'Folder hint canonicalization',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+      },
+      item: [
+        {
+          name: '/applications/{id}',
+          item: [
+            {
+              name: 'Get application by alias',
+              request: {
+                method: 'GET',
+                url: 'https://api.scalar.com/applications/{{applicationId}}',
+              },
+            },
+            {
+              name: 'Delete application by fake id',
+              request: {
+                method: 'DELETE',
+                url: 'https://api.scalar.com/applications/{{fakeAppId}}',
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    const result = convert(collection)
+    const pathKeys = Object.keys(result.paths ?? {})
+    expect(pathKeys).toEqual(['/applications/{id}'])
+
+    const mergedPath = result.paths?.['/applications/{id}']
+    expect(mergedPath?.get?.parameters).toEqual([
+      {
+        name: 'id',
+        in: 'path',
+        required: true,
+        schema: { type: 'string' },
+      },
+    ])
+    expect(mergedPath?.delete?.parameters).toEqual([
+      {
+        name: 'id',
+        in: 'path',
+        required: true,
+        schema: { type: 'string' },
+      },
+    ])
+  })
 })

--- a/packages/postman-to-openapi/src/convert.ts
+++ b/packages/postman-to-openapi/src/convert.ts
@@ -468,7 +468,7 @@ const findFolderTemplateHint = (
       }
 
       for (const tag of operation.tags ?? []) {
-        const folderNames = tag.split(' > ').map((segment) => segment.trim())
+        const folderNames = tag.split(' > ').map((segment: string) => segment.trim())
 
         for (const folderName of folderNames) {
           if (!folderName.startsWith('/')) {
@@ -492,7 +492,12 @@ const findFolderTemplateHint = (
   return undefined
 }
 
-const unifyEquivalentPathParameters = (paths: OpenAPIV3_1.PathsObject): OpenAPIV3_1.PathsObject => {
+type PathUnificationResult = {
+  paths: OpenAPIV3_1.PathsObject
+  canonicalPathByPath: Map<string, string>
+}
+
+const unifyEquivalentPathParameters = (paths: OpenAPIV3_1.PathsObject): PathUnificationResult => {
   const pathEntries = Object.entries(paths).filter((entry): entry is [string, OpenAPIV3_1.PathItemObject] =>
     Boolean(entry[1]),
   )
@@ -515,6 +520,7 @@ const unifyEquivalentPathParameters = (paths: OpenAPIV3_1.PathsObject): OpenAPIV
   })
 
   const unifiedPaths: OpenAPIV3_1.PathsObject = {}
+  const canonicalPathByPath = new Map<string, string>()
   const processedPathKeys = new Set<string>()
 
   pathEntries.forEach(([pathKey]) => {
@@ -529,6 +535,7 @@ const unifyEquivalentPathParameters = (paths: OpenAPIV3_1.PathsObject): OpenAPIV
       const pathItem = paths[pathKey]
       if (pathItem) {
         unifiedPaths[pathKey] = pathItem
+        canonicalPathByPath.set(pathKey, pathKey)
       }
       processedPathKeys.add(pathKey)
       return
@@ -555,11 +562,12 @@ const unifyEquivalentPathParameters = (paths: OpenAPIV3_1.PathsObject): OpenAPIV
     group.forEach(({ pathKey: groupedPathKey, pathItem, parameterNames }) => {
       const normalizedPathItem = renamePathItemParameterNames(pathItem, parameterNames, canonicalParameterNames)
       mergePathItem(unifiedPaths, canonicalPath, normalizedPathItem, true)
+      canonicalPathByPath.set(groupedPathKey, canonicalPath)
       processedPathKeys.add(groupedPathKey)
     })
   })
 
-  return unifiedPaths
+  return { paths: unifiedPaths, canonicalPathByPath }
 }
 
 export type ConvertOptions = {
@@ -722,9 +730,20 @@ export function convert(
   }
 
   // Extract all unique paths from the document
+  let canonicalPathByPath = new Map<string, string>()
   if (openapi.paths) {
-    openapi.paths = unifyEquivalentPathParameters(openapi.paths)
+    const unificationResult = unifyEquivalentPathParameters(openapi.paths)
+    openapi.paths = unificationResult.paths
+    canonicalPathByPath = unificationResult.canonicalPathByPath
   }
+
+  const normalizedServerUsage = allServerUsage.map((usage) => {
+    const normalizedUsagePath = normalizePath(usage.path)
+    return {
+      ...usage,
+      path: canonicalPathByPath.get(normalizedUsagePath) ?? normalizedUsagePath,
+    }
+  })
 
   // Extract all unique paths from the document
   const allUniquePaths = new Set<string>()
@@ -735,7 +754,7 @@ export function convert(
   }
 
   // Analyze server distribution and place servers at appropriate levels
-  const serverPlacement = analyzeServerDistribution(allServerUsage, allUniquePaths)
+  const serverPlacement = analyzeServerDistribution(normalizedServerUsage, allUniquePaths)
 
   // Add servers to document level
   if (serverPlacement.document.length > 0) {

--- a/packages/postman-to-openapi/src/convert.ts
+++ b/packages/postman-to-openapi/src/convert.ts
@@ -358,14 +358,13 @@ const chooseMostCommonName = (names: string[]): string | undefined => {
     }
   })
 
-  return [...counts.entries()]
-    .sort((a, b) => {
-      if (a[1] !== b[1]) {
-        return b[1] - a[1]
-      }
+  return [...counts.entries()].sort((a, b) => {
+    if (a[1] !== b[1]) {
+      return b[1] - a[1]
+    }
 
-      return (firstIndex.get(a[0]) ?? Number.POSITIVE_INFINITY) - (firstIndex.get(b[0]) ?? Number.POSITIVE_INFINITY)
-    })[0]?.[0]
+    return (firstIndex.get(a[0]) ?? Number.POSITIVE_INFINITY) - (firstIndex.get(b[0]) ?? Number.POSITIVE_INFINITY)
+  })[0]?.[0]
 }
 
 const renameParameters = (
@@ -385,7 +384,8 @@ const renameParameters = (
     }
 
     const nextName = parameter.in === 'path' ? (renameMap.get(parameter.name) ?? parameter.name) : parameter.name
-    const renamedParameter: OpenAPIV3_1.ParameterObject = nextName === parameter.name ? parameter : { ...parameter, name: nextName }
+    const renamedParameter: OpenAPIV3_1.ParameterObject =
+      nextName === parameter.name ? parameter : { ...parameter, name: nextName }
     const parameterKey = `${renamedParameter.name}/${renamedParameter.in}`
     const existingParameter = mergedParameters.get(parameterKey)
 
@@ -493,8 +493,13 @@ const findFolderTemplateHint = (
 }
 
 const unifyEquivalentPathParameters = (paths: OpenAPIV3_1.PathsObject): OpenAPIV3_1.PathsObject => {
-  const pathEntries = Object.entries(paths).filter((entry): entry is [string, OpenAPIV3_1.PathItemObject] => Boolean(entry[1]))
-  const groups = new Map<string, Array<{ pathKey: string; pathItem: OpenAPIV3_1.PathItemObject; parameterNames: string[] }>>()
+  const pathEntries = Object.entries(paths).filter((entry): entry is [string, OpenAPIV3_1.PathItemObject] =>
+    Boolean(entry[1]),
+  )
+  const groups = new Map<
+    string,
+    Array<{ pathKey: string; pathItem: OpenAPIV3_1.PathItemObject; parameterNames: string[] }>
+  >()
 
   pathEntries.forEach(([pathKey, pathItem]) => {
     const signature = getPathStructuralSignature(pathKey)

--- a/packages/postman-to-openapi/src/convert.ts
+++ b/packages/postman-to-openapi/src/convert.ts
@@ -9,7 +9,7 @@ import { DEFAULT_EXAMPLE_NAME, OPERATION_KEYS, mergePathItem } from '@/helpers/m
 import { processItem } from '@/helpers/path-items'
 import { pruneDocument } from '@/helpers/prune-document'
 import { analyzeServerDistribution } from '@/helpers/servers'
-import { normalizePath } from '@/helpers/urls'
+import { getPathStructuralSignature, normalizePath } from '@/helpers/urls'
 
 import type { Description, Item, ItemGroup, PostmanCollection } from './types'
 
@@ -317,6 +317,246 @@ const cleanupOperations = (paths: OpenAPIV3_1.PathsObject): void => {
   })
 }
 
+const getOrderedPathParameterNames = (path: string): string[] =>
+  normalizePath(path)
+    .split('/')
+    .flatMap((segment) => {
+      const match = segment.match(/^\{([^{}]+)\}$/)
+      return match?.[1] ? [match[1]] : []
+    })
+
+const rewritePathParameterNames = (path: string, parameterNames: string[]): string => {
+  const segments = normalizePath(path).split('/')
+  let parameterIndex = 0
+
+  const rewrittenSegments = segments.map((segment) => {
+    if (!/^\{[^{}]+\}$/.test(segment)) {
+      return segment
+    }
+
+    const canonicalName = parameterNames[parameterIndex]
+    parameterIndex += 1
+
+    return canonicalName ? `{${canonicalName}}` : segment
+  })
+
+  return rewrittenSegments.join('/')
+}
+
+const chooseMostCommonName = (names: string[]): string | undefined => {
+  if (names.length === 0) {
+    return undefined
+  }
+
+  const counts = new Map<string, number>()
+  const firstIndex = new Map<string, number>()
+
+  names.forEach((name, index) => {
+    counts.set(name, (counts.get(name) ?? 0) + 1)
+    if (!firstIndex.has(name)) {
+      firstIndex.set(name, index)
+    }
+  })
+
+  return [...counts.entries()]
+    .sort((a, b) => {
+      if (a[1] !== b[1]) {
+        return b[1] - a[1]
+      }
+
+      return (firstIndex.get(a[0]) ?? Number.POSITIVE_INFINITY) - (firstIndex.get(b[0]) ?? Number.POSITIVE_INFINITY)
+    })[0]?.[0]
+}
+
+const renameParameters = (
+  parameters: OpenAPIV3_1.ParameterObject[] | OpenAPIV3_1.ReferenceObject[] | undefined,
+  renameMap: Map<string, string>,
+): OpenAPIV3_1.PathItemObject['parameters'] => {
+  if (!parameters || renameMap.size === 0) {
+    return parameters
+  }
+
+  const mergedParameters = new Map<string, OpenAPIV3_1.ParameterObject | OpenAPIV3_1.ReferenceObject>()
+
+  parameters.forEach((parameter, index) => {
+    if (!parameter || '$ref' in parameter) {
+      mergedParameters.set(`$ref/${index}`, parameter)
+      return
+    }
+
+    const nextName = parameter.in === 'path' ? (renameMap.get(parameter.name) ?? parameter.name) : parameter.name
+    const renamedParameter: OpenAPIV3_1.ParameterObject = nextName === parameter.name ? parameter : { ...parameter, name: nextName }
+    const parameterKey = `${renamedParameter.name}/${renamedParameter.in}`
+    const existingParameter = mergedParameters.get(parameterKey)
+
+    if (!existingParameter || '$ref' in existingParameter || '$ref' in renamedParameter) {
+      mergedParameters.set(parameterKey, renamedParameter)
+      return
+    }
+
+    mergedParameters.set(parameterKey, {
+      ...existingParameter,
+      ...renamedParameter,
+      examples: {
+        ...(existingParameter.examples ?? {}),
+        ...(renamedParameter.examples ?? {}),
+      },
+    })
+  })
+
+  return [...mergedParameters.values()] as OpenAPIV3_1.PathItemObject['parameters']
+}
+
+const renamePathParametersForOperation = (
+  operation: OpenAPIV3_1.OperationObject,
+  renameMap: Map<string, string>,
+): OpenAPIV3_1.OperationObject => {
+  if (!operation.parameters || renameMap.size === 0) {
+    return operation
+  }
+
+  return {
+    ...operation,
+    parameters: renameParameters(operation.parameters, renameMap) as OpenAPIV3_1.OperationObject['parameters'],
+  }
+}
+
+const renamePathItemParameterNames = (
+  pathItem: OpenAPIV3_1.PathItemObject,
+  sourceNames: string[],
+  targetNames: string[],
+): OpenAPIV3_1.PathItemObject => {
+  const renameMap = new Map<string, string>()
+
+  sourceNames.forEach((sourceName, index) => {
+    const targetName = targetNames[index]
+    if (sourceName && targetName && sourceName !== targetName) {
+      renameMap.set(sourceName, targetName)
+    }
+  })
+
+  if (renameMap.size === 0) {
+    return pathItem
+  }
+
+  const renamedPathItem: OpenAPIV3_1.PathItemObject = {
+    ...pathItem,
+    parameters: renameParameters(pathItem.parameters, renameMap),
+  }
+
+  OPERATION_KEYS.forEach((operationKey) => {
+    const operation = pathItem[operationKey]
+    if (!operation) {
+      return
+    }
+
+    renamedPathItem[operationKey] = renamePathParametersForOperation(operation, renameMap)
+  })
+
+  return renamedPathItem
+}
+
+const findFolderTemplateHint = (
+  pathItemGroup: { pathItem: OpenAPIV3_1.PathItemObject; parameterNames: string[] }[],
+  signature: string,
+): string[] | undefined => {
+  for (const { pathItem, parameterNames } of pathItemGroup) {
+    for (const operationKey of OPERATION_KEYS) {
+      const operation = pathItem[operationKey]
+      if (!operation) {
+        continue
+      }
+
+      for (const tag of operation.tags ?? []) {
+        const folderNames = tag.split(' > ').map((segment) => segment.trim())
+
+        for (const folderName of folderNames) {
+          if (!folderName.startsWith('/')) {
+            continue
+          }
+
+          const normalizedFolderName = normalizePath(folderName)
+          if (getPathStructuralSignature(normalizedFolderName) !== signature) {
+            continue
+          }
+
+          const folderParameterNames = getOrderedPathParameterNames(normalizedFolderName)
+          if (folderParameterNames.length === parameterNames.length) {
+            return folderParameterNames
+          }
+        }
+      }
+    }
+  }
+
+  return undefined
+}
+
+const unifyEquivalentPathParameters = (paths: OpenAPIV3_1.PathsObject): OpenAPIV3_1.PathsObject => {
+  const pathEntries = Object.entries(paths).filter((entry): entry is [string, OpenAPIV3_1.PathItemObject] => Boolean(entry[1]))
+  const groups = new Map<string, Array<{ pathKey: string; pathItem: OpenAPIV3_1.PathItemObject; parameterNames: string[] }>>()
+
+  pathEntries.forEach(([pathKey, pathItem]) => {
+    const signature = getPathStructuralSignature(pathKey)
+    if (!groups.has(signature)) {
+      groups.set(signature, [])
+    }
+
+    groups.get(signature)?.push({
+      pathKey,
+      pathItem,
+      parameterNames: getOrderedPathParameterNames(pathKey),
+    })
+  })
+
+  const unifiedPaths: OpenAPIV3_1.PathsObject = {}
+  const processedPathKeys = new Set<string>()
+
+  pathEntries.forEach(([pathKey]) => {
+    if (processedPathKeys.has(pathKey)) {
+      return
+    }
+
+    const signature = getPathStructuralSignature(pathKey)
+    const group = groups.get(signature) ?? []
+
+    if (group.length < 2) {
+      const pathItem = paths[pathKey]
+      if (pathItem) {
+        unifiedPaths[pathKey] = pathItem
+      }
+      processedPathKeys.add(pathKey)
+      return
+    }
+
+    const firstGroupEntry = group[0]
+    if (!firstGroupEntry || firstGroupEntry.pathKey !== pathKey) {
+      return
+    }
+
+    const parameterCount = firstGroupEntry.parameterNames.length
+    const folderTemplateHint = findFolderTemplateHint(group, signature)
+    const canonicalParameterNames =
+      folderTemplateHint ??
+      Array.from({ length: parameterCount }, (_, parameterIndex) => {
+        const namesInOrder = group
+          .map((entry) => entry.parameterNames[parameterIndex])
+          .filter((name): name is string => Boolean(name))
+
+        return chooseMostCommonName(namesInOrder) ?? namesInOrder[0] ?? ''
+      })
+
+    const canonicalPath = rewritePathParameterNames(firstGroupEntry.pathKey, canonicalParameterNames)
+    group.forEach(({ pathKey: groupedPathKey, pathItem, parameterNames }) => {
+      const normalizedPathItem = renamePathItemParameterNames(pathItem, parameterNames, canonicalParameterNames)
+      mergePathItem(unifiedPaths, canonicalPath, normalizedPathItem, true)
+      processedPathKeys.add(groupedPathKey)
+    })
+  })
+
+  return unifiedPaths
+}
+
 export type ConvertOptions = {
   /**
    * Whether to merge operations with the same path and method.
@@ -474,6 +714,11 @@ export function convert(
         }
       })
     }
+  }
+
+  // Extract all unique paths from the document
+  if (openapi.paths) {
+    openapi.paths = unifyEquivalentPathParameters(openapi.paths)
   }
 
   // Extract all unique paths from the document

--- a/packages/postman-to-openapi/src/helpers/urls.test.ts
+++ b/packages/postman-to-openapi/src/helpers/urls.test.ts
@@ -4,6 +4,7 @@ import {
   extractPathFromUrl,
   extractPathParameterNames,
   extractServerFromUrl,
+  getPathStructuralSignature,
   getDomainFromUrl,
   normalizePath,
 } from './urls'
@@ -33,6 +34,17 @@ describe('urls', () => {
 
   it('converts colon parameters to curly braces', () => {
     expect(normalizePath('/users/:userId/posts/:postId')).toBe('/users/{userId}/posts/{postId}')
+  })
+
+  it('generates matching structural signatures for paths that differ by parameter names', () => {
+    expect(getPathStructuralSignature('/applications/{applicationId}')).toBe('/applications/{*}')
+    expect(getPathStructuralSignature('/applications/{fakeAppId}')).toBe('/applications/{*}')
+    expect(getPathStructuralSignature('/applications/:id')).toBe('/applications/{*}')
+  })
+
+  it('keeps literal segments in structural signatures', () => {
+    expect(getPathStructuralSignature('/applications/{id}/logs/{logId}')).toBe('/applications/{*}/logs/{*}')
+    expect(getPathStructuralSignature('/applications/active')).toBe('/applications/active')
   })
 
   it('extracts double curly brace parameters', () => {

--- a/packages/postman-to-openapi/src/helpers/urls.ts
+++ b/packages/postman-to-openapi/src/helpers/urls.ts
@@ -46,6 +46,23 @@ export function extractPathFromUrl(url: string | undefined): string {
 export const normalizePath = (path: string): string => path.replace(/:(\w+)/g, '{$1}')
 
 /**
+ * Generates a structural path signature by replacing parameter segments with `{*}`.
+ * Paths with the same signature are equivalent except for parameter names.
+ */
+export const getPathStructuralSignature = (path: string): string => {
+  const normalizedPath = normalizePath(path)
+
+  if (normalizedPath === '') {
+    return ''
+  }
+
+  const segments = normalizedPath.split('/')
+  const signatureSegments = segments.map((segment) => (/^\{[^{}]+\}$/.test(segment) ? '{*}' : segment))
+
+  return signatureSegments.join('/')
+}
+
+/**
  * Extracts parameter names from a path string.
  * Handles double curly braces {{param}}, single curly braces {param}, and colon format :param.
  */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When the same endpoint appears in a Postman collection with different path-variable names (for example `{{applicationId}}`, `{{applicationId2}}`, and `{{fakeAppId}}`), the converter emitted separate OpenAPI paths even though the routes are structurally identical. This splits one endpoint into multiple paths and can break downstream tooling.

## Solution

- added a structural path signature helper that normalizes path-parameter segments to `{*}` for grouping
- added a post-processing pass in `convert.ts` (after item walk and before operation cleanup) that:
  - groups paths by structural signature
  - chooses canonical path-parameter names using folder template hints first (`/path/{name}` folder names), then most-common name, then first-seen name
  - rewrites and merges equivalent path items into one canonical path while preserving operation variants via existing merge logic
  - updates path-level and operation-level `in: path` parameter names to match the canonical path
- remapped collected `serverUsage` paths to canonical unified paths before server placement analysis, preventing stale pre-unification paths from misplacing or dropping server entries
- added focused tests for structural signature generation and converter behavior (most-common canonicalization + folder-hint canonicalization + server placement regression)
- added a changeset for `@scalar/postman-to-openapi`

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c48d9c63-6f2d-40ec-afee-6e4a244f5b17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c48d9c63-6f2d-40ec-afee-6e4a244f5b17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

