### PR TITLE
docs(pricing): simplify pricing page layout

### DIFF
--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -1,1146 +1,185 @@
-<div class="flex flex-col gap-3 hero small-test">
-  <scalar-heading level="2" slug="pricing" class="text-balance">
-    Pricing
-  </scalar-heading>
-  <p>
- One platform for all your API needs: Docs, SDKs, Governance & API Client all based on OpenAPI™.
-  </p>
+# Simple Pricing for your API needs
+
+One platform for: APIs, Docs, Agents, SDKs, Governance & API Client all based on OpenAPI™.
+
+<div class="flex gap-2 flex-wrap">
+  <a class="t-editor__button" href="https://dashboard.scalar.com/register">Get started</a>
+  <a class="t-editor__button" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Talk to sales</a>
 </div>
 
+<scalar-row>
+<scalar-card title="Free">
+**Best for:** self-hosting, local development, and personal API workflows.
 
-<div class="mobiletabs">
-  <div class="mobiletabs-container">
-    <label for="tab1"><input type="radio" name="mobiletabs" id="tab1" aria-controls="marzen" checked>Free</label>
-    <label for="tab2"><input type="radio" name="mobiletabs" id="tab2" aria-controls="rauchbier">Pro</label>
-    <label for="tab3"><input type="radio" name="mobiletabs" id="tab3" aria-controls="dunkles">
-    Enterprise</label>
+- Self-hosted docs
+- API Client for personal use
+- Agent on `localhost`
+</scalar-card>
+
+<scalar-card title="Hobby">
+**Best for:** solo builders who want hosted docs and a cleaner publishing workflow.
+
+- 1 hosted docs site
+- Custom domain
+- Cloud-synced client workflows
+</scalar-card>
+</scalar-row>
+
+<scalar-row>
+<scalar-card title="Pro">
+**Best for:** teams shipping production docs, client collaboration, and embedded agents.
+
+- `$24 / seat / month`
+- Minimum 3 seats (`$72 / month` base)
+- Production Agent usage and shared workspaces
+</scalar-card>
+
+<scalar-card title="Enterprise">
+**Best for:** platform teams that need governance, access control, and support.
+
+- Custom pricing
+- SSO / SAML and RBAC
+- Priority support and rollout help
+</scalar-card>
+</scalar-row>
+
+## Trusted by the world's best API teams
+
+<div class="pricing-logowall">
+  <div class="pricing-logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-tr.svg"></scalar-icon>
   </div>
-  <div class="tab-panels">
-    <div class="pricing">
-      <main class="pricing-table">
-        <header class="pricing-table-group_header _sticky">
-            <div class="pricing-table-row">
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column">
-                <b class="text-sm">Free</b>
-                <p class="text-xl font-bold ">$0</p>
-                <p class=" text-c-2 text-sm font-normal">* Perfect for individuals getting started with our Platform</p>
-                <a href="https://dashboard.scalar.com/register" class="pricing-cta">Try For Free</a>
-              </div>
-              <div class="pricing-table-column">
-                <b class="text-sm">Pro</b>
-                <p class="text-xl font-bold ">$24 / seat / month*</p>
-                <p class=" text-c-2 text-sm font-normal">* Minimum 3 seats ($72/month base). A seat is one team member with editor access. Additional fees apply only for extra seats, usage-based products, or optional services.</p>
-                <p></p>
-                <a href="https://dashboard.scalar.com/register" class="pricing-cta pricing-cta-main">Try For Free</a>
-              </div>
-              <div class="pricing-table-column">
-                <b class="text-sm">Enterprise</b>
-                <p class="text-xl font-bold ">Custom Pricing</p>
-                <p class=" text-c-2 text-sm font-normal">* Custom pricing tailored to your API & business needs</p>
-                <a href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" class="pricing-cta">Contact Sales</a>
-              </div>
-            </div>
-          </header>
-          <div class="st_wrap_table text-sm" data-table_id="0">
-          <div class="pricing-table-group">
-            <header class="pricing-table-group-heading">Docs</header>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Subdomains</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">API References (OpenAPI)</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Themes</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Custom HTML/CSS/JS</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Email Domain Access Control</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Viewer Seats</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Editor Seats</div>
-              <div class="pricing-table-column">1</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Custom Domains</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Guides</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Versions</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Git Sync</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Markdown + MDX</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Landing Pages</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Full Developer Portal</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">SSO/SAML</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">RBAC</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Priority Support</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Dedicated Slack/Teams Channel</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-          </div>
-        </div>
-        <div class="st_wrap_table" data-table_id="1">
-          <header class="pricing-table-group-heading">API Client</header>
-                    <div class="pricing-table-group">
-           <div class="pricing-table-row">
-             <div class="pricing-table-column">REST Client</div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">Collections</div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">Pre-request scripting</div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">After-response scripting</div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">Collection environments</div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">Global environments</div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">Local and private sub-environments</div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">Test results</div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">Collection runner</div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">Open-Source (MIT)</div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">Offline First</div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">Web, MacOS, Linux, Windows</div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">OpenAPI Support</div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">No Vendor Lock In</div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-               <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-             </div>
-            <div class="pricing-table-row">
-               <div class="pricing-table-column">GRPC Client</div>
-               <div class="pricing-table-column">Coming Soon</div>
-               <div class="pricing-table-column">Coming Soon</div>
-               <div class="pricing-table-column">Coming Soon</div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">GraphQL Client</div>
-               <div class="pricing-table-column">Coming Soon</div>
-               <div class="pricing-table-column">Coming Soon</div>
-               <div class="pricing-table-column">Coming Soon</div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">SOAP Client</div>
-               <div class="pricing-table-column">Coming Soon</div>
-               <div class="pricing-table-column">Coming Soon</div>
-               <div class="pricing-table-column">Coming Soon</div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">WebSocket Client</div>
-               <div class="pricing-table-column">Coming Soon</div>
-               <div class="pricing-table-column">Coming Soon</div>
-               <div class="pricing-table-column">Coming Soon</div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">SSE Client</div>
-               <div class="pricing-table-column">Coming Soon</div>
-               <div class="pricing-table-column">Coming Soon</div>
-               <div class="pricing-table-column">Coming Soon</div>
-             </div>
-             <div class="pricing-table-row">
-               <div class="pricing-table-column">Cloud Sync</div>
-               <div class="pricing-table-column"></div>
-               <div class="pricing-table-column">Coming Soon</div>
-               <div class="pricing-table-column">Coming Soon</div>
-             </div>
-             <div class="pricing-table-row">
-              <div class="pricing-table-column">SSO/SAML</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">RBAC</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-           </div>
-        </div>
-        <div class="st_wrap_table" data-table_id="2">
-          <header class="pricing-table-group-heading">SDKs</header>
-          <div class="pricing-table-group">
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">TypeScript SDK</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column">+ $100</div>
-              <div class="pricing-table-column">+ $100</div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Python SDK</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column">+ $100</div>
-              <div class="pricing-table-column">+ $100</div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">C# SDK</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column">+ $100</div>
-              <div class="pricing-table-column">+ $100</div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Java SDK</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column">+ $100</div>
-              <div class="pricing-table-column">+ $100</div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">PHP SDK</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column">+ $100</div>
-              <div class="pricing-table-column">+ $100</div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">GO SDK</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column">+ $100</div>
-              <div class="pricing-table-column">+ $100</div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">automated github workflow</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Custom-code</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Code Samples</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Full OpenAPI Auth support</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">File Streaming</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Full language publishing registry</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Automatic sync with docs</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Webhooks support</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Migration services</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">SLAs</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">SSO/SAML</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Dedicated Slack channel</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-          </div>
-        </div>
-        <div class="st_wrap_table" data-table_id="3">
-          <header class="pricing-table-group-heading">Registry</header>
-          <div class="pricing-table-group">
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">OpenAPI, JSON Schema support</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Spectral Rules</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Preview API References</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Viewer Seats</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Editor Seats</div>
-              <div class="pricing-table-column">1</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">CLI</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Private + Public Access</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Git Integration</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">CI/CD workflows</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">custom domains</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">SSO/SAML</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">RBAC</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Migration services</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Dedicated Slack channel</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Max APIs</div>
-              <div class="pricing-table-column">3</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-          </div>
-        </div>
-        <div class="st_wrap_table" data-table_id="4">
-          <header class="pricing-table-group-heading">Agent</header>
-          <div class="pricing-table-group">
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Chat on localhost</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">10 free messages (localhost)</div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Production deployment</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-              <div class="pricing-table-column"><scalar-icon src="phosphor/bold/check"></scalar-icon></div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Messages included</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column">250</div>
-              <div class="pricing-table-column">250</div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Additional messages</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column">$0.02/msg</div>
-              <div class="pricing-table-column">$0.02/msg</div>
-            </div>
-          </div>
-        </div>
-        <div class="st_wrap_table" data-table_id="4">
-          <header class="pricing-table-group-heading">agent.scalar.com</header>
-          <div class="pricing-table-group">
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Tokens included</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column">2,000,000</div>
-              <div class="pricing-table-column">2,000,000</div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Additional input tokens</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column">$2/M</div>
-              <div class="pricing-table-column">$2/M</div>
-            </div>
-            <div class="pricing-table-row">
-              <div class="pricing-table-column">Additional output tokens</div>
-              <div class="pricing-table-column"></div>
-              <div class="pricing-table-column">$10/M</div>
-              <div class="pricing-table-column">$10/M</div>
-            </div>
-          </div>
-        </div>
-      </main>
-    </div>
-<div class="cta flex flex-col gap-3 small-test">
-  <scalar-heading level="2" class="text-balance" slug="what-are-you-waiting-for">What are you waiting for?</scalar-heading>
-  <p>
-    We're committed to enabling developers and companies to practice the highest
-    of API industry standards.
-  </p>
-  <div class="flex gap-2 mb-11">
-    <a class="t-editor__button" href="https://dashboard.scalar.com/register">Get Started</a>
-    <a class="t-editor__button" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a Demo</a>
+  <div class="pricing-logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-maersk.svg"></scalar-icon>
   </div>
-  <a class="expander-hover-link" href="https://discord.gg/scalar" target="_blank" aria-label="Join Scalar community on Discord">Community →</a>
-  <a class="expander-hover-link" href="https://github.com/scalar/scalar" target="_blank" aria-label="View Scalar on GitHub">GitHub →</a>
-  <a class="expander-hover-link" href="mailto:support@scalar.com" target="_blank" aria-label="Contact Scalar support">Contact Us →</a>
-</div>
-<div class="expander-container">
-  <div class="expander-hover">
-    <div class="expander-hover-preview">
-      <img alt="API Client Preview" class="light-image" src="/api-client-static.svg" />
-      <img alt="API Client Preview" class="dark-image" src="/api-client-static-dark.svg" />
-    </div>
-    <div class="relative">
-      <div class="expander-hover-sticker">
-        <object class="sticker-clip-client" width="156" height="110"
-          data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/JXS6tZ4EbKIkeGpjP6QKc.svg"></object>
-      </div>
-      <div class="expander-hover-title">API Client</div>
-      <div class="expander">
-        <div class="expander-content">
-          Minimal, powerful, fully open-source API Client built on open standards by us + our community.
-        </div>
-      </div>
-      <a class="expander-hover-link" href="https://client.scalar.com/" target="_blank" aria-label="Learn more about API Client">Learn More</a>
-    </div>
+  <div class="pricing-logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-bobcat.svg"></scalar-icon>
   </div>
-  <div class="expander-hover">
-    <div class="expander-hover-preview">
-      <img alt="SDKs Preview" class="light-image" src="/sdks-static.svg" />
-      <img alt="SDKs Preview" class="dark-image" src="/sdks-static-dark.svg" />
-    </div>
-    <div class="relative">
-      <div class="expander-hover-sticker">
-        <object class="sticker-clip-sdk" width="145" height="145"
-          data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/gM-mqYTBYMkqpnexTIr-r.svg"></object>
-      </div>
-      <div class="expander-hover-title">SDKs</div>
-      <div class="expander">
-        <div class="expander-content">
-          Bring your OpenAPI document and get type-safe client libraries for TypeScript, Python and more.
-        </div>
-      </div>
-      <a class="expander-hover-link" href="/products/sdks/getting-started" aria-label="Learn more about SDKs">Learn More</a>
-    </div>
+  <div class="pricing-logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-clerk.svg?v=2"></scalar-icon>
   </div>
-  <div class="expander-hover">
-    <div class="expander-hover-preview">
-      <img alt="API Registry Preview" class="light-image" src="/registry-static.svg" />
-      <img alt="API Registry Preview" class="dark-image" src="/registry-static-dark.svg" />
-    </div>
-    <div class="relative">
-      <div class="expander-hover-sticker">
-      <object class="sticker-clip-registry" width="136" height="186"
-          data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/jgGF_IKsu-T_irS-6MMOy.svg"></object>
-      </div>
-      <div class="expander-hover-title">API Registry</div>
-      <div class="expander">
-        <div class="expander-content">
-          Managing & versioning OpenAPI Documents with a deep Git integration.
-        </div>
-      </div>
-      <a class="expander-hover-link" href="/products/registry/getting-started" aria-label="Learn more about API Registry">Learn More</a>
-    </div>
+  <div class="pricing-logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-lufthansa.svg"></scalar-icon>
   </div>
-  <div class="expander-hover">
-    <div class="expander-hover-preview">
-      <img alt="API Docs Preview" class="light-image" src="/api-docs-static-zoom.svg" />
-      <img alt="API Docs Preview" class="dark-image" src="/api-docs-static-zoom-dark.svg" />
-    </div>
-    <div class="relative">
-      <div class="expander-hover-sticker">
-        <object class="sticker-clip-docs" width="113" height="143" data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/HLhbFqJ4vSzo4UDEZX2dq.svg"></object>
-      </div>
-      <div class="expander-hover-title">API Docs</div>
-      <div class="expander">
-        <div class="expander-content">
-          Write beautiful documentation with Markdown + MDX + Git Sync.
-        </div>
-      </div>
-      <a class="expander-hover-link" href="/products/docs/getting-started" aria-label="Learn more about API Docs">Learn More</a>
-    </div>
+  <div class="pricing-logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-partech.svg?v=2"></scalar-icon>
   </div>
 </div>
-<div class="pricing footer container-full">
-  <div class="footer-content">
-      <div>
-        <span class="text-c-1">
-          <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
-        </span>
-        <p class="mt-10 text-c-3 text-sm text-balance">The OpenAPI company.</p>
-        <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
-      </div>
-      <div class="flex text-sm">
-        <div class="w-1/3 flex flex-col gap-2">
-          <b>Products</b>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="https://" target="_blank">API References</a>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="https://client.scalar.com/" target="_blank">API Client</a>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="https://docs.scalar.com/" target="_blank">API Docs</a>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="https://editor.scalar.com/" target="_blank">Swagger Editor</a>
-        </div>
-        <div class="w-1/3 flex flex-col gap-2">
-          <b>Company</b>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="mailto:support@scalar.com" target="_blank">Support</a>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="/legal/terms-and-conditions">Terms of Service</a>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="/legal/privacy-policy">Privacy Policy</a>
-          <button class="cky-banner-element text-c-2 hover:text-c-1 font-normal">Cookie Preferences</button>
-        </div>
-        <div class="w-1/3 flex flex-col gap-2">
-          <b>Socials</b>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="https://twitter.com/scalar" target="_blank">x (formerly Twitter)</a>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="https://github.com/scalar/scalar" target="_blank">GitHub</a>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="https://discord.gg/scalar" target="_blank">Discord</a>
-          <a class="text-c-2 hover:text-c-1 font-normal" href="https://www.linkedin.com/company/scalar-org" target="_blank">Linkedin</a>
-        </div>
-      </div>
-  </div>
-  <!-- footer animation -->
-  <div class="footer-animation">
-    <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/v1Pu6_BCmly6VhPAuotVZ.svg"></scalar-icon>
-  </div>
-</div>
-<div class="sticker-filter-effect">
-  <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/utn6gGF3Iucolqx4jmXmY.svg">
-</div>
+
+## Developer Docs
+
+Everything you need to publish OpenAPI-powered docs, from self-hosted starts to branded multi-site portals.
+
+| Feature | Free | Hobby | Pro | Enterprise |
+| ------- | ---- | ----- | --- | ---------- |
+| Hosted sites | Self-host | 1 | Unlimited | Unlimited |
+| Custom domain | — | ✓ | ✓ | ✓ |
+| Remove Scalar branding | — | — | ✓ | ✓ |
+| Git sync & versioning | ✓ | ✓ | ✓ | ✓ |
+| Preview deployments | — | — | ✓ | ✓ |
+| Custom CSS / theming | — | — | ✓ | ✓ |
+| Password protection | — | — | ✓ | ✓ |
+
+## Agent Scalar
+
+Use Agent locally for free, add production usage on paid plans, and scale with credit packs when you need more.
+
+<scalar-row>
+<scalar-card title="One credit per agent action">
+Every agent response costs `1 credit`. Every API call your agent makes on your behalf costs `1 credit`. Complex tasks may use more than one credit, and failed calls are never charged.
+</scalar-card>
+
+<scalar-card title="Bring your own key">
+Paid plans can connect OpenAI, Anthropic, Gemini, or custom API keys. Agent reasoning runs on your own account, and only the API calls the agent makes count toward Scalar credits.
+</scalar-card>
+</scalar-row>
+
+| Agent product | Included with | Details |
+| ------------- | ------------- | ------- |
+| Local Agent | Free | 10 free localhost messages, no setup required |
+| Embedded Agent in docs and references | Pro / Enterprise | 250 messages included, `$0.02 / message` after that |
+| `agent.scalar.com` | Pro / Enterprise | 2,000,000 tokens included, `$2 / M` input and `$10 / M` output |
+
+| Credit pack | Price | Effective rate |
+| ----------- | ----- | -------------- |
+| 1,000 credits | $10 | `$0.010 / credit` |
+| 5,000 credits | $40 | `$0.008 / credit` |
+| 25,000 credits | $150 | `$0.006 / credit` |
+
+## Team & Access
+
+Collaboration, access control, and governance features for teams moving from personal workflows to shared API platforms.
+
+| Feature | Free | Hobby | Pro | Enterprise |
+| ------- | ---- | ----- | --- | ---------- |
+| Full API Client with cloud sync | ✓ | ✓ | ✓ | ✓ |
+| Unlimited personal collections | ✓ | ✓ | ✓ | ✓ |
+| Agent embedded in client | ✓ | ✓ | ✓ | ✓ |
+| Team workspaces | — | — | ✓ | ✓ |
+| Shared collections | — | — | ✓ | ✓ |
+| Role-based access control | — | — | — | ✓ |
+| SSO / SAML | — | — | — | ✓ |
+| Priority support | — | — | — | ✓ |
+
+## FAQ
+
+Everything else you might want to know. Still unclear on something? [Talk to our team](https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a) — we'd rather explain it once than have you guess.
+
+### What exactly is a credit?
+
+One credit equals one agent action. A question asked to the agent is `1 credit`. An API call made by the agent on your behalf is `1 credit`. A complex task with multiple calls might cost 5-10 credits. We show the expected cost before you run anything, and failed calls are never charged.
+
+### What if I run out of credits mid-month?
+
+Buy a credit pack on any paid plan — starting at 1,000 credits for $10. Credits from packs do not expire, and volume discounts kick in at larger sizes.
+
+### Can I really bring my own LLM key?
+
+Yes. On any paid plan you can connect an OpenAI, Anthropic, Gemini, or custom API key. When you do, agent reasoning runs on your account at your rates. Only API calls the agent makes on your behalf count toward your Scalar credits. Keys are stored on your device, not ours.
+
+### Who counts as an "editor"?
+
+Anyone who can edit your docs, API Client workspaces, or registries. Viewers (anyone reading your published docs) are unlimited and free on every tier — we do not charge per reader.
+
+### What happens in the Pro trial?
+
+14 days of full Pro access, including the 1,000 agent credits. No credit card required to start. If you upgrade, any credits you used during trial do not count against your first month's allocation.
+
 <style>
-.mobiletabs input {
-  position: absolute;
-  left: -200vw;
+.pricing-logowall {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin: 16px 0 40px;
 }
-.mobiletabs {
-  margin-top: 40px !important;
-}
-.mobiletabs-container {
-  display: none;
-  gap: 18px;
-  border-bottom: var(--scalar-border-width) solid var(--scalar-border-color)
-}
-.mobiletabs label {
-  color: var(--scalar-color-2);
-  padding-bottom: 12px;
-}
-.mobiletabs label:has(input:checked) {
-  color: var(--scalar-color-1);
-  font-weight: var(--scalar-semibold);
-  border-bottom: 1px solid currentColor
-}
-.pricing-table {
-    border: var(--scalar-border-width) solid var(--scalar-border-color);
-    border-radius: var(--scalar-radius);
-    contain: paint;
-}
-h4.t-editor__heading {
-    margin-top: 0;
-}
-[data-table_id="0"]{
-  --pricing-table-bg: var(--scalar-color-blue);
-}
-[data-table_id="1"]{
-  --pricing-table-bg: var(--scalar-color-orange);
-}
-[data-table_id="2"]{
-  --pricing-table-bg: var(--scalar-color-purple);
-}
-[data-table_id="3"]{
-  --pricing-table-bg: var(--scalar-color-green);
-}
-[data-table_id="4"]{
-  --pricing-table-bg: var(--scalar-color-red);
-}
-.st_wrap_table svg {
-    fill: var(--pricing-table-bg)
-}
-.st_wrap_table {
-    background-color: color-mix(in srgb, var(--pricing-table-bg), transparent 99%)
-}
-.st_wrap_table .pricing-table-row:nth-child(even){
-    background-color: color-mix(in srgb, var(--pricing-table-bg), transparent 97%)
-}
-.dark-mode .st_wrap_table {
-    background-color: color-mix(in srgb, var(--pricing-table-bg), transparent 94%)
-}
-.dark-mode .st_wrap_table .pricing-table-row:nth-child(even){
-    background-color: color-mix(in srgb, var(--pricing-table-bg), transparent 96%)
-}
-.pricing-cta {
-    padding: 8px 12px;
-    text-align: center;
-    border-radius: var(--scalar-radius-lg);
-    background: var(--scalar-background-2);
-    display: block;
-    font-size: var(--scalar-font-size-4);
-    border: var(--scalar-border-width) solid var(--scalar-border-color);
-    cursor: pointer;
-    font-weight: var(--scalar-font-medium);
-    margin-top: auto;
-}
-.pricing-cta-main {
-    background: var(--scalar-button-1);
-    color: var(--scalar-button-1-color)
-}
-.pricing {
-    padding-top: 20px
-}
-.pricing-table-column {
-    width: 25%;
-    padding: 8px 12px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    font-size: var(--scalar-font-size-4);
-    gap: 12px;
-   font-weight: var(--scalar-font-medium);
-   color: var(--pricing-table-bg)
-}
-.pricing-table-column:first-child {
-  color: var(--scalar-color-1)
-}
-/* ##   header */
-.pricing-table-group_header{
-    background-color: var(--scalar-background-1);
-}
-.pricing-table-group_header._sticky {
-    top: var(--scalar-header-height);
-    position: sticky;
-    z-index: 1;
-}
-._sticky .pricing-table-column {
-    padding: 12px
-}
-.pricing-table-group-heading {
-    position: sticky;
-    top: 228px;
-    padding: 8px 12px;
-    background: var(--pricing-table-bg);
-    font-weight: var(--scalar-bold);
-}
-.pricing-table-group-heading {
-    color: var(--scalar-background-1);
-    font-size: var(--scalar-font-size-4);
-}
-.pricing-table-group_header h2{
-  font-weight: 400;
-  margin: 0 20px;
-  padding: 20px 0 0;
-}
-/* ##  table */
-.pricing-table-group{
-    display: flex;
-    flex-direction: column;
-}
-/* #   row */
-.pricing-table-row{
+
+.pricing-logowall-item {
+  align-items: center;
+  background: var(--scalar-background-2);
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
+  border-radius: var(--scalar-radius-lg);
   display: flex;
-  margin: 0;
+  justify-content: center;
+  min-height: 72px;
+  padding: 16px;
 }
-@media screen and (max-width: 880px) {
-  .mobiletabs-container {
-    display: flex;
-  }
-  .pricing-table-column {
-    width: 50%;
-  }
-  .pricing-table-group_header._sticky .pricing-table-column:first-of-type {
-    display: none;
-  }
-  .pricing-table-group_header._sticky .pricing-table-column {
-    width: 100%;
-  }
-  .pricing-table-group-heading,
-  .pricing-table-group_header._sticky {
-    position: static;
-  }
-  .mobiletabs .tab-panel {
-    display: none;
-  }
-  .mobiletabs > .mobiletabs-container:has(label:first-child input:checked) ~ .tab-panels .pricing-table-column:nth-of-type(3),
-  .mobiletabs > .mobiletabs-container:has(label:first-child input:checked) ~ .tab-panels .pricing-table-column:nth-of-type(4) {
-    display: none;
-  }
-  .mobiletabs > .mobiletabs-container:has(label:nth-child(2) input:checked) ~ .tab-panels .pricing-table-column:nth-of-type(2),
-  .mobiletabs > .mobiletabs-container:has(label:nth-child(2) input:checked) ~ .tab-panels .pricing-table-column:nth-of-type(4) {
-    display: none;
-  }
-  .mobiletabs > .mobiletabs-container:has(label:nth-child(3) input:checked) ~ .tab-panels .pricing-table-column:nth-of-type(2),
-  .mobiletabs > .mobiletabs-container:has(label:nth-child(3) input:checked) ~ .tab-panels .pricing-table-column:nth-of-type(3) {
-    display: none;
+
+.pricing-logowall-item svg {
+  height: 24px;
+  max-width: 136px;
+  opacity: 0.8;
+  width: 100%;
+}
+
+@media screen and (max-width: 800px) {
+  .pricing-logowall {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
-  .t-editor__page-title,
-  .t-editor__page-nav,
-  .notify-container,
-  .subheading,
-  .page-nav,
-  :not(.pricing).footer,
-  .t-editor .page-header {
-    display: none;
+
+@media screen and (max-width: 520px) {
+  .pricing-logowall {
+    grid-template-columns: 1fr;
   }
-  main.content {
-    overflow-x: clip;
-  }
-  .t-doc .layout-header {
-    z-index: 10000;
-  }
-  .t-editor__button {
-    min-width: 160px;
-    justify-content: center;
-  }
-  .t-editor .editor-content,
-  .t-editor {
-    padding-bottom: 0;
-  }
-  h3.t-editor__heading,
-  h2.t-editor__heading {
-    --font-size: var(--scalar-heading-1);
-      margin-top: 0;
-  }
-  :root {
-    --scalar-container-width: 960px;
-  }
-  .hero.hero {
-    margin-top: 88px;
-  }
-  .small-test {
-    max-width: 440px;
-    margin-top: 44px;
-    position: relative;
-  }
-  .t-editor.page {
-    margin-right: unset;
-  }
-  .t-editor .editor-static .page-node,
-  .t-editor .page-node,
-  .t-editor .content {
-    max-width: var(--scalar-container-width);
-    padding-bottom: 0;
-    margin-bottom: 0;
-  }
-  .container {
-    width: var(--scalar-container-width);
-    margin: auto;
-    position: relative;
-  }
-  .container-full {
-    --scalar-container-sidebar-gap: calc(
-      (
-        (100dvw - var(--scalar-container-width) - var(--scalar-sidebar-width)) /
-          2
-      )
-    );
-    width: calc(100dvw - var(--scalar-sidebar-width));
-    margin-left: min(-1 * var(--scalar-container-sidebar-gap), -50px);
-  }
-  .container {
-    width: 900px;
-    margin: auto;
-    position: relative;
-  }
-  /* new stuff  */
-  .expander {
-    display: grid;
-    grid-template-rows: 0fr;
-    overflow: hidden;
-    opacity: 0;
-    transition: grid-template-rows 0.25s, opacity 0.25s ease-in-out;
-  }
-  .expander-content {
-    min-height: 0;
-    margin-bottom: 12px;
-    margin-top: 6px;
-    line-height: 1.45;
-    font-size: 14px;
-  }
-  .expander-hover {
-    height: 370px;
-    width: 25%;
-    position: relative;
-  }
-  .expander-hover:hover .expander {
-    grid-template-rows: 1fr;
-    opacity: 1;
-    transition: grid-template-rows 0.5s, opacity 0.5s ease-in-out;
-  }
-  .expander.expanded .expander-content {
-    visibility: visible;
-  }
-  .expander-hover-title {
-    font-size: 20px;
-    font-weight: var(--scalar-semibold);
-    margin-top: 24px;
-  }
-  .expander-hover-link {
-    --font-color: var(--scalar-color-2);
-    --font-visited: var(--scalar-color-2);
-    color: var(--font-color, var(--scalar-color-1));
-    font-weight: var(--scalar-semibold);
-    text-underline-offset: 0.25rem;
-    text-decoration-thickness: 1px;
-    text-decoration: underline;
-    text-decoration-color: color-mix(
-      in srgb,
-      var(--font-color, var(--scalar-color-1)) 30%,
-      transparent
-    );
-    margin-top: 6px;
-  }
-  .expander-hover:hover .expander-hover-link {
-    --font-color: var(--scalar-color-1);
-  }
-  .expander-hover-preview {
-    position: absolute;
-    left: -120px;
-    top: -220px;
-    width: 1100px;
-    mask-image: radial-gradient(circle at top left, black 25%, transparent 40%);
-    pointer-events: none;
-    opacity: 0;
-    transition: all 0.3s ease-in-out;
-    transform: rotate(1deg) translate3d(-10px, -10px, 0);
-    max-height: 500px;
-    overflow: hidden;
-  }
-  .expander-hover .relative {
-    z-index: 1;
-  }
-  .expander-hover:hover .expander-hover-preview {
-    opacity: 1;
-    transform: rotate(2deg) translate3d(0, 0, 0);
-    transition: all 0.3s ease-in-out 0.2s;
-  }
-  .expander-hover-preview img {
-    margin-left: 0;
-    mask-image: linear-gradient(black, transparent);
-    width: 100%;
-  }
-  .expander-hover-sticker {
-    height: 143px;
-    width: 100%;
-    display: flex;
-    align-items: center;
-    position: relative;
-    margin-left: -12px;
-    transition: transform 0.3s ease-in-out;
-    justify-content: flex-start;
-  }
-  .expander-hover-sticker object {
-    pointer-events: none;
-  }
-  .expander-hover-sticker img {
-    max-height: initial;
-    margin-left: initial;
-  }
-  .expander-hover:hover .expander-hover-sticker {
-    transform: rotate(-3deg);
-  }
-  .expander-container {
-    display: flex;
-    gap: 44px;
-  }
-  .cta {
-    padding: 80px 0;
-    margin-top: 0 !important;
-  }
-  .mb-11 {
-    margin-bottom: 44px;
-  }
-  /* footer */
-  .pricing.footer {
-    position: relative;
-    overflow: hidden;
-    background: var(--scalar-background-2);
-    padding-bottom: 200px;
-    margin-top: 100px;
-  }
-  .footer-animation svg {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-  }
-  .footer-content {
-    display: flex;
-    gap: 48px;
-    max-width: var(--scalar-container-width);
-    width: 100%;
-    margin: auto;
-    padding-top: 92px;
-  }
-  .footer-content > * {
-    flex: 1;
-  }
-  .footer-content span,
-  .footer-content p,
-  .footer-content a,
-  .footer-content button {
-    position: relative;
-    z-index: 1;
-  }
-  .w-1\/3 {
-    width: 33.33%
-  }
-  .light-mode .dark-image {
-    display: none;
-  }
-  .dark-mode .light-image {
-    display: none;
-  }
-  .sticker-clip-client {
-    clip-path: path("M158 91.9102C158 95.8908 154.773 99.1172 150.792 99.1172L147.269 99.1172L147.269 105.78C147.268 107.948 145.511 109.705 143.343 109.705L86.2051 109.705C84.0373 109.705 82.2795 107.948 82.2793 105.78L82.2793 99.1172L7.208 99.1172C3.22741 99.1172 1.10673e-05 95.8908 -4.01752e-06 91.9101L-3.50643e-06 80.2178C-3.47119e-06 79.4117 0.135571 78.6109 0.400387 77.8496L25.7949 4.83984C26.8028 1.94219 29.5346 -5.6154e-06 32.6025 -5.4813e-06L150.792 -3.15072e-07C154.773 -1.41078e-07 158 3.22654 158 7.20703L158 91.9102Z")
-  }
-  .sticker-clip-sdk {
-    clip-path: path("M60.0562 8.61129C65.9233 -1.83053 81.0294 -1.61478 86.5955 8.99068L142.416 115.353C144.543 119.406 141.567 124.259 136.991 124.201L114.679 123.918L114.138 135.797C113.962 139.654 110.761 142.678 106.9 142.634L32.9393 141.782C29.1212 141.738 26.0084 138.707 25.864 134.891L25.406 122.787L6.28841 122.544C1.70363 122.486 -1.1476 117.543 1.09835 113.545L60.0562 8.61129Z")
-  }
-  .sticker-clip-registry {
-    clip-path: path("M71.0986 1.13334C75.8537 -0.596969 81.1116 1.85514 82.8428 6.6099L90.3037 27.1079H98.5059C104.199 27.108 108.814 31.7235 108.814 37.4165V77.9663L121.32 112.329C119.703 112.128 118.003 112.298 116.351 112.899C110.96 114.861 108.12 120.659 110.009 125.848C111.898 131.038 117.8 133.654 123.191 131.692C124.844 131.091 126.254 130.127 127.364 128.933L134.608 148.835C136.339 153.591 133.887 158.849 129.132 160.58L73.3945 180.866C68.6393 182.596 63.3816 180.145 61.6504 175.39L58.958 167.994H2.29102C1.02582 167.994 0 166.968 0 165.703V29.398C0.000538247 28.1333 1.02616 27.1079 2.29102 27.1079H9.8125C10.6721 24.5603 12.6383 22.4116 15.3613 21.4204L71.0986 1.13334Z")
-  }
-  .sticker-clip-docs {
-    overflow: hidden;
-    border-radius: 20px;
-  }
-  @media screen and (max-width: 1000px) {
-    .t-doc {
-      --scalar-sidebar-width: 0px;
-    }
-    .t-editor.page {
-      padding-inline: 30px;
-    }
-    .container-full {
-      --scalar-container-sidebar-gap: 30px;
-      width: 100dvw;
-      padding-inline: 30px;
-      margin-inline: -30px;
-    }
-    .quotes-item {
-      flex: 0 0 100%;
-    }
-    .product,
-    .product-reversed {
-      flex-direction: column;
-      gap: 60px;
-    }
-    .product > * {
-      flex: initial;
-    }
-    .product-copy {
-      padding-block: 0;
-    }
-    .product-copy .lg-only {
-      display: none;
-    }
-    .expander-container {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-      row-gap: 0;
-    }
-    .expander-hover {
-      width: auto;
-    }
-    .expander-hover .expander {
-      grid-template-rows: 1fr;
-      opacity: 1;
-    }
-    .expander .expander-content {
-      visibility: visible;
-    }
-    .footer-content {
-      flex-direction: column;
-    }
-    .footer-content > * {
-      flex: initial;
-    }
-  }
-  @media screen and (max-width: 500px) {
-    .mobile-hide {
-      display: none;
-    }
-  }
+}
 </style>

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -2,11 +2,6 @@
 
 One platform for: APIs, Docs, Agents, SDKs, Governance & API Client all based on OpenAPI™.
 
-<div class="flex gap-2 flex-wrap">
-  <a class="t-editor__button" href="https://dashboard.scalar.com/register">Get started</a>
-  <a class="t-editor__button" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Talk to sales</a>
-</div>
-
 <scalar-row>
 <scalar-card title="Free">
 **Best for:** self-hosting, local development, and personal API workflows.

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -685,7 +685,7 @@
           },
           "/pricing": {
             "title": "Pricing",
-            "description": "Transparent pricing for developer documentation, SDKs, and API tools. Start free and scale as you grow.",
+            "description": "Simple pricing for APIs, docs, agents, SDKs, governance, and API Client workflows built on OpenAPI.",
             "icon": "phosphor/regular/coin-vertical",
             "filepath": "documentation/guides/pricing.md",
             "type": "page",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `/pricing` page used a large custom HTML and CSS implementation that was hard to scan and harder to maintain. We want a simpler Scalar markdown page with a clearer structure for pricing cards, product sections, and FAQ content.

## Solution

Replaced the bespoke layout in `documentation/guides/pricing.md` with a markdown-first page using built-in docs patterns:
- added a new H1 and description
- simplified the pricing overview into card-based plan summaries
- added a trusted-by logo wall
- reorganized content into `Developer Docs`, `Agent Scalar`, and `Team & Access`
- rewrote the FAQ section to match the requested heading and description

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8effa33-bb26-4034-92a6-71be5f3eeae3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8effa33-bb26-4034-92a6-71be5f3eeae3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

