### PR TITLE
feat(api-client): add posthog tracking for api client requests

### DIFF
--- a/.changeset/posthog-request-event.md
+++ b/.changeset/posthog-request-event.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+Rename PostHog event for request tracking from `hooks:on:request:sent` to `api-client-request` for cleaner analytics

--- a/packages/api-client/src/plugins/posthog/index.ts
+++ b/packages/api-client/src/plugins/posthog/index.ts
@@ -27,7 +27,7 @@ export const PostHogClientPlugin = (config: PostHogConfig): ClientPlugin => {
 
   return {
     on: {
-      'hooks:on:request:sent': () => posthog?.capture('hooks:on:request:sent'),
+      'hooks:on:request:sent': () => posthog?.capture('api-client-request'),
       'operation:create:operation': () => posthog?.capture('operation:create:operation'),
       'operation:delete:operation': () => posthog?.capture('operation:delete:operation'),
       'document:create:empty-document': () => posthog?.capture('document:create:empty-document'),

--- a/packages/api-client/src/plugins/posthog/posthog-plugin.test.ts
+++ b/packages/api-client/src/plugins/posthog/posthog-plugin.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @vitest-environment jsdom
+ */
 import { describe, expect, it, vi } from 'vitest'
 
 const mockPostHogInstance = vi.hoisted(() => ({
@@ -66,7 +69,6 @@ describe('posthog-plugin', () => {
     plugin.lifecycle?.onInit?.()
 
     const trackedEvents = [
-      'hooks:on:request:sent',
       'operation:create:operation',
       'operation:delete:operation',
       'document:create:empty-document',
@@ -84,6 +86,15 @@ describe('posthog-plugin', () => {
       plugin.on?.[event]?.({} as never)
       expect(mockPostHogInstance.capture).toHaveBeenCalledWith(event)
     }
+  })
+
+  it('captures api-client-request when request is sent', () => {
+    const plugin = PostHogClientPlugin(TEST_CONFIG)
+    plugin.lifecycle?.onInit?.()
+
+    mockPostHogInstance.capture.mockClear()
+    plugin.on?.['hooks:on:request:sent']?.({} as never)
+    expect(mockPostHogInstance.capture).toHaveBeenCalledWith('api-client-request')
   })
 
   it('resets PostHog on onDestroy', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The PostHog analytics funnel shows 0% conversion for the `api-client-request` step because the event being captured was named `hooks:on:request:sent` (an internal hook name) instead of a user-friendly analytics event name `api-client-request`.

This makes it difficult to track API request events from the standalone API client (client.scalar.com) in PostHog dashboards and funnels.

## Solution

Renamed the PostHog capture event from `hooks:on:request:sent` to `api-client-request` when a request is sent from the API client. The plugin still listens for the same internal event bus event (`hooks:on:request:sent`), but now captures it with a cleaner, analytics-friendly name.

Also fixed the test environment for the PostHog plugin tests by adding `@vitest-environment jsdom` directive, which was causing tests to fail due to the `window` check in the plugin initialization.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation. (Not needed - no documentation changes required)

## Ticket

Part of DOC-5246
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07RNPTKCB1/p1776879384483199?thread_ts=1776879384.483199&cid=C07RNPTKCB1)

<div><a href="https://cursor.com/agents/bc-2bbfdb03-65a1-5acd-b08b-5257442d100f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bbfdb03-65a1-5acd-b08b-5257442d100f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

