### PR TITLE
fix(json-magic): strip a leading UTF-8 BOM before JSON.parse in normalize so BOM-prefixed files parse correctly

### DIFF
--- a/.changeset/lemon-falcons-hear.md
+++ b/.changeset/lemon-falcons-hear.md
@@ -1,0 +1,5 @@
+---
+'@scalar/json-magic': patch
+---
+
+fix: strip a leading UTF-8 BOM before JSON.parse in normalize so BOM-prefixed files parse correctly

--- a/packages/json-magic/src/bundle/bundle.test.ts
+++ b/packages/json-magic/src/bundle/bundle.test.ts
@@ -86,6 +86,37 @@ describe('bundle', () => {
       },
     )
 
+    it('bundles external references when the remote JSON is prefixed with a UTF-8 BOM', async () => {
+      const external = {
+        prop: 'from bom payload',
+      }
+      server.get('/', (_, reply) => {
+        reply.header('Content-Type', 'application/json').send(`\uFEFF${JSON.stringify(external)}`)
+      })
+
+      await server.listen({ port: 0 })
+      url = `http://localhost:${(server.server.address() as AddressInfo).port}`
+
+      const input = {
+        d: {
+          '$ref': `${url}#/prop`,
+        },
+      }
+
+      await bundle(input, { plugins: [fetchUrls(), readFiles()], treeShake: false })
+
+      expect(input).toEqual({
+        'x-ext': {
+          [getHash(url)]: {
+            ...external,
+          },
+        },
+        d: {
+          $ref: `#/x-ext/${getHash(url)}/prop`,
+        },
+      })
+    })
+
     it('bundles external urls from resolved external piece', async () => {
       const chunk2 = {
         hey: 'hey',
@@ -1959,6 +1990,23 @@ describe('bundle', () => {
           [getHash(chunk1Path)]: chunk1Path,
         },
       })
+    })
+
+    it('parses file path input when the file is JSON prefixed with a UTF-8 BOM', async () => {
+      const spec = {
+        openapi: '3.1.0',
+        info: { title: 'BOM entry', version: '1' },
+        paths: {},
+      }
+      const name = `${randomUUID()}.json`
+      const fullPath = path.join(import.meta.dirname, name)
+      await fs.writeFile(fullPath, `\uFEFF${JSON.stringify(spec)}`, 'utf8')
+
+      const result = await bundle(fullPath, { plugins: [fetchUrls(), readFiles()], treeShake: false })
+
+      await fs.rm(fullPath)
+
+      expect(result).toEqual(spec)
     })
   })
 

--- a/packages/json-magic/src/helpers/normalize.test.ts
+++ b/packages/json-magic/src/helpers/normalize.test.ts
@@ -7,9 +7,14 @@ describe('normalize', () => {
     expect(normalize(null)).toEqual(undefined)
   })
 
-  it('should parse JSON string specifications', () => {
+  it('parses JSON string specifications', () => {
     const jsonString = '{"foo": "bar"}'
     expect(normalize(jsonString)).toEqual({ foo: 'bar' })
+  })
+
+  it('parses JSON with a leading UTF-8 BOM', () => {
+    const jsonWithBom = `\uFEFF${JSON.stringify({ foo: 'bar' })}`
+    expect(normalize(jsonWithBom)).toEqual({ foo: 'bar' })
   })
 
   it('should parse YAML string specifications', () => {

--- a/packages/json-magic/src/helpers/normalize.ts
+++ b/packages/json-magic/src/helpers/normalize.ts
@@ -1,30 +1,39 @@
 import { parse } from 'yaml'
 
 /**
+ * Strip a leading UTF-8 BOM (U+FEFF). Editors on Windows often write this
+ * prefix; {@link JSON.parse} rejects it as an unexpected token.
+ */
+const stripLeadingUtf8Bom = (value: string): string => (value.startsWith('\uFEFF') ? value.slice(1) : value)
+
+/**
  * Normalize a string (YAML, JSON, object) to a JavaScript datatype.
  */
-export function normalize(content: any) {
+export function normalize(content: unknown): unknown {
   if (content === null) {
     return undefined
   }
 
   if (typeof content === 'string') {
-    if (content.trim() === '') {
+    const withoutBom = stripLeadingUtf8Bom(content)
+
+    if (withoutBom.trim() === '') {
       return undefined
     }
 
     try {
-      return JSON.parse(content)
-    } catch (_error) {
+      return JSON.parse(withoutBom)
+    } catch {
       // Does it look like YAML?
-      const hasColon = /^[^:]+:/.test(content)
-      const isJson = content.slice(0, 50).trimStart().startsWith('{')
+      const hasColon = /^[^:]+:/.test(withoutBom)
+      const trimmedStart = withoutBom.slice(0, 50).trimStart()
+      const looksLikeJson = trimmedStart.startsWith('{') || trimmedStart.startsWith('[')
 
-      if (!hasColon || isJson) {
+      if (!hasColon || looksLikeJson) {
         return undefined
       }
 
-      return parse(content, {
+      return parse(withoutBom, {
         maxAliasCount: 10000,
         merge: true,
       })


### PR DESCRIPTION
Fixes: #9097

For documents which starts with a UTF-8 BOM, `JSON.parse` throws an error, which was causing bundling json documents bundling to fail.

This PR strips `U+FEFF` so we can safe parse it.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to input normalization that only strips a leading BOM before parsing, with added tests covering remote and file-based JSON bundling paths.
> 
> **Overview**
> Fixes BOM-prefixed JSON inputs by stripping a leading UTF-8 BOM (`U+FEFF`) before attempting `JSON.parse` in `normalize`, and updates the JSON/YAML sniffing logic to use the sanitized string.
> 
> Adds regression tests to ensure bundling works for BOM-prefixed remote JSON payloads and BOM-prefixed JSON files, plus a direct `normalize` unit test, and includes a patch changeset for `@scalar/json-magic`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 895f1c71737904d83ca9d0e0098d5d0ab9c4f0d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->