### PR TITLE
fix(api-reference): preserve OAuth redirect URI when switching OpenAPI documents

### DIFF
--- a/.changeset/fix-oauth-redirect-uri-document-switch.md
+++ b/.changeset/fix-oauth-redirect-uri-document-switch.md
@@ -1,0 +1,16 @@
+---
+'@scalar/api-reference': patch
+'@scalar/workspace-store': patch
+---
+
+fix(api-reference): preserve OAuth redirect URI when switching OpenAPI documents
+
+When using multiple OpenAPI documents with OAuth configured via `oauth2RedirectUri`,
+switching to another document no longer clears the Redirect URL in the Authentication
+section.
+
+The fix threads `oauth2RedirectUri` from the top-level configuration into the security
+scheme merge chain so that each newly loaded document's OAuth flows are pre-populated
+with the configured redirect URI, rather than relying solely on a component-level watcher
+that would skip re-population when the same OAuth flow identity was detected across
+documents.

--- a/packages/api-reference/src/components/Content/Auth/Auth.vue
+++ b/packages/api-reference/src/components/Content/Auth/Auth.vue
@@ -18,7 +18,7 @@ const { document, environment, eventBus, options, securitySchemes, authStore } =
   defineProps<{
     options: Pick<
       ApiReferenceConfigurationRaw,
-      'authentication' | 'persistAuth' | 'proxyUrl'
+      'authentication' | 'oauth2RedirectUri' | 'persistAuth' | 'proxyUrl'
     >
     authStore: AuthStore
     document: WorkspaceDocument | undefined
@@ -67,6 +67,7 @@ const selectedSecurity = computed(() =>
     isStatic
     layout="reference"
     :meta="{ type: 'document' }"
+    :options="{ oauth2RedirectUri: options.oauth2RedirectUri }"
     :persistAuth="options.persistAuth"
     :proxyUrl="options.proxyUrl ?? ''"
     :securityRequirements

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -59,6 +59,7 @@ const {
     | 'hiddenClients'
     | 'hideTestRequestButton'
     | 'layout'
+    | 'oauth2RedirectUri'
     | 'orderRequiredPropertiesFirst'
     | 'orderSchemaPropertiesBy'
     | 'persistAuth'
@@ -141,6 +142,7 @@ const securitySchemes = computed(() =>
     options.authentication?.securitySchemes,
     authStore,
     openApiClientDocument.value?.['x-scalar-navigation']?.name ?? '',
+    options.oauth2RedirectUri,
   ),
 )
 

--- a/packages/workspace-store/src/request-example/context/security/extract-security-scheme-secrets.test.ts
+++ b/packages/workspace-store/src/request-example/context/security/extract-security-scheme-secrets.test.ts
@@ -943,6 +943,128 @@ describe('extractSecuritySchemeSecrets', () => {
       expect((result as OAuth2ObjectSecret).flows.authorizationCode?.['x-scalar-secret-redirect-uri']).toBe('')
     })
 
+    it('uses oauth2RedirectUri as fallback when no auth store or config redirect URI is set for authorizationCode', () => {
+      const authStore = createAuthStore()
+      const scheme: ConfigAuthScheme = {
+        type: 'oauth2',
+        flows: {
+          authorizationCode: {
+            authorizationUrl: 'https://example.com/oauth/authorize',
+            tokenUrl: 'https://example.com/oauth/token',
+            scopes: {},
+            refreshUrl: '',
+            'x-usePkce': 'no',
+          },
+        },
+      }
+
+      const result = extractSecuritySchemeSecrets(
+        scheme,
+        authStore,
+        schemeName,
+        documentSlug,
+        'https://app.example.com/oauth/callback',
+      )
+
+      expect((result as OAuth2ObjectSecret).flows.authorizationCode?.['x-scalar-secret-redirect-uri']).toBe(
+        'https://app.example.com/oauth/callback',
+      )
+    })
+
+    it('oauth2RedirectUri does not override an explicitly cleared redirect URI in auth store', () => {
+      const authStore = createAuthStore()
+      authStore.setAuthSecrets(documentSlug, schemeName, {
+        type: 'oauth2',
+        authorizationCode: {
+          'x-scalar-secret-redirect-uri': '',
+        },
+      })
+
+      const scheme: ConfigAuthScheme = {
+        type: 'oauth2',
+        flows: {
+          authorizationCode: {
+            authorizationUrl: 'https://example.com/oauth/authorize',
+            tokenUrl: 'https://example.com/oauth/token',
+            scopes: {},
+            refreshUrl: '',
+            'x-usePkce': 'no',
+          },
+        },
+      }
+
+      const result = extractSecuritySchemeSecrets(
+        scheme,
+        authStore,
+        schemeName,
+        documentSlug,
+        'https://app.example.com/oauth/callback',
+      )
+
+      expect((result as OAuth2ObjectSecret).flows.authorizationCode?.['x-scalar-secret-redirect-uri']).toBe('')
+    })
+
+    it('uses oauth2RedirectUri as fallback for implicit flow when no auth store or config redirect URI', () => {
+      const authStore = createAuthStore()
+      const scheme: ConfigAuthScheme = {
+        type: 'oauth2',
+        flows: {
+          implicit: {
+            authorizationUrl: 'https://example.com/oauth/authorize',
+            scopes: {},
+            refreshUrl: '',
+          },
+        },
+      }
+
+      const result = extractSecuritySchemeSecrets(
+        scheme,
+        authStore,
+        schemeName,
+        documentSlug,
+        'https://app.example.com/oauth/callback',
+      )
+
+      expect((result as OAuth2ObjectSecret).flows.implicit?.['x-scalar-secret-redirect-uri']).toBe(
+        'https://app.example.com/oauth/callback',
+      )
+    })
+
+    it('auth store redirect URI takes priority over oauth2RedirectUri', () => {
+      const authStore = createAuthStore()
+      authStore.setAuthSecrets(documentSlug, schemeName, {
+        type: 'oauth2',
+        authorizationCode: {
+          'x-scalar-secret-redirect-uri': 'https://store.example.com/callback',
+        },
+      })
+
+      const scheme: ConfigAuthScheme = {
+        type: 'oauth2',
+        flows: {
+          authorizationCode: {
+            authorizationUrl: 'https://example.com/oauth/authorize',
+            tokenUrl: 'https://example.com/oauth/token',
+            scopes: {},
+            refreshUrl: '',
+            'x-usePkce': 'no',
+          },
+        },
+      }
+
+      const result = extractSecuritySchemeSecrets(
+        scheme,
+        authStore,
+        schemeName,
+        documentSlug,
+        'https://app.example.com/oauth/callback',
+      )
+
+      expect((result as OAuth2ObjectSecret).flows.authorizationCode?.['x-scalar-secret-redirect-uri']).toBe(
+        'https://store.example.com/callback',
+      )
+    })
+
     it('handles authorizationCode flow with PKCE enabled', () => {
       const authStore = createAuthStore()
       const scheme: ConfigAuthScheme = {

--- a/packages/workspace-store/src/request-example/context/security/extract-security-scheme-secrets.ts
+++ b/packages/workspace-store/src/request-example/context/security/extract-security-scheme-secrets.ts
@@ -47,6 +47,7 @@ const mergeFlowSecrets = <const T extends readonly (keyof typeof SECRET_TO_INPUT
   properties: T,
   configSecrets: Record<string, unknown>,
   authStoreSecrets: Record<string, unknown> = {},
+  oauth2RedirectUri?: string,
 ): Record<T[number], string> =>
   Object.fromEntries(
     properties.map((property) => {
@@ -60,9 +61,13 @@ const mergeFlowSecrets = <const T extends readonly (keyof typeof SECRET_TO_INPUT
           ? configSecrets[SECRET_TO_INPUT_FIELD_MAP[property]]
           : undefined
 
+      // oauth2RedirectUri (top-level config option) is used as a global fallback for the redirect URI,
+      // applied only when neither the auth store nor per-scheme config have a value. This ensures
+      // the configured redirect URI persists when switching between documents with the same OAuth config,
+      // because each document starts with no stored redirect URI (authStoreValue === undefined).
       const value =
         property === 'x-scalar-secret-redirect-uri'
-          ? (authStoreValue ?? configValue ?? configInputValue ?? '')
+          ? (authStoreValue ?? configValue ?? configInputValue ?? oauth2RedirectUri ?? '')
           : authStoreValue || configValue || configInputValue || ''
 
       return [property, value]
@@ -101,6 +106,7 @@ const extractCredentialsLocation = (
 const extractOAuthFlowSecrets = (
   flows: Record<string, unknown> | undefined,
   storeSecrets?: Partial<SecretsOAuthFlows> | Partial<SecretsOpenIdConnect>,
+  oauth2RedirectUri?: string,
 ): {
   flows: OAuthFlowsObjectSecret
   selectedScopes: string[]
@@ -131,6 +137,7 @@ const extractOAuthFlowSecrets = (
           ],
           flow,
           storeSecrets?.implicit,
+          oauth2RedirectUri,
         ),
         ...extractRefreshTokenSecret(storeSecrets?.implicit),
       } satisfies OAuthFlowImplicitSecret
@@ -191,6 +198,7 @@ const extractOAuthFlowSecrets = (
           ],
           flow,
           storeSecrets?.authorizationCode,
+          oauth2RedirectUri,
         ),
         ...extractCredentialsLocation(flow, storeSecrets?.authorizationCode),
         ...extractRefreshTokenSecret(storeSecrets?.authorizationCode),
@@ -210,6 +218,7 @@ export const extractSecuritySchemeSecrets = (
   authStore: AuthStore,
   name: string,
   documentSlug: string,
+  oauth2RedirectUri?: string,
 ): SecuritySchemeObjectSecret => {
   const secrets = authStore.getAuthSecrets(documentSlug, name)
 
@@ -236,7 +245,7 @@ export const extractSecuritySchemeSecrets = (
   // Handle OAuth2 security schemes and all supported flows
   if (scheme.type === 'oauth2') {
     const storeSecrets = secrets?.type === 'oauth2' ? secrets : undefined
-    const extracted = extractOAuthFlowSecrets(scheme.flows, storeSecrets)
+    const extracted = extractOAuthFlowSecrets(scheme.flows, storeSecrets, oauth2RedirectUri)
     const configuredDefaultScopes = Array.isArray(scheme['x-default-scopes'])
       ? scheme['x-default-scopes'].filter((scope): scope is string => typeof scope === 'string')
       : []
@@ -260,6 +269,7 @@ export const extractSecuritySchemeSecrets = (
         authorizationCode: storeSecrets?.authorizationCode,
       },
       storeSecrets,
+      oauth2RedirectUri,
     )
 
     return {

--- a/packages/workspace-store/src/request-example/context/security/merge-security.ts
+++ b/packages/workspace-store/src/request-example/context/security/merge-security.ts
@@ -24,6 +24,7 @@ export const mergeSecurity = (
   configSecuritySchemes: AuthenticationConfiguration['securitySchemes'] = {},
   authStore: AuthStore,
   documentName: string,
+  oauth2RedirectUri?: string,
 ): MergedSecuritySchemes => {
   /** Resolve any refs in the document security schemes */
   const resolvedDocumentSecuritySchemes = objectEntries(documentSecuritySchemes).reduce(
@@ -48,7 +49,7 @@ export const mergeSecurity = (
     // We then overwrite it back with the original value to keep any other fields like description, etc.
     const merged = { ...coerced, ...value }
 
-    acc[name] = extractSecuritySchemeSecrets(merged, authStore, name, documentName)
+    acc[name] = extractSecuritySchemeSecrets(merged, authStore, name, documentName, oauth2RedirectUri)
     return acc
   }, {} as MergedSecuritySchemes)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the bug where the Redirect URL in the Authentication section is cleared when switching between OpenAPI documents that share the same OAuth configuration.

### Root Cause

Two related issues:

1. **`oauth2RedirectUri` was never forwarded to `AuthSelector` in the reference's static auth panel.** `Auth.vue` did not include `oauth2RedirectUri` in its `options` prop pick, and did not pass `:options` to `AuthSelector`.

2. **`oauth2RedirectUri` was not part of the security scheme merge chain.** When switching documents, each new document starts with no stored redirect URI in the auth store (`undefined`). The fallback chain in `mergeFlowSecrets` ended at `''`, so the merged flow was always empty on first visit — even when `oauth2RedirectUri` was configured. A component-level watcher in `OAuth2.vue` was intended to fill in the default, but was skipped because two documents sharing identical OAuth URLs/scopes produce the same "flow identity", so `hasHandledRedirectPrefill` remained `true` from the previous document.

### Fix

Thread `oauth2RedirectUri` (the top-level configuration option) into the security scheme merge chain so the correct redirect URI is populated at the data layer rather than as a side effect:

- Added optional `oauth2RedirectUri` parameter to `mergeSecurity`, `extractSecuritySchemeSecrets`, `extractOAuthFlowSecrets`, and `mergeFlowSecrets` in `@scalar/workspace-store`
- Used `oauth2RedirectUri` as a fallback for `x-scalar-secret-redirect-uri` **after** auth store and per-scheme config values, preserving user-cleared values (because an explicit `''` in the auth store is preserved via nullish coalescing `??`)
- Added `oauth2RedirectUri` to `Content.vue`'s options `Pick` and passed it to `mergeSecurity`
- Added `oauth2RedirectUri` to `Auth.vue`'s options `Pick` and passes it to `AuthSelector` via `:options`

### Behavior

| Scenario | Before | After |
|---|---|---|
| First document load with `oauth2RedirectUri` | Redirect URI populated ✓ | Redirect URI populated ✓ |
| Switch to second document (same OAuth config) | Redirect URI **cleared** ✗ | Redirect URI populated ✓ |
| User explicitly clears redirect URI | Stays cleared ✓ | Stays cleared ✓ |
| Auth store value takes priority | ✓ | ✓ |

## Ticket

Closes #9128
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C05TFBEPV6Z/p1778143956830579?thread_ts=1778143956.830579&cid=C05TFBEPV6Z)

<div><a href="https://cursor.com/agents/bc-66f721df-64f3-5c6c-9ba7-509b378c052b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66f721df-64f3-5c6c-9ba7-509b378c052b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

