### PR TITLE
fix(workspace-store): build multipart body from schema object examples

### DIFF
--- a/.changeset/bright-lamps-film.md
+++ b/.changeset/bright-lamps-film.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix multipart/form-data request body generation for schema-derived object examples

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
@@ -378,6 +378,29 @@ describe('buildRequestBody', () => {
     assert(result?.value === mockFile)
   })
 
+  it('returns raw File for multipart/form-data when example value is a File instance', () => {
+    const mockFile = new File(['binary content'], 'payload.bin', { type: 'application/octet-stream' })
+    const requestBody = {
+      content: {
+        'multipart/form-data': {
+          examples: {
+            default: {
+              value: mockFile,
+            },
+          },
+        },
+      },
+    }
+
+    const result = buildRequestBody(requestBody, 'default')
+
+    expect(result).toStrictEqual({
+      mode: 'raw',
+      value: mockFile,
+      contentType: 'application/octet-stream',
+    })
+  })
+
   it('skips form entries with empty names', () => {
     const requestBody = {
       content: {

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
@@ -314,6 +314,47 @@ describe('buildRequestBody', () => {
     expect(result.value[1].value).toBe('Test file')
   })
 
+  it('builds FormData for schema-generated multipart/form-data object examples', () => {
+    const requestBody = coerceValue(RequestBodyObjectSchema, {
+      content: {
+        'multipart/form-data': {
+          schema: {
+            type: 'object',
+            properties: {
+              image: {
+                type: 'string',
+                format: 'binary',
+              },
+              description: {
+                type: 'string',
+                default: 'An image upload',
+              },
+            },
+            required: ['image'],
+          },
+        },
+      },
+    })
+
+    const result = buildRequestBody(requestBody, 'default')
+
+    expect(result?.mode).toBe('formdata')
+    assert(result?.mode === 'formdata')
+
+    expect(result.value).toStrictEqual([
+      {
+        type: 'text',
+        key: 'image',
+        value: '@filename',
+      },
+      {
+        type: 'text',
+        key: 'description',
+        value: 'An image upload',
+      },
+    ])
+  })
+
   it('returns File bodies for raw binary request examples', () => {
     const mockFile = new File(['binary content'], 'payload.bin', { type: 'application/octet-stream' })
     const requestBody = {

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -178,6 +178,67 @@ export const buildRequestBody = (
     return result
   }
 
+  // Form data - object format (from schema examples)
+  if (
+    bodyContentType === 'multipart/form-data' &&
+    example.value !== null &&
+    typeof example.value === 'object' &&
+    !Array.isArray(example.value)
+  ) {
+    const result: FormData = {
+      mode: 'formdata',
+      value: [],
+    }
+
+    for (const [key, value] of Object.entries(example.value)) {
+      if (!key || value === undefined || value === null) {
+        continue
+      }
+
+      const partContentType = getMultipartEncodingContentType(requestBody, bodyContentType, key)
+
+      if (value instanceof File) {
+        const unwrappedValue = unpackProxyObject(value)
+        const encodedValue =
+          partContentType && partContentType !== unwrappedValue.type
+            ? new File([unwrappedValue], unwrappedValue.name, {
+                type: partContentType,
+                lastModified: unwrappedValue.lastModified,
+              })
+            : unwrappedValue
+
+        result.value.push({
+          type: 'file',
+          key,
+          value: encodedValue,
+          contentType: partContentType,
+        })
+        continue
+      }
+
+      const serializedValue =
+        typeof value === 'object' && value !== null ? JSON.stringify(unpackProxyObject(value)) : String(value)
+
+      if (partContentType) {
+        result.value.push({
+          type: 'blob',
+          key,
+          value: new Blob([serializedValue], { type: partContentType }),
+          contentType: partContentType,
+        })
+        continue
+      }
+
+      result.value.push({
+        type: 'text',
+        key,
+        value: serializedValue,
+      })
+    }
+
+    return result
+  }
+
   // Any other type
   const exampleValue =
     example.value !== null && typeof example.value === 'object' ? unpackProxyObject(example.value) : example.value

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -1,4 +1,5 @@
 // import { replaceEnvVariables } from '@scalar/helpers/regex/replace-variables'
+import { isObject } from '@scalar/helpers/object/is-object'
 import { unpackProxyObject } from '@scalar/workspace-store/helpers/unpack-proxy'
 import type { RequestBodyObject } from '@scalar/workspace-store/schemas/v3.1/strict/request-body'
 
@@ -153,12 +154,7 @@ export const buildRequestBody = (
   // Form data - object format (from schema examples)
   // When the example value is a plain object and content type is form-urlencoded,
   // convert to URLSearchParams instead of JSON stringifying
-  if (
-    bodyContentType === 'application/x-www-form-urlencoded' &&
-    example.value !== null &&
-    typeof example.value === 'object' &&
-    !Array.isArray(example.value)
-  ) {
+  if (bodyContentType === 'application/x-www-form-urlencoded' && isObject(example.value)) {
     const result: UrlEncoded = {
       mode: 'urlencoded',
       value: [],
@@ -179,12 +175,7 @@ export const buildRequestBody = (
   }
 
   // Form data - object format (from schema examples)
-  if (
-    bodyContentType === 'multipart/form-data' &&
-    example.value !== null &&
-    typeof example.value === 'object' &&
-    !Array.isArray(example.value)
-  ) {
+  if (bodyContentType === 'multipart/form-data' && isObject(example.value)) {
     const result: FormData = {
       mode: 'formdata',
       value: [],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`multipart/form-data` requests generated from schema-only examples could fall back to a JSON raw body before any user interaction.

When the generated example was object-shaped (for example `{ "image": "@filename" }`), `buildRequestBody` did not treat it as form data and instead serialized it as `application/json`.

## Solution

- Added a dedicated `multipart/form-data` object-format branch in `buildRequestBody`.
- Convert object entries into `mode: 'formdata'` rows so schema-generated examples now follow multipart semantics by default.
- Preserve existing encoding behavior (`encoding.contentType`) and file handling logic for multipart entries.
- Added a regression test for schema-generated multipart object examples (`image` binary field generating `@filename`) to ensure the request body is built as form data rather than raw JSON.
- Added a patch changeset for `@scalar/workspace-store`.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Fixes #9032
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd619220-cf5f-45df-afcf-c723bbe2c629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd619220-cf5f-45df-afcf-c723bbe2c629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

