### PR TITLE
docs(changeset): code split tailwind CSS to reduce bundle size

### DIFF
--- a/.changeset/agent-chat-tailwind-build.md
+++ b/.changeset/agent-chat-tailwind-build.md
@@ -1,5 +1,0 @@
----
-'@scalar/agent-chat': patch
----
-
-Align Agent Chat with the Tailwind CLI style build used by components, sidebar, and api-client (vue-styles extraction, optimized dist/style.css, and tailwind.config.css export).

--- a/.changeset/real-worlds-listen.md
+++ b/.changeset/real-worlds-listen.md
@@ -1,0 +1,9 @@
+---
+'@scalar/agent-chat': patch
+'@scalar/api-client': patch
+'@scalar/api-reference': patch
+'@scalar/components': patch
+'@scalar/sidebar': patch
+---
+
+feat: code split tailwind CSS to reduce bundle size


### PR DESCRIPTION
Looks like I missed this 🤦‍♀️  see #9064

