### PR TITLE
fix(api-client): prevent stuck response overlay after overlapping sends

### DIFF
--- a/.changeset/tangy-ducks-hammer.md
+++ b/.changeset/tangy-ducks-hammer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: prevent stuck response overlay after overlapping sends

--- a/.changeset/tangy-ducks-hammer.md
+++ b/.changeset/tangy-ducks-hammer.md
@@ -3,3 +3,6 @@
 ---
 
 fix: prevent stuck response overlay after overlapping sends
+
+Fixes a case where the response loading overlay could stay visible indefinitely and **Cancel** had no effect after opening an example and sending a request very quickly (or when multiple sends overlapped).
+The reason for that is that `ResponseLoadingOverlay` delays showing the spinner by 1s. Each `hooks:on:request:sent` scheduled a new `setTimeout` without clearing the previous one. Overlapping `sent` events could leave an orphaned timer that still called `loader.start()` after the request had already finished and `hooks:on:request:complete` had run—so the overlay turned on with no further `complete`, and **Cancel** targeted an `AbortController` that no longer matched the finished request.

--- a/packages/api-client/src/v2/blocks/response-block/components/ResponseLoadingOverlay.test.ts
+++ b/packages/api-client/src/v2/blocks/response-block/components/ResponseLoadingOverlay.test.ts
@@ -1,0 +1,48 @@
+import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ResponseLoadingOverlay from './ResponseLoadingOverlay.vue'
+
+describe('ResponseLoadingOverlay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not leave loading controls visible when overlapping sent events finish before the delayed start', async () => {
+    const eventBus = createWorkspaceEventBus()
+    const meta = {
+      method: 'get' as const,
+      path: '/api',
+      exampleKey: 'example',
+    }
+
+    const wrapper = mount(ResponseLoadingOverlay, {
+      props: { eventBus },
+      global: {
+        stubs: {
+          Transition: { template: '<div><slot /></div>' },
+          ScalarLoading: { template: '<span />' },
+        },
+      },
+    })
+
+    await flushPromises()
+
+    eventBus.emit('hooks:on:request:sent', { meta })
+    eventBus.emit('hooks:on:request:sent', { meta })
+    eventBus.emit('hooks:on:request:complete', { payload: undefined, meta })
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(wrapper.findAll('button').length).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(700)
+
+    expect(wrapper.findAll('button').length).toBe(0)
+  })
+})

--- a/packages/api-client/src/v2/blocks/response-block/components/ResponseLoadingOverlay.vue
+++ b/packages/api-client/src/v2/blocks/response-block/components/ResponseLoadingOverlay.vue
@@ -16,6 +16,10 @@ const loader = useLoadingState()
 const timeout = ref<ReturnType<typeof setTimeout>>()
 
 const startLoading = () => {
+  // Replace any pending delayed start so overlapping `hooks:on:request:sent` events
+  // (rapid send, navigation, double submit) cannot leave an orphaned timer that
+  // calls `loader.start()` after the matching request already completed.
+  clearTimeout(timeout.value)
   timeout.value = setTimeout(() => loader.start(), 1000)
 }
 


### PR DESCRIPTION
Fixes a case where the response loading overlay could stay visible indefinitely and **Cancel** had no effect after opening an example and sending a request very quickly (or when multiple sends overlapped).

The problem was because `ResponseLoadingOverlay` delays showing the spinner by 1s. Each `hooks:on:request:sent` scheduled a new `setTimeout` without clearing the previous one. Overlapping `sent` events could leave an orphaned timer that still called `loader.start()` after the request had already finished and `hooks:on:request:complete` had run—so the overlay turned on with no further `complete`, and **Cancel** targeted an `AbortController` that no longer matched the finished request.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state fix that only changes delayed loading overlay timing behavior and adds a unit test to guard against regressions.
> 
> **Overview**
> Fixes a race where overlapping `hooks:on:request:sent` events could leave an orphaned delayed timer, causing `ResponseLoadingOverlay` to activate after the request completed and leaving **Cancel** ineffective.
> 
> `ResponseLoadingOverlay` now clears any pending delayed `setTimeout` before scheduling a new one, adds a Vitest case covering overlapping sends finishing before the 1s delay, and includes a patch changeset for `@scalar/api-client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21206f72f451d70ab25dc40851c7b82c9f5b1ac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->