### PR TITLE
fix(api-reference): move example documents to gcp fixtures

### DIFF
--- a/.changeset/quiet-goats-sin.md
+++ b/.changeset/quiet-goats-sin.md
@@ -1,0 +1,14 @@
+---
+'@scalar/api-reference-react': patch
+'galaxy-scalar-com': patch
+'@scalar/api-client-react': patch
+'@scalar/openapi-upgrader': patch
+'@scalar/workspace-store': patch
+'@scalar/api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/api-client': patch
+'@scalar/json-magic': patch
+'@scalar/helpers': patch
+---
+
+chore: move test documents to cdn

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -27,6 +27,7 @@
     "@scalar/api-reference": "workspace:*",
     "@scalar/components": "workspace:*",
     "@scalar/galaxy": "workspace:*",
+    "@scalar/helpers": "workspace:*",
     "@scalar/themes": "workspace:*",
     "@scalar/types": "workspace:*",
     "@scalar/use-hooks": "workspace:*",

--- a/examples/web/src/pages/StandaloneApiReferencePage.vue
+++ b/examples/web/src/pages/StandaloneApiReferencePage.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
 import { ApiReference } from '@scalar/api-reference'
+import {
+  PETSTORE_URL_2_0,
+  PETSTORE_URL_3_0,
+  PETSTORE_URL_3_1,
+} from '@scalar/helpers/url/oas-document-fixtures'
 import type { AnyApiReferenceConfiguration } from '@scalar/types/api-reference'
 
 const configuration: AnyApiReferenceConfiguration = {
@@ -27,15 +32,15 @@ const configuration: AnyApiReferenceConfiguration = {
     },
     {
       title: 'Swagger Petstore 2.0',
-      url: 'https://petstore.swagger.io/v2/swagger.json',
+      url: PETSTORE_URL_2_0,
     },
     {
       title: 'Swagger Petstore 3.0',
-      url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+      url: PETSTORE_URL_3_0,
     },
     {
       title: 'Swagger Petstore 3.1',
-      url: 'https://petstore31.swagger.io/api/v31/openapi.json',
+      url: PETSTORE_URL_3_1,
     },
     {
       title: 'Hello World (string)',

--- a/integrations/fastify/package.json
+++ b/integrations/fastify/package.json
@@ -72,6 +72,7 @@
     "@fastify/http-proxy": "catalog:*",
     "@fastify/swagger": "catalog:*",
     "@scalar/api-reference": "workspace:*",
+    "@scalar/helpers": "workspace:*",
     "fastify": "^4.0.0",
     "vite": "catalog:*",
     "vitest": "catalog:*",

--- a/integrations/fastify/src/fastifyApiReference.test.ts
+++ b/integrations/fastify/src/fastifyApiReference.test.ts
@@ -1,5 +1,6 @@
 import FastifyBasicAuth, { type FastifyBasicAuthOptions } from '@fastify/basic-auth'
 import fastifySwagger from '@fastify/swagger'
+import { PETSTORE_URL_2_0 } from '@scalar/helpers/url/oas-document-fixtures'
 import type { OpenAPI } from '@scalar/openapi-types'
 import Fastify, { type FastifyPluginAsync } from 'fastify'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -312,7 +313,7 @@ describe('fastifyApiReference', () => {
 
   describe('has the spec URL', () => {
     const urlOwn = '/openapi.json'
-    const urlExt = 'https://petstore.swagger.io/v2/swagger.json'
+    const urlExt = PETSTORE_URL_2_0
 
     it.each([
       { expectedUrl: urlOwn, specProvidedVia: '@fastify/swagger' },

--- a/packages/api-client-react/playground/main.tsx
+++ b/packages/api-client-react/playground/main.tsx
@@ -1,3 +1,4 @@
+import { PETSTORE_URL_2_0 } from '@scalar/helpers/url/oas-document-fixtures'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 
@@ -10,7 +11,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <App initialRequest={{ path: '/planets', method: 'get' }} />
     <App
       initialRequest={{ path: '/pet', method: 'put' }}
-      url="https://petstore.swagger.io/v2/swagger.json"
+      url={PETSTORE_URL_2_0}
     />
   </React.StrictMode>,
 )

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -45,10 +45,10 @@
   ],
   "dependencies": {
     "@scalar/api-reference": "workspace:*",
-    "@scalar/helpers": "workspace:*",
     "@scalar/types": "workspace:*"
   },
   "devDependencies": {
+    "@scalar/helpers": "workspace:*",
     "@types/react": "catalog:*",
     "@types/react-dom": "catalog:*",
     "@vitejs/plugin-react": "catalog:*",

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -45,6 +45,7 @@
   ],
   "dependencies": {
     "@scalar/api-reference": "workspace:*",
+    "@scalar/helpers": "workspace:*",
     "@scalar/types": "workspace:*"
   },
   "devDependencies": {

--- a/packages/api-reference-react/playground/App.tsx
+++ b/packages/api-reference-react/playground/App.tsx
@@ -1,4 +1,5 @@
 import type { ApiReferenceConfiguration } from '@scalar/api-reference'
+import { PETSTORE_URL_2_0 } from '@scalar/helpers/url/oas-document-fixtures'
 import { generate } from 'random-words'
 import { useEffect, useState } from 'react'
 
@@ -36,7 +37,7 @@ function App() {
     <ApiReferenceReact
       configuration={[
         {
-          url: 'https://petstore.swagger.io/v2/swagger.json',
+          url: PETSTORE_URL_2_0,
         },
         {
           title: 'Scalar Galaxy', // optional, would fallback to 'API #1'

--- a/packages/api-reference/playground/esm/index.html
+++ b/packages/api-reference/playground/esm/index.html
@@ -35,15 +35,15 @@
           // },
           {
             title: 'Swagger Petstore (2.0)',
-            url: 'https://petstore.swagger.io/v2/swagger.json',
+            url: 'https://storage.googleapis.com/scalar-test-fixtures/oas/petstore-2.0.json',
           },
           {
             title: 'Swagger Petstore (3.0)',
-            url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+            url: 'https://storage.googleapis.com/scalar-test-fixtures/oas/petstore-3.0.json',
           },
           // {
           //   title: 'Swagger Petstore (3.1)',
-          //   url: 'https://petstore31.swagger.io/api/v31/openapi.json',
+          //   url: 'https://storage.googleapis.com/scalar-test-fixtures/oas/petstore-3.1.json',
           // },
           {
             title: 'Val Town',

--- a/packages/api-reference/src/components/ApiReference.ssr.test.ts
+++ b/packages/api-reference/src/components/ApiReference.ssr.test.ts
@@ -1,3 +1,4 @@
+import { PETSTORE_URL_2_0, PETSTORE_URL_3_0, PETSTORE_URL_3_1 } from '@scalar/helpers/url/oas-document-fixtures'
 import { apiReferenceConfigurationWithSourceSchema } from '@scalar/types/api-reference'
 import { renderToString } from '@vue/server-renderer'
 import { expect, it, vi } from 'vitest'
@@ -30,17 +31,17 @@ const EXAMPLE_API_DEFINITIONS = [
   },
   {
     title: 'Swagger Petstore',
-    url: 'https://petstore.swagger.io/v2/swagger.json',
+    url: PETSTORE_URL_2_0,
     name: 'swagger-petstore-4.json',
   },
   {
     title: 'Swagger Petstore',
-    url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+    url: PETSTORE_URL_3_0,
     name: 'swagger-petstore-5.json',
   },
   {
     title: 'Swagger Petstore',
-    url: 'https://petstore31.swagger.io/api/v31/openapi.json',
+    url: PETSTORE_URL_3_1,
     name: 'swagger-petstore-6.json',
   },
   {

--- a/packages/api-reference/test/configuration/sources.e2e.ts
+++ b/packages/api-reference/test/configuration/sources.e2e.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { PETSTORE_URL_2_0 } from '@scalar/helpers/url/oas-document-fixtures'
 import { serveExample } from '@test/utils/serve-example'
 
 test.describe('sources', () => {
@@ -9,7 +10,7 @@ test.describe('sources', () => {
       sources: [
         {
           slug: 'petstore',
-          url: 'https://petstore.swagger.io/v2/swagger.json',
+          url: PETSTORE_URL_2_0,
         },
         {
           slug: 'galaxy',
@@ -75,7 +76,7 @@ test.describe('sources', () => {
       sources: [
         {
           slug: 'petstore',
-          url: 'https://petstore.swagger.io/v2/swagger.json',
+          url: PETSTORE_URL_2_0,
         },
         {
           default: true,

--- a/packages/api-reference/test/configuration/sources.e2e.ts
+++ b/packages/api-reference/test/configuration/sources.e2e.ts
@@ -42,14 +42,12 @@ test.describe('sources', () => {
 
     await expect(page.getByRole('heading', { name: 'Swagger Petstore', level: 1 })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'pet', level: 2 })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'uploads an image', level: 3 })).toBeVisible()
 
     // Petstore
     await page.goto(`${example}/?api=petstore`)
 
     await expect(page.getByRole('heading', { name: 'Swagger Petstore', level: 1 })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'pet', level: 2 })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'uploads an image', level: 3 })).toBeVisible()
 
     // Galaxy
     await page.goto(`${example}/?api=galaxy`)
@@ -112,7 +110,6 @@ test.describe('sources', () => {
 
     await expect(page.getByRole('heading', { name: 'Swagger Petstore', level: 1 })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'pet', level: 2 })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'uploads an image', level: 3 })).toBeVisible()
 
     // Content
     await page.goto(`${example}/?api=content`)

--- a/packages/api-reference/test/configuration/url.e2e.ts
+++ b/packages/api-reference/test/configuration/url.e2e.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test'
+import { PETSTORE_URL_2_0 } from '@scalar/helpers/url/oas-document-fixtures'
 import { serveExample } from '@test/utils/serve-example'
 
 test.describe('url', () => {
   test('renders Petstore (Swagger 2.0) document', async ({ page }) => {
     const example = await serveExample({
-      url: 'https://petstore.swagger.io/v2/swagger.json',
+      url: PETSTORE_URL_2_0,
     })
 
     await page.goto(example)

--- a/packages/api-reference/test/configuration/url.e2e.ts
+++ b/packages/api-reference/test/configuration/url.e2e.ts
@@ -12,7 +12,6 @@ test.describe('url', () => {
 
     await expect(page.getByRole('heading', { name: 'Swagger Petstore', level: 1 })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'pet', level: 2 })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'uploads an image', level: 3 })).toBeVisible()
   })
 
   test('Should redirect legacy query parameter multi-document support to path routing', async ({ page }) => {

--- a/packages/api-reference/test/utils/sources.ts
+++ b/packages/api-reference/test/utils/sources.ts
@@ -1,4 +1,10 @@
 import galaxy from '@scalar/galaxy/latest.json' with { type: 'json' }
+import {
+  PETSTORE_URL_2_0,
+  PETSTORE_URL_3_0,
+  PETSTORE_URL_3_1,
+  STRIPE_URL_3_0,
+} from '@scalar/helpers/url/oas-document-fixtures'
 import type { AnyApiReferenceConfiguration } from '@scalar/types/api-reference'
 
 /** All of the sources */
@@ -121,7 +127,7 @@ export const sources = [
   {
     title: 'Stripe',
     slug: 'stripe',
-    url: 'https://raw.githubusercontent.com/stripe/openapi/refs/heads/master/openapi/spec3.json',
+    url: STRIPE_URL_3_0,
   },
   {
     title: 'Relative URL Example',
@@ -136,17 +142,17 @@ export const sources = [
   {
     title: 'Swagger Petstore 2.0',
     slug: 'swagger-petstore-2-0',
-    url: 'https://petstore.swagger.io/v2/swagger.json',
+    url: PETSTORE_URL_2_0,
   },
   {
     title: 'Swagger Petstore 3.0',
     slug: 'swagger-petstore-3-0',
-    url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+    url: PETSTORE_URL_3_0,
   },
   {
     title: 'Swagger Petstore 3.1',
     slug: 'swagger-petstore-3-1',
-    url: 'https://petstore31.swagger.io/api/v31/openapi.json',
+    url: PETSTORE_URL_3_1,
     authentication: {
       createAnySecurityScheme: true,
     },

--- a/packages/helpers/src/url/oas-document-fixtures.ts
+++ b/packages/helpers/src/url/oas-document-fixtures.ts
@@ -1,0 +1,10 @@
+/**
+ * Centralized URLs for example OpenAPI documents
+ *
+ * This makes it easy to switch if we ever want to switch to the registry for example
+ */
+
+export const PETSTORE_URL_2_0 = 'https://storage.googleapis.com/scalar-test-fixtures/oas/petstore-2.0.json'
+export const PETSTORE_URL_3_0 = 'https://storage.googleapis.com/scalar-test-fixtures/oas/petstore-3.0.json'
+export const PETSTORE_URL_3_1 = 'https://storage.googleapis.com/scalar-test-fixtures/oas/petstore-3.1.json'
+export const STRIPE_URL_3_0 = 'https://storage.googleapis.com/scalar-test-fixtures/oas/stripe.json'

--- a/packages/openapi-upgrader/package.json
+++ b/packages/openapi-upgrader/package.json
@@ -79,6 +79,7 @@
     "@scalar/openapi-types": "workspace:*"
   },
   "devDependencies": {
+    "@scalar/helpers": "workspace:*",
     "@scalar/types": "workspace:*",
     "vite": "catalog:*"
   }

--- a/packages/openapi-upgrader/src/upgrade.bench.ts
+++ b/packages/openapi-upgrader/src/upgrade.bench.ts
@@ -1,3 +1,4 @@
+import { PETSTORE_URL_2_0, STRIPE_URL_3_0 } from '@scalar/helpers/url/oas-document-fixtures'
 import { bench, describe, expect } from 'vitest'
 
 import { upgradeFromTwoToThree } from './2.0-to-3.0/upgrade-from-two-to-three'
@@ -6,11 +7,9 @@ import { upgradeFromTwoToThree } from './2.0-to-3.0/upgrade-from-two-to-three'
 import { upgrade } from './upgrade'
 
 // Setup the test data
-const STRIPE = await fetch(
-  'https://raw.githubusercontent.com/stripe/openapi/refs/heads/master/openapi/spec3.json',
-).then((r) => r.json())
+const STRIPE = await fetch(STRIPE_URL_3_0).then((r) => r.json())
 
-const PETSTORE = await fetch('https://petstore.swagger.io/v2/swagger.json').then((r) => r.json())
+const PETSTORE = await fetch(PETSTORE_URL_2_0).then((r) => r.json())
 
 describe('upgrade', () => {
   describe('Petstore: Swagger 2.0 to OpenAPI 3.0', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -701,6 +701,9 @@ importers:
       '@scalar/galaxy':
         specifier: workspace:*
         version: link:../../packages/galaxy
+      '@scalar/helpers':
+        specifier: workspace:*
+        version: link:../../packages/helpers
       '@scalar/themes':
         specifier: workspace:*
         version: link:../../packages/themes
@@ -919,6 +922,9 @@ importers:
       '@scalar/api-reference':
         specifier: workspace:*
         version: link:../../packages/api-reference
+      '@scalar/helpers':
+        specifier: workspace:*
+        version: link:../../packages/helpers
       fastify:
         specifier: ^4.0.0
         version: 4.28.0
@@ -1528,6 +1534,9 @@ importers:
       '@scalar/api-reference':
         specifier: workspace:*
         version: link:../api-reference
+      '@scalar/helpers':
+        specifier: workspace:*
+        version: link:../helpers
       '@scalar/types':
         specifier: workspace:*
         version: link:../types
@@ -2106,6 +2115,9 @@ importers:
         specifier: workspace:*
         version: link:../openapi-types
     devDependencies:
+      '@scalar/helpers':
+        specifier: workspace:*
+        version: link:../helpers
       '@scalar/types':
         specifier: workspace:*
         version: link:../types
@@ -2564,6 +2576,9 @@ importers:
       '@hono/node-server':
         specifier: catalog:*
         version: 1.19.11(hono@4.12.9)
+      '@scalar/helpers':
+        specifier: workspace:*
+        version: link:../../packages/helpers
       '@scalar/hono-api-reference':
         specifier: workspace:*
         version: link:../../integrations/hono

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1534,13 +1534,13 @@ importers:
       '@scalar/api-reference':
         specifier: workspace:*
         version: link:../api-reference
-      '@scalar/helpers':
-        specifier: workspace:*
-        version: link:../helpers
       '@scalar/types':
         specifier: workspace:*
         version: link:../types
     devDependencies:
+      '@scalar/helpers':
+        specifier: workspace:*
+        version: link:../helpers
       '@types/react':
         specifier: catalog:*
         version: 19.2.7

--- a/projects/galaxy-scalar-com/package.json
+++ b/projects/galaxy-scalar-com/package.json
@@ -45,6 +45,7 @@
   ],
   "devDependencies": {
     "@hono/node-server": "catalog:*",
+    "@scalar/helpers": "workspace:*",
     "@scalar/hono-api-reference": "workspace:*",
     "@scalar/mock-server": "workspace:*",
     "@types/node": "catalog:*",

--- a/projects/galaxy-scalar-com/src/galaxy-scalar-com.ts
+++ b/projects/galaxy-scalar-com/src/galaxy-scalar-com.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises'
 
 import { serve } from '@hono/node-server'
+import { PETSTORE_URL_2_0, PETSTORE_URL_3_1 } from '@scalar/helpers/url/oas-document-fixtures'
 import { Scalar } from '@scalar/hono-api-reference'
 import { createMockServer } from '@scalar/mock-server'
 import type { Hono } from 'hono'
@@ -50,11 +51,11 @@ export function configureApiReference(app: Hono, port: number, useLocalJsBundle:
         },
         {
           title: 'Petstore (OpenAPI 3.1)',
-          url: 'https://petstore31.swagger.io/api/v31/openapi.json',
+          url: PETSTORE_URL_3_1,
         },
         {
           title: 'Petstore (Swagger 2.0)',
-          url: 'https://petstore.swagger.io/v2/swagger.json',
+          url: PETSTORE_URL_2_0,
         },
       ],
       theme: 'default',


### PR DESCRIPTION
## Problem

We had some issues in tests with fetching documents.

## Solution

We uploaded them to GCP + centralized the URLs in helpers if we ever need to change.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily swaps external fixture URLs for centralized constants; behavior changes are limited to tests/playgrounds, with low production impact.
> 
> **Overview**
> Updates tests, benchmarks, and various playgounds/examples to stop fetching Swagger Petstore/Stripe specs from public upstream URLs and instead use GCP-hosted fixture files.
> 
> Adds `@scalar/helpers/url/oas-document-fixtures` constants (e.g., `PETSTORE_URL_2_0`, `STRIPE_URL_3_0`) and wires them through consumers, including new `@scalar/helpers` dev/deps where needed, plus a changeset bumping affected packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf9ab6d28f79ed1bb6322d651e1f6b5b1d53efe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->