### PR TITLE
fix(scalar-app): correct tailwind compilation and restructure css imports

### DIFF
--- a/.changeset/purple-garlics-jump.md
+++ b/.changeset/purple-garlics-jump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+refactor: remove the main import file since it was empty

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -36,11 +36,6 @@
   },
   "type": "module",
   "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    },
     "./style.css": "./dist/style.css",
     "./tailwind.config.css": "./dist/styles/tailwind.config.css",
     "./vue-styles.css": "./dist/vue-styles.css",

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,1 +1,0 @@
-// Nothing

--- a/projects/scalar-app/entrypoints/electron/renderer/src/main.ts
+++ b/projects/scalar-app/entrypoints/electron/renderer/src/main.ts
@@ -1,5 +1,4 @@
 import '@/style.css'
-import '@scalar/api-client/style.css'
 
 import { appState } from '@electron/renderer/src/app-state'
 import { commandPaletteState } from '@electron/renderer/src/features/command-palette'

--- a/projects/scalar-app/entrypoints/web/src/main.ts
+++ b/projects/scalar-app/entrypoints/web/src/main.ts
@@ -1,5 +1,4 @@
 import '@/style.css'
-import '@scalar/api-client/style.css'
 
 import { appState } from '@web/app-state'
 import { router } from '@web/router'

--- a/projects/scalar-app/src/style.css
+++ b/projects/scalar-app/src/style.css
@@ -1,25 +1,22 @@
-/**
- * App Styles
- */
-
 @import "@scalar/themes/style.css"; /* Theme Base Styles and Reset */
 @import "@scalar/themes/tailwind.css"; /* Tailwind Theme + Config */
-@import "@scalar/components/style.css"; /* Component Library Styles */
 
-/* Dashboard Theme Extensions */
-@theme {
-  --container-content: 720px;
-  --container-layout-aside: 360px;
-}
+/* Dependency Vue SFC styles */
+@import "@scalar/api-client/vue-styles.css";
+@import "@scalar/components/vue-styles.css";
+@import "@scalar/sidebar/vue-styles.css";
 
-/* Generate all the Tailwind classes for the consuming project */
+/* Dependency Tailwind Configurations */
+@import "@scalar/api-client/tailwind.config.css";
+@import "@scalar/components/tailwind.config.css";
+@import "@scalar/sidebar/tailwind.config.css";
+
 .scalar-app {
-  @import "tailwindcss/utilities.css";
-}
-
-/* Base Styles */
-.scalar-app {
+  /** Base Styles */
   @apply text-base leading-normal;
+
+  /* Generate the Tailwind Utilities (scoped) */
+  @import "tailwindcss/utilities.css";
 }
 
 body {
@@ -33,7 +30,7 @@ body {
 
 /* Search for Tailwind classes in the source files */
 @source "./";
-@source "../index.html";
+@source "../entrypoints/";
 
 body > img[src*="fathom"] {
   display: none;


### PR DESCRIPTION
Looks like the tailwind changes broke the app layout.


| Before | After |
| :--- | :---: |
| <img width="780" height="681" alt="image" src="https://github.com/user-attachments/assets/3cb5e482-6bd6-4e74-9e35-987628c72c89" /> | <img width="780" height="681" alt="image" src="https://github.com/user-attachments/assets/841a1e5a-963b-448f-bddb-adf53cad887f" /> |


## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how core app and dependency styles/Tailwind configs are imported and where Tailwind scans for classes, which can cause missing/duplicated CSS or layout regressions across web/electron builds.
> 
> **Overview**
> Fixes Scalar app styling by **moving dependency CSS imports into `projects/scalar-app/src/style.css`** and scoping Tailwind utility generation under `.scalar-app`, rather than importing `@scalar/api-client/style.css` from entrypoints.
> 
> Updates Tailwind content discovery by switching `@source` from `../index.html` to `../entrypoints/`, and refactors `@scalar/api-client` packaging by removing its empty `src/index.ts` and dropping the root `exports["."]` entry (documented via a patch changeset).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00ac11d3c1cfc32d70cd46e0e87d04635a1c2c06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->