### PR TITLE
fix(components): dismiss and debounce ScalarTooltip hide behavior

### DIFF
--- a/.changeset/fix-scalar-tooltip-lingering-flickering.md
+++ b/.changeset/fix-scalar-tooltip-lingering-flickering.md
@@ -1,0 +1,9 @@
+---
+'@scalar/components': patch
+---
+
+Fix lingering and flickering ScalarTooltip behavior
+
+- Dismiss the tooltip when the user clicks anywhere outside the tooltip or its target element, matching native browser tooltip behavior
+- Add a 100ms debounce when hiding the tooltip on `mouseleave` to prevent flickering when the cursor briefly crosses the gap between the target and the tooltip
+- Cancel the hide debounce when the cursor enters the tooltip element itself

--- a/packages/components/src/components/ScalarIconButton/ScalarIconButton.test.ts
+++ b/packages/components/src/components/ScalarIconButton/ScalarIconButton.test.ts
@@ -322,8 +322,9 @@ describe('ScalarIconButton', () => {
       await nextTick()
       expect(tooltipElement?.style.display).toBe('block')
 
-      // Hide tooltip on mouseleave
+      // Hide tooltip on mouseleave (debounced)
       wrapper.element.dispatchEvent(new MouseEvent('mouseleave'))
+      await vi.runAllTimersAsync()
       await nextTick()
 
       expect(tooltipElement?.style.display).toBe('none')
@@ -348,8 +349,9 @@ describe('ScalarIconButton', () => {
       await nextTick()
       expect(tooltipElement?.style.display).toBe('block')
 
-      // Hide tooltip on blur
+      // Hide tooltip on blur (debounced)
       wrapper.element.dispatchEvent(new FocusEvent('blur'))
+      await vi.runAllTimersAsync()
       await nextTick()
 
       expect(tooltipElement?.style.display).toBe('none')

--- a/packages/components/src/components/ScalarTooltip/useTooltip.test.ts
+++ b/packages/components/src/components/ScalarTooltip/useTooltip.test.ts
@@ -77,7 +77,7 @@ describe('useTooltip', () => {
     expect(tooltipElement?.textContent).toBe('Test tooltip')
   })
 
-  it('should hide tooltip on mouseleave', () => {
+  it('hides tooltip on mouseleave after debounce', async () => {
     useTooltip({
       content: 'Test tooltip',
       targetRef: targetElement,
@@ -85,16 +85,26 @@ describe('useTooltip', () => {
 
     // Show tooltip
     targetElement.dispatchEvent(new MouseEvent('mouseenter'))
-    vi.runAllTimers()
-
-    // Hide tooltip
-    targetElement.dispatchEvent(new MouseEvent('mouseleave'))
+    await vi.runAllTimersAsync()
+    await nextTick()
 
     const tooltipElement = document.getElementById(ELEMENT_ID)
+    expect(tooltipElement?.style.display).toBe('block')
+
+    // Trigger mouseleave
+    targetElement.dispatchEvent(new MouseEvent('mouseleave'))
+
+    // Tooltip is still visible during the debounce window (timer not yet elapsed)
+    expect(tooltipElement?.style.display).toBe('block')
+
+    // Advance past the hide debounce and flush watchers
+    await vi.runAllTimersAsync()
+    await nextTick()
+
     expect(tooltipElement?.style.display).toBe('none')
   })
 
-  it('should hide tooltip on escape key', async () => {
+  it('hides tooltip on escape key', async () => {
     useTooltip({
       content: 'Test tooltip',
       targetRef: targetElement,
@@ -110,8 +120,8 @@ describe('useTooltip', () => {
 
     expect(tooltipElement?.style.display).toBe('block')
 
-    // Press escape
-    targetElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    // Press escape (fires on document, which captures it)
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
 
     await nextTick()
 
@@ -135,7 +145,7 @@ describe('useTooltip', () => {
     expect(tooltipElement?.textContent).toBe('Test tooltip')
   })
 
-  it('should hide tooltip on blur', async () => {
+  it('hides tooltip on blur', async () => {
     useTooltip({
       content: 'Test tooltip',
       targetRef: targetElement,
@@ -148,9 +158,9 @@ describe('useTooltip', () => {
     const tooltipElement = document.getElementById(ELEMENT_ID)
     expect(tooltipElement?.style.display).toBe('block')
 
-    // Hide tooltip via blur
+    // Hide tooltip via blur (debounced)
     targetElement.dispatchEvent(new FocusEvent('blur'))
-    await nextTick()
+    await vi.runAllTimersAsync()
 
     expect(tooltipElement?.style.display).toBe('none')
   })
@@ -293,7 +303,7 @@ describe('useTooltip', () => {
     expect(tooltipElement?.textContent).toBe('Italic text')
   })
 
-  it('should work with reactive content and contentTarget', async () => {
+  it('works with reactive content and contentTarget', async () => {
     const content = ref('Initial content')
     const contentTarget = ref<'textContent' | 'innerHTML'>('textContent')
 
@@ -325,5 +335,76 @@ describe('useTooltip', () => {
     // Should now render as HTML
     expect(tooltipElement?.innerHTML).toBe('<strong>Bold</strong> content')
     expect(tooltipElement?.textContent).toBe('Bold content')
+  })
+
+  it('hides tooltip when clicking outside the tooltip and target', async () => {
+    useTooltip({
+      content: 'Test tooltip',
+      targetRef: targetElement,
+    })
+
+    // Show tooltip
+    targetElement.dispatchEvent(new MouseEvent('mouseenter'))
+    vi.runAllTimers()
+    await nextTick()
+
+    const tooltipElement = document.getElementById(ELEMENT_ID)
+    expect(tooltipElement?.style.display).toBe('block')
+
+    // Click somewhere outside
+    const outsideEl = document.createElement('div')
+    document.body.appendChild(outsideEl)
+    outsideEl.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    await nextTick()
+
+    expect(tooltipElement?.style.display).toBe('none')
+  })
+
+  it('keeps tooltip visible when clicking inside the target', async () => {
+    useTooltip({
+      content: 'Test tooltip',
+      targetRef: targetElement,
+    })
+
+    // Show tooltip
+    targetElement.dispatchEvent(new MouseEvent('mouseenter'))
+    vi.runAllTimers()
+    await nextTick()
+
+    const tooltipElement = document.getElementById(ELEMENT_ID)
+    expect(tooltipElement?.style.display).toBe('block')
+
+    // Click inside the target element itself
+    targetElement.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    await nextTick()
+
+    expect(tooltipElement?.style.display).toBe('block')
+  })
+
+  it('cancels hide debounce when cursor enters the tooltip element', async () => {
+    useTooltip({
+      content: 'Test tooltip',
+      targetRef: targetElement,
+      delay: 0,
+    })
+
+    // Show tooltip immediately
+    targetElement.dispatchEvent(new MouseEvent('mouseenter'))
+    await nextTick()
+
+    const tooltipElement = document.getElementById(ELEMENT_ID)
+    expect(tooltipElement?.style.display).toBe('block')
+
+    // Cursor leaves target, debounce starts
+    targetElement.dispatchEvent(new MouseEvent('mouseleave'))
+    expect(tooltipElement?.style.display).toBe('block')
+
+    // Cursor enters tooltip before debounce fires
+    tooltipElement?.dispatchEvent(new MouseEvent('mouseenter'))
+
+    // Advance full timer — hide should be cancelled
+    await vi.runAllTimersAsync()
+
+    expect(tooltipElement?.style.display).toBe('block')
   })
 })

--- a/packages/components/src/components/ScalarTooltip/useTooltip.ts
+++ b/packages/components/src/components/ScalarTooltip/useTooltip.ts
@@ -9,7 +9,7 @@ import type { Timer, TooltipConfiguration } from './types'
 // ---------------------------------------------------------------------------
 
 /**
- * The delay timer for the tooltip
+ * The delay timer for the tooltip show/hide debounce
  *
  * If there's not a timer running it should be undefined
  */
@@ -28,6 +28,9 @@ const el = ref<HTMLElement>()
  * If no tooltip is active it should be undefined
  */
 const config = ref<TooltipConfiguration>()
+
+/** Debounce delay (ms) applied when hiding the tooltip to prevent flickering */
+const HIDE_DEBOUNCE_MS = 100
 
 // ---------------------------------------------------------------------------
 // Core watcher and floating UI setup
@@ -121,6 +124,7 @@ function initializeTooltipElement(): void {
     el.value.classList.add(ELEMENT_CLASS)
     el.value.classList.add('scalar-app')
     el.value.style.setProperty('display', 'none')
+    el.value.addEventListener('mouseenter', clearTimer)
     el.value.addEventListener('mouseleave', hideTooltip)
     document.body.appendChild(el.value)
   }
@@ -130,6 +134,7 @@ function initializeTooltipElement(): void {
  * Cleanup and reset the tooltip element
  */
 export function cleanupTooltipElement() {
+  document.removeEventListener('pointerdown', handleOutsideClick, { capture: true } as EventListenerOptions)
   document.getElementById(ELEMENT_ID)?.remove()
   el.value = undefined
 }
@@ -139,9 +144,21 @@ export function cleanupTooltipElement() {
 // ---------------------------------------------------------------------------
 
 /**
- * Hide the tooltip
+ * Hide the tooltip immediately, without debounce
  *
- * If the mouse is moving between the tooltip and the target we don't hide the tooltip
+ * Used for keyboard and outside-click dismissals where instant hiding is appropriate
+ */
+function hideTooltipImmediately() {
+  clearTimer()
+  config.value = undefined
+  document.removeEventListener('pointerdown', handleOutsideClick, { capture: true } as EventListenerOptions)
+}
+
+/**
+ * Hide the tooltip after a short debounce delay
+ *
+ * The delay prevents flickering when the cursor briefly leaves the target on
+ * its way to the tooltip (e.g., due to layout gaps between them).
  */
 function hideTooltip(_e: Event) {
   if (!isMovingOffElements(_e)) {
@@ -149,11 +166,35 @@ function hideTooltip(_e: Event) {
     return
   }
 
-  // Clear any existing timer
+  // Clear any existing show timer
   clearTimer()
 
-  // Hide the tooltip
-  config.value = undefined
+  // Debounce the hide to prevent flickering
+  timer.value = setTimeout(() => {
+    config.value = undefined
+    document.removeEventListener('pointerdown', handleOutsideClick, { capture: true } as EventListenerOptions)
+  }, HIDE_DEBOUNCE_MS)
+}
+
+/**
+ * Handle clicks outside the tooltip and its target
+ *
+ * Matches the behaviour of the native browser tooltip, which disappears as
+ * soon as the user clicks anywhere on the page.
+ */
+function handleOutsideClick(e: Event) {
+  const target = unref(config.value?.targetRef)
+  if (!(e.target instanceof Node)) {
+    hideTooltipImmediately()
+    return
+  }
+
+  const clickedInsideTooltip = el.value?.contains(e.target as Node)
+  const clickedInsideTarget = target?.contains(e.target as Node)
+
+  if (!clickedInsideTooltip && !clickedInsideTarget) {
+    hideTooltipImmediately()
+  }
 }
 
 /**
@@ -166,7 +207,7 @@ function hideTooltip(_e: Event) {
 function handleEscape(e: KeyboardEvent) {
   if (e.key === 'Escape') {
     e.stopPropagation()
-    hideTooltip(e)
+    hideTooltipImmediately()
   }
 }
 
@@ -238,6 +279,9 @@ export function useTooltip(opts: TooltipConfiguration) {
 
     // Handle the escape key
     document.addEventListener('keydown', handleEscape, { once: true, capture: true })
+
+    // Dismiss the tooltip when the user clicks anywhere outside it
+    document.addEventListener('pointerdown', handleOutsideClick, { capture: true })
 
     // Show the tooltip
     config.value = opts


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two UX quirks with `ScalarTooltip`:

### Fix 1: Tooltip stays visible after clicking outside

**Problem:** Clicking anywhere on the screen after a tooltip shows did not dismiss it — the tooltip lingered indefinitely.

**Fix:** When a tooltip becomes visible, a `pointerdown` capture listener is added to `document`. If the click lands outside both the tooltip element and the trigger element, the tooltip is dismissed immediately (matching native browser tooltip behavior). The listener is removed as soon as the tooltip hides.

### Fix 2: Tooltip flickers

**Problem:** Rapid hide/show cycles caused flickering, especially with custom offsets that create a gap between the trigger element and the floating tooltip.

**Fix:** `mouseleave` hide is now debounced by 100ms. A new `mouseenter` listener on the tooltip element itself cancels the pending hide, so moving the cursor from the trigger into the tooltip no longer causes a flash.

Escape key and outside-click dismissals remain instant (no debounce).

## Changes

- `useTooltip.ts`: add `HIDE_DEBOUNCE_MS`, split `hideTooltipImmediately` from debounced `hideTooltip`, add `handleOutsideClick` registered on `pointerdown` capture, add tooltip `mouseenter` to cancel hide debounce, clean up listener in `cleanupTooltipElement`
- `useTooltip.test.ts`: update existing mouseleave/blur tests for the debounce, add three new tests (outside-click dismissal, click-inside-target, debounce-cancel-on-hover)

## Ticket

Fixes DOC-5336

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07TEEPG2JX/p1777782134696419?thread_ts=1777782134.696419&cid=C07TEEPG2JX)

<div><a href="https://cursor.com/agents/bc-a648f285-f1f7-5ec8-b8e1-b1aff24712c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a648f285-f1f7-5ec8-b8e1-b1aff24712c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

