### PR TITLE
fix(workspace-store): ignore schema defaults with type mismatch

### DIFF
--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
@@ -718,6 +718,15 @@ describe('getExampleFromSchema', () => {
     expect(getExampleFromSchema(schema)).toBe('BAD_REQUEST_EXCEPTION')
   })
 
+  it('ignores invalid defaults when they do not match primitive schema type', () => {
+    const schema = coerceValue(SchemaObjectSchema, {
+      type: 'number',
+      default: 'invalid',
+    })
+
+    expect(getExampleFromSchema(schema)).toBe(1)
+  })
+
   it('normalizes empty string defaults to null for nullable integers', () => {
     const schema = coerceValue(SchemaObjectSchema, {
       type: ['integer', 'null'],
@@ -725,6 +734,15 @@ describe('getExampleFromSchema', () => {
     })
 
     expect(getExampleFromSchema(schema)).toBeNull()
+  })
+
+  it('ignores invalid defaults for composed schemas', () => {
+    const schema = coerceValue(SchemaObjectSchema, {
+      oneOf: [{ type: 'string' }, { type: 'null' }],
+      default: 123,
+    })
+
+    expect(getExampleFromSchema(schema)).toBe('')
   })
 
   it('keeps empty string defaults for nullable strings', () => {

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
@@ -239,11 +239,7 @@ const isValueOfType = (value: unknown, targetType: SchemaPrimitiveType): boolean
   }
 }
 
-const schemaAllowsValue = (
-  schema: SchemaObject,
-  value: unknown,
-  seen: Set<object> = new Set(),
-): boolean => {
+const schemaAllowsValue = (schema: SchemaObject, value: unknown, seen: Set<object> = new Set()): boolean => {
   const rawSchema = getSchemaCacheTarget(schema)
 
   if (seen.has(rawSchema)) {

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
@@ -218,57 +218,108 @@ const mergeExamples = (baseValue: unknown, newValue: unknown): unknown => {
 type CompositionKeyword = 'anyOf' | 'oneOf'
 type SchemaPrimitiveType = 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null' | 'integer'
 
-const schemaIncludesType = (
+const isValueOfType = (value: unknown, targetType: SchemaPrimitiveType): boolean => {
+  switch (targetType) {
+    case 'string':
+      return typeof value === 'string'
+    case 'number':
+      return typeof value === 'number' && !Number.isNaN(value)
+    case 'integer':
+      return typeof value === 'number' && Number.isInteger(value)
+    case 'boolean':
+      return typeof value === 'boolean'
+    case 'object':
+      return typeof value === 'object' && value !== null && !Array.isArray(value)
+    case 'array':
+      return Array.isArray(value)
+    case 'null':
+      return value === null
+    default:
+      return false
+  }
+}
+
+const schemaAllowsValue = (
   schema: SchemaObject,
-  targetType: SchemaPrimitiveType,
-  seen: WeakSet<object> = new WeakSet(),
+  value: unknown,
+  seen: Set<object> = new Set(),
 ): boolean => {
   const rawSchema = getSchemaCacheTarget(schema)
 
   if (seen.has(rawSchema)) {
-    return false
+    return true
   }
   seen.add(rawSchema)
 
-  if ('type' in schema) {
-    if (Array.isArray(schema.type)) {
-      return schema.type.includes(targetType)
-    }
-
-    if (schema.type === targetType) {
-      return true
-    }
-  }
-
-  const compositions = [schema.oneOf, schema.anyOf, schema.allOf]
-  for (const composition of compositions) {
-    if (!Array.isArray(composition)) {
-      continue
-    }
-
-    for (const item of composition) {
-      const resolved = resolve.schema(item)
-      if (resolved && schemaIncludesType(resolved, targetType, seen)) {
+  if ('type' in schema && schema.type) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type]
+    const matchesType = types.some((targetType) => {
+      if (targetType === 'number' && isValueOfType(value, 'integer')) {
         return true
       }
+
+      return isValueOfType(value, targetType)
+    })
+
+    if (!matchesType) {
+      seen.delete(rawSchema)
+      return false
     }
   }
 
-  return false
+  const anyOf = schema.anyOf
+  if (Array.isArray(anyOf) && anyOf.length > 0) {
+    const matchesAnyOf = anyOf.some((item) => {
+      const resolved = resolve.schema(item)
+      return !!resolved && schemaAllowsValue(resolved, value, seen)
+    })
+
+    if (!matchesAnyOf) {
+      seen.delete(rawSchema)
+      return false
+    }
+  }
+
+  const oneOf = schema.oneOf
+  if (Array.isArray(oneOf) && oneOf.length > 0) {
+    const matchesOneOf = oneOf.some((item) => {
+      const resolved = resolve.schema(item)
+      return !!resolved && schemaAllowsValue(resolved, value, seen)
+    })
+
+    if (!matchesOneOf) {
+      seen.delete(rawSchema)
+      return false
+    }
+  }
+
+  const allOf = schema.allOf
+  if (Array.isArray(allOf) && allOf.length > 0) {
+    const matchesAllOf = allOf.every((item) => {
+      const resolved = resolve.schema(item)
+      return !resolved || schemaAllowsValue(resolved, value, seen)
+    })
+
+    if (!matchesAllOf) {
+      seen.delete(rawSchema)
+      return false
+    }
+  }
+
+  seen.delete(rawSchema)
+  return true
 }
 
-const normalizeSchemaDefault = (schema: SchemaObject): unknown => {
-  if (schema.default !== '') {
-    return schema.default
+const INVALID_DEFAULT = Symbol('INVALID_DEFAULT')
+
+const normalizeSchemaDefault = (schema: SchemaObject): unknown | typeof INVALID_DEFAULT => {
+  const defaultValue = schema.default
+
+  if (schemaAllowsValue(schema, defaultValue)) {
+    return defaultValue
   }
 
-  const allowsNull = schemaIncludesType(schema, 'null')
-  const allowsString = schemaIncludesType(schema, 'string')
-  if (allowsNull && !allowsString) {
-    return null
-  }
-
-  return schema.default
+  return INVALID_DEFAULT
 }
 
 const getCompositionSelectionKey = (schemaPath: string[], composition: CompositionKeyword): string =>
@@ -683,8 +734,12 @@ export const getExampleFromSchema = (
     return cache(_schema, _schema.example, cacheKey)
   }
   if (_schema.default !== undefined) {
-    seen.delete(targetValue)
-    return cache(_schema, normalizeSchemaDefault(_schema), cacheKey)
+    const normalizedDefault = normalizeSchemaDefault(_schema)
+
+    if (normalizedDefault !== INVALID_DEFAULT) {
+      seen.delete(targetValue)
+      return cache(_schema, normalizedDefault, cacheKey)
+    }
   }
   if (_schema.const !== undefined) {
     seen.delete(targetValue)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A review comment on the nullable default handling pointed out that the current normalization is too narrow because it only special-cases empty strings. Invalid defaults can appear in other forms and should not override generated examples.

## Solution

- Replaced the empty-string nullable special case with schema-aware default validation.
- Added `schemaAllowsValue` to validate defaults against declared `type`, `oneOf`, `anyOf`, and `allOf` constraints.
- When a default is invalid for the schema, `getExampleFromSchema` now ignores it and continues through the normal fallback path.
- Added focused tests for invalid primitive and composed defaults while keeping nullable behavior covered.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-716c0ad2-3931-455b-b2e0-2ac998680792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-716c0ad2-3931-455b-b2e0-2ac998680792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

