### PR TITLE
fix(api-client): broken types

### DIFF
--- a/packages/api-client/src/v2/features/app/app-state.test.ts
+++ b/packages/api-client/src/v2/features/app/app-state.test.ts
@@ -212,21 +212,17 @@ describe('app-state', () => {
     ).toBe(false)
   })
 
-  it('does not seed a drafts document when persisting a team workspace', async () => {
+  it('does not seed a drafts document when loading a persisted team workspace', async () => {
+    // Persist an empty team workspace before bootstrapping app state so it
+    // is in IndexedDB by the time the route handler asks for it. We go
+    // through the persistence layer directly because the create flow is
+    // currently gated behind TEAM_WORKSPACES_ENABLED.
+    await persistWorkspace({ teamSlug: 'no-drafts-team', slug: 'default', name: 'Team Workspace' })
+
     const router = setupRouter()
-    const appState = await createAppState({ router })
-
-    // Persist a team workspace through the same path the app uses internally
-    // (via the workspace store persistence layer rather than the create flow,
-    // which is currently gated behind TEAM_WORKSPACES_ENABLED).
-    const persistence = await createWorkspaceStorePersistence()
-    const draftStore = createWorkspaceStore()
-    await persistence.workspace.setItem(
-      { teamSlug: 'no-drafts-team', slug: 'default' },
-      { name: 'Team Workspace', workspace: draftStore.exportWorkspace() },
-    )
-
-    appState.activeEntities.setTeamSlug('no-drafts-team')
+    // `currentTeam` is the supported way to drive `activeEntities.teamSlug`
+    // from a test - the legacy `setTeamSlug` setter has been removed.
+    const appState = await createAppState({ router, currentTeam: ref(teamWithSlug('no-drafts-team')) })
 
     await router.push({
       name: 'workspace.get-started',


### PR DESCRIPTION
Looks like there was a logical conflict with main branch since a PR was merged before.

We should probably enforce merging main into your branch before merging....

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a unit test update to match a new app-state API and persisted-workspace loading flow.
> 
> **Overview**
> Updates the `app-state` test that verifies team workspaces don’t auto-seed a `drafts` document by **pre-populating IndexedDB via `persistWorkspace` before app bootstrap** and by **driving team context through `currentTeam`** (since the legacy `setTeamSlug` setter is no longer available).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adfa0441f11754a44b818870d75f9919e858dd4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->