### PR TITLE
feat(api-client): add empty state for the team workspace

### DIFF
--- a/.changeset/ten-papers-pick.md
+++ b/.changeset/ten-papers-pick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': minor
+---
+
+feat: add empty state for the team workspace

--- a/packages/api-client/src/v2/features/app/App.vue
+++ b/packages/api-client/src/v2/features/app/App.vue
@@ -217,6 +217,7 @@ const routerViewProps = computed<RouteProps>(() => {
     path: app.activeEntities.path.value,
     workspaceStore: app.store.value!,
     activeWorkspace: app.workspace.activeWorkspace.value!,
+    isTeamWorkspace: app.workspace.isTeamWorkspace.value,
     plugins,
     isDarkMode: app.isDarkMode.value,
     currentTheme: app.theme.styles.value.themeStyles,

--- a/packages/api-client/src/v2/features/app/components/AppSidebar.vue
+++ b/packages/api-client/src/v2/features/app/components/AppSidebar.vue
@@ -486,7 +486,7 @@ const sidebarWidth = defineModel<number>('sidebarWidth', {
               <ScalarIconFolderDashed
                 class="size-10"
                 weight="light" />
-              <p class="text-sm font-medium">No APIs yet</p>
+              <p class="text-sm font-medium">Nothing added yet</p>
             </div>
             <ScalarSidebarItems v-else>
               <!-- Show pinned documents after we add support for it -->

--- a/packages/api-client/src/v2/features/app/helpers/routes.ts
+++ b/packages/api-client/src/v2/features/app/helpers/routes.ts
@@ -49,6 +49,10 @@ export type RouteProps = {
   workspaceStore: WorkspaceStore
   /** The currently active workspace */
   activeWorkspace: { id: string; label: string }
+  /**
+   * Whether the active workspace is backed by a team (i.e. not the built-in `local` team).
+   */
+  isTeamWorkspace?: boolean
   /** Client plugins */
   plugins: ClientPlugin[]
   /** Custom themes available to the team */

--- a/packages/api-client/src/v2/features/collection/components/GetStarted.vue
+++ b/packages/api-client/src/v2/features/collection/components/GetStarted.vue
@@ -2,23 +2,36 @@
 /**
  * Workspace get started page.
  *
- * Shown as the landing view for a workspace with no request selected. Displays
- * an ASCII art mark and a short list of keyboard shortcuts to help the user
- * bootstrap their workspace (open the command palette, jump to settings, or
- * focus the sidebar filter).
+ * Shown as the landing view for a workspace with no request selected.
+ *
+ * On a local workspace it displays an ASCII art mark and a short list of
+ * keyboard shortcuts to help the user bootstrap their workspace (open the
+ * command palette, jump to settings, or focus the sidebar filter).
+ *
+ * On an empty team workspace it instead surfaces a focused "Create a
+ * Document" call-to-action: team workspaces are intended to back a real
+ * OpenAPI document and the registry, so the keyboard-shortcut helper would
+ * be a confusing first impression. The CTA reuses the command palette by
+ * opening its `create-openapi-document` action so the actual creation flow
+ * remains a single source of truth.
  */
 export default {}
 </script>
 
 <script setup lang="ts">
-import { ScalarHotkey } from '@scalar/components'
-import { ScalarIconDownloadSimple } from '@scalar/icons'
+import { ScalarButton, ScalarHotkey } from '@scalar/components'
+import {
+  ScalarIconBracketsCurly,
+  ScalarIconDownloadSimple,
+} from '@scalar/icons'
+import { computed } from 'vue'
 
 import Computer from '@/assets/computer.ascii?raw'
 import ScalarAsciiArt from '@/components/ScalarAsciiArt.vue'
 import type { RouteProps } from '@/v2/features/app/helpers/routes'
 
-const { eventBus, layout } = defineProps<RouteProps>()
+const { eventBus, isTeamWorkspace, layout, workspaceStore } =
+  defineProps<RouteProps>()
 
 const openCommandPalette = () => {
   eventBus.emit('ui:open:command-palette')
@@ -44,11 +57,67 @@ const openSettings = () => {
 const focusSearch = () => {
   eventBus.emit('ui:focus:search')
 }
+
+/**
+ * Open the command palette directly on the "Create OpenAPI Document" form.
+ * The empty team workspace CTA delegates to this action so the create flow
+ * stays in one place.
+ */
+const openCreateDocument = () => {
+  eventBus.emit('ui:open:command-palette', {
+    action: 'create-openapi-document',
+    payload: undefined,
+  })
+}
+
+/**
+ * Whether the active workspace is a team workspace that has no real
+ * documents yet. The auto-created `drafts` scratch document does not count
+ * as content, so a workspace whose only entry is `drafts` is still treated
+ * as empty.
+ */
+const isEmptyTeamWorkspace = computed(() => {
+  if (!isTeamWorkspace) {
+    return false
+  }
+
+  const documentNames = Object.keys(workspaceStore?.workspace?.documents ?? {})
+  return documentNames.every((name) => name === 'drafts')
+})
 </script>
 
 <template>
   <div class="flex h-full w-full flex-col items-center justify-center p-6">
-    <div class="flex flex-col items-stretch gap-10">
+    <!--
+      Empty team workspace: surface a focused CTA pointing the user at the
+      command palette's create-document flow rather than the local-workspace
+      keyboard cheatsheet.
+    -->
+    <div
+      v-if="isEmptyTeamWorkspace && isTeamWorkspace"
+      class="flex max-w-sm flex-col gap-4">
+      <ScalarIconBracketsCurly
+        class="text-c-accent size-10"
+        weight="bold" />
+      <h2 class="text-c-1 text-base font-semibold">Create a Document</h2>
+      <p class="text-c-2 text-sm leading-relaxed">
+        The OpenAPI standard provides a descriptor of your API. Bringing it to
+        our Registry allows you to manage, lint &amp; version your OpenAPI
+        Documents. Create Docs &amp; SDKs from your OpenAPI Document.
+      </p>
+      <div>
+        <ScalarButton
+          class="mt-2"
+          @click="openCreateDocument">
+          Create Document
+        </ScalarButton>
+      </div>
+    </div>
+
+    <!-- Local workspace fallback: ASCII art mark and keyboard shortcuts. -->
+    <div
+      v-else
+      class="flex flex-col items-stretch gap-10">
       <ScalarAsciiArt
         :art="Computer"
         class="text-c-3 self-center" />


### PR DESCRIPTION
When a team workspace have no document we now show this:

<img width="873" height="622" alt="Screenshot 2026-04-28 at 7 35 55 PM" src="https://github.com/user-attachments/assets/5fc63b09-59c2-41cb-bb5b-9000309fa79f" />


## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX changes plus an additive `RouteProps.isTeamWorkspace` flag; minimal logic added but could affect the get-started view rendering for team workspaces.
> 
> **Overview**
> Adds a new *team-workspace empty state* on the workspace "Get started" screen: when the workspace is a team workspace with no real documents (only `drafts`), it shows a "Create Document" CTA that opens the command palette on `create-openapi-document`.
> 
> Plumbs `isTeamWorkspace` through route props from `App.vue` (and documents it in `routes.ts`) and tweaks the sidebar empty-state copy to "Nothing added yet". Includes a changeset bumping `@scalar/api-client` as a minor release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d956126f65af86ddd22923ddafdce1113ba6c31e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->