### PR TITLE
fix(api-client): correctly handle custom file imports

### DIFF
--- a/.changeset/ripe-sails-reply.md
+++ b/.changeset/ripe-sails-reply.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: correctly handle custom file imports

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.test.ts
@@ -21,33 +21,11 @@ vi.mock('vue-router', () => ({
  * picking a file without needing a real `<input type="file">`.
  */
 const mockFileDialogOpen = vi.fn()
-let mockFileDialogOnChange: ((files: FileList | null) => void | Promise<void>) | undefined
-vi.mock('@/hooks/use-file-dialog', () => ({
-  useFileDialog: (options?: { onChange?: (files: FileList | null) => void | Promise<void> }) => {
-    mockFileDialogOnChange = options?.onChange
-    return {
-      open: mockFileDialogOpen,
-    }
-  },
-}))
-
-/**
- * Build a `FileList`-like object wrapping a single in-memory `File`. jsdom
- * does not provide a `FileList` constructor, so we fake the minimum surface
- * the component relies on (indexed access and `length`).
- */
-const createFileList = (contents: string, name = 'import.json'): FileList => {
-  const file = new File([contents], name, { type: 'application/json' })
-  const list = [file] as unknown as FileList & File[]
-  // The component only reads `files[0]`, so an array with a `length` is enough.
-  return list
-}
 
 describe('CommandPaletteImport', () => {
   beforeEach(() => {
     mockPush.mockClear()
     mockFileDialogOpen.mockClear()
-    mockFileDialogOnChange = undefined
   })
 
   afterEach(() => {
@@ -850,61 +828,6 @@ describe('CommandPaletteImport', () => {
 
     await expect(slotImport()?.('/path/to/collection.json', 'file')).resolves.toBeUndefined()
 
-    expect(emitSpy).not.toHaveBeenCalledWith(
-      'ui:open:command-palette',
-      expect.objectContaining({ action: 'import-postman-collection' }),
-    )
-  })
-
-  it('routes Postman collections from the default file picker to the Postman modal', async () => {
-    const workspaceStore = createWorkspaceStore()
-    const eventBus = createWorkspaceEventBus()
-    const emitSpy = vi.fn()
-    eventBus.emit = emitSpy
-
-    mount(CommandPaletteImport, {
-      props: {
-        workspaceStore,
-        eventBus,
-      },
-    })
-
-    expect(mockFileDialogOnChange).toBeTypeOf('function')
-    await mockFileDialogOnChange?.(createFileList(minimalPostmanCollectionJson))
-    // FileReader resolves its load event asynchronously, so we yield until the
-    // callback has had a chance to run and emit on the event bus.
-    await vi.waitFor(() =>
-      expect(emitSpy).toHaveBeenCalledWith('ui:open:command-palette', {
-        action: 'import-postman-collection',
-        payload: {
-          inputValue: minimalPostmanCollectionJson,
-        },
-      }),
-    )
-  })
-
-  it('does not route OpenAPI uploads from the default file picker to the Postman modal', async () => {
-    const workspaceStore = createWorkspaceStore()
-    const eventBus = createWorkspaceEventBus()
-    const emitSpy = vi.fn()
-    eventBus.emit = emitSpy
-
-    mount(CommandPaletteImport, {
-      props: {
-        workspaceStore,
-        eventBus,
-      },
-    })
-
-    const openApiContent = JSON.stringify({
-      openapi: '3.1.0',
-      info: { title: 'Test API', version: '1.0.0' },
-    })
-
-    await mockFileDialogOnChange?.(createFileList(openApiContent))
-
-    // Give the async FileReader callback a chance to run before asserting.
-    await vi.waitFor(() => expect(emitSpy.mock.calls.length).toBeGreaterThanOrEqual(0))
     expect(emitSpy).not.toHaveBeenCalledWith(
       'ui:open:command-palette',
       expect.objectContaining({ action: 'import-postman-collection' }),

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.test.ts
@@ -1,3 +1,4 @@
+import type { LoaderPlugin } from '@scalar/json-magic/bundle'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import { mount } from '@vue/test-utils'
@@ -14,18 +15,39 @@ vi.mock('vue-router', () => ({
   }),
 }))
 
-// Mock file dialog hook
+/**
+ * Mock for the file dialog hook. `mockFileDialogOnChange` captures the
+ * `onChange` callback registered by the component so tests can simulate a user
+ * picking a file without needing a real `<input type="file">`.
+ */
 const mockFileDialogOpen = vi.fn()
+let mockFileDialogOnChange: ((files: FileList | null) => void | Promise<void>) | undefined
 vi.mock('@/hooks/use-file-dialog', () => ({
-  useFileDialog: () => ({
-    open: mockFileDialogOpen,
-  }),
+  useFileDialog: (options?: { onChange?: (files: FileList | null) => void | Promise<void> }) => {
+    mockFileDialogOnChange = options?.onChange
+    return {
+      open: mockFileDialogOpen,
+    }
+  },
 }))
+
+/**
+ * Build a `FileList`-like object wrapping a single in-memory `File`. jsdom
+ * does not provide a `FileList` constructor, so we fake the minimum surface
+ * the component relies on (indexed access and `length`).
+ */
+const createFileList = (contents: string, name = 'import.json'): FileList => {
+  const file = new File([contents], name, { type: 'application/json' })
+  const list = [file] as unknown as FileList & File[]
+  // The component only reads `files[0]`, so an array with a `length` is enough.
+  return list
+}
 
 describe('CommandPaletteImport', () => {
   beforeEach(() => {
     mockPush.mockClear()
     mockFileDialogOpen.mockClear()
+    mockFileDialogOnChange = undefined
   })
 
   afterEach(() => {
@@ -708,6 +730,185 @@ describe('CommandPaletteImport', () => {
 
     /** Input should still be visible for URLs */
     expect(wrapper.findComponent({ name: 'CommandActionInput' }).exists()).toBe(true)
+  })
+
+  /** Stub loader plugin that resolves a virtual path to a fixed text payload. */
+  const createStubFileLoader = (content: string): LoaderPlugin => ({
+    type: 'loader',
+    validate: () => true,
+    exec: vi.fn(async () => ({
+      ok: true,
+      data: {},
+      raw: content,
+    })),
+  })
+
+  type SlotImport = (source: string, type: 'file' | 'raw') => Promise<void>
+
+  /**
+   * Mount the component and capture the `import` function the component
+   * exposes on the `fileUpload` slot so tests can invoke it like a consumer.
+   */
+  const mountWithSlotCapture = (
+    props: Parameters<typeof mount<typeof CommandPaletteImport>>[1] extends infer P
+      ? P extends { props?: infer Props }
+        ? Props
+        : never
+      : never,
+  ): { slotImport: () => SlotImport | undefined } => {
+    let slotImport: SlotImport | undefined
+
+    mount(CommandPaletteImport, {
+      props,
+      slots: {
+        fileUpload: (slotProps: { import: SlotImport }) => {
+          slotImport = slotProps.import
+          return null
+        },
+      },
+    })
+
+    return { slotImport: () => slotImport }
+  }
+
+  it('exposes the import function on the fileUpload slot', () => {
+    const workspaceStore = createWorkspaceStore()
+    const eventBus = createWorkspaceEventBus()
+
+    const { slotImport } = mountWithSlotCapture({ workspaceStore, eventBus })
+
+    expect(slotImport()).toBeTypeOf('function')
+  })
+
+  it('routes path-based Postman imports from the fileUpload slot to the Postman modal', async () => {
+    const workspaceStore = createWorkspaceStore()
+    const eventBus = createWorkspaceEventBus()
+    const emitSpy = vi.fn()
+    eventBus.emit = emitSpy
+
+    const fileLoader = createStubFileLoader(minimalPostmanCollectionJson)
+    const { slotImport } = mountWithSlotCapture({ workspaceStore, eventBus, fileLoader })
+
+    await slotImport()?.('/path/to/collection.json', 'file')
+
+    expect(fileLoader.exec).toHaveBeenCalledWith('/path/to/collection.json')
+    expect(emitSpy).toHaveBeenCalledWith('ui:open:command-palette', {
+      action: 'import-postman-collection',
+      payload: {
+        inputValue: minimalPostmanCollectionJson,
+      },
+    })
+  })
+
+  it('routes raw Postman content from the fileUpload slot to the Postman modal', async () => {
+    const workspaceStore = createWorkspaceStore()
+    const eventBus = createWorkspaceEventBus()
+    const emitSpy = vi.fn()
+    eventBus.emit = emitSpy
+
+    const { slotImport } = mountWithSlotCapture({ workspaceStore, eventBus })
+
+    await slotImport()?.(minimalPostmanCollectionJson, 'raw')
+
+    expect(emitSpy).toHaveBeenCalledWith('ui:open:command-palette', {
+      action: 'import-postman-collection',
+      payload: {
+        inputValue: minimalPostmanCollectionJson,
+      },
+    })
+  })
+
+  it('does not route non-Postman content from the fileUpload slot to the Postman modal', async () => {
+    const workspaceStore = createWorkspaceStore()
+    const eventBus = createWorkspaceEventBus()
+    const emitSpy = vi.fn()
+    eventBus.emit = emitSpy
+
+    const openApiContent = JSON.stringify({
+      openapi: '3.1.0',
+      info: { title: 'Test API', version: '1.0.0' },
+    })
+
+    const fileLoader = createStubFileLoader(openApiContent)
+    const { slotImport } = mountWithSlotCapture({ workspaceStore, eventBus, fileLoader })
+
+    await slotImport()?.('/path/to/openapi.json', 'file')
+
+    expect(emitSpy).not.toHaveBeenCalledWith(
+      'ui:open:command-palette',
+      expect.objectContaining({ action: 'import-postman-collection' }),
+    )
+  })
+
+  it('does not crash when the fileUpload slot is used without a file loader', async () => {
+    const workspaceStore = createWorkspaceStore()
+    const eventBus = createWorkspaceEventBus()
+    const emitSpy = vi.fn()
+    eventBus.emit = emitSpy
+
+    const { slotImport } = mountWithSlotCapture({ workspaceStore, eventBus })
+
+    await expect(slotImport()?.('/path/to/collection.json', 'file')).resolves.toBeUndefined()
+
+    expect(emitSpy).not.toHaveBeenCalledWith(
+      'ui:open:command-palette',
+      expect.objectContaining({ action: 'import-postman-collection' }),
+    )
+  })
+
+  it('routes Postman collections from the default file picker to the Postman modal', async () => {
+    const workspaceStore = createWorkspaceStore()
+    const eventBus = createWorkspaceEventBus()
+    const emitSpy = vi.fn()
+    eventBus.emit = emitSpy
+
+    mount(CommandPaletteImport, {
+      props: {
+        workspaceStore,
+        eventBus,
+      },
+    })
+
+    expect(mockFileDialogOnChange).toBeTypeOf('function')
+    await mockFileDialogOnChange?.(createFileList(minimalPostmanCollectionJson))
+    // FileReader resolves its load event asynchronously, so we yield until the
+    // callback has had a chance to run and emit on the event bus.
+    await vi.waitFor(() =>
+      expect(emitSpy).toHaveBeenCalledWith('ui:open:command-palette', {
+        action: 'import-postman-collection',
+        payload: {
+          inputValue: minimalPostmanCollectionJson,
+        },
+      }),
+    )
+  })
+
+  it('does not route OpenAPI uploads from the default file picker to the Postman modal', async () => {
+    const workspaceStore = createWorkspaceStore()
+    const eventBus = createWorkspaceEventBus()
+    const emitSpy = vi.fn()
+    eventBus.emit = emitSpy
+
+    mount(CommandPaletteImport, {
+      props: {
+        workspaceStore,
+        eventBus,
+      },
+    })
+
+    const openApiContent = JSON.stringify({
+      openapi: '3.1.0',
+      info: { title: 'Test API', version: '1.0.0' },
+    })
+
+    await mockFileDialogOnChange?.(createFileList(openApiContent))
+
+    // Give the async FileReader callback a chance to run before asserting.
+    await vi.waitFor(() => expect(emitSpy.mock.calls.length).toBeGreaterThanOrEqual(0))
+    expect(emitSpy).not.toHaveBeenCalledWith(
+      'ui:open:command-palette',
+      expect.objectContaining({ action: 'import-postman-collection' }),
+    )
   })
 
   it('handles empty input after having content', async () => {

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.test.ts
@@ -15,17 +15,9 @@ vi.mock('vue-router', () => ({
   }),
 }))
 
-/**
- * Mock for the file dialog hook. `mockFileDialogOnChange` captures the
- * `onChange` callback registered by the component so tests can simulate a user
- * picking a file without needing a real `<input type="file">`.
- */
-const mockFileDialogOpen = vi.fn()
-
 describe('CommandPaletteImport', () => {
   beforeEach(() => {
     mockPush.mockClear()
-    mockFileDialogOpen.mockClear()
   })
 
   afterEach(() => {

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.vue
@@ -63,7 +63,13 @@ const emit = defineEmits<{
 }>()
 
 defineSlots<{
-  /** Slot for custom file upload component that can trigger import */
+  /**
+   * Slot for custom file upload component that can trigger import.
+   *
+   * The provided `import` function automatically detects Postman collections
+   * and routes them to the Postman import modal, matching the behavior of the
+   * default file picker.
+   */
   fileUpload(props: {
     /** Function to trigger import with source content and type */
     import: (source: string, type: 'file' | 'raw') => Promise<void>
@@ -200,6 +206,47 @@ const navigateToDocument = (documentName: string): void => {
 }
 
 /**
+ * Import a file, routing Postman collections to the Postman import modal and
+ * everything else through the OpenAPI import flow.
+ *
+ * Shared between the default file picker and the `fileUpload` slot so custom
+ * path-based importers get the same Postman detection behavior.
+ *
+ * When `type` is `'file'` the `source` is a file path resolved through the
+ * configured `fileLoader`; when `type` is `'raw'` the `source` is treated as
+ * the file's text content directly.
+ */
+const handleFileImport: (
+  source: string,
+  type?: 'file' | 'raw',
+) => Promise<void> = async (source, type = 'raw') => {
+  // Resolve the raw text content so we can sniff for a Postman collection.
+  // For raw pastes / uploads the source already is the text. For path-based
+  // imports we delegate to the file loader plugin, if one is configured.
+  const rawContent = await (async (): Promise<string> => {
+    if (type === 'raw') {
+      return source
+    }
+
+    const result = await fileLoader?.exec(source)
+    return result?.ok ? result.raw : ''
+  })()
+
+  if (isPostmanCollection(rawContent)) {
+    eventBus.emit('ui:open:command-palette', {
+      action: 'import-postman-collection',
+      payload: {
+        inputValue: rawContent,
+      },
+    })
+    await loader.clear()
+    return
+  }
+
+  await handleImport(source, type)
+}
+
+/**
  * Handle file selection and import from file dialog.
  * Reads the file as text and imports it as OpenAPI or Postman collection.
  * Shows loading state during the import process.
@@ -216,17 +263,7 @@ const { open: openSpecFileDialog } = useFileDialog({
 
     const onLoad = async (event: ProgressEvent<FileReader>): Promise<void> => {
       const text = event.target?.result as string
-      if (isPostmanCollection(text)) {
-        eventBus.emit('ui:open:command-palette', {
-          action: 'import-postman-collection',
-          payload: {
-            inputValue: text,
-          },
-        })
-        await loader.clear()
-        return
-      }
-      await handleImport(text, 'raw')
+      await handleFileImport(text, 'raw')
     }
 
     const reader = new FileReader()
@@ -313,7 +350,7 @@ const handleBack = (event: KeyboardEvent): void => {
       <div class="flex w-full flex-row items-center justify-between gap-3">
         <!-- Custom file upload slot or default button -->
         <slot
-          :import="handleImport"
+          :import="handleFileImport"
           name="fileUpload">
           <!-- Default file upload button -->
           <ScalarButton


### PR DESCRIPTION
Currently, the client app overrides the import file flow to fully bundle a file along with its references. However, this override unintentionally skips the logic that detects whether the imported file is a Postman collection.

This PR fixes the issue by pre-reading the input file and checking if it is a Postman collection before proceeding with the standard import and bundling flow.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to import routing logic with added tests; main risk is import-type edge cases for path-based loaders.
> 
> **Overview**
> Fixes custom `fileUpload` slot imports so they **pre-read file content and detect Postman collections** before running the normal OpenAPI/bundling import path.
> 
> Introduces a shared `handleFileImport` used by both the default file picker and the slot-provided `import` function (including safe behavior when no `fileLoader` is configured), and adds focused tests covering raw vs path-based Postman/non-Postman routing plus a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d85b35b07e8e0880499d8bdd29eb983a7ddeb4b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->