### PR TITLE
feat(api-reference): `deepObject` rendering

### DIFF
--- a/.changeset/eight-forks-hunt.md
+++ b/.changeset/eight-forks-hunt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): flatten deepObject query parameter display in parameter rendering

--- a/.changeset/green-laws-divide.md
+++ b/.changeset/green-laws-divide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): ignore undefined examples on flattened deepObject parameters

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.test.ts
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.test.ts
@@ -62,6 +62,84 @@ describe('OperationParameters', () => {
       expect(wrapper.text()).toContain('Query Parameters')
       expect(wrapper.text()).toContain('search')
     })
+
+    it('renders deepObject query parameters as flattened bracket names', () => {
+      const wrapper = mount(OperationParameters, {
+        props: {
+          eventBus: null,
+          options: defaultSchemaOptions,
+          parameters: [
+            {
+              in: 'query',
+              name: 'page',
+              style: 'deepObject',
+              explode: true,
+              schema: coerceValue(SchemaObjectSchema, {
+                type: 'object',
+                properties: {
+                  number: {
+                    type: 'integer',
+                    minimum: 1,
+                    default: 1,
+                    description: 'Page number',
+                  },
+                  size: {
+                    type: 'integer',
+                    minimum: 1,
+                    default: 15,
+                    description: 'Page size',
+                  },
+                },
+                required: ['number'],
+              }),
+              required: false,
+              deprecated: false,
+            },
+          ],
+        },
+      })
+
+      expect(wrapper.text()).toContain('Query Parameters')
+      expect(wrapper.text()).toContain('page[number]')
+      expect(wrapper.text()).toContain('page[size]')
+      expect(wrapper.text()).toContain('Page number')
+      expect(wrapper.text()).toContain('Page size')
+      expect(wrapper.text()).not.toContain('pageobject')
+    })
+
+    it('renders nested deepObject query properties with recursive bracket names', () => {
+      const wrapper = mount(OperationParameters, {
+        props: {
+          eventBus: null,
+          options: defaultSchemaOptions,
+          parameters: [
+            {
+              in: 'query',
+              name: 'filter',
+              style: 'deepObject',
+              explode: true,
+              schema: coerceValue(SchemaObjectSchema, {
+                type: 'object',
+                properties: {
+                  pagination: {
+                    type: 'object',
+                    properties: {
+                      number: {
+                        type: 'integer',
+                      },
+                    },
+                  },
+                },
+              }),
+              required: false,
+              deprecated: false,
+            },
+          ],
+        },
+      })
+
+      expect(wrapper.text()).toContain('filter[pagination][number]')
+    })
   })
 
   describe('header parameters', () => {

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.test.ts
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.test.ts
@@ -140,6 +140,43 @@ describe('OperationParameters', () => {
 
       expect(wrapper.text()).toContain('filter[pagination][number]')
     })
+
+    it('does not re-add the top-level deepObject parameter when a nested object has empty properties', () => {
+      const wrapper = mount(OperationParameters, {
+        props: {
+          eventBus: null,
+          options: defaultSchemaOptions,
+          parameters: [
+            {
+              in: 'query',
+              name: 'filter',
+              style: 'deepObject',
+              explode: true,
+              schema: coerceValue(SchemaObjectSchema, {
+                type: 'object',
+                properties: {
+                  pagination: {
+                    type: 'object',
+                    properties: {},
+                  },
+                  status: {
+                    type: 'string',
+                  },
+                },
+              }),
+              required: false,
+              deprecated: false,
+            },
+          ],
+        },
+      })
+
+      const queryParameterNames = wrapper
+        .findAllComponents({ name: 'ParameterListItem' })
+        .map((item) => item.props('name'))
+
+      expect(queryParameterNames).toStrictEqual(['filter[pagination]', 'filter[status]'])
+    })
   })
 
   describe('header parameters', () => {

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.vue
@@ -5,6 +5,7 @@ import type {
   ParameterObject,
   ReferenceType,
   RequestBodyObject,
+  SchemaObject,
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed } from 'vue'
 
@@ -28,6 +29,60 @@ const { parameters = [], requestBody } = defineProps<{
 /** Thread the selected request body content type up to the layout */
 const selectedContentType = defineModel<string>('selectedContentType')
 
+type ParameterLocation = 'cookie' | 'header' | 'path' | 'query'
+
+/**
+ * Deep object query parameters serialize as name[prop] pairs in URLs.
+ * Rendering the same shape here keeps docs aligned with the request UI.
+ */
+const flattenDeepObjectQueryParameter = (parameter: ParameterObject): ParameterObject[] => {
+  if (parameter.in !== 'query' || parameter.style !== 'deepObject') {
+    return [parameter]
+  }
+
+  if (!('schema' in parameter) || !parameter.schema) {
+    return [parameter]
+  }
+
+  const resolvedSchema = getResolvedRef(parameter.schema)
+
+  return flattenDeepObjectProperties(parameter, resolvedSchema, parameter.name)
+}
+
+const flattenDeepObjectProperties = (
+  parameter: ParameterObject,
+  schema: SchemaObject,
+  namePrefix: string,
+): ParameterObject[] => {
+  if (schema.type !== 'object' || !schema.properties) {
+    return [parameter]
+  }
+
+  const requiredProperties = new Set(schema.required ?? [])
+  const flattenedParameters = Object.entries(schema.properties).flatMap(([propertyName, propertySchema]) => {
+    const resolvedPropertySchema = getResolvedRef(propertySchema)
+    const nestedName = `${namePrefix}[${propertyName}]`
+
+    if (resolvedPropertySchema.type === 'object' && resolvedPropertySchema.properties) {
+      return flattenDeepObjectProperties(parameter, resolvedPropertySchema, nestedName)
+    }
+
+    return [
+      {
+        ...parameter,
+        name: nestedName,
+        description: resolvedPropertySchema.description ?? parameter.description,
+        required: requiredProperties.has(propertyName),
+        schema: resolvedPropertySchema,
+        example: undefined,
+        examples: undefined,
+      },
+    ]
+  })
+
+  return flattenedParameters.length > 0 ? flattenedParameters : [parameter]
+}
+
 /** Use a single loop to reduce parameters by type(in) */
 const splitParameters = computed(() =>
   (parameters ?? []).reduce(
@@ -35,7 +90,10 @@ const splitParameters = computed(() =>
       const parameter = getResolvedRef(p)
       // Filter out ignored parameters
       if (!shouldIgnoreEntity(parameter)) {
-        acc[parameter.in].push(parameter)
+        const flattenedParameters = flattenDeepObjectQueryParameter(parameter)
+        flattenedParameters.forEach((flattenedParameter) => {
+          acc[flattenedParameter.in as ParameterLocation].push(flattenedParameter)
+        })
       }
       return acc
     },

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.vue
@@ -3,10 +3,12 @@ import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type {
   ParameterObject,
+  ParameterWithSchemaObject,
   ReferenceType,
   RequestBodyObject,
   SchemaObject,
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { isObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
 import { computed } from 'vue'
 
 import { shouldIgnoreEntity } from '@/features/Operation/helpers/should-ignore-entity'
@@ -30,55 +32,90 @@ const { parameters = [], requestBody } = defineProps<{
 const selectedContentType = defineModel<string>('selectedContentType')
 
 type ParameterLocation = 'cookie' | 'header' | 'path' | 'query'
+type ParameterWithRequiredSchema = ParameterWithSchemaObject & {
+  schema: ReferenceType<SchemaObject>
+}
+
+const isParameterWithSchema = (
+  parameter: ParameterObject,
+): parameter is ParameterWithRequiredSchema =>
+  'schema' in parameter && parameter.schema !== undefined
+
+const resolveSchema = (schema: unknown): SchemaObject | undefined => {
+  const resolvedSchema = getResolvedRef(
+    schema as SchemaObject | { '$ref': string; '$ref-value': SchemaObject },
+  )
+
+  return resolvedSchema as SchemaObject | undefined
+}
 
 /**
  * Deep object query parameters serialize as name[prop] pairs in URLs.
  * Rendering the same shape here keeps docs aligned with the request UI.
  */
-const flattenDeepObjectQueryParameter = (parameter: ParameterObject): ParameterObject[] => {
-  if (parameter.in !== 'query' || parameter.style !== 'deepObject') {
+const flattenDeepObjectQueryParameter = (
+  parameter: ParameterObject,
+): ParameterObject[] => {
+  if (
+    parameter.in !== 'query' ||
+    !isParameterWithSchema(parameter) ||
+    parameter.style !== 'deepObject'
+  ) {
     return [parameter]
   }
 
-  if (!('schema' in parameter) || !parameter.schema) {
+  const resolvedSchema = resolveSchema(parameter.schema)
+  if (!resolvedSchema || !isObjectSchema(resolvedSchema)) {
     return [parameter]
   }
-
-  const resolvedSchema = getResolvedRef(parameter.schema)
 
   return flattenDeepObjectProperties(parameter, resolvedSchema, parameter.name)
 }
 
 const flattenDeepObjectProperties = (
-  parameter: ParameterObject,
-  schema: SchemaObject,
+  parameter: ParameterWithRequiredSchema,
+  schema: Extract<SchemaObject, { type: 'object' }>,
   namePrefix: string,
 ): ParameterObject[] => {
-  if (schema.type !== 'object' || !schema.properties) {
+  if (!schema.properties) {
     return [parameter]
   }
 
   const requiredProperties = new Set(schema.required ?? [])
-  const flattenedParameters = Object.entries(schema.properties).flatMap(([propertyName, propertySchema]) => {
-    const resolvedPropertySchema = getResolvedRef(propertySchema)
-    const nestedName = `${namePrefix}[${propertyName}]`
+  const flattenedParameters = Object.entries(schema.properties).flatMap(
+    ([propertyName, propertySchema]) => {
+      const resolvedPropertySchema = resolveSchema(propertySchema)
+      const nestedName = `${namePrefix}[${propertyName}]`
 
-    if (resolvedPropertySchema.type === 'object' && resolvedPropertySchema.properties) {
-      return flattenDeepObjectProperties(parameter, resolvedPropertySchema, nestedName)
-    }
+      if (!resolvedPropertySchema) {
+        return []
+      }
 
-    return [
-      {
-        ...parameter,
-        name: nestedName,
-        description: resolvedPropertySchema.description ?? parameter.description,
-        required: requiredProperties.has(propertyName),
-        schema: resolvedPropertySchema,
-        example: undefined,
-        examples: undefined,
-      },
-    ]
-  })
+      if (
+        isObjectSchema(resolvedPropertySchema) &&
+        resolvedPropertySchema.properties
+      ) {
+        return flattenDeepObjectProperties(
+          parameter,
+          resolvedPropertySchema,
+          nestedName,
+        )
+      }
+
+      return [
+        {
+          ...parameter,
+          name: nestedName,
+          description:
+            resolvedPropertySchema.description ?? parameter.description,
+          required: requiredProperties.has(propertyName),
+          schema: resolvedPropertySchema,
+          example: undefined,
+          examples: undefined,
+        },
+      ]
+    },
+  )
 
   return flattenedParameters.length > 0 ? flattenedParameters : [parameter]
 }
@@ -92,7 +129,9 @@ const splitParameters = computed(() =>
       if (!shouldIgnoreEntity(parameter)) {
         const flattenedParameters = flattenDeepObjectQueryParameter(parameter)
         flattenedParameters.forEach((flattenedParameter) => {
-          acc[flattenedParameter.in as ParameterLocation].push(flattenedParameter)
+          acc[flattenedParameter.in as ParameterLocation].push(
+            flattenedParameter,
+          )
         })
       }
       return acc

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.vue
@@ -3,14 +3,12 @@ import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type {
   ParameterObject,
-  ParameterWithSchemaObject,
   ReferenceType,
   RequestBodyObject,
-  SchemaObject,
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-import { isObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
 import { computed } from 'vue'
 
+import { flattenDeepObjectQueryParameter } from '@/features/Operation/helpers/flatten-deep-object-query-parameter'
 import { shouldIgnoreEntity } from '@/features/Operation/helpers/should-ignore-entity'
 import type { OperationProps } from '@/features/Operation/Operation.vue'
 
@@ -32,97 +30,6 @@ const { parameters = [], requestBody } = defineProps<{
 const selectedContentType = defineModel<string>('selectedContentType')
 
 type ParameterLocation = 'cookie' | 'header' | 'path' | 'query'
-type ParameterWithRequiredSchema = ParameterWithSchemaObject & {
-  schema: ReferenceType<SchemaObject>
-}
-
-const isParameterWithSchema = (
-  parameter: ParameterObject,
-): parameter is ParameterWithRequiredSchema =>
-  'schema' in parameter && parameter.schema !== undefined
-
-const resolveSchema = (schema: unknown): SchemaObject | undefined => {
-  const resolvedSchema = getResolvedRef(
-    schema as SchemaObject | { '$ref': string; '$ref-value': SchemaObject },
-  )
-
-  return resolvedSchema as SchemaObject | undefined
-}
-
-/**
- * Deep object query parameters serialize as name[prop] pairs in URLs.
- * Rendering the same shape here keeps docs aligned with the request UI.
- */
-const flattenDeepObjectQueryParameter = (
-  parameter: ParameterObject,
-): ParameterObject[] => {
-  if (
-    parameter.in !== 'query' ||
-    !isParameterWithSchema(parameter) ||
-    parameter.style !== 'deepObject'
-  ) {
-    return [parameter]
-  }
-
-  const resolvedSchema = resolveSchema(parameter.schema)
-  if (!resolvedSchema || !isObjectSchema(resolvedSchema)) {
-    return [parameter]
-  }
-
-  return flattenDeepObjectProperties(parameter, resolvedSchema, parameter.name)
-}
-
-const flattenDeepObjectProperties = (
-  parameter: ParameterWithRequiredSchema,
-  schema: Extract<SchemaObject, { type: 'object' }>,
-  namePrefix: string,
-): ParameterObject[] => {
-  if (!schema.properties) {
-    return [parameter]
-  }
-
-  const requiredProperties = new Set(schema.required ?? [])
-  const flattenedParameters = Object.entries(schema.properties).flatMap(
-    ([propertyName, propertySchema]) => {
-      const resolvedPropertySchema = resolveSchema(propertySchema)
-      const nestedName = `${namePrefix}[${propertyName}]`
-      const nestedParameter: ParameterWithRequiredSchema = {
-        ...parameter,
-        name: nestedName,
-        description:
-          resolvedPropertySchema?.description ?? parameter.description,
-        required: requiredProperties.has(propertyName),
-        schema: resolvedPropertySchema ?? parameter.schema,
-        example: undefined,
-        examples: undefined,
-      }
-
-      if (!resolvedPropertySchema) {
-        return []
-      }
-
-      if (
-        isObjectSchema(resolvedPropertySchema) &&
-        resolvedPropertySchema.properties
-      ) {
-        return flattenDeepObjectProperties(
-          nestedParameter,
-          resolvedPropertySchema,
-          nestedName,
-        )
-      }
-
-      return [
-        {
-          ...nestedParameter,
-          schema: resolvedPropertySchema,
-        },
-      ]
-    },
-  )
-
-  return flattenedParameters.length > 0 ? flattenedParameters : [parameter]
-}
 
 /** Use a single loop to reduce parameters by type(in) */
 const splitParameters = computed(() =>

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.vue
@@ -86,6 +86,16 @@ const flattenDeepObjectProperties = (
     ([propertyName, propertySchema]) => {
       const resolvedPropertySchema = resolveSchema(propertySchema)
       const nestedName = `${namePrefix}[${propertyName}]`
+      const nestedParameter: ParameterWithRequiredSchema = {
+        ...parameter,
+        name: nestedName,
+        description:
+          resolvedPropertySchema?.description ?? parameter.description,
+        required: requiredProperties.has(propertyName),
+        schema: resolvedPropertySchema ?? parameter.schema,
+        example: undefined,
+        examples: undefined,
+      }
 
       if (!resolvedPropertySchema) {
         return []
@@ -96,7 +106,7 @@ const flattenDeepObjectProperties = (
         resolvedPropertySchema.properties
       ) {
         return flattenDeepObjectProperties(
-          parameter,
+          nestedParameter,
           resolvedPropertySchema,
           nestedName,
         )
@@ -104,14 +114,8 @@ const flattenDeepObjectProperties = (
 
       return [
         {
-          ...parameter,
-          name: nestedName,
-          description:
-            resolvedPropertySchema.description ?? parameter.description,
-          required: requiredProperties.has(propertyName),
+          ...nestedParameter,
           schema: resolvedPropertySchema,
-          example: undefined,
-          examples: undefined,
         },
       ]
     },

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -21,6 +21,7 @@ import type { OperationProps } from '@/features/Operation/Operation.vue'
 
 import ContentTypeSelect from './ContentTypeSelect.vue'
 import Headers from './Headers.vue'
+import { getParameterExamples } from './helpers/get-parameter-examples'
 
 const { name, parameter, options, collapsableItems } = defineProps<{
   parameter: ParameterObject | ResponseObject
@@ -96,22 +97,12 @@ const value = computed(() => {
   const deprecated =
     'deprecated' in parameter ? parameter.deprecated : schema.value?.deprecated
 
-  // Convert examples to schema examples which is an array
-  const paramExamples = 'examples' in parameter ? parameter.examples : {}
-  const recordExamples = Object.values({
-    ...paramExamples,
-    ...content.value?.[selectedContentType.value]?.examples,
+  /** Combine param/content/schema examples while ignoring undefined values. */
+  const examples = getParameterExamples({
+    parameter,
+    schemaExamples: schema.value?.examples,
+    contentExamples: content.value?.[selectedContentType.value]?.examples,
   })
-
-  // Only use parameter.example as fallback if no other examples exist
-  const arrayExamples =
-    schema.value?.examples ??
-    (recordExamples.length === 0 && 'example' in parameter
-      ? [parameter.example]
-      : [])
-
-  /** Combine param examples with content ones */
-  const examples = [...recordExamples, ...arrayExamples]
 
   return {
     ...resolvedBase,

--- a/packages/api-reference/src/features/Operation/components/helpers/get-parameter-examples.test.ts
+++ b/packages/api-reference/src/features/Operation/components/helpers/get-parameter-examples.test.ts
@@ -1,8 +1,5 @@
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
-import {
-  ParameterObjectSchema,
-  SchemaObjectSchema,
-} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { ParameterObjectSchema, SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { describe, expect, it } from 'vitest'
 
 import { getParameterExamples } from './get-parameter-examples'

--- a/packages/api-reference/src/features/Operation/components/helpers/get-parameter-examples.test.ts
+++ b/packages/api-reference/src/features/Operation/components/helpers/get-parameter-examples.test.ts
@@ -1,0 +1,74 @@
+import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
+import {
+  ParameterObjectSchema,
+  SchemaObjectSchema,
+} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { describe, expect, it } from 'vitest'
+
+import { getParameterExamples } from './get-parameter-examples'
+
+describe('get-parameter-examples', () => {
+  it('ignores undefined example keys and returns no examples', () => {
+    const parameter = coerceValue(ParameterObjectSchema, {
+      in: 'query',
+      name: 'filter[status]',
+      required: false,
+      schema: coerceValue(SchemaObjectSchema, {
+        type: 'string',
+      }),
+      example: undefined,
+      examples: undefined,
+    })
+
+    const examples = getParameterExamples({
+      parameter,
+      schemaExamples: undefined,
+      contentExamples: undefined,
+    })
+
+    expect(examples).toStrictEqual([])
+  })
+
+  it('uses parameter example fallback when defined and no other examples exist', () => {
+    const parameter = coerceValue(ParameterObjectSchema, {
+      in: 'query',
+      name: 'filter[status]',
+      required: false,
+      schema: coerceValue(SchemaObjectSchema, {
+        type: 'string',
+      }),
+      example: 'active',
+    })
+
+    const examples = getParameterExamples({
+      parameter,
+      schemaExamples: undefined,
+      contentExamples: undefined,
+    })
+
+    expect(examples).toStrictEqual(['active'])
+  })
+
+  it('prefers schema examples and removes undefined entries', () => {
+    const parameter = coerceValue(ParameterObjectSchema, {
+      in: 'query',
+      name: 'filter[status]',
+      required: false,
+      schema: coerceValue(SchemaObjectSchema, {
+        type: 'string',
+      }),
+      example: 'active',
+      examples: {
+        first: { value: undefined },
+      },
+    })
+
+    const examples = getParameterExamples({
+      parameter,
+      schemaExamples: [undefined, 'archived'],
+      contentExamples: undefined,
+    })
+
+    expect(examples).toStrictEqual([{ value: undefined }, 'archived'])
+  })
+})

--- a/packages/api-reference/src/features/Operation/components/helpers/get-parameter-examples.ts
+++ b/packages/api-reference/src/features/Operation/components/helpers/get-parameter-examples.ts
@@ -1,13 +1,8 @@
-import type {
-  ParameterObject,
-  ResponseObject,
-} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import type { ParameterObject, ResponseObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  Boolean(value) && typeof value === 'object'
+const isRecord = (value: unknown): value is Record<string, unknown> => Boolean(value) && typeof value === 'object'
 
-const filterUndefined = (example: unknown): example is unknown =>
-  example !== undefined
+const filterUndefined = (example: unknown): example is unknown => example !== undefined
 
 type GetParameterExamplesArgs = {
   parameter: ParameterObject | ResponseObject
@@ -24,10 +19,7 @@ export const getParameterExamples = ({
   schemaExamples,
   contentExamples,
 }: GetParameterExamplesArgs): unknown[] => {
-  const paramExamples =
-    'examples' in parameter && isRecord(parameter.examples)
-      ? parameter.examples
-      : {}
+  const paramExamples = 'examples' in parameter && isRecord(parameter.examples) ? parameter.examples : {}
 
   const recordExamples = Object.values({
     ...paramExamples,
@@ -35,11 +27,7 @@ export const getParameterExamples = ({
   }).filter(filterUndefined)
 
   const fallbackExample =
-    recordExamples.length === 0 &&
-    'example' in parameter &&
-    parameter.example !== undefined
-      ? [parameter.example]
-      : []
+    recordExamples.length === 0 && 'example' in parameter && parameter.example !== undefined ? [parameter.example] : []
 
   const arrayExamples = (schemaExamples ?? fallbackExample).filter(filterUndefined)
 

--- a/packages/api-reference/src/features/Operation/components/helpers/get-parameter-examples.ts
+++ b/packages/api-reference/src/features/Operation/components/helpers/get-parameter-examples.ts
@@ -1,6 +1,5 @@
 import type { ParameterObject, ResponseObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-
-const isRecord = (value: unknown): value is Record<string, unknown> => Boolean(value) && typeof value === 'object'
+import { isObjectLike } from '@scalar/helpers/object/is-object'
 
 const filterUndefined = (example: unknown): example is unknown => example !== undefined
 
@@ -19,11 +18,11 @@ export const getParameterExamples = ({
   schemaExamples,
   contentExamples,
 }: GetParameterExamplesArgs): unknown[] => {
-  const paramExamples = 'examples' in parameter && isRecord(parameter.examples) ? parameter.examples : {}
+  const paramExamples = 'examples' in parameter && isObjectLike(parameter.examples) ? parameter.examples : {}
 
   const recordExamples = Object.values({
     ...paramExamples,
-    ...(isRecord(contentExamples) ? contentExamples : {}),
+    ...(isObjectLike(contentExamples) ? contentExamples : {}),
   }).filter(filterUndefined)
 
   const fallbackExample =

--- a/packages/api-reference/src/features/Operation/components/helpers/get-parameter-examples.ts
+++ b/packages/api-reference/src/features/Operation/components/helpers/get-parameter-examples.ts
@@ -1,0 +1,47 @@
+import type {
+  ParameterObject,
+  ResponseObject,
+} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object'
+
+const filterUndefined = (example: unknown): example is unknown =>
+  example !== undefined
+
+type GetParameterExamplesArgs = {
+  parameter: ParameterObject | ResponseObject
+  schemaExamples?: unknown[]
+  contentExamples?: unknown
+}
+
+/**
+ * Build a normalized examples array from parameter/content/schema examples.
+ * Undefined values are removed so the UI does not render "undefined" entries.
+ */
+export const getParameterExamples = ({
+  parameter,
+  schemaExamples,
+  contentExamples,
+}: GetParameterExamplesArgs): unknown[] => {
+  const paramExamples =
+    'examples' in parameter && isRecord(parameter.examples)
+      ? parameter.examples
+      : {}
+
+  const recordExamples = Object.values({
+    ...paramExamples,
+    ...(isRecord(contentExamples) ? contentExamples : {}),
+  }).filter(filterUndefined)
+
+  const fallbackExample =
+    recordExamples.length === 0 &&
+    'example' in parameter &&
+    parameter.example !== undefined
+      ? [parameter.example]
+      : []
+
+  const arrayExamples = (schemaExamples ?? fallbackExample).filter(filterUndefined)
+
+  return [...recordExamples, ...arrayExamples]
+}

--- a/packages/api-reference/src/features/Operation/helpers/flatten-deep-object-query-parameter.test.ts
+++ b/packages/api-reference/src/features/Operation/helpers/flatten-deep-object-query-parameter.test.ts
@@ -1,8 +1,5 @@
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
-import {
-  ParameterObjectSchema,
-  SchemaObjectSchema,
-} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { ParameterObjectSchema, SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { describe, expect, it } from 'vitest'
 
 import { flattenDeepObjectQueryParameter } from './flatten-deep-object-query-parameter'
@@ -56,15 +53,9 @@ describe('flatten-deep-object-query-parameter', () => {
 
     const result = flattenDeepObjectQueryParameter(parameter)
 
-    expect(result.map((item) => item.name)).toStrictEqual([
-      'page[number]',
-      'page[size]',
-    ])
+    expect(result.map((item) => item.name)).toStrictEqual(['page[number]', 'page[size]'])
     expect(result.map((item) => item.required)).toStrictEqual([true, false])
-    expect(result.map((item) => item.description)).toStrictEqual([
-      'Page number',
-      'Page size',
-    ])
+    expect(result.map((item) => item.description)).toStrictEqual(['Page number', 'Page size'])
     expect(result.every((item) => !('example' in item))).toBe(true)
     expect(result.every((item) => !('examples' in item))).toBe(true)
   })
@@ -93,9 +84,6 @@ describe('flatten-deep-object-query-parameter', () => {
 
     const result = flattenDeepObjectQueryParameter(parameter)
 
-    expect(result.map((item) => item.name)).toStrictEqual([
-      'filter[pagination]',
-      'filter[status]',
-    ])
+    expect(result.map((item) => item.name)).toStrictEqual(['filter[pagination]', 'filter[status]'])
   })
 })

--- a/packages/api-reference/src/features/Operation/helpers/flatten-deep-object-query-parameter.test.ts
+++ b/packages/api-reference/src/features/Operation/helpers/flatten-deep-object-query-parameter.test.ts
@@ -1,0 +1,101 @@
+import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
+import {
+  ParameterObjectSchema,
+  SchemaObjectSchema,
+} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { describe, expect, it } from 'vitest'
+
+import { flattenDeepObjectQueryParameter } from './flatten-deep-object-query-parameter'
+
+describe('flatten-deep-object-query-parameter', () => {
+  it('returns non deepObject parameters unchanged', () => {
+    const parameter = coerceValue(ParameterObjectSchema, {
+      in: 'query',
+      name: 'search',
+      schema: coerceValue(SchemaObjectSchema, {
+        type: 'string',
+      }),
+      required: false,
+      deprecated: false,
+    })
+
+    const result = flattenDeepObjectQueryParameter(parameter)
+
+    expect(result).toStrictEqual([parameter])
+  })
+
+  it('flattens deepObject query parameters to bracket names', () => {
+    const parameter = coerceValue(ParameterObjectSchema, {
+      in: 'query',
+      name: 'page',
+      style: 'deepObject',
+      explode: true,
+      schema: coerceValue(SchemaObjectSchema, {
+        type: 'object',
+        properties: {
+          number: {
+            type: 'integer',
+            description: 'Page number',
+          },
+          size: {
+            type: 'integer',
+            description: 'Page size',
+          },
+        },
+        required: ['number'],
+      }),
+      required: false,
+      deprecated: false,
+      example: { number: 1, size: 10 },
+      examples: {
+        default: {
+          value: { number: 1, size: 10 },
+        },
+      },
+    })
+
+    const result = flattenDeepObjectQueryParameter(parameter)
+
+    expect(result.map((item) => item.name)).toStrictEqual([
+      'page[number]',
+      'page[size]',
+    ])
+    expect(result.map((item) => item.required)).toStrictEqual([true, false])
+    expect(result.map((item) => item.description)).toStrictEqual([
+      'Page number',
+      'Page size',
+    ])
+    expect(result.every((item) => !('example' in item))).toBe(true)
+    expect(result.every((item) => !('examples' in item))).toBe(true)
+  })
+
+  it('does not re-add the top-level parameter for empty nested object properties', () => {
+    const parameter = coerceValue(ParameterObjectSchema, {
+      in: 'query',
+      name: 'filter',
+      style: 'deepObject',
+      explode: true,
+      schema: coerceValue(SchemaObjectSchema, {
+        type: 'object',
+        properties: {
+          pagination: {
+            type: 'object',
+            properties: {},
+          },
+          status: {
+            type: 'string',
+          },
+        },
+      }),
+      required: false,
+      deprecated: false,
+    })
+
+    const result = flattenDeepObjectQueryParameter(parameter)
+
+    expect(result.map((item) => item.name)).toStrictEqual([
+      'filter[pagination]',
+      'filter[status]',
+    ])
+  })
+})

--- a/packages/api-reference/src/features/Operation/helpers/flatten-deep-object-query-parameter.ts
+++ b/packages/api-reference/src/features/Operation/helpers/flatten-deep-object-query-parameter.ts
@@ -1,0 +1,111 @@
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import type {
+  ParameterObject,
+  ParameterWithSchemaObject,
+  ReferenceType,
+  SchemaObject,
+} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { isObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
+
+type ParameterWithRequiredSchema = ParameterWithSchemaObject & {
+  schema: ReferenceType<SchemaObject>
+}
+
+const isParameterWithSchema = (
+  parameter: ParameterObject,
+): parameter is ParameterWithRequiredSchema =>
+  'schema' in parameter && parameter.schema !== undefined
+
+const resolveSchema = (schema: unknown): SchemaObject | undefined => {
+  const resolvedSchema = getResolvedRef(
+    schema as SchemaObject | { '$ref': string; '$ref-value': SchemaObject },
+  )
+
+  return resolvedSchema as SchemaObject | undefined
+}
+
+const toFlattenedDeepObjectParameter = (
+  parameter: ParameterWithRequiredSchema,
+  name: string,
+  description: string | undefined,
+  required: boolean,
+  schema: SchemaObject,
+): ParameterWithRequiredSchema => {
+  const { example: _example, examples: _examples, ...parameterWithoutExamples } =
+    parameter
+
+  return {
+    ...parameterWithoutExamples,
+    name,
+    description,
+    required,
+    schema,
+  }
+}
+
+const flattenDeepObjectProperties = (
+  parameter: ParameterWithRequiredSchema,
+  schema: Extract<SchemaObject, { type: 'object' }>,
+  namePrefix: string,
+): ParameterObject[] => {
+  if (!schema.properties) {
+    return [parameter]
+  }
+
+  const requiredProperties = new Set(schema.required ?? [])
+  const flattenedParameters = Object.entries(schema.properties).flatMap(
+    ([propertyName, propertySchema]) => {
+      const resolvedPropertySchema = resolveSchema(propertySchema)
+      if (!resolvedPropertySchema) {
+        return []
+      }
+
+      const nestedName = `${namePrefix}[${propertyName}]`
+      const nestedParameter = toFlattenedDeepObjectParameter(
+        parameter,
+        nestedName,
+        resolvedPropertySchema.description ?? parameter.description,
+        requiredProperties.has(propertyName),
+        resolvedPropertySchema,
+      )
+
+      if (
+        isObjectSchema(resolvedPropertySchema) &&
+        resolvedPropertySchema.properties
+      ) {
+        return flattenDeepObjectProperties(
+          nestedParameter,
+          resolvedPropertySchema,
+          nestedName,
+        )
+      }
+
+      return [nestedParameter]
+    },
+  )
+
+  return flattenedParameters.length > 0 ? flattenedParameters : [parameter]
+}
+
+/**
+ * Deep object query parameters serialize as name[prop] pairs in URLs.
+ * Rendering the same shape keeps docs aligned with the request UI.
+ */
+export const flattenDeepObjectQueryParameter = (
+  parameter: ParameterObject,
+): ParameterObject[] => {
+  if (
+    parameter.in !== 'query' ||
+    !isParameterWithSchema(parameter) ||
+    parameter.style !== 'deepObject'
+  ) {
+    return [parameter]
+  }
+
+  const resolvedSchema = resolveSchema(parameter.schema)
+  if (!resolvedSchema || !isObjectSchema(resolvedSchema)) {
+    return [parameter]
+  }
+
+  return flattenDeepObjectProperties(parameter, resolvedSchema, parameter.name)
+}

--- a/packages/api-reference/src/features/Operation/helpers/flatten-deep-object-query-parameter.ts
+++ b/packages/api-reference/src/features/Operation/helpers/flatten-deep-object-query-parameter.ts
@@ -11,15 +11,11 @@ type ParameterWithRequiredSchema = ParameterWithSchemaObject & {
   schema: ReferenceType<SchemaObject>
 }
 
-const isParameterWithSchema = (
-  parameter: ParameterObject,
-): parameter is ParameterWithRequiredSchema =>
+const isParameterWithSchema = (parameter: ParameterObject): parameter is ParameterWithRequiredSchema =>
   'schema' in parameter && parameter.schema !== undefined
 
 const resolveSchema = (schema: unknown): SchemaObject | undefined => {
-  const resolvedSchema = getResolvedRef(
-    schema as SchemaObject | { '$ref': string; '$ref-value': SchemaObject },
-  )
+  const resolvedSchema = getResolvedRef(schema as SchemaObject | { '$ref': string; '$ref-value': SchemaObject })
 
   return resolvedSchema as SchemaObject | undefined
 }
@@ -31,8 +27,7 @@ const toFlattenedDeepObjectParameter = (
   required: boolean,
   schema: SchemaObject,
 ): ParameterWithRequiredSchema => {
-  const { example: _example, examples: _examples, ...parameterWithoutExamples } =
-    parameter
+  const { example: _example, examples: _examples, ...parameterWithoutExamples } = parameter
 
   return {
     ...parameterWithoutExamples,
@@ -53,36 +48,27 @@ const flattenDeepObjectProperties = (
   }
 
   const requiredProperties = new Set(schema.required ?? [])
-  const flattenedParameters = Object.entries(schema.properties).flatMap(
-    ([propertyName, propertySchema]) => {
-      const resolvedPropertySchema = resolveSchema(propertySchema)
-      if (!resolvedPropertySchema) {
-        return []
-      }
+  const flattenedParameters = Object.entries(schema.properties).flatMap(([propertyName, propertySchema]) => {
+    const resolvedPropertySchema = resolveSchema(propertySchema)
+    if (!resolvedPropertySchema) {
+      return []
+    }
 
-      const nestedName = `${namePrefix}[${propertyName}]`
-      const nestedParameter = toFlattenedDeepObjectParameter(
-        parameter,
-        nestedName,
-        resolvedPropertySchema.description ?? parameter.description,
-        requiredProperties.has(propertyName),
-        resolvedPropertySchema,
-      )
+    const nestedName = `${namePrefix}[${propertyName}]`
+    const nestedParameter = toFlattenedDeepObjectParameter(
+      parameter,
+      nestedName,
+      resolvedPropertySchema.description ?? parameter.description,
+      requiredProperties.has(propertyName),
+      resolvedPropertySchema,
+    )
 
-      if (
-        isObjectSchema(resolvedPropertySchema) &&
-        resolvedPropertySchema.properties
-      ) {
-        return flattenDeepObjectProperties(
-          nestedParameter,
-          resolvedPropertySchema,
-          nestedName,
-        )
-      }
+    if (isObjectSchema(resolvedPropertySchema) && resolvedPropertySchema.properties) {
+      return flattenDeepObjectProperties(nestedParameter, resolvedPropertySchema, nestedName)
+    }
 
-      return [nestedParameter]
-    },
-  )
+    return [nestedParameter]
+  })
 
   return flattenedParameters.length > 0 ? flattenedParameters : [parameter]
 }
@@ -91,14 +77,8 @@ const flattenDeepObjectProperties = (
  * Deep object query parameters serialize as name[prop] pairs in URLs.
  * Rendering the same shape keeps docs aligned with the request UI.
  */
-export const flattenDeepObjectQueryParameter = (
-  parameter: ParameterObject,
-): ParameterObject[] => {
-  if (
-    parameter.in !== 'query' ||
-    !isParameterWithSchema(parameter) ||
-    parameter.style !== 'deepObject'
-  ) {
+export const flattenDeepObjectQueryParameter = (parameter: ParameterObject): ParameterObject[] => {
+  if (parameter.in !== 'query' || !isParameterWithSchema(parameter) || parameter.style !== 'deepObject') {
     return [parameter]
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The deepObject query-parameter rendering logic in `OperationParameters.vue` was still embedded in the component, which made it harder to reuse and review.

## Solution

- moved deepObject query flattening into `flatten-deep-object-query-parameter.ts`
- kept recursive flattening behavior for nested object properties
- stripped explicit `example` / `examples` keys from flattened parameters so they are not propagated as undefined fields
- updated `OperationParameters.vue` to consume the helper
- added targeted helper tests that cover flattening and empty nested object fallback behavior

## Visual

![DeepObject query parameters rendered as bracket notation](https://cursor.com/artifacts/c/art-35d8a80c-6d95-4cd2-8746-a5b204de3f53)
<a href="https://cursor.com/agents/bc-de030567-23c2-49a1-a511-266bf8cb1b75/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdeepobject_query_rendering_after_refactor.mp4"><img src="https://cursor.com/artifacts/c/art-a23a2d2a-5a21-48da-96f1-10b5a5b1e1d8" alt="deepobject_query_rendering_after_refactor.mp4" /></a>

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a39f1637-b73b-491e-8565-5a1676b5251c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a39f1637-b73b-491e-8565-5a1676b5251c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

