### PR TITLE
fix(code-highlight): support inline markdown inside html text blocks

### DIFF
--- a/.changeset/angry-shoes-search.md
+++ b/.changeset/angry-shoes-search.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+fix markdown inside HTML text tags like `<p>` so inline formatting is rendered.

--- a/packages/code-highlight/src/markdown/markdown.test.ts
+++ b/packages/code-highlight/src/markdown/markdown.test.ts
@@ -150,6 +150,18 @@ const x = 42;
     expect(html.trim()).toContain('Content')
   })
 
+  it('parses inline markdown inside HTML paragraphs', () => {
+    const html = htmlFromMarkdown('<p>`Foobar`</p>')
+
+    expect(html.trim()).toBe('<p><code>Foobar</code></p>')
+  })
+
+  it('does not parse markdown inside unsupported HTML tags', () => {
+    const html = htmlFromMarkdown('<div>`Foobar`</div>')
+
+    expect(html.trim()).toBe('<div>`Foobar`</div>')
+  })
+
   it('handles deeply nested markdown without breaking', () => {
     const html = htmlFromMarkdown(`
 > > > Triple nested blockquote

--- a/packages/code-highlight/src/markdown/markdown.test.ts
+++ b/packages/code-highlight/src/markdown/markdown.test.ts
@@ -156,6 +156,12 @@ const x = 42;
     expect(html.trim()).toBe('<p><code>Foobar</code></p>')
   })
 
+  it('preserves literal angle-bracket text while parsing inline markdown inside HTML paragraphs', () => {
+    const html = htmlFromMarkdown('<p>Use &lt;span&gt; with `className`</p>')
+
+    expect(html.trim()).toBe('<p>Use &#x3C;span> with <code>className</code></p>')
+  })
+
   it('does not parse markdown inside unsupported HTML tags', () => {
     const html = htmlFromMarkdown('<div>`Foobar`</div>')
 

--- a/packages/code-highlight/src/markdown/markdown.test.ts
+++ b/packages/code-highlight/src/markdown/markdown.test.ts
@@ -168,6 +168,12 @@ const x = 42;
     expect(html.trim()).toBe('<div>`Foobar`</div>')
   })
 
+  it('preserves escaped inline markdown markers in normal markdown paragraphs', () => {
+    const html = htmlFromMarkdown(String.raw`\*not italic\* \`not code\` \~\~not strike\~\~ \[not link\]`)
+
+    expect(html.trim()).toBe('<p>*not italic* `not code` ~~not strike~~ [not link]</p>')
+  })
+
   it('handles deeply nested markdown without breaking', () => {
     const html = htmlFromMarkdown(`
 > > > Triple nested blockquote

--- a/packages/code-highlight/src/markdown/markdown.ts
+++ b/packages/code-highlight/src/markdown/markdown.ts
@@ -52,7 +52,23 @@ const transformNodes =
 const TAGS_WITH_INLINE_MARKDOWN = new Set(['dd', 'dt', 'li', 'p', 'summary', 'td', 'th'])
 const MAY_CONTAIN_INLINE_MARKDOWN = /[`*_[~]/
 
-const inlineMarkdownProcessor = unified().use(remarkParse).use(remarkGfm).use(remarkRehype)
+/**
+ * Preserve HTML-like text in inline markdown by turning mdast `html` nodes into text nodes.
+ */
+const preserveHtmlLikeText = () => (tree: MdastRoot) => {
+  visit(tree, 'html', (node, index, parent) => {
+    if (typeof index !== 'number' || !parent || !('children' in parent) || !Array.isArray(parent.children)) {
+      return
+    }
+
+    parent.children[index] = {
+      type: 'text',
+      value: node.value ?? '',
+    } as MdastRootContent
+  })
+}
+
+const inlineMarkdownProcessor = unified().use(remarkParse).use(remarkGfm).use(preserveHtmlLikeText).use(remarkRehype)
 
 /**
  * Parse inline markdown and return children from the generated paragraph.

--- a/packages/code-highlight/src/markdown/markdown.ts
+++ b/packages/code-highlight/src/markdown/markdown.ts
@@ -1,4 +1,4 @@
-import type { Element as HastElement, Root as HastRoot, RootContent as HastRootContent } from 'hast'
+import type { Element as HastElement, ElementContent as HastElementContent, Root as HastRoot } from 'hast'
 import type { Heading, Node, PhrasingContent, Root as MdastRoot, RootContent as MdastRootContent } from 'mdast'
 import rehypeExternalLinks from 'rehype-external-links'
 import rehypeFormat from 'rehype-format'
@@ -57,15 +57,15 @@ const inlineMarkdownProcessor = unified().use(remarkParse).use(remarkGfm).use(re
 /**
  * Parse inline markdown and return children from the generated paragraph.
  */
-const extractInlineChildrenFromMarkdown = (value: string): HastRootContent[] => {
+const extractInlineChildrenFromMarkdown = (value: string): HastElementContent[] => {
   const tree = inlineMarkdownProcessor.runSync(inlineMarkdownProcessor.parse(value)) as HastRoot
 
   if (tree.children.length !== 1) {
     return []
   }
 
-  const [paragraph] = tree.children
-  if (paragraph.type !== 'element' || paragraph.tagName !== 'p') {
+  const paragraph = tree.children.at(0)
+  if (!paragraph || paragraph.type !== 'element' || paragraph.tagName !== 'p') {
     return []
   }
 

--- a/packages/code-highlight/src/markdown/markdown.ts
+++ b/packages/code-highlight/src/markdown/markdown.ts
@@ -2,6 +2,7 @@ import type { Element as HastElement, ElementContent as HastElementContent, Root
 import type { Heading, Node, PhrasingContent, Root as MdastRoot, RootContent as MdastRootContent } from 'mdast'
 import rehypeExternalLinks from 'rehype-external-links'
 import rehypeFormat from 'rehype-format'
+import rehypeParse from 'rehype-parse'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 import rehypeStringify from 'rehype-stringify'
@@ -69,6 +70,8 @@ const preserveHtmlLikeText = () => (tree: MdastRoot) => {
 }
 
 const inlineMarkdownProcessor = unified().use(remarkParse).use(remarkGfm).use(preserveHtmlLikeText).use(remarkRehype)
+const htmlFragmentParser = unified().use(rehypeParse, { fragment: true })
+const htmlFragmentStringifier = unified().use(rehypeStringify)
 
 /**
  * Parse inline markdown and return children from the generated paragraph.
@@ -109,6 +112,21 @@ const transformInlineMarkdownInHtml = () => (tree: HastRoot) => {
 }
 
 /**
+ * Rewrites raw HTML strings so inline markdown parsing is only applied to raw HTML input.
+ */
+const transformInlineMarkdownInRawHtml = () => (tree: HastRoot) => {
+  visit(tree, 'raw', (node) => {
+    if (typeof node.value !== 'string' || !MAY_CONTAIN_INLINE_MARKDOWN.test(node.value)) {
+      return
+    }
+
+    const htmlFragmentTree = htmlFragmentParser.parse(node.value) as HastRoot
+    transformInlineMarkdownInHtml()(htmlFragmentTree)
+    node.value = htmlFragmentStringifier.stringify(htmlFragmentTree)
+  })
+}
+
+/**
  * Take a Markdown string and generate HTML from it
  */
 export function htmlFromMarkdown(
@@ -139,10 +157,10 @@ export function htmlFromMarkdown(
     .use(remarkRehype, { allowDangerousHtml: true })
     // Adds GitHub alerts
     .use(rehypeAlert)
-    // Creates a HTML AST
+    // Parse inline markdown only inside raw HTML fragments, not normal markdown output
+    .use(transformInlineMarkdownInRawHtml)
+    // Creates an HTML AST
     .use(rehypeRaw)
-    // Enable inline markdown for text content inside selected HTML tags (for example: <p>`code`</p>)
-    .use(transformInlineMarkdownInHtml)
     // Removes disallowed tags
     .use(rehypeSanitize, {
       ...defaultSchema,

--- a/packages/code-highlight/src/markdown/markdown.ts
+++ b/packages/code-highlight/src/markdown/markdown.ts
@@ -50,7 +50,7 @@ const transformNodes =
   }
 
 const TAGS_WITH_INLINE_MARKDOWN = new Set(['dd', 'dt', 'li', 'p', 'summary', 'td', 'th'])
-const MAY_CONTAIN_INLINE_MARKDOWN = /[`*_[~]/
+const MAY_CONTAIN_INLINE_MARKDOWN = /[`*_\[~]/
 
 /**
  * Preserve HTML-like text in inline markdown by turning mdast `html` nodes into text nodes.

--- a/packages/code-highlight/src/markdown/markdown.ts
+++ b/packages/code-highlight/src/markdown/markdown.ts
@@ -1,4 +1,5 @@
-import type { Heading, Node, PhrasingContent, Root, RootContent } from 'mdast'
+import type { Element as HastElement, Root as HastRoot, RootContent as HastRootContent } from 'hast'
+import type { Heading, Node, PhrasingContent, Root as MdastRoot, RootContent as MdastRootContent } from 'mdast'
 import rehypeExternalLinks from 'rehype-external-links'
 import rehypeFormat from 'rehype-format'
 import rehypeRaw from 'rehype-raw'
@@ -48,6 +49,49 @@ const transformNodes =
     return
   }
 
+const TAGS_WITH_INLINE_MARKDOWN = new Set(['dd', 'dt', 'li', 'p', 'summary', 'td', 'th'])
+const MAY_CONTAIN_INLINE_MARKDOWN = /[`*_[~]/
+
+const inlineMarkdownProcessor = unified().use(remarkParse).use(remarkGfm).use(remarkRehype)
+
+/**
+ * Parse inline markdown and return children from the generated paragraph.
+ */
+const extractInlineChildrenFromMarkdown = (value: string): HastRootContent[] => {
+  const tree = inlineMarkdownProcessor.runSync(inlineMarkdownProcessor.parse(value)) as HastRoot
+
+  if (tree.children.length !== 1) {
+    return []
+  }
+
+  const [paragraph] = tree.children
+  if (paragraph.type !== 'element' || paragraph.tagName !== 'p') {
+    return []
+  }
+
+  return paragraph.children
+}
+
+/**
+ * Re-parses text nodes in selected HTML tags so inline markdown works in tags like <p>.
+ */
+const transformInlineMarkdownInHtml = () => (tree: HastRoot) => {
+  visit(tree, 'element', (node: HastElement) => {
+    if (!TAGS_WITH_INLINE_MARKDOWN.has(node.tagName)) {
+      return
+    }
+
+    node.children = node.children.flatMap((child) => {
+      if (child.type !== 'text' || !MAY_CONTAIN_INLINE_MARKDOWN.test(child.value)) {
+        return [child]
+      }
+
+      const markdownChildren = extractInlineChildrenFromMarkdown(child.value)
+      return markdownChildren.length ? markdownChildren : [child]
+    })
+  })
+}
+
 /**
  * Take a Markdown string and generate HTML from it
  */
@@ -81,6 +125,8 @@ export function htmlFromMarkdown(
     .use(rehypeAlert)
     // Creates a HTML AST
     .use(rehypeRaw)
+    // Enable inline markdown for text content inside selected HTML tags (for example: <p>`code`</p>)
+    .use(transformInlineMarkdownInHtml)
     // Removes disallowed tags
     .use(rehypeSanitize, {
       ...defaultSchema,
@@ -118,7 +164,7 @@ export function htmlFromMarkdown(
 /**
  * Create a Markdown AST from a string.
  */
-function getMarkdownAst(markdown: string): Root {
+function getMarkdownAst(markdown: string): MdastRoot {
   return unified().use(remarkParse).use(remarkGfm).parse(markdown)
 }
 
@@ -174,10 +220,10 @@ export function splitContent(markdown: string) {
   const tree = getMarkdownAst(markdown)
 
   /** Sections */
-  const sections: RootContent[][] = []
+  const sections: MdastRootContent[][] = []
 
   /** Nodes inside a section */
-  let nodes: RootContent[] = []
+  let nodes: MdastRootContent[] = []
 
   tree.children?.forEach((node) => {
     // If the node is a heading, start a new section
@@ -207,7 +253,7 @@ export function splitContent(markdown: string) {
 /**
  * Use remark to create a Markdown document from a list of nodes.
  */
-function createDocument(nodes: RootContent[]) {
+function createDocument(nodes: MdastRootContent[]) {
   // Create the Markdown string
   const markdown = unified().use(remarkStringify).use(remarkGfm).stringify({
     type: 'root',

--- a/packages/components/src/components/ScalarMarkdown/ScalarMarkdown.test.ts
+++ b/packages/components/src/components/ScalarMarkdown/ScalarMarkdown.test.ts
@@ -120,4 +120,16 @@ describe('ScalarMarkdown', () => {
     expect(wrapper.find('img').attributes('alt')).toBe('Jupiter with Great Red Spot')
     expect(wrapper.find('img').attributes('src')).toBe('https://cdn.scalar.com/photos/jupiter.jpg')
   })
+
+  it('parses inline markdown in HTML paragraphs', () => {
+    const wrapper = mount(ScalarMarkdown, {
+      props: {
+        value: '<p>`Foobar`</p>',
+      },
+    })
+
+    expect(wrapper.find('p').exists()).toBe(true)
+    expect(wrapper.find('code').exists()).toBe(true)
+    expect(wrapper.find('code').text()).toBe('Foobar')
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Markdown syntax inside raw HTML blocks is not rendered as markdown. For example, `<p>` with backticks renders as literal text rather than inline code.

## Solution

- Added a rehype-stage transform in `@scalar/code-highlight` that re-parses text nodes for inline markdown inside selected safe text container tags (`p`, `li`, `td`, `th`, `dd`, `dt`, `summary`).
- Kept sanitization in place after the transform so security constraints remain enforced.
- Added regression tests in `@scalar/code-highlight` and `@scalar/components` for `<p>` inline code markdown, plus a guard test ensuring unsupported tags (like `<div>`) remain unchanged.
- Tightened HAST typings in the new transform to satisfy TypeScript build checks.
- Added a patch changeset for `@scalar/code-highlight`.

## Visual

![Inline markdown in paragraph renders as code while div stays literal](https://cursor.com/artifacts/c/art-8879456d-45df-44d6-aefb-64011c239ea1)
<a href="https://cursor.com/agents/bc-596915f9-f437-4a76-9e9f-6d37a38e0cc0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmarkdown_inline_code_in_html_demo.mp4"><img src="https://cursor.com/artifacts/c/art-cf2e149e-51e1-4bc0-9bd4-2d80044b11a5" alt="markdown_inline_code_in_html_demo.mp4" /></a>

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Closes #8917
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-596915f9-f437-4a76-9e9f-6d37a38e0cc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-596915f9-f437-4a76-9e9f-6d37a38e0cc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

