### PR TITLE
feat(openapi-parser): pass resolved object to `onDereference`

### DIFF
--- a/.changeset/twelve-geckos-make.md
+++ b/.changeset/twelve-geckos-make.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': minor
+---
+
+feat: pass resolved object to onDereference callback

--- a/packages/openapi-parser/README.md
+++ b/packages/openapi-parser/README.md
@@ -63,7 +63,7 @@ The `dereference` function accepts an `onDereference` callback option that gets 
 import { dereference } from '@scalar/openapi-parser'
 
 const { schema, errors } = await dereference(specification, {
-  onDereference: ({ schema, ref }) => {
+  onDereference: ({ schema, ref, resolved }) => {
     //
   },
 })

--- a/packages/openapi-parser/src/utils/dereference.test.ts
+++ b/packages/openapi-parser/src/utils/dereference.test.ts
@@ -387,6 +387,20 @@ describe('dereference', () => {
               },
             },
           },
+          post: {
+            responses: {
+              '200': {
+                description: 'foobar',
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/Test',
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
       },
       components: {
@@ -403,10 +417,10 @@ describe('dereference', () => {
       },
     }
 
-    const dereferencedSchemas: Array<{ schema: any; ref: string }> = []
+    const dereferencedSchemas: Array<{ schema: any; ref: string; resolved: any }> = []
 
     const result = dereference(openapi, {
-      onDereference: ({ schema, ref }) => {
+      onDereference: ({ schema, ref, resolved }) => {
         expect(schema).toEqual({
           type: 'object',
           properties: {
@@ -418,12 +432,14 @@ describe('dereference', () => {
 
         expect(ref).toEqual('#/components/schemas/Test')
 
-        dereferencedSchemas.push({ schema, ref })
+        dereferencedSchemas.push({ schema, ref, resolved })
       },
     })
 
     expect(result.errors).toStrictEqual([])
-    expect(dereferencedSchemas).toHaveLength(1)
+    expect(dereferencedSchemas).toHaveLength(2)
+    expect(dereferencedSchemas[0].resolved == dereferencedSchemas[1].resolved).toBe(true);
+    expect(result.schema.components.schemas.Test == dereferencedSchemas[0].resolved).toBe(true);
   })
 
   it('dereferences operations with query operations', () => {

--- a/packages/openapi-parser/src/utils/dereference.test.ts
+++ b/packages/openapi-parser/src/utils/dereference.test.ts
@@ -438,8 +438,8 @@ describe('dereference', () => {
 
     expect(result.errors).toStrictEqual([])
     expect(dereferencedSchemas).toHaveLength(2)
-    expect(dereferencedSchemas[0].resolved == dereferencedSchemas[1].resolved).toBe(true);
-    expect(result.schema.components.schemas.Test == dereferencedSchemas[0].resolved).toBe(true);
+    expect(dereferencedSchemas[0].resolved == dereferencedSchemas[1].resolved).toBe(true)
+    expect(result.schema.components.schemas.Test == dereferencedSchemas[0].resolved).toBe(true)
   })
 
   it('dereferences operations with query operations', () => {

--- a/packages/openapi-parser/src/utils/resolve-references.ts
+++ b/packages/openapi-parser/src/utils/resolve-references.ts
@@ -30,7 +30,7 @@ export type ResolveReferencesOptions = ThrowOnErrorOption & {
    *
    * Note that for object schemas, its properties may not be dereferenced when the hook is called.
    */
-  onDereference?: (data: { schema: AnyObject; ref: string, resolved: AnyObject }) => void
+  onDereference?: (data: { schema: AnyObject; ref: string; resolved: AnyObject }) => void
 }
 
 /**

--- a/packages/openapi-parser/src/utils/resolve-references.ts
+++ b/packages/openapi-parser/src/utils/resolve-references.ts
@@ -30,7 +30,7 @@ export type ResolveReferencesOptions = ThrowOnErrorOption & {
    *
    * Note that for object schemas, its properties may not be dereferenced when the hook is called.
    */
-  onDereference?: (data: { schema: AnyObject; ref: string }) => void
+  onDereference?: (data: { schema: AnyObject; ref: string, resolved: AnyObject }) => void
 }
 
 /**
@@ -160,7 +160,7 @@ function dereference(
     }
 
     if (dereferencedRef) {
-      options?.onDereference?.({ schema, ref: dereferencedRef })
+      options?.onDereference?.({ schema, ref: dereferencedRef, resolved })
     }
   }
 


### PR DESCRIPTION
## Problem

To track the source of dereferenced object. It is useful help us to optimize for sharing components between endpoints.

## Solution

Pass the resolved source to onDereference callback with result schema and ref.

## Checklist

- [ v ] I explained why the change is needed.
- [ v ] I added a changeset. <!-- pnpm changeset -->
- [ v ] I added tests.
- [ v ] I updated the documentation.
