### PR TITLE
ci(api-client): deploy Cloudflare on main releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -787,12 +787,20 @@ jobs:
         run: echo "url=https://${{ env.DEPLOY_ID }}--scalar-components.netlify.app" >> $GITHUB_OUTPUT
 
   deploy-api-client:
-    # Run only for same-repo PRs that touch @scalar/api-client or its workspace deps
+    # Run for same-repo PR previews when @scalar/api-client changes,
+    # or for production on main release commits.
     if: |
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      !contains(github.actor, '[bot]') &&
-      needs.check-changes.outputs.api_client_changed == 'true'
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        !contains(github.actor, '[bot]') &&
+        needs.check-changes.outputs.api_client_changed == 'true'
+      ) ||
+      (
+        github.event_name == 'push' &&
+        github.ref == 'refs/heads/main' &&
+        startsWith(github.event.head_commit.message, 'RELEASING:')
+      )
     needs: [build, check-changes]
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 15
@@ -814,19 +822,30 @@ jobs:
       - name: Build playground app
         run: pnpm --filter @scalar/api-client playground:app:build
 
-      - name: Deploy to Cloudflare Pages
-        id: deploy
+      - name: Deploy to Cloudflare Pages (Preview)
+        if: github.event_name == 'pull_request'
+        id: deploy-preview
         uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy ./packages/api-client/playground/app/dist --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_API_CLIENT }} --branch=pr-${{ github.event.pull_request.number }} --commit-hash=${{ github.event.pull_request.head.sha }}
 
+      - name: Deploy to Cloudflare Pages (Production)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: deploy-production
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ./packages/api-client/playground/app/dist --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_API_CLIENT }} --branch=main --commit-hash=${{ github.sha }}
+
       - name: Set output
         id: set-output
+        if: github.event_name == 'pull_request'
         run: |
-          ALIAS_URL='${{ steps.deploy.outputs.pages-deployment-alias-url }}'
-          DEPLOYMENT_URL='${{ steps.deploy.outputs.deployment-url }}'
+          ALIAS_URL='${{ steps.deploy-preview.outputs.pages-deployment-alias-url }}'
+          DEPLOYMENT_URL='${{ steps.deploy-preview.outputs.deployment-url }}'
           if [ -n "$ALIAS_URL" ]; then
             echo "url=$ALIAS_URL" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`@scalar/api-client` deployment to Cloudflare Pages only runs for pull request previews. When a release commit lands on `main`, there is no production deployment for the API Client.

## Solution

- Updated the `deploy-api-client` CI job condition so it now runs for:
  - same-repo pull requests with API Client changes (existing preview behavior), and
  - `push` events on `main` where the head commit message starts with `RELEASING:`.
- Split Cloudflare deployment into two explicit steps:
  - preview deploy for PRs (`pr-<number>` branch),
  - production deploy for `main` release pushes (`main` branch + commit hash).
- Kept preview URL output/comment behavior scoped to pull requests only.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cb7a56f-cc59-4346-a5da-839870940d61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cb7a56f-cc59-4346-a5da-839870940d61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

