### PR TITLE
fix(api-client): hide sidebar group label when we have a single group

### DIFF
--- a/.changeset/four-lizards-know.md
+++ b/.changeset/four-lizards-know.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: hide sidebar group label when we have a single group

--- a/.changeset/lemon-groups-lie.md
+++ b/.changeset/lemon-groups-lie.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: hide sidebar section label when there is no default slot

--- a/packages/api-client/src/v2/features/app/components/AppSidebar.vue
+++ b/packages/api-client/src/v2/features/app/components/AppSidebar.vue
@@ -5,28 +5,18 @@ import {
   ScalarModal,
   ScalarSidebar,
   ScalarSidebarButton,
-  ScalarSidebarItem,
   ScalarSidebarItems,
-  ScalarSidebarNestedItems,
   ScalarSidebarSearchInput,
   ScalarSidebarSection,
   useModal,
 } from '@scalar/components'
 import {
-  ScalarIconCaretLeft,
-  ScalarIconDotsThree,
   ScalarIconFolderDashed,
   ScalarIconFunnel,
   ScalarIconGearSix,
-  ScalarIconMagnifyingGlass,
   ScalarIconPlus,
 } from '@scalar/icons'
-import {
-  filterItems,
-  SidebarItem,
-  type DraggingItem,
-  type HoveredItem,
-} from '@scalar/sidebar'
+import type { DraggingItem, HoveredItem } from '@scalar/sidebar'
 import { useToasts } from '@scalar/use-toasts'
 import { getParentEntry } from '@scalar/workspace-store/navigation'
 import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
@@ -34,6 +24,7 @@ import { computed, onBeforeMount, onBeforeUnmount, ref } from 'vue'
 
 import DeleteSidebarListElement from '@/components/Sidebar/Actions/DeleteSidebarListElement.vue'
 import { Resize } from '@/v2/components/resize'
+import SidebarDocument from '@/v2/features/app/components/SidebarDocument.vue'
 import SidebarItemMenu from '@/v2/features/app/components/SidebarItemMenu.vue'
 import { createTempOperation } from '@/v2/features/app/helpers/create-temp-operation'
 import { loadRegistryDocument } from '@/v2/features/app/helpers/load-registry-document'
@@ -82,7 +73,7 @@ const isLoadingRegistry = computed(
     app.workspace.isTeamWorkspace.value,
 )
 
-const { rest } = useSidebarDocuments({
+const { pinned, rest } = useSidebarDocuments({
   app,
   managedDocs: () => registryDocuments.documents ?? [],
 })
@@ -490,38 +481,42 @@ const sidebarWidth = defineModel<number>('sidebarWidth', {
             </div>
             <ScalarSidebarItems v-else>
               <!-- Show pinned documents after we add support for it -->
-              <!--  <ScalarSidebarSection v-if="pinned.length">
-              Pinned
-              <template #items>
-                <ScalarSidebarNestedItems
-                  v-for="item in pinned"
-                  :key="item.key"
-                  :active="isDocActive(item)"
-                  controlled
-                  :open="Boolean(openKeys[item.key])"
-                  @back="openKeys[item.key] = false"
-                  @click="handleDocumentClick(item)">
-                  <span class="truncate">{{ item.title }}</span>
-                  <template #back-label>{{ item.title }}</template>
-                  <template #items>
-                    <SidebarItem
-                      v-for="child in filterItems(item.navigation?.children ?? [])"
-                      :key="child.id"
-                      :isDraggable="false"
-                      :isDroppable="isDroppable"
-                      :isExpanded="isExpanded"
-                      :isSelected="isSelected"
-                      :item="child"
-                      layout="client"
-                      @selectItem="handleSelectItem"
-                      @toggleGroup="handleToggleGroup" />
-                  </template>
-                </ScalarSidebarNestedItems>
-              </template>
-            </ScalarSidebarSection> -->
+              <ScalarSidebarSection v-if="pinned.length">
+                <template
+                  v-if="pinned.length && rest.length"
+                  #default>
+                  Pinned
+                </template>
+                <template #items>
+                  <SidebarDocument
+                    v-for="item in pinned"
+                    :key="item.key"
+                    :active="isDocActive(item)"
+                    :isDroppable="isDroppable"
+                    :isExpanded="isExpanded"
+                    :isSelected="isSelected"
+                    :item="item"
+                    :loading="loadingKeys[item.key]"
+                    :open="isDocActive(item)"
+                    @addEmptyFolder="handleAddEmptyFolder"
+                    @back="handleBack"
+                    @click="handleDocumentClick(item)"
+                    @createOperation="handleCreateOperation"
+                    @dragEnd="handleDragEnd"
+                    @openMenu="openMenu"
+                    @openSettings="handleOpenSettings"
+                    @search="handleFilterOrSearch"
+                    @selectItem="handleSelectItem"
+                    @toggleGroup="handleToggleGroup" />
+                </template>
+              </ScalarSidebarSection>
 
               <ScalarSidebarSection>
-                All documents
+                <template
+                  v-if="pinned.length && rest.length"
+                  #default>
+                  All documents
+                </template>
                 <template #items>
                   <!--
                     Skeleton rows shown while the caller is still fetching
@@ -538,126 +533,26 @@ const sidebarWidth = defineModel<number>('sidebarWidth', {
                       <span class="bg-b-3 block h-6 rounded-md" />
                     </li>
                   </template>
-                  <ScalarSidebarNestedItems
+                  <SidebarDocument
                     v-for="item in filteredRest"
                     :key="item.key"
                     :active="isDocActive(item)"
-                    controlled
+                    :isDroppable="isDroppable"
+                    :isExpanded="isExpanded"
+                    :isSelected="isSelected"
+                    :item="item"
+                    :loading="loadingKeys[item.key]"
                     :open="isDocActive(item)"
+                    @addEmptyFolder="handleAddEmptyFolder"
                     @back="handleBack"
-                    @click="handleDocumentClick(item)">
-                    <span>{{ item.title }}</span>
-                    <template
-                      v-if="loadingKeys[item.key]"
-                      #aside>
-                      <span class="text-c-3 text-xs">Loading…</span>
-                    </template>
-                    <!-- Document back row -->
-                    <template #back>
-                      <div class="flex items-center gap-1">
-                        <ScalarSidebarButton
-                          is="button"
-                          class="text-sidebar-c-1 font-sidebar-active hover:text-sidebar-c-1 flex-1"
-                          @click="handleBack">
-                          <template #icon>
-                            <ScalarIconCaretLeft
-                              class="text-sidebar-c-2 -m-px size-4" />
-                          </template>
-                          Back
-                        </ScalarSidebarButton>
-                        <ScalarIconButton
-                          :icon="ScalarIconGearSix"
-                          label="Collection settings"
-                          size="sm"
-                          @click="handleOpenSettings" />
-                        <ScalarIconButton
-                          :icon="ScalarIconMagnifyingGlass"
-                          label="Search collection"
-                          size="sm"
-                          @click="handleFilterOrSearch" />
-                        <ScalarIconButton
-                          class="rounded-full border"
-                          :icon="ScalarIconPlus"
-                          label="Add operation"
-                          size="sm"
-                          @click="handleCreateOperation(item)" />
-                      </div>
-                    </template>
-                    <!-- Document items (operations, tags, examples) -->
-                    <template #items>
-                      <template v-if="item.navigation?.children?.length">
-                        <SidebarItem
-                          v-for="child in filterItems(
-                            'client',
-                            item.navigation.children,
-                          )"
-                          :key="child.id"
-                          :isDroppable="isDroppable"
-                          :isExpanded="isExpanded"
-                          :isSelected="isSelected"
-                          :item="child"
-                          layout="client"
-                          @onDragEnd="handleDragEnd"
-                          @selectItem="handleSelectItem"
-                          @toggleGroup="handleToggleGroup">
-                          <!--
-                            Per-item "more" dropdown for tags, operations and
-                            examples (add / edit / delete…). The dropdown is
-                            rendered once at the sidebar root and anchors
-                            itself to whichever icon button opened it.
-                            Operation settings live on the operation header
-                            (next to the environment selector), not here.
-                          -->
-                          <template #decorator="{ item: entry }">
-                            <ScalarIconButton
-                              aria-expanded="false"
-                              aria-haspopup="menu"
-                              class="bg-b-2"
-                              :icon="ScalarIconDotsThree"
-                              label="More options"
-                              size="sm"
-                              variant="ghost"
-                              weight="bold"
-                              @click.stop="
-                                (e: MouseEvent) => openMenu(e, entry)
-                              "
-                              @keydown.down.stop="
-                                (e: KeyboardEvent) => openMenu(e, entry)
-                              "
-                              @keydown.enter.stop="
-                                (e: KeyboardEvent) => openMenu(e, entry)
-                              "
-                              @keydown.space.stop="
-                                (e: KeyboardEvent) => openMenu(e, entry)
-                              "
-                              @keydown.up.stop="
-                                (e: KeyboardEvent) => openMenu(e, entry)
-                              " />
-                          </template>
-                          <!--
-                            Empty tag / folder slot. Matches the "Add operation"
-                            affordance from the old sidebar so users can create
-                            an operation directly inside the hovered tag.
-                          -->
-                          <template #empty="{ item: emptyItem }">
-                            <ScalarSidebarItem
-                              is="button"
-                              @click="handleAddEmptyFolder(emptyItem)">
-                              <template #icon>
-                                <ScalarIconPlus />
-                              </template>
-                              <template #default>Add operation</template>
-                            </ScalarSidebarItem>
-                          </template>
-                        </SidebarItem>
-                      </template>
-                      <li
-                        v-else
-                        class="text-c-3 px-3 py-1 text-xs">
-                        Empty document
-                      </li>
-                    </template>
-                  </ScalarSidebarNestedItems>
+                    @click="handleDocumentClick(item)"
+                    @createOperation="handleCreateOperation"
+                    @dragEnd="handleDragEnd"
+                    @openMenu="openMenu"
+                    @openSettings="handleOpenSettings"
+                    @search="handleFilterOrSearch"
+                    @selectItem="handleSelectItem"
+                    @toggleGroup="handleToggleGroup" />
                 </template>
               </ScalarSidebarSection>
             </ScalarSidebarItems>

--- a/packages/api-client/src/v2/features/app/components/SidebarDocument.vue
+++ b/packages/api-client/src/v2/features/app/components/SidebarDocument.vue
@@ -32,10 +32,7 @@ const { item, active, open, loading } = defineProps<{
   /** Whether the document is currently being fetched from the registry. */
   loading?: boolean
   /** Predicate to check whether a child entry can be dropped on a target. */
-  isDroppable: (
-    draggingItem: DraggingItem,
-    hoveredItem: HoveredItem,
-  ) => boolean
+  isDroppable: (draggingItem: DraggingItem, hoveredItem: HoveredItem) => boolean
   /** Predicate to check whether a child entry is currently expanded. */
   isExpanded: (id: string) => boolean
   /** Predicate to check whether a child entry is currently selected. */

--- a/packages/api-client/src/v2/features/app/components/SidebarDocument.vue
+++ b/packages/api-client/src/v2/features/app/components/SidebarDocument.vue
@@ -1,0 +1,194 @@
+<script setup lang="ts">
+import {
+  ScalarIconButton,
+  ScalarSidebarButton,
+  ScalarSidebarItem,
+  ScalarSidebarNestedItems,
+} from '@scalar/components'
+import {
+  ScalarIconCaretLeft,
+  ScalarIconDotsThree,
+  ScalarIconGearSix,
+  ScalarIconMagnifyingGlass,
+  ScalarIconPlus,
+} from '@scalar/icons'
+import {
+  filterItems,
+  SidebarItem,
+  type DraggingItem,
+  type HoveredItem,
+} from '@scalar/sidebar'
+import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
+
+import type { SidebarDocumentItem } from '@/v2/features/app/hooks/use-sidebar-documents'
+
+const { item, active, open, loading } = defineProps<{
+  /** The document row to render. */
+  item: SidebarDocumentItem
+  /** Whether the document row is the currently active sidebar entry. */
+  active: boolean
+  /** Whether the document is drilled-in (its children are shown). */
+  open: boolean
+  /** Whether the document is currently being fetched from the registry. */
+  loading?: boolean
+  /** Predicate to check whether a child entry can be dropped on a target. */
+  isDroppable: (
+    draggingItem: DraggingItem,
+    hoveredItem: HoveredItem,
+  ) => boolean
+  /** Predicate to check whether a child entry is currently expanded. */
+  isExpanded: (id: string) => boolean
+  /** Predicate to check whether a child entry is currently selected. */
+  isSelected: (id: string) => boolean
+}>()
+
+const emit = defineEmits<{
+  /** Navigate back from the drilled-in document view. */
+  (event: 'back'): void
+  /** The document row was clicked. */
+  (event: 'click', item: SidebarDocumentItem): void
+  /** Open the document (collection) settings. */
+  (event: 'openSettings'): void
+  /** Open the per-document search modal. */
+  (event: 'search'): void
+  /** Create a new operation in this document. */
+  (event: 'createOperation', item: SidebarDocumentItem): void
+  /** Add an operation inside an empty tag/folder. */
+  (event: 'addEmptyFolder', item: TraversedEntry): void
+  /** Open the contextual "more" menu for a child entry. */
+  (
+    event: 'openMenu',
+    nativeEvent: MouseEvent | KeyboardEvent,
+    entry: TraversedEntry,
+  ): void
+  /** A child entry was selected. */
+  (event: 'selectItem', id: string): void
+  /** A child group was toggled. */
+  (event: 'toggleGroup', id: string): void
+  /** A drag-and-drop operation has completed. */
+  (
+    event: 'dragEnd',
+    draggingItem: DraggingItem,
+    hoveredItem: HoveredItem,
+  ): boolean
+}>()
+
+const handleDragEnd = (
+  draggingItem: DraggingItem,
+  hoveredItem: HoveredItem,
+): boolean => emit('dragEnd', draggingItem, hoveredItem)
+</script>
+
+<template>
+  <ScalarSidebarNestedItems
+    :active="active"
+    controlled
+    :open="open"
+    @back="emit('back')"
+    @click="emit('click', item)">
+    <span>{{ item.title }}</span>
+    <template
+      v-if="loading"
+      #aside>
+      <span class="text-c-3 text-xs">Loading…</span>
+    </template>
+    <!-- Document back row -->
+    <template #back>
+      <div class="flex items-center gap-1">
+        <ScalarSidebarButton
+          is="button"
+          class="text-sidebar-c-1 font-sidebar-active hover:text-sidebar-c-1 flex-1"
+          @click="emit('back')">
+          <template #icon>
+            <ScalarIconCaretLeft class="text-sidebar-c-2 -m-px size-4" />
+          </template>
+          Back
+        </ScalarSidebarButton>
+        <ScalarIconButton
+          :icon="ScalarIconGearSix"
+          label="Collection settings"
+          size="sm"
+          @click="emit('openSettings')" />
+        <ScalarIconButton
+          :icon="ScalarIconMagnifyingGlass"
+          label="Search collection"
+          size="sm"
+          @click="emit('search')" />
+        <ScalarIconButton
+          class="rounded-full border"
+          :icon="ScalarIconPlus"
+          label="Add operation"
+          size="sm"
+          @click="emit('createOperation', item)" />
+      </div>
+    </template>
+    <!-- Document items (operations, tags, examples) -->
+    <template #items>
+      <template v-if="item.navigation?.children?.length">
+        <SidebarItem
+          v-for="child in filterItems('client', item.navigation.children)"
+          :key="child.id"
+          :isDroppable="isDroppable"
+          :isExpanded="isExpanded"
+          :isSelected="isSelected"
+          :item="child"
+          layout="client"
+          @onDragEnd="handleDragEnd"
+          @selectItem="(id: string) => emit('selectItem', id)"
+          @toggleGroup="(id: string) => emit('toggleGroup', id)">
+          <!--
+            Per-item "more" dropdown for tags, operations and examples
+            (add / edit / delete…). The dropdown is rendered once at the
+            sidebar root and anchors itself to whichever icon button opened
+            it. Operation settings live on the operation header (next to the
+            environment selector), not here.
+          -->
+          <template #decorator="{ item: entry }">
+            <ScalarIconButton
+              aria-expanded="false"
+              aria-haspopup="menu"
+              class="bg-b-2"
+              :icon="ScalarIconDotsThree"
+              label="More options"
+              size="sm"
+              variant="ghost"
+              weight="bold"
+              @click.stop="(e: MouseEvent) => emit('openMenu', e, entry)"
+              @keydown.down.stop="
+                (e: KeyboardEvent) => emit('openMenu', e, entry)
+              "
+              @keydown.enter.stop="
+                (e: KeyboardEvent) => emit('openMenu', e, entry)
+              "
+              @keydown.space.stop="
+                (e: KeyboardEvent) => emit('openMenu', e, entry)
+              "
+              @keydown.up.stop="
+                (e: KeyboardEvent) => emit('openMenu', e, entry)
+              " />
+          </template>
+          <!--
+            Empty tag / folder slot. Matches the "Add operation" affordance
+            from the old sidebar so users can create an operation directly
+            inside the hovered tag.
+          -->
+          <template #empty="{ item: emptyItem }">
+            <ScalarSidebarItem
+              is="button"
+              @click="emit('addEmptyFolder', emptyItem)">
+              <template #icon>
+                <ScalarIconPlus />
+              </template>
+              <template #default>Add operation</template>
+            </ScalarSidebarItem>
+          </template>
+        </SidebarItem>
+      </template>
+      <li
+        v-else
+        class="text-c-3 px-3 py-1 text-xs">
+        Empty document
+      </li>
+    </template>
+  </ScalarSidebarNestedItems>
+</template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarSection.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarSection.vue
@@ -53,6 +53,7 @@ const { cx } = useBindCx()
       :indent="level" />
     <ScalarSidebarButton
       is="div"
+      v-if="$slots.default"
       class="text-sm/4 py-1.75 font-bold"
       disabled
       :icon="icon"


### PR DESCRIPTION
Currently we don't support pinning documents, which was creating only a single group of documents, which were both displaying the "All documents" label

This PR removes the label if we have a single group only

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI risk: refactors sidebar document rendering into a new component and changes section header slot behavior, which could affect sidebar interactions (drill-in/back/menu/drag) but does not touch security or data logic.
> 
> **Overview**
> Fixes duplicate sidebar section headers by **only rendering `ScalarSidebarSection` labels when a default slot is provided**, allowing callers to omit the section title when there’s only one section.
> 
> In `AppSidebar.vue`, introduces a `Pinned` section (behind `pinned.length`) and conditionally shows the `Pinned`/`All documents` headers only when both `pinned` and `rest` sections exist. The document row + nested navigation UI was extracted into a reusable `SidebarDocument.vue` component and swapped in for the previous inline `ScalarSidebarNestedItems` markup, preserving events for back, settings/search, context menu, and drag/drop.
> 
> Adds patch changesets for `@scalar/api-client` and `@scalar/components`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07fe3c19c2470e365a920f6c88a43b582a44cea3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->