### PR TITLE
docs(mock-server): add mock-server agent skill

### DIFF
--- a/.agents/skills/mock-server/SKILL.md
+++ b/.agents/skills/mock-server/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: mock-server
+description: Build, customize, and troubleshoot OpenAPI mock servers with @scalar/mock-server, including x-handler, x-seed, authentication, and Docker.
+---
+
+# Scalar Mock Server Skill
+
+Reference for implementing and debugging mock APIs with `@scalar/mock-server`.
+Use this when you need realistic API responses from an OpenAPI description document, custom request behavior, seeded data, or Docker-based mock environments.
+
+## Overview
+
+- Package: `@scalar/mock-server`
+- Runtime: Node.js (package engine: `>=22`)
+- Main API: `createMockServer(options)`
+- Docs:
+  - Getting started: <https://scalar.com/tools/mock-server/getting-started>
+  - Custom request handlers (`x-handler`): <https://scalar.com/tools/mock-server/custom-request-handler>
+  - Data seeding (`x-seed`): <https://scalar.com/tools/mock-server/data-seeding>
+  - Docker: <https://scalar.com/tools/mock-server/docker>
+
+## Quick Start
+
+Fastest way to run a mock server from a local OpenAPI description:
+
+```bash
+npx @scalar/cli document mock openapi.json --watch
+```
+
+Programmatic setup:
+
+```ts
+import { serve } from '@hono/node-server'
+import { createMockServer } from '@scalar/mock-server'
+
+const app = await createMockServer({
+  document: './openapi.yaml',
+  onRequest({ context, operation }) {
+    console.log(context.req.method, context.req.path, operation.operationId)
+  },
+})
+
+serve({ fetch: app.fetch, port: 3000 })
+```
+
+## `createMockServer()` Options
+
+At least one of the following is required:
+
+- `document`: OpenAPI description document as URL, file path, or object
+- `specification`: deprecated alias for `document`
+
+Optional:
+
+- `onRequest({ context, operation })`: callback before each request is processed
+
+## Built-in Behavior
+
+When the server starts, it:
+
+1. Processes and loads the OpenAPI description document.
+2. Seeds schema data from `x-seed` extensions (idempotent: only when collection is empty).
+3. Registers authentication routes for declared security schemes.
+4. Registers operation routes for each path + method.
+5. Exposes the source document at:
+   - `/openapi.json`
+   - `/openapi.yaml`
+
+## Custom Request Logic with `x-handler`
+
+Use `x-handler` in an operation for dynamic behavior instead of static examples.
+
+Helpers available in `x-handler`:
+
+- `store` for in-memory persistence (`list`, `get`, `create`, `update`, `delete`, `clear`)
+- `faker` for generated test data
+- `req` for request data (`body`, `params`, `query`, `headers`)
+- `res` for response examples by status code (`res['200']`, `res['404']`, ...)
+
+Status behavior:
+
+- `store.get()` / `store.update()` => `200` when found, `404` when not found
+- `store.create()` => `201`
+- `store.delete()` => `204` when deleted, `404` when not found
+- `store.list()` => `200`
+- Returning `null`/`undefined` triggers `404` (uses `responses.404` example/schema when provided)
+
+## Seed Data with `x-seed`
+
+Use `x-seed` on `components.schemas.<SchemaName>` to seed initial data at startup.
+
+Helpers available in `x-seed`:
+
+- `seed.count(n, factory)`
+- `seed(array)`
+- `seed(factory)` (single item shortcut)
+- `faker`, `store`, and `schema`
+
+Key rule: the schema key name is used as the collection name.
+
+## Docker Usage
+
+Run the Docker image:
+
+```bash
+docker run -p 3000:3000 scalarapi/mock-server --url https://api.example.com/openapi.yaml
+```
+
+Document source priority (high to low):
+
+1. `--url <URL>`
+2. `OPENAPI_DOCUMENT`
+3. `OPENAPI_DOCUMENT_URL`
+4. `/docs` volume-mounted files
+
+Useful routes:
+
+- Mock endpoints: from your OpenAPI paths
+- API reference UI: `/scalar`
+- Description document: `/openapi.json`, `/openapi.yaml`
+
+## Troubleshooting Checklist
+
+- Confirm the OpenAPI description document is valid and reachable.
+- Confirm at least one document source is configured (`document`, `--url`, env var, or mounted file).
+- If seeded data is missing, check `x-seed` exists on schema keys and the collection was empty on startup.
+- If auth-protected routes return unauthorized responses, verify matching `securitySchemes` and request credentials.
+- If custom logic fails, inspect `x-handler` runtime errors (mock server returns `500` with handler error details).

--- a/documentation/guides/docs/configuration/agent-skills.md
+++ b/documentation/guides/docs/configuration/agent-skills.md
@@ -1,14 +1,13 @@
 # Agent Skills
 
-You can install reusable Scalar skills for coding agents with the [`skills`](https://www.npmjs.com/package/skills) CLI.
+You can install a reusable Scalar Docs skill for coding agents with the [`skills`](https://www.npmjs.com/package/skills) CLI.
 
-## Install available skills
+## Install the Scalar Docs skill
 
 Install directly from GitHub:
 
 ```bash
 npx skills add scalar/scalar --skill scalar-docs
-npx skills add scalar/scalar --skill mock-server
 ```
 
 ## Install to specific agents
@@ -18,7 +17,6 @@ Example for Cursor and Codex:
 ```bash
 npx skills add scalar/scalar \
   --skill scalar-docs \
-  --skill mock-server \
   --agent cursor \
   --agent codex
 ```
@@ -29,10 +27,4 @@ To make the skill available across projects:
 
 ```bash
 npx skills add scalar/scalar --skill scalar-docs --global
-npx skills add scalar/scalar --skill mock-server --global
 ```
-
-## Skill reference
-
-- `scalar-docs`: Helps agents write and update `scalar.config.json` for Scalar Docs projects.
-- `mock-server`: Helps agents build and troubleshoot `@scalar/mock-server` setups, including `x-handler`, `x-seed`, authentication, and Docker.

--- a/documentation/guides/docs/configuration/agent-skills.md
+++ b/documentation/guides/docs/configuration/agent-skills.md
@@ -28,3 +28,7 @@ To make the skill available across projects:
 ```bash
 npx skills add scalar/scalar --skill scalar-docs --global
 ```
+
+## MCP: Scalar Documentation
+
+Use `https://scalar.com/mcp` to add Scalar Documentation as an MCP server in your agent tooling.

--- a/documentation/guides/docs/configuration/agent-skills.md
+++ b/documentation/guides/docs/configuration/agent-skills.md
@@ -1,13 +1,14 @@
 # Agent Skills
 
-You can install a reusable Scalar Docs skill for coding agents with the [`skills`](https://www.npmjs.com/package/skills) CLI.
+You can install reusable Scalar skills for coding agents with the [`skills`](https://www.npmjs.com/package/skills) CLI.
 
-## Install the Scalar Docs skill
+## Install available skills
 
 Install directly from GitHub:
 
 ```bash
 npx skills add scalar/scalar --skill scalar-docs
+npx skills add scalar/scalar --skill mock-server
 ```
 
 ## Install to specific agents
@@ -17,6 +18,7 @@ Example for Cursor and Codex:
 ```bash
 npx skills add scalar/scalar \
   --skill scalar-docs \
+  --skill mock-server \
   --agent cursor \
   --agent codex
 ```
@@ -27,4 +29,10 @@ To make the skill available across projects:
 
 ```bash
 npx skills add scalar/scalar --skill scalar-docs --global
+npx skills add scalar/scalar --skill mock-server --global
 ```
+
+## Skill reference
+
+- `scalar-docs`: Helps agents write and update `scalar.config.json` for Scalar Docs projects.
+- `mock-server`: Helps agents build and troubleshoot `@scalar/mock-server` setups, including `x-handler`, `x-seed`, authentication, and Docker.

--- a/documentation/guides/mock-server/agent-skills.md
+++ b/documentation/guides/mock-server/agent-skills.md
@@ -1,0 +1,49 @@
+# Agent Skills
+
+You can install a reusable Mock Server skill for coding agents with the [`skills`](https://www.npmjs.com/package/skills) CLI.
+
+## Install the Mock Server skill
+
+Install directly from GitHub:
+
+```bash
+npx skills add scalar/scalar --skill mock-server
+```
+
+## Install to specific agents
+
+Example for Cursor and Codex:
+
+```bash
+npx skills add scalar/scalar \
+  --skill mock-server \
+  --agent cursor \
+  --agent codex
+```
+
+## Install alongside Scalar Docs
+
+If you also manage `scalar.config.json`, install both skills:
+
+```bash
+npx skills add scalar/scalar --skill scalar-docs
+npx skills add scalar/scalar --skill mock-server
+```
+
+## Install globally
+
+To make the skill available across projects:
+
+```bash
+npx skills add scalar/scalar --skill mock-server --global
+```
+
+## What this skill covers
+
+The `mock-server` skill includes guidance for:
+
+- Setting up `createMockServer()` with `document` and `onRequest`
+- Using `x-handler` for dynamic request handling
+- Using `x-seed` for startup data seeding
+- Working with authentication in OpenAPI operations
+- Running and troubleshooting `@scalar/mock-server` with Docker

--- a/documentation/guides/mock-server/agent-skills.md
+++ b/documentation/guides/mock-server/agent-skills.md
@@ -38,6 +38,10 @@ To make the skill available across projects:
 npx skills add scalar/scalar --skill mock-server --global
 ```
 
+## Use Scalar Docs as an MCP
+
+Use `https://scalar.com/mcp` to add Scalar Documentation as an MCP server for your agent.
+
 ## What this skill covers
 
 The `mock-server` skill includes guidance for:

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -2302,6 +2302,11 @@
                     "filepath": "documentation/guides/mock-server/custom-request-handler.md",
                     "type": "page"
                   },
+                  "agent-skills": {
+                    "title": "Agent Skills",
+                    "filepath": "documentation/guides/mock-server/agent-skills.md",
+                    "type": "page"
+                  },
                   "data-seeding": {
                     "title": "Data Seeding",
                     "filepath": "documentation/guides/mock-server/data-seeding.md",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Developers had no reusable agent skill for `@scalar/mock-server`, and no dedicated Mock Server docs page showing how to install it.

## Solution

- Added a new reusable `mock-server` skill at `.agents/skills/mock-server/SKILL.md`.
- Added Mock Server docs page: `documentation/guides/mock-server/agent-skills.md`.
- Linked the new page in navigation via `scalar.config.json` under `/tools/mock-server`.
- Added MCP guidance to both agent skills docs pages to use `https://scalar.com/mcp` for Scalar Documentation as an MCP server.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0542ff08-b7e5-470d-a664-0f993f841b9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0542ff08-b7e5-470d-a664-0f993f841b9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

