### PR TITLE
fix(api-reference): update code sample when switching request body content type

### DIFF
--- a/.changeset/social-rockets-buy.md
+++ b/.changeset/social-rockets-buy.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+Fix code sample missing body content type update

--- a/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.vue
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.vue
@@ -201,6 +201,18 @@ onBeforeMount(() => {
   selectedExampleKey.value ||= Object.keys(requestBodyExamples.value)[0] ?? ''
 })
 
+/** Reset the selected example key if the content type changes and the new content type doesn't have the previously selected example */
+watch(
+  () => selectedContentType,
+  () => {
+    if (
+      !Object.keys(requestBodyExamples.value).includes(selectedExampleKey.value)
+    ) {
+      selectedExampleKey.value = Object.keys(requestBodyExamples.value)[0] ?? ''
+    }
+  },
+)
+
 /** Grab any custom code samples from the operation */
 const customCodeSamples = computed(() => getCustomCodeSamples(operation))
 

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.test.ts
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.test.ts
@@ -2,6 +2,7 @@ import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
 import { SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
 
 import OperationParameters from './OperationParameters.vue'
 
@@ -207,7 +208,7 @@ describe('OperationParameters', () => {
   })
 
   describe('form data', () => {
-    it('renders form data parameters', () => {
+    it('renders form data parameters', async () => {
       const wrapper = mount(OperationParameters, {
         props: {
           eventBus: null,
@@ -227,6 +228,8 @@ describe('OperationParameters', () => {
           },
         },
       })
+
+      await nextTick()
 
       expect(wrapper.text()).toContain('Body')
       expect(wrapper.text()).toContain('username')

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.vue
@@ -25,6 +25,9 @@ const { parameters = [], requestBody } = defineProps<{
   >
 }>()
 
+/** Thread the selected request body content type up to the layout */
+const selectedContentType = defineModel<string>('selectedContentType')
+
 /** Use a single loop to reduce parameters by type(in) */
 const splitParameters = computed(() =>
   (parameters ?? []).reduce(
@@ -83,6 +86,7 @@ const splitParameters = computed(() =>
   <!-- Request body -->
   <RequestBody
     v-if="requestBody"
+    v-model:selectedContentType="selectedContentType"
     :breadcrumb="breadcrumb ? [...breadcrumb, 'body'] : undefined"
     :eventBus="eventBus"
     :options="options"

--- a/packages/api-reference/src/features/Operation/components/RequestBody.test.ts
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.test.ts
@@ -223,4 +223,35 @@ describe('RequestBody', () => {
     const schema = wrapper.findComponent(Schema)
     expect(schema.props('hideModelNames')).toBe(false)
   })
+  it('updates selectedContentType via v-model when changing the content type', async () => {
+    const wrapper = mount(RequestBody, {
+      props: {
+        eventBus: null,
+        options: defaultRequestOptions,
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: { type: 'object' },
+            },
+            'application/x-www-form-urlencoded': {
+              schema: { type: 'object' },
+            },
+          },
+        },
+        'selectedContentType': 'application/json',
+        'onUpdate:selectedContentType': (e: string) => wrapper.setProps({ selectedContentType: e }),
+      },
+      slots: {
+        title: 'Body',
+      },
+    })
+
+    const select = wrapper.findComponent({ name: 'ContentTypeSelect' })
+    expect(select.exists()).toBe(true)
+
+    // Simulate changing content type
+    await select.vm.$emit('update:modelValue', 'application/x-www-form-urlencoded')
+
+    expect(wrapper.props('selectedContentType')).toBe('application/x-www-form-urlencoded')
+  })
 })

--- a/packages/api-reference/src/features/Operation/components/RequestBody.test.ts
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.test.ts
@@ -231,10 +231,10 @@ describe('RequestBody', () => {
         requestBody: {
           content: {
             'application/json': {
-              schema: { type: 'object' },
+              schema: coerceValue(SchemaObjectSchema, { type: 'object' }),
             },
             'application/x-www-form-urlencoded': {
-              schema: { type: 'object' },
+              schema: coerceValue(SchemaObjectSchema, { type: 'object' }),
             },
           },
         },
@@ -249,7 +249,6 @@ describe('RequestBody', () => {
     const select = wrapper.findComponent({ name: 'ContentTypeSelect' })
     expect(select.exists()).toBe(true)
 
-    // Simulate changing content type
     await select.vm.$emit('update:modelValue', 'application/x-www-form-urlencoded')
 
     expect(wrapper.props('selectedContentType')).toBe('application/x-www-form-urlencoded')

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -3,7 +3,7 @@ import { ScalarMarkdown } from '@scalar/components'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { RequestBodyObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-import { computed, ref, watch } from 'vue'
+import { computed } from 'vue'
 
 import { Schema } from '@/components/Content/Schema'
 import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -3,7 +3,7 @@ import { ScalarMarkdown } from '@scalar/components'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { RequestBodyObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import { Schema } from '@/components/Content/Schema'
 import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
@@ -35,7 +35,9 @@ const availableContentTypes = computed(() =>
   Object.keys(requestBody?.content ?? {}),
 )
 
-const selectedContentType = ref<string>('application/json')
+const selectedContentType = defineModel<string>('selectedContentType', {
+  default: 'application/json',
+})
 
 if (requestBody?.content) {
   if (availableContentTypes.value[0]) {

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.test.ts
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.test.ts
@@ -213,10 +213,16 @@ describe('ClassicLayout', () => {
           required: true,
           content: {
             'application/json': {
-              schema: { type: 'object', properties: { foo: { type: 'string' } } },
+              schema: coerceValue(SchemaObjectSchema, {
+                type: 'object',
+                properties: { foo: { type: 'string' } },
+              }),
             },
             'application/x-www-form-urlencoded': {
-              schema: { type: 'object', properties: { bar: { type: 'string' } } },
+              schema: coerceValue(SchemaObjectSchema, {
+                type: 'object',
+                properties: { bar: { type: 'string' } },
+              }),
             },
           },
         },
@@ -231,24 +237,15 @@ describe('ClassicLayout', () => {
             name: 'RouterLink',
             template: '<a><slot /></a>',
           },
-          // Stub out the code sample so we don't need to mount all of CodeMirror
-          OperationCodeSample: {
-            name: 'OperationCodeSample',
-            props: ['selectedContentType'],
-            template: '<div class="stub-code-sample" :data-content-type="selectedContentType"></div>',
-          },
         },
       },
     })
 
-    const codeSample = wrapper.find('.stub-code-sample')
-    // Should initially be undefined (defaults to first in OperationCodeSample) or 'application/json' if synced back
-
-    // Find the RequestBody component and change the selectedContentType
     const requestBody = wrapper.findComponent({ name: 'RequestBody' })
     await requestBody.vm.$emit('update:selectedContentType', 'application/x-www-form-urlencoded')
     await nextTick()
 
-    expect(codeSample.attributes('data-content-type')).toBe('application/x-www-form-urlencoded')
+    const codeSample = wrapper.findComponent({ name: 'OperationCodeSample' })
+    expect(codeSample.props('selectedContentType')).toBe('application/x-www-form-urlencoded')
   })
 })

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.test.ts
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.test.ts
@@ -203,4 +203,52 @@ describe('ClassicLayout', () => {
       'requestBody.payload.anyOf': 1,
     })
   })
+  it('updates the code sample when the body content type is changed', async () => {
+    const multiContentProps: ExtractComponentProps<typeof ClassicLayout> = {
+      ...props,
+      id: 'create-widget-multi-content',
+      operation: {
+        ...operation,
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { type: 'object', properties: { foo: { type: 'string' } } },
+            },
+            'application/x-www-form-urlencoded': {
+              schema: { type: 'object', properties: { bar: { type: 'string' } } },
+            },
+          },
+        },
+      },
+    }
+
+    const wrapper = mount(ClassicLayout, {
+      props: multiContentProps,
+      global: {
+        stubs: {
+          RouterLink: {
+            name: 'RouterLink',
+            template: '<a><slot /></a>',
+          },
+          // Stub out the code sample so we don't need to mount all of CodeMirror
+          OperationCodeSample: {
+            name: 'OperationCodeSample',
+            props: ['selectedContentType'],
+            template: '<div class="stub-code-sample" :data-content-type="selectedContentType"></div>',
+          },
+        },
+      },
+    })
+
+    const codeSample = wrapper.find('.stub-code-sample')
+    // Should initially be undefined (defaults to first in OperationCodeSample) or 'application/json' if synced back
+
+    // Find the RequestBody component and change the selectedContentType
+    const requestBody = wrapper.findComponent({ name: 'RequestBody' })
+    await requestBody.vm.$emit('update:selectedContentType', 'application/x-www-form-urlencoded')
+    await nextTick()
+
+    expect(codeSample.attributes('data-content-type')).toBe('application/x-www-form-urlencoded')
+  })
 })

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -76,6 +76,9 @@ const operationExtensions = computed(() => getXKeysFromObject(operation))
 /** Track the currently selected example for passing to the modal */
 const selectedExampleKey = ref<string>('')
 
+/** Track the selected request body content type so the code sample stays in sync */
+const selectedRequestBodyContentType = ref<string | undefined>()
+
 /** Selected request body oneOf/anyOf variants; synced with schema dropdowns and code sample */
 const requestBodyCompositionSelection = ref<RequestBodyCompositionSelection>({})
 
@@ -202,6 +205,7 @@ const { copyToClipboard } = useClipboard()
           <OperationParameters
             :eventBus
             :options
+            v-model:selectedContentType="selectedRequestBodyContentType"
             :parameters="operation.parameters"
             :requestBody="getResolvedRef(operation.requestBody)" />
         </div>
@@ -253,6 +257,7 @@ const { copyToClipboard } = useClipboard()
             "
             :securitySchemes="selectedSecuritySchemes"
             :selectedClient
+            :selectedContentType="selectedRequestBodyContentType"
             :selectedServer />
         </ScalarErrorBoundary>
       </div>

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -79,6 +79,9 @@ const labelId = useId()
 
 const operationExtensions = computed(() => getXKeysFromObject(operation))
 
+/** Track the selected request body content type so the code sample stays in sync */
+const selectedRequestBodyContentType = ref<string | undefined>()
+
 /** Selected request body oneOf/anyOf variants; synced with schema dropdowns and code sample */
 const requestBodyCompositionSelection = ref<RequestBodyCompositionSelection>({})
 
@@ -164,6 +167,7 @@ provide(REQUEST_BODY_COMPOSITION_INDEX_SYMBOL, requestBodyCompositionSelection)
               :breadcrumb="[id]"
               :eventBus
               :options
+              v-model:selectedContentType="selectedRequestBodyContentType"
               :parameters="operation.parameters"
               :requestBody="getResolvedRef(operation.requestBody)" />
             <OperationResponses
@@ -208,6 +212,7 @@ provide(REQUEST_BODY_COMPOSITION_INDEX_SYMBOL, requestBodyCompositionSelection)
                 "
                 :securitySchemes="selectedSecuritySchemes"
                 :selectedClient
+                :selectedContentType="selectedRequestBodyContentType"
                 :selectedServer>
                 <template #header>
                   <OperationPath


### PR DESCRIPTION
## Problem

Switching the request body content type, the code example does not update.

## Solution

Thread the selected content type from `RequestBody` up through `OperationParameters` to the layout components (`ClassicLayout` / `ModernLayout`) using `v-model`, then pass it down to `OperationCodeSample` as a prop. Inside the code sample component, a watcher resets the selected example key when the content type changes and the current example no longer exists in the new content type.

- Converted `selectedContentType` in `RequestBody.vue` from a local `ref` to a `defineModel` so it can be two-way bound
- Added `v-model:selectedContentType` plumbing through `OperationParameters.vue` → layout components
- Passed the selected content type to `OperationCodeSample` in both `ClassicLayout` and `ModernLayout`
- Added a `watch` in `OperationCodeSample.vue` to reset the example key when the content type changes
- Added unit tests for the `v-model` behavior and the layout-level sync

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

Fixes https://github.com/scalar/scalar/issues/6990