### PR TITLE
fix(ci): cleanup cloudflare script

### DIFF
--- a/packages/api-client/src/v2/features/modal/Modal.test.ts
+++ b/packages/api-client/src/v2/features/modal/Modal.test.ts
@@ -430,6 +430,8 @@ describe('Modal', () => {
   })
 
   it('passes hideClientButton option to Operation component', async () => {
+    // This test mounts the Modal three times in sequence, which can exceed the
+    // default 5s timeout on slower CI runners. Allow extra headroom.
     const { props: baseProps, modalState } = createProps()
     modalState.open = true
 
@@ -489,5 +491,5 @@ describe('Modal', () => {
     const operationWithDefault = wrapperWithDefault.findComponent({ name: 'OperationBlock' })
     expect(operationWithDefault.exists()).toBe(true)
     expect(operationWithDefault.props('hideClientButton')).toBe(false)
-  })
+  }, 15000)
 })

--- a/tooling/scripts/delete-cloudflare-pages-preview.sh
+++ b/tooling/scripts/delete-cloudflare-pages-preview.sh
@@ -29,7 +29,11 @@ set -euo pipefail
 
 curl_command="${CURL_COMMAND:-curl}"
 base_url="${CLOUDFLARE_API_BASE_URL:-https://api.cloudflare.com/client/v4}"
-per_page="${CLOUDFLARE_PER_PAGE:-100}"
+# Cloudflare Pages caps `per_page` at 25 on the deployments list endpoint.
+# Anything larger fails with HTTP 400 "Invalid list options provided. Review
+# the page or per_page parameter.". Keep the default at the cap so we make as
+# few round trips as possible without tripping the limit.
+per_page="${CLOUDFLARE_PER_PAGE:-25}"
 
 # Use a single temp directory for all responses so we do not leak files in /tmp
 # across the run. The trap cleans up regardless of how the script exits.

--- a/tooling/scripts/delete-cloudflare-pages-preview.test.ts
+++ b/tooling/scripts/delete-cloudflare-pages-preview.test.ts
@@ -9,7 +9,8 @@ import { describe, expect, it } from 'vitest'
 const scriptPath = join(dirname(fileURLToPath(import.meta.url)), 'delete-cloudflare-pages-preview.sh')
 
 type RunOptions = {
-  perPage?: string
+  // Use `null` to omit the env var entirely so the script's own default applies.
+  perPage?: string | null
   branch?: string
 }
 
@@ -21,18 +22,27 @@ const runWithFakeCurl = (fakeCurlSource: string, options: RunOptions = {}) => {
   writeFileSync(fakeCurlPath, `#!/usr/bin/env node\n${fakeCurlSource}`)
   chmodSync(fakeCurlPath, 0o755)
 
+  const perPage = options.perPage === undefined ? '2' : options.perPage
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    BRANCH: options.branch ?? 'pr-123',
+    CLOUDFLARE_ACCOUNT_ID: 'account',
+    CLOUDFLARE_API_TOKEN: 'token',
+    CURL_COMMAND: fakeCurlPath,
+    PROJECT_NAME: 'project',
+    RECORD_FILE: recordFilePath,
+  }
+  if (perPage !== null) {
+    env.CLOUDFLARE_PER_PAGE = perPage
+  } else {
+    // Make sure a value inherited from the host environment cannot mask the
+    // script's own default.
+    delete env.CLOUDFLARE_PER_PAGE
+  }
+
   const result = spawnSync('bash', [scriptPath], {
     cwd: join(dirname(fileURLToPath(import.meta.url)), '../..'),
-    env: {
-      ...process.env,
-      BRANCH: options.branch ?? 'pr-123',
-      CLOUDFLARE_ACCOUNT_ID: 'account',
-      CLOUDFLARE_API_TOKEN: 'token',
-      CLOUDFLARE_PER_PAGE: options.perPage ?? '2',
-      CURL_COMMAND: fakeCurlPath,
-      PROJECT_NAME: 'project',
-      RECORD_FILE: recordFilePath,
-    },
+    env,
     encoding: 'utf8',
   })
 
@@ -192,6 +202,42 @@ process.stdout.write('200')
     expect(result.stdout).toContain('Failed to delete Cloudflare Pages deployment fails-to-delete (HTTP 400)')
     expect(result.stdout).toContain('active alias')
     expect(result.stdout).toContain('Failed to delete 1 of 2 deployment(s) for pr-123')
+  })
+
+  it("uses a default per_page within Cloudflare's 25-item cap for the list endpoint", () => {
+    // Cloudflare Pages\' deployments list endpoint caps `per_page` at 25 and
+    // responds with HTTP 400 ("Invalid list options provided. Review the `page`
+    // or `per_page` parameter.") for any larger value. The script must default
+    // to a value that does not exceed that cap.
+    const fakeCurlSource = String.raw`
+const { writeFileSync } = require('node:fs')
+const args = process.argv.slice(2)
+const output = args[args.indexOf('--output') + 1]
+const url = args.find((arg) => arg.startsWith('https://'))
+const method = args.includes('--request') ? args[args.indexOf('--request') + 1] : 'GET'
+
+if (method === 'GET') {
+  const perPage = Number(new URL(url).searchParams.get('per_page'))
+  if (perPage > 25) {
+    writeFileSync(output, JSON.stringify({
+      success: false,
+      errors: [{ message: 'Invalid list options provided. Review the page or per_page parameter.' }],
+    }))
+    process.stdout.write('400')
+    process.exit(0)
+  }
+}
+
+writeFileSync(output, JSON.stringify({ success: true, result: [] }))
+process.stdout.write('200')
+`
+
+    const { result } = runWithFakeCurl(fakeCurlSource, { perPage: null })
+
+    expect(result.stderr).toBe('')
+    expect(result.status).toBe(0)
+    expect(result.stdout).not.toContain('Failed to list Cloudflare Pages deployments')
+    expect(result.stdout).toContain('No preview deployments found for pr-123; nothing to delete')
   })
 
   it('reports Cloudflare API errors when listing fails', () => {


### PR DESCRIPTION
OK this time I fixed it for real!

```bash
Looking for preview deployments on branch: pr-9089
Scanned Cloudflare deployment page 1
Scanned Cloudflare deployment page 2
Scanned Cloudflare deployment page 3
Scanned Cloudflare deployment page 4
Scanned Cloudflare deployment page 5
Scanned Cloudflare deployment page 6
Scanned Cloudflare deployment page 7
Deleted deployment 65581b87-7e39-48e1-83f5-b5859be4d0db
Deleted deployment 7f2f9403-5bcc-4234-a88b-ef8688c574ea
Deleted deployment 89d73623-836e-48b7-98ce-582be44abe37
Deleted deployment eec62073-17fa-46b8-842d-ecc92d310097
Deleted deployment fa5edf0f-f9ee-4d8e-95f0-5b3601466c84
```

I also deleted any deployment older than 24 hours so its cleaned up

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI cleanup scripting and test adjustments; main behavior change is the default `per_page` used when listing Cloudflare Pages deployments.
> 
> **Overview**
> Fixes Cloudflare Pages preview cleanup by defaulting the deployments list pagination size to Cloudflare’s 25-item cap (avoiding HTTP 400s when `CLOUDFLARE_PER_PAGE` isn’t set), and adds a regression test to ensure the script’s default stays within that limit.
> 
> Stabilizes a slow-running `Modal` unit test by increasing the timeout for the case that mounts the component multiple times.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c225800432d65f63786936abcc1ad246e01ee31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->