### PR TITLE
fix(components): set specific padding and margin for nested items

### DIFF
--- a/.changeset/itchy-boxes-vanish.md
+++ b/.changeset/itchy-boxes-vanish.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): set specific padding and margin for nested items

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarNestedItems.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarNestedItems.vue
@@ -157,7 +157,7 @@ const handleBack = (event: MouseEvent) => {
         class="absolute inset-0 translate-x-full">
         <ScalarSidebarItems v-bind="$attrs">
           <div
-            class="flex flex-col gap-px sticky top-(--scalar-sidebar-sticky-offset,0) p-(--scalar-sidebar-padding) -m-(--scalar-sidebar-padding) mb-0 pb-0 bg-sidebar-b-1 z-1 animate-sidebar-border-bottom border-b-sidebar-border">
+            class="flex flex-col gap-px sticky top-(--scalar-sidebar-sticky-offset,0) pt-(--scalar-sidebar-padding) -mt-(--scalar-sidebar-padding) px-(--scalar-sidebar-padding) -mx-(--scalar-sidebar-padding) bg-sidebar-b-1 z-1 animate-sidebar-border-bottom border-b-sidebar-border">
             <slot name="back">
               <ScalarSidebarButton
                 is="button"


### PR DESCRIPTION
Was causing CSS ordering issues in Org.

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
