### PR TITLE
fix(agent): sign up messaging

### DIFF
--- a/.changeset/upset-mirrors-flash.md
+++ b/.changeset/upset-mirrors-flash.md
@@ -1,0 +1,5 @@
+---
+'@scalar/agent-chat': patch
+---
+
+fix: language around agent credits

--- a/packages/agent-chat/src/components/PaymentSection.vue
+++ b/packages/agent-chat/src/components/PaymentSection.vue
@@ -12,36 +12,36 @@ const { navigateToSignup } = useSignupLink()
       <ScalarIconInfo
         class="text-blue size-4"
         weight="bold" />
-      You've reached your free message limit. Unlock unlimited access by
-      upgrading now.
+      You've used up your complimentary Scalar Credits. Sign up to get free
+      Credits.
     </strong>
     <div class="paymentContainer">
       <button
         class="actionButton approveButton"
         type="button"
         @click="navigateToSignup">
-        Upgrade
+        Sign up
       </button>
       <div class="paymentInfo">
-        <h3>$72 <span>/ month</span></h3>
+        <h3>$0 <span>/ month</span></h3>
         <div class="paymentInfoSection">
           <div class="paymentInfoItem">
-            <span>Seat minimum</span>
-            <span>3</span>
+            <span>Credits</span>
+            <span>100</span>
+          </div>
+          <div class="paymentInfoItem">
+            <span>MCP Servers</span>
+            <span>Unlimited</span>
           </div>
           <div class="paymentInfoItem">
             <span>Base monthly total</span>
-            <span>$72.00</span>
+            <span>$0.00</span>
           </div>
         </div>
         <div class="paymentInfoSection">
           <div class="paymentInfoItem">
-            <span>Messages</span>
-            <span>250</span>
-          </div>
-          <div class="paymentInfoItem">
-            <span>Additional Messages</span>
-            <span>+ $0.02 Message</span>
+            <span>Additional Credits</span>
+            <span>+ $0.02 per Credit</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
before:
<img width="879" height="463" alt="image" src="https://github.com/user-attachments/assets/683beb14-bd41-42f8-8448-b86d766a1d0a" />

after:
<img width="1014" height="254" alt="image" src="https://github.com/user-attachments/assets/b401d924-7c46-4e25-a02a-223a354ee695" />
<img width="913" height="390" alt="image" src="https://github.com/user-attachments/assets/e154f104-9ee4-4f01-8392-756fa3f8f9f7" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk text-only UI changes plus a patch changeset; no business logic or data handling is modified.
> 
> **Overview**
> Updates the `PaymentSection` upsell UI to talk about **complimentary Scalar Credits** instead of a free message limit, changing the CTA from **Upgrade** to **Sign up** and adjusting the displayed plan details (e.g., $0/month, included credits, additional credit pricing).
> 
> Adds a patch changeset for `@scalar/agent-chat` to release the copy change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4e13419acb69815178df86d26e6b28d21982a21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->