### PR TITLE
feat(mock-server): support oauth refreshUrl endpoints

### DIFF
--- a/.changeset/many-lamps-tease.md
+++ b/.changeset/many-lamps-tease.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+feat: support oauth refreshUrl endpoints in mock server authentication routes

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -749,6 +749,46 @@ describe('createMockServer', () => {
     )
   })
 
+  it('supports oauth2 refresh token endpoint via refreshUrl', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      components: {
+        securitySchemes: {
+          oAuth2AuthCode: {
+            type: 'oauth2',
+            flows: {
+              authorizationCode: {
+                authorizationUrl: '/oauth/authorize',
+                tokenUrl: '/oauth/token',
+                refreshUrl: '/oauth/refresh',
+                scopes: {
+                  read: 'Read access',
+                },
+              },
+            },
+          },
+        },
+      },
+      paths: {},
+    }
+
+    const server = await createMockServer({ document })
+    const response = await server.request('/oauth/refresh?grant_type=refresh_token', { method: 'POST' })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Cache-Control')).toBe('no-store')
+    expect(await response.json()).toStrictEqual({
+      access_token: 'super-secret-access-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      refresh_token: 'example-refresh-token',
+    })
+  })
+
   it('handles redirect headers', async () => {
     const document = {
       openapi: '3.1.0',

--- a/packages/mock-server/src/utils/get-open-auth-token-urls.test.ts
+++ b/packages/mock-server/src/utils/get-open-auth-token-urls.test.ts
@@ -52,6 +52,27 @@ describe('getOpenAuthTokenUrls', () => {
     expect(getOpenAuthTokenUrls(schema)).toEqual(['/oauth/token'])
   })
 
+  it('returns refresh URLs from OAuth2 flows', () => {
+    const schema = createOpenApiDefinition({
+      oauth2AuthCode: {
+        type: 'oauth2',
+        flows: {
+          authorizationCode: {
+            authorizationUrl: 'https://api.example.com/oauth/authorize',
+            tokenUrl: 'https://api.example.com/oauth/token',
+            refreshUrl: 'https://api.example.com/oauth/refresh',
+          },
+          implicit: {
+            authorizationUrl: 'https://api.example.com/oauth/authorize',
+            refreshUrl: 'https://api.example.com/oauth/implicit-refresh',
+          },
+        },
+      },
+    })
+
+    expect(getOpenAuthTokenUrls(schema)).toEqual(['/oauth/token', '/oauth/refresh', '/oauth/implicit-refresh'])
+  })
+
   it('returns multiple token URLs from different OAuth2 flows', () => {
     const schema = createOpenApiDefinition({
       oauth2Password: {
@@ -72,6 +93,22 @@ describe('getOpenAuthTokenUrls', () => {
       },
     })
     expect(getOpenAuthTokenUrls(schema)).toEqual(['/oauth/password_token', '/oauth/client_token'])
+  })
+
+  it('returns unique OAuth URLs when token and refresh URLs overlap', () => {
+    const schema = createOpenApiDefinition({
+      oauth2Password: {
+        type: 'oauth2',
+        flows: {
+          password: {
+            tokenUrl: 'https://api.example.com/oauth/token',
+            refreshUrl: 'https://api.example.com/oauth/token',
+          },
+        },
+      },
+    })
+
+    expect(getOpenAuthTokenUrls(schema)).toEqual(['/oauth/token'])
   })
 
   it('ignores non-OAuth2 security schemes', () => {

--- a/packages/mock-server/src/utils/get-open-auth-token-urls.ts
+++ b/packages/mock-server/src/utils/get-open-auth-token-urls.ts
@@ -18,7 +18,7 @@ export function getPathFromUrl(url: string): string {
 }
 
 /**
- * Returns all token URLs mentioned in the securitySchemes, without the domain
+ * Returns OAuth token and refresh URLs without the domain.
  */
 // Type guard for OAuth2 security scheme
 function isOAuth2Scheme(
@@ -27,8 +27,8 @@ function isOAuth2Scheme(
   return scheme.type === 'oauth2'
 }
 
-// Validate token URL
-function isValidTokenUrl(url: string): boolean {
+// Validate OAuth URL
+function isValidOAuthUrl(url: string): boolean {
   return url.trim().length > 0
 }
 
@@ -41,7 +41,7 @@ export function getOpenAuthTokenUrls(schema?: OpenAPI.Document): string[] {
     schema.components.securitySchemes
 
   // Use Set from the start for better memory efficiency
-  const tokenUrls = new Set<string>()
+  const oauthUrls = new Set<string>()
 
   // Iterate through all security schemes
   for (const scheme of Object.values(securitySchemes)) {
@@ -51,17 +51,21 @@ export function getOpenAuthTokenUrls(schema?: OpenAPI.Document): string[] {
 
     const flows = scheme.flows // Type assertion no longer needed
 
-    // Helper to safely add valid token URLs
-    const addTokenUrl = (url?: string) => {
-      if (url && isValidTokenUrl(url)) {
-        tokenUrls.add(getPathFromUrl(url))
+    // Helper to safely add valid OAuth URLs
+    const addOAuthUrl = (url?: string) => {
+      if (url && isValidOAuthUrl(url)) {
+        oauthUrls.add(getPathFromUrl(url))
       }
     }
 
-    addTokenUrl(flows?.password?.tokenUrl)
-    addTokenUrl(flows?.clientCredentials?.tokenUrl)
-    addTokenUrl(flows?.authorizationCode?.tokenUrl)
+    addOAuthUrl(flows?.password?.tokenUrl)
+    addOAuthUrl(flows?.password?.refreshUrl)
+    addOAuthUrl(flows?.clientCredentials?.tokenUrl)
+    addOAuthUrl(flows?.clientCredentials?.refreshUrl)
+    addOAuthUrl(flows?.authorizationCode?.tokenUrl)
+    addOAuthUrl(flows?.authorizationCode?.refreshUrl)
+    addOAuthUrl(flows?.implicit?.refreshUrl)
   }
 
-  return Array.from(tokenUrls)
+  return Array.from(oauthUrls)
 }


### PR DESCRIPTION
Adding refresh token support to the api-client in #8891, I've had to add support for it in the mock server.

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- include OAuth `refreshUrl` values when collecting authentication routes in `@scalar/mock-server`
- ensure those refresh routes are registered so refresh endpoints from OpenAPI flows return token responses
- add regression tests for URL extraction and end-to-end refresh endpoint behavior in `createMockServer`
- add a patch changeset for `@scalar/mock-server`

## Testing
- ✅ `pnpm --filter @scalar/mock-server test src/utils/get-open-auth-token-urls.test.ts src/create-mock-server.test.ts`

## Ticket
- Related to this user request about refresh token endpoint support in `@scalar/mock-server`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09f7ea56-7d21-4a73-a149-25153dbd4cd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09f7ea56-7d21-4a73-a149-25153dbd4cd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

