### PR TITLE
fix(snippetz): emit CURLOPT_CUSTOMREQUEST for non-GET/POST PHP cURL methods

### DIFF
--- a/.changeset/php-curl-custom-request-method.md
+++ b/.changeset/php-curl-custom-request-method.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+fix(snippetz): emit `CURLOPT_CUSTOMREQUEST` for PHP cURL snippets when the method is not GET or POST, so DELETE/PUT/PATCH requests render with the correct verb

--- a/packages/snippetz/src/plugins/php/curl/curl.test.ts
+++ b/packages/snippetz/src/plugins/php/curl/curl.test.ts
@@ -679,6 +679,58 @@ curl_close($ch);`)
     expect(result).toContain("'Content-Type: application/x-www-form-urlencoded'")
   })
 
+  it('sets CURLOPT_CUSTOMREQUEST for DELETE requests', () => {
+    const result = phpCurl.generate({
+      url: 'https://access.scalar.com/v1/themes/{slug}',
+      method: 'DELETE',
+      headers: [
+        {
+          name: 'Authorization',
+          value: 'Bearer YOUR_SECRET_TOKEN',
+        },
+      ],
+    })
+
+    expect(result).toBe(`$ch = curl_init("https://access.scalar.com/v1/themes/{slug}");
+
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+curl_setopt($ch, CURLOPT_HTTPHEADER, ['Authorization: Bearer YOUR_SECRET_TOKEN']);
+
+curl_exec($ch);
+
+curl_close($ch);`)
+  })
+
+  it('sets CURLOPT_CUSTOMREQUEST for PUT requests', () => {
+    const result = phpCurl.generate({
+      url: 'https://example.com',
+      method: 'PUT',
+    })
+
+    expect(result).toBe(`$ch = curl_init("https://example.com");
+
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+
+curl_exec($ch);
+
+curl_close($ch);`)
+  })
+
+  it('sets CURLOPT_CUSTOMREQUEST for PATCH requests', () => {
+    const result = phpCurl.generate({
+      url: 'https://example.com',
+      method: 'PATCH',
+    })
+
+    expect(result).toBe(`$ch = curl_init("https://example.com");
+
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PATCH');
+
+curl_exec($ch);
+
+curl_close($ch);`)
+  })
+
   it('prettifies JSON body using PHP array', () => {
     const result = phpCurl.generate({
       url: 'https://example.com',

--- a/packages/snippetz/src/plugins/php/curl/curl.ts
+++ b/packages/snippetz/src/plugins/php/curl/curl.ts
@@ -40,6 +40,8 @@ export const phpCurl: Plugin = {
     // Method
     if (normalizedRequest.method === 'POST') {
       parts.push('curl_setopt($ch, CURLOPT_POST, true);')
+    } else if (normalizedRequest.method !== 'GET') {
+      parts.push(`curl_setopt($ch, CURLOPT_CUSTOMREQUEST, '${normalizedRequest.method}');`)
     }
 
     // Basic Auth


### PR DESCRIPTION
## Summary

- The PHP cURL snippet generator only emitted `CURLOPT_POST` for POST and nothing for other verbs, so DELETE, PUT, PATCH, etc. silently fell back to GET in the rendered example. A customer noticed this on a DELETE request in the API Reference.
- Fix: when the method is not GET (the cURL default) and not POST (which already uses `CURLOPT_POST`), emit `curl_setopt($ch, CURLOPT_CUSTOMREQUEST, '<METHOD>')`.
- Added regression tests for DELETE (matching the customer's exact reproduction), PUT, and PATCH.

## Before

```php
$ch = curl_init("https://access.scalar.com/v1/themes/{slug}");

curl_setopt($ch, CURLOPT_HTTPHEADER, ['Authorization: Bearer YOUR_SECRET_TOKEN']);

curl_exec($ch);

curl_close($ch);
```

## After

```php
$ch = curl_init("https://access.scalar.com/v1/themes/{slug}");

curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
curl_setopt($ch, CURLOPT_HTTPHEADER, ['Authorization: Bearer YOUR_SECRET_TOKEN']);

curl_exec($ch);

curl_close($ch);
```

## Test plan

- [x] `pnpm vitest src/plugins/php/curl --run` (in `packages/snippetz`) — 35/35 pass, including 3 new regression tests
- [x] `pnpm vitest --run` (full snippetz suite) — 855/855 pass
- [x] `pnpm biome check` and `pnpm --filter @scalar/snippetz types:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrow change to snippet string generation, covered by new regression tests for DELETE/PUT/PATCH output.
> 
> **Overview**
> Fixes the PHP cURL snippet generator to emit `CURLOPT_CUSTOMREQUEST` for any HTTP method other than `GET` or `POST`, ensuring verbs like DELETE/PUT/PATCH render correctly instead of defaulting to GET.
> 
> Adds regression tests validating the generated snippet output for DELETE (including headers), PUT, and PATCH, and includes a patch changeset for `@scalar/snippetz`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d7a9ca40f9d109e8716aff8d07296faadf8dbb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->