### PR TITLE
chore(cloud): optimize Cursor environment bootstrap for Scalar

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:24-bookworm
+
+SHELL ["/bin/bash", "-lc"]
+
+# Keep the base image minimal while ensuring standard git/ssh workflows work.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git \
+    openssh-client \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN corepack enable \
+  && corepack prepare pnpm@10.16.1 --activate

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,8 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "install": "bash .cursor/scripts/install.sh",
+  "start": "bash .cursor/scripts/start.sh"
+}

--- a/.cursor/scripts/ensure-vue-test-utils-resolution.mjs
+++ b/.cursor/scripts/ensure-vue-test-utils-resolution.mjs
@@ -1,0 +1,106 @@
+import { existsSync } from 'node:fs'
+import { lstatSync, mkdirSync, readdirSync, readlinkSync, rmSync, symlinkSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const repoRoot = join(__dirname, '..', '..')
+
+const apiClientRequire = createRequire(join(repoRoot, 'packages', 'api-client', 'package.json'))
+const workspaceRequire = createRequire(join(repoRoot, 'package.json'))
+const modulesToEnsure = ['@vue/compiler-dom', '@vue/server-renderer']
+const pnpmStoreRoot = join(repoRoot, 'node_modules', '.pnpm')
+
+const getPnpmPackagePath = (packageName) => {
+  const prefix = `${packageName.replace('/', '+')}@`
+  const candidates = readdirSync(pnpmStoreRoot)
+    .filter((entry) => entry.startsWith(prefix))
+    .sort()
+
+  if (!candidates.length) {
+    return null
+  }
+
+  const [scope, name] = packageName.split('/')
+  return join(pnpmStoreRoot, candidates[candidates.length - 1], 'node_modules', scope, name)
+}
+
+const ensureLocalAlias = (nodeModulesDir, packageName) => {
+  const [scope, name] = packageName.split('/')
+  const scopedDir = join(nodeModulesDir, scope)
+  const aliasPath = join(scopedDir, name)
+  const resolvedFromPnpm = getPnpmPackagePath(packageName)
+
+  if (!resolvedFromPnpm || !existsSync(resolvedFromPnpm)) {
+    throw new Error(`Could not locate ${packageName} in ${pnpmStoreRoot}`)
+  }
+
+  if (existsSync(aliasPath)) {
+    const currentStats = lstatSync(aliasPath)
+
+    if (!currentStats.isSymbolicLink()) {
+      return aliasPath
+    }
+
+    const linkedPath = readlinkSync(aliasPath)
+    const absoluteLinkedPath = resolve(scopedDir, linkedPath)
+
+    if (absoluteLinkedPath === resolvedFromPnpm) {
+      return aliasPath
+    }
+  }
+
+  mkdirSync(scopedDir, { recursive: true })
+  rmSync(aliasPath, { force: true, recursive: true })
+  symlinkSync(resolvedFromPnpm, aliasPath, 'dir')
+  return aliasPath
+}
+
+const testUtilsPackagePath = apiClientRequire.resolve('@vue/test-utils/package.json')
+const testUtilsRequire = createRequire(testUtilsPackagePath)
+const testUtilsNodeModulesDir = dirname(dirname(dirname(testUtilsPackagePath)))
+
+const contexts = [
+  {
+    name: 'workspace',
+    resolver: workspaceRequire,
+    nodeModulesDir: join(repoRoot, 'node_modules'),
+  },
+  {
+    name: 'api-client',
+    resolver: apiClientRequire,
+    nodeModulesDir: join(repoRoot, 'packages', 'api-client', 'node_modules'),
+  },
+  {
+    name: '@vue/test-utils runtime',
+    resolver: testUtilsRequire,
+    nodeModulesDir: testUtilsNodeModulesDir,
+  },
+]
+
+for (const context of contexts) {
+  const missingModules = modulesToEnsure.filter((packageName) => {
+    try {
+      context.resolver.resolve(packageName)
+      return false
+    } catch {
+      return true
+    }
+  })
+
+  for (const packageName of missingModules) {
+    const aliasPath = ensureLocalAlias(context.nodeModulesDir, packageName)
+    console.log(`[vue-resolution] Linked ${packageName} for ${context.name} at ${aliasPath}`)
+  }
+}
+
+for (const packageName of modulesToEnsure) {
+  try {
+    const resolvedPath = workspaceRequire.resolve(packageName)
+    console.log(`[vue-resolution] Resolved ${packageName} from workspace -> ${resolvedPath}`)
+  } catch {
+    throw new Error(`Failed to resolve ${packageName} from workspace context`)
+  }
+}

--- a/.cursor/scripts/install.sh
+++ b/.cursor/scripts/install.sh
@@ -19,7 +19,17 @@ state_dir="${HOME}/.cache/cursor-cloud-agent/scalar"
 build_marker_path="${state_dir}/build-packages-fingerprint.txt"
 mkdir -p "${state_dir}"
 
-fingerprint="$(sha256sum pnpm-lock.yaml package.json turbo.json | sha256sum | awk '{ print $1 }')"
+git_revision="nogit"
+if command -v git >/dev/null 2>&1; then
+  git_revision="$(git rev-parse HEAD 2>/dev/null || echo "nogit")"
+fi
+
+fingerprint="$(
+  {
+    printf '%s\n' "${git_revision}"
+    sha256sum pnpm-lock.yaml package.json turbo.json
+  } | sha256sum | awk '{ print $1 }'
+)"
 previous_fingerprint=""
 if [ -f "${build_marker_path}" ]; then
   read -r previous_fingerprint < "${build_marker_path}"

--- a/.cursor/scripts/install.sh
+++ b/.cursor/scripts/install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[cloud-install] Ensuring Node and pnpm versions are available..."
+node --version
+corepack enable >/dev/null 2>&1 || true
+corepack prepare pnpm@10.16.1 --activate >/dev/null 2>&1 || true
+pnpm --version
+
+if [ ! -f "pnpm-lock.yaml" ]; then
+  echo "[cloud-install] pnpm-lock.yaml not found; aborting."
+  exit 1
+fi
+
+echo "[cloud-install] Installing dependencies with a frozen lockfile..."
+pnpm install --frozen-lockfile --prefer-offline
+
+state_dir="${HOME}/.cache/cursor-cloud-agent/scalar"
+build_marker_path="${state_dir}/build-packages-fingerprint.txt"
+mkdir -p "${state_dir}"
+
+fingerprint="$(sha256sum pnpm-lock.yaml package.json turbo.json | sha256sum | awk '{ print $1 }')"
+previous_fingerprint=""
+if [ -f "${build_marker_path}" ]; then
+  read -r previous_fingerprint < "${build_marker_path}"
+fi
+
+if [ "${fingerprint}" = "${previous_fingerprint}" ]; then
+  echo "[cloud-install] Skipping build:packages (fingerprint unchanged)."
+else
+  echo "[cloud-install] Prewarming frequently used workspace outputs..."
+  pnpm build:packages
+  printf '%s\n' "${fingerprint}" > "${build_marker_path}"
+fi
+
+echo "[cloud-install] Priming Vue test-utils module resolution for api-client..."
+node .cursor/scripts/ensure-vue-test-utils-resolution.mjs
+
+echo "[cloud-install] Install step completed."

--- a/.cursor/scripts/start.sh
+++ b/.cursor/scripts/start.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[cloud-start] Activating pnpm 10.16.1..."
+corepack enable >/dev/null 2>&1 || true
+corepack prepare pnpm@10.16.1 --activate >/dev/null 2>&1 || true
+
+echo "[cloud-start] Running startup validation checks..."
+node --version
+pnpm --version
+node .cursor/scripts/ensure-vue-test-utils-resolution.mjs
+
+echo "[cloud-start] Startup validation completed."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Cursor Cloud Agents in `scalar/scalar` repeatedly spend time redoing setup (`pnpm install`, `pnpm build:packages`) and `@scalar/api-client` Vitest can intermittently fail to resolve `@vue/compiler-dom` / `@vue/server-renderer` unless `NODE_PATH` is set manually.

## Solution

- Added repo-level Cursor environment config at `.cursor/environment.json`.
- Added `.cursor/Dockerfile` based on `node:24-bookworm` and activated `pnpm@10.16.1` via Corepack.
- Added idempotent install script (`.cursor/scripts/install.sh`) that:
  - validates Node/pnpm availability,
  - runs `pnpm install --frozen-lockfile --prefer-offline`,
  - prewarms `pnpm build:packages` using a fingerprint keyed to lock/config files plus git revision,
  - runs Vue module-resolution priming for api-client tests.
- Added lightweight startup script (`.cursor/scripts/start.sh`) that validates Node/pnpm and runs the Vue resolution check.
- Added `.cursor/scripts/ensure-vue-test-utils-resolution.mjs` to deterministically ensure `@vue/compiler-dom` and `@vue/server-renderer` are resolvable from:
  - workspace root,
  - `packages/api-client`,
  - `@vue/test-utils` runtime context.

## Validation

- `bash .cursor/scripts/install.sh`
- `bash .cursor/scripts/install.sh` (rerun to confirm cache skip path)
- `bash .cursor/scripts/start.sh`
- `env -u NODE_PATH pnpm format:check`
- `env -u NODE_PATH pnpm --filter @scalar/api-client types:check`
- `env -u NODE_PATH pnpm --filter @scalar/api-client test`
- `pnpm changeset status`

All targeted workflow checks passed without manual `NODE_PATH` overrides.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. *(Not applicable: no `packages/*` or `integrations/*` source versioned output changes.)*
- [x] I added tests. *(Environment-level validation commands for startup and workflow checks.)*
- [x] I updated the documentation. *(Environment behavior is captured in repo-level Cursor config/scripts.)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1642b0b4-e988-462c-884b-3bd812dcd6f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1642b0b4-e988-462c-884b-3bd812dcd6f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

