### PR TITLE
fix(sidebar): tailwind styles regression

### DIFF
--- a/.changeset/six-boxes-tan.md
+++ b/.changeset/six-boxes-tan.md
@@ -1,0 +1,5 @@
+---
+'@scalar/sidebar': patch
+---
+
+fix: tailwind styles regression

--- a/packages/sidebar/src/styles/tailwind.config.css
+++ b/packages/sidebar/src/styles/tailwind.config.css
@@ -11,5 +11,5 @@
   @import "tailwindcss/utilities.css";
 }
 
-/* Search for Tailwind classes in the API Reference */
-@source "./";
+/* Search for Tailwind classes in the sidebar components */
+@source "../";

--- a/packages/sidebar/src/styles/tailwind.config.css
+++ b/packages/sidebar/src/styles/tailwind.config.css
@@ -7,9 +7,5 @@
 
 @import "@scalar/components/tailwind.config.css"; /* Component Library Tailwind Configuration */
 
-.scalar-app {
-  @import "tailwindcss/utilities.css";
-}
-
 /* Search for Tailwind classes in the sidebar components */
 @source "../";


### PR DESCRIPTION
Regression from #9064: the config file was moved into the styles directory, but the configuration was not updated and still references the previous path.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line Tailwind configuration fix plus a changeset; no runtime logic changes.
> 
> **Overview**
> Fixes a Tailwind styles regression in `@scalar/sidebar` by updating the Tailwind `@source` directive in `tailwind.config.css` to scan the correct directory (`../` instead of `./`) after the config was moved into `src/styles`.
> 
> Adds a patch changeset to release the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98bc65b7d726ffa841b49b0b0c4405365961da37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->