### PR TITLE
fix(api-reference): replace external URLs with local fixtures in e2e tests

### DIFF
--- a/.changeset/fix-e2e-test-flakiness.md
+++ b/.changeset/fix-e2e-test-flakiness.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix intermittently failing E2E tests by replacing external Petstore and Galaxy registry URLs with local fixtures, eliminating network dependency during test runs. Also remove leftover debug code (`console.log` and `page.pause()`) from url.e2e.ts.

--- a/packages/api-reference/examples/petstore-swagger2.json
+++ b/packages/api-reference/examples/petstore-swagger2.json
@@ -1,0 +1,590 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+    "version": "1.0.7",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": { "email": "apiteam@swagger.io" },
+    "license": { "name": "Apache 2.0", "url": "http://www.apache.org/licenses/LICENSE-2.0.html" }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v2",
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": { "description": "Find out more", "url": "http://swagger.io" }
+    },
+    { "name": "store", "description": "Access to Petstore orders" },
+    {
+      "name": "user",
+      "description": "Operations about user",
+      "externalDocs": { "description": "Find out more about our store", "url": "http://swagger.io" }
+    }
+  ],
+  "schemes": ["https", "http"],
+  "paths": {
+    "/pet/{petId}": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": { "description": "successful operation", "schema": { "$ref": "#/definitions/Pet" } },
+          "400": { "description": "Invalid ID supplied" },
+          "404": { "description": "Pet not found" }
+        },
+        "security": [{ "api_key": [] }]
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "consumes": ["application/x-www-form-urlencoded"],
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "name",
+            "in": "formData",
+            "description": "Updated name of the pet",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "in": "formData",
+            "description": "Updated status of the pet",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": { "405": { "description": "Invalid input" } },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      },
+      "delete": {
+        "tags": ["pet"],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          { "name": "api_key", "in": "header", "required": false, "type": "string" },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": { "400": { "description": "Invalid ID supplied" }, "404": { "description": "Pet not found" } },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "uploads an image",
+        "description": "",
+        "operationId": "uploadFile",
+        "consumes": ["multipart/form-data"],
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "additionalMetadata",
+            "in": "formData",
+            "description": "Additional data to pass to server",
+            "required": false,
+            "type": "string"
+          },
+          { "name": "file", "in": "formData", "description": "file to upload", "required": false, "type": "file" }
+        ],
+        "responses": {
+          "200": { "description": "successful operation", "schema": { "$ref": "#/definitions/ApiResponse" } }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "Add a new pet to the store",
+        "description": "",
+        "operationId": "addPet",
+        "consumes": ["application/json", "application/xml"],
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": true,
+            "schema": { "$ref": "#/definitions/Pet" }
+          }
+        ],
+        "responses": { "405": { "description": "Invalid input" } },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      },
+      "put": {
+        "tags": ["pet"],
+        "summary": "Update an existing pet",
+        "description": "",
+        "operationId": "updatePet",
+        "consumes": ["application/json", "application/xml"],
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": true,
+            "schema": { "$ref": "#/definitions/Pet" }
+          }
+        ],
+        "responses": {
+          "400": { "description": "Invalid ID supplied" },
+          "404": { "description": "Pet not found" },
+          "405": { "description": "Validation exception" }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "type": "array",
+            "items": { "type": "string", "enum": ["available", "pending", "sold"], "default": "available" },
+            "collectionFormat": "multi"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": { "type": "array", "items": { "$ref": "#/definitions/Pet" } }
+          },
+          "400": { "description": "Invalid status value" }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by tags",
+        "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": true,
+            "type": "array",
+            "items": { "type": "string" },
+            "collectionFormat": "multi"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": { "type": "array", "items": { "$ref": "#/definitions/Pet" } }
+          },
+          "400": { "description": "Invalid tag value" }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }],
+        "deprecated": true
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
+        "operationId": "getOrderById",
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "type": "integer",
+            "maximum": 10,
+            "minimum": 1,
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": { "description": "successful operation", "schema": { "$ref": "#/definitions/Order" } },
+          "400": { "description": "Invalid ID supplied" },
+          "404": { "description": "Order not found" }
+        }
+      },
+      "delete": {
+        "tags": ["store"],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
+        "operationId": "deleteOrder",
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "type": "integer",
+            "minimum": 1,
+            "format": "int64"
+          }
+        ],
+        "responses": { "400": { "description": "Invalid ID supplied" }, "404": { "description": "Order not found" } }
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "produces": ["application/json"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": { "type": "object", "additionalProperties": { "type": "integer", "format": "int32" } }
+          }
+        },
+        "security": [{ "api_key": [] }]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": ["store"],
+        "summary": "Place an order for a pet",
+        "description": "",
+        "operationId": "placeOrder",
+        "consumes": ["application/json"],
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "order placed for purchasing the pet",
+            "required": true,
+            "schema": { "$ref": "#/definitions/Order" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "successful operation", "schema": { "$ref": "#/definitions/Order" } },
+          "400": { "description": "Invalid Order" }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": { "description": "successful operation", "schema": { "$ref": "#/definitions/User" } },
+          "400": { "description": "Invalid username supplied" },
+          "404": { "description": "User not found" }
+        }
+      },
+      "put": {
+        "tags": ["user"],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "consumes": ["application/json"],
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be updated",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Updated user object",
+            "required": true,
+            "schema": { "$ref": "#/definitions/User" }
+          }
+        ],
+        "responses": { "400": { "description": "Invalid user supplied" }, "404": { "description": "User not found" } }
+      },
+      "delete": {
+        "tags": ["user"],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "400": { "description": "Invalid username supplied" },
+          "404": { "description": "User not found" }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "consumes": ["application/json"],
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "Created user object",
+            "required": true,
+            "schema": { "$ref": "#/definitions/User" }
+          }
+        ],
+        "responses": { "default": { "description": "successful operation" } }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs user into the system",
+        "description": "",
+        "operationId": "loginUser",
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "X-Expires-After": {
+                "type": "string",
+                "format": "date-time",
+                "description": "date in UTC when token expires"
+              },
+              "X-Rate-Limit": {
+                "type": "integer",
+                "format": "int32",
+                "description": "calls per hour allowed by the user"
+              }
+            },
+            "schema": { "type": "string" }
+          },
+          "400": { "description": "Invalid username/password supplied" }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "logoutUser",
+        "produces": ["application/json", "application/xml"],
+        "parameters": [],
+        "responses": { "default": { "description": "successful operation" } }
+      }
+    },
+    "/user/createWithArray": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithArrayInput",
+        "consumes": ["application/json"],
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of user object",
+            "required": true,
+            "schema": { "type": "array", "items": { "$ref": "#/definitions/User" } }
+          }
+        ],
+        "responses": { "default": { "description": "successful operation" } }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithListInput",
+        "consumes": ["application/json"],
+        "produces": ["application/json", "application/xml"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "List of user object",
+            "required": true,
+            "schema": { "type": "array", "items": { "$ref": "#/definitions/User" } }
+          }
+        ],
+        "responses": { "default": { "description": "successful operation" } }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "api_key": { "type": "apiKey", "name": "api_key", "in": "header" },
+    "petstore_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://petstore.swagger.io/oauth/authorize",
+      "flow": "implicit",
+      "scopes": { "read:pets": "read your pets", "write:pets": "modify pets in your account" }
+    }
+  },
+  "definitions": {
+    "Category": {
+      "type": "object",
+      "properties": { "id": { "type": "integer", "format": "int64" }, "name": { "type": "string" } },
+      "xml": { "name": "Category" }
+    },
+    "Pet": {
+      "type": "object",
+      "required": ["name", "photoUrls"],
+      "properties": {
+        "id": { "type": "integer", "format": "int64" },
+        "category": { "$ref": "#/definitions/Category" },
+        "name": { "type": "string", "example": "doggie" },
+        "photoUrls": {
+          "type": "array",
+          "xml": { "wrapped": true },
+          "items": { "type": "string", "xml": { "name": "photoUrl" } }
+        },
+        "tags": {
+          "type": "array",
+          "xml": { "wrapped": true },
+          "items": { "xml": { "name": "tag" }, "$ref": "#/definitions/Tag" }
+        },
+        "status": {
+          "type": "string",
+          "description": "pet status in the store",
+          "enum": ["available", "pending", "sold"]
+        }
+      },
+      "xml": { "name": "Pet" }
+    },
+    "Tag": {
+      "type": "object",
+      "properties": { "id": { "type": "integer", "format": "int64" }, "name": { "type": "string" } },
+      "xml": { "name": "Tag" }
+    },
+    "ApiResponse": {
+      "type": "object",
+      "properties": {
+        "code": { "type": "integer", "format": "int32" },
+        "type": { "type": "string" },
+        "message": { "type": "string" }
+      }
+    },
+    "Order": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "integer", "format": "int64" },
+        "petId": { "type": "integer", "format": "int64" },
+        "quantity": { "type": "integer", "format": "int32" },
+        "shipDate": { "type": "string", "format": "date-time" },
+        "status": { "type": "string", "description": "Order Status", "enum": ["placed", "approved", "delivered"] },
+        "complete": { "type": "boolean" }
+      },
+      "xml": { "name": "Order" }
+    },
+    "User": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "integer", "format": "int64" },
+        "username": { "type": "string" },
+        "firstName": { "type": "string" },
+        "lastName": { "type": "string" },
+        "email": { "type": "string" },
+        "password": { "type": "string" },
+        "phone": { "type": "string" },
+        "userStatus": { "type": "integer", "format": "int32", "description": "User Status" }
+      },
+      "xml": { "name": "User" }
+    }
+  },
+  "externalDocs": { "description": "Find out more about Swagger", "url": "http://swagger.io" }
+}

--- a/packages/api-reference/test/configuration/sources.e2e.ts
+++ b/packages/api-reference/test/configuration/sources.e2e.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import galaxy from '@scalar/galaxy/latest.json' with { type: 'json' }
 import { serveExample } from '@test/utils/serve-example'
 
 test.describe('sources', () => {
@@ -9,11 +10,11 @@ test.describe('sources', () => {
       sources: [
         {
           slug: 'petstore',
-          url: 'https://petstore.swagger.io/v2/swagger.json',
+          url: 'examples/petstore-swagger2.json',
         },
         {
           slug: 'galaxy',
-          url: 'https://registry.scalar.com/@scalar/apis/galaxy?format=json',
+          content: galaxy,
         },
         {
           slug: 'content',
@@ -75,7 +76,7 @@ test.describe('sources', () => {
       sources: [
         {
           slug: 'petstore',
-          url: 'https://petstore.swagger.io/v2/swagger.json',
+          url: 'examples/petstore-swagger2.json',
         },
         {
           default: true,

--- a/packages/api-reference/test/configuration/url.e2e.ts
+++ b/packages/api-reference/test/configuration/url.e2e.ts
@@ -4,7 +4,7 @@ import { serveExample } from '@test/utils/serve-example'
 test.describe('url', () => {
   test('renders Petstore (Swagger 2.0) document', async ({ page }) => {
     const example = await serveExample({
-      url: 'https://petstore.swagger.io/v2/swagger.json',
+      url: 'examples/petstore-swagger2.json',
     })
 
     await page.goto(example)
@@ -68,9 +68,7 @@ test.describe('url', () => {
       ],
     })
 
-    console.log('example', example)
     await page.goto(`${example}?api=api-two`)
-    await page.pause()
 
     await expect(page.getByRole('heading', { name: 'API Two', level: 1 })).toBeVisible()
   })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Three E2E tests in `packages/api-reference` were intermittently failing because they depended on external network requests to third-party services that have no uptime guarantee:

- `test/configuration/url.e2e.ts` — fetched `https://petstore.swagger.io/v2/swagger.json`
- `test/configuration/sources.e2e.ts` — fetched `https://petstore.swagger.io/v2/swagger.json` and `https://registry.scalar.com/@scalar/apis/galaxy?format=json`

When those services are slow, rate-limiting, or temporarily unavailable, the `toBeVisible()` assertion for `h3 'uploads an image'` (or `h1 'Scalar Galaxy'`) times out after 15 seconds, failing the CI run.

Additionally, `url.e2e.ts` had leftover debugging code — `console.log('example', example)` and `await page.pause()` — from an in-progress development session. The `page.pause()` call indefinitely suspends the test process unless Playwright runs in headed/debug mode with `--debug`, which it does not in CI.

## Changes

- **Added** `packages/api-reference/examples/petstore-swagger2.json` — a local copy of the Swagger Petstore v2 spec (same content as `https://petstore.swagger.io/v2/swagger.json`). The test server already serves `/examples/*` as static files.
- **Updated** `test/configuration/url.e2e.ts` — switch from external URL to `examples/petstore-swagger2.json`; remove `console.log` and `page.pause()` debug leftovers.
- **Updated** `test/configuration/sources.e2e.ts` — switch Petstore source from external URL to `examples/petstore-swagger2.json`; switch Galaxy source from `registry.scalar.com` URL to the local `@scalar/galaxy/latest.json` package content (already used by other tests in this package).

## Why this approach

The test server (`serve-example.ts`) already serves `examples/` as static files via `serveStatic({ root: './' })`, so using a relative URL is consistent with the existing `examples/openapi.json` and `examples/long-strings.yaml` test fixtures. Using local `content:` for Galaxy is the same pattern already used in `test/utils/sources.ts`, `test/configuration/hidden-clients.e2e.ts`, and `test/configuration/default-http-client.e2e.ts`.

## Ticket

Part of https://github.com/scalar/scalar/actions/runs/25122978494/job/73632271710

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cea7dc0-e647-48e9-8885-5c19c77aff3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cea7dc0-e647-48e9-8885-5c19c77aff3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

