### PR TITLE
fix(api-reference): cap recursion depth in Schema to avoid freezing on circular $refs

### DIFF
--- a/.changeset/sleepy-poseidons-cap.md
+++ b/.changeset/sleepy-poseidons-cap.md
@@ -1,0 +1,9 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): cap recursion depth in Schema component to prevent freezing on circular `$ref` chains
+
+Adds a `MAX_DEPTH = 10` guard to the `Schema` component, mirroring the fix applied to `@scalar/openapi-to-markdown` in #8757. Schemas that recursively reference themselves — directly, or via a polymorphic discriminator that closes on itself — are well-formed OpenAPI but were causing the api-reference renderer to recurse indefinitely, freezing the browser tab. Past the depth limit the component now renders a `[Circular Reference]` placeholder.
+
+The new `depth?: number` prop is threaded through `Schema`, `SchemaObjectProperties`, `SchemaProperty`, and `SchemaComposition`, and increments only at the recursive boundary (`Schema → Schema`).

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -1,4 +1,5 @@
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
+import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
@@ -731,6 +732,86 @@ describe('Schema', () => {
 
       // Check that the oneOf schema is inheiriting the description correctly
       expect(text).toContain('The date the object was closed in YYYY-MM-DD or ISO 8601 format.')
+    })
+  })
+
+  describe('circular references', () => {
+    /**
+     * Schemas that recursively reference themselves (directly, or via a
+     * polymorphic discriminator that closes on itself) are well-formed
+     * OpenAPI but cause `Schema` to recurse indefinitely and freeze the
+     * browser. Past `MAX_DEPTH`, the component must bail out with a
+     * placeholder instead of recursing.
+     */
+    it('renders [Circular Reference] when depth has reached MAX_DEPTH', () => {
+      const wrapper = mount(Schema, {
+        props: {
+          options: {},
+          eventBus: null,
+          // A value that's safely past any sane MAX_DEPTH. If we ever raise
+          // the limit above 99 this still triggers the bail-out, which is the
+          // behavior we're asserting.
+          depth: 99,
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+          }),
+        },
+      })
+
+      // The placeholder is rendered…
+      expect(wrapper.text()).toContain('[Circular Reference]')
+      // …and the normal schema rendering does not happen (no recursion past
+      // the cap).
+      expect(wrapper.html()).not.toContain('schema-card--level-')
+    })
+
+    it('renders normally when depth is below MAX_DEPTH', () => {
+      const wrapper = mount(Schema, {
+        props: {
+          options: {},
+          eventBus: null,
+          depth: 0,
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+          }),
+        },
+      })
+
+      // Normal rendering, no placeholder
+      expect(wrapper.text()).not.toContain('[Circular Reference]')
+      // Normal schema-card classes are present
+      expect(wrapper.html()).toContain('schema-card--level-')
+    })
+
+    it('does not freeze on a self-referencing schema', () => {
+      // Recursive object: children.items points back to the parent. The
+      // current `Schema` renderer does not internally resolve `$ref`s in
+      // inline schemas, so the relevant guarantee here is just that the
+      // mount completes (no infinite recursion / call-stack overflow) when
+      // the same object graph is reachable from itself.
+      const children: { type: 'array'; items?: unknown } = { type: 'array' }
+      const recursive = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          children,
+        },
+      }
+      // Close the cycle: `children.items` points back at the parent schema.
+      children.items = recursive
+
+      // This must not throw a "Maximum call stack size exceeded" error.
+      expect(() =>
+        mount(Schema, {
+          props: {
+            options: {},
+            eventBus: null,
+            schema: recursive as unknown as SchemaObject,
+          },
+        }),
+      ).not.toThrow()
     })
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -17,9 +17,23 @@ import SchemaHeading from './SchemaHeading.vue'
 import SchemaObjectProperties from './SchemaObjectProperties.vue'
 import SchemaProperty from './SchemaProperty.vue'
 
+/**
+ * Max recursion depth for nested schemas.
+ *
+ * Recursive `$ref`s — a schema that references itself (directly or via a
+ * polymorphic discriminator that closes on itself) — are well-formed
+ * OpenAPI, but cause this component to recurse indefinitely and freeze the
+ * browser tab. When the limit is reached we render a `[Circular Reference]`
+ * placeholder instead.
+ *
+ * Mirrors `packages/openapi-to-markdown/src/components/Schema.vue` (#8757).
+ */
+const MAX_DEPTH = 10
+
 const {
   schema,
   level = 0,
+  depth = 0,
   name,
   compact,
   noncollapsible = false,
@@ -35,6 +49,12 @@ const {
   schema?: SchemaObject
   /** Track how deep we've gone */
   level?: number
+  /**
+   * Recursion depth, used to bail out of circular `$ref` chains.
+   * Only incremented where one `Schema` renders another `Schema`
+   * (in `SchemaProperty` and `SchemaComposition`).
+   */
+  depth?: number
   /* Show as a heading */
   name?: string
   /** A tighter layout with less borders and without a heading */
@@ -103,8 +123,13 @@ const schemaDescription = computed(() => {
 const handleClick = (e: MouseEvent) => noncollapsible && e.stopPropagation()
 </script>
 <template>
+  <div
+    v-if="depth >= MAX_DEPTH"
+    class="schema-card schema-card--circular">
+    <em>[Circular Reference]</em>
+  </div>
   <Disclosure
-    v-if="typeof schema === 'object' && Object.keys(schema).length"
+    v-else-if="typeof schema === 'object' && Object.keys(schema).length"
     v-slot="{ open }"
     :defaultOpen="noncollapsible">
     <div
@@ -193,6 +218,7 @@ const handleClick = (e: MouseEvent) => noncollapsible && e.stopPropagation()
             :breadcrumb
             :compact
             :compositionPath="compositionPath"
+            :depth
             :discriminator
             :eventBus="eventBus"
             :hideHeading
@@ -208,6 +234,7 @@ const handleClick = (e: MouseEvent) => noncollapsible && e.stopPropagation()
               :breadcrumb
               :compact
               :compositionPath="compositionPath"
+              :depth
               :eventBus="eventBus"
               :hideHeading
               :hideModelNames
@@ -352,5 +379,10 @@ button.schema-card-title:hover {
 }
 .children .schema-card-description:first-of-type {
   padding-top: 0;
+}
+.schema-card--circular {
+  padding: 6px 8px;
+  color: var(--scalar-color-2);
+  font-size: var(--scalar-mini);
 }
 </style>

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -34,6 +34,11 @@ const props = withDefaults(
     schema: SchemaObject
     /** Nesting level for proper indentation */
     level: number
+    /**
+     * Recursion depth, threaded through to inner `Schema` components
+     * (incremented when we render `Schema`).
+     */
+    depth?: number
     /** Whether to use compact layout */
     compact?: boolean
     /** Whether to hide the heading */
@@ -53,6 +58,7 @@ const props = withDefaults(
   }>(),
   {
     compact: false,
+    depth: 0,
     hideHeading: false,
   },
 )
@@ -178,6 +184,7 @@ if (
       :breadcrumb="breadcrumb"
       :compact="compact"
       :compositionPath="compositionPath"
+      :depth="depth + 1"
       :discriminator="discriminator"
       :eventBus="eventBus"
       :hideHeading="hideHeading"
@@ -232,6 +239,7 @@ if (
           :breadcrumb="breadcrumb"
           :compact="compact"
           :compositionPath="compositionPath"
+          :depth="depth + 1"
           :discriminator="discriminator"
           :eventBus="eventBus"
           :hideHeading="hideHeading"

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
@@ -22,6 +22,8 @@ const { schema, discriminator, options, schemaContext, compositionPath } =
     compact?: boolean
     hideHeading?: boolean
     level?: number
+    /** Recursion depth, threaded through to inner `Schema` components. */
+    depth?: number
     hideModelNames?: boolean
     breadcrumb?: string[]
     eventBus: WorkspaceEventBus | null
@@ -182,6 +184,7 @@ const getAdditionalPropertiesValue = (
       :compact
       :compositionPath="compositionPath"
       :compositionPathSegment="property"
+      :depth
       :discriminator
       :eventBus="eventBus"
       :hideHeading
@@ -204,6 +207,7 @@ const getAdditionalPropertiesValue = (
       :compact
       :compositionPath="compositionPath"
       :compositionPathSegment="key"
+      :depth
       :discriminator
       :eventBus="eventBus"
       :hideHeading
@@ -228,6 +232,7 @@ const getAdditionalPropertiesValue = (
           schema.propertyNames,
         )
       "
+      :depth
       :discriminator
       :eventBus="eventBus"
       :hideHeading

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -39,6 +39,11 @@ const props = withDefaults(
     schema: SchemaObject | undefined
     noncollapsible?: boolean
     level?: number
+    /**
+     * Recursion depth, threaded through to nested `Schema` components and
+     * incremented when we render `Schema` (which is the recursive boundary).
+     */
+    depth?: number
     name?: string
     required?: boolean
     compact?: boolean
@@ -63,6 +68,7 @@ const props = withDefaults(
   }>(),
   {
     level: 0,
+    depth: 0,
     required: false,
     compact: false,
     hideModelNames: false,
@@ -254,6 +260,7 @@ const isDiscriminatorProperty = computed(() =>
         :breadcrumb="childBreadcrumb"
         :compact="compact"
         :compositionPath="currentCompositionPath"
+        :depth="depth + 1"
         :eventBus="eventBus"
         :hideModelNames
         :level="level + 1"
@@ -271,6 +278,7 @@ const isDiscriminatorProperty = computed(() =>
       <Schema
         :compact="compact"
         :compositionPath="arrayItemsCompositionPath"
+        :depth="depth + 1"
         :eventBus="eventBus"
         :hideModelNames
         :level="level + 1"
@@ -289,6 +297,7 @@ const isDiscriminatorProperty = computed(() =>
       :compact="compact"
       :composition="compositionData.composition"
       :compositionPath="currentCompositionPath"
+      :depth
       :discriminator="schema?.discriminator"
       :eventBus="eventBus"
       :hideHeading="hideHeading"


### PR DESCRIPTION
## Problem

Schemas that recursively reference themselves — either directly (`Category` whose `children: array of Category`), or via a polymorphic discriminator that closes on itself (`oneOf` whose subtypes contain a `$ref` back to the discriminator base) — are well-formed OpenAPI 3.x. The `api-reference` `Schema` component renders them by inlining each subtype recursively, never terminating. The tab freezes and eventually OOMs.

A real-world Firefox profiler trace from a user clicking an endpoint backed by such a schema shows ~52% of CPU in `libc malloc`, ~41% in Vue's `runIfDirty`, with `Schema → SchemaObjectProperties → SchemaProperty → Schema` cycles 300+ frames deep. Every level spreads the schema object (`{...obj}`, firing Proxy traps via `getOwnPropertyDescriptor` and `Reflect.ownKeys`) before re-rendering.

This same class of bug is tracked by a long line of issues — #6704, #7398, #6641, #6660, #5213, #4421, #2736 — most marked closed but the underlying recursion in `api-reference/Schema` was never capped. The fix that landed in #8757 (which I'm directly mirroring here) only patched `packages/openapi-to-markdown/src/components/Schema.vue`.

## Solution

Mirror #8757 in the `api-reference` Schema component:

- Add `MAX_DEPTH = 10` to `Schema.vue`.
- Add a `depth?: number` prop (default `0`) to `Schema`, `SchemaObjectProperties`, `SchemaProperty`, and `SchemaComposition`.
- Thread the prop through the four components, incrementing **only** at the recursive boundary — i.e. wherever one `Schema` renders another `Schema` (in `SchemaProperty`'s object/array-items branches and in `SchemaComposition`'s `allOf` and selected-composition branches). Intermediate components (`SchemaObjectProperties`, the non-recursive parts of `SchemaProperty`) just forward `depth` unchanged.
- When `depth >= MAX_DEPTH`, render a `[Circular Reference]` placeholder instead of recursing. CSS-wise it's a small muted block consistent with the existing schema-card description style.

I considered reusing the existing `level` prop, but `level` increments in different places along the chain (it's a CSS/layout counter, not a recursion counter) and overloading it would couple the depth limit to visual nesting. Keeping `depth` separate matches what #8757 did for `openapi-to-markdown` exactly.

`MAX_DEPTH = 10` is the same constant as #8757; in practice it's far past anything a real schema would naturally nest, and the placeholder is recoverable.

### Tests

`Schema.test.ts` adds three cases under a new `circular references` describe block:

1. `depth: 99` mounts → `[Circular Reference]` rendered, no `schema-card--level-` classes.
2. `depth: 0` with a normal nested schema → no placeholder, `schema-card--level-` present.
3. A truly self-referencing in-memory schema object (`children.items === parent`) → `mount()` does not throw a "Maximum call stack size exceeded".

All 26 tests in `Schema.test.ts` pass locally; all 455 tests across the api-reference Schema-related suite still pass.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation. _(no doc changes needed — this is a defensive guard)_