### PR TITLE
fix(workspace-store): `x-internal`/`x-scalar-ignore` on $ref wrapper schemas

### DIFF
--- a/.changeset/clean-trains-invite.md
+++ b/.changeset/clean-trains-invite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+remove outdated Biome suppression in schema traversal loop

--- a/.changeset/fix-9114-x-internal-on-ref-wrapper.md
+++ b/.changeset/fix-9114-x-internal-on-ref-wrapper.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix(workspace-store): respect x-internal and x-scalar-ignore on $ref wrapper schemas in the sidebar

--- a/.changeset/fix-9114-x-internal-on-ref-wrapper.md
+++ b/.changeset/fix-9114-x-internal-on-ref-wrapper.md
@@ -2,4 +2,4 @@
 '@scalar/workspace-store': patch
 ---
 
-fix(workspace-store): respect x-internal and x-scalar-ignore on $ref wrapper schemas in the sidebar
+fix(workspace-store): respect x-internal and x-scalar-ignore on $ref wrapper schemas, operations, and webhooks in the sidebar

--- a/packages/workspace-store/src/helpers/get-resolved-ref.ts
+++ b/packages/workspace-store/src/helpers/get-resolved-ref.ts
@@ -6,6 +6,16 @@ const defaultTransform = <Node>(node: RefNode<Node>) => {
 }
 
 /**
+ * Transform for getResolvedRef that merges sibling properties of a $ref wrapper
+ * onto the dereferenced value. Wrapper siblings take precedence over the resolved value,
+ * which matches OpenAPI 3.1 semantics where annotations alongside $ref override the target.
+ */
+export const mergeSiblingReferences = <Node>(node: RefNode<Node>): Node => {
+  const { '$ref-value': value, ...rest } = node
+  return { ...value, ...rest } as Node
+}
+
+/**
  * Resolves a node that may be a $ref object to its actual value.
  * If the node contains a $ref, applies the provided transform (default: returns '$ref-value').
  * Otherwise, returns the node as-is.

--- a/packages/workspace-store/src/helpers/is-hidden.test.ts
+++ b/packages/workspace-store/src/helpers/is-hidden.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { isHidden } from './is-hidden'
+
+describe('isHidden', () => {
+  it('returns false for undefined', () => {
+    expect(isHidden(undefined)).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isHidden(null)).toBe(false)
+  })
+
+  it('returns false for an empty object', () => {
+    expect(isHidden({})).toBe(false)
+  })
+
+  it('returns true when x-internal is true', () => {
+    expect(isHidden({ 'x-internal': true })).toBe(true)
+  })
+
+  it('returns true when x-scalar-ignore is true', () => {
+    expect(isHidden({ 'x-scalar-ignore': true })).toBe(true)
+  })
+
+  it('returns true when both flags are true', () => {
+    expect(isHidden({ 'x-internal': true, 'x-scalar-ignore': true })).toBe(true)
+  })
+
+  it('returns false when both flags are explicitly false', () => {
+    expect(isHidden({ 'x-internal': false, 'x-scalar-ignore': false })).toBe(false)
+  })
+})

--- a/packages/workspace-store/src/helpers/is-hidden.ts
+++ b/packages/workspace-store/src/helpers/is-hidden.ts
@@ -1,0 +1,9 @@
+import type { XInternal } from '@/schemas/extensions/document/x-internal'
+import type { XScalarIgnore } from '@/schemas/extensions/document/x-scalar-ignore'
+
+/**
+ * Returns true when an OpenAPI entity (tag, operation, schema, …) is marked as hidden
+ * from navigation via `x-internal` or `x-scalar-ignore`.
+ */
+export const isHidden = (entity: (XInternal & XScalarIgnore) | null | undefined): boolean =>
+  Boolean(entity?.['x-internal'] || entity?.['x-scalar-ignore'])

--- a/packages/workspace-store/src/navigation/helpers/traverse-paths.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-paths.test.ts
@@ -263,6 +263,78 @@ describe('traversePaths', () => {
     expect(tagsMap.get('Ignored')?.entries).toEqual([])
   })
 
+  it('skips $ref-wrapped operations with x-internal sibling extension', () => {
+    // The wrapper has x-internal as a sibling to $ref. The resolved target does not.
+    // See: https://github.com/scalar/scalar/issues/9114
+    const document = createDocument()
+    document.paths = {
+      '/hidden': {
+        get: {
+          'x-internal': true,
+          $ref: '#/components/operations/HiddenOp',
+          // biome-ignore lint/suspicious/noExplicitAny: simulating bundled $ref-value
+          '$ref-value': {
+            tags: ['Hidden'],
+            summary: 'Should not show',
+            operationId: 'hiddenOp',
+          },
+        } as any,
+      },
+    }
+
+    const tagsMap: TagsMap = new Map([
+      ['Hidden', { id: 'tag/hidden', parentId: 'doc-1', tag: { name: 'Hidden' }, entries: [] }],
+    ])
+
+    traversePaths({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      generateId: (props) => {
+        if (props.type === 'operation') {
+          return `${props.method?.toUpperCase()}-${props.path}`
+        }
+        return 'unknown-id'
+      },
+    })
+    expect(tagsMap.get('Hidden')?.entries).toEqual([])
+  })
+
+  it('skips $ref-wrapped operations with x-scalar-ignore sibling extension', () => {
+    const document = createDocument()
+    document.paths = {
+      '/ignored': {
+        get: {
+          'x-scalar-ignore': true,
+          $ref: '#/components/operations/IgnoredOp',
+          // biome-ignore lint/suspicious/noExplicitAny: simulating bundled $ref-value
+          '$ref-value': {
+            tags: ['Ignored'],
+            summary: 'Should not show',
+            operationId: 'ignoredOp',
+          },
+        } as any,
+      },
+    }
+
+    const tagsMap: TagsMap = new Map([
+      ['Ignored', { id: 'tag/ignored', parentId: 'doc-1', tag: { name: 'Ignored' }, entries: [] }],
+    ])
+
+    traversePaths({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      generateId: (props) => {
+        if (props.type === 'operation') {
+          return `${props.method?.toUpperCase()}-${props.path}`
+        }
+        return 'unknown-id'
+      },
+    })
+    expect(tagsMap.get('Ignored')?.entries).toEqual([])
+  })
+
   it('should handle operations with missing summary', () => {
     const document = createDocument()
     document.paths = {

--- a/packages/workspace-store/src/navigation/helpers/traverse-paths.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-paths.ts
@@ -3,7 +3,8 @@ import { isHttpMethod } from '@scalar/helpers/http/is-http-method'
 import { objectKeys } from '@scalar/helpers/object/object-keys'
 import { escapeJsonPointer } from '@scalar/json-magic/helpers/escape-json-pointer'
 
-import { getResolvedRef } from '@/helpers/get-resolved-ref'
+import { getResolvedRef, mergeSiblingReferences } from '@/helpers/get-resolved-ref'
+import { isHidden } from '@/helpers/is-hidden'
 import { traverseOperationExamples } from '@/navigation/helpers/traverse-examples'
 import type { TagsMap, TraverseSpecOptions } from '@/navigation/types'
 import { XScalarStabilityValues } from '@/schemas/extensions/operation'
@@ -121,13 +122,13 @@ export const traversePaths = ({
 
     pathKeys.forEach((method) => {
       const _operation = pathItemObject?.[method]
-      const operation = getResolvedRef(_operation)
+      const operation = getResolvedRef(_operation, mergeSiblingReferences)
       if (!operation) {
         return
       }
 
       // Skip if the operation is internal or scalar-ignore
-      if (operation['x-internal'] || operation['x-scalar-ignore'] || !isHttpMethod(method)) {
+      if (isHidden(operation) || !isHttpMethod(method)) {
         return
       }
 

--- a/packages/workspace-store/src/navigation/helpers/traverse-schemas.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-schemas.test.ts
@@ -360,6 +360,106 @@ describe('traverseSchemas', () => {
     expect(result[0]?.title).toBe('ValidSchema')
   })
 
+  it('skips $ref wrapper schemas with x-internal sibling extension', () => {
+    // The wrapper has x-internal as a sibling to $ref. The resolved target does not.
+    // See: https://github.com/scalar/scalar/issues/9114
+    const content = coerceValue(OpenAPIDocumentSchema, {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      components: {
+        schemas: {
+          'Method.v1_users_search_output': {
+            'x-internal': true,
+            $ref: '#/components/schemas/Resource.User',
+            '$ref-value': {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+              },
+            },
+          },
+          'Resource.User': {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+        },
+      },
+    })
+
+    const result = traverseSchemas({
+      document: content,
+      tagsMap: mockTagsMap,
+      documentId: 'doc-1',
+      generateId: (props) => {
+        if (props.type === 'model') {
+          if (props.name) {
+            return `model-${props.name}`
+          }
+          return 'model'
+        }
+
+        return 'unknown-id'
+      },
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.name).toBe('Resource.User')
+  })
+
+  it('skips $ref wrapper schemas with x-scalar-ignore sibling extension', () => {
+    const content = coerceValue(OpenAPIDocumentSchema, {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      components: {
+        schemas: {
+          'Method.v1_users_search_output': {
+            'x-scalar-ignore': true,
+            $ref: '#/components/schemas/Resource.User',
+            '$ref-value': {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+              },
+            },
+          },
+          'Resource.User': {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+          },
+        },
+      },
+    })
+
+    const result = traverseSchemas({
+      document: content,
+      tagsMap: mockTagsMap,
+      documentId: 'doc-1',
+      generateId: (props) => {
+        if (props.type === 'model') {
+          if (props.name) {
+            return `model-${props.name}`
+          }
+          return 'model'
+        }
+
+        return 'unknown-id'
+      },
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.name).toBe('Resource.User')
+  })
+
   it('uses the title attribute of the schema', () => {
     const content = coerceValue(OpenAPIDocumentSchema, {
       openapi: '3.1.0',

--- a/packages/workspace-store/src/navigation/helpers/traverse-schemas.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-schemas.ts
@@ -1,14 +1,9 @@
-import { getResolvedRef } from '@/helpers/get-resolved-ref'
+import { getResolvedRef, mergeSiblingReferences } from '@/helpers/get-resolved-ref'
+import { isHidden } from '@/helpers/is-hidden'
 import { getTag } from '@/navigation/helpers/get-tag'
 import type { TagsMap, TraverseSpecOptions } from '@/navigation/types'
-import type { XInternal } from '@/schemas/extensions/document/x-internal'
-import type { XScalarIgnore } from '@/schemas/extensions/document/x-scalar-ignore'
 import type { ParentTag, TraversedSchema } from '@/schemas/navigation'
 import type { OpenApiDocument, SchemaObject } from '@/schemas/v3.1/strict/openapi-document'
-
-/** Returns true when an entity is marked as hidden from navigation via x-internal or x-scalar-ignore. */
-const isHidden = (entity: (XInternal & XScalarIgnore) | undefined) =>
-  Boolean(entity?.['x-internal'] || entity?.['x-scalar-ignore'])
 
 /** Creates a traversed schema entry from an OpenAPI schema object.
  *
@@ -79,12 +74,11 @@ export const traverseSchemas = ({
       continue
     }
 
-    // The schema may be a $ref wrapper with sibling x-internal / x-scalar-ignore extensions.
-    // getResolvedRef returns only the dereferenced content, so we need to check the wrapper too.
-    const wrapper = schemas[name] as (XInternal & XScalarIgnore) | undefined
-    const schema = getResolvedRef(schemas[name])
+    // Merge wrapper siblings onto the dereferenced schema so x-internal / x-scalar-ignore
+    // set alongside a $ref are honored (e.g. https://github.com/scalar/scalar/issues/9114).
+    const schema = getResolvedRef(schemas[name], mergeSiblingReferences)
 
-    if (isHidden(wrapper) || isHidden(schema)) {
+    if (isHidden(schema)) {
       continue
     }
 

--- a/packages/workspace-store/src/navigation/helpers/traverse-schemas.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-schemas.ts
@@ -68,7 +68,6 @@ export const traverseSchemas = ({
   const schemas = document.components?.schemas ?? {}
   const untagged: TraversedSchema[] = []
 
-  // biome-ignore lint/suspicious/useGuardForIn: we do have an if statement after de-ref
   for (const name in schemas) {
     if (!Object.hasOwn(schemas, name)) {
       continue

--- a/packages/workspace-store/src/navigation/helpers/traverse-schemas.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-schemas.ts
@@ -1,8 +1,14 @@
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
 import { getTag } from '@/navigation/helpers/get-tag'
 import type { TagsMap, TraverseSpecOptions } from '@/navigation/types'
+import type { XInternal } from '@/schemas/extensions/document/x-internal'
+import type { XScalarIgnore } from '@/schemas/extensions/document/x-scalar-ignore'
 import type { ParentTag, TraversedSchema } from '@/schemas/navigation'
 import type { OpenApiDocument, SchemaObject } from '@/schemas/v3.1/strict/openapi-document'
+
+/** Returns true when an entity is marked as hidden from navigation via x-internal or x-scalar-ignore. */
+const isHidden = (entity: (XInternal & XScalarIgnore) | undefined) =>
+  Boolean(entity?.['x-internal'] || entity?.['x-scalar-ignore'])
 
 /** Creates a traversed schema entry from an OpenAPI schema object.
  *
@@ -75,15 +81,10 @@ export const traverseSchemas = ({
 
     // The schema may be a $ref wrapper with sibling x-internal / x-scalar-ignore extensions.
     // getResolvedRef returns only the dereferenced content, so we need to check the wrapper too.
-    const wrapper = schemas[name] as Record<string, unknown> | undefined
+    const wrapper = schemas[name] as (XInternal & XScalarIgnore) | undefined
     const schema = getResolvedRef(schemas[name])
 
-    if (
-      wrapper?.['x-internal'] ||
-      wrapper?.['x-scalar-ignore'] ||
-      schema?.['x-internal'] ||
-      schema?.['x-scalar-ignore']
-    ) {
+    if (isHidden(wrapper) || isHidden(schema)) {
       continue
     }
 

--- a/packages/workspace-store/src/navigation/helpers/traverse-schemas.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-schemas.ts
@@ -69,9 +69,21 @@ export const traverseSchemas = ({
 
   // biome-ignore lint/suspicious/useGuardForIn: we do have an if statement after de-ref
   for (const name in schemas) {
+    if (!Object.hasOwn(schemas, name)) {
+      continue
+    }
+
+    // The schema may be a $ref wrapper with sibling x-internal / x-scalar-ignore extensions.
+    // getResolvedRef returns only the dereferenced content, so we need to check the wrapper too.
+    const wrapper = schemas[name] as Record<string, unknown> | undefined
     const schema = getResolvedRef(schemas[name])
 
-    if (schema?.['x-internal'] || schema?.['x-scalar-ignore'] || !Object.hasOwn(schemas, name)) {
+    if (
+      wrapper?.['x-internal'] ||
+      wrapper?.['x-scalar-ignore'] ||
+      schema?.['x-internal'] ||
+      schema?.['x-scalar-ignore']
+    ) {
       continue
     }
 

--- a/packages/workspace-store/src/navigation/helpers/traverse-tags.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-tags.ts
@@ -1,5 +1,6 @@
 import { sortByOrder } from '@scalar/helpers/array/sort-by-order'
 
+import { isHidden } from '@/helpers/is-hidden'
 import { unpackProxyObject } from '@/helpers/unpack-proxy'
 import { getXKeysFromObject } from '@/navigation/helpers/get-x-keys'
 import type { TagsMap, TraverseSpecOptions } from '@/navigation/types'
@@ -99,7 +100,7 @@ const getSortedTagEntries = ({
     const { tag, entries } = getTag({ tagsMap, name: key, documentId, generateId })
 
     // Skip if the tag is internal or scalar-ignore
-    if (tag['x-internal'] || tag['x-scalar-ignore']) {
+    if (isHidden(tag)) {
       return []
     }
 

--- a/packages/workspace-store/src/navigation/helpers/traverse-webhooks.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-webhooks.test.ts
@@ -194,6 +194,86 @@ describe('traverse-webhooks', () => {
       expect(tagsMap.size).toBe(0)
     })
 
+    it('skips $ref-wrapped webhooks with x-internal sibling extension', () => {
+      // The wrapper has x-internal as a sibling to $ref. The resolved target does not.
+      // See: https://github.com/scalar/scalar/issues/9114
+      const document: OpenApiDocument = {
+        openapi: '3.1.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+        webhooks: {
+          'hidden-webhook': {
+            post: {
+              'x-internal': true,
+              $ref: '#/components/pathItems/HiddenWebhook',
+              // biome-ignore lint/suspicious/noExplicitAny: simulating bundled $ref-value
+              '$ref-value': {
+                summary: 'Should not show',
+                operationId: 'hiddenWebhook',
+              },
+            } as any,
+          },
+        },
+        'x-scalar-original-document-hash': '',
+      }
+
+      const tagsMap: TagsMap = new Map()
+
+      const result = traverseWebhooks({
+        document,
+        tagsMap,
+        generateId: (options) => {
+          if (options.type === 'webhook') {
+            return `${options.parentTag?.tag.name ?? 'untagged'}-${options.method || 'unknown'}-${options.name}`
+          }
+          return 'unknown-id'
+        },
+        documentId: 'document-id',
+        untaggedWebhooksParentId: 'document-id',
+      })
+
+      expect(result).toEqual([])
+    })
+
+    it('skips $ref-wrapped webhooks with x-scalar-ignore sibling extension', () => {
+      const document: OpenApiDocument = {
+        openapi: '3.1.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+        webhooks: {
+          'ignored-webhook': {
+            post: {
+              'x-scalar-ignore': true,
+              $ref: '#/components/pathItems/IgnoredWebhook',
+              // biome-ignore lint/suspicious/noExplicitAny: simulating bundled $ref-value
+              '$ref-value': {
+                summary: 'Should not show',
+                operationId: 'ignoredWebhook',
+              },
+            } as any,
+          },
+        },
+        'x-scalar-original-document-hash': '',
+      }
+
+      const tagsMap: TagsMap = new Map()
+
+      const result = traverseWebhooks({
+        document,
+        tagsMap,
+        generateId: (options) => {
+          if (options.type === 'webhook') {
+            return `${options.parentTag?.tag.name ?? 'untagged'}-${options.method || 'unknown'}-${options.name}`
+          }
+          return 'unknown-id'
+        },
+        documentId: 'document-id',
+        untaggedWebhooksParentId: 'document-id',
+      })
+
+      expect(result).toEqual([])
+    })
+
     it('should handle deprecated webhooks', () => {
       const document: OpenApiDocument = {
         openapi: '3.1.0',

--- a/packages/workspace-store/src/navigation/helpers/traverse-webhooks.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-webhooks.ts
@@ -2,7 +2,8 @@ import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import { isHttpMethod } from '@scalar/helpers/http/is-http-method'
 import { objectKeys } from '@scalar/helpers/object/object-keys'
 
-import { getResolvedRef } from '@/helpers/get-resolved-ref'
+import { getResolvedRef, mergeSiblingReferences } from '@/helpers/get-resolved-ref'
+import { isHidden } from '@/helpers/is-hidden'
 import { isDeprecatedOperation } from '@/navigation/helpers/traverse-paths'
 import type { TagsMap, TraverseSpecOptions } from '@/navigation/types'
 import type { ParentTag, TraversedWebhook } from '@/schemas/navigation'
@@ -103,13 +104,13 @@ export const traverseWebhooks = ({
 
     pathKeys.forEach((method) => {
       const _operation = pathItemObject?.[method]
-      const operation = getResolvedRef(_operation)
+      const operation = getResolvedRef(_operation, mergeSiblingReferences)
       if (!operation) {
         return
       }
 
       // Skip if the operation is internal or scalar-ignore
-      if (operation['x-internal'] || operation['x-scalar-ignore']) {
+      if (isHidden(operation)) {
         return
       }
 

--- a/packages/workspace-store/src/resolve.ts
+++ b/packages/workspace-store/src/resolve.ts
@@ -1,18 +1,10 @@
 import { Type } from '@scalar/typebox'
 
-import { type RefNode, getResolvedRef } from '@/helpers/get-resolved-ref'
+import { getResolvedRef, mergeSiblingReferences } from '@/helpers/get-resolved-ref'
 import { compose } from '@/schemas/compose'
 import { coerceValue } from '@/schemas/typebox-coerce'
 import { SchemaObjectSchema } from '@/schemas/v3.1/strict/openapi-document'
 import type { MaybeRefSchemaObject, SchemaObject } from '@/schemas/v3.1/strict/schema'
-
-const mergeSiblingReferences = <Node>(node: RefNode<Node>) => {
-  const { '$ref-value': value, ...rest } = node
-  return {
-    ...value,
-    ...rest,
-  }
-}
 
 type ResolvedSchema<T> = T extends undefined ? undefined : SchemaObject & { $ref?: string }
 


### PR DESCRIPTION
## Summary

- Hidden schemas were still rendering in the sidebar when `x-internal` / `x-scalar-ignore` were set as siblings of `$ref` on a wrapper schema.
- `getResolvedRef` returns only the dereferenced `$ref-value` content, so the existing check missed the wrapper's siblings. Now we check the wrapper *and* the resolved schema.
- Added two regression tests covering both extensions on a `$ref` wrapper.

## Test plan

- [x] `pnpm vitest src/navigation --run` (186 passed)
- [x] `pnpm --filter @scalar/workspace-store types:check`
- [x] Biome + Prettier on changed files
- [ ] Reviewer: load the reproduction document from the issue and confirm `Method.v1_users_search_output` is no longer in the sidebar

## Ticket

Fixes #9114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `$ref` resolution and sidebar traversal logic for schemas/operations/webhooks; could alter which items appear in navigation for specs that rely on wrapper-sibling overrides.
> 
> **Overview**
> Fixes sidebar filtering so `x-internal` and `x-scalar-ignore` are respected even when set as *siblings* on `$ref` wrapper objects.
> 
> This introduces `mergeSiblingReferences` (a `getResolvedRef` transform) and applies it during traversal of paths, schemas, and webhooks, while centralizing the hide check via a new `isHidden` helper. Adds regression tests covering `$ref`-wrapped operations, schemas, and webhooks, and removes an outdated Biome suppression in the schema traversal loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30c6388610931e5544fda24617ae3486d420906e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->