### PR TITLE
feat(scripts): generate app release changelogs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,13 +586,14 @@ jobs:
           # The pull request title.
           title: 'chore: release'
           # The command to update version, edit CHANGELOG, read and delete changesets.
-          version: 'pnpm changeset version'
+          version: 'pnpm changeset version && pnpm script generate-release-changelog --package-dir projects/scalar-app --title "Scalar API Client" --allow-missing'
           # The commit message to use.
           commit: 'chore: version packages'
           # The command to use to build and publish packages
           publish: 'pnpm -r publish --access public --no-git-checks'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SCALAR_RELEASE_CHANGELOG_API_KEY: ${{ secrets.SCALAR_RELEASE_CHANGELOG_API_KEY }}
           # https://www.npmjs.com/settings/YOUR_ACCOUNT_HANDLE/tokens/granular-access-tokens/new
           # Custom Expiration: 01-01-2100
           # Permissions: Read and Write

--- a/tooling/scripts/src/cli.ts
+++ b/tooling/scripts/src/cli.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander'
 import { cat } from '@/commands/cat'
 import { generateBlog } from '@/commands/generate-blog'
 import { generateReadme } from '@/commands/generate-readme'
+import { generateReleaseChangelog } from '@/commands/generate-release-changelog'
 import { packages } from '@/commands/packages'
 import { updatePlaywrightDocker } from '@/commands/playwright-docker/push-container'
 import { run } from '@/commands/run'
@@ -26,4 +27,5 @@ program.addCommand(run)
 program.addCommand(updatePlaywrightDocker)
 program.addCommand(generateReadme)
 program.addCommand(generateBlog)
+program.addCommand(generateReleaseChangelog)
 program.parse()

--- a/tooling/scripts/src/commands/generate-release-changelog.test.ts
+++ b/tooling/scripts/src/commands/generate-release-changelog.test.ts
@@ -93,10 +93,10 @@ describe('generate-release-changelog', () => {
     expect(context).toBeNull()
   })
 
-  it('writes release files and keeps the index newest first', async () => {
+  it('writes release entries to CHANGELOG.md newest first', async () => {
     const repoRoot = await createRepo()
 
-    const firstPath = await writeChangelogEntry(repoRoot, 'projects/scalar-app/src/data/changelog', {
+    const firstPath = await writeChangelogEntry(repoRoot, 'projects/scalar-app/CHANGELOG.md', {
       version: '1.0.0',
       date: '2026-04-21',
       title: 'Initial app release',
@@ -110,7 +110,7 @@ describe('generate-release-changelog', () => {
       },
     })
 
-    const secondPath = await writeChangelogEntry(repoRoot, 'projects/scalar-app/src/data/changelog', {
+    const secondPath = await writeChangelogEntry(repoRoot, 'projects/scalar-app/CHANGELOG.md', {
       version: '1.1.0',
       date: '2026-04-24',
       title: 'Smoother request runs',
@@ -124,28 +124,33 @@ describe('generate-release-changelog', () => {
       },
     })
 
-    const index = JSON.parse(
-      await readFile(join(repoRoot, 'projects/scalar-app/src/data/changelog/index.json'), 'utf8'),
-    )
-    const release = JSON.parse(
-      await readFile(join(repoRoot, 'projects/scalar-app/src/data/changelog/releases/1.1.0.json'), 'utf8'),
-    )
+    const changelog = await readFile(join(repoRoot, 'projects/scalar-app/CHANGELOG.md'), 'utf8')
 
-    expect(firstPath).toBe('projects/scalar-app/src/data/changelog/releases/1.0.0.json')
-    expect(secondPath).toBe('projects/scalar-app/src/data/changelog/releases/1.1.0.json')
-    expect(index).toStrictEqual({ releases: ['1.1.0', '1.0.0'] })
-    expect(release).toStrictEqual({
-      version: '1.1.0',
-      date: '2026-04-24',
-      title: 'Smoother request runs',
-      summary: 'Requests now run with the latest editor changes.',
-      highlights: ['Flush pending edits', 'Cleaner slugs'],
-      source: {
-        packageName: 'scalar-app',
-        packageDir: 'projects/scalar-app',
-        previousVersion: '1.0.0',
-        sinceCommit: 'abc123',
-      },
-    })
+    expect(firstPath).toBe('projects/scalar-app/CHANGELOG.md')
+    expect(secondPath).toBe('projects/scalar-app/CHANGELOG.md')
+    expect(changelog).toBe(`# scalar-app
+
+## 1.1.0
+
+### Smoother request runs
+
+2026-04-24
+
+Requests now run with the latest editor changes.
+
+- Flush pending edits
+- Cleaner slugs
+
+## 1.0.0
+
+### Initial app release
+
+2026-04-21
+
+Scalar API Client now has a richer app experience.
+
+- Create documents
+- Switch versions
+`)
   })
 })

--- a/tooling/scripts/src/commands/generate-release-changelog.test.ts
+++ b/tooling/scripts/src/commands/generate-release-changelog.test.ts
@@ -1,0 +1,151 @@
+import { execFile } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { collectReleaseContext, writeChangelogEntry } from './generate-release-changelog'
+
+const execFileAsync = promisify(execFile)
+
+const tempRepos: string[] = []
+
+const run = async (cwd: string, command: string, args: string[]): Promise<void> => {
+  await execFileAsync(command, args, { cwd })
+}
+
+const commit = async (repoRoot: string, message: string): Promise<void> => {
+  await run(repoRoot, 'git', ['add', '.'])
+  await run(repoRoot, 'git', ['commit', '-m', message])
+}
+
+const writePackage = async (repoRoot: string, version: string): Promise<void> => {
+  await mkdir(join(repoRoot, 'projects/scalar-app'), { recursive: true })
+  await writeFile(
+    join(repoRoot, 'projects/scalar-app/package.json'),
+    `${JSON.stringify({ name: 'scalar-app', version }, null, 2)}\n`,
+  )
+}
+
+const createRepo = async (): Promise<string> => {
+  const repoRoot = await mkdtemp(join(tmpdir(), 'release-changelog-'))
+  tempRepos.push(repoRoot)
+
+  await run(repoRoot, 'git', ['init'])
+  await run(repoRoot, 'git', ['config', 'user.email', 'test@example.com'])
+  await run(repoRoot, 'git', ['config', 'user.name', 'Test User'])
+
+  return repoRoot
+}
+
+afterEach(async () => {
+  await Promise.all(tempRepos.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe('generate-release-changelog', () => {
+  it('collects context since the package was last released', async () => {
+    const repoRoot = await createRepo()
+
+    await writePackage(repoRoot, '1.0.0')
+    await commit(repoRoot, 'release scalar app 1.0.0')
+
+    await mkdir(join(repoRoot, 'packages/api-client'), { recursive: true })
+    await writeFile(
+      join(repoRoot, 'packages/api-client/CHANGELOG.md'),
+      '# api-client\n\n## 2.0.0\n\n- Add workspaces\n',
+    )
+    await commit(repoRoot, 'release api client')
+
+    await writePackage(repoRoot, '1.1.0')
+    await writeFile(
+      join(repoRoot, 'projects/scalar-app/CHANGELOG.md'),
+      '# scalar-app\n\n## 1.1.0\n\n- Ship workspaces\n',
+    )
+
+    const context = await collectReleaseContext(repoRoot, {
+      packageDir: 'projects/scalar-app',
+      title: 'Scalar API Client',
+    })
+
+    expect(context?.packageName).toBe('scalar-app')
+    expect(context?.packageDir).toBe('projects/scalar-app')
+    expect(context?.title).toBe('Scalar API Client')
+    expect(context?.version).toBe('1.1.0')
+    expect(context?.previousVersion).toBe('1.0.0')
+    expect(typeof context?.sinceCommit).toBe('string')
+    expect(context?.currentReleaseDiff.includes('+  "version": "1.1.0"')).toBe(true)
+    expect(context?.committedReleaseLog.includes('release api client')).toBe(true)
+    expect(context?.committedChangelogDiff.includes('+## 2.0.0')).toBe(true)
+  })
+
+  it('skips when the package version did not change', async () => {
+    const repoRoot = await createRepo()
+
+    await writePackage(repoRoot, '1.0.0')
+    await commit(repoRoot, 'release scalar app 1.0.0')
+
+    const context = await collectReleaseContext(repoRoot, {
+      packageDir: 'projects/scalar-app',
+    })
+
+    expect(context).toBeNull()
+  })
+
+  it('writes release files and keeps the index newest first', async () => {
+    const repoRoot = await createRepo()
+
+    const firstPath = await writeChangelogEntry(repoRoot, 'projects/scalar-app/src/data/changelog', {
+      version: '1.0.0',
+      date: '2026-04-21',
+      title: 'Initial app release',
+      summary: 'Scalar API Client now has a richer app experience.',
+      highlights: ['Create documents', 'Switch versions'],
+      source: {
+        packageName: 'scalar-app',
+        packageDir: 'projects/scalar-app',
+        previousVersion: null,
+        sinceCommit: null,
+      },
+    })
+
+    const secondPath = await writeChangelogEntry(repoRoot, 'projects/scalar-app/src/data/changelog', {
+      version: '1.1.0',
+      date: '2026-04-24',
+      title: 'Smoother request runs',
+      summary: 'Requests now run with the latest editor changes.',
+      highlights: ['Flush pending edits', 'Cleaner slugs'],
+      source: {
+        packageName: 'scalar-app',
+        packageDir: 'projects/scalar-app',
+        previousVersion: '1.0.0',
+        sinceCommit: 'abc123',
+      },
+    })
+
+    const index = JSON.parse(
+      await readFile(join(repoRoot, 'projects/scalar-app/src/data/changelog/index.json'), 'utf8'),
+    )
+    const release = JSON.parse(
+      await readFile(join(repoRoot, 'projects/scalar-app/src/data/changelog/releases/1.1.0.json'), 'utf8'),
+    )
+
+    expect(firstPath).toBe('projects/scalar-app/src/data/changelog/releases/1.0.0.json')
+    expect(secondPath).toBe('projects/scalar-app/src/data/changelog/releases/1.1.0.json')
+    expect(index).toStrictEqual({ releases: ['1.1.0', '1.0.0'] })
+    expect(release).toStrictEqual({
+      version: '1.1.0',
+      date: '2026-04-24',
+      title: 'Smoother request runs',
+      summary: 'Requests now run with the latest editor changes.',
+      highlights: ['Flush pending edits', 'Cleaner slugs'],
+      source: {
+        packageName: 'scalar-app',
+        packageDir: 'projects/scalar-app',
+        previousVersion: '1.0.0',
+        sinceCommit: 'abc123',
+      },
+    })
+  })
+})

--- a/tooling/scripts/src/commands/generate-release-changelog.ts
+++ b/tooling/scripts/src/commands/generate-release-changelog.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { basename, join, posix, relative, resolve, sep } from 'node:path'
+import { basename, dirname, join, posix, relative, resolve, sep } from 'node:path'
 import { promisify } from 'node:util'
 
 import { Command } from 'commander'
@@ -51,6 +51,7 @@ type Options = {
 }
 
 const MAX_CONTEXT_CHARS = 60_000
+const VERSION_HEADING_PREFIX = '## '
 
 const toGitPath = (path: string): string => path.split(sep).join(posix.sep)
 
@@ -318,39 +319,65 @@ const requestChangelog = async (context: ReleaseContext, options: Options, date:
   return parseModelResponse(content, context, date)
 }
 
+const formatMarkdownEntry = (entry: ChangelogEntry): string => {
+  const highlights = entry.highlights.map((highlight) => `- ${highlight}`).join('\n')
+
+  return [
+    `${VERSION_HEADING_PREFIX}${entry.version}`,
+    '',
+    `### ${entry.title}`,
+    '',
+    entry.date,
+    '',
+    entry.summary,
+    '',
+    highlights,
+  ].join('\n')
+}
+
+const getChangelogTitle = (entry: ChangelogEntry): string => `# ${entry.source.packageName}`
+
+const findVersionSection = (lines: string[], version: string): { start: number; end: number } | null => {
+  const start = lines.findIndex((line) => line.trim() === `${VERSION_HEADING_PREFIX}${version}`)
+  if (start === -1) {
+    return null
+  }
+
+  const nextSectionOffset = lines.slice(start + 1).findIndex((line) => line.startsWith(VERSION_HEADING_PREFIX))
+  const end = nextSectionOffset === -1 ? lines.length : start + 1 + nextSectionOffset
+
+  return { start, end }
+}
+
 export const writeChangelogEntry = async (repoRoot: string, output: string, entry: ChangelogEntry): Promise<string> => {
-  const outputDir = resolve(repoRoot, output)
-  const releasesDir = join(outputDir, 'releases')
-  await mkdir(releasesDir, { recursive: true })
+  const changelogPath = resolve(repoRoot, output)
+  const releaseEntry = formatMarkdownEntry(entry)
 
-  const releasePath = join(releasesDir, `${entry.version}.json`)
-  await writeFile(releasePath, `${JSON.stringify(entry, null, 2)}\n`)
-
-  const indexPath = join(outputDir, 'index.json')
-  const index = {
-    releases: [entry.version],
-  }
-
+  let existing = ''
   try {
-    const existing = await readJson<{ releases?: unknown }>(indexPath)
-    const releases = Array.isArray(existing.releases)
-      ? existing.releases.filter((version): version is string => typeof version === 'string')
-      : []
-
-    index.releases = [entry.version, ...releases.filter((version) => version !== entry.version)]
+    existing = await readFile(changelogPath, 'utf8')
   } catch {
-    // First changelog entry for the app.
+    existing = `${getChangelogTitle(entry)}\n`
   }
 
-  await writeFile(indexPath, `${JSON.stringify(index, null, 2)}\n`)
+  const lines = existing.trimEnd().split('\n')
+  const section = findVersionSection(lines, entry.version)
+  const nextEntry = releaseEntry.split('\n')
 
-  return relative(repoRoot, releasePath)
+  const nextLines = section
+    ? [...lines.slice(0, section.start), ...nextEntry, ...lines.slice(section.end)]
+    : [lines[0]?.startsWith('# ') ? lines[0] : getChangelogTitle(entry), '', ...nextEntry, '', ...lines.slice(1)]
+
+  await mkdir(dirname(changelogPath), { recursive: true })
+  await writeFile(changelogPath, `${nextLines.join('\n').replace(/\n{3,}/g, '\n\n')}\n`)
+
+  return relative(repoRoot, changelogPath)
 }
 
 export const generateReleaseChangelog = new Command('generate-release-changelog')
   .description('Generate an LLM-written app changelog entry when a package is released')
   .requiredOption('--package-dir <path>', 'package directory to watch for version changes')
-  .option('--output <path>', 'directory for generated changelog JSON files')
+  .option('--output <path>', 'path to the generated CHANGELOG.md file')
   .option('--package-name <name>', 'package name override for the LLM prompt')
   .option('--title <title>', 'product title for the LLM prompt')
   .option('--allow-missing', 'exit successfully when the package directory does not exist')
@@ -383,7 +410,7 @@ export const generateReleaseChangelog = new Command('generate-release-changelog'
 
     const date = process.env.SCALAR_RELEASE_CHANGELOG_DATE ?? new Date().toISOString().slice(0, 10)
     const entry = await requestChangelog(context, options, date)
-    const output = options.output ?? join(context.packageDir, 'src/data/changelog')
+    const output = options.output ?? join(context.packageDir, 'CHANGELOG.md')
     const releasePath = await writeChangelogEntry(repoRoot, output, entry)
 
     console.log(`Generated ${releasePath}`)

--- a/tooling/scripts/src/commands/generate-release-changelog.ts
+++ b/tooling/scripts/src/commands/generate-release-changelog.ts
@@ -1,0 +1,390 @@
+import { execFile } from 'node:child_process'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { basename, join, posix, relative, resolve, sep } from 'node:path'
+import { promisify } from 'node:util'
+
+import { Command } from 'commander'
+
+const execFileAsync = promisify(execFile)
+
+type PackageJson = {
+  name?: string
+  version?: string
+}
+
+type ChangelogEntry = {
+  version: string
+  date: string
+  title: string
+  summary: string
+  highlights: string[]
+  source: {
+    packageName: string
+    packageDir: string
+    previousVersion: string | null
+    sinceCommit: string | null
+  }
+}
+
+type ReleaseContext = {
+  packageName: string
+  packageDir: string
+  title: string
+  version: string
+  previousVersion: string | null
+  sinceCommit: string | null
+  currentReleaseDiff: string
+  committedReleaseLog: string
+  committedChangelogDiff: string
+}
+
+type Options = {
+  packageDir: string
+  output?: string
+  packageName?: string
+  title?: string
+  allowMissing?: boolean
+  dryRun?: boolean
+  mockResponse?: string
+  model?: string
+  baseUrl?: string
+}
+
+const MAX_CONTEXT_CHARS = 60_000
+
+const toGitPath = (path: string): string => path.split(sep).join(posix.sep)
+
+const truncate = (text: string, maxLength: number): string =>
+  text.length > maxLength ? `${text.slice(0, maxLength)}\n\n[truncated]` : text
+
+const runGit = async (args: string[], cwd: string): Promise<string> => {
+  const { stdout } = await execFileAsync('git', args, { cwd, maxBuffer: 20 * 1024 * 1024 })
+  return stdout.toString().trim()
+}
+
+const readJson = async <T>(path: string): Promise<T> => JSON.parse(await readFile(path, 'utf8')) as T
+
+const readPackageJsonAtRef = async (
+  repoRoot: string,
+  packageJsonPath: string,
+  ref: string,
+): Promise<PackageJson | null> => {
+  try {
+    const contents = await runGit(['show', `${ref}:${packageJsonPath}`], repoRoot)
+    return JSON.parse(contents) as PackageJson
+  } catch {
+    return null
+  }
+}
+
+const getVersionAtRef = async (repoRoot: string, packageJsonPath: string, ref: string): Promise<string | null> => {
+  const packageJson = await readPackageJsonAtRef(repoRoot, packageJsonPath, ref)
+  return packageJson?.version ?? null
+}
+
+const findPreviousPackageReleaseCommit = async (
+  repoRoot: string,
+  packageJsonPath: string,
+  previousVersion: string | null,
+): Promise<string | null> => {
+  if (!previousVersion) {
+    return null
+  }
+
+  const commits = (await runGit(['log', '--format=%H', '--', packageJsonPath], repoRoot)).split('\n').filter(Boolean)
+
+  for (const commit of commits) {
+    const version = await getVersionAtRef(repoRoot, packageJsonPath, commit)
+    if (version !== previousVersion) {
+      continue
+    }
+
+    const parentVersion = await getVersionAtRef(repoRoot, packageJsonPath, `${commit}^`)
+    if (parentVersion !== previousVersion) {
+      return commit
+    }
+  }
+
+  return null
+}
+
+const getCurrentReleaseDiff = async (repoRoot: string, packageDir: string): Promise<string> => {
+  try {
+    return await runGit(['diff', '--unified=20', '--', packageDir, '.changeset'], repoRoot)
+  } catch {
+    return ''
+  }
+}
+
+const getCommittedReleaseLog = async (repoRoot: string, sinceCommit: string | null): Promise<string> => {
+  const args = sinceCommit
+    ? ['log', '--date=short', '--pretty=format:%h %ad %s', `${sinceCommit}..HEAD`]
+    : ['log', '--date=short', '--pretty=format:%h %ad %s', '-n', '100']
+
+  try {
+    return await runGit(args, repoRoot)
+  } catch {
+    return ''
+  }
+}
+
+const getCommittedChangelogDiff = async (repoRoot: string, sinceCommit: string | null): Promise<string> => {
+  if (!sinceCommit) {
+    return ''
+  }
+
+  try {
+    return await runGit(['diff', '--unified=0', `${sinceCommit}..HEAD`, '--', ':(glob)**/CHANGELOG.md'], repoRoot)
+  } catch {
+    return ''
+  }
+}
+
+export const collectReleaseContext = async (repoRoot: string, options: Options): Promise<ReleaseContext | null> => {
+  const packageDir = toGitPath(relative(repoRoot, resolve(repoRoot, options.packageDir)))
+  const packageJsonPath = join(packageDir, 'package.json')
+
+  let packageJson: PackageJson
+  try {
+    packageJson = await readJson<PackageJson>(resolve(repoRoot, packageJsonPath))
+  } catch (error) {
+    if (options.allowMissing) {
+      return null
+    }
+
+    throw error
+  }
+
+  const version = packageJson.version
+  if (!version) {
+    throw new Error(`${packageJsonPath} must include a version`)
+  }
+
+  const previousPackageJson = await readPackageJsonAtRef(repoRoot, packageJsonPath, 'HEAD')
+  const previousVersion = previousPackageJson?.version ?? null
+
+  if (previousVersion === version) {
+    return null
+  }
+
+  const packageName = options.packageName ?? packageJson.name ?? basename(packageDir)
+  const sinceCommit = await findPreviousPackageReleaseCommit(repoRoot, packageJsonPath, previousVersion)
+  const currentReleaseDiff = await getCurrentReleaseDiff(repoRoot, packageDir)
+  const committedReleaseLog = await getCommittedReleaseLog(repoRoot, sinceCommit)
+  const committedChangelogDiff = await getCommittedChangelogDiff(repoRoot, sinceCommit)
+
+  return {
+    packageName,
+    packageDir,
+    title: options.title ?? packageName,
+    version,
+    previousVersion,
+    sinceCommit,
+    currentReleaseDiff: truncate(currentReleaseDiff, MAX_CONTEXT_CHARS),
+    committedReleaseLog: truncate(committedReleaseLog, MAX_CONTEXT_CHARS),
+    committedChangelogDiff: truncate(committedChangelogDiff, MAX_CONTEXT_CHARS),
+  }
+}
+
+const buildPrompt = (
+  context: ReleaseContext,
+  date: string,
+): string => `Write a user-facing changelog entry for ${context.title}.
+
+Return strict JSON with this exact shape:
+{
+  "title": "short human headline",
+  "summary": "one concise paragraph, 1-2 sentences",
+  "highlights": ["2-5 concise bullets"]
+}
+
+Rules:
+- Write for product users, not maintainers.
+- Mention the most important shipped behavior since ${context.packageName} was last released.
+- Combine the current release with package releases that landed since the previous ${context.packageName} release.
+- Do not mention commits, hashes, internal package names, dependency bumps, CI, or release process details.
+- Do not invent features that are not supported by the context.
+- Today is ${date}.
+
+Package:
+${JSON.stringify(
+  {
+    name: context.packageName,
+    dir: context.packageDir,
+    version: context.version,
+    previousVersion: context.previousVersion,
+    sinceCommit: context.sinceCommit,
+  },
+  null,
+  2,
+)}
+
+Current release diff:
+${context.currentReleaseDiff || '[none]'}
+
+Committed releases since the previous package release:
+${context.committedReleaseLog || '[none]'}
+
+Changelog diffs since the previous package release:
+${context.committedChangelogDiff || '[none]'}
+`
+
+const parseModelResponse = (text: string, context: ReleaseContext, date: string): ChangelogEntry => {
+  const parsed = JSON.parse(text) as Partial<Pick<ChangelogEntry, 'title' | 'summary' | 'highlights'>>
+
+  if (typeof parsed.title !== 'string' || parsed.title.trim() === '') {
+    throw new Error('LLM changelog response must include a title')
+  }
+
+  if (typeof parsed.summary !== 'string' || parsed.summary.trim() === '') {
+    throw new Error('LLM changelog response must include a summary')
+  }
+
+  if (
+    !Array.isArray(parsed.highlights) ||
+    parsed.highlights.length === 0 ||
+    !parsed.highlights.every((highlight) => typeof highlight === 'string' && highlight.trim() !== '')
+  ) {
+    throw new Error('LLM changelog response must include at least one highlight')
+  }
+
+  return {
+    version: context.version,
+    date,
+    title: parsed.title.trim(),
+    summary: parsed.summary.trim(),
+    highlights: parsed.highlights.map((highlight) => highlight.trim()),
+    source: {
+      packageName: context.packageName,
+      packageDir: context.packageDir,
+      previousVersion: context.previousVersion,
+      sinceCommit: context.sinceCommit,
+    },
+  }
+}
+
+const requestChangelog = async (context: ReleaseContext, options: Options, date: string): Promise<ChangelogEntry> => {
+  const mockResponse = options.mockResponse ?? process.env.SCALAR_RELEASE_CHANGELOG_MOCK_RESPONSE
+  if (mockResponse) {
+    return parseModelResponse(mockResponse, context, date)
+  }
+
+  const apiKey = process.env.SCALAR_RELEASE_CHANGELOG_API_KEY ?? process.env.OPENAI_API_KEY
+  if (!apiKey) {
+    throw new Error('Set SCALAR_RELEASE_CHANGELOG_API_KEY or OPENAI_API_KEY to generate an LLM changelog')
+  }
+
+  const baseUrl = (
+    options.baseUrl ??
+    process.env.SCALAR_RELEASE_CHANGELOG_BASE_URL ??
+    'https://api.openai.com/v1'
+  ).replace(/\/$/, '')
+  const model = options.model ?? process.env.SCALAR_RELEASE_CHANGELOG_MODEL ?? 'gpt-4.1'
+  const response = await fetch(`${baseUrl}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model,
+      messages: [
+        {
+          role: 'system',
+          content: 'You write crisp product changelogs and return only valid JSON.',
+        },
+        {
+          role: 'user',
+          content: buildPrompt(context, date),
+        },
+      ],
+      response_format: { type: 'json_object' },
+      temperature: 0.4,
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`LLM changelog request failed: ${response.status} ${await response.text()}`)
+  }
+
+  const body = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string } }>
+  }
+  const content = body.choices?.[0]?.message?.content
+  if (!content) {
+    throw new Error('LLM changelog response did not include message content')
+  }
+
+  return parseModelResponse(content, context, date)
+}
+
+export const writeChangelogEntry = async (repoRoot: string, output: string, entry: ChangelogEntry): Promise<string> => {
+  const outputDir = resolve(repoRoot, output)
+  const releasesDir = join(outputDir, 'releases')
+  await mkdir(releasesDir, { recursive: true })
+
+  const releasePath = join(releasesDir, `${entry.version}.json`)
+  await writeFile(releasePath, `${JSON.stringify(entry, null, 2)}\n`)
+
+  const indexPath = join(outputDir, 'index.json')
+  const index = {
+    releases: [entry.version],
+  }
+
+  try {
+    const existing = await readJson<{ releases?: unknown }>(indexPath)
+    const releases = Array.isArray(existing.releases)
+      ? existing.releases.filter((version): version is string => typeof version === 'string')
+      : []
+
+    index.releases = [entry.version, ...releases.filter((version) => version !== entry.version)]
+  } catch {
+    // First changelog entry for the app.
+  }
+
+  await writeFile(indexPath, `${JSON.stringify(index, null, 2)}\n`)
+
+  return relative(repoRoot, releasePath)
+}
+
+export const generateReleaseChangelog = new Command('generate-release-changelog')
+  .description('Generate an LLM-written app changelog entry when a package is released')
+  .requiredOption('--package-dir <path>', 'package directory to watch for version changes')
+  .option('--output <path>', 'directory for generated changelog JSON files')
+  .option('--package-name <name>', 'package name override for the LLM prompt')
+  .option('--title <title>', 'product title for the LLM prompt')
+  .option('--allow-missing', 'exit successfully when the package directory does not exist')
+  .option('--dry-run', 'collect release context without calling the LLM or writing files')
+  .option('--mock-response <json>', 'use a local JSON response instead of calling the LLM')
+  .option('--model <model>', 'LLM model name')
+  .option('--base-url <url>', 'OpenAI-compatible chat completions base URL')
+  .action(async (options: Options) => {
+    const repoRoot = process.cwd()
+    if (options.allowMissing) {
+      try {
+        await runGit(['rev-parse', '--verify', 'HEAD'], repoRoot)
+      } catch {
+        console.log('No git HEAD found; skipping LLM changelog generation.')
+        return
+      }
+    }
+
+    const context = await collectReleaseContext(repoRoot, options)
+
+    if (!context) {
+      console.log('No package release detected; skipping LLM changelog generation.')
+      return
+    }
+
+    if (options.dryRun) {
+      console.log(JSON.stringify(context, null, 2))
+      return
+    }
+
+    const date = process.env.SCALAR_RELEASE_CHANGELOG_DATE ?? new Date().toISOString().slice(0, 10)
+    const entry = await requestChangelog(context, options, date)
+    const output = options.output ?? join(context.packageDir, 'src/data/changelog')
+    const releasePath = await writeChangelogEntry(repoRoot, output, entry)
+
+    console.log(`Generated ${releasePath}`)
+  })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`projects/scalar-app` needs committed, product-facing changelog entries whenever its package release is included in the Changesets release PR. The release should consider the current app release plus other package releases since the app package was last released.

## Solution

Add a `pnpm script generate-release-changelog` command that detects watched package version changes after `pnpm changeset version`, gathers git and changelog context since the package's previous release, asks an OpenAI-compatible LLM for a strict changelog entry, and writes the result into `projects/scalar-app/CHANGELOG.md`. The writer prepends newest entries, replaces an existing matching version on rerun, and creates the file if needed. Wire the command into the Changesets release PR version step for `projects/scalar-app`, with `--allow-missing` so the workflow remains safe until the app PR lands.

## Example output

The generated product-facing changelog could look like this going back 10 releases:

```markdown
# scalar-app

## 0.2.1

### Operation-level auth and server controls

2026-03-04

Scalar API Client now follows the auth and server settings defined on each operation, so requests better match the API description you are testing.

- Use operation-specific authentication when sending requests
- Choose the correct server for each operation

## 0.2.0

### Node 22 desktop runtime baseline

2026-03-04

The desktop app now targets the current Node runtime baseline for a more reliable build and release foundation.

- Require Node 22 or newer
- Keep the app aligned with the shared client runtime

## 0.1.300

### More reliable examples and OAuth URLs

2026-03-03

Request setup is more dependable when working with cached schema examples and OAuth flows that depend on server variables.

- Cache schema examples correctly
- Resolve OAuth2 URLs against the interpolated server URL

## 0.1.299

### Maintenance release

2026-03-02

This release keeps the desktop app aligned with the latest API Client updates.

- Pull in the latest request editor improvements
- Keep shared client behavior current

## 0.1.298

### Cleaner desktop dependencies

2026-03-02

The desktop app removes unused dependencies and picks up client fixes for security setup and navigation edge cases.

- Remove redundant app dependencies
- Improve security scheme defaults and selection handling

## 0.1.297

### Dependency refresh

2026-02-27

This release updates the shared client, components, and theme foundation used by the desktop app.

- Refresh API Client internals
- Keep UI primitives and themes aligned

## 0.1.296

### Improved forms and operation settings

2026-02-27

Forms are more consistent, and requests handle circular schemas, operation-level auth, and operation-level servers more reliably.

- Standardize form input height
- Improve deep reference handling

## 0.1.295

### Maintenance release

2026-02-26

This release keeps the desktop app on the latest client and component updates.

- Update shared API Client behavior
- Refresh shared component dependencies

## 0.1.294

### Better sidebar and security descriptions

2026-02-24

Navigation and security selection feel more polished, especially when working with nested content and Markdown descriptions.

- Add better sidebar slug and chevron behavior
- Render selected security scheme descriptions correctly

## 0.1.293

### Workspace defaults and guardrails

2026-02-19

The app improves workspace handling and defaults web-style requests through the proxy.

- Default web layout requests to the proxy
- Add guardrails for team workspaces
```

## Checklist

- [x] I explained why the change is needed.
- [x] I added tests.
- [ ] I updated the documentation.
- [ ] I added a changeset. <!-- pnpm changeset -->

No changeset: this only changes internal release tooling.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-066ae30f-768a-476c-aa12-277fd40db1a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-066ae30f-768a-476c-aa12-277fd40db1a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

