### PR TITLE
test(api-reference): add import diagnostics

### DIFF
--- a/.changeset/slow-ravens-import.md
+++ b/.changeset/slow-ravens-import.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/api-reference': patch
+---
+
+test: add import diagnostics for public entrypoints

--- a/packages/api-client/src/module-imports.test.ts
+++ b/packages/api-client/src/module-imports.test.ts
@@ -1,0 +1,104 @@
+import { performance } from 'node:perf_hooks'
+
+import { describe, expect, it, vi } from 'vitest'
+
+type ModuleImport = {
+  name: string
+  expectedExport: string
+  load: () => Promise<object>
+}
+
+type ModuleImportResult = {
+  averageMs: number
+  maxMs: number
+  minMs: number
+  name: string
+  samples: number[]
+}
+
+const samples = 3
+const timeoutMs = 30_000
+
+const moduleImports = [
+  {
+    name: 'modal entrypoint',
+    expectedExport: 'createApiClientModal',
+    load: () => import('@/v2/features/modal'),
+  },
+  {
+    name: 'app entrypoint',
+    expectedExport: 'createApiClientApp',
+    load: () => import('@/v2/features/app'),
+  },
+  {
+    name: 'operation block entrypoint',
+    expectedExport: 'OperationBlock',
+    load: () => import('@/v2/blocks/operation-block'),
+  },
+  {
+    name: 'request block entrypoint',
+    expectedExport: 'RequestBlock',
+    load: () => import('@/v2/blocks/request-block'),
+  },
+  {
+    name: 'response block entrypoint',
+    expectedExport: 'ResponseBlock',
+    load: () => import('@/v2/blocks/response-block'),
+  },
+  {
+    name: 'search feature entrypoint',
+    expectedExport: 'useSearchIndex',
+    load: () => import('@/v2/features/search'),
+  },
+] satisfies ModuleImport[]
+
+const round = (value: number): number => Number(value.toFixed(2))
+
+const measureColdImport = async (moduleImport: ModuleImport): Promise<number[]> => {
+  const durations: number[] = []
+
+  await Array.from({ length: samples }).reduce<Promise<void>>(async (previous) => {
+    await previous
+
+    vi.resetModules()
+    const start = performance.now()
+    const importedModule = await moduleImport.load()
+    const duration = performance.now() - start
+
+    expect(moduleImport.expectedExport in importedModule).toBe(true)
+    expect(Number.isFinite(duration)).toBe(true)
+    durations.push(duration)
+  }, Promise.resolve())
+
+  return durations
+}
+
+describe('module-imports', () => {
+  it(
+    'measures cold public entrypoint imports',
+    async () => {
+      expect.assertions(moduleImports.length * samples * 2)
+
+      const results: ModuleImportResult[] = []
+
+      for (const moduleImport of moduleImports) {
+        const durations = await measureColdImport(moduleImport)
+        const averageMs = durations.reduce((total, duration) => total + duration, 0) / durations.length
+
+        const result = {
+          averageMs: round(averageMs),
+          maxMs: round(Math.max(...durations)),
+          minMs: round(Math.min(...durations)),
+          name: moduleImport.name,
+          samples: durations.map(round),
+        }
+
+        console.info('[module-import]', JSON.stringify(result))
+        results.push(result)
+      }
+
+      console.info('[module-imports]', JSON.stringify(results, null, 2))
+    },
+    timeoutMs,
+  )
+})

--- a/packages/api-reference/src/module-imports.test.ts
+++ b/packages/api-reference/src/module-imports.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest'
+
+type ModuleImport = {
+  name: string
+  expectedExport: string
+  load: () => Promise<object>
+}
+
+type ModuleImportResult = {
+  averageMs: number
+  maxMs: number
+  minMs: number
+  name: string
+  samples: number[]
+}
+
+const samples = 3
+const testTimeoutMs = 30_000
+
+const moduleImports = [
+  {
+    name: 'root entrypoint',
+    expectedExport: 'createApiReference',
+    load: () => import('@/index'),
+  },
+  {
+    name: 'components entrypoint',
+    expectedExport: 'ApiReferenceContent',
+    load: () => import('@/components'),
+  },
+  {
+    name: 'blocks entrypoint',
+    expectedExport: 'InfoBlock',
+    load: () => import('@/blocks'),
+  },
+  {
+    name: 'operation feature entrypoint',
+    expectedExport: 'Operation',
+    load: () => import('@/features/Operation'),
+  },
+  {
+    name: 'search feature entrypoint',
+    expectedExport: 'SearchModal',
+    load: () => import('@/features/Search'),
+  },
+  {
+    name: 'html API entrypoint',
+    expectedExport: 'createApiReference',
+    load: () => import('@/standalone/lib/html-api'),
+  },
+] satisfies ModuleImport[]
+
+const round = (value: number): number => Number(value.toFixed(2))
+
+const measureColdImport = async (moduleImport: ModuleImport): Promise<number[]> => {
+  const durations: number[] = []
+
+  await Array.from({ length: samples }).reduce<Promise<void>>(async (previous) => {
+    await previous
+
+    vi.resetModules()
+    const start = performance.now()
+    const importedModule = await moduleImport.load()
+    const duration = performance.now() - start
+
+    expect(moduleImport.expectedExport in importedModule).toBe(true)
+    expect(Number.isFinite(duration)).toBe(true)
+    durations.push(duration)
+  }, Promise.resolve())
+
+  return durations
+}
+
+describe('module-imports', () => {
+  it(
+    'measures cold public entrypoint imports',
+    async () => {
+      expect.assertions(moduleImports.length * samples * 2)
+
+      const results: ModuleImportResult[] = []
+
+      for (const moduleImport of moduleImports) {
+        const durations = await measureColdImport(moduleImport)
+        const averageMs = durations.reduce((total, duration) => total + duration, 0) / durations.length
+
+        results.push({
+          averageMs: round(averageMs),
+          maxMs: round(Math.max(...durations)),
+          minMs: round(Math.min(...durations)),
+          name: moduleImport.name,
+          samples: durations.map(round),
+        })
+      }
+
+      console.info('[module-imports]', JSON.stringify(results, null, 2))
+    },
+    testTimeoutMs,
+  )
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Cold module imports can dominate test worker startup time, and we did not have focused coverage showing which public UI entrypoints are expensive to load.

## Solution

Add Vitest diagnostics for `@scalar/api-client` and `@scalar/api-reference` public entrypoints. Each diagnostic resets the module cache, imports key entrypoints three times, verifies the expected export exists, and logs min/max/average timing JSON in the test output.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f4d5da0-5e05-4b48-8c4d-cd7adf64bb97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f4d5da0-5e05-4b48-8c4d-cd7adf64bb97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

