### PR TITLE
fix(scalar-app): login on electron app

### DIFF
--- a/.changeset/metal-humans-shop.md
+++ b/.changeset/metal-humans-shop.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: login on electron app

--- a/projects/scalar-app/entrypoints/electron/main/actions/get-exchange-token.test.ts
+++ b/projects/scalar-app/entrypoints/electron/main/actions/get-exchange-token.test.ts
@@ -124,7 +124,7 @@ describe('get-exchange-token', () => {
   })
 
   it('opens the dashboard login page with the local callback port', async () => {
-    const resultPromise = getExchangeToken()
+    const resultPromise = getExchangeToken('login')
     await waitForLoginPageToOpen()
 
     const port = parseOpenedCallbackPort()
@@ -142,8 +142,27 @@ describe('get-exchange-token', () => {
     await resultPromise
   })
 
+  it('opens the dashboard register page when flow is register', async () => {
+    const resultPromise = getExchangeToken('register')
+    await waitForLoginPageToOpen()
+
+    const port = parseOpenedCallbackPort()
+
+    expect(openExternalMock).toHaveBeenCalledWith(
+      `https://dashboard.scalar.test/register?externalRedirect=local&port=${port}`,
+      { activate: true },
+    )
+
+    await sendCallbackRequest({
+      path: '/callback?exchangeToken=external-register-token',
+      port,
+    })
+
+    await resultPromise
+  })
+
   it('returns exchanged tokens after a valid POST callback', async () => {
-    const resultPromise = getExchangeToken()
+    const resultPromise = getExchangeToken('login')
     await waitForLoginPageToOpen()
 
     const port = parseOpenedCallbackPort()
@@ -170,7 +189,7 @@ describe('get-exchange-token', () => {
   })
 
   it('tears down the callback server after the login attempt finishes', async () => {
-    const resultPromise = getExchangeToken()
+    const resultPromise = getExchangeToken('login')
     await waitForLoginPageToOpen()
 
     const port = parseOpenedCallbackPort()
@@ -189,7 +208,7 @@ describe('get-exchange-token', () => {
   })
 
   it('accepts the dashboard callback sent to localhost', async () => {
-    const resultPromise = getExchangeToken()
+    const resultPromise = getExchangeToken('login')
     await waitForLoginPageToOpen()
 
     const port = parseOpenedCallbackPort()
@@ -219,7 +238,7 @@ describe('get-exchange-token', () => {
   })
 
   it('passes URL-decoded exchange tokens to the exchange endpoint', async () => {
-    const resultPromise = getExchangeToken()
+    const resultPromise = getExchangeToken('login')
     await waitForLoginPageToOpen()
 
     const port = parseOpenedCallbackPort()
@@ -233,7 +252,7 @@ describe('get-exchange-token', () => {
   })
 
   it('returns null and a 405 response for non-POST callbacks', async () => {
-    const resultPromise = getExchangeToken()
+    const resultPromise = getExchangeToken('login')
     await waitForLoginPageToOpen()
 
     const port = parseOpenedCallbackPort()
@@ -264,7 +283,7 @@ describe('get-exchange-token', () => {
     ['/callback', 'without a query parameter'],
     ['/callback?exchangeToken=', 'with a blank query parameter'],
   ])('returns null and a 400 response when the token is missing %s', async (path) => {
-    const resultPromise = getExchangeToken()
+    const resultPromise = getExchangeToken('login')
     await waitForLoginPageToOpen()
 
     const port = parseOpenedCallbackPort()
@@ -288,7 +307,7 @@ describe('get-exchange-token', () => {
   it('returns null and a 400 response when the exchange endpoint rejects the token', async () => {
     exchangeTokenMock.mockResolvedValue([new Error('Invalid exchange token'), null])
 
-    const resultPromise = getExchangeToken()
+    const resultPromise = getExchangeToken('login')
     await waitForLoginPageToOpen()
 
     const port = parseOpenedCallbackPort()
@@ -315,7 +334,7 @@ describe('get-exchange-token', () => {
   it('returns null when no callback arrives before the timeout', async () => {
     vi.useFakeTimers()
 
-    const resultPromise = getExchangeToken()
+    const resultPromise = getExchangeToken('login')
     await vi.dynamicImportSettled()
 
     expect(openExternalMock).toHaveBeenCalled()

--- a/projects/scalar-app/entrypoints/electron/main/actions/get-exchange-token.ts
+++ b/projects/scalar-app/entrypoints/electron/main/actions/get-exchange-token.ts
@@ -177,11 +177,11 @@ const waitForExchangeTokenCallback = ({
   })
 
 /**
- * Creates a short-lived local callback server for the desktop login flow.
+ * Creates a short-lived local callback server for the desktop login/register flow.
  * The dashboard sends the exchange token back to this server after browser auth,
  * then the app trades it for the durable access and refresh tokens it needs.
  */
-export const getExchangeToken = async (): Promise<TokenResponse | null> => {
+export const getExchangeToken = async (flow: 'login' | 'register'): Promise<TokenResponse | null> => {
   const port = await getPort()
   const server = http.createServer()
 
@@ -192,7 +192,7 @@ export const getExchangeToken = async (): Promise<TokenResponse | null> => {
     // cannot arrive before the local server is ready to process it.
     const tokenResult = waitForExchangeTokenCallback({ port, server })
 
-    void shell.openExternal(`${env.VITE_DASHBOARD_URL}/login?externalRedirect=local&port=${port}`, { activate: true })
+    void shell.openExternal(`${env.VITE_DASHBOARD_URL}/${flow}?externalRedirect=local&port=${port}`, { activate: true })
 
     const [error, data] = await tokenResult
 

--- a/projects/scalar-app/entrypoints/electron/preload/index.ts
+++ b/projects/scalar-app/entrypoints/electron/preload/index.ts
@@ -16,7 +16,7 @@ try {
       return await ipcRenderer.invoke('openFilePicker')
     },
     readFile: (filePath: string) => ipcRenderer.invoke('readFile', filePath),
-    getExchangeToken: () => ipcRenderer.invoke('getExchangeToken'),
+    getExchangeToken: (flow: 'login' | 'register') => ipcRenderer.invoke('getExchangeToken', flow),
     getPathForFile: (file: File) => webUtils.getPathForFile(file),
     customFetch: (request) => ipcRenderer.invoke('customFetch', request),
     customFetchStream: ({ streamId, callbacks }) => {

--- a/projects/scalar-app/entrypoints/electron/shims.d.ts
+++ b/projects/scalar-app/entrypoints/electron/shims.d.ts
@@ -31,7 +31,7 @@ declare global {
       /** Read a file string using to the renderer process */
       readFile: (f: string) => Promise<string | undefined>
       /** Request an exchange token from the auth service */
-      getExchangeToken: () => Promise<{
+      getExchangeToken: (flow: 'login' | 'register') => Promise<{
         accessToken: string
         refreshToken: string
       } | null>

--- a/projects/scalar-app/src/App.vue
+++ b/projects/scalar-app/src/App.vue
@@ -23,16 +23,15 @@ import {
 import { ScalarHeaderButton } from '@scalar/components'
 import { type LoaderPlugin } from '@scalar/json-magic/bundle'
 import { requestScriptsPlugin } from '@scalar/pre-post-request-scripts/plugins'
-import { useToasts } from '@scalar/use-toasts'
 import { computed, reactive } from 'vue'
 
 import AppMenuItems from '@/features/header/AppMenuItems.vue'
 import { ImportListener } from '@/features/import-listener'
-import { loginUrl, registerUrl } from '@/helpers/auth/login-url'
 import { fetchRegistryDocument } from '@/helpers/fetch-registry-document'
 import { publishRegistryDocument } from '@/helpers/publish-registry-document'
 import { publishRegistryVersion } from '@/helpers/publish-registry-version'
 import { useAuth } from '@/hooks/use-auth'
+import { useAuthHandlers } from '@/hooks/use-auth-handlers'
 import { useRegistryDocuments } from '@/hooks/use-registry-documents'
 import { useRegistryNamespaces } from '@/hooks/use-registry-namespaces'
 
@@ -40,8 +39,7 @@ const { getAppState, getCommandPaletteState, fileLoader } =
   defineProps<AppProps>()
 
 const app = getAppState()
-const { toast } = useToasts()
-const { isLoggedIn, setTokens } = useAuth()
+const { isLoggedIn } = useAuth()
 const {
   documents,
   isLoading: isDocumentsLoading,
@@ -55,26 +53,7 @@ const isDesktop = window.electron === true
 //--------------------------------------------------
 // Login
 //--------------------------------------------------
-async function handleLogin() {
-  // If we're on the web version, redirect to the dashboard login
-  if (!isDesktop) {
-    window.location.href = loginUrl()
-    return
-  }
-
-  // For desktop/electron, use the exchange token flow
-  const result = await window.api.getExchangeToken()
-  if (!result) {
-    toast('Unable to login. Please try again or contact support.', 'error', {
-      timeout: 10000,
-    })
-  } else {
-    toast('Logged in successfully', 'info')
-    setTokens(result.accessToken, result.refreshToken)
-  }
-
-  return
-}
+const { handleLogin, handleRegister } = useAuthHandlers()
 
 //--------------------------------------------------
 // Workspace handling
@@ -208,13 +187,13 @@ const registry = reactive({
         #header-end>
         <ScalarHeaderButton
           is="a"
-          :href="loginUrl()">
+          @click.prevent="handleLogin">
           Log in
         </ScalarHeaderButton>
         <ScalarHeaderButton
           is="a"
           cta
-          :href="registerUrl">
+          @click.prevent="handleRegister">
           Register
         </ScalarHeaderButton>
       </template>

--- a/projects/scalar-app/src/hooks/use-auth-handlers.test.ts
+++ b/projects/scalar-app/src/hooks/use-auth-handlers.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useAuthHandlers } from './use-auth-handlers'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockToast = vi.fn()
+vi.mock('@scalar/use-toasts', () => ({
+  useToasts: () => ({ toast: mockToast }),
+}))
+
+const mockSetTokens = vi.fn()
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: () => ({ setTokens: mockSetTokens }),
+}))
+
+vi.mock('@/helpers/auth/login-url', () => ({
+  loginUrl: () => 'https://dashboard.test/login',
+  registerUrl: () => 'https://dashboard.test/register',
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Stub window.location so we can assert href assignments without jsdom navigation. */
+const stubLocation = () => {
+  const location = { href: '' }
+  vi.stubGlobal('location', location)
+  return location
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useAuthHandlers', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+    mockToast.mockClear()
+    mockSetTokens.mockClear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('handleLogin', () => {
+    describe('web (non-desktop)', () => {
+      it('redirects to the login URL when not running in Electron', async () => {
+        vi.stubGlobal('electron', false)
+        const location = stubLocation()
+
+        const { handleLogin } = useAuthHandlers()
+        await handleLogin()
+
+        expect(location.href).toBe('https://dashboard.test/login')
+      })
+
+      it('does not call getExchangeToken on web', async () => {
+        vi.stubGlobal('electron', false)
+        stubLocation()
+
+        const getExchangeToken = vi.fn()
+        vi.stubGlobal('api', { getExchangeToken })
+
+        const { handleLogin } = useAuthHandlers()
+        await handleLogin()
+
+        expect(getExchangeToken).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('desktop (Electron)', () => {
+      beforeEach(() => {
+        vi.stubGlobal('electron', true)
+        stubLocation()
+      })
+
+      it('calls getExchangeToken with flow=login via the IPC bridge', async () => {
+        const getExchangeToken = vi.fn().mockResolvedValue(null)
+        vi.stubGlobal('api', { getExchangeToken })
+
+        const { handleLogin } = useAuthHandlers()
+        await handleLogin()
+
+        expect(getExchangeToken).toHaveBeenCalledWith('login')
+      })
+
+      it('stores tokens and shows a success toast when exchange succeeds', async () => {
+        const tokens = { accessToken: 'access.tok', refreshToken: 'refresh.tok' }
+        vi.stubGlobal('api', { getExchangeToken: vi.fn().mockResolvedValue(tokens) })
+
+        const { handleLogin } = useAuthHandlers()
+        await handleLogin()
+
+        expect(mockSetTokens).toHaveBeenCalledWith(tokens.accessToken, tokens.refreshToken)
+        expect(mockToast).toHaveBeenCalledWith('Logged in successfully', 'info')
+      })
+
+      it('shows an error toast and does not store tokens when exchange returns null', async () => {
+        vi.stubGlobal('api', { getExchangeToken: vi.fn().mockResolvedValue(null) })
+
+        const { handleLogin } = useAuthHandlers()
+        await handleLogin()
+
+        expect(mockSetTokens).not.toHaveBeenCalled()
+        expect(mockToast).toHaveBeenCalledWith(
+          'Unable to login. Please try again or contact support.',
+          'error',
+          { timeout: 10000 },
+        )
+      })
+
+      it('does not redirect window.location on desktop', async () => {
+        const location = stubLocation()
+        vi.stubGlobal('api', { getExchangeToken: vi.fn().mockResolvedValue(null) })
+
+        const { handleLogin } = useAuthHandlers()
+        await handleLogin()
+
+        expect(location.href).toBe('')
+      })
+    })
+  })
+
+  describe('handleRegister', () => {
+    describe('web (non-desktop)', () => {
+      it('redirects to the register URL', async () => {
+        vi.stubGlobal('electron', false)
+        const location = stubLocation()
+
+        const { handleRegister } = useAuthHandlers()
+        await handleRegister()
+
+        expect(location.href).toBe('https://dashboard.test/register')
+      })
+
+      it('does not call getExchangeToken on web', async () => {
+        vi.stubGlobal('electron', false)
+        stubLocation()
+
+        const getExchangeToken = vi.fn()
+        vi.stubGlobal('api', { getExchangeToken })
+
+        const { handleRegister } = useAuthHandlers()
+        await handleRegister()
+
+        expect(getExchangeToken).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('desktop (Electron)', () => {
+      beforeEach(() => {
+        vi.stubGlobal('electron', true)
+        stubLocation()
+      })
+
+      it('calls getExchangeToken with flow=register via the IPC bridge', async () => {
+        const getExchangeToken = vi.fn().mockResolvedValue(null)
+        vi.stubGlobal('api', { getExchangeToken })
+
+        const { handleRegister } = useAuthHandlers()
+        await handleRegister()
+
+        expect(getExchangeToken).toHaveBeenCalledWith('register')
+      })
+
+      it('stores tokens and shows a success toast when exchange succeeds', async () => {
+        const tokens = { accessToken: 'access.tok', refreshToken: 'refresh.tok' }
+        vi.stubGlobal('api', { getExchangeToken: vi.fn().mockResolvedValue(tokens) })
+
+        const { handleRegister } = useAuthHandlers()
+        await handleRegister()
+
+        expect(mockSetTokens).toHaveBeenCalledWith(tokens.accessToken, tokens.refreshToken)
+        expect(mockToast).toHaveBeenCalledWith('Registered successfully', 'info')
+      })
+
+      it('shows an error toast and does not store tokens when exchange returns null', async () => {
+        vi.stubGlobal('api', { getExchangeToken: vi.fn().mockResolvedValue(null) })
+
+        const { handleRegister } = useAuthHandlers()
+        await handleRegister()
+
+        expect(mockSetTokens).not.toHaveBeenCalled()
+        expect(mockToast).toHaveBeenCalledWith(
+          'Unable to register. Please try again or contact support.',
+          'error',
+          { timeout: 10000 },
+        )
+      })
+
+      it('does not redirect window.location on desktop', async () => {
+        const location = stubLocation()
+        vi.stubGlobal('api', { getExchangeToken: vi.fn().mockResolvedValue(null) })
+
+        const { handleRegister } = useAuthHandlers()
+        await handleRegister()
+
+        expect(location.href).toBe('')
+      })
+    })
+  })
+})

--- a/projects/scalar-app/src/hooks/use-auth-handlers.test.ts
+++ b/projects/scalar-app/src/hooks/use-auth-handlers.test.ts
@@ -107,11 +107,9 @@ describe('useAuthHandlers', () => {
         await handleLogin()
 
         expect(mockSetTokens).not.toHaveBeenCalled()
-        expect(mockToast).toHaveBeenCalledWith(
-          'Unable to login. Please try again or contact support.',
-          'error',
-          { timeout: 10000 },
-        )
+        expect(mockToast).toHaveBeenCalledWith('Unable to login. Please try again or contact support.', 'error', {
+          timeout: 10000,
+        })
       })
 
       it('does not redirect window.location on desktop', async () => {
@@ -186,11 +184,9 @@ describe('useAuthHandlers', () => {
         await handleRegister()
 
         expect(mockSetTokens).not.toHaveBeenCalled()
-        expect(mockToast).toHaveBeenCalledWith(
-          'Unable to register. Please try again or contact support.',
-          'error',
-          { timeout: 10000 },
-        )
+        expect(mockToast).toHaveBeenCalledWith('Unable to register. Please try again or contact support.', 'error', {
+          timeout: 10000,
+        })
       })
 
       it('does not redirect window.location on desktop', async () => {

--- a/projects/scalar-app/src/hooks/use-auth-handlers.ts
+++ b/projects/scalar-app/src/hooks/use-auth-handlers.ts
@@ -1,0 +1,62 @@
+import { useToasts } from '@scalar/use-toasts'
+
+import { loginUrl, registerUrl } from '@/helpers/auth/login-url'
+import { useAuth } from '@/hooks/use-auth'
+
+/**
+ * Shared login and register click handlers for the header auth buttons
+ *
+ * Normally a good candiate for a helper but it touches state so must be a hook
+ */
+export const useAuthHandlers = () => {
+  const { toast } = useToasts()
+  const { setTokens } = useAuth()
+
+  /**
+   * Log in handler.
+   * On desktop (Electron), uses the IPC exchange-token flow so the app captures
+   * the auth tokens without navigating away from the Electron window.
+   * On web, redirects to the dashboard login page.
+   */
+  const handleLogin = async (): Promise<void> => {
+    if (window.electron !== true) {
+      window.location.href = loginUrl()
+      return
+    }
+
+    const result = await window.api.getExchangeToken('login')
+    if (!result) {
+      toast('Unable to login. Please try again or contact support.', 'error', {
+        timeout: 10000,
+      })
+    } else {
+      toast('Logged in successfully', 'info')
+      setTokens(result.accessToken, result.refreshToken)
+    }
+  }
+
+  /**
+   * Register handler.
+   * On desktop (Electron), uses the same IPC exchange-token flow as login so
+   * the app captures auth tokens without navigating away from the Electron window.
+   * On web, redirects to the dashboard registration page.
+   */
+  const handleRegister = async (): Promise<void> => {
+    if (window.electron !== true) {
+      window.location.href = registerUrl()
+      return
+    }
+
+    const result = await window.api.getExchangeToken('register')
+    if (!result) {
+      toast('Unable to register. Please try again or contact support.', 'error', {
+        timeout: 10000,
+      })
+    } else {
+      toast('Registered successfully', 'info')
+      setTokens(result.accessToken, result.refreshToken)
+    }
+  }
+
+  return { handleLogin, handleRegister }
+}


### PR DESCRIPTION
## Problem

The login button on the header redirects in the main app window.

## Solution

Instead we switch to a click handler and add register capabilities to the app login.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Electron auth flow and IPC surface by changing `getExchangeToken` to be parameterized and wiring new UI handlers; mistakes could break desktop login/register or route users to the wrong dashboard path.
> 
> **Overview**
> Fixes Electron header auth so **login/register no longer navigate the main window** and instead trigger an IPC-backed exchange-token flow.
> 
> `getExchangeToken` is updated to accept a `flow` (`login`/`register`) and open the corresponding dashboard URL, with preload typings/API updated accordingly; `App.vue` now uses a new `useAuthHandlers` hook for click handlers, and new tests cover both the hook behavior and the new register flow in the Electron token exchange tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0186f9148b91877164f266db0038834a5d69df9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->