### PR TITLE
docs(docs): remove directives

### DIFF
--- a/documentation/guides/docs/components/buttons.md
+++ b/documentation/guides/docs/components/buttons.md
@@ -28,9 +28,6 @@ An icon to display alongside the button text in dark mode. If not provided, the 
 
 ### Basic Button
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-button
   title="View Documentation"
   href="https://docs.scalar.com">
@@ -42,23 +39,9 @@ An icon to display alongside the button text in dark mode. If not provided, the 
   href="https://docs.scalar.com">
 </scalar-button>
 ```
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-button{title="View Documentation" href="https://docs.scalar.com"}
-
-```markdown
-::scalar-button{title="View Documentation" href="https://docs.scalar.com"}
-```
-</scalar-tab>
-</scalar-tabs>
-
 
 ### Button with Icon
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
 <scalar-button
   title="Download SDK"
   href="https://github.com/scalar/scalar"
@@ -72,22 +55,9 @@ An icon to display alongside the button text in dark mode. If not provided, the 
   icon="phosphor/regular/house">
 </scalar-button>
 ```
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-button{ title="Download SDK" href="https://github.com/scalar/scalar" icon="phosphor/regular/house"}
-
-```markdown
-::scalar-button{ title="Download SDK" href="https://github.com/scalar/scalar" icon="phosphor/regular/house"}
-```
-</scalar-tab>
-</scalar-tabs>
 
 ### Button with External Icon
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
 <scalar-button
   title="Visit Website"
   href="https://scalar.com"
@@ -103,14 +73,3 @@ An icon to display alongside the button text in dark mode. If not provided, the 
   icon-dark="https://cdn.scalar.com/images/logo-dark.svg">
 </scalar-button>
 ```
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-button{ title="Visit Website" href="https://scalar.com" icon="https://cdn.scalar.com/images/logo-light.svg" icon-dark="https://cdn.scalar.com/images/logo-dark.svg"}
-
-```markdown
-::scalar-button{ title="Visit Website" href="https://scalar.com" icon="https://cdn.scalar.com/images/logo-light.svg" icon-dark="https://cdn.scalar.com/images/logo-dark.svg"}
-```
-</scalar-tab>
-</scalar-tabs>

--- a/documentation/guides/docs/components/callouts.md
+++ b/documentation/guides/docs/components/callouts.md
@@ -19,36 +19,14 @@ A custom icon to display in the callout. Uses Scalar icon format. If not provide
 
 ### Basic Callout
 
-
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-callout type="info"> This is an informational message. </scalar-callout>
 
 ```html
 <scalar-callout type="info"> This is an informational message. </scalar-callout>
 ```
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-:::scalar-callout{type="info"}
-This is an informational message.
-:::
-
-```markdown
-:::scalar-callout{type="info"}
-This is an informational message.
-:::
-```
-</scalar-tab>
-</scalar-tabs>
 
 ### Callout with Custom Icon
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-callout
   type="success"
   icon="check-circle">
@@ -62,19 +40,3 @@ This is an informational message.
   Operation completed successfully!
 </scalar-callout>
 ```
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-:::scalar-callout{ type="success" icon="check-circle" }
-Operation completed successfully!
-:::
-
-```markdown
-:::scalar-callout{ type="success" icon="check-circle" }
-Operation completed successfully!
-:::
-```
-
-</scalar-tab>
-</scalar-tabs>

--- a/documentation/guides/docs/components/cards.md
+++ b/documentation/guides/docs/components/cards.md
@@ -20,9 +20,6 @@ Displays a large icon to the left of the card content.
 
 ### Card with Body Only
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-card>
 Card with body.
 </scalar-card>
@@ -32,28 +29,9 @@ Card with body.
 Card with body.
 <scalar-card>
 ```
-
-</scalar-tab>
-<scalar-tab title="Directive">
-
-:::scalar-card
-Card with body.
-:::
-
-```markdown
-:::scalar-card
-Card with body.
-:::
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Card with Title and Body
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-card title="The Title of the Card">
 Card with title and body.
 </scalar-card>
@@ -63,28 +41,9 @@ Card with title and body.
 Card with title and body.
 </scalar-card>
 ```
-
-</scalar-tab>
-<scalar-tab title="Directive">
-
-:::scalar-card{title="The Title of the Card"}
-Card with title and body.
-:::
-
-```markdown
-:::scalar-card{title="The Title of the Card"}
-Card with title and body.
-:::
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Card with Icon and Body
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-card icon="solid/basic-shape-hexagon">
 Card with icon and body.
 </scalar-card>
@@ -94,28 +53,9 @@ Card with icon and body.
 Card with icon and body.
 </scalar-card>
 ```
-
-</scalar-tab>
-<scalar-tab title="Directive">
-
-:::scalar-card{icon="solid/basic-shape-hexagon"}
-Card with icon and body.
-:::
-
-```markdown
-:::scalar-card{icon="solid/basic-shape-hexagon"}
-Card with icon and body.
-:::
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Card with Left-Icon, Title and Body
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-card leftIcon="solid/basic-shape-hexagon" title="The Title of the Card">
 Card with a `leftIcon`, title, and body
 </scalar-card>
@@ -125,44 +65,11 @@ Card with a `leftIcon`, title, and body
 Card with a `leftIcon`, title, and body
 </scalar-card>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-:::scalar-card{ leftIcon="solid/basic-shape-hexagon" title="The Title of the Card"}
-Card with a `leftIcon`, title, and body
-:::
-
-```markdown
-:::scalar-card{ leftIcon="solid/basic-shape-hexagon" title="The Title of the Card"}
-Card with a `leftIcon`, title, and body
-:::
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Card with Title
 
-<scalar-tabs>
-
-<scalar-tab title="Custom HTML">
-
 <scalar-card title="Without Body"></scalar-card>
 
 ```markdown
 <scalar-card title="Without Body"></scalar-card>
 ```
-
-</scalar-tab>
-<scalar-tab title="Directive">
-
-::scalar-card{title="Without Body"}
-
-```markdown
-::scalar-card{title="Without Body"}
-```
-
-</scalar-tab>
-</scalar-tabs>

--- a/documentation/guides/docs/components/details.md
+++ b/documentation/guides/docs/components/details.md
@@ -31,9 +31,6 @@ to start in a collapsed state.
 
 ### Basic Collapsible Section
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-detail title="More Info">
 
 Here is some additional content.
@@ -45,29 +42,9 @@ Here is some additional content.
 Here is some additional content.
 </scalar-detail>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-:::scalar-detail{title="More Info"}
-Here is some additional content.
-:::
-
-```markdown
-:::scalar-detail{title="More Info"}
-Here is some additional content.
-:::
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Open by Default
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-detail title="Default Open" open>
 
 The section is open by default.
@@ -79,29 +56,9 @@ The section is open by default.
 The section is open by default.
 </scalar-detail>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-:::scalar-detail{title="Default Open" open='true'}
-The section is open by default.
-:::
-
-```markdown
-:::scalar-detail{title="Default Open" open='true'}
-The section is open by default.
-:::
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### With Custom Icon
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-detail title="Custom Icon" icon="airplane">
 
 Using a custom icon.
@@ -113,28 +70,8 @@ Using a custom icon.
 Using a custom icon.
 </scalar-detail>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-:::scalar-detail{title="Custom Icon" icon="airplane" }
-Using a custom icon.
-:::
-
-```markdown
-:::scalar-detail{title="Custom Icon" icon="airplane"}
-Using a custom icon.
-:::
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Non-interactive Block
-
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
 
 <scalar-detail title="Non-Interactive" interactivity=none>
 
@@ -148,28 +85,8 @@ These do not collapse when clicked.
 </scalar-detail>
 ```
 
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-:::scalar-detail{title="Non-Interactive" interactivity="none" }
-These do not collapse when clicked.
-:::
-
-```markdown
-:::scalar-detail{title="Non-Interactive" interactivity="none" }
-These do not collapse when clicked.
-:::
-```
-
-</scalar-tab>
-</scalar-tabs>
-
 ### Nested
 
-
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
 <scalar-detail title="Nested, Outer" >
 
 Outer details content.
@@ -190,26 +107,4 @@ Outer details content.
 Inner details content.
 </scalar-detail>
 </scalar-detail>
-```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::::scalar-detail{title="Nested, Outer" }
-With directives, the parent must have at least 1 more `:` than the elements it wraps.
-
-:::scalar-detail{title="Non-Interactive" }
-Inner details content.
-:::
-::::
-
-```markdown
-::::scalar-detail{title="Nested, Outer" }
-With directives, the parent must have at least 1 more `:` than the elements it wraps.
-
-:::scalar-detail{title="Non-Interactive" }
-Inner details content.
-:::
-::::
 ```

--- a/documentation/guides/docs/components/embeds.md
+++ b/documentation/guides/docs/components/embeds.md
@@ -29,9 +29,6 @@ Alternative text for accessibility. This describes the embedded content for scre
 
 ### YouTube Video
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-embed
   src="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
   caption="Never Gonna Give You Up - Rick Astley">
@@ -43,23 +40,9 @@ Alternative text for accessibility. This describes the embedded content for scre
   caption="Never Gonna Give You Up - Rick Astley">
 </scalar-embed>
 ```
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-embed{ src="https://www.youtube.com/watch?v=dQw4w9WgXcQ" caption="Never Gonna Give You Up - Rick Astley"}
-
-```markdown
-::scalar-embed{ src="https://www.youtube.com/watch?v=dQw4w9WgXcQ" caption="Never Gonna Give You Up - Rick Astley"}
-```
-</scalar-tab>
-</scalar-tabs>
 
 ### Vimeo Video
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-embed
   src="https://vimeo.com/844557780"
   caption="Beautiful nature documentary">
@@ -71,24 +54,9 @@ Alternative text for accessibility. This describes the embedded content for scre
   caption="Beautiful nature documentary">
 </scalar-embed>
 ```
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-embed{ src="https://vimeo.com/844557780" caption="Never Gonna Give You Up - Rick Astley"}
-
-```markdown
-::scalar-embed{ src="https://www.youtube.com/watch?v=dQw4w9WgXcQ" caption="Beautiful nature documentary"}
-```
-</scalar-tab>
-</scalar-tabs>
-
 
 ### Generic Iframe Content
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-embed
   src="https://en.wikipedia.org/wiki/Open_source"
   caption="Custom interactive content"
@@ -102,14 +70,3 @@ Alternative text for accessibility. This describes the embedded content for scre
   alt="Interactive demonstration of the API">
 </scalar-embed>
 ```
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-embed{ src="https://en.wikipedia.org/wiki/Open_source" caption="Custom interactive content" alt="Interactive demonstration of the API"}
-
-```markdown
-::scalar-embed{ src="https://en.wikipedia.org/wiki/Open_source" caption="Custom interactive content" alt="Interactive demonstration of the API"}
-```
-</scalar-tab>
-</scalar-tabs>

--- a/documentation/guides/docs/components/icons.md
+++ b/documentation/guides/docs/components/icons.md
@@ -32,9 +32,6 @@ The display size of the icon as a CSS width/height value. This controls how larg
 
 ### Basic Icon
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-icon
   src="check-circle"
   title="Success indicator">
@@ -47,23 +44,7 @@ The display size of the icon as a CSS width/height value. This controls how larg
 </scalar-icon>
 ```
 
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-icon{ src="check-circle" title="Success indicator" }
-
-```markdown
-::scalar-icon{ src="check-circle" title="Success indicator" }
-```
-
-</scalar-tab>
-</scalar-tabs>
-
 ### Icon with Custom Classes
-
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
 
 <scalar-icon
   src="warning"
@@ -79,23 +60,7 @@ The display size of the icon as a CSS width/height value. This controls how larg
 </scalar-icon>
 ```
 
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-icon{ src="warning" title="Warning message" class="text-yellow-500 mr-2" }
-
-```markdown
-::scalar-icon{ src="warning" title="Warning message" class="text-yellow-500 mr-2" }
-```
-
-</scalar-tab>
-</scalar-tabs>
-
 ### Sized Icon
-
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
 
 <scalar-icon
   src="info"
@@ -112,25 +77,9 @@ The display size of the icon as a CSS width/height value. This controls how larg
   class="text-blue-600">
 </scalar-icon>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-icon{ src="info" title="Information" size="24px" class="text-blue-600" }
-
-```markdown
-::scalar-icon{ src="info" title="Information" size="24px" class="text-blue-600" }
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Different Size Units
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-icon
   src="star"
   title="Small icon"
@@ -168,35 +117,11 @@ The display size of the icon as a CSS width/height value. This controls how larg
   size="2rem">
 </scalar-icon>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-icon{ src="star" title="Small icon" size="16px" }
-
-::scalar-icon{ src="star" title="Medium icon" size="1.5em" }
-
-::scalar-icon{ src="star" title="Large icon" size="2rem" }
-
-```markdown
-::scalar-icon{ src="star" title="Small icon" size="16px" }
-
-::scalar-icon{ src="star" title="Medium icon" size="1.5em" }
-
-::scalar-icon{ src="star" title="Large icon" size="2rem" }
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Icon from URL
 
 Icons can load from external URLs, supporting both SVG files and regular image formats (PNG, JPG, etc.).
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-icon
   src="https://avatars.githubusercontent.com/u/301879?s=200&v=4"
   title="Custom icon from URL"
@@ -212,16 +137,3 @@ Icons can load from external URLs, supporting both SVG files and regular image f
   size="4em">
 </scalar-icon>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-icon{ src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" title="Custom icon from URL" class="icon-custom" size="4em" }
-
-```markdown
-::scalar-icon{ src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" title="Custom icon from URL" class="icon-custom" size="4em" }
-```
-
-</scalar-tab>
-</scalar-tabs>

--- a/documentation/guides/docs/components/images.md
+++ b/documentation/guides/docs/components/images.md
@@ -70,9 +70,6 @@ Defaults to `actual`.
 
 ### Basic Image
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-image
   src="https://avatars.githubusercontent.com/u/6176314?v=4"
   alt="Application screenshot">
@@ -84,25 +81,9 @@ Defaults to `actual`.
   alt="Application screenshot">
 </scalar-image>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-image{ src="https://avatars.githubusercontent.com/u/6176314?v=4" alt="Application screenshot" }
-
-```markdown
-::scalar-image{ src="https://avatars.githubusercontent.com/u/6176314?v=4" alt="Application screenshot" }
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Image with Caption
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-image
   src="https://avatars.githubusercontent.com/u/6176314?v=4"
   alt="System architecture diagram"
@@ -116,25 +97,9 @@ Defaults to `actual`.
   caption="High-level system architecture showing data flow">
 </scalar-image>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-image{ src="https://avatars.githubusercontent.com/u/6176314?v=4" alt="System architecture diagram" caption="High-level system architecture showing data flow" }
-
-```html
-::scalar-image{ src="https://avatars.githubusercontent.com/u/6176314?v=4" alt="System architecture diagram" caption="High-level system architecture showing data flow" }
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Clickable Image
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-image
   src="https://avatars.githubusercontent.com/u/301879?s=200&v=4"
   alt="Click to view full size"
@@ -150,25 +115,9 @@ Defaults to `actual`.
   caption="Click to access the link">
 </scalar-image>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-image{ src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" alt="Click to view full size" href="https://github.com/scalar/scalar" caption="Click to access the link" }
-
-```markdown
-::scalar-image{ src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" alt="Click to view full size" href="https://github.com/scalar/scalar" caption="Click to access the link" }
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Custom Sized Image
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-image
   src="https://avatars.githubusercontent.com/u/301879?s=200&v=4"
   alt="Company logo"
@@ -186,25 +135,9 @@ Defaults to `actual`.
   caption="Company branding">
 </scalar-image>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-image{ src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" alt="Company logo" width="200" height="100" caption="Company branding" }
-
-```markdown
-::scalar-image{ src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" alt="Company logo" width="200" height="100" caption="Company branding" }
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Dark Mode Image
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-image
   src="https://avatars.githubusercontent.com/u/301879?s=200&v=4"
   src-dark="https://avatars.githubusercontent.com/u/6176314?s=200&v=4"
@@ -220,25 +153,9 @@ Defaults to `actual`.
   caption="Automatically adapts to user's theme preference">
 </scalar-image>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-image{ src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" src-dark="https://avatars.githubusercontent.com/u/6176314?s=200&v=4" alt="Theme-aware illustration" caption="Automatically adapts to user's theme preference" }
-
-```markdown
-::scalar-image{ src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" src-dark="https://avatars.githubusercontent.com/u/6176314?s=200&v=4" alt="Theme-aware illustration" caption="Automatically adapts to user's theme preference" }
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Full Width Image
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-image
   src="https://pbs.twimg.com/profile_banners/1599772885857538051/1740351609/1500x500"
   alt="Hero section background"
@@ -255,23 +172,7 @@ Defaults to `actual`.
 </scalar-image>
 ```
 
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-image{ src="https://pbs.twimg.com/profile_banners/1599772885857538051/1740351609/1500x500" alt="Hero section background" size="full" caption="Full-width hero image" }
-
-```markdown
-::scalar-image{ src="https://pbs.twimg.com/profile_banners/1599772885857538051/1740351609/1500x500" alt="Hero section background" size="full" caption="Full-width hero image" }
-```
-
-</scalar-tab>
-</scalar-tabs>
-
 ### Relative Path Link
-
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
 
 <scalar-image
   src="/hero_1500x500.jpeg"
@@ -288,18 +189,6 @@ Defaults to `actual`.
   caption="Relative path Full-width hero image">
 </scalar-image>
 ```
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-image{ src="/hero_1500x500.jpeg" alt="Hero section background" size="full" caption="Full-width hero image" }
-
-```markdown
-::scalar-image{ src="/hero_1500x500.jpeg" alt="Hero section background" size="full" caption="Full-width hero image" }
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 <scalar-callout type="info"> The path is relative based on the configured  `assetsDir`. </scalar-callout>
 
@@ -309,5 +198,3 @@ Defaults to `actual`.
   "assetsDir": "documentation/assets"
 }
 ```
-
-

--- a/documentation/guides/docs/components/math.md
+++ b/documentation/guides/docs/components/math.md
@@ -18,9 +18,6 @@ A descriptive caption for the equation. This appears below the rendered math and
 
 ### Basic Math Equation
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-math equation="x^2 + y^2 = z^2">
 </scalar-math>
 
@@ -28,25 +25,9 @@ A descriptive caption for the equation. This appears below the rendered math and
 <scalar-math equation="x^2 + y^2 = z^2">
 </scalar-math>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-math{ equation="x^2 + y^2 = z^2"}
-
-```markdown
-::scalar-math{ equation="x^2 + y^2 = z^2"}
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Math with Caption
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-math 
   equation="E = mc^2"
   caption="Einstein's mass-energy equivalence">
@@ -58,23 +39,9 @@ A descriptive caption for the equation. This appears below the rendered math and
   caption="Einstein's mass-energy equivalence">
 </scalar-math>
 ```
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-math{ equation="E = mc^2" caption="Einstein's mass-energy equivalence" }
-
-```markdown
-::scalar-math{ equation="E = mc^2" caption="Einstein's mass-energy equivalence" }
-```
-</scalar-tab>
-</scalar-tabs>
 
 ### Complex Mathematical Expression
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-math 
   equation="\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}"
   caption="Gaussian integral">
@@ -86,23 +53,9 @@ A descriptive caption for the equation. This appears below the rendered math and
   caption="Gaussian integral">
 </scalar-math>
 ```
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-math{ equation="\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}" caption="Gaussian integral" }
-
-```html
-::scalar-math{ equation="\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}" caption="Gaussian integral" }
-```
-</scalar-tab>
-</scalar-tabs>
 
 ### Matrix Equation
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-math 
   equation="\begin{pmatrix} a & b \\ c & d \end{pmatrix} \begin{pmatrix} x \\ y \end{pmatrix} = \begin{pmatrix} e \\ f \end{pmatrix}"
   caption="System of linear equations in matrix form">
@@ -114,14 +67,3 @@ A descriptive caption for the equation. This appears below the rendered math and
   caption="System of linear equations in matrix form">
 </scalar-math>
 ```
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-math{ equation="\begin{pmatrix} a & b \\ c & d \end{pmatrix} \begin{pmatrix} x \\ y \end{pmatrix} = \begin{pmatrix} e \\ f \end{pmatrix}" caption="System of linear equations in matrix form" }
-
-```html
-::scalar-math{ equation="\begin{pmatrix} a & b \\ c & d \end{pmatrix} \begin{pmatrix} x \\ y \end{pmatrix} = \begin{pmatrix} e \\ f \end{pmatrix}" caption="System of linear equations in matrix form" }
-```
-</scalar-tab>
-</scalar-tabs>

--- a/documentation/guides/docs/components/page-link.md
+++ b/documentation/guides/docs/components/page-link.md
@@ -20,9 +20,6 @@ Secondary text shown below the title. Defaults to `"Link to a page in the guide"
 
 ### Link with Path Only
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-page-link filepath="documentation/guides/docs/components/row.md">
 </scalar-page-link>
 
@@ -30,26 +27,9 @@ Secondary text shown below the title. Defaults to `"Link to a page in the guide"
 <scalar-page-link filepath="documentation/guides/docs/components/row.md">
 </scalar-page-link>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-page-link{filepath="documentation/guides/docs/components/row.md"}
-
-```markdown
-::scalar-page-link{filepath="documentation/guides/docs/components/row.md"}
-```
-
-</scalar-tab>
-</scalar-tabs>
-
 
 ### Link with Path and Title
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-page-link filepath="documentation/guides/docs/components/row.md" title="Row Docs" description="">
 </scalar-page-link>
 
@@ -57,25 +37,9 @@ Secondary text shown below the title. Defaults to `"Link to a page in the guide"
 <scalar-page-link filepath="documentation/guides/docs/components/row.md" title="Row Docs" description="">
 </scalar-page-link>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-page-link{filepath="documentation/guides/docs/components/row.md" title="Row Docs" description=""}
-
-```markdown
-::scalar-page-link{filepath="documentation/guides/docs/components/row.md" title="Row Docs" description=""}
-```
-
-</scalar-tab>
-</scalar-tabs>
 
 ### Link with Path, Title and Description
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-page-link filepath="documentation/guides/docs/components/row.md" title="Row Docs" description="Row component documentation">
 </scalar-page-link>
 
@@ -83,17 +47,3 @@ Secondary text shown below the title. Defaults to `"Link to a page in the guide"
 <scalar-page-link filepath="documentation/guides/docs/components/row.md" title="Row Docs" description="Row component documentation">
 </scalar-page-link>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::scalar-page-link{filepath="documentation/guides/docs/components/row.md" title="Row Docs" description="Row component documentation"}
-
-```markdown
-::scalar-page-link{filepath="documentation/guides/docs/components/row.md" title="Row Docs" description="Row component documentation"}
-```
-
-</scalar-tab>
-</scalar-tabs>
-

--- a/documentation/guides/docs/components/row.md
+++ b/documentation/guides/docs/components/row.md
@@ -11,9 +11,6 @@ This component does not accept any attributes.
 
 ### Row of Cards
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-row>
 <scalar-card icon="solid/basic-shape-hexagon" title="The Title of the Card">
 
@@ -45,36 +42,3 @@ Card with title, body, and icon.
 </scalar-card>
 </scalar-row>
 ```
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::::scalar-row
-:::scalar-card{icon="solid/basic-shape-hexagon" title="The Title of the Card"}
-Card with title, body, and icon.
-:::
-:::scalar-card{icon="solid/basic-shape-hexagon" title="The Title of the Card"}
-Card with title, body, and icon.
-:::
-:::scalar-card{icon="solid/basic-shape-hexagon" title="The Title of the Card"}
-Card with title, body, and icon.
-:::
-::::
-
-```markdown
-::::scalar-row
-:::scalar-card{icon="solid/basic-shape-hexagon" title="The Title of the Card"}
-Card with title, body, and icon.
-:::
-:::scalar-card{icon="solid/basic-shape-hexagon" title="The Title of the Card"}
-Card with title, body, and icon.
-:::
-:::scalar-card{icon="solid/basic-shape-hexagon" title="The Title of the Card"}
-Card with title, body, and icon.
-:::
-::::
-```
-</scalar-tab>
-</scalar-tabs>
-

--- a/documentation/guides/docs/components/steps.md
+++ b/documentation/guides/docs/components/steps.md
@@ -36,9 +36,6 @@ The position of this step within a steps container. Used internally for step ord
 
 ### Basic Step
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-step id="step-1" title="Install Dependencies">
 First, install the required dependencies by running:
   
@@ -56,35 +53,9 @@ npm install @scalar/guide-elements
 ```
 </scalar-step>
 ````
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-:::scalar-step{ id="step-1" title="Install Dependencies"}
-First, install the required dependencies by running:
-  
-```bash
-npm install @scalar/guide-elements
-```
-:::
-
-````markdown
-:::scalar-step{ id="step-1" title="Install Dependencies"}
-First, install the required dependencies by running:
-
-```bash
-npm install @scalar/guide-elements
-```
-:::
-````
-</scalar-tab>
-</scalar-tabs>
 
 ### Static Step (Non-collapsible)
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-step 
   id="step-2" 
   title="Configuration" 
@@ -116,42 +87,9 @@ const config = {
 
 </scalar-step>
 ````
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-:::scalar-step{ id="step-2" title="Configuration" interactivity="none" }
-This step cannot be collapsed and is always visible.
-
-```javascript
-const config = {
-  theme: 'dark',
-  interactive: false,
-}
-```
-:::
-
-````markdown
-::scalar-step{ id="step-2" title="Configuration" interactivity="none" }
-This step cannot be collapsed and is always visible.
-
-```javascript
-const config = {
-  theme: 'dark',
-  interactive: false,
-}
-```
-:::
-````
-</scalar-tab>
-</scalar-tabs>
 
 ### Steps Container
 
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
-
 <scalar-steps>
   <scalar-step id="step-1" title="Setup Project">
 Initialize a new project:
@@ -209,63 +147,3 @@ npm start
   </scalar-step>
 </scalar-steps>
 ````
-
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::::scalar-steps
-:::scalar-step{ id="step-1" title="Setup Project" }
-Initialize a new project:
-```bash
-mkdir my-project
-cd my-project
-npm init -y
-```
-:::  
-
-:::scalar-step{ id="step-2" title="Install Dependencies" }
-Install the required packages:
-```bash
-npm install react react-dom
-```
-:::
-
-:::scalar-step{ id="step-3" title="Start Development" }
-Begin development:
-
-```bash
-npm start
-```
-:::
-::::
-
-````markdown
-::::scalar-steps
-:::scalar-step{ id="step-1" title="Setup Project" }
-Initialize a new project:
-```bash
-mkdir my-project
-cd my-project
-npm init -y
-```
-:::  
-
-:::scalar-step{ id="step-2" title="Install Dependencies" }
-Install the required packages:
-```bash
-npm install react react-dom
-```
-:::
-
-:::scalar-step{ id="step-3" title="Start Development" }
-Begin development:
-
-```bash
-npm start
-```
-:::
-::::
-````
-</scalar-tab>
-</scalar-tabs>

--- a/documentation/guides/docs/components/tabs.md
+++ b/documentation/guides/docs/components/tabs.md
@@ -25,10 +25,7 @@ The ID of the tab that should be active by default. If not specified, the first 
 
 ### Basic Tabs
 
-<scalar-tabs outer>
-<scalar-tab title="Custom HTML" customHtml>
-<!--The actual tabs, rendered-->
-<scalar-tabs nested>
+<scalar-tabs>
   <scalar-tab title="JavaScript">
 ```javascript
 function greet(name) {
@@ -37,7 +34,7 @@ function greet(name) {
 
 console.log(greet('World'));
 ```
-  </scalar-tab javascript-end>
+  </scalar-tab>
 
   <scalar-tab title="TypeScript">
 ```typescript
@@ -47,7 +44,7 @@ function greet(name: string): string {
 
 console.log(greet('World'));
 ```
-  </scalar-tab typescript-end>
+  </scalar-tab>
 
   <scalar-tab title="Python">
 ```python
@@ -56,12 +53,11 @@ def greet(name):
 
 print(greet("World"))
 ```
-  </scalar-tab python-end>
-</scalar-tabs nested>
+  </scalar-tab>
+</scalar-tabs>
 
-<!--The tabs as raw markdown for display -->
 ````markdown
-<scalar-tabs nested>
+<scalar-tabs>
   <scalar-tab title="JavaScript">
 ```javascript
 function greet(name) {
@@ -70,7 +66,7 @@ function greet(name) {
 
 console.log(greet('World'));
 ```
-  </scalar-tab javascript-end>
+  </scalar-tab>
 
   <scalar-tab title="TypeScript">
 ```typescript
@@ -80,7 +76,7 @@ function greet(name: string): string {
 
 console.log(greet('World'));
 ```
-  </scalar-tab typescript-end>
+  </scalar-tab>
 
   <scalar-tab title="Python">
 ```python
@@ -89,119 +85,11 @@ def greet(name):
 
 print(greet("World"))
 ```
-  </scalar-tab python-end>
-</scalar-tabs nested>
+  </scalar-tab>
+</scalar-tabs>
 ````
-</scalar-tab customHtml>
-
-<scalar-tab title="Directive" directive>
-<!--The actual tabs, rendered-->
-::::scalar-tabs
-:::scalar-tab{ title="Rust" }
-
-```rust
-fn greet(name: &str) -> String {
-    format!("Hello, {}!", name)
-}
-
-fn main() {
-    println!("{}", greet("World"));
-}
-```
-:::
-:::scalar-tab{ title="Go" }
-
-```go
-package main
-
-import (
-    "fmt"
-)
-
-func greet(name string) string {
-    return fmt.Sprintf("Hello, %s!", name)
-}
-
-func main() {
-    fmt.Println(greet("World"))
-}
-```
-:::
-:::scalar-tab{ title="C++" }
-
-```cpp
-#include <iostream>
-#include <string>
-
-std::string greet(const std::string& name) {
-    return "Hello, " + name + "!";
-}
-
-int main() {
-    std::cout << greet("World") << std::endl;
-    return 0;
-}
-```
-:::
-::::
-
-<!--The tabs as raw markdown for display -->
-````markdown
-::::scalar-tabs
-:::scalar-tab{ title="Rust" }
-
-```rust
-fn greet(name: &str) -> String {
-    format!("Hello, {}!", name)
-}
-
-fn main() {
-    println!("{}", greet("World"));
-}
-```
-:::
-:::scalar-tab{ title="Go" }
-
-```go
-package main
-
-import (
-    "fmt"
-)
-
-func greet(name string) string {
-    return fmt.Sprintf("Hello, %s!", name)
-}
-
-func main() {
-    fmt.Println(greet("World"))
-}
-```
-:::
-:::scalar-tab{ title="C++" }
-
-```cpp
-#include <iostream>
-#include <string>
-
-std::string greet(const std::string& name) {
-    return "Hello, " + name + "!";
-}
-
-int main() {
-    std::cout << greet("World") << std::endl;
-    return 0;
-}
-```
-:::
-::::
-````
-</scalar-tab directive>
-</scalar-tabs outer>
 
 ### Tabs with Default Selection
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
 
 <scalar-tabs default="TypeScript">
   <scalar-tab title="JavaScript">
@@ -244,74 +132,8 @@ int main() {
   </scalar-tab>
 </scalar-tabs>
 ````
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::::scalar-tabs{ default="TypeScript" }
-:::scalar-tab{ title="JavaScript" }
-
-  ```javascript
-  const user = {
-    name: "John",
-    age: 30
-  };
-  ```
-::: 
-
-:::scalar-tab{ title="TypeScript" }
-
-  ```typescript
-  interface User {
-    name: string;
-    age: number;
-  }
-  
-  const user: User = {
-    name: "John",
-    age: 30
-  };
-  ```
-:::
-::::
-
-````markdown
-::::scalar-tabs{ default="TypeScript" }
-:::scalar-tab{ title="JavaScript" }
-
-  ```javascript
-  const user = {
-    name: "John",
-    age: 30
-  };
-  ```
-::: 
-
-:::scalar-tab{ title="TypeScript" }
-
-  ```typescript
-  interface User {
-    name: string;
-    age: number;
-  }
-  
-  const user: User = {
-    name: "John",
-    age: 30
-  };
-  ```
-:::
-::::
-````
-</scalar-tab>
-</scalar-tabs>
-</scalar-tabs>
-
 
 ### Tabs with Mixed Content
-
-<scalar-tabs>
-<scalar-tab title="Custom HTML">
 
 <scalar-tabs>
   <scalar-tab title="Overview">
@@ -363,68 +185,3 @@ int main() {
   </scalar-tab>
 </scalar-tabs>
 ````
-</scalar-tab>
-
-<scalar-tab title="Directive">
-
-::::scalar-tabs
-:::scalar-tab{ title="Overview" }
-This is the overview tab with plain text content.
-
-You can include **markdown** formatting and other elements.
-:::
-
-:::scalar-tab{ title="Code Example" }
-
-```bash
-npm install @scalar/guide-elements
-```
-
-This tab contains a code example with additional text.
-:::
-
-:::scalar-tab{ title="Configuration" }
-
-```json
-{
-  "theme": "dark",
-  "interactive": true,
-  "features": ["tabs", "steps", "callouts"]
-}
-```
-:::
-::::
-
-````html
-::::scalar-tabs
-:::scalar-tab{ title="Overview" }
-This is the overview tab with plain text content.
-
-You can include **markdown** formatting and other elements.
-:::
-
-:::scalar-tab{ title="Code Example" }
-
-```bash
-npm install @scalar/guide-elements
-```
-
-This tab contains a code example with additional text.
-:::
-
-:::scalar-tab{ title="Configuration" }
-
-```json
-{
-  "theme": "dark",
-  "interactive": true,
-  "features": ["tabs", "steps", "callouts"]
-}
-```
-:::
-::::
-````
-
-</scalar-tab>
-</scalar-tabs>
-

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -20,9 +20,8 @@
 
 ## Getting Started
 
-:::scalar-callout{ type=info }
-SDK generation is part of our paid plans and costs $100 per month per language. Keep this in mind when selecting which languages you'd like to generate SDKs for.
-:::
+> [!NOTE]
+> SDK generation is part of our paid plans and costs $100 per month per language. Keep this in mind when selecting which languages you'd like to generate SDKs for.
 
 Make sure you have created a Scalar Account & are logged in ([see create account guide](../registry/getting-started.md#create-your-scalar-account))
 

--- a/documentation/integrations/aspire.md
+++ b/documentation/integrations/aspire.md
@@ -192,9 +192,8 @@ var scalar = builder.AddScalarApiReference(options =>
 });
 ```
 
-:::scalar-callout{ type=warning }
-The `AllowSelfSignedCertificates()` method should only be used in development environments, never in production.
-:::
+> [!WARNING]
+> The `AllowSelfSignedCertificates()` method should only be used in development environments, never in production.
 
 ### How HTTPS Support Works
 
@@ -204,9 +203,8 @@ The `AllowSelfSignedCertificates()` method should only be used in development en
 - **Certificate Validation**: Self-signed certificates can be trusted in development using `AllowSelfSignedCertificates()`
 - **Fallback Behavior**: If HTTPS is preferred but unavailable, HTTP endpoints are used as fallback. Conversely, if no HTTP endpoint is available, HTTPS endpoints are automatically used
 
-:::scalar-callout{ type=info }
-Currently, the API Reference interface is hosted over HTTP, even when communicating with HTTPS services. Support for hosting the Scalar interface under HTTPS will be added in a future release.
-:::
+> [!NOTE]
+> Currently, the API Reference interface is hosted over HTTP, even when communicating with HTTPS services. Support for hosting the Scalar interface under HTTPS will be added in a future release.
 
 ## Proxy Configuration
 
@@ -278,9 +276,8 @@ var scalar = builder.AddScalarApiReference(options =>
 });
 ```
 
-:::scalar-callout{ type=info }
-When the proxy is enabled, OAuth token requests are automatically proxied through the Scalar proxy to avoid CORS issues. However, interactive authorization requests are not proxied since they occur directly in the browser, so authorization URLs must be correctly configured and accessible. See the [Aspire playground on GitHub](https://github.com/scalar/scalar/blob/main/integrations/dotnet/aspire/playground/Scalar.Aspire.BookService/Program.cs#L15-L21).
-:::
+> [!NOTE]
+> When the proxy is enabled, OAuth token requests are automatically proxied through the Scalar proxy to avoid CORS issues. However, interactive authorization requests are not proxied since they occur directly in the browser, so authorization URLs must be correctly configured and accessible. See the [Aspire playground on GitHub](https://github.com/scalar/scalar/blob/main/integrations/dotnet/aspire/playground/Scalar.Aspire.BookService/Program.cs#L15-L21).
 
 ### Service-Specific Authentication
 

--- a/documentation/integrations/aspnetcore/integration.md
+++ b/documentation/integrations/aspnetcore/integration.md
@@ -78,9 +78,8 @@ if (app.Environment.IsDevelopment())
 
 You're all set! 🎉 Navigate to `/scalar` to view your API Reference.
 
-:::scalar-callout{ type=info }
-For multiple OpenAPI documents, see [Multiple OpenAPI Documents](#configuration-options__multiple-openapi-documents).
-:::
+> [!NOTE]
+> For multiple OpenAPI documents, see [Multiple OpenAPI Documents](#configuration-options__multiple-openapi-documents).
 
 ## MapScalarApiReference Overloads
 
@@ -232,9 +231,8 @@ The `isDefault` parameter allows you to specify which document should be selecte
 
 You can also specify a document name directly in the URL path (e.g., `/scalar/v1`). However, this will override the document names specified in the `AddDocument` or `AddDocuments` methods.
 
-:::scalar-callout{ type=info }
-**Note on case sensitivity**: Scalar forwards document names to the OpenAPI generator exactly as they appear in the URL path or as they are defined, preserving the case. The behavior depends on whether your OpenAPI generator treats document names as case-sensitive. To avoid issues, use consistent casing for document names (e.g., lowercase `"v1"`).
-:::
+> [!NOTE]
+> **Note on case sensitivity**: Scalar forwards document names to the OpenAPI generator exactly as they appear in the URL path or as they are defined, preserving the case. The behavior depends on whether your OpenAPI generator treats document names as case-sensitive. To avoid issues, use consistent casing for document names (e.g., lowercase `"v1"`).
 
 ### Agent
 
@@ -268,15 +266,13 @@ For more details, see [Agent](../../configuration.md#agent) and [How to get an A
 Scalar allows you to pre-configure authentication details for your API, making it easier for developers to test your endpoints. Scalar supports API Key, OAuth2, and HTTP authentication schemes.
 
 
-:::scalar-callout{ type=warning }
-**Before you start**: Your OpenAPI document must already include authentication security schemes for Scalar to work with them. Scalar can only pre-fill authentication details for schemes that are already defined in your OpenAPI specification.
+> [!WARNING]
+> **Before you start**: Your OpenAPI document must already include authentication security schemes for Scalar to work with them. Scalar can only pre-fill authentication details for schemes that are already defined in your OpenAPI specification.
+>
+> The security schemes are added by your OpenAPI generator (`NSwag.AspNetCore`, `Swashbuckle.AspNetCore.SwaggerGen`, or `Microsoft.AspNetCore.OpenApi`). If you don't see authentication options in Scalar, check your OpenAPI generator's documentation to learn how to properly define security schemes.
 
-The security schemes are added by your OpenAPI generator (`NSwag.AspNetCore`, `Swashbuckle.AspNetCore.SwaggerGen`, or `Microsoft.AspNetCore.OpenApi`). If you don't see authentication options in Scalar, check your OpenAPI generator's documentation to learn how to properly define security schemes.
-:::
-
-:::scalar-callout{ type=danger }
-**Security Notice**: Pre-filled authentication details are visible in the browser and should **never** be used in production environments. Only use this feature for development and testing.
-:::
+> [!CAUTION]
+> **Security Notice**: Pre-filled authentication details are visible in the browser and should **never** be used in production environments. Only use this feature for development and testing.
 
 
 #### API Key Authentication
@@ -453,9 +449,8 @@ app.MapScalarApiReference(options => options
     .EnablePersistentAuthentication());
 ```
 
-:::scalar-callout{ type=danger }
-Persisting authentication information in the browser's local storage may present security risks. Use with caution.
-:::
+> [!CAUTION]
+> Persisting authentication information in the browser's local storage may present security risks. Use with caution.
 
 ### Custom HTTP Client
 
@@ -479,9 +474,8 @@ app.MapScalarApiReference(options =>
 });
 ```
 
-:::scalar-callout{ type=info }
-Fonts are loaded from a CDN by default. To disable this, use `DisableDefaultFonts()`.
-:::
+> [!NOTE]
+> Fonts are loaded from a CDN by default. To disable this, use `DisableDefaultFonts()`.
 
 ### Custom JavaScript Configuration
 
@@ -510,9 +504,8 @@ export default {
 }
 ```
 
-:::scalar-callout{ type=info }
-Make sure to expose the directory that contains your JavaScript module through static file middleware using `app.MapStaticAssets()` or `app.UseStaticFiles()`.
-:::
+> [!NOTE]
+> Make sure to expose the directory that contains your JavaScript module through static file middleware using `app.MapStaticAssets()` or `app.UseStaticFiles()`.
 
 ### Dependency Injection
 
@@ -524,9 +517,8 @@ builder.Services.Configure<ScalarOptions>(options => options.Title = "My API");
 builder.Services.AddOptions<ScalarOptions>().BindConfiguration("Scalar");
 ```
 
-:::scalar-callout{ type=info }
-Options set via `MapScalarApiReference` override those set through dependency injection.
-:::
+> [!NOTE]
+> Options set via `MapScalarApiReference` override those set through dependency injection.
 
 ## Additional Information
 

--- a/documentation/integrations/aspnetcore/openapi-extensions.md
+++ b/documentation/integrations/aspnetcore/openapi-extensions.md
@@ -65,9 +65,8 @@ app.MapGet("/internal/metrics", GetMetrics).ExcludeFromApiReference();
 public IActionResult GetInternalMetrics() => Ok();
 ```
 
-:::scalar-callout{ type=info }
-Endpoints remain accessible via the API but won't appear in the API Reference interface.
-:::
+> [!NOTE]
+> Endpoints remain accessible via the API but won't appear in the API Reference interface.
 
 ### Code Samples
 

--- a/documentation/integrations/django.md
+++ b/documentation/integrations/django.md
@@ -2,9 +2,8 @@
 
 Community member [m1guer](https://github.com/m1guer/django-scalar) wrote code to use the API Reference in a Django project built with Django Rest Framework.
 
-:::scalar-callout{ type=info }
-If you are using Django Ninja, then follow the [Django Ninja guide](django-ninja.md) instead.
-:::
+> [!NOTE]
+> If you are using Django Ninja, then follow the [Django Ninja guide](django-ninja.md) instead.
 
 ## Basic Setup
 

--- a/documentation/integrations/fastify.md
+++ b/documentation/integrations/fastify.md
@@ -295,9 +295,8 @@ await fastify.register(ScalarApiReference, {
 // …
 ```
 
-:::scalar-callout{ type=info }
-It's not really a problem to have an `import` statement in the middle of your file, it's not really common, though. Feel free to move it to the top of your files, where `import` statements usually live.
-:::
+> [!NOTE]
+> It's not really a problem to have an `import` statement in the middle of your file, it's not really common, though. Feel free to move it to the top of your files, where `import` statements usually live.
 
 Wow, this is it already. Restart the server, if it didn't already and take a look at your new API reference:
 
@@ -330,9 +329,8 @@ TypeScript should give you a nice autocomplete for all options. If you're more i
 
 Auto-generated OpenAPI files are great, but some OpenAPI purists argue it's worth to handcraft your OpenAPI files. If you're one of them, feel free to just pass an URL to your existing OpenAPI file:
 
-:::scalar-callout{ type=info }
-If you don't use `@fastify/swagger` to generate and serve an OpenAPI specification, you need to serve it manually. [To serve static files, try @fastify/static](https://github.com/fastify/fastify-static).
-:::
+> [!NOTE]
+> If you don't use `@fastify/swagger` to generate and serve an OpenAPI specification, you need to serve it manually. [To serve static files, try @fastify/static](https://github.com/fastify/fastify-static).
 
 ```javascript
 import ScalarApiReference from '@scalar/fastify-api-reference'

--- a/documentation/integrations/java.md
+++ b/documentation/integrations/java.md
@@ -10,11 +10,10 @@ The Scalar Java integration consists of **3 separate modules**:
 - **`scalar-webmvc`** - Spring Boot WebMVC integration module
 - **`scalar-webflux`** - Spring Boot WebFlux integration module
 
-:::scalar-callout{ type=warning }
-**Breaking Change**: Previously, there was only a single `scalar` module that was compatible with Spring Boot MVC. The integration has been restructured into 3 separate modules to support both WebMVC and WebFlux, and to provide a framework-agnostic core module.
-
-**Migration**: If you were using the old `scalar` module, replace it with `scalar-webmvc` for Spring Boot WebMVC applications. See the [Migration Guide](#migration-guide) below for details.
-:::
+> [!WARNING]
+> **Breaking Change**: Previously, there was only a single `scalar` module that was compatible with Spring Boot MVC. The integration has been restructured into 3 separate modules to support both WebMVC and WebFlux, and to provide a framework-agnostic core module.
+>
+> **Migration**: If you were using the old `scalar` module, replace it with `scalar-webmvc` for Spring Boot WebMVC applications. See the [Migration Guide](#migration-guide) below for details.
 
 ## Migration Guide
 
@@ -299,13 +298,11 @@ Related: [How to get an Agent key](../guides/agent/key.md).
 
 Scalar allows you to pre-configure authentication details for your API, making it easier for developers to test your endpoints.
 
-:::scalar-callout{ type=warning }
-**Before you start**: Your OpenAPI document must already include authentication security schemes for Scalar to work with them. Scalar can only pre-fill authentication details for schemes that are already defined in your OpenAPI specification.
-:::
+> [!WARNING]
+> **Before you start**: Your OpenAPI document must already include authentication security schemes for Scalar to work with them. Scalar can only pre-fill authentication details for schemes that are already defined in your OpenAPI specification.
 
-:::scalar-callout{ type=danger }
-**Security Notice**: Pre-filled authentication details are visible in the browser and should **never** be used in production environments. Only use this feature for development and testing.
-:::
+> [!CAUTION]
+> **Security Notice**: Pre-filled authentication details are visible in the browser and should **never** be used in production environments. Only use this feature for development and testing.
 
 #### API Key Authentication
 

--- a/documentation/integrations/laravel-scribe.md
+++ b/documentation/integrations/laravel-scribe.md
@@ -2,9 +2,8 @@
 
 Laravel Scribe is an amazing package to generate OpenAPI files from your existing code base. Clumsy annotations aren't required, the package will just analyze your code.
 
-:::scalar-callout{ type=info }
-There's also [Scalar for Laravel](https://github.com/scalar/laravel), which doesn't come with OpenAPI generation, but renders existing OpenAPI documents.
-:::
+> [!NOTE]
+> There's also [Scalar for Laravel](https://github.com/scalar/laravel), which doesn't come with OpenAPI generation, but renders existing OpenAPI documents.
 
 ## Create a new Laravel project (optional)
 

--- a/documentation/integrations/react.md
+++ b/documentation/integrations/react.md
@@ -50,9 +50,8 @@ ApiReference only takes one prop which is the configuration object.
 
 There are [tons of ways to set up a new React project](https://react.dev/learn/start-a-new-react-project). Here is an easy one using [Vite](https://vitejs.dev/) to get you started:
 
-:::scalar-callout{ type=info }
-We're using [pnpm](https://pnpm.io/installation) here. You can also just use npm, yarn or whatever you're used to. ✌️
-:::
+> [!NOTE]
+> We're using [pnpm](https://pnpm.io/installation) here. You can also just use npm, yarn or whatever you're used to. ✌️
 
 ```bash
 pnpm create vite my-awesome-app

--- a/documentation/integrations/spring-boot.md
+++ b/documentation/integrations/spring-boot.md
@@ -1,8 +1,7 @@
 # API Reference for Java Spring Boot
 
-:::scalar-callout{ type=warning }
-**This documentation is obsolete.** The Scalar Java integration has been restructured into a modular approach with separate modules for different Spring Boot variants. Please refer to the [Java integration documentation](java.md) for the current documentation.
-:::
+> [!WARNING]
+> **This documentation is obsolete.** The Scalar Java integration has been restructured into a modular approach with separate modules for different Spring Boot variants. Please refer to the [Java integration documentation](java.md) for the current documentation.
 
 The Scalar WebJar provides automatic integration with Spring Boot applications. It includes auto-configuration that automatically sets up the API reference endpoint with comprehensive configuration options, type-safe enums, and authentication support.
 
@@ -263,17 +262,15 @@ spring.autoconfigure.exclude=com.scalar.maven.webjar.ScalarAutoConfiguration
 
 The Scalar integration supports pre-filling authentication details for API testing and documentation. You can configure API keys, OAuth2 flows, and HTTP authentication schemes to make it easier for developers to test your endpoints.
 
-:::scalar-callout{ type=warning }
-**Before you start**: Your OpenAPI document must already include authentication security schemes for Scalar to work with them. Scalar can only pre-fill authentication details for schemes that are already defined in your OpenAPI specification.
+> [!WARNING]
+> **Before you start**: Your OpenAPI document must already include authentication security schemes for Scalar to work with them. Scalar can only pre-fill authentication details for schemes that are already defined in your OpenAPI specification.
+>
+> **Important**: The security scheme names in your Scalar configuration must exactly match the security scheme names defined in your OpenAPI document. For example, if your OpenAPI document defines a security scheme named `my-oauth-scheme`, your Scalar configuration must use the same name.
+>
+> The security schemes are added by your OpenAPI generator (SpringDoc OpenAPI, Swagger, or similar). If you don't see authentication options in Scalar, check your OpenAPI generator's documentation to learn how to properly define security schemes.
 
-**Important**: The security scheme names in your Scalar configuration must exactly match the security scheme names defined in your OpenAPI document. For example, if your OpenAPI document defines a security scheme named `my-oauth-scheme`, your Scalar configuration must use the same name.
-
-The security schemes are added by your OpenAPI generator (SpringDoc OpenAPI, Swagger, or similar). If you don't see authentication options in Scalar, check your OpenAPI generator's documentation to learn how to properly define security schemes.
-:::
-
-:::scalar-callout{ type=danger }
-**Security Notice**: Pre-filled authentication details are visible in the browser and should **never** be used in production environments. Only use this feature for development and testing.
-:::
+> [!CAUTION]
+> **Security Notice**: Pre-filled authentication details are visible in the browser and should **never** be used in production environments. Only use this feature for development and testing.
 
 ### API Key Authentication
 


### PR DESCRIPTION
directives continue to work, but we won't promote them anymore

this PR
* removes them from the documentation
* and removes the use of it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that remove directive-style examples and switch callouts to standard Markdown admonitions; no runtime code paths are affected.
> 
> **Overview**
> Removes *directive-syntax* examples (`::scalar-*` / `:::scalar-*`) from component docs, leaving only the custom element HTML/markdown usage patterns.
> 
> Updates multiple integration and SDK guide pages to use standard Markdown admonitions (`[!NOTE]`, `[!WARNING]`, `[!CAUTION]`) instead of `scalar-callout` directive blocks, and simplifies the `tabs` component docs by dropping nested “display both syntaxes” examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd12b77a40b1b04f5e514d5ad35339c5bdd07908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->