### PR TITLE
docs(api): add Scalar API SDK getting started guide

### DIFF
--- a/documentation/guides/api/getting-started.md
+++ b/documentation/guides/api/getting-started.md
@@ -58,6 +58,7 @@ const authedScalar = new Scalar({
 ## Notes
 
 - The exchange request itself can be made from a client constructed with no arguments (`new Scalar()`).
+- The exchanged access token is valid for 12 hours.
 - Timestamps are Unix seconds.
 
 ## Read more

--- a/documentation/guides/api/getting-started.md
+++ b/documentation/guides/api/getting-started.md
@@ -5,7 +5,7 @@ Use this guide to get started with the Scalar API SDK for TypeScript.
 ## Install
 
 ```bash
-pnpm add @scalar/sdk
+npm add @scalar/sdk
 ```
 
 ## Get a Scalar API key

--- a/documentation/guides/api/getting-started.md
+++ b/documentation/guides/api/getting-started.md
@@ -1,4 +1,66 @@
-# Getting Started
+# Scalar API SDK
 
-Reading this guide helps you to get started with our API. Everything you can do in our dashboard or apps can be done programatically through our API: Docs, Registry, Linting, Managing etc.
+Use this guide to get started with the Scalar API SDK for TypeScript.
+
+## Install
+
+```bash
+pnpm add @scalar/sdk
+```
+
+## Get a Scalar API key
+
+Create an API key in your Scalar account:
+
+- Dashboard: https://dashboard.scalar.com/account
+- Store it in `.env`, for example:
+
+```bash
+SCALAR_API_KEY=your_personal_token
+```
+
+## Exchange your API key for an access token
+
+The personal token is not an access token. Exchange it first with `postv1AuthExchange`.
+
+If you use the personal token directly for authenticated API calls, the API returns `401 Invalid authentication token`.
+
+```ts
+import { Scalar } from '@scalar/sdk'
+
+const scalar = new Scalar()
+
+const exchange = await scalar.auth.postv1AuthExchange({
+  personalToken: process.env.SCALAR_API_KEY!,
+})
+
+const accessToken = exchange.accessToken
+```
+
+## Use the access token
+
+Construct a second client with bearer auth. Use this authenticated client for API calls.
+
+```ts
+import { Scalar } from '@scalar/sdk'
+
+const scalar = new Scalar()
+
+const exchange = await scalar.auth.postv1AuthExchange({
+  personalToken: process.env.SCALAR_API_KEY!,
+})
+
+const authedScalar = new Scalar({
+  bearerAuth: exchange.accessToken,
+})
+```
+
+## Notes
+
+- The exchange request itself can be made from a client constructed with no arguments (`new Scalar()`).
+- Timestamps are Unix seconds.
+
+## Read more
+
+- [@scalar/sdk on npm](https://www.npmjs.com/package/@scalar/sdk)
 

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -2371,6 +2371,12 @@
                 "title": "Scalar API",
                 "icon": "phosphor/regular/database",
                 "mode": "nested"
+              },
+              "/api-sdk": {
+                "title": "Scalar API SDK",
+                "description": "Get started with the Scalar API SDK for TypeScript, including authentication token exchange.",
+                "type": "page",
+                "filepath": "documentation/guides/api/getting-started.md"
               }
             }
           },

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -2375,6 +2375,7 @@
               "/api-sdk": {
                 "title": "Scalar API SDK",
                 "description": "Get started with the Scalar API SDK for TypeScript, including authentication token exchange.",
+                "icon": "phosphor/regular/code",
                 "type": "page",
                 "filepath": "documentation/guides/api/getting-started.md"
               }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

There is no dedicated documentation page for getting started with the Scalar API SDK for TypeScript, especially around the required API key to access token exchange flow.

## Solution

- Added a new `Scalar API SDK` docs page at `documentation/guides/api/getting-started.md`.
- Documented installation using `npm add @scalar/sdk`.
- Documented API key setup in `.env`, and the required `scalar.auth.postv1AuthExchange({ personalToken })` call.
- Added guidance that using the personal token directly returns `401 Invalid authentication token`.
- Documented creating a second authenticated SDK client with `new Scalar({ bearerAuth: accessToken })`.
- Added the note that the exchanged access token is valid for 12 hours.
- Added the note that timestamps are Unix seconds and linked the npm package for further reference.
- Wired the page into docs navigation under `Tools` in `scalar.config.json` as `/tools/api-sdk`.
- Added an icon (`phosphor/regular/code`) for the new `Scalar API SDK` sidebar entry so it matches adjacent entries.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4b907b1-fc22-40f4-8f32-8f20a3563db8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4b907b1-fc22-40f4-8f32-8f20a3563db8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

