### PR TITLE
test(api-reference): stabilize long strings e2e

### DIFF
--- a/packages/api-reference/test/snapshots/operations.e2e.ts
+++ b/packages/api-reference/test/snapshots/operations.e2e.ts
@@ -74,6 +74,11 @@ if (!longStringsSource) {
 test(longStringsSource.title, async ({ page }) => {
   const example = await serveExample(longStringsSource)
   await page.goto(example)
+  await expect(
+    page.getByRole('navigation', { name: 'Sidebar for' }).getByRole('button', {
+      name: /Really Extremely Long Tag Name That Definitely Tests Wrapping Across Multiple Lines/,
+    }),
+  ).toBeVisible()
 
   await page.goto(
     `${example}#${longStringsSource.slug}/tag/really-extremely-long-tag-name-that-definitely-tests-wrapping-across-multiple-lines`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `@scalar/api-reference` Long Strings Playwright snapshot test can race document initialization. In the failing CI job, the test navigated directly to the long tag hash and timed out waiting for the tag region's `Show` button.

## Solution

Wait for the long tag to be present in the sidebar before hash navigation. This confirms the long YAML source has loaded and the reference navigation is initialized before the test interacts with the collapsed tag section.

## Testing

- `CI=1 pnpm --filter @scalar/api-reference exec playwright test test/snapshots/operations.e2e.ts -g "Long Strings Example" --workers=4 --repeat-each=10 --reporter=list`
- `CHANGED=$(git diff --name-only origin/main...HEAD) && pnpm biome check --write --diagnostic-level=error --no-errors-on-unmatched --files-ignore-unknown=true $CHANGED && pnpm prettier --write $CHANGED && pnpm --filter @scalar/api-reference types:check`
- `pnpm changeset status`
- `pnpm install --frozen-lockfile && pnpm --filter @scalar/docusaurus build && pnpm knip`

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Test-only change; no package release required. -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e35c0aa-167b-4374-8324-0f2f1d513f5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e35c0aa-167b-4374-8324-0f2f1d513f5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

