### PR TITLE
fix(api-client): a few warnings

### DIFF
--- a/.changeset/proud-buses-start.md
+++ b/.changeset/proud-buses-start.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: posthog stream warning

--- a/packages/api-client/vite.config.ts
+++ b/packages/api-client/vite.config.ts
@@ -30,7 +30,10 @@ export default defineConfig({
     dedupe: ['vue'],
   },
   optimizeDeps: {
-    exclude: ['@scalar/*'],
+    // posthog-js ships a pre-bundled dist/module.js — excluding it prevents Vite from
+    // crawling its transitive @opentelemetry/otlp-exporter-base dep, which imports the
+    // Node.js 'stream' and 'zlib' built-ins and triggers a browser-externalization warning.
+    exclude: ['@scalar/*', 'posthog-js'],
   },
   server: {
     port: 5065,

--- a/packages/api-reference/vite.config.ts
+++ b/packages/api-reference/vite.config.ts
@@ -35,6 +35,12 @@ export default defineConfig({
     },
     dedupe: ['vue'],
   },
+  optimizeDeps: {
+    // posthog-js ships a pre-bundled dist/module.js — excluding it prevents Vite from
+    // crawling its transitive @opentelemetry/otlp-exporter-base dep, which imports the
+    // Node.js 'stream' and 'zlib' built-ins and triggers a browser-externalization warning.
+    exclude: ['posthog-js'],
+  },
   build: {
     outDir: './dist',
     minify: false,


### PR DESCRIPTION
## Problem
Theres a stream warning in the console

## Solution

This clears that up

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-tooling change: only adjusts Vite dependency pre-bundling exclusions to avoid browser externalization warnings, with minimal chance of impacting runtime behavior.
> 
> **Overview**
> Prevents Vite dev/build from crawling `posthog-js` transitive OpenTelemetry deps that import Node built-ins (`stream`, `zlib`), eliminating the related browser externalization warning.
> 
> This updates `optimizeDeps.exclude` in both `api-client` and `api-reference` Vite configs (adding `posthog-js`, and keeping existing `@scalar/*` exclusions in `api-client`) and includes a patch changeset for both packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 589d095ada406c221bfe4b5d445d0ed140985ee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->