### PR TITLE
fix(workspace-store): environment variables aren't substituted in paths

### DIFF
--- a/.changeset/blue-wolves-sing.md
+++ b/.changeset/blue-wolves-sing.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Resolve environment variables in raw request paths when building request URLs, so address bar placeholders like `{{path}}` are substituted during send.

--- a/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.test.ts
+++ b/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.test.ts
@@ -173,6 +173,21 @@ describe('resolve-request-factory-url', () => {
     expect(result).toBe('https://api.example.com/users/42')
   })
 
+  it('replaces environment variables directly in the raw path', () => {
+    const request = createRequestFactory({
+      path: {
+        raw: '/{{version}}/users/{{userId}}',
+        variables: {},
+      },
+    })
+    const result = resolveRequestFactoryUrl(request, {
+      ...defaultOptions,
+      envVariables: { version: 'v2', userId: '42' },
+    })
+
+    expect(result).toBe('https://api.example.com/v2/users/42')
+  })
+
   it('replaces environment variables in query parameters', () => {
     const query = new URLSearchParams()
     query.set('{{KEY_NAME}}', '{{KEY_VALUE}}')

--- a/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.ts
+++ b/packages/workspace-store/src/request-example/builder/resolve-request-factory-url.ts
@@ -25,7 +25,8 @@ export const resolveRequestFactoryUrl = (
   )
 
   const baseUrl = replaceEnvVariables(request.baseUrl, variables)
-  const path = replacePathVariables(request.path.raw, pathVariables)
+  const rawPath = replaceEnvVariables(request.path.raw, variables)
+  const path = replacePathVariables(rawPath, pathVariables)
   const mergedUrl = mergeUrls(baseUrl, path)
   // When rendered inside an iframe with srcdoc, the browser reports
   // window.location.origin as the string "null" instead of a real origin.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Environment variables entered in the API client address bar were visible in autocomplete/tooltips but were not resolved in the outgoing request URL path during send.

## Solution

Resolve environment variables in `request.path.raw` inside `resolveRequestFactoryUrl` before path-variable replacement and URL assembly, and add a regression test that covers `{{var}}` placeholders directly in the raw path.

## Testing

- `pnpm vitest packages/workspace-store/src/request-example/builder/resolve-request-factory-url.test.ts --run`
- `pnpm vitest packages/workspace-store/src/request-example/builder/build-request.test.ts --run`
- `pnpm format`
- `pnpm knip` *(fails in this environment because `@scalar/docusaurus/dist/index.js` is missing)*

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d7df6ef-d9f4-428f-a457-ca72fe9bb832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d7df6ef-d9f4-428f-a457-ca72fe9bb832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

