### PR TITLE
fix(snippetz): emit CURLOPT_CUSTOMREQUEST for non-GET/POST methods in…

### DIFF
--- a/packages/snippetz/src/plugins/php/curl/curl.test.ts
+++ b/packages/snippetz/src/plugins/php/curl/curl.test.ts
@@ -30,6 +30,51 @@ curl_exec($ch);
 curl_close($ch);`)
   })
 
+  it('returns a DELETE request', () => {
+    const result = phpCurl.generate({
+      url: 'https://example.com',
+      method: 'delete',
+    })
+
+    expect(result).toBe(`$ch = curl_init("https://example.com");
+
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+
+curl_exec($ch);
+
+curl_close($ch);`)
+  })
+
+  it('returns a PUT request', () => {
+    const result = phpCurl.generate({
+      url: 'https://example.com',
+      method: 'put',
+    })
+
+    expect(result).toBe(`$ch = curl_init("https://example.com");
+
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+
+curl_exec($ch);
+
+curl_close($ch);`)
+  })
+
+  it('returns a PATCH request', () => {
+    const result = phpCurl.generate({
+      url: 'https://example.com',
+      method: 'patch',
+    })
+
+    expect(result).toBe(`$ch = curl_init("https://example.com");
+
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PATCH');
+
+curl_exec($ch);
+
+curl_close($ch);`)
+  })
+
   it('has headers', () => {
     const result = phpCurl.generate({
       url: 'https://example.com',

--- a/packages/snippetz/src/plugins/php/curl/curl.ts
+++ b/packages/snippetz/src/plugins/php/curl/curl.ts
@@ -40,6 +40,8 @@ export const phpCurl: Plugin = {
     // Method
     if (normalizedRequest.method === 'POST') {
       parts.push('curl_setopt($ch, CURLOPT_POST, true);')
+    } else if (normalizedRequest.method !== 'GET') {
+      parts.push(`curl_setopt($ch, CURLOPT_CUSTOMREQUEST, '${normalizedRequest.method}');`)
     }
 
     // Basic Auth


### PR DESCRIPTION
## Problem

The PHP cURL snippet generator (`packages/snippetz/src/plugins/php/curl/curl.ts`) only handled `POST` explicitly via `CURLOPT_POST`. All other non-GET methods (`DELETE`, `PUT`, `PATCH`, etc.) silently fell through without setting the HTTP method, causing generated snippets to incorrectly default to `GET`.

For example, a `DELETE` request was generating:

```php
$ch = curl_init("https://example.com/resource/1");

curl_exec($ch);

curl_close($ch);
```

## Fix

Added an else if branch that emits CURLOPT_CUSTOMREQUEST for any method that is not GET or POST:

```
if (normalizedRequest.method === 'POST') {
  parts.push('curl_setopt($ch, CURLOPT_POST, true);')
} else if (normalizedRequest.method !== 'GET') {
  parts.push(`curl_setopt($ch, CURLOPT_CUSTOMREQUEST, '${normalizedRequest.method}');`)
}
```

A `DELETE` request now correctly generates:

```
$ch = curl_init("https://example.com/resource/1");

curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');

curl_exec($ch);

curl_close($ch);
```

## Changes

- packages/snippetz/src/plugins/php/curl/curl.ts — emit CURLOPT_CUSTOMREQUEST for non-GET/POST methods
- packages/snippetz/src/plugins/php/curl/curl.test.ts — add tests for DELETE, PUT, and PATCH
