### PR TITLE
fix(api-client): remove extra comment for migration

### DIFF
--- a/packages/oas-utils/src/migrations/migrate-to-indexdb.ts
+++ b/packages/oas-utils/src/migrations/migrate-to-indexdb.ts
@@ -60,7 +60,6 @@ export const migrateLocalStorageToIndexDb = async () => {
     const shouldMigrate = await shouldMigrateToIndexDb(workspacePersistence)
 
     if (!shouldMigrate) {
-      console.info('ℹ️  No migration needed - IndexedDB already has workspaces or no legacy data exists')
       return
     }
 


### PR DESCRIPTION
This AI generated comment has served us well, but its watch has ended

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change to the migration fast-path; no impact on data transformation or persistence logic.
> 
> **Overview**
> Removes the informational `console.info` message that was emitted when `migrateLocalStorageToIndexDb` detects no migration is needed (IndexedDB already populated or no legacy localStorage data).
> 
> Behavior is otherwise unchanged; the function still returns early without migrating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c3b22f00079dc5b1216ff19b4076e25ab33d83b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->