### PR TITLE
fix(server-side-rendering): build does not emit .d.ts declaration files

### DIFF
--- a/packages/server-side-rendering/package.json
+++ b/packages/server-side-rendering/package.json
@@ -16,7 +16,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && vue-tsc -p tsconfig.build.json",
     "dev": "tsx playground/server.ts",
     "test": "vitest --run",
     "types:check": "tsc --noEmit"
@@ -44,6 +44,7 @@
     "@vitejs/plugin-vue": "catalog:*",
     "hono": "catalog:*",
     "tsx": "catalog:*",
-    "vite": "catalog:*"
+    "vite": "catalog:*",
+    "vue-tsc": "catalog:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2283,6 +2283,9 @@ importers:
       vite:
         specifier: catalog:*
         version: 8.0.0(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.19.4)(yaml@2.8.3)
+      vue-tsc:
+        specifier: catalog:*
+        version: 3.2.4(typescript@5.9.3)
 
   packages/sidebar:
     dependencies:


### PR DESCRIPTION
## Problem

<!--
  What problem does the PR solve?
  WHY did you submit the PR?

  We are interested in the WHY (LLMs won't know).
-->

`@scalar/server-side-rendering` was missing TypeScript declaration files (`.d.ts`) in its build output. 

## Solution

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

Added `vue-tsc -p tsconfig.build.json` to the build script. The `tsconfig.build.json` was already correctly configured with `declaration: true` and `noEmit: false`, it simply was never called. This follows the same pattern used by other Vite-built packages in the monorepo (`draggable`,`icons`, `openapi-to-markdown`, `sidebar`).

Added `vue-tsc` to `devDependencies` using the workspace catalog version.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

Fixes https://github.com/scalar/scalar/issues/9115
