### PR TITLE
feat(api-client): rename initial draft request from "/" to "First Request"

### DIFF
--- a/.changeset/rename-initial-draft-request.md
+++ b/.changeset/rename-initial-draft-request.md
@@ -1,0 +1,11 @@
+---
+"@scalar/api-client": patch
+"@scalar/workspace-store": patch
+"@scalar/oas-utils": patch
+---
+
+feat: rename initial draft request from "/" to "First Request"
+
+- Added summary field "First Request" to the initial draft operation
+- Updated address bar to display empty state with placeholder "Enter a URL" when path is "/"
+- Improved user experience for new users by providing clearer initial state

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -421,7 +421,7 @@ defineExpose({
           :extensions="[addressBarScrollMargins]"
           importCurl
           :layout="layout"
-          :modelValue="path"
+          :modelValue="path === '/' ? '' : path"
           :placeholder="server ? '' : 'Enter a URL'"
           server
           @blur="handlePathBlur"

--- a/packages/api-client/src/v2/features/app/app-state.ts
+++ b/packages/api-client/src/v2/features/app/app-state.ts
@@ -364,7 +364,9 @@ export const createAppState = async ({
         },
         paths: {
           '/': {
-            get: {},
+            get: {
+              summary: 'First Request',
+            },
           },
         },
         'x-scalar-original-document-hash': 'drafts',

--- a/packages/oas-utils/src/migrations/migrate-to-indexdb.ts
+++ b/packages/oas-utils/src/migrations/migrate-to-indexdb.ts
@@ -254,7 +254,9 @@ export const transformLegacyDataToWorkspace = async (legacyData: {
               },
               paths: {
                 '/': {
-                  get: {},
+                  get: {
+                    summary: 'First Request',
+                  },
                 },
               },
               'x-scalar-icon': 'interface-edit-tool-pencil',
@@ -268,7 +270,7 @@ export const transformLegacyDataToWorkspace = async (legacyData: {
           // Make sure the drafts document has a GET / route cuz that's the first route we navigate the user to
           drafts.paths ??= {}
           drafts.paths['/'] ??= {}
-          drafts.paths['/']['get'] ??= {}
+          drafts.paths['/']['get'] ??= { summary: 'First Request' }
         }
 
         store.buildSidebar(DRAFTS_DOCUMENT_NAME)

--- a/packages/workspace-store/src/mutators/document.test.ts
+++ b/packages/workspace-store/src/mutators/document.test.ts
@@ -464,7 +464,7 @@ describe('createEmptyDocument', () => {
     expect(document?.openapi).toBe('3.1.0')
     expect(document?.info.title).toBe('my-api')
     expect(document?.info.version).toBe('1.0.0')
-    expect(document?.paths).toEqual({ '/': { get: {} } })
+    expect(document?.paths).toEqual({ '/': { get: { summary: 'First Request' } } })
     expect(document?.['x-scalar-icon']).toBe('api-icon')
     expect(callback).toHaveBeenCalledWith(true)
   })

--- a/packages/workspace-store/src/mutators/document.ts
+++ b/packages/workspace-store/src/mutators/document.ts
@@ -112,7 +112,9 @@ export const createEmptyDocument = async (
       info: { title: payload.name, version: '1.0.0' },
       paths: {
         '/': {
-          get: {},
+          get: {
+            summary: 'First Request',
+          },
         },
       },
       'x-scalar-icon': payload.icon,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When users create a new workspace in the Scalar API Client, the initial draft request is displayed as "/" in the sidebar and shows "/" in the address bar. This is not user-friendly because:
- "/" is not a meaningful name for a request
- The address bar showing "/" suggests there's a path configured when the user should see an empty state ready for input

## Solution

- Added a `summary` field with value "First Request" to the initial draft operation, so the sidebar displays "First Request" instead of "/"
- Updated the address bar to display an empty state with the placeholder "Enter a URL" when the path is "/", providing a cleaner starting experience for new users

## Visual

**Sidebar showing "First Request" instead of "/":**

![Sidebar showing First Request](https://cursor.com/artifacts/c/art-489496ea-954d-4cb7-8af8-6c68b07bf757)

**Demo video:**

<a href="https://cursor.com/agents/bc-0f6d2554-0184-5fec-be96-9c12a5feda66/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffirst_request_demo.mp4"><img src="https://cursor.com/artifacts/c/art-9be2a713-cf12-48c0-858e-8c8aa7598b09" alt="first_request_demo.mp4" /></a>

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Fixes DOC-5251
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07RNPTKCB1/p1776986572900829?thread_ts=1776986572.900829&cid=C07RNPTKCB1)

<div><a href="https://cursor.com/agents/bc-0f6d2554-0184-5fec-be96-9c12a5feda66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f6d2554-0184-5fec-be96-9c12a5feda66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

