### PR TITLE
fix(api-client): restore command palette action focus

### DIFF
--- a/.changeset/fresh-timers-focus.md
+++ b/.changeset/fresh-timers-focus.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix command palette focus and keyboard navigation for active import actions.

--- a/packages/api-client/src/v2/features/command-palette/TheCommandPalette.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/TheCommandPalette.test.ts
@@ -1,0 +1,133 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { computed, defineComponent, h, nextTick, ref, shallowRef } from 'vue'
+
+import type { CommandPaletteAction, CommandPaletteState } from './hooks/use-command-palette-state'
+import TheCommandPalette from './TheCommandPalette.vue'
+
+const RegistryImportCommand = defineComponent({
+  props: {
+    selectFirst: {
+      type: Function,
+      required: false,
+    },
+    selectSecond: {
+      type: Function,
+      required: false,
+    },
+  },
+  setup(props) {
+    return () =>
+      h('div', [
+        h('input', {
+          autofocus: true,
+          placeholder: 'Type to search for a document...',
+        }),
+        h(
+          'button',
+          {
+            class: 'commandmenu-item',
+            type: 'button',
+            onClick: () => props.selectFirst?.(),
+          },
+          '@scalar/access-service',
+        ),
+        h(
+          'button',
+          {
+            class: 'commandmenu-item',
+            type: 'button',
+            onClick: () => props.selectSecond?.(),
+          },
+          '@scalar/galaxy',
+        ),
+      ])
+  },
+})
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}))
+
+const createPaletteState = (): CommandPaletteState => ({
+  isOpen: ref(true),
+  activeCommand: shallowRef(null),
+  activeCommandProps: ref(null),
+  filterQuery: ref(''),
+  filteredCommands: computed(() => [
+    {
+      commands: [],
+    },
+  ]),
+  open: vi.fn(),
+  close: vi.fn(),
+  setFilterQuery: vi.fn(),
+  reset: vi.fn(),
+})
+
+const mountCommandPalette = (paletteState: CommandPaletteState) =>
+  mount(TheCommandPalette, {
+    attachTo: document.body,
+    props: {
+      paletteState,
+      workspaceStore: { workspace: { documents: {} } } as never,
+      eventBus: {
+        on: vi.fn(),
+        off: vi.fn(),
+      } as never,
+    },
+  })
+
+describe('TheCommandPalette', () => {
+  it('focuses the search input when an active command opens', async () => {
+    const paletteState = createPaletteState()
+    const registryCommand = {
+      id: 'import-from-scalar-registry',
+      name: 'Import from Scalar Registry',
+      component: RegistryImportCommand,
+    } satisfies CommandPaletteAction
+
+    paletteState.activeCommand.value = registryCommand
+    const wrapper = mountCommandPalette(paletteState)
+    await nextTick()
+    await nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.activeElement).toBe(
+      document.body.querySelector('input[placeholder="Type to search for a document..."]'),
+    )
+
+    wrapper.unmount()
+  })
+
+  it('selects active command items with arrow keys from the search input', async () => {
+    const paletteState = createPaletteState()
+    const selectFirst = vi.fn()
+    const selectSecond = vi.fn()
+    const registryCommand = {
+      id: 'import-from-scalar-registry',
+      name: 'Import from Scalar Registry',
+      component: RegistryImportCommand,
+    } satisfies CommandPaletteAction
+
+    paletteState.activeCommandProps.value = { selectFirst, selectSecond }
+    paletteState.activeCommand.value = registryCommand
+    const wrapper = mountCommandPalette(paletteState)
+    await nextTick()
+    await nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const input = document.body.querySelector<HTMLInputElement>('input[placeholder="Type to search for a document..."]')
+    input?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    input?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    input?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+
+    expect(document.body.querySelectorAll('.commandmenu-item').item(0).getAttribute('aria-selected')).toBe('false')
+    expect(document.body.querySelectorAll('.commandmenu-item').item(1).getAttribute('aria-selected')).toBe('true')
+    expect(selectSecond).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+})

--- a/packages/api-client/src/v2/features/command-palette/TheCommandPalette.vue
+++ b/packages/api-client/src/v2/features/command-palette/TheCommandPalette.vue
@@ -63,7 +63,9 @@ const NO_SELECTION_INDEX = -1
 const router = useRouter()
 
 const selectedSearchResult = ref<number>(NO_SELECTION_INDEX)
+const selectedActiveCommandItem = ref<number>(NO_SELECTION_INDEX)
 const commandInputRef = ref<HTMLInputElement | null>(null)
+const activeCommandViewRef = ref<HTMLElement | null>(null)
 
 /**
  * Flattens the filtered commands into a single array for keyboard navigation.
@@ -78,6 +80,51 @@ const selectedCommand = computed<CommandPaletteEntry | undefined>(
   () => flattenedCommands.value[selectedSearchResult.value],
 )
 
+const activeCommandItemSelector =
+  '[data-command-palette-item], [role="option"], .commandmenu-item'
+
+const setActiveCommandItemSelected = (
+  item: HTMLElement,
+  isSelected: boolean,
+): void => {
+  item.classList.toggle('bg-b-2', isSelected)
+  item.setAttribute('aria-selected', isSelected ? 'true' : 'false')
+  item.dataset.commandPaletteSelected = isSelected ? 'true' : 'false'
+}
+
+const clearActiveCommandSelection = (): void => {
+  activeCommandViewRef.value
+    ?.querySelectorAll<HTMLElement>(activeCommandItemSelector)
+    .forEach((item) => {
+      setActiveCommandItemSelected(item, false)
+    })
+}
+
+const getActiveCommandItems = (): HTMLElement[] => {
+  return Array.from(
+    activeCommandViewRef.value?.querySelectorAll<HTMLElement>(
+      activeCommandItemSelector,
+    ) ?? [],
+  ).filter(
+    (item) =>
+      !item.hasAttribute('disabled') &&
+      item.getAttribute('aria-disabled') !== 'true' &&
+      item.getAttribute('aria-hidden') !== 'true',
+  )
+}
+
+const focusActiveCommandInput = (): void => {
+  const activeInput = activeCommandViewRef.value?.querySelector<HTMLElement>(
+    '[autofocus], input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), [role="searchbox"]',
+  )
+
+  activeInput?.focus()
+}
+
+const focusActiveCommandInputAfterRender = (): void => {
+  requestAnimationFrame(() => focusActiveCommandInput())
+}
+
 /**
  * Watch for search query changes and auto-select first result.
  * Resets selection when query is cleared.
@@ -88,6 +135,19 @@ watch(
     selectedSearchResult.value =
       newQuery && flattenedCommands.value.length > 0 ? 0 : NO_SELECTION_INDEX
   },
+)
+
+watch(
+  () => paletteState.activeCommand.value,
+  (activeCommand) => {
+    selectedActiveCommandItem.value = NO_SELECTION_INDEX
+    clearActiveCommandSelection()
+
+    if (activeCommand) {
+      nextTick(() => focusActiveCommandInputAfterRender())
+    }
+  },
+  { immediate: true },
 )
 
 /**
@@ -117,9 +177,49 @@ const handleArrowKey = (
 
   const offset = direction === 'up' ? -1 : 1
   const length = flattenedCommands.value.length
+  if (length === 0) {
+    return
+  }
 
   selectedSearchResult.value =
     (selectedSearchResult.value + offset + length) % length
+}
+
+const handleActiveCommandArrowKey = (
+  direction: 'up' | 'down',
+  event: KeyboardEvent,
+): void => {
+  const items = getActiveCommandItems()
+  const length = items.length
+
+  if (length === 0) {
+    return
+  }
+
+  event.preventDefault()
+
+  const offset = direction === 'up' ? -1 : 1
+  selectedActiveCommandItem.value =
+    (selectedActiveCommandItem.value + offset + length) % length
+
+  clearActiveCommandSelection()
+
+  const selectedItem = items[selectedActiveCommandItem.value]
+  if (selectedItem) {
+    setActiveCommandItemSelected(selectedItem, true)
+    selectedItem.scrollIntoView?.({ block: 'nearest' })
+  }
+}
+
+const handleActiveCommandSelect = (event: KeyboardEvent): void => {
+  const selectedItem = getActiveCommandItems()[selectedActiveCommandItem.value]
+
+  if (!selectedItem) {
+    return
+  }
+
+  event.preventDefault()
+  selectedItem.click()
 }
 
 /**
@@ -281,6 +381,7 @@ onBeforeUnmount(() => eventBus.off('ui:open:command-palette', onOpen))
       <!-- Active command view (specific action form) -->
       <div
         v-else
+        ref="activeCommandViewRef"
         class="flex-1 p-1.5">
         <!-- Back button to return to command list -->
         <button
@@ -295,6 +396,9 @@ onBeforeUnmount(() => eventBus.off('ui:open:command-palette', onOpen))
           :is="paletteState.activeCommand.value.component"
           v-if="paletteState.activeCommand.value"
           v-bind="paletteProps"
+          @keydown.down="handleActiveCommandArrowKey('down', $event)"
+          @keydown.enter="handleActiveCommandSelect"
+          @keydown.up="handleActiveCommandArrowKey('up', $event)"
           @back="handleBackEvent"
           @close="handleCloseEvent" />
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The command palette could lose focus after opening an active action view such as the Scalar Registry import flow. That made the document search input harder to use and prevented the parent palette from providing keyboard selection behavior inside that view.

## Solution

Focus the first actionable input after active command views render, and add shared arrow/enter handling for selectable rows rendered inside those active command views. Added focused coverage for the registry-style import view.

## Visual

<a href="https://cursor.com/agents/bc-56234bf1-d0ac-4927-a101-40f48676f242/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_client_command_palette_focus.mp4"><img src="https://cursor.com/artifacts/c/art-2d07a721-c265-4a7b-b005-34f41a30c200" alt="api_client_command_palette_focus.mp4" /></a>

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56234bf1-d0ac-4927-a101-40f48676f242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56234bf1-d0ac-4927-a101-40f48676f242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

