### PR TITLE
fix: improve Cloudflare Pages preview deletion pagination logic

### DIFF
--- a/tooling/scripts/delete-cloudflare-pages-preview.sh
+++ b/tooling/scripts/delete-cloudflare-pages-preview.sh
@@ -16,7 +16,7 @@
 # stale previews.
 #
 # Required environment variables:
-#   CLOUDFLARE_API_TOKEN   API token with Pages:Edit permission
+#   CLOUDFLARE_API_TOKEN   API token with `Pages Write` permission
 #   CLOUDFLARE_ACCOUNT_ID  Cloudflare account ID that owns the project
 #   PROJECT_NAME           Cloudflare Pages project name (the preview project)
 #   BRANCH                 Branch alias to clean up (e.g. `pr-9101`)
@@ -31,26 +31,54 @@ curl_command="${CURL_COMMAND:-curl}"
 base_url="${CLOUDFLARE_API_BASE_URL:-https://api.cloudflare.com/client/v4}"
 per_page="${CLOUDFLARE_PER_PAGE:-100}"
 
+# Use a single temp directory for all responses so we do not leak files in /tmp
+# across the run. The trap cleans up regardless of how the script exits.
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+response_file="$tmp_dir/response.json"
+deployment_ids_file="$tmp_dir/deployment_ids.txt"
+: > "$deployment_ids_file"
+
+# Print the response body when something goes wrong. Cloudflare usually returns
+# a structured `errors[]` array, but on gateway errors it may return HTML or
+# plain text — so we fall back to dumping the raw body if jq cannot parse it.
+print_error_body() {
+  local file="$1"
+  if ! jq -r '.errors[]?.message // empty' "$file" 2>/dev/null; then
+    cat "$file"
+    return
+  fi
+  # If jq parsed JSON but produced no error messages, surface the raw body so
+  # the failure is still debuggable.
+  if [ ! -s "$file" ] || [ "$(jq -r '.errors // [] | length' "$file" 2>/dev/null || echo 0)" = '0' ]; then
+    cat "$file"
+  fi
+}
+
 echo "Looking for preview deployments on branch: $BRANCH"
 
-deployment_ids_file="$(mktemp)"
 page=1
 
 while true; do
-  response_file="$(mktemp)"
+  # The list endpoint only supports filtering by `env` (production/preview),
+  # not by branch — so we fetch every preview deployment and filter client-side
+  # against `deployment_trigger.metadata.branch`.
   status_code="$("$curl_command" --silent --show-error --write-out '%{http_code}' --output "$response_file" \
     "$base_url/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT_NAME/deployments?env=preview&page=$page&per_page=$per_page" \
     --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN")"
 
   if [ "$status_code" -lt 200 ] || [ "$status_code" -ge 300 ]; then
     echo "Failed to list Cloudflare Pages deployments (HTTP $status_code)"
-    jq -r '.errors[]?.message // .' "$response_file"
+    print_error_body "$response_file"
     exit 1
   fi
 
-  if [ "$(jq -r '.success' "$response_file")" != 'true' ]; then
+  # Cloudflare can return HTTP 200 with `success: false` for logical failures
+  # (project not found, etc.), so we have to check both.
+  if [ "$(jq -r '.success' "$response_file" 2>/dev/null || echo false)" != 'true' ]; then
     echo "Failed to list Cloudflare Pages deployments"
-    jq -r '.errors[]?.message // .' "$response_file"
+    print_error_body "$response_file"
     exit 1
   fi
 
@@ -61,8 +89,9 @@ while true; do
   result_count="$(jq -r '.result // [] | length' "$response_file")"
   echo "Scanned Cloudflare deployment page $page"
 
-  # Stop once we receive a partial page. Cloudflare's listing endpoint does not
-  # always populate result_info.total_pages, so we paginate by page size instead.
+  # Stop once we receive a partial page. We paginate by page size rather than
+  # `result_info.total_pages` for robustness — the latter has been observed to
+  # be missing in practice.
   if [ "$result_count" -lt "$per_page" ]; then
     break
   fi
@@ -79,21 +108,21 @@ fi
 
 failed=0
 for deployment_id in "${deployment_ids[@]}"; do
-  response_file="$(mktemp)"
   status_code="$("$curl_command" --silent --show-error --request DELETE --write-out '%{http_code}' --output "$response_file" \
     "$base_url/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT_NAME/deployments/$deployment_id?force=true" \
     --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN")"
 
   if [ "$status_code" -lt 200 ] || [ "$status_code" -ge 300 ]; then
     echo "Failed to delete Cloudflare Pages deployment $deployment_id (HTTP $status_code)"
-    jq -r '.errors[]?.message // .' "$response_file"
+    print_error_body "$response_file"
     failed=$((failed + 1))
     continue
   fi
 
-  if [ "$(jq -r '.success' "$response_file")" != 'true' ]; then
+  # See note above: a 200 response can still indicate a logical failure.
+  if [ "$(jq -r '.success' "$response_file" 2>/dev/null || echo false)" != 'true' ]; then
     echo "Failed to delete Cloudflare Pages deployment $deployment_id"
-    jq -r '.errors[]?.message // .' "$response_file"
+    print_error_body "$response_file"
     failed=$((failed + 1))
     continue
   fi

--- a/tooling/scripts/delete-cloudflare-pages-preview.sh
+++ b/tooling/scripts/delete-cloudflare-pages-preview.sh
@@ -8,17 +8,17 @@ set -euo pipefail
 
 curl_command="${CURL_COMMAND:-curl}"
 base_url="${CLOUDFLARE_API_BASE_URL:-https://api.cloudflare.com/client/v4}"
+per_page="${CLOUDFLARE_PER_PAGE:-100}"
 
 echo "Looking for preview deployments on branch: $BRANCH"
 
 deployment_ids_file="$(mktemp)"
 page=1
-total_pages=1
 
-while [ "$page" -le "$total_pages" ]; do
+while true; do
   response_file="$(mktemp)"
   status_code="$("$curl_command" --silent --show-error --write-out '%{http_code}' --output "$response_file" \
-    "$base_url/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT_NAME/deployments?env=preview&page=$page&per_page=100" \
+    "$base_url/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT_NAME/deployments?env=preview&page=$page&per_page=$per_page" \
     --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN")"
 
   if [ "$status_code" -lt 200 ] || [ "$status_code" -ge 300 ]; then
@@ -37,8 +37,15 @@ while [ "$page" -le "$total_pages" ]; do
     '.result // [] | .[] | select(.deployment_trigger.metadata.branch? == $branch) | .id' \
     "$response_file" >> "$deployment_ids_file"
 
-  total_pages="$(jq -r '.result_info.total_pages // 1' "$response_file")"
-  echo "Scanned Cloudflare deployment page $page of $total_pages"
+  result_count="$(jq -r '.result // [] | length' "$response_file")"
+  echo "Scanned Cloudflare deployment page $page"
+
+  # Stop once we receive a partial page. Cloudflare's listing endpoint does not
+  # always populate result_info.total_pages, so we paginate by page size instead.
+  if [ "$result_count" -lt "$per_page" ]; then
+    break
+  fi
+
   page=$((page + 1))
 done
 
@@ -49,6 +56,7 @@ if [ "${#deployment_ids[@]}" -eq 0 ]; then
   exit 0
 fi
 
+failed=0
 for deployment_id in "${deployment_ids[@]}"; do
   response_file="$(mktemp)"
   status_code="$("$curl_command" --silent --show-error --request DELETE --write-out '%{http_code}' --output "$response_file" \
@@ -58,14 +66,21 @@ for deployment_id in "${deployment_ids[@]}"; do
   if [ "$status_code" -lt 200 ] || [ "$status_code" -ge 300 ]; then
     echo "Failed to delete Cloudflare Pages deployment $deployment_id (HTTP $status_code)"
     jq -r '.errors[]?.message // .' "$response_file"
-    exit 1
+    failed=$((failed + 1))
+    continue
   fi
 
   if [ "$(jq -r '.success' "$response_file")" != 'true' ]; then
     echo "Failed to delete Cloudflare Pages deployment $deployment_id"
     jq -r '.errors[]?.message // .' "$response_file"
-    exit 1
+    failed=$((failed + 1))
+    continue
   fi
 
   echo "Deleted deployment $deployment_id"
 done
+
+if [ "$failed" -gt 0 ]; then
+  echo "Failed to delete $failed of ${#deployment_ids[@]} deployment(s) for $BRANCH"
+  exit 1
+fi

--- a/tooling/scripts/delete-cloudflare-pages-preview.sh
+++ b/tooling/scripts/delete-cloudflare-pages-preview.sh
@@ -1,4 +1,25 @@
 #!/usr/bin/env bash
+#
+# Delete all Cloudflare Pages preview deployments for a given PR branch.
+#
+# Each push to a PR creates a new immutable Cloudflare Pages deployment under
+# the `pr-<number>` branch alias. Cloudflare keeps every deployment around
+# forever, so once a PR is closed or merged we want to clean up after
+# ourselves and remove all of its preview deployments — both the latest one
+# pointed at by the branch alias and every prior unique-hash deployment in
+# the history.
+#
+# This script paginates through the project's preview deployments, filters
+# them down to the ones whose trigger branch matches $BRANCH (e.g. `pr-9101`),
+# and deletes each one via the Cloudflare API. It is typically invoked from
+# the `pull_request: closed` workflow, but can also be run locally to prune
+# stale previews.
+#
+# Required environment variables:
+#   CLOUDFLARE_API_TOKEN   API token with Pages:Edit permission
+#   CLOUDFLARE_ACCOUNT_ID  Cloudflare account ID that owns the project
+#   PROJECT_NAME           Cloudflare Pages project name (the preview project)
+#   BRANCH                 Branch alias to clean up (e.g. `pr-9101`)
 set -euo pipefail
 
 : "${CLOUDFLARE_API_TOKEN:?Missing CLOUDFLARE_API_TOKEN}"

--- a/tooling/scripts/delete-cloudflare-pages-preview.test.ts
+++ b/tooling/scripts/delete-cloudflare-pages-preview.test.ts
@@ -8,7 +8,12 @@ import { describe, expect, it } from 'vitest'
 
 const scriptPath = join(dirname(fileURLToPath(import.meta.url)), 'delete-cloudflare-pages-preview.sh')
 
-const runWithFakeCurl = (fakeCurlSource: string) => {
+type RunOptions = {
+  perPage?: string
+  branch?: string
+}
+
+const runWithFakeCurl = (fakeCurlSource: string, options: RunOptions = {}) => {
   const directory = mkdtempSync(join(tmpdir(), 'cf-preview-test-'))
   const fakeCurlPath = join(directory, 'fake-curl.js')
   const recordFilePath = join(directory, 'deleted.txt')
@@ -20,9 +25,10 @@ const runWithFakeCurl = (fakeCurlSource: string) => {
     cwd: join(dirname(fileURLToPath(import.meta.url)), '../..'),
     env: {
       ...process.env,
-      BRANCH: 'pr-123',
+      BRANCH: options.branch ?? 'pr-123',
       CLOUDFLARE_ACCOUNT_ID: 'account',
       CLOUDFLARE_API_TOKEN: 'token',
+      CLOUDFLARE_PER_PAGE: options.perPage ?? '2',
       CURL_COMMAND: fakeCurlPath,
       PROJECT_NAME: 'project',
       RECORD_FILE: recordFilePath,
@@ -34,7 +40,11 @@ const runWithFakeCurl = (fakeCurlSource: string) => {
 }
 
 describe('delete-cloudflare-pages-preview', () => {
-  it('deletes matching deployments across paginated results', () => {
+  it('deletes every matching deployment across paginated results', () => {
+    // Page 1 is full (== per_page), so the script must keep paginating; page 2
+    // is partial, which is how we know we have reached the end. result_info is
+    // intentionally omitted because Cloudflare does not always include
+    // total_pages — the script must not depend on it.
     const fakeCurlSource = String.raw`
 const { appendFileSync, writeFileSync } = require('node:fs')
 const args = process.argv.slice(2)
@@ -58,7 +68,7 @@ const result = page === 1
     ]
   : [{ id: 'delete-page-2', deployment_trigger: { metadata: { branch: 'pr-123' } } }]
 
-writeFileSync(output, JSON.stringify({ success: true, result, result_info: { total_pages: 2 } }))
+writeFileSync(output, JSON.stringify({ success: true, result }))
 process.stdout.write('200')
 `
 
@@ -67,15 +77,124 @@ process.stdout.write('200')
     expect(result.status).toBe(0)
     expect(result.stdout.trim().split('\n')).toStrictEqual([
       'Looking for preview deployments on branch: pr-123',
-      'Scanned Cloudflare deployment page 1 of 2',
-      'Scanned Cloudflare deployment page 2 of 2',
+      'Scanned Cloudflare deployment page 1',
+      'Scanned Cloudflare deployment page 2',
       'Deleted deployment delete-page-1',
       'Deleted deployment delete-page-2',
     ])
     expect(readFileSync(recordFilePath, 'utf8').trim().split('\n')).toStrictEqual(['delete-page-1', 'delete-page-2'])
   })
 
-  it('reports Cloudflare API errors', () => {
+  it('stops paginating when the first page is partial', () => {
+    const fakeCurlSource = String.raw`
+const { appendFileSync, writeFileSync } = require('node:fs')
+const args = process.argv.slice(2)
+const output = args[args.indexOf('--output') + 1]
+const url = args.find((arg) => arg.startsWith('https://'))
+const method = args.includes('--request') ? args[args.indexOf('--request') + 1] : 'GET'
+
+if (method === 'DELETE') {
+  const id = url.match(/deployments\/([^?]+)/)[1]
+  appendFileSync(process.env.RECORD_FILE, id + '\n')
+  writeFileSync(output, JSON.stringify({ success: true, result: {} }))
+  process.stdout.write('200')
+  process.exit(0)
+}
+
+const page = Number(new URL(url).searchParams.get('page'))
+if (page > 1) {
+  // Should never be requested — the script should stop after the first partial page.
+  writeFileSync(output, JSON.stringify({ success: false, errors: [{ message: 'unexpected page request' }] }))
+  process.stdout.write('500')
+  process.exit(0)
+}
+
+writeFileSync(output, JSON.stringify({
+  success: true,
+  result: [{ id: 'only-deployment', deployment_trigger: { metadata: { branch: 'pr-123' } } }],
+}))
+process.stdout.write('200')
+`
+
+    const { result, recordFilePath } = runWithFakeCurl(fakeCurlSource)
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('Scanned Cloudflare deployment page 1')
+    expect(result.stdout).not.toContain('Scanned Cloudflare deployment page 2')
+    expect(readFileSync(recordFilePath, 'utf8').trim().split('\n')).toStrictEqual(['only-deployment'])
+  })
+
+  it('exits 0 with no deletions when the branch has no deployments', () => {
+    const fakeCurlSource = String.raw`
+const { writeFileSync } = require('node:fs')
+const args = process.argv.slice(2)
+const output = args[args.indexOf('--output') + 1]
+
+writeFileSync(output, JSON.stringify({
+  success: true,
+  result: [{ id: 'someone-else', deployment_trigger: { metadata: { branch: 'pr-999' } } }],
+}))
+process.stdout.write('200')
+`
+
+    const { result, recordFilePath } = runWithFakeCurl(fakeCurlSource)
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('No preview deployments found for pr-123; nothing to delete')
+    expect(() => readFileSync(recordFilePath, 'utf8')).toThrow()
+  })
+
+  it('continues deleting after an individual deletion fails and exits non-zero', () => {
+    // Cloudflare can refuse to delete the active alias deployment for a
+    // branch even with force=true. The script must still attempt the rest of
+    // the deployments instead of bailing on the first failure.
+    const fakeCurlSource = String.raw`
+const { appendFileSync, writeFileSync } = require('node:fs')
+const args = process.argv.slice(2)
+const output = args[args.indexOf('--output') + 1]
+const url = args.find((arg) => arg.startsWith('https://'))
+const method = args.includes('--request') ? args[args.indexOf('--request') + 1] : 'GET'
+
+if (method === 'DELETE') {
+  const id = url.match(/deployments\/([^?]+)/)[1]
+  appendFileSync(process.env.RECORD_FILE, id + '\n')
+  if (id === 'fails-to-delete') {
+    writeFileSync(output, JSON.stringify({ success: false, errors: [{ message: 'active alias' }] }))
+    process.stdout.write('400')
+    process.exit(0)
+  }
+  writeFileSync(output, JSON.stringify({ success: true, result: {} }))
+  process.stdout.write('200')
+  process.exit(0)
+}
+
+const page = Number(new URL(url).searchParams.get('page'))
+const result = page === 1
+  ? [
+      { id: 'delete-first', deployment_trigger: { metadata: { branch: 'pr-123' } } },
+      { id: 'fails-to-delete', deployment_trigger: { metadata: { branch: 'pr-123' } } },
+    ]
+  : []
+
+writeFileSync(output, JSON.stringify({ success: true, result }))
+process.stdout.write('200')
+`
+
+    const { result, recordFilePath } = runWithFakeCurl(fakeCurlSource)
+
+    expect(result.status).toBe(1)
+    // Every deployment must be attempted, even though one of them fails.
+    expect(readFileSync(recordFilePath, 'utf8').trim().split('\n').sort()).toStrictEqual([
+      'delete-first',
+      'fails-to-delete',
+    ])
+    expect(result.stdout).toContain('Deleted deployment delete-first')
+    expect(result.stdout).toContain('Failed to delete Cloudflare Pages deployment fails-to-delete (HTTP 400)')
+    expect(result.stdout).toContain('active alias')
+    expect(result.stdout).toContain('Failed to delete 1 of 2 deployment(s) for pr-123')
+  })
+
+  it('reports Cloudflare API errors when listing fails', () => {
     const fakeCurlSource = String.raw`
 const { writeFileSync } = require('node:fs')
 const args = process.argv.slice(2)


### PR DESCRIPTION
## Problem

The script for deleting Cloudflare Pages preview deployments had several issues:

1. **Unreliable pagination**: It relied on `result_info.total_pages` from the API, which Cloudflare doesn't always populate, making pagination logic fragile.
2. **Poor error handling**: The script would exit immediately on the first deletion failure, preventing cleanup of other deployments.
3. **Limited test coverage**: Tests didn't cover edge cases like partial pages, no deployments found, or individual deletion failures.

## Solution

**Pagination improvements:**
- Changed from relying on `total_pages` to detecting partial pages (when result count < per_page size)
- This is more robust since Cloudflare doesn't always include `total_pages` in responses
- Added configurable `CLOUDFLARE_PER_PAGE` environment variable (defaults to 100)

**Error handling improvements:**
- Changed deletion failures from immediately exiting to continuing with remaining deployments
- Tracks failed deletion count and reports summary at the end
- Script still exits with code 1 if any deletions failed, but attempts all deployments first

**Test coverage:**
- Updated existing test to verify pagination works without relying on `total_pages`
- Added test for stopping pagination when first page is partial
- Added test for handling branches with no deployments
- Added test for continuing after individual deletion failures
- Renamed "reports API errors" test to clarify it tests listing failures

**Output improvements:**
- Changed page output from "page X of Y" to just "page X" (since Y is no longer reliable)

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not applicable for tooling scripts -->
- [x] I added tests.
- [ ] I updated the documentation. <!-- Script is internal tooling -->

https://claude.ai/code/session_01NPYZKqqDB2n9PkCp9jFtAb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes pagination termination and failure handling for destructive Cloudflare API deletes; mistakes could leave previews undeleted or attempt more API calls than expected.
> 
> **Overview**
> Improves the `delete-cloudflare-pages-preview.sh` cleanup script to paginate without relying on `result_info.total_pages`, instead stopping when a page returns fewer than `CLOUDFLARE_PER_PAGE` results (now configurable). It also hardens API error reporting, reuses a single temp workspace, and changes deletion behavior to continue through all deployments while tracking failures and exiting non-zero only after attempting everything.
> 
> Updates and expands tests to cover missing `total_pages`, partial-page pagination termination, no matching deployments, and continuing after individual deletion failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6f1e97b337deff2817134c7ac0abc317fb9472f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->