### PR TITLE
docs: update cli authentication

### DIFF
--- a/documentation/guides/cli/authentication.md
+++ b/documentation/guides/cli/authentication.md
@@ -1,0 +1,33 @@
+# Authentication
+
+To use the [Scalar CLI](getting-started.md) with Scalar services, you need to authenticate first.
+
+## Login
+
+```bash
+scalar auth login
+```
+
+This opens the dashboard to authenticate, which is typically what you want on a local development machine.
+
+## Login with an API Key
+
+For CI/CD or other automated workflows, you can authenticate with an API key directly:
+
+```bash
+scalar auth login --token your-secret-scalar-api-key
+```
+
+To generate an API key, go to [https://dashboard.scalar.com](https://dashboard.scalar.com) and navigate to Account > API Keys.
+
+## Check the Current User
+
+```bash
+scalar auth whoami
+```
+
+## Logout
+
+```bash
+scalar auth logout
+```

--- a/documentation/guides/cli/getting-started.md
+++ b/documentation/guides/cli/getting-started.md
@@ -49,33 +49,8 @@ pnpm dlx @scalar/cli help
 - [team](commands.md#team) Manage user teams
 
 ## Authentication
-To authenticate with the Scalar platform you can do the following:
 
-### Web Login
-This opens a web portal which will authenticate, typical for local dev machine workflows
-
-```bash
-scalar auth login
-```
-
-Now you can interact with all the wonderful authorization endpoints
-
-### Token/Machine Based
-
-Typical if you want to use in CI workflows or programatically you need to:
-1. Visit https://dashboard.scalar.com
-2. Create an account or Login
-3. Navigate to User -> API Keys https://dashboard.scalar.com/user/api-keys
-4. Generate an API Key
-5. Store the token in a safe place!
-
-```bash
-scalar auth login --token 1234secrettoken5678
-```
-
-Now you can interact with all the wonderful authorization endpoints with just a token! Perfect for GitHub actions or scripts.
-
-
+To use the CLI with Scalar services, see the [Authentication](authentication.md) guide.
 
 ## GitHub Actions
 

--- a/documentation/guides/registry/cli.md
+++ b/documentation/guides/registry/cli.md
@@ -1,37 +1,7 @@
 # CLI
 This guide will help you interact with our registry with our CLI, programmatically. If you want to also work with the registry with our dashboard you can.
 
-### Generate Token
-If you choose to interface with our registry with our [CLI](../cli/commands.md#registry) or our API you will need to generate an API key.
-
-Go to https://dashboard.scalar.com and navigate to User > API Keys:
-
-![Scalar Create API Key](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/RlDb2KoAByHiUPxNsOAHk.png "Scalar Create API Key")
-
-Once you have your API key you can now use the CLI or API to interface with the registry.
-
-## Authentication
-First you need to login, you can do that by the following commands:
-
-```bash
-scalar auth login
-```
-
-Or using a token directly:
-
-```bash
-scalar auth login --token 1234secrettoken5678
-```
-
-You can also check your current user or logout:
-
-```bash
-# Check current user
-scalar auth whoami
-
-# Logout
-scalar auth logout
-```
+Before running any of the commands below, make sure you are [authenticated](../cli/authentication.md) with the Scalar CLI using your [API key](../cli/authentication.md#login-with-an-api-key).
 
 ## Publishing OpenAPI Documents
 To add an OpenAPI document to the registry, use the `publish` command:
@@ -51,6 +21,7 @@ scalar registry publish ./openapi.yaml --namespace your-team --slug your-api
 - `--force`: Force override an existing version (default: false)
 
 ### Examples
+
 ```bash
 # Basic publish
 scalar registry publish api/openapi.json --namespace your-team --slug user-api

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -2285,6 +2285,11 @@
                       ]
                     }
                   },
+                  "authentication": {
+                    "filepath": "documentation/guides/cli/authentication.md",
+                    "type": "page",
+                    "title": "Authentication"
+                  },
                   "commands": {
                     "filepath": "documentation/guides/cli/commands.md",
                     "type": "page",


### PR DESCRIPTION
- `cli/authentication.md` dedicated CLI Authentication page covering scalar auth login, login with an API key, whoami, and logout. Points users to Account > API Keys in the dashboard.
- registered the new page under /tools/cli, between getting-started and commands.
- `registry/cli.md`: removed the "Generate Token" + "Authentication" sections and the dashboard screenshot; replaced them with a one-line note linking to the new Authentication page (and to the API-key login section specifically). Wording uses "API key" instead of "token".
- `cli/getting-started.md`: removed the duplicate Authentication section (Web Login + Token/Machine Based); replaced with a one-line pointer to the new Authentication page.