### PR TITLE
feat(api-reference): PR previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,8 +702,8 @@ jobs:
         with:
           packages: '@scalar/api-reference...'
 
-      - name: Build index.html app
-        run: pnpm --filter @scalar/api-reference exec vite build -c ./playground/esm/vite.config.ts
+      - name: Build package root app
+        run: pnpm --filter @scalar/api-reference exec vite build . -c ./playground/esm/vite.config.ts
 
       - name: Deploy to Cloudflare Pages
         id: deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,6 +636,47 @@ jobs:
         # We're uploading it as a schema, because for documents do not support AsyncAPI yet.
         run: npx @scalar/cli@latest schema publish --namespace scalar --slug asyncapi --version ${{ steps.package-version.outputs.VERSION }} packages/galaxy/dist/asyncapi/latest.yaml
 
+  deploy-examples:
+    # Run only for PRs from the same repository
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]')
+    needs: [build]
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    timeout-minutes: 10
+    concurrency:
+      group: deploy-examples-${{ github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    outputs:
+      preview-url: ${{ steps.set-output.outputs.url }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Build
+        uses: ./.github/actions/build
+        with:
+          packages: '@scalar-examples/web...'
+
+      - name: Generate DEPLOY_ID
+        run: echo "DEPLOY_ID=$(pnpx uuid)" >> "$GITHUB_ENV"
+
+      - name: Install Netlify CLI
+        run: pnpm install -g netlify
+
+      - name: Deploy to Netlify
+        run: |
+          netlify deploy --dir "./examples/web/dist" \
+            --message "Deployed from GitHub (${{ env.DEPLOY_ID }})" \
+            --site ${{ vars.NETLIFY_SITE_ID_PREVIEW }} \
+            --auth ${{ secrets.NETLIFY_AUTH_TOKEN }} \
+            --filter @scalar-examples/web \
+            --alias=${{env.DEPLOY_ID}}
+
+      - name: Set output
+        id: set-output
+        if: github.event_name == 'pull_request'
+        run: echo "url=https://${{ env.DEPLOY_ID }}--scalar-deploy-preview.netlify.app" >> $GITHUB_OUTPUT
+
   deploy-api-reference:
     # Run only for same-repo PRs that touch @scalar/api-reference or its workspace deps
     if: |
@@ -839,7 +880,8 @@ jobs:
     # Only run for PRs from the same repository
     if: |
       always() &&
-      (needs.deploy-api-reference.result == 'success' ||
+      (needs.deploy-examples.result == 'success' ||
+       needs.deploy-api-reference.result == 'success' ||
        needs.deploy-components.result == 'success' ||
        needs.deploy-api-client.result == 'success' ||
        needs.galaxy-registry-preview.result == 'success') &&
@@ -848,6 +890,7 @@ jobs:
       !contains(github.actor, '[bot]')
     needs:
       [
+        deploy-examples,
         deploy-api-reference,
         deploy-components,
         deploy-api-client,
@@ -862,6 +905,14 @@ jobs:
         id: build-message
         run: |
           MESSAGE=""
+
+          if [ "${{ needs.deploy-examples.result }}" == "success" ]; then
+            MESSAGE="$MESSAGE**Preview Examples**
+
+          ${{ needs.deploy-examples.outputs.preview-url }}
+
+          "
+          fi
 
           if [ "${{ needs.deploy-api-reference.result }}" == "success" ]; then
             MESSAGE="$MESSAGE**Preview API Reference**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -703,7 +703,7 @@ jobs:
           packages: '@scalar/api-reference...'
 
       - name: Build package root app
-        run: pnpm --filter @scalar/api-reference exec vite build . -c ../api-reference.previews.config.ts
+        run: pnpm --filter @scalar/api-reference exec vite build . -c ./vite.previews.config.ts
 
       - name: Deploy to Cloudflare Pages
         id: deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,8 +702,8 @@ jobs:
         with:
           packages: '@scalar/api-reference...'
 
-      - name: Build playground app
-        run: pnpm --filter @scalar/api-reference exec vite build ./playground/esm -c ./playground/esm/vite.config.ts
+      - name: Build index.html app
+        run: pnpm --filter @scalar/api-reference exec vite build -c ./playground/esm/vite.config.ts
 
       - name: Deploy to Cloudflare Pages
         id: deploy
@@ -711,7 +711,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ./packages/api-reference/playground/esm/dist --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_API_REFERENCE }} --branch=pr-${{ github.event.pull_request.number }} --commit-hash=${{ github.event.pull_request.head.sha }}
+          command: pages deploy ./packages/api-reference/dist --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_API_REFERENCE }} --branch=pr-${{ github.event.pull_request.number }} --commit-hash=${{ github.event.pull_request.head.sha }}
 
       - name: Set output
         id: set-output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
       icons_changed: ${{ steps.set-outputs.outputs.icons_changed }}
       galaxy_changed: ${{ steps.set-outputs.outputs.galaxy_changed }}
       api_client_changed: ${{ steps.set-outputs.outputs.api_client_changed }}
+      api_reference_changed: ${{ steps.set-outputs.outputs.api_reference_changed }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -111,6 +112,8 @@ jobs:
               - packages/galaxy/**
             api_client_changed:
               - packages/api-client/**
+            api_reference_changed:
+              - packages/api-reference/**
 
       - name: Check whether integration package.json files were modified
         id: changed-package-files
@@ -154,6 +157,7 @@ jobs:
           echo "icons_changed=${{ steps.changed-packages-files.outputs.icons_changed_any_changed }}" >> $GITHUB_OUTPUT
           echo "galaxy_changed=${{ steps.changed-packages-files.outputs.galaxy_changed_any_changed }}" >> $GITHUB_OUTPUT
           echo "api_client_changed=${{ steps.changed-packages-files.outputs.api_client_changed_any_changed }}" >> $GITHUB_OUTPUT
+          echo "api_reference_changed=${{ steps.changed-packages-files.outputs.api_reference_changed_any_changed }}" >> $GITHUB_OUTPUT
 
   format:
     if: github.event_name == 'pull_request'
@@ -633,11 +637,15 @@ jobs:
         run: npx @scalar/cli@latest schema publish --namespace scalar --slug asyncapi --version ${{ steps.package-version.outputs.VERSION }} packages/galaxy/dist/asyncapi/latest.yaml
 
   deploy-api-reference:
-    # Run only for PRs from the same repository
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]')
-    needs: [build]
+    # Run only for same-repo PRs that touch @scalar/api-reference or its workspace deps
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.actor, '[bot]') &&
+      needs.check-changes.outputs.api_reference_changed == 'true'
+    needs: [build, check-changes]
     runs-on: blacksmith-2vcpu-ubuntu-2204
-    timeout-minutes: 10
+    timeout-minutes: 15
     concurrency:
       group: deploy-api-reference-${{ github.ref }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -648,30 +656,32 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Build
+      - name: Build workspace deps
         uses: ./.github/actions/build
         with:
-          packages: '@scalar-examples/web...'
+          packages: '@scalar/api-reference...'
 
-      - name: Generate DEPLOY_ID
-        run: echo "DEPLOY_ID=$(pnpx uuid)" >> "$GITHUB_ENV"
+      - name: Build playground app
+        run: pnpm --filter @scalar/api-reference exec vite build ./playground/esm -c ./playground/esm/vite.config.ts
 
-      - name: Install Netlify CLI
-        run: pnpm install -g netlify
-
-      - name: Deploy to Netlify
-        run: |
-          netlify deploy --dir "./examples/web/dist" \
-            --message "Deployed from GitHub (${{ env.DEPLOY_ID }})" \
-            --site ${{ vars.NETLIFY_SITE_ID_PREVIEW }} \
-            --auth ${{ secrets.NETLIFY_AUTH_TOKEN }} \
-            --filter @scalar-examples/web \
-            --alias=${{env.DEPLOY_ID}}
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ./packages/api-reference/playground/esm/dist --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_API_REFERENCE }} --branch=pr-${{ github.event.pull_request.number }} --commit-hash=${{ github.event.pull_request.head.sha }}
 
       - name: Set output
         id: set-output
-        if: github.event_name == 'pull_request'
-        run: echo "url=https://${{ env.DEPLOY_ID }}--scalar-deploy-preview.netlify.app" >> $GITHUB_OUTPUT
+        run: |
+          ALIAS_URL='${{ steps.deploy.outputs.pages-deployment-alias-url }}'
+          DEPLOYMENT_URL='${{ steps.deploy.outputs.deployment-url }}'
+          if [ -n "$ALIAS_URL" ]; then
+            echo "url=$ALIAS_URL" >> $GITHUB_OUTPUT
+          else
+            echo "url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
+          fi
 
   deploy-components:
     # Run for PRs (preview) or main branch (production)
@@ -854,7 +864,7 @@ jobs:
           MESSAGE=""
 
           if [ "${{ needs.deploy-api-reference.result }}" == "success" ]; then
-            MESSAGE="$MESSAGE**Preview Examples**
+            MESSAGE="$MESSAGE**Preview API Reference**
 
           ${{ needs.deploy-api-reference.outputs.preview-url }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -703,7 +703,7 @@ jobs:
           packages: '@scalar/api-reference...'
 
       - name: Build package root app
-        run: pnpm --filter @scalar/api-reference exec vite build . -c ./playground/esm/vite.config.ts
+        run: pnpm --filter @scalar/api-reference exec vite build . -c ../api-reference.previews.config.ts
 
       - name: Deploy to Cloudflare Pages
         id: deploy

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -58,7 +58,10 @@
     // Astro component Props interface is used by the framework
     "integrations/astro/src/ScalarComponent.astro": ["types"],
     // setupFiles string path cannot be resolved by knip
-    "packages/api-reference/vitest.config.ts": ["unresolved"]
+    "packages/api-reference/vitest.config.ts": ["unresolved"],
+    // Nuxt virtual alias resolved at runtime by Nuxt, not by knip static analysis
+    "integrations/nuxt/src/runtime/components/ScalarApiReference.vue": ["unresolved"],
+    "integrations/nuxt/src/runtime/pages/ScalarPage.vue": ["unresolved"]
   },
   "workspaces": {
     "packages/api-client": {
@@ -117,6 +120,8 @@
         "src/features/index.ts",
         "src/helpers/index.ts",
         "src/esm.ts",
+        // Used by CI deploy-api-reference preview build
+        "vite.previews.config.ts",
         // Not sure why test files are marked as unused here
         "test/**/*",
         "src/**/*.test.ts"

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -26,7 +26,7 @@
     "build": "vite build && vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "dev": "pnpm playground:web",
     "playground:app": "vite ./playground/app -c ./vite.config.ts",
-    "playground:app:build": "vite build ./playground/app -c ./vite.playground.config.ts",
+    "playground:app:build": "vite build ./playground/app -c ./vite.previews.config.ts",
     "playground:modal": "vite ./playground/modal -c ./vite.config.ts",
     "playground:web": "vite ./playground/web -c ./vite.config.ts",
     "preview": "vite preview",

--- a/packages/api-client/vite.previews.config.ts
+++ b/packages/api-client/vite.previews.config.ts
@@ -10,10 +10,10 @@ const require = createRequire(import.meta.url)
 const monacoEditorPlugin = require('vite-plugin-monaco-editor').default
 
 /**
- * App-mode build for the api-client playgrounds. The main `vite.config.ts` is
+ * App-mode build for the api-client previews. The main `vite.config.ts` is
  * configured for library output, which is incompatible with bundling a deployable
- * playground. Pass the playground folder as Vite's root, e.g.
- *   vite build playground/app -c vite.playground.config.ts
+ * preview app. Pass the app folder as Vite's root, e.g.
+ *   vite build playground/app -c vite.previews.config.ts
  */
 export default defineConfig({
   plugins: [

--- a/packages/api-reference.previews.config.ts
+++ b/packages/api-reference.previews.config.ts
@@ -1,0 +1,12 @@
+import { resolve } from 'node:path'
+
+import apiReferenceConfig from './api-reference/vite.config'
+
+export default {
+  ...apiReferenceConfig,
+  root: resolve(import.meta.dirname, './api-reference'),
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+}

--- a/packages/api-reference/vite.previews.config.ts
+++ b/packages/api-reference/vite.previews.config.ts
@@ -1,10 +1,10 @@
 import { resolve } from 'node:path'
 
-import apiReferenceConfig from './api-reference/vite.config'
+import apiReferenceConfig from './vite.config'
 
 export default {
   ...apiReferenceConfig,
-  root: resolve(import.meta.dirname, './api-reference'),
+  root: resolve(import.meta.dirname, '.'),
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The CI workflow currently posts preview URLs for API Client and other surfaces, but `packages/api-reference` did not have an equivalent package-level PR preview deployment.

## Solution

- Added `api_reference_changed` detection in `check-changes` so the API Reference package preview only runs when `packages/api-reference/**` changes.
- Added a package-level `deploy-api-reference` preview job that mirrors the API Client Cloudflare Pages pattern:
  - gate to same-repo PRs + change detection
  - build `@scalar/api-reference...`
  - build the package root app (the same surface as `pnpm dev` in `packages/api-reference`) using `packages/api-reference/vite.previews.config.ts`
  - deploy `packages/api-reference/dist` to Cloudflare Pages with PR branch + commit metadata
  - expose the deployment URL via job output using alias-url fallback logic
- Added `packages/api-reference/vite.previews.config.ts`, which extends `packages/api-reference/vite.config.ts` and overrides preview-specific build settings.
- Restored the previous examples preview deployment as a separate `deploy-examples` job (old Netlify flow preserved).
- Updated the combined PR preview comment to include both:
  - `Preview Examples` (from `deploy-examples`)
  - `Preview API Reference` (from `deploy-api-reference`)
- Renamed API Client preview config from `packages/api-client/vite.playground.config.ts` to `packages/api-client/vite.previews.config.ts` and updated `playground:app:build` to use the new name.
- Updated `knip.jsonc` so `pnpm lint:knip` recognizes the new preview config entry and ignores Nuxt runtime alias false positives.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15afb8dd-cf02-46c7-a2f8-ff90b11f531b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15afb8dd-cf02-46c7-a2f8-ff90b11f531b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

