### PR TITLE
fix(api-reference): lower badge style specificity

### DIFF
--- a/.changeset/pretty-tables-bake.md
+++ b/.changeset/pretty-tables-bake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): lower badge style specificity

--- a/packages/api-reference/src/components/Badge/Badge.vue
+++ b/packages/api-reference/src/components/Badge/Badge.vue
@@ -24,7 +24,7 @@ const badgeStyle = computed(() =>
 </template>
 
 <style scoped>
-.badge {
+:where(.badge) {
   color: var(--badge-text-color, var(--scalar-color-2));
   font-size: var(--scalar-mini);
   background: var(--badge-background-color, var(--scalar-background-2));
@@ -34,23 +34,23 @@ const badgeStyle = computed(() =>
   border-radius: 12px;
   display: inline-block;
 }
-.badge.text-orange {
+:where(.badge).text-orange {
   background: color-mix(in srgb, var(--scalar-color-orange), transparent 90%);
   border: transparent;
 }
-.badge.text-yellow {
+:where(.badge).text-yellow {
   background: color-mix(in srgb, var(--scalar-color-yellow), transparent 90%);
   border: transparent;
 }
-.badge.text-red {
+:where(.badge).text-red {
   background: color-mix(in srgb, var(--scalar-color-red), transparent 90%);
   border: transparent;
 }
-.badge.text-purple {
+:where(.badge).text-purple {
   background: color-mix(in srgb, var(--scalar-color-purple), transparent 90%);
   border: transparent;
 }
-.badge.text-green {
+:where(.badge).text-green {
   background: color-mix(in srgb, var(--scalar-color-green), transparent 90%);
   border: transparent;
 }


### PR DESCRIPTION
Looks like the specificity here was causing issues. Lowered it to 0,1,0 (cause it's scoped).

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
