### PR TITLE
feat(api-client): add the app header with the workspace switcher

### DIFF
--- a/.changeset/flat-llamas-stop.md
+++ b/.changeset/flat-llamas-stop.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': minor
+---
+
+feat: add app header

--- a/packages/api-client/playground/web/index.html
+++ b/packages/api-client/playground/web/index.html
@@ -34,10 +34,6 @@
     </style>
   </head>
   <body class="scalar-app">
-    <header class="h-header bg-b-1 border-b">
-      Playground only placeholder &bull; Web header and menu will be injected
-      here
-    </header>
     <div
       id="scalar-client"
       class="scalar-client"></div>

--- a/packages/api-client/src/v2/features/app/App.vue
+++ b/packages/api-client/src/v2/features/app/App.vue
@@ -9,6 +9,7 @@ export default {}
 
 <script setup lang="ts">
 import {
+  ScalarMenuWorkspacePicker,
   ScalarTeleportRoot,
   useModal,
   type ModalState,
@@ -20,6 +21,7 @@ import { computed, onBeforeUnmount, toValue, watch } from 'vue'
 import { RouterView } from 'vue-router'
 
 import { SidebarToggle } from '@/v2/components/sidebar'
+import AppHeader from '@/v2/features/app/components/AppHeader.vue'
 import CreateWorkspaceModal from '@/v2/features/app/components/CreateWorkspaceModal.vue'
 import SplashScreen from '@/v2/features/app/components/SplashScreen.vue'
 import type { RouteProps } from '@/v2/features/app/helpers/routes'
@@ -62,6 +64,18 @@ defineSlots<{
    * This slot is used to render custom actions or components within the create workspace modal.
    */
   'create-workspace'?: (payload: { state: ModalState }) => unknown
+  /**
+   * Slot for customizing the menu items section of the app header.
+   * Defaults to a workspace picker bound to the current app state. Overriding this slot
+   * replaces the default picker entirely, so the consumer is responsible for rendering
+   * any workspace switcher (or other menu content) they need.
+   */
+  'header-menu-items'?: () => unknown
+  /**
+   * Slot for customizing the end section of the app header.
+   * Typically used for user menus, action buttons, or other trailing controls.
+   */
+  'header-end'?: () => unknown
 }>()
 
 defineExpose({
@@ -208,6 +222,20 @@ const routerViewProps = computed<RouteProps>(() => {
           v-model="app.sidebar.isOpen.value"
           class="absolute z-60 md:hidden"
           :class="layout === 'desktop' ? 'top-14 left-4' : 'top-4 left-4'" />
+        <AppHeader>
+          <template #menuItems>
+            <slot name="header-menu-items">
+              <ScalarMenuWorkspacePicker
+                :modelValue="app.workspace.activeWorkspace.value?.id"
+                :workspaceOptions="app.workspace.workspaceGroups.value"
+                @createWorkspace="createWorkspaceModalState.show()"
+                @update:modelValue="(value) => setActiveWorkspace(value)" />
+            </slot>
+          </template>
+          <template #end>
+            <slot name="header-end" />
+          </template>
+        </AppHeader>
         <div class="flex min-h-0 flex-1 flex-row">
           <!-- App sidebar -->
           <AppSidebar

--- a/packages/api-client/src/v2/features/app/components/AppHeader.vue
+++ b/packages/api-client/src/v2/features/app/components/AppHeader.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import {
+  ScalarHeader,
+  ScalarMenu,
+  ScalarMenuResources,
+  ScalarMenuSection,
+} from '@scalar/components'
+
+const slots = defineSlots<{
+  /** Slot for customizing the menu items */
+  menuItems?(): unknown
+  /** Slot for customizing the end of the header */
+  end?(): unknown
+}>()
+</script>
+
+<template>
+  <ScalarHeader class="w-full pl-3 *:first:flex-none">
+    <template #start>
+      <ScalarMenu>
+        <template #sections>
+          <ScalarMenuSection>
+            <slot name="menuItems" />
+          </ScalarMenuSection>
+          <ScalarMenuResources />
+        </template>
+      </ScalarMenu>
+    </template>
+    <template #end>
+      <slots.end />
+    </template>
+  </ScalarHeader>
+</template>


### PR DESCRIPTION
This PR restores the workspace switcher that was lost after the new layout changes and replaces the placeholder with the actual header. It also introduces customizable slots, allowing package consumers to override specific parts of the header as needed.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout change that introduces a new header component and re-wires workspace switching via the existing state; main risk is minor visual/layout regressions in web/desktop rendering.
> 
> **Overview**
> Adds a real application header to the v2 API client and removes the playground’s placeholder header.
> 
> `App.vue` now renders a new `AppHeader` that includes a default `ScalarMenuWorkspacePicker` (restoring workspace switching) and exposes two new consumer override points via slots: `header-menu-items` and `header-end`.
> 
> Introduces `AppHeader.vue`, which wraps `@scalar/components` `ScalarHeader`/`ScalarMenu` and always includes the resources section, and adds a changeset bumping `@scalar/api-client` as a minor release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6692f5fa1c7afcc6d3ab4741d670b8ec6b44cd8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->