### PR TITLE
fix(api-client): expand query params in object

### DIFF
--- a/.changeset/neat-queries-expand.md
+++ b/.changeset/neat-queries-expand.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/workspace-store': patch
+---
+
+fix(api-client): expand object query parameters in the request UI

--- a/.changeset/setvalueatpath-helper.md
+++ b/.changeset/setvalueatpath-helper.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': minor
+---
+
+feat(helpers): add `setValueAtPath` for path-array-based nested object writes

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.test.ts
@@ -1,10 +1,11 @@
-import { createWorkspaceEventBus, type ApiReferenceEvents } from '@scalar/workspace-store/events'
+import { type ApiReferenceEvents, createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { type DefineComponent, defineComponent, markRaw } from 'vue'
 
 import RequestBody from '@/v2/blocks/request-block/components/RequestBody.vue'
+import type { TableRow } from '@/v2/blocks/request-block/components/RequestTableRow.vue'
 import { AuthSelector } from '@/v2/blocks/scalar-auth-selector-block'
 
 import RequestBlock, { type RequestBlockProps } from './RequestBlock.vue'
@@ -282,6 +283,81 @@ describe('RequestBlock', () => {
       fn.mockReset()
       vi.useRealTimers()
     }
+  })
+
+  it('renders object query parameters as expanded query rows', () => {
+    const wrapper = mount(RequestBlock, {
+      props: {
+        ...defaultProps,
+        operation: {
+          summary: '',
+          parameters: [
+            {
+              name: 'pageable',
+              in: 'query',
+              required: false,
+              schema: {
+                type: 'object',
+                properties: {
+                  page: {
+                    type: 'integer',
+                    format: 'int32',
+                  },
+                  size: {
+                    type: 'integer',
+                    format: 'int32',
+                  },
+                  sort: {
+                    type: 'array',
+                    items: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+            {
+              name: 'userSpec',
+              in: 'query',
+              required: false,
+              schema: {
+                type: 'object',
+                properties: {
+                  username: {
+                    type: 'string',
+                  },
+                  minAge: {
+                    type: 'integer',
+                    format: 'int32',
+                  },
+                  address: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    })
+
+    const queryParams = wrapper
+      .findAllComponents({ name: 'RequestParams' })
+      .find((component) => (component.props() as any).title === 'Query Parameters')
+
+    expect((queryParams?.props() as any).rows.map((row: TableRow) => row.name)).toStrictEqual([
+      'page',
+      'size',
+      'sort',
+      'username',
+      'minAge',
+      'address',
+    ])
   })
 
   it('re-emits parameter deleteAll for Cookies with mapped type', () => {

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.test.ts
@@ -2,7 +2,7 @@ import { type ApiReferenceEvents, createWorkspaceEventBus } from '@scalar/worksp
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
-import { type DefineComponent, defineComponent, markRaw } from 'vue'
+import { type DefineComponent, defineComponent, markRaw, nextTick } from 'vue'
 
 import RequestBody from '@/v2/blocks/request-block/components/RequestBody.vue'
 import type { TableRow } from '@/v2/blocks/request-block/components/RequestTableRow.vue'
@@ -357,6 +357,93 @@ describe('RequestBlock', () => {
       'username',
       'minAge',
       'address',
+    ])
+  })
+
+  it('removes deleted expanded query rows from the rendered rows', async () => {
+    const eventBus = createWorkspaceEventBus()
+    const fn = vi.fn()
+    const pageable = {
+      name: 'pageable',
+      in: 'query',
+      required: false,
+      schema: {
+        type: 'object',
+        properties: {
+          page: {
+            type: 'integer',
+            format: 'int32',
+          },
+          size: {
+            type: 'integer',
+            format: 'int32',
+          },
+          sort: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    } satisfies NonNullable<OperationObject['parameters']>[number]
+    const wrapper = mount(RequestBlock, {
+      props: {
+        ...defaultProps,
+        eventBus,
+        operation: {
+          summary: '',
+          parameters: [pageable],
+        },
+      },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    })
+
+    eventBus.on('operation:upsert:parameter', fn)
+
+    const getQueryParams = () => {
+      const queryParams = wrapper
+        .findAllComponents({ name: 'RequestParams' })
+        .find((component) => (component.props() as { title: string }).title === 'Query Parameters')
+
+      if (!queryParams) {
+        throw new Error('Query parameters section not found')
+      }
+
+      return queryParams
+    }
+
+    expect((getQueryParams().props() as { rows: TableRow[] }).rows.map((row) => row.name)).toStrictEqual([
+      'page',
+      'size',
+      'sort',
+    ])
+
+    getQueryParams().vm.$emit('delete', { index: 1 })
+    await nextTick()
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenCalledWith({
+      type: 'query',
+      payload: {
+        name: 'pageable',
+        value: {},
+        isDisabled: true,
+      },
+      originalParameter: pageable,
+      meta: {
+        method: 'get',
+        path: 'http://example.com/foo',
+        exampleKey: 'example-1',
+      },
+    })
+    expect((getQueryParams().props() as { rows: TableRow[] }).rows.map((row) => row.name)).toStrictEqual([
+      'page',
+      'sort',
     ])
   })
 

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
@@ -17,7 +17,6 @@ import { unpackProxyObject } from '@scalar/workspace-store/helpers/unpack-proxy'
 import {
   filterGlobalCookie,
   getEnvironmentVariables,
-  getExample,
   getResolvedUrl,
   type MergedSecuritySchemes,
   type SecuritySchemeObjectSecret,
@@ -39,9 +38,8 @@ import RequestCodeSnippet from '@/v2/blocks/request-block/components/RequestCode
 import RequestParams from '@/v2/blocks/request-block/components/RequestParams.vue'
 import type { TableRow } from '@/v2/blocks/request-block/components/RequestTableRow.vue'
 import { createParameterHandlers } from '@/v2/blocks/request-block/helpers/create-parameter-handlers'
-import { getParameterSchema } from '@/v2/blocks/request-block/helpers/get-parameter-schema'
+import { createParameterRows } from '@/v2/blocks/request-block/helpers/create-parameter-rows'
 import { groupBy } from '@/v2/blocks/request-block/helpers/group-by'
-import { isParamDisabled } from '@/v2/blocks/request-block/helpers/is-param-disabled'
 import { AuthSelector } from '@/v2/blocks/scalar-auth-selector-block'
 import type { OAuth2Options } from '@/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue'
 import type { ClientLayout } from '@/v2/types/layout'
@@ -115,20 +113,17 @@ const meta = computed(() => ({
 /** Parameters grouped by type (path, query, header, cookie) */
 const sections = computed(() =>
   groupBy(
-    operation.parameters?.map((param) => getResolvedRef(param)) ?? [],
+    operation.parameters
+      ?.map((param) => getResolvedRef(param))
+      .flatMap((param) =>
+        createParameterRows(param, exampleKey).map((row) => ({
+          ...row,
+          in: param.in,
+        })),
+      ) ?? [],
     'in',
-    (param) => {
-      const example = getExample(param, exampleKey, undefined)
-
-      return {
-        name: param.name,
-        value: example?.value ?? '',
-        description: param.description,
-        schema: getParameterSchema(param),
-        isRequired: param.required,
-        isDisabled: isParamDisabled(param, example),
-        originalParameter: param,
-      } as TableRow
+    ({ in: _in, ...row }) => {
+      return row as TableRow
     },
   ),
 )

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
@@ -110,13 +110,29 @@ const meta = computed(() => ({
   exampleKey,
 }))
 
+const deletedExpandedParameterPaths = ref<Record<string, string[][]>>({})
+
+const getExpandedParameterKey = (parameter: {
+  in: string
+  name: string
+}): string => `${parameter.in}:${parameter.name}`
+
+const getHiddenValuePaths = (parameter: {
+  in: string
+  name: string
+}): string[][] =>
+  deletedExpandedParameterPaths.value[getExpandedParameterKey(parameter)] ?? []
+
 /** Parameters grouped by type (path, query, header, cookie) */
 const sections = computed(() =>
   groupBy(
     operation.parameters
       ?.map((param) => getResolvedRef(param))
       .flatMap((param) =>
-        createParameterRows(param, exampleKey).map((row) => ({
+        createParameterRows(param, exampleKey, {
+          hiddenValuePaths:
+            param.in === 'query' ? getHiddenValuePaths(param) : [],
+        }).map((row) => ({
           ...row,
           in: param.in,
         })),
@@ -329,6 +345,13 @@ watch(
   },
 )
 
+watch(
+  () => [method, path, exampleKey],
+  () => {
+    deletedExpandedParameterPaths.value = {}
+  },
+)
+
 /** Handle operation summary updates */
 const handleSummaryUpdate = (event: Event): void => {
   const summary = (event.target as HTMLInputElement).value
@@ -353,6 +376,20 @@ const parameterHandlers = computed(() => ({
   }),
   query: createParameterHandlers('query', eventBus, meta.value, {
     context: sections.value.query ?? [],
+    onDeleteExpandedRow: (row) => {
+      if (!row.originalParameter || !row.sourceParameterValuePath) {
+        return
+      }
+
+      const key = getExpandedParameterKey(row.originalParameter)
+      deletedExpandedParameterPaths.value = {
+        ...deletedExpandedParameterPaths.value,
+        [key]: [
+          ...(deletedExpandedParameterPaths.value[key] ?? []),
+          row.sourceParameterValuePath,
+        ],
+      }
+    },
   }),
 }))
 

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -46,6 +46,8 @@ export type TableRow = {
   isOverridden?: boolean
   /** Track the original parameter so we can update it */
   originalParameter?: ParameterObject
+  /** Path to a value inside the original parameter example for expanded object parameters */
+  sourceParameterValuePath?: string[]
 }
 
 const {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -78,6 +78,63 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('upserts expanded object parameter rows through the parent parameter', () => {
+    const parentParameter = {
+      name: 'pageable',
+      in: 'query',
+    } as const
+    const context: TableRow[] = [
+      {
+        name: 'page',
+        value: '1',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        sourceParameterValuePath: ['page'],
+      },
+      {
+        name: 'size',
+        value: '',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        sourceParameterValuePath: ['size'],
+      },
+      {
+        name: 'sort',
+        value: 'username,asc',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        sourceParameterValuePath: ['sort'],
+      },
+    ]
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, {
+      context,
+    })
+
+    handlers.upsert(1, { name: 'size', value: '20', isDisabled: false })
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'pageable',
+          value: {
+            page: '1',
+            size: '20',
+            sort: 'username,asc',
+          },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-1',
+      },
+    )
+  })
+
   it('deletes a parameter at the correct index', () => {
     const mockRow: TableRow = {
       name: 'id',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -161,6 +161,66 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('deletes expanded object child rows by upserting the parent without the child value', () => {
+    const parentParameter = {
+      name: 'pageable',
+      in: 'query',
+    } as const
+    const onDeleteExpandedRow = vi.fn()
+    const context: TableRow[] = [
+      {
+        name: 'page',
+        value: '1',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        sourceParameterValuePath: ['page'],
+      },
+      {
+        name: 'size',
+        value: '20',
+        isRequired: true,
+        isDisabled: false,
+        originalParameter: parentParameter,
+        sourceParameterValuePath: ['size'],
+      },
+      {
+        name: 'sort',
+        value: 'username,asc',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        sourceParameterValuePath: ['sort'],
+      },
+    ]
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, {
+      context,
+      onDeleteExpandedRow,
+    })
+
+    handlers.delete({ index: 1 })
+
+    expect(onDeleteExpandedRow).toHaveBeenCalledTimes(1)
+    expect(onDeleteExpandedRow).toHaveBeenCalledWith(context[1])
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'pageable',
+          value: {
+            page: '1',
+            sort: 'username,asc',
+          },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+      },
+    )
+  })
+
   it('deletes all parameters of the given type', () => {
     const handlers = createParameterHandlers('cookie', mockEventBus, mockMeta, { context: [] })
 

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -1,28 +1,9 @@
+import { setValueAtPath } from '@scalar/helpers/object/set-value-at-path'
 import type { OperationExampleMeta, WorkspaceEventBus } from '@scalar/workspace-store/events'
 
 import type { TableRow } from '@/v2/blocks/request-block/components/RequestTableRow.vue'
 
 type ParameterType = 'path' | 'cookie' | 'header' | 'query'
-
-const setValueAtPath = (target: Record<string, unknown>, path: readonly string[], value: unknown): void => {
-  const [key, ...rest] = path
-  if (!key) {
-    return
-  }
-
-  if (!rest.length) {
-    target[key] = value
-    return
-  }
-
-  const next =
-    typeof target[key] === 'object' && target[key] !== null && !Array.isArray(target[key])
-      ? (target[key] as Record<string, unknown>)
-      : {}
-
-  target[key] = next
-  setValueAtPath(next, rest, value)
-}
 
 const isEmptyValue = (value: unknown): boolean => value === undefined || value === null || value === ''
 

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -4,6 +4,55 @@ import type { TableRow } from '@/v2/blocks/request-block/components/RequestTable
 
 type ParameterType = 'path' | 'cookie' | 'header' | 'query'
 
+const setValueAtPath = (target: Record<string, unknown>, path: readonly string[], value: unknown): void => {
+  const [key, ...rest] = path
+  if (!key) {
+    return
+  }
+
+  if (!rest.length) {
+    target[key] = value
+    return
+  }
+
+  const next =
+    typeof target[key] === 'object' && target[key] !== null && !Array.isArray(target[key])
+      ? (target[key] as Record<string, unknown>)
+      : {}
+
+  target[key] = next
+  setValueAtPath(next, rest, value)
+}
+
+const isEmptyValue = (value: unknown): boolean => value === undefined || value === null || value === ''
+
+const getExpandedObjectPayload = (
+  row: TableRow,
+  context: TableRow[],
+  payload: { name: string; value: string; isDisabled: boolean },
+): { name: string; value: Record<string, unknown>; isDisabled: boolean } => {
+  const value: Record<string, unknown> = {}
+
+  for (const contextRow of context) {
+    if (contextRow.originalParameter !== row.originalParameter || !contextRow.sourceParameterValuePath) {
+      continue
+    }
+
+    const nextValue = contextRow === row ? payload.value : contextRow.value
+    if (isEmptyValue(nextValue) && !contextRow.isRequired) {
+      continue
+    }
+
+    setValueAtPath(value, contextRow.sourceParameterValuePath, nextValue)
+  }
+
+  return {
+    name: row.originalParameter?.name ?? payload.name,
+    value,
+    isDisabled: payload.isDisabled,
+  }
+}
+
 /** Create parameter event handlers for a given type */
 export const createParameterHandlers = (
   type: ParameterType,
@@ -58,11 +107,16 @@ export const createParameterHandlers = (
       }
 
       if (index >= offset) {
+        const nextPayload =
+          row?.sourceParameterValuePath && row.originalParameter
+            ? getExpandedObjectPayload(row, context, payload)
+            : payload
+
         return eventBus.emit(
           'operation:upsert:parameter',
           {
             type,
-            payload: payload,
+            payload: nextPayload,
             originalParameter: row?.originalParameter ?? null,
             meta,
           },

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -10,7 +10,7 @@ const isEmptyValue = (value: unknown): boolean => value === undefined || value =
 const getExpandedObjectPayload = (
   row: TableRow,
   context: TableRow[],
-  payload: { name: string; value: string; isDisabled: boolean },
+  payload?: { name: string; value: string; isDisabled: boolean },
 ): { name: string; value: Record<string, unknown>; isDisabled: boolean } => {
   const value: Record<string, unknown> = {}
 
@@ -19,8 +19,12 @@ const getExpandedObjectPayload = (
       continue
     }
 
-    const nextValue = contextRow === row ? payload.value : contextRow.value
-    if (isEmptyValue(nextValue) && !contextRow.isRequired) {
+    if (contextRow === row && !payload) {
+      continue
+    }
+
+    const nextValue = contextRow === row ? payload?.value : contextRow.value
+    if (isEmptyValue(nextValue)) {
       continue
     }
 
@@ -28,9 +32,9 @@ const getExpandedObjectPayload = (
   }
 
   return {
-    name: row.originalParameter?.name ?? payload.name,
+    name: row.originalParameter?.name ?? payload?.name ?? row.name,
     value,
-    isDisabled: payload.isDisabled,
+    isDisabled: payload?.isDisabled ?? row.isDisabled ?? false,
   }
 }
 
@@ -43,24 +47,44 @@ export const createParameterHandlers = (
     context,
     defaultParameters = 0,
     globalParameters = 0,
+    onDeleteExpandedRow,
   }: {
     context: TableRow[]
     defaultParameters?: number
     globalParameters?: number
+    onDeleteExpandedRow?: (row: TableRow) => void
   },
 ) => {
   const offset = defaultParameters + globalParameters
 
   return {
     delete: (payload: { index: number }) => {
-      const originalParameter = context[payload.index]?.originalParameter
-      if (!originalParameter) {
+      const row = context[payload.index]
+      if (!row?.originalParameter) {
         return
       }
+
+      if (row.sourceParameterValuePath) {
+        onDeleteExpandedRow?.(row)
+
+        return eventBus.emit(
+          'operation:upsert:parameter',
+          {
+            type,
+            payload: getExpandedObjectPayload(row, context),
+            originalParameter: row.originalParameter,
+            meta,
+          },
+          {
+            skipUnpackProxy: true,
+          },
+        )
+      }
+
       eventBus.emit(
         'operation:delete:parameter',
         {
-          originalParameter,
+          originalParameter: row.originalParameter,
           meta,
         },
         {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
@@ -1,0 +1,211 @@
+import type { ExampleObject, ParameterObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { describe, expect, it } from 'vitest'
+
+import { createParameterRows } from './create-parameter-rows'
+
+describe('createParameterRows', () => {
+  it('expands default form query object parameters into property rows', () => {
+    const pageSchema = {
+      type: 'integer',
+      format: 'int32',
+      description: 'Page number',
+    } as const
+    const sizeSchema = {
+      type: 'integer',
+      format: 'int32',
+      description: 'Page size',
+    } as const
+    const sortSchema = {
+      type: 'array',
+      items: { type: 'string' },
+    } as const
+    const parameter: ParameterObject = {
+      name: 'pageable',
+      in: 'query',
+      required: false,
+      schema: {
+        type: 'object',
+        required: ['page'],
+        properties: {
+          page: pageSchema,
+          size: sizeSchema,
+          sort: sortSchema,
+        },
+      },
+      examples: {
+        default: {
+          value: {
+            page: 2,
+            sort: ['username,asc'],
+          },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    expect(createParameterRows(parameter, 'default')).toStrictEqual([
+      {
+        name: 'page',
+        value: '2',
+        description: 'Page number',
+        schema: pageSchema,
+        isRequired: true,
+        isDisabled: false,
+        originalParameter: parameter,
+        sourceParameterValuePath: ['page'],
+      },
+      {
+        name: 'size',
+        value: '',
+        description: 'Page size',
+        schema: sizeSchema,
+        isRequired: false,
+        isDisabled: false,
+        originalParameter: parameter,
+        sourceParameterValuePath: ['size'],
+      },
+      {
+        name: 'sort',
+        value: 'username,asc',
+        description: undefined,
+        schema: sortSchema,
+        isRequired: false,
+        isDisabled: false,
+        originalParameter: parameter,
+        sourceParameterValuePath: ['sort'],
+      },
+    ])
+  })
+
+  it('expands deepObject query parameters into bracket rows', () => {
+    const firstNameSchema = {
+      type: 'string',
+      description: 'First name',
+    } as const
+    const roleSchema = {
+      type: 'string',
+    } as const
+    const parameter: ParameterObject = {
+      name: 'filter',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+      schema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'object',
+            properties: {
+              first: firstNameSchema,
+            },
+          },
+          role: roleSchema,
+        },
+      },
+      examples: {
+        default: {
+          value: {
+            name: {
+              first: 'Alex',
+            },
+            role: 'admin',
+          },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    expect(createParameterRows(parameter, 'default')).toStrictEqual([
+      {
+        name: 'filter[name][first]',
+        value: 'Alex',
+        description: 'First name',
+        schema: firstNameSchema,
+        isRequired: false,
+        isDisabled: false,
+        originalParameter: parameter,
+        sourceParameterValuePath: ['name', 'first'],
+      },
+      {
+        name: 'filter[role]',
+        value: 'admin',
+        description: undefined,
+        schema: roleSchema,
+        isRequired: false,
+        isDisabled: false,
+        originalParameter: parameter,
+        sourceParameterValuePath: ['role'],
+      },
+    ])
+  })
+
+  it('round-trips edited expanded rows back through createParameterRows', () => {
+    const parameter: ParameterObject = {
+      name: 'pageable',
+      in: 'query',
+      required: false,
+      schema: {
+        type: 'object',
+        properties: {
+          page: { type: 'integer', format: 'int32' },
+          size: { type: 'integer', format: 'int32' },
+        },
+      },
+      examples: {
+        default: {
+          value: { page: 1 },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    const initialRows = createParameterRows(parameter, 'default')
+    expect(initialRows[0]?.value).toBe('1')
+    expect(initialRows[1]?.value).toBe('')
+
+    // Simulate the write-back: the upsert handler would set the example value
+    // to the reassembled object (e.g. { page: '1', size: '20' }).
+    const example = (parameter.examples as Record<string, ExampleObject>)['default']!
+    example.value = { page: '1', size: '20' }
+
+    const updatedRows = createParameterRows(parameter, 'default')
+    expect(updatedRows[0]?.value).toBe('1')
+    expect(updatedRows[1]?.value).toBe('20')
+  })
+
+  it('keeps unsupported object serialization as one row', () => {
+    const parameter: ParameterObject = {
+      name: 'filter',
+      in: 'query',
+      style: 'form',
+      explode: false,
+      schema: {
+        type: 'object',
+        properties: {
+          role: { type: 'string' },
+        },
+      },
+      examples: {
+        default: {
+          value: {
+            role: 'admin',
+          },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    expect(createParameterRows(parameter, 'default')).toStrictEqual([
+      {
+        name: 'filter',
+        value: '{"role":"admin"}',
+        description: undefined,
+        schema: parameter.schema,
+        isRequired: undefined,
+        isDisabled: false,
+        originalParameter: parameter,
+        sourceParameterValuePath: undefined,
+      },
+    ])
+  })
+})

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
@@ -173,6 +173,44 @@ describe('createParameterRows', () => {
     expect(updatedRows[1]?.value).toBe('20')
   })
 
+  it('omits expanded rows hidden by path', () => {
+    const parameter: ParameterObject = {
+      name: 'pageable',
+      in: 'query',
+      schema: {
+        type: 'object',
+        required: ['page'],
+        properties: {
+          page: { type: 'integer', format: 'int32' },
+          size: { type: 'integer', format: 'int32' },
+        },
+      },
+      examples: {
+        default: {
+          value: {},
+          'x-disabled': false,
+        },
+      },
+    }
+
+    expect(
+      createParameterRows(parameter, 'default', {
+        hiddenValuePaths: [['page']],
+      }),
+    ).toStrictEqual([
+      {
+        name: 'size',
+        value: '',
+        description: undefined,
+        schema: { type: 'integer', format: 'int32' },
+        isRequired: false,
+        isDisabled: false,
+        originalParameter: parameter,
+        sourceParameterValuePath: ['size'],
+      },
+    ])
+  })
+
   it('keeps unsupported object serialization as one row', () => {
     const parameter: ParameterObject = {
       name: 'filter',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -81,6 +81,8 @@ const toTableValue = (value: unknown): string => {
   return String(value)
 }
 
+const toPathKey = (path: readonly string[]): string => path.join('\u0000')
+
 const toTableRow = ({
   parameter,
   name,
@@ -146,6 +148,7 @@ const getExpandedPropertyRows = ({
   namePrefix,
   mode,
   isDisabled,
+  hiddenValuePaths,
 }: {
   parameter: ParameterObject
   schema: Extract<SchemaObject, { type: 'object' }>
@@ -154,6 +157,7 @@ const getExpandedPropertyRows = ({
   namePrefix: string
   mode: ExpansionMode
   isDisabled: boolean
+  hiddenValuePaths: ReadonlySet<string>
 }): TableRow[] => {
   if (!schema.properties) {
     return []
@@ -170,6 +174,10 @@ const getExpandedPropertyRows = ({
     const path = [...pathPrefix, propertyName]
     const name = namePrefix ? `${namePrefix}[${propertyName}]` : propertyName
 
+    if (hiddenValuePaths.has(toPathKey(path))) {
+      return []
+    }
+
     // Only deepObject style recurses into nested objects. The OpenAPI 3.1 spec says form-style
     // explode flattens only the top-level properties.
     const shouldRecurse =
@@ -184,6 +192,7 @@ const getExpandedPropertyRows = ({
         namePrefix: name,
         mode,
         isDisabled,
+        hiddenValuePaths,
       })
     }
 
@@ -210,7 +219,11 @@ const getExpandedPropertyRows = ({
  * matching how tools like Postman present the same parameter. Every other parameter passes
  * through as a single row.
  */
-export const createParameterRows = (parameter: ParameterObject, exampleKey: string): TableRow[] => {
+export const createParameterRows = (
+  parameter: ParameterObject,
+  exampleKey: string,
+  options: { hiddenValuePaths?: readonly string[][] } = {},
+): TableRow[] => {
   const example = getExample(parameter, exampleKey, undefined)
   const isDisabled = isParamDisabled(parameter, example)
   const schema = getParameterSchema(parameter)
@@ -225,6 +238,13 @@ export const createParameterRows = (parameter: ParameterObject, exampleKey: stri
   // can be displayed in the table even when the example arrives as a serialized string.
   const value = example?.value === undefined ? undefined : deSerializeParameter(example.value, parameter)
 
+  // Fall back to a single row only when the schema has no properties to expand.
+  if (!schema.properties) {
+    return [toSingleParameterRow(parameter, schema, example?.value, isDisabled)]
+  }
+
+  const hiddenValuePaths = new Set(options.hiddenValuePaths?.map(toPathKey) ?? [])
+
   const rows = getExpandedPropertyRows({
     parameter,
     schema,
@@ -234,8 +254,8 @@ export const createParameterRows = (parameter: ParameterObject, exampleKey: stri
     namePrefix: mode === 'deepObject' ? parameter.name : '',
     mode,
     isDisabled,
+    hiddenValuePaths,
   })
 
-  // Fall back to a single row if the schema had no properties to expand.
-  return rows.length > 0 ? rows : [toSingleParameterRow(parameter, schema, example?.value, isDisabled)]
+  return rows
 }

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -1,4 +1,4 @@
-import { isObject } from '@scalar/helpers/object/is-object'
+import { getValueAtPath } from '@scalar/helpers/object/get-value-at-path'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import { deSerializeParameter, getExample } from '@scalar/workspace-store/request-example'
 import type {
@@ -31,16 +31,6 @@ const getParameterStyleAndExplode = (parameter: ParameterObject): { style: strin
   const explode = 'explode' in parameter && parameter.explode !== undefined ? parameter.explode : style === 'form'
 
   return { style, explode }
-}
-
-const getValueAtPath = (source: unknown, path: readonly string[]): unknown => {
-  return path.reduce<unknown>((value, key) => {
-    if (!isObject(value)) {
-      return undefined
-    }
-
-    return value[key]
-  }, source)
 }
 
 const toTableValue = (value: unknown): string => {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -17,6 +17,9 @@ type ParameterWithRequiredSchema = ParameterWithSchemaObject & {
   schema: ReferenceType<SchemaObject>
 }
 
+/** Serialization mode for object-typed query parameters that we expand into multiple rows. */
+type ExpansionMode = 'form' | 'deepObject'
+
 const isParameterWithSchema = (parameter: ParameterObject): parameter is ParameterWithRequiredSchema =>
   'schema' in parameter && parameter.schema !== undefined
 
@@ -26,11 +29,40 @@ const resolveSchema = (schema: unknown): SchemaObject | undefined => {
   return resolvedSchema as SchemaObject | undefined
 }
 
+/**
+ * Resolves the OpenAPI serialization style and explode flag for a parameter, falling back to the
+ * spec defaults (style: 'form', explode: true when style is 'form').
+ */
 const getParameterStyleAndExplode = (parameter: ParameterObject): { style: string; explode: boolean } => {
   const style = 'style' in parameter && parameter.style ? parameter.style : 'form'
   const explode = 'explode' in parameter && parameter.explode !== undefined ? parameter.explode : style === 'form'
 
   return { style, explode }
+}
+
+/**
+ * Decides whether an object-typed query parameter should be expanded into one row per property,
+ * and which expansion mode to use. Returns null when the parameter should stay as a single row
+ * (non-query, non-object schema, or a serialization style we do not expand).
+ */
+const getExpansionMode = (parameter: ParameterObject, schema: SchemaObject | undefined): ExpansionMode | null => {
+  if (parameter.in !== 'query' || !isParameterWithSchema(parameter) || !schema || !isObjectSchema(schema)) {
+    return null
+  }
+
+  const { style, explode } = getParameterStyleAndExplode(parameter)
+  if (!explode) {
+    return null
+  }
+
+  if (style === 'form') {
+    return 'form'
+  }
+  if (style === 'deepObject') {
+    return 'deepObject'
+  }
+
+  return null
 }
 
 const toTableValue = (value: unknown): string => {
@@ -78,12 +110,41 @@ const toTableRow = ({
   sourceParameterValuePath,
 })
 
+/** Build the single-row representation used when a parameter is not expanded. */
+const toSingleParameterRow = (
+  parameter: ParameterObject,
+  schema: SchemaObject | undefined,
+  value: unknown,
+  isDisabled: boolean,
+): TableRow =>
+  toTableRow({
+    parameter,
+    name: parameter.name,
+    value,
+    description: parameter.description,
+    schema,
+    isRequired: parameter.required,
+    isDisabled,
+  })
+
+/**
+ * Walks an object schema and produces one row per property.
+ *
+ * - In `form` mode (the OpenAPI default for query parameters) only the top-level properties are
+ *   flattened, and each row is named after the property itself (`status`).
+ * - In `deepObject` mode we recurse into nested objects and emit bracketed names that mirror the
+ *   serialization on the wire (`filter[user][id]`).
+ *
+ * `pathPrefix` tracks the path inside the parent parameter value so the handler can later
+ * reassemble all sibling rows back into a single object payload.
+ */
 const getExpandedPropertyRows = ({
   parameter,
   schema,
   value,
   pathPrefix,
   namePrefix,
+  mode,
   isDisabled,
 }: {
   parameter: ParameterObject
@@ -91,6 +152,7 @@ const getExpandedPropertyRows = ({
   value: unknown
   pathPrefix: string[]
   namePrefix: string
+  mode: ExpansionMode
   isDisabled: boolean
 }): TableRow[] => {
   if (!schema.properties) {
@@ -108,15 +170,19 @@ const getExpandedPropertyRows = ({
     const path = [...pathPrefix, propertyName]
     const name = namePrefix ? `${namePrefix}[${propertyName}]` : propertyName
 
-    // Only recurse into nested objects for deepObject style (namePrefix is non-empty).
-    // Form-style explode flattens only the top-level properties per the OpenAPI 3.1 spec.
-    if (namePrefix && isObjectSchema(resolvedPropertySchema) && resolvedPropertySchema.properties) {
+    // Only deepObject style recurses into nested objects. The OpenAPI 3.1 spec says form-style
+    // explode flattens only the top-level properties.
+    const shouldRecurse =
+      mode === 'deepObject' && isObjectSchema(resolvedPropertySchema) && Boolean(resolvedPropertySchema.properties)
+
+    if (shouldRecurse) {
       return getExpandedPropertyRows({
         parameter,
         schema: resolvedPropertySchema,
         value,
         pathPrefix: path,
         namePrefix: name,
+        mode,
         isDisabled,
       })
     }
@@ -136,40 +202,27 @@ const getExpandedPropertyRows = ({
   })
 }
 
+/**
+ * Turns a single OpenAPI parameter into one or more table rows.
+ *
+ * For object-typed query parameters with `form`/`explode: true` (the default) or `deepObject`
+ * serialization, each property becomes its own row so the user can edit them individually,
+ * matching how tools like Postman present the same parameter. Every other parameter passes
+ * through as a single row.
+ */
 export const createParameterRows = (parameter: ParameterObject, exampleKey: string): TableRow[] => {
   const example = getExample(parameter, exampleKey, undefined)
   const isDisabled = isParamDisabled(parameter, example)
   const schema = getParameterSchema(parameter)
+  const mode = getExpansionMode(parameter, schema)
 
-  if (parameter.in !== 'query' || !isParameterWithSchema(parameter) || !schema || !isObjectSchema(schema)) {
-    return [
-      toTableRow({
-        parameter,
-        name: parameter.name,
-        value: example?.value,
-        description: parameter.description,
-        schema,
-        isRequired: parameter.required,
-        isDisabled,
-      }),
-    ]
+  // Non-expandable parameters: render as a single row.
+  if (mode === null || !schema || !isObjectSchema(schema)) {
+    return [toSingleParameterRow(parameter, schema, example?.value, isDisabled)]
   }
 
-  const { style, explode } = getParameterStyleAndExplode(parameter)
-  if (!explode || (style !== 'form' && style !== 'deepObject')) {
-    return [
-      toTableRow({
-        parameter,
-        name: parameter.name,
-        value: example?.value,
-        description: parameter.description,
-        schema,
-        isRequired: parameter.required,
-        isDisabled,
-      }),
-    ]
-  }
-
+  // Expand into per-property rows. The deserialized value is used so existing per-property values
+  // can be displayed in the table even when the example arrives as a serialized string.
   const value = example?.value === undefined ? undefined : deSerializeParameter(example.value, parameter)
 
   const rows = getExpandedPropertyRows({
@@ -177,21 +230,12 @@ export const createParameterRows = (parameter: ParameterObject, exampleKey: stri
     schema,
     value,
     pathPrefix: [],
-    namePrefix: style === 'deepObject' ? parameter.name : '',
+    // deepObject names every row with a `parent[child]` prefix; form-style names use bare property names.
+    namePrefix: mode === 'deepObject' ? parameter.name : '',
+    mode,
     isDisabled,
   })
 
-  return rows.length > 0
-    ? rows
-    : [
-        toTableRow({
-          parameter,
-          name: parameter.name,
-          value: example?.value,
-          description: parameter.description,
-          schema,
-          isRequired: parameter.required,
-          isDisabled,
-        }),
-      ]
+  // Fall back to a single row if the schema had no properties to expand.
+  return rows.length > 0 ? rows : [toSingleParameterRow(parameter, schema, example?.value, isDisabled)]
 }

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -1,0 +1,209 @@
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { deSerializeParameter, getExample } from '@scalar/workspace-store/request-example'
+import type {
+  ParameterObject,
+  ParameterWithSchemaObject,
+  ReferenceType,
+  SchemaObject,
+} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { isObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
+
+import type { TableRow } from '../components/RequestTableRow.vue'
+import { getParameterSchema } from './get-parameter-schema'
+import { isParamDisabled } from './is-param-disabled'
+
+type ParameterWithRequiredSchema = ParameterWithSchemaObject & {
+  schema: ReferenceType<SchemaObject>
+}
+
+const isParameterWithSchema = (parameter: ParameterObject): parameter is ParameterWithRequiredSchema =>
+  'schema' in parameter && parameter.schema !== undefined
+
+const resolveSchema = (schema: unknown): SchemaObject | undefined => {
+  const resolvedSchema = getResolvedRef(schema as SchemaObject | { '$ref': string; '$ref-value': SchemaObject })
+
+  return resolvedSchema as SchemaObject | undefined
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const getParameterStyleAndExplode = (parameter: ParameterObject): { style: string; explode: boolean } => {
+  const style = 'style' in parameter && parameter.style ? parameter.style : 'form'
+  const explode = 'explode' in parameter && parameter.explode !== undefined ? parameter.explode : style === 'form'
+
+  return { style, explode }
+}
+
+const getValueAtPath = (source: unknown, path: readonly string[]): unknown => {
+  return path.reduce<unknown>((value, key) => {
+    if (!isRecord(value)) {
+      return undefined
+    }
+
+    return value[key]
+  }, source)
+}
+
+const toTableValue = (value: unknown): string => {
+  if (value === undefined || value === null) {
+    return ''
+  }
+
+  if (Array.isArray(value)) {
+    return value.join(',')
+  }
+
+  if (typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+
+  return String(value)
+}
+
+const toTableRow = ({
+  parameter,
+  name,
+  value,
+  description,
+  schema,
+  isRequired,
+  isDisabled,
+  sourceParameterValuePath,
+}: {
+  parameter: ParameterObject
+  name: string
+  value: unknown
+  description: string | undefined
+  schema: SchemaObject | undefined
+  isRequired: boolean | undefined
+  isDisabled: boolean
+  sourceParameterValuePath?: string[]
+}): TableRow => ({
+  name,
+  value: toTableValue(value),
+  description,
+  schema,
+  isRequired,
+  isDisabled,
+  originalParameter: parameter,
+  sourceParameterValuePath,
+})
+
+const getExpandedPropertyRows = ({
+  parameter,
+  schema,
+  value,
+  pathPrefix,
+  namePrefix,
+  isDisabled,
+}: {
+  parameter: ParameterObject
+  schema: Extract<SchemaObject, { type: 'object' }>
+  value: unknown
+  pathPrefix: string[]
+  namePrefix: string
+  isDisabled: boolean
+}): TableRow[] => {
+  if (!schema.properties) {
+    return []
+  }
+
+  const requiredProperties = new Set(schema.required ?? [])
+
+  return Object.entries(schema.properties).flatMap(([propertyName, propertySchema]) => {
+    const resolvedPropertySchema = resolveSchema(propertySchema)
+    if (!resolvedPropertySchema) {
+      return []
+    }
+
+    const path = [...pathPrefix, propertyName]
+    const name = namePrefix ? `${namePrefix}[${propertyName}]` : propertyName
+
+    // Only recurse into nested objects for deepObject style (namePrefix is non-empty).
+    // Form-style explode flattens only the top-level properties per the OpenAPI 3.1 spec.
+    if (namePrefix && isObjectSchema(resolvedPropertySchema) && resolvedPropertySchema.properties) {
+      return getExpandedPropertyRows({
+        parameter,
+        schema: resolvedPropertySchema,
+        value,
+        pathPrefix: path,
+        namePrefix: name,
+        isDisabled,
+      })
+    }
+
+    return [
+      toTableRow({
+        parameter,
+        name,
+        value: getValueAtPath(value, path),
+        description: resolvedPropertySchema.description ?? parameter.description,
+        schema: resolvedPropertySchema,
+        isRequired: requiredProperties.has(propertyName),
+        isDisabled,
+        sourceParameterValuePath: path,
+      }),
+    ]
+  })
+}
+
+export const createParameterRows = (parameter: ParameterObject, exampleKey: string): TableRow[] => {
+  const example = getExample(parameter, exampleKey, undefined)
+  const isDisabled = isParamDisabled(parameter, example)
+  const schema = getParameterSchema(parameter)
+
+  if (parameter.in !== 'query' || !isParameterWithSchema(parameter) || !schema || !isObjectSchema(schema)) {
+    return [
+      toTableRow({
+        parameter,
+        name: parameter.name,
+        value: example?.value,
+        description: parameter.description,
+        schema,
+        isRequired: parameter.required,
+        isDisabled,
+      }),
+    ]
+  }
+
+  const { style, explode } = getParameterStyleAndExplode(parameter)
+  if (!explode || (style !== 'form' && style !== 'deepObject')) {
+    return [
+      toTableRow({
+        parameter,
+        name: parameter.name,
+        value: example?.value,
+        description: parameter.description,
+        schema,
+        isRequired: parameter.required,
+        isDisabled,
+      }),
+    ]
+  }
+
+  const value = example?.value === undefined ? undefined : deSerializeParameter(example.value, parameter)
+
+  const rows = getExpandedPropertyRows({
+    parameter,
+    schema,
+    value,
+    pathPrefix: [],
+    namePrefix: style === 'deepObject' ? parameter.name : '',
+    isDisabled,
+  })
+
+  return rows.length > 0
+    ? rows
+    : [
+        toTableRow({
+          parameter,
+          name: parameter.name,
+          value: example?.value,
+          description: parameter.description,
+          schema,
+          isRequired: parameter.required,
+          isDisabled,
+        }),
+      ]
+}

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -1,3 +1,4 @@
+import { isObject } from '@scalar/helpers/object/is-object'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import { deSerializeParameter, getExample } from '@scalar/workspace-store/request-example'
 import type {
@@ -25,9 +26,6 @@ const resolveSchema = (schema: unknown): SchemaObject | undefined => {
   return resolvedSchema as SchemaObject | undefined
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value)
-
 const getParameterStyleAndExplode = (parameter: ParameterObject): { style: string; explode: boolean } => {
   const style = 'style' in parameter && parameter.style ? parameter.style : 'form'
   const explode = 'explode' in parameter && parameter.explode !== undefined ? parameter.explode : style === 'form'
@@ -37,7 +35,7 @@ const getParameterStyleAndExplode = (parameter: ParameterObject): { style: strin
 
 const getValueAtPath = (source: unknown, path: readonly string[]): unknown => {
   return path.reduce<unknown>((value, key) => {
-    if (!isRecord(value)) {
+    if (!isObject(value)) {
       return undefined
     }
 

--- a/packages/helpers/src/object/set-value-at-path.test.ts
+++ b/packages/helpers/src/object/set-value-at-path.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { setValueAtPath } from './set-value-at-path'
+
+describe('setValueAtPath', () => {
+  it('sets a value at a top-level path', () => {
+    const target: Record<string, unknown> = {}
+
+    setValueAtPath(target, ['name'], 'Scalar')
+
+    expect(target).toEqual({ name: 'Scalar' })
+  })
+
+  it('creates intermediate objects as needed', () => {
+    const target: Record<string, unknown> = {}
+
+    setValueAtPath(target, ['filter', 'status'], 'active')
+
+    expect(target).toEqual({ filter: { status: 'active' } })
+  })
+
+  it('preserves existing nested objects', () => {
+    const target: Record<string, unknown> = { filter: { existing: true } }
+
+    setValueAtPath(target, ['filter', 'status'], 'active')
+
+    expect(target).toEqual({ filter: { existing: true, status: 'active' } })
+  })
+
+  it('replaces non-object intermediate values with new objects', () => {
+    const target: Record<string, unknown> = { filter: 'previous' }
+
+    setValueAtPath(target, ['filter', 'status'], 'active')
+
+    expect(target).toEqual({ filter: { status: 'active' } })
+  })
+
+  it('replaces array intermediate values with new objects', () => {
+    const target: Record<string, unknown> = { filter: ['previous'] }
+
+    setValueAtPath(target, ['filter', 'status'], 'active')
+
+    expect(target).toEqual({ filter: { status: 'active' } })
+  })
+
+  it('does nothing when the path is empty', () => {
+    const target: Record<string, unknown> = { existing: true }
+
+    setValueAtPath(target, [], 'value')
+
+    expect(target).toEqual({ existing: true })
+  })
+
+  it('throws when the path contains a prototype-pollution key', () => {
+    const target: Record<string, unknown> = {}
+
+    expect(() => setValueAtPath(target, ['__proto__', 'polluted'], true)).toThrow()
+  })
+
+  it('supports null and undefined leaf values', () => {
+    const target: Record<string, unknown> = {}
+
+    setValueAtPath(target, ['a', 'b'], null)
+    setValueAtPath(target, ['a', 'c'], undefined)
+
+    expect(target).toEqual({ a: { b: null, c: undefined } })
+  })
+})

--- a/packages/helpers/src/object/set-value-at-path.ts
+++ b/packages/helpers/src/object/set-value-at-path.ts
@@ -1,0 +1,38 @@
+import { isObject } from './is-object'
+import { preventPollution } from './prevent-pollution'
+
+/**
+ * Sets a nested value on the target object using a path array, creating
+ * intermediate plain objects as needed.
+ *
+ * Unlike json-magic's `setValueAtPath` (which accepts a JSON-pointer string and
+ * creates arrays for numeric segments), this helper uses an array of string
+ * segments and only ever creates plain objects. It mirrors the shape of
+ * `getValueAtPath` so the two compose cleanly.
+ *
+ * @example
+ * ```ts
+ * const target = {}
+ * setValueAtPath(target, ['filter', 'status'], 'active')
+ *
+ * { filter: { status: 'active' } }
+ * ```
+ */
+export const setValueAtPath = (target: Record<string, unknown>, path: readonly string[], value: unknown): void => {
+  const [key, ...rest] = path
+  if (!key) {
+    return
+  }
+
+  preventPollution(key)
+
+  if (!rest.length) {
+    target[key] = value
+    return
+  }
+
+  const next = isObject(target[key]) ? target[key] : {}
+
+  target[key] = next
+  setValueAtPath(next, rest, value)
+}

--- a/packages/workspace-store/src/events/definitions/operation.ts
+++ b/packages/workspace-store/src/events/definitions/operation.ts
@@ -193,7 +193,7 @@ export type OperationEvents = {
      */
     payload: {
       name: string
-      value: string
+      value: string | Record<string, unknown>
       isDisabled: boolean
     }
     /**


### PR DESCRIPTION
## Problem

When a query parameter has `type: object` with nested properties, the api-client displayed it as a single row instead of expanding the individual properties.

## Solution
Object-type query parameters are now expanded into one row per property, matching how tools like Postman handle this. The expansion respects OpenAPI serialization styles (`form` with `explode` and `deepObject`).

- **Added `createParameterRows` helper** - takes a parameter and returns one or more `TableRow` entries. For object-type query parameters with `explode: true` (default for `form` style) or `deepObject` style, it expands each property into its own row. Non-object parameters pass through as a single row like before.

- **`RequestBlock.vue`** - replaced the inline parameter-to-row mapping with `createParameterRows`.

- **Updated `createParameterHandlers`** - when upserting an expanded row, all sibling rows are reassembled into a single object value and emitted under the parent parameter name.

- **Added `sourceParameterValuePath` to `TableRow`** - tracks which property path each expanded row maps to inside the parent parameter, so the handler knows how to reconstruct the object.

- **Changed `operation:upsert:parameter` value type** - from `string` to `string | Record<string, unknown>` to support object payloads.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

Fixes #8615

**After fix (example from the original issue):**
<img width="1077" height="606" alt="image" src="https://github.com/user-attachments/assets/ee964733-dbf0-4a22-a499-8103430c187a" />

