### PR TITLE
feat(api-reference): add ESM standalone bundle alongside UMD

### DIFF
--- a/.changeset/esm-standalone-bundle.md
+++ b/.changeset/esm-standalone-bundle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Add an ESM standalone build (`dist/browser/standalone.esm.js`) alongside the existing UMD bundle. The new bundle works as a side-effect script (registers `window.Scalar.createApiReference` and reads `data-*` configuration) and exports `createApiReference` for direct ESM consumers. It is fully minified through Rolldown's native minifier so the total size is on par with — slightly smaller than — the UMD bundle.

--- a/.changeset/esm-standalone-bundle.md
+++ b/.changeset/esm-standalone-bundle.md
@@ -3,3 +3,5 @@
 ---
 
 Add an ESM standalone build (`dist/browser/standalone.esm.js`) alongside the existing UMD bundle. The new bundle works as a side-effect script (registers `window.Scalar.createApiReference` and reads `data-*` configuration) and exports `createApiReference` for direct ESM consumers. It is fully minified through Rolldown's native minifier so the total size is on par with — slightly smaller than — the UMD bundle.
+
+Also declares `sideEffects` in `package.json` so downstream bundlers can tree-shake unused exports from the regular ESM library build. Only CSS files and the standalone CDN bundles in `dist/browser/` are marked as having side effects; everything else is pure.

--- a/.changeset/esm-standalone-bundle.md
+++ b/.changeset/esm-standalone-bundle.md
@@ -1,7 +1,14 @@
 ---
 '@scalar/api-reference': patch
+'@scalar/api-client': patch
 ---
 
-Add an ESM standalone build (`dist/browser/standalone.esm.js`) alongside the existing UMD bundle. The new bundle works as a side-effect script (registers `window.Scalar.createApiReference` and reads `data-*` configuration) and exports `createApiReference` for direct ESM consumers. It is fully minified through Rolldown's native minifier so the total size is on par with — slightly smaller than — the UMD bundle.
+Add an ESM standalone build (`dist/browser/standalone.esm.js`) alongside the existing UMD bundle. The new bundle works as a side-effect script (registers `window.Scalar.createApiReference` and reads `data-*` configuration) and exports `createApiReference` for direct ESM consumers. It is fully minified through Rolldown's native minifier and uses code splitting so heavy features load asynchronously after first paint:
 
-Also declares `sideEffects` in `package.json` so downstream bundlers can tree-shake unused exports from the regular ESM library build. Only CSS files and the standalone CDN bundles in `dist/browser/` are marked as having side effects; everything else is pure.
+- The API client modal (request editor, response viewer, CodeMirror) is now `await import`'d inside `onMounted` instead of statically imported, moving ~265 KB into a `chunks/modal-*.js` chunk that loads in the background.
+- The Agent Scalar chat interface (already wrapped in `defineAsyncComponent`) becomes a real `chunks/AgentScalarChatInterface-*.js` chunk (~200 KB), loaded only when the agent is enabled.
+- The 84 per-icon dynamic imports from `@scalar/icons/library` are coalesced into a single `chunks/icons-*.js`.
+
+Net effect: initial sync load drops from ~3.32 MB (UMD) to ~2.73 MB (ESM) — a ~570 KB improvement — while total bundle size shrinks by ~140 KB.
+
+Also declares `sideEffects` in both packages' `package.json` so downstream bundlers can tree-shake unused exports, and adds an `@scalar/api-client/modal/map-hidden-clients-config` deep export so consumers that only need the lightweight client-list helper don't pull the full modal barrel into their static graph.

--- a/.changeset/icons-eager-default.md
+++ b/.changeset/icons-eager-default.md
@@ -1,0 +1,5 @@
+---
+'@scalar/icons': patch
+---
+
+The library icon resolver (`@scalar/icons/library`) now eagerly bundles the `interface-content-folder` SVG and pre-populates the icon cache with it. This is the default fallback used by `<SidebarItem>` whenever an item doesn't specify a custom `x-scalar-icon`, so the most common path through the sidebar no longer waits on a per-icon dynamic chunk to resolve. The other 83 SVGs in the library remain lazy.

--- a/packages/agent-chat/src/components/ActionsDropdown.vue
+++ b/packages/agent-chat/src/components/ActionsDropdown.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
-import {
-  ScalarDropdown,
-  ScalarDropdownItem,
-  useModal,
-} from '@scalar/components'
+import { useModal } from '@scalar/components/scalar-modal'
+import { ScalarDropdown, ScalarDropdownItem } from '@scalar/components/scalar-dropdown'
 import { ScalarIconMagnifyingGlass, ScalarIconUpload } from '@scalar/icons'
 
 import Catalog from '@/views/Catalog/Catalog.vue'

--- a/packages/agent-chat/src/components/RequestPreview.vue
+++ b/packages/agent-chat/src/components/RequestPreview.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarCodeBlock } from '@scalar/components'
+import { ScalarCodeBlock } from '@scalar/components/scalar-code-block'
 import { ScalarIconCaretDown, ScalarIconCaretRight } from '@scalar/icons'
 import { type DeepPartial } from 'ai'
 import { computed, ref } from 'vue'

--- a/packages/agent-chat/src/components/ResponseBody/ResponseBodyRaw.vue
+++ b/packages/agent-chat/src/components/ResponseBody/ResponseBodyRaw.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ScalarCodeBlock } from '@scalar/components'
+import { ScalarCodeBlock } from '@scalar/components/scalar-code-block'
 
 const props = defineProps<{
   content: any

--- a/packages/agent-chat/src/components/SearchPopover.vue
+++ b/packages/agent-chat/src/components/SearchPopover.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarPopover, ScalarTextInput } from '@scalar/components'
+import { ScalarPopover } from '@scalar/components/scalar-popover'
+import { ScalarTextInput } from '@scalar/components/scalar-text-input'
 import { ScalarIconMagnifyingGlass } from '@scalar/icons'
 import { computed } from 'vue'
 

--- a/packages/agent-chat/src/components/Selector.vue
+++ b/packages/agent-chat/src/components/Selector.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarListbox } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { ScalarListbox } from '@scalar/components/scalar-listbox'
 import { ScalarIconCaretDown } from '@scalar/icons'
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed } from 'vue'

--- a/packages/agent-chat/src/components/ServerSelector.vue
+++ b/packages/agent-chat/src/components/ServerSelector.vue
@@ -22,7 +22,7 @@ export default {}
 
 <script lang="ts" setup>
 import { ServerVariablesForm } from '@scalar/api-client/components/Server'
-import { ScalarMarkdown } from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { useId } from 'vue'

--- a/packages/agent-chat/src/components/UploadSection.vue
+++ b/packages/agent-chat/src/components/UploadSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarLoading, useLoadingState } from '@scalar/components'
+import { ScalarLoading, useLoadingState } from '@scalar/components/scalar-loading'
 import { ScalarIconCheck, ScalarIconXCircle } from '@scalar/icons'
 import { computed } from 'vue'
 

--- a/packages/agent-chat/src/state/state.ts
+++ b/packages/agent-chat/src/state/state.ts
@@ -1,5 +1,5 @@
 import { Chat } from '@ai-sdk/vue'
-import { type ModalState, useModal } from '@scalar/components'
+import { type ModalState, useModal } from '@scalar/components/scalar-modal'
 import { type ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
 import { apiReferenceConfigurationSchema } from '@scalar/schemas/api-reference'
 import { useToasts } from '@scalar/use-toasts'

--- a/packages/agent-chat/src/views/Catalog/Catalog.vue
+++ b/packages/agent-chat/src/views/Catalog/Catalog.vue
@@ -1,10 +1,7 @@
 <script setup lang="ts">
-import {
-  ScalarIcon,
-  ScalarModal,
-  ScalarSearchInput,
-  type ModalState,
-} from '@scalar/components'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
+import { ScalarModal, type ModalState } from '@scalar/components/scalar-modal'
+import { ScalarSearchInput } from '@scalar/components/scalar-search-input'
 import { computed } from 'vue'
 
 import { useSearch } from '@/hooks/use-search'

--- a/packages/agent-chat/src/views/Chat/Messages/AskForAuthentication.vue
+++ b/packages/agent-chat/src/views/Chat/Messages/AskForAuthentication.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarButton } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
 import { ScalarIconArrowRight } from '@scalar/icons'
 import {
   getActiveEnvironment,

--- a/packages/agent-chat/src/views/Chat/Messages/SearchOpenAPIOperationsTool.vue
+++ b/packages/agent-chat/src/views/Chat/Messages/SearchOpenAPIOperationsTool.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarPopover } from '@scalar/components'
+import { ScalarPopover } from '@scalar/components/scalar-popover'
 import { type ToolUIPart, type UIMessage } from 'ai'
 import { computed, ref, watch, type Reactive, type Ref } from 'vue'
 

--- a/packages/agent-chat/src/views/Chat/Messages/Text.vue
+++ b/packages/agent-chat/src/views/Chat/Messages/Text.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarMarkdown } from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import { type TextUIPart } from 'ai'
 import { type Ref } from 'vue'
 

--- a/packages/agent-chat/src/views/PromptForm.vue
+++ b/packages/agent-chat/src/views/PromptForm.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import {
-  ScalarIconButton,
-  ScalarLoading,
-  ScalarTooltip,
-} from '@scalar/components'
+import { ScalarIconButton } from '@scalar/components/scalar-icon-button'
+import { ScalarLoading } from '@scalar/components/scalar-loading'
+import { ScalarTooltip } from '@scalar/components/scalar-tooltip'
 import {
   ScalarIconArrowUp,
   ScalarIconCheck,

--- a/packages/agent-chat/src/views/Settings/Settings.vue
+++ b/packages/agent-chat/src/views/Settings/Settings.vue
@@ -1,10 +1,7 @@
 <script setup lang="ts">
-import {
-  ScalarColorModeToggle,
-  ScalarModal,
-  ScalarTextInput,
-  type ModalState,
-} from '@scalar/components'
+import { ScalarModal, type ModalState } from '@scalar/components/scalar-modal'
+import { ScalarTextInput } from '@scalar/components/scalar-text-input'
+import { ScalarColorModeToggle } from '@scalar/components/scalar-color-mode-toggle'
 import { ScalarIconCaretDown, ScalarIconCaretRight } from '@scalar/icons'
 
 import { URLS } from '@/consts/urls'

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -289,6 +289,11 @@
       "types": "./dist/v2/features/modal/index.d.ts",
       "default": "./dist/v2/features/modal/index.js"
     },
+    "./modal/map-hidden-clients-config": {
+      "import": "./dist/v2/features/modal/helpers/map-hidden-clients-config.js",
+      "types": "./dist/v2/features/modal/helpers/map-hidden-clients-config.d.ts",
+      "default": "./dist/v2/features/modal/helpers/map-hidden-clients-config.js"
+    },
     "./features/operation": {
       "import": "./dist/v2/features/operation/index.js",
       "types": "./dist/v2/features/operation/index.d.ts",
@@ -308,6 +313,9 @@
   "files": [
     "dist",
     "CHANGELOG.md"
+  ],
+  "sideEffects": [
+    "**/*.css"
   ],
   "dependencies": {
     "@headlessui/tailwindcss": "catalog:*",

--- a/packages/api-client/src/components/HttpMethod/HttpMethod.vue
+++ b/packages/api-client/src/components/HttpMethod/HttpMethod.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { cva, cx, ScalarListbox } from '@scalar/components'
+import { ScalarListbox } from '@scalar/components/scalar-listbox'
 import {
   getHttpMethodInfo,
   REQUEST_METHODS,
 } from '@scalar/helpers/http/http-info'
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import { objectEntries } from '@scalar/helpers/object/object-entries'
+import { cva, cx } from '@scalar/use-hooks/useBindCx'
 import { computed } from 'vue'
 
 const props = withDefaults(

--- a/packages/api-client/src/components/SectionFilter.vue
+++ b/packages/api-client/src/components/SectionFilter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts" generic="T extends string">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
 import { nextTick, ref } from 'vue'
 
 import SectionFilterButton from '@/components/SectionFilterButton.vue'

--- a/packages/api-client/src/components/Server/ServerVariablesSelect.vue
+++ b/packages/api-client/src/components/Server/ServerVariablesSelect.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
+import { ScalarButton } from '@scalar/components/scalar-button'
 import {
-  ScalarButton,
   ScalarListbox,
   type ScalarListboxOption,
-} from '@scalar/components'
+} from '@scalar/components/scalar-listbox'
 import { ScalarIconCaretDown } from '@scalar/icons'
 import { computed } from 'vue'
 

--- a/packages/api-client/src/components/Sidebar/Actions/SidebarListElementForm.vue
+++ b/packages/api-client/src/components/Sidebar/Actions/SidebarListElementForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarButton } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
 
 defineProps<{
   danger?: boolean

--- a/packages/api-client/src/components/ViewLayout/ViewLayout.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useBindCx } from '@scalar/components'
+import { useBindCx } from '@scalar/use-hooks/useBindCx'
 
 const { cx } = useBindCx()
 </script>

--- a/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
+++ b/packages/api-client/src/components/ViewLayout/ViewLayoutSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useBindCx } from '@scalar/components'
+import { useBindCx } from '@scalar/use-hooks/useBindCx'
 
 defineOptions({ inheritAttrs: false })
 

--- a/packages/api-client/src/v2/blocks/operation-block/components/Header.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/components/Header.vue
@@ -45,7 +45,8 @@ export type HeaderProps = {
 </script>
 
 <script setup lang="ts">
-import { ScalarIcon, ScalarIconButton } from '@scalar/components'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
+import { ScalarIconButton } from '@scalar/components/scalar-icon-button'
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import { ScalarIconGearSix } from '@scalar/icons'
 import type {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/components/ExamplePicker.vue
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/components/ExamplePicker.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
+import { ScalarButton } from '@scalar/components/scalar-button'
 import {
-  ScalarButton,
   ScalarListbox,
   type ScalarListboxOption,
-} from '@scalar/components'
+} from '@scalar/components/scalar-listbox'
 import { ScalarIconCaretDown } from '@scalar/icons'
 import type { MediaTypeObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed } from 'vue'

--- a/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.vue
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.vue
@@ -111,16 +111,16 @@ export default {}
 </script>
 
 <script setup lang="ts">
+import { ScalarButton } from '@scalar/components/scalar-button'
 import {
-  ScalarButton,
   ScalarCard,
   ScalarCardFooter,
   ScalarCardHeader,
   ScalarCardSection,
-  ScalarCodeBlock,
-  ScalarCombobox,
-  ScalarVirtualText,
-} from '@scalar/components'
+} from '@scalar/components/scalar-card'
+import { ScalarCodeBlock } from '@scalar/components/scalar-code-block'
+import { ScalarCombobox } from '@scalar/components/scalar-combobox'
+import { ScalarVirtualText } from '@scalar/components/scalar-virtual-text'
 import { freezeElement } from '@scalar/helpers/dom/freeze-element'
 import type { HttpMethod as HttpMethodType } from '@scalar/helpers/http/http-methods'
 import { ScalarIconCaretDown } from '@scalar/icons'

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/filter-clients-by-query.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/filter-clients-by-query.ts
@@ -1,4 +1,4 @@
-import type { ScalarComboboxFilterFunction } from '@scalar/components'
+import type { ScalarComboboxFilterFunction } from '@scalar/components/scalar-combobox'
 
 import type { CustomClientOptionGroup, CustomOrDefaultClientOption } from '@/v2/blocks/operation-code-sample/types'
 

--- a/packages/api-client/src/v2/blocks/operation-code-sample/types.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/types.ts
@@ -1,4 +1,4 @@
-import type { ScalarComboboxOption, ScalarComboboxOptionGroup } from '@scalar/components'
+import type { ScalarComboboxOption, ScalarComboboxOptionGroup } from '@scalar/components/scalar-combobox'
 import type { AvailableClients, ClientId, TargetId } from '@scalar/snippetz'
 
 /**

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarErrorBoundary } from '@scalar/components'
+import { ScalarErrorBoundary } from '@scalar/components/scalar-error-boundary'
 import { canMethodHaveBody } from '@scalar/helpers/http/can-method-have-body'
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import { REGEX } from '@scalar/helpers/regex/regex-helpers'

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestBody.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestBody.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarIcon, ScalarListbox } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
+import { ScalarListbox } from '@scalar/components/scalar-listbox'
 import { CONTENT_TYPES } from '@scalar/helpers/http/content-types'
 import { objectEntries } from '@scalar/helpers/object/object-entries'
 import type { ApiReferenceEvents } from '@scalar/workspace-store/events'

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestCodeSnippet.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestCodeSnippet.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
-import {
-  ScalarButton,
-  ScalarCodeBlock,
-  ScalarCombobox,
-  ScalarErrorBoundary,
-} from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { ScalarCodeBlock } from '@scalar/components/scalar-code-block'
+import { ScalarCombobox } from '@scalar/components/scalar-combobox'
+import { ScalarErrorBoundary } from '@scalar/components/scalar-error-boundary'
 import { ScalarIconCaretDown } from '@scalar/icons'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { computed, ref, watch } from 'vue'

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestParams.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestParams.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarTooltip } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { ScalarTooltip } from '@scalar/components/scalar-tooltip'
 import type {
   ApiReferenceEvents,
   WorkspaceEventBus,

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarIcon, ScalarIconButton } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
+import { ScalarIconButton } from '@scalar/components/scalar-icon-button'
 import { ScalarIconGlobe, ScalarIconTrash } from '@scalar/icons'
 import type { ApiReferenceEvents } from '@scalar/workspace-store/events'
 import { unpackProxyObject } from '@scalar/workspace-store/helpers/unpack-proxy'

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableTooltip.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableTooltip.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarMarkdown, ScalarPopover } from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
+import { ScalarPopover } from '@scalar/components/scalar-popover'
 import { ScalarIconInfo, ScalarIconWarning } from '@scalar/icons'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed } from 'vue'

--- a/packages/api-client/src/v2/blocks/response-block/ResponseBlock.vue
+++ b/packages/api-client/src/v2/blocks/response-block/ResponseBlock.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarErrorBoundary } from '@scalar/components'
+import { ScalarErrorBoundary } from '@scalar/components/scalar-error-boundary'
 import { isDefined } from '@scalar/helpers/array/is-defined'
 import type { ClientPlugin } from '@scalar/oas-utils/helpers'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'

--- a/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyDownload.vue
+++ b/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyDownload.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
 import { computed } from 'vue'
 
 import { getMediaTypeConfig } from '@/v2/blocks/response-block/helpers/media-types'

--- a/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyRaw.vue
+++ b/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyRaw.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ScalarCodeBlockCopy } from '@scalar/components'
+import { ScalarCodeBlockCopy } from '@scalar/components/scalar-code-block'
 import { prettyPrintJson } from '@scalar/helpers/json/pretty-print-json'
 import { useCodeMirror, type CodeMirrorLanguage } from '@scalar/use-codemirror'
 import { ref, toRef, useId } from 'vue'

--- a/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyStreaming.test.ts
+++ b/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyStreaming.test.ts
@@ -1,4 +1,4 @@
-import { ScalarButton } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
 import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'

--- a/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyStreaming.vue
+++ b/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyStreaming.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
+import { ScalarButton } from '@scalar/components/scalar-button'
 import {
-  ScalarButton,
   ScalarLoading,
   useLoadingState,
-} from '@scalar/components'
+} from '@scalar/components/scalar-loading'
 import { nextTick, onBeforeUnmount, ref, watch } from 'vue'
 
 import { CollapsibleSection } from '@/v2/components/layout'

--- a/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyVirtual.vue
+++ b/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyVirtual.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarVirtualText } from '@scalar/components'
+import { ScalarVirtualText } from '@scalar/components/scalar-virtual-text'
 import { formatJsonOrYamlString } from '@scalar/oas-utils/helpers'
 import { computed } from 'vue'
 

--- a/packages/api-client/src/v2/blocks/response-block/components/ResponseEmpty.vue
+++ b/packages/api-client/src/v2/blocks/response-block/components/ResponseEmpty.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarHotkey } from '@scalar/components'
+import { ScalarHotkey } from '@scalar/components/scalar-hotkey'
 
 import Computer from '@/assets/computer.ascii?raw'
 import { ScalarAsciiArt } from '@/components/ScalarAsciiArt'

--- a/packages/api-client/src/v2/blocks/response-block/components/ResponseLoadingOverlay.vue
+++ b/packages/api-client/src/v2/blocks/response-block/components/ResponseLoadingOverlay.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
+import { ScalarButton } from '@scalar/components/scalar-button'
 import {
-  ScalarButton,
   ScalarLoading,
   useLoadingState,
-} from '@scalar/components'
+} from '@scalar/components/scalar-loading'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -33,11 +33,9 @@ export type AddressBarProps = {
 }
 </script>
 <script setup lang="ts">
-import {
-  ScalarButton,
-  ScalarIcon,
-  ScalarWrappingText,
-} from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
+import { ScalarWrappingText } from '@scalar/components/scalar-wrapping-text'
 import { getSelector } from '@scalar/helpers/dom/get-selector'
 import { REQUEST_METHODS } from '@scalar/helpers/http/http-info'
 import type { HttpMethod as HttpMethodType } from '@scalar/helpers/http/http-methods'

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBarHistory.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBarHistory.vue
@@ -3,8 +3,8 @@ import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
 import {
   ScalarFloating,
   ScalarFloatingBackdrop,
-  ScalarIcon,
-} from '@scalar/components'
+} from '@scalar/components/scalar-floating'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
 import { formatMilliseconds } from '@scalar/helpers/formatters/format-milliseconds'
 import type { HttpMethod as HttpMethodType } from '@scalar/helpers/http/http-methods'
 import { httpStatusCodes } from '@scalar/helpers/http/http-status-codes'

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/EnvironmentSelector.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/EnvironmentSelector.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
+import { ScalarButton } from '@scalar/components/scalar-button'
 import {
-  ScalarButton,
   ScalarDropdown,
   ScalarDropdownDivider,
   ScalarDropdownItem,
-  ScalarIcon,
-} from '@scalar/components'
+} from '@scalar/components/scalar-dropdown'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
 import { computed } from 'vue'
 
 const { environments = [], activeEnvironment } = defineProps<{

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/AuthSelector.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/AuthSelector.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import {
   ScalarButton,
-  ScalarComboboxMultiselect,
-  ScalarIconButton,
-  ScalarListboxCheckbox,
-  useModal,
-  type Icon,
   type ScalarButton as ScalarButtonType,
-} from '@scalar/components'
+} from '@scalar/components/scalar-button'
+import { ScalarComboboxMultiselect } from '@scalar/components/scalar-combobox'
+import type { Icon } from '@scalar/components/scalar-icon'
+import { ScalarIconButton } from '@scalar/components/scalar-icon-button'
+import { ScalarListboxCheckbox } from '@scalar/components/scalar-listbox'
+import { useModal } from '@scalar/components/scalar-modal'
 import { ScalarIconCaretDown, ScalarIconTrash } from '@scalar/icons'
 import type { SelectedSecurity } from '@scalar/workspace-store/entities/auth'
 import type {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/DeleteRequestAuthModal.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/DeleteRequestAuthModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarModal } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { ScalarModal } from '@scalar/components/scalar-modal'
 
 defineProps<{
   state: { open: boolean; show: () => void; hide: () => void }

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
@@ -4,7 +4,8 @@ export type OAuth2Options = Pick<ApiClientConfiguration, 'oauth2RedirectUri'>
 </script>
 
 <script setup lang="ts">
-import { ScalarButton, useLoadingState } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { useLoadingState } from '@scalar/components/scalar-loading'
 import type { ApiClientConfiguration } from '@scalar/types/api-reference'
 import { pkceOptions } from '@scalar/types/entities'
 import { useToasts } from '@scalar/use-toasts'

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesAddModal.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesAddModal.test.ts
@@ -1,4 +1,4 @@
-import { useModal } from '@scalar/components'
+import { useModal } from '@scalar/components/scalar-modal'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesAddModal.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesAddModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarModal, type ModalState } from '@scalar/components'
+import { ScalarModal, type ModalState } from '@scalar/components/scalar-modal'
 import { useToasts } from '@scalar/use-toasts'
 import { ref, watch } from 'vue'
 

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import {
-  ScalarButton,
-  ScalarIcon,
-  ScalarSearchInput,
-  useModal,
-} from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
+import { useModal } from '@scalar/components/scalar-modal'
+import { ScalarSearchInput } from '@scalar/components/scalar-search-input'
 import type { ApiReferenceEvents } from '@scalar/workspace-store/events'
 import type {
   OAuthFlow,

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OpenIDConnect.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OpenIDConnect.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, useLoadingState } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { useLoadingState } from '@scalar/components/scalar-loading'
 import { useToasts } from '@scalar/use-toasts'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarMarkdownSummary } from '@scalar/components'
+import { ScalarMarkdownSummary } from '@scalar/components/scalar-markdown'
 import type {
   SecretsApiKey,
   SecretsHttp,

--- a/packages/api-client/src/v2/components/code-input/PillTooltipHost.vue
+++ b/packages/api-client/src/v2/components/code-input/PillTooltipHost.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useTooltip } from '@scalar/components'
+import { useTooltip } from '@scalar/components/scalar-tooltip'
 import { computed, h, ref, render } from 'vue'
 
 import type { PillContext } from './pill-context'

--- a/packages/api-client/src/v2/components/data-table/DataTable.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useBindCx } from '@scalar/components'
+import { useBindCx } from '@scalar/use-hooks/useBindCx'
 
 defineProps<{
   columns: (string | undefined)[]

--- a/packages/api-client/src/v2/components/data-table/DataTableCell.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTableCell.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useBindCx } from '@scalar/components'
+import { useBindCx } from '@scalar/use-hooks/useBindCx'
 import type { Component } from 'vue'
 
 withDefaults(

--- a/packages/api-client/src/v2/components/data-table/DataTableCheckbox.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTableCheckbox.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { cva, ScalarIcon } from '@scalar/components'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
+import { cva } from '@scalar/use-hooks/useBindCx'
 
 import DataTableCell from './DataTableCell.vue'
 

--- a/packages/api-client/src/v2/components/data-table/DataTableHeader.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTableHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useBindCx } from '@scalar/components'
+import { useBindCx } from '@scalar/use-hooks/useBindCx'
 
 import DataTableCell from './DataTableCell.vue'
 

--- a/packages/api-client/src/v2/components/data-table/DataTableInput.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTableInput.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIconButton } from '@scalar/components'
+import { ScalarIconButton } from '@scalar/components/scalar-icon-button'
 import { ScalarIconEye, ScalarIconEyeSlash, ScalarIconX } from '@scalar/icons'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
 import { computed, ref, useTemplateRef } from 'vue'

--- a/packages/api-client/src/v2/components/data-table/DataTableInputSelect.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTableInputSelect.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { ScalarComboboxMultiselect } from '@scalar/components/scalar-combobox'
 import {
-  ScalarButton,
-  ScalarComboboxMultiselect,
   ScalarDropdown,
   ScalarDropdownDivider,
   ScalarDropdownItem,
-  ScalarIcon,
-} from '@scalar/components'
+} from '@scalar/components/scalar-dropdown'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
 import { computed, nextTick, ref, watch } from 'vue'
 
 import type { CodeInputModelValue } from '@/v2/components/code-input/CodeInput.vue'

--- a/packages/api-client/src/v2/components/forms/ConfirmationForm.vue
+++ b/packages/api-client/src/v2/components/forms/ConfirmationForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarButton } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
 
 const { label = 'Save', variant = 'solid' } = defineProps<{
   /** The label of the submit button */

--- a/packages/api-client/src/v2/components/layout/CollapsibleSection.vue
+++ b/packages/api-client/src/v2/components/layout/CollapsibleSection.vue
@@ -11,7 +11,7 @@ export default {
 
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
 import { useId } from 'vue'
 
 import ValueEmitter from './ValueEmitter.vue'

--- a/packages/api-client/src/v2/components/modals/ModalClientContainer.spec.ts
+++ b/packages/api-client/src/v2/components/modals/ModalClientContainer.spec.ts
@@ -1,4 +1,4 @@
-import type { ModalState } from '@scalar/components'
+import type { ModalState } from '@scalar/components/scalar-modal'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'

--- a/packages/api-client/src/v2/components/modals/ModalClientContainer.vue
+++ b/packages/api-client/src/v2/components/modals/ModalClientContainer.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import {
-  addScalarClassesToHeadless,
-  ScalarTeleportRoot,
-  type ModalState,
-} from '@scalar/components'
+import { addScalarClassesToHeadless } from '@scalar/components/helpers'
+import type { ModalState } from '@scalar/components/scalar-modal'
+import { ScalarTeleportRoot } from '@scalar/components/scalar-teleport'
 import { useFocusTrap } from '@vueuse/integrations/useFocusTrap'
 import { nextTick, onBeforeMount, onBeforeUnmount, ref, watch } from 'vue'
 

--- a/packages/api-client/src/v2/components/server/ServerDropdown.vue
+++ b/packages/api-client/src/v2/components/server/ServerDropdown.vue
@@ -21,11 +21,9 @@ export type ServerDropdownProps = {
 }
 </script>
 <script setup lang="ts">
-import {
-  ScalarButton,
-  ScalarFloatingBackdrop,
-  ScalarPopover,
-} from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { ScalarFloatingBackdrop } from '@scalar/components/scalar-floating'
+import { ScalarPopover } from '@scalar/components/scalar-popover'
 import { ScalarIconPencilSimple, ScalarIconPlus } from '@scalar/icons'
 import type {
   ApiReferenceEvents,

--- a/packages/api-client/src/v2/components/server/ServerDropdownItem.vue
+++ b/packages/api-client/src/v2/components/server/ServerDropdownItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarListboxCheckbox, ScalarMarkdown } from '@scalar/components'
+import { ScalarListboxCheckbox } from '@scalar/components/scalar-listbox'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed, useId } from 'vue'
 

--- a/packages/api-client/src/v2/components/sidebar/Sidebar.vue
+++ b/packages/api-client/src/v2/components/sidebar/Sidebar.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import {
-  ScalarIconButton,
-  ScalarSidebarSearchInput,
-  type WorkspaceGroup,
-} from '@scalar/components'
+import { ScalarIconButton } from '@scalar/components/scalar-icon-button'
+import type { WorkspaceGroup } from '@scalar/components/scalar-menu'
+import { ScalarSidebarSearchInput } from '@scalar/components/scalar-sidebar'
 import { ScalarIconFileDashed, ScalarIconMagnifyingGlass } from '@scalar/icons'
 import {
   ScalarSidebar,

--- a/packages/api-client/src/v2/components/sidebar/SidebarMenu.vue
+++ b/packages/api-client/src/v2/components/sidebar/SidebarMenu.vue
@@ -8,7 +8,7 @@ import {
   ScalarMenuSupport,
   ScalarMenuWorkspacePicker,
   type WorkspaceGroup,
-} from '@scalar/components'
+} from '@scalar/components/scalar-menu'
 import { ScalarIconGear } from '@scalar/icons'
 
 const { activeWorkspace, workspaces } = defineProps<{

--- a/packages/api-client/src/v2/features/command-palette/components/CommandActionForm.vue
+++ b/packages/api-client/src/v2/features/command-palette/components/CommandActionForm.vue
@@ -32,7 +32,9 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { ScalarButton, useBindCx, type LoadingState } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import type { LoadingState } from '@scalar/components/scalar-loading'
+import { useBindCx } from '@scalar/use-hooks/useBindCx'
 
 const { loader, disabled = false } = defineProps<{
   /** Loading state from useLoadingState composable to show spinner on submit button */

--- a/packages/api-client/src/v2/features/environments/EnvironmentsList.vue
+++ b/packages/api-client/src/v2/features/environments/EnvironmentsList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, useModal } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { useModal } from '@scalar/components/scalar-modal'
 import { ScalarIconPlus } from '@scalar/icons'
 import type {
   CollectionType,

--- a/packages/api-client/src/v2/features/environments/components/Environment.vue
+++ b/packages/api-client/src/v2/features/environments/components/Environment.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ScalarIconButton } from '@scalar/components'
+import { ScalarIconButton } from '@scalar/components/scalar-icon-button'
 import { ScalarIconNotePencil, ScalarIconTrash } from '@scalar/icons'
 import type {
   CollectionType,

--- a/packages/api-client/src/v2/features/environments/components/EnvironmentColors.vue
+++ b/packages/api-client/src/v2/features/environments/components/EnvironmentColors.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
 import { computed, nextTick, ref } from 'vue'
 
 const { activeColor } = defineProps<{

--- a/packages/api-client/src/v2/features/environments/components/EnvironmentCreateModal.vue
+++ b/packages/api-client/src/v2/features/environments/components/EnvironmentCreateModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarModal, type ModalState } from '@scalar/components'
+import { ScalarModal, type ModalState } from '@scalar/components/scalar-modal'
 import type {
   CollectionType,
   WorkspaceEventBus,

--- a/packages/api-client/src/v2/features/environments/components/EnvironmentDeleteModal.vue
+++ b/packages/api-client/src/v2/features/environments/components/EnvironmentDeleteModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarModal, type ModalState } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { ScalarModal, type ModalState } from '@scalar/components/scalar-modal'
 
 const { state, name = 'unknown' } = defineProps<{
   state: ModalState

--- a/packages/api-client/src/v2/features/environments/components/EnvironmentVariablesDropdown.vue
+++ b/packages/api-client/src/v2/features/environments/components/EnvironmentVariablesDropdown.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarTeleport } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { ScalarTeleport } from '@scalar/components/scalar-teleport'
 import { ScalarIconPlus } from '@scalar/icons'
 import { POPULAR_CONTEXT_FUNCTION_KEYS } from '@scalar/workspace-store/request-example'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'

--- a/packages/api-client/src/v2/features/environments/components/EnvironmentVariablesTable.vue
+++ b/packages/api-client/src/v2/features/environments/components/EnvironmentVariablesTable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarButton } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
 import { ScalarIconTrash } from '@scalar/icons'
 import type {
   CollectionType,

--- a/packages/api-client/src/v2/features/modal/Modal.test.ts
+++ b/packages/api-client/src/v2/features/modal/Modal.test.ts
@@ -1,4 +1,4 @@
-import { useModal } from '@scalar/components'
+import { useModal } from '@scalar/components/scalar-modal'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'

--- a/packages/api-client/src/v2/features/modal/Modal.vue
+++ b/packages/api-client/src/v2/features/modal/Modal.vue
@@ -33,7 +33,8 @@ export default {}
 </script>
 
 <script setup lang="ts">
-import { type ModalState, type ScalarListboxOption } from '@scalar/components'
+import type { ScalarListboxOption } from '@scalar/components/scalar-listbox'
+import type { ModalState } from '@scalar/components/scalar-modal'
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import type { ClientPlugin } from '@scalar/oas-utils/helpers'
 import { ScalarToasts } from '@scalar/use-toasts'

--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
@@ -1,4 +1,4 @@
-import { type ModalState, useModal } from '@scalar/components'
+import { type ModalState, useModal } from '@scalar/components/scalar-modal'
 import type { ClientPlugin } from '@scalar/oas-utils/helpers'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import { type WorkspaceEventBus, createWorkspaceEventBus } from '@scalar/workspace-store/events'
@@ -9,9 +9,9 @@ import {
   type RoutePayload,
   resolveRouteParameters,
 } from '@/v2/features/modal/helpers/resolve-route-parameters'
-import type { ApiClientOptions, ApiClientOptionsRef } from '@/v2/types/options'
 import { useModalSidebar } from '@/v2/features/modal/hooks/use-modal-sidebar'
 import Modal, { type ModalProps } from '@/v2/features/modal/Modal.vue'
+import type { ApiClientOptions, ApiClientOptionsRef } from '@/v2/types/options'
 
 type CreateApiClientOptions = {
   /** Element to mount the client modal to. */

--- a/packages/api-client/src/v2/features/modal/modal-events.ts
+++ b/packages/api-client/src/v2/features/modal/modal-events.ts
@@ -1,4 +1,4 @@
-import type { ModalState } from '@scalar/components'
+import type { ModalState } from '@scalar/components/scalar-modal'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'

--- a/packages/api-client/src/v2/features/search/components/DocumentSearchModal.vue
+++ b/packages/api-client/src/v2/features/search/components/DocumentSearchModal.vue
@@ -1,10 +1,7 @@
 <script setup lang="ts">
-import {
-  ScalarModal,
-  ScalarSearchInput,
-  ScalarSearchResultList,
-  type ModalState,
-} from '@scalar/components'
+import { ScalarModal, type ModalState } from '@scalar/components/scalar-modal'
+import { ScalarSearchInput } from '@scalar/components/scalar-search-input'
+import { ScalarSearchResultList } from '@scalar/components/scalar-search-results'
 import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { nanoid } from 'nanoid'
 import { computed, ref, watch } from 'vue'

--- a/packages/api-client/src/v2/features/search/components/SearchResult.vue
+++ b/packages/api-client/src/v2/features/search/components/SearchResult.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarSearchResultItem } from '@scalar/components'
+import { ScalarSearchResultItem } from '@scalar/components/scalar-search-results'
 import {
   ScalarIconTag,
   ScalarIconTerminalWindow,

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -99,6 +99,10 @@
     "!dist/webpack-stats.json",
     "CHANGELOG.md"
   ],
+  "sideEffects": [
+    "**/*.css",
+    "./dist/browser/**"
+  ],
   "browser": "./dist/browser/standalone.js",
   "esm.sh": {
     "bundle": true

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -25,9 +25,10 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "pnpm build:default && pnpm build:styles && pnpm build:standalone && vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
+    "build": "pnpm build:default && pnpm build:styles && pnpm build:standalone && pnpm build:standalone:esm && vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:default": "vite build",
     "build:standalone": "vite build -c vite.standalone.config.ts",
+    "build:standalone:esm": "vite build -c vite.standalone.esm.config.ts",
     "build:styles": "cp -r src/styles dist && tailwindcss --optimize -i src/style.css -o dist/style.css && cat dist/vue-styles.css >> dist/style.css",
     "dev": "vite",
     "dev:standalone": "vite -c vite.standalone.config.ts",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -96,7 +96,8 @@
   },
   "files": [
     "dist",
-    "!dist/browser/webpack-stats*.json",
+    "!dist/browser/webpack-stats.json",
+    "!dist/browser/webpack-stats.esm.json",
     "CHANGELOG.md"
   ],
   "sideEffects": [

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -96,7 +96,7 @@
   },
   "files": [
     "dist",
-    "!dist/webpack-stats.json",
+    "!dist/browser/webpack-stats*.json",
     "CHANGELOG.md"
   ],
   "sideEffects": [

--- a/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientDropdown.vue
+++ b/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientDropdown.vue
@@ -7,7 +7,8 @@ import {
   type ClientOptionGroup,
   type CustomClientOption,
 } from '@scalar/api-client/blocks/operation-code-sample'
-import { ScalarCombobox, ScalarIcon } from '@scalar/components'
+import { ScalarCombobox } from '@scalar/components/scalar-combobox'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
 import { freezeElement } from '@scalar/helpers/dom/freeze-element'
 import type { AvailableClients, TargetId } from '@scalar/types/snippetz'
 import { type WorkspaceEventBus } from '@scalar/workspace-store/events'

--- a/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientSelector.vue
+++ b/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientSelector.vue
@@ -4,7 +4,8 @@ import {
   DEFAULT_CLIENT,
   type ClientOptionGroup,
 } from '@scalar/api-client/blocks/operation-code-sample'
-import { ScalarCodeBlock, ScalarMarkdown } from '@scalar/components'
+import { ScalarCodeBlock } from '@scalar/components/scalar-code-block'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import type { AvailableClient } from '@scalar/snippetz'
 import { type WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { XScalarSdkInstallation } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-sdk-installation'

--- a/packages/api-reference/src/blocks/scalar-info-block/components/InfoDescription.test.ts
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/InfoDescription.test.ts
@@ -1,4 +1,4 @@
-import { ScalarMarkdown } from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/api-reference/src/blocks/scalar-info-block/components/InfoMarkdownSection.test.ts
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/InfoMarkdownSection.test.ts
@@ -1,4 +1,4 @@
-import { ScalarMarkdown } from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/api-reference/src/blocks/scalar-info-block/components/InfoMarkdownSection.vue
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/InfoMarkdownSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Node } from '@scalar/code-highlight'
-import { ScalarMarkdown } from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { useTemplateRef } from 'vue'
 

--- a/packages/api-reference/src/blocks/scalar-server-selector-block/components/Selector.vue
+++ b/packages/api-reference/src/blocks/scalar-server-selector-block/components/Selector.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, ScalarListbox } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { ScalarListbox } from '@scalar/components/scalar-listbox'
 import { ScalarIconCaretDown } from '@scalar/icons'
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed } from 'vue'

--- a/packages/api-reference/src/blocks/scalar-server-selector-block/components/ServerSelector.vue
+++ b/packages/api-reference/src/blocks/scalar-server-selector-block/components/ServerSelector.vue
@@ -22,7 +22,7 @@ export default {}
 
 <script lang="ts" setup>
 import { ServerVariablesForm } from '@scalar/api-client/components/Server'
-import { ScalarMarkdown } from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { useId } from 'vue'

--- a/packages/api-reference/src/components/AgentScalar/AgentScalarDrawer.vue
+++ b/packages/api-reference/src/components/AgentScalar/AgentScalarDrawer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIconButton } from '@scalar/components'
+import { ScalarIconButton } from '@scalar/components/scalar-icon-button'
 import { ScalarIconX } from '@scalar/icons'
 import type {
   ApiReferenceConfigurationWithSource,

--- a/packages/api-reference/src/components/AgentScalar/OpenMCPButton.vue
+++ b/packages/api-reference/src/components/AgentScalar/OpenMCPButton.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useLoadingState } from '@scalar/components'
+import { useLoadingState } from '@scalar/components/scalar-loading'
 import { isValidUrl } from '@scalar/helpers/url/is-valid-url'
 import { ScalarIconArrowUpRight } from '@scalar/icons'
 import type { ExternalUrls } from '@scalar/types/api-reference'

--- a/packages/api-reference/src/components/Anchor/Anchor.vue
+++ b/packages/api-reference/src/components/Anchor/Anchor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarButton, useBindCx } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { useBindCx } from '@scalar/use-hooks/useBindCx'
 import { ScalarIconHash } from '@scalar/icons'
 import { useId } from 'vue'
 

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -15,7 +15,7 @@ import { OpenApiClientButton } from '@scalar/api-client/blocks/operation-block'
 import type { ApiClientModal } from '@scalar/api-client/modal'
 import { ScalarColorModeToggleButton, ScalarColorModeToggleIcon } from '@scalar/components/scalar-color-mode-toggle'
 import { ScalarSidebarFooter } from '@scalar/components/scalar-sidebar'
-import { addScalarClassesToHeadless } from '@scalar/components'
+import { addScalarClassesToHeadless } from '@scalar/components/helpers'
 import { isLocalUrl } from '@scalar/helpers/url/is-local-url'
 import { apiReferenceConfigurationSchema } from '@scalar/schemas/api-reference'
 import {

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -12,10 +12,7 @@ if (version && typeof window !== 'undefined') {
 <script setup lang="ts">
 import { provideUseId } from '@headlessui/vue'
 import { OpenApiClientButton } from '@scalar/api-client/blocks/operation-block'
-import {
-  createApiClientModal,
-  type ApiClientModal,
-} from '@scalar/api-client/modal'
+import type { ApiClientModal } from '@scalar/api-client/modal'
 import {
   addScalarClassesToHeadless,
   ScalarColorModeToggleButton,
@@ -764,10 +761,20 @@ provide(AGENT_CONTEXT_SYMBOL, agent)
 // --------------------------------------------------------------------------- */
 // Api Client Modal
 
-// Setup the ApiClient on mount
+// Setup the ApiClient on mount.
+// The modal is dynamic-imported so its dependency graph (CodeMirror, the request
+// editor, the response viewer, etc.) becomes a separate chunk that loads
+// asynchronously after the API reference paints.
 const modal = useTemplateRef<HTMLElement>('modal')
 const apiClient = ref<ApiClientModal | null>(null)
-onMounted(() => {
+onMounted(async () => {
+  if (!modal.value) {
+    return
+  }
+
+  const { createApiClientModal } = await import('@scalar/api-client/modal')
+
+  // Bail if the component unmounted while the chunk was loading.
   if (!modal.value) {
     return
   }

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -13,12 +13,9 @@ if (version && typeof window !== 'undefined') {
 import { provideUseId } from '@headlessui/vue'
 import { OpenApiClientButton } from '@scalar/api-client/blocks/operation-block'
 import type { ApiClientModal } from '@scalar/api-client/modal'
-import {
-  addScalarClassesToHeadless,
-  ScalarColorModeToggleButton,
-  ScalarColorModeToggleIcon,
-  ScalarSidebarFooter,
-} from '@scalar/components'
+import { ScalarColorModeToggleButton, ScalarColorModeToggleIcon } from '@scalar/components/scalar-color-mode-toggle'
+import { ScalarSidebarFooter } from '@scalar/components/scalar-sidebar'
+import { addScalarClassesToHeadless } from '@scalar/components'
 import { isLocalUrl } from '@scalar/helpers/url/is-local-url'
 import { apiReferenceConfigurationSchema } from '@scalar/schemas/api-reference'
 import {

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { generateClientOptions } from '@scalar/api-client/blocks/operation-code-sample'
-import { mapHiddenClientsConfig } from '@scalar/api-client/modal'
+import { mapHiddenClientsConfig } from '@scalar/api-client/modal/map-hidden-clients-config'
 import { ScalarErrorBoundary } from '@scalar/components'
 import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
 import type { Heading } from '@scalar/types/legacy'

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { generateClientOptions } from '@scalar/api-client/blocks/operation-code-sample'
 import { mapHiddenClientsConfig } from '@scalar/api-client/modal/map-hidden-clients-config'
-import { ScalarErrorBoundary } from '@scalar/components'
+import { ScalarErrorBoundary } from '@scalar/components/scalar-error-boundary'
 import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
 import type { Heading } from '@scalar/types/legacy'
 import type { AuthStore } from '@scalar/workspace-store/entities/auth'

--- a/packages/api-reference/src/components/Content/Models/components/ModernLayout.vue
+++ b/packages/api-reference/src/components/Content/Models/components/ModernLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarErrorBoundary } from '@scalar/components'
+import { ScalarErrorBoundary } from '@scalar/components/scalar-error-boundary'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarIcon, ScalarMarkdown } from '@scalar/components'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type {
   DiscriminatorObject,

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ScalarListbox, type ScalarListboxOption } from '@scalar/components'
+import { ScalarListbox, type ScalarListboxOption } from '@scalar/components/scalar-listbox'
 import { isDefined } from '@scalar/helpers/array/is-defined'
 import { ScalarIconCaretDown } from '@scalar/icons'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnumPropertyItem.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnumPropertyItem.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import { ScalarMarkdown, ScalarWrappingText } from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
+import { ScalarWrappingText } from '@scalar/components/scalar-wrapping-text'
 
 defineProps<{
   label: string

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnums.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnums.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarButton } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
 import { ScalarIconPlus } from '@scalar/icons'
 import { resolve } from '@scalar/workspace-store/resolve'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'

--- a/packages/api-reference/src/components/Content/Schema/SchemaHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaHeading.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ScalarWrappingText } from '@scalar/components'
+import { ScalarWrappingText } from '@scalar/components/scalar-wrapping-text'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { isArraySchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
 import { computed } from 'vue'

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectExampleCodeBlock.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectExampleCodeBlock.vue
@@ -1,11 +1,7 @@
 <script setup lang="ts">
 import { ExamplePicker } from '@scalar/api-client/blocks/operation-code-sample'
-import {
-  ScalarCard,
-  ScalarCardFooter,
-  ScalarCardSection,
-  ScalarCodeBlock,
-} from '@scalar/components'
+import { ScalarCard, ScalarCardFooter, ScalarCardSection } from '@scalar/components/scalar-card'
+import { ScalarCodeBlock } from '@scalar/components/scalar-code-block'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed, ref } from 'vue'
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -1,4 +1,4 @@
-import { ScalarListbox } from '@scalar/components'
+import { ScalarListbox } from '@scalar/components/scalar-listbox'
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
 import { SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import { ScalarMarkdown, ScalarWrappingText } from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
+import { ScalarWrappingText } from '@scalar/components/scalar-wrapping-text'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { resolve } from '@scalar/workspace-store/resolve'
 import type {

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyDefault.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyDefault.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 
 import { formatValue } from './helpers/format-value'

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
 import { isDefined } from '@scalar/helpers/array/is-defined'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { computed } from 'vue'

--- a/packages/api-reference/src/components/Content/Tags/components/ClassicLayout.vue
+++ b/packages/api-reference/src/components/Content/Tags/components/ClassicLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarMarkdown } from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { TraversedTag } from '@scalar/workspace-store/schemas/navigation'
 

--- a/packages/api-reference/src/components/Content/Tags/components/TagSection.vue
+++ b/packages/api-reference/src/components/Content/Tags/components/TagSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarMarkdown } from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { TraversedTag } from '@scalar/workspace-store/schemas/navigation'
 

--- a/packages/api-reference/src/components/GettingStarted.vue
+++ b/packages/api-reference/src/components/GettingStarted.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarButton } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
 import { themeLabels, type ThemeId } from '@scalar/themes'
 
 defineProps<{

--- a/packages/api-reference/src/components/MobileHeader.vue
+++ b/packages/api-reference/src/components/MobileHeader.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { cva, ScalarIconButton } from '@scalar/components'
+import { ScalarIconButton } from '@scalar/components/scalar-icon-button'
+import { cva } from '@scalar/use-hooks/useBindCx'
 import { ScalarIconList, ScalarIconX } from '@scalar/icons'
 
 defineProps<{

--- a/packages/api-reference/src/components/OperationsList/OperationsList.test.ts
+++ b/packages/api-reference/src/components/OperationsList/OperationsList.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import OperationsList from './OperationsList.vue'
 
 // Mock Scalar components
-vi.mock('@scalar/components', () => ({
+vi.mock('@scalar/components/scalar-card', () => ({
   ScalarCard: {
     name: 'ScalarCard',
     template: '<div class="scalar-card"><slot /></div>',

--- a/packages/api-reference/src/components/OperationsList/OperationsList.vue
+++ b/packages/api-reference/src/components/OperationsList/OperationsList.vue
@@ -1,9 +1,5 @@
 <script setup lang="ts">
-import {
-  ScalarCard,
-  ScalarCardHeader,
-  ScalarCardSection,
-} from '@scalar/components'
+import { ScalarCard, ScalarCardHeader, ScalarCardSection } from '@scalar/components/scalar-card'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { TraversedTag } from '@scalar/workspace-store/schemas/navigation'
 import { computed } from 'vue'

--- a/packages/api-reference/src/components/RenderPlugins/RenderPlugins.vue
+++ b/packages/api-reference/src/components/RenderPlugins/RenderPlugins.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarErrorBoundary } from '@scalar/components'
+import { ScalarErrorBoundary } from '@scalar/components/scalar-error-boundary'
 
 import { usePluginManager } from '@/plugins'
 

--- a/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
+++ b/packages/api-reference/src/features/Operation/components/ContentTypeSelect.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { cva, ScalarButton, ScalarListbox } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { ScalarListbox } from '@scalar/components/scalar-listbox'
+import { cva } from '@scalar/use-hooks/useBindCx'
 import { ScalarIconCaretDown } from '@scalar/icons'
 import type { MediaTypeObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed } from 'vue'

--- a/packages/api-reference/src/features/Operation/components/Headers.vue
+++ b/packages/api-reference/src/features/Operation/components/Headers.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import { ScalarIcon } from '@scalar/components'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { HeaderObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
-import {
-  ScalarMarkdown,
-  ScalarMarkdownSummary,
-  ScalarWrappingText,
-} from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
+import { ScalarWrappingText } from '@scalar/components/scalar-wrapping-text'
+import { ScalarMarkdownSummary } from '@scalar/components/scalar-markdown'
 import { ScalarIconCaretRight } from '@scalar/icons'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarMarkdown } from '@scalar/components'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { RequestBodyObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'

--- a/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.vue
+++ b/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarPopover } from '@scalar/components'
+import { ScalarPopover } from '@scalar/components/scalar-popover'
 import { ScalarIconLockSimple, ScalarIconLockSimpleOpen } from '@scalar/icons'
 import { computed } from 'vue'
 

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.test.ts
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.test.ts
@@ -1,4 +1,4 @@
-import { ScalarListbox } from '@scalar/components'
+import { ScalarListbox } from '@scalar/components/scalar-listbox'
 import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
 import type { OperationObject, ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { OperationCodeSample } from '@scalar/api-client/blocks/operation-code-sample'
-import {
-  ScalarErrorBoundary,
-  ScalarIconButton,
-  ScalarMarkdown,
-} from '@scalar/components'
+import { ScalarErrorBoundary } from '@scalar/components/scalar-error-boundary'
+import { ScalarIconButton } from '@scalar/components/scalar-icon-button'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import {
   ScalarIconCopy,
   ScalarIconPlay,

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { OperationCodeSample } from '@scalar/api-client/blocks/operation-code-sample'
-import { ScalarErrorBoundary, ScalarMarkdown } from '@scalar/components'
+import { ScalarErrorBoundary } from '@scalar/components/scalar-error-boundary'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import { ScalarIconWebhooksLogo } from '@scalar/icons'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { SecuritySchemeObjectSecret } from '@scalar/workspace-store/request-example'

--- a/packages/api-reference/src/features/Search/components/SearchButton.vue
+++ b/packages/api-reference/src/features/Search/components/SearchButton.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import {
-  ScalarIconButton,
-  ScalarSidebarSearchButton,
-  useModal,
-} from '@scalar/components'
+import { ScalarIconButton } from '@scalar/components/scalar-icon-button'
+import { useModal } from '@scalar/components/scalar-modal'
+import { ScalarSidebarSearchButton } from '@scalar/components/scalar-sidebar'
 import { isMacOS } from '@scalar/helpers/general/is-mac-os'
 import { ScalarIconMagnifyingGlass } from '@scalar/icons'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'

--- a/packages/api-reference/src/features/Search/components/SearchModal.vue
+++ b/packages/api-reference/src/features/Search/components/SearchModal.vue
@@ -1,10 +1,7 @@
 <script setup lang="ts">
-import {
-  ScalarModal,
-  ScalarSearchInput,
-  ScalarSearchResultList,
-  type ModalState,
-} from '@scalar/components'
+import { ScalarModal, type ModalState } from '@scalar/components/scalar-modal'
+import { ScalarSearchInput } from '@scalar/components/scalar-search-input'
+import { ScalarSearchResultList } from '@scalar/components/scalar-search-results'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { nanoid } from 'nanoid'

--- a/packages/api-reference/src/features/Search/components/SearchResult.vue
+++ b/packages/api-reference/src/features/Search/components/SearchResult.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarSearchResultItem } from '@scalar/components'
+import { ScalarSearchResultItem } from '@scalar/components/scalar-search-results'
 import {
   ScalarIconBracketsCurly,
   ScalarIconTag,

--- a/packages/api-reference/src/features/developer-tools/components/ApiReferenceToolbarConfigLayout.vue
+++ b/packages/api-reference/src/features/developer-tools/components/ApiReferenceToolbarConfigLayout.vue
@@ -1,8 +1,5 @@
 <script lang="ts" setup>
-import {
-  ScalarCheckboxRadioGroup,
-  type ScalarCheckboxOption,
-} from '@scalar/components'
+import { ScalarCheckboxRadioGroup, type ScalarCheckboxOption } from '@scalar/components/scalar-checkbox-input'
 import { computed } from 'vue'
 
 const ModernOption = { label: 'Modern', value: 'modern' } as const

--- a/packages/api-reference/src/features/developer-tools/components/ApiReferenceToolbarConfigLayoutOptions.vue
+++ b/packages/api-reference/src/features/developer-tools/components/ApiReferenceToolbarConfigLayoutOptions.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ScalarFormInputGroup, ScalarToggleInput } from '@scalar/components'
+import { ScalarFormInputGroup } from '@scalar/components/scalar-form'
+import { ScalarToggleInput } from '@scalar/components/scalar-toggle'
 import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
 
 type LayoutOptions = {

--- a/packages/api-reference/src/features/developer-tools/components/ApiReferenceToolbarConfigTheme.vue
+++ b/packages/api-reference/src/features/developer-tools/components/ApiReferenceToolbarConfigTheme.vue
@@ -1,10 +1,8 @@
 <script lang="ts" setup>
-import {
-  ScalarCombobox,
-  ScalarFormInput,
-  ScalarListboxCheckbox,
-  ScalarThemeSwatches,
-} from '@scalar/components'
+import { ScalarCombobox } from '@scalar/components/scalar-combobox'
+import { ScalarFormInput } from '@scalar/components/scalar-form'
+import { ScalarListboxCheckbox } from '@scalar/components/scalar-listbox'
+import { ScalarThemeSwatches } from '@scalar/components/scalar-theme-swatches'
 import { ScalarIconCaretDown } from '@scalar/icons'
 import { presets, themeIds, themeLabels, type ThemeId } from '@scalar/themes'
 import { computed } from 'vue'

--- a/packages/api-reference/src/features/developer-tools/components/ApiReferenceToolbarPopover.vue
+++ b/packages/api-reference/src/features/developer-tools/components/ApiReferenceToolbarPopover.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import { ScalarFloatingBackdrop, ScalarPopover } from '@scalar/components'
+import { ScalarFloatingBackdrop } from '@scalar/components/scalar-floating'
+import { ScalarPopover } from '@scalar/components/scalar-popover'
 import { ScalarIconCaretDown, ScalarIconInfo } from '@scalar/icons'
 </script>
 

--- a/packages/api-reference/src/features/developer-tools/components/ApiReferenceToolbarRegisterButton.vue
+++ b/packages/api-reference/src/features/developer-tools/components/ApiReferenceToolbarRegisterButton.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import { ScalarButton, useLoadingState } from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { useLoadingState } from '@scalar/components/scalar-loading'
 import type { ExternalUrls } from '@scalar/types/api-reference'
 import { useToasts } from '@scalar/use-toasts'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'

--- a/packages/api-reference/src/features/developer-tools/components/ApiReferenceToolbarShareTemporary.vue
+++ b/packages/api-reference/src/features/developer-tools/components/ApiReferenceToolbarShareTemporary.vue
@@ -1,9 +1,7 @@
 <script lang="ts" setup>
-import {
-  ScalarButton,
-  ScalarTextInputCopy,
-  useLoadingState,
-} from '@scalar/components'
+import { ScalarButton } from '@scalar/components/scalar-button'
+import { useLoadingState } from '@scalar/components/scalar-loading'
+import { ScalarTextInputCopy } from '@scalar/components/scalar-text-input'
 import type { ExternalUrls } from '@scalar/types/api-reference'
 import { useToasts } from '@scalar/use-toasts'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'

--- a/packages/api-reference/src/features/developer-tools/components/ApiReferenceToolbarTitle.vue
+++ b/packages/api-reference/src/features/developer-tools/components/ApiReferenceToolbarTitle.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ScalarIconButton } from '@scalar/components'
+import { ScalarIconButton } from '@scalar/components/scalar-icon-button'
 import { ScalarIconCopy, ScalarIconInfo } from '@scalar/icons'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 

--- a/packages/api-reference/src/features/developer-tools/components/DeployApiReference.vue
+++ b/packages/api-reference/src/features/developer-tools/components/DeployApiReference.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ScalarFormSection } from '@scalar/components'
+import { ScalarFormSection } from '@scalar/components/scalar-form'
 import type { ExternalUrls } from '@scalar/types/api-reference'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 

--- a/packages/api-reference/src/features/developer-tools/components/ModifyConfiguration.vue
+++ b/packages/api-reference/src/features/developer-tools/components/ModifyConfiguration.vue
@@ -1,9 +1,7 @@
 <script lang="ts" setup>
-import {
-  ScalarCodeBlock,
-  ScalarFormField,
-  ScalarFormSection,
-} from '@scalar/components'
+import { ScalarCodeBlock } from '@scalar/components/scalar-code-block'
+import { ScalarFormSection } from '@scalar/components/scalar-form'
+import { ScalarFormField } from '@scalar/components/scalar-form'
 import { prettyPrintJson } from '@scalar/helpers/json/pretty-print-json'
 import { type ThemeId } from '@scalar/themes'
 import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'

--- a/packages/api-reference/src/features/developer-tools/components/ShareApiReference.vue
+++ b/packages/api-reference/src/features/developer-tools/components/ShareApiReference.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ScalarFormSection } from '@scalar/components'
+import { ScalarFormSection } from '@scalar/components/scalar-form'
 import type { ExternalUrls } from '@scalar/types/api-reference'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 

--- a/packages/api-reference/src/features/example-responses/ExampleResponse.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponse.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { getResolvedRefDeep } from '@scalar/api-client/blocks/operation-code-sample'
-import { ScalarCodeBlock, ScalarVirtualText } from '@scalar/components'
+import { ScalarCodeBlock } from '@scalar/components/scalar-code-block'
+import { ScalarVirtualText } from '@scalar/components/scalar-virtual-text'
 import { prettyPrintJson } from '@scalar/helpers/json/pretty-print-json'
 import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
 import type {

--- a/packages/api-reference/src/features/example-responses/ExampleResponseTabList.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponseTabList.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { TabGroup, TabList } from '@headlessui/vue'
-import { ScalarCardHeader } from '@scalar/components'
+import { ScalarCardHeader } from '@scalar/components/scalar-card'
 
 const emit = defineEmits<{
   (e: 'change', index: number): void

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.vue
@@ -1,12 +1,8 @@
 <script lang="ts" setup>
 import { ExamplePicker } from '@scalar/api-client/blocks/operation-code-sample'
-import {
-  ScalarCard,
-  ScalarCardFooter,
-  ScalarCardSection,
-  ScalarIcon,
-  ScalarMarkdown,
-} from '@scalar/components'
+import { ScalarCard, ScalarCardFooter, ScalarCardSection } from '@scalar/components/scalar-card'
+import { ScalarIcon } from '@scalar/components/scalar-icon'
+import { ScalarMarkdown } from '@scalar/components/scalar-markdown'
 import { objectKeys } from '@scalar/helpers/object/object-keys'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'

--- a/packages/api-reference/src/features/example-responses/ExampleSchema.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleSchema.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { getResolvedRefDeep } from '@scalar/api-client/blocks/operation-code-sample'
-import { ScalarCodeBlock, ScalarVirtualText } from '@scalar/components'
+import { ScalarCodeBlock } from '@scalar/components/scalar-code-block'
+import { ScalarVirtualText } from '@scalar/components/scalar-virtual-text'
 import { prettyPrintJson } from '@scalar/helpers/json/pretty-print-json'
 import type { ReferenceType } from '@scalar/workspace-store/schemas/v3.1/strict/reference'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/schema'

--- a/packages/api-reference/src/features/info-object/Contact.vue
+++ b/packages/api-reference/src/features/info-object/Contact.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { cva } from '@scalar/components'
+import { cva } from '@scalar/use-hooks/useBindCx'
 import { ScalarIconEnvelopeSimple } from '@scalar/icons'
 import type { ContactObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 

--- a/packages/api-reference/src/features/multiple-documents/DocumentSelector.vue
+++ b/packages/api-reference/src/features/multiple-documents/DocumentSelector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarListbox } from '@scalar/components'
+import { ScalarListbox } from '@scalar/components/scalar-listbox'
 import { ScalarIconCaretDown } from '@scalar/icons'
 import { computed } from 'vue'
 

--- a/packages/api-reference/src/features/specification-extension/SpecificationExtension.vue
+++ b/packages/api-reference/src/features/specification-extension/SpecificationExtension.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarErrorBoundary } from '@scalar/components'
+import { ScalarErrorBoundary } from '@scalar/components/scalar-error-boundary'
 import { computed } from 'vue'
 
 import { usePluginManager } from '@/plugins'

--- a/packages/api-reference/src/standalone.esm.ts
+++ b/packages/api-reference/src/standalone.esm.ts
@@ -1,0 +1,12 @@
+import '@/style.css'
+
+import { createApiReference, findDataAttributes, getConfigurationFromDataAttributes } from '@/standalone/lib/html-api'
+import { registerGlobals } from '@/standalone/lib/register-globals'
+
+registerGlobals()
+
+// Look for data attributes in the HTML (legacy)
+findDataAttributes(document, getConfigurationFromDataAttributes(document))
+
+// Expose the public API so consumers can `import { createApiReference } from '...'`
+export { createApiReference }

--- a/packages/api-reference/vite.standalone.config.ts
+++ b/packages/api-reference/vite.standalone.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
     vue(),
     tailwindcss(),
     cssInjectedByJsPlugin(),
-    webpackStats(),
+    webpackStats({ fileName: 'webpack-stats.umd.json' }),
     banner({
       outDir: 'dist/browser',
       content: replaceVariables(licenseBannerTemplate, {

--- a/packages/api-reference/vite.standalone.config.ts
+++ b/packages/api-reference/vite.standalone.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
     vue(),
     tailwindcss(),
     cssInjectedByJsPlugin(),
-    webpackStats({ fileName: 'webpack-stats.umd.json' }),
+    webpackStats(),
     banner({
       outDir: 'dist/browser',
       content: replaceVariables(licenseBannerTemplate, {

--- a/packages/api-reference/vite.standalone.config.ts
+++ b/packages/api-reference/vite.standalone.config.ts
@@ -69,6 +69,11 @@ export default defineConfig({
       // is ever rendered in the standalone API reference. They leak in through the
       // @scalar/components barrel via @scalar/api-client but are never mounted.
       external: [/^radix-vue/, /^@scalar\/openapi-parser/],
+      // Treat every non-CSS module as side-effect-free so Rolldown can drop
+      // unreachable code paths from the bundle (matches the default lib config).
+      treeshake: {
+        moduleSideEffects: (id) => id.includes('.css'),
+      },
       output: {
         entryFileNames: '[name].js',
         globals: {

--- a/packages/api-reference/vite.standalone.esm.config.ts
+++ b/packages/api-reference/vite.standalone.esm.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
     vue(),
     tailwindcss(),
     cssInjectedByJsPlugin(),
-    webpackStats(),
+    webpackStats({ fileName: 'webpack-stats.esm.json' }),
     banner({
       outDir: 'dist/browser',
       content: replaceVariables(licenseBannerTemplate, {

--- a/packages/api-reference/vite.standalone.esm.config.ts
+++ b/packages/api-reference/vite.standalone.esm.config.ts
@@ -68,11 +68,38 @@ export default defineConfig({
       // Match the UMD config: ScalarMenu (the only radix-vue consumer) is never
       // mounted in the standalone reference, so radix-vue can be safely externalized.
       external: [/^radix-vue/, /^@scalar\/openapi-parser/],
+      // Treat every non-CSS module as side-effect-free so Rolldown can drop
+      // unreachable code paths from the single-file standalone bundle.
+      treeshake: {
+        moduleSideEffects: (id) => id.includes('.css'),
+      },
       output: {
         entryFileNames: '[name].js',
-        // Collapse all chunks into a single file so the ESM bundle matches the UMD
-        // layout (one JS file) and the size comparison is apples-to-apples.
-        codeSplitting: false,
+        chunkFileNames: 'chunks/[name]-[hash].js',
+        // Enable code splitting so genuinely-async boundaries become real lazy
+        // chunks: the API client modal (heaviest by far — pulls in CodeMirror),
+        // the AgentScalar drawer, the YAML parser used for downloads, and the
+        // icon library's per-SVG dynamic imports.
+        //
+        // `minShareCount: Infinity` disables Rolldown's automatic shared-chunk
+        // extraction for synchronous code so static graphs stay in the entry
+        // bundle. Code that's used by *both* the entry and a lazy chunk still
+        // gets hoisted into a shared chunk — that's how ESM avoids duplication.
+        codeSplitting: {
+          minShareCount: Number.POSITIVE_INFINITY,
+          // Coalesce the ~84 per-SVG dynamic imports from `@scalar/icons/library`
+          // into a single `chunks/icons-*.js` instead of one tiny file per icon.
+          groups: [
+            {
+              name(moduleId) {
+                if (moduleId.includes('/library/icons/') && moduleId.endsWith('.svg.js')) {
+                  return 'icons'
+                }
+                return null
+              },
+            },
+          ],
+        },
         // Vite forces `minifyWhitespace: false` for ES library builds, so we bypass
         // it by enabling Rolldown's native minifier on the output. This produces a
         // fully-minified bundle equivalent to what UMD already gets from Rolldown.

--- a/packages/api-reference/vite.standalone.esm.config.ts
+++ b/packages/api-reference/vite.standalone.esm.config.ts
@@ -79,27 +79,12 @@ export default defineConfig({
         // Enable code splitting so genuinely-async boundaries become real lazy
         // chunks: the API client modal (heaviest by far — pulls in CodeMirror),
         // the AgentScalar drawer, the YAML parser used for downloads, and the
-        // icon library's per-SVG dynamic imports.
-        //
-        // `minShareCount: Infinity` disables Rolldown's automatic shared-chunk
-        // extraction for synchronous code so static graphs stay in the entry
-        // bundle. Code that's used by *both* the entry and a lazy chunk still
-        // gets hoisted into a shared chunk — that's how ESM avoids duplication.
-        codeSplitting: {
-          minShareCount: Number.POSITIVE_INFINITY,
-          // Coalesce the ~84 per-SVG dynamic imports from `@scalar/icons/library`
-          // into a single `chunks/icons-*.js` instead of one tiny file per icon.
-          groups: [
-            {
-              name(moduleId) {
-                if (moduleId.includes('/library/icons/') && moduleId.endsWith('.svg.js')) {
-                  return 'icons'
-                }
-                return null
-              },
-            },
-          ],
-        },
+        // ~84 per-SVG dynamic imports from `@scalar/icons/library`. Each icon
+        // becomes its own ~1 KB chunk that only fetches if the sidebar actually
+        // renders that icon — the typical API only references a handful of them
+        // out of the catalog, so this nets a smaller real-world page weight than
+        // bundling them all into a single ~125 KB chunk.
+        codeSplitting: true,
         // Vite forces `minifyWhitespace: false` for ES library builds, so we bypass
         // it by enabling Rolldown's native minifier on the output. This produces a
         // fully-minified bundle equivalent to what UMD already gets from Rolldown.

--- a/packages/api-reference/vite.standalone.esm.config.ts
+++ b/packages/api-reference/vite.standalone.esm.config.ts
@@ -1,0 +1,87 @@
+import { resolve } from 'node:path'
+
+import tailwindcss from '@tailwindcss/vite'
+import vue from '@vitejs/plugin-vue'
+import { webpackStats } from 'rollup-plugin-webpack-stats'
+import { defineConfig } from 'vite'
+import banner from 'vite-plugin-banner'
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
+
+import { name, version } from './package.json'
+
+const licenseBannerTemplate = String.raw`/**
+ *    _____ _________    __    ___    ____
+ *   / ___// ____/   |  / /   /   |  / __ \
+ *   \__ \/ /   / /| | / /   / /| | / /_/ /
+ *  ___/ / /___/ ___ |/ /___/ ___ |/ _, _/
+ * /____/\____/_/  |_/_____/_/  |_/_/ |_|
+ *
+ * {{ packageName }} {{ version }}
+ *
+ * Website: https://scalar.com
+ * GitHub:  https://github.com/scalar/scalar
+ * License: https://github.com/scalar/scalar/blob/main/LICENSE
+**/
+`
+
+const replaceVariables = (template: string, variables: Record<string, string>) =>
+  Object.entries(variables).reduce(
+    (content, [key, value]) => content.replace(new RegExp(`\\{\\{ ${key} \\}\\}`, 'g'), value),
+    template,
+  )
+
+export default defineConfig({
+  define: {
+    'process.env.NODE_ENV': '"production"',
+    'PACKAGE_VERSION': `"${version}"`,
+  },
+  resolve: {
+    alias: {
+      '@': resolve(import.meta.dirname, './src'),
+      '@test': resolve(import.meta.dirname, './test'),
+    },
+    dedupe: ['vue'],
+  },
+  plugins: [
+    vue(),
+    tailwindcss(),
+    cssInjectedByJsPlugin(),
+    webpackStats(),
+    banner({
+      outDir: 'dist/browser',
+      content: replaceVariables(licenseBannerTemplate, {
+        packageName: name,
+        version: version,
+      }),
+    }),
+  ],
+  build: {
+    emptyOutDir: false,
+    outDir: 'dist/browser',
+    cssCodeSplit: false,
+    lib: {
+      entry: { 'standalone.esm': 'src/standalone.esm.ts' },
+      name: '@scalar/api-reference',
+      formats: ['es'],
+    },
+    rolldownOptions: {
+      // Match the UMD config: ScalarMenu (the only radix-vue consumer) is never
+      // mounted in the standalone reference, so radix-vue can be safely externalized.
+      external: [/^radix-vue/, /^@scalar\/openapi-parser/],
+      output: {
+        entryFileNames: '[name].js',
+        // Collapse all chunks into a single file so the ESM bundle matches the UMD
+        // layout (one JS file) and the size comparison is apples-to-apples.
+        codeSplitting: false,
+        // Vite forces `minifyWhitespace: false` for ES library builds, so we bypass
+        // it by enabling Rolldown's native minifier on the output. This produces a
+        // fully-minified bundle equivalent to what UMD already gets from Rolldown.
+        minify: true,
+        globals: {
+          'radix-vue': '{}',
+          'radix-vue/namespaced': '{}',
+        },
+      },
+    },
+  },
+})

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,6 +41,176 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./scalar-button": {
+      "types": "./dist/components/ScalarButton/index.d.ts",
+      "import": "./dist/components/ScalarButton/index.js",
+      "default": "./dist/components/ScalarButton/index.js"
+    },
+    "./scalar-card": {
+      "types": "./dist/components/ScalarCard/index.d.ts",
+      "import": "./dist/components/ScalarCard/index.js",
+      "default": "./dist/components/ScalarCard/index.js"
+    },
+    "./scalar-checkbox-input": {
+      "types": "./dist/components/ScalarCheckboxInput/index.d.ts",
+      "import": "./dist/components/ScalarCheckboxInput/index.js",
+      "default": "./dist/components/ScalarCheckboxInput/index.js"
+    },
+    "./scalar-code-block": {
+      "types": "./dist/components/ScalarCodeBlock/index.d.ts",
+      "import": "./dist/components/ScalarCodeBlock/index.js",
+      "default": "./dist/components/ScalarCodeBlock/index.js"
+    },
+    "./scalar-color-mode-toggle": {
+      "types": "./dist/components/ScalarColorModeToggle/index.d.ts",
+      "import": "./dist/components/ScalarColorModeToggle/index.js",
+      "default": "./dist/components/ScalarColorModeToggle/index.js"
+    },
+    "./scalar-combobox": {
+      "types": "./dist/components/ScalarCombobox/index.d.ts",
+      "import": "./dist/components/ScalarCombobox/index.js",
+      "default": "./dist/components/ScalarCombobox/index.js"
+    },
+    "./scalar-copy": {
+      "types": "./dist/components/ScalarCopy/index.d.ts",
+      "import": "./dist/components/ScalarCopy/index.js",
+      "default": "./dist/components/ScalarCopy/index.js"
+    },
+    "./scalar-dropdown": {
+      "types": "./dist/components/ScalarDropdown/index.d.ts",
+      "import": "./dist/components/ScalarDropdown/index.js",
+      "default": "./dist/components/ScalarDropdown/index.js"
+    },
+    "./scalar-error-boundary": {
+      "types": "./dist/components/ScalarErrorBoundary/index.d.ts",
+      "import": "./dist/components/ScalarErrorBoundary/index.js",
+      "default": "./dist/components/ScalarErrorBoundary/index.js"
+    },
+    "./scalar-file-upload": {
+      "types": "./dist/components/ScalarFileUpload/index.d.ts",
+      "import": "./dist/components/ScalarFileUpload/index.js",
+      "default": "./dist/components/ScalarFileUpload/index.js"
+    },
+    "./scalar-floating": {
+      "types": "./dist/components/ScalarFloating/index.d.ts",
+      "import": "./dist/components/ScalarFloating/index.js",
+      "default": "./dist/components/ScalarFloating/index.js"
+    },
+    "./scalar-form": {
+      "types": "./dist/components/ScalarForm/index.d.ts",
+      "import": "./dist/components/ScalarForm/index.js",
+      "default": "./dist/components/ScalarForm/index.js"
+    },
+    "./scalar-header": {
+      "types": "./dist/components/ScalarHeader/index.d.ts",
+      "import": "./dist/components/ScalarHeader/index.js",
+      "default": "./dist/components/ScalarHeader/index.js"
+    },
+    "./scalar-hotkey": {
+      "types": "./dist/components/ScalarHotkey/index.d.ts",
+      "import": "./dist/components/ScalarHotkey/index.js",
+      "default": "./dist/components/ScalarHotkey/index.js"
+    },
+    "./scalar-icon": {
+      "types": "./dist/components/ScalarIcon/index.d.ts",
+      "import": "./dist/components/ScalarIcon/index.js",
+      "default": "./dist/components/ScalarIcon/index.js"
+    },
+    "./scalar-icon-button": {
+      "types": "./dist/components/ScalarIconButton/index.d.ts",
+      "import": "./dist/components/ScalarIconButton/index.js",
+      "default": "./dist/components/ScalarIconButton/index.js"
+    },
+    "./scalar-listbox": {
+      "types": "./dist/components/ScalarListbox/index.d.ts",
+      "import": "./dist/components/ScalarListbox/index.js",
+      "default": "./dist/components/ScalarListbox/index.js"
+    },
+    "./scalar-loading": {
+      "types": "./dist/components/ScalarLoading/index.d.ts",
+      "import": "./dist/components/ScalarLoading/index.js",
+      "default": "./dist/components/ScalarLoading/index.js"
+    },
+    "./scalar-markdown": {
+      "types": "./dist/components/ScalarMarkdown/index.d.ts",
+      "import": "./dist/components/ScalarMarkdown/index.js",
+      "default": "./dist/components/ScalarMarkdown/index.js"
+    },
+    "./scalar-menu": {
+      "types": "./dist/components/ScalarMenu/index.d.ts",
+      "import": "./dist/components/ScalarMenu/index.js",
+      "default": "./dist/components/ScalarMenu/index.js"
+    },
+    "./scalar-modal": {
+      "types": "./dist/components/ScalarModal/index.d.ts",
+      "import": "./dist/components/ScalarModal/index.js",
+      "default": "./dist/components/ScalarModal/index.js"
+    },
+    "./scalar-popover": {
+      "types": "./dist/components/ScalarPopover/index.d.ts",
+      "import": "./dist/components/ScalarPopover/index.js",
+      "default": "./dist/components/ScalarPopover/index.js"
+    },
+    "./scalar-save-prompt": {
+      "types": "./dist/components/ScalarSavePrompt/index.d.ts",
+      "import": "./dist/components/ScalarSavePrompt/index.js",
+      "default": "./dist/components/ScalarSavePrompt/index.js"
+    },
+    "./scalar-search-input": {
+      "types": "./dist/components/ScalarSearchInput/index.d.ts",
+      "import": "./dist/components/ScalarSearchInput/index.js",
+      "default": "./dist/components/ScalarSearchInput/index.js"
+    },
+    "./scalar-search-results": {
+      "types": "./dist/components/ScalarSearchResults/index.d.ts",
+      "import": "./dist/components/ScalarSearchResults/index.js",
+      "default": "./dist/components/ScalarSearchResults/index.js"
+    },
+    "./scalar-sidebar": {
+      "types": "./dist/components/ScalarSidebar/index.d.ts",
+      "import": "./dist/components/ScalarSidebar/index.js",
+      "default": "./dist/components/ScalarSidebar/index.js"
+    },
+    "./scalar-teleport": {
+      "types": "./dist/components/ScalarTeleport/index.d.ts",
+      "import": "./dist/components/ScalarTeleport/index.js",
+      "default": "./dist/components/ScalarTeleport/index.js"
+    },
+    "./scalar-text-area": {
+      "types": "./dist/components/ScalarTextArea/index.d.ts",
+      "import": "./dist/components/ScalarTextArea/index.js",
+      "default": "./dist/components/ScalarTextArea/index.js"
+    },
+    "./scalar-text-input": {
+      "types": "./dist/components/ScalarTextInput/index.d.ts",
+      "import": "./dist/components/ScalarTextInput/index.js",
+      "default": "./dist/components/ScalarTextInput/index.js"
+    },
+    "./scalar-theme-swatches": {
+      "types": "./dist/components/ScalarThemeSwatches/index.d.ts",
+      "import": "./dist/components/ScalarThemeSwatches/index.js",
+      "default": "./dist/components/ScalarThemeSwatches/index.js"
+    },
+    "./scalar-toggle": {
+      "types": "./dist/components/ScalarToggle/index.d.ts",
+      "import": "./dist/components/ScalarToggle/index.js",
+      "default": "./dist/components/ScalarToggle/index.js"
+    },
+    "./scalar-tooltip": {
+      "types": "./dist/components/ScalarTooltip/index.d.ts",
+      "import": "./dist/components/ScalarTooltip/index.js",
+      "default": "./dist/components/ScalarTooltip/index.js"
+    },
+    "./scalar-virtual-text": {
+      "types": "./dist/components/ScalarVirtualText/index.d.ts",
+      "import": "./dist/components/ScalarVirtualText/index.js",
+      "default": "./dist/components/ScalarVirtualText/index.js"
+    },
+    "./scalar-wrapping-text": {
+      "types": "./dist/components/ScalarWrappingText/index.d.ts",
+      "import": "./dist/components/ScalarWrappingText/index.js",
+      "default": "./dist/components/ScalarWrappingText/index.js"
+    },
     "./style.css": "./dist/style.css",
     "./tailwind.config.css": "./dist/styles/tailwind.config.css",
     "./vue-styles.css": "./dist/vue-styles.css"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -101,6 +101,11 @@
       "import": "./dist/components/ScalarForm/index.js",
       "default": "./dist/components/ScalarForm/index.js"
     },
+    "./helpers": {
+      "types": "./dist/helpers/index.d.ts",
+      "import": "./dist/helpers/index.js",
+      "default": "./dist/helpers/index.js"
+    },
     "./scalar-header": {
       "types": "./dist/components/ScalarHeader/index.d.ts",
       "import": "./dist/components/ScalarHeader/index.js",

--- a/packages/icons/src/library/icons.ts
+++ b/packages/icons/src/library/icons.ts
@@ -1,10 +1,18 @@
-import { markRaw, type Component } from 'vue'
+import { type Component, markRaw } from 'vue'
 
 import type { LibraryIconDefinition } from './types'
 
 const iconLoaders: Record<string, () => Promise<Component>> = import.meta.glob('./icons/*.svg', {
   eager: false,
 })
+
+// Eagerly bundle the default fallback icon. The sidebar uses this for every
+// item without a custom `x-scalar-icon` — i.e. the vast majority of items in
+// the typical API document — so it's always wanted at first paint and not
+// worth the per-item HTTP request that the dynamic glob otherwise produces.
+const defaultIconModule = import.meta.glob<{ default: Component }>('./icons/interface-content-folder.svg', {
+  eager: true,
+})['./icons/interface-content-folder.svg']
 
 const iconNames = Object.keys(iconLoaders).map((filename) => filename.replace('./icons/', '').replace('.svg', ''))
 
@@ -16,6 +24,12 @@ export const libraryIcons: LibraryIconDefinition[] = iconNames.map((name) => ({
 }))
 
 const iconCache = new Map<string, Component>()
+
+// Pre-populate the cache for the eagerly-bundled default icon so the first
+// `getLibraryIcon('interface-content-folder')` resolves synchronously.
+if (defaultIconModule?.default) {
+  iconCache.set('interface-content-folder', markRaw(defaultIconModule.default))
+}
 
 export async function getLibraryIcon(src: string): Promise<Component | undefined> {
   const cached = iconCache.get(src)

--- a/packages/sidebar/src/components/ScalarSidebar.test.ts
+++ b/packages/sidebar/src/components/ScalarSidebar.test.ts
@@ -1,4 +1,4 @@
-import { ScalarSidebar, ScalarSidebarItems } from '@scalar/components'
+import { ScalarSidebar, ScalarSidebarItems } from '@scalar/components/scalar-sidebar'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 

--- a/packages/sidebar/src/components/ScalarSidebar.vue
+++ b/packages/sidebar/src/components/ScalarSidebar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScalarSidebar, ScalarSidebarItems } from '@scalar/components'
+import { ScalarSidebar, ScalarSidebarItems } from '@scalar/components/scalar-sidebar'
 
 import { filterItems } from '@/helpers/filter-items'
 import type {

--- a/packages/sidebar/src/components/SidebarItem.test.ts
+++ b/packages/sidebar/src/components/SidebarItem.test.ts
@@ -1,9 +1,4 @@
-import {
-  ScalarSidebarGroup,
-  ScalarSidebarItem,
-  ScalarSidebarItem as ScalarSidebarItemComponent,
-  ScalarSidebarSection,
-} from '@scalar/components'
+import { ScalarSidebarGroup, ScalarSidebarItem, ScalarSidebarItem as ScalarSidebarItemComponent, ScalarSidebarSection } from '@scalar/components/scalar-sidebar'
 import { LibraryIcon } from '@scalar/icons/library'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'

--- a/packages/sidebar/src/components/SidebarItem.vue
+++ b/packages/sidebar/src/components/SidebarItem.vue
@@ -1,9 +1,5 @@
 <script lang="ts" setup>
-import {
-  ScalarSidebarGroup,
-  ScalarSidebarItem,
-  ScalarSidebarSection,
-} from '@scalar/components'
+import { ScalarSidebarGroup, ScalarSidebarItem, ScalarSidebarSection } from '@scalar/components/scalar-sidebar'
 import { LibraryIcon } from '@scalar/icons/library'
 import { computed } from 'vue'
 

--- a/packages/sidebar/src/components/SidebarItemLabel.vue
+++ b/packages/sidebar/src/components/SidebarItemLabel.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ScalarWrappingText } from '@scalar/components'
+import { ScalarWrappingText } from '@scalar/components/scalar-wrapping-text'
 
 import type { Item } from '@/types'
 


### PR DESCRIPTION
## Summary

closes #5743

Adds an ESM standalone build (`dist/browser/standalone.esm.js`) alongside the existing UMD bundle, then layers code-splitting and tree-shaking improvements on top of it. The new bundle works as a side-effect script (registers `window.Scalar.createApiReference`, reads `data-*` configuration) **and** exports `createApiReference` for direct ESM consumers, so the same file covers both legacy `<script type="module">` usage and `import { createApiReference } from '...'`.

UMD is unchanged in behaviour — UMD can't code-split, so its dynamic imports get inlined back into the single file.

## Bundle layout (ESM standalone)

```
Sync (loaded with the entry, in parallel):
  standalone.esm.js                              577 KB
  chunks/map-hidden-clients-config-*.js        1,941 KB
  chunks/local-storage-*.js                      120 KB
  chunks/browser-*.js                            104 KB
  chunks/runtime-core.esm-bundler-*.js            71 KB
  chunks/interface-content-folder.svg-*.js         1 KB   ← default sidebar icon, eagerly bundled
  chunks/rolldown-runtime-*.js                     1 KB
  ────────────────────────────────────────────────────
  TOTAL SYNC                                  ~2,816 KB

Lazy (fetched on demand):
  chunks/modal-*.js                              265 KB   ← API client modal + CodeMirror
  chunks/AgentScalarChatInterface-*.js           200 KB   ← AI agent UI
  83 × per-icon chunks                            ~92 KB total (~1.1 KB each)
  ────────────────────────────────────────────────────
  TOTAL LAZY (worst case)                       ~558 KB
```

| | UMD (today) | New ESM | Δ |
|---|---|---|---|
| Initial sync | ~3,479 KB | **~2,816 KB** | **−663 KB** |
| Total worst case | ~3,479 KB | ~3,373 KB | −106 KB |

For a typical document the user only fetches the modal chunk (when they open Test Request) plus a handful of icons (whichever the sidebar actually displays), so real-world page weight is meaningfully lower.

## What's lazy

**API client modal (~265 KB)** — `ApiReference.vue` was statically importing `createApiClientModal` from `@scalar/api-client/modal`; that module pulls in CodeMirror, the request editor, the response viewer, and the auth/header/body editors. Replaced with `await import('@scalar/api-client/modal')` inside `onMounted` so the modal chunk loads in the background after first paint. Existing optional-chaining on `apiClient.value?.route(...)` already handles "modal not ready yet" gracefully.

To keep this static import out of the entry graph, `Content.vue` now imports `mapHiddenClientsConfig` from a new `@scalar/api-client/modal/map-hidden-clients-config` deep export rather than the modal barrel, and `@scalar/api-client` declares `"sideEffects": ["**/*.css"]` so downstream bundlers can tree-shake the barrel themselves.

**AgentScalar chat interface (~200 KB)** — already wrapped in `defineAsyncComponent`, but with `codeSplitting: false` it was being inlined. Now it gets its own chunk that only loads when the agent is enabled (default: only on local URLs).

## Icons

`@scalar/icons/library` uses `import.meta.glob('./icons/*.svg', { eager: false })` so every SVG becomes a lazy chunk. The standalone bundle takes advantage of that:

- Each of the 84 library SVGs is its own ~1 KB chunk, fetched on demand as the sidebar renders. A typical OpenAPI doc references only a handful, so most chunks never load.
- The default fallback `interface-content-folder` (used by every sidebar item without a custom `x-scalar-icon`) is eagerly bundled via a second `import.meta.glob(..., { eager: true })` and the icon cache is pre-populated so `getLibraryIcon('interface-content-folder')` resolves synchronously. No HTTP delay or "no icon yet" frame on first sidebar render.

I considered grouping the 84 SVGs into a single ~125 KB chunk — that's smaller in worst-case total (−39 KB) but always loads everything; per-icon nets a smaller real-world page weight.

## Tree-shaking

- `@scalar/api-reference` declares `"sideEffects": ["**/*.css", "./dist/browser/**"]` — only CSS and the pre-bundled standalone files are side-effectful; the rest of the library is pure. Verified with esbuild that importing a single helper produces a ~491 byte bundle (vs ~3.67 MB when importing `createApiReference`), proving unused exports are dead-code-eliminated.
- `@scalar/api-client` declares `"sideEffects": ["**/*.css"]` for the same reason.
- Both standalone configs (UMD and ESM) set `treeshake.moduleSideEffects: id => id.includes('.css')` to match the default lib config.
- ESM standalone uses Rolldown's native `output.minify: true` to bypass Vite's library-mode default of `minifyWhitespace: false`, so the ESM file is genuinely minified instead of pretty-printed-but-mangled.

## Test plan

- [ ] `pnpm --filter @scalar/api-reference build` succeeds and emits `dist/browser/standalone.esm.js` plus the chunks/ directory.
- [ ] `pnpm --filter @scalar/api-reference test` (standalone unit tests) passes.
- [ ] `pnpm --filter @scalar/api-reference types:check` is clean.
- [ ] `pnpm --filter @scalar/icons test` passes.
- [ ] Manually load the standalone ESM bundle in a browser, confirm the API reference renders and the modal opens on "Test Request" (modal chunk fetches lazily in the network panel).
- [ ] Verify that custom `x-scalar-icon` values still resolve (lazy per-icon fetch) and that items without a custom icon use `interface-content-folder` immediately.

https://claude.ai/code/session_01J6EEZ5mBRX4rH4H1NRCN4r