### PR TITLE
feat(server-side-rendering): add unhead SSR head rendering

### DIFF
--- a/.changeset/slimy-lobsters-doubt.md
+++ b/.changeset/slimy-lobsters-doubt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/server-side-rendering': patch
+---
+
+Integrate Unhead server-side head rendering in SSR output so `metaData` and title tags are included in the server-rendered HTML document.

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -323,10 +323,7 @@
       "default": "./dist/v2/features/settings/index.js"
     }
   },
-  "files": [
-    "dist",
-    "CHANGELOG.md"
-  ],
+  "files": ["dist", "CHANGELOG.md"],
   "dependencies": {
     "@headlessui/tailwindcss": "catalog:*",
     "@headlessui/vue": "catalog:*",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -323,7 +323,10 @@
       "default": "./dist/v2/features/settings/index.js"
     }
   },
-  "files": ["dist", "CHANGELOG.md"],
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@headlessui/tailwindcss": "catalog:*",
     "@headlessui/vue": "catalog:*",

--- a/packages/server-side-rendering/package.json
+++ b/packages/server-side-rendering/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@scalar/api-reference": "workspace:*",
     "@scalar/types": "workspace:*",
+    "@unhead/vue": "^2.1.12",
     "vue": "catalog:*"
   },
   "devDependencies": {

--- a/packages/server-side-rendering/src/ssr-html-attrs.test.ts
+++ b/packages/server-side-rendering/src/ssr-html-attrs.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('ssr-html-attrs', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('keeps lang="en" when other html attributes are present', async () => {
+    const app = {
+      config: {} as { idPrefix?: string },
+      use: vi.fn(),
+    }
+
+    vi.doMock('vue', () => ({
+      createSSRApp: () => app,
+      h: vi.fn(() => ({ vnode: 'mock-vnode' })),
+    }))
+    vi.doMock('vue/server-renderer', () => ({
+      renderToString: vi.fn(async () => '<div>mock-html</div>'),
+    }))
+    vi.doMock('@scalar/api-reference', () => ({
+      ApiReference: 'MockApiReference',
+    }))
+    vi.doMock('@unhead/vue', () => ({
+      useServerSeoMeta: vi.fn(),
+    }))
+    vi.doMock('@unhead/vue/server', () => ({
+      createHead: (options?: { init?: Array<{ htmlAttrs?: { lang?: string } }> }) => ({ options }),
+      renderSSRHead: async (head: { options?: { init?: Array<{ htmlAttrs?: { lang?: string } }> } }) => {
+        const lang = head.options?.init?.[0]?.htmlAttrs?.lang
+        const langAttribute = lang ? ` lang="${lang}"` : ''
+
+        return {
+          htmlAttrs: `${langAttribute} data-testid="html-attrs"`,
+          bodyAttrs: '',
+          bodyTagsOpen: '',
+          bodyTags: '',
+          headTags: '',
+        }
+      },
+    }))
+
+    const { renderApiReference } = await import('./ssr')
+    const html = await renderApiReference({ config: {}, css: '' })
+
+    expect(html).toContain('<html lang="en" data-testid="html-attrs">')
+  })
+})

--- a/packages/server-side-rendering/src/ssr-html-attrs.test.ts
+++ b/packages/server-side-rendering/src/ssr-html-attrs.test.ts
@@ -28,7 +28,7 @@ describe('ssr-html-attrs', () => {
     }))
     vi.doMock('@unhead/vue/server', () => ({
       createHead: (options?: { init?: Array<{ htmlAttrs?: { lang?: string } }> }) => ({ options }),
-      renderSSRHead: async (head: { options?: { init?: Array<{ htmlAttrs?: { lang?: string } }> } }) => {
+      renderSSRHead: (head: { options?: { init?: Array<{ htmlAttrs?: { lang?: string } }> } }) => {
         const lang = head.options?.init?.[0]?.htmlAttrs?.lang
         const langAttribute = lang ? ` lang="${lang}"` : ''
 

--- a/packages/server-side-rendering/src/ssr-hydration-config.test.ts
+++ b/packages/server-side-rendering/src/ssr-hydration-config.test.ts
@@ -11,6 +11,7 @@ describe('ssr-hydration-config', () => {
     const app = {
       app: 'mock-app',
       config: {} as { idPrefix?: string },
+      use: vi.fn(),
     }
     const createSSRApp = vi.fn((renderRoot: () => unknown) => {
       renderRoot()
@@ -36,6 +37,7 @@ describe('ssr-hydration-config', () => {
     expect(h).toHaveBeenCalledWith('MockApiReference', {
       configuration: { url: 'https://example.com/openapi.json' },
     })
+    expect(app.use).toHaveBeenCalledTimes(1)
     expect(app.config.idPrefix).toBe('scalar-refs')
   })
 })

--- a/packages/server-side-rendering/src/ssr-hydration-config.test.ts
+++ b/packages/server-side-rendering/src/ssr-hydration-config.test.ts
@@ -13,10 +13,7 @@ describe('ssr-hydration-config', () => {
       config: {} as { idPrefix?: string },
       use: vi.fn(),
     }
-    const createSSRApp = vi.fn((renderRoot: () => unknown) => {
-      renderRoot()
-      return app
-    })
+    const createSSRApp = vi.fn(() => app)
     const h = vi.fn(() => ({ vnode: 'mock-vnode' }))
     const renderToString = vi.fn(async () => '<div>mock-html</div>')
 
@@ -33,6 +30,18 @@ describe('ssr-hydration-config', () => {
 
     const { renderApiReferenceToString } = await import('./ssr')
     await renderApiReferenceToString([{ url: 'https://example.com/openapi.json' }])
+
+    const firstCreateSsrCall = createSSRApp.mock.calls.at(0)
+    const rootComponent = firstCreateSsrCall?.at(0) as
+      | {
+          setup?: () => unknown
+        }
+      | undefined
+    expect(typeof rootComponent?.setup).toBe('function')
+
+    const renderRoot = rootComponent?.setup?.() as (() => unknown) | undefined
+    expect(typeof renderRoot).toBe('function')
+    renderRoot?.()
 
     expect(h).toHaveBeenCalledWith('MockApiReference', {
       configuration: { url: 'https://example.com/openapi.json' },

--- a/packages/server-side-rendering/src/ssr.test.ts
+++ b/packages/server-side-rendering/src/ssr.test.ts
@@ -148,6 +148,17 @@ describe('ssr', () => {
       expect(html).toContain('<div id="app">')
     })
 
+    it('includes default SSR head tags exactly once', async () => {
+      const html = await renderApiReference({ config: {}, css: '' })
+
+      const charsetTagCount = html.match(/<meta charset="utf-8">/g)?.length ?? 0
+      const viewportTagCount =
+        html.match(/<meta name="viewport" content="width=device-width, initial-scale=1">/g)?.length ?? 0
+
+      expect(charsetTagCount).toBe(1)
+      expect(viewportTagCount).toBe(1)
+    })
+
     it('includes the color mode detection script', async () => {
       const html = await renderApiReference({ config: {}, css: '' })
 
@@ -185,6 +196,20 @@ describe('ssr', () => {
       const html = await renderApiReference({ config: {}, pageTitle: 'My API', css: '' })
 
       expect(html).toContain('<title>My API</title>')
+    })
+
+    it('renders metadata from config in SSR head tags', async () => {
+      const html = await renderApiReference({
+        config: {
+          metaData: {
+            description: 'Server-rendered description',
+          },
+        },
+        css: '',
+      })
+
+      expect(html).toContain('name="description"')
+      expect(html).toContain('content="Server-rendered description"')
     })
 
     it('escapes HTML in page title', async () => {

--- a/packages/server-side-rendering/src/ssr.ts
+++ b/packages/server-side-rendering/src/ssr.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from 'node:path'
 
 import { ApiReference } from '@scalar/api-reference'
 import type { AnyApiReferenceConfiguration } from '@scalar/types/api-reference'
+import { createHead, renderSSRHead } from '@unhead/vue/server'
 import { createSSRApp, h } from 'vue'
 import { renderToString } from 'vue/server-renderer'
 
@@ -90,6 +91,47 @@ function getInitialBodyClass(configuration: AnyApiReferenceConfiguration): 'dark
   return 'dark-mode'
 }
 
+type RenderedSsrHead = Awaited<ReturnType<typeof renderSSRHead>>
+
+const createHeadInstance = (pageTitle?: string) => createHead(pageTitle ? { init: [{ title: pageTitle }] } : undefined)
+
+/**
+ * Ensure the initial body class from Scalar config always exists.
+ * If Unhead provides body classes, merge them rather than overriding.
+ */
+function mergeBodyAttrsWithInitialClass(bodyAttrs: string, initialBodyClass: 'dark-mode' | 'light-mode'): string {
+  const classAttributePattern = /\sclass=(['"])(.*?)\1/i
+  const classMatch = bodyAttrs.match(classAttributePattern)
+
+  if (!classMatch) {
+    return `${bodyAttrs} class="${initialBodyClass}"`
+  }
+
+  const existingClasses = classMatch[2].split(/\s+/).filter(Boolean)
+  const mergedClasses = Array.from(new Set([...existingClasses, initialBodyClass])).join(' ')
+
+  return bodyAttrs.replace(classAttributePattern, ` class="${mergedClasses}"`)
+}
+
+async function renderApiReferenceApp(options: {
+  configuration: AnyApiReferenceConfiguration
+  pageTitle?: string
+}): Promise<{ html: string; head: RenderedSsrHead }> {
+  const normalizedConfiguration = unwrapConfig(options.configuration)
+  const app = createSSRApp(() => h(ApiReference, { configuration: normalizedConfiguration }))
+  const head = createHeadInstance(options.pageTitle)
+  app.use(head)
+  app.config.idPrefix = 'scalar-refs'
+
+  const html = await renderToString(app)
+  const headTags = await renderSSRHead(head)
+
+  return {
+    html,
+    head: headTags,
+  }
+}
+
 /**
  * Render the Scalar API Reference to an HTML string for server-side rendering.
  * Use createApiReference on the client to hydrate the server-rendered output.
@@ -99,11 +141,8 @@ function getInitialBodyClass(configuration: AnyApiReferenceConfiguration): 'dark
  * interfere with Vue hydration.
  */
 export async function renderApiReferenceToString(configuration: AnyApiReferenceConfiguration): Promise<string> {
-  const normalizedConfiguration = unwrapConfig(configuration)
-  const app = createSSRApp(() => h(ApiReference, { configuration: normalizedConfiguration }))
-  app.config.idPrefix = 'scalar-refs'
-
-  return await renderToString(app)
+  const { html } = await renderApiReferenceApp({ configuration })
+  return html
 }
 
 let _cachedCss: string | undefined
@@ -330,27 +369,31 @@ export async function renderApiReference(options: {
   /** URL path to the standalone JS bundle. Defaults to "/scalar/scalar.js". */
   cdn?: string
 }): Promise<string> {
-  const title = escapeHtml(options.pageTitle ?? 'Scalar API Reference')
+  const title = options.pageTitle ?? 'Scalar API Reference'
   const css = options.css ?? getDefaultCss()
   const cdn = escapeHtmlAttribute(options.cdn ?? '/scalar/scalar.js')
-  const html = await renderApiReferenceToString(options.config)
+  const { html, head } = await renderApiReferenceApp({
+    configuration: options.config,
+    pageTitle: title,
+  })
   const bodyScript = generateBodyScript(options.config)
   const initialBodyClass = getInitialBodyClass(options.config)
+  const bodyAttrs = mergeBodyAttrsWithInitialClass(head.bodyAttrs, initialBodyClass)
   const configJs = serializeConfigToJs(unwrapConfig(options.config))
 
   return `<!doctype html>
-<html lang="en">
+<html${head.htmlAttrs || ' lang="en"'}>
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>${title}</title>
+    ${head.headTags}
     <style>${css}</style>
   </head>
-  <body class="${initialBodyClass}">
+  <body${bodyAttrs}>
+    ${head.bodyTagsOpen}
     ${bodyScript}
     <div id="app">${html}</div>
     <script src="${cdn}"></script>
     <script>Scalar.createApiReference('#app', ${configJs})</script>
+    ${head.bodyTags}
   </body>
 </html>`
 }

--- a/packages/server-side-rendering/src/ssr.ts
+++ b/packages/server-side-rendering/src/ssr.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from 'node:path'
 
 import { ApiReference } from '@scalar/api-reference'
 import type { AnyApiReferenceConfiguration } from '@scalar/types/api-reference'
+import { useServerSeoMeta } from '@unhead/vue'
 import { createHead, renderSSRHead } from '@unhead/vue/server'
 import { createSSRApp, h } from 'vue'
 import { renderToString } from 'vue/server-renderer'
@@ -107,7 +108,8 @@ function mergeBodyAttrsWithInitialClass(bodyAttrs: string, initialBodyClass: 'da
     return `${bodyAttrs} class="${initialBodyClass}"`
   }
 
-  const existingClasses = classMatch[2].split(/\s+/).filter(Boolean)
+  const existingClassValue = classMatch[2] ?? ''
+  const existingClasses = existingClassValue.split(/\s+/).filter(Boolean)
   const mergedClasses = Array.from(new Set([...existingClasses, initialBodyClass])).join(' ')
 
   return bodyAttrs.replace(classAttributePattern, ` class="${mergedClasses}"`)
@@ -118,7 +120,16 @@ async function renderApiReferenceApp(options: {
   pageTitle?: string
 }): Promise<{ html: string; head: RenderedSsrHead }> {
   const normalizedConfiguration = unwrapConfig(options.configuration)
-  const app = createSSRApp(() => h(ApiReference, { configuration: normalizedConfiguration }))
+  const app = createSSRApp({
+    setup: () => {
+      const metaData = normalizedConfiguration.metaData
+      if (metaData && typeof metaData === 'object') {
+        useServerSeoMeta(metaData as Parameters<typeof useServerSeoMeta>[0])
+      }
+
+      return () => h(ApiReference, { configuration: normalizedConfiguration })
+    },
+  })
   const head = createHeadInstance(options.pageTitle)
   app.use(head)
   app.config.idPrefix = 'scalar-refs'

--- a/packages/server-side-rendering/src/ssr.ts
+++ b/packages/server-side-rendering/src/ssr.ts
@@ -94,7 +94,15 @@ function getInitialBodyClass(configuration: AnyApiReferenceConfiguration): 'dark
 
 type RenderedSsrHead = Awaited<ReturnType<typeof renderSSRHead>>
 
-const createHeadInstance = (pageTitle?: string) => createHead(pageTitle ? { init: [{ title: pageTitle }] } : undefined)
+const createHeadInstance = (pageTitle?: string) =>
+  createHead({
+    init: [
+      {
+        htmlAttrs: { lang: 'en' },
+        ...(pageTitle ? { title: pageTitle } : {}),
+      },
+    ],
+  })
 
 /**
  * Ensure the initial body class from Scalar config always exists.
@@ -393,7 +401,7 @@ export async function renderApiReference(options: {
   const configJs = serializeConfigToJs(unwrapConfig(options.config))
 
   return `<!doctype html>
-<html${head.htmlAttrs || ' lang="en"'}>
+<html${head.htmlAttrs}>
   <head>
     ${head.headTags}
     <style>${css}</style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2294,6 +2294,9 @@ importers:
       '@scalar/types':
         specifier: workspace:*
         version: link:../types
+      '@unhead/vue':
+        specifier: ^2.1.12
+        version: 2.1.12(vue@3.5.30(typescript@5.9.3))
       vue:
         specifier: catalog:*
         version: 3.5.30(typescript@5.9.3)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`@scalar/server-side-rendering` rendered the API reference HTML, but did not install a server head manager during SSR, so head metadata generated by `@scalar/api-reference` (for example via `metaData`) was not rendered into the server HTML.

## Solution

- Installed Unhead server support in `@scalar/server-side-rendering`.
- Refactored SSR rendering to use a shared app render path that mounts `createHead()` and collects `renderSSRHead()` output.
- Integrated rendered head output into `renderApiReference` while preserving existing hydration script order and dark/light initialization behavior.
- Added server metadata projection from `config.metaData` using `useServerSeoMeta` in the SSR root setup so metadata is emitted in server-rendered head tags.
- Added tests for SSR head rendering (`meta`/`title`) and duplicate baseline tags.
- Updated hydration-config tests to assert the new SSR root component shape and plugin installation.
- Added a patch changeset for `@scalar/server-side-rendering`.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ddfe109-b543-4d84-8051-32034a6c8c15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ddfe109-b543-4d84-8051-32034a6c8c15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

