### PR TITLE
fix(workspace-store): omit disabled default headers when building requests

### DIFF
--- a/.changeset/perky-waves-decide.md
+++ b/.changeset/perky-waves-decide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: omit disabled default headers when building requests

--- a/packages/workspace-store/src/request-example/builder/request-factory.test.ts
+++ b/packages/workspace-store/src/request-example/builder/request-factory.test.ts
@@ -45,6 +45,29 @@ const createBaseArgs = (overrides: Partial<FactoryArgs> = {}): FactoryArgs => ({
 })
 
 describe('requestFactory', () => {
+  it('does not include default headers disabled for the example', () => {
+    const operation: OperationObject = {
+      parameters: [],
+      'x-scalar-disable-parameters': {
+        'default-headers': {
+          default: {
+            accept: true,
+          },
+        },
+      },
+    }
+
+    const { request } = requestFactory(
+      createBaseArgs({
+        operation,
+        defaultHeaders: { Accept: '*/*', 'X-Custom': 'yes' },
+      }),
+    )
+
+    expect(request.headers.get('Accept')).toBeNull()
+    expect(request.headers.get('X-Custom')).toBe('yes')
+  })
+
   it('returns a factory with empty base URL when server is null', () => {
     const { request } = requestFactory(createBaseArgs())
 

--- a/packages/workspace-store/src/request-example/builder/request-factory.ts
+++ b/packages/workspace-store/src/request-example/builder/request-factory.ts
@@ -14,6 +14,7 @@ import {
 import type { SecuritySchemeObjectSecret } from '@/request-example/builder/security/secret-types'
 import type { RequestExampleMeta } from '@/request-example/types'
 
+import { filterDisabledDefaultHeaders } from '../context/headers'
 import { type RequestBody, buildRequestBody } from './body/build-request-body'
 import { buildRequestParameters } from './header/build-request-parameters'
 
@@ -236,7 +237,10 @@ export const requestFactory = ({
   const params = buildRequestParameters(operation.parameters ?? [], exampleName)
   const security = buildRequestSecurity(selectedSecuritySchemes)
 
-  const headers = new Headers({ ...defaultHeaders, ...params.headers })
+  const headers = new Headers({
+    ...filterDisabledDefaultHeaders(operation, exampleName, defaultHeaders),
+    ...params.headers,
+  })
 
   // If the method can have a body, build the request body, otherwise set it to null
   const body = canMethodHaveBody(method)

--- a/packages/workspace-store/src/request-example/context/headers.test.ts
+++ b/packages/workspace-store/src/request-example/context/headers.test.ts
@@ -1,7 +1,47 @@
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { describe, expect, it } from 'vitest'
 
-import { getDefaultHeaders } from './headers'
+import { filterDisabledDefaultHeaders, getDefaultHeaders } from './headers'
+
+describe('filterDisabledDefaultHeaders', () => {
+  it('removes headers marked disabled for the example', () => {
+    const operation: OperationObject = {
+      'x-scalar-disable-parameters': {
+        'default-headers': {
+          'example-1': {
+            accept: true,
+          },
+        },
+      },
+    }
+
+    const filtered = filterDisabledDefaultHeaders(operation, 'example-1', {
+      Accept: '*/*',
+      'Content-Type': 'application/json',
+    })
+
+    expect(filtered.Accept).toBeUndefined()
+    expect(filtered['Content-Type']).toBe('application/json')
+  })
+
+  it('matches disable keys case-insensitively', () => {
+    const operation: OperationObject = {
+      'x-scalar-disable-parameters': {
+        'default-headers': {
+          default: {
+            accept: true,
+          },
+        },
+      },
+    }
+
+    const filtered = filterDisabledDefaultHeaders(operation, 'default', {
+      accept: 'text/plain',
+    })
+
+    expect(filtered.accept).toBeUndefined()
+  })
+})
 
 describe('getDefaultHeaders', () => {
   it('does not add Content-Type header when contentType is "none"', () => {

--- a/packages/workspace-store/src/request-example/context/headers.ts
+++ b/packages/workspace-store/src/request-example/context/headers.ts
@@ -7,6 +7,24 @@ import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/stric
 const DEFAULT_ACCEPT = '*/*'
 
 /**
+ * Drops default header entries that are disabled for this example via
+ * `operation['x-scalar-disable-parameters']['default-headers'][exampleName]`.
+ *
+ * Context builders keep the full default header map for the UI; call this when merging into the
+ * outbound request (for example in `requestFactory`).
+ */
+export const filterDisabledDefaultHeaders = (
+  operation: OperationObject,
+  exampleName: string,
+  headers: Record<string, string>,
+): Record<string, string> => {
+  const disabledHeaders = operation['x-scalar-disable-parameters']?.['default-headers']?.[exampleName] ?? {}
+  return Object.fromEntries(
+    Object.entries(headers).filter(([headerName]) => disabledHeaders[headerName.toLowerCase()] !== true),
+  )
+}
+
+/**
  * Generates a list of default headers for an OpenAPI operation and HTTP method.
  *
  * This function intelligently adds standard HTTP headers based on the request context:
@@ -45,7 +63,6 @@ export const getDefaultHeaders = ({
     isElectron: boolean
   }
 }): Record<string, string> => {
-  const disabledHeaders = operation['x-scalar-disable-parameters']?.['default-headers']?.[exampleName] ?? {}
   const headers = new Headers()
   const requestBody = getResolvedRef(operation.requestBody)
 
@@ -72,12 +89,11 @@ export const getDefaultHeaders = ({
     headers.set('User-Agent', `Scalar/${options.appVersion}`)
   }
 
-  // Filter out disabled headers if requested
+  const asRecord = Object.fromEntries(headers.entries())
+
   if (hideDisabledHeaders) {
-    return Object.fromEntries(
-      Array.from(headers.entries()).filter(([headerName]) => disabledHeaders[headerName.toLowerCase()] !== true),
-    )
+    return filterDisabledDefaultHeaders(operation, exampleName, asRecord)
   }
 
-  return Object.fromEntries(headers.entries())
+  return asRecord
 }


### PR DESCRIPTION
`getRequestExampleContext` intentionally keeps the full default header map (including headers the user turned off) so the request UI can show them. `requestFactory` was merging that map straight into outbound headers, so disabled defaults were still sent.

This PR filters `defaultHeaders` with the same `x-scalar-disable-parameters.default-headers` rules

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how outbound request headers are constructed, which could alter real HTTP requests for operations relying on previously-sent (but UI-disabled) default headers. Scope is small and covered by new unit tests.
> 
> **Overview**
> Fixes request building to **not send default headers that a user disabled for a given example** via `x-scalar-disable-parameters.default-headers`.
> 
> Adds `filterDisabledDefaultHeaders` in `request-example/context/headers.ts` and applies it in `requestFactory` when merging `defaultHeaders` into outbound `Headers`, plus new tests covering header removal and case-insensitive matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80652af1085891170b9b81a73ce23d1fe07dbcc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->