### PR TITLE
docs(aspire): rename .NET Aspire references

### DIFF
--- a/.changeset/mean-mice-hunt.md
+++ b/.changeset/mean-mice-hunt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspire': patch
+---
+
+Rename `.NET Aspire` references to `Aspire` after the product rebrand.

--- a/.changeset/mean-mice-hunt.md
+++ b/.changeset/mean-mice-hunt.md
@@ -2,4 +2,4 @@
 '@scalar/aspire': patch
 ---
 
-Rename `.NET Aspire` references to `Aspire` after the product rebrand.
+Rename legacy Aspire branding references after the product rebrand.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -390,7 +390,7 @@
     },
 
     {
-      "description": "Disable any docker updates for .NET Aspire",
+      "description": "Disable any docker updates for Aspire",
       "matchFileNames": ["**/aspire/**"],
       "matchDatasources": ["docker"],
       "enabled": false

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ And there's an ever-growing list of plugins and integrations:
 
 - [HTML/JS API](https://scalar.com/products/api-references/integrations/html-js) (works everywhere)
 - [.NET ASP.NET Core](https://scalar.com/products/api-references/integrations/aspnetcore/integration)
-- [.NET Aspire](https://scalar.com/products/api-references/integrations/aspire)
+- [Aspire](https://scalar.com/products/api-references/integrations/aspire)
 - [AdonisJS](https://scalar.com/products/api-references/integrations/adonisjs)
 - [Astro](https://scalar.com/products/api-references/integrations/astro)
 - [Django Ninja](https://scalar.com/products/api-references/integrations/django-ninja)

--- a/documentation/integrations/aspire.md
+++ b/documentation/integrations/aspire.md
@@ -1,6 +1,6 @@
-# API Reference for .NET Aspire
+# API Reference for Aspire
 
-The `Scalar.Aspire` package seamlessly integrates API Reference into your .NET Aspire applications, providing a unified documentation interface for all your services.
+The `Scalar.Aspire` package seamlessly integrates API Reference into your Aspire applications, providing a unified documentation interface for all your services.
 
 ## Overview
 

--- a/documentation/migration/zuplo.md
+++ b/documentation/migration/zuplo.md
@@ -101,7 +101,7 @@ Scalar provides official integrations for all major web frameworks, making it ea
 | Docusaurus    | ✓         |
 | Astro         | ✓         |
 | ASP.NET Core  | ✓         |
-| .NET Aspire   | ✓         |
+| Aspire   | ✓         |
 | FastAPI       | ✓         |
 | Django Ninja  | ✓         |
 | Spring (Java) | ✓         |

--- a/integrations/dotnet/README.md
+++ b/integrations/dotnet/README.md
@@ -6,7 +6,7 @@ This folder contains the .NET packages for Scalar API documentation.
 
 - **`shared/`** - Contains `Scalar.Shared` project with shared resources
 - **`aspnetcore/`** - Contains `Scalar.AspNetCore` package for ASP.NET Core applications
-- **`aspire/`** - Contains `Scalar.Aspire` package for .NET Aspire applications
+- **`aspire/`** - Contains `Scalar.Aspire` package for Aspire applications
 
 Each project has its own solution file (`.slnx`):
 - `Scalar.Shared.slnx` - For working with shared code

--- a/integrations/dotnet/aspire/CHANGELOG.md
+++ b/integrations/dotnet/aspire/CHANGELOG.md
@@ -1312,7 +1312,7 @@
 
 ### Minor Changes
 
-- a974b26: feat(Scalar.Aspire): initial .NET Aspire integration
+- a974b26: feat(Scalar.Aspire): initial Aspire integration
 
 ### Patch Changes
 

--- a/integrations/dotnet/aspire/README.md
+++ b/integrations/dotnet/aspire/README.md
@@ -11,7 +11,7 @@
 [![Downloads](https://img.shields.io/nuget/dt/Scalar.Aspire)](https://www.nuget.org/packages/Scalar.Aspire)
 [![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
 
-Automatically discover and create a unified, interactive API Reference for all your .NET Aspire services from their OpenAPI/Swagger documents.
+Automatically discover and create a unified, interactive API Reference for all your Aspire services from their OpenAPI/Swagger documents.
 
 ## Documentation
 

--- a/integrations/dotnet/aspire/package.json
+++ b/integrations/dotnet/aspire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scalar/aspire",
-  "description": "Automatically discover and create a unified, interactive API Reference for all your .NET Aspire services from their OpenAPI/Swagger documents.",
+  "description": "Automatically discover and create a unified, interactive API Reference for all your Aspire services from their OpenAPI/Swagger documents.",
   "license": "MIT",
   "author": "Scalar (https://github.com/scalar)",
   "homepage": "https://github.com/scalar/scalar",

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/Options/ScalarAspireOptions.cs
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/Options/ScalarAspireOptions.cs
@@ -1,7 +1,7 @@
 namespace Scalar.Aspire;
 
 /// <summary>
-/// Represents configuration options specific to Scalar API reference integration with .NET Aspire.
+/// Represents configuration options specific to Scalar API reference integration with Aspire.
 /// Extends <see cref="ScalarOptions"/> with Aspire-specific settings.
 /// </summary>
 public sealed class ScalarAspireOptions : ScalarOptions

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/Scalar.Aspire.csproj
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/Scalar.Aspire.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <Title>Scalar.Aspire</Title>
-    <Description>Automatically discover and create a unified, interactive API Reference for all your .NET Aspire services from their OpenAPI/Swagger documents.</Description>
+    <Description>Automatically discover and create a unified, interactive API Reference for all your Aspire services from their OpenAPI/Swagger documents.</Description>
     <Authors>Scalar</Authors>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/scalar/scalar</RepositoryUrl>

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1528,7 +1528,7 @@
                         "type": "page"
                       },
                       "aspire": {
-                        "title": ".NET Aspire",
+                        "title": "Aspire",
                         "filepath": "documentation/integrations/aspire.md",
                         "type": "page"
                       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The integration and docs still use legacy Aspire branding even though the product was rebranded to `Aspire`.

## Solution

- Replaced legacy branding mentions with `Aspire` across docs, integration metadata, and config navigation labels.
- Added a changeset for `@scalar/aspire` to capture the wording update in release notes.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [ ] I added tests.
- [x] I updated the documentation.

## Ticket

Fixes #8905
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c247e024-d5d0-4656-8cc9-c893b18a8766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c247e024-d5d0-4656-8cc9-c893b18a8766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

