### PR TITLE
feat(api-client): support header for web layout

### DIFF
--- a/.changeset/tender-garlics-decide.md
+++ b/.changeset/tender-garlics-decide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat(api-client): support header for web layout

--- a/packages/api-client/playground/web/index.html
+++ b/packages/api-client/playground/web/index.html
@@ -34,7 +34,10 @@
     </style>
   </head>
   <body class="scalar-app">
-    <header class="h-header border-b">Header / Menu Go Here</header>
+    <header class="h-header bg-b-1 border-b">
+      Playground only placeholder &bull; Web header and menu will be injected
+      here
+    </header>
     <div
       id="scalar-client"
       class="scalar-client"></div>

--- a/packages/api-client/playground/web/index.html
+++ b/packages/api-client/playground/web/index.html
@@ -18,7 +18,7 @@
       }
       body {
         display: grid;
-        grid-template-rows: var(--scalar-header-height) 1fr;
+        grid-template-rows: auto 1fr;
       }
       body > header {
         display: flex;
@@ -27,7 +27,8 @@
       }
       #scalar-client,
       #scalar-client > main {
-        display: grid;
+        display: flex;
+        flex: 1;
         min-height: 0;
       }
     </style>

--- a/packages/api-client/playground/web/index.html
+++ b/packages/api-client/playground/web/index.html
@@ -10,8 +10,30 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0" />
     <title>Scalar API Client Web</title>
+    <style>
+      html,
+      body {
+        height: 100dvh;
+        overflow: hidden;
+      }
+      body {
+        display: grid;
+        grid-template-rows: var(--scalar-header-height) 1fr;
+      }
+      body > header {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      #scalar-client,
+      #scalar-client > main {
+        display: grid;
+        min-height: 0;
+      }
+    </style>
   </head>
   <body class="scalar-app">
+    <header class="h-header border-b">Header / Menu Go Here</header>
     <div
       id="scalar-client"
       class="scalar-client"></div>

--- a/packages/api-client/src/v2/components/sidebar/Sidebar.vue
+++ b/packages/api-client/src/v2/components/sidebar/Sidebar.vue
@@ -121,10 +121,15 @@ const handleSelectItem = (id: string) => {
           <div class="mac:h-12 mac:app-drag-region h-2"></div>
           <div
             class="bg-sidebar-b-1 z-1 flex flex-col gap-1.5 px-3 pb-1.5"
-            :class="{ 'max-md:pt-12': layout !== 'modal' }">
+            :class="{
+              'max-md:pt-12': layout === 'desktop',
+              'max-md:pt-2 max-md:pl-4!': layout === 'modal',
+              'pt-1 max-md:pt-2 max-md:pl-14': layout === 'web',
+            }">
             <div
               v-if="layout !== 'web'"
-              class="flex items-center justify-between">
+              class="flex items-center justify-between"
+              :class="{ 'max-md:pl-10': layout === 'desktop' }">
               <!-- Desktop gets the workspace menu here  -->
               <SidebarMenu
                 v-if="layout !== 'modal'"
@@ -143,8 +148,10 @@ const handleSelectItem = (id: string) => {
 
               <!-- Toggle search, always visible on web -->
               <ScalarIconButton
+                class="hover:bg-b-2 active:text-c-1 size-8 rounded p-2"
                 :icon="ScalarIconMagnifyingGlass"
                 label="Search"
+                size="sm"
                 @click="isSearchVisible = !isSearchVisible" />
             </div>
 

--- a/packages/api-client/src/v2/components/sidebar/Sidebar.vue
+++ b/packages/api-client/src/v2/components/sidebar/Sidebar.vue
@@ -122,7 +122,9 @@ const handleSelectItem = (id: string) => {
           <div
             class="bg-sidebar-b-1 z-1 flex flex-col gap-1.5 px-3 pb-1.5"
             :class="{ 'max-md:pt-12': layout !== 'modal' }">
-            <div class="flex items-center justify-between">
+            <div
+              v-if="layout !== 'web'"
+              class="flex items-center justify-between">
               <!-- Desktop gets the workspace menu here  -->
               <SidebarMenu
                 v-if="layout !== 'modal'"
@@ -147,9 +149,9 @@ const handleSelectItem = (id: string) => {
             </div>
 
             <ScalarSidebarSearchInput
-              v-if="isSearchVisible"
+              v-if="isSearchVisible || layout === 'web'"
               v-model="query"
-              autofocus />
+              :autofocus="layout !== 'web'" />
           </div>
         </template>
 

--- a/packages/api-client/src/v2/components/sidebar/SidebarToggle.vue
+++ b/packages/api-client/src/v2/components/sidebar/SidebarToggle.vue
@@ -6,7 +6,7 @@ const isSidebarOpen = defineModel<boolean>({
 <template>
   <button
     :aria-pressed="isSidebarOpen"
-    class="scalar-sidebar-toggle text-c-3 hover:bg-b-2 active:text-c-1 rounded-lg p-2"
+    class="scalar-sidebar-toggle text-c-3 hover:bg-b-2 active:text-c-1 rounded p-2"
     type="button"
     @click="isSidebarOpen = !isSidebarOpen">
     <span class="sr-only">{{ isSidebarOpen ? 'Hide' : 'Show' }} sidebar</span>

--- a/packages/api-client/src/v2/features/app/App.vue
+++ b/packages/api-client/src/v2/features/app/App.vue
@@ -201,7 +201,9 @@ const routerViewProps = computed<RouteProps>(() => {
         app.workspace.activeWorkspace.value !== null &&
         !app.loading.value
       ">
-      <div class="relative flex h-dvh w-dvw flex-1 flex-col">
+      <div
+        class="relative flex w-dvw flex-col"
+        :class="layout === 'web' ? 'min-h-0' : 'h-dvh'">
         <SidebarToggle
           v-model="app.sidebar.isOpen.value"
           class="absolute top-4 left-3 z-[60] md:hidden" />
@@ -227,7 +229,7 @@ const routerViewProps = computed<RouteProps>(() => {
             </template>
           </AppSidebar>
 
-          <div class="flex flex-1 flex-col">
+          <div class="flex min-h-0 flex-1 flex-col">
             <!-- App Tabs -->
             <DesktopTabs
               v-if="layout === 'desktop'"

--- a/packages/api-client/src/v2/features/app/App.vue
+++ b/packages/api-client/src/v2/features/app/App.vue
@@ -206,7 +206,8 @@ const routerViewProps = computed<RouteProps>(() => {
         :class="layout === 'web' ? 'min-h-0' : 'h-dvh'">
         <SidebarToggle
           v-model="app.sidebar.isOpen.value"
-          class="absolute top-4 left-3 z-[60] md:hidden" />
+          class="absolute z-60 md:hidden"
+          :class="layout === 'desktop' ? 'top-14 left-4' : 'top-4 left-4'" />
         <div class="flex min-h-0 flex-1 flex-row">
           <!-- App sidebar -->
           <AppSidebar

--- a/packages/api-client/src/v2/features/app/components/AppSidebar.vue
+++ b/packages/api-client/src/v2/features/app/components/AppSidebar.vue
@@ -293,7 +293,7 @@ const navigateToOperationsPage = (item: TraversedOperation) => {
       :activeWorkspace="activeWorkspace"
       :class="[
         'max-md:inset-y-0 max-md:z-2 max-md:w-full!',
-        isSidebarOpen ? 'max-md:fixed! max-md:flex!' : 'max-md:hidden!',
+        isSidebarOpen ? 'max-md:absolute! max-md:flex!' : 'max-md:hidden!',
       ]"
       :documents="Object.values(store.workspace.documents)"
       :isDroppable="isDroppable"

--- a/packages/api-client/src/v2/features/modal/Modal.vue
+++ b/packages/api-client/src/v2/features/modal/Modal.vue
@@ -164,12 +164,12 @@ defineExpose({
       class="relative flex h-full min-h-0 w-full flex-1">
       <SidebarToggle
         v-model="isSidebarOpen"
-        class="absolute top-2 left-3 z-2" />
+        class="absolute top-2 left-4 z-10 max-md:top-4" />
       <Sidebar
         v-show="isSidebarOpen"
         v-model:sidebarWidth="sidebarWidth"
         :activeWorkspace="activeWorkspace"
-        class="h-full max-md:absolute! max-md:w-full!"
+        class="h-full max-md:absolute! max-md:z-5 max-md:w-full!"
         :documents="[document.value]"
         :eventBus
         :isDroppable="() => false"


### PR DESCRIPTION
Trying this again, updates the client to support a header in the web layout.

- Hides app menu for the web layout
- Makes the search always visible on web
- Fixes a bunch of layout and mobile issues

<img width="3046" height="1958" alt="CleanShot 2026-04-21 at 15 28 19@2x" src="https://github.com/user-attachments/assets/8e222b1e-9e35-452e-8841-ddddb2854e3c" />

Mobile versions (Open & Closed):

Modal:

<img width="49%" alt="CleanShot 2026-04-21 at 15 25 13@2x" src="https://github.com/user-attachments/assets/5715f33e-cd6e-4343-897a-8cb2efe68407" />
<img width="49%" alt="CleanShot 2026-04-21 at 15 25 15@2x" src="https://github.com/user-attachments/assets/197b601c-748a-41ea-ad82-f4a2775ef3c9" />

App:

<img width="49%" alt="CleanShot 2026-04-21 at 15 25 06@2x" src="https://github.com/user-attachments/assets/62e6a33c-3e68-4cd7-b089-01617e75930b" />
<img width="49%" alt="CleanShot 2026-04-21 at 15 25 09@2x" src="https://github.com/user-attachments/assets/20ab3e5e-0b7a-4015-a6ab-64a378468781" />

Web:

<img width="49%" alt="CleanShot 2026-04-21 at 15 23 50@2x" src="https://github.com/user-attachments/assets/32dcabb1-f5e9-4880-8f43-41a4468c01a2" />
<img width="49%" alt="CleanShot 2026-04-21 at 15 23 52@2x" src="https://github.com/user-attachments/assets/f9e5fb37-6688-495d-84a1-73bf12998ac5" />



## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

Fixes DOC-5217

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
