### PR TITLE
ci(api-client): on release, deploy main to cloudflare

### DIFF
--- a/.changeset/loose-bears-swim.md
+++ b/.changeset/loose-bears-swim.md
@@ -2,4 +2,4 @@
 'scalar-app': patch
 ---
 
-chore: minor change to trigger preview ci
+chore: use both services URL AND api URL in the scalar-app

--- a/.changeset/loose-bears-swim.md
+++ b/.changeset/loose-bears-swim.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+chore: minor change to trigger preview ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -788,12 +788,18 @@ jobs:
         run: echo "url=https://${{ env.DEPLOY_ID }}--scalar-components.netlify.app" >> $GITHUB_OUTPUT
 
   deploy-api-client:
-    # Run only for same-repo PRs that touch @scalar/api-client or its workspace deps
+    # Run for same-repo PR previews, or for main when publishing a release commit
     if: |
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      !contains(github.actor, '[bot]') &&
-      needs.check-changes.outputs.api_client_changed == 'true'
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        !contains(github.actor, '[bot]') &&
+        needs.check-changes.outputs.api_client_changed == 'true'
+      ) ||
+      (
+        github.ref == 'refs/heads/main' &&
+        startsWith(github.event.head_commit.message, 'RELEASING:')
+      )
     needs: [build, check-changes]
     runs-on: blacksmith-2vcpu-ubuntu-2204
     environment: staging
@@ -820,19 +826,30 @@ jobs:
           VITE_API_URL: ${{ vars.API_URL }}
           VITE_ENV: ${{ vars.ENVIRONMENT }}
 
-      - name: Deploy to Cloudflare Pages
-        id: deploy
+      - name: Deploy PR preview to Cloudflare Pages
+        if: github.event_name == 'pull_request'
+        id: deploy-preview
         uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy ./projects/scalar-app/dist/web --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_API_CLIENT }} --branch=pr-${{ github.event.pull_request.number }} --commit-hash=${{ github.event.pull_request.head.sha }}
 
+      - name: Deploy main branch to Cloudflare Pages
+        if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
+        id: deploy-main
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ./projects/scalar-app/dist/web --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_API_CLIENT }} --branch=main --commit-hash=${{ github.sha }}
+
       - name: Set output
+        if: github.event_name == 'pull_request'
         id: set-output
         run: |
-          ALIAS_URL='${{ steps.deploy.outputs.pages-deployment-alias-url }}'
-          DEPLOYMENT_URL='${{ steps.deploy.outputs.deployment-url }}'
+          ALIAS_URL='${{ steps.deploy-preview.outputs.pages-deployment-alias-url }}'
+          DEPLOYMENT_URL='${{ steps.deploy-preview.outputs.deployment-url }}'
           if [ -n "$ALIAS_URL" ]; then
             echo "url=$ALIAS_URL" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -787,8 +787,11 @@ jobs:
         if: github.event_name == 'pull_request'
         run: echo "url=https://${{ env.DEPLOY_ID }}--scalar-components.netlify.app" >> $GITHUB_OUTPUT
 
+  # Run for:
+  # - same-repo PR previews (staging)
+  # - merges to main that are not a release commit (staging)
+  # - merges to main that are a release commit (production)
   deploy-api-client:
-    # Run for same-repo PR previews, or for main when publishing a release commit
     if: |
       (
         github.event_name == 'pull_request' &&
@@ -796,65 +799,17 @@ jobs:
         !contains(github.actor, '[bot]') &&
         needs.check-changes.outputs.api_client_changed == 'true'
       ) ||
-      (
-        github.ref == 'refs/heads/main' &&
-        startsWith(github.event.head_commit.message, 'RELEASING:')
-      )
+      github.ref == 'refs/heads/main'
     needs: [build, check-changes]
-    runs-on: blacksmith-2vcpu-ubuntu-2204
-    environment: staging
-    timeout-minutes: 15
     concurrency:
       group: deploy-api-client-${{ github.ref }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-    outputs:
-      preview-url: ${{ steps.set-output.outputs.url }}
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Build workspace deps
-        uses: ./.github/actions/build
-        with:
-          packages: 'scalar-app...'
-
-      - name: Build web app
-        run: pnpm --filter scalar-app build:web
-        env:
-          VITE_DASHBOARD_URL: ${{ vars.DASHBOARD_URL }}
-          VITE_API_URL: ${{ vars.API_URL }}
-          VITE_ENV: ${{ vars.ENVIRONMENT }}
-
-      - name: Deploy PR preview to Cloudflare Pages
-        if: github.event_name == 'pull_request'
-        id: deploy-preview
-        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ./projects/scalar-app/dist/web --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_API_CLIENT }} --branch=pr-${{ github.event.pull_request.number }} --commit-hash=${{ github.event.pull_request.head.sha }}
-
-      - name: Deploy main branch to Cloudflare Pages
-        if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
-        id: deploy-main
-        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ./projects/scalar-app/dist/web --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_API_CLIENT }} --branch=main --commit-hash=${{ github.sha }}
-
-      - name: Set output
-        if: github.event_name == 'pull_request'
-        id: set-output
-        run: |
-          ALIAS_URL='${{ steps.deploy-preview.outputs.pages-deployment-alias-url }}'
-          DEPLOYMENT_URL='${{ steps.deploy-preview.outputs.deployment-url }}'
-          if [ -n "$ALIAS_URL" ]; then
-            echo "url=$ALIAS_URL" >> $GITHUB_OUTPUT
-          else
-            echo "url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
-          fi
+    uses: ./.github/workflows/deploy-api-client.yml
+    with:
+      environment: ${{ startsWith(github.event.head_commit.message, 'RELEASING:') && 'production' || 'staging' }}
+      pr-number: ${{ github.event.pull_request.number }}
+      sha: ${{ github.event.pull_request.head.sha || github.sha }}
+    secrets: inherit
 
   galaxy-registry-preview:
     # Only run for PRs from the same repository

--- a/.github/workflows/deploy-api-client.yml
+++ b/.github/workflows/deploy-api-client.yml
@@ -45,6 +45,7 @@ jobs:
         env:
           VITE_DASHBOARD_URL: ${{ vars.DASHBOARD_URL }}
           VITE_API_URL: ${{ vars.API_URL }}
+          VITE_SERVICES_URL: ${{ vars.SERVICES_URL }}
           VITE_ENV: ${{ vars.ENVIRONMENT }}
 
       # PR preview deploy — branch name creates a unique Cloudflare Pages alias URL per PR

--- a/.github/workflows/deploy-api-client.yml
+++ b/.github/workflows/deploy-api-client.yml
@@ -88,8 +88,8 @@ jobs:
           fi
 
   # Delete Cloudflare Pages preview deployments when a PR merges to main.
-  # Note: Cloudflare does not allow deleting the latest deployment for a branch,
-  # so the branch alias URL will persist, but all older deployments are cleaned up.
+  # The ?force=true parameter allows deletion of aliased (latest) deployments,
+  # so this should clean up all deployments including the branch alias URL.
   teardown:
     if: |
       github.event_name == 'pull_request' &&
@@ -98,8 +98,6 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       !contains(github.actor, '[bot]')
     runs-on: blacksmith-2vcpu-ubuntu-2204
-    # The staging environment holds the CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID,
-    # and CLOUDFLARE_PROJECT_API_CLIENT_PREVIEW vars needed for the preview project.
     environment: staging
     timeout-minutes: 5
     permissions:
@@ -129,5 +127,5 @@ jobs:
             curl -s -X DELETE \
               "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT_NAME/deployments/$ID?force=true" \
               -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" | \
-              jq -r 'if .success then "Deleted " + .result.id else "Skipped: " + (.errors[0].message // "unknown error") end'
+              jq -r 'if .success then "Deleted " + (.result.id // "deployment") else "Skipped: " + (.errors[0].message // "unknown error") end'
           done

--- a/.github/workflows/deploy-api-client.yml
+++ b/.github/workflows/deploy-api-client.yml
@@ -1,6 +1,8 @@
 name: Deploy API Client
 
 on:
+  pull_request:
+    types: [closed]
   workflow_call:
     inputs:
       environment:
@@ -23,6 +25,8 @@ on:
 
 jobs:
   deploy:
+    # Only run when invoked as a reusable workflow — not on pull_request: closed
+    if: github.event_name == 'workflow_call'
     runs-on: blacksmith-2vcpu-ubuntu-2204
     # Setting environment here (not at the workflow level) is what grants access
     # to the environment-scoped vars.* and secrets.* for staging or production.
@@ -82,3 +86,48 @@ jobs:
           else
             echo "url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
           fi
+
+  # Delete Cloudflare Pages preview deployments when a PR merges to main.
+  # Note: Cloudflare does not allow deleting the latest deployment for a branch,
+  # so the branch alias URL will persist, but all older deployments are cleaned up.
+  teardown:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.actor, '[bot]')
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    # The staging environment holds the CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID,
+    # and CLOUDFLARE_PROJECT_API_CLIENT_PREVIEW vars needed for the preview project.
+    environment: staging
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Delete PR preview deployments from Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT_NAME: ${{ vars.CLOUDFLARE_PROJECT_API_CLIENT_PREVIEW }}
+          BRANCH: pr-${{ github.event.pull_request.number }}
+        run: |
+          echo "Looking for preview deployments on branch: $BRANCH"
+
+          DEPLOYMENT_IDS=$(curl -s \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT_NAME/deployments?page=1&per_page=100" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" | \
+            jq -r ".result[] | select(.deployment_trigger.metadata.branch == \"$BRANCH\") | .id")
+
+          if [ -z "$DEPLOYMENT_IDS" ]; then
+            echo "No preview deployments found for $BRANCH — nothing to delete"
+            exit 0
+          fi
+
+          for ID in $DEPLOYMENT_IDS; do
+            echo "Deleting deployment $ID..."
+            curl -s -X DELETE \
+              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT_NAME/deployments/$ID?force=true" \
+              -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" | \
+              jq -r 'if .success then "Deleted " + .result.id else "Skipped: " + (.errors[0].message // "unknown error") end'
+          done

--- a/.github/workflows/deploy-api-client.yml
+++ b/.github/workflows/deploy-api-client.yml
@@ -1,0 +1,83 @@
+name: Deploy API Client
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Deployment environment — "staging" for PR previews, "production" for releases'
+        type: string
+        required: true
+      pr-number:
+        description: 'Pull request number (required for staging previews)'
+        type: string
+        required: false
+        default: ''
+      sha:
+        description: 'Commit SHA to deploy — PR head SHA for previews, git SHA for releases'
+        type: string
+        required: true
+    outputs:
+      preview-url:
+        description: 'The Cloudflare Pages deployment URL (staging only)'
+        value: ${{ jobs.deploy.outputs.preview-url }}
+
+jobs:
+  deploy:
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    # Setting environment here (not at the workflow level) is what grants access
+    # to the environment-scoped vars.* and secrets.* for staging or production.
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 15
+    outputs:
+      preview-url: ${{ steps.set-output.outputs.url }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Build
+      - name: Build workspace deps
+        uses: ./.github/actions/build
+        with:
+          packages: 'scalar-app...'
+      - name: Build web app
+        run: pnpm --filter scalar-app build:web
+        env:
+          VITE_DASHBOARD_URL: ${{ vars.DASHBOARD_URL }}
+          VITE_API_URL: ${{ vars.API_URL }}
+          VITE_ENV: ${{ vars.ENVIRONMENT }}
+
+      # PR preview deploy — branch name creates a unique Cloudflare Pages alias URL per PR
+      - name: Deploy PR preview to Cloudflare Pages
+        if: inputs.pr-number != ''
+        id: deploy-preview
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ./projects/scalar-app/dist/web --project-name=${{ vars.CLOUDFLARE_PROJECT_API_CLIENT_PREVIEW }} --branch=pr-${{ inputs.pr-number }} --commit-hash=${{ inputs.sha }}
+
+      # Main branch deploy — used for both staging (merge) and production (release).
+      # The active environment determines which vars/secrets are used, not this step.
+      - name: Deploy to Cloudflare Pages
+        if: inputs.pr-number == ''
+        id: deploy-main
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ./projects/scalar-app/dist/web --project-name=${{ vars.CLOUDFLARE_PROJECT_API_CLIENT }} --branch=main --commit-hash=${{ inputs.sha }}
+
+      # Only set the preview URL when deploying from a PR — merge and release deploys
+      # have no PR comment to link back to.
+      - name: Set output
+        if: inputs.pr-number != ''
+        id: set-output
+        run: |
+          ALIAS_URL='${{ steps.deploy-preview.outputs.pages-deployment-alias-url }}'
+          DEPLOYMENT_URL='${{ steps.deploy-preview.outputs.deployment-url }}'
+          if [ -n "$ALIAS_URL" ]; then
+            echo "url=$ALIAS_URL" >> $GITHUB_OUTPUT
+          else
+            echo "url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/deploy-api-client.yml
+++ b/.github/workflows/deploy-api-client.yml
@@ -25,8 +25,8 @@ on:
 
 jobs:
   deploy:
-    # Only run when invoked as a reusable workflow — not on pull_request: closed
-    if: github.event_name == 'workflow_call'
+    # Skip when triggered directly by pull_request: closed (that path runs teardown instead).
+    if: github.event.action != 'closed'
     runs-on: blacksmith-2vcpu-ubuntu-2204
     # Setting environment here (not at the workflow level) is what grants access
     # to the environment-scoped vars.* and secrets.* for staging or production.

--- a/projects/scalar-app/.env.example
+++ b/projects/scalar-app/.env.example
@@ -1,2 +1,3 @@
 VITE_DASHBOARD_URL=http://localhost:3560
-VITE_API_URL=http://localhost:9999
+VITE_API_URL=http://localhost:9999/access
+VITE_SERVICES_URL=http://localhost:9999

--- a/projects/scalar-app/src/App.vue
+++ b/projects/scalar-app/src/App.vue
@@ -40,6 +40,7 @@ const { getAppState, getCommandPaletteState, fileLoader } =
 
 const app = getAppState()
 const { isLoggedIn } = useAuth()
+const { handleLogin, handleRegister } = useAuthHandlers()
 const {
   documents,
   isLoading: isDocumentsLoading,
@@ -49,11 +50,6 @@ const { namespaces, isLoading: isNamespacesLoading } = useRegistryNamespaces()
 
 /** Whether the app is running on electron */
 const isDesktop = window.electron === true
-
-//--------------------------------------------------
-// Login
-//--------------------------------------------------
-const { handleLogin, handleRegister } = useAuthHandlers()
 
 //--------------------------------------------------
 // Workspace handling

--- a/projects/scalar-app/src/environment.ts
+++ b/projects/scalar-app/src/environment.ts
@@ -5,6 +5,7 @@ const deployEnvironments = union([literal('development'), literal('test'), liter
 const environmentSchema = object({
   VITE_ENV: deployEnvironments,
   VITE_API_URL: string(),
+  VITE_SERVICES_URL: string(),
   VITE_DASHBOARD_URL: string(),
 })
 

--- a/projects/scalar-app/src/helpers/auth/exchange-token.test.ts
+++ b/projects/scalar-app/src/helpers/auth/exchange-token.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { exchangeToken } from './exchange-token'
 
 vi.mock('@/environment', () => ({
-  env: { VITE_API_URL: 'https://api.scalar.test' },
+  env: { VITE_SERVICES_URL: 'https://api.scalar.test' },
 }))
 
 const VALID_RESPONSE = {

--- a/projects/scalar-app/src/helpers/auth/exchange-token.ts
+++ b/projects/scalar-app/src/helpers/auth/exchange-token.ts
@@ -8,7 +8,7 @@ import { type TokenResponse, tokenResponseSchema } from './schema'
 /** Exchange a short lived exchange token for access and refresh tokens */
 export const exchangeToken = async (token: string): Promise<ErrorResponse<TokenResponse>> => {
   try {
-    const response = await fetch(`${env.VITE_API_URL}/core/login/exchange`, {
+    const response = await fetch(`${env.VITE_SERVICES_URL}/core/login/exchange`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',

--- a/projects/scalar-app/src/helpers/scalar-client.ts
+++ b/projects/scalar-app/src/helpers/scalar-client.ts
@@ -14,7 +14,7 @@ export const DEFAULT_REFETCH_INTERVAL = 1000 * 60
 
 /** Single SDK client for the app */
 export const scalarClient = new Scalar({
-  serverURL: `${env.VITE_API_URL}/access`,
+  serverURL: `${env.VITE_API_URL}`,
   bearerAuth: async () => {
     // Ensure the access token is fresh
     await checkRefresh()

--- a/projects/scalar-app/src/hooks/use-auth.test.ts
+++ b/projects/scalar-app/src/hooks/use-auth.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/environment', () => ({
-  env: { VITE_API_URL: 'https://api.scalar.test' },
+  env: { VITE_SERVICES_URL: 'https://api.scalar.test' },
 }))
 
 import { useAuth } from './use-auth'

--- a/projects/scalar-app/src/hooks/use-auth.ts
+++ b/projects/scalar-app/src/hooks/use-auth.ts
@@ -100,7 +100,7 @@ const refreshTokens = (): Promise<void> => {
 
   const execute = async (): Promise<void> => {
     try {
-      const response = await fetch(`${env.VITE_API_URL}/core/login/refresh`, {
+      const response = await fetch(`${env.VITE_SERVICES_URL}/core/login/refresh`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`deploy-api-client` only deploys pull request previews right now, so release commits on `main` do not publish a main-branch Cloudflare Pages deployment for the API client.

## Solution

- Expand the job-level `if` condition to also run when the workflow is on `main` and the head commit message starts with `RELEASING:`.
- Split Cloudflare deployment into two explicit steps:
  - PR preview deploy (`--branch=pr-<number>`, PR commit hash)
  - main release deploy (`--branch=main`, `${{ github.sha }}`)
- Keep preview URL output generation scoped to pull requests so the preview comment flow remains unchanged.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-192dfdb1-17eb-4ada-9424-277c13df6c10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-192dfdb1-17eb-4ada-9424-277c13df6c10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

