### PR TITLE
chore(api-client): reorganize app layout

### DIFF
--- a/.changeset/afraid-clouds-dream.md
+++ b/.changeset/afraid-clouds-dream.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+chore: reorganize app layout

--- a/.changeset/afraid-clouds-dream.md
+++ b/.changeset/afraid-clouds-dream.md
@@ -3,3 +3,5 @@
 ---
 
 chore: reorganize app layout
+
+Move the tabs on top of the page for the app layout and make the layout better for small screens

--- a/packages/api-client/src/v2/features/app/App.vue
+++ b/packages/api-client/src/v2/features/app/App.vue
@@ -247,11 +247,21 @@ const routerViewProps = computed<RouteProps>(() => {
         app.workspace.activeWorkspace.value !== null &&
         !app.loading.value
       ">
-      <div class="relative flex h-dvh w-dvw flex-col">
+      <div
+        class="relative flex h-dvh w-dvw flex-col"
+        :style="{
+          '--app-desktop-tabs-height': layout === 'desktop' ? '2.5rem' : '0px',
+        }">
+        <!--
+          Sits in the same visual slot as the operation Header gutter (size-8).
+          Offset = desktop tab strip (layout desktop only) + ScalarHeader (min-h-header)
+          + OperationBlock outer p-2 + Header pt-2 (1rem total) so we clear app chrome.
+          `--app-desktop-tabs-height` is set on this shell so the mobile sidebar inset
+          matches (see AppSidebar).
+        -->
         <SidebarToggle
           v-model="app.sidebar.isOpen.value"
-          class="absolute z-60 md:hidden"
-          :class="layout === 'desktop' ? 'top-14 left-4' : 'top-4 left-4'" />
+          class="app-no-drag-region absolute top-[calc(var(--app-desktop-tabs-height)+var(--spacing-header,48px)+1rem)] left-4 z-60 md:hidden" />
         <!-- App Tabs -->
         <DesktopTabs
           v-if="layout === 'desktop'"
@@ -325,11 +335,7 @@ const routerViewProps = computed<RouteProps>(() => {
                 @revert="handleRevertDocument"
                 @save="handleSaveDocument" />
               <!--
-                Vertical divider between the document-scoped action cluster
-                (workspace-mode buttons + `header-actions`) and the trailing
-                `header-end` cluster. Only rendered when both sides have
-                content so single-cluster headers do not get an orphaned
-                separator.
+                Vertical divider
               -->
               <span
                 v-if="$slots['header-end']"
@@ -350,10 +356,10 @@ const routerViewProps = computed<RouteProps>(() => {
             :sidebarWidth="app.sidebar.width.value"
             @update:sidebarWidth="app.sidebar.handleSidebarWidthUpdate" />
 
-            <!-- Router view min-h-0 is required for scrolling, do not remove it -->
-            <div class="bg-b-1 relative min-h-0 flex-1">
-              <RouterView v-bind="routerViewProps" />
-            </div>
+          <!-- Router view min-h-0 is required for scrolling, do not remove it -->
+          <div class="bg-b-1 relative min-h-0 flex-1">
+            <RouterView v-bind="routerViewProps" />
+          </div>
         </div>
       </div>
       <!-- Create workspace modal -->

--- a/packages/api-client/src/v2/features/app/App.vue
+++ b/packages/api-client/src/v2/features/app/App.vue
@@ -252,6 +252,12 @@ const routerViewProps = computed<RouteProps>(() => {
           v-model="app.sidebar.isOpen.value"
           class="absolute z-60 md:hidden"
           :class="layout === 'desktop' ? 'top-14 left-4' : 'top-4 left-4'" />
+        <!-- App Tabs -->
+        <DesktopTabs
+          v-if="layout === 'desktop'"
+          :activeTabIndex="app.tabs.activeTabIndex.value"
+          :eventBus="app.eventBus"
+          :tabs="app.tabs.state.value" />
         <AppHeader
           :menuTitle="app.workspace.isTeamWorkspace.value ? 'Team' : 'Local'"
           @navigate:to:settings="
@@ -344,19 +350,10 @@ const routerViewProps = computed<RouteProps>(() => {
             :sidebarWidth="app.sidebar.width.value"
             @update:sidebarWidth="app.sidebar.handleSidebarWidthUpdate" />
 
-          <div class="flex min-h-0 flex-1 flex-col">
-            <!-- App Tabs -->
-            <DesktopTabs
-              v-if="layout === 'desktop'"
-              :activeTabIndex="app.tabs.activeTabIndex.value"
-              :eventBus="app.eventBus"
-              :tabs="app.tabs.state.value" />
-
             <!-- Router view min-h-0 is required for scrolling, do not remove it -->
             <div class="bg-b-1 relative min-h-0 flex-1">
               <RouterView v-bind="routerViewProps" />
             </div>
-          </div>
         </div>
       </div>
       <!-- Create workspace modal -->

--- a/packages/api-client/src/v2/features/app/components/AppHeader.vue
+++ b/packages/api-client/src/v2/features/app/components/AppHeader.vue
@@ -58,7 +58,9 @@ const slots = defineSlots<{
         <template
           v-if="menuTitle"
           #title>
-          {{ menuTitle }}
+          <span class="max-md:hidden">
+            {{ menuTitle }}
+          </span>
         </template>
         <template #products>
           <ScalarMenuProducts selected="client" />

--- a/packages/api-client/src/v2/features/app/components/AppHeaderActions.vue
+++ b/packages/api-client/src/v2/features/app/components/AppHeaderActions.vue
@@ -57,10 +57,12 @@ const emit = defineEmits<{
         thickness="1.5" />
     </ScalarButton>
     <ScalarButton
+      aria-label="Save"
       class="shrink-0 gap-1.5"
       data-testid="app-header-save-button"
       :disabled="!isActiveDocumentDirty"
       size="xs"
+      title="Save"
       type="button"
       variant="solid"
       @click="emit('save')">
@@ -68,7 +70,7 @@ const emit = defineEmits<{
         class="size-3.5"
         size="sm"
         thickness="1.5" />
-      <span>Save</span>
+      <span class="max-md:hidden">Save</span>
     </ScalarButton>
   </template>
   <!--
@@ -94,12 +96,12 @@ const emit = defineEmits<{
         thickness="1.5" />
     </ScalarButton>
     <ScalarButton
-      :aria-label="isOffline ? 'Pull (offline)' : undefined"
+      :aria-label="isOffline ? 'Pull (offline)' : 'Pull'"
       class="shrink-0 gap-1.5"
       data-testid="app-header-pull-button"
       :disabled="!canPullActiveDocument"
       size="xs"
-      :title="isOffline ? 'You are offline.' : undefined"
+      :title="isOffline ? 'You are offline.' : 'Pull'"
       type="button"
       variant="solid"
       @click="emit('pull')">
@@ -113,15 +115,15 @@ const emit = defineEmits<{
         class="size-3.5"
         size="sm"
         thickness="1.5" />
-      <span>Pull</span>
+      <span class="max-md:hidden">Pull</span>
     </ScalarButton>
     <ScalarButton
-      :aria-label="isOffline ? 'Push (offline)' : undefined"
+      :aria-label="isOffline ? 'Push (offline)' : 'Push'"
       class="shrink-0 gap-1.5"
       data-testid="app-header-push-button"
       :disabled="!canPushActiveDocument"
       size="xs"
-      :title="isOffline ? 'You are offline.' : undefined"
+      :title="isOffline ? 'You are offline.' : 'Push'"
       type="button"
       variant="solid"
       @click="emit('push')">
@@ -135,7 +137,7 @@ const emit = defineEmits<{
         class="size-3.5"
         size="sm"
         thickness="1.5" />
-      <span>Push</span>
+      <span class="max-md:hidden">Push</span>
     </ScalarButton>
   </template>
   <!--
@@ -146,12 +148,12 @@ const emit = defineEmits<{
   -->
   <ScalarButton
     v-if="showTeamPublishAction"
-    :aria-label="isOffline ? 'Publish (offline)' : undefined"
+    :aria-label="isOffline ? 'Publish (offline)' : 'Publish'"
     class="shrink-0 gap-1.5"
     data-testid="app-header-publish-button"
     :disabled="isOffline"
     size="xs"
-    :title="isOffline ? 'You are offline.' : undefined"
+    :title="isOffline ? 'You are offline.' : 'Publish'"
     type="button"
     variant="solid"
     @click="emit('publish')">
@@ -165,6 +167,6 @@ const emit = defineEmits<{
       class="size-3.5"
       size="sm"
       thickness="1.5" />
-    <span>Publish</span>
+    <span class="max-md:hidden">Publish</span>
   </ScalarButton>
 </template>

--- a/packages/api-client/src/v2/features/app/components/AppSidebar.vue
+++ b/packages/api-client/src/v2/features/app/components/AppSidebar.vue
@@ -44,14 +44,11 @@ import type {
 
 const {
   app,
-  indent = 20,
   registryDocuments = { status: 'success', documents: [] },
   fetchRegistryDocument,
 } = defineProps<{
   /** The app state from @scalar/api-client. */
   app: AppState
-  /** Horizontal indent applied to nested sidebar items, in pixels. */
-  indent?: number
   /**
    * The list of all available registry documents, wrapped in a loading state
    * so the sidebar can render skeleton placeholders while the registry is
@@ -427,8 +424,7 @@ const sidebarWidth = defineModel<number>('sidebarWidth', {
     <template #default>
       <div class="flex flex-1">
         <ScalarSidebar
-          class="flex min-h-0 flex-1 flex-col max-md:pt-12"
-          :style="{ '--scalar-sidebar-indent': indent + 'px' }">
+          class="flex min-h-0 flex-1 flex-col max-md:pt-[calc(var(--app-desktop-tabs-height)+var(--spacing-header,48px)+2.5rem)]">
           <!-- Top-level sidebar header -->
           <div
             v-if="!isOnDocumentPage"

--- a/packages/api-client/src/v2/features/app/components/DesktopTabs.vue
+++ b/packages/api-client/src/v2/features/app/components/DesktopTabs.vue
@@ -44,7 +44,7 @@ const handleCopyTabUrl = (index: number): void => {
 </script>
 
 <template>
-  <nav class="t-app__top-nav">
+  <nav class="z-10">
     <!-- drag region (macos) -->
     <div class="mac:app-drag-region mac:pl-[72px]">
       <div class="z-1 flex h-10 items-center gap-2 px-2">

--- a/packages/api-client/src/v2/features/app/components/DesktopTabs.vue
+++ b/packages/api-client/src/v2/features/app/components/DesktopTabs.vue
@@ -46,7 +46,7 @@ const handleCopyTabUrl = (index: number): void => {
 <template>
   <nav class="t-app__top-nav">
     <!-- drag region (macos) -->
-    <div class="mac:app-drag-region">
+    <div class="mac:app-drag-region mac:pl-[72px]">
       <div class="z-1 flex h-10 items-center gap-2 px-2">
         <DesktopTab
           v-for="(tab, index) in tabs"

--- a/packages/api-client/src/v2/features/app/components/DocumentBreadcrumb.vue
+++ b/packages/api-client/src/v2/features/app/components/DocumentBreadcrumb.vue
@@ -376,7 +376,7 @@ const handleCreateVersion = async (version: string) => {
   <nav
     v-if="isVisible"
     aria-label="Document breadcrumb"
-    class="flex min-w-0 items-center gap-2 text-sm font-medium">
+    class="flex min-w-0 items-center gap-2 text-sm font-medium max-md:gap-0 max-md:text-xs">
     <!--
       The breadcrumb leads with a vertical bar to visually divide it from
       the menu trigger to its left. The menu trigger itself surfaces the


### PR DESCRIPTION
Move the tabs on top of the page for the app layout

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/layout and accessibility tweaks; main risk is unintended spacing/stacking regressions across responsive breakpoints (especially mobile sidebar/tabs/header offsets).
> 
> **Overview**
> Moves `DesktopTabs` to the top of the app shell (above `AppHeader`) and introduces a shared `--app-desktop-tabs-height` CSS variable to keep the mobile sidebar inset and sidebar toggle positioning aligned with the new tab strip.
> 
> Improves small-screen UI by hiding some header/menu/button text under `max-md` breakpoints, refining breadcrumb spacing, and adding explicit `aria-label`/`title` values for Save/Pull/Push/Publish actions (including offline states).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb35e916a4169d6e961b5697e168998f4ff20f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->