### PR TITLE
fix(api-client): flush debounced edits before execute

### DIFF
--- a/.changeset/fast-owls-flush.md
+++ b/.changeset/fast-owls-flush.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/workspace-store': patch
+---
+
+Flush pending debounced operation edits before executing API client requests.

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
@@ -4,7 +4,7 @@ import type { AuthMeta, WorkspaceEventBus } from '@scalar/workspace-store/events
 import { type RequestPayload, buildRequest, requestFactory } from '@scalar/workspace-store/request-example'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
 import type { XScalarCookie } from '@scalar/workspace-store/schemas/extensions/general/x-scalar-cookies'
-import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import type { OpenApiDocument, ParameterObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/operation'
 import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -90,6 +90,7 @@ const createMockEventBus = (): WorkspaceEventBus => ({
   once: vi.fn(),
   off: vi.fn(),
   emit: vi.fn(() => null),
+  flushDebouncedEmits: vi.fn(),
 })
 
 /**
@@ -313,6 +314,130 @@ describe('OperationBlock', () => {
       requestPayload: ['https://api.example.com/api/users', expect.objectContaining({ method: 'GET' })],
       plugins: [],
     })
+  })
+
+  it('flushes debounced events before building a request', async () => {
+    const mockEventBus = createMockEventBus()
+    vi.mocked(sendRequest).mockResolvedValue([
+      null,
+      {
+        timestamp: Date.now(),
+        requestPayload: ['https://api.example.com/api/users', { method: 'GET', headers: new Headers() }],
+        response: {} as ResponseInstance,
+        originalResponse: createMockOriginalResponse(),
+      },
+    ])
+
+    const wrapper = mount(OperationBlock, {
+      props: { ...createDefaultProps(), eventBus: mockEventBus },
+    })
+
+    await triggerExecute(wrapper)
+
+    const flushDebouncedEmits = mockEventBus.flushDebouncedEmits
+    if (!flushDebouncedEmits) {
+      throw new Error('Expected flushDebouncedEmits to exist')
+    }
+
+    const flushOrder = vi.mocked(flushDebouncedEmits).mock.invocationCallOrder.at(0) ?? 0
+    const requestFactoryOrder = vi.mocked(requestFactory).mock.invocationCallOrder[0] ?? 0
+
+    expect(flushOrder).toBeLessThan(requestFactoryOrder)
+  })
+
+  it('flushes debounced events before validating path parameters', async () => {
+    const pathParameter: ParameterObject = {
+      name: 'id',
+      in: 'path',
+      required: true,
+      examples: {
+        default: {
+          value: '',
+        },
+      },
+    }
+    const operation = createMockOperation({
+      parameters: [pathParameter],
+    })
+    const mockEventBus = createMockEventBus()
+
+    const wrapper = mount(OperationBlock, {
+      props: {
+        ...createDefaultProps(),
+        eventBus: mockEventBus,
+        operation,
+        path: '/api/users/{id}',
+      },
+    })
+
+    await triggerExecute(wrapper)
+
+    const flushDebouncedEmits = mockEventBus.flushDebouncedEmits
+    if (!flushDebouncedEmits) {
+      throw new Error('Expected flushDebouncedEmits to exist')
+    }
+
+    const flushOrder = vi.mocked(flushDebouncedEmits).mock.invocationCallOrder.at(0) ?? 0
+    const toastOrder = mockToast.mock.invocationCallOrder[0] ?? 0
+
+    expect(flushOrder).toBeLessThan(toastOrder)
+    expect(mockToast).toHaveBeenCalledWith('Path parameters must have values.', 'error')
+    expect(requestFactory).not.toHaveBeenCalled()
+    expect(sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('uses path parameter values committed by a debounced flush before validation', async () => {
+    const pathParameter: ParameterObject = {
+      name: 'id',
+      in: 'path',
+      required: true,
+      examples: {
+        default: {
+          value: '',
+        },
+      },
+    }
+    const operation = createMockOperation({
+      parameters: [pathParameter],
+    })
+    const mockEventBus = createMockEventBus()
+
+    const flushDebouncedEmits = mockEventBus.flushDebouncedEmits
+    if (!flushDebouncedEmits) {
+      throw new Error('Expected flushDebouncedEmits to exist')
+    }
+
+    vi.mocked(flushDebouncedEmits).mockImplementation(() => {
+      pathParameter.examples = {
+        default: {
+          value: '123',
+        },
+      }
+    })
+    vi.mocked(sendRequest).mockResolvedValue([
+      null,
+      {
+        timestamp: Date.now(),
+        requestPayload: ['https://api.example.com/api/users/123', { method: 'GET', headers: new Headers() }],
+        response: {} as ResponseInstance,
+        originalResponse: createMockOriginalResponse(),
+      },
+    ])
+
+    const wrapper = mount(OperationBlock, {
+      props: {
+        ...createDefaultProps(),
+        eventBus: mockEventBus,
+        operation,
+        path: '/api/users/{id}',
+      },
+    })
+
+    await triggerExecute(wrapper)
+
+    expect(mockToast).not.toHaveBeenCalled()
+    expect(requestFactory).toHaveBeenCalledOnce()
+    expect(sendRequest).toHaveBeenCalledOnce()
   })
 
   it('displays toast error when buildRequest fails', async () => {

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -193,6 +193,8 @@ const cancelRequest = () => abortController.value?.abort(ERRORS.REQUEST_ABORTED)
 
 /** Execute the current operation example */
 const handleExecute = async () => {
+  eventBus.flushDebouncedEmits?.()
+
   const pathValidation = validatePathParameters(
     operation.parameters ?? [],
     exampleKey,

--- a/packages/workspace-store/src/events/bus.test.ts
+++ b/packages/workspace-store/src/events/bus.test.ts
@@ -2,6 +2,27 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createWorkspaceEventBus } from './bus'
 
+const debounceInstances = vi.hoisted((): Array<{ flushAll: ReturnType<typeof vi.fn> }> => [])
+
+vi.mock('@scalar/helpers/general/debounce', async (importOriginal) => {
+  type DebounceModule = typeof import('@scalar/helpers/general/debounce')
+  const actual = await importOriginal<DebounceModule>()
+
+  return {
+    debounce: vi.fn((options: Parameters<DebounceModule['debounce']>[0]) => {
+      const debounced = actual.debounce(options)
+      const flushAll = vi.fn(debounced.flushAll)
+
+      debounceInstances.push({ flushAll })
+
+      return {
+        ...debounced,
+        flushAll,
+      }
+    }),
+  }
+})
+
 const flushDebouncedEmits = (bus: ReturnType<typeof createWorkspaceEventBus>) => {
   if (!bus.flushDebouncedEmits) {
     throw new Error('Expected flushDebouncedEmits to exist')
@@ -12,6 +33,7 @@ const flushDebouncedEmits = (bus: ReturnType<typeof createWorkspaceEventBus>) =>
 
 describe('createWorkspaceEventBus', () => {
   beforeEach(() => {
+    debounceInstances.length = 0
     vi.clearAllMocks()
   })
 
@@ -329,6 +351,16 @@ describe('createWorkspaceEventBus', () => {
     expect(handler).toHaveBeenCalledTimes(1)
 
     vi.useRealTimers()
+  })
+
+  it('delegates debounced emit flushing to debounce flushAll', () => {
+    const bus = createWorkspaceEventBus()
+
+    bus.emit('update:dark-mode', true, { debounceKey: 'test' })
+    flushDebouncedEmits(bus)
+
+    expect(debounceInstances.length).toBe(1)
+    expect(debounceInstances[0]?.flushAll).toHaveBeenCalledTimes(1)
   })
 
   it('flushes the latest payload for each pending debounce key', () => {

--- a/packages/workspace-store/src/events/bus.test.ts
+++ b/packages/workspace-store/src/events/bus.test.ts
@@ -2,6 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createWorkspaceEventBus } from './bus'
 
+const flushDebouncedEmits = (bus: ReturnType<typeof createWorkspaceEventBus>) => {
+  if (!bus.flushDebouncedEmits) {
+    throw new Error('Expected flushDebouncedEmits to exist')
+  }
+
+  bus.flushDebouncedEmits()
+}
+
 describe('createWorkspaceEventBus', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -311,7 +319,7 @@ describe('createWorkspaceEventBus', () => {
 
     expect(handler).toHaveBeenCalledTimes(0)
 
-    bus.flushDebouncedEmits()
+    flushDebouncedEmits(bus)
 
     expect(handler).toHaveBeenCalledTimes(1)
     expect(handler).toHaveBeenCalledWith(true)
@@ -333,7 +341,7 @@ describe('createWorkspaceEventBus', () => {
     bus.emit('update:dark-mode', false, { debounceKey: 'first' })
     bus.emit('update:dark-mode', true, { debounceKey: 'second' })
 
-    bus.flushDebouncedEmits()
+    flushDebouncedEmits(bus)
 
     expect(handler).toHaveBeenCalledTimes(2)
     expect(handler).toHaveBeenNthCalledWith(1, false)
@@ -358,7 +366,7 @@ describe('createWorkspaceEventBus', () => {
 
     expect(handler).toHaveBeenCalledTimes(1)
 
-    bus.flushDebouncedEmits()
+    flushDebouncedEmits(bus)
 
     expect(handler).toHaveBeenCalledTimes(1)
 

--- a/packages/workspace-store/src/events/bus.test.ts
+++ b/packages/workspace-store/src/events/bus.test.ts
@@ -300,4 +300,68 @@ describe('createWorkspaceEventBus', () => {
 
     vi.useRealTimers()
   })
+
+  it('flushes pending debounced emits immediately', () => {
+    vi.useFakeTimers()
+    const bus = createWorkspaceEventBus()
+    const handler = vi.fn()
+
+    bus.on('update:dark-mode', handler)
+    bus.emit('update:dark-mode', true, { debounceKey: 'test' })
+
+    expect(handler).toHaveBeenCalledTimes(0)
+
+    bus.flushDebouncedEmits()
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith(true)
+
+    vi.advanceTimersByTime(400)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
+  })
+
+  it('flushes the latest payload for each pending debounce key', () => {
+    vi.useFakeTimers()
+    const bus = createWorkspaceEventBus()
+    const handler = vi.fn()
+
+    bus.on('update:dark-mode', handler)
+    bus.emit('update:dark-mode', true, { debounceKey: 'first' })
+    bus.emit('update:dark-mode', false, { debounceKey: 'first' })
+    bus.emit('update:dark-mode', true, { debounceKey: 'second' })
+
+    bus.flushDebouncedEmits()
+
+    expect(handler).toHaveBeenCalledTimes(2)
+    expect(handler).toHaveBeenNthCalledWith(1, false)
+    expect(handler).toHaveBeenNthCalledWith(2, true)
+
+    vi.advanceTimersByTime(400)
+
+    expect(handler).toHaveBeenCalledTimes(2)
+
+    vi.useRealTimers()
+  })
+
+  it('does not flush already executed debounced emits again', () => {
+    vi.useFakeTimers()
+    const bus = createWorkspaceEventBus()
+    const handler = vi.fn()
+
+    bus.on('update:dark-mode', handler)
+    bus.emit('update:dark-mode', true, { debounceKey: 'test' })
+
+    vi.advanceTimersByTime(400)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    bus.flushDebouncedEmits()
+
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
+  })
 })

--- a/packages/workspace-store/src/events/bus.ts
+++ b/packages/workspace-store/src/events/bus.ts
@@ -90,6 +90,11 @@ export type WorkspaceEventBus = {
    * bus.emit('scalar-update-sidebar', { value: true })
    */
   emit<E extends keyof ApiReferenceEvents>(...args: EmitParameters<E>): void
+
+  /**
+   * Flush all queued debounced emits immediately.
+   */
+  flushDebouncedEmits?(): void
 }
 
 /**
@@ -149,7 +154,10 @@ export const createWorkspaceEventBus = (options: EventBusOptions = {}): Workspac
    * Single debounce instance for all debounced emits
    * Uses keys to separate different event + debounceKey combinations
    */
-  const { execute: debouncedEmitter } = debounce({ delay: 328 })
+  const { execute: debouncedEmitter, flush: flushDebouncedEmitter } = debounce({
+    delay: 328,
+  })
+  const debouncedEmitKeys = new Set<string>()
 
   /**
    * Get or create a listener set for an event
@@ -284,8 +292,22 @@ export const createWorkspaceEventBus = (options: EventBusOptions = {}): Workspac
     // Create a unique key for this event + debounce key combination
     const debounceMapKey = `${event}-${options.debounceKey}`
 
+    debouncedEmitKeys.add(debounceMapKey)
+
     // Pass the closure directly - debounce will store the latest version
-    debouncedEmitter(debounceMapKey, () => performEmit(event, payload, options))
+    debouncedEmitter(debounceMapKey, () => {
+      debouncedEmitKeys.delete(debounceMapKey)
+      performEmit(event, payload, options)
+    })
+  }
+
+  const flushDebouncedEmits = (): void => {
+    const keys = [...debouncedEmitKeys]
+    debouncedEmitKeys.clear()
+
+    for (const key of keys) {
+      flushDebouncedEmitter(key)
+    }
   }
 
   return {
@@ -293,5 +315,6 @@ export const createWorkspaceEventBus = (options: EventBusOptions = {}): Workspac
     once,
     off,
     emit,
+    flushDebouncedEmits,
   }
 }

--- a/packages/workspace-store/src/events/bus.ts
+++ b/packages/workspace-store/src/events/bus.ts
@@ -154,10 +154,9 @@ export const createWorkspaceEventBus = (options: EventBusOptions = {}): Workspac
    * Single debounce instance for all debounced emits
    * Uses keys to separate different event + debounceKey combinations
    */
-  const { execute: debouncedEmitter, flush: flushDebouncedEmitter } = debounce({
+  const { execute: debouncedEmitter, flushAll: flushDebouncedEmitters } = debounce({
     delay: 328,
   })
-  const debouncedEmitKeys = new Set<string>()
 
   /**
    * Get or create a listener set for an event
@@ -292,22 +291,12 @@ export const createWorkspaceEventBus = (options: EventBusOptions = {}): Workspac
     // Create a unique key for this event + debounce key combination
     const debounceMapKey = `${event}-${options.debounceKey}`
 
-    debouncedEmitKeys.add(debounceMapKey)
-
     // Pass the closure directly - debounce will store the latest version
-    debouncedEmitter(debounceMapKey, () => {
-      debouncedEmitKeys.delete(debounceMapKey)
-      performEmit(event, payload, options)
-    })
+    debouncedEmitter(debounceMapKey, () => performEmit(event, payload, options))
   }
 
   const flushDebouncedEmits = (): void => {
-    const keys = [...debouncedEmitKeys]
-    debouncedEmitKeys.clear()
-
-    for (const key of keys) {
-      flushDebouncedEmitter(key)
-    }
+    flushDebouncedEmitters()
   }
 
   return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Executing a request immediately after editing debounced API client fields can build the request from stale operation state. This is visible for query parameter edits followed quickly by the execute hotkey.

## Solution

Add a workspace event bus API to flush queued debounced emits immediately, and call it at the start of API client request execution before path validation and request building. This keeps execution immediate while ensuring pending parameter/body edits are committed first.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Fixes #9047
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-865be023-8da6-45c7-a705-e5814589db30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-865be023-8da6-45c7-a705-e5814589db30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

