### PR TITLE
fix(scalar-app): use the correct scalar api url

### DIFF
--- a/.changeset/kind-knives-serve.md
+++ b/.changeset/kind-knives-serve.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: api url

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -817,7 +817,7 @@ jobs:
         run: pnpm --filter scalar-app build:web
         env:
           VITE_DASHBOARD_URL: ${{ vars.DASHBOARD_URL }}
-          VITE_API_URL: ${{ vars.SERVICES_URL }}
+          VITE_API_URL: ${{ vars.API_URL }}
           VITE_ENV: ${{ vars.ENVIRONMENT }}
 
       - name: Deploy to Cloudflare Pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -817,7 +817,7 @@ jobs:
         run: pnpm --filter scalar-app build:web
         env:
           VITE_DASHBOARD_URL: ${{ vars.DASHBOARD_URL }}
-          VITE_SERVICES_URL: ${{ vars.SERVICES_URL }}
+          VITE_API_URL: ${{ vars.SERVICES_URL }}
           VITE_ENV: ${{ vars.ENVIRONMENT }}
 
       - name: Deploy to Cloudflare Pages

--- a/projects/scalar-app/.env.example
+++ b/projects/scalar-app/.env.example
@@ -1,3 +1,2 @@
 VITE_DASHBOARD_URL=http://localhost:3560
-# Note: The electron node context cannot leverage the Vite proxy plugin so we need the full URL
-VITE_SERVICES_URL=http://localhost:9999
+VITE_API_URL=http://localhost:9999

--- a/projects/scalar-app/src/App.vue
+++ b/projects/scalar-app/src/App.vue
@@ -185,13 +185,10 @@ const registry = reactive({
       <template
         v-if="!isLoggedIn"
         #header-end>
-        <ScalarHeaderButton
-          is="a"
-          @click.prevent="handleLogin">
+        <ScalarHeaderButton @click.prevent="handleLogin">
           Log in
         </ScalarHeaderButton>
         <ScalarHeaderButton
-          is="a"
           cta
           @click.prevent="handleRegister">
           Register

--- a/projects/scalar-app/src/environment.ts
+++ b/projects/scalar-app/src/environment.ts
@@ -4,7 +4,7 @@ const deployEnvironments = union([literal('development'), literal('test'), liter
 
 const environmentSchema = object({
   VITE_ENV: deployEnvironments,
-  VITE_SERVICES_URL: string(),
+  VITE_API_URL: string(),
   VITE_DASHBOARD_URL: string(),
 })
 

--- a/projects/scalar-app/src/helpers/auth/exchange-token.test.ts
+++ b/projects/scalar-app/src/helpers/auth/exchange-token.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { exchangeToken } from './exchange-token'
 
 vi.mock('@/environment', () => ({
-  env: { VITE_SERVICES_URL: 'https://api.scalar.test' },
+  env: { VITE_API_URL: 'https://api.scalar.test' },
 }))
 
 const VALID_RESPONSE = {

--- a/projects/scalar-app/src/helpers/auth/exchange-token.ts
+++ b/projects/scalar-app/src/helpers/auth/exchange-token.ts
@@ -8,7 +8,7 @@ import { type TokenResponse, tokenResponseSchema } from './schema'
 /** Exchange a short lived exchange token for access and refresh tokens */
 export const exchangeToken = async (token: string): Promise<ErrorResponse<TokenResponse>> => {
   try {
-    const response = await fetch(`${env.VITE_SERVICES_URL}/core/login/exchange`, {
+    const response = await fetch(`${env.VITE_API_URL}/core/login/exchange`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',

--- a/projects/scalar-app/src/helpers/scalar-client.ts
+++ b/projects/scalar-app/src/helpers/scalar-client.ts
@@ -14,7 +14,7 @@ export const DEFAULT_REFETCH_INTERVAL = 1000 * 60
 
 /** Single SDK client for the app */
 export const scalarClient = new Scalar({
-  serverURL: `${env.VITE_SERVICES_URL}/access`,
+  serverURL: `${env.VITE_API_URL}/access`,
   bearerAuth: async () => {
     // Ensure the access token is fresh
     await checkRefresh()

--- a/projects/scalar-app/src/hooks/use-auth.test.ts
+++ b/projects/scalar-app/src/hooks/use-auth.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/environment', () => ({
-  env: { VITE_SERVICES_URL: 'https://api.scalar.test' },
+  env: { VITE_API_URL: 'https://api.scalar.test' },
 }))
 
 import { useAuth } from './use-auth'

--- a/projects/scalar-app/src/hooks/use-auth.ts
+++ b/projects/scalar-app/src/hooks/use-auth.ts
@@ -100,7 +100,7 @@ const refreshTokens = (): Promise<void> => {
 
   const execute = async (): Promise<void> => {
     try {
-      const response = await fetch(`${env.VITE_SERVICES_URL}/core/login/refresh`, {
+      const response = await fetch(`${env.VITE_API_URL}/core/login/refresh`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',


### PR DESCRIPTION
## Problem

Previously I had grabbed the wrong services URL.

## Solution

Bruno informed me of the correct API URL. I have updated it in github

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk variable rename/rewire affecting where the app points for auth and SDK requests; main risk is misconfiguration if `API_URL`/`VITE_API_URL` isn’t set consistently across environments.
> 
> **Overview**
> **Updates `scalar-app` to use the correct API base URL.** Replaces `VITE_SERVICES_URL` with `VITE_API_URL` in environment validation and all API calls (token exchange/refresh and the `Scalar` SDK `serverURL`).
> 
> Aligns configuration by updating `.env.example` and the CI workflow deploy step to pass `VITE_API_URL` from `vars.API_URL`. Also includes a small template cleanup in `App.vue` (removes `is="a"` on header buttons) and adds a changeset for a patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdee3a100f994eed97682c870965db678983d7a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->