### PR TITLE
fix(scalar-app): monaco editor vite plugin

### DIFF
--- a/.changeset/common-cows-fall.md
+++ b/.changeset/common-cows-fall.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: monaco editor vite plugin

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,9 @@ catalogs:
     vite-plugin-monaco-editor:
       specifier: 1.1.0
       version: 1.1.0
+    vite-plugin-monaco-editor-esm:
+      specifier: 2.0.2
+      version: 2.0.2
     vite-ssg:
       specifier: 28.3.0
       version: 28.3.0
@@ -2706,9 +2709,6 @@ importers:
       undici:
         specifier: 7.24.4
         version: 7.24.4
-      vite-plugin-monaco-editor:
-        specifier: catalog:*
-        version: 1.1.0(monaco-editor@0.55.1)
     devDependencies:
       '@playwright/test':
         specifier: catalog:*
@@ -2734,6 +2734,12 @@ importers:
       vite:
         specifier: catalog:*
         version: 8.0.0(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite-plugin-monaco-editor:
+        specifier: catalog:*
+        version: 1.1.0(monaco-editor@0.55.1)
+      vite-plugin-monaco-editor-esm:
+        specifier: catalog:*
+        version: 2.0.2(monaco-editor@0.55.1)
       vue:
         specifier: catalog:*
         version: 3.5.30(typescript@5.9.3)
@@ -18247,6 +18253,11 @@ packages:
     peerDependenciesMeta:
       '@nuxt/kit':
         optional: true
+
+  vite-plugin-monaco-editor-esm@2.0.2:
+    resolution: {integrity: sha512-XVkOpL/r0rw1NpbO30vUwG4S0THkC9KB1vjjV8olGd49h4/EQsKl3DrxB6KRDwyZNC9mKiiZgk2L6njUYj3oKQ==}
+    peerDependencies:
+      monaco-editor: '>=0.33.0'
 
   vite-plugin-monaco-editor@1.1.0:
     resolution: {integrity: sha512-IvtUqZotrRoVqwT0PBBDIZPNraya3BxN/bfcNfnxZ5rkJiGcNtO5eAOWWSgT7zullIAEqQwxMU83yL9J5k7gww==}
@@ -38342,6 +38353,10 @@ snapshots:
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
     transitivePeerDependencies:
       - supports-color
+
+  vite-plugin-monaco-editor-esm@2.0.2(monaco-editor@0.55.1):
+    dependencies:
+      monaco-editor: 0.55.1
 
   vite-plugin-monaco-editor@1.1.0(monaco-editor@0.55.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -93,6 +93,7 @@ catalogs:
     truncate-json: 3.0.1
     tsx: 4.19.4
     vite-plugin-monaco-editor: 1.1.0
+    vite-plugin-monaco-editor-esm: 2.0.2
     vite-ssg: 28.3.0
     vite-svg-loader: 5.1.1
     vite-plugin-css-injected-by-js: ^5.0.0

--- a/projects/scalar-app/package.json
+++ b/projects/scalar-app/package.json
@@ -65,8 +65,7 @@
     "monaco-editor": "catalog:*",
     "monaco-yaml": "catalog:*",
     "posthog-js": "catalog:*",
-    "undici": "catalog:*",
-    "vite-plugin-monaco-editor": "catalog:*"
+    "undici": "catalog:*"
   },
   "devDependencies": {
     "@playwright/test": "catalog:*",
@@ -77,6 +76,8 @@
     "electron": "41.2.2",
     "electron-vite": "6.0.0-beta.1",
     "vite": "catalog:*",
-    "vue": "catalog:*"
+    "vue": "catalog:*",
+    "vite-plugin-monaco-editor": "catalog:*",
+    "vite-plugin-monaco-editor-esm": "catalog:*"
   }
 }

--- a/projects/scalar-app/vite.config.ts
+++ b/projects/scalar-app/vite.config.ts
@@ -1,13 +1,13 @@
-import { createRequire } from 'node:module'
-import { resolve } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
+import monacoEditorPlugin from 'vite-plugin-monaco-editor-esm'
 
-const require = createRequire(import.meta.url)
-const monacoEditorPlugin = require('vite-plugin-monaco-editor').default
-const { version: scalarAppVersion } = require('./package.json')
+import packageJson from './package.json' with { type: 'json' }
+
+const { version: scalarAppVersion } = packageJson
 
 export default defineConfig({
   root: resolve('entrypoints/web'),
@@ -39,6 +39,10 @@ export default defineConfig({
           entry: 'monaco-yaml/yaml.worker',
         },
       ],
+      // The plugin computes its dist path with `path.join(root, outDir, base, publicPath)`,
+      // which produces a broken nested path when `root` and `outDir` are absolute (as they
+      // are here). Resolve it ourselves so workers land in `<outDir>/monacoeditorwork/`.
+      customDistPath: (_root, outDir, _base) => join(outDir, 'monacoeditorwork'),
     }),
   ],
   build: {


### PR DESCRIPTION
## Problem

The monaco bundle was nowhere to be found.

## Solution

Switched to the better maintained ESM package and set a custom path so we know its there. Verified its there on build. Will verify it works in the preview.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes build tooling for Monaco (plugin swap + custom worker dist path), which could break editor worker loading or asset paths in production builds.
> 
> **Overview**
> Fixes `scalar-app` Monaco bundling by switching the web build from `vite-plugin-monaco-editor` (CJS via `createRequire`) to `vite-plugin-monaco-editor-esm` and reading `package.json` via ESM JSON import.
> 
> Adds a `customDistPath` override in `projects/scalar-app/vite.config.ts` so Monaco worker assets are emitted to a predictable `<outDir>/monacoeditorwork` directory when `root`/`outDir` are absolute. Dependency/catalog and lockfile updates add `vite-plugin-monaco-editor-esm`, and `scalar-app` moves Monaco Vite plugins into `devDependencies`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6b753045aaa10852a9baf5043bbdc10cf211a4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->