### PR TITLE
feat(astro): better Starlight support

### DIFF
--- a/.changeset/api-reference-destroy-listeners.md
+++ b/.changeset/api-reference-destroy-listeners.md
@@ -1,0 +1,16 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): clean up deprecated document listeners on destroy
+
+`createApiReference()` registered three document-level listeners
+(`scalar:reload-references`, `scalar:destroy-references`,
+`scalar:update-references-config`) but `destroy()` only unmounted the
+Vue app — the listeners stayed attached forever. In environments that
+mount and destroy instances repeatedly (notably the Astro integration's
+`renderMode="client"` with view transitions), each navigation leaked
+three permanent listeners on `document`.
+
+Tie the listeners to an `AbortController` and abort it from `destroy()`
+so they all come off in one shot.

--- a/.changeset/astro-extract-client-script.md
+++ b/.changeset/astro-extract-client-script.md
@@ -1,7 +1,0 @@
----
-'@scalar/astro': patch
----
-
-refactor(astro): extract client mount logic, dedupe in-flight CDN loads, harden against unsafe CDN URLs
-
-The `<ScalarComponent renderMode="client" />` component now keeps a small hoisted script in the template and delegates mounting, unmounting, and CDN/stylesheet loading to a dedicated `client.ts` module. Per-instance configuration flows through a `data-scalar-config` attribute on the container instead of inline `define:vars`. The CDN script and stylesheet loaders now cache their in-flight promise on global state, so multiple `<ScalarComponent />` instances on the same page no longer race to append duplicate `<script>` or `<link>` tags. As defense in depth, CDN URLs with non-`http(s)` schemes (`javascript:`, `data:`, etc.) are now refused with a console error rather than written to `<script src>`, and container ids are run through `CSS.escape` so ids with selector metacharacters do not break `querySelector`. No public API change for consumers.

--- a/.changeset/astro-extract-client-script.md
+++ b/.changeset/astro-extract-client-script.md
@@ -1,0 +1,7 @@
+---
+'@scalar/astro': patch
+---
+
+refactor(astro): extract client mount logic, dedupe in-flight CDN loads, harden against unsafe CDN URLs
+
+The `<ScalarComponent renderMode="client" />` component now keeps a small hoisted script in the template and delegates mounting, unmounting, and CDN/stylesheet loading to a dedicated `client.ts` module. Per-instance configuration flows through a `data-scalar-config` attribute on the container instead of inline `define:vars`. The CDN script and stylesheet loaders now cache their in-flight promise on global state, so multiple `<ScalarComponent />` instances on the same page no longer race to append duplicate `<script>` or `<link>` tags. As defense in depth, CDN URLs with non-`http(s)` schemes (`javascript:`, `data:`, etc.) are now refused with a console error rather than written to `<script src>`, and container ids are run through `CSS.escape` so ids with selector metacharacters do not break `querySelector`. No public API change for consumers.

--- a/.changeset/astro-starlight-support.md
+++ b/.changeset/astro-starlight-support.md
@@ -1,0 +1,7 @@
+---
+'@scalar/astro': minor
+---
+
+feat(astro): improve Starlight support
+
+Adds a `renderMode="client"` mode to `<ScalarComponent />` that mounts Scalar on the client and re-mounts around Astro view-transition events (`astro:before-swap`, `astro:page-load`). This fixes the "content appears only after a refresh" issue on Starlight pages and other Astro sites that use client-side navigation. A new `mountElementId` prop allows overriding the mount container id; if omitted, a unique `scalar-app-<uuid>` is generated per render so multiple components can coexist on one page. Function-valued config props (`content`, `plugins`, `onLoaded`, custom `fetch`, ...) are preserved through the same source-serialization that static mode already uses.

--- a/.changeset/dirty-tomatoes-fall.md
+++ b/.changeset/dirty-tomatoes-fall.md
@@ -1,0 +1,5 @@
+---
+'@scalar/astro': patch
+---
+
+fix(astro): add client render mode for Astro view transitions

--- a/.changeset/dirty-tomatoes-fall.md
+++ b/.changeset/dirty-tomatoes-fall.md
@@ -1,5 +1,0 @@
----
-'@scalar/astro': patch
----
-
-fix(astro): add client render mode for Astro view transitions

--- a/.changeset/safe-stars-protect.md
+++ b/.changeset/safe-stars-protect.md
@@ -1,0 +1,10 @@
+---
+'@scalar/client-side-rendering': patch
+'@scalar/astro': patch
+---
+
+fix(client-side-rendering): escape `</script>` and `<!--` in inline-script config
+
+User-controlled values in the configuration (a `content` string, a custom callback's source, the CDN URL, etc.) used to be embedded into the inline `<script>` tag verbatim. A value containing `</script>` would terminate the surrounding script element early, breaking the API reference mount and letting any trailing characters be parsed as HTML. Both the static-mode `getScriptTags` (used by `renderApiReference`) and the Astro `renderMode="client"` script were affected.
+
+The serialization now lives in a single `serializeConfigToScript` helper in `@scalar/client-side-rendering` and applies HTML-safe escaping (`</script` → `<\/script`, `<!--` → `<\!--`). The escape preserves the JavaScript string value while preventing the HTML parser from matching the dangerous sequence. The Astro integration was updated to reuse this helper instead of its own copy of the function-preserving serialization.

--- a/documentation/integrations/astro.md
+++ b/documentation/integrations/astro.md
@@ -90,3 +90,28 @@ import { ScalarComponent } from '@scalar/astro'
   proxyUrl: 'https://proxy.scalar.com',
 }} />
 ```
+
+### Starlight and View Transitions
+
+If your Astro site uses client-side page transitions (for example Starlight with View Transitions),
+use `renderMode: 'client'` to mount Scalar after navigation events.
+
+This avoids the "content appears only after a refresh" issue on API reference pages.
+
+```astro
+---
+import { ScalarComponent } from '@scalar/astro'
+---
+
+<ScalarComponent
+  renderMode="client"
+  configuration={{
+    url: '/openapi.json',
+  }}
+/>
+```
+
+#### Client render mode options
+
+- `renderMode`: `'static' | 'client'` (defaults to `'static'`)
+- `mountElementId`: custom mount element id for client mode (defaults to `'scalar-app'`)

--- a/documentation/integrations/astro.md
+++ b/documentation/integrations/astro.md
@@ -93,6 +93,8 @@ import { ScalarComponent } from '@scalar/astro'
 
 ### Starlight and View Transitions
 
+For a Starlight-specific guide, see [API Reference for Starlight](./starlight.md).
+
 If your Astro site uses client-side page transitions (for example Starlight with View Transitions),
 use `renderMode: 'client'` to mount Scalar after navigation events.
 

--- a/documentation/integrations/astro.md
+++ b/documentation/integrations/astro.md
@@ -116,4 +116,4 @@ import { ScalarComponent } from '@scalar/astro'
 #### Client render mode options
 
 - `renderMode`: `'static' | 'client'` (defaults to `'static'`)
-- `mountElementId`: custom mount element id for client mode (defaults to `'scalar-app'`)
+- `mountElementId`: custom mount element id for client mode (defaults to a random `scalar-app-<uuid>` so multiple components on the same page do not collide)

--- a/documentation/integrations/starlight.md
+++ b/documentation/integrations/starlight.md
@@ -1,0 +1,40 @@
+# API Reference for Starlight (Astro)
+
+Starlight is built on Astro, so the Scalar integration for Starlight uses `@scalar/astro`.
+
+Use `renderMode="client"` so Scalar mounts correctly after Starlight navigation events.
+
+## Installation
+
+```bash
+npm install @scalar/astro
+```
+
+## Usage
+
+Use `ScalarComponent` in a Starlight page, and set `renderMode` to `client`:
+
+```astro
+---
+import { ScalarComponent } from '@scalar/astro'
+---
+
+<ScalarComponent
+  renderMode="client"
+  configuration={{
+    // Read more about configuration:
+    // https://scalar.com/products/api-references/configuration
+    url: '/openapi.json',
+  }}
+/>
+```
+
+## Why use `renderMode="client"` in Starlight
+
+Starlight commonly uses view transitions and client-side navigation. In this setup, static server-rendered HTML can appear empty after route changes until a full refresh.
+
+Client mode remounts Scalar on page transitions, which avoids that issue.
+
+## Related Astro guide
+
+For Astro usage outside of Starlight, see [API Reference for Astro](./astro.md).

--- a/integrations/astro/package.json
+++ b/integrations/astro/package.json
@@ -22,7 +22,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "dev": "cd playground && pnpm dev"
+    "dev": "cd playground && pnpm dev",
+    "test": "vitest --run"
   },
   "type": "module",
   "exports": {
@@ -51,7 +52,9 @@
     "@scalar/client-side-rendering": "workspace:*"
   },
   "devDependencies": {
-    "astro": "^4.0.0 || ^5.0.0 || ^6.0.0"
+    "astro": "^4.0.0 || ^5.0.0 || ^6.0.0",
+    "jsdom": "catalog:*",
+    "vitest": "catalog:*"
   },
   "peerDependencies": {
     "astro": "^4.0.0 || ^5.0.0"

--- a/integrations/astro/playground/src/pages/about.astro
+++ b/integrations/astro/playground/src/pages/about.astro
@@ -1,0 +1,10 @@
+---
+import { ClientRouter } from 'astro:transitions'
+---
+
+<ClientRouter />
+<h1>Astro playground page</h1>
+
+<p>
+  <a href="/client">Back to client mode example</a>
+</p>

--- a/integrations/astro/playground/src/pages/client.astro
+++ b/integrations/astro/playground/src/pages/client.astro
@@ -1,6 +1,12 @@
 ---
 import { ScalarComponent } from '@scalar/astro'
+import { ClientRouter } from 'astro:transitions'
 ---
+
+<ClientRouter />
+<h1>Client mode API reference</h1>
+<p><a href="/about">Go to another page</a></p>
+<p><a href="/">Back to static mode example</a></p>
 
 <ScalarComponent
   renderMode="client"

--- a/integrations/astro/playground/src/pages/client.astro
+++ b/integrations/astro/playground/src/pages/client.astro
@@ -1,0 +1,10 @@
+---
+import { ScalarComponent } from '@scalar/astro'
+---
+
+<ScalarComponent
+  renderMode="client"
+  configuration={{
+    url: 'https://registry.scalar.com/@scalar/apis/galaxy?format=json',
+  }}
+/>

--- a/integrations/astro/playground/src/pages/index.astro
+++ b/integrations/astro/playground/src/pages/index.astro
@@ -2,6 +2,8 @@
 import { ScalarComponent } from '@scalar/astro'
 ---
 
+<p><a href="/client">Client mode example</a></p>
+
 <ScalarComponent configuration={{
 	url: 'https://registry.scalar.com/@scalar/apis/galaxy?format=json',
 }} />

--- a/integrations/astro/src/ScalarComponent.astro
+++ b/integrations/astro/src/ScalarComponent.astro
@@ -3,6 +3,19 @@ import { renderApiReference, type HtmlRenderingConfiguration } from '@scalar/cli
 
 export interface Props {
   configuration: Partial<HtmlRenderingConfiguration>
+  /**
+   * Rendering strategy for Astro pages.
+   *
+   * - `static` renders pre-generated HTML (default)
+   * - `client` mounts Scalar on the client and re-mounts on `astro:page-load`
+   */
+  renderMode?: 'static' | 'client'
+  /**
+   * Element id used as the client mount point.
+   *
+   * Only used when `renderMode` is `client`.
+   */
+  mountElementId?: string
 }
 
 /**
@@ -13,18 +26,119 @@ const DEFAULT_CONFIGURATION: Partial<HtmlRenderingConfiguration> = {
   // _integration: 'astro',
 }
 
-const { configuration } = Astro.props
+const { configuration, renderMode = 'static', mountElementId = 'scalar-app' }: Props = Astro.props
 
 const finalConfiguration = {
   ...DEFAULT_CONFIGURATION,
   ...configuration,
 }
 const { cdn, pageTitle, ...config } = finalConfiguration
-const html = renderApiReference({
-  config,
-  cdn,
-  pageTitle,
-})
+const html =
+  renderMode === 'static'
+    ? renderApiReference({
+        config,
+        cdn,
+        pageTitle,
+      })
+    : null
 ---
 
-<div set:html={html}></div>
+{
+  renderMode === 'static' ? (
+    <div set:html={html ?? ''}></div>
+  ) : (
+    <>
+      <div id={mountElementId}></div>
+      <script lang="ts">
+        type ScalarGlobal = {
+          createApiReference: (selector: string, configuration: Record<string, unknown>) => {
+            destroy: () => void
+          }
+        }
+
+        const mountSelector = {JSON.stringify(`#${mountElementId}`)}
+        const configuration = {JSON.stringify(config)}
+        const cdn = {JSON.stringify(cdn ?? null)}
+
+        let scalarInstance: { destroy: () => void } | null = null
+
+        const ensureCdnLoaded = async (): Promise<void> => {
+          const globalScalar = (window as Window & { Scalar?: ScalarGlobal }).Scalar
+
+          if (globalScalar?.createApiReference) {
+            return
+          }
+
+          await new Promise<void>((resolve, reject) => {
+            const existing = document.querySelector<HTMLScriptElement>('script[data-scalar-astro-cdn="true"]')
+
+            if (existing?.dataset.loaded === 'true') {
+              resolve()
+              return
+            }
+
+            if (existing) {
+              existing.addEventListener('load', () => resolve(), { once: true })
+              existing.addEventListener('error', () => reject(new Error('Failed to load Scalar CDN script')), {
+                once: true,
+              })
+              return
+            }
+
+            const script = document.createElement('script')
+            script.src = cdn ?? 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
+            script.dataset.scalarAstroCdn = 'true'
+            script.addEventListener(
+              'load',
+              () => {
+                script.dataset.loaded = 'true'
+                resolve()
+              },
+              { once: true },
+            )
+            script.addEventListener('error', () => reject(new Error('Failed to load Scalar CDN script')), {
+              once: true,
+            })
+            document.head.appendChild(script)
+          })
+        }
+
+        const mountScalar = async (): Promise<void> => {
+          const container = document.querySelector(mountSelector)
+
+          if (!container) {
+            return
+          }
+
+          if (scalarInstance) {
+            scalarInstance.destroy()
+            scalarInstance = null
+          }
+
+          await ensureCdnLoaded()
+
+          const scalar = (window as Window & { Scalar?: ScalarGlobal }).Scalar
+
+          if (!scalar?.createApiReference) {
+            return
+          }
+
+          scalarInstance = scalar.createApiReference(mountSelector, configuration)
+        }
+
+        document.addEventListener('astro:before-swap', () => {
+          if (scalarInstance) {
+            scalarInstance.destroy()
+            scalarInstance = null
+          }
+        })
+
+        document.addEventListener('astro:page-load', () => {
+          void mountScalar()
+        })
+
+        void mountScalar()
+      </script>
+    </>
+  )
+}

--- a/integrations/astro/src/ScalarComponent.astro
+++ b/integrations/astro/src/ScalarComponent.astro
@@ -49,28 +49,76 @@ const html =
   ) : (
     <>
       <div id={mountElementId}></div>
-      <script lang="ts">
-        type ScalarGlobal = {
-          createApiReference: (selector: string, configuration: Record<string, unknown>) => {
-            destroy: () => void
+      <script define:vars={{ mountSelector: `#${mountElementId}`, configuration: config, cdn: cdn ?? null }}>
+        const stateKey = '__scalarAstroState'
+        const globalState = (window[stateKey] ??= { instances: {}, listeners: {} })
+        const defaultCdn = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
+
+        const getStyleHref = () => {
+          const cdnUrl = (cdn ?? defaultCdn).replace(/\/$/, '')
+
+          if (/\/dist\/browser\/[^/]+\.js(?:\?.*)?$/.test(cdnUrl)) {
+            return cdnUrl.replace(/\/dist\/browser\/[^/]+\.js(?:\?.*)?$/, '/dist/style.css')
           }
+
+          if (/\.js(?:\?.*)?$/.test(cdnUrl)) {
+            return cdnUrl.replace(/\/[^/]+\.js(?:\?.*)?$/, '/style.css')
+          }
+
+          if (/\/dist$/.test(cdnUrl)) {
+            return `${cdnUrl}/style.css`
+          }
+
+          return `${cdnUrl}/dist/style.css`
         }
 
-        const mountSelector = {JSON.stringify(`#${mountElementId}`)}
-        const configuration = {JSON.stringify(config)}
-        const cdn = {JSON.stringify(cdn ?? null)}
+        const ensureStylesLoaded = async () => {
+          const styleHref = getStyleHref()
+          const existing = document.querySelector('link[data-scalar-astro-style="true"]')
 
-        let scalarInstance: { destroy: () => void } | null = null
+          if (existing?.getAttribute('href') === styleHref && existing.dataset.loaded === 'true') {
+            return
+          }
 
-        const ensureCdnLoaded = async (): Promise<void> => {
-          const globalScalar = (window as Window & { Scalar?: ScalarGlobal }).Scalar
+          if (existing) {
+            existing.remove()
+          }
+
+          await new Promise((resolve, reject) => {
+            const link = document.createElement('link')
+            link.rel = 'stylesheet'
+            link.href = styleHref
+            link.dataset.scalarAstroStyle = 'true'
+            link.addEventListener(
+              'load',
+              () => {
+                link.dataset.loaded = 'true'
+                resolve()
+              },
+              { once: true },
+            )
+            link.addEventListener(
+              'error',
+              () => {
+                reject(new Error('Failed to load Scalar CDN stylesheet'))
+              },
+              {
+                once: true,
+              },
+            )
+            document.head.appendChild(link)
+          })
+        }
+
+        const ensureCdnLoaded = async () => {
+          const globalScalar = window.Scalar
 
           if (globalScalar?.createApiReference) {
             return
           }
 
-          await new Promise<void>((resolve, reject) => {
-            const existing = document.querySelector<HTMLScriptElement>('script[data-scalar-astro-cdn="true"]')
+          await new Promise((resolve, reject) => {
+            const existing = document.querySelector('script[data-scalar-astro-cdn="true"]')
 
             if (existing?.dataset.loaded === 'true') {
               resolve()
@@ -86,7 +134,7 @@ const html =
             }
 
             const script = document.createElement('script')
-            script.src = cdn ?? 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
+            script.src = cdn ?? defaultCdn
             script.dataset.scalarAstroCdn = 'true'
             script.addEventListener(
               'load',
@@ -96,46 +144,70 @@ const html =
               },
               { once: true },
             )
-            script.addEventListener('error', () => reject(new Error('Failed to load Scalar CDN script')), {
-              once: true,
-            })
+            script.addEventListener(
+              'error',
+              () => {
+                reject(new Error('Failed to load Scalar CDN script'))
+              },
+              {
+                once: true,
+              },
+            )
             document.head.appendChild(script)
           })
         }
 
-        const mountScalar = async (): Promise<void> => {
+        const destroyScalar = () => {
+          const existingInstance = globalState.instances[mountSelector]
+          if (existingInstance?.destroy) {
+            existingInstance.destroy()
+          }
+          globalState.instances[mountSelector] = null
+
+          const container = document.querySelector(mountSelector)
+          if (container) {
+            container.innerHTML = ''
+          }
+        }
+
+        const mountScalar = async () => {
           const container = document.querySelector(mountSelector)
 
           if (!container) {
             return
           }
 
-          if (scalarInstance) {
-            scalarInstance.destroy()
-            scalarInstance = null
-          }
+          destroyScalar()
 
+          await ensureStylesLoaded()
           await ensureCdnLoaded()
 
-          const scalar = (window as Window & { Scalar?: ScalarGlobal }).Scalar
+          const scalar = window.Scalar
 
           if (!scalar?.createApiReference) {
             return
           }
 
-          scalarInstance = scalar.createApiReference(mountSelector, configuration)
+          globalState.instances[mountSelector] = scalar.createApiReference(mountSelector, configuration)
         }
 
-        document.addEventListener('astro:before-swap', () => {
-          if (scalarInstance) {
-            scalarInstance.destroy()
-            scalarInstance = null
-          }
-        })
+        const previousListeners = globalState.listeners[mountSelector]
+        if (previousListeners) {
+          document.removeEventListener('astro:before-swap', previousListeners.beforeSwap)
+          document.removeEventListener('astro:page-load', previousListeners.pageLoad)
+        }
 
-        document.addEventListener('astro:page-load', () => {
+        const beforeSwap = () => {
+          destroyScalar()
+        }
+
+        const pageLoad = () => {
           void mountScalar()
-        })
+        }
+
+        globalState.listeners[mountSelector] = { beforeSwap, pageLoad }
+        document.addEventListener('astro:before-swap', beforeSwap)
+        document.addEventListener('astro:page-load', pageLoad)
 
         void mountScalar()
       </script>

--- a/integrations/astro/src/ScalarComponent.astro
+++ b/integrations/astro/src/ScalarComponent.astro
@@ -41,6 +41,8 @@ const html =
         pageTitle,
       })
     : null
+
+const clientPayload = renderMode === 'client' ? JSON.stringify({ configuration: config, cdn: cdn ?? null }) : null
 ---
 
 {
@@ -48,166 +50,11 @@ const html =
     <div set:html={html ?? ''}></div>
   ) : (
     <>
-      <div id={mountElementId}></div>
-      <script define:vars={{ mountSelector: `#${mountElementId}`, configuration: config, cdn: cdn ?? null }}>
-        const stateKey = '__scalarAstroState'
-        const globalState = (window[stateKey] ??= { instances: {}, listeners: {} })
-        const defaultCdn = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
+      <div id={mountElementId} data-scalar-mount data-scalar-config={clientPayload}></div>
+      <script>
+        import { initScalarAstro } from './client'
 
-        const getStyleHref = () => {
-          const cdnUrl = (cdn ?? defaultCdn).replace(/\/$/, '')
-
-          if (/\/dist\/browser\/[^/]+\.js(?:\?.*)?$/.test(cdnUrl)) {
-            return cdnUrl.replace(/\/dist\/browser\/[^/]+\.js(?:\?.*)?$/, '/dist/style.css')
-          }
-
-          if (/\.js(?:\?.*)?$/.test(cdnUrl)) {
-            return cdnUrl.replace(/\/[^/]+\.js(?:\?.*)?$/, '/style.css')
-          }
-
-          if (/\/dist$/.test(cdnUrl)) {
-            return `${cdnUrl}/style.css`
-          }
-
-          return `${cdnUrl}/dist/style.css`
-        }
-
-        const ensureStylesLoaded = async () => {
-          const styleHref = getStyleHref()
-          const existing = document.querySelector('link[data-scalar-astro-style="true"]')
-
-          if (existing?.getAttribute('href') === styleHref && existing.dataset.loaded === 'true') {
-            return
-          }
-
-          if (existing) {
-            existing.remove()
-          }
-
-          await new Promise((resolve, reject) => {
-            const link = document.createElement('link')
-            link.rel = 'stylesheet'
-            link.href = styleHref
-            link.dataset.scalarAstroStyle = 'true'
-            link.addEventListener(
-              'load',
-              () => {
-                link.dataset.loaded = 'true'
-                resolve()
-              },
-              { once: true },
-            )
-            link.addEventListener(
-              'error',
-              () => {
-                reject(new Error('Failed to load Scalar CDN stylesheet'))
-              },
-              {
-                once: true,
-              },
-            )
-            document.head.appendChild(link)
-          })
-        }
-
-        const ensureCdnLoaded = async () => {
-          const globalScalar = window.Scalar
-
-          if (globalScalar?.createApiReference) {
-            return
-          }
-
-          await new Promise((resolve, reject) => {
-            const existing = document.querySelector('script[data-scalar-astro-cdn="true"]')
-
-            if (existing?.dataset.loaded === 'true') {
-              resolve()
-              return
-            }
-
-            if (existing) {
-              existing.addEventListener('load', () => resolve(), { once: true })
-              existing.addEventListener('error', () => reject(new Error('Failed to load Scalar CDN script')), {
-                once: true,
-              })
-              return
-            }
-
-            const script = document.createElement('script')
-            script.src = cdn ?? defaultCdn
-            script.dataset.scalarAstroCdn = 'true'
-            script.addEventListener(
-              'load',
-              () => {
-                script.dataset.loaded = 'true'
-                resolve()
-              },
-              { once: true },
-            )
-            script.addEventListener(
-              'error',
-              () => {
-                reject(new Error('Failed to load Scalar CDN script'))
-              },
-              {
-                once: true,
-              },
-            )
-            document.head.appendChild(script)
-          })
-        }
-
-        const destroyScalar = () => {
-          const existingInstance = globalState.instances[mountSelector]
-          if (existingInstance?.destroy) {
-            existingInstance.destroy()
-          }
-          globalState.instances[mountSelector] = null
-
-          const container = document.querySelector(mountSelector)
-          if (container) {
-            container.innerHTML = ''
-          }
-        }
-
-        const mountScalar = async () => {
-          const container = document.querySelector(mountSelector)
-
-          if (!container) {
-            return
-          }
-
-          destroyScalar()
-
-          await ensureStylesLoaded()
-          await ensureCdnLoaded()
-
-          const scalar = window.Scalar
-
-          if (!scalar?.createApiReference) {
-            return
-          }
-
-          globalState.instances[mountSelector] = scalar.createApiReference(mountSelector, configuration)
-        }
-
-        const previousListeners = globalState.listeners[mountSelector]
-        if (previousListeners) {
-          document.removeEventListener('astro:before-swap', previousListeners.beforeSwap)
-          document.removeEventListener('astro:page-load', previousListeners.pageLoad)
-        }
-
-        const beforeSwap = () => {
-          destroyScalar()
-        }
-
-        const pageLoad = () => {
-          void mountScalar()
-        }
-
-        globalState.listeners[mountSelector] = { beforeSwap, pageLoad }
-        document.addEventListener('astro:before-swap', beforeSwap)
-        document.addEventListener('astro:page-load', pageLoad)
+        initScalarAstro()
       </script>
     </>
   )

--- a/integrations/astro/src/ScalarComponent.astro
+++ b/integrations/astro/src/ScalarComponent.astro
@@ -28,7 +28,13 @@ const DEFAULT_CONFIGURATION: Partial<HtmlRenderingConfiguration> = {
   // _integration: 'astro',
 }
 
-const { configuration, renderMode = 'static', mountElementId = 'scalar-app' }: Props = Astro.props
+// Generate a unique id per render so multiple `<ScalarComponent />` instances
+// on the same page do not collide on the default mount id.
+const {
+  configuration,
+  renderMode = 'static',
+  mountElementId = `scalar-app-${crypto.randomUUID()}`,
+}: Props = Astro.props
 
 const finalConfiguration = {
   ...DEFAULT_CONFIGURATION,

--- a/integrations/astro/src/ScalarComponent.astro
+++ b/integrations/astro/src/ScalarComponent.astro
@@ -1,5 +1,5 @@
 ---
-import { renderApiReference, type HtmlRenderingConfiguration } from '@scalar/client-side-rendering'
+import { getConfiguration, renderApiReference, type HtmlRenderingConfiguration } from '@scalar/client-side-rendering'
 
 import { serializeClientConfig } from './serialize-client-config'
 
@@ -50,9 +50,16 @@ const html =
       })
     : null
 
+// Run the config through the same normalization the static path applies via
+// `renderApiReference`, so client mode also drops `content` when `url` is set
+// and resolves function-valued `content`.
 const clientScript =
   renderMode === 'client'
-    ? serializeClientConfig({ key: mountElementId, configuration: config, cdn: cdn ?? null })
+    ? serializeClientConfig({
+        key: mountElementId,
+        configuration: getConfiguration(config as Record<string, unknown>),
+        cdn: cdn ?? null,
+      })
     : null
 ---
 

--- a/integrations/astro/src/ScalarComponent.astro
+++ b/integrations/astro/src/ScalarComponent.astro
@@ -1,6 +1,8 @@
 ---
 import { renderApiReference, type HtmlRenderingConfiguration } from '@scalar/client-side-rendering'
 
+import { serializeClientConfig } from './serialize-client-config'
+
 export interface Props {
   configuration: Partial<HtmlRenderingConfiguration>
   /**
@@ -42,7 +44,10 @@ const html =
       })
     : null
 
-const clientPayload = renderMode === 'client' ? JSON.stringify({ configuration: config, cdn: cdn ?? null }) : null
+const clientScript =
+  renderMode === 'client'
+    ? serializeClientConfig({ key: mountElementId, configuration: config, cdn: cdn ?? null })
+    : null
 ---
 
 {
@@ -50,7 +55,13 @@ const clientPayload = renderMode === 'client' ? JSON.stringify({ configuration: 
     <div set:html={html ?? ''}></div>
   ) : (
     <>
-      <div id={mountElementId} data-scalar-mount data-scalar-config={clientPayload}></div>
+      <div id={mountElementId} data-scalar-mount></div>
+      {/*
+        Per-instance registration script. Emits raw JS (not JSON) so function-
+        valued config props (`content`, `plugins`, `onLoaded`, custom `fetch`,
+        ...) survive into the browser instead of being dropped by `JSON.stringify`.
+      */}
+      <script is:inline set:html={clientScript ?? ''}></script>
       <script>
         import { initScalarAstro } from './client'
 

--- a/integrations/astro/src/ScalarComponent.astro
+++ b/integrations/astro/src/ScalarComponent.astro
@@ -208,8 +208,6 @@ const html =
         globalState.listeners[mountSelector] = { beforeSwap, pageLoad }
         document.addEventListener('astro:before-swap', beforeSwap)
         document.addEventListener('astro:page-load', pageLoad)
-
-        void mountScalar()
       </script>
     </>
   )

--- a/integrations/astro/src/client.test.ts
+++ b/integrations/astro/src/client.test.ts
@@ -145,6 +145,33 @@ describe('initScalarAstro', () => {
     expect(scalar.createApiReference).not.toHaveBeenCalled()
   })
 
+  it.each([['javascript:alert(1)'], ['data:text/javascript,alert(1)'], ['vbscript:msgbox("x")']])(
+    'refuses to mount when cdn URL has unsafe scheme: %s',
+    async (cdn) => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      addMountElement('a', { url: '/a.json' }, cdn)
+
+      initScalarAstro()
+      document.dispatchEvent(new Event('astro:page-load'))
+      await tick()
+
+      expect(scalar.createApiReference).not.toHaveBeenCalled()
+      expect(document.querySelectorAll('script[data-scalar-astro-cdn="true"]')).toHaveLength(0)
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('unsafe URL scheme'))
+    },
+  )
+
+  it('escapes container ids that contain CSS metacharacters', async () => {
+    addMountElement('foo.bar:baz', { url: '/x.json' })
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(scalar.createApiReference).toHaveBeenCalledWith(`#${CSS.escape('foo.bar:baz')}`, { url: '/x.json' })
+  })
+
   it('keeps unmounting other instances even if one destroy throws', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 

--- a/integrations/astro/src/client.test.ts
+++ b/integrations/astro/src/client.test.ts
@@ -37,12 +37,25 @@ const seedLoadedStylesheet = (href: string = DEFAULT_STYLE_HREF) => {
   document.head.appendChild(link)
 }
 
+const seedLoadedCdnScript = (src: string = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference') => {
+  const script = document.createElement('script')
+  script.src = src
+  script.dataset.scalarAstroCdn = 'true'
+  script.dataset.loaded = 'true'
+  document.head.appendChild(script)
+}
+
 const stubScalarGlobal = () => {
   const destroy = vi.fn()
   const createApiReference = vi.fn(() => ({ destroy }))
   ;(window as unknown as { Scalar: { createApiReference: typeof createApiReference } }).Scalar = {
     createApiReference,
   }
+  // Seed a matching loaded CDN script so `ensureCdnLoaded` short-circuits via
+  // the `dataset.loaded === 'true'` branch in `loadCdn`. Required because the
+  // loader no longer skips just because `window.Scalar` is set — that early
+  // return ignored the requested `cdn` URL and was the bug behind issue 6.
+  seedLoadedCdnScript()
   return { createApiReference, destroy }
 }
 
@@ -55,10 +68,11 @@ const resetEnvironment = () => {
 }
 
 const tick = async () => {
-  // A few microtask flushes cover the `await ensureStylesLoaded` + `await ensureCdnLoaded` chain.
-  await Promise.resolve()
-  await Promise.resolve()
-  await Promise.resolve()
+  // Flush enough microtasks to cover the `await ensureStylesLoaded` and
+  // `await ensureCdnLoaded` chains plus any chained `.catch(...)` handlers.
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve()
+  }
 }
 
 describe('initScalarAstro', () => {
@@ -112,15 +126,33 @@ describe('initScalarAstro', () => {
     await tick()
     document.dispatchEvent(new Event('astro:before-swap'))
 
-    // Simulate the new page's `is:inline` registration script repopulating the
-    // registry during the DOM swap, before `astro:page-load` fires.
-    registerConfig('a', { configuration: { url: '/a.json' }, cdn: null })
-
     document.dispatchEvent(new Event('astro:page-load'))
     await tick()
 
     expect(scalar.createApiReference).toHaveBeenCalledTimes(2)
     expect(scalar.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the config registry across navigations so revisited pages still mount', async () => {
+    // Astro's ClientRouter dedupes identical inline scripts during a session,
+    // so a previously-visited page's registration script may not re-run on
+    // revisit. The registry must persist across `astro:before-swap` for the
+    // mount to find its config.
+    addMountElement('a', { url: '/a.json' })
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    document.dispatchEvent(new Event('astro:before-swap'))
+
+    const registry = (window as unknown as RegistryWindow).__scalarAstro?.configs ?? {}
+    expect(registry.a).toEqual({ configuration: { url: '/a.json' }, cdn: null })
+
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(scalar.createApiReference).toHaveBeenCalledTimes(2)
   })
 
   it('is idempotent — calling initScalarAstro twice does not double-mount', async () => {
@@ -174,7 +206,11 @@ describe('initScalarAstro', () => {
       await tick()
 
       expect(scalar.createApiReference).not.toHaveBeenCalled()
-      expect(document.querySelectorAll('script[data-scalar-astro-cdn="true"]')).toHaveLength(0)
+      // Make sure no script tag was created for the unsafe scheme. The
+      // beforeEach seeds an unrelated default-cdn script, so check by URL
+      // scheme rather than by total count.
+      const scripts = Array.from(document.querySelectorAll<HTMLScriptElement>('script[data-scalar-astro-cdn="true"]'))
+      expect(scripts.some((script) => script.src === cdn || script.getAttribute('src') === cdn)).toBe(false)
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('unsafe URL scheme'))
     },
   )
@@ -189,7 +225,7 @@ describe('initScalarAstro', () => {
     expect(scalar.createApiReference).toHaveBeenCalledWith(`#${CSS.escape('foo.bar:baz')}`, { url: '/x.json' })
   })
 
-  it('does not leak instance state or registry entries across navigations', async () => {
+  it('does not leak instance state across navigations', async () => {
     initScalarAstro()
 
     for (let i = 0; i < 100; i++) {
@@ -203,10 +239,8 @@ describe('initScalarAstro', () => {
     }
 
     const state = (window as unknown as Record<string, { instances: Record<string, unknown> }>)[STATE_KEY]
-    const registry = (window as unknown as RegistryWindow).__scalarAstro?.configs ?? {}
 
     expect(Object.keys(state.instances)).toHaveLength(0)
-    expect(Object.keys(registry)).toHaveLength(0)
   })
 
   it('keeps unmounting other instances even if one destroy throws', async () => {
@@ -313,6 +347,36 @@ describe('CDN and stylesheet deduplication', () => {
     await tick()
 
     expect(document.querySelectorAll('script[data-scalar-astro-cdn="true"]')).toHaveLength(1)
+  })
+
+  it('loads a distinct CDN script when a later mount requests a different cdn', async () => {
+    // A previously-loaded Scalar bundle must not short-circuit a later mount
+    // whose `cdn` points at a different URL. The earlier code cached a single
+    // `cdnPromise` and returned early once any `window.Scalar` was set, so the
+    // second `cdn` was ignored — the wrong Scalar runtime would render against
+    // styles or version pins meant for the requested bundle.
+    const existingScript = document.createElement('script')
+    existingScript.dataset.scalarAstroCdn = 'true'
+    existingScript.dataset.loaded = 'true'
+    existingScript.src = 'https://cdn-a.example.com/api-reference.js'
+    document.head.appendChild(existingScript)
+    ;(window as unknown as { Scalar: unknown }).Scalar = {
+      createApiReference: vi.fn(() => ({ destroy: vi.fn() })),
+    }
+
+    seedLoadedStylesheet('https://cdn-b.example.com/style.css')
+    addMountElement('b', { url: '/b.json' }, 'https://cdn-b.example.com/api-reference.js')
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    const sources = Array.from(
+      document.querySelectorAll<HTMLScriptElement>('script[data-scalar-astro-cdn="true"]'),
+    ).map((s) => s.src)
+
+    expect(sources).toContain('https://cdn-a.example.com/api-reference.js')
+    expect(sources).toContain('https://cdn-b.example.com/api-reference.js')
   })
 })
 

--- a/integrations/astro/src/client.test.ts
+++ b/integrations/astro/src/client.test.ts
@@ -5,13 +5,23 @@ import { getStyleHref, initScalarAstro } from './client'
 const STATE_KEY = '__scalarAstroState'
 const DEFAULT_STYLE_HREF = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/dist/style.css'
 
+type RegistryEntry = { configuration: unknown; cdn: string | null }
+type RegistryWindow = { __scalarAstro?: { configs?: Record<string, RegistryEntry> } }
+
+const registerConfig = (id: string, entry: RegistryEntry) => {
+  const win = window as unknown as RegistryWindow
+  win.__scalarAstro ??= { configs: {} }
+  win.__scalarAstro.configs ??= {}
+  win.__scalarAstro.configs[id] = entry
+}
+
 const addMountElement = (id: string, configuration: object | null, cdn: string | null = null): HTMLElement => {
   const el = document.createElement('div')
   el.id = id
   el.setAttribute('data-scalar-mount', '')
 
   if (configuration !== null) {
-    el.setAttribute('data-scalar-config', JSON.stringify({ configuration, cdn }))
+    registerConfig(id, { configuration, cdn })
   }
 
   document.body.appendChild(el)
@@ -41,6 +51,7 @@ const resetEnvironment = () => {
   document.head.replaceChildren()
   delete (window as unknown as Record<string, unknown>)[STATE_KEY]
   delete (window as unknown as Record<string, unknown>).Scalar
+  delete (window as unknown as Record<string, unknown>).__scalarAstro
 }
 
 const tick = async () => {
@@ -118,7 +129,7 @@ describe('initScalarAstro', () => {
     expect(scalar.createApiReference).toHaveBeenCalledTimes(1)
   })
 
-  it('skips containers without a config attribute', async () => {
+  it('skips containers with no entry in the config registry', async () => {
     const el = document.createElement('div')
     el.id = 'a'
     el.setAttribute('data-scalar-mount', '')
@@ -131,18 +142,19 @@ describe('initScalarAstro', () => {
     expect(scalar.createApiReference).not.toHaveBeenCalled()
   })
 
-  it('skips containers with malformed JSON config', async () => {
-    const el = document.createElement('div')
-    el.id = 'a'
-    el.setAttribute('data-scalar-mount', '')
-    el.setAttribute('data-scalar-config', '{not valid json')
-    document.body.appendChild(el)
+  it('preserves function-valued config props through the registry', async () => {
+    const onLoaded = () => 'on-loaded'
+    const customFetch = (request: Request) => fetch(request)
+    addMountElement('a', { url: '/a.json', onLoaded, fetch: customFetch })
 
     initScalarAstro()
     document.dispatchEvent(new Event('astro:page-load'))
     await tick()
 
-    expect(scalar.createApiReference).not.toHaveBeenCalled()
+    expect(scalar.createApiReference).toHaveBeenCalledTimes(1)
+    const [, configurationPassed] = scalar.createApiReference.mock.calls[0] as [string, Record<string, unknown>]
+    expect(configurationPassed.onLoaded).toBe(onLoaded)
+    expect(configurationPassed.fetch).toBe(customFetch)
   })
 
   it.each([['javascript:alert(1)'], ['data:text/javascript,alert(1)'], ['vbscript:msgbox("x")']])(

--- a/integrations/astro/src/client.test.ts
+++ b/integrations/astro/src/client.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getStyleHref, initScalarAstro } from './client'
+
+const STATE_KEY = '__scalarAstroState'
+const DEFAULT_STYLE_HREF = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/dist/style.css'
+
+const addMountElement = (id: string, configuration: object | null, cdn: string | null = null): HTMLElement => {
+  const el = document.createElement('div')
+  el.id = id
+  el.setAttribute('data-scalar-mount', '')
+
+  if (configuration !== null) {
+    el.setAttribute('data-scalar-config', JSON.stringify({ configuration, cdn }))
+  }
+
+  document.body.appendChild(el)
+  return el
+}
+
+const seedLoadedStylesheet = (href: string = DEFAULT_STYLE_HREF) => {
+  const link = document.createElement('link')
+  link.rel = 'stylesheet'
+  link.href = href
+  link.dataset.scalarAstroStyle = 'true'
+  link.dataset.loaded = 'true'
+  document.head.appendChild(link)
+}
+
+const stubScalarGlobal = () => {
+  const destroy = vi.fn()
+  const createApiReference = vi.fn(() => ({ destroy }))
+  ;(window as unknown as { Scalar: { createApiReference: typeof createApiReference } }).Scalar = {
+    createApiReference,
+  }
+  return { createApiReference, destroy }
+}
+
+const resetEnvironment = () => {
+  document.body.replaceChildren()
+  document.head.replaceChildren()
+  delete (window as unknown as Record<string, unknown>)[STATE_KEY]
+  delete (window as unknown as Record<string, unknown>).Scalar
+}
+
+const tick = async () => {
+  // A few microtask flushes cover the `await ensureStylesLoaded` + `await ensureCdnLoaded` chain.
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('initScalarAstro', () => {
+  let scalar: { createApiReference: ReturnType<typeof vi.fn>; destroy: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    resetEnvironment()
+    seedLoadedStylesheet()
+    scalar = stubScalarGlobal()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('mounts each container on astro:page-load', async () => {
+    addMountElement('a', { url: '/a.json' })
+    addMountElement('b', { url: '/b.json' })
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(scalar.createApiReference).toHaveBeenCalledTimes(2)
+    expect(scalar.createApiReference).toHaveBeenCalledWith('#a', { url: '/a.json' })
+    expect(scalar.createApiReference).toHaveBeenCalledWith('#b', { url: '/b.json' })
+  })
+
+  it('destroys instances and clears the container on astro:before-swap', async () => {
+    const container = addMountElement('a', { url: '/a.json' })
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    // Simulate Scalar having rendered some children into the container.
+    container.appendChild(document.createElement('span'))
+    expect(container.children).toHaveLength(1)
+
+    document.dispatchEvent(new Event('astro:before-swap'))
+
+    expect(scalar.destroy).toHaveBeenCalledOnce()
+    expect(container.children).toHaveLength(0)
+  })
+
+  it('re-mounts on subsequent astro:page-load events', async () => {
+    addMountElement('a', { url: '/a.json' })
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+    document.dispatchEvent(new Event('astro:before-swap'))
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(scalar.createApiReference).toHaveBeenCalledTimes(2)
+    expect(scalar.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('is idempotent — calling initScalarAstro twice does not double-mount', async () => {
+    addMountElement('a', { url: '/a.json' })
+
+    initScalarAstro()
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(scalar.createApiReference).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips containers without a config attribute', async () => {
+    const el = document.createElement('div')
+    el.id = 'a'
+    el.setAttribute('data-scalar-mount', '')
+    document.body.appendChild(el)
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(scalar.createApiReference).not.toHaveBeenCalled()
+  })
+
+  it('skips containers with malformed JSON config', async () => {
+    const el = document.createElement('div')
+    el.id = 'a'
+    el.setAttribute('data-scalar-mount', '')
+    el.setAttribute('data-scalar-config', '{not valid json')
+    document.body.appendChild(el)
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(scalar.createApiReference).not.toHaveBeenCalled()
+  })
+
+  it('keeps unmounting other instances even if one destroy throws', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    addMountElement('a', { url: '/a.json' })
+    addMountElement('b', { url: '/b.json' })
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    // The first .destroy call throws, the second should still run.
+    scalar.destroy.mockImplementationOnce(() => {
+      throw new Error('boom')
+    })
+
+    document.dispatchEvent(new Event('astro:before-swap'))
+
+    expect(scalar.destroy).toHaveBeenCalledTimes(2)
+    expect(consoleSpy).toHaveBeenCalled()
+  })
+})
+
+describe('CDN and stylesheet deduplication', () => {
+  beforeEach(() => {
+    resetEnvironment()
+  })
+
+  it('appends only one stylesheet link when many containers mount in parallel', async () => {
+    // No preloaded stylesheet — the first mount drives the actual load.
+    for (let i = 0; i < 5; i++) {
+      addMountElement(`c${i}`, { url: '/x.json' })
+    }
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await Promise.resolve()
+
+    expect(document.querySelectorAll('link[data-scalar-astro-style="true"]')).toHaveLength(1)
+  })
+
+  it('appends only one CDN script when many containers mount in parallel', async () => {
+    // Seed the stylesheet so `ensureStylesLoaded` resolves synchronously and we
+    // can observe the CDN loader behavior. `window.Scalar` stays undefined so
+    // the CDN loader actually runs.
+    seedLoadedStylesheet()
+
+    for (let i = 0; i < 5; i++) {
+      addMountElement(`c${i}`, { url: '/x.json' })
+    }
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(document.querySelectorAll('script[data-scalar-astro-cdn="true"]')).toHaveLength(1)
+  })
+})
+
+describe('getStyleHref', () => {
+  it.each([
+    [
+      'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
+      'https://cdn.jsdelivr.net/npm/@scalar/api-reference/dist/style.css',
+    ],
+    [
+      'https://cdn.jsdelivr.net/npm/@scalar/api-reference/dist/browser/standalone.js',
+      'https://cdn.jsdelivr.net/npm/@scalar/api-reference/dist/style.css',
+    ],
+    ['https://example.com/foo/bar.js', 'https://example.com/foo/style.css'],
+    ['https://example.com/pkg/dist', 'https://example.com/pkg/dist/style.css'],
+    ['https://example.com/pkg/', 'https://example.com/pkg/dist/style.css'],
+    [
+      'https://cdn.jsdelivr.net/npm/@scalar/api-reference/dist/browser/standalone.js?v=1',
+      'https://cdn.jsdelivr.net/npm/@scalar/api-reference/dist/style.css',
+    ],
+    ['https://example.com/foo/bar.js?v=2', 'https://example.com/foo/style.css'],
+  ])('resolves %s to %s', (cdn, expected) => {
+    expect(getStyleHref(cdn)).toBe(expected)
+  })
+
+  it('falls back to the default CDN when given null', () => {
+    expect(getStyleHref(null)).toBe(DEFAULT_STYLE_HREF)
+  })
+})

--- a/integrations/astro/src/client.test.ts
+++ b/integrations/astro/src/client.test.ts
@@ -211,6 +211,55 @@ describe('CDN and stylesheet deduplication', () => {
     resetEnvironment()
   })
 
+  it('attaches to a still-loading same-href stylesheet instead of removing it', async () => {
+    // Pre-place a Scalar-marked stylesheet that has not finished loading yet.
+    // The bug was that the loader would remove this element mid-load.
+    const existingLink = document.createElement('link')
+    existingLink.rel = 'stylesheet'
+    existingLink.href = DEFAULT_STYLE_HREF
+    existingLink.dataset.scalarAstroStyle = 'true'
+    document.head.appendChild(existingLink)
+
+    ;(window as unknown as { Scalar: unknown }).Scalar = {
+      createApiReference: vi.fn(() => ({ destroy: vi.fn() })),
+    }
+
+    addMountElement('a', { url: '/a.json' })
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await Promise.resolve()
+
+    // The pre-placed link must survive untouched.
+    const links = document.querySelectorAll('link[data-scalar-astro-style="true"]')
+    expect(links).toHaveLength(1)
+    expect(links[0]).toBe(existingLink)
+
+    // Once the original link's load fires, the mount can proceed.
+    existingLink.dispatchEvent(new Event('load'))
+    await tick()
+    expect(existingLink.dataset.loaded).toBe('true')
+  })
+
+  it('replaces a Scalar stylesheet whose href no longer matches', async () => {
+    const stale = document.createElement('link')
+    stale.rel = 'stylesheet'
+    stale.href = 'https://old.example.com/dist/style.css'
+    stale.dataset.scalarAstroStyle = 'true'
+    stale.dataset.loaded = 'true'
+    document.head.appendChild(stale)
+
+    addMountElement('a', { url: '/a.json' }, 'https://new.example.com/dist/api-reference.js')
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await Promise.resolve()
+
+    const links = document.querySelectorAll('link[data-scalar-astro-style="true"]')
+    expect(links).toHaveLength(1)
+    expect(links[0]).not.toBe(stale)
+    expect(links[0].getAttribute('href')).toBe('https://new.example.com/dist/style.css')
+  })
+
   it('appends only one stylesheet link when many containers mount in parallel', async () => {
     // No preloaded stylesheet — the first mount drives the actual load.
     for (let i = 0; i < 5; i++) {

--- a/integrations/astro/src/client.test.ts
+++ b/integrations/astro/src/client.test.ts
@@ -111,6 +111,11 @@ describe('initScalarAstro', () => {
     document.dispatchEvent(new Event('astro:page-load'))
     await tick()
     document.dispatchEvent(new Event('astro:before-swap'))
+
+    // Simulate the new page's `is:inline` registration script repopulating the
+    // registry during the DOM swap, before `astro:page-load` fires.
+    registerConfig('a', { configuration: { url: '/a.json' }, cdn: null })
+
     document.dispatchEvent(new Event('astro:page-load'))
     await tick()
 
@@ -182,6 +187,27 @@ describe('initScalarAstro', () => {
     await tick()
 
     expect(scalar.createApiReference).toHaveBeenCalledWith(`#${CSS.escape('foo.bar:baz')}`, { url: '/x.json' })
+  })
+
+  it('does not leak instance state or registry entries across navigations', async () => {
+    const STATE_KEY_LOCAL = '__scalarAstroState'
+    initScalarAstro()
+
+    for (let i = 0; i < 100; i++) {
+      const id = `mount-${i}`
+      addMountElement(id, { url: `/${i}.json` })
+      document.dispatchEvent(new Event('astro:page-load'))
+      await tick()
+      document.dispatchEvent(new Event('astro:before-swap'))
+      // Simulate the next page's swap clearing out the old container.
+      document.getElementById(id)?.remove()
+    }
+
+    const state = (window as unknown as Record<string, { instances: Record<string, unknown> }>)[STATE_KEY_LOCAL]
+    const registry = (window as unknown as RegistryWindow).__scalarAstro?.configs ?? {}
+
+    expect(Object.keys(state.instances)).toHaveLength(0)
+    expect(Object.keys(registry)).toHaveLength(0)
   })
 
   it('keeps unmounting other instances even if one destroy throws', async () => {

--- a/integrations/astro/src/client.test.ts
+++ b/integrations/astro/src/client.test.ts
@@ -190,7 +190,6 @@ describe('initScalarAstro', () => {
   })
 
   it('does not leak instance state or registry entries across navigations', async () => {
-    const STATE_KEY_LOCAL = '__scalarAstroState'
     initScalarAstro()
 
     for (let i = 0; i < 100; i++) {
@@ -203,7 +202,7 @@ describe('initScalarAstro', () => {
       document.getElementById(id)?.remove()
     }
 
-    const state = (window as unknown as Record<string, { instances: Record<string, unknown> }>)[STATE_KEY_LOCAL]
+    const state = (window as unknown as Record<string, { instances: Record<string, unknown> }>)[STATE_KEY]
     const registry = (window as unknown as RegistryWindow).__scalarAstro?.configs ?? {}
 
     expect(Object.keys(state.instances)).toHaveLength(0)

--- a/integrations/astro/src/client.ts
+++ b/integrations/astro/src/client.ts
@@ -255,7 +255,8 @@ const destroyInstance = (state: GlobalState, selector: string): void => {
     }
   }
 
-  state.instances[selector] = null
+  // Callers either `delete` the key (`unmountAll`) or overwrite it with a
+  // fresh instance (`mountContainer`), so we do not need to null it here.
 
   const container = document.querySelector(selector)
 

--- a/integrations/astro/src/client.ts
+++ b/integrations/astro/src/client.ts
@@ -23,6 +23,9 @@ type ScalarGlobal = {
 type GlobalState = {
   instances: Record<string, ScalarApiReferenceInstance | null>
   initialized: boolean
+  cdnPromise: Promise<void> | null
+  stylePromise: Promise<void> | null
+  styleHref: string | null
 }
 
 type ScalarWindow = typeof window & {
@@ -38,14 +41,22 @@ type MountOptions = {
 
 const getGlobalState = (): GlobalState => {
   const win = window as ScalarWindow
-  win[stateKey] ??= { instances: {}, initialized: false }
-  return win[stateKey] as GlobalState
+  win[stateKey] ??= {
+    instances: {},
+    initialized: false,
+    cdnPromise: null,
+    stylePromise: null,
+    styleHref: null,
+  }
+  return win[stateKey]
 }
 
 /**
  * Resolve the stylesheet URL for a given Scalar CDN script URL.
+ *
+ * Exported for unit testing.
  */
-const getStyleHref = (cdn: string | null): string => {
+export const getStyleHref = (cdn: string | null): string => {
   const cdnUrl = (cdn ?? DEFAULT_CDN).replace(/\/$/, '')
 
   if (/\/dist\/browser\/[^/]+\.js(?:\?.*)?$/.test(cdnUrl)) {
@@ -63,19 +74,19 @@ const getStyleHref = (cdn: string | null): string => {
   return `${cdnUrl}/dist/style.css`
 }
 
-const ensureStylesLoaded = async (cdn: string | null): Promise<void> => {
-  const styleHref = getStyleHref(cdn)
-  const existing = document.querySelector<HTMLLinkElement>(`link[${STYLE_MARKER}="true"]`)
+const loadStylesheet = (styleHref: string): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    const existing = document.querySelector<HTMLLinkElement>(`link[${STYLE_MARKER}="true"]`)
 
-  if (existing?.getAttribute('href') === styleHref && existing.dataset.loaded === 'true') {
-    return
-  }
+    if (existing?.getAttribute('href') === styleHref && existing.dataset.loaded === 'true') {
+      resolve()
+      return
+    }
 
-  if (existing) {
-    existing.remove()
-  }
+    if (existing) {
+      existing.remove()
+    }
 
-  await new Promise<void>((resolve, reject) => {
     const link = document.createElement('link')
     link.rel = 'stylesheet'
     link.href = styleHref
@@ -91,16 +102,38 @@ const ensureStylesLoaded = async (cdn: string | null): Promise<void> => {
     link.addEventListener('error', () => reject(new Error('Failed to load Scalar CDN stylesheet')), { once: true })
     document.head.appendChild(link)
   })
-}
 
-const ensureCdnLoaded = async (cdn: string | null): Promise<void> => {
-  const win = window as ScalarWindow
+const ensureStylesLoaded = async (cdn: string | null): Promise<void> => {
+  const styleHref = getStyleHref(cdn)
+  const state = getGlobalState()
 
-  if (win.Scalar?.createApiReference) {
+  if (state.stylePromise && state.styleHref === styleHref) {
+    await state.stylePromise
     return
   }
 
-  await new Promise<void>((resolve, reject) => {
+  // Different href requested: wait for any in-flight load to settle first so
+  // we do not race against an older `<link>` element being removed.
+  if (state.stylePromise) {
+    try {
+      await state.stylePromise
+    } catch {
+      // ignore — we are about to replace the stylesheet anyway
+    }
+  }
+
+  state.styleHref = styleHref
+  state.stylePromise = loadStylesheet(styleHref).catch((error) => {
+    state.stylePromise = null
+    state.styleHref = null
+    throw error
+  })
+
+  await state.stylePromise
+}
+
+const loadCdn = (cdn: string | null): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
     const existing = document.querySelector<HTMLScriptElement>(`script[${CDN_MARKER}="true"]`)
 
     if (existing?.dataset.loaded === 'true') {
@@ -128,6 +161,22 @@ const ensureCdnLoaded = async (cdn: string | null): Promise<void> => {
     script.addEventListener('error', () => reject(new Error('Failed to load Scalar CDN script')), { once: true })
     document.head.appendChild(script)
   })
+
+const ensureCdnLoaded = async (cdn: string | null): Promise<void> => {
+  const win = window as ScalarWindow
+
+  if (win.Scalar?.createApiReference) {
+    return
+  }
+
+  const state = getGlobalState()
+
+  state.cdnPromise ??= loadCdn(cdn).catch((error) => {
+    state.cdnPromise = null
+    throw error
+  })
+
+  await state.cdnPromise
 }
 
 const readMountOptions = (container: HTMLElement): MountOptions | null => {
@@ -157,7 +206,11 @@ const destroyInstance = (state: GlobalState, selector: string): void => {
   const instance = state.instances[selector]
 
   if (instance?.destroy) {
-    instance.destroy()
+    try {
+      instance.destroy()
+    } catch (error) {
+      console.error('[scalar/astro] failed to destroy instance', error)
+    }
   }
 
   state.instances[selector] = null

--- a/integrations/astro/src/client.ts
+++ b/integrations/astro/src/client.ts
@@ -43,9 +43,19 @@ type GlobalState = {
   styleHref: string | null
 }
 
+type ClientConfigEntry = {
+  configuration?: unknown
+  cdn?: string | null
+}
+
+type AstroRegistry = {
+  configs?: Record<string, ClientConfigEntry>
+}
+
 type ScalarWindow = typeof window & {
   Scalar?: ScalarGlobal
   [stateKey]?: GlobalState
+  __scalarAstro?: AstroRegistry
 }
 
 type MountOptions = {
@@ -199,23 +209,19 @@ const readMountOptions = (container: HTMLElement): MountOptions | null => {
     return null
   }
 
-  const raw = container.dataset.scalarConfig
+  const win = window as ScalarWindow
+  const entry = win.__scalarAstro?.configs?.[container.id]
 
-  if (!raw) {
+  if (!entry) {
     return null
   }
 
-  try {
-    const parsed = JSON.parse(raw) as { configuration?: unknown; cdn?: string | null }
-    return {
-      // Escape the id so element ids containing CSS metacharacters (`.`, `:`,
-      // `[`, etc.) do not throw in `querySelector` or break selector-keyed state.
-      selector: `#${CSS.escape(container.id)}`,
-      configuration: parsed.configuration ?? {},
-      cdn: parsed.cdn ?? null,
-    }
-  } catch {
-    return null
+  return {
+    // Escape the id so element ids containing CSS metacharacters (`.`, `:`,
+    // `[`, etc.) do not throw in `querySelector` or break selector-keyed state.
+    selector: `#${CSS.escape(container.id)}`,
+    configuration: entry.configuration ?? {},
+    cdn: entry.cdn ?? null,
   }
 }
 

--- a/integrations/astro/src/client.ts
+++ b/integrations/astro/src/client.ts
@@ -11,6 +11,21 @@ const stateKey = '__scalarAstroState'
 const STYLE_MARKER = 'data-scalar-astro-style'
 const CDN_MARKER = 'data-scalar-astro-cdn'
 const DEFAULT_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
+const SAFE_PROTOCOLS = new Set(['http:', 'https:'])
+
+/**
+ * Reject CDN URLs that would let untrusted config execute code via
+ * `javascript:`, `data:`, or other non-http(s) schemes when assigned to
+ * `<script src>`. Defense in depth — the developer controls `cdn`, but a
+ * misconfiguration should fail closed rather than execute arbitrary code.
+ */
+const isSafeCdnUrl = (url: string): boolean => {
+  try {
+    return SAFE_PROTOCOLS.has(new URL(url, window.location.href).protocol)
+  } catch {
+    return false
+  }
+}
 
 type ScalarApiReferenceInstance = {
   destroy?: () => void
@@ -193,7 +208,9 @@ const readMountOptions = (container: HTMLElement): MountOptions | null => {
   try {
     const parsed = JSON.parse(raw) as { configuration?: unknown; cdn?: string | null }
     return {
-      selector: `#${container.id}`,
+      // Escape the id so element ids containing CSS metacharacters (`.`, `:`,
+      // `[`, etc.) do not throw in `querySelector` or break selector-keyed state.
+      selector: `#${CSS.escape(container.id)}`,
       configuration: parsed.configuration ?? {},
       cdn: parsed.cdn ?? null,
     }
@@ -226,6 +243,13 @@ const mountContainer = async (container: HTMLElement): Promise<void> => {
   const options = readMountOptions(container)
 
   if (!options) {
+    return
+  }
+
+  const cdnUrl = options.cdn ?? DEFAULT_CDN
+
+  if (!isSafeCdnUrl(cdnUrl)) {
+    console.error(`[scalar/astro] Refusing to load CDN with unsafe URL scheme: ${cdnUrl}`)
     return
   }
 

--- a/integrations/astro/src/client.ts
+++ b/integrations/astro/src/client.ts
@@ -39,7 +39,7 @@ type ScalarGlobal = {
 type GlobalState = {
   instances: Record<string, ScalarApiReferenceInstance | null>
   initialized: boolean
-  cdnPromise: Promise<void> | null
+  cdnPromises: Record<string, Promise<void>>
   stylePromise: Promise<void> | null
   styleHref: string | null
 }
@@ -70,7 +70,7 @@ const getGlobalState = (): GlobalState => {
   win[stateKey] ??= {
     instances: {},
     initialized: false,
-    cdnPromise: null,
+    cdnPromises: {},
     stylePromise: null,
     styleHref: null,
   }
@@ -176,9 +176,22 @@ const ensureStylesLoaded = async (cdn: string | null): Promise<void> => {
   await state.stylePromise
 }
 
-const loadCdn = (cdn: string | null): Promise<void> =>
+const findExistingCdnScript = (src: string): HTMLScriptElement | null => {
+  const scripts = document.querySelectorAll<HTMLScriptElement>(`script[${CDN_MARKER}="true"]`)
+
+  for (const script of scripts) {
+    // Compare resolved hrefs so relative and absolute forms of the same URL match.
+    if (script.src === new URL(src, window.location.href).href) {
+      return script
+    }
+  }
+
+  return null
+}
+
+const loadCdn = (src: string): Promise<void> =>
   new Promise<void>((resolve, reject) => {
-    const existing = document.querySelector<HTMLScriptElement>(`script[${CDN_MARKER}="true"]`)
+    const existing = findExistingCdnScript(src)
 
     if (existing?.dataset.loaded === 'true') {
       resolve()
@@ -192,7 +205,7 @@ const loadCdn = (cdn: string | null): Promise<void> =>
     }
 
     const script = document.createElement('script')
-    script.src = cdn ?? DEFAULT_CDN
+    script.src = src
     script.dataset.scalarAstroCdn = 'true'
     script.addEventListener(
       'load',
@@ -207,20 +220,19 @@ const loadCdn = (cdn: string | null): Promise<void> =>
   })
 
 const ensureCdnLoaded = async (cdn: string | null): Promise<void> => {
-  const win = window as ScalarWindow
-
-  if (win.Scalar?.createApiReference) {
-    return
-  }
-
+  const src = cdn ?? DEFAULT_CDN
   const state = getGlobalState()
 
-  state.cdnPromise ??= loadCdn(cdn).catch((error) => {
-    state.cdnPromise = null
+  // Track promises per resolved URL so a later mount with a different `cdn`
+  // (for example a version pin or a self-hosted bundle) actually loads its
+  // requested script instead of returning early because some other CDN
+  // already populated `window.Scalar`.
+  state.cdnPromises[src] ??= loadCdn(src).catch((error) => {
+    delete state.cdnPromises[src]
     throw error
   })
 
-  await state.cdnPromise
+  await state.cdnPromises[src]
 }
 
 const readMountOptions = (container: HTMLElement): MountOptions | null => {
@@ -310,13 +322,11 @@ const unmountAll = (): void => {
     delete state.instances[selector]
   }
 
-  // Clear the per-instance config registry too. The new page's `is:inline`
-  // registration scripts run during DOM swap (after this fires), so they
-  // repopulate the registry before `astro:page-load` triggers `mountAll`.
-  const win = window as ScalarWindow
-  if (win.__scalarAstro) {
-    win.__scalarAstro.configs = {}
-  }
+  // Intentionally do not clear `window.__scalarAstro.configs`. In static
+  // Starlight builds, Astro's ClientRouter executes identical inline scripts
+  // only once per session, so a previously-visited page's registration script
+  // does not re-run on revisit. Wiping the registry here would leave that
+  // page's mount with no entry and render blank until a full reload.
 }
 
 /**

--- a/integrations/astro/src/client.ts
+++ b/integrations/astro/src/client.ts
@@ -306,6 +306,15 @@ const unmountAll = (): void => {
 
   for (const selector of Object.keys(state.instances)) {
     destroyInstance(state, selector)
+    delete state.instances[selector]
+  }
+
+  // Clear the per-instance config registry too. The new page's `is:inline`
+  // registration scripts run during DOM swap (after this fires), so they
+  // repopulate the registry before `astro:page-load` triggers `mountAll`.
+  const win = window as ScalarWindow
+  if (win.__scalarAstro) {
+    win.__scalarAstro.configs = {}
   }
 }
 

--- a/integrations/astro/src/client.ts
+++ b/integrations/astro/src/client.ts
@@ -1,0 +1,226 @@
+/**
+ * Client-side mounting logic for the Astro integration.
+ *
+ * Each `<ScalarComponent renderMode="client" />` renders a container element
+ * tagged with `data-scalar-mount` and a JSON-encoded `data-scalar-config`. The
+ * single hoisted script in the component imports `initScalarAstro` to wire up
+ * the Astro view-transition lifecycle once per page.
+ */
+
+const stateKey = '__scalarAstroState'
+const STYLE_MARKER = 'data-scalar-astro-style'
+const CDN_MARKER = 'data-scalar-astro-cdn'
+const DEFAULT_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
+
+type ScalarApiReferenceInstance = {
+  destroy?: () => void
+}
+
+type ScalarGlobal = {
+  createApiReference?: (selector: string, configuration: unknown) => ScalarApiReferenceInstance
+}
+
+type GlobalState = {
+  instances: Record<string, ScalarApiReferenceInstance | null>
+  initialized: boolean
+}
+
+type ScalarWindow = typeof window & {
+  Scalar?: ScalarGlobal
+  [stateKey]?: GlobalState
+}
+
+type MountOptions = {
+  selector: string
+  configuration: unknown
+  cdn: string | null
+}
+
+const getGlobalState = (): GlobalState => {
+  const win = window as ScalarWindow
+  win[stateKey] ??= { instances: {}, initialized: false }
+  return win[stateKey] as GlobalState
+}
+
+/**
+ * Resolve the stylesheet URL for a given Scalar CDN script URL.
+ */
+const getStyleHref = (cdn: string | null): string => {
+  const cdnUrl = (cdn ?? DEFAULT_CDN).replace(/\/$/, '')
+
+  if (/\/dist\/browser\/[^/]+\.js(?:\?.*)?$/.test(cdnUrl)) {
+    return cdnUrl.replace(/\/dist\/browser\/[^/]+\.js(?:\?.*)?$/, '/dist/style.css')
+  }
+
+  if (/\.js(?:\?.*)?$/.test(cdnUrl)) {
+    return cdnUrl.replace(/\/[^/]+\.js(?:\?.*)?$/, '/style.css')
+  }
+
+  if (/\/dist$/.test(cdnUrl)) {
+    return `${cdnUrl}/style.css`
+  }
+
+  return `${cdnUrl}/dist/style.css`
+}
+
+const ensureStylesLoaded = async (cdn: string | null): Promise<void> => {
+  const styleHref = getStyleHref(cdn)
+  const existing = document.querySelector<HTMLLinkElement>(`link[${STYLE_MARKER}="true"]`)
+
+  if (existing?.getAttribute('href') === styleHref && existing.dataset.loaded === 'true') {
+    return
+  }
+
+  if (existing) {
+    existing.remove()
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const link = document.createElement('link')
+    link.rel = 'stylesheet'
+    link.href = styleHref
+    link.dataset.scalarAstroStyle = 'true'
+    link.addEventListener(
+      'load',
+      () => {
+        link.dataset.loaded = 'true'
+        resolve()
+      },
+      { once: true },
+    )
+    link.addEventListener('error', () => reject(new Error('Failed to load Scalar CDN stylesheet')), { once: true })
+    document.head.appendChild(link)
+  })
+}
+
+const ensureCdnLoaded = async (cdn: string | null): Promise<void> => {
+  const win = window as ScalarWindow
+
+  if (win.Scalar?.createApiReference) {
+    return
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(`script[${CDN_MARKER}="true"]`)
+
+    if (existing?.dataset.loaded === 'true') {
+      resolve()
+      return
+    }
+
+    if (existing) {
+      existing.addEventListener('load', () => resolve(), { once: true })
+      existing.addEventListener('error', () => reject(new Error('Failed to load Scalar CDN script')), { once: true })
+      return
+    }
+
+    const script = document.createElement('script')
+    script.src = cdn ?? DEFAULT_CDN
+    script.dataset.scalarAstroCdn = 'true'
+    script.addEventListener(
+      'load',
+      () => {
+        script.dataset.loaded = 'true'
+        resolve()
+      },
+      { once: true },
+    )
+    script.addEventListener('error', () => reject(new Error('Failed to load Scalar CDN script')), { once: true })
+    document.head.appendChild(script)
+  })
+}
+
+const readMountOptions = (container: HTMLElement): MountOptions | null => {
+  if (!container.id) {
+    return null
+  }
+
+  const raw = container.dataset.scalarConfig
+
+  if (!raw) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as { configuration?: unknown; cdn?: string | null }
+    return {
+      selector: `#${container.id}`,
+      configuration: parsed.configuration ?? {},
+      cdn: parsed.cdn ?? null,
+    }
+  } catch {
+    return null
+  }
+}
+
+const destroyInstance = (state: GlobalState, selector: string): void => {
+  const instance = state.instances[selector]
+
+  if (instance?.destroy) {
+    instance.destroy()
+  }
+
+  state.instances[selector] = null
+
+  const container = document.querySelector(selector)
+
+  if (container) {
+    container.replaceChildren()
+  }
+}
+
+const mountContainer = async (container: HTMLElement): Promise<void> => {
+  const options = readMountOptions(container)
+
+  if (!options) {
+    return
+  }
+
+  const state = getGlobalState()
+  destroyInstance(state, options.selector)
+
+  await ensureStylesLoaded(options.cdn)
+  await ensureCdnLoaded(options.cdn)
+
+  const win = window as ScalarWindow
+
+  if (!win.Scalar?.createApiReference) {
+    return
+  }
+
+  state.instances[options.selector] = win.Scalar.createApiReference(options.selector, options.configuration)
+}
+
+const mountAll = (): void => {
+  const containers = document.querySelectorAll<HTMLElement>('[data-scalar-mount]')
+
+  for (const container of containers) {
+    void mountContainer(container)
+  }
+}
+
+const unmountAll = (): void => {
+  const state = getGlobalState()
+
+  for (const selector of Object.keys(state.instances)) {
+    destroyInstance(state, selector)
+  }
+}
+
+/**
+ * Wire up Astro view-transition listeners that mount and unmount Scalar
+ * instances around page navigations. Safe to call multiple times - listeners
+ * are only attached once per page lifecycle.
+ */
+export const initScalarAstro = (): void => {
+  const state = getGlobalState()
+
+  if (state.initialized) {
+    return
+  }
+
+  state.initialized = true
+
+  document.addEventListener('astro:before-swap', unmountAll)
+  document.addEventListener('astro:page-load', mountAll)
+}

--- a/integrations/astro/src/client.ts
+++ b/integrations/astro/src/client.ts
@@ -1,10 +1,11 @@
 /**
  * Client-side mounting logic for the Astro integration.
  *
- * Each `<ScalarComponent renderMode="client" />` renders a container element
- * tagged with `data-scalar-mount` and a JSON-encoded `data-scalar-config`. The
- * single hoisted script in the component imports `initScalarAstro` to wire up
- * the Astro view-transition lifecycle once per page.
+ * Each `<ScalarComponent renderMode="client" />` renders a container marked
+ * with `data-scalar-mount` and emits a per-instance inline script that
+ * registers its config on `window.__scalarAstro.configs` keyed by mount id.
+ * The single hoisted script in the component calls `initScalarAstro` to wire
+ * up the Astro view-transition lifecycle once per page.
  */
 
 const stateKey = '__scalarAstroState'
@@ -103,11 +104,29 @@ const loadStylesheet = (styleHref: string): Promise<void> =>
   new Promise<void>((resolve, reject) => {
     const existing = document.querySelector<HTMLLinkElement>(`link[${STYLE_MARKER}="true"]`)
 
-    if (existing?.getAttribute('href') === styleHref && existing.dataset.loaded === 'true') {
-      resolve()
+    if (existing?.getAttribute('href') === styleHref) {
+      if (existing.dataset.loaded === 'true') {
+        resolve()
+        return
+      }
+      // Same href, still loading: attach to the in-flight element instead of
+      // removing it, otherwise we orphan the partial download and race against
+      // anyone else awaiting that load.
+      existing.addEventListener(
+        'load',
+        () => {
+          existing.dataset.loaded = 'true'
+          resolve()
+        },
+        { once: true },
+      )
+      existing.addEventListener('error', () => reject(new Error('Failed to load Scalar CDN stylesheet')), {
+        once: true,
+      })
       return
     }
 
+    // Different href: replace the previous Scalar stylesheet entirely.
     if (existing) {
       existing.remove()
     }

--- a/integrations/astro/src/serialize-client-config.test.ts
+++ b/integrations/astro/src/serialize-client-config.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import { serializeClientConfig } from './serialize-client-config'
+
+describe('serializeClientConfig', () => {
+  it('writes JSON-safe config as a JSON object literal', () => {
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: { url: '/a.json', theme: 'default' },
+      cdn: null,
+    })
+
+    expect(script).toContain('"mount-1"')
+    expect(script).toContain('configuration:{"url":"/a.json","theme":"default"}')
+    expect(script).toContain('cdn:null')
+  })
+
+  it('inlines top-level function-valued props as raw source', () => {
+    const onLoaded = function namedHandler() {
+      return 'hello'
+    }
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: { url: '/a.json', onLoaded },
+      cdn: null,
+    })
+
+    expect(script).toContain('"url":"/a.json"')
+    // The raw function source is present, not stripped to undefined like JSON.stringify would.
+    expect(script).toContain('"onLoaded":')
+    expect(script).toContain('namedHandler')
+    expect(script).toMatch(/return ['"]hello['"]/)
+  })
+
+  it('inlines arrays containing function entries', () => {
+    const plugin = function pluginFactory() {
+      return { name: 'fn-plugin' }
+    }
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: {
+        plugins: ['plain', plugin],
+      },
+      cdn: null,
+    })
+
+    expect(script).toContain('"plugins":["plain",')
+    expect(script).toContain('pluginFactory')
+  })
+
+  it('emits a config object when every prop is a function', () => {
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: { onLoaded: function namedHandler() {} },
+      cdn: null,
+    })
+
+    // Should not produce `{}` and then drop the function — the object literal
+    // must contain the function entry.
+    expect(script).toContain('configuration:{"onLoaded":')
+    expect(script).toContain('namedHandler')
+    expect(script).not.toContain('configuration:{}')
+  })
+
+  it('round-trips the cdn value via JSON', () => {
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: {},
+      cdn: 'https://example.com/scalar.js',
+    })
+
+    expect(script).toContain('cdn:"https://example.com/scalar.js"')
+  })
+
+  it('keys entries by the provided id', () => {
+    const a = serializeClientConfig({ key: 'a', configuration: {}, cdn: null })
+    const b = serializeClientConfig({ key: 'b-with-dashes', configuration: {}, cdn: null })
+
+    expect(a).toContain('configs["a"]')
+    expect(b).toContain('configs["b-with-dashes"]')
+  })
+
+  it('initializes the registry idempotently', () => {
+    const script = serializeClientConfig({ key: 'a', configuration: {}, cdn: null })
+
+    // Uses `||` so a second emission does not clobber the existing registry.
+    expect(script).toContain('window.__scalarAstro=window.__scalarAstro||{configs:{}}')
+  })
+})

--- a/integrations/astro/src/serialize-client-config.test.ts
+++ b/integrations/astro/src/serialize-client-config.test.ts
@@ -44,8 +44,7 @@ describe('serializeClientConfig', () => {
       cdn: null,
     })
 
-    expect(script).toContain('"plugins":["plain",')
-    expect(script).toContain('pluginFactory')
+    expect(script).toContain('"plugins": ["plain", function pluginFactory')
   })
 
   it('emits a config object when every prop is a function', () => {
@@ -57,9 +56,48 @@ describe('serializeClientConfig', () => {
 
     // Should not produce `{}` and then drop the function — the object literal
     // must contain the function entry.
-    expect(script).toContain('configuration:{"onLoaded":')
+    expect(script).toContain('configuration:{ "onLoaded":')
     expect(script).toContain('namedHandler')
     expect(script).not.toContain('configuration:{}')
+  })
+
+  it('escapes </script> in string config values so it cannot break out of the script tag', () => {
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: { content: '</script><img src=x onerror=alert(1)>' },
+      cdn: null,
+    })
+
+    // The escaped `<\/script` is parsed as the same string by the JS engine
+    // but does not match the HTML parser's end-tag scanner.
+    expect(script).not.toContain('</script')
+    expect(script).toContain('<\\/script')
+  })
+
+  it('escapes </script> in function source', () => {
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: {
+        onLoaded: function leak() {
+          return '</script>'
+        },
+      },
+      cdn: null,
+    })
+
+    expect(script).not.toContain('</script')
+    expect(script).toContain('<\\/script')
+  })
+
+  it('escapes </script> in the cdn URL', () => {
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: {},
+      cdn: 'https://evil.example.com/</script><img src=x>',
+    })
+
+    expect(script).not.toContain('</script')
+    expect(script).toContain('<\\/script')
   })
 
   it('round-trips the cdn value via JSON', () => {

--- a/integrations/astro/src/serialize-client-config.ts
+++ b/integrations/astro/src/serialize-client-config.ts
@@ -1,0 +1,57 @@
+/**
+ * Serialize a Scalar configuration object to a JavaScript expression string.
+ *
+ * Mirrors the function-preserving serialization used by `getScriptTags` in
+ * `@scalar/client-side-rendering`: top-level function-valued props (and
+ * arrays containing functions) are emitted as raw source via `Function#toString`
+ * instead of being silently dropped by `JSON.stringify`. This matters for
+ * config keys like `content`, `plugins`, `onLoaded`, and custom `fetch`.
+ */
+
+const serializeArrayWithFunctions = (arr: readonly unknown[]): string =>
+  `[${arr.map((item) => (typeof item === 'function' ? item.toString() : JSON.stringify(item))).join(',')}]`
+
+const serializeConfigObject = (config: Record<string, unknown>): string => {
+  const jsonSafe: Record<string, unknown> = { ...config }
+  const functionEntries: string[] = []
+
+  for (const [key, value] of Object.entries(config)) {
+    if (typeof value === 'function') {
+      functionEntries.push(`${JSON.stringify(key)}:${(value as (...args: unknown[]) => unknown).toString()}`)
+      delete jsonSafe[key]
+    } else if (Array.isArray(value) && value.some((item) => typeof item === 'function')) {
+      functionEntries.push(`${JSON.stringify(key)}:${serializeArrayWithFunctions(value)}`)
+      delete jsonSafe[key]
+    }
+  }
+
+  const json = JSON.stringify(jsonSafe)
+
+  if (functionEntries.length === 0) {
+    return json
+  }
+
+  if (json === '{}') {
+    return `{${functionEntries.join(',')}}`
+  }
+
+  // Inject function entries before the closing brace of the JSON object literal.
+  return `${json.slice(0, -1)},${functionEntries.join(',')}}`
+}
+
+type SerializeArgs = {
+  key: string
+  configuration: Record<string, unknown>
+  cdn: string | null
+}
+
+/**
+ * Build the inline-script body that registers a single Scalar mount config on
+ * the shared `window.__scalarAstro.configs` registry.
+ */
+export const serializeClientConfig = ({ key, configuration, cdn }: SerializeArgs): string => {
+  const keyLiteral = JSON.stringify(key)
+  const configLiteral = serializeConfigObject(configuration)
+  const cdnLiteral = JSON.stringify(cdn)
+  return `(window.__scalarAstro=window.__scalarAstro||{configs:{}}).configs[${keyLiteral}]={configuration:${configLiteral},cdn:${cdnLiteral}}`
+}

--- a/integrations/astro/src/serialize-client-config.ts
+++ b/integrations/astro/src/serialize-client-config.ts
@@ -1,43 +1,15 @@
 /**
- * Serialize a Scalar configuration object to a JavaScript expression string.
+ * Build the inline-script body that registers a single Scalar mount config on
+ * the shared `window.__scalarAstro.configs` registry.
  *
- * Mirrors the function-preserving serialization used by `getScriptTags` in
- * `@scalar/client-side-rendering`: top-level function-valued props (and
- * arrays containing functions) are emitted as raw source via `Function#toString`
- * instead of being silently dropped by `JSON.stringify`. This matters for
- * config keys like `content`, `plugins`, `onLoaded`, and custom `fetch`.
+ * Delegates the function-preserving + script-safe serialization of the config
+ * to `@scalar/client-side-rendering` so client mode and static mode stay in
+ * sync, then escapes the wrapper too because `key` and `cdn` are user
+ * controlled and could otherwise contain `</script>` or `<!--` sequences that
+ * break out of the surrounding inline script tag.
  */
 
-const serializeArrayWithFunctions = (arr: readonly unknown[]): string =>
-  `[${arr.map((item) => (typeof item === 'function' ? item.toString() : JSON.stringify(item))).join(',')}]`
-
-const serializeConfigObject = (config: Record<string, unknown>): string => {
-  const jsonSafe: Record<string, unknown> = { ...config }
-  const functionEntries: string[] = []
-
-  for (const [key, value] of Object.entries(config)) {
-    if (typeof value === 'function') {
-      functionEntries.push(`${JSON.stringify(key)}:${(value as (...args: unknown[]) => unknown).toString()}`)
-      delete jsonSafe[key]
-    } else if (Array.isArray(value) && value.some((item) => typeof item === 'function')) {
-      functionEntries.push(`${JSON.stringify(key)}:${serializeArrayWithFunctions(value)}`)
-      delete jsonSafe[key]
-    }
-  }
-
-  const json = JSON.stringify(jsonSafe)
-
-  if (functionEntries.length === 0) {
-    return json
-  }
-
-  if (json === '{}') {
-    return `{${functionEntries.join(',')}}`
-  }
-
-  // Inject function entries before the closing brace of the JSON object literal.
-  return `${json.slice(0, -1)},${functionEntries.join(',')}}`
-}
+import { escapeForInlineScript, serializeConfigToScript } from '@scalar/client-side-rendering'
 
 type SerializeArgs = {
   key: string
@@ -45,13 +17,11 @@ type SerializeArgs = {
   cdn: string | null
 }
 
-/**
- * Build the inline-script body that registers a single Scalar mount config on
- * the shared `window.__scalarAstro.configs` registry.
- */
 export const serializeClientConfig = ({ key, configuration, cdn }: SerializeArgs): string => {
   const keyLiteral = JSON.stringify(key)
-  const configLiteral = serializeConfigObject(configuration)
+  const configLiteral = serializeConfigToScript(configuration)
   const cdnLiteral = JSON.stringify(cdn)
-  return `(window.__scalarAstro=window.__scalarAstro||{configs:{}}).configs[${keyLiteral}]={configuration:${configLiteral},cdn:${cdnLiteral}}`
+  return escapeForInlineScript(
+    `(window.__scalarAstro=window.__scalarAstro||{configs:{}}).configs[${keyLiteral}]={configuration:${configLiteral},cdn:${cdnLiteral}}`,
+  )
 }

--- a/integrations/astro/vitest.config.ts
+++ b/integrations/astro/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
     environment: 'jsdom',
     include: ['src/**/*.test.ts'],
     root: fileURLToPath(new URL('./', import.meta.url)),
+    setupFiles: ['./vitest.setup.ts'],
   },
 })

--- a/integrations/astro/vitest.config.ts
+++ b/integrations/astro/vitest.config.ts
@@ -1,0 +1,11 @@
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts'],
+    root: fileURLToPath(new URL('./', import.meta.url)),
+  },
+})

--- a/integrations/astro/vitest.setup.ts
+++ b/integrations/astro/vitest.setup.ts
@@ -1,0 +1,54 @@
+// jsdom does not ship `CSS.escape`. Polyfill it for tests so code that relies
+// on it behaves as it would in any real browser.
+// Spec: https://drafts.csswg.org/cssom/#serialize-an-identifier
+const cssEscape = (value: string): string => {
+  const string = String(value)
+  const length = string.length
+  let result = ''
+
+  for (let index = 0; index < length; index++) {
+    const codeUnit = string.charCodeAt(index)
+
+    if (codeUnit === 0x0000) {
+      result += '�'
+      continue
+    }
+
+    if (
+      (codeUnit >= 0x0001 && codeUnit <= 0x001f) ||
+      codeUnit === 0x007f ||
+      (index === 0 && codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+      (index === 1 && codeUnit >= 0x0030 && codeUnit <= 0x0039 && string.charCodeAt(0) === 0x002d)
+    ) {
+      result += `\\${codeUnit.toString(16)} `
+      continue
+    }
+
+    if (index === 0 && length === 1 && codeUnit === 0x002d) {
+      result += `\\${string.charAt(index)}`
+      continue
+    }
+
+    if (
+      codeUnit >= 0x0080 ||
+      codeUnit === 0x002d ||
+      codeUnit === 0x005f ||
+      (codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+      (codeUnit >= 0x0041 && codeUnit <= 0x005a) ||
+      (codeUnit >= 0x0061 && codeUnit <= 0x007a)
+    ) {
+      result += string.charAt(index)
+      continue
+    }
+
+    result += `\\${string.charAt(index)}`
+  }
+
+  return result
+}
+
+if (typeof globalThis.CSS === 'undefined') {
+  ;(globalThis as unknown as { CSS: { escape: typeof cssEscape } }).CSS = { escape: cssEscape }
+} else if (typeof globalThis.CSS.escape !== 'function') {
+  globalThis.CSS.escape = cssEscape
+}

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -324,10 +324,7 @@
       "default": "./dist/v2/features/settings/index.js"
     }
   },
-  "files": [
-    "dist",
-    "CHANGELOG.md"
-  ],
+  "files": ["dist", "CHANGELOG.md"],
   "dependencies": {
     "@headlessui/tailwindcss": "catalog:*",
     "@headlessui/vue": "catalog:*",
@@ -370,6 +367,7 @@
   },
   "devDependencies": {
     "@scalar/pre-post-request-scripts": "workspace:*",
+    "@scalar/sdk": "catalog:*",
     "@tailwindcss/cli": "catalog:*",
     "@tailwindcss/vite": "catalog:*",
     "@types/shell-quote": "^1.7.5",
@@ -382,7 +380,6 @@
     "tailwindcss": "catalog:*",
     "vite": "catalog:*",
     "vite-svg-loader": "catalog:*",
-    "vitest": "catalog:*",
-    "@scalar/sdk": "catalog:*"
+    "vitest": "catalog:*"
   }
 }

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createSSRApp, h, nextTick } from 'vue'
 
 import ApiReference from '@/components/ApiReference.vue'
+
 import { createApiReference, createContainer, findDataAttributes, getConfigurationFromDataAttributes } from './html-api'
 
 vi.mock('@unhead/vue/client', async () => {
@@ -159,6 +160,26 @@ describe('createApiReference', () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       'scalar:update-references-config event has been deprecated, please use scalarInstance.updateConfiguration instead.',
     )
+  })
+
+  it('removes the deprecated document listeners on destroy', () => {
+    const element = document.querySelector('#mount-point')
+    const config = { _integration: 'html' }
+
+    const apiReference = createApiReference(element!, apiReferenceConfigurationSchema.parse(config))
+
+    consoleWarnSpy.mockClear()
+    apiReference.destroy()
+
+    document.dispatchEvent(new Event('scalar:reload-references'))
+    document.dispatchEvent(new Event('scalar:destroy-references'))
+    document.dispatchEvent(new CustomEvent('scalar:update-references-config', { detail: {} }))
+
+    // Listeners are scoped to the instance's `AbortController`, so dispatching
+    // these events after `destroy()` must not run their deprecation warnings —
+    // otherwise each remount during Astro view transitions would leak three
+    // permanent listeners on `document`.
+    expect(consoleWarnSpy).not.toHaveBeenCalled()
   })
 
   it('allows mounting after creation', async () => {

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -215,6 +215,16 @@ export const createApiReference: CreateApiReference = (
     }
   }
 
+  // Tie the deprecated `document` listeners to an AbortController so `destroy`
+  // can remove them all at once. Without this, every `createApiReference()`
+  // call leaks three permanent listeners — visible during Astro view
+  // transitions where each navigation creates a new instance.
+  const abortController = new AbortController()
+  const listenerOptions: AddEventListenerOptions = {
+    capture: false,
+    signal: abortController.signal,
+  }
+
   /**
    * Reload the API Reference
    * @deprecated
@@ -249,11 +259,12 @@ export const createApiReference: CreateApiReference = (
       app = createReferenceApp()
       app.mount(currentElement)
     },
-    false,
+    listenerOptions,
   )
 
   /** Destroy the current API Reference instance */
   const destroy = () => {
+    abortController.abort()
     props.configuration = {}
     app.unmount()
   }
@@ -268,7 +279,7 @@ export const createApiReference: CreateApiReference = (
       console.warn('scalar:destroy-references event has been deprecated, please use scalarInstance.destroy instead.')
       destroy()
     },
-    false,
+    listenerOptions,
   )
 
   /**
@@ -285,7 +296,7 @@ export const createApiReference: CreateApiReference = (
         Object.assign(props, ev.detail)
       }
     },
-    false,
+    listenerOptions,
   )
 
   const instance = {

--- a/packages/client-side-rendering/src/html-rendering.test.ts
+++ b/packages/client-side-rendering/src/html-rendering.test.ts
@@ -99,7 +99,7 @@ describe('html-rendering', () => {
           content: { foo: 'bar' },
         },
       })
-      expect(html).toContain('"url": "https://api.example.com/spec"')
+      expect(html).toContain('"url":"https://api.example.com/spec"')
       expect(html).not.toContain('"content"')
     })
 
@@ -173,8 +173,8 @@ describe('html-rendering', () => {
       }
 
       const tags = getScriptTags(config, 'https://example.com/script.js')
-      expect(tags).toContain('"tagsSorter": "alpha"')
-      expect(tags).toContain('"operationsSorter": "method"')
+      expect(tags).toContain('"tagsSorter":"alpha"')
+      expect(tags).toContain('"operationsSorter":"method"')
     })
 
     it('generates complete HTML document with configuration', () => {
@@ -208,7 +208,7 @@ describe('html-rendering', () => {
       expect(html).toContain('<script src="https://example.com/script.js"></script>')
 
       // Check that configuration is properly embedded
-      expect(html).toContain('"theme": "kepler"')
+      expect(html).toContain('"theme":"kepler"')
       expect(html).toContain('"tagsSorter": (a, b) => a.name.localeCompare(b.name)')
       // Check the onLoaded callback is included (whitespace may vary)
       expect(html).toContain('"onLoaded":')
@@ -225,7 +225,7 @@ describe('html-rendering', () => {
       const tags = getScriptTags(config, 'https://example.com/script.js')
 
       // Check that non-function properties are JSON stringified
-      expect(tags).toContain('"theme": "kepler"')
+      expect(tags).toContain('"theme":"kepler"')
       // Check that function properties are preserved
       expect(tags).toContain('"tagsSorter": (a, b) => a.name.localeCompare(b.name)')
       expect(tags).toContain('"onLoaded": () => console.log("loaded")')
@@ -262,11 +262,11 @@ describe('html-rendering', () => {
 
       const tags = getScriptTags(config, 'https://example.com/script.js')
 
-      expect(tags).toContain('"theme": "kepler"')
+      expect(tags).toContain('"theme":"kepler"')
       expect(tags).toContain('"onLoaded": () => console.log("loaded")')
-      expect(tags).toContain('{\n        "theme": "kepler",')
-      expect(tags).toContain('\n        "onLoaded": () => console.log("loaded")\n      }')
-      expect(tags).not.toContain('"theme": "kepler",,')
+      // Function entries are spliced before the closing brace of the JSON object literal.
+      expect(tags).toContain('{"theme":"kepler", "onLoaded": () => console.log("loaded")}')
+      expect(tags).not.toContain('"theme":"kepler",,')
     })
 
     it('preserves plugins array containing functions', () => {

--- a/packages/client-side-rendering/src/html-rendering.ts
+++ b/packages/client-side-rendering/src/html-rendering.ts
@@ -1,5 +1,7 @@
 import type { AnyApiReferenceConfiguration, HtmlRenderingConfiguration } from '@scalar/types/api-reference'
 
+import { escapeForInlineScript, serializeConfigToScript } from './serialize-config'
+
 export type { AnyApiReferenceConfiguration, HtmlRenderingConfiguration }
 
 const DEFAULT_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
@@ -103,50 +105,15 @@ export function renderApiReference(
 }
 
 /**
- * Helper function to serialize arrays that may contain functions
- */
-const serializeArrayWithFunctions = (arr: unknown[]): string => {
-  return `[${arr.map((item) => (typeof item === 'function' ? item.toString() : JSON.stringify(item))).join(', ')}]`
-}
-
-/**
  * The script tags to load the @scalar/api-reference package from the CDN.
  */
 export function getScriptTags(configuration: Record<string, unknown>, cdn?: string): string {
-  const restConfig = { ...configuration }
-
-  const functionProps: string[] = []
-
-  for (const [key, value] of Object.entries(configuration)) {
-    if (typeof value === 'function') {
-      functionProps.push(`"${key}": ${value.toString()}`)
-      delete restConfig[key]
-    } else if (Array.isArray(value) && value.some((item) => typeof item === 'function')) {
-      functionProps.push(`"${key}": ${serializeArrayWithFunctions(value)}`)
-      delete restConfig[key]
-    }
-  }
-
-  const jsonString = JSON.stringify(restConfig, null, 2)
-  const indentedJsonString = jsonString
-    .split('\n')
-    .map((line, index) => (index === 0 ? line : `      ${line}`))
-    .join('\n')
-
-  let configString = indentedJsonString
-
-  if (functionProps.length > 0) {
-    if (jsonString === '{}') {
-      configString = `{\n        ${functionProps.join(',\n        ')}\n      }`
-    } else {
-      const jsonWithoutClosingBrace = indentedJsonString.split('\n').slice(0, -1).join('\n')
-      configString = `${jsonWithoutClosingBrace},\n        ${functionProps.join(',\n        ')}\n      }`
-    }
-  }
+  const configString = serializeConfigToScript(configuration)
+  const cdnUrl = escapeForInlineScript(cdn ?? DEFAULT_CDN)
 
   return `
     <!-- Load the Script -->
-    <script src="${cdn ?? DEFAULT_CDN}"></script>
+    <script src="${cdnUrl}"></script>
 
     <!-- Initialize the Scalar API Reference -->
     <script type="text/javascript">

--- a/packages/client-side-rendering/src/index.ts
+++ b/packages/client-side-rendering/src/index.ts
@@ -1,7 +1,8 @@
 export {
+  type AnyApiReferenceConfiguration,
+  type HtmlRenderingConfiguration,
   getConfiguration,
   getScriptTags,
   renderApiReference,
-  type AnyApiReferenceConfiguration,
-  type HtmlRenderingConfiguration,
 } from './html-rendering'
+export { escapeForInlineScript, serializeConfigToScript } from './serialize-config'

--- a/packages/client-side-rendering/src/serialize-config.test.ts
+++ b/packages/client-side-rendering/src/serialize-config.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+
+import { escapeForInlineScript, serializeConfigToScript } from './serialize-config'
+
+describe('escapeForInlineScript', () => {
+  it('escapes lowercase </script>', () => {
+    expect(escapeForInlineScript('a</script>b')).toBe('a<\\/script>b')
+  })
+
+  it('escapes uppercase or mixed-case </script>', () => {
+    expect(escapeForInlineScript('a</SCRIPT>b')).toBe('a<\\/SCRIPT>b')
+    expect(escapeForInlineScript('a</ScRiPt>b')).toBe('a<\\/ScRiPt>b')
+  })
+
+  it('escapes <!-- so it cannot start an HTML comment', () => {
+    expect(escapeForInlineScript('a<!--b')).toBe('a<\\!--b')
+  })
+
+  it('leaves other content untouched', () => {
+    expect(escapeForInlineScript('regular text < > / \\')).toBe('regular text < > / \\')
+  })
+
+  it('is idempotent — escaping an already-escaped value does nothing', () => {
+    const once = escapeForInlineScript('</script><!--')
+    expect(escapeForInlineScript(once)).toBe(once)
+  })
+})
+
+describe('serializeConfigToScript', () => {
+  it('returns a JSON-safe object literal when no functions are present', () => {
+    expect(serializeConfigToScript({ url: '/a.json', theme: 'kepler' })).toBe('{"url":"/a.json","theme":"kepler"}')
+  })
+
+  it('inlines function-valued props as raw source', () => {
+    const result = serializeConfigToScript({
+      url: '/a.json',
+      onLoaded: function namedHandler() {
+        return 'hello'
+      },
+    })
+
+    expect(result).toContain('"url":"/a.json"')
+    expect(result).toContain('"onLoaded":')
+    expect(result).toContain('namedHandler')
+    expect(result).toMatch(/return ['"]hello['"]/)
+  })
+
+  it('preserves function entries inside arrays', () => {
+    const plugin = function pluginFactory() {
+      return { name: 'fn-plugin' }
+    }
+
+    const result = serializeConfigToScript({ plugins: ['plain', plugin] })
+
+    expect(result).toContain('"plugins": ["plain", function pluginFactory')
+  })
+
+  it('emits a valid object literal when every prop is a function', () => {
+    const result = serializeConfigToScript({
+      onLoaded: function namedHandler() {
+        return null
+      },
+    })
+
+    expect(result).toContain('"onLoaded":')
+    expect(result).toContain('namedHandler')
+    expect(result).not.toContain('{,')
+    expect(result).not.toMatch(/^\{}$/)
+  })
+
+  it('drops `undefined` props from the JSON portion (matches JSON.stringify semantics)', () => {
+    const result = serializeConfigToScript({ customCss: undefined, onLoaded: () => 1 })
+    expect(result).not.toContain('customCss')
+    expect(result).toContain('"onLoaded":')
+  })
+
+  it('escapes </script> in string values so it cannot terminate the inline script', () => {
+    const result = serializeConfigToScript({ content: '</script><img src=x onerror=alert(1)>' })
+
+    // Raw `</script` would close the surrounding <script> element. The escaped
+    // `<\/script` is parsed as the same string by the JS engine but does not
+    // match the HTML parser's end-tag scanner.
+    expect(result).not.toContain('</script')
+    expect(result).toContain('<\\/script')
+  })
+
+  it('escapes </script> inside function source', () => {
+    const onLoaded = function leak() {
+      // This source survives `Function#toString()` and would otherwise close
+      // the surrounding inline script.
+      return '</script><img src=x>'
+    }
+
+    const result = serializeConfigToScript({ onLoaded })
+
+    expect(result).not.toContain('</script')
+    expect(result).toContain('<\\/script')
+  })
+
+  it('escapes <!-- in user input', () => {
+    const result = serializeConfigToScript({ content: 'a<!--b' })
+
+    expect(result).not.toContain('<!--')
+    expect(result).toContain('<\\!--')
+  })
+})

--- a/packages/client-side-rendering/src/serialize-config.ts
+++ b/packages/client-side-rendering/src/serialize-config.ts
@@ -1,0 +1,55 @@
+/**
+ * Escape sequences that would let a value break out of an inline `<script>` tag.
+ *
+ * The HTML parser scans script bodies for `</script` (case-insensitive) and
+ * `<!--`. A user-controlled string in the configuration (for example
+ * `content`, a custom callback's source, or a CDN URL) that contains those
+ * sequences would terminate the script element early — leaving the trailing
+ * characters to be parsed as HTML and potentially executing injected markup.
+ *
+ * Inserting a backslash keeps the JavaScript string value identical (`\/` is
+ * just `/` to the JS engine) while preventing the HTML parser from matching
+ * the dangerous sequence.
+ */
+export const escapeForInlineScript = (source: string): string =>
+  source.replace(/<\/(script)/gi, '<\\/$1').replace(/<!--/g, '<\\!--')
+
+const serializeArrayWithFunctions = (arr: readonly unknown[]): string =>
+  `[${arr.map((item) => (typeof item === 'function' ? item.toString() : JSON.stringify(item))).join(', ')}]`
+
+/**
+ * Serialize a configuration object to a JavaScript expression string that can
+ * be safely embedded inside an inline `<script>` tag.
+ *
+ * - Preserves top-level function-valued props (and arrays containing
+ *   functions) by emitting raw source via `Function#toString` instead of
+ *   silently dropping them (which `JSON.stringify` would do).
+ * - Escapes any `</script` or `<!--` sequences in the result.
+ */
+export const serializeConfigToScript = (config: Record<string, unknown>): string => {
+  const jsonSafe: Record<string, unknown> = { ...config }
+  const functionEntries: string[] = []
+
+  for (const [key, value] of Object.entries(config)) {
+    if (typeof value === 'function') {
+      functionEntries.push(`${JSON.stringify(key)}: ${(value as (...args: unknown[]) => unknown).toString()}`)
+      delete jsonSafe[key]
+    } else if (Array.isArray(value) && value.some((item) => typeof item === 'function')) {
+      functionEntries.push(`${JSON.stringify(key)}: ${serializeArrayWithFunctions(value)}`)
+      delete jsonSafe[key]
+    }
+  }
+
+  const json = JSON.stringify(jsonSafe)
+
+  let result: string
+  if (functionEntries.length === 0) {
+    result = json
+  } else if (json === '{}') {
+    result = `{ ${functionEntries.join(', ')} }`
+  } else {
+    result = `${json.slice(0, -1)}, ${functionEntries.join(', ')}}`
+  }
+
+  return escapeForInlineScript(result)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -775,6 +775,12 @@ importers:
       astro:
         specifier: ^4.0.0 || ^5.0.0 || ^6.0.0
         version: 5.15.9(@netlify/blobs@9.1.2)(@types/node@24.10.13)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      jsdom:
+        specifier: catalog:*
+        version: 27.4.0(@noble/hashes@1.8.0)
+      vitest:
+        specifier: catalog:*
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))
 
   integrations/astro/playground:
     dependencies:
@@ -38515,7 +38521,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
@@ -38544,7 +38550,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
@@ -38573,7 +38579,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
@@ -38602,7 +38608,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
@@ -38631,7 +38637,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
@@ -38660,7 +38666,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2

--- a/projects/scalar-app/package.json
+++ b/projects/scalar-app/package.json
@@ -1,9 +1,16 @@
 {
   "name": "scalar-app",
   "description": "HTTP Client to play with any API",
+  "license": "MIT",
+  "author": "Scalar (https://github.com/scalar)",
+  "homepage": "https://github.com/scalar/scalar",
+  "bugs": "https://github.com/scalar/scalar/issues/new/choose",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/scalar/scalar.git",
+    "directory": "projects/scalar-app"
+  },
   "version": "1.0.8",
-  "author": "Copyright API Documentation Inc. 2026",
-  "license": "UNLICENSED",
   "private": true,
   "engines": {
     "node": ">=20"
@@ -16,9 +23,9 @@
     "dev:app": "electron-vite dev",
     "dev:app:update": "electron-vite dev -- --runtime-simulate-updates=update-available",
     "dev:web": "vite",
+    "lint:fix": "biome check --write --unsafe && pnpm eslint \"**/*.vue\" --fix",
     "preview:app": "electron-vite preview",
     "preview:web": "vite preview",
-    "lint:fix": "biome check --write --unsafe && pnpm eslint \"**/*.vue\" --fix",
     "test": "vitest",
     "test:e2e": "playwright test",
     "todesktop:build": "todesktop build",
@@ -33,13 +40,6 @@
   },
   "type": "module",
   "main": "./dist/main/index.js",
-  "homepage": "https://github.com/scalar/scalar",
-  "bugs": "https://github.com/scalar/scalar/issues/new/choose",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/scalar/scalar.git",
-    "directory": "projects/scalar-app"
-  },
   "dependencies": {
     "@electron-toolkit/utils": "^4.0.0",
     "@scalar/api-client": "workspace:*",

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -365,6 +365,10 @@
           "to": "/products/api-references/integrations/astro"
         },
         {
+          "from": "/scalar/scalar-api-references/integrations/starlight",
+          "to": "/products/api-references/integrations/starlight"
+        },
+        {
           "from": "/scalar/scalar-api-references/integrations/django",
           "to": "/products/api-references/integrations/django"
         },
@@ -1606,6 +1610,11 @@
                       "astro": {
                         "title": "Astro",
                         "filepath": "documentation/integrations/astro.md",
+                        "type": "page"
+                      },
+                      "starlight": {
+                        "title": "Starlight",
+                        "filepath": "documentation/integrations/starlight.md",
                         "type": "page"
                       },
                       "django": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Astro integration users running Starlight with View Transitions can hit a broken navigation flow where the API reference content does not render after client-side navigation unless the page is refreshed.

## Solution

- Add a new `renderMode` prop to `ScalarComponent`:
  - `static` (default): existing server-generated HTML behavior.
  - `client`: client-side mount mode tailored for Astro page transitions.
- In client mode, mount Scalar into a stable element id and wire lifecycle hooks:
  - mount on first load
  - destroy on `astro:before-swap`
  - re-mount on `astro:page-load`
- Reuse global state to avoid duplicate listeners/instances and cleanly remount on transitions.
- Load Scalar assets in client mode when needed:
  - Script from CDN (`@scalar/api-reference`)
  - Stylesheet URL derived from CDN with support for package root and browser bundle paths.
- Document Starlight/View Transitions usage in the Astro integration docs.
- Extend the Astro playground with a transition route (`/about`) and a client mode demo page for reproduction.

## Visual

<a href="https://cursor.com/agents/bc-47f1a5f0-7a73-49c2-ae30-bd31dcb82e84/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fastro_client_mode_view_transitions_fixed.mp4"><img src="https://cursor.com/artifacts/c/art-3ddb68ab-7e1e-4a9a-9c9f-7f24568c72bb" alt="astro_client_mode_view_transitions_fixed.mp4" /></a>
![Scalar client mode rendering after Astro transition navigation](https://cursor.com/artifacts/c/art-dd00a36e-47c2-4112-8d32-7c07533c0c5f)

## Validation Logs

[astro_client_repro_check.log](https://cursor.com/artifacts/c/art-06409223-24fd-4ad5-a8b2-c994ca77eece)

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47f1a5f0-7a73-49c2-ae30-bd31dcb82e84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47f1a5f0-7a73-49c2-ae30-bd31dcb82e84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

