### PR TITLE
feat(workspace-store): added once modifier back to the event bus

### DIFF
--- a/.changeset/shaky-mice-hammer.md
+++ b/.changeset/shaky-mice-hammer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+feat: added once back to the event bus

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
@@ -87,6 +87,7 @@ vi.mock('@/components/ViewLayout/ViewLayoutContent.vue', () => ({
  */
 const createMockEventBus = (): WorkspaceEventBus => ({
   on: vi.fn(),
+  once: vi.fn(),
   off: vi.fn(),
   emit: vi.fn(() => null),
 })

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportCurl.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportCurl.test.ts
@@ -17,6 +17,7 @@ describe('CommandPaletteImportCurl', () => {
   const createMockEventBus = () => ({
     emit: vi.fn(),
     on: vi.fn(),
+    once: vi.fn(),
     off: vi.fn(),
   })
 

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteOpenApiDocument.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteOpenApiDocument.test.ts
@@ -25,6 +25,7 @@ describe('CommandPaletteDocument', () => {
   const createMockEventBus = () => ({
     emit: vi.fn(),
     on: vi.fn(),
+    once: vi.fn(),
     off: vi.fn(),
   })
 

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteRequest.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteRequest.test.ts
@@ -26,6 +26,7 @@ describe('CommandPaletteRequest', () => {
   const createMockEventBus = () => ({
     emit: vi.fn(),
     on: vi.fn(),
+    once: vi.fn(),
     off: vi.fn(),
   })
 

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteTag.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteTag.test.ts
@@ -18,6 +18,7 @@ describe('CommandPaletteTag', () => {
   const createMockEventBus = () => ({
     emit: vi.fn(),
     on: vi.fn(),
+    once: vi.fn(),
     off: vi.fn(),
   })
 

--- a/packages/api-reference/src/blocks/scalar-info-block/components/DownloadLink.test.ts
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/DownloadLink.test.ts
@@ -12,6 +12,7 @@ import DownloadLink from './DownloadLink.vue'
  */
 const createMockEventBus = (): WorkspaceEventBus => ({
   on: vi.fn(),
+  once: vi.fn(),
   off: vi.fn(),
   emit: vi.fn(() => null),
 })

--- a/packages/api-reference/src/features/test-request-button/TestRequestButton.test.ts
+++ b/packages/api-reference/src/features/test-request-button/TestRequestButton.test.ts
@@ -10,6 +10,7 @@ import TestRequestButton from './TestRequestButton.vue'
  */
 const createMockEventBus = (): WorkspaceEventBus => ({
   on: vi.fn(),
+  once: vi.fn(),
   off: vi.fn(),
   emit: vi.fn(() => null),
 })

--- a/packages/workspace-store/src/events/bus.test.ts
+++ b/packages/workspace-store/src/events/bus.test.ts
@@ -127,6 +127,72 @@ describe('createWorkspaceEventBus', () => {
     expect(handler3).toHaveBeenCalledTimes(2)
   })
 
+  describe('once', () => {
+    it('fires the listener exactly once', () => {
+      const bus = createWorkspaceEventBus()
+      const handler = vi.fn()
+
+      bus.once('update:dark-mode', handler)
+      bus.emit('update:dark-mode', true)
+      bus.emit('update:dark-mode', false)
+      bus.emit('update:dark-mode', true)
+
+      expect(handler).toHaveBeenCalledTimes(1)
+      expect(handler).toHaveBeenCalledWith(true)
+    })
+
+    it('passes the payload to the listener', () => {
+      const bus = createWorkspaceEventBus()
+      const handler = vi.fn()
+
+      bus.once('update:active-document', handler)
+      bus.emit('update:active-document', 'doc-abc')
+
+      expect(handler).toHaveBeenCalledWith('doc-abc')
+    })
+
+    it('returns an unsubscribe function that prevents the listener from firing', () => {
+      const bus = createWorkspaceEventBus()
+      const handler = vi.fn()
+
+      const unsubscribe = bus.once('update:dark-mode', handler)
+      unsubscribe()
+      bus.emit('update:dark-mode', true)
+
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('does not interfere with regular on() listeners for the same event', () => {
+      const bus = createWorkspaceEventBus()
+      const onceHandler = vi.fn()
+      const onHandler = vi.fn()
+
+      bus.once('update:dark-mode', onceHandler)
+      bus.on('update:dark-mode', onHandler)
+
+      bus.emit('update:dark-mode', true)
+      bus.emit('update:dark-mode', false)
+
+      expect(onceHandler).toHaveBeenCalledTimes(1)
+      expect(onHandler).toHaveBeenCalledTimes(2)
+    })
+
+    it('multiple once() listeners each fire only once independently', () => {
+      const bus = createWorkspaceEventBus()
+      const handler1 = vi.fn()
+      const handler2 = vi.fn()
+
+      bus.once('update:dark-mode', handler1)
+      bus.once('update:dark-mode', handler2)
+
+      bus.emit('update:dark-mode', true)
+      bus.emit('update:dark-mode', false)
+
+      expect(handler1).toHaveBeenCalledTimes(1)
+      expect(handler2).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('handles debouncing when there is a debounce key present', () => {
     vi.useFakeTimers()
     const bus = createWorkspaceEventBus()

--- a/packages/workspace-store/src/events/bus.ts
+++ b/packages/workspace-store/src/events/bus.ts
@@ -63,6 +63,21 @@ export type WorkspaceEventBus = {
   off<E extends keyof ApiReferenceEvents>(event: E, listener: EventListener<E>): void
 
   /**
+   * Subscribe to an event, but only trigger the listener once.
+   * The listener is automatically removed after the first invocation.
+   *
+   * @param event - The event name to listen for
+   * @param listener - Callback function that receives the event detail
+   * @returns Unsubscribe function to remove the listener before it fires
+   *
+   * @example
+   * bus.once('scalar-update-sidebar', (detail) => {
+   *   console.log('Fired once:', detail.value)
+   * })
+   */
+  once<E extends keyof ApiReferenceEvents>(event: E, listener: EventListener<E>): Unsubscribe
+
+  /**
    * Emit an event with its payload
    *
    * @param event - The event name to emit
@@ -190,6 +205,14 @@ export const createWorkspaceEventBus = (options: EventBusOptions = {}): Workspac
     }
   }
 
+  const once = <E extends keyof ApiReferenceEvents>(event: E, listener: EventListener<E>): Unsubscribe => {
+    const wrapper = (payload: ApiReferenceEvents[E] | undefined): void => {
+      off(event, wrapper as EventListener<E>)
+      ;(listener as (payload: ApiReferenceEvents[E] | undefined) => void)(payload)
+    }
+    return on(event, wrapper as EventListener<E>)
+  }
+
   const on = <E extends keyof ApiReferenceEvents>(event: E, listener: EventListener<E>): Unsubscribe => {
     const listeners = getListeners(event)
     listeners.add(listener as EventListener<keyof ApiReferenceEvents>)
@@ -267,6 +290,7 @@ export const createWorkspaceEventBus = (options: EventBusOptions = {}): Workspac
 
   return {
     on,
+    once,
     off,
     emit,
   }


### PR DESCRIPTION
## Problem

We used to have a "once" modifier on the event bus.

## Solution

We are just adding it back

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 548ed7009c3fd510359bb6b3d68d6c9546d47df8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->