### PR TITLE
fix(command-palette): openapi import trailing newline

### DIFF
--- a/.changeset/fresh-lions-trim.md
+++ b/.changeset/fresh-lions-trim.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix command palette OpenAPI URL imports with surrounding whitespace

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.test.ts
@@ -312,6 +312,25 @@ describe('CommandPaletteImport', () => {
     expect(watchToggle.props('disabled')).toBe(false)
   })
 
+  it('enables watch mode toggle for URL input with a trailing newline', async () => {
+    const workspaceStore = createWorkspaceStore()
+    const eventBus = createWorkspaceEventBus()
+
+    const wrapper = mount(CommandPaletteImport, {
+      props: {
+        workspaceStore,
+        eventBus,
+      },
+    })
+
+    const input = wrapper.findComponent({ name: 'CommandActionInput' })
+    await input.vm.$emit('update:modelValue', 'https://example.com/api.json\n')
+    await nextTick()
+
+    const watchToggle = wrapper.findComponent({ name: 'WatchModeToggle' })
+    expect(watchToggle.props('disabled')).toBe(false)
+  })
+
   it('automatically disables watch mode when switching from URL to content', async () => {
     const workspaceStore = createWorkspaceStore()
     const eventBus = createWorkspaceEventBus()

--- a/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandPaletteImport.vue
@@ -84,10 +84,13 @@ const loader = useLoadingState()
 const inputContent = ref('')
 const watchMode = ref(false)
 
+/** Trim paste noise for URL checks without changing raw JSON/YAML content. */
+const normalizedInputContent = computed<string>(() => inputContent.value.trim())
+
 /** Check if the input content is a URL */
-const isUrlInput = computed<boolean>(() => isUrl(inputContent.value))
+const isUrlInput = computed<boolean>(() => isUrl(normalizedInputContent.value))
 const isLocalUrlInput = computed<boolean>(
-  () => isUrlInput.value && isLocalUrl(inputContent.value),
+  () => isUrlInput.value && isLocalUrl(normalizedInputContent.value),
 )
 
 const documentDetails = computed(() =>
@@ -159,16 +162,18 @@ const handleImport = async (
       return type
     }
 
-    if (isUrlInput.value) {
+    if (isUrl(newSource.trim())) {
       return 'url'
     }
 
     return 'raw'
   })()
 
+  const source = eventType === 'url' ? newSource.trim() : newSource
+
   const isSuccessfullyLoaded = await loadDocumentFromSource(
     draftStore,
-    { source: newSource, type: eventType },
+    { source, type: eventType },
     TEMP_DOCUMENT_NAME,
     watchMode.value,
   )

--- a/packages/api-client/src/v2/features/command-palette/helpers/load-document-from-source.test.ts
+++ b/packages/api-client/src/v2/features/command-palette/helpers/load-document-from-source.test.ts
@@ -1,5 +1,5 @@
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
-import { assert, describe, expect, it } from 'vitest'
+import { assert, describe, expect, it, vi } from 'vitest'
 
 import type { ImportEventData } from './load-document-from-source'
 import { loadDocumentFromSource } from './load-document-from-source'
@@ -585,6 +585,40 @@ paths:
 
     expect(document['x-scalar-original-source-url']).toBe('/path/to/openapi.yaml')
     expect(document['x-scalar-watch-mode']).toBeUndefined()
+  })
+
+  it('trims surrounding whitespace from URL imports before fetching', async () => {
+    const remoteOpenApi = JSON.stringify({
+      openapi: '3.1.0',
+      info: {
+        title: 'Remote API',
+        version: '1.0.0',
+      },
+      paths: {},
+    })
+    const fetch = vi.fn(async () => new Response(remoteOpenApi))
+    const workspaceStore = createWorkspaceStore({ fetch })
+
+    const result = await loadDocumentFromSource(
+      workspaceStore,
+      {
+        source: 'https://example.com/openapi.json\n',
+        type: 'url',
+      },
+      'remote-api',
+      false,
+    )
+
+    expect(result).toBe(true)
+    expect(fetch).toHaveBeenCalledWith('https://example.com/openapi.json', {
+      headers: undefined,
+    })
+
+    const document = workspaceStore.workspace.documents['remote-api']
+
+    expect(document).toBeDefined()
+    assert(document)
+    expect(document['x-scalar-original-source-url']).toBe('https://example.com/openapi.json')
   })
 
   it('ignores watch mode when adding document from file', async () => {

--- a/packages/api-client/src/v2/features/command-palette/helpers/load-document-from-source.ts
+++ b/packages/api-client/src/v2/features/command-palette/helpers/load-document-from-source.ts
@@ -62,7 +62,9 @@ export const loadDocumentFromSource = async (
   watchMode: boolean,
 ): Promise<boolean> => {
   const { source, type } = importEventData
-  if (!source) {
+  const normalizedSource = type === 'url' ? source.trim() : source
+
+  if (!normalizedSource) {
     // No source provided, do nothing.
     return false
   }
@@ -71,7 +73,7 @@ export const loadDocumentFromSource = async (
   if (type === 'url') {
     return await workspaceStore.addDocument({
       name,
-      url: source,
+      url: normalizedSource,
       meta: {
         'x-scalar-watch-mode': watchMode,
       },

--- a/packages/api-client/src/v2/helpers/is-url.test.ts
+++ b/packages/api-client/src/v2/helpers/is-url.test.ts
@@ -13,6 +13,11 @@ describe('isUrl', () => {
     expect(result).toBe(true)
   })
 
+  it('returns true for valid URL with surrounding whitespace', () => {
+    const result = isUrl(' \nhttps://example.com/openapi.json\n')
+    expect(result).toBe(true)
+  })
+
   it('returns true for http URL with path', () => {
     const result = isUrl('http://example.com/api/users')
     expect(result).toBe(true)

--- a/packages/api-client/src/v2/helpers/is-url.ts
+++ b/packages/api-client/src/v2/helpers/is-url.ts
@@ -1,5 +1,7 @@
 import { isValidUrl } from '@scalar/helpers/url/is-valid-url'
 
 export const isUrl = (input: string) => {
-  return (input.startsWith('http://') || input.startsWith('https://')) && isValidUrl(input)
+  const trimmedInput = input.trim()
+
+  return (trimmedInput.startsWith('http://') || trimmedInput.startsWith('https://')) && isValidUrl(trimmedInput)
 }


### PR DESCRIPTION
## Problem

Importing an OpenAPI URL through the API client command palette could fail (with non informative error) when the pasted URL included surrounding whitespace, especially a trailing newline from copy + paste.

Example:

```text
https://petstore3.swagger.io/api/v3/openapi.json

```
https://github.com/user-attachments/assets/b8fc8919-e7d8-4789-98ab-6ad61e417c76

## Solution

Trim surrounding whitespace for URL imports before URL validation and before passing the source to the document loader. Raw JSON/YAML imports unchanged so pasted document content is not accidentally modified.

Added regression tests for:
- URL detection with surrounding whitespace
- command palette URL state with a trailing newline
- URL imports fetching the trimmed source

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.