### PR TITLE
chore(docs): add vector tracking

### DIFF
--- a/documentation/assets/vector.js
+++ b/documentation/assets/vector.js
@@ -1,0 +1,48 @@
+function initVector() {
+  try {
+    if (window.vector) {
+      console.log('Vector snippet included more than once.')
+      return
+    }
+
+    var vector = { q: [] }
+
+    var methods = ['load', 'identify', 'on']
+
+    var createQueuedMethod = function (method) {
+      return function () {
+        var args = Array.prototype.slice.call(arguments)
+        vector.q.push([method, args])
+      }
+    }
+
+    for (var index = 0; index < methods.length; index++) {
+      var method = methods[index]
+      vector[method] = createQueuedMethod(method)
+    }
+
+    window.vector = vector
+
+    if (!vector.loaded) {
+      var firstScript = document.getElementsByTagName('script')[0]
+      var script = document.createElement('script')
+
+      script.type = 'text/javascript'
+      script.async = true
+      script.src = 'https://cdn.vector.co/pixel.js'
+
+      if (firstScript && firstScript.parentNode) {
+        firstScript.parentNode.insertBefore(script, firstScript)
+      } else {
+        document.head.appendChild(script)
+      }
+
+      vector.loaded = true
+    }
+  } catch (error) {
+    console.error('Error loading Vector:', error)
+  }
+}
+
+initVector()
+window.vector.load('35f38258-8949-4041-a905-81ffb5a51704')

--- a/documentation/assets/vector.js
+++ b/documentation/assets/vector.js
@@ -45,4 +45,7 @@ function initVector() {
 }
 
 initVector()
-window.vector.load('35f38258-8949-4041-a905-81ffb5a51704')
+
+if (window.vector) {
+  window.vector.load('35f38258-8949-4041-a905-81ffb5a51704')
+}

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -21,6 +21,7 @@
     "documentation/assets/fathom.js",
     "documentation/assets/posthog.js",
     "documentation/assets/apollo.js",
+    "documentation/assets/vector.js",
     "documentation/assets/enterprise-contact-form.js",
     // Generated Docusaurus build directory
     "integrations/docusaurus/playground/.docusaurus/**"

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -25,6 +25,9 @@
           "path": "documentation/assets/apollo.js"
         },
         {
+          "path": "documentation/assets/vector.js"
+        },
+        {
           "url": "https://cdn-cookieyes.com/client_data/3515bc1505967122c1cef7c0f2247082/script.js"
         }
       ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Apollo tracking is already injected into the docs site, but Vector tracking is not loaded on the same surface.

## Solution

Add a dedicated `documentation/assets/vector.js` loader using the provided Vector snippet and register it in `scalar.config.json` alongside the existing Apollo asset so both trackers load in the docs head. Follow up by guarding the `window.vector.load(...)` call so a failed init does not throw, and add `documentation/assets/vector.js` to `knip.jsonc` because docs assets referenced from `scalar.config.json` are intentionally ignored by knip.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

## Visual

[tracking_scripts_runtime_after_fix.json](https://cursor.com/artifacts/c/art-34eb74e4-c408-4cf8-8db6-313e8651d9bf)
[vector_preview_asset.log](https://cursor.com/artifacts/c/art-ecbdb6b5-56ca-408b-8691-88f67bbdf99e)
[check_config_vector.log](https://cursor.com/artifacts/c/art-f538fc61-59af-48e3-a61f-0f24567d7da4)

## Ticket

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f25fee8d-f7c0-4e85-a2f2-201b21f3228a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f25fee8d-f7c0-4e85-a2f2-201b21f3228a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

