### PR TITLE
fix(workspace-store): preserve multipart boundaries for object examples

### DIFF
--- a/.changeset/fuzzy-dolls-breathe.md
+++ b/.changeset/fuzzy-dolls-breathe.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix multipart object request bodies to be sent as form data

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
@@ -223,6 +223,40 @@ describe('buildRequestBody', () => {
     expect(result.value[1].value).toBe('{{productId}}')
   })
 
+  it('stringifies object values in URL-encoded array format', () => {
+    const requestBody = {
+      content: {
+        'application/x-www-form-urlencoded': {
+          examples: {
+            default: {
+              value: [
+                {
+                  name: 'filters',
+                  value: {
+                    category: 'books',
+                    inStock: true,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    }
+
+    const result = buildRequestBody(requestBody, 'default')
+
+    expect(result?.mode).toBe('urlencoded')
+    assert(result?.mode === 'urlencoded')
+
+    expect(result.value).toStrictEqual([
+      {
+        key: 'filters',
+        value: '{"category":"books","inStock":true}',
+      },
+    ])
+  })
+
   it('builds FormData for multipart/form-data with object example value', () => {
     const requestBody = {
       content: {
@@ -319,6 +353,36 @@ describe('buildRequestBody', () => {
     assert(result.value[2])
     expect(result.value[2].key).toBe('name')
     expect(result.value[2].value).toBe('test')
+  })
+
+  it('stringifies object values in form-urlencoded object format', () => {
+    const requestBody = {
+      content: {
+        'application/x-www-form-urlencoded': {
+          examples: {
+            default: {
+              value: {
+                profile: {
+                  name: 'Ada',
+                  role: 'admin',
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+    const result = buildRequestBody(requestBody, 'default')
+
+    expect(result?.mode).toBe('urlencoded')
+    assert(result?.mode === 'urlencoded')
+
+    expect(result.value).toStrictEqual([
+      {
+        key: 'profile',
+        value: '{"name":"Ada","role":"admin"}',
+      },
+    ])
   })
 
   it('skips null and undefined values in form-urlencoded object format', () => {

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
@@ -223,6 +223,71 @@ describe('buildRequestBody', () => {
     expect(result.value[1].value).toBe('{{productId}}')
   })
 
+  it('builds FormData for multipart/form-data with object example value', () => {
+    const requestBody = {
+      content: {
+        'multipart/form-data': {
+          examples: {
+            default: {
+              value: {
+                username: 'jane',
+                age: 42,
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = buildRequestBody(requestBody, 'default')
+
+    expect(result?.mode).toBe('formdata')
+    assert(result?.mode === 'formdata')
+
+    expect(result.value).toStrictEqual([
+      { type: 'text', key: 'username', value: 'jane' },
+      { type: 'text', key: 'age', value: '42' },
+    ])
+  })
+
+  it('builds multipart file parts for object example values', () => {
+    const mockFile = new File(['hello world'], 'hello.txt', { type: 'text/plain', lastModified: 1234 })
+    const requestBody = {
+      content: {
+        'multipart/form-data': {
+          examples: {
+            default: {
+              value: {
+                file: mockFile,
+                note: 'upload',
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = buildRequestBody(requestBody, 'default')
+
+    expect(result?.mode).toBe('formdata')
+    assert(result?.mode === 'formdata')
+
+    expect(result.value[0]).toBeDefined()
+    assert(result.value[0])
+    expect(result.value[0]).toMatchObject({
+      type: 'file',
+      key: 'file',
+    })
+    expect(result.value[0].value).toBeInstanceOf(File)
+    expect((result.value[0].value as File).name).toBe('hello.txt')
+
+    expect(result.value[1]).toStrictEqual({
+      type: 'text',
+      key: 'note',
+      value: 'upload',
+    })
+  })
+
   it('converts non-string values to strings in form-urlencoded object format', () => {
     const requestBody = {
       content: {

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -47,6 +47,79 @@ export type RequestBody = FormData | UrlEncoded | Raw
 const getMultipartEncodingContentType = (requestBody: RequestBodyObject, bodyContentType: string, fieldName: string) =>
   requestBody.content[bodyContentType]?.encoding?.[fieldName]?.contentType
 
+const appendMultipartValue = ({
+  fieldName,
+  fieldValue,
+  requestBody,
+  bodyContentType,
+  target,
+}: {
+  fieldName: string
+  fieldValue: unknown
+  requestBody: RequestBodyObject
+  bodyContentType: string
+  target: FormData['value']
+}): void => {
+  if (!fieldName || fieldValue === undefined || fieldValue === null) {
+    return
+  }
+
+  const partContentType = getMultipartEncodingContentType(requestBody, bodyContentType, fieldName)
+
+  if (fieldValue instanceof File) {
+    /**
+     * We need to unwrap proxies so file metadata access keeps the right "this" context.
+     */
+    const unwrappedValue = unpackProxyObject(fieldValue)
+    const encodedValue =
+      partContentType && partContentType !== unwrappedValue.type
+        ? new File([unwrappedValue], unwrappedValue.name, {
+            type: partContentType,
+            lastModified: unwrappedValue.lastModified,
+          })
+        : unwrappedValue
+
+    target.push({
+      type: 'file',
+      key: fieldName,
+      value: encodedValue,
+      contentType: partContentType,
+    })
+    return
+  }
+
+  if (fieldValue instanceof Blob) {
+    const encodedValue =
+      partContentType && partContentType !== fieldValue.type ? new Blob([fieldValue], { type: partContentType }) : fieldValue
+    target.push({
+      type: 'blob',
+      key: fieldName,
+      value: encodedValue,
+      contentType: partContentType,
+    })
+    return
+  }
+
+  const serializedValue =
+    typeof fieldValue === 'object' ? JSON.stringify(unpackProxyObject(fieldValue)) : String(fieldValue)
+
+  if (partContentType) {
+    target.push({
+      type: 'blob',
+      key: fieldName,
+      value: new Blob([serializedValue], { type: partContentType }),
+      contentType: partContentType,
+    })
+    return
+  }
+
+  target.push({
+    type: 'text',
+    key: fieldName,
+    value: serializedValue,
+  })
+}
+
 /**
  * Create the fetch request body
  */
@@ -94,84 +167,68 @@ export const buildRequestBody = (
 
     // Loop over all entries and add them to the form
     exampleValue.forEach(({ name, value }) => {
-      if (!name) {
+      if (result.mode === 'formdata') {
+        appendMultipartValue({
+          fieldName: name,
+          fieldValue: value,
+          requestBody,
+          bodyContentType,
+          target: result.value,
+        })
         return
       }
-      const partContentType =
-        result.mode === 'formdata' ? getMultipartEncodingContentType(requestBody, bodyContentType, name) : undefined
 
-      // Handle file uploads
-      if (value instanceof File && result.mode === 'formdata') {
-        /**
-         * We need to unwrap the proxies to get the file name due to the
-         * "this" context in the proxy causing an illegal invocation error
-         */
-        const unwrappedValue = unpackProxyObject(value)
-        const encodedValue =
-          partContentType && partContentType !== unwrappedValue.type
-            ? new File([unwrappedValue], unwrappedValue.name, {
-                type: partContentType,
-                lastModified: unwrappedValue.lastModified,
-              })
-            : unwrappedValue
-
-        return result.value.push({
-          type: 'file',
+      if (name && value !== undefined && value !== null) {
+        result.value.push({
           key: name,
-          value: encodedValue,
-          contentType: partContentType,
+          value: typeof value === 'string' ? value : String(value),
         })
       }
-
-      // Text and structured inputs
-      if (value !== undefined && value !== null) {
-        const serializedValue =
-          typeof value === 'object' && value !== null ? JSON.stringify(unpackProxyObject(value)) : String(value)
-
-        if (result.mode === 'formdata' && partContentType) {
-          return result.value.push({
-            type: 'blob',
-            key: name,
-            value: new Blob([serializedValue], { type: partContentType }),
-            contentType: partContentType,
-          })
-        }
-
-        return result.value.push({
-          type: 'text',
-          key: name,
-          value: serializedValue,
-        })
-      }
-
-      return
     })
 
     return result
   }
 
   // Form data - object format (from schema examples)
-  // When the example value is a plain object and content type is form-urlencoded,
-  // convert to URLSearchParams instead of JSON stringifying
+  // Convert plain objects to form fields instead of JSON stringifying.
   if (
-    bodyContentType === 'application/x-www-form-urlencoded' &&
+    (bodyContentType === 'multipart/form-data' || bodyContentType === 'application/x-www-form-urlencoded') &&
     example.value !== null &&
     typeof example.value === 'object' &&
-    !Array.isArray(example.value)
+    !Array.isArray(example.value) &&
+    !(example.value instanceof File) &&
+    !(example.value instanceof Blob)
   ) {
-    const result: UrlEncoded = {
-      mode: 'urlencoded',
-      value: [],
-    }
+    const unwrappedExampleValue = unpackProxyObject(example.value) as Record<string, unknown>
+    const result: FormData | UrlEncoded =
+      bodyContentType === 'multipart/form-data'
+        ? {
+            mode: 'formdata',
+            value: [],
+          }
+        : {
+            mode: 'urlencoded',
+            value: [],
+          }
 
     // Convert object properties to form fields
-    for (const [key, value] of Object.entries(example.value)) {
+    for (const [key, value] of Object.entries(unwrappedExampleValue)) {
       if (key && value !== undefined && value !== null) {
-        const stringValue = typeof value === 'string' ? value : String(value)
-        result.value.push({
-          key,
-          value: stringValue,
-        })
+        if (result.mode === 'formdata') {
+          appendMultipartValue({
+            fieldName: key,
+            fieldValue: value,
+            requestBody,
+            bodyContentType,
+            target: result.value,
+          })
+        } else {
+          const stringValue = typeof value === 'string' ? value : String(value)
+          result.value.push({
+            key,
+            value: stringValue,
+          })
+        }
       }
     }
 

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -90,7 +90,9 @@ const appendMultipartValue = ({
 
   if (fieldValue instanceof Blob) {
     const encodedValue =
-      partContentType && partContentType !== fieldValue.type ? new Blob([fieldValue], { type: partContentType }) : fieldValue
+      partContentType && partContentType !== fieldValue.type
+        ? new Blob([fieldValue], { type: partContentType })
+        : fieldValue
     target.push({
       type: 'blob',
       key: fieldName,

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -122,6 +122,14 @@ const appendMultipartValue = ({
   })
 }
 
+const serializeUrlEncodedValue = (value: unknown): string => {
+  if (typeof value === 'object' && value !== null && !(value instanceof File) && !(value instanceof Blob)) {
+    return JSON.stringify(unpackProxyObject(value))
+  }
+
+  return typeof value === 'string' ? value : String(value)
+}
+
 /**
  * Create the fetch request body
  */
@@ -183,7 +191,7 @@ export const buildRequestBody = (
       if (name && value !== undefined && value !== null) {
         result.value.push({
           key: name,
-          value: typeof value === 'string' ? value : String(value),
+          value: serializeUrlEncodedValue(value),
         })
       }
     })
@@ -225,10 +233,9 @@ export const buildRequestBody = (
             target: result.value,
           })
         } else {
-          const stringValue = typeof value === 'string' ? value : String(value)
           result.value.push({
             key,
-            value: stringValue,
+            value: serializeUrlEncodedValue(value),
           })
         }
       }

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -123,6 +123,8 @@ const appendMultipartValue = ({
 }
 
 const serializeUrlEncodedValue = (value: unknown): string => {
+  // Urlencoded examples historically JSON-encode object-like values.
+  // Using String(value) here would turn objects into "[object Object]".
   if (typeof value === 'object' && value !== null && !(value instanceof File) && !(value instanceof Blob)) {
     return JSON.stringify(unpackProxyObject(value))
   }
@@ -175,7 +177,8 @@ export const buildRequestBody = (
             value: [],
           }
 
-    // Loop over all entries and add them to the form
+    // Loop over all entries and add them to the selected form mode.
+    // Multipart keeps rich value types (file/blob/text), while urlencoded keeps plain key/value strings.
     exampleValue.forEach(({ name, value }) => {
       if (result.mode === 'formdata') {
         appendMultipartValue({
@@ -199,7 +202,7 @@ export const buildRequestBody = (
     return result
   }
 
-  // Form data - object format (from schema examples)
+  // Form data & Form Urlencoded - object format (from schema examples)
   // Convert plain objects to form fields instead of JSON stringifying.
   if (
     (bodyContentType === 'multipart/form-data' || bodyContentType === 'application/x-www-form-urlencoded') &&

--- a/packages/workspace-store/src/request-example/builder/request-factory.test.ts
+++ b/packages/workspace-store/src/request-example/builder/request-factory.test.ts
@@ -218,6 +218,40 @@ describe('requestFactory', () => {
     expect(request.headers.get('Content-Type')).toBe(null)
   })
 
+  it('removes Content-Type for multipart object examples so the runtime can set the boundary', () => {
+    const { request } = requestFactory(
+      createBaseArgs({
+        method: 'post',
+        defaultHeaders: {
+          'Content-Type': 'application/json',
+        },
+        operation: {
+          requestBody: {
+            content: {
+              'multipart/form-data': {
+                examples: {
+                  default: {
+                    value: {
+                      fileName: 'report.pdf',
+                      description: 'Quarterly report',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        } as OperationObject,
+      }),
+    )
+
+    assert(request.body?.mode === 'formdata')
+    expect(request.body.value).toStrictEqual([
+      { type: 'text', key: 'fileName', value: 'report.pdf' },
+      { type: 'text', key: 'description', value: 'Quarterly report' },
+    ])
+    expect(request.headers.get('Content-Type')).toBe(null)
+  })
+
   it('removes Content-Type when the body is URL-encoded', () => {
     const { request } = requestFactory(
       createBaseArgs({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8997

## Problem

Multipart request-body examples expressed as plain objects could be converted to raw JSON payloads instead of multipart form data. That can leave requests with `Content-Type: multipart/form-data` but no runtime-generated boundary, which causes server-side parsing errors.

## Solution

- Ensure object-shaped examples for `multipart/form-data` are converted into `formdata` entries.
- Keep file/blob/object/text handling consistent for multipart object inputs.
- Add regression tests for multipart object examples in both body building and request factory coverage.
- Add a patch changeset for `@scalar/workspace-store`.

## Visual

<a href="https://cursor.com/agents/bc-5d432240-62ee-40fd-a34d-4c4107da2d11/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmultipart_formdata_file_selection_and_send.mp4"><img src="https://cursor.com/artifacts/c/art-11a40f13-b13a-48fc-b7f8-9954a8caabc2" alt="multipart_formdata_file_selection_and_send.mp4" /></a>
![Multipart file selected in Test Request modal](https://cursor.com/artifacts/c/art-2ea3482f-097d-4a4f-a06c-adff649ee78a)
![Multipart request sent successfully with 200 response](https://cursor.com/artifacts/c/art-31256b9c-a599-4209-aa1e-5f36688ab434)

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d432240-62ee-40fd-a34d-4c4107da2d11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d432240-62ee-40fd-a34d-4c4107da2d11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

