### PR TITLE
fix(api-client): path routing on initial load

### DIFF
--- a/.changeset/three-chairs-return.md
+++ b/.changeset/three-chairs-return.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: api client initial routing

--- a/packages/api-client/src/v2/features/app/app-state.test.ts
+++ b/packages/api-client/src/v2/features/app/app-state.test.ts
@@ -80,6 +80,35 @@ describe('app-state', () => {
     expect(router.currentRoute.value.name).toBe('document.overview')
   })
 
+  it('syncs the active tab path to the URL-based route on initial load when saved tabs exist', async () => {
+    const savedTabPath = '/@local/sync-tabs/document/drafts/servers'
+    await persistWorkspace({
+      slug: 'sync-tabs',
+      tabs: [{ path: savedTabPath, title: 'Saved Tab' }],
+    })
+
+    const router = setupRouter()
+    const appState = await createAppState({ router })
+
+    await router.push({
+      name: 'document.overview',
+      params: { namespace: 'local', workspaceSlug: 'sync-tabs', documentSlug: 'drafts' },
+    })
+
+    // Wait until the workspace has finished loading — once store.value is populated
+    // the tabs computed switches from the currentRoute fallback to persisted tabs.
+    // Without the fix, that persisted path would still be stale.
+    await vi.waitFor(() => {
+      expect(appState.store.value).not.toBeNull()
+    })
+
+    const activeIndex = appState.tabs.activeTabIndex.value
+    const activeTab = appState.tabs.state.value[activeIndex]
+    // The active tab must track the URL-based route, not the stale persisted path
+    expect(activeTab?.path).toBe(router.currentRoute.value.path)
+    expect(activeTab?.path).not.toBe(savedTabPath)
+  })
+
   it('redirects to the saved tab path when switching workspaces after initial load', async () => {
     const savedTabPath = '/@local/switch-target/document/drafts/servers'
     await persistWorkspace({ slug: 'switch-source' })

--- a/packages/api-client/src/v2/features/app/app-state.test.ts
+++ b/packages/api-client/src/v2/features/app/app-state.test.ts
@@ -1,0 +1,113 @@
+import { createWorkspaceStore } from '@scalar/workspace-store/client'
+import { createWorkspaceStorePersistence } from '@scalar/workspace-store/persistence'
+import { flushPromises } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import 'fake-indexeddb/auto'
+
+import { createAppState } from './app-state'
+import { ROUTES } from './helpers/routes'
+
+const persistWorkspace = async ({
+  namespace = 'local',
+  slug,
+  name = 'Test Workspace',
+  tabs,
+}: {
+  namespace?: string
+  slug: string
+  name?: string
+  tabs?: { path: string; title: string }[]
+}) => {
+  const store = createWorkspaceStore()
+
+  if (tabs) {
+    store.workspace['x-scalar-tabs'] = tabs
+    store.workspace['x-scalar-active-tab'] = 0
+  }
+
+  const persistence = await createWorkspaceStorePersistence()
+  await persistence.workspace.setItem({ namespace, slug }, { name, workspace: store.exportWorkspace() })
+}
+
+const setupRouter = () => createRouter({ history: createMemoryHistory(), routes: ROUTES })
+
+const waitForNavigation = async () => {
+  await nextTick()
+  await flushPromises()
+  // Multiple flushes are needed to drain the nested promise chain (IndexedDB load → router.replace → afterEach again).
+  await flushPromises()
+  await flushPromises()
+}
+
+describe('app-state', () => {
+  it('preserves the initial route when workspace has saved tabs on first load', async () => {
+    const savedTabPath = '/@local/preserve-route/document/drafts/servers'
+    await persistWorkspace({
+      slug: 'preserve-route',
+      tabs: [{ path: savedTabPath, title: 'Saved Tab' }],
+    })
+
+    const router = setupRouter()
+    await createAppState({ router })
+
+    await router.push({
+      name: 'document.overview',
+      params: { namespace: 'local', workspaceSlug: 'preserve-route', documentSlug: 'drafts' },
+    })
+    await router.isReady()
+    await waitForNavigation()
+
+    // The URL routing should take precedence over the saved tab on initial load
+    expect(router.currentRoute.value.name).toBe('document.overview')
+    expect(router.currentRoute.value.path).not.toBe(savedTabPath)
+  })
+
+  it('stays on the current route when workspace has no saved tabs on initial load', async () => {
+    await persistWorkspace({ slug: 'no-tabs' })
+
+    const router = setupRouter()
+    await createAppState({ router })
+
+    await router.push({
+      name: 'document.overview',
+      params: { namespace: 'local', workspaceSlug: 'no-tabs', documentSlug: 'drafts' },
+    })
+    await router.isReady()
+    await waitForNavigation()
+
+    expect(router.currentRoute.value.name).toBe('document.overview')
+  })
+
+  it('redirects to the saved tab path when switching workspaces after initial load', async () => {
+    const savedTabPath = '/@local/switch-target/document/drafts/servers'
+    await persistWorkspace({ slug: 'switch-source' })
+    await persistWorkspace({
+      slug: 'switch-target',
+      tabs: [{ path: savedTabPath, title: 'Saved Tab' }],
+    })
+
+    const router = setupRouter()
+    await createAppState({ router })
+
+    // Initial load on workspace A — consumes the isInitialLoad flag
+    await router.push({
+      name: 'document.overview',
+      params: { namespace: 'local', workspaceSlug: 'switch-source', documentSlug: 'drafts' },
+    })
+    await router.isReady()
+    await waitForNavigation()
+
+    // Switch to workspace B which has a saved tab
+    await router.push({
+      name: 'document.overview',
+      params: { namespace: 'local', workspaceSlug: 'switch-target', documentSlug: 'drafts' },
+    })
+
+    // changeWorkspace is async/fire-and-forget from router.afterEach, so poll until the redirect lands
+    await vi.waitFor(() => {
+      expect(router.currentRoute.value.path).toBe(savedTabPath)
+    })
+  })
+})

--- a/packages/api-client/src/v2/features/app/app-state.ts
+++ b/packages/api-client/src/v2/features/app/app-state.ts
@@ -479,7 +479,7 @@ export const createAppState = async ({
    *    - If found, navigates to the active tab path (if available).
    *    - If not found, creates the default workspace and navigates to it.
    */
-  const changeWorkspace = async (namespace: string, slug: string) => {
+  const changeWorkspace = async (namespace: string, slug: string, to?: RouteLocationNormalizedGeneric) => {
     /** For initial load we want to fall through to our router default behaviour */
     const isInitialLoad = activeWorkspace.value === null
 
@@ -518,6 +518,14 @@ export const createAppState = async ({
           'x-scalar-tabs': [createTabFromRoute(currentRoute.value)],
           'x-scalar-active-tab': 0,
         })
+      }
+
+      // On initial load the router.replace above is skipped, so syncTabs/syncSidebar
+      // are never reached via handleRouteChange's normal flow. Call them here to
+      // align the tab bar and sidebar with the URL-based route.
+      if (isInitialLoad && to) {
+        syncTabs(to)
+        syncSidebar(to)
       }
 
       isSyncingWorkspace.value = false
@@ -932,7 +940,7 @@ export const createAppState = async ({
     }
 
     if (getWorkspaceId(namespace.value, slug) !== activeWorkspace.value?.id) {
-      return changeWorkspace(namespace.value, slug)
+      return changeWorkspace(namespace.value, slug, to)
     }
 
     // Update the active document if the document slug has changes

--- a/packages/api-client/src/v2/features/app/app-state.ts
+++ b/packages/api-client/src/v2/features/app/app-state.ts
@@ -7,8 +7,6 @@ import { migrateLocalStorageToIndexDb } from '@scalar/oas-utils/migrations'
 import { createSidebarState, generateReverseIndex } from '@scalar/sidebar'
 import type { Theme } from '@scalar/themes'
 import { type WorkspaceStore, createWorkspaceStore } from '@scalar/workspace-store/client'
-
-import type { ApiClientAppOptions } from '@/v2/features/app/helpers/create-api-client-app'
 import {
   type OperationExampleMeta,
   type WorkspaceEventBus,
@@ -37,6 +35,7 @@ import {
 } from 'vue'
 import type { RouteLocationNormalizedGeneric, RouteLocationRaw, Router } from 'vue-router'
 
+import type { ApiClientAppOptions } from '@/v2/features/app/helpers/create-api-client-app'
 import { getRouteParam } from '@/v2/features/app/helpers/get-route-param'
 import { groupWorkspacesByTeam } from '@/v2/features/app/helpers/group-workspaces'
 import { useTheme } from '@/v2/features/app/hooks/use-theme'
@@ -481,6 +480,9 @@ export const createAppState = async ({
    *    - If not found, creates the default workspace and navigates to it.
    */
   const changeWorkspace = async (namespace: string, slug: string) => {
+    /** For initial load we want to fall through to our router default behaviour */
+    const isInitialLoad = activeWorkspace.value === null
+
     // Clear the current store and set loading to true before loading new workspace.
     store.value = null
     isSyncingWorkspace.value = true
@@ -494,7 +496,8 @@ export const createAppState = async ({
       const tabs = result.workspace['x-scalar-tabs']
       const tab = tabs?.[index]
 
-      if (tab) {
+      // On initial load let the URL-based routing (catch-all → getLastPath) take precedence
+      if (tab && !isInitialLoad) {
         // Preserve query parameters when navigating to the active tab
         await router.replace({
           path: tab.path,


### PR DESCRIPTION
## Problem

We had some logic overwriting our default path routing for initial load. This meant you always went to your last path regardless of the URL.

## Solution

We skip the workspace change routing on initial load and just let the router handle it.

The tests are kind of ugly but 🤷🏾 can improve them later

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `createAppState` routing/workspace-switch behavior, so regressions could impact navigation/tab sync across workspaces; changes are small and covered by new tests.
> 
> **Overview**
> Fixes initial routing so the first URL a user lands on is **not overridden** by a persisted workspace’s saved active tab.
> 
> `changeWorkspace` now treats the first workspace activation differently: it skips the `router.replace` to a saved tab on initial load, but still syncs tabs/sidebar to the URL route; subsequent workspace switches continue to redirect to the persisted active tab.
> 
> Adds a new `app-state` test suite covering initial-load route preservation, tab-path syncing, and post-initial-load workspace switching behavior, plus a patch changeset for `@scalar/api-client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 568c53ae11d5f7f1c6536e264938062ee82d33f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->