### PR TITLE
feat(api-client): thread oauth2 redirect uri through app state

### DIFF
--- a/.changeset/few-crowds-smash.md
+++ b/.changeset/few-crowds-smash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat(api-client): add app-level oauth2 redirect URI override plumbing for auth prefill

--- a/packages/api-client/src/v2/features/app/App.test.ts
+++ b/packages/api-client/src/v2/features/app/App.test.ts
@@ -20,6 +20,8 @@ describe('App', () => {
   const WORKSPACE_NAMESPACE = 'local'
   const WORKSPACE_SLUG = 'default'
   const DOCUMENT_ID = 'doc1'
+  const OAUTH_SCHEME_NAME = 'OAuth2Auth'
+  const OAUTH_REDIRECT_URI = 'myapp://oauth/callback'
 
   const setupWorkspace = async () => {
     const store = createWorkspaceStore()
@@ -41,7 +43,31 @@ describe('App', () => {
       document: {
         openapi: '3.1.0',
         info: { title: 'Test Document', version: '1.0.0' },
-        paths: {},
+        paths: {
+          '/pets': {
+            get: {
+              operationId: 'getPets',
+              responses: {},
+            },
+          },
+        },
+        security: [{ [OAUTH_SCHEME_NAME]: [] }],
+        components: {
+          securitySchemes: {
+            [OAUTH_SCHEME_NAME]: {
+              type: 'oauth2',
+              flows: {
+                authorizationCode: {
+                  authorizationUrl: 'https://example.com/oauth/authorize',
+                  tokenUrl: 'https://example.com/oauth/token',
+                  scopes: {
+                    read: 'Read access',
+                  },
+                },
+              },
+            },
+          },
+        },
         'x-scalar-environments': {
           prod: {
             variables: [{ name: 'API_KEY', value: 'prod-key-123' }],
@@ -60,7 +86,15 @@ describe('App', () => {
     )
   }
 
-  const setupApp = async (layout: 'web' | 'desktop' = 'web') => {
+  const setupApp = async ({
+    layout = 'web',
+    oauth2RedirectUri,
+    routeName = 'document.overview',
+  }: {
+    layout?: 'web' | 'desktop'
+    oauth2RedirectUri?: string
+    routeName?: 'document.overview' | 'document.authentication'
+  } = {}) => {
     await setupWorkspace()
 
     const router = createRouter({
@@ -68,10 +102,10 @@ describe('App', () => {
       routes: ROUTES,
     })
 
-    const appState = await createAppState({ router })
+    const appState = await createAppState({ router, oauth2RedirectUri })
 
     await router.push({
-      name: 'document.overview',
+      name: routeName,
       params: { namespace: WORKSPACE_NAMESPACE, workspaceSlug: WORKSPACE_SLUG, documentSlug: DOCUMENT_ID },
     })
 
@@ -135,5 +169,25 @@ describe('App', () => {
      */
     expect(appState.document.value).toBeDefined()
     expect(appState.document.value?.info.title).toBe('Test Document')
+  })
+
+  it('prefills OAuth redirect URI from createAppState oauth2RedirectUri option in auth flow', async () => {
+    const { wrapper, appState } = await setupApp({
+      oauth2RedirectUri: OAUTH_REDIRECT_URI,
+      routeName: 'document.authentication',
+    })
+
+    await nextTick()
+    await flushPromises()
+
+    const savedOAuthSecrets = appState.store.value?.auth.getAuthSecrets(DOCUMENT_ID, OAUTH_SCHEME_NAME)
+    expect(savedOAuthSecrets).toMatchObject({
+      type: 'oauth2',
+      authorizationCode: {
+        'x-scalar-secret-redirect-uri': OAUTH_REDIRECT_URI,
+      },
+    })
+
+    expect(wrapper.text()).toContain('Authentication')
   })
 })

--- a/packages/api-client/src/v2/features/app/App.vue
+++ b/packages/api-client/src/v2/features/app/App.vue
@@ -181,6 +181,9 @@ const routerViewProps = computed<RouteProps>(() => {
     onUpdateTelemetry: (value: boolean) => {
       app.telemetry.value = value
     },
+    options: {
+      oauth2RedirectUri: app.oauth2RedirectUri,
+    },
   }
 })
 </script>

--- a/packages/api-client/src/v2/features/app/app-state.ts
+++ b/packages/api-client/src/v2/features/app/app-state.ts
@@ -122,6 +122,8 @@ export type AppState = {
   currentRoute: Ref<RouteLocationNormalizedGeneric | null>
   /** Whether the workspace is currently syncing */
   loading: Ref<boolean>
+  /** Optional OAuth2 redirect URI override for auth prefill */
+  oauth2RedirectUri?: string
   /** The currently active entities */
   activeEntities: {
     /** The namespace of the current entity, e.g. "default" or a custom namespace */
@@ -176,12 +178,14 @@ export const createAppState = async ({
   fallbackThemeSlug = () => 'default',
   customThemes = () => [],
   telemetryDefault,
+  oauth2RedirectUri,
 }: {
   router: Router
   fileLoader?: LoaderPlugin
   customThemes?: MaybeRefOrGetter<Theme[]>
   fallbackThemeSlug?: MaybeRefOrGetter<string>
   telemetryDefault?: boolean
+  oauth2RedirectUri?: string
 }): Promise<AppState> => {
   /** Workspace event bus for handling workspace-level events. */
   const eventBus = createWorkspaceEventBus({
@@ -1034,6 +1038,7 @@ export const createAppState = async ({
     router,
     currentRoute,
     loading: isSyncingWorkspace,
+    oauth2RedirectUri,
     activeEntities: {
       namespace,
       workspaceSlug,

--- a/packages/api-client/src/v2/features/app/helpers/create-api-client-app.ts
+++ b/packages/api-client/src/v2/features/app/helpers/create-api-client-app.ts
@@ -41,6 +41,8 @@ type CreateApiClientOptions = {
    * Whether or not to send telemetry events.
    */
   telemetry?: boolean
+  /** Optional OAuth2 redirect URI override for auth prefill */
+  oauth2RedirectUri?: string
 }
 
 /**
@@ -68,6 +70,7 @@ export const createApiClientApp = async (
     fallbackThemeSlug,
     fetchRegistryDocument,
     telemetry = true,
+    oauth2RedirectUri,
   }: CreateApiClientOptions,
 ) => {
   // Add the router
@@ -77,6 +80,7 @@ export const createApiClientApp = async (
     customThemes,
     fallbackThemeSlug,
     telemetryDefault: telemetry,
+    oauth2RedirectUri,
   })
   const commandPaletteState = useCommandPaletteState()
 

--- a/packages/api-client/src/v2/features/app/helpers/routes.ts
+++ b/packages/api-client/src/v2/features/app/helpers/routes.ts
@@ -6,6 +6,7 @@ import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
 import type { WorkspaceDocument } from '@scalar/workspace-store/schemas/workspace'
+import type { MaybeRefOrGetter } from 'vue'
 import type { RouteRecordRaw } from 'vue-router'
 
 import Authentication from '@/v2/features/collection/components/Authentication.vue'
@@ -19,6 +20,7 @@ import Settings from '@/v2/features/collection/components/Settings.vue'
 import DocumentCollection from '@/v2/features/collection/DocumentCollection.vue'
 import OperationCollection from '@/v2/features/collection/OperationCollection.vue'
 import WorkspaceCollection from '@/v2/features/collection/WorkspaceCollection.vue'
+import type { ApiClientModalOptions } from '@/v2/features/modal/helpers/types'
 import { Operation } from '@/v2/features/operation'
 import { workspaceStorage } from '@/v2/helpers/storage'
 import type { ImportDocumentFromRegistry } from '@/v2/types/configuration'
@@ -63,6 +65,8 @@ export type RouteProps = {
   telemetry?: boolean
   /** Updates the telemetry enabled state */
   onUpdateTelemetry?: (value: boolean) => void
+  /** App or modal options forwarded to operation/auth blocks */
+  options?: MaybeRefOrGetter<ApiClientModalOptions>
 }
 
 /** When in the collections pages */

--- a/packages/api-client/src/v2/features/collection/components/Authentication.vue
+++ b/packages/api-client/src/v2/features/collection/components/Authentication.vue
@@ -27,6 +27,7 @@ const {
   method,
   collectionType,
   layout,
+  options,
 } = defineProps<CollectionProps>()
 
 /**
@@ -224,6 +225,7 @@ const handleToggleOperationSecurity = (value: boolean) => {
         :eventBus="eventBus"
         isStatic
         :meta="authMeta"
+        :options
         :proxyUrl="proxyUrl"
         :securityRequirements="securityRequirements"
         :securitySchemes

--- a/packages/api-client/src/v2/features/collection/components/Authentication.vue
+++ b/packages/api-client/src/v2/features/collection/components/Authentication.vue
@@ -10,9 +10,10 @@ import {
   getServers,
   mergeSecurity,
 } from '@scalar/workspace-store/request-example'
-import { computed, ref, watchEffect } from 'vue'
+import { computed, ref, toValue, watchEffect } from 'vue'
 
 import { AuthSelector } from '@/v2/blocks/scalar-auth-selector-block'
+import type { OAuth2Options } from '@/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue'
 import type { CollectionProps } from '@/v2/features/app/helpers/routes'
 import { getDefaultOperationSecurityToggle } from '@/v2/features/collection/helpers/get-default-operation-security-toggle'
 import Section from '@/v2/features/settings/components/Section.vue'
@@ -144,6 +145,18 @@ const server = computed(() => {
   )
 })
 
+/** Auth selector only needs OAuth2-specific option overrides. */
+const authOptions = computed<OAuth2Options | undefined>(() => {
+  const routeOptions = toValue(options)
+  if (!routeOptions?.oauth2RedirectUri) {
+    return undefined
+  }
+
+  return {
+    oauth2RedirectUri: routeOptions.oauth2RedirectUri,
+  }
+})
+
 /**
  * Handles toggling operation-level security authentication. (Only for operation collections)
  * When enabled (`value` is true), overrides document-level authentication for the current operation.
@@ -225,7 +238,7 @@ const handleToggleOperationSecurity = (value: boolean) => {
         :eventBus="eventBus"
         isStatic
         :meta="authMeta"
-        :options
+        :options="authOptions"
         :proxyUrl="proxyUrl"
         :securityRequirements="securityRequirements"
         :securitySchemes

--- a/packages/api-client/src/v2/features/operation/Operation.vue
+++ b/packages/api-client/src/v2/features/operation/Operation.vue
@@ -22,7 +22,6 @@ import { OperationBlock } from '@/v2/blocks/operation-block'
 import { APP_VERSION } from '@/v2/constants'
 import type { RouteProps } from '@/v2/features/app/helpers/routes'
 import { mapHiddenClientsConfig } from '@/v2/features/modal/helpers/map-hidden-clients-config'
-import type { ApiClientModalOptionsRef } from '@/v2/features/modal/helpers/types'
 
 const {
   document,
@@ -38,8 +37,6 @@ const {
   documentSlug,
 } = defineProps<
   RouteProps & {
-    /** Subset of config options for the modal */
-    options?: ApiClientModalOptionsRef
     /** Selected anyOf/oneOf request-body variants keyed by schema path */
     requestBodyCompositionSelection?: Record<string, number>
   }


### PR DESCRIPTION
Follow-up of #8661, because I just found out we're not using `createApiClientApp`, but `createAppState` for the electron app

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `oauth2RedirectUri?: string` to `createAppState` options and expose it on `AppState`
- thread app-level options into `ClientApp` route props and set `options: { oauth2RedirectUri: app.oauth2RedirectUri }` in `App.vue`
- pass route-level `options` into authentication collections so OAuth2 prefill can consume app-level redirect URI overrides
- add one app-level test that verifies `createAppState({ oauth2RedirectUri })` writes the OAuth authorization code redirect URI secret
- narrow `Authentication.vue` forwarding to OAuth-only options (`OAuth2Options`) to satisfy build typing
- align `Operation.vue` prop typing with `RouteProps` so typecheck accepts app and modal option shapes

## Testing
- `pnpm install`
- `pnpm --filter @scalar/api-client types:check`
- `pnpm --filter @scalar/api-client build`
- `NODE_PATH="/workspace/node_modules/.pnpm/@vue+compiler-dom@3.5.30/node_modules:/workspace/node_modules/.pnpm/@vue+server-renderer@3.5.30_vue@3.5.30_typescript@5.9.3_/node_modules" pnpm exec vitest src/v2/features/app/App.test.ts --run`
- `NODE_PATH="/workspace/node_modules/.pnpm/@vue+compiler-dom@3.5.30/node_modules:/workspace/node_modules/.pnpm/@vue+server-renderer@3.5.30_vue@3.5.30_typescript@5.9.3_/node_modules" pnpm exec vitest src/v2/blocks/scalar-auth-selector-block/components/OAuth2.test.ts --run`
- `pnpm format`
- `pnpm --filter @scalar/docusaurus build`
- `pnpm knip` *(fails on existing unresolved Nuxt auto-import aliases)*
- `pnpm changeset status`

## Visual
- N/A (non-visual wiring + test update)

## Ticket
- Related to requested oauth2 redirect URI app-state propagation task.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93bc675d-8c8a-4163-876c-fc2e9d0a281e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93bc675d-8c8a-4163-876c-fc2e9d0a281e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

