### PR TITLE
fix(aspire): avoid container tunnel startup hang

### DIFF
--- a/.changeset/few-flies-applaud.md
+++ b/.changeset/few-flies-applaud.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspire': patch
+---
+
+fix(aspire): remove OTLP exporter annotations from Scalar resources before startup to avoid universal container tunnel hangs

--- a/integrations/dotnet/aspire/CHANGELOG.md
+++ b/integrations/dotnet/aspire/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.9.28
 
+### Patch Changes
+
+- [#8995](https://github.com/scalar/scalar/pull/8995): fix(aspire): prevent startup hangs with `ASPIRE_ENABLE_CONTAINER_TUNNEL=true` by removing `OtlpExporterAnnotation` from the Scalar container resource before startup.
+
 ## 0.9.27
 
 ## 0.9.26

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/Extensions/DistributedApplicationBuilderExtensions.cs
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/Extensions/DistributedApplicationBuilderExtensions.cs
@@ -50,6 +50,17 @@ public static class DistributedApplicationBuilderExtensions
         }
 
         var resource = new ScalarResource(name);
+
+        // Aspire's universal container tunnel can hang indefinitely when tunnel endpoint
+        // allocation is requested for telemetry exporters on container resources.
+        // Scalar does not require OTLP endpoint references to run, so we remove these
+        // annotations during startup to keep tunnel bootstrap non-blocking.
+        builder.Eventing.Subscribe<BeforeStartEvent>((_, _) =>
+        {
+            RemoveOtlpExporterAnnotations(resource);
+            return Task.CompletedTask;
+        });
+
         return builder
             .AddResource(resource)
             .WithImage(Image)
@@ -65,5 +76,14 @@ public static class DistributedApplicationBuilderExtensions
             {
                 await ScalarResourceConfigurator.ConfigureScalarResourceAsync(context);
             });
+    }
+
+    internal static void RemoveOtlpExporterAnnotations(ScalarResource resource)
+    {
+        var otlpExporterAnnotations = resource.Annotations.OfType<OtlpExporterAnnotation>().ToArray();
+        foreach (var annotation in otlpExporterAnnotations)
+        {
+            resource.Annotations.Remove(annotation);
+        }
     }
 }

--- a/integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/ScalarResourceConfiguratorTests.cs
+++ b/integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/ScalarResourceConfiguratorTests.cs
@@ -559,4 +559,19 @@ public class ScalarResourceConfiguratorTests
             .WhoseValue.Should().Be("https://localhost:5001");
         envVars.Should().NotContainKey("services__my-api__http__0");
     }
+
+    [Fact]
+    public void RemoveOtlpExporterAnnotations_RemovesOnlyOtlpAnnotations()
+    {
+        var scalarResource = new ScalarResource(ScalarResourceName);
+        var callbackAnnotation = new EnvironmentCallbackAnnotation(_ => Task.CompletedTask);
+        scalarResource.Annotations.Add(new OtlpExporterAnnotation());
+        scalarResource.Annotations.Add(new OtlpExporterAnnotation { RequiredProtocol = OtlpProtocol.Grpc });
+        scalarResource.Annotations.Add(callbackAnnotation);
+
+        DistributedApplicationBuilderExtensions.RemoveOtlpExporterAnnotations(scalarResource);
+
+        scalarResource.Annotations.OfType<OtlpExporterAnnotation>().Should().BeEmpty();
+        scalarResource.Annotations.Should().Contain(callbackAnnotation);
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`AddScalarApiReference()` can trigger a startup hang in Aspire when universal container tunnel is enabled (`ASPIRE_ENABLE_CONTAINER_TUNNEL=true`). In the affected flow, AppHost stays on `Starting dashboard...` and does not progress.

## Solution

- Subscribe to `BeforeStartEvent` in `AddScalarApiReference`.
- Remove `OtlpExporterAnnotation` from the Scalar container resource before startup.
- Keep other resource annotations unchanged.
- Add a regression test that verifies only OTLP exporter annotations are removed.
- Add changelog and changeset entries for `@scalar/aspire`.

## Validation

- `dotnet test integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/Scalar.Aspire.Tests.csproj -f net10.0`
- `dotnet test integrations/dotnet/aspire/tests/Scalar.Aspire.Service.Tests/Scalar.Aspire.Service.Tests.csproj -f net10.0`
- `pnpm format:check`
- `pnpm format`
- `pnpm changeset status`
- `pnpm --filter @scalar/aspire test` (package has no Vitest test files)
- `pnpm knip` (known workspace error unrelated to this change)

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation.

## Ticket

Fixes #8990
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57168b2b-7a9c-4009-9c48-ebc0527a38f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57168b2b-7a9c-4009-9c48-ebc0527a38f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

