### PR TITLE
fix(workspace-store): JSON-stringify nested values in urlencoded bodies

### DIFF
--- a/.changeset/curly-sloths-jump.md
+++ b/.changeset/curly-sloths-jump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix urlencoded request body serialization for nested object and array values

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
@@ -256,6 +256,34 @@ describe('buildRequestBody', () => {
     expect(result.value[2].value).toBe('test')
   })
 
+  it('JSON-stringifies nested object and array values in form-urlencoded object format', () => {
+    const requestBody = {
+      content: {
+        'application/x-www-form-urlencoded': {
+          examples: {
+            default: {
+              value: {
+                tags: ['a', 'b'],
+                meta: { foo: 'bar' },
+              },
+            },
+          },
+        },
+      },
+    }
+    const result = buildRequestBody(requestBody, 'default')
+
+    expect(result?.mode).toBe('urlencoded')
+    assert(result?.mode === 'urlencoded')
+
+    assert(result.value[0])
+    expect(result.value[0].key).toBe('tags')
+    expect(result.value[0].value).toBe('["a","b"]')
+    assert(result.value[1])
+    expect(result.value[1].key).toBe('meta')
+    expect(result.value[1].value).toBe('{"foo":"bar"}')
+  })
+
   it('skips null and undefined values in form-urlencoded object format', () => {
     const requestBody = {
       content: {

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -163,7 +163,8 @@ export const buildRequestBody = (
     // Convert object properties to form fields
     for (const [key, value] of Object.entries(example.value)) {
       if (key && value !== undefined && value !== null) {
-        const stringValue = typeof value === 'string' ? value : String(value)
+        const stringValue =
+          typeof value === 'object' && value !== null ? JSON.stringify(unpackProxyObject(value)) : String(value)
         result.value.push({
           key,
           value: stringValue,


### PR DESCRIPTION
## Summary

- Fix the schema-object path for `application/x-www-form-urlencoded` request bodies, which serialized nested object and array values via `String(value)` — yielding `"[object Object]"` or comma-joined strings.
- Mirror the `JSON.stringify` treatment used by the multipart object-form path so structured values are serialized consistently.
- Add a regression test covering nested object and array values.

## Background

Split out from the closed PR #8998. The original branch also tried to address #8997, but that issue is already fixed on `main` (Content-Type filtering in `request-factory.ts` and `build-request-parameters.ts`, plus the multipart object-form branch added in #9054). This PR keeps only the unrelated urlencoded fix.

## Test plan

- [ ] `pnpm --filter @scalar/workspace-store test` (regression test passes; fails before the fix with `'a,b'` instead of `'["a","b"]'`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to `application/x-www-form-urlencoded` example serialization plus a regression test; main risk is behavior change for clients that previously relied on `[object Object]`/comma-joined coercion.
> 
> **Overview**
> Fixes `application/x-www-form-urlencoded` *object-form* request-body example serialization to **JSON-stringify nested object/array values** (using `unpackProxyObject`) instead of producing `[object Object]` or comma-joined arrays.
> 
> Adds a regression test covering nested `tags` arrays and `meta` objects, and includes a patch changeset for `@scalar/workspace-store`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9398fccab005bbdb56733004d73f709acd3f58fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->