### PR TITLE
feat(ts-to-openapi): add fastify route extraction

### DIFF
--- a/.changeset/fast-badgers-teach.md
+++ b/.changeset/fast-badgers-teach.md
@@ -1,0 +1,5 @@
+---
+'@scalar/ts-to-openapi': minor
+---
+
+feat: add Fastify route OpenAPI generation

--- a/packages/ts-to-openapi/README.MD
+++ b/packages/ts-to-openapi/README.MD
@@ -9,5 +9,120 @@ This an extremely early version of a typescript type to OpenAPI document convert
 would normally use when developing an API and convert them to an OpenAPI document which will then be used to power the
 standalone Scalar API References.
 
-This package is not meant to be used directly, but will be the core technology behind framework specific integrations
-starting with Next.js.
+This package is not meant to be used directly, but will be the core technology behind framework specific integrations.
+
+## Fastify examples
+
+Fastify route generics can be converted into OpenAPI paths. Fastify `schema` values are preferred when present because
+they include validation keywords such as `required`, `format`, and `minLength`.
+
+```ts
+import { generateFastifyOpenApiDocument } from '@scalar/ts-to-openapi'
+
+fastify.post<{
+  Body: {
+    name: string
+    email: string
+  }
+  Reply: {
+    201: {
+      id: string
+      name: string
+      email: string
+    }
+  }
+}>(
+  '/users',
+  {
+    schema: {
+      summary: 'Create a user',
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', minLength: 1 },
+          email: { type: 'string', format: 'email' },
+        },
+        required: ['name', 'email'],
+      },
+      response: {
+        201: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            email: { type: 'string', format: 'email' },
+          },
+          required: ['id', 'name', 'email'],
+        },
+      },
+    },
+  },
+  async (request) => ({
+    id: 'user-1',
+    name: request.body.name,
+    email: request.body.email,
+  }),
+)
+```
+
+Routes without Fastify validation schemas can still be described from their route generic input and response types:
+
+```ts
+fastify.post<{
+  Body: {
+    name: string
+    email: string
+    role: 'admin' | 'member'
+  }
+  Querystring: {
+    invite?: boolean
+  }
+  Headers: {
+    'x-tenant': string
+  }
+  Reply: {
+    201: {
+      id: string
+      role: 'admin' | 'member'
+    }
+    400: {
+      error: string
+    }
+  }
+}>('/typed-users', async (request) => ({
+  id: 'user-2',
+  role: request.body.role,
+}))
+```
+
+The same extraction supports `fastify.route` declarations:
+
+```ts
+fastify.route<{
+  Body: {
+    enabled: boolean
+  }
+  Reply: {
+    204: null
+  }
+}>({
+  method: 'PATCH',
+  url: '/users/:id/settings',
+  schema: {
+    summary: 'Update user settings',
+    body: {
+      type: 'object',
+      properties: {
+        enabled: { type: 'boolean' },
+      },
+      required: ['enabled'],
+    },
+    response: {
+      204: {
+        description: 'Settings updated',
+      },
+    },
+  },
+  handler: async () => null,
+})
+```

--- a/packages/ts-to-openapi/src/fastify.test.ts
+++ b/packages/ts-to-openapi/src/fastify.test.ts
@@ -110,10 +110,10 @@ describe('generateFastifyOpenApiDocument', () => {
                 name: {
                   type: 'string',
                 },
-              email: {
-                type: 'string',
-                format: 'email',
-              },
+                email: {
+                  type: 'string',
+                  format: 'email',
+                },
               },
               required: ['id', 'name', 'email'],
             },

--- a/packages/ts-to-openapi/src/fastify.test.ts
+++ b/packages/ts-to-openapi/src/fastify.test.ts
@@ -1,0 +1,302 @@
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { fileNameResolver, program } from '../test/test-setup'
+import { generateFastifyOpenApiDocument } from './fastify'
+
+describe('generateFastifyOpenApiDocument', () => {
+  const sourceFilePath = path.join(import.meta.dirname, '../test/fixtures/fastify-routes.ts')
+  const sourceFile = program.getSourceFile(sourceFilePath)
+
+  if (!sourceFile) {
+    throw new Error('Fastify fixture source file was not loaded')
+  }
+
+  const document = generateFastifyOpenApiDocument(sourceFile, program, fileNameResolver, {
+    title: 'Fastify Users API',
+    version: '2026.05.01',
+  })
+  const paths = document.paths ?? {}
+
+  it('generates document metadata', () => {
+    expect(document.openapi).toBe('3.1.0')
+    expect(document.info).toStrictEqual({
+      title: 'Fastify Users API',
+      version: '2026.05.01',
+    })
+  })
+
+  it('generates validation schemas for typed shorthand route inputs', () => {
+    expect(paths['/users']?.post?.requestBody).toStrictEqual({
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+                minLength: 1,
+              },
+              email: {
+                type: 'string',
+                format: 'email',
+              },
+            },
+            required: ['name', 'email'],
+          },
+        },
+      },
+    })
+
+    expect(paths['/users']?.post?.parameters).toStrictEqual([])
+
+    expect(paths['/typed-users']?.post?.requestBody).toStrictEqual({
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+              email: {
+                type: 'string',
+              },
+              role: {
+                type: 'string',
+                enum: ['admin', 'member'],
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(paths['/typed-users']?.post?.parameters).toStrictEqual([
+      {
+        in: 'query',
+        name: 'invite',
+        required: false,
+        schema: {
+          type: 'boolean',
+        },
+      },
+      {
+        in: 'header',
+        name: 'x-tenant',
+        required: false,
+        schema: {
+          type: 'string',
+        },
+      },
+    ])
+  })
+
+  it('generates status responses from Fastify Reply generics', () => {
+    expect(paths['/users']?.post?.responses).toStrictEqual({
+      '201': {
+        description: 'Successful response',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'string',
+                },
+                name: {
+                  type: 'string',
+                },
+              email: {
+                type: 'string',
+                format: 'email',
+              },
+              },
+              required: ['id', 'name', 'email'],
+            },
+          },
+        },
+      },
+    })
+
+    expect(paths['/typed-users']?.post?.responses).toStrictEqual({
+      '201': {
+        description: 'Successful response',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'string',
+                },
+                role: {
+                  type: 'string',
+                  enum: ['admin', 'member'],
+                },
+              },
+            },
+          },
+        },
+      },
+      '400': {
+        description: 'Successful response',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                error: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+
+  it('prefers Fastify schema literals over route generic inputs', () => {
+    expect(paths['/users/{id}']?.get?.parameters).toStrictEqual([
+      {
+        in: 'path',
+        name: 'id',
+        required: true,
+        schema: {
+          type: 'string',
+          format: 'uuid',
+        },
+      },
+      {
+        in: 'query',
+        name: 'includePosts',
+        required: false,
+        schema: {
+          type: 'boolean',
+        },
+      },
+    ])
+
+    expect(paths['/users/{id}']?.get?.responses).toStrictEqual({
+      '200': {
+        description: 'Successful response',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'string',
+                },
+                name: {
+                  type: 'string',
+                },
+                email: {
+                  type: 'string',
+                },
+                posts: {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '404': {
+        description: 'Successful response',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                error: {
+                  type: 'string',
+                  example: 'not_found',
+                },
+                message: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+
+  it('generates typed-only request inputs when schemas are omitted', () => {
+    expect(paths['/typed-users']?.post?.requestBody).toStrictEqual({
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+              email: {
+                type: 'string',
+              },
+              role: {
+                type: 'string',
+                enum: ['admin', 'member'],
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(paths['/typed-users']?.post?.parameters).toStrictEqual([
+      {
+        in: 'query',
+        name: 'invite',
+        required: false,
+        schema: {
+          type: 'boolean',
+        },
+      },
+      {
+        in: 'header',
+        name: 'x-tenant',
+        required: false,
+        schema: {
+          type: 'string',
+        },
+      },
+    ])
+  })
+
+  it('generates operations from fastify.route calls', () => {
+    expect(paths['/users/{id}/settings']?.patch?.requestBody).toStrictEqual({
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              enabled: {
+                type: 'boolean',
+              },
+            },
+            required: ['enabled'],
+          },
+        },
+      },
+    })
+
+    expect(paths['/users/{id}/settings']?.patch?.responses).toStrictEqual({
+      '204': {
+        description: 'Settings updated',
+      },
+    })
+  })
+})

--- a/packages/ts-to-openapi/src/fastify.ts
+++ b/packages/ts-to-openapi/src/fastify.ts
@@ -1,0 +1,462 @@
+import type { OpenAPIV3_1 } from 'openapi-types'
+import {
+  type CallExpression,
+  type Expression,
+  type Node,
+  type ObjectLiteralExpression,
+  type Program,
+  SyntaxKind,
+  type TypeLiteralNode,
+  forEachChild,
+  isArrayLiteralExpression,
+  isCallExpression,
+  isExpressionStatement,
+  isIdentifier,
+  isNoSubstitutionTemplateLiteral,
+  isNumericLiteral,
+  isObjectLiteralExpression,
+  isPrefixUnaryExpression,
+  isPropertyAccessExpression,
+  isPropertyAssignment,
+  isPropertySignature,
+  isShorthandPropertyAssignment,
+  isSourceFile,
+  isStringLiteral,
+  isTypeLiteralNode,
+  isVariableStatement,
+} from 'typescript'
+
+import { getSchemaFromTypeNode } from './type-nodes'
+import type { FileNameResolver } from './types'
+
+const FASTIFY_METHODS = ['delete', 'get', 'head', 'patch', 'post', 'put', 'options'] as const
+
+type FastifyMethod = (typeof FASTIFY_METHODS)[number]
+
+const ROUTE_INPUT_TO_PARAMETER_IN = {
+  Params: 'path',
+  Querystring: 'query',
+  Headers: 'header',
+} as const
+
+type RouteInputName = keyof typeof ROUTE_INPUT_TO_PARAMETER_IN
+
+type RouteGenericSchemas = Partial<Record<'Body' | 'Headers' | 'Params' | 'Querystring' | 'Reply', OpenAPIV3_1.SchemaObject>>
+
+const isFastifyMethod = (method: string): method is FastifyMethod =>
+  FASTIFY_METHODS.includes(method as FastifyMethod)
+
+const getPropertyName = (name: Node): string | undefined => {
+  if (isIdentifier(name) || isStringLiteral(name) || isNumericLiteral(name)) {
+    return name.text
+  }
+
+  return undefined
+}
+
+const getObjectLiteralProperty = (objectLiteral: ObjectLiteralExpression, propertyName: string): Expression | undefined => {
+  const property = objectLiteral.properties.find((item) => {
+    if (isPropertyAssignment(item)) {
+      return getPropertyName(item.name) === propertyName
+    }
+
+    return isShorthandPropertyAssignment(item) && item.name.text === propertyName
+  })
+
+  if (property && isPropertyAssignment(property)) {
+    return property.initializer
+  }
+
+  if (property && isShorthandPropertyAssignment(property)) {
+    return property.name
+  }
+
+  return undefined
+}
+
+const getStringValue = (expression: Expression | undefined): string | undefined => {
+  if (!expression) {
+    return undefined
+  }
+
+  if (isStringLiteral(expression) || isNoSubstitutionTemplateLiteral(expression)) {
+    return expression.text
+  }
+
+  return undefined
+}
+
+const toOpenApiPath = (url: string): string => url.replaceAll(/:([A-Za-z0-9_]+)/g, '{$1}')
+
+const getLiteralValue = (expression: Expression): unknown => {
+  if (isStringLiteral(expression) || isNoSubstitutionTemplateLiteral(expression)) {
+    return expression.text
+  }
+
+  if (isNumericLiteral(expression)) {
+    return Number(expression.text)
+  }
+
+  if (expression.kind === SyntaxKind.TrueKeyword) {
+    return true
+  }
+
+  if (expression.kind === SyntaxKind.FalseKeyword) {
+    return false
+  }
+
+  if (expression.kind === SyntaxKind.NullKeyword) {
+    return null
+  }
+
+  if (isPrefixUnaryExpression(expression) && isNumericLiteral(expression.operand)) {
+    return expression.operator === SyntaxKind.MinusToken ? -Number(expression.operand.text) : Number(expression.operand.text)
+  }
+
+  if (isArrayLiteralExpression(expression)) {
+    return expression.elements.map((element) => getLiteralValue(element))
+  }
+
+  return undefined
+}
+
+const getJsonSchemaFromObjectLiteral = (objectLiteral: ObjectLiteralExpression): OpenAPIV3_1.SchemaObject => {
+  return objectLiteral.properties.reduce<OpenAPIV3_1.SchemaObject>((schema, property) => {
+    if (!isPropertyAssignment(property)) {
+      return schema
+    }
+
+    const propertyName = getPropertyName(property.name)
+
+    if (!propertyName) {
+      return schema
+    }
+
+    if (propertyName === 'properties' && isObjectLiteralExpression(property.initializer)) {
+      return {
+        ...schema,
+        properties: property.initializer.properties.reduce<NonNullable<OpenAPIV3_1.SchemaObject['properties']>>(
+          (properties, schemaProperty) => {
+            if (!isPropertyAssignment(schemaProperty)) {
+              return properties
+            }
+
+            const schemaPropertyName = getPropertyName(schemaProperty.name)
+
+            return schemaPropertyName
+              ? {
+                  ...properties,
+                  [schemaPropertyName]: isObjectLiteralExpression(schemaProperty.initializer)
+                    ? getJsonSchemaFromObjectLiteral(schemaProperty.initializer)
+                    : {},
+                }
+              : properties
+          },
+          {},
+        ),
+      }
+    }
+
+    if (isObjectLiteralExpression(property.initializer)) {
+      return {
+        ...schema,
+        [propertyName]: getJsonSchemaFromObjectLiteral(property.initializer),
+      }
+    }
+
+    return {
+      ...schema,
+      [propertyName]: getLiteralValue(property.initializer),
+    }
+  }, {})
+}
+
+const getSchemaProperty = (
+  schemaNode: Expression | undefined,
+  propertyName: string,
+): OpenAPIV3_1.SchemaObject | undefined => {
+  if (!schemaNode || !isObjectLiteralExpression(schemaNode)) {
+    return undefined
+  }
+
+  const property = getObjectLiteralProperty(schemaNode, propertyName)
+
+  return property && isObjectLiteralExpression(property) ? getJsonSchemaFromObjectLiteral(property) : undefined
+}
+
+const getRouteGenericSchemas = (
+  typeLiteral: TypeLiteralNode | undefined,
+  program: Program,
+  fileNameResolver: FileNameResolver,
+): RouteGenericSchemas => {
+  if (!typeLiteral) {
+    return {}
+  }
+
+  return typeLiteral.members.reduce<RouteGenericSchemas>((schemas, member) => {
+    if (isPropertySignature(member) && member.type && isIdentifier(member.name)) {
+      const name = member.name.text
+
+      if (name === 'Body' || name === 'Headers' || name === 'Params' || name === 'Querystring' || name === 'Reply') {
+        return {
+          ...schemas,
+          [name]: getSchemaFromTypeNode(member.type, program, fileNameResolver),
+        }
+      }
+    }
+
+    return schemas
+  }, {})
+}
+
+const getFastifyRouteCall = (node: Node): CallExpression | undefined => {
+  if (isExpressionStatement(node) && isCallExpression(node.expression)) {
+    return node.expression
+  }
+
+  if (isVariableStatement(node)) {
+    for (const declaration of node.declarationList.declarations) {
+      if (declaration.initializer && isCallExpression(declaration.initializer)) {
+        return declaration.initializer
+      }
+    }
+  }
+
+  return undefined
+}
+
+const getFastifyRouteCalls = (node: Node): CallExpression[] => {
+  const calls: CallExpression[] = []
+
+  const visit = (currentNode: Node): void => {
+    const callExpression = getFastifyRouteCall(currentNode)
+
+    if (callExpression && getRouteMetadata(callExpression)) {
+      calls.push(callExpression)
+      return
+    }
+
+    forEachChild(currentNode, visit)
+  }
+
+  visit(node)
+
+  return calls
+}
+
+const getRouteMetadata = (
+  callExpression: CallExpression,
+): { method: FastifyMethod; url: string; options: ObjectLiteralExpression | undefined } | undefined => {
+  const expression = callExpression.expression
+
+  if (isPropertyAccessExpression(expression)) {
+    const methodName = expression.name.text
+
+    if (isFastifyMethod(methodName)) {
+      const [urlExpression, optionsExpression] = callExpression.arguments
+      const url = getStringValue(urlExpression)
+
+      if (!url) {
+        return undefined
+      }
+
+      return {
+        method: methodName,
+        url,
+        options: optionsExpression && isObjectLiteralExpression(optionsExpression) ? optionsExpression : undefined,
+      }
+    }
+
+    if (methodName === 'route') {
+      const [routeOptions] = callExpression.arguments
+
+      if (!routeOptions || !isObjectLiteralExpression(routeOptions)) {
+        return undefined
+      }
+
+      const method = getStringValue(getObjectLiteralProperty(routeOptions, 'method'))?.toLowerCase()
+      const url = getStringValue(getObjectLiteralProperty(routeOptions, 'url'))
+
+      if (!method || !isFastifyMethod(method) || !url) {
+        return undefined
+      }
+
+      return {
+        method,
+        url,
+        options: routeOptions,
+      }
+    }
+  }
+
+  return undefined
+}
+
+const getRouteTypeLiteral = (callExpression: CallExpression): TypeLiteralNode | undefined => {
+  const [typeArgument] = callExpression.typeArguments ?? []
+
+  return typeArgument && isTypeLiteralNode(typeArgument) ? typeArgument : undefined
+}
+
+const getParameters = (
+  routeGenericSchemas: RouteGenericSchemas,
+  schemaNode: Expression | undefined,
+): OpenAPIV3_1.ParameterObject[] => {
+  return (Object.keys(ROUTE_INPUT_TO_PARAMETER_IN) as RouteInputName[]).flatMap((inputName) => {
+    const schema = getSchemaProperty(schemaNode, inputName.toLowerCase()) ?? routeGenericSchemas[inputName]
+
+    if (!schema || !schema.properties) {
+      return []
+    }
+
+    const required = Array.isArray(schema.required) ? schema.required.map(String) : []
+
+    return Object.entries(schema.properties).map(
+      ([name, propertySchema]) =>
+        ({
+          in: ROUTE_INPUT_TO_PARAMETER_IN[inputName],
+          name,
+          required: inputName === 'Params' || required.includes(name),
+          schema: propertySchema,
+        }) as OpenAPIV3_1.ParameterObject,
+    )
+  })
+}
+
+const getRequestBody = (
+  routeGenericSchemas: RouteGenericSchemas,
+  schemaNode: Expression | undefined,
+): OpenAPIV3_1.RequestBodyObject | undefined => {
+  const schema = getSchemaProperty(schemaNode, 'body') ?? routeGenericSchemas.Body
+
+  if (!schema) {
+    return undefined
+  }
+
+  return {
+    required: true,
+    content: {
+      'application/json': {
+        schema,
+      },
+    },
+  }
+}
+
+const getResponses = (
+  routeGenericSchemas: RouteGenericSchemas,
+  schemaNode: Expression | undefined,
+): OpenAPIV3_1.ResponsesObject => {
+  const responseSchema = getSchemaProperty(schemaNode, 'response')
+
+  if (responseSchema) {
+    return Object.entries(responseSchema).reduce<OpenAPIV3_1.ResponsesObject>((responses, [status, schema]) => {
+      const responseBodySchema = schema as OpenAPIV3_1.SchemaObject
+      const { description, ...contentSchema } = responseBodySchema
+      const hasContentSchema = Object.keys(contentSchema).length > 0
+
+      return {
+        ...responses,
+        [status]: {
+          description: typeof description === 'string' ? description : 'Successful response',
+          ...(hasContentSchema
+            ? {
+                content: {
+                  'application/json': {
+                    schema: contentSchema,
+                  },
+                },
+              }
+            : {}),
+        },
+      }
+    }, {})
+  }
+
+  if (routeGenericSchemas.Reply?.properties) {
+    return Object.entries(routeGenericSchemas.Reply.properties).reduce<OpenAPIV3_1.ResponsesObject>(
+      (responses, [status, schema]) => ({
+        ...responses,
+        [status]: {
+          description: 'Successful response',
+          content: {
+            'application/json': {
+              schema: schema as OpenAPIV3_1.SchemaObject,
+            },
+          },
+        },
+      }),
+      {},
+    )
+  }
+
+  return {
+    200: {
+      description: 'Successful response',
+    },
+  }
+}
+
+/**
+ * Generate OpenAPI paths from Fastify route declarations.
+ */
+export const getFastifyRoutes = (
+  node: Node | undefined,
+  program: Program,
+  fileNameResolver: FileNameResolver,
+): OpenAPIV3_1.PathsObject => {
+  if (!node) {
+    return {}
+  }
+
+  const sourceFile = isSourceFile(node) ? node : node.getSourceFile()
+  return getFastifyRouteCalls(sourceFile).reduce<OpenAPIV3_1.PathsObject>((paths, callExpression) => {
+    const routeMetadata = getRouteMetadata(callExpression)
+
+    if (!routeMetadata) {
+      return paths
+    }
+
+    const routeGenericSchemas = getRouteGenericSchemas(getRouteTypeLiteral(callExpression), program, fileNameResolver)
+    const schemaNode = routeMetadata.options ? getObjectLiteralProperty(routeMetadata.options, 'schema') : undefined
+    const path = toOpenApiPath(routeMetadata.url)
+    const operation: OpenAPIV3_1.OperationObject = {
+      ...(schemaNode && isObjectLiteralExpression(schemaNode) && getStringValue(getObjectLiteralProperty(schemaNode, 'description'))
+        ? { description: getStringValue(getObjectLiteralProperty(schemaNode, 'description')) }
+        : {}),
+      ...(schemaNode && isObjectLiteralExpression(schemaNode) && getStringValue(getObjectLiteralProperty(schemaNode, 'summary'))
+        ? { summary: getStringValue(getObjectLiteralProperty(schemaNode, 'summary')) }
+        : {}),
+      parameters: getParameters(routeGenericSchemas, schemaNode),
+      responses: getResponses(routeGenericSchemas, schemaNode),
+      ...(getRequestBody(routeGenericSchemas, schemaNode)
+        ? { requestBody: getRequestBody(routeGenericSchemas, schemaNode) }
+        : {}),
+    }
+
+    return {
+      ...paths,
+      [path]: {
+        ...paths[path],
+        [routeMetadata.method]: operation,
+      },
+    }
+  }, {})
+}
+
+/**
+ * Generate a minimal OpenAPI document from Fastify route declarations.
+ */
+export const generateFastifyOpenApiDocument = (
+  node: Node | undefined,
+  program: Program,
+  fileNameResolver: FileNameResolver,
+  info: OpenAPIV3_1.InfoObject = {
+    title: 'Fastify API',
+    version: '0.0.0',
+  },
+): OpenAPIV3_1.Document => ({
+  openapi: '3.1.0',
+  info,
+  paths: getFastifyRoutes(node, program, fileNameResolver),
+})

--- a/packages/ts-to-openapi/src/fastify.ts
+++ b/packages/ts-to-openapi/src/fastify.ts
@@ -41,10 +41,11 @@ const ROUTE_INPUT_TO_PARAMETER_IN = {
 
 type RouteInputName = keyof typeof ROUTE_INPUT_TO_PARAMETER_IN
 
-type RouteGenericSchemas = Partial<Record<'Body' | 'Headers' | 'Params' | 'Querystring' | 'Reply', OpenAPIV3_1.SchemaObject>>
+type RouteGenericSchemas = Partial<
+  Record<'Body' | 'Headers' | 'Params' | 'Querystring' | 'Reply', OpenAPIV3_1.SchemaObject>
+>
 
-const isFastifyMethod = (method: string): method is FastifyMethod =>
-  FASTIFY_METHODS.includes(method as FastifyMethod)
+const isFastifyMethod = (method: string): method is FastifyMethod => FASTIFY_METHODS.includes(method as FastifyMethod)
 
 const getPropertyName = (name: Node): string | undefined => {
   if (isIdentifier(name) || isStringLiteral(name) || isNumericLiteral(name)) {
@@ -54,7 +55,10 @@ const getPropertyName = (name: Node): string | undefined => {
   return undefined
 }
 
-const getObjectLiteralProperty = (objectLiteral: ObjectLiteralExpression, propertyName: string): Expression | undefined => {
+const getObjectLiteralProperty = (
+  objectLiteral: ObjectLiteralExpression,
+  propertyName: string,
+): Expression | undefined => {
   const property = objectLiteral.properties.find((item) => {
     if (isPropertyAssignment(item)) {
       return getPropertyName(item.name) === propertyName
@@ -110,7 +114,9 @@ const getLiteralValue = (expression: Expression): unknown => {
   }
 
   if (isPrefixUnaryExpression(expression) && isNumericLiteral(expression.operand)) {
-    return expression.operator === SyntaxKind.MinusToken ? -Number(expression.operand.text) : Number(expression.operand.text)
+    return expression.operator === SyntaxKind.MinusToken
+      ? -Number(expression.operand.text)
+      : Number(expression.operand.text)
   }
 
   if (isArrayLiteralExpression(expression)) {
@@ -421,10 +427,14 @@ export const getFastifyRoutes = (
     const schemaNode = routeMetadata.options ? getObjectLiteralProperty(routeMetadata.options, 'schema') : undefined
     const path = toOpenApiPath(routeMetadata.url)
     const operation: OpenAPIV3_1.OperationObject = {
-      ...(schemaNode && isObjectLiteralExpression(schemaNode) && getStringValue(getObjectLiteralProperty(schemaNode, 'description'))
+      ...(schemaNode &&
+      isObjectLiteralExpression(schemaNode) &&
+      getStringValue(getObjectLiteralProperty(schemaNode, 'description'))
         ? { description: getStringValue(getObjectLiteralProperty(schemaNode, 'description')) }
         : {}),
-      ...(schemaNode && isObjectLiteralExpression(schemaNode) && getStringValue(getObjectLiteralProperty(schemaNode, 'summary'))
+      ...(schemaNode &&
+      isObjectLiteralExpression(schemaNode) &&
+      getStringValue(getObjectLiteralProperty(schemaNode, 'summary'))
         ? { summary: getStringValue(getObjectLiteralProperty(schemaNode, 'summary')) }
         : {}),
       parameters: getParameters(routeGenericSchemas, schemaNode),

--- a/packages/ts-to-openapi/src/index.ts
+++ b/packages/ts-to-openapi/src/index.ts
@@ -1,3 +1,4 @@
+export { generateFastifyOpenApiDocument, getFastifyRoutes } from './fastify'
 export { getJSDocFromNode } from './js-doc'
 export { generateResponses, getReturnStatements } from './responses'
 export { getSchemaFromTypeNode } from './type-nodes'

--- a/packages/ts-to-openapi/src/node.ts
+++ b/packages/ts-to-openapi/src/node.ts
@@ -16,6 +16,7 @@ import {
   isObjectLiteralExpression,
   isPrefixUnaryExpression,
   isPropertyAssignment,
+  isShorthandPropertyAssignment,
   isStringLiteral,
   isVariableDeclaration,
 } from 'typescript'
@@ -120,6 +121,15 @@ export const getSchemaFromNode = (node: Node, typeChecker: TypeChecker): OpenAPI
     return {
       type: 'object',
       properties: node.properties.reduce((prev, property) => {
+        if (isShorthandPropertyAssignment(property)) {
+          const key = String(property.name.escapedText)
+
+          return {
+            ...prev,
+            [key]: getSchemaFromNode(property.name, typeChecker),
+          }
+        }
+
         const key = property.name && isIdentifier(property.name) ? (property.name.escapedText ?? 'unkown') : 'unknown'
         return {
           ...prev,

--- a/packages/ts-to-openapi/src/type-nodes.ts
+++ b/packages/ts-to-openapi/src/type-nodes.ts
@@ -1,6 +1,7 @@
 import type { OpenAPIV3_1 } from 'openapi-types'
 import {
   type Program,
+  type PropertyName,
   SyntaxKind,
   type TypeNode,
   isArrayTypeNode,
@@ -20,6 +21,14 @@ import {
 } from 'typescript'
 
 import type { FileNameResolver, Literals } from './types'
+
+const getPropertyName = (name: PropertyName): string | undefined => {
+  if (isIdentifier(name) || isStringLiteral(name) || isNumericLiteral(name)) {
+    return name.text
+  }
+
+  return undefined
+}
 
 /**
  * Traverse type nodes to create schemas
@@ -132,11 +141,17 @@ export const getSchemaFromTypeNode = (
       type: 'object',
       properties: typeNode.members.reduce((prev, member) => {
         // Regular properties
-        if (isPropertySignature(member) && member.type && isIdentifier(member.name)) {
+        if (isPropertySignature(member) && member.type) {
+          const name = getPropertyName(member.name)
+
+          if (!name) {
+            return prev
+          }
+
           // console.log(typeNode)
           return {
             ...prev,
-            [member.name?.escapedText ?? 'unkownKey']: getSchemaFromTypeNode(member.type, program, fileNameResolver),
+            [name]: getSchemaFromTypeNode(member.type, program, fileNameResolver),
           }
         }
         // Index Signatures

--- a/packages/ts-to-openapi/test/fixtures/fastify-routes.ts
+++ b/packages/ts-to-openapi/test/fixtures/fastify-routes.ts
@@ -1,0 +1,173 @@
+type UserParams = {
+  id: string
+}
+
+type RouteHandler = (
+  request: { body: Record<string, string> },
+  reply: { code: (status: number) => { send: (payload: unknown) => unknown } },
+) => unknown
+
+type RouteOptions = Record<string, unknown>
+
+type FastifyFixture = {
+  get: <RouteGeneric>(url: string, options: RouteOptions, handler: RouteHandler) => RouteGeneric | void
+  post: <RouteGeneric>(
+    url: string,
+    optionsOrHandler: RouteOptions | RouteHandler,
+    handler?: RouteHandler,
+  ) => RouteGeneric | void
+  route: <RouteGeneric>(options: RouteOptions) => RouteGeneric | void
+}
+
+export const registerUserRoutes = (fastify: FastifyFixture) => {
+  fastify.get<{
+    Params: UserParams
+    Querystring: {
+      includePosts?: boolean
+    }
+    Reply: {
+      200: {
+        id: string
+        name: string
+        email: string
+        posts: string[]
+      }
+      404: {
+        error: 'not_found'
+        message: string
+      }
+    }
+  }>(
+    '/users/:id',
+    {
+      schema: {
+        summary: 'Get a user',
+        description: 'Fetches one user by ID',
+        tags: ['Users'],
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+          },
+          required: ['id'],
+        },
+        querystring: {
+          type: 'object',
+          properties: {
+            includePosts: { type: 'boolean' },
+          },
+        },
+      },
+    },
+    async (_request, reply) => {
+      return reply.code(200).send({
+        id: 'user-1',
+        name: 'Ada Lovelace',
+        email: 'ada@example.com',
+        posts: ['first-post'],
+      })
+    },
+  )
+
+  fastify.post<{
+    Body: {
+      name: string
+      email: string
+    }
+    Reply: {
+      201: {
+        id: string
+        name: string
+        email: string
+      }
+      '4xx': {
+        error: string
+      }
+    }
+  }>(
+    '/users',
+    {
+      schema: {
+        summary: 'Create a user',
+        body: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', minLength: 1 },
+            email: { type: 'string', format: 'email' },
+          },
+          required: ['name', 'email'],
+        },
+        response: {
+          201: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              name: { type: 'string' },
+              email: { type: 'string', format: 'email' },
+            },
+            required: ['id', 'name', 'email'],
+          },
+        },
+      },
+    },
+    async (request) => ({
+      id: 'user-2',
+      name: request.body.name,
+      email: request.body.email,
+    }),
+  )
+
+  fastify.post<{
+    Body: {
+      name: string
+      email: string
+      role: 'admin' | 'member'
+    }
+    Querystring: {
+      invite?: boolean
+    }
+    Headers: {
+      'x-tenant': string
+    }
+    Reply: {
+      201: {
+        id: string
+        role: 'admin' | 'member'
+      }
+      400: {
+        error: string
+      }
+    }
+  }>('/typed-users', async (request) => ({
+    id: 'user-3',
+    role: request.body.role,
+  }))
+
+  fastify.route<{
+    Body: {
+      enabled: boolean
+    }
+    Reply: {
+      204: null
+    }
+  }>({
+    method: 'PATCH',
+    url: '/users/:id/settings',
+    schema: {
+      summary: 'Update user settings',
+      body: {
+        type: 'object',
+        properties: {
+          enabled: { type: 'boolean' },
+        },
+        required: ['enabled'],
+      },
+      response: {
+        204: {
+          description: 'Settings updated',
+        },
+      },
+    },
+    handler: async () => null,
+  })
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`@scalar/ts-to-openapi` had early support for TypeScript types and Next-style `Response.json` returns, but no Fastify route extraction path. Fastify users commonly define request validation with route `schema` objects and request/response types with route generics, so the package needed a Fastify-oriented adapter plus examples.

## Solution

Added Fastify route extraction for shorthand methods and `fastify.route`, generating OpenAPI paths from Fastify URLs, schema validation objects, generic request inputs, and generic/schema response maps. Added focused fixtures and Vitest coverage for validation schemas, type-only inputs, and responses, plus README examples showing the expected Fastify usage.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fa872ce-539b-4203-95e6-ae517f3afbef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fa872ce-539b-4203-95e6-ae517f3afbef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

