### PR TITLE
chore: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -429,6 +429,33 @@ Use consistent terminology:
 - **Bundle** - pull external `$ref` values into a single file
 - **Resolve** - look up value at a `$ref` without modifying the document
 
+## Cursor Cloud specific instructions
+
+### Environment
+
+- **Node.js v24** is managed via nvm. The update script handles installation automatically.
+- **pnpm v10.16.1** is activated via corepack. No global install needed.
+- After `pnpm install`, you may see a warning about ignored esbuild build scripts. This is safe to ignore — Vite 8 uses Rolldown and the build succeeds without esbuild's platform binary.
+
+### Running dev servers
+
+- There is no single root `pnpm dev`. Start the specific package you need (see the Key Commands table above).
+- `pnpm --filter @scalar/api-reference dev` starts on **port 5173**.
+- `pnpm --filter @scalar/api-client dev` starts on a Vite-assigned port (check terminal output).
+- All packages must be built first (`pnpm build:packages`) before running any dev server.
+
+### Testing caveats
+
+- Some packages have test failures related to `@/` path alias resolution in Vitest (e.g., `openapi-parser`, `snippetz`). These are pre-existing and not caused by environment issues.
+- Tests that require network services need test servers running first: `pnpm script run test-servers` (starts void-server on port 5052 and proxy on port 5051).
+- For a quick validation that the test framework works, run: `pnpm vitest packages/oas-utils --run`
+
+### Lint and format
+
+- `pnpm lint:check` runs Biome on all TS files. This is the primary lint command.
+- For Vue files: `pnpm lint:vue` (ESLint).
+- For formatting: `pnpm format:check` (Prettier + Biome format).
+
 ## Further Reading
 
 - [CONTRIBUTING.md](./CONTRIBUTING.md) - PR requirements, changesets, auto-generated files


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Cloud agents starting fresh sessions in this repository lack non-obvious environment caveats and startup guidance specific to the Cursor Cloud VM. This leads to repeated discovery of the same gotchas (e.g., esbuild warning being safe to ignore, `@/` path alias test failures being pre-existing, dev servers requiring prior `pnpm build:packages`).

## Solution

Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting:
- Environment setup notes (nvm, corepack, esbuild warning)
- Dev server startup guidance (no single root `pnpm dev`, per-package servers)
- Testing caveats (pre-existing `@/` alias failures, test server requirements)
- Lint/format command reference

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed for docs-only AGENTS.md change -->
- [ ] I added tests. <!-- Not applicable -->
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64f40c06-a7f4-4e4f-9777-2d1d02a0a61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64f40c06-a7f4-4e4f-9777-2d1d02a0a61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

