### PR TITLE
fix(void-server): return valid zip file with request JSON

### DIFF
--- a/.changeset/fair-carrots-drum.md
+++ b/.changeset/fair-carrots-drum.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+fix zip responses to return a valid archive with request JSON payload

--- a/packages/void-server/src/create-void-server.test.ts
+++ b/packages/void-server/src/create-void-server.test.ts
@@ -2,6 +2,27 @@ import { describe, expect, it } from 'vitest'
 
 import { createVoidServer } from '@/create-void-server'
 
+const getSignature = (bytes: Uint8Array, offset: number): number => {
+  return new DataView(bytes.buffer, bytes.byteOffset + offset, 4).getUint32(0, true)
+}
+
+const extractStoredEntry = (bytes: Uint8Array): { content: string; fileName: string } => {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const fileNameLength = view.getUint16(26, true)
+  const extraFieldLength = view.getUint16(28, true)
+  const fileNameOffset = 30
+  const contentOffset = fileNameOffset + fileNameLength + extraFieldLength
+  const uncompressedSize = view.getUint32(22, true)
+
+  const fileName = new TextDecoder().decode(bytes.slice(fileNameOffset, fileNameOffset + fileNameLength))
+  const content = new TextDecoder().decode(bytes.slice(contentOffset, contentOffset + uncompressedSize))
+
+  return {
+    fileName,
+    content,
+  }
+}
+
 describe('createVoidServer', () => {
   it('GET /foobar', async () => {
     const server = await createVoidServer()
@@ -331,6 +352,22 @@ describe('createVoidServer', () => {
     expect(response.headers.get('Content-Type')).toContain('application/json')
   })
 
+  it('returns ZIP for path ending with .zip', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/foobar.zip?foo=bar')
+    const zipBytes = new Uint8Array(await response.arrayBuffer())
+
+    expect(response.headers.get('Content-Type')).toContain('application/zip')
+    expect(getSignature(zipBytes, 0)).toBe(0x04034b50)
+    expect(getSignature(zipBytes, zipBytes.length - 22)).toBe(0x06054b50)
+
+    const { fileName, content } = extractStoredEntry(zipBytes)
+    expect(fileName).toBe('request.json')
+    expect(content).toContain('"path": "/foobar.zip"')
+    expect(content).toContain('"foo": "bar"')
+  })
+
   it('returns XML', async () => {
     const server = await createVoidServer()
 
@@ -342,6 +379,26 @@ describe('createVoidServer', () => {
 
     expect(await response.text()).toContain('<method>GET</method>')
     expect(response.headers.get('Content-Type')).toContain('application/xml')
+  })
+
+  it('returns ZIP for accept header application/zip', async () => {
+    const server = await createVoidServer()
+
+    const response = await server.request('/mirror', {
+      headers: {
+        Accept: 'application/zip',
+      },
+    })
+    const zipBytes = new Uint8Array(await response.arrayBuffer())
+
+    expect(response.headers.get('Content-Type')).toContain('application/zip')
+    expect(getSignature(zipBytes, 0)).toBe(0x04034b50)
+    expect(getSignature(zipBytes, zipBytes.length - 22)).toBe(0x06054b50)
+
+    const { fileName, content } = extractStoredEntry(zipBytes)
+    expect(fileName).toBe('request.json')
+    expect(content).toContain('"path": "/mirror"')
+    expect(content).toContain('"method": "GET"')
   })
 
   it('returns XML for a path ending with .xml', async () => {

--- a/packages/void-server/src/create-void-server.ts
+++ b/packages/void-server/src/create-void-server.ts
@@ -61,7 +61,7 @@ export function createVoidServer() {
       return createXmlResponse(c, requestData)
     }
     if (filename?.endsWith('.zip')) {
-      return createZipFileResponse(c)
+      return createZipFileResponse(c, requestData)
     }
 
     return createJsonResponse(c, requestData)
@@ -86,7 +86,7 @@ export function createVoidServer() {
       return createXmlResponse(c, requestData)
     }
     if (acceptedContentType === 'application/zip') {
-      return createZipFileResponse(c)
+      return createZipFileResponse(c, requestData)
     }
 
     return createJsonResponse(c, requestData)

--- a/packages/void-server/src/utils/create-zip-file-response.test.ts
+++ b/packages/void-server/src/utils/create-zip-file-response.test.ts
@@ -4,11 +4,40 @@ import { describe, expect, it } from 'vitest'
 import { createMockContext } from '../../test/utils/create-mock-context'
 import { createZipFileResponse } from './create-zip-file-response'
 
+const getSignature = (bytes: Uint8Array, offset: number): number => {
+  return new DataView(bytes.buffer, bytes.byteOffset + offset, 4).getUint32(0, true)
+}
+
+const extractStoredEntry = (bytes: Uint8Array): { content: string; fileName: string } => {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const fileNameLength = view.getUint16(26, true)
+  const extraFieldLength = view.getUint16(28, true)
+  const fileNameOffset = 30
+  const contentOffset = fileNameOffset + fileNameLength + extraFieldLength
+  const uncompressedSize = view.getUint32(22, true)
+
+  const fileName = new TextDecoder().decode(bytes.slice(fileNameOffset, fileNameOffset + fileNameLength))
+  const content = new TextDecoder().decode(bytes.slice(contentOffset, contentOffset + uncompressedSize))
+
+  return {
+    fileName,
+    content,
+  }
+}
+
 describe('create-zip-file-response', () => {
+  const requestData = {
+    method: 'POST',
+    path: '/foobar.zip',
+    query: {
+      foo: 'bar',
+    },
+  }
+
   it('sets the content-type header to application/zip', () => {
     const mockContext = createMockContext()
 
-    createZipFileResponse(mockContext as unknown as Context)
+    createZipFileResponse(mockContext as unknown as Context, requestData)
 
     expect(mockContext._headers['Content-Type']).toBe('application/zip')
   })
@@ -16,10 +45,27 @@ describe('create-zip-file-response', () => {
   it('calls the body method with content', () => {
     const mockContext = createMockContext()
 
-    createZipFileResponse(mockContext as unknown as Context)
+    createZipFileResponse(mockContext as unknown as Context, requestData)
 
     expect(mockContext.body).toHaveBeenCalled()
     expect(mockContext._getBodyContent()).not.toBeNull()
+  })
+
+  it('returns a valid zip containing request.json', () => {
+    const mockContext = createMockContext()
+
+    createZipFileResponse(mockContext as unknown as Context, requestData)
+
+    const zipBytes = mockContext._getBodyContent()
+    expect(zipBytes).toBeInstanceOf(Uint8Array)
+
+    const typedZipBytes = zipBytes as Uint8Array
+    expect(getSignature(typedZipBytes, 0)).toBe(0x04034b50)
+    expect(getSignature(typedZipBytes, typedZipBytes.length - 22)).toBe(0x06054b50)
+
+    const { fileName, content } = extractStoredEntry(typedZipBytes)
+    expect(fileName).toBe('request.json')
+    expect(content).toBe(JSON.stringify(requestData, null, 2))
   })
 
   it('sets the header before returning the body', () => {
@@ -29,12 +75,12 @@ describe('create-zip-file-response', () => {
     mockContext.header.mockImplementation(() => {
       callOrder.push('header')
     })
-    mockContext.body.mockImplementation((content: string) => {
+    mockContext.body.mockImplementation((content: unknown) => {
       callOrder.push('body')
       return content
     })
 
-    createZipFileResponse(mockContext as unknown as Context)
+    createZipFileResponse(mockContext as unknown as Context, requestData)
 
     expect(callOrder).toEqual(['header', 'body'])
   })

--- a/packages/void-server/src/utils/create-zip-file-response.ts
+++ b/packages/void-server/src/utils/create-zip-file-response.ts
@@ -1,14 +1,201 @@
 import type { Context } from 'hono'
 
 /**
- * Creates an empty Zip file response
+ * Creates a ZIP response with a request.json file.
  */
-export function createZipFileResponse(c: Context) {
-  c.header('Content-Type', 'application/zip')
+export function createZipFileResponse(c: Context, data: Record<string, unknown>) {
+  const fileName = 'request.json'
+  const fileNameBytes = new TextEncoder().encode(fileName)
+  const fileContentBytes = new TextEncoder().encode(JSON.stringify(data, null, 2))
+  const crc32 = calculateCrc32(fileContentBytes)
 
-  const blob = new Blob([new Uint8Array([80, 75, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).buffer], {
-    type: 'application/zip',
+  const localFileHeader = createLocalFileHeader({
+    crc32,
+    fileNameBytes,
+    uncompressedSize: fileContentBytes.length,
+  })
+  const centralDirectoryHeader = createCentralDirectoryHeader({
+    crc32,
+    fileNameBytes,
+    localFileHeaderOffset: 0,
+    uncompressedSize: fileContentBytes.length,
+  })
+  const endOfCentralDirectoryRecord = createEndOfCentralDirectoryRecord({
+    centralDirectoryOffset: localFileHeader.length + fileContentBytes.length + fileNameBytes.length,
+    centralDirectorySize: centralDirectoryHeader.length + fileNameBytes.length,
+    totalEntries: 1,
   })
 
-  return c.body(blob.toString())
+  const zipFileBytes = new Uint8Array(
+    localFileHeader.length +
+      fileNameBytes.length +
+      fileContentBytes.length +
+      centralDirectoryHeader.length +
+      fileNameBytes.length +
+      endOfCentralDirectoryRecord.length,
+  )
+
+  let offset = 0
+  zipFileBytes.set(localFileHeader, offset)
+  offset += localFileHeader.length
+  zipFileBytes.set(fileNameBytes, offset)
+  offset += fileNameBytes.length
+  zipFileBytes.set(fileContentBytes, offset)
+  offset += fileContentBytes.length
+  zipFileBytes.set(centralDirectoryHeader, offset)
+  offset += centralDirectoryHeader.length
+  zipFileBytes.set(fileNameBytes, offset)
+  offset += fileNameBytes.length
+  zipFileBytes.set(endOfCentralDirectoryRecord, offset)
+
+  c.header('Content-Type', 'application/zip')
+
+  return c.body(zipFileBytes)
+}
+
+type ZipHeaderInput = {
+  crc32: number
+  fileNameBytes: Uint8Array
+  uncompressedSize: number
+}
+
+type CentralDirectoryInput = ZipHeaderInput & {
+  localFileHeaderOffset: number
+}
+
+type EndOfCentralDirectoryInput = {
+  centralDirectoryOffset: number
+  centralDirectorySize: number
+  totalEntries: number
+}
+
+const createLocalFileHeader = ({ crc32, fileNameBytes, uncompressedSize }: ZipHeaderInput): Uint8Array => {
+  const header = new Uint8Array(30)
+  const view = new DataView(header.buffer)
+
+  // Local file header signature
+  view.setUint32(0, 0x04034b50, true)
+  // Version needed to extract (2.0)
+  view.setUint16(4, 20, true)
+  // General purpose bit flag
+  view.setUint16(6, 0, true)
+  // Compression method (stored)
+  view.setUint16(8, 0, true)
+  // Last mod file time/date
+  view.setUint16(10, 0, true)
+  view.setUint16(12, 0, true)
+  // CRC-32
+  view.setUint32(14, crc32 >>> 0, true)
+  // Compressed size
+  view.setUint32(18, uncompressedSize, true)
+  // Uncompressed size
+  view.setUint32(22, uncompressedSize, true)
+  // File name length
+  view.setUint16(26, fileNameBytes.length, true)
+  // Extra field length
+  view.setUint16(28, 0, true)
+
+  return header
+}
+
+const createCentralDirectoryHeader = ({
+  crc32,
+  fileNameBytes,
+  localFileHeaderOffset,
+  uncompressedSize,
+}: CentralDirectoryInput): Uint8Array => {
+  const header = new Uint8Array(46)
+  const view = new DataView(header.buffer)
+
+  // Central file header signature
+  view.setUint32(0, 0x02014b50, true)
+  // Version made by
+  view.setUint16(4, 20, true)
+  // Version needed to extract
+  view.setUint16(6, 20, true)
+  // General purpose bit flag
+  view.setUint16(8, 0, true)
+  // Compression method (stored)
+  view.setUint16(10, 0, true)
+  // Last mod file time/date
+  view.setUint16(12, 0, true)
+  view.setUint16(14, 0, true)
+  // CRC-32
+  view.setUint32(16, crc32 >>> 0, true)
+  // Compressed size
+  view.setUint32(20, uncompressedSize, true)
+  // Uncompressed size
+  view.setUint32(24, uncompressedSize, true)
+  // File name length
+  view.setUint16(28, fileNameBytes.length, true)
+  // Extra field length
+  view.setUint16(30, 0, true)
+  // File comment length
+  view.setUint16(32, 0, true)
+  // Disk number start
+  view.setUint16(34, 0, true)
+  // Internal file attributes
+  view.setUint16(36, 0, true)
+  // External file attributes
+  view.setUint32(38, 0, true)
+  // Relative offset of local header
+  view.setUint32(42, localFileHeaderOffset, true)
+
+  return header
+}
+
+const createEndOfCentralDirectoryRecord = ({
+  centralDirectoryOffset,
+  centralDirectorySize,
+  totalEntries,
+}: EndOfCentralDirectoryInput): Uint8Array => {
+  const record = new Uint8Array(22)
+  const view = new DataView(record.buffer)
+
+  // End of central dir signature
+  view.setUint32(0, 0x06054b50, true)
+  // Number of this disk
+  view.setUint16(4, 0, true)
+  // Number of the disk with the start of the central directory
+  view.setUint16(6, 0, true)
+  // Total entries in central directory on this disk
+  view.setUint16(8, totalEntries, true)
+  // Total entries in central directory
+  view.setUint16(10, totalEntries, true)
+  // Size of the central directory
+  view.setUint32(12, centralDirectorySize, true)
+  // Offset of start of central directory
+  view.setUint32(16, centralDirectoryOffset, true)
+  // ZIP file comment length
+  view.setUint16(20, 0, true)
+
+  return record
+}
+
+const CRC_TABLE = createCrcTable()
+
+const createCrcTable = (): Uint32Array => {
+  const table = new Uint32Array(256)
+
+  for (let index = 0; index < 256; index += 1) {
+    let crc = index
+
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc & 1) !== 0 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1
+    }
+
+    table[index] = crc >>> 0
+  }
+
+  return table
+}
+
+const calculateCrc32 = (input: Uint8Array): number => {
+  let crc = 0xffffffff
+
+  for (const byte of input) {
+    crc = (crc >>> 8) ^ CRC_TABLE[(crc ^ byte) & 0xff]
+  }
+
+  return (crc ^ 0xffffffff) >>> 0
 }

--- a/packages/void-server/src/utils/create-zip-file-response.ts
+++ b/packages/void-server/src/utils/create-zip-file-response.ts
@@ -172,8 +172,6 @@ const createEndOfCentralDirectoryRecord = ({
   return record
 }
 
-const CRC_TABLE = createCrcTable()
-
 const createCrcTable = (): Uint32Array => {
   const table = new Uint32Array(256)
 
@@ -189,6 +187,8 @@ const createCrcTable = (): Uint32Array => {
 
   return table
 }
+
+const CRC_TABLE = createCrcTable()
 
 const calculateCrc32 = (input: Uint8Array): number => {
   let crc = 0xffffffff

--- a/packages/void-server/src/utils/create-zip-file-response.ts
+++ b/packages/void-server/src/utils/create-zip-file-response.ts
@@ -194,7 +194,9 @@ const calculateCrc32 = (input: Uint8Array): number => {
   let crc = 0xffffffff
 
   for (const byte of input) {
-    crc = (crc >>> 8) ^ CRC_TABLE[(crc ^ byte) & 0xff]
+    const tableIndex = (crc ^ byte) & 0xff
+    const tableValue = CRC_TABLE[tableIndex] ?? 0
+    crc = (crc >>> 8) ^ tableValue
   }
 
   return (crc ^ 0xffffffff) >>> 0

--- a/packages/void-server/test/utils/create-mock-context.ts
+++ b/packages/void-server/test/utils/create-mock-context.ts
@@ -23,7 +23,7 @@ export function createMockContext(options: MockContextOptions = {}) {
   let htmlContent = ''
   let jsonContent: Record<string, unknown> | null = null
   let textContent = ''
-  let bodyContent: string | null = null
+  let bodyContent: unknown = null
 
   return {
     header: vi.fn((key: string, value: string) => {
@@ -54,7 +54,7 @@ export function createMockContext(options: MockContextOptions = {}) {
       }
       return content
     }),
-    body: vi.fn((content: string) => {
+    body: vi.fn((content: unknown) => {
       bodyContent = content
       return content
     }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `@scalar/void-server` ZIP endpoint returned a corrupt archive payload. The implementation set `Content-Type: application/zip` but returned `blob.toString()`, which serializes to a string representation instead of ZIP bytes.

## Solution

- Replaced the ZIP response builder with a binary ZIP writer that returns a valid archive payload.
- Added a single `request.json` entry containing the full mirrored request data.
- Wired `requestData` into ZIP responses for both `.zip` extension routes and `Accept: application/zip` negotiation.
- Added targeted tests that validate ZIP signatures and confirm `request.json` content.
- Updated test mocks so response bodies can capture binary (`Uint8Array`) content.
- Fixed strict TypeScript build failure by safely handling CRC table lookup value typing.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1b2264a-ce57-494b-8ca8-166ac156661a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1b2264a-ce57-494b-8ca8-166ac156661a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

