### PR TITLE
chore(agents): require lint, format, and typecheck after changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,30 @@ All workspace packages use `workspace:*` for internal dependencies. Shared third
 
 ## Code Standards
 
+### Reuse helpers before writing new ones
+
+Before writing a new utility function, check `@scalar/helpers` (`packages/helpers/src/`) first. It already covers a wide range of common needs, organized by category:
+
+| Category | Examples |
+|----------|---------|
+| `array` | array manipulation utilities |
+| `dom` | DOM helpers |
+| `errors` | error handling utilities |
+| `file` | file utilities |
+| `formatters` | value formatting |
+| `general` | miscellaneous general utilities |
+| `http` | HTTP methods, headers, status codes, MIME types |
+| `json` | JSON pointer helpers, pretty-print |
+| `markdown` | heading extraction |
+| `object` | deep equality, key helpers, path access, local storage |
+| `queue` | async queue |
+| `regex` | variable finding/replacing |
+| `string` | capitalize, hash, truncate, camel-to-title |
+| `testing` | sleep, measure, console spies |
+| `url` | URL validation, merging, proxy helpers |
+
+If the helper you need already exists there, import it from `@scalar/helpers`. Only add a new helper to `@scalar/helpers` (or another package) if nothing suitable already exists.
+
 ### TypeScript
 
 - Prefer `type` over `interface`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,12 +288,26 @@ pnpm changeset
 
 ### After-change checklist
 
-After making **any** code changes, always run the following commands in order and fix all errors before committing:
+After making **any** code changes, run lint, format, and type-check scoped to only the files and packages you touched. Do not run whole-repo checks.
+
+**1. Lint and format only the changed files:**
 
 ```bash
-pnpm lint:fix      # Auto-fix linting issues (Biome + ESLint)
-pnpm format        # Format all files (Prettier + Biome)
-pnpm types:check   # Type-check all packages
+# Collect the files you changed (adjust the revision as needed)
+CHANGED=$(git diff --name-only HEAD)
+
+# Biome: lint + format TypeScript/JS files
+pnpm biome check --write --diagnostic-level=error --no-errors-on-unmatched --files-ignore-unknown=true $CHANGED
+
+# Prettier: format Vue, Markdown, JSON, CSS, YAML, and other non-TS files
+pnpm prettier --write $CHANGED
+```
+
+**2. Type-check only the affected package(s):**
+
+```bash
+# Replace <package-name> with the actual package (e.g. api-client, helpers, oas-utils)
+pnpm --filter @scalar/<package-name> types:check
 ```
 
 Then, before opening or updating a PR, also run:
@@ -302,7 +316,7 @@ Then, before opening or updating a PR, also run:
 pnpm knip          # Detect unused exports, files, and dependencies
 ```
 
-> All four commands must pass cleanly. Do not commit code that has lint errors, type errors, or unused exports.
+> All checks must pass cleanly. Do not commit code that has lint errors, type errors, or unused exports.
 
 ## Visual Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,14 +286,23 @@ If a package version should bump, add a changeset:
 pnpm changeset
 ```
 
-### Pre-PR command checklist
+### After-change checklist
 
-After making code changes, run:
+After making **any** code changes, always run the following commands in order and fix all errors before committing:
 
 ```bash
-pnpm format
-pnpm knip
+pnpm lint:fix      # Auto-fix linting issues (Biome + ESLint)
+pnpm format        # Format all files (Prettier + Biome)
+pnpm types:check   # Type-check all packages
 ```
+
+Then, before opening or updating a PR, also run:
+
+```bash
+pnpm knip          # Detect unused exports, files, and dependencies
+```
+
+> All four commands must pass cleanly. Do not commit code that has lint errors, type errors, or unused exports.
 
 ## Visual Testing
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds two new guidance sections to `AGENTS.md`:

1. **After-change checklist** — lint, format, and type-check scoped to only the changed files/packages (using `git diff --name-only HEAD` + `pnpm --filter`), matching how the existing `lefthook.yml` pre-commit hooks already work. `pnpm knip` is kept as a whole-repo pre-PR step.

2. **Reuse helpers before writing new ones** — agents must check `@scalar/helpers` (`packages/helpers/src/`) before writing a new utility function. The section includes a full category table (array, dom, errors, file, formatters, general, http, json, markdown, object, queue, regex, string, testing, url) so agents know exactly what is already available.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e495dd90-63dc-4870-9b8e-2a8fe317d6b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e495dd90-63dc-4870-9b8e-2a8fe317d6b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

