### PR TITLE
feat(api-client): surface actual OAuth error messages

### DIFF
--- a/.changeset/neat-walls-bow.md
+++ b/.changeset/neat-walls-bow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Surface actual OAuth error messages instead of generic failure messages

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth-callback.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth-callback.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getOAuthCallbackData,
+  getOAuthCallbackParam,
+  getOAuthCallbackParams,
+  getOAuthCallbackParamWithSource,
+} from './oauth-callback'
+
+describe('oauth-callback', () => {
+  it('splits query and hash callback parameters', () => {
+    const { searchParams, hashParams } = getOAuthCallbackParams(
+      'https://callback.example.com/cb?code=query_code&state=query_state#access_token=hash_token&refresh_token=hash_refresh',
+    )
+
+    expect(searchParams.toString()).toBe('code=query_code&state=query_state')
+    expect(hashParams.toString()).toBe('access_token=hash_token&refresh_token=hash_refresh')
+  })
+
+  it('decodes encoded query and hash values', () => {
+    const { searchParams, hashParams } = getOAuthCallbackParams(
+      'https://callback.example.com/cb?state=a%20b%2Bc#access_token=token%2Bwith%2Bplus',
+    )
+
+    expect(searchParams.get('state')).toBe('a b+c')
+    expect(hashParams.get('access_token')).toBe('token+with+plus')
+  })
+
+  it('prefers query values when query and hash contain the same parameter', () => {
+    const result = getOAuthCallbackParam(
+      'https://callback.example.com/cb?state=query_state#state=hash_state&access_token=hash_token',
+      'state',
+    )
+
+    expect(result).toBe('query_state')
+  })
+
+  it('falls back to hash values when a query parameter is absent', () => {
+    const result = getOAuthCallbackParam('https://callback.example.com/cb?code=query_code#state=hash_state', 'state')
+
+    expect(result).toBe('hash_state')
+  })
+
+  it('preserves empty callback values', () => {
+    const result = getOAuthCallbackParam('https://callback.example.com/cb?state=#access_token=hash_token', 'state')
+
+    expect(result).toBe('')
+  })
+
+  it('returns null when the parameter is absent from query and hash', () => {
+    const result = getOAuthCallbackParam(
+      'https://callback.example.com/cb?code=query_code#access_token=hash_token',
+      'state',
+    )
+
+    expect(result).toBe(null)
+  })
+
+  it('throws for invalid callback URLs', () => {
+    expect(() => getOAuthCallbackParams('not a valid callback url')).toThrow(TypeError)
+  })
+
+  it('returns the query parameter source when the parameter is in the query string', () => {
+    const searchParams = new URLSearchParams('state=query_state')
+    const hashParams = new URLSearchParams('state=hash_state')
+
+    const result = getOAuthCallbackParamWithSource(searchParams, hashParams, 'state')
+
+    expect(result.value).toBe('query_state')
+    expect(result.params).toBe(searchParams)
+  })
+
+  it('returns the hash parameter source when the parameter is absent from the query string', () => {
+    const searchParams = new URLSearchParams('code=query_code')
+    const hashParams = new URLSearchParams('state=hash_state')
+
+    const result = getOAuthCallbackParamWithSource(searchParams, hashParams, 'state')
+
+    expect(result.value).toBe('hash_state')
+    expect(result.params).toBe(hashParams)
+  })
+
+  it('returns null values when a source-aware callback parameter is absent', () => {
+    const result = getOAuthCallbackParamWithSource(new URLSearchParams(), new URLSearchParams(), 'state')
+
+    expect(result).toEqual({ params: null, value: null })
+  })
+
+  it('extracts source-aware callback data from query and hash parameters', () => {
+    const result = getOAuthCallbackData(
+      () =>
+        'https://callback.example.com/cb?code=query_code&state=query_state&error=query_error#error_description=hash_error&refresh_token=hash_refresh',
+    )
+
+    expect(result.accessToken).toBe(null)
+    expect(result.accessTokenParams).toBe(null)
+    expect(result.code).toBe('query_code')
+    expect(result.codeParams?.get('state')).toBe('query_state')
+    expect(result.error).toBe('query_error')
+    expect(result.errorDescription).toBe('hash_error')
+    expect(result.refreshToken).toBe('hash_refresh')
+  })
+
+  it('extracts custom access tokens with their source parameters', () => {
+    const result = getOAuthCallbackData(
+      () => 'https://callback.example.com/cb?state=query_state#custom_token=hash_token&state=hash_state',
+      'custom_token',
+    )
+
+    expect(result.accessToken).toBe('hash_token')
+    expect(result.accessTokenParams?.get('state')).toBe('hash_state')
+    expect(result.code).toBe(null)
+    expect(result.codeParams).toBe(null)
+  })
+
+  it('returns empty callback data when the popup URL cannot be read', () => {
+    const result = getOAuthCallbackData(() => {
+      throw new Error('Cross-origin popup')
+    })
+
+    expect(result).toEqual({
+      accessToken: null,
+      accessTokenParams: null,
+      code: null,
+      codeParams: null,
+      error: null,
+      errorDescription: null,
+      refreshToken: null,
+    })
+  })
+})

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth-callback.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth-callback.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest'
 import {
   getOAuthCallbackData,
   getOAuthCallbackParam,
-  getOAuthCallbackParams,
   getOAuthCallbackParamWithSource,
+  getOAuthCallbackParams,
 } from './oauth-callback'
 
 describe('oauth-callback', () => {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth-callback.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth-callback.test.ts
@@ -26,6 +26,28 @@ describe('oauth-callback', () => {
     expect(hashParams.get('access_token')).toBe('token+with+plus')
   })
 
+  it('parses hash callback parameters with a leading question mark', () => {
+    const { hashParams } = getOAuthCallbackParams(
+      'https://callback.example.com/cb?ignored=query_value#?access_token=hash_token&state=hash_state',
+    )
+
+    expect(hashParams.get('access_token')).toBe('hash_token')
+    expect(hashParams.get('state')).toBe('hash_state')
+  })
+
+  it('keeps duplicate callback parameters in source order', () => {
+    const { searchParams, hashParams } = getOAuthCallbackParams(
+      'https://callback.example.com/cb?state=first_query&state=second_query#state=first_hash&state=second_hash',
+    )
+
+    expect(searchParams.getAll('state')).toEqual(['first_query', 'second_query'])
+    expect(hashParams.getAll('state')).toEqual(['first_hash', 'second_hash'])
+    expect(getOAuthCallbackParamWithSource(searchParams, hashParams, 'state')).toEqual({
+      params: searchParams,
+      value: 'first_query',
+    })
+  })
+
   it('prefers query values when query and hash contain the same parameter', () => {
     const result = getOAuthCallbackParam(
       'https://callback.example.com/cb?state=query_state#state=hash_state&access_token=hash_token',
@@ -113,10 +135,58 @@ describe('oauth-callback', () => {
     expect(result.codeParams).toBe(null)
   })
 
+  it('keeps authorization-code state tied to the code source', () => {
+    const result = getOAuthCallbackData(
+      () => 'https://callback.example.com/cb?state=query_state#code=hash_code&state=hash_state',
+    )
+
+    expect(result.code).toBe('hash_code')
+    expect(result.codeParams?.get('state')).toBe('hash_state')
+    expect(result.accessToken).toBe(null)
+    expect(result.accessTokenParams).toBe(null)
+  })
+
+  it('does not borrow query state for hash credentials', () => {
+    const result = getOAuthCallbackData(
+      () => 'https://callback.example.com/cb?state=query_state#access_token=hash_token',
+    )
+
+    expect(result.accessToken).toBe('hash_token')
+    expect(result.accessTokenParams?.get('state')).toBe(null)
+    expect(result.code).toBe(null)
+    expect(result.codeParams).toBe(null)
+  })
+
+  it('uses the configured token name instead of a default access token', () => {
+    const result = getOAuthCallbackData(
+      () => 'https://callback.example.com/cb?custom_token=query_token&state=query_state#access_token=hash_token',
+      'custom_token',
+    )
+
+    expect(result.accessToken).toBe('query_token')
+    expect(result.accessTokenParams?.get('state')).toBe('query_state')
+    expect(result.code).toBe(null)
+    expect(result.codeParams).toBe(null)
+  })
+
   it('returns empty callback data when the popup URL cannot be read', () => {
     const result = getOAuthCallbackData(() => {
       throw new Error('Cross-origin popup')
     })
+
+    expect(result).toEqual({
+      accessToken: null,
+      accessTokenParams: null,
+      code: null,
+      codeParams: null,
+      error: null,
+      errorDescription: null,
+      refreshToken: null,
+    })
+  })
+
+  it('returns empty callback data for invalid popup URLs', () => {
+    const result = getOAuthCallbackData(() => 'not a valid callback url')
 
     expect(result).toEqual({
       accessToken: null,

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth-callback.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth-callback.ts
@@ -1,0 +1,127 @@
+/**
+ * Keeps a callback parameter paired with the URL component it was read from.
+ * State validation depends on this source so query and hash values cannot be
+ * mixed across different OAuth callback shapes.
+ */
+type OAuthCallbackParamResult = {
+  /** The query or hash parameters that contained the value. */
+  params: URLSearchParams | null
+  /** The callback parameter value, or null when the parameter is missing. */
+  value: string | null
+}
+
+/**
+ * Normalized OAuth callback data used after the popup returns to a readable
+ * redirect URL. Credential params are retained so callers can validate state
+ * from the same URL component as the returned credential.
+ */
+type OAuthCallbackData = {
+  /** Access token returned by implicit or token-based flows. */
+  accessToken: string | null
+  /** The URL component that contained the access token. */
+  accessTokenParams: URLSearchParams | null
+  /** Authorization code returned by authorization-code flows. */
+  code: string | null
+  /** The URL component that contained the authorization code. */
+  codeParams: URLSearchParams | null
+  /** OAuth error code returned by the provider. */
+  error: string | null
+  /** Provider-supplied details for the OAuth error. */
+  errorDescription: string | null
+  /** Refresh token returned by providers that include one in the callback. */
+  refreshToken: string | null
+}
+
+/**
+ * Splits an OAuth redirect URL into query and hash parameters.
+ *
+ * OAuth providers are inconsistent about where they return callback data:
+ * authorization-code flows usually use the query string, while implicit flows
+ * commonly use the URL fragment. Keeping both sets separate lets callers decide
+ * which source should win when a provider sends duplicate keys.
+ */
+export const getOAuthCallbackParams = (
+  callbackUrl: string,
+): { searchParams: URLSearchParams; hashParams: URLSearchParams } => {
+  const parsedUrl = new URL(callbackUrl)
+
+  return {
+    searchParams: parsedUrl.searchParams,
+    hashParams: new URLSearchParams(parsedUrl.hash.slice(1)),
+  }
+}
+
+/**
+ * Reads a callback parameter from the query string first, then the hash fragment.
+ *
+ * Query-string values intentionally take precedence because they are the
+ * standard location for authorization-code callbacks. The hash lookup keeps
+ * implicit-flow callbacks and non-standard providers working.
+ */
+export const getOAuthCallbackParam = (callbackUrl: string, paramName: string): string | null => {
+  const { searchParams, hashParams } = getOAuthCallbackParams(callbackUrl)
+  return searchParams.get(paramName) ?? hashParams.get(paramName)
+}
+
+/**
+ * Reads a callback parameter and returns the URL component it came from.
+ *
+ * OAuth state must be validated from the same component as the credential
+ * (`code` or `access_token`) so mixed query/hash callbacks cannot pair a
+ * trusted state with an untrusted credential.
+ */
+export const getOAuthCallbackParamWithSource = (
+  searchParams: URLSearchParams,
+  hashParams: URLSearchParams,
+  paramName: string,
+): OAuthCallbackParamResult => {
+  const searchValue = searchParams.get(paramName)
+  if (searchValue !== null) {
+    return { params: searchParams, value: searchValue }
+  }
+
+  const hashValue = hashParams.get(paramName)
+  if (hashValue !== null) {
+    return { params: hashParams, value: hashValue }
+  }
+
+  return { params: null, value: null }
+}
+
+/**
+ * Safely reads the OAuth popup callback data.
+ *
+ * Accessing the popup URL can throw while it is still on another origin, so
+ * callers get null values until the popup returns to a readable callback URL.
+ */
+export const getOAuthCallbackData = (
+  getCallbackUrl: () => string,
+  tokenName = 'access_token',
+): OAuthCallbackData => {
+  try {
+    const { searchParams, hashParams } = getOAuthCallbackParams(getCallbackUrl())
+    const accessTokenResult = getOAuthCallbackParamWithSource(searchParams, hashParams, tokenName)
+    const codeResult = getOAuthCallbackParamWithSource(searchParams, hashParams, 'code')
+
+    return {
+      accessToken: accessTokenResult.value,
+      accessTokenParams: accessTokenResult.params,
+      code: codeResult.value,
+      codeParams: codeResult.params,
+      error: searchParams.get('error') ?? hashParams.get('error'),
+      errorDescription: searchParams.get('error_description') ?? hashParams.get('error_description'),
+      refreshToken: searchParams.get('refresh_token') ?? hashParams.get('refresh_token'),
+    }
+  } catch (_e) {
+    // Ignore CORS errors while the popup is still on the provider origin.
+    return {
+      accessToken: null,
+      accessTokenParams: null,
+      code: null,
+      codeParams: null,
+      error: null,
+      errorDescription: null,
+      refreshToken: null,
+    }
+  }
+}

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth-callback.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth-callback.ts
@@ -94,10 +94,7 @@ export const getOAuthCallbackParamWithSource = (
  * Accessing the popup URL can throw while it is still on another origin, so
  * callers get null values until the popup returns to a readable callback URL.
  */
-export const getOAuthCallbackData = (
-  getCallbackUrl: () => string,
-  tokenName = 'access_token',
-): OAuthCallbackData => {
+export const getOAuthCallbackData = (getCallbackUrl: () => string, tokenName = 'access_token'): OAuthCallbackData => {
   try {
     const { searchParams, hashParams } = getOAuthCallbackParams(getCallbackUrl())
     const accessTokenResult = getOAuthCallbackParamWithSource(searchParams, hashParams, tokenName)

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
@@ -5,7 +5,12 @@ import { flushPromises } from '@vue/test-utils'
 import { encode } from 'js-base64'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { authorizeOauth2, getOAuthCallbackParam, getOAuthCallbackParams, refreshOauth2Token } from './oauth'
+import {
+  authorizeOauth2,
+  getActiveServerBase,
+  getServerUrl,
+  refreshOauth2Token,
+} from './oauth'
 
 const baseFlow = {
   'refreshUrl': 'https://auth.example.com/refresh',
@@ -59,57 +64,51 @@ describe('oauth', () => {
     url: 'https://api.example.com',
   } as ServerObject
 
-  describe('OAuth callback parsing', () => {
-    it('splits query and hash callback parameters', () => {
-      const { searchParams, hashParams } = getOAuthCallbackParams(
-        'https://callback.example.com/cb?code=query_code&state=query_state#access_token=hash_token&refresh_token=hash_refresh',
-      )
+  describe('Server URL helpers', () => {
+    it('resolves server URLs with OpenAPI server variables and environment variables', () => {
+      const server: ServerObject = {
+        url: '{protocol}://{{hostname}}/{basePath}',
+        variables: {
+          protocol: { default: 'https' },
+          basePath: { default: 'v1' },
+        },
+      }
 
-      expect(searchParams.toString()).toBe('code=query_code&state=query_state')
-      expect(hashParams.toString()).toBe('access_token=hash_token&refresh_token=hash_refresh')
+      const result = getServerUrl(server, { hostname: 'api.example.com' })
+
+      expect(result).toBe('https://api.example.com/v1')
     })
 
-    it('decodes encoded query and hash values', () => {
-      const { searchParams, hashParams } = getOAuthCallbackParams(
-        'https://callback.example.com/cb?state=a%20b%2Bc#access_token=token%2Bwith%2Bplus',
-      )
-
-      expect(searchParams.get('state')).toBe('a b+c')
-      expect(hashParams.get('access_token')).toBe('token+with+plus')
-    })
-
-    it('prefers query values when query and hash contain the same parameter', () => {
-      const result = getOAuthCallbackParam(
-        'https://callback.example.com/cb?state=query_state#state=hash_state&access_token=hash_token',
-        'state',
-      )
-
-      expect(result).toBe('query_state')
-    })
-
-    it('falls back to hash values when a query parameter is absent', () => {
-      const result = getOAuthCallbackParam('https://callback.example.com/cb?code=query_code#state=hash_state', 'state')
-
-      expect(result).toBe('hash_state')
-    })
-
-    it('preserves empty callback values', () => {
-      const result = getOAuthCallbackParam('https://callback.example.com/cb?state=#access_token=hash_token', 'state')
+    it('returns an empty server URL when no active server is selected', () => {
+      const result = getServerUrl(null)
 
       expect(result).toBe('')
     })
 
-    it('returns null when the parameter is absent from query and hash', () => {
-      const result = getOAuthCallbackParam(
-        'https://callback.example.com/cb?code=query_code#access_token=hash_token',
-        'state',
-      )
+    it('returns a baseUrl for absolute active server URLs', () => {
+      const server: ServerObject = {
+        url: 'https://api.example.com',
+      }
 
-      expect(result).toBe(null)
+      const result = getActiveServerBase(server)
+
+      expect(result).toEqual({ baseUrl: 'https://api.example.com' })
     })
 
-    it('throws for invalid callback URLs', () => {
-      expect(() => getOAuthCallbackParams('not a valid callback url')).toThrow(TypeError)
+    it('returns a browser basePath for relative active server URLs', () => {
+      const server: ServerObject = {
+        url: '/api/{{version}}',
+      }
+
+      const result = getActiveServerBase(server, { version: 'v2' })
+
+      expect(result).toEqual({ basePath: '/api/v2' })
+    })
+
+    it('returns an empty base when no active server URL is available', () => {
+      const result = getActiveServerBase(null)
+
+      expect(result).toEqual({})
     })
   })
 
@@ -514,6 +513,18 @@ describe('oauth', () => {
       expect(callArgs).toBeDefined()
       const body = callArgs![1]?.body as URLSearchParams
       expect(body.get('code')).toBe('auth_code_from_hash')
+    })
+
+    it('rejects authorization code callbacks when code and state come from different URL components', async () => {
+      const promise = authorizeOauth2(scheme, 'authorizationCode', selectedScopes, mockServer, '')
+
+      mockWindow.location.href = `${scheme.authorizationCode['x-scalar-secret-redirect-uri']}?state=${state}#code=auth_code_from_hash&state=bad_state`
+      vi.advanceTimersByTime(200)
+
+      const [error, result] = await promise
+      expect(result).toBe(null)
+      expect(error).toBeInstanceOf(Error)
+      expect(error!.message).toBe('State mismatch')
     })
 
     it('handles malformed popup callback URLs as closed authorization windows', async () => {
@@ -1231,7 +1242,7 @@ describe('oauth', () => {
       expect(result).toEqual({ accessToken: 'query_token_123' })
     })
 
-    it('uses query state before hash state for implicit callbacks', async () => {
+    it('rejects implicit callbacks when token and state come from different URL components', async () => {
       const promise = authorizeOauth2(scheme, 'implicit', selectedScopes, mockServer, '')
 
       mockWindow.location.href = `${scheme.implicit['x-scalar-secret-redirect-uri']}?state=${state}#access_token=implicit_token_123&state=bad_state`
@@ -1240,8 +1251,9 @@ describe('oauth', () => {
       vi.runAllTicks()
 
       const [error, result] = await promise
-      expect(error).toBe(null)
-      expect(result).toEqual({ accessToken: 'implicit_token_123' })
+      expect(result).toBe(null)
+      expect(error).toBeInstanceOf(Error)
+      expect(error!.message).toBe('State mismatch')
     })
 
     it('rejects implicit callbacks that return a token without state', async () => {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
@@ -5,12 +5,7 @@ import { flushPromises } from '@vue/test-utils'
 import { encode } from 'js-base64'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import {
-  authorizeOauth2,
-  getActiveServerBase,
-  getServerUrl,
-  refreshOauth2Token,
-} from './oauth'
+import { authorizeOauth2, getActiveServerBase, getServerUrl, refreshOauth2Token } from './oauth'
 
 const baseFlow = {
   'refreshUrl': 'https://auth.example.com/refresh',

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
@@ -691,7 +691,34 @@ describe('oauth', () => {
       const [error, result] = await authorizeOauth2(scheme, 'clientCredentials', selectedScopes, mockServer, '')
       expect(result).toBe(null)
       expect(error).toBeInstanceOf(Error)
-      expect(error!.message).toBe('Failed to get an access token. Please check your credentials.')
+      expect(error!.message).toBe('Network error')
+    })
+
+    it('surfaces OAuth error when server returns error response', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            error: 'invalid_client',
+            error_description: 'Client authentication failed',
+          }),
+      })
+      const [error, result] = await authorizeOauth2(scheme, 'clientCredentials', selectedScopes, mockServer, '')
+      expect(result).toBe(null)
+      expect(error).toBeInstanceOf(Error)
+      expect(error!.message).toBe('Client authentication failed')
+    })
+
+    it('surfaces OAuth error without description when only error code is provided', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            error: 'invalid_grant',
+          }),
+      })
+      const [error, result] = await authorizeOauth2(scheme, 'clientCredentials', selectedScopes, mockServer, '')
+      expect(result).toBe(null)
+      expect(error).toBeInstanceOf(Error)
+      expect(error!.message).toBe('invalid_grant')
     })
 
     it('should use custom token name when x-tokenName is specified', async () => {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
@@ -5,7 +5,7 @@ import { flushPromises } from '@vue/test-utils'
 import { encode } from 'js-base64'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { authorizeOauth2, refreshOauth2Token } from './oauth'
+import { authorizeOauth2, getOAuthCallbackParam, getOAuthCallbackParams, refreshOauth2Token } from './oauth'
 
 const baseFlow = {
   'refreshUrl': 'https://auth.example.com/refresh',
@@ -58,6 +58,60 @@ describe('oauth', () => {
   const mockServer = {
     url: 'https://api.example.com',
   } as ServerObject
+
+  describe('OAuth callback parsing', () => {
+    it('splits query and hash callback parameters', () => {
+      const { searchParams, hashParams } = getOAuthCallbackParams(
+        'https://callback.example.com/cb?code=query_code&state=query_state#access_token=hash_token&refresh_token=hash_refresh',
+      )
+
+      expect(searchParams.toString()).toBe('code=query_code&state=query_state')
+      expect(hashParams.toString()).toBe('access_token=hash_token&refresh_token=hash_refresh')
+    })
+
+    it('decodes encoded query and hash values', () => {
+      const { searchParams, hashParams } = getOAuthCallbackParams(
+        'https://callback.example.com/cb?state=a%20b%2Bc#access_token=token%2Bwith%2Bplus',
+      )
+
+      expect(searchParams.get('state')).toBe('a b+c')
+      expect(hashParams.get('access_token')).toBe('token+with+plus')
+    })
+
+    it('prefers query values when query and hash contain the same parameter', () => {
+      const result = getOAuthCallbackParam(
+        'https://callback.example.com/cb?state=query_state#state=hash_state&access_token=hash_token',
+        'state',
+      )
+
+      expect(result).toBe('query_state')
+    })
+
+    it('falls back to hash values when a query parameter is absent', () => {
+      const result = getOAuthCallbackParam('https://callback.example.com/cb?code=query_code#state=hash_state', 'state')
+
+      expect(result).toBe('hash_state')
+    })
+
+    it('preserves empty callback values', () => {
+      const result = getOAuthCallbackParam('https://callback.example.com/cb?state=#access_token=hash_token', 'state')
+
+      expect(result).toBe('')
+    })
+
+    it('returns null when the parameter is absent from query and hash', () => {
+      const result = getOAuthCallbackParam(
+        'https://callback.example.com/cb?code=query_code#access_token=hash_token',
+        'state',
+      )
+
+      expect(result).toBe(null)
+    })
+
+    it('throws for invalid callback URLs', () => {
+      expect(() => getOAuthCallbackParams('not a valid callback url')).toThrow(TypeError)
+    })
+  })
 
   describe('Authorization Code Grant', () => {
     const scheme = {
@@ -421,6 +475,83 @@ describe('oauth', () => {
       expect(result).toBe(null)
       expect(error).toBeInstanceOf(Error)
       expect(error!.message).toBe('State mismatch')
+    })
+
+    it('uses query state before hash state when both are present', async () => {
+      const promise = authorizeOauth2(scheme, 'authorizationCode', selectedScopes, mockServer, '')
+      const accessToken = 'access_token_123'
+
+      mockWindow.location.href = `${scheme.authorizationCode['x-scalar-secret-redirect-uri']}?code=auth_code_123&state=${state}#state=bad_state`
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        json: () => Promise.resolve({ access_token: accessToken }),
+      })
+
+      vi.advanceTimersByTime(200)
+
+      const [error, result] = await promise
+      expect(error).toBe(null)
+      expect(result).toEqual({ accessToken })
+    })
+
+    it('accepts authorization code callbacks that return code and state in the hash', async () => {
+      const promise = authorizeOauth2(scheme, 'authorizationCode', selectedScopes, mockServer, '')
+      const accessToken = 'access_token_from_hash_123'
+
+      mockWindow.location.href = `${scheme.authorizationCode['x-scalar-secret-redirect-uri']}#code=auth_code_from_hash&state=${state}`
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        json: () => Promise.resolve({ access_token: accessToken }),
+      })
+
+      vi.advanceTimersByTime(200)
+
+      const [error, result] = await promise
+      expect(error).toBe(null)
+      expect(result).toEqual({ accessToken })
+
+      const callArgs = vi.mocked(global.fetch).mock.calls[0]
+      expect(callArgs).toBeDefined()
+      const body = callArgs![1]?.body as URLSearchParams
+      expect(body.get('code')).toBe('auth_code_from_hash')
+    })
+
+    it('handles malformed popup callback URLs as closed authorization windows', async () => {
+      const promise = authorizeOauth2(scheme, 'authorizationCode', selectedScopes, mockServer, '')
+
+      mockWindow.location.href = 'not a valid callback url'
+      mockWindow.closed = true
+      vi.advanceTimersByTime(200)
+
+      const [error, result] = await promise
+      expect(result).toBe(null)
+      expect(error).toBeInstanceOf(Error)
+      expect(error!.message).toBe('Window was closed without granting authorization')
+    })
+
+    it('resolves unexpected token exchange rejections as error tuples', async () => {
+      const throwingSecurityBodyFlow = {
+        ...scheme.authorizationCode,
+      }
+
+      Object.defineProperty(throwingSecurityBodyFlow, 'x-scalar-security-body', {
+        get: () => {
+          throw new Error('Unexpected token exchange failure')
+        },
+      })
+
+      const flows = {
+        authorizationCode: throwingSecurityBodyFlow,
+      } as OAuthFlowsObjectSecret
+      const promise = authorizeOauth2(flows, 'authorizationCode', selectedScopes, mockServer, '')
+
+      mockWindow.location.href = `${flows.authorizationCode!['x-scalar-secret-redirect-uri']}?code=auth_code_123&state=${state}`
+      vi.advanceTimersByTime(200)
+
+      const [error, result] = await promise
+      expect(result).toBe(null)
+      expect(error).toBeInstanceOf(Error)
+      expect(error!.message).toBe('Unexpected token exchange failure')
     })
 
     it('should use the proxy if provided', async () => {
@@ -1085,6 +1216,46 @@ describe('oauth', () => {
       const [error, result] = await promise
       expect(error).toBe(null)
       expect(result).toEqual({ accessToken: 'custom_implicit_token_123' })
+    })
+
+    it('accepts implicit tokens from query parameters', async () => {
+      const promise = authorizeOauth2(scheme, 'implicit', selectedScopes, mockServer, '')
+
+      mockWindow.location.href = `${scheme.implicit['x-scalar-secret-redirect-uri']}?access_token=query_token_123&state=${state}`
+
+      vi.advanceTimersByTime(200)
+      vi.runAllTicks()
+
+      const [error, result] = await promise
+      expect(error).toBe(null)
+      expect(result).toEqual({ accessToken: 'query_token_123' })
+    })
+
+    it('uses query state before hash state for implicit callbacks', async () => {
+      const promise = authorizeOauth2(scheme, 'implicit', selectedScopes, mockServer, '')
+
+      mockWindow.location.href = `${scheme.implicit['x-scalar-secret-redirect-uri']}?state=${state}#access_token=implicit_token_123&state=bad_state`
+
+      vi.advanceTimersByTime(200)
+      vi.runAllTicks()
+
+      const [error, result] = await promise
+      expect(error).toBe(null)
+      expect(result).toEqual({ accessToken: 'implicit_token_123' })
+    })
+
+    it('rejects implicit callbacks that return a token without state', async () => {
+      const promise = authorizeOauth2(scheme, 'implicit', selectedScopes, mockServer, '')
+
+      mockWindow.location.href = `${scheme.implicit['x-scalar-secret-redirect-uri']}#access_token=implicit_token_123`
+
+      vi.advanceTimersByTime(200)
+      vi.runAllTicks()
+
+      const [error, result] = await promise
+      expect(result).toBe(null)
+      expect(error).toBeInstanceOf(Error)
+      expect(error!.message).toBe('State mismatch')
     })
 
     it('should handle relative authorization URL in implicit flow', async () => {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
@@ -1583,7 +1583,7 @@ describe('oauth', () => {
       const [error, result] = await refreshOauth2Token(refreshScheme, 'authorizationCode', '', mockServer)
       expect(result).toBe(null)
       expect(error).toBeInstanceOf(Error)
-      expect(error!.message).toBe('Failed to refresh the access token. Please re-authorize.')
+      expect(error!.message).toBe('Network error')
     })
 
     it('returns the server error_description when the token endpoint rejects the refresh', async () => {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
@@ -279,8 +279,9 @@ export const authorizeOauth2 = async (
       })
     }
     return [new Error('Failed to open auth window'), null]
-  } catch (_) {
-    return [new Error('Failed to authorize oauth2 flow'), null]
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Failed to authorize oauth2 flow'
+    return [new Error(errorMessage), null]
   }
 }
 
@@ -399,9 +400,15 @@ const authorizeServers = async (
     const accessToken = responseData[tokenName]
     const refreshToken = responseData.refresh_token
 
+    if (!accessToken) {
+      return [new Error(responseData.error_description ?? responseData.error ?? 'Failed to get an access token'), null]
+    }
+
     return [null, { accessToken, ...(typeof refreshToken === 'string' ? { refreshToken } : {}) }]
-  } catch {
-    return [new Error('Failed to get an access token. Please check your credentials.'), null]
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Failed to get an access token. Please check your credentials.'
+    return [new Error(errorMessage), null]
   }
 }
 
@@ -496,7 +503,9 @@ export const refreshOauth2Token = async (
         ...(typeof newRefreshToken === 'string' ? { refreshToken: newRefreshToken } : { refreshToken }),
       },
     ]
-  } catch {
-    return [new Error('Failed to refresh the access token. Please re-authorize.'), null]
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Failed to refresh the access token. Please re-authorize.'
+    return [new Error(errorMessage), null]
   }
 }

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
@@ -8,6 +8,8 @@ import { getServerVariables } from '@scalar/workspace-store/request-example'
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { encode, fromUint8Array } from 'js-base64'
 
+import { getOAuthCallbackData } from './oauth-callback'
+
 /** Oauth2 security schemes which are not implicit */
 type NonImplicitFlows = Omit<OAuthFlowsObjectSecret, 'implicit'>
 
@@ -16,6 +18,8 @@ type PKCEState = {
   codeChallenge: string
   codeChallengeMethod: string
 }
+
+type ActiveServerBase = { basePath: string } | { baseUrl: string } | Record<string, never>
 
 export type OAuth2Tokens = {
   accessToken: string
@@ -26,46 +30,29 @@ export type OAuth2Tokens = {
 type RefreshableFlows = Exclude<keyof OAuthFlowsObjectSecret, 'implicit'>
 
 /**
- * Splits an OAuth redirect URL into query and hash parameters.
- *
- * OAuth providers are inconsistent about where they return callback data:
- * authorization-code flows usually use the query string, while implicit flows
- * commonly use the URL fragment. Keeping both sets separate lets callers decide
- * which source should win when a provider sends duplicate keys.
+ * Resolves the active server URL using OpenAPI server variables first, then
+ * Scalar environment variables.
  */
-export const getOAuthCallbackParams = (
-  callbackUrl: string,
-): { searchParams: URLSearchParams; hashParams: URLSearchParams } => {
-  const parsedUrl = new URL(callbackUrl)
-
-  return {
-    searchParams: parsedUrl.searchParams,
-    hashParams: new URLSearchParams(parsedUrl.hash.slice(1)),
-  }
-}
-
-/**
- * Reads a callback parameter from the query string first, then the hash fragment.
- *
- * Query-string values intentionally take precedence because they are the
- * standard location for authorization-code callbacks. The hash lookup keeps
- * implicit-flow callbacks and non-standard providers working.
- */
-export const getOAuthCallbackParam = (callbackUrl: string, paramName: string): string | null => {
-  const { searchParams, hashParams } = getOAuthCallbackParams(callbackUrl)
-  return searchParams.get(paramName) ?? hashParams.get(paramName)
-}
-
-const getServerUrl = (activeServer: ServerObject | null, environmentVariables: Record<string, string> = {}) => {
-  return replaceEnvVariables(
+export const getServerUrl = (
+  activeServer: ServerObject | null,
+  environmentVariables: Record<string, string> = {},
+): string =>
+  replaceEnvVariables(
     replacePathVariables(activeServer?.url ?? '', getServerVariables(activeServer)),
     environmentVariables,
   )
-}
 
-const getActiveServerBase = (activeServer: ServerObject | null, environmentVariables: Record<string, string> = {}) => {
+/**
+ * Builds the base option used when OAuth URLs are relative to the active server.
+ *
+ * Relative server URLs become browser-only base paths because they need the
+ * current window location to resolve correctly.
+ */
+export const getActiveServerBase = (
+  activeServer: ServerObject | null,
+  environmentVariables: Record<string, string> = {},
+): ActiveServerBase => {
   const serverUrl = getServerUrl(activeServer, environmentVariables)
-
   if (!serverUrl) {
     return {}
   }
@@ -230,26 +217,8 @@ export const authorizeOauth2 = async (
       // We need to return a promise here due to the setInterval
       return new Promise<ErrorResponse<OAuth2Tokens>>((resolve) => {
         const checkWindowClosed = setInterval(() => {
-          let accessToken: string | null = null
-          let refreshToken: string | null = null
-          let code: string | null = null
-          let error: string | null = null
-          let errorDescription: string | null = null
-          let callbackUrl: string | null = null
-
-          try {
-            callbackUrl = authWindow.location.href
-            const { searchParams, hashParams } = getOAuthCallbackParams(callbackUrl)
-            const tokenName = flow['x-tokenName'] || 'access_token'
-
-            accessToken = searchParams.get(tokenName) ?? hashParams.get(tokenName)
-            refreshToken = searchParams.get('refresh_token') ?? hashParams.get('refresh_token')
-            code = searchParams.get('code') ?? hashParams.get('code')
-            error = searchParams.get('error') ?? hashParams.get('error')
-            errorDescription = searchParams.get('error_description') ?? hashParams.get('error_description')
-          } catch (_e) {
-            // Ignore CORS error from popup
-          }
+          const { accessToken, accessTokenParams, code, codeParams, error, errorDescription, refreshToken } =
+            getOAuthCallbackData(() => authWindow.location.href, flow['x-tokenName'] || 'access_token')
 
           // The window has closed OR we have what we are looking for so we stop polling
           if (authWindow.closed || accessToken || code || error) {
@@ -263,7 +232,7 @@ export const authorizeOauth2 = async (
 
             // Implicit Flow
             if (accessToken) {
-              const _state = callbackUrl ? getOAuthCallbackParam(callbackUrl, 'state') : null
+              const _state = accessTokenParams?.get('state') ?? null
 
               if (_state === state) {
                 resolve([null, { accessToken, ...(refreshToken ? { refreshToken } : {}) }])
@@ -275,7 +244,7 @@ export const authorizeOauth2 = async (
 
             // Authorization Code Server Flow
             if (code && type === 'authorizationCode') {
-              const _state = callbackUrl ? getOAuthCallbackParam(callbackUrl, 'state') : null
+              const _state = codeParams?.get('state') ?? null
 
               if (_state === state) {
                 void authorizeServers(

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
@@ -25,6 +25,37 @@ export type OAuth2Tokens = {
 /** Flow types that support token refresh (all except implicit) */
 type RefreshableFlows = Exclude<keyof OAuthFlowsObjectSecret, 'implicit'>
 
+/**
+ * Splits an OAuth redirect URL into query and hash parameters.
+ *
+ * OAuth providers are inconsistent about where they return callback data:
+ * authorization-code flows usually use the query string, while implicit flows
+ * commonly use the URL fragment. Keeping both sets separate lets callers decide
+ * which source should win when a provider sends duplicate keys.
+ */
+export const getOAuthCallbackParams = (
+  callbackUrl: string,
+): { searchParams: URLSearchParams; hashParams: URLSearchParams } => {
+  const parsedUrl = new URL(callbackUrl)
+
+  return {
+    searchParams: parsedUrl.searchParams,
+    hashParams: new URLSearchParams(parsedUrl.hash.slice(1)),
+  }
+}
+
+/**
+ * Reads a callback parameter from the query string first, then the hash fragment.
+ *
+ * Query-string values intentionally take precedence because they are the
+ * standard location for authorization-code callbacks. The hash lookup keeps
+ * implicit-flow callbacks and non-standard providers working.
+ */
+export const getOAuthCallbackParam = (callbackUrl: string, paramName: string): string | null => {
+  const { searchParams, hashParams } = getOAuthCallbackParams(callbackUrl)
+  return searchParams.get(paramName) ?? hashParams.get(paramName)
+}
+
 const getServerUrl = (activeServer: ServerObject | null, environmentVariables: Record<string, string> = {}) => {
   return replaceEnvVariables(
     replacePathVariables(activeServer?.url ?? '', getServerVariables(activeServer)),
@@ -204,24 +235,18 @@ export const authorizeOauth2 = async (
           let code: string | null = null
           let error: string | null = null
           let errorDescription: string | null = null
+          let callbackUrl: string | null = null
 
           try {
-            const urlParams = new URL(authWindow.location.href).searchParams
+            callbackUrl = authWindow.location.href
+            const { searchParams, hashParams } = getOAuthCallbackParams(callbackUrl)
             const tokenName = flow['x-tokenName'] || 'access_token'
-            accessToken = urlParams.get(tokenName)
-            refreshToken = urlParams.get('refresh_token')
-            code = urlParams.get('code')
 
-            error = urlParams.get('error')
-            errorDescription = urlParams.get('error_description')
-
-            // We may get the properties in a hash
-            const hashParams = new URLSearchParams(authWindow.location.href.split('#')[1])
-            accessToken ||= hashParams.get(tokenName)
-            refreshToken ||= hashParams.get('refresh_token')
-            code ||= hashParams.get('code')
-            error ||= hashParams.get('error')
-            errorDescription ||= hashParams.get('error_description')
+            accessToken = searchParams.get(tokenName) ?? hashParams.get(tokenName)
+            refreshToken = searchParams.get('refresh_token') ?? hashParams.get('refresh_token')
+            code = searchParams.get('code') ?? hashParams.get('code')
+            error = searchParams.get('error') ?? hashParams.get('error')
+            errorDescription = searchParams.get('error_description') ?? hashParams.get('error_description')
           } catch (_e) {
             // Ignore CORS error from popup
           }
@@ -233,27 +258,27 @@ export const authorizeOauth2 = async (
 
             if (error) {
               resolve([new Error(`OAuth error: ${error}${errorDescription ? ` (${errorDescription})` : ''}`), null])
+              return
             }
 
             // Implicit Flow
-            else if (accessToken) {
-              // State is a hash fragment and cannot be found through search params
-              const _state = authWindow.location.href.match(/state=([^&]*)/)?.[1]
+            if (accessToken) {
+              const _state = callbackUrl ? getOAuthCallbackParam(callbackUrl, 'state') : null
 
               if (_state === state) {
                 resolve([null, { accessToken, ...(refreshToken ? { refreshToken } : {}) }])
               } else {
                 resolve([new Error('State mismatch'), null])
               }
+              return
             }
 
             // Authorization Code Server Flow
-            else if (code && type === 'authorizationCode') {
-              const _state = new URL(authWindow.location.href).searchParams.get('state')
+            if (code && type === 'authorizationCode') {
+              const _state = callbackUrl ? getOAuthCallbackParam(callbackUrl, 'state') : null
 
               if (_state === state) {
-                // biome-ignore lint/nursery/noFloatingPromises: output of authorizeServers must be returned
-                authorizeServers(
+                void authorizeServers(
                   flows,
                   type,
                   scopes,
@@ -264,24 +289,29 @@ export const authorizeOauth2 = async (
                   },
                   activeServer,
                   environmentVariables,
-                ).then(resolve)
+                )
+                  .then(resolve)
+                  .catch((error: unknown) => {
+                    resolve([
+                      error instanceof Error ? error : new Error('Failed to get an access token', { cause: error }),
+                      null,
+                    ])
+                  })
               } else {
                 resolve([new Error('State mismatch'), null])
               }
+              return
             }
+
             // User closed window without authorizing
-            else {
-              clearInterval(checkWindowClosed)
-              resolve([new Error('Window was closed without granting authorization'), null])
-            }
+            resolve([new Error('Window was closed without granting authorization'), null])
           }
         }, 200)
       })
     }
     return [new Error('Failed to open auth window'), null]
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Failed to authorize oauth2 flow'
-    return [new Error(errorMessage), null]
+    return [error instanceof Error ? error : new Error('Failed to authorize oauth2 flow', { cause: error }), null]
   }
 }
 
@@ -406,9 +436,12 @@ const authorizeServers = async (
 
     return [null, { accessToken, ...(typeof refreshToken === 'string' ? { refreshToken } : {}) }]
   } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : 'Failed to get an access token. Please check your credentials.'
-    return [new Error(errorMessage), null]
+    return [
+      error instanceof Error
+        ? error
+        : new Error('Failed to get an access token. Please check your credentials.', { cause: error }),
+      null,
+    ]
   }
 }
 
@@ -504,8 +537,11 @@ export const refreshOauth2Token = async (
       },
     ]
   } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : 'Failed to refresh the access token. Please re-authorize.'
-    return [new Error(errorMessage), null]
+    return [
+      error instanceof Error
+        ? error
+        : new Error('Failed to refresh the access token. Please re-authorize.', { cause: error }),
+      null,
+    ]
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Surfaces actual OAuth error messages from authentication servers instead of showing generic "Failed to authorize" messages. This helps developers understand exactly what went wrong with their OAuth configuration.

## Changes

- Updated `authorizeServers` function to check for `error_description` and `error` fields in OAuth response
- Modified catch blocks to preserve original error messages instead of replacing them with generic text
- Added test cases for OAuth error response handling
- Updated existing test to expect preserved network error messages

## Visual

### OAuth Configuration Form
![OAuth2 Client Credentials configuration form](https://cursor.com/artifacts/c/art-2bdc6b2b-4514-4c25-a94b-1b8fe4a82ec9)

### Error Message - Before
Previously, users would see a generic message like "Failed to authorize" without any details about what went wrong.

### Error Message - After  
![OAuth error message showing: Invalid grant_type: client_credentials](https://cursor.com/artifacts/c/art-c38f45d4-783b-42a3-aa17-5ae186ca685d)

Now users see the actual OAuth error from the server (e.g., "Invalid grant_type: client_credentials"), making it much easier to debug OAuth configuration issues.

### Multiple Error Types Supported
![Different OAuth error with GitHub endpoint](https://cursor.com/artifacts/c/art-83ce3785-8e14-4a0c-acdd-e3cdda3a62da)

The implementation handles various OAuth error responses from different providers.

## Testing

- Manually tested with Google OAuth2 endpoint (invalid credentials)
- Manually tested with GitHub OAuth endpoint  
- Added unit tests for error response handling
- Updated existing tests to expect preserved error messages
- Verified error messages are properly displayed in toast notifications

## Impact

This improvement significantly enhances the developer experience when configuring OAuth2 authentication by:
- Providing specific, actionable error messages
- Surfacing server-side error descriptions
- Making OAuth debugging much faster and easier
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C086SC1U7NU/p1777476143859369?thread_ts=1777476143.859369&cid=C086SC1U7NU)

<div><a href="https://cursor.com/agents/bc-37ad677d-ed7a-5696-aae9-275bbf8e0f2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37ad677d-ed7a-5696-aae9-275bbf8e0f2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

