### PR TITLE
feat(api-client): show inline errors in command palette instead of silent disable

### DIFF
--- a/.changeset/fluffy-birds-kiss.md
+++ b/.changeset/fluffy-birds-kiss.md
@@ -1,5 +1,5 @@
 ---
-'@scalar/api-client': minor
+'@scalar/api-client': patch
 ---
 
 feat: show inline errors in command palette instead of silent disable

--- a/.changeset/fluffy-birds-kiss.md
+++ b/.changeset/fluffy-birds-kiss.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': minor
+---
+
+feat: show inline errors in command palette instead of silent disable

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteExample.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteExample.test.ts
@@ -1050,4 +1050,102 @@ describe('CommandPaletteExample', () => {
 
     expect(wrapper.emitted('back')).toBeFalsy()
   })
+
+  it('shows an inline error when the example name conflicts with an existing one', async () => {
+    const document = createMockDocument({
+      paths: {
+        '/api/users': {
+          get: {
+            operationId: 'op1',
+            'x-draft-examples': ['default', 'custom'],
+          },
+        },
+      },
+    })
+    const workspaceStore = await createMockWorkspaceStore({ 'doc1': document })
+    const eventBus = createWorkspaceEventBus()
+
+    const wrapper = mount(CommandPaletteExample, {
+      props: {
+        workspaceStore,
+        eventBus,
+      },
+    })
+
+    await nextTick()
+
+    const input = wrapper.findComponent({ name: 'CommandActionInput' })
+    await input.vm.$emit('update:modelValue', 'custom')
+    await nextTick()
+
+    const error = wrapper.find('[data-testid="command-palette-example-error"]')
+    expect(error.exists()).toBe(true)
+    expect(error.attributes('role')).toBe('alert')
+    expect(error.text()).toContain('custom')
+    expect(error.text()).toContain('already exists')
+
+    const form = wrapper.findComponent({ name: 'CommandActionForm' })
+    expect(form.props('disabled')).toBe(true)
+  })
+
+  it('does not show the inline error when the example name is unique', async () => {
+    const document = createMockDocument({
+      paths: {
+        '/api/users': {
+          get: {
+            operationId: 'op1',
+            'x-draft-examples': ['default'],
+          },
+        },
+      },
+    })
+    const workspaceStore = await createMockWorkspaceStore({ 'doc1': document })
+    const eventBus = createWorkspaceEventBus()
+
+    const wrapper = mount(CommandPaletteExample, {
+      props: {
+        workspaceStore,
+        eventBus,
+      },
+    })
+
+    await nextTick()
+
+    const input = wrapper.findComponent({ name: 'CommandActionInput' })
+    await input.vm.$emit('update:modelValue', 'fresh-name')
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="command-palette-example-error"]').exists()).toBe(false)
+  })
+
+  it('does not show the inline error in edit mode when the name is unchanged', async () => {
+    const document = createMockDocument({
+      paths: {
+        '/api/users': {
+          get: {
+            operationId: 'op1',
+            'x-draft-examples': ['default', 'custom'],
+          },
+        },
+      },
+    })
+    const workspaceStore = await createMockWorkspaceStore({ 'doc1': document })
+    const eventBus = createWorkspaceEventBus()
+
+    const wrapper = mount(CommandPaletteExample, {
+      props: {
+        workspaceStore,
+        eventBus,
+        documentName: 'doc1',
+        example: {
+          id: 'example-custom',
+          type: 'example',
+          title: 'custom',
+          name: 'custom',
+        },
+      },
+    })
+
+    expect(wrapper.find('[data-testid="command-palette-example-error"]').exists()).toBe(false)
+  })
 })

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteExample.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteExample.vue
@@ -34,7 +34,7 @@ import type {
   TraversedExample,
   TraversedOperation,
 } from '@scalar/workspace-store/schemas/navigation'
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, type ComputedRef } from 'vue'
 
 import HttpMethodBadge from '@/v2/blocks/operation-code-sample/components/HttpMethod.vue'
 
@@ -168,8 +168,41 @@ const handleSelect = (operation: OperationOption | undefined): void => {
 }
 
 /**
- * Check if the form should be disabled.
- * Disabled when any required field is missing or empty.
+ * Validation message surfaced under the input.
+ *
+ * Resolves to `null` when the form is valid; otherwise to a human-readable
+ * reason the user can act on. Empty input or an unchanged name in edit mode
+ * are treated as the default state so the modal does not greet the user
+ * with a misleading error.
+ */
+const errorMessage: ComputedRef<string | null> = computed(() => {
+  if (
+    !exampleNameTrimmed.value ||
+    !selectedDocument.value ||
+    !selectedOperation.value
+  ) {
+    return null
+  }
+
+  if (isEditMode.value && exampleNameTrimmed.value === example?.name) {
+    return null
+  }
+
+  const nameConflict = selectedOperation.value.exampleNames.some(
+    (name) => name === exampleNameTrimmed.value && name !== example?.name,
+  )
+
+  if (nameConflict) {
+    return `An example named "${exampleNameTrimmed.value}" already exists for ${selectedOperation.value.method.toUpperCase()} ${selectedOperation.value.path}. Try a different name.`
+  }
+
+  return null
+})
+
+/**
+ * Submit is blocked while required fields are missing, the name is unchanged
+ * in edit mode, or another example already uses the same name. The inline
+ * `errorMessage` explains the duplicate case so the user knows how to recover.
  */
 const isDisabled = computed<boolean>(() => {
   if (
@@ -180,21 +213,11 @@ const isDisabled = computed<boolean>(() => {
     return true
   }
 
-  if (isEditMode.value && example) {
-    if (exampleNameTrimmed.value === example.name) {
-      return true
-    }
-  }
-
-  if (
-    selectedOperation.value.exampleNames.some(
-      (name) => name === exampleNameTrimmed.value && name !== example?.name,
-    )
-  ) {
+  if (isEditMode.value && exampleNameTrimmed.value === example?.name) {
     return true
   }
 
-  return false
+  return errorMessage.value !== null
 })
 
 /**
@@ -257,6 +280,14 @@ const handleCancel = (): void => {
       label="Example Name"
       placeholder="Example Name"
       @delete="handleBack" />
+
+    <p
+      v-if="errorMessage"
+      class="text-red px-2 pb-1 text-xs"
+      data-testid="command-palette-example-error"
+      role="alert">
+      {{ errorMessage }}
+    </p>
 
     <!-- Selectors for document and operation -->
     <template #options>

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.test.ts
@@ -7,17 +7,9 @@ import { nextTick } from 'vue'
 
 import CommandPaletteImport from './CommandPaletteImport.vue'
 
-// Mock router
-const mockPush = vi.fn()
-vi.mock('vue-router', () => ({
-  useRouter: () => ({
-    push: mockPush,
-  }),
-}))
-
 describe('CommandPaletteImport', () => {
   beforeEach(() => {
-    mockPush.mockClear()
+    vi.clearAllMocks()
   })
 
   afterEach(() => {

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.vue
@@ -31,7 +31,6 @@ import {
 } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { computed, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
 
 import { useFileDialog } from '@/hooks/use-file-dialog'
 import { getOpenApiDocumentDetails } from '@/v2/features/command-palette/helpers/get-openapi-document-details'
@@ -78,7 +77,6 @@ defineSlots<{
 
 const { toast } = useToasts()
 
-const router = useRouter()
 const loader = useLoadingState()
 
 const inputContent = ref('')
@@ -199,9 +197,10 @@ const handleImport = async (
 
 /** Navigate to the document overview page after successful import */
 const navigateToDocument = (documentName: string): void => {
-  router.push({
-    name: 'document.overview',
-    params: { documentSlug: documentName },
+  eventBus.emit('ui:navigate', {
+    page: 'document',
+    path: 'overview',
+    documentSlug: documentName,
   })
 }
 

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportCurl.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportCurl.test.ts
@@ -5,14 +5,6 @@ import { nextTick } from 'vue'
 
 import CommandPaletteImportCurl from './CommandPaletteImportCurl.vue'
 
-// Mock router
-const mockPush = vi.fn()
-vi.mock('vue-router', () => ({
-  useRouter: () => ({
-    push: mockPush,
-  }),
-}))
-
 describe('CommandPaletteImportCurl', () => {
   const createMockEventBus = () => ({
     emit: vi.fn(),
@@ -22,7 +14,7 @@ describe('CommandPaletteImportCurl', () => {
   })
 
   beforeEach(() => {
-    mockPush.mockClear()
+    vi.clearAllMocks()
   })
 
   afterEach(() => {
@@ -293,6 +285,71 @@ describe('CommandPaletteImportCurl', () => {
     expect(form.props('disabled')).toBe(true)
   })
 
+  it('shows an inline error when the operation already exists', async () => {
+    const workspaceStore = createWorkspaceStore()
+    await workspaceStore.addDocument({
+      name: 'test-doc',
+      document: {
+        openapi: '3.1.0',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {
+          '/users': {
+            get: {
+              operationId: 'getUsers',
+            },
+          },
+        },
+      },
+    })
+    const eventBus = createMockEventBus()
+
+    const wrapper = mount(CommandPaletteImportCurl, {
+      props: {
+        workspaceStore,
+        eventBus,
+        inputValue: 'curl https://example.com/users',
+      },
+    })
+
+    const input = wrapper.findComponent({ name: 'CommandActionInput' })
+    await input.vm.$emit('update:modelValue', 'example-1')
+    await nextTick()
+
+    const error = wrapper.find('[data-testid="command-palette-import-curl-error"]')
+    expect(error.exists()).toBe(true)
+    expect(error.attributes('role')).toBe('alert')
+    expect(error.text()).toContain('GET')
+    expect(error.text()).toContain('/users')
+    expect(error.text()).toContain('already exists')
+  })
+
+  it('does not show an inline error when the operation does not conflict', async () => {
+    const workspaceStore = createWorkspaceStore()
+    await workspaceStore.addDocument({
+      name: 'test-doc',
+      document: {
+        openapi: '3.1.0',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {},
+      },
+    })
+    const eventBus = createMockEventBus()
+
+    const wrapper = mount(CommandPaletteImportCurl, {
+      props: {
+        workspaceStore,
+        eventBus,
+        inputValue: 'curl https://example.com/users',
+      },
+    })
+
+    const input = wrapper.findComponent({ name: 'CommandActionInput' })
+    await input.vm.$emit('update:modelValue', 'example-1')
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="command-palette-import-curl-error"]').exists()).toBe(false)
+  })
+
   it('enables form when operation does not exist', async () => {
     const workspaceStore = createWorkspaceStore()
     await workspaceStore.addDocument({
@@ -546,14 +603,12 @@ describe('CommandPaletteImportCurl', () => {
     const callback = emitCall?.[1]?.callback
     callback?.(true)
 
-    expect(mockPush).toHaveBeenCalledWith({
-      name: 'example',
-      params: {
-        documentSlug: 'test-doc',
-        pathEncoded: encodeURIComponent('/users'),
-        method: 'get',
-        exampleName: 'my-example',
-      },
+    expect(eventBus.emit).toHaveBeenCalledWith('ui:navigate', {
+      page: 'example',
+      documentSlug: 'test-doc',
+      path: '/users',
+      method: 'get',
+      exampleName: 'my-example',
     })
   })
 
@@ -588,11 +643,11 @@ describe('CommandPaletteImportCurl', () => {
     const callback = emitCall?.[1]?.callback
     callback?.(true)
 
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      'ui:navigate',
       expect.objectContaining({
-        params: expect.objectContaining({
-          pathEncoded: expect.any(String),
-        }),
+        page: 'example',
+        path: expect.stringMatching(/^\//),
       }),
     )
   })
@@ -631,7 +686,7 @@ describe('CommandPaletteImportCurl', () => {
     callback?.(false)
 
     expect(workspaceStore.buildSidebar).not.toHaveBeenCalled()
-    expect(mockPush).not.toHaveBeenCalled()
+    expect(eventBus.emit).not.toHaveBeenCalledWith('ui:navigate', expect.anything())
   })
 
   it('renders submit button with correct text', () => {

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportCurl.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImportCurl.vue
@@ -31,8 +31,7 @@ import {
 } from '@scalar/components'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
-import { computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { computed, ref, type ComputedRef } from 'vue'
 
 import HttpMethod from '@/v2/blocks/operation-code-sample/components/HttpMethod.vue'
 import CommandActionForm from '@/v2/features/command-palette/components/CommandActionForm.vue'
@@ -55,8 +54,6 @@ const emit = defineEmits<{
   (event: 'back', keyboardEvent: KeyboardEvent): void
 }>()
 
-const router = useRouter()
-
 const exampleKey = ref('')
 
 /** Trimmed version of the example key for validation and submission */
@@ -78,25 +75,38 @@ const selectedDocument = ref<ScalarComboboxOption | undefined>(
 )
 
 /**
- * Check if the form should be disabled.
- * Disabled when:
- * - Example key is empty
- * - No document is selected
- * - An operation with the same path and method already exists in the selected document
+ * Validation message surfaced under the input.
+ *
+ * Resolves to `null` when the form is valid; otherwise to a human-readable
+ * reason the user can act on. Empty input is the default state so we keep
+ * the field free of error styling — `isDisabled` still blocks submission
+ * there, matching the {@link CommandPaletteOpenApiDocument} pattern.
  */
-const isDisabled = computed<boolean>(() => {
+const errorMessage: ComputedRef<string | null> = computed(() => {
   if (!exampleKeyTrimmed.value || !selectedDocument.value) {
-    return true
+    return null
   }
 
-  /** Prevent creating duplicate operations at the same path/method */
   const document = workspaceStore.workspace.documents[selectedDocument.value.id]
+
   if (document?.paths?.[path]?.[method]) {
-    return true
+    return `A ${method.toUpperCase()} operation at "${path}" already exists in "${selectedDocument.value.label}". Importing this cURL would conflict with it.`
   }
 
-  return false
+  return null
 })
+
+/**
+ * Submit is blocked while required fields are missing or a duplicate exists.
+ * The inline `errorMessage` makes the duplicate case explicit so the user
+ * understands why import is unavailable rather than seeing a silent disable.
+ */
+const isDisabled = computed<boolean>(
+  () =>
+    !exampleKeyTrimmed.value ||
+    !selectedDocument.value ||
+    errorMessage.value !== null,
+)
 
 /**
  * Handle the import submission.
@@ -119,25 +129,25 @@ const handleImportClick = (): void => {
     operation: result.operation,
     exampleKey: exampleKeyTrimmed.value,
     callback: (success) => {
-      if (success) {
-        // build the sidebar
-        workspaceStore.buildSidebar(documentName.id)
-
-        const path = result.path.startsWith('/')
-          ? result.path
-          : `/${result.path}`
-
-        // navigate to the operation
-        router.push({
-          name: 'example',
-          params: {
-            documentSlug: documentName.id,
-            pathEncoded: encodeURIComponent(path),
-            method: result.method,
-            exampleName: exampleKeyTrimmed.value,
-          },
-        })
+      if (!success) {
+        return
       }
+
+      // build the sidebar
+      workspaceStore.buildSidebar(documentName.id)
+
+      const normalizedPath = result.path.startsWith('/')
+        ? result.path
+        : `/${result.path}`
+
+      // Navigate to the new example via the event bus rather than the router
+      eventBus.emit('ui:navigate', {
+        page: 'example',
+        documentSlug: documentName.id,
+        path: normalizedPath,
+        method: result.method,
+        exampleName: exampleKeyTrimmed.value,
+      })
     },
   })
 
@@ -158,6 +168,14 @@ const handleBack = (event: KeyboardEvent): void => {
       v-model="exampleKey"
       placeholder="Curl example key (e.g., example-1)"
       @delete="handleBack" />
+
+    <p
+      v-if="errorMessage"
+      class="text-red px-2 pb-1 text-xs"
+      data-testid="command-palette-import-curl-error"
+      role="alert">
+      {{ errorMessage }}
+    </p>
 
     <!-- Preview of the parsed cURL request (method + URL + path) -->
     <div class="flex flex-1 flex-col gap-2">

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteOpenApiDocument.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteOpenApiDocument.test.ts
@@ -5,14 +5,6 @@ import { nextTick } from 'vue'
 
 import CommandPaletteDocument from './CommandPaletteOpenApiDocument.vue'
 
-// Mock router
-const mockPush = vi.fn()
-vi.mock('vue-router', () => ({
-  useRouter: () => ({
-    push: mockPush,
-  }),
-}))
-
 describe('CommandPaletteDocument', () => {
   const createMockWorkspaceStore = async (documents: Record<string, Record<string, unknown>> = {}) => {
     const store = createWorkspaceStore()
@@ -30,7 +22,7 @@ describe('CommandPaletteDocument', () => {
   })
 
   beforeEach(() => {
-    mockPush.mockClear()
+    vi.clearAllMocks()
   })
 
   afterEach(() => {
@@ -559,7 +551,7 @@ describe('CommandPaletteDocument', () => {
     expect(wrapper.emitted('close')).toHaveLength(1)
   })
 
-  it('uses the trimmed document name in router params', async () => {
+  it('uses the trimmed document name when navigating after creation', async () => {
     const workspaceStore = await createMockWorkspaceStore()
     const eventBus = createMockEventBus()
 
@@ -582,11 +574,36 @@ describe('CommandPaletteDocument', () => {
     const callback = emitCall?.[1]?.callback
     callback?.(true)
 
-    expect(mockPush).toHaveBeenCalledWith({
-      name: 'document.overview',
-      params: {
-        documentSlug: 'My Document',
+    expect(eventBus.emit).toHaveBeenCalledWith('ui:navigate', {
+      page: 'document',
+      path: 'overview',
+      documentSlug: 'My Document',
+    })
+  })
+
+  it('does not navigate when document creation callback fails', async () => {
+    const workspaceStore = await createMockWorkspaceStore()
+    const eventBus = createMockEventBus()
+
+    const wrapper = mount(CommandPaletteDocument, {
+      props: {
+        workspaceStore,
+        eventBus,
       },
     })
+
+    const input = wrapper.findComponent({ name: 'CommandActionInput' })
+    await input.vm.$emit('update:modelValue', 'My Document')
+    await nextTick()
+
+    const form = wrapper.findComponent({ name: 'CommandActionForm' })
+    await form.vm.$emit('submit')
+    await nextTick()
+
+    const emitCall = eventBus.emit.mock.calls.find((call) => call[0] === 'document:create:empty-document')
+    const callback = emitCall?.[1]?.callback
+    callback?.(false)
+
+    expect(eventBus.emit).not.toHaveBeenCalledWith('ui:navigate', expect.anything())
   })
 })

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteOpenApiDocument.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteOpenApiDocument.vue
@@ -23,7 +23,6 @@ import { LibraryIcon } from '@scalar/icons/library'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { computed, ref, type ComputedRef } from 'vue'
-import { useRouter } from 'vue-router'
 
 import IconSelector from '@/components/IconSelector.vue'
 
@@ -43,8 +42,6 @@ const emit = defineEmits<{
   /** Emitted when user navigates back (e.g., backspace on empty input) */
   (event: 'back', keyboardEvent: KeyboardEvent): void
 }>()
-
-const router = useRouter()
 
 const documentName = ref('')
 const documentNameTrimmed = computed(() => documentName.value.trim())
@@ -93,14 +90,16 @@ const handleSubmit = (): void => {
     name: documentNameTrimmed.value,
     icon: documentIcon.value,
     callback: (success) => {
-      if (success) {
-        router.push({
-          name: 'document.overview',
-          params: {
-            documentSlug: documentNameTrimmed.value,
-          },
-        })
+      if (!success) {
+        return
       }
+
+      // Navigate via the event bus rather than the router
+      eventBus.emit('ui:navigate', {
+        page: 'document',
+        path: 'overview',
+        documentSlug: documentNameTrimmed.value,
+      })
     },
   })
 

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteRequest.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteRequest.test.ts
@@ -6,14 +6,6 @@ import { nextTick } from 'vue'
 
 import CommandPaletteRequest from './CommandPaletteRequest.vue'
 
-// Mock router
-const mockPush = vi.fn()
-vi.mock('vue-router', () => ({
-  useRouter: () => ({
-    push: mockPush,
-  }),
-}))
-
 describe('CommandPaletteRequest', () => {
   const createMockWorkspaceStore = async (documents: Record<string, Record<string, unknown>> = {}) => {
     const store = createWorkspaceStore()
@@ -45,7 +37,7 @@ describe('CommandPaletteRequest', () => {
   }
 
   beforeEach(() => {
-    mockPush.mockClear()
+    vi.clearAllMocks()
   })
 
   afterEach(() => {
@@ -218,6 +210,95 @@ describe('CommandPaletteRequest', () => {
 
     const form = wrapper.findComponent({ name: 'CommandActionForm' })
     expect(form.props('disabled')).toBe(true)
+  })
+
+  it('shows an inline error when the operation already exists', async () => {
+    const document = createMockDocument({
+      paths: {
+        '/users': {
+          get: {
+            operationId: 'getUsers',
+          },
+        },
+      },
+    })
+    const workspaceStore = await createMockWorkspaceStore({ 'doc1': document })
+    const eventBus = createMockEventBus()
+
+    const wrapper = mount(CommandPaletteRequest, {
+      props: {
+        workspaceStore,
+        eventBus,
+      },
+    })
+
+    const input = wrapper.findComponent({ name: 'CommandActionInput' })
+    await input.vm.$emit('update:modelValue', '/users')
+    await nextTick()
+
+    const error = wrapper.find('[data-testid="command-palette-request-error"]')
+    expect(error.exists()).toBe(true)
+    expect(error.attributes('role')).toBe('alert')
+    expect(error.text()).toContain('GET')
+    expect(error.text()).toContain('/users')
+    expect(error.text()).toContain('already exists')
+  })
+
+  it('does not show an inline error when the path is empty', async () => {
+    const document = createMockDocument({
+      paths: {
+        '/users': {
+          get: {
+            operationId: 'getUsers',
+          },
+        },
+      },
+    })
+    const workspaceStore = await createMockWorkspaceStore({ 'doc1': document })
+    const eventBus = createMockEventBus()
+
+    const wrapper = mount(CommandPaletteRequest, {
+      props: {
+        workspaceStore,
+        eventBus,
+      },
+    })
+
+    const input = wrapper.findComponent({ name: 'CommandActionInput' })
+    await input.vm.$emit('update:modelValue', '   ')
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="command-palette-request-error"]').exists()).toBe(false)
+  })
+
+  it('clears the inline error when the user picks a non-conflicting method', async () => {
+    const document = createMockDocument({
+      paths: {
+        '/users': {
+          get: {
+            operationId: 'getUsers',
+          },
+        },
+      },
+    })
+    const workspaceStore = await createMockWorkspaceStore({ 'doc1': document })
+    const eventBus = createMockEventBus()
+
+    const wrapper = mount(CommandPaletteRequest, {
+      props: {
+        workspaceStore,
+        eventBus,
+      },
+    })
+
+    const input = wrapper.findComponent({ name: 'CommandActionInput' })
+    await input.vm.$emit('update:modelValue', '/users')
+    await nextTick()
+    expect(wrapper.find('[data-testid="command-palette-request-error"]').exists()).toBe(true)
+
+    await input.vm.$emit('update:modelValue', '/products')
+    await nextTick()
+    expect(wrapper.find('[data-testid="command-palette-request-error"]').exists()).toBe(false)
   })
 
   it('normalizes path by adding leading slash when checking for duplicates', async () => {
@@ -635,14 +716,12 @@ describe('CommandPaletteRequest', () => {
     const callback = emitCall?.[1]?.callback
     callback?.(true)
 
-    expect(mockPush).toHaveBeenCalledWith({
-      name: 'example',
-      params: {
-        documentSlug: 'doc1',
-        pathEncoded: encodeURIComponent('/api/users'),
-        method: 'get',
-        exampleName: 'default',
-      },
+    expect(eventBus.emit).toHaveBeenCalledWith('ui:navigate', {
+      page: 'example',
+      documentSlug: 'doc1',
+      path: '/api/users',
+      method: 'get',
+      exampleName: 'default',
     })
   })
 
@@ -673,7 +752,7 @@ describe('CommandPaletteRequest', () => {
     callback?.(false)
 
     expect(workspaceStore.buildSidebar).not.toHaveBeenCalled()
-    expect(mockPush).not.toHaveBeenCalled()
+    expect(eventBus.emit).not.toHaveBeenCalledWith('ui:navigate', expect.anything())
   })
 
   it('renders submit button with correct text', async () => {
@@ -745,11 +824,11 @@ describe('CommandPaletteRequest', () => {
     const callback = emitCall?.[1]?.callback
     callback?.(true)
 
-    expect(mockPush).toHaveBeenCalledWith(
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      'ui:navigate',
       expect.objectContaining({
-        params: expect.objectContaining({
-          pathEncoded: encodeURIComponent('/api/users'),
-        }),
+        page: 'example',
+        path: '/api/users',
       }),
     )
   })

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteRequest.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteRequest.vue
@@ -36,8 +36,7 @@ import {
 } from '@scalar/helpers/http/http-methods'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
-import { computed, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { computed, ref, watch, type ComputedRef } from 'vue'
 
 import HttpMethodBadge from '@/v2/blocks/operation-code-sample/components/HttpMethod.vue'
 
@@ -75,10 +74,15 @@ type TagOption = {
   label: string
 }
 
-const router = useRouter()
-
 const requestPath = ref('/')
 const requestPathTrimmed = computed(() => requestPath.value.trim())
+
+/** Ensure path starts with '/' for consistent lookup */
+const normalizedRequestPath = computed<string>(() =>
+  requestPathTrimmed.value.startsWith('/')
+    ? requestPathTrimmed.value
+    : `/${requestPathTrimmed.value}`,
+)
 
 /** All available documents (collections) in the workspace */
 const availableDocuments = computed(() =>
@@ -140,48 +144,44 @@ watch(selectedDocument, () => {
 })
 
 /**
- * Check if an operation with the same path and method already exists.
- * Used to prevent creating duplicate operations.
+ * Validation message surfaced under the input.
+ *
+ * Resolves to `null` when the form is valid; otherwise to a human-readable
+ * reason the user can act on. Empty input is the default state so we keep
+ * the field free of error styling — `isDisabled` still blocks submission
+ * there, matching the {@link CommandPaletteOpenApiDocument} pattern.
  */
-const operationExists = computed<boolean>(() => {
-  if (
-    !selectedDocument.value ||
-    !selectedMethod.value ||
-    !requestPathTrimmed.value
-  ) {
-    return false
-  }
-
-  const document = workspaceStore.workspace.documents[selectedDocument.value.id]
-
-  /** Ensure path starts with '/' for consistent lookup */
-  const normalizedPath = requestPathTrimmed.value.startsWith('/')
-    ? requestPathTrimmed.value
-    : `/${requestPathTrimmed.value}`
-
-  return !!document?.paths?.[normalizedPath]?.[selectedMethod.value.method]
-})
-
-/**
- * Check if the form should be disabled.
- * Disabled when any required field is missing or operation already exists.
- */
-const isDisabled = computed<boolean>(() => {
+const errorMessage: ComputedRef<string | null> = computed(() => {
   if (
     !requestPathTrimmed.value ||
     !selectedDocument.value ||
     !selectedMethod.value
   ) {
-    return true
+    return null
   }
 
-  /** Prevent creating duplicate operations */
-  if (operationExists.value) {
-    return true
+  const document = workspaceStore.workspace.documents[selectedDocument.value.id]
+  const method = selectedMethod.value.method
+
+  if (document?.paths?.[normalizedRequestPath.value]?.[method]) {
+    return `A ${method.toUpperCase()} operation at "${normalizedRequestPath.value}" already exists in "${selectedDocument.value.label}". Try a different path or method.`
   }
 
-  return false
+  return null
 })
+
+/**
+ * Submit is blocked while required fields are missing or a duplicate exists.
+ * The inline `errorMessage` explains the duplicate case so the user knows how
+ * to recover instead of facing a silently disabled button.
+ */
+const isDisabled = computed<boolean>(
+  () =>
+    !requestPathTrimmed.value ||
+    !selectedDocument.value ||
+    !selectedMethod.value ||
+    errorMessage.value !== null,
+)
 
 /** Handle HTTP method selection from dropdown */
 const handleSelectMethod = (method: MethodOption | undefined): void => {
@@ -220,25 +220,21 @@ const handleSubmit = (): void => {
       tags: selectedTag.value?.id ? [selectedTag.value.id] : undefined,
     },
     callback: (success) => {
-      if (success) {
-        /** Build the sidebar */
-        workspaceStore.buildSidebar(selectedDocument.value?.id ?? '')
-
-        const path = requestPathTrimmed.value.startsWith('/')
-          ? requestPathTrimmed.value
-          : `/${requestPathTrimmed.value}`
-
-        /** Navigate to the example */
-        router.push({
-          name: 'example',
-          params: {
-            documentSlug: selectedDocument.value?.id,
-            pathEncoded: encodeURIComponent(path),
-            method: selectedMethod.value?.method,
-            exampleName: 'default',
-          },
-        })
+      if (!success) {
+        return
       }
+
+      /** Build the sidebar */
+      workspaceStore.buildSidebar(selectedDocument.value?.id ?? '')
+
+      /** Navigate to the example via the event bus rather than the router */
+      eventBus.emit('ui:navigate', {
+        page: 'example',
+        documentSlug: selectedDocument.value?.id,
+        path: normalizedRequestPath.value,
+        method: selectedMethod.value?.method ?? 'get',
+        exampleName: 'default',
+      })
     },
   })
 
@@ -260,6 +256,14 @@ const handleBack = (event: KeyboardEvent): void => {
       label="Request Path"
       placeholder="/users"
       @delete="handleBack" />
+
+    <p
+      v-if="errorMessage"
+      class="text-red px-2 pb-1 text-xs"
+      data-testid="command-palette-request-error"
+      role="alert">
+      {{ errorMessage }}
+    </p>
 
     <!-- Selectors for document, method, and tag -->
     <template #options>

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteTag.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteTag.test.ts
@@ -150,6 +150,103 @@ describe('CommandPaletteTag', () => {
     expect(form.props('disabled')).toBe(true)
   })
 
+  it('shows an inline error when the tag name already exists', async () => {
+    const document = createMockDocument({
+      tags: [{ name: 'Existing Tag' }],
+    })
+    const workspaceStore = await createMockWorkspaceStore({ 'doc1': document })
+    const eventBus = createMockEventBus()
+
+    const wrapper = mount(CommandPaletteTag, {
+      props: {
+        workspaceStore,
+        eventBus,
+      },
+    })
+
+    const input = wrapper.findComponent({ name: 'CommandActionInput' })
+    await input.vm.$emit('update:modelValue', 'Existing Tag')
+    await nextTick()
+
+    const error = wrapper.find('[data-testid="command-palette-tag-error"]')
+    expect(error.exists()).toBe(true)
+    expect(error.attributes('role')).toBe('alert')
+    expect(error.text()).toContain('Existing Tag')
+    expect(error.text()).toContain('already exists')
+  })
+
+  it('does not show an inline error when the tag name is empty', async () => {
+    const document = createMockDocument({
+      tags: [{ name: 'Existing Tag' }],
+    })
+    const workspaceStore = await createMockWorkspaceStore({ 'doc1': document })
+    const eventBus = createMockEventBus()
+
+    const wrapper = mount(CommandPaletteTag, {
+      props: {
+        workspaceStore,
+        eventBus,
+      },
+    })
+
+    expect(wrapper.find('[data-testid="command-palette-tag-error"]').exists()).toBe(false)
+
+    const input = wrapper.findComponent({ name: 'CommandActionInput' })
+    await input.vm.$emit('update:modelValue', '   ')
+    await nextTick()
+
+    expect(wrapper.find('[data-testid="command-palette-tag-error"]').exists()).toBe(false)
+  })
+
+  it('clears the inline error once the user types a unique tag name', async () => {
+    const document = createMockDocument({
+      tags: [{ name: 'Existing Tag' }],
+    })
+    const workspaceStore = await createMockWorkspaceStore({ 'doc1': document })
+    const eventBus = createMockEventBus()
+
+    const wrapper = mount(CommandPaletteTag, {
+      props: {
+        workspaceStore,
+        eventBus,
+      },
+    })
+
+    const input = wrapper.findComponent({ name: 'CommandActionInput' })
+    await input.vm.$emit('update:modelValue', 'Existing Tag')
+    await nextTick()
+    expect(wrapper.find('[data-testid="command-palette-tag-error"]').exists()).toBe(true)
+
+    await input.vm.$emit('update:modelValue', 'New Tag')
+    await nextTick()
+    expect(wrapper.find('[data-testid="command-palette-tag-error"]').exists()).toBe(false)
+  })
+
+  it('does not show the inline error in edit mode when the name is unchanged', async () => {
+    const document = createMockDocument({
+      tags: [{ name: 'Existing Tag' }],
+    })
+    const workspaceStore = await createMockWorkspaceStore({ 'doc1': document })
+    const eventBus = createMockEventBus()
+
+    const wrapper = mount(CommandPaletteTag, {
+      props: {
+        workspaceStore,
+        eventBus,
+        documentName: 'doc1',
+        tag: {
+          type: 'tag',
+          id: 'doc1.tags/Existing Tag',
+          title: 'Existing Tag',
+          name: 'Existing Tag',
+          isGroup: false,
+        },
+      },
+    })
+
+    expect(wrapper.find('[data-testid="command-palette-tag-error"]').exists()).toBe(false)
+  })
+
   it('enables form when tag name is valid and unique', async () => {
     const document = createMockDocument({
       tags: [{ name: 'Existing Tag' }],

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteTag.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteTag.vue
@@ -43,7 +43,7 @@ import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { TraversedTag } from '@scalar/workspace-store/schemas/navigation'
-import { computed, ref } from 'vue'
+import { computed, ref, type ComputedRef } from 'vue'
 
 import CommandActionForm from './CommandActionForm.vue'
 import CommandActionInput from './CommandActionInput.vue'
@@ -88,18 +88,46 @@ const selectedDocument = ref<{ id: string; label: string } | undefined>(
 )
 
 /**
- * Check if the form should be disabled.
+ * Validation message surfaced under the input.
  *
- * In edit mode, disabled when:
- * - Tag name is empty
- * - Name is unchanged from the original
- * - The new name conflicts with an existing tag in the same document
+ * Resolves to `null` when the form is valid; otherwise to a human-readable
+ * reason the user can act on. Empty input is the default state so we keep
+ * the field free of error styling — `isDisabled` still blocks submission
+ * there, matching the {@link CommandPaletteOpenApiDocument} pattern.
  *
- * In create mode, disabled when:
- * - Tag name is empty
- * - No collection is selected
- * - The selected document does not exist
- * - A tag with the same name already exists in the selected document
+ * In edit mode, an unchanged name is treated as a no-op (no error shown,
+ * but submit stays disabled) so opening the modal does not greet the user
+ * with a confusing message about their current name.
+ */
+const errorMessage: ComputedRef<string | null> = computed(() => {
+  if (!nameTrimmed.value) {
+    return null
+  }
+
+  const document =
+    workspaceStore.workspace.documents[selectedDocument.value?.id ?? '']
+
+  if (!selectedDocument.value || !document) {
+    return null
+  }
+
+  // Unchanged name in edit mode is a silent no-op rather than an error
+  if (isEditMode.value && nameTrimmed.value === tag?.name) {
+    return null
+  }
+
+  if (document.tags?.some((existing) => existing.name === nameTrimmed.value)) {
+    return `A tag named "${nameTrimmed.value}" already exists in "${selectedDocument.value.label}". Try a different name.`
+  }
+
+  return null
+})
+
+/**
+ * Submit is blocked while required fields are missing, the name is unchanged
+ * in edit mode, or a duplicate tag exists. The inline `errorMessage` makes
+ * the duplicate case explicit instead of leaving the user staring at a
+ * silently disabled button.
  */
 const isDisabled = computed<boolean>(() => {
   const document =
@@ -108,19 +136,11 @@ const isDisabled = computed<boolean>(() => {
     return true
   }
 
-  // In edit mode, disable if the name has not changed
-  if (isEditMode.value) {
-    if (nameTrimmed.value === tag?.name) {
-      return true
-    }
-  }
-
-  // Prevent creating duplicate tags with the same name
-  if (document.tags?.some((tag) => tag.name === nameTrimmed.value)) {
+  if (isEditMode.value && nameTrimmed.value === tag?.name) {
     return true
   }
 
-  return false
+  return errorMessage.value !== null
 })
 
 /**
@@ -179,6 +199,14 @@ const handleCancel = (): void => {
       label="Tag Name"
       placeholder="Tag Name"
       @delete="handleBack" />
+
+    <p
+      v-if="errorMessage"
+      class="text-red px-2 pb-1 text-xs"
+      data-testid="command-palette-tag-error"
+      role="alert">
+      {{ errorMessage }}
+    </p>
 
     <!-- Collection selector (hidden in edit mode) -->
     <template #options>


### PR DESCRIPTION
## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes command-palette navigation from `vue-router` pushes to `eventBus.emit('ui:navigate')` and adjusts validation/disable logic across multiple flows. UI-only but touches core creation/import flows that users rely on.
> 
> **Overview**
> Improves command palette UX by surfacing **inline validation errors** (via `role="alert"`) for duplicate names/paths (examples, requests, tags, cURL imports) instead of only disabling submit, while keeping empty/unchanged edit states error-free.
> 
> Refactors command-palette flows to **navigate via `eventBus`** (`ui:navigate`) after successful document import/creation and operation/example creation, updating tests accordingly and adding coverage for the new inline-error cases and non-navigation on failed callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe758c754923debe34fc3f822ba1284dce6e16ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->