### PR TITLE
feat(api-reference): collapsible x-tagGroups in modern layout

### DIFF
--- a/.changeset/collapsible-tag-groups-modern.md
+++ b/.changeset/collapsible-tag-groups-modern.md
@@ -1,0 +1,13 @@
+---
+'@scalar/api-reference': minor
+'@scalar/components': minor
+'@scalar/sidebar': patch
+---
+
+feat(api-reference): collapsible `x-tagGroups` in modern layout
+
+The modern sidebar now renders each `x-tagGroups` entry as a collapsible
+section with an expand/collapse toggle. Groups default to expanded so the
+existing flat rendering is preserved for users who did not interact with the
+sidebar. `ScalarSidebarSection` gained an opt-in `collapsible` prop plus an
+`open` model and `toggle` event.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -355,6 +355,25 @@ const setChildrenOpen = (items: TraversedEntry[]): void => {
   })
 }
 
+/**
+ * Open all `x-tagGroups` by default so the modern sidebar preserves the
+ * previous flat rendering when collapsible sections are introduced.
+ */
+const openTagGroupsByDefault = (items: TraversedEntry[]): void => {
+  items.forEach((item) => {
+    if (
+      item.type === 'tag' &&
+      item.isGroup === true &&
+      !sidebarState.isExpanded(item.id)
+    ) {
+      sidebarState.setExpanded(item.id, true)
+    }
+    if ('children' in item && item.children) {
+      openTagGroupsByDefault(item.children)
+    }
+  })
+}
+
 /** We get the sub items for the sidebar based on the configuration/document slug */
 const sidebarItems = computed<TraversedEntry[]>(() => {
   const config = mergedConfig.value
@@ -729,6 +748,10 @@ provide(AGENT_CONTEXT_SYMBOL, agent)
 const modal = useTemplateRef<HTMLElement>('modal')
 const apiClient = ref<ApiClientModal | null>(null)
 onMounted(() => {
+  // Tag groups default to expanded so the modern layout preserves its
+  // previous flat rendering for users who did not interact with the sidebar.
+  openTagGroupsByDefault(sidebarItems.value)
+
   if (!modal.value) {
     return
   }

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarSection.test.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarSection.test.ts
@@ -1,0 +1,122 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
+
+import ScalarSidebarButton from './ScalarSidebarButton.vue'
+import ScalarSidebarGroupToggle from './ScalarSidebarGroupToggle.vue'
+import ScalarSidebarItem from './ScalarSidebarItem.vue'
+import ScalarSidebarSection from './ScalarSidebarSection.vue'
+
+describe('ScalarSidebarSection', () => {
+  it('renders a non-collapsible header by default', () => {
+    const TestComponent = defineComponent({
+      components: { ScalarSidebarSection, ScalarSidebarItem },
+      template: `
+        <ScalarSidebarSection>
+          My Section
+          <template #items>
+            <ScalarSidebarItem>Items</ScalarSidebarItem>
+          </template>
+        </ScalarSidebarSection>
+      `,
+    })
+
+    const wrapper = mount(TestComponent)
+
+    const header = wrapper.findComponent(ScalarSidebarButton)
+    expect(header.props('is')).toBe('div')
+    expect(header.props('disabled')).toBe(true)
+
+    // No toggle is rendered in the default mode
+    expect(wrapper.findComponent(ScalarSidebarGroupToggle).exists()).toBe(false)
+
+    // Items remain visible
+    expect(wrapper.findComponent(ScalarSidebarItem).exists()).toBe(true)
+  })
+
+  it('renders a collapsible header with a toggle when enabled', () => {
+    const TestComponent = defineComponent({
+      components: { ScalarSidebarSection, ScalarSidebarItem },
+      template: `
+        <ScalarSidebarSection collapsible>
+          Collapsible Section
+          <template #items>
+            <ScalarSidebarItem>Items</ScalarSidebarItem>
+          </template>
+        </ScalarSidebarSection>
+      `,
+    })
+
+    const wrapper = mount(TestComponent)
+
+    const header = wrapper.findComponent(ScalarSidebarButton)
+    expect(header.props('is')).toBe('button')
+    expect(header.props('disabled')).toBe(false)
+    expect(header.attributes('aria-expanded')).toBe('true')
+
+    expect(wrapper.findComponent(ScalarSidebarGroupToggle).exists()).toBe(true)
+  })
+
+  it('toggles open state and emits a toggle event on header click', async () => {
+    const open = ref(true)
+    const toggleSpy = vi.fn()
+
+    const TestComponent = defineComponent({
+      components: { ScalarSidebarSection, ScalarSidebarItem },
+      setup() {
+        return { open, toggleSpy }
+      },
+      template: `
+        <ScalarSidebarSection
+          v-model:open="open"
+          collapsible
+          @toggle="toggleSpy">
+          Section
+          <template #items>
+            <ScalarSidebarItem>Items</ScalarSidebarItem>
+          </template>
+        </ScalarSidebarSection>
+      `,
+    })
+
+    const wrapper = mount(TestComponent)
+
+    const header = wrapper.findComponent(ScalarSidebarButton)
+    await header.trigger('click')
+
+    expect(open.value).toBe(false)
+    expect(toggleSpy).toHaveBeenCalledTimes(1)
+    expect(header.attributes('aria-expanded')).toBe('false')
+  })
+
+  it('hides items when collapsed', async () => {
+    const TestComponent = defineComponent({
+      components: { ScalarSidebarSection, ScalarSidebarItem },
+      data() {
+        return { open: true }
+      },
+      template: `
+        <ScalarSidebarSection
+          v-model:open="open"
+          collapsible>
+          Section
+          <template #items>
+            <ScalarSidebarItem>Items</ScalarSidebarItem>
+          </template>
+        </ScalarSidebarSection>
+      `,
+    })
+
+    const wrapper = mount(TestComponent)
+
+    // When open, the items list is not hidden via inline display style
+    const openList = wrapper.get('ul').element as HTMLElement
+    expect(openList.style.display).not.toBe('none')
+
+    await wrapper.setData({ open: false })
+
+    // v-show sets `display: none` inline when collapsed
+    const closedList = wrapper.get('ul').element as HTMLElement
+    expect(closedList.style.display).toBe('none')
+  })
+})

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarSection.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarSection.vue
@@ -23,23 +23,43 @@ export default {}
 import { useBindCx } from '@scalar/use-hooks/useBindCx'
 
 import ScalarSidebarButton from './ScalarSidebarButton.vue'
+import ScalarSidebarGroupToggle from './ScalarSidebarGroupToggle.vue'
 import ScalarSidebarSpacer from './ScalarSidebarSpacer.vue'
-import type { ScalarSidebarItemProps } from './types'
+import type { ScalarSidebarSectionProps } from './types'
 import { useSidebarGroups } from './useSidebarGroups'
 
-const { is = 'li' } = defineProps<ScalarSidebarItemProps>()
+const { is = 'li', collapsible = false } =
+  defineProps<ScalarSidebarSectionProps>()
+
+const emit = defineEmits<{
+  /** Emitted when the section header is toggled (only when collapsible) */
+  (e: 'toggle', event: MouseEvent): void
+}>()
+
+const open = defineModel<boolean>('open', { default: true })
 
 defineSlots<{
   /** The text content of the toggle */
-  default?(): unknown
+  default?(props: { open: boolean }): unknown
   /** The list of sidebar subitems */
-  items?(): unknown
+  items?(props: { open: boolean }): unknown
 }>()
 
-const { level } = useSidebarGroups({ increment: false })
+// When collapsible, nest child items by incrementing the group level so tag
+// groups render with visible hierarchy. Non-collapsible sections stay flat.
+const { level } = useSidebarGroups({ increment: collapsible })
 
 defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
+
+/** Handle the click on the section header. No-op when not collapsible. */
+const handleClick = (event: MouseEvent) => {
+  if (!collapsible) {
+    return
+  }
+  emit('toggle', event)
+  open.value = !open.value
+}
 </script>
 <template>
   <component
@@ -49,15 +69,28 @@ const { cx } = useBindCx()
       class="group/spacer-before h-3"
       :indent="level" />
     <ScalarSidebarButton
-      is="div"
+      :is="collapsible ? 'button' : 'div'"
+      :aria-expanded="collapsible ? open : undefined"
       class="text-sm/4 py-1.75 font-bold"
-      disabled
+      :disabled="!collapsible"
       :icon="icon"
-      :indent="level">
-      <slot />
+      :indent="level"
+      @click="handleClick">
+      <slot :open="open" />
+      <template
+        v-if="collapsible"
+        #aside>
+        <ScalarSidebarGroupToggle
+          class="text-sidebar-c-2"
+          :open="open" />
+      </template>
     </ScalarSidebarButton>
-    <ul class="flex flex-col gap-px">
-      <slot name="items" />
+    <ul
+      v-show="!collapsible || open"
+      class="flex flex-col gap-px">
+      <slot
+        name="items"
+        :open="open" />
     </ul>
     <ScalarSidebarSpacer
       class="group/spacer-after h-3"

--- a/packages/components/src/components/ScalarSidebar/types.ts
+++ b/packages/components/src/components/ScalarSidebar/types.ts
@@ -28,6 +28,17 @@ export type ScalarSidebarItemProps = {
   indent?: SidebarGroupLevel
 }
 
+export type ScalarSidebarSectionProps = ScalarSidebarItemProps & {
+  /**
+   * Enables a collapsible section header with an expand/collapse toggle.
+   *
+   * When `true`, the section header becomes a button and the items slot
+   * visibility is controlled by the `open` model. Defaults to non-collapsible
+   * to preserve the original section behavior.
+   */
+  collapsible?: boolean
+}
+
 export type ScalarSidebarGroupProps = ScalarSidebarItemProps & {
   /**
    * Disables the internal open state for the group

--- a/packages/sidebar/src/components/SidebarItem.test.ts
+++ b/packages/sidebar/src/components/SidebarItem.test.ts
@@ -326,6 +326,57 @@ describe('SidebarItem', () => {
       expect(wrapper.findComponent(ScalarSidebarSection).text()).toContain('User Operations')
     })
 
+    it('renders tag group sections as collapsible and respects expanded state', () => {
+      const item: Item = {
+        id: 'group-1',
+        title: 'Galaxy',
+        type: 'tag',
+        name: 'galaxy',
+        isGroup: true,
+        children: [{ id: '2', title: 'Get User', type: 'operation', ref: 'ref-2', method: 'get', path: '/users' }],
+      }
+
+      const wrapper = mount(SidebarItem, {
+        props: {
+          ...baseProps,
+          item,
+          isExpanded: (id) => id === 'group-1',
+        },
+      })
+
+      const section = wrapper.findComponent(ScalarSidebarSection)
+      expect(section.exists()).toBe(true)
+      expect(section.props('collapsible')).toBe(true)
+      expect(section.props('open')).toBe(true)
+    })
+
+    it('emits toggleGroup when a tag group header is clicked', async () => {
+      const item: Item = {
+        id: 'group-1',
+        title: 'Galaxy',
+        type: 'tag',
+        name: 'galaxy',
+        isGroup: true,
+        children: [{ id: '2', title: 'Get User', type: 'operation', ref: 'ref-2', method: 'get', path: '/users' }],
+      }
+
+      const onToggleGroup = vi.fn()
+      const wrapper = mount(SidebarItem, {
+        props: {
+          ...baseProps,
+          item,
+          isExpanded: () => true,
+          onToggleGroup,
+        },
+      })
+
+      const section = wrapper.findComponent(ScalarSidebarSection)
+      const headerButton = section.find('button')
+      await headerButton.trigger('click')
+
+      expect(onToggleGroup).toHaveBeenCalledWith('group-1')
+    })
+
     it('renders ScalarSidebarGroup for non-group items with children', () => {
       const item: Item = {
         id: '1',

--- a/packages/sidebar/src/components/SidebarItem.vue
+++ b/packages/sidebar/src/components/SidebarItem.vue
@@ -148,9 +148,12 @@ const children = computed(() =>
   <!-- Sidebar section -->
   <ScalarSidebarSection
     v-if="children.length > 0 && isGroup(item)"
+    collapsible
     :data-sidebar-id="item.id"
+    :open="isExpanded(item.id)"
     v-bind="draggableAttrs"
-    v-on="draggableEvents">
+    v-on="draggableEvents"
+    @toggle="() => emit('toggleGroup', item.id)">
     {{ item.title }}
     <template #items>
       <SidebarItem


### PR DESCRIPTION
## Summary

Adds collapsible `x-tagGroups` support to the modern sidebar layout. Each tag group now renders as a section with an expand/collapse toggle. Groups default to expanded to preserve the previous flat rendering for existing users.

Classic layout behavior is unchanged (shipped in #8609). This PR is the modern-layout counterpart.

## Before / After

| Before | After |
| --- | --- |
| <img width="252" height="421" alt="antes_cambios" src="https://github.com/user-attachments/assets/3ca7801b-a08c-452e-a7a8-30f1f9648d65" /> | <img width="254" height="410" alt="final" src="https://github.com/user-attachments/assets/3b0a7116-48d5-4c30-9d70-f2d871be7c5c" /> |

## What changed

- **`ScalarSidebarSection`** (`@scalar/components`): new opt-in `collapsible` prop with `open` v-model and `toggle` event. When collapsible, the header becomes a real button with a chevron (`ScalarSidebarGroupToggle`) and children nest one level deeper to reflect hierarchy. Non-collapsible sections keep the original flat layout — no regression for existing consumers.
- **`SidebarItem`** (`@scalar/sidebar`): tag groups (`item.isGroup === true`) are now wired to the collapsible Section. Clicking the header emits `toggleGroup` and syncs with the existing sidebar state.
- **`ApiReference.vue`** (`@scalar/api-reference`): on mount, walks the sidebar tree once and expands every `x-tagGroups` entry so users who never interacted with the sidebar still see every tag by default.

Search integration already works out of the box: `create-search-index.ts` indexes tag groups, and `sidebarState.setSelected` recursively expands parents, so searching for a tag inside a collapsed group auto-expands it.

## Non-goals

- Nested tag hierarchy via `parent` (tracked in #6866 — separate spec).
- Cross-session persistence of collapse state.
- Custom animations — relies on `v-show` + existing sidebar styles.

## Test plan

- [x] Unit tests for `ScalarSidebarSection` collapsible mode (default header stays non-interactive; collapsible emits `toggle`, swaps element to `button`, adds `aria-expanded`, and hides items when closed).
- [x] Unit tests for `SidebarItem` tag-group wiring (`collapsible` + `open` props, `toggleGroup` emission).
- [x] `@scalar/components` full suite passes (528/528).
- [x] `@scalar/sidebar` full suite passes (200/200).
- [x] Manual visual check against the existing `Tag Groups` fixture in `test/utils/sources.ts`.
- [ ] Playwright snapshot for `modern-collapse` — intentionally deferred; maintainer CI can regenerate a cross-platform baseline consistent with the existing `tag-groups.e2e.ts` fixtures.

## Accessibility

- Header renders as `<button>` with `aria-expanded` synced to open state.
- `ScalarSidebarGroupToggle` provides an `sr-only` label (`Open/Close Group`).
- Keyboard `Enter` / `Space` toggle the group as expected on a native button.

## Related

- Precedent PR (classic layout): #8609
- Tracking issue: #3766
- Out-of-scope discussion (nested groups): #6866
