### PR TITLE
fix(api-client): do not auto create drafts for team workspaces

### DIFF
--- a/.changeset/team-workspaces-skip-drafts.md
+++ b/.changeset/team-workspaces-skip-drafts.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+feat(api-client): team workspaces no longer auto-create a "drafts" document or deep-link to it. New team workspaces start empty and land on the workspace get-started page; local workspaces still seed a drafts document and navigate to it as before.

--- a/packages/api-client/src/v2/features/app/app-state.test.ts
+++ b/packages/api-client/src/v2/features/app/app-state.test.ts
@@ -201,6 +201,79 @@ describe('app-state', () => {
     ).toBe(false)
   })
 
+  it('does not seed a drafts document when persisting a team workspace', async () => {
+    const router = setupRouter()
+    const appState = await createAppState({ router })
+
+    // Persist a team workspace through the same path the app uses internally
+    // (via the workspace store persistence layer rather than the create flow,
+    // which is currently gated behind TEAM_WORKSPACES_ENABLED).
+    const persistence = await createWorkspaceStorePersistence()
+    const draftStore = createWorkspaceStore()
+    await persistence.workspace.setItem(
+      { teamSlug: 'no-drafts-team', slug: 'default' },
+      { name: 'Team Workspace', workspace: draftStore.exportWorkspace() },
+    )
+
+    appState.activeEntities.setTeamSlug('no-drafts-team')
+
+    await router.push({
+      name: 'workspace.get-started',
+      params: { teamSlug: 'no-drafts-team', workspaceSlug: 'default' },
+    })
+    await router.isReady()
+    await waitForNavigation()
+
+    await vi.waitFor(() => {
+      expect(appState.store.value).not.toBeNull()
+    })
+
+    // Team workspaces start empty - no auto-seeded "drafts" document.
+    expect(appState.store.value?.workspace.documents.drafts).toBeUndefined()
+    expect(Object.keys(appState.store.value?.workspace.documents ?? {})).toHaveLength(0)
+  })
+
+  it('navigates team workspaces to the get-started page instead of the drafts route', async () => {
+    const router = setupRouter()
+    const appState = await createAppState({ router })
+
+    // Capture the initial push target before downstream tab-sync effects can
+    // replace the route - tabs:update:tabs is wired to navigateToCurrentTab
+    // which would otherwise mutate currentRoute before our assertion runs.
+    const pushed: { name?: string; params?: Record<string, unknown> }[] = []
+    const originalPush = router.push.bind(router)
+    router.push = ((to: any) => {
+      if (typeof to === 'object' && to !== null) {
+        pushed.push({ name: to.name, params: to.params })
+      }
+      return originalPush(to)
+    }) as typeof router.push
+
+    await appState.workspace.navigateToWorkspace('team-nav', 'default')
+
+    expect(pushed[0]?.name).toBe('workspace.get-started')
+    expect(pushed[0]?.params?.documentSlug).toBeUndefined()
+  })
+
+  it('still navigates local workspaces directly to the drafts example route', async () => {
+    const router = setupRouter()
+    const appState = await createAppState({ router })
+
+    const pushed: { name?: string; params?: Record<string, unknown> }[] = []
+    const originalPush = router.push.bind(router)
+    router.push = ((to: any) => {
+      if (typeof to === 'object' && to !== null) {
+        pushed.push({ name: to.name, params: to.params })
+      }
+      return originalPush(to)
+    }) as typeof router.push
+
+    await appState.workspace.navigateToWorkspace('local', 'drafts-target')
+
+    expect(pushed[0]?.name).toBe('example')
+    expect(pushed[0]?.params?.documentSlug).toBe('drafts')
+  })
+
   it('redirects to the saved tab path when switching workspaces after initial load', async () => {
     const savedTabPath = '/@local/switch-target/document/drafts/servers'
     await persistWorkspace({ slug: 'switch-source' })

--- a/packages/api-client/src/v2/features/app/app-state.ts
+++ b/packages/api-client/src/v2/features/app/app-state.ts
@@ -384,8 +384,12 @@ export const createAppState = async ({
   }
 
   /**
-   * Creates and persists the default workspace with a blank draft document.
-   * Used when no workspaces exist yet.
+   * Creates and persists a new workspace.
+   *
+   * Local workspaces are seeded with a blank "drafts" document so the user
+   * lands on a usable starting point. Team workspaces start empty - their
+   * documents come from the registry, so seeding a local-only draft would
+   * just create dead state that is never synced.
    */
   const createAndPersistWorkspace = async ({
     name,
@@ -397,25 +401,29 @@ export const createAppState = async ({
     slug: string
   }) => {
     const draftStore = createWorkspaceStore()
-    await draftStore.addDocument({
-      name: 'drafts',
-      document: {
-        openapi: '3.1.0',
-        info: {
-          title: 'Drafts',
-          version: '1.0.0',
-        },
-        paths: {
-          '/': {
-            get: {
-              summary: 'First Request',
+    const isTeam = Boolean(teamSlug && teamSlug !== 'local')
+
+    if (!isTeam) {
+      await draftStore.addDocument({
+        name: 'drafts',
+        document: {
+          openapi: '3.1.0',
+          info: {
+            title: 'Drafts',
+            version: '1.0.0',
+          },
+          paths: {
+            '/': {
+              get: {
+                summary: 'First Request',
+              },
             },
           },
+          'x-scalar-original-document-hash': 'drafts',
+          'x-scalar-icon': 'interface-edit-tool-pencil',
         },
-        'x-scalar-original-document-hash': 'drafts',
-        'x-scalar-icon': 'interface-edit-tool-pencil',
-      },
-    })
+      })
+    }
 
     // Persist the workspace
     const workspace = await persistence.setItem(
@@ -448,7 +456,22 @@ export const createAppState = async ({
       return
     }
 
-    // We should always have this drafts document available in a new workspace
+    // Team workspaces no longer ship with a default "drafts" document, so
+    // there is nothing meaningful to deep-link to. Drop the user on the
+    // workspace get-started page where they can import or create a document.
+    if (teamSlug !== 'local') {
+      await router.push({
+        name: 'workspace.get-started',
+        params: {
+          teamSlug,
+          workspaceSlug: slug,
+        },
+      })
+      return
+    }
+
+    // Local workspaces always have the seeded drafts document available, so
+    // we can land directly on its first example.
     await router.push({
       name: 'example',
       params: {


### PR DESCRIPTION
## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace initialization and routing behavior for all non-`local` team slugs, which could affect first-load navigation and persisted workspace state. Impact is bounded to workspace creation/persistence and the `navigateToWorkspace` flow.
> 
> **Overview**
> **Team workspaces now start empty.** `createAndPersistWorkspace` only seeds the default `drafts` OpenAPI document for *local* workspaces; non-`local` (team) workspaces persist with no documents.
> 
> **Navigation behavior changes for team workspaces.** `navigateToWorkspace` routes team workspaces to `workspace.get-started` instead of deep-linking to the `drafts` example, while local workspaces still land on the `drafts` example route.
> 
> Adds coverage in `app-state.test.ts` for team workspace persistence not creating `drafts`, for the new team navigation target, and for unchanged local navigation, plus a changeset bump for `@scalar/api-client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4d0519305f8a3510891cb92f01efbfe0e7b4241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->