### PR TITLE
fix(agent-chat): include platform token in doc fetch

### DIFF
--- a/.changeset/spicy-steaks-know.md
+++ b/.changeset/spicy-steaks-know.md
@@ -1,0 +1,5 @@
+---
+'@scalar/agent-chat': patch
+---
+
+Include platform token in doc fetch

--- a/packages/agent-chat/package.json
+++ b/packages/agent-chat/package.json
@@ -18,6 +18,7 @@
     "build": "vite build && vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && shx cp package.json dist",
     "build:watch": "vite build --watch",
     "playground": "cd playground && vite",
+    "test": "vitest --run",
     "types:check": "vue-tsc --noEmit"
   },
   "type": "module",
@@ -69,9 +70,12 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "catalog:*",
+    "@types/jsdom": "catalog:*",
     "@vitejs/plugin-vue": "catalog:*",
     "hono": "catalog:*",
+    "jsdom": "catalog:*",
     "tailwindcss": "catalog:*",
-    "vite": "catalog:*"
+    "vite": "catalog:*",
+    "vitest": "catalog:*"
   }
 }

--- a/packages/agent-chat/src/registry/add-documents-to-store.test.ts
+++ b/packages/agent-chat/src/registry/add-documents-to-store.test.ts
@@ -69,7 +69,14 @@ describe('add-documents-to-store', () => {
 
       expect(result.success).toBe(true)
 
-      const registryCall = mockFetch.mock.calls.find(([url]) => String(url).startsWith(registryUrl))
+      const registryCall = mockFetch.mock.calls.find(([url]) => {
+        try {
+          return new URL(String(url)).origin === new URL(registryUrl).origin
+        }
+        catch {
+          return false
+        }
+      })
       expect(registryCall).toBeDefined()
       const [calledUrl, calledOptions] = registryCall!
       expect(String(calledUrl)).toBe('https://registry.example.com/@test-ns/apis/test-slug/latest')
@@ -89,7 +96,14 @@ describe('add-documents-to-store', () => {
         api: createMockApi(),
       })
 
-      const registryCall = mockFetch.mock.calls.find(([url]) => String(url).startsWith(registryUrl))
+      const registryCall = mockFetch.mock.calls.find(([url]) => {
+        try {
+          return new URL(String(url)).origin === new URL(registryUrl).origin
+        }
+        catch {
+          return false
+        }
+      })
       expect(registryCall).toBeDefined()
       const [, calledOptions] = registryCall!
       // fetchUrls passes `headers: undefined` when no domain entry matches.

--- a/packages/agent-chat/src/registry/add-documents-to-store.test.ts
+++ b/packages/agent-chat/src/registry/add-documents-to-store.test.ts
@@ -72,8 +72,7 @@ describe('add-documents-to-store', () => {
       const registryCall = mockFetch.mock.calls.find(([url]) => {
         try {
           return new URL(String(url)).origin === new URL(registryUrl).origin
-        }
-        catch {
+        } catch {
           return false
         }
       })
@@ -99,8 +98,7 @@ describe('add-documents-to-store', () => {
       const registryCall = mockFetch.mock.calls.find(([url]) => {
         try {
           return new URL(String(url)).origin === new URL(registryUrl).origin
-        }
-        catch {
+        } catch {
           return false
         }
       })

--- a/packages/agent-chat/src/registry/add-documents-to-store.test.ts
+++ b/packages/agent-chat/src/registry/add-documents-to-store.test.ts
@@ -1,0 +1,118 @@
+import type { WorkspaceStore } from '@scalar/workspace-store/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import type { Api } from '@/api'
+import { loadDocument } from '@/registry/add-documents-to-store'
+
+const apiMetadata = {
+  id: 'doc-1',
+  title: 'Test API',
+  namespace: 'test-ns',
+  currentVersion: '1.0.0',
+  logoUrl: null,
+  slug: 'test-slug',
+}
+
+const minimalOpenApiDoc = {
+  openapi: '3.1.0',
+  info: { title: 'Test API', version: '1.0.0' },
+  paths: {},
+}
+
+const createMockApi = () =>
+  ({
+    getDocument: vi.fn(async () => ({ success: true as const, data: apiMetadata })),
+  }) as unknown as Api
+
+const createMockWorkspaceStore = () =>
+  ({
+    addDocument: vi.fn(async () => {}),
+    update: vi.fn(),
+    auth: { load: vi.fn() },
+  }) as unknown as WorkspaceStore
+
+describe('add-documents-to-store', () => {
+  describe('loadDocument', () => {
+    let mockFetch: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      mockFetch = vi.fn(
+        async () =>
+          new Response(JSON.stringify(minimalOpenApiDoc), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+      )
+      vi.stubGlobal('fetch', mockFetch)
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+      vi.restoreAllMocks()
+    })
+
+    it('includes the x-scalar-auth header when getAccessToken returns a token', async () => {
+      const token = 'platform-token-123'
+      const registryUrl = 'https://registry.example.com'
+
+      const result = await loadDocument({
+        namespace: 'test-ns',
+        slug: 'test-slug',
+        workspaceStore: createMockWorkspaceStore(),
+        registryDocuments: ref([]),
+        getAccessToken: () => token,
+        registryUrl,
+        config: {},
+        api: createMockApi(),
+      })
+
+      expect(result.success).toBe(true)
+
+      const registryCall = mockFetch.mock.calls.find(([url]) => String(url).startsWith(registryUrl))
+      expect(registryCall).toBeDefined()
+      const [calledUrl, calledOptions] = registryCall!
+      expect(String(calledUrl)).toBe('https://registry.example.com/@test-ns/apis/test-slug/latest')
+      expect(calledOptions?.headers).toMatchObject({ 'x-scalar-auth': token })
+    })
+
+    it('omits the x-scalar-auth header when getAccessToken is not provided', async () => {
+      const registryUrl = 'https://registry.example.com'
+
+      await loadDocument({
+        namespace: 'test-ns',
+        slug: 'test-slug',
+        workspaceStore: createMockWorkspaceStore(),
+        registryDocuments: ref([]),
+        registryUrl,
+        config: {},
+        api: createMockApi(),
+      })
+
+      const registryCall = mockFetch.mock.calls.find(([url]) => String(url).startsWith(registryUrl))
+      expect(registryCall).toBeDefined()
+      const [, calledOptions] = registryCall!
+      // fetchUrls passes `headers: undefined` when no domain entry matches.
+      expect(calledOptions?.headers).toBeUndefined()
+    })
+
+    it('omits the x-scalar-auth header when getAccessToken returns an empty string', async () => {
+      const registryUrl = 'https://registry.example.com'
+
+      await loadDocument({
+        namespace: 'test-ns',
+        slug: 'test-slug',
+        workspaceStore: createMockWorkspaceStore(),
+        registryDocuments: ref([]),
+        getAccessToken: () => '',
+        registryUrl,
+        config: {},
+        api: createMockApi(),
+      })
+
+      const registryCall = mockFetch.mock.calls.find(([url]) => String(url).startsWith(registryUrl))
+      const [, calledOptions] = registryCall!
+      expect(calledOptions?.headers).toBeUndefined()
+    })
+  })
+})

--- a/packages/agent-chat/src/registry/add-documents-to-store.ts
+++ b/packages/agent-chat/src/registry/add-documents-to-store.ts
@@ -18,6 +18,7 @@ export const loadDocument = n.safeFn(
     slug,
     workspaceStore,
     registryDocuments,
+    getAccessToken,
     registryUrl,
     config,
     api,
@@ -26,6 +27,7 @@ export const loadDocument = n.safeFn(
     namespace: string
     slug: string
     workspaceStore: WorkspaceStore
+    getAccessToken?: () => string
     registryDocuments: Ref<ApiMetadata[]>
     registryUrl: string
     config: Partial<ApiReferenceConfiguration>
@@ -45,8 +47,28 @@ export const loadDocument = n.safeFn(
 
     const url = new URL(`/@${namespace}/apis/${slug}/latest`, registryUrl)
 
+    const headers: {
+      headers: HeadersInit
+      domains: string[]
+    }[] = []
+
+    const token = getAccessToken?.()
+
+    if (token) {
+      headers.push({
+        domains: [new URL(registryUrl).host],
+        headers: {
+          'x-scalar-auth': token,
+        },
+      })
+    }
+
     const document: OpenAPIV3_1.Document = await bundle(url.toString(), {
-      plugins: [fetchUrls()],
+      plugins: [
+        fetchUrls({
+          headers,
+        }),
+      ],
       treeShake: false,
     })
 

--- a/packages/agent-chat/src/state/state.ts
+++ b/packages/agent-chat/src/state/state.ts
@@ -269,6 +269,7 @@ export function createState({
       registryUrl,
       registryDocuments,
       config: config.value,
+      getAccessToken,
       api,
       removable,
     })
@@ -330,6 +331,7 @@ export function createState({
         registryUrl,
         registryDocuments,
         config: config.value,
+        getAccessToken,
         api,
         removable,
       })

--- a/packages/agent-chat/vite.config.ts
+++ b/packages/agent-chat/vite.config.ts
@@ -40,5 +40,8 @@ export default defineConfig({
       output: createPreserveModulesOutput(),
     },
   },
-  test: {},
+  test: {
+    environment: 'jsdom',
+    root: resolve(import.meta.dirname, './'),
+  },
 })

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -318,7 +318,10 @@
       "default": "./dist/v2/features/settings/index.js"
     }
   },
-  "files": ["dist", "CHANGELOG.md"],
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
   "dependencies": {
     "@headlessui/tailwindcss": "catalog:*",
     "@headlessui/vue": "catalog:*",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -318,10 +318,7 @@
       "default": "./dist/v2/features/settings/index.js"
     }
   },
-  "files": [
-    "dist",
-    "CHANGELOG.md"
-  ],
+  "files": ["dist", "CHANGELOG.md"],
   "dependencies": {
     "@headlessui/tailwindcss": "catalog:*",
     "@headlessui/vue": "catalog:*",
@@ -340,8 +337,8 @@
     "@scalar/use-codemirror": "workspace:*",
     "@scalar/use-hooks": "workspace:*",
     "@scalar/use-toasts": "workspace:*",
-    "@scalar/workspace-store": "workspace:*",
     "@scalar/validation": "workspace:*",
+    "@scalar/workspace-store": "workspace:*",
     "@types/har-format": "^1.2.16",
     "@vueuse/core": "catalog:*",
     "@vueuse/integrations": "catalog:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1168,18 +1168,27 @@ importers:
       '@tailwindcss/vite':
         specifier: catalog:*
         version: 4.2.1(vite@8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/jsdom':
+        specifier: catalog:*
+        version: 28.0.1
       '@vitejs/plugin-vue':
         specifier: catalog:*
         version: 6.0.5(vite@8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
       hono:
         specifier: catalog:*
         version: 4.12.9
+      jsdom:
+        specifier: catalog:*
+        version: 27.4.0(@noble/hashes@1.8.0)
       tailwindcss:
         specifier: catalog:*
         version: 4.2.1
       vite:
         specifier: catalog:*
         version: 8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: catalog:*
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/api-client:
     dependencies:
@@ -16490,10 +16499,6 @@ packages:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
-  tinyrainbow@3.0.3:
-    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
-    engines: {node: '>=14.0.0'}
-
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
@@ -17734,6 +17739,9 @@ packages:
   vue-component-type-helpers@3.2.6:
     resolution: {integrity: sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==}
 
+  vue-component-type-helpers@3.2.7:
+    resolution: {integrity: sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==}
+
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
     engines: {node: '>=12'}
@@ -18482,7 +18490,7 @@ snapshots:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      lru-cache: 11.2.6
+      lru-cache: 11.2.7
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
@@ -18496,9 +18504,9 @@ snapshots:
     dependencies:
       '@asamuzakjp/nwsapi': 2.3.9
       bidi-js: 1.0.3
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.2.6
+      lru-cache: 11.2.7
 
   '@asamuzakjp/dom-selector@7.0.4':
     dependencies:
@@ -24385,7 +24393,7 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.30(typescript@5.9.3)
-      vue-component-type-helpers: 3.2.6
+      vue-component-type-helpers: 3.2.7
 
   '@sveltejs/acorn-typescript@1.0.5(acorn@8.15.0)':
     dependencies:
@@ -25348,7 +25356,7 @@ snapshots:
       '@vitest/spy': 4.1.0
       '@vitest/utils': 4.1.0
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -25397,7 +25405,7 @@ snapshots:
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -25445,7 +25453,7 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.1.0
       convert-source-map: 2.0.0
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/utils@4.1.2':
     dependencies:
@@ -27517,9 +27525,9 @@ snapshots:
   cssstyle@5.3.7:
     dependencies:
       '@asamuzakjp/css-color': 4.1.1
-      '@csstools/css-syntax-patches-for-csstree': 1.1.0
-      css-tree: 3.1.0
-      lru-cache: 11.2.6
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
+      css-tree: 3.2.1
+      lru-cache: 11.2.7
 
   cssstyle@6.2.0:
     dependencies:
@@ -30372,12 +30380,12 @@ snapshots:
       parse5: 8.0.0
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 6.0.0
+      tough-cookie: 6.0.1
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
-      ws: 8.18.3
+      ws: 8.19.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -35526,7 +35534,7 @@ snapshots:
     dependencies:
       commander: 11.1.0
       css-select: 5.1.0
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       css-what: 6.1.0
       csso: 5.0.5
       picocolors: 1.1.1
@@ -35536,7 +35544,7 @@ snapshots:
     dependencies:
       commander: 11.1.0
       css-select: 5.1.0
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       css-what: 6.1.0
       csso: 5.0.5
       picocolors: 1.1.1
@@ -35715,8 +35723,6 @@ snapshots:
   tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
-
-  tinyrainbow@3.0.3: {}
 
   tinyrainbow@3.1.0: {}
 
@@ -36949,7 +36955,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
       vite: 8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -36978,7 +36984,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
       vite: 8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -37007,7 +37013,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
       vite: 8.0.0(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -37036,7 +37042,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
       vite: 8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.19.4)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -37065,7 +37071,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
       vite: 8.0.2(@types/node@24.10.13)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -37143,6 +37149,8 @@ snapshots:
   vue-component-type-helpers@2.2.10: {}
 
   vue-component-type-helpers@3.2.6: {}
+
+  vue-component-type-helpers@3.2.7: {}
 
   vue-demi@0.14.10(vue@3.5.30(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION
## Problem
<!--
  What problem does the PR solve?
  WHY did you submit the PR?

  We are interested in the WHY (LLMs won't know).
-->
Currently we're not propagating platform tokens correctly through agent chat so that registry doc fetches with just the platform token can be retrieved (this specifically affects agent.scalar.com where we don't have an agent key being used)

With this change, we are injecting the token correctly when calling the provided registry domain

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication-related request headers for registry document fetching; mistakes could cause failed loads or unintended header propagation, though scope is limited to a single fetch pathway and is now covered by tests.
> 
> **Overview**
> Fixes registry OpenAPI document loading in `@scalar/agent-chat` to *optionally* send the platform token by passing an `x-scalar-auth` header to the registry domain during bundling (`loadDocument` now accepts `getAccessToken`).
> 
> Adds a small Vitest suite to assert header injection/omission behavior and wires up agent-chat’s test setup (Vitest script, `jsdom` environment/deps), plus a patch changeset for release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a5a224da29adfece319a016118fa56005880b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->