### PR TITLE
fix(api-client): close environment selector dropdown after selection

### DIFF
--- a/.changeset/every-grapes-end.md
+++ b/.changeset/every-grapes-end.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: close environment selector dropdown after selection

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/EnvironmentSelector.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/EnvironmentSelector.vue
@@ -123,7 +123,7 @@ const handleSelectEnvironment = (environmentName: string) => {
         <ScalarDropdownItem
           v-if="hasActiveEnvironment"
           class="group/item flex w-full items-center gap-1.5"
-          @click.stop="handleSelectEnvironment('')">
+          @click="handleSelectEnvironment('')">
           <div
             class="flex h-4 w-4 items-center justify-center rounded-full p-[3px]"
             :class="
@@ -146,7 +146,7 @@ const handleSelectEnvironment = (environmentName: string) => {
           v-for="environmentName in environments"
           :key="environmentName"
           class="group/item flex w-full min-w-0 items-center gap-1.5 overflow-hidden text-ellipsis whitespace-nowrap"
-          @click.stop="handleSelectEnvironment(environmentName)">
+          @click="handleSelectEnvironment(environmentName)">
           <div
             class="flex h-4 w-4 items-center justify-center rounded-full p-[3px]"
             :class="


### PR DESCRIPTION
## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI event-handling change limited to a dropdown click handler plus a patch changeset; low blast radius.
> 
> **Overview**
> Selecting an environment in `EnvironmentSelector.vue` now uses plain `@click` handlers (removing `.stop`) so the dropdown can close after a selection.
> 
> Adds a changeset bumping `@scalar/api-client` with a patch release for this behavior fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ab6871201697258a00a211923a9aef7290b8e00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->