### PR TITLE
fix(workspace-store): handle nullable numeric empty-string defaults

### DIFF
--- a/.changeset/flat-melons-drum.md
+++ b/.changeset/flat-melons-drum.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Prevent infinite recursion when validating defaults on circular composed schemas.

--- a/.changeset/silent-pumas-love.md
+++ b/.changeset/silent-pumas-love.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix nullable numeric schema defaults so empty-string defaults are normalized to null in generated request body examples.

--- a/packages/workspace-store/src/request-example/builder/body/get-request-body-example.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/get-request-body-example.test.ts
@@ -146,42 +146,6 @@ describe('get-request-body-example', () => {
     expect(result).toEqual({ value: { source: 'service' } })
   })
 
-  it('normalizes nullable integer default empty strings to null in generated request examples', () => {
-    const requestBody = coerceValue(RequestBodyObjectSchema, {
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              username: {
-                type: ['string', 'null'],
-                default: null,
-              },
-              password: {
-                type: ['string', 'null'],
-                default: null,
-              },
-              passcode: {
-                type: ['integer', 'null'],
-                default: '',
-              },
-            },
-          },
-        },
-      },
-    })
-
-    const result = getExampleFromBody(requestBody, 'application/json', 'default')
-
-    expect(result).toEqual({
-      value: {
-        username: null,
-        password: null,
-        passcode: null,
-      },
-    })
-  })
-
   it('deep resolves nested refs when generating selected nested composition examples', () => {
     const requestBody = coerceValue(RequestBodyObjectSchema, {
       content: {

--- a/packages/workspace-store/src/request-example/builder/body/get-request-body-example.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/get-request-body-example.test.ts
@@ -146,6 +146,42 @@ describe('get-request-body-example', () => {
     expect(result).toEqual({ value: { source: 'service' } })
   })
 
+  it('normalizes nullable integer default empty strings to null in generated request examples', () => {
+    const requestBody = coerceValue(RequestBodyObjectSchema, {
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              username: {
+                type: ['string', 'null'],
+                default: null,
+              },
+              password: {
+                type: ['string', 'null'],
+                default: null,
+              },
+              passcode: {
+                type: ['integer', 'null'],
+                default: '',
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const result = getExampleFromBody(requestBody, 'application/json', 'default')
+
+    expect(result).toEqual({
+      value: {
+        username: null,
+        password: null,
+        passcode: null,
+      },
+    })
+  })
+
   it('deep resolves nested refs when generating selected nested composition examples', () => {
     const requestBody = coerceValue(RequestBodyObjectSchema, {
       content: {

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
@@ -718,6 +718,24 @@ describe('getExampleFromSchema', () => {
     expect(getExampleFromSchema(schema)).toBe('BAD_REQUEST_EXCEPTION')
   })
 
+  it('normalizes empty string defaults to null for nullable integers', () => {
+    const schema = coerceValue(SchemaObjectSchema, {
+      type: ['integer', 'null'],
+      default: '',
+    })
+
+    expect(getExampleFromSchema(schema)).toBeNull()
+  })
+
+  it('keeps empty string defaults for nullable strings', () => {
+    const schema = coerceValue(SchemaObjectSchema, {
+      type: ['string', 'null'],
+      default: '',
+    })
+
+    expect(getExampleFromSchema(schema)).toBe('')
+  })
+
   it('uses the const value', () => {
     const schema = coerceValue(SchemaObjectSchema, {
       type: 'string',

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
@@ -745,6 +745,18 @@ describe('getExampleFromSchema', () => {
     expect(getExampleFromSchema(schema)).toBe('')
   })
 
+  it('does not recurse forever when validating defaults on circular composed schemas', () => {
+    const schema = {
+      type: 'object',
+      default: {},
+      anyOf: [],
+    } as SchemaObject
+
+    schema.anyOf = [schema]
+
+    expect(getExampleFromSchema(schema)).toStrictEqual({})
+  })
+
   it('keeps empty string defaults for nullable strings', () => {
     const schema = coerceValue(SchemaObjectSchema, {
       type: ['string', 'null'],

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
@@ -718,6 +718,15 @@ describe('getExampleFromSchema', () => {
     expect(getExampleFromSchema(schema)).toBe('BAD_REQUEST_EXCEPTION')
   })
 
+  it('ignores invalid defaults when they do not match primitive schema type', () => {
+    const schema = coerceValue(SchemaObjectSchema, {
+      type: 'number',
+      default: 'invalid',
+    })
+
+    expect(getExampleFromSchema(schema)).toBe(1)
+  })
+
   it('normalizes empty string defaults to null for nullable integers', () => {
     const schema = coerceValue(SchemaObjectSchema, {
       type: ['integer', 'null'],
@@ -725,6 +734,15 @@ describe('getExampleFromSchema', () => {
     })
 
     expect(getExampleFromSchema(schema)).toBeNull()
+  })
+
+  it('ignores invalid defaults for composed schemas', () => {
+    const schema = coerceValue(SchemaObjectSchema, {
+      oneOf: [{ type: 'string' }, { type: 'null' }],
+      default: 123,
+    })
+
+    expect(getExampleFromSchema(schema)).toBe('')
   })
 
   it('keeps empty string defaults for nullable strings', () => {

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
@@ -217,6 +217,59 @@ const mergeExamples = (baseValue: unknown, newValue: unknown): unknown => {
 
 type CompositionKeyword = 'anyOf' | 'oneOf'
 
+const schemaIncludesType = (
+  schema: SchemaObject,
+  targetType: string,
+  seen: WeakSet<object> = new WeakSet(),
+): boolean => {
+  const rawSchema = getSchemaCacheTarget(schema)
+
+  if (seen.has(rawSchema)) {
+    return false
+  }
+  seen.add(rawSchema)
+
+  if ('type' in schema) {
+    if (Array.isArray(schema.type)) {
+      return schema.type.includes(targetType)
+    }
+
+    if (schema.type === targetType) {
+      return true
+    }
+  }
+
+  const compositions = [schema.oneOf, schema.anyOf, schema.allOf]
+  for (const composition of compositions) {
+    if (!Array.isArray(composition)) {
+      continue
+    }
+
+    for (const item of composition) {
+      const resolved = resolve.schema(item)
+      if (resolved && schemaIncludesType(resolved, targetType, seen)) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+const normalizeSchemaDefault = (schema: SchemaObject): unknown => {
+  if (schema.default !== '') {
+    return schema.default
+  }
+
+  const allowsNull = schemaIncludesType(schema, 'null')
+  const allowsString = schemaIncludesType(schema, 'string')
+  if (allowsNull && !allowsString) {
+    return null
+  }
+
+  return schema.default
+}
+
 const getCompositionSelectionKey = (schemaPath: string[], composition: CompositionKeyword): string =>
   [...schemaPath, composition].join('.')
 
@@ -630,7 +683,7 @@ export const getExampleFromSchema = (
   }
   if (_schema.default !== undefined) {
     seen.delete(targetValue)
-    return cache(_schema, _schema.default, cacheKey)
+    return cache(_schema, normalizeSchemaDefault(_schema), cacheKey)
   }
   if (_schema.const !== undefined) {
     seen.delete(targetValue)

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
@@ -216,10 +216,11 @@ const mergeExamples = (baseValue: unknown, newValue: unknown): unknown => {
 }
 
 type CompositionKeyword = 'anyOf' | 'oneOf'
+type SchemaPrimitiveType = 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null' | 'integer'
 
 const schemaIncludesType = (
   schema: SchemaObject,
-  targetType: string,
+  targetType: SchemaPrimitiveType,
   seen: WeakSet<object> = new WeakSet(),
 ): boolean => {
   const rawSchema = getSchemaCacheTarget(schema)

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
@@ -217,6 +217,10 @@ const mergeExamples = (baseValue: unknown, newValue: unknown): unknown => {
 
 type CompositionKeyword = 'anyOf' | 'oneOf'
 type SchemaPrimitiveType = 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null' | 'integer'
+const MAX_SCHEMA_VALIDATION_DEPTH = MAX_LEVELS_DEEP * 5
+
+/** Cache composed schema resolution to preserve identity across recursion checks. */
+const composedSchemaResolutionCache = new WeakMap<object, SchemaObject | undefined>()
 
 const isValueOfType = (value: unknown, targetType: SchemaPrimitiveType): boolean => {
   switch (targetType) {
@@ -239,7 +243,28 @@ const isValueOfType = (value: unknown, targetType: SchemaPrimitiveType): boolean
   }
 }
 
-const schemaAllowsValue = (schema: SchemaObject, value: unknown, seen: Set<object> = new Set()): boolean => {
+const resolveComposedSchemaMember = (schema: SchemaObject): SchemaObject | undefined => {
+  const rawSchema = getSchemaCacheTarget(schema)
+  if (composedSchemaResolutionCache.has(rawSchema)) {
+    return composedSchemaResolutionCache.get(rawSchema)
+  }
+
+  const resolved = '$ref' in schema ? resolve.schema(schema) : schema
+  composedSchemaResolutionCache.set(rawSchema, resolved)
+  return resolved
+}
+
+const schemaAllowsValue = (
+  schema: SchemaObject,
+  value: unknown,
+  seen: Set<object> = new Set(),
+  level: number = 0,
+): boolean => {
+  // Depth guard prevents stack overflows when composed schemas loop through wrapped resolver objects.
+  if (level > MAX_SCHEMA_VALIDATION_DEPTH) {
+    return true
+  }
+
   const rawSchema = getSchemaCacheTarget(schema)
 
   if (seen.has(rawSchema)) {
@@ -266,8 +291,8 @@ const schemaAllowsValue = (schema: SchemaObject, value: unknown, seen: Set<objec
   const anyOf = schema.anyOf
   if (Array.isArray(anyOf) && anyOf.length > 0) {
     const matchesAnyOf = anyOf.some((item) => {
-      const resolved = resolve.schema(item)
-      return !!resolved && schemaAllowsValue(resolved, value, seen)
+      const resolved = resolveComposedSchemaMember(item as SchemaObject)
+      return !!resolved && schemaAllowsValue(resolved, value, seen, level + 1)
     })
 
     if (!matchesAnyOf) {
@@ -279,8 +304,8 @@ const schemaAllowsValue = (schema: SchemaObject, value: unknown, seen: Set<objec
   const oneOf = schema.oneOf
   if (Array.isArray(oneOf) && oneOf.length > 0) {
     const matchesOneOf = oneOf.some((item) => {
-      const resolved = resolve.schema(item)
-      return !!resolved && schemaAllowsValue(resolved, value, seen)
+      const resolved = resolveComposedSchemaMember(item as SchemaObject)
+      return !!resolved && schemaAllowsValue(resolved, value, seen, level + 1)
     })
 
     if (!matchesOneOf) {
@@ -292,8 +317,8 @@ const schemaAllowsValue = (schema: SchemaObject, value: unknown, seen: Set<objec
   const allOf = schema.allOf
   if (Array.isArray(allOf) && allOf.length > 0) {
     const matchesAllOf = allOf.every((item) => {
-      const resolved = resolve.schema(item)
-      return !resolved || schemaAllowsValue(resolved, value, seen)
+      const resolved = resolveComposedSchemaMember(item as SchemaObject)
+      return !resolved || schemaAllowsValue(resolved, value, seen, level + 1)
     })
 
     if (!matchesAllOf) {

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
@@ -218,57 +218,104 @@ const mergeExamples = (baseValue: unknown, newValue: unknown): unknown => {
 type CompositionKeyword = 'anyOf' | 'oneOf'
 type SchemaPrimitiveType = 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null' | 'integer'
 
-const schemaIncludesType = (
-  schema: SchemaObject,
-  targetType: SchemaPrimitiveType,
-  seen: WeakSet<object> = new WeakSet(),
-): boolean => {
+const isValueOfType = (value: unknown, targetType: SchemaPrimitiveType): boolean => {
+  switch (targetType) {
+    case 'string':
+      return typeof value === 'string'
+    case 'number':
+      return typeof value === 'number' && !Number.isNaN(value)
+    case 'integer':
+      return typeof value === 'number' && Number.isInteger(value)
+    case 'boolean':
+      return typeof value === 'boolean'
+    case 'object':
+      return typeof value === 'object' && value !== null && !Array.isArray(value)
+    case 'array':
+      return Array.isArray(value)
+    case 'null':
+      return value === null
+    default:
+      return false
+  }
+}
+
+const schemaAllowsValue = (schema: SchemaObject, value: unknown, seen: Set<object> = new Set()): boolean => {
   const rawSchema = getSchemaCacheTarget(schema)
 
   if (seen.has(rawSchema)) {
-    return false
+    return true
   }
   seen.add(rawSchema)
 
-  if ('type' in schema) {
-    if (Array.isArray(schema.type)) {
-      return schema.type.includes(targetType)
-    }
-
-    if (schema.type === targetType) {
-      return true
-    }
-  }
-
-  const compositions = [schema.oneOf, schema.anyOf, schema.allOf]
-  for (const composition of compositions) {
-    if (!Array.isArray(composition)) {
-      continue
-    }
-
-    for (const item of composition) {
-      const resolved = resolve.schema(item)
-      if (resolved && schemaIncludesType(resolved, targetType, seen)) {
+  if ('type' in schema && schema.type) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type]
+    const matchesType = types.some((targetType) => {
+      if (targetType === 'number' && isValueOfType(value, 'integer')) {
         return true
       }
+
+      return isValueOfType(value, targetType)
+    })
+
+    if (!matchesType) {
+      seen.delete(rawSchema)
+      return false
     }
   }
 
-  return false
+  const anyOf = schema.anyOf
+  if (Array.isArray(anyOf) && anyOf.length > 0) {
+    const matchesAnyOf = anyOf.some((item) => {
+      const resolved = resolve.schema(item)
+      return !!resolved && schemaAllowsValue(resolved, value, seen)
+    })
+
+    if (!matchesAnyOf) {
+      seen.delete(rawSchema)
+      return false
+    }
+  }
+
+  const oneOf = schema.oneOf
+  if (Array.isArray(oneOf) && oneOf.length > 0) {
+    const matchesOneOf = oneOf.some((item) => {
+      const resolved = resolve.schema(item)
+      return !!resolved && schemaAllowsValue(resolved, value, seen)
+    })
+
+    if (!matchesOneOf) {
+      seen.delete(rawSchema)
+      return false
+    }
+  }
+
+  const allOf = schema.allOf
+  if (Array.isArray(allOf) && allOf.length > 0) {
+    const matchesAllOf = allOf.every((item) => {
+      const resolved = resolve.schema(item)
+      return !resolved || schemaAllowsValue(resolved, value, seen)
+    })
+
+    if (!matchesAllOf) {
+      seen.delete(rawSchema)
+      return false
+    }
+  }
+
+  seen.delete(rawSchema)
+  return true
 }
 
-const normalizeSchemaDefault = (schema: SchemaObject): unknown => {
-  if (schema.default !== '') {
-    return schema.default
+const INVALID_DEFAULT = Symbol('INVALID_DEFAULT')
+
+const normalizeSchemaDefault = (schema: SchemaObject): unknown | typeof INVALID_DEFAULT => {
+  const defaultValue = schema.default
+
+  if (schemaAllowsValue(schema, defaultValue)) {
+    return defaultValue
   }
 
-  const allowsNull = schemaIncludesType(schema, 'null')
-  const allowsString = schemaIncludesType(schema, 'string')
-  if (allowsNull && !allowsString) {
-    return null
-  }
-
-  return schema.default
+  return INVALID_DEFAULT
 }
 
 const getCompositionSelectionKey = (schemaPath: string[], composition: CompositionKeyword): string =>
@@ -683,8 +730,12 @@ export const getExampleFromSchema = (
     return cache(_schema, _schema.example, cacheKey)
   }
   if (_schema.default !== undefined) {
-    seen.delete(targetValue)
-    return cache(_schema, normalizeSchemaDefault(_schema), cacheKey)
+    const normalizedDefault = normalizeSchemaDefault(_schema)
+
+    if (normalizedDefault !== INVALID_DEFAULT) {
+      seen.delete(targetValue)
+      return cache(_schema, normalizedDefault, cacheKey)
+    }
   }
   if (_schema.const !== undefined) {
     seen.delete(targetValue)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`[DefaultValue(null)]` on nullable numeric fields in .NET can surface in the document as an empty string default for a nullable numeric schema. Scalar then renders request-body examples with `""` instead of `null` for those fields.

## Solution

- Keep the runtime fix scoped to `getExampleFromSchema`.
- Normalize empty-string defaults to `null` when the schema allows `null` and does not allow `string`.
- Keep existing empty-string behavior for nullable strings.
- Add regression tests in `get-example-from-schema.test.ts` only.
- Follow-up CI fix: tighten the helper argument type to the schema primitive union so `workspace-store` TypeScript build succeeds.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Fixes #8721
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85a7170e-9ccc-4586-bb28-5037ee2befa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85a7170e-9ccc-4586-bb28-5037ee2befa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

