### PR TITLE
fix(agent-chat): warnings in the chat for optional config

### DIFF
--- a/.changeset/plain-ravens-wish.md
+++ b/.changeset/plain-ravens-wish.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: agent scalar warnings

--- a/packages/api-reference/src/components/AgentScalar/AgentScalarChatInterface.vue
+++ b/packages/api-reference/src/components/AgentScalar/AgentScalarChatInterface.vue
@@ -13,7 +13,7 @@ const {
   workspaceStore,
   prefilledMessage,
 } = defineProps<{
-  agentScalarConfiguration: ApiReferenceConfigurationWithSource['agent']
+  agentScalarConfiguration?: ApiReferenceConfigurationWithSource['agent']
   externalUrls: ExternalUrls
   workspaceStore: WorkspaceStore
   prefilledMessage?: Ref<string>

--- a/packages/api-reference/src/components/AgentScalar/AgentScalarDrawer.vue
+++ b/packages/api-reference/src/components/AgentScalar/AgentScalarDrawer.vue
@@ -11,7 +11,7 @@ import { defineAsyncComponent } from 'vue'
 import { useAgentContext } from '@/hooks/use-agent'
 
 defineProps<{
-  agentScalarConfiguration: ApiReferenceConfigurationWithSource['agent']
+  agentScalarConfiguration?: ApiReferenceConfigurationWithSource['agent']
   externalUrls: ExternalUrls
   workspaceStore: WorkspaceStore
 }>()


### PR DESCRIPTION
## Problem

The config is optional but some types were missing the `?`

## Solution

Added a couple `?`'s

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: type-only prop optionality changes plus a patch changeset; runtime behavior should be unchanged aside from eliminating undefined-access warnings.
> 
> **Overview**
> Fixes agent chat integration warnings by making `agentScalarConfiguration` optional in `AgentScalarChatInterface.vue` and `AgentScalarDrawer.vue`, aligning the prop typing with an optional config.
> 
> Adds a patch changeset for `@scalar/api-reference` documenting the warning fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dab24f5eea0a48170489e1918e6ad6a3ad85ac6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->