### PR TITLE
ci(api-client): clean up Cloudflare PR previews

### DIFF
--- a/.github/workflows/deploy-api-client.yml
+++ b/.github/workflows/deploy-api-client.yml
@@ -1,8 +1,6 @@
 name: Deploy API Client
 
 on:
-  pull_request:
-    types: [closed]
   workflow_call:
     inputs:
       environment:
@@ -25,8 +23,6 @@ on:
 
 jobs:
   deploy:
-    # Skip when triggered directly by pull_request: closed (that path runs teardown instead).
-    if: github.event.action != 'closed'
     runs-on: blacksmith-2vcpu-ubuntu-2204
     # Setting environment here (not at the workflow level) is what grants access
     # to the environment-scoped vars.* and secrets.* for staging or production.
@@ -86,46 +82,3 @@ jobs:
           else
             echo "url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
           fi
-
-  # Delete Cloudflare Pages preview deployments when a PR merges to main.
-  # The ?force=true parameter allows deletion of aliased (latest) deployments,
-  # so this should clean up all deployments including the branch alias URL.
-  teardown:
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.base.ref == 'main' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      !contains(github.actor, '[bot]')
-    runs-on: blacksmith-2vcpu-ubuntu-2204
-    environment: staging
-    timeout-minutes: 5
-    permissions:
-      contents: read
-    steps:
-      - name: Delete PR preview deployments from Cloudflare Pages
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          PROJECT_NAME: ${{ vars.CLOUDFLARE_PROJECT_API_CLIENT_PREVIEW }}
-          BRANCH: pr-${{ github.event.pull_request.number }}
-        run: |
-          echo "Looking for preview deployments on branch: $BRANCH"
-
-          DEPLOYMENT_IDS=$(curl -s \
-            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT_NAME/deployments?page=1&per_page=100" \
-            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" | \
-            jq -r ".result[] | select(.deployment_trigger.metadata.branch == \"$BRANCH\") | .id")
-
-          if [ -z "$DEPLOYMENT_IDS" ]; then
-            echo "No preview deployments found for $BRANCH — nothing to delete"
-            exit 0
-          fi
-
-          for ID in $DEPLOYMENT_IDS; do
-            echo "Deleting deployment $ID..."
-            curl -s -X DELETE \
-              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT_NAME/deployments/$ID?force=true" \
-              -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" | \
-              jq -r 'if .success then "Deleted " + (.result.id // "deployment") else "Skipped: " + (.errors[0].message // "unknown error") end'
-          done

--- a/.github/workflows/teardown-api-client-preview.yml
+++ b/.github/workflows/teardown-api-client-preview.yml
@@ -1,0 +1,31 @@
+name: Teardown API Client Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  teardown:
+    # PR previews are only deployed for same-repository PRs targeting main.
+    if: |
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: staging
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Delete PR preview deployments from Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT_NAME: ${{ vars.CLOUDFLARE_PROJECT_API_CLIENT_PREVIEW }}
+          BRANCH: pr-${{ github.event.pull_request.number }}
+        shell: bash
+        run: bash ./tooling/scripts/delete-cloudflare-pages-preview.sh

--- a/tooling/scripts/delete-cloudflare-pages-preview.sh
+++ b/tooling/scripts/delete-cloudflare-pages-preview.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${CLOUDFLARE_API_TOKEN:?Missing CLOUDFLARE_API_TOKEN}"
+: "${CLOUDFLARE_ACCOUNT_ID:?Missing CLOUDFLARE_ACCOUNT_ID}"
+: "${PROJECT_NAME:?Missing PROJECT_NAME}"
+: "${BRANCH:?Missing BRANCH}"
+
+curl_command="${CURL_COMMAND:-curl}"
+base_url="${CLOUDFLARE_API_BASE_URL:-https://api.cloudflare.com/client/v4}"
+
+echo "Looking for preview deployments on branch: $BRANCH"
+
+deployment_ids_file="$(mktemp)"
+page=1
+total_pages=1
+
+while [ "$page" -le "$total_pages" ]; do
+  response_file="$(mktemp)"
+  status_code="$("$curl_command" --silent --show-error --write-out '%{http_code}' --output "$response_file" \
+    "$base_url/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT_NAME/deployments?env=preview&page=$page&per_page=100" \
+    --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN")"
+
+  if [ "$status_code" -lt 200 ] || [ "$status_code" -ge 300 ]; then
+    echo "Failed to list Cloudflare Pages deployments (HTTP $status_code)"
+    jq -r '.errors[]?.message // .' "$response_file"
+    exit 1
+  fi
+
+  if [ "$(jq -r '.success' "$response_file")" != 'true' ]; then
+    echo "Failed to list Cloudflare Pages deployments"
+    jq -r '.errors[]?.message // .' "$response_file"
+    exit 1
+  fi
+
+  jq -r --arg branch "$BRANCH" \
+    '.result // [] | .[] | select(.deployment_trigger.metadata.branch? == $branch) | .id' \
+    "$response_file" >> "$deployment_ids_file"
+
+  total_pages="$(jq -r '.result_info.total_pages // 1' "$response_file")"
+  echo "Scanned Cloudflare deployment page $page of $total_pages"
+  page=$((page + 1))
+done
+
+mapfile -t deployment_ids < <(sort -u "$deployment_ids_file")
+
+if [ "${#deployment_ids[@]}" -eq 0 ]; then
+  echo "No preview deployments found for $BRANCH; nothing to delete"
+  exit 0
+fi
+
+for deployment_id in "${deployment_ids[@]}"; do
+  response_file="$(mktemp)"
+  status_code="$("$curl_command" --silent --show-error --request DELETE --write-out '%{http_code}' --output "$response_file" \
+    "$base_url/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT_NAME/deployments/$deployment_id?force=true" \
+    --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN")"
+
+  if [ "$status_code" -lt 200 ] || [ "$status_code" -ge 300 ]; then
+    echo "Failed to delete Cloudflare Pages deployment $deployment_id (HTTP $status_code)"
+    jq -r '.errors[]?.message // .' "$response_file"
+    exit 1
+  fi
+
+  if [ "$(jq -r '.success' "$response_file")" != 'true' ]; then
+    echo "Failed to delete Cloudflare Pages deployment $deployment_id"
+    jq -r '.errors[]?.message // .' "$response_file"
+    exit 1
+  fi
+
+  echo "Deleted deployment $deployment_id"
+done

--- a/tooling/scripts/delete-cloudflare-pages-preview.test.ts
+++ b/tooling/scripts/delete-cloudflare-pages-preview.test.ts
@@ -1,0 +1,97 @@
+import { spawnSync } from 'node:child_process'
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const scriptPath = join(dirname(fileURLToPath(import.meta.url)), 'delete-cloudflare-pages-preview.sh')
+
+const runWithFakeCurl = (fakeCurlSource: string) => {
+  const directory = mkdtempSync(join(tmpdir(), 'cf-preview-test-'))
+  const fakeCurlPath = join(directory, 'fake-curl.js')
+  const recordFilePath = join(directory, 'deleted.txt')
+
+  writeFileSync(fakeCurlPath, `#!/usr/bin/env node\n${fakeCurlSource}`)
+  chmodSync(fakeCurlPath, 0o755)
+
+  const result = spawnSync('bash', [scriptPath], {
+    cwd: join(dirname(fileURLToPath(import.meta.url)), '../..'),
+    env: {
+      ...process.env,
+      BRANCH: 'pr-123',
+      CLOUDFLARE_ACCOUNT_ID: 'account',
+      CLOUDFLARE_API_TOKEN: 'token',
+      CURL_COMMAND: fakeCurlPath,
+      PROJECT_NAME: 'project',
+      RECORD_FILE: recordFilePath,
+    },
+    encoding: 'utf8',
+  })
+
+  return { result, recordFilePath }
+}
+
+describe('delete-cloudflare-pages-preview', () => {
+  it('deletes matching deployments across paginated results', () => {
+    const fakeCurlSource = String.raw`
+const { appendFileSync, writeFileSync } = require('node:fs')
+const args = process.argv.slice(2)
+const output = args[args.indexOf('--output') + 1]
+const url = args.find((arg) => arg.startsWith('https://'))
+const method = args.includes('--request') ? args[args.indexOf('--request') + 1] : 'GET'
+
+if (method === 'DELETE') {
+  const id = url.match(/deployments\/([^?]+)/)[1]
+  appendFileSync(process.env.RECORD_FILE, id + '\n')
+  writeFileSync(output, JSON.stringify({ success: true, result: {} }))
+  process.stdout.write('200')
+  process.exit(0)
+}
+
+const page = Number(new URL(url).searchParams.get('page'))
+const result = page === 1
+  ? [
+      { id: 'skip-other-branch', deployment_trigger: { metadata: { branch: 'pr-999' } } },
+      { id: 'delete-page-1', deployment_trigger: { metadata: { branch: 'pr-123' } } },
+    ]
+  : [{ id: 'delete-page-2', deployment_trigger: { metadata: { branch: 'pr-123' } } }]
+
+writeFileSync(output, JSON.stringify({ success: true, result, result_info: { total_pages: 2 } }))
+process.stdout.write('200')
+`
+
+    const { result, recordFilePath } = runWithFakeCurl(fakeCurlSource)
+
+    expect(result.status).toBe(0)
+    expect(result.stdout.trim().split('\n')).toStrictEqual([
+      'Looking for preview deployments on branch: pr-123',
+      'Scanned Cloudflare deployment page 1 of 2',
+      'Scanned Cloudflare deployment page 2 of 2',
+      'Deleted deployment delete-page-1',
+      'Deleted deployment delete-page-2',
+    ])
+    expect(readFileSync(recordFilePath, 'utf8').trim().split('\n')).toStrictEqual(['delete-page-1', 'delete-page-2'])
+  })
+
+  it('reports Cloudflare API errors', () => {
+    const fakeCurlSource = String.raw`
+const { writeFileSync } = require('node:fs')
+const args = process.argv.slice(2)
+const output = args[args.indexOf('--output') + 1]
+
+writeFileSync(output, JSON.stringify({ success: false, result: null, errors: [{ message: 'project not found' }] }))
+process.stdout.write('200')
+`
+
+    const { result } = runWithFakeCurl(fakeCurlSource)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout.trim().split('\n')).toStrictEqual([
+      'Looking for preview deployments on branch: pr-123',
+      'Failed to list Cloudflare Pages deployments',
+      'project not found',
+    ])
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

API client Cloudflare preview teardown was colocated in the reusable deploy workflow, so the main-branch CI run showed a skipped teardown job even though PR-close cleanup should be a separate path. The direct PR-close run also failed when Cloudflare returned an error-shaped response with a null `result`, and the old condition only attempted cleanup for merged PRs.

## Solution

Move PR preview cleanup into a dedicated `pull_request.closed` workflow for same-repo PRs targeting `main`. The workflow checks out the base ref and runs a reusable shell script that paginates preview deployments, filters by the `pr-<number>` branch, deletes matching deployments with `force=true`, and reports Cloudflare API errors clearly.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. Not applicable; CI/tooling only.
- [x] I added tests.
- [ ] I updated the documentation. Not applicable; workflow-only change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-123eaa92-4fa7-42e0-b8fc-1b8e4fcaa924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-123eaa92-4fa7-42e0-b8fc-1b8e4fcaa924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

