### PR TITLE
feat(workspace-store): simple AsyncAPI support

### DIFF
--- a/packages/agent-chat/src/helpers.ts
+++ b/packages/agent-chat/src/helpers.ts
@@ -12,9 +12,9 @@ import {
   getServers,
   mergeSecurity,
 } from '@scalar/workspace-store/request-example'
-import type { WorkspaceDocument } from '@scalar/workspace-store/schemas'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
-import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import type { OpenApiDocument, OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
 export function getOperations(doc: Partial<OpenAPIV3_1.Document>) {
   return Object.values(doc.paths ?? {}).flatMap((path) => Object.values(path ?? {})) as OperationObject[]
@@ -23,7 +23,7 @@ export function getOperations(doc: Partial<OpenAPIV3_1.Document>) {
 /** Flattens all security requirements from a document */
 function getSecurityFromDocument(
   documentName: string,
-  document: WorkspaceDocument,
+  document: OpenApiDocument,
   authStore: AuthStore,
 ): SecuritySchemeObjectSecret[] {
   const mergedSecurity = mergeSecurity(document?.components?.securitySchemes, {}, authStore, documentName)
@@ -42,22 +42,24 @@ function getSecurityFromDocument(
   return getSecuritySchemes(mergedSecurity, selectedSecurity.selectedSchemes[selectedSecurity.selectedIndex] ?? {})
 }
 
-/** Generate document settings from workspace store */
+/** Generate document settings from workspace store. AsyncAPI docs are skipped — this feature is OpenAPI-native. */
 export function createDocumentSettings(workspaceStore: WorkspaceStore) {
   return Object.fromEntries(
-    Object.entries(workspaceStore.workspace.documents).map(([key, document]) => {
-      const servers = getServers(document.servers, {
-        documentUrl: document?.['x-scalar-original-source-url'],
-      })
+    Object.entries(workspaceStore.workspace.documents)
+      .filter((entry): entry is [string, OpenApiDocument] => isOpenApiDocument(entry[1]))
+      .map(([key, document]) => {
+        const servers = getServers(document.servers, {
+          documentUrl: document['x-scalar-original-source-url'],
+        })
 
-      return [
-        key,
-        {
-          activeServer: getSelectedServer(document, null, null, servers),
-          securitySchemes: getSecurityFromDocument(key, document, workspaceStore.auth),
-        },
-      ]
-    }),
+        return [
+          key,
+          {
+            activeServer: getSelectedServer(document, null, null, servers),
+            securitySchemes: getSecurityFromDocument(key, document, workspaceStore.auth),
+          },
+        ]
+      }),
   )
 }
 

--- a/packages/agent-chat/src/views/Chat/Messages/AskForAuthentication.vue
+++ b/packages/agent-chat/src/views/Chat/Messages/AskForAuthentication.vue
@@ -6,6 +6,7 @@ import {
   getSelectedServer,
   getServers,
 } from '@scalar/workspace-store/request-example'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import type { ToolUIPart } from 'ai'
 import { computed, type Ref } from 'vue'
 
@@ -30,7 +31,8 @@ const document = computed(() => {
     return
   }
 
-  return workspaceStore.workspace.documents[documentName.value]
+  const doc = workspaceStore.workspace.documents[documentName.value]
+  return isOpenApiDocument(doc) ? doc : undefined
 })
 
 const environment = computed(() => {

--- a/packages/agent-chat/src/views/Settings/Auth.vue
+++ b/packages/agent-chat/src/views/Settings/Auth.vue
@@ -9,8 +9,10 @@ import {
   mergeSecurity,
 } from '@scalar/workspace-store/request-example'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
-import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-import type { WorkspaceDocument } from '@scalar/workspace-store/schemas/workspace'
+import type {
+  OpenApiDocument,
+  ServerObject,
+} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { useFocusWithin } from '@vueuse/core'
 import { computed, shallowRef, watch } from 'vue'
 
@@ -24,7 +26,7 @@ const { document, name, environment, eventBus, options, authStore } =
     >
     name: string
     authStore: AuthStore
-    document: WorkspaceDocument | undefined
+    document: OpenApiDocument | undefined
     eventBus: WorkspaceEventBus
     selectedServer: ServerObject | null
     environment: XScalarEnvironment

--- a/packages/agent-chat/src/views/Settings/DocSettings.vue
+++ b/packages/agent-chat/src/views/Settings/DocSettings.vue
@@ -4,7 +4,7 @@ import {
   getSelectedServer,
   getServers,
 } from '@scalar/workspace-store/request-example'
-import { type WorkspaceDocument } from '@scalar/workspace-store/schemas/workspace'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed } from 'vue'
 
 import ServerSelector from '@/components/ServerSelector.vue'
@@ -12,7 +12,7 @@ import { useState } from '@/state/state'
 import Auth from '@/views/Settings/Auth.vue'
 
 const { document, name } = defineProps<{
-  document: WorkspaceDocument
+  document: OpenApiDocument
   name: string
 }>()
 

--- a/packages/agent-chat/src/views/Settings/Settings.vue
+++ b/packages/agent-chat/src/views/Settings/Settings.vue
@@ -6,6 +6,7 @@ import {
   type ModalState,
 } from '@scalar/components'
 import { ScalarIconCaretDown, ScalarIconCaretRight } from '@scalar/icons'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 
 import { URLS } from '@/consts/urls'
 import { useState } from '@/state/state'
@@ -52,7 +53,11 @@ function selectDocument(name: string) {
               v-if="workspaceStore.workspace.activeDocument === document" />
             <ScalarIconCaretRight v-else />
           </button>
-          <div v-if="workspaceStore.workspace.activeDocument === document">
+          <div
+            v-if="
+              workspaceStore.workspace.activeDocument === document &&
+              isOpenApiDocument(document)
+            ">
             <DocSettings
               :document
               :name />

--- a/packages/api-client/src/v2/components/sidebar/Sidebar.vue
+++ b/packages/api-client/src/v2/components/sidebar/Sidebar.vue
@@ -13,6 +13,7 @@ import {
 } from '@scalar/sidebar'
 import type { WorkspaceDocument } from '@scalar/workspace-store/schemas'
 import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { computed, ref } from 'vue'
 
 import { Resize } from '@/v2/components/resize'
@@ -84,7 +85,9 @@ const isDraft = (item: TraversedEntry) => {
 }
 
 /** We handle search results out here so we can show them in the sidebar */
-const { query, results } = useSearchIndex(() => documents)
+const { query, results } = useSearchIndex(() =>
+  documents.filter(isOpenApiDocument),
+)
 
 /** We show either the search results or the sidebar items */
 const items = computed(() => results.value ?? sidebarState.items.value)

--- a/packages/api-client/src/v2/features/app/App.vue
+++ b/packages/api-client/src/v2/features/app/App.vue
@@ -18,6 +18,7 @@ import type { ClientPlugin } from '@scalar/oas-utils/helpers'
 import { ScalarToasts } from '@scalar/use-toasts'
 import { getWorkspaceId } from '@scalar/workspace-store/persistence'
 import { extensions } from '@scalar/workspace-store/schemas/extensions'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { computed, onBeforeUnmount, toValue, watch } from 'vue'
 import { RouterView } from 'vue-router'
 
@@ -203,9 +204,12 @@ const createWorkspaceModalState = useModal()
 
 /** Props to pass to the RouterView component. */
 const routerViewProps = computed<RouteProps>(() => {
+  // The API client is OpenAPI-native; AsyncAPI docs surface as `null` here so operation /
+  // collection views render their empty state instead of trying to read `.paths`.
+  const activeDocument = app.store.value?.workspace.activeDocument
   return {
     documentSlug: app.activeEntities.documentSlug.value ?? '',
-    document: app.store.value?.workspace.activeDocument ?? null,
+    document: isOpenApiDocument(activeDocument) ? activeDocument : null,
     environment: app.environment.value,
     eventBus: app.eventBus,
     exampleName: app.activeEntities.exampleName.value,

--- a/packages/api-client/src/v2/features/app/app-events.ts
+++ b/packages/api-client/src/v2/features/app/app-events.ts
@@ -1,6 +1,7 @@
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { OperationExampleMeta, WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { type ShallowRef, computed } from 'vue'
 import { type NavigationFailure, NavigationFailureType, type Router } from 'vue-router'
 
@@ -93,7 +94,8 @@ export function initializeAppEventHandlers({
             // Redirect to the new example if the mutation was successful
             if (status === 'success') {
               // Rebuild the sidebar with the updated order
-              rebuildSidebar(store.value?.workspace.activeDocument?.['x-scalar-navigation']?.name)
+              const activeDoc = store.value?.workspace.activeDocument
+              rebuildSidebar(isOpenApiDocument(activeDoc) ? activeDoc['x-scalar-navigation']?.name : undefined)
 
               // Now this redirect works for any example
               await router.replace({

--- a/packages/api-client/src/v2/features/app/app-state.ts
+++ b/packages/api-client/src/v2/features/app/app-state.ts
@@ -22,6 +22,7 @@ import { extensions } from '@scalar/workspace-store/schemas/extensions'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
 import type { Tab } from '@scalar/workspace-store/schemas/extensions/workspace/x-scalar-tabs'
 import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import {
   type ComputedRef,
   type MaybeRefOrGetter,
@@ -651,7 +652,10 @@ export const createAppState = async ({
     const order = activeStore.workspace['x-scalar-order'] ?? Object.keys(activeStore.workspace.documents)
 
     return sortByOrder(Object.keys(activeStore.workspace.documents), order, (item) => item)
-      .map((doc) => activeStore.workspace.documents[doc]?.['x-scalar-navigation'])
+      .map((doc) => {
+        const entry = activeStore.workspace.documents[doc]
+        return isOpenApiDocument(entry) ? entry['x-scalar-navigation'] : undefined
+      })
       .filter(isDefined) as TraversedEntry[]
   })
 
@@ -874,7 +878,9 @@ export const createAppState = async ({
    * consistent (e.g., after adding a new example via the UI).
    */
   const refreshSidebarAfterExampleCreation = (payload: OperationExampleMeta & { documentName?: string }) => {
-    const documentName = payload.documentName ?? activeDocument.value?.['x-scalar-navigation']?.name
+    const activeDoc = activeDocument.value
+    const documentName =
+      payload.documentName ?? (isOpenApiDocument(activeDoc) ? activeDoc['x-scalar-navigation']?.name : undefined)
     if (!documentName) {
       return
     }

--- a/packages/api-client/src/v2/features/app/components/AppSidebar.vue
+++ b/packages/api-client/src/v2/features/app/components/AppSidebar.vue
@@ -30,6 +30,7 @@ import {
 import { useToasts } from '@scalar/use-toasts'
 import { getParentEntry } from '@scalar/workspace-store/navigation'
 import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { computed, onBeforeMount, onBeforeUnmount, ref } from 'vue'
 
 import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
@@ -241,9 +242,10 @@ const handleAddEmptyFolder = (item: TraversedEntry) => {
     return
   }
 
+  const doc = store.workspace.documents[documentName]
   createTempOperation(documentName, {
     existingPaths: new Set(
-      Object.keys(store.workspace.documents[documentName]?.paths ?? {}),
+      Object.keys((isOpenApiDocument(doc) ? doc.paths : undefined) ?? {}),
     ),
     eventBus: app.eventBus,
     tags: tagName ? [tagName] : undefined,

--- a/packages/api-client/src/v2/features/app/components/AppSidebar.vue
+++ b/packages/api-client/src/v2/features/app/components/AppSidebar.vue
@@ -274,9 +274,10 @@ const handleCreateOperation = (item: SidebarDocumentItem) => {
     return
   }
 
+  const doc = store.workspace.documents[documentName]
   createTempOperation(documentName, {
     existingPaths: new Set(
-      Object.keys(store.workspace.documents[documentName]?.paths ?? {}),
+      Object.keys((isOpenApiDocument(doc) ? doc.paths : undefined) ?? {}),
     ),
     eventBus: app.eventBus,
   })
@@ -327,9 +328,13 @@ const searchModal = useModal()
 /**
  * The OpenAPI document currently selected in the workspace. The search modal
  * scopes its Fuse index to this document so results never leak across
- * collections.
+ * collections. AsyncAPI documents are excluded since the search index is
+ * OpenAPI-specific.
  */
-const activeDocument = computed(() => app.store.value?.workspace.activeDocument)
+const activeDocument = computed(() => {
+  const doc = app.store.value?.workspace.activeDocument
+  return isOpenApiDocument(doc) ? doc : undefined
+})
 
 const handleFilterOrSearch = () => {
   // Inside a document, this icon opens a modal search that is scoped to that

--- a/packages/api-client/src/v2/features/app/components/SidebarItemMenu.vue
+++ b/packages/api-client/src/v2/features/app/components/SidebarItemMenu.vue
@@ -11,6 +11,7 @@ import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getParentEntry } from '@scalar/workspace-store/navigation'
 import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { nextTick, ref, watch } from 'vue'
 
 import { createTempOperation } from '@/v2/features/app/helpers/create-temp-operation'
@@ -135,11 +136,10 @@ const handleAddOperation = () => {
     console.error('Document name not found')
     return
   }
+  const doc = workspaceStore.workspace.documents[documentName]
   createTempOperation(documentName, {
     existingPaths: new Set(
-      Object.keys(
-        workspaceStore.workspace.documents[documentName]?.paths ?? {},
-      ),
+      Object.keys((isOpenApiDocument(doc) ? doc.paths : undefined) ?? {}),
     ),
     eventBus,
     tags: tagName ? [tagName] : undefined,

--- a/packages/api-client/src/v2/features/app/helpers/load-registry-document.ts
+++ b/packages/api-client/src/v2/features/app/helpers/load-registry-document.ts
@@ -1,5 +1,6 @@
 import { coerce, object, string } from '@scalar/validation'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 
 import { generateUniqueSlug } from '@/v2/features/command-palette/helpers/generate-unique-slug'
 import type { ImportDocumentFromRegistry } from '@/v2/types/configuration'
@@ -21,7 +22,7 @@ export const loadRegistryDocument = async ({
   const documents = workspaceStore.workspace.documents
 
   const existing = Object.entries(documents).find(([, doc]) => {
-    const meta = doc?.['x-scalar-registry-meta']
+    const meta = isOpenApiDocument(doc) ? doc['x-scalar-registry-meta'] : undefined
     return meta?.namespace === namespace && meta?.slug === slug
   })
 

--- a/packages/api-client/src/v2/features/app/helpers/routes.ts
+++ b/packages/api-client/src/v2/features/app/helpers/routes.ts
@@ -5,7 +5,7 @@ import type { Theme } from '@scalar/themes'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
-import type { WorkspaceDocument } from '@scalar/workspace-store/schemas/workspace'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import type { MaybeRefOrGetter } from 'vue'
 import type { RouteRecordRaw } from 'vue-router'
 
@@ -32,7 +32,7 @@ export type RouteProps = {
   /** The slug of the currently selected document in the workspace */
   documentSlug: string
   /** The currently active document */
-  document: WorkspaceDocument | null
+  document: OpenApiDocument | null
   /** The workspace event bus */
   eventBus: WorkspaceEventBus
   /** The layout of the client */
@@ -75,7 +75,7 @@ export type CollectionProps = RouteProps &
   (
     | {
         collectionType: 'document' | 'operation'
-        document: WorkspaceDocument
+        document: OpenApiDocument
       }
     | {
         collectionType: 'workspace'

--- a/packages/api-client/src/v2/features/app/hooks/use-document-watcher.test.ts
+++ b/packages/api-client/src/v2/features/app/hooks/use-document-watcher.test.ts
@@ -1,4 +1,5 @@
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { type FastifyInstance, fastify } from 'fastify'
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
@@ -48,7 +49,7 @@ describe('useDocumentWatcher', () => {
       url,
     })
 
-    const defaultDocument = store.workspace.documents['default']
+    const defaultDocument = store.workspace.documents['default'] as OpenApiDocument | undefined
     assert(defaultDocument)
 
     // Enable watch mode on the document so the watcher starts polling
@@ -93,8 +94,8 @@ describe('useDocumentWatcher', () => {
       url: `${url}/b`,
     })
 
-    const documentA = store.workspace.documents['a']
-    const documentB = store.workspace.documents['b']
+    const documentA = store.workspace.documents['a'] as OpenApiDocument | undefined
+    const documentB = store.workspace.documents['b'] as OpenApiDocument | undefined
     assert(documentA)
     assert(documentB)
 
@@ -140,7 +141,7 @@ describe('useDocumentWatcher', () => {
       url,
     })
 
-    const defaultDocument = store.workspace.documents['default']
+    const defaultDocument = store.workspace.documents['default'] as OpenApiDocument | undefined
     assert(defaultDocument)
     defaultDocument['x-scalar-watch-mode'] = true
 

--- a/packages/api-client/src/v2/features/app/hooks/use-document-watcher.ts
+++ b/packages/api-client/src/v2/features/app/hooks/use-document-watcher.ts
@@ -1,5 +1,6 @@
 import type { Difference } from '@scalar/json-magic/diff'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { type MaybeRefOrGetter, computed, onBeforeUnmount, toValue, watch } from 'vue'
 
 /**
@@ -130,7 +131,9 @@ export const useDocumentWatcher = ({
     if (!storeValue || !documentNameValue) {
       return null
     }
-    return storeValue.workspace.documents[documentNameValue]
+    const doc = storeValue.workspace.documents[documentNameValue]
+    // The watcher only applies to OpenAPI documents; AsyncAPI docs are ignored
+    return isOpenApiDocument(doc) ? doc : null
   })
 
   const timerManager = createTimerManager()

--- a/packages/api-client/src/v2/features/app/hooks/use-sidebar-documents.test.ts
+++ b/packages/api-client/src/v2/features/app/hooks/use-sidebar-documents.test.ts
@@ -16,6 +16,12 @@ type FakeDocument = Partial<WorkspaceDocument> & {
  * Creates the tiny slice of `AppState` the hook actually consumes. A full
  * `AppState` is heavy to construct and would pull in router/persistence
  * machinery that is unrelated to the grouping logic exercised here.
+ *
+ * Stamps `openapi: '3.1.0'` onto every fixture document so it passes the
+ * `isOpenApiDocument` discriminator. Real workspace documents always carry a
+ * spec discriminator (`openapi` for OpenAPI, `asyncapi` for AsyncAPI); the hook
+ * uses that to skip non-OpenAPI documents when reading OpenAPI-only extensions
+ * like `x-scalar-registry-meta` and `x-scalar-navigation`.
  */
 const createFakeApp = ({
   documents = {},
@@ -26,7 +32,10 @@ const createFakeApp = ({
   isTeamWorkspace?: boolean
   documentSlug?: string
 }) => {
-  const store = shallowRef({ workspace: { documents } })
+  const stamped = Object.fromEntries(
+    Object.entries(documents).map(([name, doc]) => [name, { openapi: '3.1.0', ...doc }]),
+  )
+  const store = shallowRef({ workspace: { documents: stamped } })
   const teamFlag = ref(isTeamWorkspace)
   const slug = ref<string | undefined>(documentSlug)
 

--- a/packages/api-client/src/v2/features/app/hooks/use-sidebar-documents.ts
+++ b/packages/api-client/src/v2/features/app/hooks/use-sidebar-documents.ts
@@ -1,5 +1,6 @@
 import type { AppState } from '@scalar/api-client/v2/features/app'
 import type { TraversedDocument } from '@scalar/workspace-store/schemas/navigation'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { type MaybeRefOrGetter, computed, toValue } from 'vue'
 
 /**
@@ -103,8 +104,9 @@ export function useSidebarDocuments({
     }
 
     return Object.entries(store.workspace.documents).map(([name, doc]) => {
-      const registry = doc?.['x-scalar-registry-meta']
-      const navigation = doc?.['x-scalar-navigation'] as TraversedDocument | undefined
+      const isOpenApi = isOpenApiDocument(doc)
+      const registry = isOpenApi ? doc['x-scalar-registry-meta'] : undefined
+      const navigation = isOpenApi ? (doc['x-scalar-navigation'] as TraversedDocument | undefined) : undefined
 
       const title = navigation?.title || doc?.info?.title || 'Untitled'
 

--- a/packages/api-client/src/v2/features/collection/DocumentCollection.test.ts
+++ b/packages/api-client/src/v2/features/collection/DocumentCollection.test.ts
@@ -1,5 +1,5 @@
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
-import type { WorkspaceDocument } from '@scalar/workspace-store/schemas/workspace'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { flushPromises, mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { createRouter, createWebHistory } from 'vue-router'
@@ -14,7 +14,7 @@ import DocumentCollection from './DocumentCollection.vue'
  * Tests focus on document rendering, fallback states, routing integration, and prop handling
  */
 describe('DocumentCollection', () => {
-  const createMockDocument = (overrides?: Partial<WorkspaceDocument>): WorkspaceDocument =>
+  const createMockDocument = (overrides?: Partial<OpenApiDocument>): OpenApiDocument =>
     ({
       uid: 'test-doc-123',
       info: {
@@ -23,7 +23,7 @@ describe('DocumentCollection', () => {
       },
       'x-scalar-client-config-icon': 'interface-content-folder',
       ...overrides,
-    }) as WorkspaceDocument
+    }) as unknown as OpenApiDocument
 
   const createMockWorkspaceStore = (): WorkspaceStore =>
     ({
@@ -48,7 +48,7 @@ describe('DocumentCollection', () => {
     })
   }
 
-  const mountWithRouter = async (document: WorkspaceDocument | null, extraProps?: Record<string, unknown>) => {
+  const mountWithRouter = async (document: OpenApiDocument | null, extraProps?: Record<string, unknown>) => {
     const router = createRouterInstance()
     const workspaceStore = createMockWorkspaceStore()
 

--- a/packages/api-client/src/v2/features/collection/components/Authentication.test.ts
+++ b/packages/api-client/src/v2/features/collection/components/Authentication.test.ts
@@ -2,8 +2,8 @@ import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { MergedSecuritySchemes } from '@scalar/workspace-store/request-example'
-import type { WorkspaceDocument } from '@scalar/workspace-store/schemas'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
@@ -52,7 +52,7 @@ const baseDocument = {
       },
     },
   },
-} satisfies WorkspaceDocument
+} satisfies OpenApiDocument
 
 const baseEnvironment = {
   description: 'Default environment',
@@ -77,7 +77,7 @@ const defaultProps = {
 
 const mountWithProps = (
   custom: Partial<{
-    document: WorkspaceDocument | null
+    document: OpenApiDocument | null
     environment: typeof baseEnvironment
     collectionType: 'document' | 'operation'
     path: string
@@ -187,7 +187,7 @@ describe('document collection', () => {
         ...baseDocument,
         security: undefined,
         components: undefined,
-      } as WorkspaceDocument,
+      } as OpenApiDocument,
     })
 
     const authSelector = wrapper.findComponent(AuthSelector)

--- a/packages/api-client/src/v2/features/collection/components/DocumentScriptsEditors.vue
+++ b/packages/api-client/src/v2/features/collection/components/DocumentScriptsEditors.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ScalarIconArrowRight, ScalarIconCheckCircle } from '@scalar/icons'
-import type { WorkspaceDocument } from '@scalar/workspace-store/schemas'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import * as monaco from 'monaco-editor'
 import {
   computed,
@@ -12,7 +12,7 @@ import {
 } from 'vue'
 
 const { document } = defineProps<{
-  document: WorkspaceDocument | null
+  document: OpenApiDocument | null
 }>()
 
 const emit = defineEmits<{

--- a/packages/api-client/src/v2/features/collection/components/Environment.test.ts
+++ b/packages/api-client/src/v2/features/collection/components/Environment.test.ts
@@ -1,7 +1,7 @@
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
-import type { WorkspaceDocument } from '@scalar/workspace-store/schemas'
 import { xScalarEnvironmentsSchema } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 
@@ -33,7 +33,7 @@ const createMockDocument = (environments?: any) =>
   ({
     name: 'Test Document',
     'x-scalar-environments': environments,
-  }) as unknown as WorkspaceDocument
+  }) as unknown as OpenApiDocument
 
 const createMockWorkspaceStore = (environments?: any): WorkspaceStore =>
   ({

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteExample.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteExample.vue
@@ -34,6 +34,7 @@ import type {
   TraversedExample,
   TraversedOperation,
 } from '@scalar/workspace-store/schemas/navigation'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { computed, ref, watch } from 'vue'
 
 import HttpMethodBadge from '@/v2/blocks/operation-code-sample/components/HttpMethod.vue'
@@ -120,7 +121,7 @@ const availableOperations = computed(() => {
   }
 
   const document = workspaceStore.workspace.documents[selectedDocument.value.id]
-  if (!document || !document['x-scalar-navigation']) {
+  if (!isOpenApiDocument(document) || !document['x-scalar-navigation']) {
     return []
   }
 

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportCurl.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportCurl.vue
@@ -31,6 +31,7 @@ import {
 } from '@scalar/components'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
@@ -91,7 +92,7 @@ const isDisabled = computed<boolean>(() => {
 
   /** Prevent creating duplicate operations at the same path/method */
   const document = workspaceStore.workspace.documents[selectedDocument.value.id]
-  if (document?.paths?.[path]?.[method]) {
+  if (isOpenApiDocument(document) && document.paths?.[path]?.[method]) {
     return true
   }
 

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportPostman.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportPostman.vue
@@ -16,6 +16,7 @@ import type { ConvertOptions } from '@scalar/postman-to-openapi'
 import { useToasts } from '@scalar/use-toasts'
 import { type WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed, ref, watch } from 'vue'
 
@@ -68,7 +69,8 @@ watch(importTargetDocumentName, async (value) => {
     baseDocument.value = null
     return
   }
-  baseDocument.value = await workspaceStore.getEditableDocument(value.slug)
+  const editable = await workspaceStore.getEditableDocument(value.slug)
+  baseDocument.value = isOpenApiDocument(editable) ? editable : null
 })
 
 const mergeSamePathAndMethod = ref(false)

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteRequest.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteRequest.vue
@@ -36,6 +36,7 @@ import {
 } from '@scalar/helpers/http/http-methods'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
@@ -117,7 +118,7 @@ const availableTags = computed<TagOption[]>(() => {
   }
 
   const document = workspaceStore.workspace.documents[selectedDocument.value.id]
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     return []
   }
 
@@ -159,7 +160,10 @@ const operationExists = computed<boolean>(() => {
     ? requestPathTrimmed.value
     : `/${requestPathTrimmed.value}`
 
-  return !!document?.paths?.[normalizedPath]?.[selectedMethod.value.method]
+  return (
+    isOpenApiDocument(document) &&
+    !!document.paths?.[normalizedPath]?.[selectedMethod.value.method]
+  )
 })
 
 /**

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteTag.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteTag.vue
@@ -43,6 +43,7 @@ import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { TraversedTag } from '@scalar/workspace-store/schemas/navigation'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { computed, ref } from 'vue'
 
 import CommandActionForm from './CommandActionForm.vue'
@@ -104,7 +105,11 @@ const selectedDocument = ref<{ id: string; label: string } | undefined>(
 const isDisabled = computed<boolean>(() => {
   const document =
     workspaceStore.workspace.documents[selectedDocument.value?.id ?? '']
-  if (!nameTrimmed.value || !selectedDocument.value || !document) {
+  if (
+    !nameTrimmed.value ||
+    !selectedDocument.value ||
+    !isOpenApiDocument(document)
+  ) {
     return true
   }
 

--- a/packages/api-client/src/v2/features/command-palette/helpers/import-document-to-workspace.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/helpers/import-document-to-workspace.test.ts
@@ -1,4 +1,5 @@
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { assert, describe, expect, it } from 'vitest'
 
 import { importDocumentToWorkspace } from './import-document-to-workspace'
@@ -324,7 +325,7 @@ describe('importDocumentToWorkspace', () => {
     })
 
     assert(result.ok)
-    const importedDoc = workspaceStore.workspace.documents[result.slug]
+    const importedDoc = workspaceStore.workspace.documents[result.slug] as OpenApiDocument | undefined
     expect(importedDoc).toBeDefined()
     expect(importedDoc?.info.title).toBe('Complex API')
     expect(importedDoc?.info.version).toBe('2.0.0')
@@ -516,7 +517,7 @@ describe('importDocumentToWorkspace', () => {
     })
 
     assert(result.ok)
-    const importedDoc = workspaceStore.workspace.documents[result.slug]
+    const importedDoc = workspaceStore.workspace.documents[result.slug] as OpenApiDocument | undefined
     expect(importedDoc?.['x-scalar-navigation']).toBeDefined()
     expect(importedDoc?.['x-scalar-navigation']?.name).toBe('api-with-navigation')
   })

--- a/packages/api-client/src/v2/features/command-palette/helpers/load-document-from-source.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/helpers/load-document-from-source.test.ts
@@ -1,4 +1,5 @@
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { assert, describe, expect, it } from 'vitest'
 
 import type { ImportEventData } from './load-document-from-source'
@@ -51,7 +52,7 @@ describe('loadDocumentFromSource', () => {
     expect(result).toBe(true)
 
     // Find the document that was added
-    const documents = Object.values(workspaceStore.workspace.documents)
+    const documents = Object.values(workspaceStore.workspace.documents) as OpenApiDocument[]
     const addedDocument = documents.find((doc) => doc.info.title === 'Raw API')
 
     expect(addedDocument).toBeDefined()
@@ -87,7 +88,7 @@ paths:
     expect(result).toBe(true)
 
     // Find the document that was added
-    const documents = Object.values(workspaceStore.workspace.documents)
+    const documents = Object.values(workspaceStore.workspace.documents) as OpenApiDocument[]
     const addedDocument = documents.find((doc) => doc.info.title === 'YAML API')
 
     expect(addedDocument).toBeDefined()
@@ -166,7 +167,7 @@ paths:
 
     expect(result).toBe(true)
 
-    const documents = Object.values(workspaceStore.workspace.documents)
+    const documents = Object.values(workspaceStore.workspace.documents) as OpenApiDocument[]
     const addedDocument = documents.find((doc) => doc.info.title === 'Complex API')
 
     expect(addedDocument).toBeDefined()
@@ -195,7 +196,7 @@ paths:
 
     expect(result).toBe(true)
 
-    const documents = Object.values(workspaceStore.workspace.documents)
+    const documents = Object.values(workspaceStore.workspace.documents) as OpenApiDocument[]
     const addedDocument = documents.find((doc) => doc.info.title === 'Minified API')
 
     expect(addedDocument).toBeDefined()
@@ -237,7 +238,7 @@ paths:
 
     expect(result).toBe(true)
 
-    const documents = Object.values(workspaceStore.workspace.documents)
+    const documents = Object.values(workspaceStore.workspace.documents) as OpenApiDocument[]
     const addedDocument = documents.find((doc) => doc.info.title === 'My Postman API')
 
     expect(addedDocument).toBeDefined()
@@ -274,7 +275,7 @@ paths:
 
     expect(result).toBe(true)
 
-    const documents = Object.values(workspaceStore.workspace.documents)
+    const documents = Object.values(workspaceStore.workspace.documents) as OpenApiDocument[]
     const addedDocument = documents.find((doc) => doc.info.title === 'Exported Postman API')
 
     expect(addedDocument).toBeDefined()
@@ -340,7 +341,7 @@ paths:
 
     expect(result).toBe(true)
 
-    const documents = Object.values(workspaceStore.workspace.documents)
+    const documents = Object.values(workspaceStore.workspace.documents) as OpenApiDocument[]
     const addedDocument = documents.find((doc) => doc.info.title === 'Complex Postman Collection')
 
     expect(addedDocument).toBeDefined()
@@ -372,7 +373,7 @@ paths:
 
     expect(result).toBe(true)
 
-    const documents = Object.values(workspaceStore.workspace.documents)
+    const documents = Object.values(workspaceStore.workspace.documents) as OpenApiDocument[]
     const addedDocument = documents.find((doc) => doc.info.title === 'Postman Collection Watch Test')
 
     expect(addedDocument).toBeDefined()
@@ -430,7 +431,7 @@ paths:
 
     expect(result).toBe(true)
 
-    const documents = Object.values(workspaceStore.workspace.documents)
+    const documents = Object.values(workspaceStore.workspace.documents) as OpenApiDocument[]
     const addedDocument = documents.find((doc) => doc.info.title === 'Empty Postman Collection')
 
     expect(addedDocument).toBeDefined()
@@ -477,7 +478,7 @@ paths:
 
     expect(result).toBe(true)
 
-    const documents = Object.values(workspaceStore.workspace.documents)
+    const documents = Object.values(workspaceStore.workspace.documents) as OpenApiDocument[]
     const addedDocument = documents.find((doc) => doc.info.title === 'Authenticated API')
 
     expect(addedDocument).toBeDefined()
@@ -547,7 +548,7 @@ paths:
 
     expect(result).toBe(true)
 
-    const documents = Object.values(workspaceStore.workspace.documents)
+    const documents = Object.values(workspaceStore.workspace.documents) as OpenApiDocument[]
     const addedDocument = documents.find((doc) => doc.info.title === 'API with Variables')
 
     expect(addedDocument).toBeDefined()
@@ -578,7 +579,7 @@ paths:
 
     expect(result).toBe(true)
 
-    const document = workspaceStore.workspace.documents['file-api']
+    const document = workspaceStore.workspace.documents['file-api'] as OpenApiDocument | undefined
 
     expect(document).toBeDefined()
     assert(document)
@@ -611,7 +612,7 @@ paths:
 
     expect(result).toBe(true)
 
-    const document = workspaceStore.workspace.documents['file-api-watch-test']
+    const document = workspaceStore.workspace.documents['file-api-watch-test'] as OpenApiDocument | undefined
 
     expect(document).toBeDefined()
     assert(document)

--- a/packages/api-client/src/v2/features/modal/Modal.test.ts
+++ b/packages/api-client/src/v2/features/modal/Modal.test.ts
@@ -68,7 +68,9 @@ const createModalProps = async (documentOverrides: Partial<OpenApiDocument> = {}
   const method = computed<'get' | 'post' | undefined>(() => 'get')
   const exampleName = computed<string | undefined>(() => 'default')
 
-  const document = computed(() => store.workspace.documents[documentSlug.value ?? ''] ?? null)
+  const document = computed<OpenApiDocument | null>(
+    () => (store.workspace.documents[documentSlug.value ?? ''] as OpenApiDocument | undefined) ?? null,
+  )
   const modalState = useModal()
   const requestBodyCompositionSelection = ref<Record<string, number>>({})
 

--- a/packages/api-client/src/v2/features/modal/Modal.vue
+++ b/packages/api-client/src/v2/features/modal/Modal.vue
@@ -6,8 +6,8 @@ import type { ApiClientOptions } from '@/v2/types/options'
 export type ModalProps = {
   /** The workspace store must be initialized and passed in */
   workspaceStore: WorkspaceStore
-  /** The document must be initialized and passed in */
-  document: ComputedRef<WorkspaceDocument | null>
+  /** The document must be initialized and passed in. OpenAPI-only — the modal has no AsyncAPI path. */
+  document: ComputedRef<OpenApiDocument | null>
   /** The path must be initialized and passed in */
   path: ComputedRef<string | undefined>
   /** The event bus for handling all events */
@@ -44,7 +44,7 @@ import { ScalarToasts } from '@scalar/use-toasts'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import { type WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getActiveEnvironment } from '@scalar/workspace-store/request-example'
-import type { WorkspaceDocument } from '@scalar/workspace-store/schemas'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import {
   computed,
   onBeforeUnmount,

--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.test.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.test.ts
@@ -650,7 +650,7 @@ describe('createApiClientModal', () => {
 
     // Get the active document
     const documentSlug = workspaceStore.workspace['x-scalar-active-document']
-    const document = workspaceStore.workspace.documents[documentSlug || '']
+    const document = workspaceStore.workspace.documents[documentSlug || ''] as OpenApiDocument | undefined
     expect(document).toBeDefined()
 
     const snapshot = deepClone(document)

--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
@@ -2,6 +2,7 @@ import { type ModalState, useModal } from '@scalar/components'
 import type { ClientPlugin } from '@scalar/oas-utils/helpers'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import { type WorkspaceEventBus, createWorkspaceEventBus } from '@scalar/workspace-store/events'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { type App, type MaybeRefOrGetter, computed, createApp, isRef, reactive, ref, toValue, watch } from 'vue'
 
 import {
@@ -9,9 +10,9 @@ import {
   type RoutePayload,
   resolveRouteParameters,
 } from '@/v2/features/modal/helpers/resolve-route-parameters'
-import type { ApiClientOptions, ApiClientOptionsRef } from '@/v2/types/options'
 import { useModalSidebar } from '@/v2/features/modal/hooks/use-modal-sidebar'
 import Modal, { type ModalProps } from '@/v2/features/modal/Modal.vue'
+import type { ApiClientOptions, ApiClientOptionsRef } from '@/v2/types/options'
 
 type CreateApiClientOptions = {
   /** Element to mount the client modal to. */
@@ -81,8 +82,11 @@ export const createApiClientModal = ({
   const path = computed(() => resolvedParameters.value.path)
   const method = computed(() => resolvedParameters.value.method)
   const exampleName = computed(() => resolvedParameters.value.example)
-  /** The document from the workspace store. */
-  const document = computed(() => workspaceStore.workspace.documents[documentSlug.value ?? ''] ?? null)
+  /** The document from the workspace store. Modal is OpenAPI-only; AsyncAPI docs surface as null. */
+  const document = computed(() => {
+    const doc = workspaceStore.workspace.documents[documentSlug.value ?? '']
+    return isOpenApiDocument(doc) ? doc : null
+  })
 
   /** Sidebar state and selection handling. */
   const sidebarState = useModalSidebar({

--- a/packages/api-client/src/v2/features/modal/helpers/resolve-route-parameters.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/resolve-route-parameters.ts
@@ -3,6 +3,7 @@ import { isHttpMethod } from '@scalar/helpers/http/is-http-method'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import { getOperationEntries } from '@scalar/workspace-store/navigation'
 import type { TraversedEntry, TraversedExample } from '@scalar/workspace-store/schemas/navigation'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 
 /** Payload for routing and opening the API client modal. */
 export type RoutePayload = {
@@ -27,8 +28,12 @@ const isExample = (entry: TraversedEntry): entry is TraversedExample => entry.ty
 /**
  * Gets the document from the workspace store.
  * Returns undefined if the document slug is not provided or the document does not exist.
+ * Modal routing is OpenAPI-only — AsyncAPI docs surface as undefined here.
  */
-const getDocument = (ctx: ResolverContext) => ctx.store.workspace.documents[ctx.documentSlug ?? '']
+const getDocument = (ctx: ResolverContext) => {
+  const doc = ctx.store.workspace.documents[ctx.documentSlug ?? '']
+  return isOpenApiDocument(doc) ? doc : undefined
+}
 
 /**
  * Resolves the document slug from a raw input value.

--- a/packages/api-client/src/v2/features/modal/hooks/use-modal-sidebar.ts
+++ b/packages/api-client/src/v2/features/modal/hooks/use-modal-sidebar.ts
@@ -3,6 +3,7 @@ import { createSidebarState, generateReverseIndex, getChildEntry } from '@scalar
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import { getParentEntry } from '@scalar/workspace-store/navigation'
 import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { type ComputedRef, computed, toValue, watch } from 'vue'
 
 import type { RoutePayload } from '@/v2/features/modal/helpers/resolve-route-parameters'
@@ -51,9 +52,10 @@ export const useModalSidebar = ({
   exampleName: ComputedRef<string | undefined>
   route: (payload: RoutePayload) => void
 }): UseModalSidebarReturn => {
-  const entries = computed(
-    () => workspaceStore?.workspace.documents[toValue(documentSlug) ?? '']?.['x-scalar-navigation']?.children ?? [],
-  )
+  const entries = computed<TraversedEntry[]>(() => {
+    const doc = workspaceStore?.workspace.documents[toValue(documentSlug) ?? '']
+    return isOpenApiDocument(doc) ? (doc['x-scalar-navigation']?.children ?? []) : []
+  })
   const state = createSidebarState(entries)
 
   /**

--- a/packages/api-client/src/v2/features/modal/modal-events.ts
+++ b/packages/api-client/src/v2/features/modal/modal-events.ts
@@ -2,6 +2,7 @@ import type { ModalState } from '@scalar/components'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { type Ref, ref } from 'vue'
 
 import type { UseModalSidebarReturn } from '@/v2/features/modal/hooks/use-modal-sidebar'
@@ -79,9 +80,10 @@ export function initializeModalEvents({
     }
     // We must find the ID first from the entries
     else if ('method' in payload && 'path' in payload) {
+      const activeDoc = store.workspace.activeDocument
       sidebarState.handleSelectItem(
         sidebarState.getEntryByLocation({
-          document: store.workspace.activeDocument?.['x-scalar-navigation']?.id ?? '',
+          document: isOpenApiDocument(activeDoc) ? (activeDoc['x-scalar-navigation']?.id ?? '') : '',
           path: payload.path,
           method: payload.method,
           example: payload.exampleName,

--- a/packages/api-client/src/v2/helpers/drag-handle-factory.test.ts
+++ b/packages/api-client/src/v2/helpers/drag-handle-factory.test.ts
@@ -63,7 +63,7 @@ const getSidebarState = (store: ReturnType<typeof createWorkspaceStore>) => {
   const entries = computed(() => {
     const order = store.workspace['x-scalar-order'] ?? Object.keys(store.workspace.documents)
     return order
-      .map((doc) => store.workspace.documents[doc]?.['x-scalar-navigation'])
+      .map((doc) => (store.workspace.documents as Record<string, OpenApiDocument>)[doc]?.['x-scalar-navigation'])
       .filter((nav) => nav !== undefined) as TraversedEntry[]
   })
 
@@ -144,7 +144,7 @@ describe('handleDragEnd', () => {
 
   it('returns false when dragging document over non-document item', () => {
     const sidebarState = getSidebarState(store)
-    const navigation = store.workspace.documents['doc-1']?.['x-scalar-navigation']
+    const navigation = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.['x-scalar-navigation']
     const tagId = navigation?.children?.find((child) => child.type === 'tag')?.id
 
     assert(tagId, 'Tag ID is required')
@@ -163,10 +163,10 @@ describe('handleDragEnd', () => {
   // TAGS
   //------------------------------------------------------------------------------------------------
   it('successfully reorders tags within the same parent', () => {
-    const document = store.workspace.documents['doc-1']
+    const document = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']
 
     const sidebarState = getSidebarState(store)
-    const navigation = store.workspace.documents['doc-1']?.['x-scalar-navigation']
+    const navigation = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.['x-scalar-navigation']
     const tags = navigation?.children?.filter((child) => child.type === 'tag') ?? []
     const tagUsers = tags.find((tag) => tag.name === 'users')
     const tagPets = tags.find((tag) => tag.name === 'pets')
@@ -181,7 +181,9 @@ describe('handleDragEnd', () => {
     store.buildSidebar('doc-1')
 
     // Check the order of the tags
-    const sidebarStructure = store.workspace.documents['doc-1']?.['x-scalar-navigation']
+    const sidebarStructure = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.[
+      'x-scalar-navigation'
+    ]
     assert(sidebarStructure, 'Sidebar structure is required')
 
     const order = sidebarStructure.children?.map((child) => child.id)
@@ -198,11 +200,13 @@ describe('handleDragEnd', () => {
     )
 
     expect(result).toBe(true)
-    const updatedDoc = store.workspace.documents['doc-1']
+    const updatedDoc = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']
     expect(updatedDoc?.['x-scalar-order']).toEqual([tagPets.id, tagUsers.id, 'doc-1/description/introduction'])
 
     // Check the order of the tags
-    const updatedSidebarStructre = store.workspace.documents['doc-1']?.['x-scalar-navigation']
+    const updatedSidebarStructre = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.[
+      'x-scalar-navigation'
+    ]
     assert(updatedSidebarStructre, 'Updated sidebar structure is required')
     const updatedOrder = updatedSidebarStructre.children?.map((child) => child.id)
     expect(updatedOrder).toEqual([tagPets.id, tagUsers.id, 'doc-1/description/introduction'])
@@ -231,8 +235,8 @@ describe('handleDragEnd', () => {
     store.buildSidebar('doc-2')
 
     const sidebarState = getSidebarState(store)
-    const nav1 = store.workspace.documents['doc-1']?.['x-scalar-navigation']
-    const nav2 = store.workspace.documents['doc-2']?.['x-scalar-navigation']
+    const nav1 = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.['x-scalar-navigation']
+    const nav2 = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-2']?.['x-scalar-navigation']
     const tag1 = nav1?.children?.find((child) => child.type === 'tag' && child.name === 'users')
     const tag2 = nav2?.children?.find((child) => child.type === 'tag' && child.name === 'items')
 
@@ -251,7 +255,7 @@ describe('handleDragEnd', () => {
 
   it('returns false when trying to drop tag into parent', () => {
     const sidebarState = getSidebarState(store)
-    const navigation = store.workspace.documents['doc-1']?.['x-scalar-navigation']
+    const navigation = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.['x-scalar-navigation']
     const tag = navigation?.children?.find((child) => child.type === 'tag')
 
     assert(tag, 'Tag is required')
@@ -271,7 +275,7 @@ describe('handleDragEnd', () => {
   //------------------------------------------------------------------------------------------------
   it('successfully reorders operations within the same parent', () => {
     store.buildSidebar('doc-1')
-    const document = store.workspace.documents['doc-1']
+    const document = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']
 
     const sidebarState = getSidebarState(store)
     const navigation = document?.['x-scalar-navigation']
@@ -300,12 +304,16 @@ describe('handleDragEnd', () => {
     const result = handleDragEnd({ id: opPost.id, parentId: null }, { id: opGet.id, parentId: null, offset: 'before' })
 
     expect(result).toBe(true)
-    const tagObject = store.workspace.documents['doc-1']?.tags?.find((it) => it.name === 'users')
+    const tagObject = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.tags?.find(
+      (it) => it.name === 'users',
+    )
     assert(tagObject, 'Tag object is required')
     expect(tagObject['x-scalar-order']).toEqual([opPost.id, opGet.id])
 
     // Check the order of the sidebar structure
-    const updatedNavigation = store.workspace.documents['doc-1']?.['x-scalar-navigation']
+    const updatedNavigation = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.[
+      'x-scalar-navigation'
+    ]
     assert(updatedNavigation, 'Updated navigation is required')
     const updatedTag =
       updatedNavigation.children?.filter((child) => child.type === 'tag' && child.name === 'users') ?? []
@@ -316,7 +324,7 @@ describe('handleDragEnd', () => {
 
   it('returns false when trying to reorder operations from different parents', () => {
     const sidebarState = getSidebarState(store)
-    const navigation = store.workspace.documents['doc-1']?.['x-scalar-navigation']
+    const navigation = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.['x-scalar-navigation']
     const tagUsers = navigation?.children?.find((child) => child.type === 'tag' && child.name === 'users')
     const tagPets = navigation?.children?.find((child) => child.type === 'tag' && child.name === 'pets')
 
@@ -405,7 +413,9 @@ describe('handleDragEnd', () => {
     store.buildSidebar('circular-doc')
 
     const sidebarState = getSidebarState(store)
-    const navigation = store.workspace.documents['circular-doc']?.['x-scalar-navigation']
+    const navigation = (store.workspace.documents as Record<string, OpenApiDocument>)['circular-doc']?.[
+      'x-scalar-navigation'
+    ]
 
     const tagPeople = navigation?.children?.find((child) => child.type === 'tag' && child.name === 'people')
     const tagAnimals = navigation?.children?.find((child) => child.type === 'tag' && child.name === 'animals')
@@ -434,7 +444,7 @@ describe('handleDragEnd', () => {
     expect(result).toBe(true)
 
     // Verify the operation was moved
-    const updatedDoc = store.workspace.documents['circular-doc']
+    const updatedDoc = (store.workspace.documents as Record<string, OpenApiDocument>)['circular-doc']
     const peopleOp = updatedDoc?.paths?.['/people']?.get as
       | { tags?: string[]; responses?: Record<string, unknown> }
       | undefined
@@ -566,7 +576,7 @@ describe('isDroppable', () => {
 
   it('returns false when dragging document over non-document', () => {
     const sidebarState = getSidebarState(store)
-    const navigation = store.workspace.documents['doc-1']?.['x-scalar-navigation']
+    const navigation = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.['x-scalar-navigation']
     const tag = navigation?.children?.find((child) => child.type === 'tag')
 
     assert(tag, 'Tag is required')
@@ -586,7 +596,7 @@ describe('isDroppable', () => {
   //------------------------------------------------------------------------------------------------
   it('returns true when dragging tag over another tag with same parent', () => {
     const sidebarState = getSidebarState(store)
-    const navigation = store.workspace.documents['doc-1']?.['x-scalar-navigation']
+    const navigation = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.['x-scalar-navigation']
     const tags = navigation?.children?.filter((child) => child.type === 'tag') ?? []
     const tag1 = tags[0]
     const tag2 = tags[1]
@@ -629,8 +639,8 @@ describe('isDroppable', () => {
     store.buildSidebar('doc-2')
 
     const sidebarState = getSidebarState(store)
-    const nav1 = store.workspace.documents['doc-1']?.['x-scalar-navigation']
-    const nav2 = store.workspace.documents['doc-2']?.['x-scalar-navigation']
+    const nav1 = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.['x-scalar-navigation']
+    const nav2 = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-2']?.['x-scalar-navigation']
     const tag1 = nav1?.children?.find((child) => child.type === 'tag' && child.name === 'users')
     const tag2 = nav2?.children?.find((child) => child.type === 'tag' && child.name === 'items')
 
@@ -654,7 +664,7 @@ describe('isDroppable', () => {
   //------------------------------------------------------------------------------------------------
   it('returns true when reordering operations with same parent', () => {
     const sidebarState = getSidebarState(store)
-    const navigation = store.workspace.documents['doc-1']?.['x-scalar-navigation']
+    const navigation = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.['x-scalar-navigation']
     const tag = navigation?.children?.find((child) => child.type === 'tag' && child.name === 'users')
     const operations =
       tag && 'children' in tag ? (tag.children?.filter((child) => child.type === 'operation') ?? []) : []
@@ -678,7 +688,7 @@ describe('isDroppable', () => {
 
   it('returns false when trying to reorder operations with different parents', () => {
     const sidebarState = getSidebarState(store)
-    const navigation = store.workspace.documents['doc-1']?.['x-scalar-navigation']
+    const navigation = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.['x-scalar-navigation']
     const tagUsers = navigation?.children?.find((child) => child.type === 'tag' && child.name === 'users')
     const tagPets = navigation?.children?.find((child) => child.type === 'tag' && child.name === 'pets')
     const op1 =
@@ -703,7 +713,7 @@ describe('isDroppable', () => {
 
   it('returns false when dragging example item', () => {
     const sidebarState = getSidebarState(store)
-    const navigation = store.workspace.documents['doc-1']?.['x-scalar-navigation']
+    const navigation = (store.workspace.documents as Record<string, OpenApiDocument>)['doc-1']?.['x-scalar-navigation']
     assert(navigation, 'Navigation is required')
 
     const tag = navigation.children?.find((child) => child.type === 'tag')

--- a/packages/api-client/src/v2/helpers/drag-handle-factory.ts
+++ b/packages/api-client/src/v2/helpers/drag-handle-factory.ts
@@ -6,14 +6,14 @@ import type { DragOffset, DraggingItem, HoveredItem, SidebarState } from '@scala
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import { unpackProxyObject } from '@scalar/workspace-store/helpers/unpack-proxy'
 import { getOpenapiObject, getParentEntry } from '@scalar/workspace-store/navigation'
-import type { WorkspaceDocument } from '@scalar/workspace-store/schemas'
 import type {
   TraversedDocument,
   TraversedEntry,
   TraversedOperation,
   TraversedTag,
 } from '@scalar/workspace-store/schemas/navigation'
-import type { TagObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
+import type { OpenApiDocument, TagObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/operation'
 import { type MaybeRefOrGetter, toValue } from 'vue'
 
@@ -142,7 +142,7 @@ const rebuildSidebar = ({ store, entry }: { store: WorkspaceStore; entry: Traver
  * Falls back to children IDs if no explicit order exists.
  */
 const getCurrentOrder = (
-  parent: WorkspaceDocument | TagObject,
+  parent: OpenApiDocument | TagObject,
   parentEntry: TraversedDocument | TraversedTag,
 ): string[] => {
   const order = parent['x-scalar-order']
@@ -163,8 +163,10 @@ const handleReorderWithinParent = (
     return false
   }
 
-  const parent = getOpenapiObject({ store, entry: parentEntry })
-  if (!parent) {
+  const parent = getOpenapiObject({ store, entry: parentEntry }) as OpenApiDocument | TagObject | null
+  // Reorder only applies to OpenAPI-shaped parents (documents/tags with `x-scalar-order`).
+  // AsyncAPI docs have no operations to reorder, so we bail early.
+  if (!parent || (parentEntry.type === 'document' && !isOpenApiDocument(parent))) {
     return false
   }
 
@@ -207,8 +209,8 @@ const updateOperationTags = (
  * Moves an operation from one document to another.
  */
 const moveOperationBetweenDocuments = (
-  draggingDocument: WorkspaceDocument,
-  hoveredDocument: WorkspaceDocument,
+  draggingDocument: OpenApiDocument,
+  hoveredDocument: OpenApiDocument,
   draggingItem: TraversedOperation,
   operationCopy: OperationObject,
 ): void => {
@@ -237,7 +239,7 @@ const moveOperationBetweenDocuments = (
  * This resolves all $ref references so you always get the full, dereferenced operation.
  */
 const getDereferencedOperation = (
-  document: WorkspaceDocument,
+  document: OpenApiDocument,
   path: string,
   method: HttpMethod,
 ): OperationObject | undefined => {
@@ -272,7 +274,8 @@ const handleMoveOperation = (
   const draggingDocument = getOpenapiObject({ store, entry: draggingDocumentEntry })
   const hoveredDocument = getOpenapiObject({ store, entry: hoveredDocumentEntry })
 
-  if (!draggingDocument || !hoveredDocument) {
+  // Moving operations only applies to OpenAPI documents — bail on AsyncAPI.
+  if (!isOpenApiDocument(draggingDocument) || !isOpenApiDocument(hoveredDocument)) {
     return false
   }
 
@@ -433,7 +436,8 @@ export const dragHandleFactory = ({
       }
 
       const hoveredDocument = getOpenapiObject({ store, entry: hoveredDocumentEntry })
-      if (!hoveredDocument) {
+      // Dropping operations only makes sense on OpenAPI docs.
+      if (!isOpenApiDocument(hoveredDocument)) {
         return false
       }
 

--- a/packages/api-reference/src/blocks/scalar-server-selector-block/components/ServerSelector.test.ts
+++ b/packages/api-reference/src/blocks/scalar-server-selector-block/components/ServerSelector.test.ts
@@ -1,6 +1,6 @@
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
-import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import type { OpenApiDocument, ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import { nextTick } from 'vue'
@@ -334,9 +334,9 @@ describe('ServerSelector', () => {
 
     const wrapper = mount(ServerSelector, {
       props: {
-        servers: store.workspace.activeDocument!.servers!,
+        servers: (store.workspace.activeDocument as OpenApiDocument).servers!,
         eventBus,
-        selectedServer: store.workspace.activeDocument!.servers![1]!,
+        selectedServer: (store.workspace.activeDocument as OpenApiDocument).servers![1]!,
       },
     })
 
@@ -355,7 +355,8 @@ describe('ServerSelector', () => {
     })
 
     // Update the default value in the store
-    store.workspace.activeDocument!.servers![1]!.variables!.protocol!.default = '1234'
+    const activeDocument = store.workspace.activeDocument as OpenApiDocument
+    activeDocument.servers![1]!.variables!.protocol!.default = '1234'
     await nextTick()
 
     // Check that the variables form props have been updated

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -48,6 +48,7 @@ import type {
   TraversedEntry,
   TraversedTag,
 } from '@scalar/workspace-store/schemas/navigation'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { useScrollLock } from '@vueuse/core'
 import diff from 'microdiff'
 import {
@@ -333,6 +334,17 @@ const { toggleColorMode, isDarkMode } = useColorMode({
 })
 
 /**
+ * The active document narrowed to an OpenAPI document.
+ *
+ * api-reference is OpenAPI-native, so AsyncAPI documents are surfaced as
+ * undefined to downstream components.
+ */
+const activeOpenApiDocument = computed(() => {
+  const doc = workspaceStore.workspace.activeDocument
+  return isOpenApiDocument(doc) ? doc : undefined
+})
+
+/**
  * Create top level sidebar entries for each document
  * This allows sharing a single sidebar state for across the workspace
  */
@@ -344,7 +356,9 @@ const itemsFromWorkspace = computed<TraversedEntry[]>(() => {
       description: document.info.description,
       name: document.info.title ?? slug,
       title: document.info.title ?? slug,
-      children: document?.['x-scalar-navigation']?.children ?? [],
+      children: isOpenApiDocument(document)
+        ? (document['x-scalar-navigation']?.children ?? [])
+        : [],
     }),
   )
 })
@@ -582,7 +596,7 @@ const changeSelectedDocument = async (
     // If the document does not have a selected server we set it to the first server
     if (
       result === true &&
-      document !== undefined &&
+      isOpenApiDocument(document) &&
       document['x-scalar-selected-server'] === undefined
     ) {
       // Set the active server if the document is loaded successfully
@@ -1039,7 +1053,7 @@ const showMCPButton = computed(() => {
           <SearchButton
             v-if="!mergedConfig.hideSearch"
             class="my-2"
-            :document="workspaceStore.workspace.activeDocument"
+            :document="activeOpenApiDocument"
             :eventBus="eventBus"
             :hideModels="mergedConfig.hideModels"
             :searchHotKey="mergedConfig.searchHotKey"
@@ -1075,7 +1089,7 @@ const showMCPButton = computed(() => {
                 v-if="!mergedConfig.hideSearch"
                 class="flex gap-1.5 px-3 pt-3">
                 <SearchButton
-                  :document="workspaceStore.workspace.activeDocument"
+                  :document="activeOpenApiDocument"
                   :eventBus="eventBus"
                   :hideModels="mergedConfig.hideModels"
                   :searchHotKey="mergedConfig.searchHotKey" />
@@ -1169,7 +1183,7 @@ const showMCPButton = computed(() => {
               <SearchButton
                 v-if="!mergedConfig.hideSearch"
                 class="t-doc__sidebar max-w-64"
-                :document="workspaceStore.workspace.activeDocument"
+                :document="activeOpenApiDocument"
                 :eventBus="eventBus"
                 :hideModels="mergedConfig.hideModels"
                 :searchHotKey="mergedConfig.searchHotKey" />

--- a/packages/api-reference/src/components/Content/Auth/Auth.vue
+++ b/packages/api-reference/src/components/Content/Auth/Auth.vue
@@ -9,6 +9,7 @@ import {
   type MergedSecuritySchemes,
 } from '@scalar/workspace-store/request-example'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import type { WorkspaceDocument } from '@scalar/workspace-store/schemas/workspace'
 import { computed } from 'vue'
@@ -29,14 +30,18 @@ const { document, environment, eventBus, options, securitySchemes, authStore } =
 
 /** Compute what the security requirements should be for the document */
 const securityRequirements = computed(() =>
-  getSecurityRequirements(document?.security),
+  getSecurityRequirements(
+    isOpenApiDocument(document) ? document.security : undefined,
+  ),
 )
 
 /** Grab the selected security for the document from the auth store */
 const documentSelectedSecurity = computed(() =>
   authStore.getAuthSelectedSchemas({
     type: 'document',
-    documentName: document?.['x-scalar-navigation']?.name ?? '',
+    documentName: isOpenApiDocument(document)
+      ? (document['x-scalar-navigation']?.name ?? '')
+      : '',
   }),
 )
 

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -13,6 +13,7 @@ import {
 } from '@scalar/workspace-store/request-example'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
 import type { TraversedEntry as TraversedEntryType } from '@scalar/workspace-store/schemas/navigation'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import type {
   Workspace,
   WorkspaceDocument,
@@ -78,6 +79,17 @@ const clientOptions = computed(() =>
   generateClientOptions(mapHiddenClientsConfig(options.hiddenClients)),
 )
 
+/**
+ * Narrow the (possibly AsyncAPI) documents to OpenAPI documents. api-reference
+ * is OpenAPI-native, so AsyncAPI fields surface as undefined/empty.
+ */
+const openApiDocument = computed(() =>
+  isOpenApiDocument(document) ? document : undefined,
+)
+const openApiClientDocument = computed(() =>
+  isOpenApiDocument(clientDocument) ? clientDocument : undefined,
+)
+
 /** Computed property to get all OpenAPI extension fields from the root document object */
 const documentExtensions = computed(() => getXKeysFromObject(document))
 
@@ -86,7 +98,7 @@ const infoExtensions = computed(() => getXKeysFromObject(document?.info))
 
 /** Compute the servers for the document */
 const servers = computed(() =>
-  getServers(options?.servers ?? clientDocument?.servers, {
+  getServers(options?.servers ?? openApiClientDocument.value?.servers, {
     baseServerUrl: options?.baseServerURL,
     documentUrl: clientDocument?.['x-scalar-original-source-url'],
   }),
@@ -94,16 +106,21 @@ const servers = computed(() =>
 
 /** Compute the selected server for the document only (for now) */
 const selectedServer = computed(() =>
-  getSelectedServer(clientDocument ?? null, null, null, servers.value),
+  getSelectedServer(
+    openApiClientDocument.value ?? null,
+    null,
+    null,
+    servers.value,
+  ),
 )
 
 /** Merge authentication config with the document security schemes */
 const securitySchemes = computed(() =>
   mergeSecurity(
-    clientDocument?.components?.securitySchemes,
+    openApiClientDocument.value?.components?.securitySchemes,
     options.authentication?.securitySchemes,
     authStore,
-    clientDocument?.['x-scalar-navigation']?.name ?? '',
+    openApiClientDocument.value?.['x-scalar-navigation']?.name ?? '',
   ),
 )
 
@@ -126,12 +143,12 @@ onMounted(() => {
       :documentExtensions
       :documentUrl="document?.['x-scalar-original-source-url']"
       :eventBus
-      :externalDocs="document?.externalDocs"
+      :externalDocs="openApiDocument?.externalDocs"
       :headingSlugGenerator
       :info="document?.info"
       :infoExtensions
       :layout="options.layout"
-      :oasVersion="document?.['x-original-oas-version']">
+      :oasVersion="openApiDocument?.['x-original-oas-version']">
       <template #selectors>
         <!-- Server Selector -->
         <ScalarErrorBoundary>
@@ -172,7 +189,7 @@ onMounted(() => {
               :eventBus
               :selectedClient="xScalarDefaultClient"
               :xScalarSdkInstallation="
-                document?.info?.['x-scalar-sdk-installation']
+                openApiDocument?.info?.['x-scalar-sdk-installation']
               " />
           </IntroductionCardItem>
         </ScalarErrorBoundary>
@@ -182,10 +199,10 @@ onMounted(() => {
     <!-- Render traversed operations and webhooks -->
     <!-- Use recursive component for cleaner rendering -->
     <TraversedEntry
-      v-if="items.length && document"
+      v-if="items.length && openApiDocument"
       :authStore
       :clientOptions
-      :document
+      :document="openApiDocument"
       :entries="items"
       :eventBus
       :expandedItems

--- a/packages/api-reference/src/components/Content/Operations/TraversedEntry.vue
+++ b/packages/api-reference/src/components/Content/Operations/TraversedEntry.vue
@@ -6,7 +6,6 @@ import type { AuthStore } from '@scalar/workspace-store/entities/auth'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { MergedSecuritySchemes } from '@scalar/workspace-store/request-example'
-import type { WorkspaceDocument } from '@scalar/workspace-store/schemas'
 import type {
   TraversedEntry,
   TraversedModels,
@@ -15,7 +14,10 @@ import type {
   TraversedTag,
   TraversedWebhook,
 } from '@scalar/workspace-store/schemas/navigation'
-import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import type {
+  OpenApiDocument,
+  ServerObject,
+} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
 import Model from '@/components/Content/Models/Model.vue'
 import ModelTag from '@/components/Content/Models/ModelTag.vue'
@@ -38,7 +40,7 @@ const {
   /** Traversed entries to render */
   entries: TraversedEntry[]
   /** The document object */
-  document: WorkspaceDocument
+  document: OpenApiDocument
   /** The http client options for the dropdown */
   clientOptions: ClientOptionGroup[]
   /** The subset of the configuration object required for the operation component */

--- a/packages/api-reference/src/features/Operation/Operation.test.ts
+++ b/packages/api-reference/src/features/Operation/Operation.test.ts
@@ -3,8 +3,10 @@ import { apiReferenceConfigurationSchema } from '@scalar/types/api-reference'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
-import { OpenAPIDocumentSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-import type { WorkspaceDocument } from '@scalar/workspace-store/schemas/workspace'
+import {
+  OpenAPIDocumentSchema,
+  type OpenApiDocument,
+} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 
@@ -96,7 +98,7 @@ describe('Operation', () => {
     enableConsoleError()
   })
 
-  const createMockDocument = (): WorkspaceDocument =>
+  const createMockDocument = (): OpenApiDocument =>
     coerceValue(OpenAPIDocumentSchema, {
       openapi: '3.1.0',
       info: {

--- a/packages/api-reference/test/utils/sources.ts
+++ b/packages/api-reference/test/utils/sources.ts
@@ -22,6 +22,11 @@ export const sources = [
     layout: 'classic',
   },
   {
+    title: 'Scalar Galaxy (AsyncAPI)',
+    slug: 'scalar-galaxy-events',
+    url: 'https://registry.scalar.com/@scalar/schemas/asyncapi?format=json',
+  },
+  {
     title: 'Tag Groups',
     slug: 'tag-groups',
     content: {

--- a/packages/oas-utils/src/migrations/migrate-to-indexdb.test.ts
+++ b/packages/oas-utils/src/migrations/migrate-to-indexdb.test.ts
@@ -1,5 +1,6 @@
 import { type SecurityScheme, securitySchemeSchema } from '@scalar/types/entities'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { assert, beforeEach, describe, expect, it } from 'vitest'
 import 'fake-indexeddb/auto'
 
@@ -454,7 +455,8 @@ describe('migrate-to-indexdb', () => {
 
       // Verify security scheme is in document components
       expect(
-        resultWorkspace.workspace.documents['test-api']!.components?.securitySchemes?.['api-key-auth'],
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['test-api']!.components
+          ?.securitySchemes?.['api-key-auth'],
       ).toMatchObject({
         type: 'apiKey',
         name: 'X-API-Key',
@@ -463,15 +465,18 @@ describe('migrate-to-indexdb', () => {
       })
       expect(
         // @ts-expect-error - value is not in the type
-        resultWorkspace.workspace.documents['test-api']!.components?.securitySchemes?.['api-key-auth']?.value,
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['test-api']!.components
+          ?.securitySchemes?.['api-key-auth']?.value,
       ).toBeUndefined()
       expect(
         // @ts-expect-error - uid is not in the type
-        resultWorkspace.workspace.documents['test-api']!.components?.securitySchemes?.['api-key-auth']?.uid,
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['test-api']!.components
+          ?.securitySchemes?.['api-key-auth']?.uid,
       ).toBeUndefined()
       expect(
         // @ts-expect-error - nameKey is not in the type
-        resultWorkspace.workspace.documents['test-api']!.components?.securitySchemes?.['api-key-auth']?.nameKey,
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['test-api']!.components
+          ?.securitySchemes?.['api-key-auth']?.nameKey,
       ).toBeUndefined()
 
       // Verify security scheme secrets are in auth store
@@ -502,7 +507,8 @@ describe('migrate-to-indexdb', () => {
 
       // Verify security scheme is in document components
       expect(
-        resultWorkspace.workspace.documents['bearer-api']!.components?.securitySchemes?.['bearer-auth'],
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['bearer-api']!.components
+          ?.securitySchemes?.['bearer-auth'],
       ).toMatchObject({
         type: 'http',
         scheme: 'bearer',
@@ -510,15 +516,18 @@ describe('migrate-to-indexdb', () => {
       })
       expect(
         // @ts-expect-error - token is not in the type
-        resultWorkspace.workspace.documents['bearer-api']!.components?.securitySchemes?.['bearer-auth']?.token,
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['bearer-api']!.components
+          ?.securitySchemes?.['bearer-auth']?.token,
       ).toBeUndefined()
       expect(
         // @ts-expect-error - uid is not in the type
-        resultWorkspace.workspace.documents['bearer-api']!.components?.securitySchemes?.['bearer-auth']?.uid,
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['bearer-api']!.components
+          ?.securitySchemes?.['bearer-auth']?.uid,
       ).toBeUndefined()
       expect(
         // @ts-expect-error - nameKey is not in the type
-        resultWorkspace.workspace.documents['bearer-api']!.components?.securitySchemes?.['bearer-auth']?.nameKey,
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['bearer-api']!.components
+          ?.securitySchemes?.['bearer-auth']?.nameKey,
       ).toBeUndefined()
 
       // Verify security scheme secrets are in auth store
@@ -553,26 +562,31 @@ describe('migrate-to-indexdb', () => {
 
       // Verify security scheme is in document components
       expect(
-        resultWorkspace.workspace.documents['basic-auth-api']!.components?.securitySchemes?.['basic-auth'],
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['basic-auth-api']!.components
+          ?.securitySchemes?.['basic-auth'],
       ).toMatchObject({
         type: 'http',
         scheme: 'basic',
       })
       expect(
         // @ts-expect-error - username and password are not in the type
-        resultWorkspace.workspace.documents['basic-auth-api']!.components?.securitySchemes?.['basic-auth']?.username,
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['basic-auth-api']!.components
+          ?.securitySchemes?.['basic-auth']?.username,
       ).toBeUndefined()
       expect(
         // @ts-expect-error - username and password are not in the type
-        resultWorkspace.workspace.documents['basic-auth-api']!.components?.securitySchemes?.['basic-auth']?.password,
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['basic-auth-api']!.components
+          ?.securitySchemes?.['basic-auth']?.password,
       ).toBeUndefined()
       expect(
         // @ts-expect-error - uid is not in the type
-        resultWorkspace.workspace.documents['basic-auth-api']!.components?.securitySchemes?.['basic-auth']?.uid,
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['basic-auth-api']!.components
+          ?.securitySchemes?.['basic-auth']?.uid,
       ).toBeUndefined()
       expect(
         // @ts-expect-error - nameKey is not in the type
-        resultWorkspace.workspace.documents['basic-auth-api']!.components?.securitySchemes?.['basic-auth']?.nameKey,
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['basic-auth-api']!.components
+          ?.securitySchemes?.['basic-auth']?.nameKey,
       ).toBeUndefined()
 
       // Verify security scheme secrets are in auth store
@@ -617,7 +631,8 @@ describe('migrate-to-indexdb', () => {
       const resultWorkspace = result[0]!
 
       // Verify security scheme is in document components
-      const oauthScheme = resultWorkspace.workspace.documents['oauth-api']!.components?.securitySchemes?.['oauth2-auth']
+      const oauthScheme = (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['oauth-api']!
+        .components?.securitySchemes?.['oauth2-auth']
       if (oauthScheme && 'type' in oauthScheme && oauthScheme.type === 'oauth2') {
         expect(oauthScheme.type).toBe('oauth2')
         expect(oauthScheme.flows?.authorizationCode).toEqual({
@@ -707,13 +722,17 @@ describe('migrate-to-indexdb', () => {
       const resultWorkspace = result[0]!
 
       // Verify both documents have their security schemes
-      expect(resultWorkspace.workspace.documents['api-one']!.components?.securitySchemes?.['api-key']).toMatchObject({
+      expect(
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['api-one']!.components
+          ?.securitySchemes?.['api-key'],
+      ).toMatchObject({
         type: 'apiKey',
         name: 'X-API-Key',
         in: 'header',
       })
       expect(
-        resultWorkspace.workspace.documents['api-two']!.components?.securitySchemes?.['bearer-token'],
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['api-two']!.components
+          ?.securitySchemes?.['bearer-token'],
       ).toMatchObject({
         type: 'http',
         scheme: 'bearer',
@@ -742,8 +761,11 @@ describe('migrate-to-indexdb', () => {
       const resultWorkspace = result[0]!
 
       // Document should exist but have no security schemes
-      expect(resultWorkspace.workspace.documents['no-auth-api']).toBeDefined()
-      expect(resultWorkspace.workspace.documents['no-auth-api']!.components?.securitySchemes).toMatchObject({})
+      expect((resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['no-auth-api']).toBeDefined()
+      expect(
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['no-auth-api']!.components
+          ?.securitySchemes,
+      ).toMatchObject({})
 
       // Auth store should exist but be empty or have empty secrets
       expect(resultWorkspace.workspace.auth['no-auth-api']).toBeDefined()
@@ -1053,7 +1075,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['env-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['env-api']
         assert(doc)
 
         expect(doc['x-scalar-environments']).toStrictEqual({
@@ -1089,7 +1111,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['multi-env-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['multi-env-api']
         assert(doc)
 
         expect(doc['x-scalar-environments']).toStrictEqual({
@@ -1110,7 +1132,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['no-env-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['no-env-api']
         assert(doc)
         expect(doc['x-scalar-environments']).toBeUndefined()
       })
@@ -1134,7 +1156,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['active-env-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['active-env-api']
 
         assert(doc)
         expect(doc['x-scalar-active-environment']).toBe('production')
@@ -1146,7 +1168,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['no-active-env-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'no-active-env-api'
+        ]
 
         assert(doc)
         expect(doc['x-scalar-active-environment']).toBeUndefined()
@@ -1168,7 +1192,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['server-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['server-api']
 
         assert(doc)
         expect(doc['x-scalar-selected-server']).toBe('https://api.example.com/v1')
@@ -1180,7 +1204,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['no-server-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['no-server-api']
 
         assert(doc)
         expect(doc['x-scalar-selected-server']).toBeUndefined()
@@ -1193,7 +1217,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['missing-server-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'missing-server-api'
+        ]
 
         assert(doc)
         expect(doc['x-scalar-selected-server']).toBeUndefined()
@@ -1219,7 +1245,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['multi-server-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'multi-server-api'
+        ]
 
         assert(doc)
         expect(doc['x-scalar-selected-server']).toBe('https://api.prod.example.com')
@@ -1234,7 +1262,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['icon-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['icon-api']
 
         assert(doc)
         expect(doc['x-scalar-icon']).toBe('interface-home')
@@ -1246,7 +1274,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['default-icon-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'default-icon-api'
+        ]
 
         assert(doc)
         // The collection schema defaults to 'interface-content-folder'
@@ -1284,7 +1314,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['full-meta-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['full-meta-api']
 
         assert(doc)
 
@@ -1355,8 +1385,8 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc1 = result[0]?.workspace.documents['api-one']
-        const doc2 = result[0]?.workspace.documents['api-two']
+        const doc1 = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['api-one']
+        const doc2 = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['api-two']
 
         assert(doc1)
         assert(doc2)
@@ -1390,7 +1420,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['single-server-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'single-server-api'
+        ]
 
         assert(doc)
         expect(doc.servers).toHaveLength(1)
@@ -1428,7 +1460,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['multi-server-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'multi-server-api'
+        ]
 
         assert(doc)
         expect(doc.servers).toMatchObject([
@@ -1451,7 +1485,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['minimal-server-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'minimal-server-api'
+        ]
 
         assert(doc)
         expect(doc.servers).toMatchObject([{ url: 'https://minimal.example.com' }])
@@ -1463,7 +1499,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['no-servers-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['no-servers-api']
 
         assert(doc)
         expect(doc.servers).toEqual([])
@@ -1495,7 +1531,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['templated-server-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'templated-server-api'
+        ]
 
         assert(doc)
         expect(doc.servers).toMatchObject([
@@ -1534,7 +1572,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['default-var-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['default-var-api']
 
         assert(doc)
         expect(doc.servers).toMatchObject([
@@ -1577,7 +1615,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['multi-var-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['multi-var-api']
 
         assert(doc)
         expect(doc.servers).toMatchObject([
@@ -1641,8 +1679,8 @@ describe('migrate-to-indexdb', () => {
         expect(result).toHaveLength(1)
         const resultWorkspace = result[0]!
 
-        const doc1 = resultWorkspace.workspace.documents['api-one']
-        const doc2 = resultWorkspace.workspace.documents['api-two']
+        const doc1 = (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['api-one']
+        const doc2 = (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['api-two']
 
         assert(doc1)
         assert(doc2)
@@ -1692,8 +1730,8 @@ describe('migrate-to-indexdb', () => {
         const result = await transformLegacyDataToWorkspace(legacyData)
         const resultWorkspace = result[0]!
 
-        const docAlpha = resultWorkspace.workspace.documents['api-alpha']
-        const docBeta = resultWorkspace.workspace.documents['api-beta']
+        const docAlpha = (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['api-alpha']
+        const docBeta = (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['api-beta']
 
         assert(docAlpha)
         assert(docBeta)
@@ -1757,8 +1795,8 @@ describe('migrate-to-indexdb', () => {
 
         expect(result).toHaveLength(2)
 
-        const devDoc = result[0]?.workspace.documents['dev-api']
-        const prodDoc = result[1]?.workspace.documents['prod-api']
+        const devDoc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['dev-api']
+        const prodDoc = (result[1]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['prod-api']
 
         assert(devDoc)
         assert(prodDoc)
@@ -1805,8 +1843,8 @@ describe('migrate-to-indexdb', () => {
         const result = await transformLegacyDataToWorkspace(legacyData)
         const resultWorkspace = result[0]!
 
-        const docWith = resultWorkspace.workspace.documents['with-server']
-        const docWithout = resultWorkspace.workspace.documents['without-server']
+        const docWith = (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['with-server']
+        const docWithout = (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['without-server']
 
         assert(docWith)
         assert(docWithout)
@@ -1833,7 +1871,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['no-server-refs-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'no-server-refs-api'
+        ]
 
         assert(doc)
         // Unreferenced servers should not appear in the document
@@ -1851,7 +1891,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['ghost-server-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'ghost-server-api'
+        ]
 
         assert(doc)
         // Non-existent servers should be filtered out, not produce errors
@@ -1876,7 +1918,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['mixed-servers-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'mixed-servers-api'
+        ]
 
         assert(doc)
         // Only the valid server should appear
@@ -1913,7 +1957,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['tags-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['tags-api']
 
         assert(doc)
         expect(doc.tags).toEqual([
@@ -1958,7 +2002,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['nested-tags-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['nested-tags-api']
 
         assert(doc)
 
@@ -2023,7 +2067,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['multi-group-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['multi-group-api']
 
         assert(doc)
         expect(doc.tags).toEqual([
@@ -2076,7 +2120,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['mixed-tags-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['mixed-tags-api']
 
         assert(doc)
         expect(doc.tags).toEqual([
@@ -2111,7 +2155,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['missing-children-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'missing-children-api'
+        ]
 
         assert(doc)
         expect(doc.tags).toEqual([])
@@ -2140,7 +2186,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['documented-tags-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'documented-tags-api'
+        ]
 
         assert(doc)
         expect(doc.tags).toEqual([
@@ -2178,7 +2226,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc.paths?.['/users']?.get).toEqual({
@@ -2219,7 +2267,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc.paths?.['/users']?.post).toEqual({
@@ -2272,7 +2320,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(getResolvedRef(doc.paths?.['/users/{id}']?.get)?.parameters).toMatchObject([
@@ -2321,7 +2369,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc.paths).toEqual({
@@ -2370,7 +2418,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -2446,7 +2494,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -2512,7 +2560,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['api']
         assert(doc)
 
         expect(doc).toMatchObject({
@@ -2570,7 +2618,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -2633,7 +2681,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['auth-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['auth-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -2708,7 +2756,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['auth-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['auth-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -2771,7 +2819,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -2831,7 +2879,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['config-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['config-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -2891,7 +2939,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['data-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['data-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -2951,7 +2999,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['upload-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['upload-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -3028,7 +3076,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['auth-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['auth-api']
         expect(
           getResolvedRef(getResolvedRef(doc?.paths?.['/login']?.post)?.requestBody)?.['x-scalar-selected-content-type'],
         ).toEqual({
@@ -3063,7 +3111,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
         expect(getResolvedRef(doc?.paths?.['/users']?.get)?.requestBody).toBeUndefined()
       })
 
@@ -3094,7 +3142,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -3220,7 +3268,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['test-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['test-api']
         expect(doc).toMatchObject({
           openapi: '3.1.0',
           info: { title: 'Test API', version: '1.0.0' },
@@ -3299,7 +3347,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['scalar-galaxy']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['scalar-galaxy']
         expect(doc).toMatchObject({
           openapi: '3.1.0',
           info: { title: 'Scalar Galaxy', version: '1.0.0' },
@@ -3405,7 +3453,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['test-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['test-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -3474,7 +3522,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -3531,7 +3579,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -3581,7 +3629,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -3625,7 +3673,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -3663,7 +3711,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -3697,7 +3745,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -3729,7 +3777,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['local-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['local-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -3768,7 +3816,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['multi-server-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'multi-server-api'
+        ]
 
         assert(doc)
         expect(doc.servers).toEqual(
@@ -3813,7 +3863,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc.servers).toEqual([
@@ -3856,7 +3906,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['malformed-paths-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'malformed-paths-api'
+        ]
 
         assert(doc)
         expect(doc.servers).toEqual([])
@@ -3898,7 +3950,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc.servers).toEqual(
@@ -3934,7 +3986,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -3980,7 +4032,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['mixed-paths-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['mixed-paths-api']
 
         assert(doc)
         expect(doc.servers).toEqual(
@@ -4023,7 +4075,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['complex-url-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['complex-url-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4055,7 +4107,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['no-protocol-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['no-protocol-api']
 
         assert(doc)
         expect(doc.servers).toEqual([])
@@ -4099,7 +4151,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['dedup-server-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'dedup-server-api'
+        ]
 
         assert(doc)
         expect(doc.servers).toEqual([{ url: 'https://api.example.com' }])
@@ -4140,7 +4194,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['query-params-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'query-params-api'
+        ]
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4179,7 +4235,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc.servers).toEqual([
@@ -4206,7 +4262,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['root-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['root-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4245,7 +4301,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['relative-paths-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'relative-paths-api'
+        ]
 
         assert(doc)
         expect(doc.servers).toEqual([])
@@ -4280,7 +4338,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['subdomain-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['subdomain-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4312,7 +4370,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['nested-path-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['nested-path-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4358,7 +4416,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['protected-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['protected-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4422,7 +4480,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['protected-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['protected-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4490,7 +4548,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['protected-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['protected-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4559,7 +4617,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['oauth-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['oauth-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4610,7 +4668,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['public-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['public-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4642,7 +4700,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4711,7 +4769,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['mixed-security-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'mixed-security-api'
+        ]
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4771,7 +4831,9 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['experimental-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.[
+          'experimental-api'
+        ]
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4804,7 +4866,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['internal-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['internal-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4838,7 +4900,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4880,7 +4942,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4921,7 +4983,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4937,7 +4999,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['empty-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['empty-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4963,7 +5025,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['legacy-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['legacy-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -4995,7 +5057,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['root-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['root-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -5025,7 +5087,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['root-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['root-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -5089,8 +5151,8 @@ describe('migrate-to-indexdb', () => {
         const result = await transformLegacyDataToWorkspace(legacyData)
         const resultWorkspace = result[0]!
 
-        const doc1 = resultWorkspace.workspace.documents['api-one']
-        const doc2 = resultWorkspace.workspace.documents['api-two']
+        const doc1 = (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['api-one']
+        const doc2 = (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['api-two']
 
         assert(doc1)
         assert(doc2)
@@ -5152,7 +5214,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['users-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['users-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -5219,7 +5281,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['webhook-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['webhook-api']
 
         assert(doc)
         expect(doc).toMatchObject({
@@ -5286,7 +5348,7 @@ describe('migrate-to-indexdb', () => {
           legacyData.records.collections['collection-1'].components.schemas.TreeNode
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['tree-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['tree-api']
         expect(doc).toMatchObject({
           openapi: '3.1.0',
           info: {
@@ -5353,7 +5415,7 @@ describe('migrate-to-indexdb', () => {
           legacyData.records.collections['collection-1'].components.schemas.Person
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['people-api']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['people-api']
         expect(doc).toMatchObject({
           openapi: '3.1.0',
           info: { title: 'People API', version: '1.0.0' },
@@ -5509,7 +5571,7 @@ describe('migrate-to-indexdb', () => {
         })
 
         const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = result[0]?.workspace.documents['scalar-galaxy']
+        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['scalar-galaxy']
 
         expect(doc).toMatchObject({
           openapi: '3.1.0',
@@ -5680,9 +5742,15 @@ describe('migrate-to-indexdb', () => {
       expect(documentNames).toContain('my-api-1')
       expect(documentNames).toContain('my-api-2')
 
-      expect(resultWorkspace.workspace.documents['my-api']?.info.version).toBe('1.0.0')
-      expect(resultWorkspace.workspace.documents['my-api-1']?.info.version).toBe('2.0.0')
-      expect(resultWorkspace.workspace.documents['my-api-2']?.info.version).toBe('3.0.0')
+      expect((resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['my-api']?.info.version).toBe(
+        '1.0.0',
+      )
+      expect((resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['my-api-1']?.info.version).toBe(
+        '2.0.0',
+      )
+      expect((resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['my-api-2']?.info.version).toBe(
+        '3.0.0',
+      )
     })
 
     it('handles documents with special characters in names', async () => {
@@ -5786,10 +5854,18 @@ describe('migrate-to-indexdb', () => {
       expect(documentNames).toContain('duplicate-api-1')
       expect(documentNames).toContain('another-unique-api')
 
-      expect(resultWorkspace.workspace.documents['unique-api']?.info.version).toBe('1.0.0')
-      expect(resultWorkspace.workspace.documents['duplicate-api']?.info.version).toBe('1.0.0')
-      expect(resultWorkspace.workspace.documents['duplicate-api-1']?.info.version).toBe('2.0.0')
-      expect(resultWorkspace.workspace.documents['another-unique-api']?.info.version).toBe('1.0.0')
+      expect((resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['unique-api']?.info.version).toBe(
+        '1.0.0',
+      )
+      expect(
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['duplicate-api']?.info.version,
+      ).toBe('1.0.0')
+      expect(
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['duplicate-api-1']?.info.version,
+      ).toBe('2.0.0')
+      expect(
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['another-unique-api']?.info.version,
+      ).toBe('1.0.0')
     })
 
     it('handles documents without title falling back to default title', async () => {
@@ -5906,11 +5982,21 @@ describe('migrate-to-indexdb', () => {
       expect(documentNames).toContain('repeated-api-3')
       expect(documentNames).toContain('repeated-api-4')
 
-      expect(resultWorkspace.workspace.documents['repeated-api']?.info.version).toBe('1.0.0')
-      expect(resultWorkspace.workspace.documents['repeated-api-1']?.info.version).toBe('2.0.0')
-      expect(resultWorkspace.workspace.documents['repeated-api-2']?.info.version).toBe('3.0.0')
-      expect(resultWorkspace.workspace.documents['repeated-api-3']?.info.version).toBe('4.0.0')
-      expect(resultWorkspace.workspace.documents['repeated-api-4']?.info.version).toBe('5.0.0')
+      expect(
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['repeated-api']?.info.version,
+      ).toBe('1.0.0')
+      expect(
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['repeated-api-1']?.info.version,
+      ).toBe('2.0.0')
+      expect(
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['repeated-api-2']?.info.version,
+      ).toBe('3.0.0')
+      expect(
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['repeated-api-3']?.info.version,
+      ).toBe('4.0.0')
+      expect(
+        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['repeated-api-4']?.info.version,
+      ).toBe('5.0.0')
     })
 
     it('preserves "Drafts" special case normalization with duplicates', async () => {
@@ -5952,8 +6038,12 @@ describe('migrate-to-indexdb', () => {
       expect(documentNames).toContain('drafts')
       expect(documentNames).toContain('drafts-1')
 
-      expect(resultWorkspace.workspace.documents['drafts']?.info.version).toBe('1.0.0')
-      expect(resultWorkspace.workspace.documents['drafts-1']?.info.version).toBe('2.0.0')
+      expect((resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['drafts']?.info.version).toBe(
+        '1.0.0',
+      )
+      expect((resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['drafts-1']?.info.version).toBe(
+        '2.0.0',
+      )
     })
 
     it('ensures uniqueness is per workspace, not global', async () => {
@@ -6030,10 +6120,18 @@ describe('migrate-to-indexdb', () => {
       expect(workspace2DocNames).toContain('shared-name-api-1')
       expect(workspace2DocNames).toContain('drafts')
 
-      expect(workspace1Result.workspace.documents['shared-name-api']?.info.version).toBe('1.0.0')
-      expect(workspace1Result.workspace.documents['shared-name-api-1']?.info.version).toBe('2.0.0')
-      expect(workspace2Result.workspace.documents['shared-name-api']?.info.version).toBe('3.0.0')
-      expect(workspace2Result.workspace.documents['shared-name-api-1']?.info.version).toBe('4.0.0')
+      expect(
+        (workspace1Result.workspace.documents as Record<string, OpenApiDocument>)['shared-name-api']?.info.version,
+      ).toBe('1.0.0')
+      expect(
+        (workspace1Result.workspace.documents as Record<string, OpenApiDocument>)['shared-name-api-1']?.info.version,
+      ).toBe('2.0.0')
+      expect(
+        (workspace2Result.workspace.documents as Record<string, OpenApiDocument>)['shared-name-api']?.info.version,
+      ).toBe('3.0.0')
+      expect(
+        (workspace2Result.workspace.documents as Record<string, OpenApiDocument>)['shared-name-api-1']?.info.version,
+      ).toBe('4.0.0')
     })
   })
 })

--- a/packages/oas-utils/src/migrations/migrate-to-indexdb.test.ts
+++ b/packages/oas-utils/src/migrations/migrate-to-indexdb.test.ts
@@ -454,30 +454,20 @@ describe('migrate-to-indexdb', () => {
       assert(resultWorkspace)
 
       // Verify security scheme is in document components
-      expect(
-        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['test-api']!.components
-          ?.securitySchemes?.['api-key-auth'],
-      ).toMatchObject({
+      const apiKeyScheme = (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['test-api']!
+        .components?.securitySchemes?.['api-key-auth']
+      expect(apiKeyScheme).toMatchObject({
         type: 'apiKey',
         name: 'X-API-Key',
         in: 'header',
         description: 'API Key authentication',
       })
-      expect(
-        // @ts-expect-error - value is not in the type
-        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['test-api']!.components
-          ?.securitySchemes?.['api-key-auth']?.value,
-      ).toBeUndefined()
-      expect(
-        // @ts-expect-error - uid is not in the type
-        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['test-api']!.components
-          ?.securitySchemes?.['api-key-auth']?.uid,
-      ).toBeUndefined()
-      expect(
-        // @ts-expect-error - nameKey is not in the type
-        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['test-api']!.components
-          ?.securitySchemes?.['api-key-auth']?.nameKey,
-      ).toBeUndefined()
+      // @ts-expect-error - value is not in the type
+      expect(apiKeyScheme?.value).toBeUndefined()
+      // @ts-expect-error - uid is not in the type
+      expect(apiKeyScheme?.uid).toBeUndefined()
+      // @ts-expect-error - nameKey is not in the type
+      expect(apiKeyScheme?.nameKey).toBeUndefined()
 
       // Verify security scheme secrets are in auth store
       expect(resultWorkspace.workspace.auth['test-api']?.secrets['api-key-auth']).toEqual({
@@ -506,29 +496,19 @@ describe('migrate-to-indexdb', () => {
       const resultWorkspace = result[0]!
 
       // Verify security scheme is in document components
-      expect(
-        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['bearer-api']!.components
-          ?.securitySchemes?.['bearer-auth'],
-      ).toMatchObject({
+      const bearerScheme = (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['bearer-api']!
+        .components?.securitySchemes?.['bearer-auth']
+      expect(bearerScheme).toMatchObject({
         type: 'http',
         scheme: 'bearer',
         bearerFormat: 'JWT',
       })
-      expect(
-        // @ts-expect-error - token is not in the type
-        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['bearer-api']!.components
-          ?.securitySchemes?.['bearer-auth']?.token,
-      ).toBeUndefined()
-      expect(
-        // @ts-expect-error - uid is not in the type
-        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['bearer-api']!.components
-          ?.securitySchemes?.['bearer-auth']?.uid,
-      ).toBeUndefined()
-      expect(
-        // @ts-expect-error - nameKey is not in the type
-        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['bearer-api']!.components
-          ?.securitySchemes?.['bearer-auth']?.nameKey,
-      ).toBeUndefined()
+      // @ts-expect-error - token is not in the type
+      expect(bearerScheme?.token).toBeUndefined()
+      // @ts-expect-error - uid is not in the type
+      expect(bearerScheme?.uid).toBeUndefined()
+      // @ts-expect-error - nameKey is not in the type
+      expect(bearerScheme?.nameKey).toBeUndefined()
 
       // Verify security scheme secrets are in auth store
       expect(resultWorkspace.workspace.auth['bearer-api']!.secrets['bearer-auth']).toEqual({
@@ -561,33 +541,20 @@ describe('migrate-to-indexdb', () => {
       const resultWorkspace = result[0]!
 
       // Verify security scheme is in document components
-      expect(
-        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['basic-auth-api']!.components
-          ?.securitySchemes?.['basic-auth'],
-      ).toMatchObject({
+      const basicScheme = (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['basic-auth-api']!
+        .components?.securitySchemes?.['basic-auth']
+      expect(basicScheme).toMatchObject({
         type: 'http',
         scheme: 'basic',
       })
-      expect(
-        // @ts-expect-error - username and password are not in the type
-        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['basic-auth-api']!.components
-          ?.securitySchemes?.['basic-auth']?.username,
-      ).toBeUndefined()
-      expect(
-        // @ts-expect-error - username and password are not in the type
-        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['basic-auth-api']!.components
-          ?.securitySchemes?.['basic-auth']?.password,
-      ).toBeUndefined()
-      expect(
-        // @ts-expect-error - uid is not in the type
-        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['basic-auth-api']!.components
-          ?.securitySchemes?.['basic-auth']?.uid,
-      ).toBeUndefined()
-      expect(
-        // @ts-expect-error - nameKey is not in the type
-        (resultWorkspace.workspace.documents as Record<string, OpenApiDocument>)['basic-auth-api']!.components
-          ?.securitySchemes?.['basic-auth']?.nameKey,
-      ).toBeUndefined()
+      // @ts-expect-error - username and password are not in the type
+      expect(basicScheme?.username).toBeUndefined()
+      // @ts-expect-error - username and password are not in the type
+      expect(basicScheme?.password).toBeUndefined()
+      // @ts-expect-error - uid is not in the type
+      expect(basicScheme?.uid).toBeUndefined()
+      // @ts-expect-error - nameKey is not in the type
+      expect(basicScheme?.nameKey).toBeUndefined()
 
       // Verify security scheme secrets are in auth store
       expect(resultWorkspace.workspace.auth['basic-auth-api']!.secrets['basic-auth']).toEqual({

--- a/packages/oas-utils/src/migrations/migrate-to-indexdb.ts
+++ b/packages/oas-utils/src/migrations/migrate-to-indexdb.ts
@@ -16,6 +16,7 @@ import {
 import { xScalarCookieSchema } from '@scalar/workspace-store/schemas/extensions/general/x-scalar-cookies'
 import type { XTagGroup } from '@scalar/workspace-store/schemas/extensions/tag'
 import type { InMemoryWorkspace } from '@scalar/workspace-store/schemas/inmemory-workspace'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
 import type {
   OperationObject,
@@ -263,7 +264,9 @@ export const transformLegacyDataToWorkspace = async (legacyData: {
 
         const drafts = store.workspace.documents[DRAFTS_DOCUMENT_NAME]
 
-        if (drafts) {
+        // The drafts document is always OpenAPI-shaped (constructed above with `paths`); the
+        // guard narrows the WorkspaceDocument union so we can access `.paths` safely.
+        if (isOpenApiDocument(drafts)) {
           // Make sure the drafts document has a GET / route cuz that's the first route we navigate the user to
           drafts.paths ??= {}
           drafts.paths['/'] ??= {}

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -1,11 +1,13 @@
 import { cwd } from 'node:process'
 
-import { consoleErrorSpy, resetConsoleSpies } from '@scalar/helpers/testing/console-spies'
+import { consoleErrorSpy, consoleWarnSpy, resetConsoleSpies } from '@scalar/helpers/testing/console-spies'
 import { getRaw } from '@scalar/json-magic/magic-proxy'
 import fastify, { type FastifyInstance } from 'fastify'
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { type WorkspaceDocumentInput, createWorkspaceStore } from '@/client'
+import type { AsyncApiDocument } from '@/schemas/asyncapi/asyncapi-document'
+import { isAsyncApiDocument } from '@/schemas/type-guards'
 import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 import { createServerWorkspaceStore } from '@/server'
 
@@ -3640,6 +3642,95 @@ describe('create-workspace-store', () => {
         ],
       })
     })
+  })
+})
+
+describe('asyncapi ingestion', () => {
+  beforeEach(() => {
+    resetConsoleSpies()
+  })
+
+  const minimalAsyncApi = {
+    asyncapi: '3.0.0',
+    info: {
+      title: 'Streetlights API',
+      version: '1.0.0',
+    },
+  }
+
+  it('lands in the workspace without OpenAPI validation noise', async () => {
+    const store = createWorkspaceStore()
+
+    await store.addDocument({ name: 'default', document: { ...minimalAsyncApi } })
+
+    const doc = store.workspace.documents['default']
+    expect(doc).toBeDefined()
+    expect(isAsyncApiDocument(doc)).toBe(true)
+
+    // No OpenAPI validation warnings, no AsyncAPI validation warnings
+    expect(consoleWarnSpy).not.toHaveBeenCalled()
+  })
+
+  it('injects the store-managed metadata extensions', async () => {
+    const store = createWorkspaceStore()
+
+    await store.addDocument({ name: 'default', document: { ...minimalAsyncApi } })
+
+    const doc = store.workspace.documents['default'] as AsyncApiDocument
+    expect(doc['x-original-aas-version']).toBe('3.0.0')
+    expect(doc['x-scalar-original-document-hash']).toEqual(expect.any(String))
+    // No source url for in-memory docs
+    expect(doc['x-scalar-original-source-url']).toBeUndefined()
+  })
+
+  it('preserves the original raw document', async () => {
+    const store = createWorkspaceStore()
+    const input = { ...minimalAsyncApi }
+
+    await store.addDocument({ name: 'default', document: input })
+
+    // The original document snapshot stays untouched — byte-identical to the input object
+    expect(store.getOriginalDocument('default')).toEqual(input)
+  })
+
+  it('logs an AsyncAPI-prefixed warning for a misshapen document', async () => {
+    const store = createWorkspaceStore()
+
+    await store.addDocument({
+      name: 'default',
+      document: {
+        asyncapi: '3.0.0',
+        // Missing required info.title — triggers AsyncApiDocumentSchema validation
+        info: { version: '1.0.0' },
+      },
+    })
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'AsyncAPI document validation errors:',
+      expect.arrayContaining([expect.objectContaining({ path: expect.stringContaining('title') })]),
+    )
+  })
+
+  it('replaceDocument works on an AsyncAPI-backed document', async () => {
+    const store = createWorkspaceStore()
+
+    await store.addDocument({ name: 'default', document: { ...minimalAsyncApi } })
+    await store.replaceDocument('default', { ...minimalAsyncApi, info: { ...minimalAsyncApi.info, title: 'Renamed' } })
+
+    const doc = store.workspace.documents['default'] as AsyncApiDocument
+    expect(isAsyncApiDocument(doc)).toBe(true)
+    expect(doc.info.title).toBe('Renamed')
+  })
+
+  it('revertDocumentChanges works on an AsyncAPI-backed document', async () => {
+    const store = createWorkspaceStore()
+
+    await store.addDocument({ name: 'default', document: { ...minimalAsyncApi } })
+    await store.replaceDocument('default', { ...minimalAsyncApi, info: { ...minimalAsyncApi.info, title: 'Renamed' } })
+    await store.revertDocumentChanges('default')
+
+    const doc = store.workspace.documents['default'] as AsyncApiDocument
+    expect(doc.info.title).toBe('Streetlights API')
   })
 })
 

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -6,8 +6,9 @@ import fastify, { type FastifyInstance } from 'fastify'
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { type WorkspaceDocumentInput, createWorkspaceStore } from '@/client'
+import { createTag } from '@/mutators/tag'
 import type { AsyncApiDocument } from '@/schemas/asyncapi/asyncapi-document'
-import { isAsyncApiDocument } from '@/schemas/type-guards'
+import { isAsyncApiDocument, isOpenApiDocument } from '@/schemas/type-guards'
 import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 import { createServerWorkspaceStore } from '@/server'
 
@@ -3731,6 +3732,57 @@ describe('asyncapi ingestion', () => {
 
     const doc = store.workspace.documents['default'] as AsyncApiDocument
     expect(doc.info.title).toBe('Streetlights API')
+  })
+
+  it('accepts OpenAPI and AsyncAPI documents in the same workspace', async () => {
+    const store = createWorkspaceStore()
+
+    await store.addDocument({
+      name: 'api',
+      document: { openapi: '3.1.0', info: { title: 'Rest', version: '1.0.0' } },
+    })
+    await store.addDocument({ name: 'events', document: { ...minimalAsyncApi } })
+
+    expect(isOpenApiDocument(store.workspace.documents['api'])).toBe(true)
+    expect(isAsyncApiDocument(store.workspace.documents['events'])).toBe(true)
+  })
+
+  it('createTag no-ops and logs when pointed at an AsyncAPI document', async () => {
+    const store = createWorkspaceStore()
+    await store.addDocument({ name: 'events', document: { ...minimalAsyncApi } })
+
+    createTag(store, { documentName: 'events', name: 'new-tag' })
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Document not found', expect.any(Object))
+    // Guard must prevent the mutator from touching the doc
+    expect((store.workspace.documents['events'] as AsyncApiDocument & { tags?: unknown }).tags).toBeUndefined()
+  })
+
+  it('rebaseDocument detects NO_CHANGES_DETECTED on an unchanged AsyncAPI doc', async () => {
+    // Serve the same AsyncAPI doc from a URL, load it, then rebase against the same URL. With
+    // both the stored hash and the re-fetched hash identical, rebase must short-circuit with
+    // NO_CHANGES_DETECTED — which is only reachable if the hash check on line ~1479 now reads
+    // the field off the AsyncAPI branch too.
+    const port = 9991
+    const rebaseServer = fastify({ logger: false })
+    rebaseServer.get('/events.json', async () => minimalAsyncApi)
+    await rebaseServer.listen({ port })
+
+    try {
+      const store = createWorkspaceStore()
+      await store.addDocument({ name: 'events', url: `http://localhost:${port}/events.json` })
+
+      const result = await store.rebaseDocument({
+        name: 'events',
+        url: `http://localhost:${port}/events.json`,
+      })
+
+      expect(result.ok).toBe(false)
+      assert(!result.ok)
+      expect(result.type).toBe('NO_CHANGES_DETECTED')
+    } finally {
+      await rebaseServer.close()
+    }
   })
 })
 

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -6,6 +6,7 @@ import fastify, { type FastifyInstance } from 'fastify'
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { type WorkspaceDocumentInput, createWorkspaceStore } from '@/client'
+import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 import { createServerWorkspaceStore } from '@/server'
 
 // Test document
@@ -134,11 +135,15 @@ describe('create-workspace-store', () => {
 
     // Should update the active document
     store.updateDocument('active', 'x-scalar-selected-server', 'server-2')
-    expect(store.workspace.documents['default']?.['x-scalar-selected-server']).toBe('server-2')
+    expect((store.workspace.documents['default'] as OpenApiDocument | undefined)?.['x-scalar-selected-server']).toBe(
+      'server-2',
+    )
 
     // Should update a specific document
     store.updateDocument('default', 'x-scalar-selected-server', 'server-3')
-    expect(store.workspace.documents['default']?.['x-scalar-selected-server']).toBe('server-3')
+    expect((store.workspace.documents['default'] as OpenApiDocument | undefined)?.['x-scalar-selected-server']).toBe(
+      'server-3',
+    )
   })
 
   it('does not throw when updating non-existent document', () => {
@@ -175,10 +180,12 @@ describe('create-workspace-store', () => {
     expect(result).toBe(true)
 
     // Should update the meta field
-    expect(store.workspace.documents['test-doc']?.['x-scalar-selected-server']).toBe('updated-server')
+    expect((store.workspace.documents['test-doc'] as OpenApiDocument | undefined)?.['x-scalar-selected-server']).toBe(
+      'updated-server',
+    )
 
     // Should preserve other document fields (note: openapi version gets upgraded to 3.1.1)
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.info.title).toBe('Test API')
     expect(document?.openapi).toBeDefined()
   })
@@ -213,13 +220,13 @@ describe('create-workspace-store', () => {
     })
 
     // Correctly gets the active document
-    expect(store.workspace.activeDocument?.info?.title).toBe('My API')
+    expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.info?.title).toBe('My API')
 
     store.update('x-scalar-active-document', 'document2')
-    expect(store.workspace.activeDocument?.info?.title).toBe('Second API')
+    expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.info?.title).toBe('Second API')
 
     // Correctly get a specific document
-    expect(store.workspace.documents['default']).toEqual({
+    expect(store.workspace.documents['default'] as OpenApiDocument | undefined).toEqual({
       info: {
         title: 'My API',
         version: '',
@@ -340,8 +347,8 @@ describe('create-workspace-store', () => {
     })
 
     expect(
-      (store?.workspace?.activeDocument?.paths?.['/users']?.get as any)?.responses?.[200]?.content['application/json']
-        .schema.items['$ref-value'].properties.name,
+      ((store?.workspace?.activeDocument as OpenApiDocument | undefined)?.paths?.['/users']?.get as any)
+        ?.responses?.[200]?.content['application/json'].schema.items['$ref-value'].properties.name,
     ).toEqual({
       type: 'string',
       description: 'The user name',
@@ -377,7 +384,7 @@ describe('create-workspace-store', () => {
     })
 
     // The operation should not be resolved on the fly
-    expect(store.workspace.activeDocument?.paths?.['/users']?.get).toEqual({
+    expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.paths?.['/users']?.get).toEqual({
       '$ref': 'http://localhost:9988/default/operations/~1users/get#',
       $global: true,
     })
@@ -386,14 +393,14 @@ describe('create-workspace-store', () => {
     await store.resolve(['paths', '/users', 'get'])
 
     // We expect the ref to have been resolved with the correct contents
-    expect((store.workspace.activeDocument?.paths?.['/users']?.get as any)['$ref-value'].summary).toEqual(
-      getDocument().paths['/users'].get.summary,
-    )
+    expect(
+      ((store.workspace.activeDocument as OpenApiDocument | undefined)?.paths?.['/users']?.get as any)['$ref-value']
+        .summary,
+    ).toEqual(getDocument().paths['/users'].get.summary)
 
     expect(
-      (store.workspace.activeDocument?.paths?.['/users']?.get as any)['$ref-value']?.responses?.[200]?.content[
-        'application/json'
-      ]?.schema?.items['$ref-value']['$ref-value'],
+      ((store.workspace.activeDocument as OpenApiDocument | undefined)?.paths?.['/users']?.get as any)['$ref-value']
+        ?.responses?.[200]?.content['application/json']?.schema?.items['$ref-value']['$ref-value'],
     ).toEqual({
       ...getDocument().components.schemas.User,
     })
@@ -415,13 +422,17 @@ describe('create-workspace-store', () => {
     })
 
     expect(Object.keys(store.workspace.documents)).toEqual(['default'])
-    expect(store.workspace.documents['default']?.info?.title).toEqual(getDocument().info.title)
+    expect((store.workspace.documents['default'] as OpenApiDocument | undefined)?.info?.title).toEqual(
+      getDocument().info.title,
+    )
 
     // Add a new remote file
     await store.addDocument({ name: 'new', url: url })
 
     expect(Object.keys(store.workspace.documents)).toEqual(['default', 'new'])
-    expect(store.workspace.documents['new']?.info?.title).toEqual(getDocument().info.title)
+    expect((store.workspace.documents['new'] as OpenApiDocument | undefined)?.info?.title).toEqual(
+      getDocument().info.title,
+    )
   })
 
   // TODO: handle server side preprocessed documents (nested refs)
@@ -505,7 +516,7 @@ describe('create-workspace-store', () => {
     })
 
     // The operation should not be resolved on the fly
-    expect(store.workspace.activeDocument?.paths?.['/users']?.get).toEqual({
+    expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.paths?.['/users']?.get).toEqual({
       '$ref': `${url}/default/operations/~1users/get#`,
       $global: true,
     })
@@ -513,7 +524,11 @@ describe('create-workspace-store', () => {
     // We resolve the ref
     await store.resolve(['paths', '/users', 'get'])
 
-    expect((store.workspace.activeDocument?.components?.schemas?.['User'] as any)['$ref-value'].type).toBe('object')
+    expect(
+      ((store.workspace.activeDocument as OpenApiDocument | undefined)?.components?.schemas?.['User'] as any)[
+        '$ref-value'
+      ].type,
+    ).toBe('object')
   })
 
   it('build the sidebar client side', async () => {
@@ -711,7 +726,9 @@ describe('create-workspace-store', () => {
 
     const result = store.buildSidebar('test-doc')
     expect(result).toBe(true)
-    expect(store.workspace.documents['test-doc']?.['x-scalar-navigation']).toBeDefined()
+    expect(
+      (store.workspace.documents['test-doc'] as OpenApiDocument | undefined)?.['x-scalar-navigation'],
+    ).toBeDefined()
   })
 
   it('bundles the document if the document is not preprocessed by the server-side-store', async () => {
@@ -748,7 +765,7 @@ describe('create-workspace-store', () => {
       },
     })
 
-    expect(store.workspace.documents['default']).toEqual({
+    expect(store.workspace.documents['default'] as OpenApiDocument | undefined).toEqual({
       info: {
         title: '',
         version: '',
@@ -858,7 +875,7 @@ describe('create-workspace-store', () => {
       },
     })
 
-    expect(store.workspace.documents['default']).toEqual({
+    expect(store.workspace.documents['default'] as OpenApiDocument | undefined).toEqual({
       components: {
         schemas: {
           User: {
@@ -1378,7 +1395,10 @@ describe('create-workspace-store', () => {
       '{"documents":{"default":{"openapi":"3.1.1","paths":{"/users":{"get":{"requestBody":{"$ref":"#/x-ext/26e1ce1"}}}},"x-original-oas-version":"3.1.1","x-scalar-original-document-hash":"22a67d89a1832713","x-scalar-original-source-url":"http://localhost:9988","x-ext-urls":{"26e1ce1":"a"},"x-ext":{"26e1ce1":{"description":"Some description","content":{}}},"info":{"title":"","version":""},"x-scalar-order":["default/description/introduction","default/GET/users"],"x-scalar-navigation":{"id":"default","type":"document","title":"Untitled Document","name":"default","children":[{"id":"default/description/introduction","title":"Introduction","type":"text"},{"id":"default/GET/users","title":"/users","path":"/users","method":"get","ref":"#/paths/~1users/get","type":"operation","isDeprecated":false}]}}},"meta":{},"originalDocuments":{"default":{"openapi":"3.1.1","paths":{"/users":{"get":{"requestBody":{"$ref":"http://localhost:9988/a"}}}}}},"intermediateDocuments":{"default":{"openapi":"3.1.1","paths":{"/users":{"get":{"requestBody":{"$ref":"http://localhost:9988/a"}}}}}},"overrides":{"default":{}},"history":{},"auth":{}}',
     )
 
-    await store.replaceDocument('default', getRaw(store.workspace.documents['default'] ?? {}))
+    await store.replaceDocument(
+      'default',
+      getRaw((store.workspace.documents['default'] as OpenApiDocument | undefined) ?? {}),
+    )
 
     expect(JSON.stringify(store.exportWorkspace())).toEqual(
       '{"documents":{"default":{"openapi":"3.1.1","paths":{"/users":{"get":{"requestBody":{"$ref":"#/x-ext/26e1ce1"}}}},"x-original-oas-version":"3.1.1","x-scalar-original-document-hash":"22a67d89a1832713","x-scalar-original-source-url":"http://localhost:9988","x-ext-urls":{"26e1ce1":"a"},"x-ext":{"26e1ce1":{"description":"Some description","content":{}}},"info":{"title":"","version":""},"x-scalar-order":["default/description/introduction","default/GET/users"],"x-scalar-navigation":{"id":"default","type":"document","title":"Untitled Document","name":"default","children":[{"id":"default/description/introduction","title":"Introduction","type":"text"},{"id":"default/GET/users","title":"/users","path":"/users","method":"get","ref":"#/paths/~1users/get","type":"operation","isDeprecated":false}]},"x-scalar-is-dirty":true}},"meta":{},"originalDocuments":{"default":{"openapi":"3.1.1","paths":{"/users":{"get":{"requestBody":{"$ref":"http://localhost:9988/a"}}}}}},"intermediateDocuments":{"default":{"openapi":"3.1.1","paths":{"/users":{"get":{"requestBody":{"$ref":"http://localhost:9988/a"}}}}}},"overrides":{"default":{}},"history":{},"auth":{}}',
@@ -1599,8 +1619,8 @@ describe('create-workspace-store', () => {
       },
     })
 
-    expect(store.workspace.activeDocument?.['x-original-oas-version']).toBe('2.0')
-    expect(store.workspace.activeDocument?.['x-scalar-order']).toEqual([
+    expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.['x-original-oas-version']).toBe('2.0')
+    expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.['x-scalar-order']).toEqual([
       'default/description/introduction',
       'default/GET/ping',
     ])
@@ -1644,8 +1664,8 @@ describe('create-workspace-store', () => {
       },
     })
 
-    expect(store.workspace.activeDocument?.['x-original-oas-version']).toBe('3.0.0')
-    expect(store.workspace.activeDocument?.['x-scalar-order']).toEqual([
+    expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.['x-original-oas-version']).toBe('3.0.0')
+    expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.['x-scalar-order']).toEqual([
       'default/description/introduction',
       'default/GET/ping',
     ])
@@ -1660,16 +1680,16 @@ describe('create-workspace-store', () => {
       },
     })
 
-    expect(store.workspace.activeDocument?.['x-scalar-is-dirty']).toBeUndefined()
+    expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.['x-scalar-is-dirty']).toBeUndefined()
 
     assert(store.workspace.activeDocument)
     store.workspace.activeDocument.info.title = 'My API'
 
-    expect(store.workspace.activeDocument?.['x-scalar-is-dirty']).toBe(true)
+    expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.['x-scalar-is-dirty']).toBe(true)
 
     await store.saveDocument('default')
 
-    expect(store.workspace.activeDocument?.['x-scalar-is-dirty']).toBe(false)
+    expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.['x-scalar-is-dirty']).toBe(false)
   })
 
   it('does uses the file loader plugin to resolve local file references', async () => {
@@ -1754,8 +1774,10 @@ describe('create-workspace-store', () => {
 
       expect(result).toBe(true)
       expect(fileLoaderExec).toHaveBeenCalledWith('/path/to/openapi.yaml')
-      expect(store.workspace.documents['fs-document']).toBeDefined()
-      expect(store.workspace.documents['fs-document']?.info.title).toBe('File System API')
+      expect(store.workspace.documents['fs-document'] as OpenApiDocument | undefined).toBeDefined()
+      expect((store.workspace.documents['fs-document'] as OpenApiDocument | undefined)?.info.title).toBe(
+        'File System API',
+      )
     })
 
     it('sets the correct document source when loading from file path', async () => {
@@ -1782,7 +1804,7 @@ describe('create-workspace-store', () => {
         path: '/Users/projects/specs/api.yaml',
       })
 
-      const document = store.workspace.documents['local-doc']
+      const document = store.workspace.documents['local-doc'] as OpenApiDocument | undefined
       expect(document?.['x-scalar-original-source-url']).toBe('/Users/projects/specs/api.yaml')
     })
 
@@ -1797,8 +1819,10 @@ describe('create-workspace-store', () => {
 
       expect(result).toBe(false)
       expect(consoleErrorSpy).toHaveBeenCalledWith('No loader provided for loading files')
-      expect(store.workspace.documents['missing-loader']).toBeDefined()
-      expect(store.workspace.documents['missing-loader']?.info.title).toContain('could not be loaded')
+      expect(store.workspace.documents['missing-loader'] as OpenApiDocument | undefined).toBeDefined()
+      expect((store.workspace.documents['missing-loader'] as OpenApiDocument | undefined)?.info.title).toContain(
+        'could not be loaded',
+      )
     })
 
     it('preserves document metadata when loading from file', async () => {
@@ -1828,7 +1852,7 @@ describe('create-workspace-store', () => {
         },
       })
 
-      const document = store.workspace.documents['test-doc']
+      const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
       expect(document?.['x-scalar-selected-server']).toBe('staging')
     })
 
@@ -1887,7 +1911,7 @@ describe('create-workspace-store', () => {
 
       expect(fileLoaderExec).toHaveBeenCalledWith('./main-spec.yaml')
       expect(fileLoaderExec).toHaveBeenCalledWith(`${cwd()}/operations/get-items.yaml`)
-      expect(store.workspace.documents['ref-doc']).toBeDefined()
+      expect(store.workspace.documents['ref-doc'] as OpenApiDocument | undefined).toBeDefined()
     })
 
     it('stores the original document hash when loading from file', async () => {
@@ -1914,7 +1938,7 @@ describe('create-workspace-store', () => {
         path: '/specs/test.yaml',
       })
 
-      const document = store.workspace.documents['hash-doc']
+      const document = store.workspace.documents['hash-doc'] as OpenApiDocument | undefined
       expect(document?.['x-scalar-original-document-hash']).toBeDefined()
       expect(typeof document?.['x-scalar-original-document-hash']).toBe('string')
     })
@@ -1966,8 +1990,8 @@ describe('create-workspace-store', () => {
 
       expect(result1).toBe(true)
       expect(result2).toBe(true)
-      expect(store.workspace.documents['doc1']?.info.title).toBe('API 1')
-      expect(store.workspace.documents['doc2']?.info.title).toBe('API 2')
+      expect((store.workspace.documents['doc1'] as OpenApiDocument | undefined)?.info.title).toBe('API 1')
+      expect((store.workspace.documents['doc2'] as OpenApiDocument | undefined)?.info.title).toBe('API 2')
     })
   })
 
@@ -2059,8 +2083,9 @@ describe('create-workspace-store', () => {
         document: getDocument(),
       })
 
-      if (store.workspace.documents['api-3']?.info?.title) {
-        store.workspace.documents['api-3'].info.title = 'Updated API'
+      const apiThreeDoc = store.workspace.documents['api-3'] as OpenApiDocument | undefined
+      if (apiThreeDoc?.info?.title) {
+        apiThreeDoc.info.title = 'Updated API'
       }
 
       // Write the changes back to the original document
@@ -2106,8 +2131,9 @@ describe('create-workspace-store', () => {
         },
       })
 
-      if (store.workspace.activeDocument?.info?.title) {
-        store.workspace.activeDocument.info.title = 'Updated API'
+      const activeDoc = store.workspace.activeDocument as OpenApiDocument | undefined
+      if (activeDoc?.info?.title) {
+        activeDoc.info.title = 'Updated API'
       }
 
       // Write the changes back to the original document
@@ -2193,8 +2219,9 @@ describe('create-workspace-store', () => {
         document: getDocument(),
       })
 
-      if (store.workspace.documents['api-3']?.info?.title) {
-        store.workspace.documents['api-3'].info.title = 'Updated API'
+      const apiThreeDoc = store.workspace.documents['api-3'] as OpenApiDocument | undefined
+      if (apiThreeDoc?.info?.title) {
+        apiThreeDoc.info.title = 'Updated API'
       }
 
       expect(store.workspace?.documents['api-3']?.info?.title).toBe('Updated API')
@@ -2230,7 +2257,7 @@ describe('create-workspace-store', () => {
       const doc = getDocument()
       await store.addDocument({ name: 'default', document: doc })
 
-      const result = await store.getEditableDocument('default')
+      const result = (await store.getEditableDocument('default')) as OpenApiDocument | null
 
       expect(result).not.toBeNull()
       // Store upgrades OpenAPI to 3.1.x when adding document
@@ -2285,7 +2312,7 @@ describe('create-workspace-store', () => {
         result.info.title = 'Mutated title'
       }
 
-      const workspaceDoc = store.workspace.documents['default']
+      const workspaceDoc = store.workspace.documents['default'] as OpenApiDocument | undefined
       const rawDoc = getRaw(workspaceDoc as object) as { info?: { title?: string } }
       expect(rawDoc?.info?.title).not.toBe('Mutated title')
     })
@@ -2298,7 +2325,7 @@ describe('create-workspace-store', () => {
         name: 'default',
         document: { openapi: '3.1.0', info: { title: 'Initial', version: '1.0.0' } },
       })
-      const doc = store.workspace.documents['default']
+      const doc = store.workspace.documents['default'] as OpenApiDocument | undefined
       if (doc?.info) {
         doc.info.title = 'Updated title'
       }
@@ -2333,7 +2360,7 @@ describe('create-workspace-store', () => {
         name: 'api',
         document: { openapi: '3.1.0', info: { title: 'A', version: '1.0.0' } },
       })
-      const doc = store.workspace.documents['api']
+      const doc = store.workspace.documents['api'] as OpenApiDocument | undefined
       if (doc?.info) {
         doc.info.title = 'B'
       }
@@ -2550,9 +2577,9 @@ describe('create-workspace-store', () => {
         },
       })
 
-      expect(store.workspace.documents['default']?.info?.title).toBe('My Updated API')
-      expect(store.workspace.documents['default']?.info?.version).toBe('2.0.0')
-      expect(store.workspace.documents['default']?.openapi).toBe('3.1.1')
+      expect((store.workspace.documents['default'] as OpenApiDocument | undefined)?.info?.title).toBe('My Updated API')
+      expect((store.workspace.documents['default'] as OpenApiDocument | undefined)?.info?.version).toBe('2.0.0')
+      expect((store.workspace.documents['default'] as OpenApiDocument | undefined)?.openapi).toBe('3.1.1')
     })
 
     it('edit the override values', async () => {
@@ -2569,7 +2596,7 @@ describe('create-workspace-store', () => {
         },
       })
 
-      const defaultDocument = store.workspace.documents['default']
+      const defaultDocument = store.workspace.documents['default'] as OpenApiDocument | undefined
 
       if (!defaultDocument) {
         throw new Error('Default document not found')
@@ -2596,7 +2623,7 @@ describe('create-workspace-store', () => {
         },
       })
 
-      const defaultDocument = store.workspace.documents['default']
+      const defaultDocument = store.workspace.documents['default'] as OpenApiDocument | undefined
 
       if (!defaultDocument) {
         throw new Error('Default document not found')
@@ -2628,7 +2655,7 @@ describe('create-workspace-store', () => {
         },
       })
 
-      const defaultDocument = store.workspace.documents['default']
+      const defaultDocument = store.workspace.documents['default'] as OpenApiDocument | undefined
 
       if (!defaultDocument) {
         throw new Error('Default document not found')
@@ -2649,7 +2676,7 @@ describe('create-workspace-store', () => {
 
       expect(newStore.workspace.documents['default']?.info.title).toBe('Edited title')
       expect(newStore.workspace.documents['default']?.info.version).toBe('2.0.0')
-      expect(newStore.workspace.documents['default']?.openapi).toBe('3.1.1')
+      expect((newStore.workspace.documents['default'] as OpenApiDocument | undefined)?.openapi).toBe('3.1.1')
     })
 
     it('revert should never change the overrides fields', async () => {
@@ -2666,7 +2693,7 @@ describe('create-workspace-store', () => {
         },
       })
 
-      const defaultDocument = store.workspace.documents['default']
+      const defaultDocument = store.workspace.documents['default'] as OpenApiDocument | undefined
 
       if (!defaultDocument) {
         throw new Error('Default document not found')
@@ -2803,7 +2830,7 @@ describe('create-workspace-store', () => {
         },
       })
 
-      expect(store.workspace.documents['default']?.info.title).toBe('My Updated API')
+      expect((store.workspace.documents['default'] as OpenApiDocument | undefined)?.info.title).toBe('My Updated API')
     })
   })
 
@@ -2964,7 +2991,7 @@ describe('create-workspace-store', () => {
         },
       })
 
-      expect(store.workspace.documents['default']).toEqual({
+      expect(store.workspace.documents['default'] as OpenApiDocument | undefined).toEqual({
         'openapi': '3.1.1',
         'info': { 'title': 'My API', 'version': '1.0.0' },
         'paths': {
@@ -3095,7 +3122,7 @@ describe('create-workspace-store', () => {
       })
 
       // Should still preserve the generated navigation and upgrade the document to the latest when we try to replace it
-      expect(store.workspace.documents['default']).toEqual({
+      expect(store.workspace.documents['default'] as OpenApiDocument | undefined).toEqual({
         components: {
           schemas: {
             User: {
@@ -3319,7 +3346,9 @@ describe('create-workspace-store', () => {
         '{"openapi":"3.1.1","info":{"title":"A new title which should conflict","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}},"x-scalar-order":["default/description/introduction","default/GET/users","default/models"]}',
       )
 
-      expect(store.workspace.activeDocument?.info.title).toEqual('A new title which should conflict')
+      expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.info.title).toEqual(
+        'A new title which should conflict',
+      )
     })
 
     it('applies the whole document when user passes resolvedDocument instead of resolvedConflicts', async () => {
@@ -3358,8 +3387,10 @@ describe('create-workspace-store', () => {
       } | null
       expect(intermediate?.info?.title).toBe('User-provided full document')
       expect(intermediate?.info?.version).toBe('2.0.0')
-      expect(store.workspace.activeDocument?.info.title).toBe('User-provided full document')
-      expect(store.workspace.activeDocument?.info.version).toBe('2.0.0')
+      expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.info.title).toBe(
+        'User-provided full document',
+      )
+      expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.info.version).toBe('2.0.0')
     })
 
     it('should override conflicting changes made to the active document while we are rebasing with a new origin', async () => {
@@ -3388,7 +3419,7 @@ describe('create-workspace-store', () => {
       await result.applyChanges({ resolvedConflicts: result.conflicts.flatMap((it) => it[1]) })
 
       // should override conflicts to the active document on rebase to the one from original
-      expect(store.workspace.activeDocument?.info.version).toBe('1.0.1')
+      expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.info.version).toBe('1.0.1')
     })
 
     it('should return the error if the document we try to rebase does not exists', async () => {
@@ -3449,7 +3480,7 @@ describe('create-workspace-store', () => {
         document: getDocument(),
       })
 
-      expect(store.workspace.activeDocument?.['x-scalar-navigation']).toEqual({
+      expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.['x-scalar-navigation']).toEqual({
         type: 'document',
         id: 'default',
         name: 'default',
@@ -3515,7 +3546,7 @@ describe('create-workspace-store', () => {
       assert(result.ok)
       await result.applyChanges({ resolvedConflicts: [] }) // No conflicts to apply
 
-      expect(store.workspace.activeDocument?.['x-scalar-navigation']).toEqual({
+      expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.['x-scalar-navigation']).toEqual({
         type: 'document',
         id: 'default',
         name: 'default',
@@ -3571,7 +3602,7 @@ describe('create-workspace-store', () => {
         },
       )
 
-      expect(store.workspace.activeDocument?.['x-scalar-navigation']).toEqual({
+      expect((store.workspace.activeDocument as OpenApiDocument | undefined)?.['x-scalar-navigation']).toEqual({
         type: 'document',
         id: 'document-1',
         name: 'document-1',

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -6,7 +6,12 @@ import fastify, { type FastifyInstance } from 'fastify'
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { type WorkspaceDocumentInput, createWorkspaceStore } from '@/client'
-import { createTag } from '@/mutators/tag'
+import { updateSecurityScheme } from '@/mutators/auth'
+import { upsertCookie } from '@/mutators/cookie'
+import { updateDocumentIcon, updateDocumentInfo, updateWatchMode } from '@/mutators/document'
+import { upsertEnvironment } from '@/mutators/environment'
+import { addServer } from '@/mutators/server'
+import { createTag, deleteTag, editTag } from '@/mutators/tag'
 import type { AsyncApiDocument } from '@/schemas/asyncapi/asyncapi-document'
 import { isAsyncApiDocument, isOpenApiDocument } from '@/schemas/type-guards'
 import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
@@ -3672,6 +3677,25 @@ describe('asyncapi ingestion', () => {
     expect(consoleWarnSpy).not.toHaveBeenCalled()
   })
 
+  it('dispatches AsyncAPI input through the AsyncAPI ingestion path (not OpenAPI)', async () => {
+    // Direct dispatch assertion: an AsyncAPI input must produce the AsyncAPI metadata signature.
+    // The AsyncAPI branch injects `x-original-aas-version`; the OpenAPI branch injects
+    // `x-original-oas-version`. Asserting one is set and the other is not pins the dispatcher
+    // — a regression where the OpenAPI path runs would silently flip these.
+    const store = createWorkspaceStore()
+    await store.addDocument({ name: 'default', document: { ...minimalAsyncApi } })
+
+    const doc = store.workspace.documents['default'] as AsyncApiDocument & {
+      'x-original-oas-version'?: unknown
+      paths?: unknown
+    }
+    expect(doc['x-original-aas-version']).toBe('3.0.0')
+    expect(doc['x-original-oas-version']).toBeUndefined()
+    // The OpenAPI ingestion path injects an empty `paths` object when missing; the AsyncAPI
+    // path leaves the doc shape alone aside from the metadata extensions.
+    expect(doc.paths).toBeUndefined()
+  })
+
   it('injects the store-managed metadata extensions', async () => {
     const store = createWorkspaceStore()
 
@@ -3747,15 +3771,121 @@ describe('asyncapi ingestion', () => {
     expect(isAsyncApiDocument(store.workspace.documents['events'])).toBe(true)
   })
 
-  it('createTag no-ops and logs when pointed at an AsyncAPI document', async () => {
-    const store = createWorkspaceStore()
-    await store.addDocument({ name: 'events', document: { ...minimalAsyncApi } })
+  // The mutator no-ops below act as canaries: each one exercises a different mutator module
+  // (document, server, cookie, environment, tag, auth) on an AsyncAPI document and asserts the
+  // doc is left untouched. Mutators apply their `isOpenApiDocument` / `isAsyncApiDocument` guards
+  // independently, so dropping a guard in any module would only show up here.
+  describe('mutators no-op on AsyncAPI documents', () => {
+    const setup = async () => {
+      const store = createWorkspaceStore()
+      await store.addDocument({ name: 'events', document: { ...minimalAsyncApi } })
+      const doc = store.workspace.documents['events'] as AsyncApiDocument
+      // Snapshot of every key the doc carries — assertions below check this set is unchanged
+      // after a mutator call.
+      const snapshot = JSON.stringify(doc)
+      return { store, doc, snapshot }
+    }
 
-    createTag(store, { documentName: 'events', name: 'new-tag' })
+    it('updateWatchMode leaves the document untouched', async () => {
+      const { doc, snapshot } = await setup()
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Document not found', expect.any(Object))
-    // Guard must prevent the mutator from touching the doc
-    expect((store.workspace.documents['events'] as AsyncApiDocument & { tags?: unknown }).tags).toBeUndefined()
+      updateWatchMode(doc, true)
+
+      expect(JSON.stringify(doc)).toBe(snapshot)
+      expect((doc as AsyncApiDocument & { 'x-scalar-watch-mode'?: unknown })['x-scalar-watch-mode']).toBeUndefined()
+    })
+
+    it('updateDocumentInfo leaves the info object untouched', async () => {
+      const { doc } = await setup()
+
+      updateDocumentInfo(doc, { title: 'Renamed' })
+
+      expect(doc.info.title).toBe('Streetlights API')
+    })
+
+    it('updateDocumentIcon does not add an icon field', async () => {
+      const { doc } = await setup()
+
+      updateDocumentIcon(doc, 'interface-content-folder')
+
+      expect((doc as AsyncApiDocument & { 'x-scalar-icon'?: unknown })['x-scalar-icon']).toBeUndefined()
+    })
+
+    it('addServer does not add a servers array', async () => {
+      const { doc, snapshot } = await setup()
+
+      addServer(doc, { url: 'https://api.example.com', meta: { type: 'document' } })
+
+      // The mutator logs through `getServerTarget` when it cannot resolve a target
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Target not found', expect.any(Object))
+      expect(JSON.stringify(doc)).toBe(snapshot)
+    })
+
+    it('upsertCookie does not add an x-scalar-cookies array', async () => {
+      const { doc } = await setup()
+
+      const result = upsertCookie(doc, {
+        payload: { name: 'session', value: 'abc', domain: 'example.com', path: '/' },
+      })
+
+      expect(result).toBeUndefined()
+      expect((doc as AsyncApiDocument & { 'x-scalar-cookies'?: unknown })['x-scalar-cookies']).toBeUndefined()
+    })
+
+    it('upsertEnvironment does not add an x-scalar-environments map', async () => {
+      const { store, doc } = await setup()
+
+      const result = upsertEnvironment(store.workspace, doc, {
+        environmentName: 'production',
+        payload: { color: '#FF0000', variables: [{ name: 'API_URL', value: 'https://api.example.com' }] },
+      })
+
+      expect(result).toBeUndefined()
+      expect((doc as AsyncApiDocument & { 'x-scalar-environments'?: unknown })['x-scalar-environments']).toBeUndefined()
+    })
+
+    it('createTag does not add a tags array (and logs)', async () => {
+      const { store, doc } = await setup()
+
+      createTag(store, { documentName: 'events', name: 'new-tag' })
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Document not found', expect.any(Object))
+      expect((doc as AsyncApiDocument & { tags?: unknown }).tags).toBeUndefined()
+    })
+
+    it('editTag does not mutate the document', async () => {
+      const { store, doc, snapshot } = await setup()
+
+      editTag(store, {
+        documentName: 'events',
+        tag: { id: 'events/tag/old', type: 'tag', title: 'old', name: 'old', children: [], isGroup: false },
+        newName: 'new',
+      })
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Document not found', expect.any(Object))
+      expect(JSON.stringify(doc)).toBe(snapshot)
+    })
+
+    it('deleteTag silently no-ops', async () => {
+      const { store, doc, snapshot } = await setup()
+
+      deleteTag(store, { documentName: 'events', name: 'old' })
+
+      // deleteTag returns early without logging — different from createTag/editTag, but the
+      // contract that matters is the document remains untouched.
+      expect(JSON.stringify(doc)).toBe(snapshot)
+    })
+
+    it('updateSecurityScheme does not create components.securitySchemes', async () => {
+      const { doc } = await setup()
+
+      updateSecurityScheme(doc, {
+        name: 'BearerAuth',
+        payload: { type: 'http', scheme: 'bearer' },
+      })
+
+      expect((doc as AsyncApiDocument & { components?: unknown }).components).toBeUndefined()
+    })
   })
 
   it('rebaseDocument detects NO_CHANGES_DETECTED on an unchanged AsyncAPI doc', async () => {

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -38,6 +38,7 @@ import {
 } from '@/plugins/bundler'
 import { extensions } from '@/schemas/extensions'
 import type { InMemoryWorkspace } from '@/schemas/inmemory-workspace'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 import { coerceValue } from '@/schemas/typebox-coerce'
 import { generateSchema } from '@/schemas/v3.1/openapi'
 import { recursiveRef } from '@/schemas/v3.1/openapi/reference'
@@ -656,7 +657,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
               } satisfies WorkspaceStateChangeEvent
 
               // Don't mark as dirty when the document is first created
-              if (event.path.length > 0 && event.path[0] !== 'x-scalar-is-dirty') {
+              if (isOpenApiDocument(document) && event.path.length > 0 && event.path[0] !== 'x-scalar-is-dirty') {
                 // The document has been modified since it was last saved
                 document['x-scalar-is-dirty'] = true
               }
@@ -682,7 +683,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
               } satisfies WorkspaceStateChangeEvent
 
               // Don't mark as dirty when the document is first created
-              if (event.path.length > 0 && event.path[0] !== 'x-scalar-is-dirty') {
+              if (isOpenApiDocument(document) && event.path.length > 0 && event.path[0] !== 'x-scalar-is-dirty') {
                 // The document has been modified since it was last saved
                 document['x-scalar-is-dirty'] = true
               }
@@ -868,7 +869,9 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     // Store the new document in the intermediate documents map
     intermediateDocuments[documentName] = newDocument
     // Mark the document as not dirty since we are saving it
-    activeDocument['x-scalar-is-dirty'] = false
+    if (isOpenApiDocument(activeDocument)) {
+      activeDocument['x-scalar-is-dirty'] = false
+    }
     return true
   }
 
@@ -1123,7 +1126,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     // Remove top level properties that should only exist in memory for the original document
     // These properties are used for internal purposes and are not needed in the final bundled document
     for (const property of EXCLUDE_KEYS) {
-      delete original[property as keyof WorkspaceDocument]
+      delete (original as Record<string, unknown>)[property]
     }
 
     return original
@@ -1148,6 +1151,11 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     if (!document) {
       // Log and exit if the document does not exist in the workspace
       console.error(`Document '${documentName}' does not exist in the workspace.`)
+      return false
+    }
+
+    // Sidebar navigation is OpenAPI-only for now.
+    if (!isOpenApiDocument(document)) {
       return false
     }
 
@@ -1203,13 +1211,15 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
         return console.error(`Document '${documentName}' does not exist in the workspace.`)
       }
 
+      const isOas = isOpenApiDocument(currentDocument)
+
       // Replace the whole document
       await addInMemoryDocument({
         name: documentName,
         document: input,
         // Preserve the current metadata
-        documentSource: currentDocument['x-scalar-original-source-url'],
-        documentHash: currentDocument['x-scalar-original-document-hash'],
+        documentSource: isOas ? currentDocument['x-scalar-original-source-url'] : undefined,
+        documentHash: isOas ? (currentDocument['x-scalar-original-document-hash'] ?? '') : '',
         meta: {
           // Set the document as dirty
           'x-scalar-is-dirty': true,
@@ -1293,11 +1303,13 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
         return
       }
 
+      const isOas = isOpenApiDocument(workspaceDocument)
+
       await addInMemoryDocument({
         name: documentName,
         document: intermediate,
-        documentSource: workspaceDocument['x-scalar-original-source-url'],
-        documentHash: workspaceDocument['x-scalar-original-document-hash'],
+        documentSource: isOas ? workspaceDocument['x-scalar-original-source-url'] : undefined,
+        documentHash: isOas ? (workspaceDocument['x-scalar-original-document-hash'] ?? '') : '',
         initialize: false,
       })
     },
@@ -1400,7 +1412,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       // Compare document hashes to see if the document has changed
       // When the hashes match, we can skip the rebase process
       const newHash = generateHash(resolve.raw)
-      if (activeDocument['x-scalar-original-document-hash'] === newHash) {
+      if (isOpenApiDocument(activeDocument) && activeDocument['x-scalar-original-document-hash'] === newHash) {
         return {
           ok: false,
           type: 'NO_CHANGES_DETECTED' as const,

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -36,7 +36,7 @@ import {
   restoreOriginalRefs,
   syncPathParameters,
 } from '@/plugins/bundler'
-import type { AsyncApiDocument } from '@/schemas/asyncapi/asyncapi-document'
+import { type AsyncApiDocument, AsyncApiDocumentSchema } from '@/schemas/asyncapi/asyncapi-document'
 import { extensions } from '@/schemas/extensions'
 import type { InMemoryWorkspace } from '@/schemas/inmemory-workspace'
 import { isAsyncApiDocument, isOpenApiDocument } from '@/schemas/type-guards'
@@ -903,6 +903,18 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
         extraDocumentConfigurations[name] = { fetch: input.fetch }
       }
     })
+
+    // Sanity-check the doc against the minimal AsyncAPI schema. The discriminator only verified
+    // `asyncapi` is a string; this catches missing/misshapen `info` so we can surface a useful path
+    // instead of silently storing a broken doc. Log-only — mirrors how the OpenAPI branch behaves.
+    const isValid = Value.Check(AsyncApiDocumentSchema, input.document)
+    if (!isValid) {
+      const errors = Array.from(Value.Errors(AsyncApiDocumentSchema, input.document))
+      console.warn(
+        'AsyncAPI document validation errors:',
+        errors.map((e) => ({ path: e.path, message: e.message })),
+      )
+    }
 
     workspace.documents[name] = createMagicProxy({ ...clonedRawInputDocument, ...meta }) as AsyncApiDocument
   }

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -939,7 +939,13 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       )
     }
 
-    workspace.documents[name] = createMagicProxy({ ...clonedRawInputDocument, ...meta }) as AsyncApiDocument
+    workspace.documents[name] = createMagicProxy({
+      ...clonedRawInputDocument,
+      ...meta,
+      'x-original-aas-version': originalDocuments[name]?.asyncapi,
+      'x-scalar-original-document-hash': input.documentHash,
+      'x-scalar-original-source-url': input.documentSource,
+    }) as AsyncApiDocument
   }
 
   // Add a document to the store synchronously from an in-memory OpenAPI document
@@ -1275,15 +1281,14 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
         return console.error(`Document '${documentName}' does not exist in the workspace.`)
       }
 
-      const isOas = isOpenApiDocument(currentDocument)
-
-      // Replace the whole document
+      // Both OpenApi and AsyncApi documents carry the store-managed metadata extensions, so we
+      // can read them off the union without branching on the doc kind.
       await addInMemoryDocument({
         name: documentName,
         document: input,
         // Preserve the current metadata
-        documentSource: isOas ? currentDocument['x-scalar-original-source-url'] : undefined,
-        documentHash: isOas ? (currentDocument['x-scalar-original-document-hash'] ?? '') : '',
+        documentSource: currentDocument['x-scalar-original-source-url'],
+        documentHash: currentDocument['x-scalar-original-document-hash'] ?? '',
         meta: {
           // Set the document as dirty
           'x-scalar-is-dirty': true,
@@ -1367,13 +1372,11 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
         return
       }
 
-      const isOas = isOpenApiDocument(workspaceDocument)
-
       await addInMemoryDocument({
         name: documentName,
         document: intermediate,
-        documentSource: isOas ? workspaceDocument['x-scalar-original-source-url'] : undefined,
-        documentHash: isOas ? (workspaceDocument['x-scalar-original-document-hash'] ?? '') : '',
+        documentSource: workspaceDocument['x-scalar-original-source-url'],
+        documentHash: workspaceDocument['x-scalar-original-document-hash'] ?? '',
         initialize: false,
       })
     },
@@ -1476,7 +1479,7 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       // Compare document hashes to see if the document has changed
       // When the hashes match, we can skip the rebase process
       const newHash = generateHash(resolve.raw)
-      if (isOpenApiDocument(activeDocument) && activeDocument['x-scalar-original-document-hash'] === newHash) {
+      if (activeDocument['x-scalar-original-document-hash'] === newHash) {
         return {
           ok: false,
           type: 'NO_CHANGES_DETECTED' as const,
@@ -1541,10 +1544,13 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
           // TODO: In the future, implement smarter conflict resolution if needed
           const changesetB = changesB.diffs.concat(changesB.conflicts.flatMap((it) => it[0]))
 
-          const newActiveDocument = coerceValue(
-            OpenAPIDocumentSchemaStrict,
-            apply(deepClone(newIntermediateDocument), changesetB),
-          )
+          // Coerce the applied document against the right schema for its kind. AsyncAPI docs
+          // skip the OpenAPI strict coercion (which would strip their fields); everything else
+          // keeps the existing behavior.
+          const appliedDocument = apply(deepClone(newIntermediateDocument), changesetB)
+          const newActiveDocument = isAsyncApiDocument(appliedDocument)
+            ? appliedDocument
+            : coerceValue(OpenAPIDocumentSchemaStrict, appliedDocument)
 
           // add the new active document to the workspace but don't re-initialize
           await addInMemoryDocument({

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -883,15 +883,16 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
   // document and spam console.warn). Everything else continues through the existing OpenAPI flow.
   async function addInMemoryDocument(input: AddInMemoryInput, navigationOptions?: NavigationOptions) {
     if (isAsyncApiDocument(input.document)) {
-      return addAsyncApiDocument(input)
+      return await addAsyncApiDocument(input)
     }
     return await addOpenApiDocument(input, navigationOptions)
   }
 
-  // Minimal AsyncAPI ingestion. Stores the raw document as-is — no upgrade, no bundling, no
-  // coercion, no OpenAPI schema validation, no navigation generation. AsyncAPI-specific validation
-  // lives in its own follow-up (plans/asyncapi-loading/02-asyncapi-validation.md).
-  function addAsyncApiDocument(input: AddInMemoryInput) {
+  // Minimal AsyncAPI ingestion. Skips the OpenAPI-specific upgrade/coerce/validate pipeline and
+  // runs only the format-neutral subset of bundler plugins (loaders + normalizeRefs +
+  // externalValueResolver). OpenAPI-shaped plugins (refsEverywhere, normalizeAuthSchemes,
+  // syncPathParameters) are intentionally omitted — see plans/asyncapi-loading/03.
+  async function addAsyncApiDocument(input: AddInMemoryInput) {
     const { name, meta } = input
     const clonedRawInputDocument = withMeasurementSync('deepClone', () => deepClone(input.document))
 
@@ -903,6 +904,28 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
         extraDocumentConfigurations[name] = { fetch: input.fetch }
       }
     })
+
+    // Resolve `$ref`s with the format-neutral plugin set. Mirrors the OpenAPI branch's loader
+    // setup so external refs resolve against the document's own origin.
+    const loaders = [
+      fetchUrls({
+        fetch: extraDocumentConfigurations[name]?.fetch ?? workspaceProps?.fetch,
+      }),
+    ]
+    if (workspaceProps?.fileLoader) {
+      loaders.push(workspaceProps.fileLoader)
+    }
+
+    await withMeasurementAsync(
+      'bundle',
+      async () =>
+        await bundle(clonedRawInputDocument, {
+          treeShake: false,
+          plugins: [...loaders, normalizeRefs(), externalValueResolver()],
+          urlMap: true,
+          origin: input.documentSource,
+        }),
+    )
 
     // Sanity-check the doc against the minimal AsyncAPI schema. The discriminator only verified
     // `asyncapi` is a string; this catches missing/misshapen `info` so we can surface a useful path

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -36,9 +36,10 @@ import {
   restoreOriginalRefs,
   syncPathParameters,
 } from '@/plugins/bundler'
+import type { AsyncApiDocument } from '@/schemas/asyncapi/asyncapi-document'
 import { extensions } from '@/schemas/extensions'
 import type { InMemoryWorkspace } from '@/schemas/inmemory-workspace'
-import { isOpenApiDocument } from '@/schemas/type-guards'
+import { isAsyncApiDocument, isOpenApiDocument } from '@/schemas/type-guards'
 import { coerceValue } from '@/schemas/typebox-coerce'
 import { generateSchema } from '@/schemas/v3.1/openapi'
 import { recursiveRef } from '@/schemas/v3.1/openapi/reference'
@@ -875,11 +876,39 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     return true
   }
 
+  type AddInMemoryInput = ObjectDoc & { initialize?: boolean; documentSource?: string; documentHash: string }
+
+  // Dispatch ingestion based on the document kind. AsyncAPI docs take a minimal path that skips
+  // the OpenAPI-specific upgrade/bundle/coerce/validate pipeline (which would otherwise mangle the
+  // document and spam console.warn). Everything else continues through the existing OpenAPI flow.
+  async function addInMemoryDocument(input: AddInMemoryInput, navigationOptions?: NavigationOptions) {
+    if (isAsyncApiDocument(input.document)) {
+      return addAsyncApiDocument(input)
+    }
+    return await addOpenApiDocument(input, navigationOptions)
+  }
+
+  // Minimal AsyncAPI ingestion. Stores the raw document as-is — no upgrade, no bundling, no
+  // coercion, no OpenAPI schema validation, no navigation generation. AsyncAPI-specific validation
+  // lives in its own follow-up (plans/asyncapi-loading/02-asyncapi-validation.md).
+  function addAsyncApiDocument(input: AddInMemoryInput) {
+    const { name, meta } = input
+    const clonedRawInputDocument = withMeasurementSync('deepClone', () => deepClone(input.document))
+
+    withMeasurementSync('initialize', () => {
+      if (input.initialize !== false) {
+        originalDocuments[name] = deepClone(clonedRawInputDocument)
+        intermediateDocuments[name] = deepClone(clonedRawInputDocument)
+        overrides[name] = input.overrides ?? {}
+        extraDocumentConfigurations[name] = { fetch: input.fetch }
+      }
+    })
+
+    workspace.documents[name] = createMagicProxy({ ...clonedRawInputDocument, ...meta }) as AsyncApiDocument
+  }
+
   // Add a document to the store synchronously from an in-memory OpenAPI document
-  async function addInMemoryDocument(
-    input: ObjectDoc & { initialize?: boolean; documentSource?: string; documentHash: string },
-    navigationOptions?: NavigationOptions,
-  ) {
+  async function addOpenApiDocument(input: AddInMemoryInput, navigationOptions?: NavigationOptions) {
     const { name, meta } = input
     const clonedRawInputDocument = withMeasurementSync('deepClone', () => deepClone(input.document))
 

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -928,8 +928,9 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     )
 
     // Sanity-check the doc against the minimal AsyncAPI schema. The discriminator only verified
-    // `asyncapi` is a string; this catches missing/misshapen `info` so we can surface a useful path
-    // instead of silently storing a broken doc. Log-only — mirrors how the OpenAPI branch behaves.
+    // `asyncapi` is a string; this surfaces missing/misshapen `info` to the console so consumers
+    // get a useful pointer when something is off. The doc is still stored regardless — the OpenAPI
+    // branch behaves the same way, leaving "should we reject?" as a separate policy decision.
     const isValid = Value.Check(AsyncApiDocumentSchema, input.document)
     if (!isValid) {
       const errors = Array.from(Value.Errors(AsyncApiDocumentSchema, input.document))

--- a/packages/workspace-store/src/mutators/auth.test.ts
+++ b/packages/workspace-store/src/mutators/auth.test.ts
@@ -10,11 +10,11 @@ import {
   updateSelectedScopes,
   updateSelectedSecuritySchemes,
 } from '@/mutators/auth'
-import type { WorkspaceDocument } from '@/schemas'
+import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 import type { SecurityRequirementObject } from '@/schemas/v3.1/strict/security-requirement'
 import type { OAuth2Object, SecuritySchemeObject } from '@/schemas/v3.1/strict/security-scheme'
 
-function createDocument(initial?: Partial<WorkspaceDocument>): WorkspaceDocument {
+function createDocument(initial?: Partial<OpenApiDocument>): OpenApiDocument {
   return {
     openapi: '3.1.0',
     info: { title: 'Test', version: '1.0.0' },
@@ -71,7 +71,7 @@ describe('updateSelectedSecuritySchemes', () => {
       meta: { type: 'document' },
     })
 
-    const securitySchemes = store.workspace.activeDocument?.components?.securitySchemes
+    const securitySchemes = (store.workspace.activeDocument as OpenApiDocument | undefined)?.components?.securitySchemes
     assert(securitySchemes)
 
     // A unique name should be generated because ApiKeyAuth already exists
@@ -163,7 +163,9 @@ describe('updateSelectedSecuritySchemes', () => {
     })
 
     // Components should include the newly created scheme
-    expect(store.workspace.activeDocument?.components?.securitySchemes?.['BearerAuth']).toEqual({
+    expect(
+      (store.workspace.activeDocument as OpenApiDocument | undefined)?.components?.securitySchemes?.['BearerAuth'],
+    ).toEqual({
       type: 'http',
       scheme: 'bearer',
     })
@@ -718,7 +720,8 @@ describe('deleteSecurityScheme', () => {
 
     deleteSecurityScheme(store, store.workspace.activeDocument!, { names: ['A', 'B', 'X'] })
 
-    const components = store.workspace.activeDocument?.components
+    const activeDocument = store.workspace.activeDocument as OpenApiDocument | undefined
+    const components = activeDocument?.components
     // Components
     assert(components?.securitySchemes)
     expect(components.securitySchemes?.A).toBeUndefined()
@@ -731,10 +734,10 @@ describe('deleteSecurityScheme', () => {
     expect(docSchemes.selectedSchemes).toEqual([{ C: [] }])
 
     // Document security array
-    expect(store.workspace.activeDocument?.security).toEqual([{ D: [] }])
+    expect(activeDocument?.security).toEqual([{ D: [] }])
 
     // Operation level filtering
-    const op = getResolvedRef(store.workspace.activeDocument?.paths!['/p']?.get)
+    const op = getResolvedRef(activeDocument?.paths!['/p']?.get)
     assert(op)
     expect(op.security).toEqual([{ E: [] }])
     const opSchemes = store.auth.getAuthSelectedSchemas({ type: 'operation', documentName, path: '/p', method: 'get' })

--- a/packages/workspace-store/src/mutators/auth.ts
+++ b/packages/workspace-store/src/mutators/auth.ts
@@ -6,6 +6,7 @@ import { isNonOptionalSecurityRequirement } from '@/helpers/is-non-optional-secu
 import { mergeObjects } from '@/helpers/merge-object'
 import { unpackProxyObject } from '@/helpers/unpack-proxy'
 import type { WorkspaceDocument } from '@/schemas'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 import type { SecurityRequirementObject } from '@/schemas/v3.1/strict/security-requirement'
 import type { OAuth2Object } from '@/schemas/v3.1/strict/security-scheme'
 
@@ -38,7 +39,10 @@ export const updateSelectedSecuritySchemes = async (
   document: WorkspaceDocument | null,
   { selectedRequirements, newSchemes, meta }: AuthEvents['auth:update:selected-security-schemes'],
 ) => {
-  const documentName = document?.['x-scalar-navigation']?.name
+  if (!isOpenApiDocument(document)) {
+    return
+  }
+  const documentName = document['x-scalar-navigation']?.name
   if (!documentName) {
     return
   }
@@ -125,7 +129,10 @@ const clearSelectedSecuritySchemes = (
   document: WorkspaceDocument | null,
   { meta }: AuthEvents['auth:clear:selected-security-schemes'],
 ) => {
-  const documentName = document?.['x-scalar-navigation']?.name
+  if (!isOpenApiDocument(document)) {
+    return
+  }
+  const documentName = document['x-scalar-navigation']?.name
   if (!documentName) {
     return
   }
@@ -163,7 +170,10 @@ export const updateSecurityScheme = (
   document: WorkspaceDocument | null,
   { payload, name }: AuthEvents['auth:update:security-scheme'],
 ) => {
-  const target = getResolvedRef(document?.components?.securitySchemes?.[name])
+  if (!isOpenApiDocument(document)) {
+    return
+  }
+  const target = getResolvedRef(document.components?.securitySchemes?.[name])
   if (!target) {
     console.error(`Security scheme ${name} not found`)
     return
@@ -182,7 +192,10 @@ const updateSecuritySchemeSecrets = (
   document: WorkspaceDocument | null,
   { payload, name, overwrite = false }: AuthEvents['auth:update:security-scheme-secrets'],
 ) => {
-  const documentName = document?.['x-scalar-navigation']?.name
+  if (!isOpenApiDocument(document)) {
+    return
+  }
+  const documentName = document['x-scalar-navigation']?.name
   if (!documentName) {
     return
   }
@@ -206,7 +219,10 @@ const clearSecuritySchemeSecrets = (
   document: WorkspaceDocument | null,
   { name }: AuthEvents['auth:clear:security-scheme-secrets'],
 ) => {
-  const documentName = document?.['x-scalar-navigation']?.name
+  if (!isOpenApiDocument(document)) {
+    return
+  }
+  const documentName = document['x-scalar-navigation']?.name
   if (!documentName) {
     return
   }
@@ -245,13 +261,16 @@ export const updateSelectedAuthTab = (
   document: WorkspaceDocument | null,
   { index, meta }: AuthEvents['auth:update:active-index'],
 ) => {
-  const documentName = document?.['x-scalar-navigation']?.name
+  if (!isOpenApiDocument(document)) {
+    return
+  }
+  const documentName = document['x-scalar-navigation']?.name
   if (!documentName) {
     return
   }
 
   // Ensure the path/method exists in the document
-  if (meta.type === 'operation' && document?.paths?.[meta.path]?.[meta.method] === undefined) {
+  if (meta.type === 'operation' && document.paths?.[meta.path]?.[meta.method] === undefined) {
     return
   }
 
@@ -322,7 +341,10 @@ export const updateSelectedScopes = (
   document: WorkspaceDocument | null,
   { id, name, scopes, newScopePayload, meta }: AuthEvents['auth:update:selected-scopes'],
 ) => {
-  const documentName = document?.['x-scalar-navigation']?.name
+  if (!isOpenApiDocument(document)) {
+    return
+  }
+  const documentName = document['x-scalar-navigation']?.name
   if (!documentName) {
     return
   }
@@ -391,9 +413,12 @@ export const deleteSecurityScheme = (
   document: WorkspaceDocument | null,
   { names }: AuthEvents['auth:delete:security-scheme'],
 ) => {
-  const documentName = document?.['x-scalar-navigation']?.name
-  if (!documentName) {
+  if (!isOpenApiDocument(document)) {
     // Early exit if there is no document to modify
+    return
+  }
+  const documentName = document['x-scalar-navigation']?.name
+  if (!documentName) {
     return
   }
 

--- a/packages/workspace-store/src/mutators/cookie.test.ts
+++ b/packages/workspace-store/src/mutators/cookie.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import type { Workspace, WorkspaceDocument } from '@/schemas'
+import type { Workspace } from '@/schemas'
+import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 
 import { deleteCookie, upsertCookie } from './cookie'
 
-function createDocument(initial?: Partial<WorkspaceDocument>): WorkspaceDocument {
+function createDocument(initial?: Partial<OpenApiDocument>): OpenApiDocument {
   return {
     openapi: '3.1.0',
     info: { title: 'Test', version: '1.0.0' },

--- a/packages/workspace-store/src/mutators/cookie.ts
+++ b/packages/workspace-store/src/mutators/cookie.ts
@@ -1,6 +1,7 @@
 import type { CookieEvents } from '@/events/definitions/cookie'
 import type { Workspace, WorkspaceDocument } from '@/schemas'
 import { type XScalarCookie, xScalarCookieSchema } from '@/schemas/extensions/general/x-scalar-cookies'
+import { isAsyncApiDocument } from '@/schemas/type-guards'
 import { coerceValue } from '@/schemas/typebox-coerce'
 
 type Event<T extends keyof CookieEvents> = Omit<CookieEvents[T], 'collectionType'>
@@ -19,7 +20,7 @@ export const upsertCookie = (
   collection: WorkspaceDocument | Workspace | null,
   { payload, index }: Event<'cookie:upsert:cookie'>,
 ): XScalarCookie | undefined => {
-  if (!collection) {
+  if (!collection || isAsyncApiDocument(collection)) {
     return
   }
 
@@ -63,7 +64,7 @@ export const deleteCookie = (
   collection: WorkspaceDocument | Workspace | null,
   { index }: Event<'cookie:delete:cookie'>,
 ): boolean => {
-  if (!collection || !collection['x-scalar-cookies']) {
+  if (!collection || isAsyncApiDocument(collection) || !collection['x-scalar-cookies']) {
     return false
   }
 

--- a/packages/workspace-store/src/mutators/document.test.ts
+++ b/packages/workspace-store/src/mutators/document.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { createWorkspaceStore } from '@/client'
-import type { WorkspaceDocument } from '@/schemas'
+import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 
 import {
   createEmptyDocument,
@@ -12,9 +12,9 @@ import {
   updateWatchMode,
 } from './document'
 
-type TestDocument = WorkspaceDocument & Record<string, unknown>
+type TestDocument = OpenApiDocument & Record<string, unknown>
 
-function createDocument(initial?: Partial<WorkspaceDocument> & Record<string, unknown>): TestDocument {
+function createDocument(initial?: Partial<OpenApiDocument> & Record<string, unknown>): TestDocument {
   return {
     openapi: '3.1.0',
     info: { title: 'Test', version: '1.0.0' },
@@ -459,7 +459,7 @@ describe('createEmptyDocument', () => {
       callback: callback,
     })
 
-    const document = store.workspace.documents['my-api']
+    const document = store.workspace.documents['my-api'] as OpenApiDocument | undefined
     expect(document).toBeDefined()
     expect(document?.openapi).toBe('3.1.0')
     expect(document?.info.title).toBe('my-api')

--- a/packages/workspace-store/src/mutators/document.ts
+++ b/packages/workspace-store/src/mutators/document.ts
@@ -2,6 +2,7 @@ import type { WorkspaceStore } from '@/client'
 import type { DocumentEvents } from '@/events/definitions/document'
 import { mergeObjects } from '@/helpers/merge-object'
 import type { WorkspaceDocument } from '@/schemas'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 
 /**
  * Updates extension fields on the document (e.g. x-pre-request, x-post-response).
@@ -11,7 +12,7 @@ export const updateDocumentExtension = (
   document: WorkspaceDocument | null,
   payload: DocumentEvents['document:update:extension'],
 ) => {
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     return
   }
   mergeObjects(document, payload)
@@ -26,7 +27,7 @@ export const updateDocumentExtension = (
  * If document is null, does nothing.
  */
 export const updateWatchMode = (document: WorkspaceDocument | null, watchMode: boolean) => {
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     return
   }
 
@@ -48,7 +49,7 @@ export const updateDocumentInfo = (
   document: WorkspaceDocument | null,
   payload: DocumentEvents['document:update:info'],
 ) => {
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     return
   }
   // Merge the given payload into the document's info object
@@ -68,7 +69,7 @@ export const updateDocumentInfo = (
  * Does not perform a sidebar rebuild for performance benefit
  */
 export const updateDocumentIcon = (document: WorkspaceDocument | null, icon: string) => {
-  if (!document || !document['x-scalar-navigation']) {
+  if (!isOpenApiDocument(document) || !document['x-scalar-navigation']) {
     return
   }
 

--- a/packages/workspace-store/src/mutators/environment.ts
+++ b/packages/workspace-store/src/mutators/environment.ts
@@ -7,6 +7,7 @@ import {
   xScalarEnvVarSchema,
   xScalarEnvironmentSchema,
 } from '@/schemas/extensions/document/x-scalar-environments'
+import { isAsyncApiDocument } from '@/schemas/type-guards'
 import { coerceValue } from '@/schemas/typebox-coerce'
 
 type Event<T extends keyof EnvironmentEvents> = Omit<EnvironmentEvents[T], 'collectionType'>
@@ -27,7 +28,7 @@ export const upsertEnvironment = (
   { environmentName, payload, oldEnvironmentName }: Event<'environment:upsert:environment'>,
 ): XScalarEnvironment | undefined => {
   /** Discriminating between document and workspace */
-  if (!collection || !workspace) {
+  if (!collection || !workspace || isAsyncApiDocument(collection)) {
     return
   }
 
@@ -75,7 +76,7 @@ export const deleteEnvironment = (
   collection: WorkspaceDocument | Workspace | null,
   { environmentName }: Event<'environment:delete:environment'>,
 ) => {
-  if (!collection || !workspace) {
+  if (!collection || !workspace || isAsyncApiDocument(collection)) {
     return
   }
 
@@ -96,8 +97,11 @@ export const upsertEnvironmentVariable = (
   collection: WorkspaceDocument | Workspace | null,
   { environmentName, variable, index }: Event<'environment:upsert:environment-variable'>,
 ): XScalarEnvVar | undefined => {
+  if (!collection || isAsyncApiDocument(collection)) {
+    return
+  }
   // The environment should exist by now if we are upserting a variable
-  if (!collection?.['x-scalar-environments']?.[environmentName]) {
+  if (!collection['x-scalar-environments']?.[environmentName]) {
     console.error('Environment not found', environmentName)
     return
   }
@@ -127,11 +131,14 @@ export const deleteEnvironmentVariable = (
   collection: WorkspaceDocument | Workspace | null,
   { environmentName, index }: Event<'environment:delete:environment-variable'>,
 ) => {
-  if (!collection?.['x-scalar-environments']?.[environmentName]) {
+  if (!collection || isAsyncApiDocument(collection)) {
+    return
+  }
+  if (!collection['x-scalar-environments']?.[environmentName]) {
     console.error('Environment not found', environmentName)
     return
   }
-  collection['x-scalar-environments']?.[environmentName]?.variables?.splice(index, 1)
+  collection['x-scalar-environments'][environmentName]?.variables?.splice(index, 1)
 }
 
 export const environmentMutatorsFactory = ({

--- a/packages/workspace-store/src/mutators/operation/body.test.ts
+++ b/packages/workspace-store/src/mutators/operation/body.test.ts
@@ -6,9 +6,9 @@ import {
   updateOperationRequestBodyExample,
   updateOperationRequestBodyFormValue,
 } from '@/mutators/operation/body'
-import type { WorkspaceDocument } from '@/schemas'
+import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 
-const createDocument = (initial?: Partial<WorkspaceDocument>): WorkspaceDocument => {
+const createDocument = (initial?: Partial<OpenApiDocument>): OpenApiDocument => {
   return {
     openapi: '3.1.0',
     info: { title: 'Test', version: '1.0.0' },

--- a/packages/workspace-store/src/mutators/operation/body.ts
+++ b/packages/workspace-store/src/mutators/operation/body.ts
@@ -2,6 +2,7 @@ import type { OperationEvents } from '@/events/definitions/operation'
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
 import { unpackProxyObject } from '@/helpers/unpack-proxy'
 import type { WorkspaceDocument } from '@/schemas'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 import type { ExampleObject } from '@/schemas/v3.1/strict/example'
 
 /** Ensure the json that we need exists up to the example object in the request body */
@@ -10,7 +11,10 @@ const findOrCreateRequestBodyExample = (
   contentType: string,
   meta: OperationEvents['operation:update:requestBody:contentType']['meta'],
 ): ExampleObject | null => {
-  const operation = getResolvedRef(document?.paths?.[meta.path]?.[meta.method])
+  if (!isOpenApiDocument(document)) {
+    return null
+  }
+  const operation = getResolvedRef(document.paths?.[meta.path]?.[meta.method])
   if (!operation) {
     return null
   }
@@ -51,7 +55,7 @@ export const updateOperationRequestBodyContentType = (
   document: WorkspaceDocument | null,
   { meta, payload }: OperationEvents['operation:update:requestBody:contentType'],
 ) => {
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     return
   }
 

--- a/packages/workspace-store/src/mutators/operation/extensions.test.ts
+++ b/packages/workspace-store/src/mutators/operation/extensions.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
-import type { WorkspaceDocument } from '@/schemas'
+import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 
 import { updateOperationExtension } from './extensions'
 
-const createDocument = (initial?: Partial<WorkspaceDocument>): WorkspaceDocument => {
+const createDocument = (initial?: Partial<OpenApiDocument>): OpenApiDocument => {
   return {
     openapi: '3.1.0',
     info: { title: 'Test', version: '1.0.0' },

--- a/packages/workspace-store/src/mutators/operation/extensions.ts
+++ b/packages/workspace-store/src/mutators/operation/extensions.ts
@@ -2,6 +2,7 @@ import type { OperationEvents } from '@/events'
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
 import { mergeObjects } from '@/helpers/merge-object'
 import type { WorkspaceDocument } from '@/schemas'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 
 /**
  * Updates an extension of the operation
@@ -19,7 +20,10 @@ export const updateOperationExtension = (
   document: WorkspaceDocument | null,
   { meta, payload }: OperationEvents['operation:update:extension'],
 ) => {
-  const operation = getResolvedRef(document?.paths?.[meta.path]?.[meta.method])
+  if (!isOpenApiDocument(document)) {
+    return
+  }
+  const operation = getResolvedRef(document.paths?.[meta.path]?.[meta.method])
   if (!operation) {
     return
   }

--- a/packages/workspace-store/src/mutators/operation/history.test.ts
+++ b/packages/workspace-store/src/mutators/operation/history.test.ts
@@ -3,9 +3,9 @@ import { assert, describe, expect, it, vi } from 'vitest'
 import { createWorkspaceStore } from '@/client'
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
 import { addResponseToHistory, reloadOperationHistory } from '@/mutators/operation/history'
-import type { WorkspaceDocument } from '@/schemas'
+import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 
-const createDocument = (initial?: Partial<WorkspaceDocument>): WorkspaceDocument => {
+const createDocument = (initial?: Partial<OpenApiDocument>): OpenApiDocument => {
   return {
     openapi: '3.1.0',
     info: { title: 'Test', version: '1.0.0' },
@@ -31,7 +31,7 @@ describe('addResponseToHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     const mockResponse = {
@@ -84,7 +84,7 @@ describe('addResponseToHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     const createMockPayload = (index: number) => ({
@@ -137,7 +137,7 @@ describe('addResponseToHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     const history = store.history.getHistory('test-doc', '/products', 'post')
@@ -186,7 +186,7 @@ describe('addResponseToHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     await addResponseToHistory(store, document, {
@@ -231,7 +231,7 @@ describe('addResponseToHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     await addResponseToHistory(store, document, {
@@ -289,7 +289,7 @@ describe('addResponseToHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     await expect(
@@ -318,7 +318,7 @@ describe('addResponseToHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     await expect(
@@ -355,7 +355,7 @@ describe('reloadOperationHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     // Add a history entry
@@ -423,7 +423,7 @@ describe('reloadOperationHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     // Add multiple history entries
@@ -512,7 +512,7 @@ describe('reloadOperationHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     // Add history with path variables
@@ -593,7 +593,7 @@ describe('reloadOperationHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
@@ -627,7 +627,7 @@ describe('reloadOperationHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
@@ -661,7 +661,7 @@ describe('reloadOperationHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
@@ -707,7 +707,7 @@ describe('reloadOperationHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     const callbackSpy = vi.fn()
@@ -740,7 +740,7 @@ describe('reloadOperationHistory', () => {
       }),
     })
 
-    const document = store.workspace.documents['test-doc']!
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument
     assert(document)
 
     const callbackSpy = vi.fn()

--- a/packages/workspace-store/src/mutators/operation/history.ts
+++ b/packages/workspace-store/src/mutators/operation/history.ts
@@ -3,6 +3,7 @@ import type { HooksEvents } from '@/events/definitions/hooks'
 import type { OperationEvents } from '@/events/definitions/operation'
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
 import type { WorkspaceDocument } from '@/schemas'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 import { isContentTypeParameterObject } from '@/schemas/v3.1/strict/type-guards'
 
 import { fetchRequestToHar } from './helpers/fetch-request-to-har'
@@ -14,8 +15,11 @@ export const addResponseToHistory = async (
   document: WorkspaceDocument | null,
   { payload, meta }: HooksEvents['hooks:on:request:complete'],
 ) => {
-  const documentName = document?.['x-scalar-navigation']?.name
-  if (!document || !documentName || !payload) {
+  if (!isOpenApiDocument(document)) {
+    return
+  }
+  const documentName = document['x-scalar-navigation']?.name
+  if (!documentName || !payload) {
     return
   }
 
@@ -60,7 +64,7 @@ export const reloadOperationHistory = (
   document: WorkspaceDocument | null,
   { meta, index, callback }: OperationEvents['operation:reload:history'],
 ) => {
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     console.error('Document not found', meta.path, meta.method)
     return
   }

--- a/packages/workspace-store/src/mutators/operation/operation.test.ts
+++ b/packages/workspace-store/src/mutators/operation/operation.test.ts
@@ -2,7 +2,7 @@ import { assert, describe, expect, it } from 'vitest'
 
 import { createWorkspaceStore } from '@/client'
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
-import type { WorkspaceDocument } from '@/schemas'
+import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 
 import {
   createOperation,
@@ -14,7 +14,7 @@ import {
   updateOperationPathMethod,
 } from './operation'
 
-const createDocument = (initial?: Partial<WorkspaceDocument>): WorkspaceDocument => {
+const createDocument = (initial?: Partial<OpenApiDocument>): OpenApiDocument => {
   return {
     openapi: '3.1.0',
     info: { title: 'Test', version: '1.0.0' },
@@ -47,7 +47,7 @@ describe('updateOperationPathMethod (method only)', () => {
       }),
     })
     store.buildSidebar('test')
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
     expect(document['x-scalar-order']).toStrictEqual([
       'test/description/introduction',
       'test/GET/users',
@@ -120,7 +120,7 @@ describe('updateOperationPathMethod (method only)', () => {
       }),
     })
     store.buildSidebar('test2')
-    const document = store.workspace.documents.test2!
+    const document = store.workspace.documents.test2 as OpenApiDocument
     expect(document.tags?.[0]?.['x-scalar-order']).toStrictEqual([
       'test2/tag/products/GET/products',
       'test2/tag/products/DELETE/products',
@@ -172,7 +172,7 @@ describe('updateOperationPathMethod (method only)', () => {
       }),
     })
     store.buildSidebar('test3')
-    const document = store.workspace.documents.test3!
+    const document = store.workspace.documents.test3 as OpenApiDocument
 
     let callbackResult: 'success' | 'no-change' | 'conflict' | undefined
 
@@ -208,7 +208,7 @@ describe('updateOperationPathMethod (path only)', () => {
       }),
     })
     store.buildSidebar('test')
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
 
     updateOperationPathMethod(document, store, {
       meta: { method: 'get', path: '/users' },
@@ -258,7 +258,7 @@ describe('updateOperationPathMethod (path only)', () => {
       }),
     })
     store.buildSidebar('test')
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
 
     updateOperationPathMethod(document, store, {
       meta: { method: 'post', path: '/posts' },
@@ -310,7 +310,7 @@ describe('updateOperationPathMethod (path only)', () => {
       }),
     })
     store.buildSidebar('test')
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
 
     updateOperationPathMethod(document, store, {
       meta: { method: 'get', path: '/users' },
@@ -354,7 +354,7 @@ describe('updateOperationPathMethod (path only)', () => {
       }),
     })
     store.buildSidebar('test')
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
 
     updateOperationPathMethod(document, store, {
       meta: { method: 'get', path: '/users/{id}' },
@@ -397,7 +397,7 @@ describe('updateOperationPathMethod (path only)', () => {
       }),
     })
     store.buildSidebar('test')
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
 
     updateOperationPathMethod(document, store, {
       meta: { method: 'get', path: '/users/{id}' },
@@ -441,7 +441,7 @@ describe('updateOperationPathMethod (path only)', () => {
       }),
     })
     store.buildSidebar('test')
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
 
     updateOperationPathMethod(document, store, {
       meta: { method: 'get', path: '/users/{id}/{limit}' },
@@ -485,7 +485,7 @@ describe('updateOperationPathMethod (path only)', () => {
       }),
     })
     store.buildSidebar('test')
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
 
     updateOperationPathMethod(document, store, {
       meta: { method: 'get', path: '/users/{id}' },
@@ -528,7 +528,7 @@ describe('updateOperationPathMethod (path only)', () => {
       }),
     })
     store.buildSidebar('test')
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
 
     updateOperationPathMethod(document, store, {
       meta: { method: 'get', path: '/users/{id}' },
@@ -567,7 +567,7 @@ describe('updateOperationPathMethod (path only)', () => {
       }),
     })
     store.buildSidebar('test')
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
 
     let callbackResult: 'success' | 'no-change' | 'conflict' | undefined
 
@@ -605,7 +605,7 @@ describe('updateOperationPathMethod (path only)', () => {
       }),
     })
     store.buildSidebar('test')
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
 
     let callbackResult: 'success' | 'no-change' | 'conflict' | undefined
 
@@ -645,7 +645,7 @@ describe('createOperation', () => {
     })
 
     expect(normalizedPath).toBe('/users')
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
     expect(document.paths?.['/users']?.get).toEqual({
       summary: 'Get users',
       description: 'Retrieve all users',
@@ -670,7 +670,7 @@ describe('createOperation', () => {
     })
 
     expect(normalizedPath).toBe('/users')
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
     expect(document.paths?.['/users']?.post).toBeDefined()
   })
 
@@ -752,7 +752,7 @@ describe('createOperation', () => {
       },
     })
 
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
     expect(document.paths?.['/users']?.get).toEqual({ summary: 'Get users' })
     expect(document.paths?.['/users']?.post).toEqual({ summary: 'Create user' })
   })
@@ -776,7 +776,7 @@ describe('createOperation', () => {
       },
     })
 
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
     expect(document.servers).toHaveLength(2)
     expect(document.servers).toContainEqual({ url: 'https://existing.example.com' })
     expect(document.servers).toContainEqual({ url: 'https://new.example.com' })
@@ -801,7 +801,7 @@ describe('createOperation', () => {
       },
     })
 
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
     expect(document.servers).toHaveLength(1)
     expect(document.servers?.[0]?.url).toBe('https://api.example.com')
   })
@@ -826,7 +826,7 @@ describe('createOperation', () => {
       },
     })
 
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
     expect(document.servers).toHaveLength(3)
     expect(document.servers).toContainEqual({ url: 'https://existing.example.com' })
     expect(document.servers).toContainEqual({ url: 'https://server1.example.com' })
@@ -854,7 +854,7 @@ describe('createOperation', () => {
       },
     })
 
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
     expect(document['x-scalar-selected-server']).toBe('https://new.example.com')
   })
 
@@ -877,7 +877,7 @@ describe('createOperation', () => {
       },
     })
 
-    const document = store.workspace.documents.test!
+    const document = store.workspace.documents.test as OpenApiDocument
     expect(document['x-scalar-selected-server']).toBe('https://existing.example.com')
   })
 })
@@ -911,7 +911,7 @@ describe('deleteOperation', () => {
       meta: { method: 'get', path: '/users' },
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.paths?.['/users']?.get).toBeUndefined()
     expect(document?.paths?.['/users']?.post).toBeDefined()
   })
@@ -936,7 +936,7 @@ describe('deleteOperation', () => {
       meta: { method: 'get', path: '/users' },
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.paths?.['/users']).toBeUndefined()
   })
 
@@ -982,7 +982,7 @@ describe('deleteOperation', () => {
       }),
     ).not.toThrow()
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.paths?.['/users']?.get).toBeDefined()
   })
 
@@ -1008,7 +1008,7 @@ describe('deleteOperation', () => {
       }),
     ).not.toThrow()
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.paths?.['/users']?.get).toBeDefined()
   })
 
@@ -1034,7 +1034,7 @@ describe('deleteOperation', () => {
       meta: { method: 'get', path: '/users' },
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.paths?.['/users']?.get).toBeUndefined()
     expect(document?.paths?.['/users']?.post).toBeDefined()
     expect(document?.paths?.['/products']?.get).toBeDefined()
@@ -1064,7 +1064,7 @@ describe('deleteOperation', () => {
       meta: { method: 'post', path: '/users' },
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.paths?.['/users']?.get).toBeUndefined()
     expect(document?.paths?.['/users']?.post).toBeUndefined()
     expect(document?.paths?.['/users']?.delete).toBeDefined()
@@ -1094,7 +1094,7 @@ describe('createOperationDraftExample', () => {
       exampleName: 'draft-1',
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     const operation = getResolvedRef(document?.paths?.['/users']?.get)
     expect(operation?.['x-draft-examples']).toEqual(['existing', 'draft-1'])
   })
@@ -1120,7 +1120,7 @@ describe('createOperationDraftExample', () => {
       exampleName: 'draft-1',
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     const operation = getResolvedRef(document?.paths?.['/users']?.get)
     expect(operation?.['x-draft-examples']).toEqual(['draft-1'])
   })
@@ -1147,7 +1147,7 @@ describe('createOperationDraftExample', () => {
       exampleName: 'draft-1',
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     const operation = getResolvedRef(document?.paths?.['/users']?.get)
     expect(operation?.['x-draft-examples']).toEqual(['draft-1', 'draft-2'])
   })
@@ -1218,7 +1218,7 @@ describe('deleteOperationExample', () => {
       meta: { method: 'get', path: '/users', exampleKey: 'draft-1' },
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     const operation = getResolvedRef(document?.paths?.['/users']?.get)
     expect(operation?.['x-draft-examples']).toEqual(['default', 'draft-2'])
   })
@@ -1254,7 +1254,7 @@ describe('deleteOperationExample', () => {
       meta: { method: 'get', path: '/users', exampleKey: 'custom' },
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     const operation = getResolvedRef(document?.paths?.['/users']?.get)
     const param = getResolvedRef(operation?.parameters?.[0])
     assert(param && 'examples' in param)
@@ -1294,7 +1294,7 @@ describe('deleteOperationExample', () => {
       meta: { method: 'post', path: '/users', exampleKey: 'custom' },
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     const operation = getResolvedRef(document?.paths?.['/users']?.post)
     const requestBody = getResolvedRef(operation?.requestBody)
     const examples = requestBody?.content?.['application/json']?.examples
@@ -1340,7 +1340,7 @@ describe('deleteOperationExample', () => {
       meta: { method: 'post', path: '/users', exampleKey: 'custom' },
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     const operation = getResolvedRef(document?.paths?.['/users']?.post)
     const requestBody = getResolvedRef(operation?.requestBody)
     expect(requestBody?.content?.['application/json']?.examples?.default).toBeDefined()
@@ -1391,7 +1391,7 @@ describe('deleteOperationExample', () => {
       meta: { method: 'post', path: '/users', exampleKey: 'custom' },
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     const operation = getResolvedRef(document?.paths?.['/users']?.post)
     const param = getResolvedRef(operation?.parameters?.[0])
     const requestBody = getResolvedRef(operation?.requestBody)
@@ -1475,7 +1475,7 @@ describe('deleteOperationExample', () => {
     ).not.toThrow()
 
     // Parameter example should still be deleted
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     const operation = getResolvedRef(document?.paths?.['/users']?.get)
     const param = getResolvedRef(operation?.parameters?.[0])
     assert(param && 'examples' in param)
@@ -1514,7 +1514,7 @@ describe('deleteOperationExample', () => {
       meta: { method: 'get', path: '/users', exampleKey: 'small' },
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     const operation = getResolvedRef(document?.paths?.['/users']?.get)
     const param = getResolvedRef(operation?.parameters?.[0])
     assert(param && 'examples' in param)
@@ -1572,7 +1572,7 @@ describe('renameOperationExample', () => {
       payload: { name: 'renamed' },
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     const operation = getResolvedRef(document?.paths?.['/users']?.post)
     const parameter = getResolvedRef(operation?.parameters?.[0])
     const requestBody = getResolvedRef(operation?.requestBody)
@@ -1619,7 +1619,7 @@ describe('renameOperationExample', () => {
       payload: { name: 'default' },
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     const operation = getResolvedRef(document?.paths?.['/users']?.get)
     const parameter = getResolvedRef(operation?.parameters?.[0])
 
@@ -1660,7 +1660,7 @@ describe('renameOperationExample', () => {
       payload: { name: 'existing' },
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     const operation = getResolvedRef(document?.paths?.['/users']?.post)
     const requestBody = getResolvedRef(operation?.requestBody)
     const examples = requestBody?.content?.['application/json']?.examples
@@ -1686,7 +1686,7 @@ describe('updateOperationMeta', () => {
         },
       }),
     })
-    const document = store.workspace.documents['meta-test']!
+    const document = store.workspace.documents['meta-test'] as OpenApiDocument
 
     updateOperationMeta(store, document, {
       meta: { method: 'get', path: '/users' },
@@ -1713,7 +1713,7 @@ describe('updateOperationMeta', () => {
         },
       }),
     })
-    const document = store.workspace.documents['meta-test-summary']!
+    const document = store.workspace.documents['meta-test-summary'] as OpenApiDocument
 
     updateOperationMeta(store, document, {
       meta: { method: 'get', path: '/pets' },
@@ -1740,7 +1740,7 @@ describe('updateOperationMeta', () => {
         },
       }),
     })
-    const document = store.workspace.documents['meta-test-deprecated']!
+    const document = store.workspace.documents['meta-test-deprecated'] as OpenApiDocument
 
     updateOperationMeta(store, document, {
       meta: { method: 'get', path: '/legacy' },
@@ -1768,7 +1768,7 @@ describe('updateOperationMeta', () => {
         },
       }),
     })
-    const document = store.workspace.documents['meta-test-multi']!
+    const document = store.workspace.documents['meta-test-multi'] as OpenApiDocument
 
     updateOperationMeta(store, document, {
       meta: { method: 'post', path: '/items' },
@@ -1798,7 +1798,7 @@ describe('updateOperationMeta', () => {
       }),
     })
     store.buildSidebar('meta-test-null-doc')
-    const document = store.workspace.documents['meta-test-null-doc']!
+    const document = store.workspace.documents['meta-test-null-doc'] as OpenApiDocument
 
     updateOperationMeta(store, null, {
       meta: { method: 'get', path: '/users' },
@@ -1821,7 +1821,7 @@ describe('updateOperationMeta', () => {
         },
       }),
     })
-    const document = store.workspace.documents['meta-test-null-store']!
+    const document = store.workspace.documents['meta-test-null-store'] as OpenApiDocument
 
     updateOperationMeta(null, document, {
       meta: { method: 'get', path: '/users' },

--- a/packages/workspace-store/src/mutators/operation/operation.ts
+++ b/packages/workspace-store/src/mutators/operation/operation.ts
@@ -12,6 +12,7 @@ import { getOperationEntries } from '@/navigation'
 import { getNavigationOptions } from '@/navigation/get-navigation-options'
 import { updateOrderIds } from '@/navigation/helpers/update-order-ids'
 import type { WorkspaceDocument } from '@/schemas'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 
 /**
  * Creates a new operation at a specific path and method in the document.
@@ -34,7 +35,7 @@ export const createOperation = (
   payload: OperationEvents['operation:create:operation'],
 ): string | undefined => {
   const document = workspaceStore?.workspace.documents[payload.documentName]
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     payload.callback?.(false)
     return undefined
   }
@@ -109,7 +110,7 @@ export const updateOperationMeta = (
   document: WorkspaceDocument | null,
   { meta, payload }: OperationEvents['operation:update:meta'],
 ) => {
-  if (!document || !store) {
+  if (!store || !isOpenApiDocument(document)) {
     return
   }
 
@@ -168,15 +169,20 @@ export const updateOperationPathMethod = (
   const finalMethod = methodChanged ? method : meta.method
   const finalPath = pathChanged ? path : meta.path
 
+  if (!store || !isOpenApiDocument(document)) {
+    console.error('Document or workspace not found', { document })
+    return
+  }
+
   // Check for conflicts at the target location
-  if (document?.paths?.[finalPath]?.[finalMethod as HttpMethod]) {
+  if (document.paths?.[finalPath]?.[finalMethod as HttpMethod]) {
     callback('conflict', blurTargetSelector)
     return
   }
 
-  const documentNavigation = document?.['x-scalar-navigation']
-  if (!documentNavigation || !store) {
-    console.error('Document or workspace not found', { document })
+  const documentNavigation = document['x-scalar-navigation']
+  if (!documentNavigation) {
+    console.error('Document navigation missing', { document })
     return
   }
 
@@ -268,7 +274,7 @@ export const deleteOperation = (
   { meta, documentName }: OperationEvents['operation:delete:operation'],
 ) => {
   const document = workspace?.workspace.documents[documentName]
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     return
   }
 
@@ -295,7 +301,7 @@ export const createOperationDraftExample = (
   { meta: { path, method }, documentName, exampleName }: OperationEvents['operation:create:draft-example'],
 ) => {
   const document = workspace?.workspace.documents[documentName]
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     console.error('Document not found', { documentName })
     return
   }
@@ -330,7 +336,7 @@ export const deleteOperationExample = (
 ) => {
   // Find the document in workspace based on documentName
   const document = workspace?.workspace.documents[documentName]
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     return
   }
 
@@ -393,7 +399,7 @@ export const renameOperationExample = (
   { meta: { path, method, exampleKey }, documentName, payload }: OperationEvents['operation:rename:example'],
 ) => {
   const document = workspace?.workspace.documents[documentName]
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     return
   }
 

--- a/packages/workspace-store/src/mutators/operation/parameters.test.ts
+++ b/packages/workspace-store/src/mutators/operation/parameters.test.ts
@@ -7,9 +7,9 @@ import {
   updateOperationExtraParameters,
   upsertOperationParameter,
 } from '@/mutators/operation/parameters'
-import type { WorkspaceDocument } from '@/schemas'
+import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 
-const createDocument = (initial?: Partial<WorkspaceDocument>): WorkspaceDocument => {
+const createDocument = (initial?: Partial<OpenApiDocument>): OpenApiDocument => {
   return {
     openapi: '3.1.0',
     info: { title: 'Test', version: '1.0.0' },

--- a/packages/workspace-store/src/mutators/operation/parameters.ts
+++ b/packages/workspace-store/src/mutators/operation/parameters.ts
@@ -3,6 +3,7 @@ import { getResolvedRef } from '@/helpers/get-resolved-ref'
 import { unpackProxyObject } from '@/helpers/unpack-proxy'
 import type { WorkspaceDocument } from '@/schemas'
 import type { DisableParametersConfig } from '@/schemas/extensions/operation/x-scalar-disable-parameters'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 import type { ExampleObject } from '@/schemas/v3.1/strict/example'
 import type { ReferenceType } from '@/schemas/v3.1/strict/reference'
 
@@ -52,7 +53,10 @@ export const upsertOperationParameter = (
   }
 
   // We are adding a new parameter
-  const operation = getResolvedRef(document?.paths?.[meta.path]?.[meta.method])
+  if (!isOpenApiDocument(document)) {
+    return
+  }
+  const operation = getResolvedRef(document.paths?.[meta.path]?.[meta.method])
   if (!operation) {
     console.error('Operation not found', { meta, document })
     return
@@ -98,7 +102,7 @@ export const updateOperationExtraParameters = (
   type In = OperationEvents['operation:update:extra-parameters']['in']
 
   // Ensure there's a valid document
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     return
   }
 
@@ -156,7 +160,10 @@ export const deleteOperationParameter = (
   document: WorkspaceDocument | null,
   { meta, originalParameter }: OperationEvents['operation:delete:parameter'],
 ) => {
-  const operation = getResolvedRef(document?.paths?.[meta.path]?.[meta.method])
+  if (!isOpenApiDocument(document)) {
+    return
+  }
+  const operation = getResolvedRef(document.paths?.[meta.path]?.[meta.method])
 
   // Lets check if its on the operation first as its more likely
   const operationIndex = operation?.parameters?.findIndex((it) => getResolvedRef(it) === originalParameter) ?? -1
@@ -171,7 +178,7 @@ export const deleteOperationParameter = (
   }
 
   // If it wasn't on the operation it might be on the path
-  const path = getResolvedRef(document?.paths?.[meta.path])
+  const path = getResolvedRef(document.paths?.[meta.path])
   const pathIndex = path?.parameters?.findIndex((it) => getResolvedRef(it) === originalParameter) ?? -1
 
   if (path && pathIndex >= 0) {
@@ -199,7 +206,7 @@ export const deleteAllOperationParameters = (
   document: WorkspaceDocument | null,
   { meta, type }: OperationEvents['operation:delete-all:parameters'],
 ) => {
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     return
   }
 

--- a/packages/workspace-store/src/mutators/server.test.ts
+++ b/packages/workspace-store/src/mutators/server.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
-import type { WorkspaceDocument } from '@/schemas'
+import type { OpenApiDocument } from '@/schemas/v3.1/strict/openapi-document'
 
 import {
   addServer,
@@ -14,9 +14,9 @@ import {
 } from './server'
 
 /**
- * Helper to create a minimal WorkspaceDocument for testing.
+ * Helper to create a minimal OpenApiDocument for testing.
  */
-function createDocument(initial?: Partial<WorkspaceDocument>): WorkspaceDocument {
+function createDocument(initial?: Partial<OpenApiDocument>): OpenApiDocument {
   return {
     openapi: '3.1.0',
     info: { title: 'Test', version: '1.0.0' },

--- a/packages/workspace-store/src/mutators/server.ts
+++ b/packages/workspace-store/src/mutators/server.ts
@@ -3,6 +3,7 @@ import { findVariables } from '@scalar/helpers/regex/find-variables'
 import type { ServerEvents, ServerMeta } from '@/events/definitions/server'
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
 import { unpackProxyObject } from '@/helpers/unpack-proxy'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 import { coerceValue } from '@/schemas/typebox-coerce'
 import { type ServerObject, ServerObjectSchema } from '@/schemas/v3.1/strict/openapi-document'
 import type { WorkspaceDocument } from '@/schemas/workspace'
@@ -21,7 +22,7 @@ type ServerTarget = {
  * Document-level servers live on the document; operation-level servers on the operation object.
  */
 const getServerTarget = (document: WorkspaceDocument | null, meta: ServerMeta): ServerTarget | null => {
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     return null
   }
   if (meta.type === 'document') {

--- a/packages/workspace-store/src/mutators/tag.test.ts
+++ b/packages/workspace-store/src/mutators/tag.test.ts
@@ -27,7 +27,7 @@ describe('createTag', () => {
 
     createTag(store, { documentName: 'test-doc', name: 'new-tag' })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags).toHaveLength(2)
     expect(document?.tags?.[0]?.name).toBe('existing-tag')
     expect(document?.tags?.[1]?.name).toBe('new-tag')
@@ -42,7 +42,7 @@ describe('createTag', () => {
 
     createTag(store, { documentName: 'test-doc', name: 'first-tag' })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags).toHaveLength(1)
     expect(document?.tags?.[0]?.name).toBe('first-tag')
   })
@@ -55,7 +55,7 @@ describe('createTag', () => {
 
     createTag(store, { documentName: 'non-existent', name: 'tag' })
 
-    expect(consoleSpy).toHaveBeenCalledWith('Document not found', expect.any(Object))
+    expect(consoleSpy).toHaveBeenCalledWith('Document not found or not an OpenAPI document', expect.any(Object))
     consoleSpy.mockRestore()
   })
 
@@ -66,7 +66,7 @@ describe('createTag', () => {
 
     createTag(null, { documentName: 'test-doc', name: 'tag' })
 
-    expect(consoleSpy).toHaveBeenCalledWith('Document not found', expect.any(Object))
+    expect(consoleSpy).toHaveBeenCalledWith('Document not found or not an OpenAPI document', expect.any(Object))
     consoleSpy.mockRestore()
   })
 
@@ -81,7 +81,7 @@ describe('createTag', () => {
     createTag(store, { documentName: 'test-doc', name: 'tag-2' })
     createTag(store, { documentName: 'test-doc', name: 'tag-3' })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags).toHaveLength(3)
     expect(document?.tags?.map((t) => t.name)).toEqual(['tag-1', 'tag-2', 'tag-3'])
   })
@@ -99,7 +99,7 @@ describe('deleteTag', () => {
 
     deleteTag(store, { documentName: 'test-doc', name: 'tag-2' })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags).toHaveLength(2)
     expect(document?.tags?.map((t) => t.name)).toEqual(['tag-1', 'tag-3'])
   })
@@ -127,7 +127,7 @@ describe('deleteTag', () => {
 
     deleteTag(store, { documentName: 'test-doc', name: 'users' })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags?.map((t) => t.name)).toEqual(['admin'])
     expect(getResolvedRef(document?.paths?.['/users']?.get)?.tags).toEqual(['admin'])
     expect(getResolvedRef(document?.paths?.['/users']?.post)?.tags).toEqual([])
@@ -152,7 +152,7 @@ describe('deleteTag', () => {
 
     deleteTag(store, { documentName: 'test-doc', name: 'webhook-tag' })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags?.map((t) => t.name)).toEqual(['other-tag'])
     expect(getResolvedRef(document?.webhooks?.newUser?.post)?.tags).toEqual(['other-tag'])
   })
@@ -188,7 +188,7 @@ describe('deleteTag', () => {
 
     expect(() => deleteTag(store, { documentName: 'test-doc', name: 'tag' })).not.toThrow()
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags).toEqual([])
     expect(getResolvedRef(document?.paths?.['/users']?.get)?.tags).toEqual([])
   })
@@ -212,7 +212,7 @@ describe('deleteTag', () => {
 
     expect(() => deleteTag(store, { documentName: 'test-doc', name: 'tag' })).not.toThrow()
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags).toEqual([])
   })
 
@@ -227,7 +227,7 @@ describe('deleteTag', () => {
 
     deleteTag(store, { documentName: 'test-doc', name: 'tag' })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags).toEqual([])
   })
 
@@ -249,7 +249,7 @@ describe('deleteTag', () => {
 
     deleteTag(store, { documentName: 'test-doc', name: 'tag' })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags).toEqual([])
     expect(getResolvedRef(document?.paths?.['/users']?.get)?.tags).toEqual([])
   })
@@ -271,7 +271,7 @@ describe('deleteTag', () => {
 
     deleteTag(store, { documentName: 'test-doc', name: 'tag' })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags).toBeUndefined()
     expect(getResolvedRef(document?.paths?.['/users']?.get)?.tags).toEqual([])
   })
@@ -298,7 +298,7 @@ describe('deleteTag', () => {
 
     deleteTag(store, { documentName: 'test-doc', name: 'common' })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags?.map((t) => t.name)).toEqual(['specific'])
     expect(getResolvedRef(document?.paths?.['/users']?.get)?.tags).toEqual([])
     expect(getResolvedRef(document?.paths?.['/users']?.post)?.tags).toEqual(['specific'])
@@ -324,7 +324,7 @@ describe('deleteTag', () => {
     deleteTag(store, { documentName: 'test-doc', name: 'non-existent-tag' })
 
     // Tags array and operation tags should remain unchanged
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags?.map((t) => t.name)).toEqual(['existing-tag'])
     expect(getResolvedRef(document?.paths?.['/users']?.get)?.tags).toEqual(['existing-tag'])
   })
@@ -362,7 +362,7 @@ describe('editTag', () => {
       newName: 'renamed-tag',
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags?.map((tag) => tag.name)).toEqual(['existing-tag'])
     expect(getResolvedRef(document?.paths?.['/users']?.get)?.tags).toEqual(['existing-tag'])
   })
@@ -407,7 +407,7 @@ describe('editTag', () => {
       newName: 'customers',
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags?.map((tag) => tag.name)).toEqual(['customers', 'admin'])
     expect(getResolvedRef(document?.paths?.['/users']?.get)?.tags).toEqual(['customers', 'admin'])
     expect(getResolvedRef(document?.paths?.['/users']?.post)?.tags).toEqual(['customers'])
@@ -446,7 +446,7 @@ describe('editTag', () => {
     // Simulate the external rebuild triggered by onAfterExecute
     store.buildSidebar('test-doc')
 
-    const navigation = store.workspace.documents['test-doc']?.['x-scalar-navigation']
+    const navigation = (store.workspace.documents['test-doc'] as OpenApiDocument | undefined)?.['x-scalar-navigation']
     const tagEntry = navigation?.children?.find((c: { type: string; name?: string }) => c.type === 'tag') as
       | { name?: string }
       | undefined
@@ -498,7 +498,7 @@ describe('editTag', () => {
       newName: 'alerts',
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags?.map((tag) => tag.name)).toEqual(['alerts', 'billing'])
     expect(getResolvedRef(document?.webhooks?.newUser?.post)?.tags).toEqual(['alerts'])
     expect(getResolvedRef(document?.webhooks?.paymentReceived?.post)?.tags).toEqual(['alerts', 'billing'])
@@ -523,7 +523,7 @@ describe('editTag', () => {
     // Simulate a user-defined custom ordering: POST before GET (reverse of default).
     // The IDs follow the pattern generated by getNavigationOptions for document "test-doc"
     // and tag "users": "test-doc/tag/users/METHOD/path".
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     const usersTag = document?.tags?.find((t) => t.name === 'users')
     const oldPostId = 'test-doc/tag/users/POST/users'
     const oldGetId = 'test-doc/tag/users/GET/users'
@@ -539,7 +539,9 @@ describe('editTag', () => {
     })
 
     // The tag object itself should now be renamed
-    const renamedTag = store.workspace.documents['test-doc']?.tags?.find((t) => t.name === 'customers')
+    const renamedTag = (store.workspace.documents['test-doc'] as OpenApiDocument | undefined)?.tags?.find(
+      (t) => t.name === 'customers',
+    )
     expect(renamedTag).toBeDefined()
 
     // x-scalar-order must have the SAME relative ordering, but with new IDs.
@@ -579,7 +581,7 @@ describe('editTag', () => {
       newName: 'customers',
     })
 
-    const document = store.workspace.documents['test-doc']
+    const document = store.workspace.documents['test-doc'] as OpenApiDocument | undefined
     expect(document?.tags?.map((tag) => tag.name)).toEqual(['customers', 'admin'])
     expect(document?.['x-tagGroups']?.[0]?.tags).toEqual(['customers', 'admin'])
     expect(document?.['x-tagGroups']?.[1]?.tags).toEqual(['admin'])

--- a/packages/workspace-store/src/mutators/tag.test.ts
+++ b/packages/workspace-store/src/mutators/tag.test.ts
@@ -55,7 +55,7 @@ describe('createTag', () => {
 
     createTag(store, { documentName: 'non-existent', name: 'tag' })
 
-    expect(consoleSpy).toHaveBeenCalledWith('Document not found or not an OpenAPI document', expect.any(Object))
+    expect(consoleSpy).toHaveBeenCalledWith('Document not found', expect.any(Object))
     consoleSpy.mockRestore()
   })
 
@@ -66,7 +66,7 @@ describe('createTag', () => {
 
     createTag(null, { documentName: 'test-doc', name: 'tag' })
 
-    expect(consoleSpy).toHaveBeenCalledWith('Document not found or not an OpenAPI document', expect.any(Object))
+    expect(consoleSpy).toHaveBeenCalledWith('Document not found', expect.any(Object))
     consoleSpy.mockRestore()
   })
 

--- a/packages/workspace-store/src/mutators/tag.ts
+++ b/packages/workspace-store/src/mutators/tag.ts
@@ -5,6 +5,7 @@ import { unpackProxyObject } from '@/helpers/unpack-proxy'
 import { getNavigationOptions } from '@/navigation/get-navigation-options'
 import { getTagEntries } from '@/navigation/helpers/get-tag-entries'
 import { updateOrderIds } from '@/navigation/helpers/update-order-ids'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 
 /**
  * Adds a new tag to the WorkspaceDocument's `tags` array.
@@ -17,8 +18,8 @@ import { updateOrderIds } from '@/navigation/helpers/update-order-ids'
 export const createTag = (store: WorkspaceStore | null, payload: TagEvents['tag:create:tag']) => {
   const document = store?.workspace.documents[payload.documentName]
 
-  if (!document) {
-    console.error('Document not found', { payload, store })
+  if (!isOpenApiDocument(document)) {
+    console.error('Document not found or not an OpenAPI document', { payload, store })
     return
   }
 
@@ -39,9 +40,13 @@ export const createTag = (store: WorkspaceStore | null, payload: TagEvents['tag:
  */
 export const editTag = (store: WorkspaceStore | null, payload: TagEvents['tag:edit:tag']) => {
   const document = store?.workspace.documents[payload.documentName]
-  const documentNavigation = document?.['x-scalar-navigation']
-  if (!document || !documentNavigation) {
-    console.error('Document not found', { payload, store })
+  if (!store || !isOpenApiDocument(document)) {
+    console.error('Document not found or not an OpenAPI document', { payload, store })
+    return
+  }
+  const documentNavigation = document['x-scalar-navigation']
+  if (!documentNavigation) {
+    console.error('Document navigation missing', { payload, store })
     return
   }
 
@@ -117,7 +122,7 @@ export const editTag = (store: WorkspaceStore | null, payload: TagEvents['tag:ed
  */
 export const deleteTag = (workspace: WorkspaceStore | null, payload: TagEvents['tag:delete:tag']) => {
   const document = workspace?.workspace.documents[payload.documentName]
-  if (!document) {
+  if (!isOpenApiDocument(document)) {
     return
   }
 

--- a/packages/workspace-store/src/mutators/tag.ts
+++ b/packages/workspace-store/src/mutators/tag.ts
@@ -19,7 +19,7 @@ export const createTag = (store: WorkspaceStore | null, payload: TagEvents['tag:
   const document = store?.workspace.documents[payload.documentName]
 
   if (!isOpenApiDocument(document)) {
-    console.error('Document not found or not an OpenAPI document', { payload, store })
+    console.error('Document not found', { payload, store })
     return
   }
 
@@ -41,7 +41,7 @@ export const createTag = (store: WorkspaceStore | null, payload: TagEvents['tag:
 export const editTag = (store: WorkspaceStore | null, payload: TagEvents['tag:edit:tag']) => {
   const document = store?.workspace.documents[payload.documentName]
   if (!store || !isOpenApiDocument(document)) {
-    console.error('Document not found or not an OpenAPI document', { payload, store })
+    console.error('Document not found', { payload, store })
     return
   }
   const documentNavigation = document['x-scalar-navigation']

--- a/packages/workspace-store/src/navigation/helpers/get-openapi-object.ts
+++ b/packages/workspace-store/src/navigation/helpers/get-openapi-object.ts
@@ -2,6 +2,7 @@ import type { WorkspaceStore } from '@/client'
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
 import type { WorkspaceDocument } from '@/schemas'
 import type { TraversedDocument, TraversedEntry, TraversedOperation, TraversedTag } from '@/schemas/navigation'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 import type { OperationObject, TagObject } from '@/schemas/v3.1/strict/openapi-document'
 
 import { getParentEntry } from './get-parent-entry'
@@ -60,6 +61,11 @@ export const getOpenapiObject = <Entry extends TraversedOrderable>({
 
   if (entry.type === 'document') {
     return document as GetOpenapiObject<Entry>
+  }
+
+  // Tag and operation lookups only make sense on OpenAPI documents.
+  if (!isOpenApiDocument(document)) {
+    return null
   }
 
   if (entry.type === 'tag') {

--- a/packages/workspace-store/src/navigation/helpers/update-order-ids.ts
+++ b/packages/workspace-store/src/navigation/helpers/update-order-ids.ts
@@ -4,6 +4,7 @@ import type { WorkspaceStore } from '@/client'
 import { canHaveOrder, getOpenapiObject } from '@/navigation/helpers/get-openapi-object'
 import { getParentEntry } from '@/navigation/helpers/get-parent-entry'
 import type { IdGenerator, TraversedOperation, TraversedTag, TraversedWebhook, WithParent } from '@/schemas/navigation'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 import type { TagObject } from '@/schemas/v3.1/strict/openapi-document'
 import type { OperationObject } from '@/schemas/v3.1/strict/operation'
 
@@ -65,7 +66,9 @@ export const updateOrderIds = ({ store, generateId, ...rest }: UpdateOrderIdPara
       if (oldTagId !== newTagId) {
         const documentEntry = getParentEntry('document', entry)
         const document = documentEntry ? store.workspace.documents[documentEntry.name] : null
-        const renamedTagObj = document?.tags?.find((t) => t.name === rest.tag.name)
+        const renamedTagObj = isOpenApiDocument(document)
+          ? document.tags?.find((t) => t.name === rest.tag.name)
+          : undefined
         const childOrder = renamedTagObj?.['x-scalar-order']
 
         if (renamedTagObj && Array.isArray(childOrder)) {

--- a/packages/workspace-store/src/request-example/context/environment.ts
+++ b/packages/workspace-store/src/request-example/context/environment.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceStore } from '@/client'
 import { type XScalarEnvironment, xScalarEnvironmentSchema } from '@/schemas/extensions/document/x-scalar-environments'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 import { coerceValue } from '@/schemas/typebox-coerce'
 import type { WorkspaceDocument } from '@/schemas/workspace'
 
@@ -45,7 +46,7 @@ export const getActiveEnvironment = (
   const workspaceEnv = workspace.workspace['x-scalar-environments']?.[activeEnv] ?? {
     variables: [],
   }
-  const documentEnv = document?.['x-scalar-environments']?.[activeEnv] ?? {
+  const documentEnv = (isOpenApiDocument(document) ? document['x-scalar-environments']?.[activeEnv] : undefined) ?? {
     variables: [],
   }
 

--- a/packages/workspace-store/src/request-example/context/get-request-example-context.ts
+++ b/packages/workspace-store/src/request-example/context/get-request-example-context.ts
@@ -17,6 +17,7 @@ import { getSelectedServer, getServers } from '@/request-example/context/servers
 import type { RequestExampleMeta, Result } from '@/request-example/types'
 import type { XScalarEnvironment } from '@/schemas/extensions/document/x-scalar-environments'
 import type { XScalarCookie } from '@/schemas/extensions/general/x-scalar-cookies'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 import type { OperationObject } from '@/schemas/v3.1/strict/operation'
 import type { SecurityRequirementObject } from '@/schemas/v3.1/strict/security-requirement'
 import type { ServerObject } from '@/schemas/v3.1/strict/server'
@@ -78,6 +79,12 @@ export const getRequestExampleContext = (
     return {
       ok: false,
       error: `Document ${documentName} not found`,
+    }
+  }
+  if (!isOpenApiDocument(document)) {
+    return {
+      ok: false,
+      error: `Document ${documentName} is not an OpenAPI document`,
     }
   }
 

--- a/packages/workspace-store/src/request-example/context/servers.test.ts
+++ b/packages/workspace-store/src/request-example/context/servers.test.ts
@@ -246,20 +246,27 @@ describe('servers', () => {
       { url: 'https://dev.example.com' },
     ]
 
-    it('returns the server matching document x-scalar-selected-server when configServers is set', () => {
-      const document = {
-        'x-scalar-selected-server': 'https://staging.example.com',
-      }
+    const minimalOasDocument = (overrides: Record<string, unknown>) =>
+      ({
+        openapi: '3.1.0',
+        info: { title: 'Test', version: '1.0.0' },
+        ...overrides,
+      }) as unknown as WorkspaceDocument
 
-      const result = getSelectedServer(document as WorkspaceDocument, null, [], servers)
+    it('returns the server matching document x-scalar-selected-server when configServers is set', () => {
+      const document = minimalOasDocument({
+        'x-scalar-selected-server': 'https://staging.example.com',
+      })
+
+      const result = getSelectedServer(document, null, [], servers)
 
       expect(result).toEqual({ url: 'https://staging.example.com' })
     })
 
     it('returns the server matching document x-scalar-selected-server when configServers is null', () => {
-      const document = { 'x-scalar-selected-server': 'https://staging.example.com' }
+      const document = minimalOasDocument({ 'x-scalar-selected-server': 'https://staging.example.com' })
 
-      const result = getSelectedServer(document as WorkspaceDocument, null, null, servers)
+      const result = getSelectedServer(document, null, null, servers)
 
       expect(result).toEqual({ url: 'https://staging.example.com' })
     })
@@ -273,32 +280,27 @@ describe('servers', () => {
     })
 
     it('prefers operation x-scalar-selected-server over document when configServers is null', () => {
-      const document = { 'x-scalar-selected-server': 'https://api.example.com' }
+      const document = minimalOasDocument({ 'x-scalar-selected-server': 'https://api.example.com' })
       const operation = { 'x-scalar-selected-server': 'https://staging.example.com' }
 
-      const result = getSelectedServer(document as WorkspaceDocument, operation as OperationObject, null, servers)
+      const result = getSelectedServer(document, operation as OperationObject, null, servers)
 
       expect(result).toEqual({ url: 'https://staging.example.com' })
     })
 
     it('ignores operation x-scalar-selected-server when configServers is non-null', () => {
-      const document = { 'x-scalar-selected-server': 'https://api.example.com' }
+      const document = minimalOasDocument({ 'x-scalar-selected-server': 'https://api.example.com' })
       const operation = { 'x-scalar-selected-server': 'https://dev.example.com' }
 
-      const result = getSelectedServer(
-        document as WorkspaceDocument,
-        operation as OperationObject,
-        [{} as ServerObject],
-        servers,
-      )
+      const result = getSelectedServer(document, operation as OperationObject, [{} as ServerObject], servers)
 
       expect(result).toEqual({ url: 'https://api.example.com' })
     })
 
     it('returns null when selected URL does not match any server URL', () => {
-      const document = { 'x-scalar-selected-server': 'https://nonexistent.example.com' }
+      const document = minimalOasDocument({ 'x-scalar-selected-server': 'https://nonexistent.example.com' })
 
-      const result = getSelectedServer(document as WorkspaceDocument, null, null, servers)
+      const result = getSelectedServer(document, null, null, servers)
 
       expect(result).toBeNull()
     })
@@ -316,9 +318,9 @@ describe('servers', () => {
     })
 
     it('returns null when x-scalar-selected-server is empty string (user un-selected)', () => {
-      const document = { 'x-scalar-selected-server': '' }
+      const document = minimalOasDocument({ 'x-scalar-selected-server': '' })
 
-      const result = getSelectedServer(document as WorkspaceDocument, null, null, [{ url: 'https://api.example.com' }])
+      const result = getSelectedServer(document, null, null, [{ url: 'https://api.example.com' }])
 
       expect(result).toBeNull()
     })

--- a/packages/workspace-store/src/request-example/context/servers.ts
+++ b/packages/workspace-store/src/request-example/context/servers.ts
@@ -2,6 +2,7 @@ import { combineUrlAndPath } from '@scalar/helpers/url/merge-urls'
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
 import type { WorkspaceDocument } from '@/schemas'
+import { isOpenApiDocument } from '@/schemas/type-guards'
 import type { OperationObject } from '@/schemas/v3.1/strict/operation'
 
 /**
@@ -107,10 +108,9 @@ export const getSelectedServer = (
   configServers: ServerObject[] | null,
   servers: ServerObject[],
 ): ServerObject | null => {
+  const documentSelectedServer = isOpenApiDocument(document) ? document['x-scalar-selected-server'] : undefined
   const selectedServerUrl =
-    configServers != null
-      ? document?.['x-scalar-selected-server']
-      : (operation?.['x-scalar-selected-server'] ?? document?.['x-scalar-selected-server'])
+    configServers != null ? documentSelectedServer : (operation?.['x-scalar-selected-server'] ?? documentSelectedServer)
 
   if (selectedServerUrl == null) {
     return servers[0] ?? null

--- a/packages/workspace-store/src/schemas.ts
+++ b/packages/workspace-store/src/schemas.ts
@@ -1,2 +1,9 @@
 // biome-ignore lint/performance/noBarrelFile: This is a barrel file that re-exports workspace schemas
-export { type Workspace, type WorkspaceDocument, WorkspaceDocumentSchema, WorkspaceSchema } from './schemas/workspace'
+export { type AsyncApiDocument, AsyncApiDocumentSchema } from './schemas/asyncapi/asyncapi-document'
+export { isAsyncApiDocument, isOpenApiDocument } from './schemas/type-guards'
+export {
+  type Workspace,
+  type WorkspaceDocument,
+  WorkspaceDocumentSchema,
+  WorkspaceSchema,
+} from './schemas/workspace'

--- a/packages/workspace-store/src/schemas/asyncapi/asyncapi-document.test.ts
+++ b/packages/workspace-store/src/schemas/asyncapi/asyncapi-document.test.ts
@@ -1,0 +1,69 @@
+import type { Static } from '@scalar/typebox'
+import { Value } from '@scalar/typebox/value'
+import type { RequiredDeep } from 'type-fest'
+import { describe, expect, it } from 'vitest'
+
+import { coerceValue } from '@/schemas/typebox-coerce'
+
+import { type AsyncApiDocument, AsyncApiDocumentSchema } from './asyncapi-document'
+
+describe('asyncapi-document', () => {
+  describe('strict type checking', () => {
+    it('matches the TypeScript type to the schema', () => {
+      type SchemaType = RequiredDeep<Static<typeof AsyncApiDocumentSchema>>
+      type TypescriptType = RequiredDeep<AsyncApiDocument>
+
+      const _test: SchemaType = {} as TypescriptType
+      const _test2: TypescriptType = {} as SchemaType
+      expect(_test).toEqual(_test2)
+    })
+  })
+
+  describe('value checking', () => {
+    it('parses a minimal valid document', () => {
+      const validInput = {
+        asyncapi: '3.0.0',
+        info: {
+          title: 'Streetlights API',
+          version: '1.0.0',
+        },
+      }
+
+      const result = coerceValue(AsyncApiDocumentSchema, validInput)
+
+      expect(result).toEqual(validInput)
+    })
+
+    it('parses a document with an info description', () => {
+      const validInput = {
+        asyncapi: '3.0.0',
+        info: {
+          title: 'Streetlights API',
+          version: '1.0.0',
+          description: 'Turn the lights on and off.',
+        },
+      }
+
+      const result = coerceValue(AsyncApiDocumentSchema, validInput)
+
+      expect(result).toEqual(validInput)
+    })
+
+    it('rejects a document missing the asyncapi field', () => {
+      const invalidInput = {
+        info: { title: 'x', version: '1' },
+      }
+
+      expect(Value.Check(AsyncApiDocumentSchema, invalidInput)).toBe(false)
+    })
+
+    it('rejects a document missing required info fields', () => {
+      const invalidInput = {
+        asyncapi: '3.0.0',
+        info: { title: 'x' },
+      }
+
+      expect(Value.Check(AsyncApiDocumentSchema, invalidInput)).toBe(false)
+    })
+  })
+})

--- a/packages/workspace-store/src/schemas/asyncapi/asyncapi-document.ts
+++ b/packages/workspace-store/src/schemas/asyncapi/asyncapi-document.ts
@@ -1,0 +1,46 @@
+import { Type } from '@scalar/typebox'
+
+/**
+ * Minimal AsyncAPI Info Object.
+ *
+ * Intentionally scoped to the fields we surface in the MVP. AsyncAPI's real Info Object
+ * is a superset (contact, license, termsOfService, tags, externalDocs, ...) — we can
+ * grow this as consumers need the extra fields.
+ */
+export const AsyncApiInfoObjectSchema = Type.Object({
+  /** REQUIRED. The title of the application. */
+  title: Type.String(),
+  /** REQUIRED. Provides the version of the application API (not the AsyncAPI Specification version). */
+  version: Type.String(),
+  /** A short description of the application. CommonMark syntax can be used for rich text representation. */
+  description: Type.Optional(Type.String()),
+})
+
+export type AsyncApiInfoObject = {
+  /** REQUIRED. The title of the application. */
+  title: string
+  /** REQUIRED. Provides the version of the application API (not the AsyncAPI Specification version). */
+  version: string
+  /** A short description of the application. CommonMark syntax can be used for rich text representation. */
+  description?: string
+}
+
+/**
+ * Minimal AsyncAPI Document.
+ *
+ * MVP shape: just the spec version discriminator + the minimal Info Object.
+ * Present on the discriminated {@link WorkspaceDocument} union via the required `asyncapi` field.
+ */
+export const AsyncApiDocumentSchema = Type.Object({
+  /** REQUIRED. The AsyncAPI Specification version the document uses (for example "3.0.0"). */
+  asyncapi: Type.String(),
+  /** REQUIRED. Provides metadata about the application. */
+  info: AsyncApiInfoObjectSchema,
+})
+
+export type AsyncApiDocument = {
+  /** REQUIRED. The AsyncAPI Specification version the document uses (for example "3.0.0"). */
+  asyncapi: string
+  /** REQUIRED. Provides metadata about the application. */
+  info: AsyncApiInfoObject
+}

--- a/packages/workspace-store/src/schemas/asyncapi/asyncapi-document.ts
+++ b/packages/workspace-store/src/schemas/asyncapi/asyncapi-document.ts
@@ -1,5 +1,7 @@
 import { Type } from '@scalar/typebox'
 
+import { compose } from '@/schemas/compose'
+
 /**
  * Minimal AsyncAPI Info Object.
  *
@@ -26,21 +28,51 @@ export type AsyncApiInfoObject = {
 }
 
 /**
+ * Store-managed metadata extensions for AsyncAPI documents. Parallels the OpenAPI set:
+ * `x-original-aas-version` is the AsyncAPI analog of `x-original-oas-version`. All fields are
+ * optional on the schema because validation runs against the raw user input (these get injected
+ * by the store during ingestion).
+ */
+export const AsyncApiExtensionsSchema = Type.Partial(
+  Type.Object({
+    /** Original AsyncAPI Specification version the document was loaded with. */
+    'x-original-aas-version': Type.String(),
+    /** Original document source url — when loaded from an external source. */
+    'x-scalar-original-source-url': Type.String(),
+    /** Content hash of the original document, used for change detection on rebase. */
+    'x-scalar-original-document-hash': Type.String(),
+  }),
+)
+
+export type AsyncApiExtensions = Partial<{
+  /** Original AsyncAPI Specification version the document was loaded with. */
+  'x-original-aas-version': string
+  /** Original document source url — when loaded from an external source. */
+  'x-scalar-original-source-url': string
+  /** Content hash of the original document, used for change detection on rebase. */
+  'x-scalar-original-document-hash': string
+}>
+
+/**
  * Minimal AsyncAPI Document.
  *
- * MVP shape: just the spec version discriminator + the minimal Info Object.
- * Present on the discriminated {@link WorkspaceDocument} union via the required `asyncapi` field.
+ * MVP shape: the spec version discriminator, the minimal Info Object, and the shared
+ * store-managed metadata extensions. Present on the discriminated {@link WorkspaceDocument}
+ * union via the required `asyncapi` field.
  */
-export const AsyncApiDocumentSchema = Type.Object({
-  /** REQUIRED. The AsyncAPI Specification version the document uses (for example "3.0.0"). */
-  asyncapi: Type.String(),
-  /** REQUIRED. Provides metadata about the application. */
-  info: AsyncApiInfoObjectSchema,
-})
+export const AsyncApiDocumentSchema = compose(
+  Type.Object({
+    /** REQUIRED. The AsyncAPI Specification version the document uses (for example "3.0.0"). */
+    asyncapi: Type.String(),
+    /** REQUIRED. Provides metadata about the application. */
+    info: AsyncApiInfoObjectSchema,
+  }),
+  AsyncApiExtensionsSchema,
+)
 
 export type AsyncApiDocument = {
   /** REQUIRED. The AsyncAPI Specification version the document uses (for example "3.0.0"). */
   asyncapi: string
   /** REQUIRED. Provides metadata about the application. */
   info: AsyncApiInfoObject
-}
+} & AsyncApiExtensions

--- a/packages/workspace-store/src/schemas/asyncapi/asyncapi-document.ts
+++ b/packages/workspace-store/src/schemas/asyncapi/asyncapi-document.ts
@@ -9,7 +9,7 @@ import { compose } from '@/schemas/compose'
  * is a superset (contact, license, termsOfService, tags, externalDocs, ...) — we can
  * grow this as consumers need the extra fields.
  */
-export const AsyncApiInfoObjectSchema = Type.Object({
+const AsyncApiInfoObjectSchema = Type.Object({
   /** REQUIRED. The title of the application. */
   title: Type.String(),
   /** REQUIRED. Provides the version of the application API (not the AsyncAPI Specification version). */
@@ -33,7 +33,7 @@ export type AsyncApiInfoObject = {
  * optional on the schema because validation runs against the raw user input (these get injected
  * by the store during ingestion).
  */
-export const AsyncApiExtensionsSchema = Type.Partial(
+const AsyncApiExtensionsSchema = Type.Partial(
   Type.Object({
     /** Original AsyncAPI Specification version the document was loaded with. */
     'x-original-aas-version': Type.String(),

--- a/packages/workspace-store/src/schemas/type-guards.test.ts
+++ b/packages/workspace-store/src/schemas/type-guards.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import { isAsyncApiDocument, isOpenApiDocument } from './type-guards'
+import type { WorkspaceDocument } from './workspace'
+
+describe('type-guards', () => {
+  const openApiDocument = {
+    openapi: '3.1.0',
+    info: { title: 'Pet Store', version: '1.0.0' },
+  } as unknown as WorkspaceDocument
+
+  const asyncApiDocument = {
+    asyncapi: '3.0.0',
+    info: { title: 'Streetlights', version: '1.0.0' },
+  } as unknown as WorkspaceDocument
+
+  describe('isOpenApiDocument', () => {
+    it('returns true for an OpenAPI document', () => {
+      expect(isOpenApiDocument(openApiDocument)).toBe(true)
+    })
+
+    it('returns false for an AsyncAPI document', () => {
+      expect(isOpenApiDocument(asyncApiDocument)).toBe(false)
+    })
+
+    it('returns false for undefined and null', () => {
+      expect(isOpenApiDocument(undefined)).toBe(false)
+      expect(isOpenApiDocument(null)).toBe(false)
+    })
+
+    it('narrows the type when used as a guard', () => {
+      const document: WorkspaceDocument = openApiDocument
+
+      if (isOpenApiDocument(document)) {
+        // Should compile: `openapi` field is accessible after narrowing.
+        const version: string = document.openapi
+        expect(version).toBe('3.1.0')
+      }
+    })
+  })
+
+  describe('isAsyncApiDocument', () => {
+    it('returns true for an AsyncAPI document', () => {
+      expect(isAsyncApiDocument(asyncApiDocument)).toBe(true)
+    })
+
+    it('returns false for an OpenAPI document', () => {
+      expect(isAsyncApiDocument(openApiDocument)).toBe(false)
+    })
+
+    it('returns false for undefined and null', () => {
+      expect(isAsyncApiDocument(undefined)).toBe(false)
+      expect(isAsyncApiDocument(null)).toBe(false)
+    })
+
+    it('narrows the type when used as a guard', () => {
+      const document: WorkspaceDocument = asyncApiDocument
+
+      if (isAsyncApiDocument(document)) {
+        // Should compile: `asyncapi` field is accessible after narrowing.
+        const version: string = document.asyncapi
+        expect(version).toBe('3.0.0')
+      }
+    })
+  })
+})

--- a/packages/workspace-store/src/schemas/type-guards.ts
+++ b/packages/workspace-store/src/schemas/type-guards.ts
@@ -1,0 +1,26 @@
+import type { AsyncApiDocument } from './asyncapi/asyncapi-document'
+import type { OpenApiDocument } from './v3.1/strict/openapi-document'
+
+/**
+ * Narrow a value to an OpenAPI document.
+ *
+ * Discriminated by the required `openapi` string field on OAS documents. Accepts `unknown`
+ * so it can narrow at any call site (e.g., workspace lookups typed as `WorkspaceDocument`,
+ * or broader contexts that mix documents with the workspace itself).
+ */
+export const isOpenApiDocument = (value: unknown): value is OpenApiDocument =>
+  typeof value === 'object' &&
+  value !== null &&
+  'openapi' in value &&
+  typeof (value as { openapi: unknown }).openapi === 'string'
+
+/**
+ * Narrow a value to an AsyncAPI document.
+ *
+ * Discriminated by the required `asyncapi` string field on AsyncAPI documents.
+ */
+export const isAsyncApiDocument = (value: unknown): value is AsyncApiDocument =>
+  typeof value === 'object' &&
+  value !== null &&
+  'asyncapi' in value &&
+  typeof (value as { asyncapi: unknown }).asyncapi === 'string'

--- a/packages/workspace-store/src/schemas/workspace.ts
+++ b/packages/workspace-store/src/schemas/workspace.ts
@@ -16,6 +16,7 @@ import { type XScalarOrder, XScalarOrderSchema } from '@/schemas/extensions/gene
 import { type XScalarActiveProxy, XScalarActiveProxySchema } from '@/schemas/extensions/workspace/x-scalar-active-proxy'
 import { type XScalarTabs, XScalarTabsSchema } from '@/schemas/extensions/workspace/x-scalar-tabs'
 
+import { type AsyncApiDocument, AsyncApiDocumentSchema } from './asyncapi/asyncapi-document'
 import { OpenAPIDocumentSchema, type OpenAPIExtensions, type OpenApiDocument } from './v3.1/strict/openapi-document'
 
 export type WorkspaceDocumentMeta = Omit<
@@ -23,9 +24,13 @@ export type WorkspaceDocumentMeta = Omit<
   'x-original-oas-version' | 'x-scalar-original-source-url' | 'x-scalar-original-document-hash'
 >
 
-// Note: use Type.Intersect to combine schemas here because Type.Compose does not work as expected with Modules
-export const WorkspaceDocumentSchema = OpenAPIDocumentSchema
-export type WorkspaceDocument = OpenApiDocument
+/**
+ * A document held by the workspace — a discriminated union of OpenAPI and AsyncAPI.
+ * Narrow with the `isOpenApiDocument` / `isAsyncApiDocument` guards in `@/schemas/type-guards`
+ * before touching spec-specific fields.
+ */
+export const WorkspaceDocumentSchema = Type.Union([OpenAPIDocumentSchema, AsyncApiDocumentSchema])
+export type WorkspaceDocument = OpenApiDocument | AsyncApiDocument
 
 export const ColorModeSchema = Type.Union([Type.Literal('system'), Type.Literal('light'), Type.Literal('dark')])
 

--- a/packages/workspace-store/src/server.test.ts
+++ b/packages/workspace-store/src/server.test.ts
@@ -6,7 +6,7 @@ import { type FastifyInstance, fastify } from 'fastify'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { coerceValue } from '@/schemas/typebox-coerce'
-import { SchemaObjectSchema } from '@/schemas/v3.1/strict/openapi-document'
+import { type OpenApiDocument, SchemaObjectSchema } from '@/schemas/v3.1/strict/openapi-document'
 
 import { allFilesMatch } from '../test/helpers'
 import {
@@ -285,7 +285,7 @@ describe('create-server-store', () => {
         ],
       })
 
-      const document = store.getWorkspace().documents['doc-1']
+      const document = store.getWorkspace().documents['doc-1'] as OpenApiDocument | undefined
       expect(document?.['x-scalar-order']).toEqual(['doc-1/description/introduction', 'doc-1/workspace-operation'])
       expect(document?.['x-scalar-navigation']?.children?.[1]?.id).toBe('doc-1/workspace-operation')
     })
@@ -310,7 +310,7 @@ describe('create-server-store', () => {
         },
       )
 
-      const document = store.getWorkspace().documents['doc-2']
+      const document = store.getWorkspace().documents['doc-2'] as OpenApiDocument | undefined
       expect(document?.['x-scalar-order']).toEqual(['doc-2/description/introduction', 'doc-2/add-document-operation'])
       expect(document?.['x-scalar-navigation']?.children?.[1]?.id).toBe('doc-2/add-document-operation')
     })


### PR DESCRIPTION
## Problem

I’ve submitted a few PRs to add AsyncAPI support, but they all failed. The PRs were large and became stale with lots of conflicts before we were able to merge them.

See #7080

## Solution

This PR is a new attempt, what I tried now: 

* Keeping the AsyncAPI schema super small (just `asyncapi` version, `info.title`, `info.description`, `info.version` for now). 
* I’ll ff with the correct schemas. 
* Adds basic AsyncAPI support to the `@scalar/workspace-store` already.

## Preview

<img width="1257" height="931" alt="Screenshot 2026-04-27 at 16 27 43" src="https://github.com/user-attachments/assets/14380ec3-e2ea-4781-8806-e96cf2664180" />

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
