### PR TITLE
fix(ci): setup go before running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,11 @@ jobs:
       - name: Check built declaration alias imports
         if: matrix.shard-index == 1
         run: pnpm lint:check:dist-dts-aliases
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: projects/proxy-scalar-com/go.mod
+          cache: false
       - name: Start test servers
         run: pnpm script run test-servers & pnpm script wait -p 5051 5052
         timeout-minutes: 1


### PR DESCRIPTION
## Problem

test-packages started the Go proxy without setup-go, so CI sometimes spent the whole wait window downloading go1.26.2 and port 5051 never opened.

## Solution

add actions/setup-go before starting test servers so proxy-scalar-com can launch immediately

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only reordering of setup steps; main risk is unexpected CI runtime/caching behavior changes, not product logic.
> 
> **Overview**
> Updates the CI `test-packages` job to **set up Go before starting the Node-based test servers and running package tests**, using `actions/setup-go` with `projects/proxy-scalar-com/go.mod` as the version source.
> 
> This reorders environment provisioning to reduce flakiness from late Go installs/port-race conditions during test execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc453d69bdf65b17f94ebee42737e09f69d72b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->