### PR TITLE
fix(use-codemirror): codemirror performance issues

### DIFF
--- a/.changeset/sparkly-worms-doubt.md
+++ b/.changeset/sparkly-worms-doubt.md
@@ -1,0 +1,6 @@
+---
+'@scalar/use-codemirror': patch
+'@scalar/api-client': patch
+---
+
+fix: codemirror performance issues

--- a/packages/api-client/src/v2/components/code-input/CodeInput.test.ts
+++ b/packages/api-client/src/v2/components/code-input/CodeInput.test.ts
@@ -1,6 +1,8 @@
+import { EditorView, StateEffect } from '@scalar/use-codemirror'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
 
 import CodeInput from './CodeInput.vue'
 
@@ -805,5 +807,186 @@ describe('CodeInput', () => {
     componentInstance.showDropdown = true
 
     expect(componentInstance.displayVariablesDropdown).toBe(false)
+  })
+
+  describe('performance', () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    /**
+     * Normalise the `effects` field from a dispatch TransactionSpec — it can be
+     * a single StateEffect, an array, or undefined — and check whether any
+     * effect is a `StateEffect.reconfigure`.
+     */
+    const hasReconfigure = (args: unknown[]): boolean => {
+      const spec = args[0] as { effects?: unknown } | undefined
+      if (!spec?.effects) return false
+      const effects = Array.isArray(spec.effects) ? spec.effects : [spec.effects]
+      return effects.some(
+        (e): e is { is: (t: unknown) => boolean } =>
+          typeof (e as { is?: unknown }).is === 'function' &&
+          (e as { is: (t: unknown) => boolean }).is(StateEffect.reconfigure),
+      )
+    }
+
+    /**
+     * Problem 1 (fixed): `codeMirrorExtensions` is now a stable module-level constant
+     * rather than a computed, so its array reference never changes across renders.
+     * The pill plugin receives a getter for `environment` and updates decorations
+     * internally on each CodeMirror update cycle — no ViewPlugin replacement needed.
+     */
+    it('codeMirrorExtensions is the same array reference after a same-value environment change', async () => {
+      const wrapper = mount(CodeInput, {
+        props: {
+          modelValue: 'hello',
+          layout: 'desktop' as const,
+          environment: mockEnvironment,
+        },
+      })
+
+      await nextTick()
+
+      const vm = wrapper.vm as any
+
+      // Capture the extensions array reference before the prop change.
+      const before = vm.codeMirrorExtensions
+
+      // Replace environment with a structurally identical object (new reference).
+      await wrapper.setProps({
+        environment: {
+          color: mockEnvironment.color,
+          variables: [...mockEnvironment.variables],
+        } satisfies XScalarEnvironment,
+      })
+
+      // Capture the extensions array reference after the prop change.
+      const after = vm.codeMirrorExtensions
+
+      // The array reference must be identical — no new ViewPlugin was constructed.
+      expect(before).toBe(after)
+    })
+
+    /**
+     * Problem 2 (fixed): Updating the `environment` prop to an object with identical
+     * values no longer causes a `StateEffect.reconfigure` dispatch. The pill plugin
+     * reads `environment` via a getter on every CodeMirror update cycle, so the
+     * ViewPlugin instance never needs to be replaced.
+     */
+    it('same-value environment prop change does not dispatch StateEffect.reconfigure', async () => {
+      const rafCallbacks: FrameRequestCallback[] = []
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        rafCallbacks.push(cb)
+        return rafCallbacks.length
+      })
+
+      const dispatchSpy = vi.spyOn(EditorView.prototype, 'dispatch')
+
+      const wrapper = mount(CodeInput, {
+        props: {
+          modelValue: 'hello',
+          layout: 'desktop' as const,
+          environment: mockEnvironment,
+        },
+      })
+
+      // Settle initial mount and drain any rAF callbacks it scheduled.
+      await nextTick()
+      rafCallbacks.splice(0).forEach((cb) => cb(performance.now()))
+
+      // Reset the spy so we only count dispatches that happen after the prop change.
+      dispatchSpy.mockClear()
+
+      // Update environment to a new object reference with identical values.
+      await wrapper.setProps({
+        environment: {
+          color: mockEnvironment.color,
+          variables: [...mockEnvironment.variables],
+        } satisfies XScalarEnvironment,
+      })
+
+      await nextTick()
+      rafCallbacks.splice(0).forEach((cb) => cb(performance.now()))
+
+      const reconfigureCount = dispatchSpy.mock.calls.filter(hasReconfigure).length
+
+      expect(reconfigureCount).toBe(0)
+    })
+
+    /**
+     * Problem 3 (confirmed not regressed): Changing `modelValue` (simulating user
+     * typing) must NOT trigger a `StateEffect.reconfigure` dispatch. Typing should
+     * only update CodeMirror's document content.
+     */
+    it('modelValue change does not dispatch StateEffect.reconfigure', async () => {
+      const rafCallbacks: FrameRequestCallback[] = []
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        rafCallbacks.push(cb)
+        return rafCallbacks.length
+      })
+
+      const dispatchSpy = vi.spyOn(EditorView.prototype, 'dispatch')
+
+      const wrapper = mount(CodeInput, {
+        props: {
+          modelValue: 'initial',
+          layout: 'desktop' as const,
+          environment: mockEnvironment,
+        },
+      })
+
+      // Settle initial mount and drain any rAF callbacks it scheduled.
+      await nextTick()
+      rafCallbacks.splice(0).forEach((cb) => cb(performance.now()))
+
+      // Snapshot how many reconfigures happened during mount — we only care about
+      // the delta caused by the modelValue change below.
+      const reconfiguresBefore = dispatchSpy.mock.calls.filter(hasReconfigure).length
+
+      await wrapper.setProps({ modelValue: 'updated' })
+
+      await nextTick()
+      rafCallbacks.splice(0).forEach((cb) => cb(performance.now()))
+
+      const reconfiguresAfter = dispatchSpy.mock.calls.filter(hasReconfigure).length
+
+      // A content-only change must not produce any additional reconfigure dispatches.
+      expect(reconfiguresAfter).toBe(reconfiguresBefore)
+    })
+
+    /**
+     * Problem 4: `backspaceCommand` is defined at module level and must be a stable
+     * reference across all `CodeInput` instances.
+     *
+     * It is the last element added in `codeMirrorExtensions`, so comparing the final
+     * element of the extensions array from two independent mounts verifies stability.
+     */
+    it('backspaceCommand is the same reference across separate CodeInput instances', () => {
+      const wrapperA = mount(CodeInput, {
+        props: {
+          modelValue: 'a',
+          layout: 'desktop' as const,
+          environment: mockEnvironment,
+        },
+      })
+
+      const wrapperB = mount(CodeInput, {
+        props: {
+          modelValue: 'b',
+          layout: 'desktop' as const,
+          environment: mockEnvironment,
+        },
+      })
+
+      const extensionsA: any[] = (wrapperA.vm as any).codeMirrorExtensions
+      const extensionsB: any[] = (wrapperB.vm as any).codeMirrorExtensions
+
+      // The last element is `backspaceCommand` (module-level constant).
+      // Both instances must reference the exact same object.
+      const backspaceA = extensionsA[extensionsA.length - 1]
+      const backspaceB = extensionsB[extensionsB.length - 1]
+
+      expect(backspaceA).toBe(backspaceB)
+    })
   })
 })

--- a/packages/api-client/src/v2/components/code-input/CodeInput.test.ts
+++ b/packages/api-client/src/v2/components/code-input/CodeInput.test.ts
@@ -961,6 +961,55 @@ describe('CodeInput', () => {
      * It is the last element added in `codeMirrorExtensions`, so comparing the final
      * element of the extensions array from two independent mounts verifies stability.
      */
+    /**
+     * Bug fix: when the environment prop changes without any editor interaction,
+     * CodeInput must dispatch a no-op transaction so CodeMirror's update() cycle
+     * fires and the pill plugin rebuilds its decorations with the fresh values.
+     *
+     * Without the fix, the pill plugin's update() would never be called (it only
+     * runs during CodeMirror's own transaction cycle), leaving pills showing stale
+     * variable values until the user interacted with the editor.
+     */
+    it('environment prop change dispatches a no-op transaction to refresh pill decorations', async () => {
+      const dispatchSpy = vi.spyOn(EditorView.prototype, 'dispatch')
+
+      const wrapper = mount(CodeInput, {
+        props: {
+          modelValue: '{{baseUrl}}',
+          layout: 'desktop' as const,
+          environment: mockEnvironment,
+          withVariables: true,
+        },
+      })
+
+      await nextTick()
+      dispatchSpy.mockClear()
+
+      // Change the environment to a genuinely different object (new color + variable value).
+      const updatedEnvironment: XScalarEnvironment = {
+        color: '#00ff00',
+        variables: [{ name: 'baseUrl', value: 'https://new.example.com' }],
+      }
+      await wrapper.setProps({ environment: updatedEnvironment })
+      await nextTick()
+
+      // At least one dispatch must have fired — the no-op that kicks the update() cycle.
+      expect(dispatchSpy).toHaveBeenCalled()
+
+      // It must be a plain no-op dispatch (no effects, no changes, no selection).
+      const noOpCall = dispatchSpy.mock.calls.find((args) => {
+        const spec = args[0] as Record<string, unknown> | undefined
+        if (!spec) return true
+        return !spec.changes && !spec.effects && !spec.selection && !spec.annotations
+      })
+      expect(noOpCall).toBeDefined()
+
+      // And it must not have triggered a StateEffect.reconfigure — the extensions
+      // array is stable and the pill plugin refreshes internally via update().
+      const reconfigureCount = dispatchSpy.mock.calls.filter(hasReconfigure).length
+      expect(reconfigureCount).toBe(0)
+    })
+
     it('backspaceCommand is the same reference across separate CodeInput instances', () => {
       const wrapperA = mount(CodeInput, {
         props: {

--- a/packages/api-client/src/v2/components/code-input/CodeInput.vue
+++ b/packages/api-client/src/v2/components/code-input/CodeInput.vue
@@ -327,6 +327,19 @@ watch(codeMirror, () => {
   }
 })
 
+/**
+ * When the environment prop changes (user switches environments or edits a variable),
+ * dispatch a no-op transaction to kick CodeMirror's update cycle. The pill plugin's
+ * update() is only called during CodeMirror's own transaction processing, so without
+ * this, pills would show stale values until the next editor interaction.
+ */
+watch(
+  () => environment,
+  () => {
+    codeMirror.value?.dispatch({})
+  },
+)
+
 // ---------------------------------------------------------------------------
 // Environment variable dropdown
 

--- a/packages/api-client/src/v2/components/code-input/CodeInput.vue
+++ b/packages/api-client/src/v2/components/code-input/CodeInput.vue
@@ -249,20 +249,6 @@ const handleSelectChange = (value: string): void =>
 // CodeMirror setup
 
 /**
- * Build extensions array.
- * Note: Extensions are not reactive after initialization.
- */
-const buildExtensions = (): Extension[] => {
-  const extensionsList: Extension[] = [...extensions]
-
-  if (colorPicker) {
-    extensionsList.push(colorPickerExtension)
-  }
-
-  return extensionsList
-}
-
-/**
  * Reactive pill plugin for environment variable visualization.
  */
 const contextFunctionDropdownItems = computed(() =>
@@ -275,16 +261,15 @@ const contextFunctionDropdownItems = computed(() =>
 )
 
 /**
- * The pill plugin is created once and receives getter functions so it can
- * always read the latest `environment` and `isReadOnly` values without the
- * ViewPlugin instance ever needing to be replaced. Replacing the instance
- * would require a full `StateEffect.reconfigure` on every environment change,
- * which causes a costly CodeMirror measure cycle on every keystroke.
+ * The pill plugin is created once and receives a getter for `environment` so
+ * it can always read the latest value without the ViewPlugin instance ever
+ * needing to be replaced. Replacing the instance would require a full
+ * `StateEffect.reconfigure` on every environment change, causing a costly
+ * CodeMirror measure cycle on every keystroke.
  */
 const pillPluginExtension = pillPlugin({
   environment: () => environment,
   isContextFunctionName,
-  isReadOnly: () => layout === 'modal',
 })
 
 /**
@@ -296,7 +281,8 @@ const pillPluginExtension = pillPlugin({
  * getter on every CodeMirror update cycle).
  */
 const codeMirrorExtensions: Extension[] = [
-  ...buildExtensions(),
+  ...extensions,
+  ...(colorPicker ? [colorPickerExtension] : []),
   pillPluginExtension,
   backspaceCommand,
 ]

--- a/packages/api-client/src/v2/components/code-input/CodeInput.vue
+++ b/packages/api-client/src/v2/components/code-input/CodeInput.vue
@@ -274,22 +274,32 @@ const contextFunctionDropdownItems = computed(() =>
     : [],
 )
 
-const pillPluginExtension = computed(() =>
-  pillPlugin({
-    environment,
-    isContextFunctionName,
-    isReadOnly: layout === 'modal',
-  }),
-)
+/**
+ * The pill plugin is created once and receives getter functions so it can
+ * always read the latest `environment` and `isReadOnly` values without the
+ * ViewPlugin instance ever needing to be replaced. Replacing the instance
+ * would require a full `StateEffect.reconfigure` on every environment change,
+ * which causes a costly CodeMirror measure cycle on every keystroke.
+ */
+const pillPluginExtension = pillPlugin({
+  environment: () => environment,
+  isContextFunctionName,
+  isReadOnly: () => layout === 'modal',
+})
 
 /**
  * Combined extensions for CodeMirror.
+ *
+ * Defined as a constant (not a computed) so the array reference is stable
+ * across renders. Individual extensions that need reactivity carry their own
+ * internal update mechanisms (e.g. the pill plugin reads environment via a
+ * getter on every CodeMirror update cycle).
  */
-const codeMirrorExtensions = computed((): Extension[] => [
+const codeMirrorExtensions: Extension[] = [
   ...buildExtensions(),
-  pillPluginExtension.value,
+  pillPluginExtension,
   backspaceCommand,
-])
+]
 
 const codeMirrorRef: Ref<HTMLDivElement | null> = ref(null)
 

--- a/packages/api-client/src/v2/components/code-input/code-variable-widget.test.ts
+++ b/packages/api-client/src/v2/components/code-input/code-variable-widget.test.ts
@@ -32,7 +32,7 @@ describe('code-variable-widget', () => {
     const doc = '{{testVar}}'
     const state = EditorState.create({
       doc,
-      extensions: [pillPlugin({ environment, isReadOnly: false })],
+      extensions: [pillPlugin({ environment })],
     })
 
     const view = new EditorView({
@@ -50,7 +50,7 @@ describe('code-variable-widget', () => {
     const doc = '{{testVar}} and {{apiKey}}'
     const state = EditorState.create({
       doc,
-      extensions: [pillPlugin({ environment, isReadOnly: false })],
+      extensions: [pillPlugin({ environment })],
     })
 
     const view = new EditorView({
@@ -69,7 +69,7 @@ describe('code-variable-widget', () => {
     const doc = '{{test\nVar}}'
     const state = EditorState.create({
       doc,
-      extensions: [pillPlugin({ environment, isReadOnly: false })],
+      extensions: [pillPlugin({ environment })],
     })
 
     // This should not throw an error
@@ -90,7 +90,7 @@ describe('code-variable-widget', () => {
     const doc = '{{testVar}}\n{{apiKey}}'
     const state = EditorState.create({
       doc,
-      extensions: [pillPlugin({ environment, isReadOnly: false })],
+      extensions: [pillPlugin({ environment })],
     })
 
     const view = new EditorView({
@@ -107,7 +107,7 @@ describe('code-variable-widget', () => {
     const doc = '{{testVar}}'
     const state = EditorState.create({
       doc,
-      extensions: [pillPlugin({ environment: undefined, isReadOnly: false })],
+      extensions: [pillPlugin({ environment: undefined })],
     })
 
     const view = new EditorView({
@@ -128,26 +128,8 @@ describe('code-variable-widget', () => {
         pillPlugin({
           environment,
           isContextFunctionName,
-          isReadOnly: false,
         }),
       ],
-    })
-
-    const view = new EditorView({
-      state,
-      parent: container,
-    })
-
-    expect(view.state.doc.toString()).toBe(doc)
-
-    view.destroy()
-  })
-
-  it('works in read-only mode', () => {
-    const doc = '{{testVar}}'
-    const state = EditorState.create({
-      doc,
-      extensions: [pillPlugin({ environment, isReadOnly: true })],
     })
 
     const view = new EditorView({
@@ -170,7 +152,7 @@ Variable}}
 
     const state = EditorState.create({
       doc,
-      extensions: [pillPlugin({ environment, isReadOnly: false })],
+      extensions: [pillPlugin({ environment })],
     })
 
     // This should not throw the line break decoration error
@@ -190,7 +172,7 @@ Variable}}
     const initialDoc = '{{testVar}}'
     const state = EditorState.create({
       doc: initialDoc,
-      extensions: [pillPlugin({ environment, isReadOnly: false })],
+      extensions: [pillPlugin({ environment })],
     })
 
     const view = new EditorView({

--- a/packages/api-client/src/v2/components/code-input/code-variable-widget.ts
+++ b/packages/api-client/src/v2/components/code-input/code-variable-widget.ts
@@ -111,26 +111,37 @@ class PillWidget extends WidgetType {
 /**
  * Styles the active environment variable pill.
  * This plugin creates decorations for environment variables in the editor.
+ *
+ * Accepts a getter function for `environment` and `isReadOnly` so the
+ * ViewPlugin instance remains stable across Vue prop updates — the getters
+ * are called on every `update()` instead, which avoids a full
+ * `StateEffect.reconfigure` whenever the environment reference changes.
  */
 export const pillPlugin = (props: {
-  environment: XScalarEnvironment | undefined
-  isReadOnly: boolean | undefined
+  /** Getter so the stable plugin instance always reads the latest environment. */
+  environment: (() => XScalarEnvironment | undefined) | XScalarEnvironment | undefined
+  isReadOnly: (() => boolean | undefined) | boolean | undefined
   isContextFunctionName?: (name: string) => boolean
-}) =>
-  ViewPlugin.fromClass(
+}) => {
+  const getEnvironment = (): XScalarEnvironment | undefined =>
+    typeof props.environment === 'function' ? props.environment() : props.environment
+
+  return ViewPlugin.fromClass(
     class {
       decorations: DecorationSet
       lastEnvironment: XScalarEnvironment | undefined
 
       constructor(view: EditorView) {
-        this.lastEnvironment = props.environment
+        this.lastEnvironment = getEnvironment()
         this.decorations = this.buildDecorations(view)
       }
 
       update(update: ViewUpdate): void {
+        const currentEnvironment = getEnvironment()
+
         // Rebuild decorations if environment changed
-        if (props.environment !== this.lastEnvironment) {
-          this.lastEnvironment = props.environment
+        if (currentEnvironment !== this.lastEnvironment) {
+          this.lastEnvironment = currentEnvironment
           this.decorations = this.buildDecorations(update.view)
           return
         }
@@ -142,6 +153,7 @@ export const pillPlugin = (props: {
       }
 
       buildDecorations(view: EditorView): DecorationSet {
+        const environment = getEnvironment()
         const builder = new RangeSetBuilder<Decoration>()
         const isContextFn = props.isContextFunctionName ?? (() => false)
 
@@ -169,7 +181,7 @@ export const pillPlugin = (props: {
               start,
               end,
               Decoration.widget({
-                widget: new PillWidget(variableName, props.environment, variant),
+                widget: new PillWidget(variableName, environment, variant),
                 side: 1,
               }),
             )
@@ -183,6 +195,7 @@ export const pillPlugin = (props: {
       decorations: (v) => v.decorations,
     },
   )
+}
 
 /**
  * Custom backspace handler for the editor.

--- a/packages/api-client/src/v2/components/code-input/code-variable-widget.ts
+++ b/packages/api-client/src/v2/components/code-input/code-variable-widget.ts
@@ -120,7 +120,6 @@ class PillWidget extends WidgetType {
 export const pillPlugin = (props: {
   /** Getter so the stable plugin instance always reads the latest environment. */
   environment: (() => XScalarEnvironment | undefined) | XScalarEnvironment | undefined
-  isReadOnly: (() => boolean | undefined) | boolean | undefined
   isContextFunctionName?: (name: string) => boolean
 }) => {
   const getEnvironment = (): XScalarEnvironment | undefined =>

--- a/packages/use-codemirror/src/hooks/useCodeMirror.test.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
+import { type Extension, StateEffect } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
-import { describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { type Ref, nextTick, ref, shallowRef } from 'vue'
 
 import { useCodeMirror } from '../hooks/useCodeMirror'
 
@@ -77,5 +78,173 @@ describe('useCodeMirror', () => {
     })
 
     expect(codeMirror.value?.dom.querySelector('.cm-placeholder')).not.toBeNull()
+  })
+
+  describe('performance', () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    /** Normalise the `effects` field from a dispatch TransactionSpec — it can be
+     * a single StateEffect, an array, or undefined — and check whether any
+     * effect is a StateEffect.reconfigure. */
+    const hasReconfigure = (args: unknown[]): boolean => {
+      const spec = args[0] as { effects?: unknown } | undefined
+      if (!spec?.effects) return false
+      const effects = Array.isArray(spec.effects) ? spec.effects : [spec.effects]
+      return effects.some(
+        (e): e is { is: (t: unknown) => boolean } =>
+          typeof (e as { is?: unknown }).is === 'function' &&
+          (e as { is: (t: unknown) => boolean }).is(StateEffect.reconfigure),
+      )
+    }
+
+    it('changing content only does not trigger extension reconfiguration', async () => {
+      const rafCallbacks: FrameRequestCallback[] = []
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        rafCallbacks.push(cb)
+        return rafCallbacks.length
+      })
+
+      const dispatchSpy = vi.spyOn(EditorView.prototype, 'dispatch')
+
+      const content = ref('initial content')
+      const codeMirrorRef = ref(document.createElement('div'))
+      useCodeMirror({
+        codeMirrorRef,
+        content,
+        language: undefined,
+      })
+
+      // Flush Vue watchers and drain any rAF callbacks scheduled during mount
+      await nextTick()
+      rafCallbacks.splice(0).forEach((cb) => cb(performance.now()))
+
+      // Count reconfigure dispatches after the initial mount is settled
+      const reconfiguresBefore = dispatchSpy.mock.calls.filter(hasReconfigure).length
+
+      // Change only content — extension config fields are untouched
+      content.value = 'updated content'
+      await nextTick()
+      rafCallbacks.splice(0).forEach((cb) => cb(performance.now()))
+
+      const reconfiguresAfter = dispatchSpy.mock.calls.filter(hasReconfigure).length
+
+      // A content-only change must not produce any additional reconfigure dispatches
+      expect(reconfiguresAfter).toBe(reconfiguresBefore)
+    })
+
+    it('mounting with static config does not dispatch StateEffect.reconfigure', async () => {
+      const rafCallbacks: FrameRequestCallback[] = []
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        rafCallbacks.push(cb)
+        return rafCallbacks.length
+      })
+
+      const dispatchSpy = vi.spyOn(EditorView.prototype, 'dispatch')
+
+      const codeMirrorRef = ref(document.createElement('div'))
+      useCodeMirror({
+        codeMirrorRef,
+        content: 'static content',
+        language: undefined,
+      })
+
+      // Flush Vue watchers and drain every rAF (including CodeMirror\'s own
+      // internal measure rAF that fires on EditorView construction).
+      await nextTick()
+      rafCallbacks.splice(0).forEach((cb) => cb(performance.now()))
+
+      // None of the rAF callbacks should have dispatched a StateEffect.reconfigure.
+      // Previously the extensions watch ran with { immediate: true }, which queued
+      // a redundant reconfigure rAF on every mount. With the watch removed, only
+      // meaningful config changes trigger a reconfigure.
+      const reconfigureCount = dispatchSpy.mock.calls.filter(hasReconfigure).length
+      expect(reconfigureCount).toBe(0)
+    })
+
+    it('replacing the extensions ref with a new array identity triggers reconfiguration', async () => {
+      const rafCallbacks: FrameRequestCallback[] = []
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        rafCallbacks.push(cb)
+        return rafCallbacks.length
+      })
+
+      const dispatchSpy = vi.spyOn(EditorView.prototype, 'dispatch')
+
+      // A stable extension that will be reused across both array references.
+      // Typed explicitly to avoid TS2589 deep instantiation from EditorView.theme.
+      const stableExtension: Extension = EditorView.theme({})
+      const extensions: Ref<Extension[]> = shallowRef([stableExtension])
+
+      const codeMirrorRef = ref(document.createElement('div'))
+      useCodeMirror({
+        codeMirrorRef,
+        content: 'hello',
+        language: undefined,
+        extensions,
+      })
+
+      // Settle initial mount
+      await nextTick()
+      rafCallbacks.splice(0).forEach((cb) => cb(performance.now()))
+
+      const reconfiguresBefore = dispatchSpy.mock.calls.filter(hasReconfigure).length
+
+      // Replace the array with a new reference (same extension objects inside).
+      // useCodeMirror tracks array identity in reconfigureSignal, so this
+      // intentionally triggers a reconfigure — it is the caller's responsibility
+      // to keep the array reference stable when the contents have not changed.
+      // CodeInput does this by using a module-level constant instead of a computed.
+      extensions.value = [stableExtension]
+      await nextTick()
+      rafCallbacks.splice(0).forEach((cb) => cb(performance.now()))
+
+      const reconfiguresAfter = dispatchSpy.mock.calls.filter(hasReconfigure).length
+
+      // A new array reference — even with identical contents — triggers one
+      // reconfigure. Callers must stabilize their arrays to avoid this cost.
+      expect(reconfiguresAfter).toBe(reconfiguresBefore + 1)
+    })
+
+    it('reconfigure dispatch is deferred to requestAnimationFrame, not synchronous', async () => {
+      const rafCallbacks: FrameRequestCallback[] = []
+      vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        rafCallbacks.push(cb)
+        return rafCallbacks.length
+      })
+
+      const dispatchSpy = vi.spyOn(EditorView.prototype, 'dispatch')
+
+      const language = ref<'json' | 'yaml' | undefined>(undefined)
+      const codeMirrorRef = ref(document.createElement('div'))
+      useCodeMirror({
+        codeMirrorRef,
+        content: '{}',
+        language,
+      })
+
+      // Settle initial mount and drain the rAF it schedules
+      await nextTick()
+      rafCallbacks.splice(0).forEach((cb) => cb(performance.now()))
+
+      const reconfigureCountAfterMount = dispatchSpy.mock.calls.filter(hasReconfigure).length
+
+      // Trigger an extension config change by switching language
+      language.value = 'json'
+      await nextTick()
+
+      // The dispatch must NOT have fired yet — it is queued inside rAF
+      const reconfigureCountSynchronous = dispatchSpy.mock.calls.filter(hasReconfigure).length
+      expect(reconfigureCountSynchronous).toBe(reconfigureCountAfterMount)
+
+      // Now manually flush the pending rAF callbacks
+      rafCallbacks.splice(0).forEach((cb) => cb(performance.now()))
+
+      const reconfigureCountAfterRaf = dispatchSpy.mock.calls.filter(hasReconfigure).length
+
+      // After the rAF flushes, exactly one new reconfigure must have been dispatched
+      expect(reconfigureCountAfterRaf).toBe(reconfigureCountAfterMount + 1)
+    })
   })
 })

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -24,7 +24,7 @@ import {
   lineNumbers as lineNumbersExtension,
   placeholder as placeholderExtension,
 } from '@codemirror/view'
-import { type MaybeRefOrGetter, type Ref, computed, onBeforeUnmount, ref, toValue, watch } from 'vue'
+import { type MaybeRefOrGetter, type Ref, onBeforeUnmount, ref, toValue, watch } from 'vue'
 
 const CHEVRON_DOWN =
   '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="m18 10-6 6-6-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>'
@@ -139,35 +139,13 @@ export const useCodeMirror = (
     })
   }
 
-  // Scalar fields that, when changed, require a full extension reconfiguration.
-  // Watched individually so Vue can do primitive === comparisons rather than
-  // comparing a freshly-allocated object on every reactive flush — which would
-  // always appear dirty and schedule a redundant StateEffect.reconfigure.
-  const extensionConfig = computed(() => ({
-    onChange: params.onChange,
-    onBlur: params.onBlur,
-    onFocus: params.onFocus,
-    disableTabIndent: toValue(params.disableTabIndent),
-    language: toValue(params.language),
-    classes: toValue(params.classes),
-    readOnly: toValue(params.readOnly),
-    lineNumbers: toValue(params.lineNumbers),
-    withVariables: toValue(params.withVariables),
-    forceFoldGutter: toValue(params.forceFoldGutter),
-    disableEnter: toValue(params.disableEnter),
-    disableCloseBrackets: toValue(params.disableCloseBrackets),
-    withoutTheme: toValue(params.withoutTheme),
-    lint: toValue(params.lint),
-    additionalExtensions: toValue(params.extensions),
-    placeholder: toValue(params.placeholder),
-  }))
-
   // Primitive-level sources for the extensions watcher. Listed as individual
   // getter functions so Vue's multi-source watch can do per-element === comparison.
   // A single `computed(() => ({ ... }))` always produces a new object reference
   // and would appear dirty on every flush; a single `computed(() => [...])` has
   // the same problem. Individual sources are compared element-wise, so the watch
   // only fires when a value actually changes.
+  // NOTE: when adding a new param, add its getter here AND add its `toValue()` call inside `buildExtensions`.
   const reconfigureSources = [
     () => params.onChange,
     () => params.onBlur,
@@ -202,14 +180,35 @@ export const useCodeMirror = (
   // Cleanup codemirror
   onBeforeUnmount(() => codeMirror.value?.destroy())
 
+  // Builds the full extension list from the current param values.
+  // NOTE: when adding a new param, add its getter here AND add its `toValue()` call inside `buildExtensions`.
+  function buildExtensions(provider: Extension | null): Extension[] {
+    return getCodeMirrorExtensions({
+      onChange: params.onChange,
+      onBlur: params.onBlur,
+      onFocus: params.onFocus,
+      provider,
+      language: toValue(params.language),
+      classes: toValue(params.classes),
+      readOnly: toValue(params.readOnly),
+      lineNumbers: toValue(params.lineNumbers),
+      withVariables: toValue(params.withVariables),
+      forceFoldGutter: toValue(params.forceFoldGutter),
+      disableEnter: toValue(params.disableEnter),
+      disableCloseBrackets: toValue(params.disableCloseBrackets),
+      disableTabIndent: toValue(params.disableTabIndent),
+      withoutTheme: toValue(params.withoutTheme),
+      lint: toValue(params.lint),
+      additionalExtensions: toValue(params.extensions),
+      placeholder: toValue(params.placeholder),
+    })
+  }
+
   // Initializes CodeMirror.
   function mountCodeMirror() {
     if (params.codeMirrorRef.value) {
       const provider = hasProvider(params) ? toValue(params.provider) : null
-      const extensions = getCodeMirrorExtensions({
-        ...extensionConfig.value,
-        provider,
-      })
+      const extensions = buildExtensions(provider)
 
       codeMirror.value = new EditorView({
         parent: params.codeMirrorRef.value,
@@ -253,10 +252,7 @@ export const useCodeMirror = (
     }
 
     const provider = hasProvider(params) ? toValue(params.provider) : null
-    const extensions = getCodeMirrorExtensions({
-      ...extensionConfig.value,
-      provider,
-    })
+    const extensions = buildExtensions(provider)
 
     requestAnimationFrame(() => {
       codeMirror.value?.dispatch({

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -139,7 +139,10 @@ export const useCodeMirror = (
     })
   }
 
-  // All options except provider
+  // Scalar fields that, when changed, require a full extension reconfiguration.
+  // Watched individually so Vue can do primitive === comparisons rather than
+  // comparing a freshly-allocated object on every reactive flush — which would
+  // always appear dirty and schedule a redundant StateEffect.reconfigure.
   const extensionConfig = computed(() => ({
     onChange: params.onChange,
     onBlur: params.onBlur,
@@ -158,6 +161,33 @@ export const useCodeMirror = (
     additionalExtensions: toValue(params.extensions),
     placeholder: toValue(params.placeholder),
   }))
+
+  // Primitive-level sources for the extensions watcher. Listed as individual
+  // getter functions so Vue's multi-source watch can do per-element === comparison.
+  // A single `computed(() => ({ ... }))` always produces a new object reference
+  // and would appear dirty on every flush; a single `computed(() => [...])` has
+  // the same problem. Individual sources are compared element-wise, so the watch
+  // only fires when a value actually changes.
+  const reconfigureSources = [
+    () => params.onChange,
+    () => params.onBlur,
+    () => params.onFocus,
+    () => toValue(params.disableTabIndent),
+    () => toValue(params.language),
+    () => toValue(params.classes),
+    () => toValue(params.readOnly),
+    () => toValue(params.lineNumbers),
+    () => toValue(params.withVariables),
+    () => toValue(params.forceFoldGutter),
+    () => toValue(params.disableEnter),
+    () => toValue(params.disableCloseBrackets),
+    () => toValue(params.withoutTheme),
+    () => toValue(params.lint),
+    // Array identity: only triggers when the caller passes a new array reference.
+    // Callers must keep their extensions array stable to avoid spurious reconfigures.
+    () => toValue(params.extensions),
+    () => toValue(params.placeholder),
+  ]
 
   // Unmounts CodeMirror if it's mounted already, and mounts CodeMirror, if the given ref exists.
   watch(
@@ -206,29 +236,34 @@ export const useCodeMirror = (
     },
   )
 
-  // Update the extensions whenever parameters changes
-  watch(
-    extensionConfig,
-    () => {
-      if (!codeMirror.value) {
-        return
-      }
-      // If a provider is
+  // Update the extensions when any scalar config field or the extensions array
+  // identity actually changes. We watch `reconfigureSignal` (a tuple of
+  // primitives + the array ref) rather than `extensionConfig` (an object)
+  // because Vue compares computed values with ===: an object computed always
+  // looks dirty, whereas a tuple of primitives only looks dirty when a value
+  // inside it changes.
+  //
+  // We intentionally do NOT use { immediate: true } here because
+  // mountCodeMirror() already applies the correct extensions when the editor
+  // is first created — an immediate run would schedule a redundant
+  // StateEffect.reconfigure on every mount.
+  watch(reconfigureSources, () => {
+    if (!codeMirror.value) {
+      return
+    }
 
-      const provider = hasProvider(params) ? toValue(params.provider) : null
-      const extensions = getCodeMirrorExtensions({
-        ...extensionConfig.value,
-        provider,
-      })
+    const provider = hasProvider(params) ? toValue(params.provider) : null
+    const extensions = getCodeMirrorExtensions({
+      ...extensionConfig.value,
+      provider,
+    })
 
-      requestAnimationFrame(() => {
-        codeMirror.value?.dispatch({
-          effects: StateEffect.reconfigure.of(extensions),
-        })
+    requestAnimationFrame(() => {
+      codeMirror.value?.dispatch({
+        effects: StateEffect.reconfigure.of(extensions),
       })
-    },
-    { immediate: true },
-  )
+    })
+  })
 
   // ---------------------------------------------------------------------------
 

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -167,21 +167,9 @@ export const useCodeMirror = (
     () => toValue(params.placeholder),
   ]
 
-  // Unmounts CodeMirror if it's mounted already, and mounts CodeMirror, if the given ref exists.
-  watch(
-    params.codeMirrorRef,
-    () => {
-      codeMirror.value?.destroy()
-      mountCodeMirror()
-    },
-    { immediate: true },
-  )
-
-  // Cleanup codemirror
-  onBeforeUnmount(() => codeMirror.value?.destroy())
-
   // Builds the full extension list from the current param values.
   // NOTE: when adding a new param, add its getter here AND add its `toValue()` call inside `buildExtensions`.
+  // Must be declared before the immediate codeMirrorRef watch below to avoid a temporal dead zone error.
   const buildExtensions = (provider: Extension | null): Extension[] =>
     getCodeMirrorExtensions({
       onChange: params.onChange,
@@ -220,6 +208,19 @@ export const useCodeMirror = (
       }
     }
   }
+
+  // Unmounts CodeMirror if it's mounted already, and mounts CodeMirror, if the given ref exists.
+  watch(
+    params.codeMirrorRef,
+    () => {
+      codeMirror.value?.destroy()
+      mountCodeMirror()
+    },
+    { immediate: true },
+  )
+
+  // Cleanup codemirror
+  onBeforeUnmount(() => codeMirror.value?.destroy())
 
   // ---------------------------------------------------------------------------
 

--- a/packages/use-codemirror/src/hooks/useCodeMirror.ts
+++ b/packages/use-codemirror/src/hooks/useCodeMirror.ts
@@ -182,8 +182,8 @@ export const useCodeMirror = (
 
   // Builds the full extension list from the current param values.
   // NOTE: when adding a new param, add its getter here AND add its `toValue()` call inside `buildExtensions`.
-  function buildExtensions(provider: Extension | null): Extension[] {
-    return getCodeMirrorExtensions({
+  const buildExtensions = (provider: Extension | null): Extension[] =>
+    getCodeMirrorExtensions({
       onChange: params.onChange,
       onBlur: params.onBlur,
       onFocus: params.onFocus,
@@ -202,7 +202,6 @@ export const useCodeMirror = (
       additionalExtensions: toValue(params.extensions),
       placeholder: toValue(params.placeholder),
     })
-  }
 
   // Initializes CodeMirror.
   function mountCodeMirror() {


### PR DESCRIPTION
## Problem

Codemirror is eating up a lot of cpu cycles which is exacerbated on react.

## Solution

I saw something in the console and decided to try and memoize some of the watch triggers. This is the same issue that bites us time and time again of creating new objects and feeding into a watcher. 

Also isReadOnly wasn't even used as its handled in a div

Lets give this a shot


## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CodeMirror extension reconfiguration and plugin update behavior; a mistake could cause stale decorations or missed reconfigures, but changes are narrowly scoped and covered by new regression/perf tests.
> 
> **Overview**
> Reduces CodeMirror CPU churn by **avoiding redundant `StateEffect.reconfigure` dispatches** during mount and on unrelated reactive updates. `useCodeMirror` now watches a per-field list of primitive sources (plus extensions array identity) instead of a computed config object, and no longer runs the reconfigure watch immediately.
> 
> In `CodeInput`, the CodeMirror extensions list is made a stable constant and the environment “pill” ViewPlugin is instantiated once using an `environment` getter, preventing plugin replacement on prop identity changes. To keep pills fresh when the environment changes without editor interaction, `CodeInput` dispatches a no-op transaction to trigger the plugin update cycle.
> 
> Adds a changeset plus targeted performance/regression tests asserting stable extension references and ensuring environment/content updates do not trigger reconfiguration (while true config changes still do).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef83d2a9f78db5cf095d4545e4f3cfda34c62d1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->