### PR TITLE
feat(api-reference): add anchors and copy link buttons to allOf body parameters

### DIFF
--- a/.changeset/tricky-parrots-move.md
+++ b/.changeset/tricky-parrots-move.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+feat(api-reference): add anchors and copy link buttons to allOf body parameters

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -715,4 +715,37 @@ describe('SchemaProperty', () => {
       expect(wrapper.text()).toContain('0')
     })
   })
+
+  describe('anchor link behavior', () => {
+    it('renders anchor id for level-2 property with breadcrumb and name', () => {
+      // Level-2 properties appear inside allOf groups — they need anchors too
+      const wrapper = mount(SchemaProperty, {
+        props: {
+          eventBus: null,
+          breadcrumb: ['body', 'BaseObject'],
+          level: 2,
+          name: 'myField',
+          schema: coerceValue(SchemaObjectSchema, { type: 'string' }),
+          options: {},
+        },
+      })
+
+      expect(wrapper.find('#body\\.BaseObject\\.myField').exists()).toBe(true)
+    })
+
+    it('does not render anchor id for level-3 property', () => {
+      const wrapper = mount(SchemaProperty, {
+        props: {
+          eventBus: null,
+          breadcrumb: ['body', 'BaseObject'],
+          level: 3,
+          name: 'nestedField',
+          schema: coerceValue(SchemaObjectSchema, { type: 'string' }),
+          options: {},
+        },
+      })
+
+      expect(wrapper.find('#body\\.BaseObject\\.nestedField').exists()).toBe(false)
+    })
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -89,7 +89,7 @@ const arrayItemsCompositionPath = computed<string[]>(() => [
   'items',
 ])
 
-const shouldHaveLink = computed(() => props.level <= 1)
+const shouldHaveLink = computed(() => props.level <= 2)
 
 /** Checks if array items have complex structure */
 const hasComplexArrayItemsComputed = computed(() =>
@@ -402,6 +402,10 @@ const isDiscriminatorProperty = computed(() =>
   border-radius: var(--scalar-radius-lg);
   display: flex;
   flex-direction: column;
+}
+
+.property--level-2 :deep(.relative > button) {
+  left: -2rem;
 }
 
 .property-rule


### PR DESCRIPTION
## Problem

Request body parameters composed via `allOf` are rendered as a merged group inside a bordered box. 

These parameters have no anchor IDs and no copy link buttons, even though top-level body parameters do.

### Regular body parameters

<img width="797" height="306" alt="SCR-20260421-kjdh" src="https://github.com/user-attachments/assets/216f6a7a-289a-466d-b8d7-87c3c4ba4be3" />

### Body parameters composed via allOf

<img width="789" height="339" alt="SCR-20260421-kioz" src="https://github.com/user-attachments/assets/41b45ba9-9e15-46f3-b194-e5440617054c" />

## Root cause

When a schema uses `allOf`, SchemaComposition.vue merges the sub-schemas and passes the result to a nested `<Schema>`, which adds one extra level of nesting. This pushed those properties to `level 2`, while `shouldHaveLink` only enabled anchors for `level <= 1`. So `WithBreadcrumb` never received a breadcrumb for those properties, meaning no `id` anchor and no copy button were rendered.

## Solution

- SchemaProperty.vue — raise the `shouldHaveLink` threshold from `level <= 1` to `level <= 2`, so properties inside `allOf` groups receive their breadcrumb and the resulting anchor + copy-link button.
- SchemaProperty.vue — add a scoped CSS rule for `.property--level-2` that shifts the copy-link button further left (`left: -2rem`). Without this, the button's default position (`-left-4.5`) lands on top of the left border of the `allOf` group box. The extra offset moves it outside the box, consistent with how the button appears for level-1 properties outside any box.