### PR TITLE
chore(playwright): upgrade playwright to 1.59.1

### DIFF
--- a/.changeset/petite-ghosts-relate.md
+++ b/.changeset/petite-ghosts-relate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': patch
+---
+
+feat(helpers): add a helper playwright utilities

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
     needs: [build]
     runs-on: blacksmith-4vcpu-ubuntu-2204
     container:
-      image: scalarapi/playwright-runner:1.56.0
+      image: scalarapi/playwright-runner:1.59.1
       options: --privileged
       env:
         VM_ID: ${{ env.VM_ID }}
@@ -328,7 +328,7 @@ jobs:
     needs: [build]
     runs-on: blacksmith-4vcpu-ubuntu-2204
     container:
-      image: scalarapi/playwright-runner:1.56.0
+      image: scalarapi/playwright-runner:1.59.1
       options: --privileged
       env:
         VM_ID: ${{ env.VM_ID }}
@@ -379,7 +379,7 @@ jobs:
     needs: [build]
     runs-on: blacksmith-4vcpu-ubuntu-2204
     container:
-      image: scalarapi/playwright-runner:1.56.0
+      image: scalarapi/playwright-runner:1.59.1
       options: --privileged
       env:
         VM_ID: ${{ env.VM_ID }}
@@ -428,7 +428,7 @@ jobs:
     needs: [build]
     runs-on: blacksmith-8vcpu-ubuntu-2204
     container:
-      image: scalarapi/playwright-runner:1.56.0
+      image: scalarapi/playwright-runner:1.59.1
       options: --privileged
       env:
         VM_ID: ${{ env.VM_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,7 @@ jobs:
           report-tag: test-references-e2e
           footer: |
             > [!IMPORTANT]
-            > These tests include snapshots that may need to be updated if there are intentional changes to the UI components. To update the snapshots run `pnpm test:e2e:update` in `packages/api-reference` and commit the changes.
+            > These tests include snapshots that may need to be updated if there are intentional changes to the UI components. To update the snapshots run `pnpm test:e2e --update-snapshots` in `packages/api-reference` and commit the changes.
 
   test-component-snapshots:
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.head_ref == 'changeset-release/main' || github.head_ref == 'main'
@@ -474,7 +474,7 @@ jobs:
             > [!IMPORTANT]
             > These tests detect visual differences between the current PR and the latest CDN build which means **they may be affected by other changes in `main` that haven't been released yet**.
             >
-            > They can help determine if the changes in the PR are causing any unexpected visual regressions but may be less helpful in isolating the exact cause. For more details see the [readme](https://github.com/scalar/scalar/blob/main/packages/api-reference/test-snapshots/README.md).
+            > They can help determine if the changes in the PR are causing any unexpected visual regressions but may be less helpful in isolating the exact cause. For more details see the [readme](https://github.com/scalar/scalar/blob/main/packages/api-reference/test/snapshots-cdn/README.md).
 
   # ---------------------------------------------------------------------------------------------------------
   # Publish and deploy packages

--- a/packages/api-reference/playwright.config.ts
+++ b/packages/api-reference/playwright.config.ts
@@ -1,4 +1,5 @@
 import { type PlaywrightTestConfig, defineConfig } from '@playwright/test'
+import { getDockerServer } from '@scalar/helpers/playwright/docker'
 
 const IS_CDN = process.env.TEST_MODE === 'CDN'
 const CI = Boolean(process.env.CI)
@@ -48,20 +49,7 @@ export default defineConfig({
    * Outside of CI we run the playwright test server in a docker container for
    * consistent cross-platform results.
    */
-  webServer: CI
-    ? undefined
-    : {
-        name: 'Playwright',
-        command:
-          'docker run --name scalar-playwright --rm --platform linux/amd64 --entrypoint="playwright" --network=host scalarapi/playwright-runner:1.59.1 run-server --port 5001 --host 0.0.0.0',
-        url: 'http://localhost:5001',
-        timeout: 120 * 1000,
-        reuseExistingServer: !CI,
-        gracefulShutdown: {
-          signal: 'SIGINT',
-          timeout: 10 * 1000,
-        },
-      },
+  webServer: CI ? undefined : getDockerServer(),
   snapshotPathTemplate: '{testFileDir}/{testFileName}.snapshots/{arg}{ext}',
   expect: {
     toHaveScreenshot: {

--- a/packages/api-reference/playwright.config.ts
+++ b/packages/api-reference/playwright.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
     : {
         name: 'Playwright',
         command:
-          'docker run --name scalar-playwright --rm --entrypoint="playwright" --network=host scalarapi/playwright-runner:1.59.1 run-server --port 5001 --host 0.0.0.0',
+          'docker run --name scalar-playwright --rm --platform linux/amd64 --entrypoint="playwright" --network=host scalarapi/playwright-runner:1.59.1 run-server --port 5001 --host 0.0.0.0',
         url: 'http://localhost:5001',
         timeout: 120 * 1000,
         reuseExistingServer: !CI,

--- a/packages/api-reference/playwright.config.ts
+++ b/packages/api-reference/playwright.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
     : {
         name: 'Playwright',
         command:
-          'docker run --name scalar-playwright --rm --entrypoint="playwright" --network=host scalarapi/playwright-runner:1.56.0 run-server --port 5001 --host 0.0.0.0',
+          'docker run --name scalar-playwright --rm --entrypoint="playwright" --network=host scalarapi/playwright-runner:1.59.1 run-server --port 5001 --host 0.0.0.0',
         url: 'http://localhost:5001',
         timeout: 120 * 1000,
         reuseExistingServer: !CI,

--- a/packages/api-reference/test/README.md
+++ b/packages/api-reference/test/README.md
@@ -1,54 +1,49 @@
-# Scalar Reference End to End Testing
+# API reference end-to-end tests
 
-This directory contains end to end testing infrastructure for the API references package including automated snapshot testing using Playwright.
+Playwright tests for `@scalar/api-reference`: feature flows, configuration behavior, committed **visual snapshots**, and standalone layout checks.
 
 ## Overview
 
-The testing setup uses Playwright to capture visual snapshots of different parts of the API reference and to conduct end to end testing of it's features.
+- **Docker-backed browser** — Outside CI, tests connect to Playwright inside **`scalarapi/playwright-runner`** so fonts and rendering match Linux CI. See [`@scalar/helpers/playwright`](../../helpers/src/playwright/README.md).
+- **Serving examples** — Most tests get a URL from **`serveExample`** (`test/utils/serve-example.ts`), a **Hono** server that serves HTML plus the local standalone bundle. This is not the Vite dev playground; build the package before running E2E.
+- **Visual snapshots** — Under `test/snapshots/`, Playwright compares screenshots to images committed under each test’s `.snapshots` directory.
+- **CDN comparison** — A separate suite under [`test/snapshots-cdn/`](./snapshots-cdn/README.md) diffs local builds against the latest package on jsDelivr (`TEST_MODE=CDN`). It is optional context and **non-blocking** in CI.
 
-## How It Works
+## Prerequisites
 
-1. **Docker Container**: Playwright runs in a Docker container for consistent cross-platform results (and to be consistent with CI)
-2. **Visual Regression Detection**: Playwright compares screenshots against stored snapshots to detect changes
-3. **End to End test**: Playwright uses a hono server to test the configurations and features of the API references.
+1. Install dependencies and build upstream packages as usual for the monorepo.
+2. Ensure the **standalone browser bundle** exists (E2E loads `dist/browser/standalone.js`). From `packages/api-reference`, a full package build satisfies this.
 
-## Running Tests
+## Non-Linux / Docker networking
 
-### Non-Linux Systems
+On macOS or Windows, the runner container uses **`--network=host`**. Docker Desktop often does not support host networking; use an implementation that does (for example [OrbStack](https://orbstack.dev/)), or rely on CI for authoritative snapshot runs.
 
-On non-Linux systems (e.g. macOS, Windows) you need to access to a docker implementation that supports the `--network=host` flag. Docker Desktop on macOS and Windows does not support this flag so you will need to use an alternative such as [OrbStack](https://orbstack.dev/).
+## Running tests
 
-### Fetching the Image
-
-The tests run using the `scalarapi/playwright:1.56.0` Docker image. Sometimes the `test:e2e` script will not successfully pull the image (it looks like it does but it doesn't). You can force the pull by running:
-
-```bash
-pnpm test:e2e:playwright
-```
-
-### Local Development
-
-The Playwright browser is run in a Docker container to have consistent results with CI. In order to run the test locally or update snapshots you **must** have Docker set up on your system. 
+From `packages/api-reference`:
 
 ```bash
-# Run tests (starts Docker container automatically)
+# Default E2E (features, snapshots, configuration, standalone)
 pnpm test:e2e
 
-# Update snapshots
-pnpm test:e2e:update
+# Refresh committed baseline screenshots after intentional UI changes
+pnpm test:e2e --update-snapshots
 ```
 
-### Debugging Tests
-
-Run the playwright UI to debug your tests
+Debug with the Playwright UI:
 
 ```bash
-pnpm test:e2e:ui
+pnpm test:e2e --ui
 ```
 
-### CI/CD
+**CDN vs local** visual checks (different config; see `test/snapshots-cdn/README.md`):
 
-Tests run automatically in CI using the same Docker container for consistency. The CI environment:
-- Uses the containerized Playwright setup
-- Compares snapshots against committed baseline images
-- Fails the build if visual regressions are detected
+```bash
+pnpm test:e2e:cdn
+```
+
+## CI
+
+The **`test-e2e-api-reference`** job runs `pnpm --filter api-reference test:e2e:ci` inside `scalarapi/playwright-runner`. Snapshot and screenshot assertions are **blocking**: fix regressions or update baselines with `pnpm test:e2e:update-snapshots` and commit the changed images.
+
+The **CDN snapshot** job is separate, informational, and does not block merges.

--- a/packages/api-reference/test/snapshots-cdn/README.md
+++ b/packages/api-reference/test/snapshots-cdn/README.md
@@ -1,40 +1,31 @@
-# Scalar API Reference Snapshot Testing
+# CDN vs local snapshot tests
 
-This directory contains automated snapshot testing infrastructure for Scalar API References.
+This folder holds Playwright tests that compare **full-page screenshots** of the API reference when it loads **`@scalar/api-reference` from jsDelivr** versus when it loads the **standalone bundle built from your branch** (`https://cdn.jsdelivr.net/npm/@scalar/api-reference` vs local `scalar.js`).
 
-## Overview
+## Why this exists
 
-The testing setup uses Playwright to capture visual snapshots of different reference configuration and compares the snapshots of the current branch to snapshots of the CDN (`https://cdn.jsdelivr.net/npm/@scalar/api-reference`).
+Released npm assets and `main` can diverge, so a failing diff does not always mean your PR broke the UI. Treat results as a signal: unexpected changes are worth inspecting; noise from unreleased work elsewhere on `main` is normal.
 
-Because of variability between the latest released version and `main` there may be differences that are caused by other changes in `main` that aren't part of the current branch.
+## How it works
 
-## How It Works
+1. **HTML examples** — Tests use `serveExample` from `test/utils/serve-example.ts`: a small **Hono** app serves HTML from `@scalar/core`’s `getHtmlDocument`, either with a `cdn` URL (jsDelivr) or the local bundle from the package `browser` field (`dist/browser/standalone.js`).
+2. **Browser environment** — Locally, Playwright talks to **`scalarapi/playwright-runner`** via `PW_TEST_CONNECT_WS_ENDPOINT` (see [`@scalar/helpers/playwright`](../../../helpers/src/playwright/README.md)). CI runs the same image as the job container and uses `pnpm test:e2e:cdn:ci` (no separate Docker `webServer`).
+3. **Per test** — For each entry in `test/utils/sources`: open the CDN-backed page, wait for a stable body ARIA snapshot, capture a full-page PNG as the **expected** image; open the local-backed page, then `toHaveScreenshot` compares the local render to that PNG.
 
-1. **Vite Dev Server**: The tests run the Vite dev server hosting the `index.html` and `cdn.html` files.
-2. **Docker Container**: Playwright runs in a Docker container for consistent cross-platform results.
-3. **CDN Snapshot Generation**: A screenshot is taken of the current `CDN` rendered reference.
-4. **Visual Diff**: Playwright takes a screenshot of the local rendered reference and compares it to the CDN version.
+## Prerequisites
 
-## Running Tests
+Build `@scalar/api-reference` first so the standalone JavaScript bundle exists (same requirement as the rest of the package E2E tests).
 
-### Building Storybook
+## Running locally
 
-If you're not running the dev server Playwright will automatically run `pnpm dev`.
-
-### Local Development
-
-The Playwright browser is run in a Docker container to have consistent results with CI. In order to run the test locally you **must** have Docker set up on your system. 
+From `packages/api-reference`:
 
 ```bash
-# Run snapshot diff (starts Docker container automatically)
-pnpm test:e2e:snapshots
+pnpm test:e2e:cdn
 ```
 
-### CI/CD
+You need Docker (or a compatible runtime) that supports **`--network=host`** for the Playwright runner, same as the main E2E tests. Docker Desktop on macOS/Windows often does not; alternatives such as [OrbStack](https://orbstack.dev/) are commonly used.
 
-Tests run automatically in CI using the same Docker container for consistency. The CI environment:
-- Uses the containerized Playwright setup
-- Compares snapshots of the CDN to the current branch
+## CI
 
-> [!IMPORTANT]
-> These tests will not fail the CI build because the snapshots don't match.
+The **`test-cdn-snapshots`** workflow runs `pnpm --filter api-reference test:e2e:cdn:ci`. A custom reporter (`test/utils/ci-reporter.ts`) treats failures as **non-blocking** so mismatches do not fail the merge; HTML/JSON reports are still produced for review (including PR comments when configured).

--- a/packages/components/playwright.config.ts
+++ b/packages/components/playwright.config.ts
@@ -1,6 +1,5 @@
-import { type PlaywrightTestConfig, defineConfig } from '@playwright/test'
-
-type WebServer = PlaywrightTestConfig['webServer']
+import { defineConfig } from '@playwright/test'
+import { type WebServer, getDockerServer } from '@scalar/helpers/playwright/docker'
 
 const CI = !!process.env.CI
 
@@ -12,18 +11,7 @@ const isLinux = process.platform === 'linux' && !CI
  * This runs the playwright test browser(s) in a docker container to make sure
  * the tests are run in a consistent environment locally and in CI.
  */
-const playwrightServer: WebServer = {
-  name: 'Playwright',
-  command:
-    'docker run --name scalar-playwright --rm --platform linux/amd64 --entrypoint="playwright" --network=host scalarapi/playwright-runner:1.59.1 run-server --port 5001 --host 0.0.0.0',
-  url: 'http://localhost:5001',
-  timeout: 120 * 1000,
-  reuseExistingServer: !CI,
-  gracefulShutdown: {
-    signal: 'SIGTERM',
-    timeout: 10 * 1000,
-  },
-} as const
+const playwrightServer: WebServer = getDockerServer()
 
 /**
  * Storybook

--- a/packages/components/playwright.config.ts
+++ b/packages/components/playwright.config.ts
@@ -15,7 +15,7 @@ const isLinux = process.platform === 'linux' && !CI
 const playwrightServer: WebServer = {
   name: 'Playwright',
   command:
-    'docker run --name scalar-playwright --rm --entrypoint="playwright" --network=host scalarapi/playwright-runner:1.59.1 run-server --port 5001 --host 0.0.0.0',
+    'docker run --name scalar-playwright --rm --platform linux/amd64 --entrypoint="playwright" --network=host scalarapi/playwright-runner:1.59.1 run-server --port 5001 --host 0.0.0.0',
   url: 'http://localhost:5001',
   timeout: 120 * 1000,
   reuseExistingServer: !CI,

--- a/packages/components/playwright.config.ts
+++ b/packages/components/playwright.config.ts
@@ -15,7 +15,7 @@ const isLinux = process.platform === 'linux' && !CI
 const playwrightServer: WebServer = {
   name: 'Playwright',
   command:
-    'docker run --name scalar-playwright --rm --entrypoint="playwright" --network=host scalarapi/playwright-runner:1.56.0 run-server --port 5001 --host 0.0.0.0',
+    'docker run --name scalar-playwright --rm --entrypoint="playwright" --network=host scalarapi/playwright-runner:1.59.1 run-server --port 5001 --host 0.0.0.0',
   url: 'http://localhost:5001',
   timeout: 120 * 1000,
   reuseExistingServer: !CI,

--- a/packages/components/test/README.md
+++ b/packages/components/test/README.md
@@ -1,101 +1,75 @@
-# Scalar Components Testing
+# Scalar components — Playwright visual tests
 
-This directory contains the testing infrastructure for Scalar Components, specifically automated snapshot testing using Playwright.
+Playwright snapshot tests run against **Storybook**: each `*.e2e.ts` file opens stories in the browser and compares screenshots to images under a `snapshots/` folder next to that file (`snapshotPathTemplate` in `playwright.config.ts`).
 
 ## Overview
 
-The testing setup uses Playwright to capture visual snapshots of Storybook stories, ensuring visual consistency and catching regressions across all component variants. Each component can have multiple stories tested, and custom interaction tests can be added for components with dynamic behavior.
+1. **Storybook** — Locally, Playwright starts **`pnpm preview`**, which serves the **static build** from `storybook-static` (Vite preview, port **5100**). If `pnpm dev` is already running on that port, that server is reused (`reuseExistingServer`).
+2. **Docker browser** — Outside CI, tests connect to Playwright inside **`scalarapi/playwright-runner`** (version pinned in `@scalar/helpers` — see [`playwright/docker`](../../helpers/src/playwright/README.md)). CI runs inside the same image, so only the Storybook `webServer` runs there.
+3. **Regression detection** — `toHaveScreenshot` diffs against committed PNGs; CI fails when snapshots drift without an update.
 
-## How It Works
+## Non-Linux systems
 
-1. **Storybook Integration**: Tests run against the built Storybook static files
-2. **Docker Container**: Playwright runs in a Docker container for consistent cross-platform results
-3. **Snapshot Generation**: Screenshots are captured of each story and stored in component-specific `snapshots/` directories
-4. **Visual Regression Detection**: Playwright compares new screenshots against stored snapshots to detect changes
+The runner uses **`--network=host`** so the container can reach Storybook on the host. Docker Desktop on macOS and Windows often does not support host networking; use a runtime that does (for example [OrbStack](https://orbstack.dev/)), or rely on CI for authoritative runs.
 
-## Running Tests
+If pulls look fine but the image is wrong or stale, pull explicitly — see the helpers README for the tag to use (it tracks the workspace `@playwright/test` version).
 
-### Non-Linux Systems
+## Prerequisites
 
-On non-Linux systems (e.g. macOS, Windows) you need to access to a docker implementation that supports the `--network=host` flag. Docker Desktop on macOS and Windows does not support this flag so you will need to use an alternative such as [OrbStack](https://orbstack.dev/).
-
-### Fetching the Image
-
-The tests run using the `scalarapi/playwright:1.55.0` Docker image. The `test:e2e` script will not successfully pull the image (it looks like it does but it doesn't). You can force the pull by running:
-
-```bash
-pnpm test:e2e:playwright
-```
-
-### Building Storybook
-
-If you're not running the components dev server Playwright will automatically start serving the built Storybook files from `storybook-static`. This means **before running tests you have to run**,
+Build Storybook static assets before the first run (or whenever stories change):
 
 ```bash
 pnpm build:storybook
 ```
 
-It's recommend to run the tests against the built Storybook files rather than the dev server because that's what's used in CI and will yield the most accurate snapshots.
+Using the **built** output matches CI and avoids dev-only flakiness in snapshots.
 
-### Local Development
+## Running tests
 
-The Playwright browser is run in a Docker container to have consistent results with CI. In order to run the test locally or update snapshots you **must** have Docker set up on your system. 
+From `packages/components`:
 
 ```bash
-# Run tests (starts Docker container automatically)
+# Run all Playwright tests (starts Docker runner + Storybook preview unless already up)
 pnpm test:e2e
 
-# Run specific test file
-pnpm test:e2e ScalarCard.e2e.ts
+# Limit to one file (pass-through args after the script name)
+pnpm test:e2e -- src/components/ScalarCard/ScalarCard.e2e.ts
 
 # Update snapshots
 pnpm test:e2e --update-snapshots
 ```
 
-### Debugging Tests
-
-Run the playwright UI to debug your tests
+Debug with the Playwright UI:
 
 ```bash
-pnpm test:e2e:ui
+pnpm test:e2e --ui
 ```
 
-### CI/CD
+## CI
 
-Tests run automatically in CI using the same Docker container for consistency. The CI environment:
-- Uses the containerized Playwright setup
-- Compares snapshots against committed baseline images
-- Fails the build if visual regressions are detected
+The components snapshot job runs **`pnpm test:e2e:ci`** inside `scalarapi/playwright-runner`. Mismatched snapshots **fail** the build until you run `pnpm test:e2e:update` and commit the updated images.
 
 ## Contributing
 
-When adding new components or modifying existing ones:
+When adding or changing components:
 
-1. **Create test file**: Add `ComponentName.e2e.ts` with appropriate stories
-2. **Generate snapshots**: Run tests to create initial snapshots
-3. **Review snapshots**: Ensure they capture the intended visual state
-4. **Commit snapshots**: Include snapshot files in your pull request
-5. **Update on changes**: Regenerate snapshots when making visual modifications
+1. Add `ComponentName.e2e.ts` beside the component (or extend an existing file).
+2. Run `pnpm test:e2e` (or `:update`) and review generated PNGs under `snapshots/`.
+3. Commit snapshot changes with the code.
 
-The testing setup ensures that all visual changes are intentional and documented, maintaining the quality and consistency of the Scalar Components library.
-
-### Basic Component Test
-
-To capture a basic snapshots of your stories create an `.e2e.ts` file next to your component:
+### Basic snapshot test
 
 ```ts
 import { takeSnapshot, test } from '@test/helpers'
 
-test.describe('ScalarCard', 
-  () => ['Base', 'With Actions', 'Minimal']
-  // takeSnapshot is a simple test function that just take a single snapshot
-  .forEach((story) => test(story, takeSnapshot))
+test.describe('ScalarCard', () =>
+  ['Base', 'With Actions', 'Minimal'].forEach((story) => test(story, takeSnapshot)),
 )
 ```
 
-### Advanced Component Test with Interactions
+`takeSnapshot` is a small wrapper that calls the `snapshot` fixture once with no extra interaction.
 
-For components that require user interaction:
+### Interaction before capture
 
 ```ts
 import { test } from '@test/helpers'
@@ -103,34 +77,30 @@ import { test } from '@test/helpers'
 test.describe('ScalarDropdown', () =>
   ['Base', 'Custom Classes'].forEach((story) =>
     test(story, async ({ page, snapshot }) => {
-      // Open the dropdown
       await page.getByRole('button', { name: 'Click Me' }).click()
-      // Take a snapshot
       await snapshot()
     }),
-  ))
+  ),
+)
 ```
 
-### Fixtures and Options
+### Fixtures and `test.use`
 
-The test helper automatically tries to pull the component name and the story name from the describe block title and from the test title. If you want to use a different test title you can set the component name and story manually via [`test.use`](https://playwright.dev/docs/test-use-options#configuration-scopes).
+The helpers infer **component** from the nearest `test.describe` title and **story** from the `test` title when you do not set them explicitly. Override or tune behavior with [`test.use`](https://playwright.dev/docs/test-use-options#configuration-scopes).
 
-#### Available fixtures
+**Fixtures**
 
-Fixtures are accessible via the test context.
+- **`openStory`** — Navigates to the configured Storybook story (runs as a fixture dependency before your test body).
+- **`snapshot(suffix?)`** — Captures a screenshot with a normalized name (optional suffix for multiple shots per story).
 
-**`snapshot(suffix?)`**: Captures a screenshot named `story[-suffix].png` using the configured options.
+**Common options** (`test/helpers.ts`)
 
-#### Available options:
+- **`component`**, **`story`** — Storybook ids; inferred from titles when omitted.
+- **`args`** — Story args encoded into the Storybook URL.
+- **`scale`** — Device scale factor for screenshots (default **2**).
+- **`background`** — Whether to render with a background (default **false**).
+- **`crop`** — Crop to `#storybook-root > *` instead of full page (default **false**).
+- **`device`** — One of the emulated device keys defined in the helpers (`Chrome`, `Firefox`, etc.).
+- **`colorModes`** — `['light']`, `['dark']`, or `['light', 'dark']` for theme-specific captures.
 
-Options can be configured using [`test.use`](https://playwright.dev/docs/test-use-options#configuration-scopes).
-
-
-- **`component: string`**: The component name in Storybook, _inferred from the nearest `test.describe` title if not provided explicitly_.
-- **`story: string`**: The story name in Storybook, _inferred from the `test` title if not provided explicitly_.
-- **`scale: number`**: Device scale factor for crisp screenshots (default 2).
-- **`background: boolean`**: Render with background (default false).
-- **`crop: boolean`**: Crop to `#storybook-root > *` instead of full page (default false).
-
-
-
+Implementation details live in `test/helpers.ts`.

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -87,6 +87,11 @@
       "types": "./dist/object/*.d.ts",
       "default": "./dist/object/*.js"
     },
+    "./playwright/*": {
+      "import": "./dist/playwright/*.js",
+      "types": "./dist/playwright/*.d.ts",
+      "default": "./dist/playwright/*.js"
+    },
     "./regex/*": {
       "import": "./dist/regex/*.js",
       "types": "./dist/regex/*.d.ts",
@@ -119,6 +124,7 @@
   ],
   "sideEffects": false,
   "devDependencies": {
+    "@playwright/test": "catalog:*",
     "jsdom": "catalog:*",
     "vitest": "catalog:*"
   }

--- a/packages/helpers/src/playwright/README.md
+++ b/packages/helpers/src/playwright/README.md
@@ -1,0 +1,31 @@
+# Playwright helpers (`@scalar/helpers/playwright`)
+
+Shared Playwright utilities for Scalar packages. Today this folder is mainly the Docker-backed **test server** helper used so local E2E runs use the same browser environment as CI.
+
+## `getDockerServer` (`./docker`)
+
+Returns a Playwright [`webServer`](https://playwright.dev/docs/test-webserver) object that runs:
+
+```text
+docker run … scalarapi/playwright-runner:<version> run-server --port <port> --host 0.0.0.0
+```
+
+- **Image:** `scalarapi/playwright-runner` (Playwright’s published runner image), tagged with the same Playwright version the repo pins in `DEFAULT_PLAYWRIGHT_VERSION` in `docker.ts`. Keep that tag in sync with the workspace `@playwright/test` version.
+- **Platform:** `linux/amd64` so Apple Silicon machines still exercise the same stack CI uses on `amd64`.
+- **Why use it:** Browsers inside the container match Linux CI for fonts, rendering, and snapshot stability better than a native macOS/Windows install alone.
+
+### Docker and `--network=host`
+
+The command uses `--network=host` so the browser in the container can reach services listening on the host (Storybook, Vite, etc.). **Docker Desktop on macOS and Windows often does not support host networking.** Use a Docker implementation that does (for example [OrbStack](https://orbstack.dev/)), or rely on CI/Linux for authoritative snapshot runs.
+
+If pulls appear to succeed but the image is missing or stale, pull explicitly:
+
+```bash
+docker pull scalarapi/playwright-runner:<version>
+```
+
+Replace `<version>` with the value of `DEFAULT_PLAYWRIGHT_VERSION` in `docker.ts` (or the `version` you pass into `getDockerServer`).
+
+### Overrides
+
+`getDockerServer({ ... })` merges any extra `webServer` fields (for example `reuseExistingServer: !CI`) onto the returned object.

--- a/packages/helpers/src/playwright/docker.ts
+++ b/packages/helpers/src/playwright/docker.ts
@@ -1,0 +1,43 @@
+import type { FullConfig } from '@playwright/test'
+
+export type WebServer = NonNullable<FullConfig['webServer']>
+
+/** Default playwright version */
+export const DEFAULT_PLAYWRIGHT_VERSION = '1.59.1'
+
+/** Options for getting a docker server */
+type GetDockerServerOptions = {
+  version: string
+  port: number
+} & Partial<WebServer>
+
+/** Default options for getting a docker server */
+const DEFAULT_OPTS = {
+  version: DEFAULT_PLAYWRIGHT_VERSION,
+  port: 5001,
+} as const satisfies GetDockerServerOptions
+
+/**
+ * Builds a Playwright {@link https://playwright.dev/docs/test-webserver | webServer} config
+ * that starts the browser-side `playwright run-server` inside
+ * {@link https://hub.docker.com/r/scalarapi/playwright-runner | `scalarapi/playwright-runner`}.
+ *
+ * **Important:** The `version` must stay aligned with the workspace `@playwright/test` major/minor
+ * so the client and container speak the same protocol.
+ */
+export const getDockerServer = (opts: Partial<GetDockerServerOptions> = {}): WebServer => {
+  const { version, port, ...rest } = { ...DEFAULT_OPTS, ...opts }
+  return {
+    name: 'Playwright',
+    command: `docker run --name scalar-playwright --rm --platform linux/amd64 --entrypoint="playwright" --network=host scalarapi/playwright-runner:${version} run-server --port ${port} --host 0.0.0.0`,
+    url: `http://localhost:${port}`,
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+    gracefulShutdown: {
+      signal: 'SIGTERM',
+      timeout: 10 * 1000,
+    },
+    // Apply any additional option overrides
+    ...rest,
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ catalogs:
       specifier: ^11.1.11
       version: 11.1.11
     '@playwright/test':
-      specifier: 1.56.0
-      version: 1.56.0
+      specifier: 1.59.1
+      version: 1.59.1
     '@scalar/typebox':
       specifier: 0.1.3
       version: 0.1.3
@@ -279,7 +279,7 @@ importers:
         version: 4.4.1(@vue/compiler-sfc@3.5.30)(prettier@3.8.0)
       '@playwright/test':
         specifier: catalog:*
-        version: 1.56.0
+        version: 1.59.1
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^5.2.2
         version: 5.2.2(@vue/compiler-sfc@3.5.30)(prettier@3.8.0)(svelte@5.55.2)
@@ -515,7 +515,7 @@ importers:
         version: link:../../integrations/nextjs
       next:
         specifier: catalog:*
-        version: 15.5.10(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.10(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: catalog:*
         version: 19.2.3
@@ -1027,7 +1027,7 @@ importers:
         version: 6.0.1(vite@8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))
       next:
         specifier: catalog:*
-        version: 15.5.10(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.10(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: catalog:*
         version: 19.2.3
@@ -1461,7 +1461,7 @@ importers:
         version: 1.19.11(hono@4.12.9)
       '@playwright/test':
         specifier: catalog:*
-        version: 1.56.0
+        version: 1.59.1
       '@scalar/core':
         specifier: workspace:*
         version: link:../core
@@ -1666,7 +1666,7 @@ importers:
         version: 0.2.2(tailwindcss@4.2.1)
       '@playwright/test':
         specifier: catalog:*
-        version: 1.56.0
+        version: 1.59.1
       '@storybook/addon-docs':
         specifier: 10.3.5
         version: 10.3.5(@types/react@19.2.7)(esbuild@0.27.2)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.103.0(esbuild@0.27.2))
@@ -1907,7 +1907,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       next:
         specifier: catalog:*
-        version: 15.5.10(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.10(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
@@ -6821,13 +6821,8 @@ packages:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.56.0':
-    resolution: {integrity: sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  '@playwright/test@1.56.1':
-    resolution: {integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==}
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -14168,23 +14163,13 @@ packages:
     resolution: {integrity: sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==}
     engines: {node: '>=16.0.0'}
 
-  playwright-core@1.56.0:
-    resolution: {integrity: sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==}
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright-core@1.56.1:
-    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.56.0:
-    resolution: {integrity: sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.56.1:
-    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -23752,14 +23737,9 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@playwright/test@1.56.0':
+  '@playwright/test@1.59.1':
     dependencies:
-      playwright: 1.56.0
-
-  '@playwright/test@1.56.1':
-    dependencies:
-      playwright: 1.56.1
-    optional: true
+      playwright: 1.59.1
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -31761,7 +31741,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  next@15.5.10(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@15.5.10(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 15.5.10
       '@swc/helpers': 0.5.15
@@ -31780,7 +31760,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 15.5.7
       '@next/swc-win32-x64-msvc': 15.5.7
       '@opentelemetry/api': 1.9.0
-      '@playwright/test': 1.56.1
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -32994,23 +32974,13 @@ snapshots:
       pvutils: 1.1.5
       tslib: 2.8.1
 
-  playwright-core@1.56.0: {}
+  playwright-core@1.59.1: {}
 
-  playwright-core@1.56.1:
-    optional: true
-
-  playwright@1.56.0:
+  playwright@1.59.1:
     dependencies:
-      playwright-core: 1.56.0
+      playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
-
-  playwright@1.56.1:
-    dependencies:
-      playwright-core: 1.56.1
-    optionalDependencies:
-      fsevents: 2.3.2
-    optional: true
 
   plimit-lit@1.6.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1756,6 +1756,9 @@ importers:
 
   packages/helpers:
     devDependencies:
+      '@playwright/test':
+        specifier: catalog:*
+        version: 1.59.1
       jsdom:
         specifier: catalog:*
         version: 27.4.0(@noble/hashes@1.8.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,7 +33,7 @@ catalogs:
     '@nestjs/schematics': '^11.0.9'
     '@nestjs/swagger': '^7.3.1'
     '@nestjs/testing': '^11.1.11'
-    '@playwright/test': 1.56.0
+    '@playwright/test': 1.59.1
     '@scalar/typebox': 0.1.3
     '@tailwindcss/vite': ^4.2.0
     '@types/express': 5.0.3


### PR DESCRIPTION
Updates Playwright to version 1.59.1 and improves some of the docs. Also consolidates some logic into `@scalar/helpers/playwright`.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
