### PR TITLE
fix(sidebar): remove extra tailwind generate lines

### DIFF
--- a/packages/sidebar/src/styles/tailwind.config.css
+++ b/packages/sidebar/src/styles/tailwind.config.css
@@ -7,9 +7,5 @@
 
 @import "@scalar/components/tailwind.config.css"; /* Component Library Tailwind Configuration */
 
-.scalar-app {
-  @import "tailwindcss/utilities.css";
-}
-
 /* Search for Tailwind classes in the API Reference */
 @source "./";


### PR DESCRIPTION
The config files are supposed to generate classes but this snuck into the sidebar config somehow.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
