### PR TITLE
fix(postman-to-openapi): resolve Postman templates in server urls

### DIFF
--- a/.changeset/orange-toys-pretend.md
+++ b/.changeset/orange-toys-pretend.md
@@ -1,0 +1,5 @@
+---
+'@scalar/postman-to-openapi': patch
+---
+
+resolve Postman `{{variables}}` in server URLs by substituting collection variable values and emitting OpenAPI server variables when values are unresolved or recursive

--- a/packages/postman-to-openapi/src/convert.test.ts
+++ b/packages/postman-to-openapi/src/convert.test.ts
@@ -949,4 +949,129 @@ describe('convert', () => {
       },
     ])
   })
+
+  it('resolves Postman variables in server URLs from collection variables', () => {
+    const collection: PostmanCollection = {
+      info: {
+        name: 'Variable servers',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+      },
+      variable: [
+        { key: 'url-languagesAPI', value: 'localhost:3005' },
+        { key: 'url-applicationAPI', value: 'https://application.example.com' },
+      ],
+      item: [
+        {
+          name: 'Languages',
+          request: {
+            method: 'GET',
+            url: {
+              raw: 'https://{{url-languagesAPI}}/languages',
+            },
+          },
+        },
+        {
+          name: 'Language by ID',
+          request: {
+            method: 'GET',
+            url: {
+              raw: 'https://{{url-languagesAPI}}/languages/{{languageId}}',
+            },
+          },
+        },
+        {
+          name: 'Application',
+          request: {
+            method: 'GET',
+            url: {
+              raw: 'https://{{url-applicationAPI}}/applications',
+            },
+          },
+        },
+      ],
+    }
+
+    const result = convert(collection)
+
+    expect(result.servers).toEqual([
+      {
+        url: 'https://localhost:3005',
+      },
+    ])
+    expect(result.paths?.['/applications']?.get?.servers).toEqual([
+      {
+        url: 'https://application.example.com',
+      },
+    ])
+  })
+
+  it('emits unresolved Postman server templates as OpenAPI server variables', () => {
+    const collection: PostmanCollection = {
+      info: {
+        name: 'Unresolved variable servers',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+      },
+      variable: [{ key: 'url-local', value: 'localhost:3005' }],
+      item: [
+        {
+          name: 'Notifications',
+          request: {
+            method: 'GET',
+            url: {
+              raw: 'https://{{url-notificationAPI}}/notifications',
+            },
+          },
+        },
+      ],
+    }
+
+    const result = convert(collection)
+
+    expect(result.servers).toEqual([
+      {
+        url: 'https://{url-notificationAPI}',
+        variables: {
+          'url-notificationAPI': {
+            default: 'example.com',
+            description: 'Declared in Postman collection variables.',
+          },
+        },
+      },
+    ])
+  })
+
+  it('falls back to OpenAPI server variables for recursive Postman values', () => {
+    const collection: PostmanCollection = {
+      info: {
+        name: 'Recursive variable servers',
+        schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+      },
+      variable: [{ key: 'url-exampleAPI', value: '{{url-local}}' }],
+      item: [
+        {
+          name: 'Recursive',
+          request: {
+            method: 'GET',
+            url: {
+              raw: 'https://{{url-exampleAPI}}/status',
+            },
+          },
+        },
+      ],
+    }
+
+    const result = convert(collection)
+
+    expect(result.servers).toEqual([
+      {
+        url: 'https://{url-exampleAPI}',
+        variables: {
+          'url-exampleAPI': {
+            default: 'example.com',
+            description: 'Declared in Postman collection variables.',
+          },
+        },
+      },
+    ])
+  })
 })

--- a/packages/postman-to-openapi/src/convert.ts
+++ b/packages/postman-to-openapi/src/convert.ts
@@ -12,10 +12,11 @@ import {
   POSTMAN_POST_RESPONSE_SCRIPTS_EXTENSION,
   POSTMAN_PRE_REQUEST_SCRIPTS_EXTENSION,
   processItem,
+  type ServerUsage,
 } from '@/helpers/path-items'
 import { pruneDocument } from '@/helpers/prune-document'
 import { analyzeServerDistribution } from '@/helpers/servers'
-import { getPathStructuralSignature, normalizePath } from '@/helpers/urls'
+import { createCollectionVariableLookup, getPathStructuralSignature, normalizePath } from '@/helpers/urls'
 
 import type { Description, Item, ItemGroup, PostmanCollection } from './types'
 
@@ -445,11 +446,13 @@ const mergeServerLists = (
   existing: OpenAPIV3_1.ServerObject[] | undefined,
   incoming: OpenAPIV3_1.ServerObject[],
 ): OpenAPIV3_1.ServerObject[] => {
-  const seen = new Set((existing ?? []).map((s) => s.url))
+  const createServerKey = (server: OpenAPIV3_1.ServerObject): string => JSON.stringify(server)
+  const seen = new Set((existing ?? []).map(createServerKey))
   const out = [...(existing ?? [])]
   for (const server of incoming) {
-    if (!seen.has(server.url)) {
-      seen.add(server.url)
+    const serverKey = createServerKey(server)
+    if (!seen.has(serverKey)) {
+      seen.add(serverKey)
       out.push(server)
     }
   }
@@ -878,11 +881,9 @@ export function convert(
   }
 
   // Process each item in the collection and merge into OpenAPI spec
-  const allServerUsage: Array<{
-    serverUrl: string
-    path: string
-    method: 'get' | 'put' | 'post' | 'delete' | 'options' | 'head' | 'patch' | 'trace'
-  }> = []
+  const allServerUsage: ServerUsage[] = []
+
+  const collectionVariableLookup = createCollectionVariableLookup(collection.variable)
 
   if (collection.item) {
     const usePathFilter = requestIndexPaths !== undefined
@@ -903,7 +904,15 @@ export function convert(
           paths: itemPaths,
           components: itemComponents,
           serverUsage,
-        } = processItem(node, DEFAULT_EXAMPLE_NAME, parentTags, '', mergeOperation, resolveTagName)
+        } = processItem(
+          node,
+          DEFAULT_EXAMPLE_NAME,
+          parentTags,
+          '',
+          mergeOperation,
+          resolveTagName,
+          collectionVariableLookup,
+        )
 
         allServerUsage.push(...serverUsage)
 
@@ -930,7 +939,15 @@ export function convert(
           paths: itemPaths,
           components: itemComponents,
           serverUsage,
-        } = processItem(item, DEFAULT_EXAMPLE_NAME, [], '', mergeOperation, resolveTagName)
+        } = processItem(
+          item,
+          DEFAULT_EXAMPLE_NAME,
+          [],
+          '',
+          mergeOperation,
+          resolveTagName,
+          collectionVariableLookup,
+        )
 
         allServerUsage.push(...serverUsage)
 

--- a/packages/postman-to-openapi/src/convert.ts
+++ b/packages/postman-to-openapi/src/convert.ts
@@ -11,8 +11,8 @@ import {
   POSTMAN_FOLDER_SEGMENTS_EXTENSION,
   POSTMAN_POST_RESPONSE_SCRIPTS_EXTENSION,
   POSTMAN_PRE_REQUEST_SCRIPTS_EXTENSION,
-  processItem,
   type ServerUsage,
+  processItem,
 } from '@/helpers/path-items'
 import { pruneDocument } from '@/helpers/prune-document'
 import { analyzeServerDistribution } from '@/helpers/servers'
@@ -939,15 +939,7 @@ export function convert(
           paths: itemPaths,
           components: itemComponents,
           serverUsage,
-        } = processItem(
-          item,
-          DEFAULT_EXAMPLE_NAME,
-          [],
-          '',
-          mergeOperation,
-          resolveTagName,
-          collectionVariableLookup,
-        )
+        } = processItem(item, DEFAULT_EXAMPLE_NAME, [], '', mergeOperation, resolveTagName, collectionVariableLookup)
 
         allServerUsage.push(...serverUsage)
 

--- a/packages/postman-to-openapi/src/helpers/path-items.ts
+++ b/packages/postman-to-openapi/src/helpers/path-items.ts
@@ -9,7 +9,7 @@ import { processPostResponseScripts } from './post-response-scripts'
 import { processPreRequestScripts } from './pre-request-scripts'
 import { extractRequestBody } from './request-body'
 import { DEFAULT_RESPONSE_DESCRIPTIONS, extractResponses } from './responses'
-import { extractPathFromUrl, extractPathParameterNames, extractServerFromUrl, normalizePath } from './urls'
+import { extractPathFromUrl, extractPathParameterNames, extractServerObjectFromUrl, normalizePath } from './urls'
 
 type HttpMethods = 'get' | 'put' | 'post' | 'delete' | 'options' | 'head' | 'patch' | 'trace'
 
@@ -26,9 +26,12 @@ export const POSTMAN_FOLDER_SEGMENTS_EXTENSION = 'x-postman-folder-segments'
  */
 export type ServerUsage = {
   serverUrl: string
+  server?: OpenAPIV3_1.ServerObject
   path: string
   method: HttpMethods
 }
+
+type CollectionVariableLookup = ReadonlyMap<string, string>
 
 function ensureRequestBodyContent(requestBody: OpenAPIV3_1.RequestBodyObject): void {
   const content = requestBody.content ?? {}
@@ -61,6 +64,7 @@ export function processItem(
   parentPath: string = '',
   preserveCollapsedVariants: boolean = false,
   resolveTagName?: (segments: string[]) => string | undefined,
+  collectionVariableLookup: CollectionVariableLookup = new Map(),
 ): {
   paths: OpenAPIV3_1.PathsObject
   components: OpenAPIV3_1.ComponentsObject
@@ -80,6 +84,7 @@ export function processItem(
         `${parentPath}/${item.name || ''}`,
         preserveCollapsedVariants,
         resolveTagName,
+        collectionVariableLookup,
       )
       // Merge child paths and components
       for (const [pathKey, pathItem] of Object.entries(childResult.paths)) {
@@ -125,10 +130,11 @@ export function processItem(
   const normalizedPath = normalizePath(path)
 
   // Extract server URL from request URL
-  const serverUrl = extractServerFromUrl(requestUrl)
-  if (serverUrl) {
+  const server = extractServerObjectFromUrl(requestUrl, collectionVariableLookup)
+  if (server?.url) {
     serverUsage.push({
-      serverUrl,
+      serverUrl: server.url,
+      server,
       path: normalizedPath,
       method,
     })

--- a/packages/postman-to-openapi/src/helpers/servers.ts
+++ b/packages/postman-to-openapi/src/helpers/servers.ts
@@ -50,21 +50,24 @@ export function analyzeServerDistribution(serverUsage: ServerUsage[], allUniqueP
     return placement
   }
 
-  // Build a map: serverUrl -> Set<operationKey>
+  // Build a map: serverKey -> { server, operations }
   // Using string keys instead of objects because JavaScript Sets compare by reference
-  const serverMap = new Map<string, Set<string>>()
+  const serverMap = new Map<string, { server: OpenAPIV3_1.ServerObject; operations: Set<string> }>()
 
   for (const usage of serverUsage) {
-    if (!serverMap.has(usage.serverUrl)) {
-      serverMap.set(usage.serverUrl, new Set())
+    const serverObject: OpenAPIV3_1.ServerObject = usage.server ?? { url: usage.serverUrl }
+    const serverKey = JSON.stringify(serverObject)
+    if (!serverMap.has(serverKey)) {
+      serverMap.set(serverKey, {
+        server: serverObject,
+        operations: new Set(),
+      })
     }
-    serverMap.get(usage.serverUrl)!.add(createOperationKey(usage.path, usage.method))
+    serverMap.get(serverKey)!.operations.add(createOperationKey(usage.path, usage.method))
   }
 
   // For each server, determine its placement
-  for (const [serverUrl, operationKeys] of serverMap.entries()) {
-    const serverObject: OpenAPIV3_1.ServerObject = { url: serverUrl }
-
+  for (const { server: serverObject, operations: operationKeys } of serverMap.values()) {
     // Parse operation keys back to path/method pairs
     const operations = Array.from(operationKeys).map(parseOperationKey)
 

--- a/packages/postman-to-openapi/src/helpers/urls.test.ts
+++ b/packages/postman-to-openapi/src/helpers/urls.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  createCollectionVariableLookup,
   extractPathFromUrl,
   extractPathParameterNames,
+  extractServerObjectFromUrl,
   extractServerFromUrl,
   getPathStructuralSignature,
   getDomainFromUrl,
@@ -144,6 +146,48 @@ describe('urls', () => {
 
     it('handles URL with only domain', () => {
       expect(extractServerFromUrl('http://example.com')).toBe('http://example.com')
+    })
+
+    it('resolves host fragment variables from collection variables', () => {
+      const lookup = createCollectionVariableLookup([{ key: 'url-languagesAPI', value: 'localhost:3005' }])
+
+      expect(extractServerObjectFromUrl('https://{{url-languagesAPI}}/v1/languages', lookup)).toEqual({
+        url: 'https://localhost:3005',
+      })
+    })
+
+    it('resolves complete URL variables when template is the full host', () => {
+      const lookup = createCollectionVariableLookup([{ key: 'url-applicationAPI', value: 'https://app.example.com' }])
+
+      expect(extractServerObjectFromUrl('https://{{url-applicationAPI}}/users', lookup)).toEqual({
+        url: 'https://app.example.com',
+      })
+    })
+
+    it('rewrites unresolved variables to OpenAPI server variables', () => {
+      expect(extractServerObjectFromUrl('https://{{url-notificationAPI}}/events')).toEqual({
+        url: 'https://{url-notificationAPI}',
+        variables: {
+          'url-notificationAPI': {
+            default: 'example.com',
+            description: 'Declared in Postman collection variables.',
+          },
+        },
+      })
+    })
+
+    it('falls back to OpenAPI variables when value is recursive template syntax', () => {
+      const lookup = createCollectionVariableLookup([{ key: 'url-exampleAPI', value: '{{url-local}}' }])
+
+      expect(extractServerObjectFromUrl('https://{{url-exampleAPI}}/status', lookup)).toEqual({
+        url: 'https://{url-exampleAPI}',
+        variables: {
+          'url-exampleAPI': {
+            default: 'example.com',
+            description: 'Declared in Postman collection variables.',
+          },
+        },
+      })
     })
   })
 })

--- a/packages/postman-to-openapi/src/helpers/urls.ts
+++ b/packages/postman-to-openapi/src/helpers/urls.ts
@@ -61,6 +61,25 @@ const createServerVariableDefinition = (): NonNullable<OpenAPIV3_1.ServerObject[
   description: SERVER_VARIABLE_DESCRIPTION,
 })
 
+const extractFullHostTemplateVariableName = (rawServerUrl: string): string | undefined => {
+  const protocolSeparatorIndex = rawServerUrl.indexOf('://')
+  if (protocolSeparatorIndex === -1) {
+    return undefined
+  }
+
+  const hostCandidate = rawServerUrl.slice(protocolSeparatorIndex + 3)
+  if (!hostCandidate.startsWith('{{') || !hostCandidate.endsWith('}}')) {
+    return undefined
+  }
+
+  const variableName = hostCandidate.slice(2, -2).trim()
+  if (!variableName || variableName.includes('{') || variableName.includes('}')) {
+    return undefined
+  }
+
+  return variableName
+}
+
 /**
  * Extracts Postman collection variables into a lookup table.
  */
@@ -156,9 +175,9 @@ export function extractServerObjectFromUrl(
     }
 
     const unresolvedVariables = new Set<string>()
-    const fullHostTemplateMatch = rawServerUrl.match(/^https?:\/\/\{\{\s*([^{}]{0,1000})\s*\}\}$/i)
-    if (fullHostTemplateMatch?.[1]) {
-      const variableName = fullHostTemplateMatch[1].trim()
+    const fullHostTemplateVariableName = extractFullHostTemplateVariableName(rawServerUrl)
+    if (fullHostTemplateVariableName) {
+      const variableName = fullHostTemplateVariableName
       const variableValue = collectionVariableLookup.get(variableName)
       if (!variableValue || hasPostmanTemplateSyntax(variableValue)) {
         unresolvedVariables.add(variableName)

--- a/packages/postman-to-openapi/src/helpers/urls.ts
+++ b/packages/postman-to-openapi/src/helpers/urls.ts
@@ -1,6 +1,11 @@
 import { REGEX } from '@scalar/helpers/regex/regex-helpers'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 
 import type { ParsedUrl } from '@/types'
+
+const POSTMAN_TEMPLATE_REGEX = /\{\{([^{}]{0,1000})\}\}/g
+const DEFAULT_SERVER_VARIABLE_VALUE = 'example.com'
+const SERVER_VARIABLE_DESCRIPTION = 'Declared in Postman collection variables.'
 
 /**
  * Parses a URL string into its component parts.
@@ -34,7 +39,7 @@ export function extractPathFromUrl(url: string | undefined): string {
   const path = url.replace(/^(?:https?:\/\/)?[^/]+(\/|$)/, '/').split(/[?#]/)[0] ?? ''
 
   // Replace Postman variables and ensure single leading slash
-  const finalPath = ('/' + path.replace(/\{\{([^{}]{0,1000})\}\}/g, '{$1}').replace(/^\/+/, '')).replace(/\/\/+/g, '/')
+  const finalPath = ('/' + path.replace(POSTMAN_TEMPLATE_REGEX, '{$1}').replace(/^\/+/, '')).replace(/\/\/+/g, '/')
 
   return finalPath
 }
@@ -44,6 +49,34 @@ export function extractPathFromUrl(url: string | undefined): string {
  * e.g., '/users/:id' becomes '/users/{id}'
  */
 export const normalizePath = (path: string): string => path.replace(/:(\w+)/g, '{$1}')
+
+type CollectionVariableLookup = ReadonlyMap<string, string>
+
+const isCompleteUrl = (value: string): boolean => /^(https?:\/\/)/i.test(value)
+
+const hasPostmanTemplateSyntax = (value: string): boolean => /\{\{([^{}]{0,1000})\}\}/.test(value)
+
+const createServerVariableDefinition = (): NonNullable<OpenAPIV3_1.ServerObject['variables']>[string] => ({
+  default: DEFAULT_SERVER_VARIABLE_VALUE,
+  description: SERVER_VARIABLE_DESCRIPTION,
+})
+
+/**
+ * Extracts Postman collection variables into a lookup table.
+ */
+export function createCollectionVariableLookup(
+  variables: ReadonlyArray<{ key?: string; value?: string | number | boolean; disabled?: boolean }> | undefined,
+): ReadonlyMap<string, string> {
+  const variableLookup = new Map<string, string>()
+  for (const variable of variables ?? []) {
+    const key = variable.key?.trim()
+    if (!key || variable.disabled || variable.value === undefined) {
+      continue
+    }
+    variableLookup.set(key, String(variable.value))
+  }
+  return variableLookup
+}
 
 /**
  * Generates a structural path signature by replacing parameter segments with `{*}`.
@@ -87,6 +120,16 @@ export function extractPathParameterNames(path: string): string[] {
  * Returns undefined if no valid server URL can be extracted.
  */
 export function extractServerFromUrl(url: string | undefined): string | undefined {
+  return extractServerObjectFromUrl(url)?.url
+}
+
+/**
+ * Extracts the server object from a request URL and resolves Postman templates.
+ */
+export function extractServerObjectFromUrl(
+  url: string | undefined,
+  collectionVariableLookup: CollectionVariableLookup = new Map(),
+): OpenAPIV3_1.ServerObject | undefined {
   if (!url) {
     return undefined
   }
@@ -104,9 +147,54 @@ export function extractServerFromUrl(url: string | undefined): string | undefine
 
     const hostPart = urlMatch[1]
     // Preserve the original protocol if present, otherwise default to https
-    const serverUrl = protocol ? `${protocol}${hostPart}`.replace(/\/$/, '') : `https://${hostPart}`.replace(/\/$/, '')
+    const rawServerUrl = protocol
+      ? `${protocol}${hostPart}`.replace(/\/$/, '')
+      : `https://${hostPart}`.replace(/\/$/, '')
+    const templateMatches = Array.from(rawServerUrl.matchAll(POSTMAN_TEMPLATE_REGEX))
+    if (templateMatches.length === 0) {
+      return { url: rawServerUrl }
+    }
 
-    return serverUrl
+    const unresolvedVariables = new Set<string>()
+    const fullHostTemplateMatch = rawServerUrl.match(/^https?:\/\/\{\{\s*([^{}]{0,1000})\s*\}\}$/i)
+    if (fullHostTemplateMatch?.[1]) {
+      const variableName = fullHostTemplateMatch[1].trim()
+      const variableValue = collectionVariableLookup.get(variableName)
+      if (!variableValue || hasPostmanTemplateSyntax(variableValue)) {
+        unresolvedVariables.add(variableName)
+      } else if (isCompleteUrl(variableValue)) {
+        return { url: variableValue.replace(/\/$/, '') }
+      }
+    }
+
+    const resolvedUrl = rawServerUrl.replace(POSTMAN_TEMPLATE_REGEX, (_, rawName: string) => {
+      const variableName = rawName.trim()
+      const variableValue = collectionVariableLookup.get(variableName)
+      if (!variableValue || hasPostmanTemplateSyntax(variableValue)) {
+        unresolvedVariables.add(variableName)
+        return `{${variableName}}`
+      }
+
+      if (isCompleteUrl(variableValue)) {
+        unresolvedVariables.add(variableName)
+        return `{${variableName}}`
+      }
+
+      return variableValue
+    })
+
+    if (unresolvedVariables.size > 0) {
+      const variables: NonNullable<OpenAPIV3_1.ServerObject['variables']> = {}
+      for (const variableName of unresolvedVariables) {
+        variables[variableName] = createServerVariableDefinition()
+      }
+      return {
+        url: resolvedUrl,
+        variables,
+      }
+    }
+
+    return { url: resolvedUrl.replace(/\/$/, '') }
   } catch (error) {
     console.error(`Error extracting server from URL "${url}":`, error)
     return undefined


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Postman collection server templates like `https://{{url-languagesAPI}}` were preserved literally in generated OpenAPI `servers`, which is neither a resolvable URL nor valid OpenAPI server-variable syntax.

A CodeQL alert also flagged polynomial regex behavior in the full-host template detection path.

## Solution

- added collection variable lookup + server URL resolution for Postman `{{...}}` templates in `@scalar/postman-to-openapi`
- when a matching collection variable exists:
  - substitute hostname fragments directly into the URL
  - if the entire host template maps to a full URL, use that URL as the server
- when no variable is found (or value is recursive template syntax), rewrite to OpenAPI `{name}` and emit `server.variables[name]` metadata with defaults
- threaded resolved server objects through server-distribution logic so `variables` metadata is preserved at document/path/operation placement
- replaced full-host template regex matching with deterministic string parsing to avoid regex complexity on uncontrolled input
- added targeted tests for resolved, unresolved, recursive, and mixed-value scenarios
- added a patch changeset for `@scalar/postman-to-openapi`

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-881b664e-9b41-4bb8-859a-0019bf3baba7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-881b664e-9b41-4bb8-859a-0019bf3baba7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

