### PR TITLE
fix(api-client): provide a defailt summary when creating a new temp operation

### DIFF
--- a/.changeset/curly-wolves-join.md
+++ b/.changeset/curly-wolves-join.md
@@ -2,4 +2,4 @@
 '@scalar/api-client': patch
 ---
 
-fix: provide a defailt summary when creating a new temp operation
+fix: provide a default summary when creating a new temp operation

--- a/.changeset/curly-wolves-join.md
+++ b/.changeset/curly-wolves-join.md
@@ -1,5 +1,5 @@
 ---
-'@scalar/api-client': minor
+'@scalar/api-client': patch
 ---
 
-feat: provide a defailt summary when creating a new temp operation
+fix: provide a defailt summary when creating a new temp operation

--- a/.changeset/curly-wolves-join.md
+++ b/.changeset/curly-wolves-join.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': minor
+---
+
+feat: provide a defailt summary when creating a new temp operation

--- a/packages/api-client/src/v2/features/app/helpers/create-temp-operation.ts
+++ b/packages/api-client/src/v2/features/app/helpers/create-temp-operation.ts
@@ -51,6 +51,7 @@ export const createTempOperation = (
     path: uniquePath,
     method: 'get',
     operation: {
+      summary: 'New operation',
       tags: options.tags ?? [],
     },
     callback: (success) => {


### PR DESCRIPTION
## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to temp operation creation that only affects initial operation metadata; minimal risk of regressions beyond UI display/serialization expectations.
> 
> **Overview**
> When creating a temp operation via `createTempOperation`, the emitted `operation` payload now includes a default `summary` (`"New operation"`) instead of leaving it unset.
> 
> Adds a patch changeset for `@scalar/api-client` to release this fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84f1f60fadb184bdafe0c51a7d81558410d8292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->