### PR TITLE
fix(scalar-app): redirect URL on register

### DIFF
--- a/.changeset/brave-lilies-matter.md
+++ b/.changeset/brave-lilies-matter.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: register URL

--- a/projects/scalar-app/src/App.vue
+++ b/projects/scalar-app/src/App.vue
@@ -214,7 +214,7 @@ const registry = reactive({
         <ScalarHeaderButton
           is="a"
           cta
-          :href="registerUrl">
+          :href="registerUrl()">
           Register
         </ScalarHeaderButton>
       </template>


### PR DESCRIPTION
## Problem

We switched the login/register URLs to a method so they can behave differently for the previews.

## Solution

Add the brackets!

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Very small UI change that corrects the `Register` link to call `registerUrl()`; low risk aside from potential redirect/URL behavior differences in environments.
> 
> **Overview**
> Fixes the unauthenticated header **Register** button to use `registerUrl()` (matching the `Log in` link) so the href is computed correctly.
> 
> Adds a patch changeset for `scalar-app` documenting the register URL fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e2242f50c7cfab795771cf44d20439346cfebe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->