### PR TITLE
chore: added cursor environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "baseImage": "ghcr.io/cursor-images/node-24:latest",
+  "install": "corepack enable && corepack prepare pnpm@10.16.1 --activate && pnpm install && pnpm build:packages"
+}


### PR DESCRIPTION
## Problem
Trying to fix this environment issue.
<img width="575" height="312" alt="image" src="https://github.com/user-attachments/assets/2ad27753-2f73-446e-ba09-65ffe6c6a3ad" />


## Solution

We can just use an image that has eveyrthing pre-installed instead of using the script

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a Cursor-only dev environment config that changes how dependencies are installed/built in that editor context; no production/runtime code is affected.
> 
> **Overview**
> Adds `.cursor/environment.json` to define a Cursor development environment using the `ghcr.io/cursor-images/node-24:latest` base image and an install command that enables Corepack, pins `pnpm@10.16.1`, runs `pnpm install`, and builds packages via `pnpm build:packages`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5415560019fbd0d620243c3c4133b76d8c9940c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->