### PR TITLE
fix(api-reference): use overflow-wrap break-word for tag labels

### DIFF
--- a/.changeset/small-ravens-help.md
+++ b/.changeset/small-ravens-help.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): use overflow-wrap break-word for tag labels

--- a/packages/api-reference/src/components/Anchor/Anchor.vue
+++ b/packages/api-reference/src/components/Anchor/Anchor.vue
@@ -14,7 +14,7 @@ const labelId = useId()
 const { cx } = useBindCx()
 </script>
 <template>
-  <span v-bind="cx('group/heading word-break-all relative')">
+  <span v-bind="cx('group/heading wrap-break-word relative')">
     <span
       :id="labelId"
       class="contents">


### PR DESCRIPTION
We were using [`word-break: break-word;`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/word-break#break-word) (or trying to) where we should have been using [`overflow-wrap: break-word;`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/overflow-wrap#:~:text=Note%3A%20In%20contrast%20to%20word%2Dbreak%2C%20overflow%2Dwrap%20will%20only%20create%20a%20break%20if%20an%20entire%20word%20cannot%20be%20placed%20on%20its%20own%20line%20without%20overflowing.).

Fixes #9092


## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
