### PR TITLE
chore: re-added old changesets

### DIFF
--- a/.changeset/brave-actors-send.md
+++ b/.changeset/brave-actors-send.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: allow masking all temp urls

--- a/.changeset/clever-hounds-grin.md
+++ b/.changeset/clever-hounds-grin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+fix(galaxy): align operation and webhook security requirements with intended auth behavior

--- a/.changeset/eight-forks-hunt.md
+++ b/.changeset/eight-forks-hunt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): flatten deepObject query parameter display in parameter rendering

--- a/.changeset/fair-ghosts-march.md
+++ b/.changeset/fair-ghosts-march.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': minor
+---
+
+feat: extra metadata for registry documents

--- a/.changeset/few-mangos-drum.md
+++ b/.changeset/few-mangos-drum.md
@@ -1,0 +1,5 @@
+---
+'@scalar/validation': patch
+---
+
+chore(validation): include package publish files

--- a/.changeset/four-lizards-know.md
+++ b/.changeset/four-lizards-know.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: hide sidebar group label when we have a single group

--- a/.changeset/fuzzy-papers-yell.md
+++ b/.changeset/fuzzy-papers-yell.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix inline composed schema descriptions in api-reference

--- a/.changeset/green-laws-divide.md
+++ b/.changeset/green-laws-divide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): ignore undefined examples on flattened deepObject parameters

--- a/.changeset/hip-planes-serve.md
+++ b/.changeset/hip-planes-serve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': minor
+---
+
+feat: support version switching for regsitry documents

--- a/.changeset/hungry-houses-stop.md
+++ b/.changeset/hungry-houses-stop.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: remove extraneous eventBus prop from AgentScalarDrawer to eliminate Vue warning

--- a/.changeset/itchy-boxes-vanish.md
+++ b/.changeset/itchy-boxes-vanish.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): set specific padding and margin for nested items

--- a/.changeset/lemon-groups-lie.md
+++ b/.changeset/lemon-groups-lie.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix: hide sidebar section label when there is no default slot

--- a/.changeset/nine-comics-rhyme.md
+++ b/.changeset/nine-comics-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': minor
+---
+
+feat: support title for the scalar menu component

--- a/.changeset/old-apples-sneeze.md
+++ b/.changeset/old-apples-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': minor
+---
+
+refactor: adopt strict versioned @scalar/openapi-types imports in parser types

--- a/.changeset/public-dolls-laugh.md
+++ b/.changeset/public-dolls-laugh.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': minor
+---
+
+feat: ensure teams can have only one workspace and create default workspace of the team on demand

--- a/.changeset/security-requirement-badge.md
+++ b/.changeset/security-requirement-badge.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+feat(api-reference): show an "auth required" / "auth optional" badge next to each operation's path. Requirements are resolved via `operation.security ?? document.security`; hover reveals the scheme names, types, and any required scopes.

--- a/.changeset/shaky-mice-hammer.md
+++ b/.changeset/shaky-mice-hammer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+feat: added once back to the event bus

--- a/.changeset/silly-cars-chew.md
+++ b/.changeset/silly-cars-chew.md
@@ -1,0 +1,7 @@
+---
+'@scalar/workspace-store': minor
+'@scalar/api-client': minor
+'@scalar/oas-utils': minor
+---
+
+chore: migrate api-client from namespaces to teamSlug and convert team workspaces

--- a/.changeset/ten-papers-pick.md
+++ b/.changeset/ten-papers-pick.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': minor
+---
+
+feat: add empty state for the team workspace

--- a/.changeset/tiny-taxes-stay.md
+++ b/.changeset/tiny-taxes-stay.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: move scalar version logs

--- a/.changeset/two-carrots-hug.md
+++ b/.changeset/two-carrots-hug.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': minor
+---
+
+feat: make breadcrumbs navigable, add workspace selector fallback, and support team logo slots


### PR DESCRIPTION
We had a broken release. I checked out all the changesets to ensure we grabbed em all. We may have duplicates but at least we will not miss anything

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime code changes; the main risk is release/versioning noise (duplicate or unintended bumps) if some of these Changesets already landed elsewhere.
> 
> **Overview**
> Restores a collection of Changesets that were missed during a broken release, covering patch/minor bumps across `@scalar/api-client`, `@scalar/api-reference`, `@scalar/workspace-store`, `@scalar/components`, `@scalar/galaxy`, `@scalar/openapi-parser`, `@scalar/oas-utils`, and `@scalar/validation`.
> 
> This PR only adds release metadata (Changeset files) describing previously intended fixes/features (e.g., auth requirement badge, team/workspace migrations, UI tweaks, parser type import refactor), to ensure they are included in the next publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c9e44326e17c852ff15f9040f4e5689ca7e1fff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->