### PR TITLE
fix(components): remove tooltip when scope is disposed

### DIFF
--- a/.changeset/six-teeth-hide.md
+++ b/.changeset/six-teeth-hide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): remove tooltip when scope is disposed

--- a/packages/components/src/components/ScalarTooltip/ScalarTooltip.test.ts
+++ b/packages/components/src/components/ScalarTooltip/ScalarTooltip.test.ts
@@ -150,4 +150,34 @@ describe('ScalarTooltip', () => {
     expect(tooltip?.style.display).toBe('block')
     expect(tooltip?.textContent).toBe('Tooltip Content')
   })
+
+  it('hides the tooltip when the component unmounts while the tooltip is open', async () => {
+    const wrapper = mount(ScalarTooltip, {
+      props: {
+        content: 'Tooltip Content',
+        delay: 0,
+      },
+      slots: {
+        default: '<button type="button">Hover me</button>',
+      },
+    })
+
+    await nextTick()
+
+    await wrapper.find('button').trigger('mouseenter')
+    await vi.runAllTimers()
+    await nextTick()
+
+    const tooltip = document.getElementById(ELEMENT_ID)
+    expect(tooltip?.style.display).toBe('block')
+
+    wrapper.unmount()
+    await nextTick()
+
+    const tooltipAfterUnmount = document.getElementById(ELEMENT_ID)
+    expect(
+      tooltipAfterUnmount?.style.display,
+      'global tooltip portal must be hidden when the ScalarTooltip instance is torn down',
+    ).toBe('none')
+  })
 })

--- a/packages/components/src/components/ScalarTooltip/useTooltip.ts
+++ b/packages/components/src/components/ScalarTooltip/useTooltip.ts
@@ -1,5 +1,5 @@
 import { autoUpdate, flip, shift, useFloating } from '@floating-ui/vue'
-import { computed, ref, unref, watch } from 'vue'
+import { computed, onScopeDispose, ref, unref, watch } from 'vue'
 
 import { DEFAULT_DELAY, DEFAULT_OFFSET, ELEMENT_CLASS, ELEMENT_ID } from './constants'
 import type { Timer, TooltipConfiguration } from './types'
@@ -265,4 +265,23 @@ export function useTooltip(opts: TooltipConfiguration) {
     },
     { immediate: true },
   )
+
+  // Cleanup the tooltip when the component is unmounted
+  onScopeDispose(() => {
+    clearTimer()
+
+    const target = unref(opts.targetRef)
+    if (target) {
+      target.removeEventListener('mouseenter', showTooltipAfterDelay)
+      target.removeEventListener('mouseleave', hideTooltip)
+      target.removeEventListener('focus', showTooltip)
+      target.removeEventListener('blur', hideTooltip)
+      target.removeAttribute('aria-describedby')
+    }
+
+    // If the tooltip is showing on this target hide it
+    if (unref(config.value?.targetRef) === unref(opts.targetRef)) {
+      config.value = undefined
+    }
+  })
 }


### PR DESCRIPTION
We weren't always removing the tooltip when component consuming the hook was unmounted. Normally this was fine because a blur event would fire and focus would change before unmount but with Vue router it can swap the page without moving focus leading to lingering tooltips.

This makes sure we clean up any open tooltips when scope is disposed.
## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
