### PR TITLE
chore: fix environment.json to use npm install -g pnpm

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,4 @@
 {
   "baseImage": "ghcr.io/cursor-images/node-24:latest",
-  "install": "corepack enable && corepack prepare pnpm@10.16.1 --activate && pnpm install && pnpm build:packages"
+  "install": "npm install -g pnpm@10.16.1 && pnpm install && pnpm build:packages"
 }

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,4 @@
 {
   "baseImage": "ghcr.io/cursor-images/node-24:latest",
-  "install": "npm install -g pnpm@10.16.1 && pnpm install && pnpm build:packages"
+  "install": "curl -fsSL https://github.com/pnpm/pnpm/releases/download/v10.16.1/pnpm-linux-x64 -o /usr/local/bin/pnpm && chmod +x /usr/local/bin/pnpm && pnpm install && pnpm build:packages"
 }

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,4 @@
 {
   "baseImage": "ghcr.io/cursor-images/node-24:latest",
-  "install": "npm install -g pnpm@10.16.1 && pnpm install && pnpm build:packages"
+  "install": "corepack enable && corepack prepare pnpm@10.16.1 --activate && pnpm install && pnpm build:packages"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `.cursor/environment.json` install command to use the pnpm standalone binary download since neither `npm` nor `corepack` are available in the `ghcr.io/cursor-images/node-24:latest` base image.

## Changes

- Downloads pnpm v10.16.1 standalone binary directly from GitHub releases
- Places it at `/usr/local/bin/pnpm` with execute permission
- Then runs `pnpm install && pnpm build:packages` as before

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1042afa5-b135-4d03-884b-cba74329f852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1042afa5-b135-4d03-884b-cba74329f852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

