### PR TITLE
fix(workspace-store): prevent proxy leak into document meta breaking IndexedDB persistence

### DIFF
--- a/.changeset/sharp-chefs-peel.md
+++ b/.changeset/sharp-chefs-peel.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: prevent proxy leak into document meta breaking IndexedDB persistence

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -58,6 +58,46 @@ const getDocument = (version?: string) => ({
   },
 })
 
+/**
+ * Creates a workspace store wired to a plugin that records every
+ * `documents` change event and attempts to structured-clone its value -
+ * mirroring how the persistence plugin writes events into IndexedDB.
+ * Lets a test assert that no proxy ever leaks into the persisted payload.
+ */
+const createPersistedStoreSpy = () => {
+  const cloneErrors: unknown[] = []
+  const persistedDocumentEvents: Array<Record<string, unknown>> = []
+
+  const store = createWorkspaceStore({
+    plugins: [
+      {
+        hooks: {
+          onWorkspaceStateChanges: (event) => {
+            if (event.type !== 'documents') {
+              return
+            }
+            persistedDocumentEvents.push(event.value as Record<string, unknown>)
+            try {
+              structuredClone(event.value)
+            } catch (error) {
+              cloneErrors.push(error)
+            }
+          },
+        },
+      },
+    ],
+  })
+
+  return { store, cloneErrors, persistedDocumentEvents }
+}
+
+const REGISTRY_META = {
+  namespace: 'team',
+  slug: 'api',
+  version: '1.0.0',
+  commitHash: 'abc123',
+} as const
+
 describe('create-workspace-store', () => {
   let server: FastifyInstance
   const port = 9988
@@ -2216,6 +2256,35 @@ describe('create-workspace-store', () => {
         '{"openapi":"3.0.0","info":{"title":"My API","version":"1.0.0"},"components":{"schemas":{"User":{"type":"object","properties":{"id":{"type":"string","description":"The user ID"},"name":{"type":"string","description":"The user name"},"email":{"type":"string","format":"email","description":"The user email"}}}}},"paths":{"/users":{"get":{"summary":"Get all users","responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/User"}}}}}}}}}}',
       )
     })
+
+    it('persists registry meta as plain data after revert (regression: DataCloneError)', async () => {
+      // The persistence plugin forwards `event.value` straight into
+      // IndexedDB, which uses structured cloning. Forwarding the proxied
+      // workspace document back into `addInMemoryDocument` used to leak
+      // a magic proxy onto `x-scalar-registry-meta`, throwing
+      // `DataCloneError` when the change event was persisted.
+      const { store, cloneErrors, persistedDocumentEvents } = createPersistedStoreSpy()
+
+      await store.addDocument({
+        name: 'default',
+        document: getDocument(),
+        meta: { 'x-scalar-registry-meta': { ...REGISTRY_META } },
+      })
+
+      const defaultDocument = store.workspace.documents['default']
+      assert(defaultDocument, 'Default document should exist')
+
+      defaultDocument.info.title = 'Edited title'
+      expect(defaultDocument['x-scalar-is-dirty']).toBe(true)
+
+      cloneErrors.length = 0
+      persistedDocumentEvents.length = 0
+
+      await store.revertDocumentChanges('default')
+
+      expect(cloneErrors).toEqual([])
+      expect(persistedDocumentEvents.at(-1)?.['x-scalar-registry-meta']).toEqual(REGISTRY_META)
+    })
   })
 
   describe('getEditableDocument', () => {
@@ -3236,6 +3305,33 @@ describe('create-workspace-store', () => {
 
       expect(consoleErrorSpy).toHaveBeenCalledWith("Document 'non-existing' does not exist in the workspace.")
       expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('persists registry meta as plain data after replace (regression: DataCloneError)', async () => {
+      // The persistence plugin forwards `event.value` straight into
+      // IndexedDB, which uses structured cloning. Forwarding the proxied
+      // workspace document back into `addInMemoryDocument` used to leak
+      // a magic proxy onto `x-scalar-registry-meta`, throwing
+      // `DataCloneError` when the change event was persisted.
+      const { store, cloneErrors, persistedDocumentEvents } = createPersistedStoreSpy()
+
+      await store.addDocument({
+        name: 'default',
+        document: getDocument(),
+        meta: { 'x-scalar-registry-meta': { ...REGISTRY_META } },
+      })
+
+      cloneErrors.length = 0
+      persistedDocumentEvents.length = 0
+
+      await store.replaceDocument('default', {
+        openapi: '3.1.1',
+        info: { title: 'Replaced API', version: '2.0.0' },
+        paths: {},
+      })
+
+      expect(cloneErrors).toEqual([])
+      expect(persistedDocumentEvents.at(-1)?.['x-scalar-registry-meta']).toEqual(REGISTRY_META)
     })
   })
 

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -961,7 +961,8 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     input: ObjectDoc & { initialize?: boolean; documentSource?: string; documentHash: string },
     navigationOptions?: NavigationOptions,
   ) {
-    const { name, meta } = input
+    const { name } = input
+    const meta = deepClone(input.meta)
     const clonedRawInputDocument = withMeasurementSync('deepClone', () => deepClone(input.document))
 
     withMeasurementSync('initialize', () => {
@@ -1261,7 +1262,8 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
       return true
     },
     async replaceDocument(documentName: string, input: Record<string, unknown>) {
-      const currentDocument = workspace.documents[documentName]
+      // Used to preserve the original metadata of the document (we need to unpack so we don't store a proxy object)
+      const currentDocument = unpackProxyObject(workspace.documents[documentName], { depth: 1 })
 
       if (!currentDocument) {
         return console.error(`Document '${documentName}' does not exist in the workspace.`)
@@ -1352,7 +1354,8 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     saveDocument,
     promoteIntermediateToOriginal,
     async revertDocumentChanges(documentName: string) {
-      const workspaceDocument = workspace.documents[documentName]
+      // Used to preserve the original metadata of the document (we need to unpack so we don't store a proxy object)
+      const workspaceDocument = unpackProxyObject(workspace.documents[documentName], { depth: 1 })
       // Restore from the original (last saved) snapshot. `saveDocument`
       // writes here, so this reliably rolls back to whatever the user
       // last persisted - matching the soft-deprecation path away from the


### PR DESCRIPTION
Reverting (or replacing) a registry-backed document with a dirty state crashed with `DataCloneError: Failed to execute 'put' on 'IDBObjectStore': #<Object> could not be cloned` and the document never made it back to its baseline.

`replaceDocument` and `revertDocumentChanges` forwarded `x-scalar-registry-meta` directly off the proxied workspace document into `addInMemoryDocument`. The magic proxy then leaked onto the new workspace document, and when the persistence plugin handed the resulting change event to IndexedDB, structured cloning rejected it.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core workspace document lifecycle (`addInMemoryDocument`, `replaceDocument`, `revertDocumentChanges`) to change how metadata is cloned/unproxied, which could affect document state preservation during edits/replaces/reverts. Risk is mitigated by new regression tests that simulate IndexedDB structured cloning.
> 
> **Overview**
> Prevents `DataCloneError` during IndexedDB persistence by ensuring document metadata passed through `replaceDocument`/`revertDocumentChanges` (and into `addInMemoryDocument`) is **plain cloned data**, not a magic proxy (notably `x-scalar-registry-meta`).
> 
> Adds regression tests that mirror the persistence plugin by `structuredClone`-ing emitted `documents` change events, asserting revert/replace no longer leak proxies into persisted payloads. Includes a patch changeset for `@scalar/workspace-store`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d4861166a9547705d6c2a5ebeb3964bc723039d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->