### PR TITLE
feat(api-client): support full masking of temp URLs

### DIFF
--- a/.changeset/brave-actors-send.md
+++ b/.changeset/brave-actors-send.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: allow masking all temp urls

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
@@ -185,6 +185,7 @@ const createDefaultProps = (): OperationBlockProps => ({
   proxyUrl: '',
   workspaceCookies: [],
   documentCookies: [],
+  documentSlug: 'test-document',
   path: '/api/users',
   method: 'get' as const,
   httpClients: AVAILABLE_CLIENTS,

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -453,6 +453,7 @@ onBeforeUnmount(() => {
       <!-- Address Bar -->
       <Header
         :activeEnvironment
+        :document
         :documentUrl
         :environment
         :environments

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -23,6 +23,8 @@ export type OperationBlockProps = {
   appVersion: string
   /** Openapi document */
   document: OpenApiDocument
+  /** Openapi document slug */
+  documentSlug: string
   /** Workspace cookies */
   workspaceCookies: XScalarCookie[]
   /** Document cookies */
@@ -151,6 +153,7 @@ const {
   eventBus,
   exampleKey,
   document,
+  documentSlug,
   workspaceCookies = [],
   documentCookies = [],
   hideClientButton,
@@ -453,11 +456,12 @@ onBeforeUnmount(() => {
       <!-- Address Bar -->
       <Header
         :activeEnvironment
-        :document
+        :documentSlug
         :documentUrl
         :environment
         :environments
         :eventBus
+        :exampleKey
         :hideClientButton
         :history="operationHistory"
         :integration

--- a/packages/api-client/src/v2/blocks/operation-block/components/Header.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/components/Header.test.ts
@@ -14,6 +14,8 @@ describe('Header', () => {
   const defaultProps = {
     path: '/pets',
     method: 'get' as const,
+    documentSlug: 'test-document',
+    exampleKey: 'default',
     layout: 'web' as const,
     isSidebarOpen: true,
     showSidebar: true,

--- a/packages/api-client/src/v2/blocks/operation-block/components/Header.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/components/Header.vue
@@ -17,8 +17,10 @@ export type HeaderProps = {
   hideClientButton?: boolean
   /** Client integration  */
   integration?: string | null
-  /** Openapi document */
-  document: OpenApiDocument
+  /** Openapi document slug */
+  documentSlug: string
+  /** Currently selected example key for the current operation */
+  exampleKey: string
   /** Openapi document url for `modal` mode to open the client app */
   documentUrl?: string
   /** Client source */
@@ -51,10 +53,7 @@ import type {
   WorkspaceEventBus,
 } from '@scalar/workspace-store/events'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
-import type {
-  OpenApiDocument,
-  ServerObject,
-} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
 import { AddressBar, type History } from '@/v2/blocks/scalar-address-bar-block'
 import EnvironmentSelector from '@/v2/blocks/scalar-address-bar-block/components/EnvironmentSelector.vue'
@@ -65,7 +64,8 @@ import OpenApiClientButton from './OpenApiClientButton.vue'
 const {
   hideClientButton = false,
   eventBus,
-  document,
+  exampleKey,
+  documentSlug,
 } = defineProps<HeaderProps>()
 
 const emit = defineEmits<{
@@ -102,10 +102,11 @@ const handleAddEnvironment = () => {
     </div>
     <AddressBar
       :activeEnvironment
-      :document
+      :documentSlug
       :environment
       :environments
       :eventBus
+      :exampleKey
       :history
       :layout
       :method

--- a/packages/api-client/src/v2/blocks/operation-block/components/Header.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/components/Header.vue
@@ -17,6 +17,8 @@ export type HeaderProps = {
   hideClientButton?: boolean
   /** Client integration  */
   integration?: string | null
+  /** Openapi document */
+  document: OpenApiDocument
   /** Openapi document url for `modal` mode to open the client app */
   documentUrl?: string
   /** Client source */
@@ -49,7 +51,10 @@ import type {
   WorkspaceEventBus,
 } from '@scalar/workspace-store/events'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
-import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import type {
+  OpenApiDocument,
+  ServerObject,
+} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
 import { AddressBar, type History } from '@/v2/blocks/scalar-address-bar-block'
 import EnvironmentSelector from '@/v2/blocks/scalar-address-bar-block/components/EnvironmentSelector.vue'
@@ -57,7 +62,11 @@ import type { ClientLayout } from '@/v2/types/layout'
 
 import OpenApiClientButton from './OpenApiClientButton.vue'
 
-const { hideClientButton = false, eventBus } = defineProps<HeaderProps>()
+const {
+  hideClientButton = false,
+  eventBus,
+  document,
+} = defineProps<HeaderProps>()
 
 const emit = defineEmits<{
   /** Execute the current operation example */
@@ -93,6 +102,7 @@ const handleAddEnvironment = () => {
     </div>
     <AddressBar
       :activeEnvironment
+      :document
       :environment
       :environments
       :eventBus

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/response-cache.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/response-cache.ts
@@ -1,3 +1,4 @@
+import { isDefined } from '@scalar/helpers/array/is-defined'
 import type { RequestPayload } from '@scalar/workspace-store/request-example'
 
 import type { ResponseInstance } from '@/v2/blocks/operation-block/helpers/send-request'
@@ -17,10 +18,16 @@ export const responseCache = new Map<string, { response: ResponseInstance; reque
  * @param method - HTTP method (e.g., "GET", "POST")
  * @param path - The request path (e.g., "/pets")
  * @param exampleKey - A unique key identifying the example/request variant
+ * @param documentSlug - Optionally add the document slug to the key
  * @returns The constructed cache key string
  */
-export function getOperationExampleKey(method: string, path: string, exampleKey: string): string {
-  return `${method}|${path}|${exampleKey}`
+export function getOperationExampleKey(
+  method: string,
+  path: string,
+  exampleKey: string,
+  documentSlug?: string,
+): string {
+  return [documentSlug, method, path, exampleKey].filter(isDefined).join('|')
 }
 
 /**

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.test.ts
@@ -30,7 +30,7 @@ describe('AddressBar', () => {
   }
 
   const mountWithProps = (custom: Partial<AddressBarProps> = {}) => {
-    const eventBus = createWorkspaceEventBus()
+    const eventBus = custom.eventBus ?? createWorkspaceEventBus()
 
     const wrapper = mount(AddressBar, {
       props: {
@@ -40,6 +40,8 @@ describe('AddressBar', () => {
         servers: custom.servers ?? [baseServer],
         history: custom.history ?? [],
         layout: (custom.layout ?? 'web') as ClientLayout,
+        documentSlug: custom.documentSlug ?? 'test-doc',
+        exampleKey: custom.exampleKey ?? 'default',
         eventBus,
         environment: baseEnvironment,
         serverMeta: {

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import type { ClientLayout } from '@/v2/types/layout'
+import { refocusBlurTarget } from '@/v2/blocks/scalar-address-bar-block/helpers/refocus-blur-target'
 
 import AddressBar, { type AddressBarProps } from './AddressBar.vue'
 
@@ -17,6 +18,10 @@ vi.mock('vue', async () => {
     useId: () => 'address-bar-test-id',
   }
 })
+
+vi.mock('@/v2/blocks/scalar-address-bar-block/helpers/refocus-blur-target', () => ({
+  refocusBlurTarget: vi.fn(),
+}))
 
 describe('AddressBar', () => {
   const baseEnvironment = {
@@ -374,6 +379,154 @@ describe('AddressBar', () => {
     })
   })
 
+  describe('handlePathSubmit', () => {
+    it('uses the pasted URL path — not the current path prop — when a full URL is submitted via Enter', async () => {
+      const { wrapper, eventBus } = mountWithProps({
+        path: '/',
+        method: 'get',
+        servers: [baseServer],
+        server: baseServer,
+      })
+
+      const emitSpy = vi.spyOn(eventBus, 'emit')
+
+      const codeInput = wrapper.findComponent({ name: 'CodeInput' })
+      const submitEvent = new KeyboardEvent('keydown', { key: 'Enter' })
+
+      /**
+       * Simulate the user pasting a full URL into the address bar and pressing Enter.
+       * The submit event carries the editor's current text content (the pasted URL),
+       * not the `path` prop value ('/').
+       */
+      await codeInput.vm.$emit('submit', 'https://api.example.com/v2/users', submitEvent)
+      await nextTick()
+
+      /**
+       * The server portion should be extracted and the remaining path (/v2/users)
+       * sent as the payload — NOT the original path prop ('/').
+       */
+      expect(emitSpy).toHaveBeenCalledWith(
+        'operation:update:pathMethod',
+        expect.objectContaining({
+          blurTargetSelector: '[data-addressbar-action="send"]',
+          payload: { method: 'get', path: '/v2/users' },
+        }),
+      )
+    })
+
+    it('keeps a pasted URL when the deferred placeholder mask runs before Enter', async () => {
+      const animationFrameCallbacks: FrameRequestCallback[] = []
+      const requestAnimationFrameSpy = vi
+        .spyOn(globalThis, 'requestAnimationFrame')
+        .mockImplementation((callback) => {
+          animationFrameCallbacks.push(callback)
+          return animationFrameCallbacks.length
+        })
+
+      const { wrapper, eventBus } = mountWithProps({
+        path: '/',
+        method: 'get',
+        servers: [baseServer],
+        server: baseServer,
+      })
+
+      try {
+        await nextTick()
+
+        const codeInput = wrapper.findComponent({ name: 'CodeInput' })
+        const pastedUrl = 'https://api.example.com/v2/users'
+        codeInput.vm.setCodeMirrorContent(pastedUrl)
+
+        for (const callback of animationFrameCallbacks) {
+          callback(performance.now())
+        }
+
+        expect(codeInput.vm.codeMirror.state.doc.toString()).toBe(pastedUrl)
+
+        const emitSpy = vi.spyOn(eventBus, 'emit')
+        const submitEvent = new KeyboardEvent('keydown', { key: 'Enter' })
+        await codeInput.vm.$emit('submit', pastedUrl, submitEvent)
+        await nextTick()
+
+        expect(emitSpy).toHaveBeenCalledWith(
+          'operation:update:pathMethod',
+          expect.objectContaining({
+            blurTargetSelector: '[data-addressbar-action="send"]',
+            payload: { method: 'get', path: '/v2/users' },
+          }),
+        )
+      } finally {
+        requestAnimationFrameSpy.mockRestore()
+      }
+    })
+
+    it('submits the empty masked path instead of the CodeMirror placeholder on Enter', async () => {
+      const animationFrameCallbacks: FrameRequestCallback[] = []
+      const requestAnimationFrameSpy = vi
+        .spyOn(globalThis, 'requestAnimationFrame')
+        .mockImplementation((callback) => {
+          animationFrameCallbacks.push(callback)
+          return animationFrameCallbacks.length
+        })
+      const originalGetClientRects = Range.prototype.getClientRects
+      Object.defineProperty(Range.prototype, 'getClientRects', {
+        configurable: true,
+        value: () =>
+          ({
+            length: 0,
+            item: () => null,
+            [Symbol.iterator]: () => [][Symbol.iterator](),
+          }) as DOMRectList,
+      })
+
+      const { wrapper, eventBus } = mountWithProps({
+        path: '/',
+        method: 'get',
+        documentSlug: 'drafts',
+        server: null,
+        servers: [],
+      })
+
+      try {
+        await nextTick()
+
+        for (const callback of animationFrameCallbacks) {
+          callback(performance.now())
+        }
+
+        await nextTick()
+
+        const codeInput = wrapper.findComponent({ name: 'CodeInput' })
+        expect(codeInput.vm.codeMirror.state.doc.toString()).toBe('')
+        const editorContent = codeInput.find('.cm-content')
+        editorContent.element.append('Enter a URL')
+        expect(editorContent.text()).toBe('Enter a URL')
+
+        const emitSpy = vi.spyOn(eventBus, 'emit')
+        await editorContent.trigger('keydown.enter')
+        await nextTick()
+
+        expect(emitSpy).toHaveBeenCalledWith(
+          'operation:update:pathMethod',
+          expect.objectContaining({
+            blurTargetSelector: '[data-addressbar-action="send"]',
+            payload: { method: 'get', path: '/' },
+          }),
+        )
+      } finally {
+        requestAnimationFrameSpy.mockRestore()
+        if (originalGetClientRects) {
+          Object.defineProperty(Range.prototype, 'getClientRects', {
+            configurable: true,
+            value: originalGetClientRects,
+          })
+        } else {
+          delete (Range.prototype as Partial<Range>).getClientRects
+        }
+      }
+    })
+  })
+
   describe('handleMethodChange', () => {
     it('emits operation:update:pathMethod with new method and current path', async () => {
       const { wrapper, eventBus } = mountWithProps({
@@ -563,6 +716,33 @@ describe('AddressBar', () => {
       )
 
       cleanup()
+    })
+
+    it('does not refocus the blur target when the update conflicts', async () => {
+      const { wrapper, eventBus } = mountWithProps({
+        path: '/api/test',
+        method: 'get',
+      })
+
+      const { event, sendEl, cleanup } = makeSendBlurEvent()
+
+      vi.spyOn(eventBus, 'emit').mockImplementation((eventName, _payload) => {
+        const payload = _payload as ApiReferenceEvents['operation:update:pathMethod']
+        if (eventName === 'operation:update:pathMethod' && payload?.callback) {
+          payload.callback('conflict', getSelector(sendEl))
+        }
+        return eventBus
+      })
+
+      try {
+        const codeInput = wrapper.findComponent({ name: 'CodeInput' })
+        await codeInput.vm.$emit('blur', '/api/new-path', event)
+        await nextTick()
+
+        expect(refocusBlurTarget).not.toHaveBeenCalled()
+      } finally {
+        cleanup()
+      }
     })
 
     it('uses methodConflict as method when a method conflict is active', async () => {

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.test.ts
@@ -380,6 +380,106 @@ describe('AddressBar', () => {
   })
 
   describe('handlePathSubmit', () => {
+    it('masks the next placeholder navigation when a path update never calls back', async () => {
+      const animationFrameCallbacks: FrameRequestCallback[] = []
+      const requestAnimationFrameSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((callback) => {
+        animationFrameCallbacks.push(callback)
+        return animationFrameCallbacks.length
+      })
+      const originalGetClientRects = Range.prototype.getClientRects
+      Object.defineProperty(Range.prototype, 'getClientRects', {
+        configurable: true,
+        value: () =>
+          ({
+            length: 0,
+            item: () => null,
+            [Symbol.iterator]: () => [][Symbol.iterator](),
+          }) as DOMRectList,
+      })
+
+      const { wrapper, eventBus } = mountWithProps({
+        path: '/api/test',
+        method: 'get',
+      })
+
+      vi.spyOn(eventBus, 'emit').mockImplementation(() => eventBus)
+
+      try {
+        await nextTick()
+        animationFrameCallbacks.length = 0
+
+        const codeInput = wrapper.findComponent({ name: 'CodeInput' })
+        const submitEvent = new KeyboardEvent('keydown', { key: 'Enter' })
+        await codeInput.vm.$emit('submit', '/api/new-path', submitEvent)
+        await nextTick()
+
+        await wrapper.setProps({ path: '/_scalar_temp1a2b3c4d' })
+        await nextTick()
+
+        for (const callback of animationFrameCallbacks) {
+          callback(performance.now())
+        }
+
+        expect(codeInput.vm.codeMirror.state.doc.toString()).toBe('')
+      } finally {
+        requestAnimationFrameSpy.mockRestore()
+        if (originalGetClientRects) {
+          Object.defineProperty(Range.prototype, 'getClientRects', {
+            configurable: true,
+            value: originalGetClientRects,
+          })
+        } else {
+          delete (Range.prototype as Partial<Range>).getClientRects
+        }
+      }
+    })
+
+    it('does not clear user-entered text when a deferred placeholder mask runs', async () => {
+      const animationFrameCallbacks: FrameRequestCallback[] = []
+      const requestAnimationFrameSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((callback) => {
+        animationFrameCallbacks.push(callback)
+        return animationFrameCallbacks.length
+      })
+      const originalGetClientRects = Range.prototype.getClientRects
+      Object.defineProperty(Range.prototype, 'getClientRects', {
+        configurable: true,
+        value: () =>
+          ({
+            length: 0,
+            item: () => null,
+            [Symbol.iterator]: () => [][Symbol.iterator](),
+          }) as DOMRectList,
+      })
+
+      const { wrapper } = mountWithProps({
+        path: '/_scalar_temp1a2b3c4d',
+        method: 'get',
+      })
+
+      try {
+        await nextTick()
+
+        const codeInput = wrapper.findComponent({ name: 'CodeInput' })
+        codeInput.vm.setCodeMirrorContent('/users')
+
+        for (const callback of animationFrameCallbacks) {
+          callback(performance.now())
+        }
+
+        expect(codeInput.vm.codeMirror.state.doc.toString()).toBe('/users')
+      } finally {
+        requestAnimationFrameSpy.mockRestore()
+        if (originalGetClientRects) {
+          Object.defineProperty(Range.prototype, 'getClientRects', {
+            configurable: true,
+            value: originalGetClientRects,
+          })
+        } else {
+          delete (Range.prototype as Partial<Range>).getClientRects
+        }
+      }
+    })
+
     it('uses the pasted URL path — not the current path prop — when a full URL is submitted via Enter', async () => {
       const { wrapper, eventBus } = mountWithProps({
         path: '/',

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.test.ts
@@ -6,8 +6,8 @@ import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
-import type { ClientLayout } from '@/v2/types/layout'
 import { refocusBlurTarget } from '@/v2/blocks/scalar-address-bar-block/helpers/refocus-blur-target'
+import type { ClientLayout } from '@/v2/types/layout'
 
 import AddressBar, { type AddressBarProps } from './AddressBar.vue'
 
@@ -416,12 +416,10 @@ describe('AddressBar', () => {
 
     it('keeps a pasted URL when the deferred placeholder mask runs before Enter', async () => {
       const animationFrameCallbacks: FrameRequestCallback[] = []
-      const requestAnimationFrameSpy = vi
-        .spyOn(globalThis, 'requestAnimationFrame')
-        .mockImplementation((callback) => {
-          animationFrameCallbacks.push(callback)
-          return animationFrameCallbacks.length
-        })
+      const requestAnimationFrameSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((callback) => {
+        animationFrameCallbacks.push(callback)
+        return animationFrameCallbacks.length
+      })
 
       const { wrapper, eventBus } = mountWithProps({
         path: '/',
@@ -462,12 +460,10 @@ describe('AddressBar', () => {
 
     it('submits the empty masked path instead of the CodeMirror placeholder on Enter', async () => {
       const animationFrameCallbacks: FrameRequestCallback[] = []
-      const requestAnimationFrameSpy = vi
-        .spyOn(globalThis, 'requestAnimationFrame')
-        .mockImplementation((callback) => {
-          animationFrameCallbacks.push(callback)
-          return animationFrameCallbacks.length
-        })
+      const requestAnimationFrameSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((callback) => {
+        animationFrameCallbacks.push(callback)
+        return animationFrameCallbacks.length
+      })
       const originalGetClientRects = Range.prototype.getClientRects
       Object.defineProperty(Range.prototype, 'getClientRects', {
         configurable: true,

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.test.ts
@@ -514,6 +514,45 @@ describe('AddressBar', () => {
       )
     })
 
+    it('waits for a pasted URL server to be selected before replaying Send', async () => {
+      const pastedUrl = 'https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.json'
+      const selectedServer = { url: 'https://cdn.jsdelivr.net' }
+      const { wrapper, eventBus } = mountWithProps({
+        path: '/',
+        method: 'get',
+        server: null,
+        servers: [],
+      })
+
+      let replayServerUrl: string | null = null
+      vi.mocked(refocusBlurTarget).mockImplementation(() => {
+        replayServerUrl = wrapper.props('server')?.url ?? null
+      })
+      vi.spyOn(eventBus, 'emit').mockImplementation((eventName, _payload) => {
+        if (eventName === 'server:add:server') {
+          wrapper.setProps({ server: selectedServer, servers: [selectedServer] })
+        }
+
+        const payload = _payload as ApiReferenceEvents['operation:update:pathMethod']
+        if (eventName === 'operation:update:pathMethod' && payload?.callback) {
+          payload.callback('success', '[data-addressbar-action="send"]')
+        }
+
+        return eventBus
+      })
+
+      const codeInput = wrapper.findComponent({ name: 'CodeInput' })
+      const submitEvent = new KeyboardEvent('keydown', { key: 'Enter' })
+      codeInput.vm.$emit('submit', pastedUrl, submitEvent)
+
+      expect(refocusBlurTarget).not.toHaveBeenCalled()
+
+      await nextTick()
+
+      expect(refocusBlurTarget).toHaveBeenCalledWith('[data-addressbar-action="send"]')
+      expect(replayServerUrl).toBe('https://cdn.jsdelivr.net')
+    })
+
     it('keeps a pasted URL when the deferred placeholder mask runs before Enter', async () => {
       const animationFrameCallbacks: FrameRequestCallback[] = []
       const requestAnimationFrameSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((callback) => {

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -190,7 +190,11 @@ const { beginLocalEdit, endLocalEdit } = usePathMasking({
   isReady: () => addressBarRef.value?.codeMirror,
   operationKey: () => uniqueKey.value,
   shouldMask: () => isPlaceholderPath(path, documentSlug),
-  onMask: () => handleFocusAddressBar({ clear: true }),
+  // Defer to the next frame so focus() runs after click-handler side
+  // effects that move focus (e.g. a dropdown refocusing its trigger),
+  // which would otherwise blur our input and emit a spurious path
+  // update against the now-empty value.
+  onMask: () => requestAnimationFrame(() => handleFocusAddressBar({ clear: true })),
 })
 
 // ───────────────────────────────────────────────────────────────────

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -371,16 +371,16 @@ const navigateToServersPage = (): void => {
 // Lifecycle
 // ───────────────────────────────────────────────────────────────────
 
-let unsubscribes: Array<() => void> = []
+const unsubscribes: Array<() => void> = []
 
 onMounted(() => {
-  unsubscribes = [
+  unsubscribes.push(
     eventBus.on('ui:focus:address-bar', handleFocusAddressBar),
     eventBus.on('ui:focus:send-button', handleFocusSendButton),
     eventBus.on('copy-url:address-bar', copyUrl),
     eventBus.on('hooks:on:request:sent', startLoading),
     eventBus.on('hooks:on:request:complete', stopLoading),
-  ]
+  )
 })
 
 onBeforeUnmount(() => {

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -182,11 +182,11 @@ const handleFocusAddressBar = (
 // Drafts on `/` and auto-generated `/_scalar_temp...` paths are internal
 // placeholders — the address bar focuses and clears on mount and on
 // navigation so the user sees a blank prompt instead of the internal
-// path. Local edits are skipped via `markLocalEdit` so that blurring
-// away from a typed path does not re-focus the input.
+// path. The deferred mask only clears when CodeMirror still contains that
+// placeholder path, so a user edit that lands before the frame is preserved.
 // ───────────────────────────────────────────────────────────────────
 
-const { beginLocalEdit, endLocalEdit } = usePathMasking({
+usePathMasking({
   isReady: () => addressBarRef.value?.codeMirror,
   operationKey: () => uniqueKey.value,
   shouldMask: () => isPlaceholderPath(path, documentSlug),
@@ -195,7 +195,16 @@ const { beginLocalEdit, endLocalEdit } = usePathMasking({
   // which would otherwise blur our input and emit a spurious path
   // update against the now-empty value.
   onMask: () =>
-    requestAnimationFrame(() => handleFocusAddressBar({ clear: true })),
+    requestAnimationFrame(() => {
+      const editorContent =
+        addressBarRef.value?.codeMirror?.state.doc.toString()
+
+      if (editorContent && editorContent !== path) {
+        return
+      }
+
+      handleFocusAddressBar({ clear: true })
+    }),
 })
 
 // ───────────────────────────────────────────────────────────────────
@@ -249,20 +258,11 @@ const emitPathMethodUpdate = (
   // Keep CodeMirror in sync so a conflict does not leave a stale value on screen
   addressBarRef.value?.setCodeMirrorContent(normalizedPath)
 
-  // Tell the masking watcher that the next `uniqueKey` change (if any) was
-  // user-initiated; `endLocalEdit` in the callback reconciles the flag.
-  beginLocalEdit()
-
   eventBus.emit('operation:update:pathMethod', {
     meta: { method, path },
     blurTargetSelector,
     payload: { method: targetMethod, path: normalizedPath },
     callback: (status, returnedSelector) => {
-      // Only 'success' mutates the document (and therefore fires the masking
-      // watcher). For 'conflict' and 'no-change' we clear the flag now so it
-      // does not leak into the next legitimate navigation.
-      endLocalEdit(status === 'success')
-
       if (status === 'success' || status === 'no-change') {
         methodConflict.value = null
         pathConflict.value = null

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -146,7 +146,6 @@ const uniqueKey = computed(() =>
 
 /** Clear conflict state when switching to a different operation */
 watch(uniqueKey, () => {
-  console.log('clearing conflict', uniqueKey.value)
   pathConflict.value = null
   methodConflict.value = null
 })

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -273,6 +273,8 @@ const emitPathMethodUpdate = (
         if (normalizedPath !== path) {
           pathConflict.value = normalizedPath
         }
+
+        return
       }
 
       // Edge case: pasting a full URL extracts the server but leaves the path

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -194,7 +194,8 @@ const { beginLocalEdit, endLocalEdit } = usePathMasking({
   // effects that move focus (e.g. a dropdown refocusing its trigger),
   // which would otherwise blur our input and emit a spurious path
   // update against the now-empty value.
-  onMask: () => requestAnimationFrame(() => handleFocusAddressBar({ clear: true })),
+  onMask: () =>
+    requestAnimationFrame(() => handleFocusAddressBar({ clear: true })),
 })
 
 // ───────────────────────────────────────────────────────────────────

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -12,8 +12,10 @@ export type AddressBarProps = {
   path: string
   /** Current request method */
   method: HttpMethodType
-  /** Openapi document */
-  document: OpenApiDocument
+  /** Openapi document slug */
+  documentSlug: string
+  /** Currently selected example key for the current operation */
+  exampleKey: string
   /** Currently selected server */
   server: ServerObject | null
   /** Server list available for operation/document */
@@ -54,12 +56,10 @@ import {
   getResolvedUrl,
 } from '@scalar/workspace-store/request-example'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
-import type {
-  OpenApiDocument,
-  ServerObject,
-} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import {
   computed,
+  nextTick,
   onBeforeUnmount,
   onMounted,
   ref,
@@ -69,6 +69,7 @@ import {
 } from 'vue'
 
 import { HttpMethod } from '@/components/HttpMethod'
+import { getOperationExampleKey } from '@/v2/blocks/operation-block/helpers/response-cache'
 import { useLoadingAnimation } from '@/v2/blocks/scalar-address-bar-block/hooks/use-loading-animation'
 import { CodeInput } from '@/v2/components/code-input'
 import { ServerDropdown } from '@/v2/components/server'
@@ -81,8 +82,9 @@ const {
   method,
   layout,
   eventBus,
+  exampleKey,
   history,
-  document: openapiDocument,
+  documentSlug,
   server,
   servers,
   environment,
@@ -117,14 +119,16 @@ const methodConflict = ref<HttpMethodType | null>(null)
 /** Whether there is a path or method conflict */
 const hasConflict = computed(() => methodConflict.value || pathConflict.value)
 
-/** Clear conflict state when switching to a different operation */
-watch(
-  () => [path, method],
-  () => {
-    pathConflict.value = null
-    methodConflict.value = null
-  },
+/** Detect if we have changed to a different example */
+const uniqueKey = computed(() =>
+  getOperationExampleKey(method, path, exampleKey, documentSlug),
 )
+
+/** Clear conflict state when switching to a different operation */
+watch(uniqueKey, () => {
+  pathConflict.value = null
+  methodConflict.value = null
+})
 
 /** Check if the path contains a server URL, extract it, and select or add the server */
 const checkForServer = (targetPath: string) => {
@@ -176,6 +180,15 @@ const emitPathMethodUpdate = (
 
   // Update the local state of codemirror so we don't have werid path on conflict
   addressBarRef.value?.setCodeMirrorContent(normalizedPath)
+
+  // The `uniqueKey` watch runs masking when path/method changes. A local edit
+  // here shouldn't re-focus the address bar (the user may have clicked
+  // elsewhere), so skip the next mask trigger. Reset in `nextTick` to cover
+  // the `no-change` case where the watch never fires.
+  skipNextMask.value = true
+  nextTick(() => {
+    skipNextMask.value = false
+  })
 
   eventBus.emit('operation:update:pathMethod', {
     meta: { method, path },
@@ -288,15 +301,12 @@ const handleFocusAddressBar = (
 ) => {
   // If it already has focus we just propagate native behavior which should focus the browser address bar
   if (addressBarRef.value?.isFocused && layout !== 'desktop') {
-    console.log('already focused')
     return
   }
 
-  console.log('focusing', addressBarRef.value)
   addressBarRef.value?.focus('end')
 
   if (payload && 'clear' in payload && payload.clear) {
-    console.log('clearing')
     addressBarRef.value?.setCodeMirrorContent('')
   }
 
@@ -305,17 +315,39 @@ const handleFocusAddressBar = (
   }
 }
 
+/**
+ * We use this trick to mask the path when we are on drafts and its / or any of those temp paths used for new operations
+ */
+const handleMaskingPath = () => {
+  // For drafts that are just /
+  if (documentSlug.toLowerCase() === 'drafts' && path === '/') {
+    handleFocusAddressBar({ clear: true })
+  }
+}
+
+/**
+ * Set when the `uniqueKey` change originates from a local edit (blur, submit,
+ * method change) so we can differentiate from sidebar/route-driven changes
+ * and avoid re-focusing the address bar after the user clicked away.
+ */
+const skipNextMask = ref(false)
+
+// For masking on initial load and changing examples/operations via navigation
+watch([() => addressBarRef.value?.codeMirror, uniqueKey], ([codeMirror]) => {
+  if (!codeMirror) return
+  if (skipNextMask.value) {
+    skipNextMask.value = false
+    return
+  }
+  handleMaskingPath()
+})
+
 onMounted(() => {
   eventBus.on('ui:focus:address-bar', handleFocusAddressBar)
   eventBus.on('ui:focus:send-button', handleFocusSendButton)
   eventBus.on('copy-url:address-bar', copyUrl)
   eventBus.on('hooks:on:request:sent', startLoading)
   eventBus.on('hooks:on:request:complete', stopLoading)
-
-  if (openapiDocument.info?.title.toLowerCase() === 'drafts' && path === '/') {
-    console.log('asdhasdkj')
-    handleFocusAddressBar({ clear: true })
-  }
 })
 
 onBeforeUnmount(() => {

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -12,6 +12,8 @@ export type AddressBarProps = {
   path: string
   /** Current request method */
   method: HttpMethodType
+  /** Openapi document */
+  document: OpenApiDocument
   /** Currently selected server */
   server: ServerObject | null
   /** Server list available for operation/document */
@@ -52,7 +54,10 @@ import {
   getResolvedUrl,
 } from '@scalar/workspace-store/request-example'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
-import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import type {
+  OpenApiDocument,
+  ServerObject,
+} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import {
   computed,
   onBeforeUnmount,
@@ -77,6 +82,7 @@ const {
   layout,
   eventBus,
   history,
+  document: openapiDocument,
   server,
   servers,
   environment,
@@ -282,13 +288,16 @@ const handleFocusAddressBar = (
 ) => {
   // If it already has focus we just propagate native behavior which should focus the browser address bar
   if (addressBarRef.value?.isFocused && layout !== 'desktop') {
+    console.log('already focused')
     return
   }
 
+  console.log('focusing', addressBarRef.value)
   addressBarRef.value?.focus('end')
 
   if (payload && 'clear' in payload && payload.clear) {
-    addressBarRef.value?.setCodeMirrorContent('/')
+    console.log('clearing')
+    addressBarRef.value?.setCodeMirrorContent('')
   }
 
   if (payload && 'event' in payload) {
@@ -302,6 +311,11 @@ onMounted(() => {
   eventBus.on('copy-url:address-bar', copyUrl)
   eventBus.on('hooks:on:request:sent', startLoading)
   eventBus.on('hooks:on:request:complete', stopLoading)
+
+  if (openapiDocument.info?.title.toLowerCase() === 'drafts' && path === '/') {
+    console.log('asdhasdkj')
+    handleFocusAddressBar({ clear: true })
+  }
 })
 
 onBeforeUnmount(() => {
@@ -411,7 +425,7 @@ defineExpose({
           ref="addressBarRef"
           alwaysEmitChange
           aria-label="Path"
-          class="min-w-fit outline-none"
+          class="min-w-fit pl-px outline-none"
           disableCloseBrackets
           :disabled="layout === 'modal'"
           disableEnter

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -59,7 +59,6 @@ import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensi
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import {
   computed,
-  nextTick,
   onBeforeUnmount,
   onMounted,
   ref,
@@ -70,7 +69,10 @@ import {
 
 import { HttpMethod } from '@/components/HttpMethod'
 import { getOperationExampleKey } from '@/v2/blocks/operation-block/helpers/response-cache'
+import { isPlaceholderPath } from '@/v2/blocks/scalar-address-bar-block/helpers/is-placeholder-path'
+import { refocusBlurTarget } from '@/v2/blocks/scalar-address-bar-block/helpers/refocus-blur-target'
 import { useLoadingAnimation } from '@/v2/blocks/scalar-address-bar-block/hooks/use-loading-animation'
+import { usePathMasking } from '@/v2/blocks/scalar-address-bar-block/hooks/use-path-masking'
 import { CodeInput } from '@/v2/components/code-input'
 import { ServerDropdown } from '@/v2/components/server'
 import type { ClientLayout } from '@/v2/types/layout'
@@ -83,7 +85,6 @@ const {
   layout,
   eventBus,
   exampleKey,
-  history,
   documentSlug,
   server,
   servers,
@@ -98,208 +99,69 @@ const emit = defineEmits<{
   (e: 'select:history:item', payload: { index: number }): void
 }>()
 
+// ───────────────────────────────────────────────────────────────────
+// Template refs & reactive state
+// ───────────────────────────────────────────────────────────────────
+
 const id = useId()
+const sendButtonRef = useTemplateRef('sendButtonRef')
+const addressBarRef = useTemplateRef('addressBarRef')
+
 const { percentage, startLoading, stopLoading, isLoading } =
   useLoadingAnimation()
 
-/** Calculate the style for the address bar */
-const style = computed(() => ({
-  backgroundColor: `color-mix(in srgb, transparent 90%, ${REQUEST_METHODS[method].colorVar})`,
-  transform: `translate3d(-${percentage.value}%,0,0)`,
-}))
+const pathConflict = ref<string | null>(null)
+const methodConflict = ref<HttpMethodType | null>(null)
+const tabbedOut = ref(false)
+const isServerDropdownOpen = ref(false)
+const isHistoryDropdownOpen = ref(false)
+
+// ───────────────────────────────────────────────────────────────────
+// Derived state
+// ───────────────────────────────────────────────────────────────────
 
 /** Keeps the cursor visible past the fade-right overlay while typing */
 const addressBarScrollMargins = EditorView.scrollMargins.of(() => ({
   right: 24,
 }))
 
-const pathConflict = ref<string | null>(null)
-const methodConflict = ref<HttpMethodType | null>(null)
+/** Animated background transform for the loading indicator */
+const style = computed(() => ({
+  backgroundColor: `color-mix(in srgb, transparent 90%, ${REQUEST_METHODS[method].colorVar})`,
+  transform: `translate3d(-${percentage.value}%,0,0)`,
+}))
 
 /** Whether there is a path or method conflict */
 const hasConflict = computed(() => methodConflict.value || pathConflict.value)
 
-/** Detect if we have changed to a different example */
+/** Whether either dropdown (server or history) is open */
+const isDropdownOpen = computed(
+  () => isServerDropdownOpen.value || isHistoryDropdownOpen.value,
+)
+
+/** Uniquely identifies the currently selected operation + example */
 const uniqueKey = computed(() =>
   getOperationExampleKey(method, path, exampleKey, documentSlug),
 )
 
 /** Clear conflict state when switching to a different operation */
 watch(uniqueKey, () => {
+  console.log('clearing conflict', uniqueKey.value)
   pathConflict.value = null
   methodConflict.value = null
 })
 
-/** Check if the path contains a server URL, extract it, and select or add the server */
-const checkForServer = (targetPath: string) => {
-  const extracted = extractServerFromPath(targetPath)
-  if (!extracted) {
-    return targetPath
-  }
+// ───────────────────────────────────────────────────────────────────
+// Focus helpers
+// ───────────────────────────────────────────────────────────────────
 
-  const [url, newPath] = extracted
-
-  // Server is already selected — nothing to change
-  if (url === server?.url) {
-    return newPath
-  }
-
-  const matchingServer = servers.find((s) => s.url === url)
-
-  // Select the server if it already exists in the list
-  if (matchingServer) {
-    eventBus.emit('server:update:selected', {
-      url,
-      meta: serverMeta,
-    })
-  }
-  // Otherwise add it as a new operation-level server
-  else {
-    eventBus.emit('server:add:server', {
-      url,
-      select: true,
-      meta: {
-        type: 'operation',
-        path,
-        method,
-      },
-    })
-  }
-
-  return newPath
-}
-
-/** Emit the path/method update event with conflict handling */
-const emitPathMethodUpdate = (
-  targetMethod: HttpMethodType,
-  targetPath: string,
-  blurTargetSelector: string | null = null,
-): void => {
-  const newPath = checkForServer(targetPath)
-  const normalizedPath = newPath.startsWith('/') ? newPath : `/${newPath}`
-
-  // Update the local state of codemirror so we don't have werid path on conflict
-  addressBarRef.value?.setCodeMirrorContent(normalizedPath)
-
-  // The `uniqueKey` watch runs masking when path/method changes. A local edit
-  // here shouldn't re-focus the address bar (the user may have clicked
-  // elsewhere), so skip the next mask trigger. Reset in `nextTick` to cover
-  // the `no-change` case where the watch never fires.
-  skipNextMask.value = true
-  nextTick(() => {
-    skipNextMask.value = false
-  })
-
-  eventBus.emit('operation:update:pathMethod', {
-    meta: { method, path },
-    blurTargetSelector,
-    payload: { method: targetMethod, path: normalizedPath },
-    callback: (status, blurTargetSelector) => {
-      // Clear conflicts if the operation was successful or no change was made
-      if (status === 'success' || status === 'no-change') {
-        methodConflict.value = null
-        pathConflict.value = null
-      }
-      // Otherwise set the conflict if needed
-      else if (status === 'conflict') {
-        if (targetMethod !== method) {
-          methodConflict.value = targetMethod
-        }
-        if (normalizedPath !== path) {
-          pathConflict.value = normalizedPath
-        }
-      }
-
-      // Edge case: pasting a full URL extracts the server but leaves the path unchanged.
-      // The CodeMirror DOM still shows the full URL, so we force it back to just the path.
-      if (
-        status === 'no-change' &&
-        addressBarRef.value?.codeMirrorRef?.textContent &&
-        addressBarRef.value.codeMirrorRef.textContent !== newPath
-      ) {
-        addressBarRef.value.setCodeMirrorContent(newPath)
-      }
-
-      // Re-trigger the click or focus event if we have a blur target selector
-      if (blurTargetSelector) {
-        const element = document.querySelector(blurTargetSelector)
-
-        // Re-trigger clicks on buttons
-        if (element instanceof HTMLButtonElement) {
-          element.click()
-        }
-
-        // Re-trigger focus on inputs and codeInputs
-        else if (
-          element instanceof HTMLInputElement ||
-          element instanceof HTMLTextAreaElement ||
-          (element instanceof HTMLElement &&
-            element.getAttribute('contenteditable') === 'true')
-        ) {
-          element.focus()
-        }
-      }
-    },
-  })
-}
-
-/** Update the operation's HTTP method, handling conflicts */
-const handleMethodChange = (newMethod: HttpMethodType): void =>
-  emitPathMethodUpdate(newMethod, pathConflict.value ?? path)
-
-/**
- * Update the operation's path, handling conflicts also we extract the blur target selector to re-trigger click events
- *
- * We have special handling for the tab key to prevent it from triggering a click on the focused button
- */
-const handlePathBlur = (newPath: string, event: FocusEvent): void => {
-  const relatedTarget = event.relatedTarget as Element | null
-  const blurTargetSelector = tabbedOut.value ? null : getSelector(relatedTarget)
-
-  tabbedOut.value = false
-
-  emitPathMethodUpdate(
-    methodConflict.value ?? method,
-    newPath,
-    blurTargetSelector,
-  )
-}
-
-/** Lets unset the server when backspace is pressed and the path is empty */
-const handlePathBackspace = (event: KeyboardEvent): void => {
-  if ((event.target as HTMLElement)?.innerText === '\n') {
-    eventBus.emit('server:update:selected', {
-      url: '',
-      meta: serverMeta,
-    })
-  }
-}
-
-/** Handle path submit (Enter key) — saves the path and triggers execution via blurTargetSelector */
-const handlePathSubmit = (
-  newPath: string,
-  event: KeyboardEvent | FocusEvent,
-): void => {
-  // Prevent the global hotkey listener
-  event.stopPropagation()
-
-  emitPathMethodUpdate(
-    methodConflict.value ?? method,
-    newPath,
-    '[data-addressbar-action="send"]',
-  )
-}
-
-/** Handle focus events */
-const sendButtonRef = useTemplateRef('sendButtonRef')
-const addressBarRef = useTemplateRef('addressBarRef')
-const tabbedOut = ref(false)
-const handleFocusSendButton = () => sendButtonRef.value?.$el?.focus()
+const handleFocusSendButton = (): void => sendButtonRef.value?.$el?.focus()
 
 const handleFocusAddressBar = (
   payload: ApiReferenceEvents['ui:focus:address-bar'],
-) => {
-  // If it already has focus we just propagate native behavior which should focus the browser address bar
+): void => {
+  // On non-desktop layouts, if already focused we let the browser handle the
+  // native behavior (e.g. selecting the browser's own address bar).
   if (addressBarRef.value?.isFocused && layout !== 'desktop') {
     return
   }
@@ -315,88 +177,216 @@ const handleFocusAddressBar = (
   }
 }
 
+// ───────────────────────────────────────────────────────────────────
+// Path masking
+//
+// Drafts on `/` and auto-generated `/_scalar_temp...` paths are internal
+// placeholders — the address bar focuses and clears on mount and on
+// navigation so the user sees a blank prompt instead of the internal
+// path. Local edits are skipped via `markLocalEdit` so that blurring
+// away from a typed path does not re-focus the input.
+// ───────────────────────────────────────────────────────────────────
+
+const { beginLocalEdit, endLocalEdit } = usePathMasking({
+  isReady: () => addressBarRef.value?.codeMirror,
+  operationKey: () => uniqueKey.value,
+  shouldMask: () => isPlaceholderPath(path, documentSlug),
+  onMask: () => handleFocusAddressBar({ clear: true }),
+})
+
+// ───────────────────────────────────────────────────────────────────
+// Server extraction
+// ───────────────────────────────────────────────────────────────────
+
+/** If the path contains a server URL, extract it and select or add that server */
+const extractAndSelectServer = (targetPath: string): string => {
+  const extracted = extractServerFromPath(targetPath)
+  if (!extracted) {
+    return targetPath
+  }
+
+  const [url, remainingPath] = extracted
+
+  // Server is already selected — nothing to do
+  if (url === server?.url) {
+    return remainingPath
+  }
+
+  const matchingServer = servers.find((s) => s.url === url)
+  if (matchingServer) {
+    eventBus.emit('server:update:selected', { url, meta: serverMeta })
+  } else {
+    eventBus.emit('server:add:server', {
+      url,
+      select: true,
+      meta: { type: 'operation', path, method },
+    })
+  }
+
+  return remainingPath
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Path / method updates
+// ───────────────────────────────────────────────────────────────────
+
+const normalizePath = (value: string): string =>
+  value.startsWith('/') ? value : `/${value}`
+
+/** Emit a path/method update and reconcile conflicts + cursor state on the result */
+const emitPathMethodUpdate = (
+  targetMethod: HttpMethodType,
+  targetPath: string,
+  blurTargetSelector: string | null = null,
+): void => {
+  const extractedPath = extractAndSelectServer(targetPath)
+  const normalizedPath = normalizePath(extractedPath)
+
+  // Keep CodeMirror in sync so a conflict does not leave a stale value on screen
+  addressBarRef.value?.setCodeMirrorContent(normalizedPath)
+
+  // Tell the masking watcher that the next `uniqueKey` change (if any) was
+  // user-initiated; `endLocalEdit` in the callback reconciles the flag.
+  beginLocalEdit()
+
+  eventBus.emit('operation:update:pathMethod', {
+    meta: { method, path },
+    blurTargetSelector,
+    payload: { method: targetMethod, path: normalizedPath },
+    callback: (status, returnedSelector) => {
+      // Only 'success' mutates the document (and therefore fires the masking
+      // watcher). For 'conflict' and 'no-change' we clear the flag now so it
+      // does not leak into the next legitimate navigation.
+      endLocalEdit(status === 'success')
+
+      if (status === 'success' || status === 'no-change') {
+        methodConflict.value = null
+        pathConflict.value = null
+      } else if (status === 'conflict') {
+        if (targetMethod !== method) {
+          methodConflict.value = targetMethod
+        }
+        if (normalizedPath !== path) {
+          pathConflict.value = normalizedPath
+        }
+      }
+
+      // Edge case: pasting a full URL extracts the server but leaves the path
+      // unchanged. CodeMirror still shows the full URL, so force it back to
+      // just the path.
+      const mirrorContent = addressBarRef.value?.codeMirrorRef?.textContent
+      if (
+        status === 'no-change' &&
+        mirrorContent &&
+        mirrorContent !== extractedPath
+      ) {
+        addressBarRef.value?.setCodeMirrorContent(extractedPath)
+      }
+
+      refocusBlurTarget(returnedSelector)
+    },
+  })
+}
+
+/** Change the operation's method, preferring the conflicting path if present */
+const handleMethodChange = (newMethod: HttpMethodType): void =>
+  emitPathMethodUpdate(newMethod, pathConflict.value ?? path)
+
 /**
- * We use this trick to mask the path when we are on drafts and its / or any of those temp paths used for new operations
+ * Save the path on blur and replay the click that caused the blur (so e.g. a
+ * click on the Send button still fires after the async update resolves).
+ * Tab-outs explicitly do not replay — tabbing to a button should not trigger
+ * its click.
  */
-const handleMaskingPath = () => {
-  // For drafts that are just /
-  if (documentSlug.toLowerCase() === 'drafts' && path === '/') {
-    handleFocusAddressBar({ clear: true })
+const handlePathBlur = (newPath: string, event: FocusEvent): void => {
+  const relatedTarget = event.relatedTarget as Element | null
+  const blurTargetSelector = tabbedOut.value ? null : getSelector(relatedTarget)
+  tabbedOut.value = false
+
+  emitPathMethodUpdate(
+    methodConflict.value ?? method,
+    newPath,
+    blurTargetSelector,
+  )
+}
+
+/** Save the path on Enter and trigger the Send button after the update resolves */
+const handlePathSubmit = (
+  newPath: string,
+  event: KeyboardEvent | FocusEvent,
+): void => {
+  // Prevent the global hotkey listener from also handling this Enter press
+  event.stopPropagation()
+
+  emitPathMethodUpdate(
+    methodConflict.value ?? method,
+    newPath,
+    '[data-addressbar-action="send"]',
+  )
+}
+
+/** Unset the server when backspace is pressed on an empty path */
+const handlePathBackspace = (event: KeyboardEvent): void => {
+  if ((event.target as HTMLElement)?.innerText === '\n') {
+    eventBus.emit('server:update:selected', { url: '', meta: serverMeta })
   }
 }
 
-/**
- * Set when the `uniqueKey` change originates from a local edit (blur, submit,
- * method change) so we can differentiate from sidebar/route-driven changes
- * and avoid re-focusing the address bar after the user clicked away.
- */
-const skipNextMask = ref(false)
-
-// For masking on initial load and changing examples/operations via navigation
-watch([() => addressBarRef.value?.codeMirror, uniqueKey], ([codeMirror]) => {
-  if (!codeMirror) return
-  if (skipNextMask.value) {
-    skipNextMask.value = false
-    return
-  }
-  handleMaskingPath()
-})
-
-onMounted(() => {
-  eventBus.on('ui:focus:address-bar', handleFocusAddressBar)
-  eventBus.on('ui:focus:send-button', handleFocusSendButton)
-  eventBus.on('copy-url:address-bar', copyUrl)
-  eventBus.on('hooks:on:request:sent', startLoading)
-  eventBus.on('hooks:on:request:complete', stopLoading)
-})
-
-onBeforeUnmount(() => {
-  eventBus.off('ui:focus:address-bar', handleFocusAddressBar)
-  eventBus.off('ui:focus:send-button', handleFocusSendButton)
-  eventBus.off('copy-url:address-bar', copyUrl)
-  eventBus.off('hooks:on:request:sent', startLoading)
-  eventBus.off('hooks:on:request:complete', stopLoading)
-
-  // Stop the animation when the component is unmounted
-  // This is to prevent the animation from continuing after the component is unmounted
-  stopLoading()
-})
+// ───────────────────────────────────────────────────────────────────
+// Clipboard
+// ───────────────────────────────────────────────────────────────────
 
 const { copyToClipboard } = useClipboard()
 
-/** Copy the resolved URL with the environment variables to the clipboard */
-const copyUrl = async () => {
+/** Copy the fully resolved URL (with environment variables applied) */
+const copyUrl = async (): Promise<void> => {
   const resolvedUrl = getResolvedUrl({ server, path })
-  const environmentVariables = getEnvironmentVariables(environment)
-  const resolvedUrlWithEnvVars = replaceEnvVariables(
-    resolvedUrl,
-    environmentVariables,
-  )
-  await copyToClipboard(resolvedUrlWithEnvVars)
+  const variables = getEnvironmentVariables(environment)
+  await copyToClipboard(replaceEnvVariables(resolvedUrl, variables))
 }
 
-const isServerDropdownOpen = ref(false)
-const isHistoryDropdownOpen = ref(false)
+// ───────────────────────────────────────────────────────────────────
+// Navigation
+// ───────────────────────────────────────────────────────────────────
 
-/** Whether either dropdown is open */
-const isDropdownOpen = computed(
-  () => isServerDropdownOpen.value || isHistoryDropdownOpen.value,
-)
-
-const navigateToServersPage = () => {
+const navigateToServersPage = (): void => {
   if (serverMeta.type === 'operation') {
-    return eventBus.emit('ui:navigate', {
+    eventBus.emit('ui:navigate', {
       page: 'operation',
       path: 'servers',
       operationPath: serverMeta.path,
       method: serverMeta.method,
     })
+    return
   }
-  return eventBus.emit('ui:navigate', {
-    page: 'document',
-    path: 'servers',
-  })
+
+  eventBus.emit('ui:navigate', { page: 'document', path: 'servers' })
 }
+
+// ───────────────────────────────────────────────────────────────────
+// Lifecycle
+// ───────────────────────────────────────────────────────────────────
+
+let unsubscribes: Array<() => void> = []
+
+onMounted(() => {
+  unsubscribes = [
+    eventBus.on('ui:focus:address-bar', handleFocusAddressBar),
+    eventBus.on('ui:focus:send-button', handleFocusSendButton),
+    eventBus.on('copy-url:address-bar', copyUrl),
+    eventBus.on('hooks:on:request:sent', startLoading),
+    eventBus.on('hooks:on:request:complete', stopLoading),
+  ]
+})
+
+onBeforeUnmount(() => {
+  for (const unsubscribe of unsubscribes) {
+    unsubscribe()
+  }
+
+  // Prevents the loading animation from continuing after unmount
+  stopLoading()
+})
 
 defineExpose({
   methodConflict,

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -59,6 +59,7 @@ import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensi
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import {
   computed,
+  nextTick,
   onBeforeUnmount,
   onMounted,
   ref,
@@ -289,7 +290,7 @@ const emitPathMethodUpdate = (
         addressBarRef.value?.setCodeMirrorContent(extractedPath)
       }
 
-      refocusBlurTarget(returnedSelector)
+      nextTick(() => refocusBlurTarget(returnedSelector))
     },
   })
 }

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/helpers/is-placeholder-path.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/helpers/is-placeholder-path.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { isPlaceholderPath } from './is-placeholder-path'
+
+describe('isPlaceholderPath', () => {
+  it('returns true for the drafts document on the root path', () => {
+    expect(isPlaceholderPath('/', 'drafts')).toBe(true)
+  })
+
+  it('matches the drafts slug case-insensitively', () => {
+    expect(isPlaceholderPath('/', 'Drafts')).toBe(true)
+    expect(isPlaceholderPath('/', 'DRAFTS')).toBe(true)
+  })
+
+  it('returns false for drafts on any non-root path', () => {
+    expect(isPlaceholderPath('/users', 'drafts')).toBe(false)
+    expect(isPlaceholderPath('/users/{id}', 'drafts')).toBe(false)
+  })
+
+  it('returns false for the root path on non-drafts documents', () => {
+    expect(isPlaceholderPath('/', 'my-api')).toBe(false)
+  })
+
+  it('returns true for auto-generated temp paths with hex suffixes', () => {
+    expect(isPlaceholderPath('/_scalar_temp1a2b3c4d', 'my-api')).toBe(true)
+    expect(isPlaceholderPath('/_scalar_tempABCDEF', 'my-api')).toBe(true)
+    expect(isPlaceholderPath('/_scalar_temp0', 'my-api')).toBe(true)
+  })
+
+  it('returns true for the bare fallback temp path', () => {
+    // `createTempOperation` falls back to `/_scalar_temp` after too many collisions
+    expect(isPlaceholderPath('/_scalar_temp', 'my-api')).toBe(true)
+  })
+
+  it('returns false for temp paths with non-hex characters after the prefix', () => {
+    expect(isPlaceholderPath('/_scalar_temp-path', 'my-api')).toBe(false)
+    expect(isPlaceholderPath('/_scalar_temp_extra', 'my-api')).toBe(false)
+    expect(isPlaceholderPath('/_scalar_temp/extra', 'my-api')).toBe(false)
+  })
+
+  it('returns false for paths that start with a similar but different prefix', () => {
+    expect(isPlaceholderPath('/temp1a2b3c4d', 'my-api')).toBe(false)
+    expect(isPlaceholderPath('/_scalar/temp1a2b', 'my-api')).toBe(false)
+    expect(isPlaceholderPath('/template', 'my-api')).toBe(false)
+  })
+})

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/helpers/is-placeholder-path.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/helpers/is-placeholder-path.ts
@@ -1,0 +1,26 @@
+/**
+ * Matches auto-generated temp paths produced by `createTempOperation`.
+ *
+ * Temp paths look like `/_scalar_temp<hex>` (e.g. `/_scalar_temp1a2b3c4d`) —
+ * the suffix is a truncated UUID, which is always hex. The namespaced prefix
+ * avoids colliding with any real user-authored path.
+ */
+const TEMP_PATH_PATTERN = /^\/_scalar_temp[a-f0-9]*$/i
+
+/**
+ * Returns true when the given path is a placeholder that should be hidden
+ * from the user. Two cases qualify:
+ *
+ * 1. Drafts documents viewing the root path `/` (a new, empty draft).
+ * 2. Auto-generated temp paths created when the user adds a new operation.
+ *
+ * In both cases the path is an implementation detail rather than something
+ * the user authored, so the UI masks it by focusing the address bar and
+ * clearing the visible text.
+ */
+export const isPlaceholderPath = (path: string, documentSlug: string): boolean => {
+  if (documentSlug.toLowerCase() === 'drafts' && path === '/') {
+    return true
+  }
+  return TEMP_PATH_PATTERN.test(path)
+}

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/helpers/refocus-blur-target.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/helpers/refocus-blur-target.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { refocusBlurTarget } from './refocus-blur-target'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('refocusBlurTarget', () => {
+  it('does nothing when given a null selector', () => {
+    const querySelector = vi.spyOn(document, 'querySelector')
+    refocusBlurTarget(null)
+    expect(querySelector).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the selector matches no element', () => {
+    expect(() => refocusBlurTarget('#does-not-exist')).not.toThrow()
+  })
+
+  it('clicks a matching button element', () => {
+    const button = document.createElement('button')
+    button.id = 'target'
+    document.body.appendChild(button)
+    const click = vi.spyOn(button, 'click')
+
+    refocusBlurTarget('#target')
+
+    expect(click).toHaveBeenCalledTimes(1)
+  })
+
+  it('focuses a matching input element', () => {
+    const input = document.createElement('input')
+    input.id = 'target'
+    document.body.appendChild(input)
+    const focus = vi.spyOn(input, 'focus')
+
+    refocusBlurTarget('#target')
+
+    expect(focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('focuses a matching textarea element', () => {
+    const textarea = document.createElement('textarea')
+    textarea.id = 'target'
+    document.body.appendChild(textarea)
+    const focus = vi.spyOn(textarea, 'focus')
+
+    refocusBlurTarget('#target')
+
+    expect(focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('focuses a matching contenteditable element', () => {
+    const editable = document.createElement('div')
+    editable.id = 'target'
+    editable.setAttribute('contenteditable', 'true')
+    document.body.appendChild(editable)
+    const focus = vi.spyOn(editable, 'focus')
+
+    refocusBlurTarget('#target')
+
+    expect(focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores elements that are neither buttons nor editable', () => {
+    const div = document.createElement('div')
+    div.id = 'target'
+    document.body.appendChild(div)
+    const focus = vi.spyOn(div, 'focus')
+
+    refocusBlurTarget('#target')
+
+    expect(focus).not.toHaveBeenCalled()
+  })
+})

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/helpers/refocus-blur-target.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/helpers/refocus-blur-target.ts
@@ -1,0 +1,35 @@
+/**
+ * Re-triggers the interaction that caused the address bar to blur.
+ *
+ * When the user clicks a button or focuses another input while the address
+ * bar is focused, CodeMirror's blur fires first and the path/method update
+ * event runs asynchronously. By the time the update resolves, the click has
+ * already been consumed — so we capture the blur target via a selector and
+ * replay the original interaction once the update completes.
+ *
+ * - Buttons get a synthetic click to complete the action the user started.
+ * - Text inputs and contenteditable elements regain focus so typing resumes
+ *   where the user intended.
+ * - Anything else is ignored silently.
+ */
+export const refocusBlurTarget = (selector: string | null): void => {
+  if (!selector) {
+    return
+  }
+
+  const element = document.querySelector(selector)
+
+  if (element instanceof HTMLButtonElement) {
+    element.click()
+    return
+  }
+
+  const isEditable =
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement ||
+    (element instanceof HTMLElement && element.getAttribute('contenteditable') === 'true')
+
+  if (isEditable) {
+    ;(element as HTMLElement).focus()
+  }
+}

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/hooks/use-path-masking.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/hooks/use-path-masking.test.ts
@@ -1,0 +1,190 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick, ref, watch } from 'vue'
+
+import { usePathMasking } from './use-path-masking'
+
+type HarnessProps = {
+  shouldMask: () => boolean
+  onMask: () => void
+}
+
+/**
+ * Mounts a throwaway component so the composable has an owner instance and
+ * its watchers behave like they would inside a real component. Returns the
+ * reactive inputs plus the composable return value.
+ */
+const mountHarness = (props: HarnessProps) => {
+  const isReady = ref<unknown>(null)
+  const operationKey = ref(0)
+  let beginLocalEdit: () => void = () => {}
+  let endLocalEdit: (didApply: boolean) => void = () => {}
+
+  const Harness = defineComponent({
+    setup() {
+      const api = usePathMasking({
+        isReady: () => isReady.value,
+        operationKey: () => operationKey.value,
+        shouldMask: props.shouldMask,
+        onMask: props.onMask,
+      })
+      beginLocalEdit = api.beginLocalEdit
+      endLocalEdit = api.endLocalEdit
+      return () => h('div')
+    },
+  })
+
+  const wrapper = mount(Harness)
+
+  return {
+    wrapper,
+    isReady,
+    operationKey,
+    beginLocalEdit: (): void => beginLocalEdit(),
+    endLocalEdit: (didApply: boolean): void => endLocalEdit(didApply),
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('usePathMasking', () => {
+  it('does not mask while the ready signal is falsy', async () => {
+    const onMask = vi.fn()
+    const { operationKey } = mountHarness({ shouldMask: () => true, onMask })
+
+    operationKey.value = 1
+    await nextTick()
+
+    expect(onMask).not.toHaveBeenCalled()
+  })
+
+  it('masks once the ready signal becomes truthy and the predicate passes', async () => {
+    const onMask = vi.fn()
+    const { isReady } = mountHarness({ shouldMask: () => true, onMask })
+
+    isReady.value = {}
+    await nextTick()
+
+    expect(onMask).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not mask when the predicate returns false', async () => {
+    const onMask = vi.fn()
+    const { isReady } = mountHarness({ shouldMask: () => false, onMask })
+
+    isReady.value = {}
+    await nextTick()
+
+    expect(onMask).not.toHaveBeenCalled()
+  })
+
+  it('masks again when operationKey changes', async () => {
+    const onMask = vi.fn()
+    const { isReady, operationKey } = mountHarness({ shouldMask: () => true, onMask })
+
+    isReady.value = {}
+    await nextTick()
+    expect(onMask).toHaveBeenCalledTimes(1)
+
+    operationKey.value = 1
+    await nextTick()
+    expect(onMask).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips masking when a local edit applied, then resumes', async () => {
+    const onMask = vi.fn()
+    const { isReady, operationKey, beginLocalEdit, endLocalEdit } = mountHarness({
+      shouldMask: () => true,
+      onMask,
+    })
+
+    isReady.value = {}
+    await nextTick()
+    expect(onMask).toHaveBeenCalledTimes(1)
+
+    // Simulate an emit whose change applied: begin → mutate → endLocalEdit(true)
+    beginLocalEdit()
+    operationKey.value = 1
+    endLocalEdit(true)
+    await nextTick()
+    expect(onMask).toHaveBeenCalledTimes(1)
+
+    operationKey.value = 2
+    await nextTick()
+    expect(onMask).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears the flag immediately when a local edit did not apply', async () => {
+    const onMask = vi.fn()
+    const { isReady, operationKey, beginLocalEdit, endLocalEdit } = mountHarness({
+      shouldMask: () => true,
+      onMask,
+    })
+
+    isReady.value = {}
+    await nextTick()
+    onMask.mockClear()
+
+    // Simulate a 'no-change' or 'conflict' status: no mutation, so no watcher
+    // fires. endLocalEdit(false) must clear the flag synchronously so it does
+    // not leak into the next legitimate navigation.
+    beginLocalEdit()
+    endLocalEdit(false)
+    await nextTick()
+
+    operationKey.value = 1
+    await nextTick()
+    expect(onMask).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs onMask after sibling pre-flush watchers that react to the same operationKey', async () => {
+    /**
+     * Regression for the CodeInput content-sync race. When the parent (our
+     * hook) and a child (e.g. CodeInput's `modelValue` → CodeMirror sync)
+     * both watch `operationKey`, the child's pre-flush watcher runs after
+     * the parent's and would overwrite our clear with the new path value.
+     *
+     * Using `flush: 'post'` inside the hook guarantees our mask runs after
+     * all pre-flush watchers, so the clear sticks.
+     */
+    const isReady = ref<unknown>(null)
+    const operationKey = ref('initial')
+    let lastContent = ''
+
+    const Harness = defineComponent({
+      setup() {
+        // Hook's watcher is registered first — without `flush: 'post'` it
+        // would run before the sibling below and its clear would be
+        // overwritten.
+        usePathMasking({
+          isReady: () => isReady.value,
+          operationKey: () => operationKey.value,
+          shouldMask: () => true,
+          onMask: () => {
+            lastContent = ''
+          },
+        })
+
+        // Sibling pre-flush watcher — simulates CodeInput syncing `modelValue`
+        // into the CodeMirror instance on each prop change.
+        watch(operationKey, (next) => {
+          lastContent = String(next)
+        })
+
+        return () => h('div')
+      },
+    })
+
+    mount(Harness)
+
+    isReady.value = {}
+    await nextTick()
+
+    operationKey.value = '/_scalar_temp1a2b3c4d'
+    await nextTick()
+
+    expect(lastContent).toBe('')
+  })
+})

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/hooks/use-path-masking.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/hooks/use-path-masking.test.ts
@@ -17,19 +17,15 @@ type HarnessProps = {
 const mountHarness = (props: HarnessProps) => {
   const isReady = ref<unknown>(null)
   const operationKey = ref(0)
-  let beginLocalEdit: () => void = () => {}
-  let endLocalEdit: (didApply: boolean) => void = () => {}
 
   const Harness = defineComponent({
     setup() {
-      const api = usePathMasking({
+      usePathMasking({
         isReady: () => isReady.value,
         operationKey: () => operationKey.value,
         shouldMask: props.shouldMask,
         onMask: props.onMask,
       })
-      beginLocalEdit = api.beginLocalEdit
-      endLocalEdit = api.endLocalEdit
       return () => h('div')
     },
   })
@@ -40,8 +36,6 @@ const mountHarness = (props: HarnessProps) => {
     wrapper,
     isReady,
     operationKey,
-    beginLocalEdit: (): void => beginLocalEdit(),
-    endLocalEdit: (didApply: boolean): void => endLocalEdit(didApply),
   }
 }
 
@@ -91,52 +85,6 @@ describe('usePathMasking', () => {
     operationKey.value = 1
     await nextTick()
     expect(onMask).toHaveBeenCalledTimes(2)
-  })
-
-  it('skips masking when a local edit applied, then resumes', async () => {
-    const onMask = vi.fn()
-    const { isReady, operationKey, beginLocalEdit, endLocalEdit } = mountHarness({
-      shouldMask: () => true,
-      onMask,
-    })
-
-    isReady.value = {}
-    await nextTick()
-    expect(onMask).toHaveBeenCalledTimes(1)
-
-    // Simulate an emit whose change applied: begin → mutate → endLocalEdit(true)
-    beginLocalEdit()
-    operationKey.value = 1
-    endLocalEdit(true)
-    await nextTick()
-    expect(onMask).toHaveBeenCalledTimes(1)
-
-    operationKey.value = 2
-    await nextTick()
-    expect(onMask).toHaveBeenCalledTimes(2)
-  })
-
-  it('clears the flag immediately when a local edit did not apply', async () => {
-    const onMask = vi.fn()
-    const { isReady, operationKey, beginLocalEdit, endLocalEdit } = mountHarness({
-      shouldMask: () => true,
-      onMask,
-    })
-
-    isReady.value = {}
-    await nextTick()
-    onMask.mockClear()
-
-    // Simulate a 'no-change' or 'conflict' status: no mutation, so no watcher
-    // fires. endLocalEdit(false) must clear the flag synchronously so it does
-    // not leak into the next legitimate navigation.
-    beginLocalEdit()
-    endLocalEdit(false)
-    await nextTick()
-
-    operationKey.value = 1
-    await nextTick()
-    expect(onMask).toHaveBeenCalledTimes(1)
   })
 
   it('runs onMask after sibling pre-flush watchers that react to the same operationKey', async () => {

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/hooks/use-path-masking.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/hooks/use-path-masking.ts
@@ -29,12 +29,7 @@ type UsePathMaskingOptions = {
  * Fires on the initial ready state and on every `operationKey` change. The
  * consumer owns any content-aware guard needed before clearing visible text.
  */
-export const usePathMasking = ({
-  isReady,
-  operationKey,
-  shouldMask,
-  onMask,
-}: UsePathMaskingOptions): void => {
+export const usePathMasking = ({ isReady, operationKey, shouldMask, onMask }: UsePathMaskingOptions): void => {
   watch(
     [isReady, operationKey],
     ([ready]) => {

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/hooks/use-path-masking.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/hooks/use-path-masking.ts
@@ -1,0 +1,90 @@
+import { watch } from 'vue'
+
+type UsePathMaskingOptions = {
+  /**
+   * Watched for becoming truthy before any masking fires. Typically a getter
+   * for the editor instance (e.g. the CodeMirror view) so we do not try to
+   * mask before the input is ready to accept focus and content updates.
+   */
+  isReady: () => unknown
+  /**
+   * Key that changes whenever navigation switches to a different operation
+   * or example. The masking re-runs every time this value changes.
+   */
+  operationKey: () => unknown
+  /**
+   * Predicate evaluated on every trigger. Returning `true` performs the mask.
+   */
+  shouldMask: () => boolean
+  /**
+   * Callback invoked when a mask should happen. Typically focuses the input
+   * and clears its visible text.
+   */
+  onMask: () => void
+}
+
+/**
+ * Masks placeholder paths in an editable input (e.g. the address bar).
+ *
+ * Fires on the initial ready state and on every `operationKey` change — but
+ * not on changes the user triggered locally. Consumers coordinate with the
+ * hook via `beginLocalEdit` / `endLocalEdit` around their emit so that an
+ * edit followed by a blur does not re-focus the input against the user's
+ * intent.
+ *
+ * The pair is deterministic: the watcher consumes the flag synchronously
+ * when the key actually changes, and `endLocalEdit(false)` clears it when
+ * the change never propagated (conflict or no-change). No timers involved.
+ */
+export const usePathMasking = ({
+  isReady,
+  operationKey,
+  shouldMask,
+  onMask,
+}: UsePathMaskingOptions): {
+  /** Call before triggering a local path/method update. */
+  beginLocalEdit: () => void
+  /**
+   * Call synchronously from the update callback. Pass `true` when the update
+   * actually mutated the operation (so the watcher will fire and consume
+   * the flag); pass `false` when it did not (so the flag is cleared now).
+   */
+  endLocalEdit: (didApply: boolean) => void
+} => {
+  let isLocalEdit = false
+
+  const beginLocalEdit = (): void => {
+    isLocalEdit = true
+  }
+
+  const endLocalEdit = (didApply: boolean): void => {
+    if (!didApply) {
+      isLocalEdit = false
+    }
+  }
+
+  watch(
+    [isReady, operationKey],
+    ([ready]) => {
+      if (!ready) {
+        return
+      }
+
+      if (isLocalEdit) {
+        isLocalEdit = false
+        return
+      }
+
+      if (shouldMask()) {
+        onMask()
+      }
+    },
+    // `post` flush runs after all pre-flush watchers — including child
+    // components that sync their `modelValue` into the underlying input
+    // (e.g. CodeInput → CodeMirror). Without this, the child watcher would
+    // run after ours and overwrite the cleared content with the new path.
+    { flush: 'post' },
+  )
+
+  return { beginLocalEdit, endLocalEdit }
+}

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/hooks/use-path-masking.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/hooks/use-path-masking.ts
@@ -74,12 +74,8 @@ export const usePathMasking = ({
         return
       }
 
-      // Defer to the next frame so focus() runs after click-handler side
-      // effects that move focus (e.g. a dropdown refocusing its trigger),
-      // which would otherwise blur our input and emit a spurious path
-      // update against the now-empty value.
       if (shouldMask()) {
-        requestAnimationFrame(() => onMask())
+        onMask()
       }
     },
     // `post` flush runs after child watchers sync `modelValue` into the

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/hooks/use-path-masking.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/hooks/use-path-masking.ts
@@ -26,51 +26,19 @@ type UsePathMaskingOptions = {
 /**
  * Masks placeholder paths in an editable input (e.g. the address bar).
  *
- * Fires on the initial ready state and on every `operationKey` change — but
- * not on changes the user triggered locally. Consumers coordinate with the
- * hook via `beginLocalEdit` / `endLocalEdit` around their emit so that an
- * edit followed by a blur does not re-focus the input against the user's
- * intent.
- *
- * The pair is deterministic: the watcher consumes the flag synchronously
- * when the key actually changes, and `endLocalEdit(false)` clears it when
- * the change never propagated (conflict or no-change). No timers involved.
+ * Fires on the initial ready state and on every `operationKey` change. The
+ * consumer owns any content-aware guard needed before clearing visible text.
  */
 export const usePathMasking = ({
   isReady,
   operationKey,
   shouldMask,
   onMask,
-}: UsePathMaskingOptions): {
-  /** Call before triggering a local path/method update. */
-  beginLocalEdit: () => void
-  /**
-   * Pass `true` if the update mutated the operation (watcher consumes the
-   * flag); `false` to clear it now.
-   */
-  endLocalEdit: (didApply: boolean) => void
-} => {
-  let isLocalEdit = false
-
-  const beginLocalEdit = (): void => {
-    isLocalEdit = true
-  }
-
-  const endLocalEdit = (didApply: boolean): void => {
-    if (!didApply) {
-      isLocalEdit = false
-    }
-  }
-
+}: UsePathMaskingOptions): void => {
   watch(
     [isReady, operationKey],
     ([ready]) => {
       if (!ready) {
-        return
-      }
-
-      if (isLocalEdit) {
-        isLocalEdit = false
         return
       }
 
@@ -83,6 +51,4 @@ export const usePathMasking = ({
     // overwrite the cleared content with the new path.
     { flush: 'post' },
   )
-
-  return { beginLocalEdit, endLocalEdit }
 }

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/hooks/use-path-masking.ts
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/hooks/use-path-masking.ts
@@ -45,9 +45,8 @@ export const usePathMasking = ({
   /** Call before triggering a local path/method update. */
   beginLocalEdit: () => void
   /**
-   * Call synchronously from the update callback. Pass `true` when the update
-   * actually mutated the operation (so the watcher will fire and consume
-   * the flag); pass `false` when it did not (so the flag is cleared now).
+   * Pass `true` if the update mutated the operation (watcher consumes the
+   * flag); `false` to clear it now.
    */
   endLocalEdit: (didApply: boolean) => void
 } => {
@@ -75,14 +74,17 @@ export const usePathMasking = ({
         return
       }
 
+      // Defer to the next frame so focus() runs after click-handler side
+      // effects that move focus (e.g. a dropdown refocusing its trigger),
+      // which would otherwise blur our input and emit a spurious path
+      // update against the now-empty value.
       if (shouldMask()) {
-        onMask()
+        requestAnimationFrame(() => onMask())
       }
     },
-    // `post` flush runs after all pre-flush watchers — including child
-    // components that sync their `modelValue` into the underlying input
-    // (e.g. CodeInput → CodeMirror). Without this, the child watcher would
-    // run after ours and overwrite the cleared content with the new path.
+    // `post` flush runs after child watchers sync `modelValue` into the
+    // underlying input (e.g. CodeInput → CodeMirror); otherwise they would
+    // overwrite the cleared content with the new path.
     { flush: 'post' },
   )
 

--- a/packages/api-client/src/v2/components/code-input/CodeInput.vue
+++ b/packages/api-client/src/v2/components/code-input/CodeInput.vue
@@ -384,7 +384,7 @@ const handleKeyDown = (key: string, event: KeyboardEvent): void => {
   }
 
   if (key === 'enter' && event.target instanceof HTMLDivElement) {
-    handleSubmit(event.target.textContent ?? '', event)
+    handleSubmit(codeMirror.value?.state.doc.toString() ?? '', event)
   }
 }
 

--- a/packages/api-client/src/v2/features/app/app-state.ts
+++ b/packages/api-client/src/v2/features/app/app-state.ts
@@ -385,7 +385,9 @@ export const createAppState = async ({
         },
         paths: {
           '/': {
-            get: {},
+            get: {
+              summary: 'First Request',
+            },
           },
         },
         'x-scalar-original-document-hash': 'drafts',

--- a/packages/api-client/src/v2/features/app/helpers/create-temp-operation.ts
+++ b/packages/api-client/src/v2/features/app/helpers/create-temp-operation.ts
@@ -15,11 +15,11 @@ import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 const generateUniquePath = (existingPaths: Set<string>, attempts: number = 0) => {
   if (attempts > 10) {
     // After 10 failed attempts, fallback to a generic path
-    return '/temp-path'
+    return '/_scalar_temp'
   }
 
   // Generate a random path using a truncated UUID for uniqueness
-  const path = `/temp${crypto.randomUUID().slice(0, 8)}`
+  const path = `/_scalar_temp${crypto.randomUUID().slice(0, 8)}`
 
   if (existingPaths.has(path)) {
     // If path exists, try again recursively with incremented attempts

--- a/packages/api-client/src/v2/features/app/helpers/create-temp-operation.ts
+++ b/packages/api-client/src/v2/features/app/helpers/create-temp-operation.ts
@@ -55,22 +55,16 @@ export const createTempOperation = (
       tags: options.tags ?? [],
     },
     callback: (success) => {
-      if (success) {
-        options.eventBus.emit('ui:navigate', {
-          page: 'example',
-          documentSlug: documentName,
-          path: uniquePath,
-          method: 'get',
-          exampleName: 'default',
-          callback: async () => {
-            await new Promise((resolve) => requestAnimationFrame(resolve))
-            // Focus the address bar, clearing its contents after navigation
-            options.eventBus.emit('ui:focus:address-bar', {
-              clear: true,
-            })
-          },
-        })
+      if (!success) {
+        return
       }
+      options.eventBus.emit('ui:navigate', {
+        page: 'example',
+        documentSlug: documentName,
+        path: uniquePath,
+        method: 'get',
+        exampleName: 'default',
+      })
     },
   })
 }

--- a/packages/api-client/src/v2/features/operation/Operation.vue
+++ b/packages/api-client/src/v2/features/operation/Operation.vue
@@ -140,6 +140,7 @@ const httpClients = computed(() =>
       :document
       :documentCookies
       :documentSecurity="document?.security ?? []"
+      :documentSlug
       :documentUrl="document?.['x-scalar-original-source-url']"
       :environment
       :environments

--- a/packages/api-client/src/v2/helpers/test-utils.ts
+++ b/packages/api-client/src/v2/helpers/test-utils.ts
@@ -3,7 +3,7 @@ import { vi } from 'vitest'
 
 /** Mock event bus for all your testing needs */
 export const mockEventBus = {
-  on: vi.fn(),
+  on: vi.fn(() => vi.fn()),
   off: vi.fn(),
   emit: vi.fn(() => null),
 } as unknown as WorkspaceEventBus


### PR DESCRIPTION
## The ask
- hide all temp urls that we generate to be openapi compliant on new operations
- hide the initial / that you see when in drafts, mostly just for the first operation but made it drafts wide

## Solution

Had to add a bunch more focus logic hacks, got pretty crazy. Ended up doing a full refactor and extracted out a log of the focus logic which I hope cleans up the component a bit. 

Still need to test all addressbar cases but I think its good

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors address-bar path/method update and focus-replay logic, which is UI-interaction heavy and timing-sensitive (async updates, deferred masking, replayed clicks), so regressions could affect request sending and navigation flows.
> 
> **Overview**
> Masks internal placeholder paths in the address bar so users don’t see drafts root `/` or auto-generated temp operation URLs (now `/_scalar_temp...`), using a new `usePathMasking` hook plus `isPlaceholderPath` detection.
> 
> Refactors `AddressBar` path/method update flow to extract servers from pasted URLs, normalize paths, and *replay* the original blur target interaction after async `operation:update:pathMethod` completes (via new `refocusBlurTarget`), with added conflict handling to avoid replay on conflicts.
> 
> Threads `documentSlug` and `exampleKey` through `OperationBlock` → `Header` → `AddressBar` and updates response-cache key generation to optionally include `documentSlug`, plus adds extensive new tests and a changeset patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a24cf3277532fb5a4be46e58b090468839888caf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->