### PR TITLE
fix(api-reference): better search results for parameter, body, and schemas

### DIFF
--- a/.changeset/clever-keys-rank.md
+++ b/.changeset/clever-keys-rank.md
@@ -2,4 +2,4 @@
 '@scalar/api-reference': patch
 ---
 
-fix(api-reference): improve search ranking for parameter and request-body field names
+fix(api-reference): improve search ranking for parameter and request-body field names, including polymorphic (oneOf/anyOf/allOf) bodies

--- a/.changeset/clever-keys-rank.md
+++ b/.changeset/clever-keys-rank.md
@@ -2,4 +2,4 @@
 '@scalar/api-reference': patch
 ---
 
-fix(api-reference): improve search ranking for parameter and request-body field names, including polymorphic (oneOf/anyOf/allOf) bodies
+fix(api-reference): improve search ranking for parameter, request-body, and model field names, including polymorphic (oneOf/anyOf/allOf) schemas

--- a/.changeset/clever-keys-rank.md
+++ b/.changeset/clever-keys-rank.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): improve search ranking for parameter and request-body field names

--- a/packages/api-reference/src/features/Search/helpers/create-fuse-instance.ts
+++ b/packages/api-reference/src/features/Search/helpers/create-fuse-instance.ts
@@ -9,26 +9,36 @@ import type { FuseData } from '@/features/Search/types'
  */
 export function createFuseInstance(): Fuse<FuseData> {
   return new Fuse([], {
-    // Define searchable fields with weights to prioritize more important matches
+    // Define searchable fields with weights to prioritize more important matches.
+    //
+    // Field design: short, high-signal fields (`title`, `parameters`, `body`) are weighted higher than
+    // long verbose fields (`description`, `parameterDescriptions`, `bodyDescriptions`). This way an
+    // exact match on a parameter or body field name surfaces the right operation, even when an
+    // unrelated operation happens to mention that word in its prose description.
     keys: [
-      // Highest weight - titles are most descriptive
+      // Highest weight - titles are the most descriptive identifier of an entry.
       { name: 'title', weight: 0.7 },
-      // Medium weight - helpful but often verbose
-      { name: 'description', weight: 0.3 },
-      // Lowest weight - parameters are searchable but they can be very long and noisy
-      { name: 'parameters', weight: 0.2 },
-      // Lowest weight - can be very long and noisy
-      { name: 'body', weight: 0.2 },
-      // Low-medium weight - response examples can help full-text matching
-      { name: 'responseExamples', weight: 0.25 },
-      // High weight - unique identifiers for operations
+      // High weight - operationIds are explicit unique identifiers.
       { name: 'operationId', weight: 0.6 },
-      // Good weight - endpoint paths are searchable
+      // Clean parameter names. Above `path` so `userId` ranks the operation that defines the param
+      // higher than another operation that merely contains it in its path string.
+      { name: 'parameters', weight: 0.55 },
+      // Clean request-body property names — same reasoning as `parameters`.
+      { name: 'body', weight: 0.55 },
+      // Endpoint paths.
       { name: 'path', weight: 0.5 },
-      // Medium-high weight - helps with categorization
+      // Tag names — useful for categorization.
       { name: 'tag', weight: 0.4 },
-      // Medium weight - useful for filtering by method
+      // Verbose prose — helpful but often noisy.
+      { name: 'description', weight: 0.3 },
+      // HTTP method - useful for filtering.
       { name: 'method', weight: 0.3 },
+      // Response examples can help full-text matching.
+      { name: 'responseExamples', weight: 0.25 },
+      // Verbose parameter descriptions — supplementary signal only.
+      { name: 'parameterDescriptions', weight: 0.2 },
+      // Verbose request-body descriptions — supplementary signal only.
+      { name: 'bodyDescriptions', weight: 0.2 },
     ],
 
     // Threshold controls how strict the matching is (0.0 = perfect match, 1.0 = very loose)

--- a/packages/api-reference/src/features/Search/helpers/create-search-index.test.ts
+++ b/packages/api-reference/src/features/Search/helpers/create-search-index.test.ts
@@ -130,7 +130,7 @@ describe('createSearchIndex', () => {
       expect(index.map((item) => item.title)).toEqual(['Introduction', 'Get Users', 'Create User', 'Get Posts'])
     })
 
-    it('includes path item parameters in operation index body', () => {
+    it('includes path item parameter names and descriptions in the operation index', () => {
       const document = createMockDocument({
         paths: {
           '/users/{userId}': {
@@ -155,8 +155,9 @@ describe('createSearchIndex', () => {
       expect(operationEntry).toMatchObject({
         type: 'operation',
         title: 'Get User',
-        body: '',
-        parameters: ['userId REQUIRED path Unique user identifier'],
+        body: [],
+        parameters: ['userId'],
+        parameterDescriptions: ['Unique user identifier'],
       })
     })
 
@@ -190,7 +191,7 @@ describe('createSearchIndex', () => {
       expect(operationEntry).toMatchObject({
         type: 'operation',
         title: 'Create User',
-        body: expect.arrayContaining(['Body', 'name optional string', 'email optional string']),
+        body: ['name', 'email'],
       })
     })
 
@@ -223,7 +224,7 @@ describe('createSearchIndex', () => {
       expect(operationEntry).toMatchObject({
         type: 'operation',
         title: 'Create User',
-        body: expect.arrayContaining(['Body', 'xmlField optional string']),
+        body: ['xmlField'],
       })
     })
 
@@ -264,7 +265,7 @@ describe('createSearchIndex', () => {
       expect(operationEntry).toMatchObject({
         type: 'operation',
         title: 'Create User',
-        body: expect.arrayContaining(['jsonField optional string', 'xmlField optional number']),
+        body: ['jsonField', 'xmlField'],
       })
     })
 
@@ -292,11 +293,13 @@ describe('createSearchIndex', () => {
       expect(operationEntry).toEqual({
         type: 'operation',
         title: 'Get Users',
-        parameters: ['limit optional query Number of users to return'],
+        parameters: ['limit'],
+        parameterDescriptions: ['Number of users to return'],
         path: '/users',
         method: 'get',
         responseExamples: [],
-        body: '',
+        body: [],
+        bodyDescriptions: [],
         description: '',
         entry: expect.any(Object),
         id: expect.any(String),
@@ -383,7 +386,8 @@ describe('createSearchIndex', () => {
         {
           title: 'User Model',
           description: 'Model',
-          body: 'A user object',
+          body: '',
+          bodyDescriptions: ['A user object'],
         },
       ])
 
@@ -415,6 +419,7 @@ describe('createSearchIndex', () => {
           title: 'Post Model',
           description: 'Model',
           body: '',
+          bodyDescriptions: [],
         },
       ])
     })
@@ -442,8 +447,8 @@ describe('createSearchIndex', () => {
       expect(index.length).toEqual(4) // Introduction + models heading + 2 schemas
       expect(index[0]).toMatchObject({ type: 'heading', title: 'Introduction' })
       expect(index[1]).toMatchObject({ type: 'heading', title: 'Models' })
-      expect(index[2]).toMatchObject({ title: 'User Model', body: 'A user object' })
-      expect(index[3]).toMatchObject({ title: 'Post Model', body: 'A post object' })
+      expect(index[2]).toMatchObject({ title: 'User Model', bodyDescriptions: ['A user object'] })
+      expect(index[3]).toMatchObject({ title: 'Post Model', bodyDescriptions: ['A post object'] })
     })
   })
 
@@ -505,7 +510,8 @@ describe('createSearchIndex', () => {
           method: 'delete',
           title: 'User Deleted Webhook',
           description: 'Webhook',
-          body: 'Triggered when a user is deleted',
+          body: '',
+          bodyDescriptions: ['Triggered when a user is deleted'],
         },
       ])
     })
@@ -536,6 +542,7 @@ describe('createSearchIndex', () => {
           title: 'User Updated Webhook',
           description: 'Webhook',
           body: '',
+          bodyDescriptions: [],
         },
       ])
     })

--- a/packages/api-reference/src/features/Search/helpers/create-search-index.test.ts
+++ b/packages/api-reference/src/features/Search/helpers/create-search-index.test.ts
@@ -361,7 +361,7 @@ describe('createSearchIndex', () => {
   })
 
   describe('schemas', () => {
-    it('adds a single schema', () => {
+    it('adds a single schema with property names and descriptions', () => {
       const index = createSearchIndex(
         createMockDocument({
           components: {
@@ -370,6 +370,10 @@ describe('createSearchIndex', () => {
                 type: 'object',
                 title: 'User Model',
                 description: 'A user object',
+                properties: {
+                  name: { type: 'string', description: 'Display name' },
+                  email: { type: 'string' },
+                },
               },
             },
           },
@@ -386,15 +390,15 @@ describe('createSearchIndex', () => {
         {
           title: 'User Model',
           description: 'Model',
-          body: '',
-          bodyDescriptions: ['A user object'],
+          body: ['name', 'email'],
+          bodyDescriptions: ['A user object', 'Display name'],
         },
       ])
 
       expect(index.length).toEqual(3)
     })
 
-    it('adds schema without description', () => {
+    it('adds schema without description or properties', () => {
       const index = createSearchIndex(
         createMockDocument({
           components: {
@@ -418,7 +422,7 @@ describe('createSearchIndex', () => {
         {
           title: 'Post Model',
           description: 'Model',
-          body: '',
+          body: [],
           bodyDescriptions: [],
         },
       ])
@@ -449,6 +453,44 @@ describe('createSearchIndex', () => {
       expect(index[1]).toMatchObject({ type: 'heading', title: 'Models' })
       expect(index[2]).toMatchObject({ title: 'User Model', bodyDescriptions: ['A user object'] })
       expect(index[3]).toMatchObject({ title: 'Post Model', bodyDescriptions: ['A post object'] })
+    })
+
+    it('collects property names through a oneOf model schema', () => {
+      // Mirrors the Galaxy spec's CelestialBody — top-level oneOf of two $ref-ed object schemas.
+      const planet = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          failureCallbackUrl: { type: 'string' },
+        },
+      }
+      const satellite = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          diameter: { type: 'number' },
+        },
+      }
+      const document = createMockDocument({
+        components: {
+          schemas: {
+            Planet: planet,
+            Satellite: satellite,
+            CelestialBody: {
+              title: 'CelestialBody',
+              oneOf: [
+                { $ref: '#/components/schemas/Planet', '$ref-value': planet },
+                { $ref: '#/components/schemas/Satellite', '$ref-value': satellite },
+              ],
+            },
+          },
+        },
+      } as unknown as Partial<OpenApiDocument>)
+
+      const index = createSearchIndex(document)
+      const celestialEntry = index.find((item) => item.type === 'model' && item.title === 'CelestialBody')
+
+      expect(celestialEntry?.body).toEqual(['name', 'failureCallbackUrl', 'diameter'])
     })
   })
 

--- a/packages/api-reference/src/features/Search/helpers/create-search-index.ts
+++ b/packages/api-reference/src/features/Search/helpers/create-search-index.ts
@@ -9,7 +9,12 @@ import type {
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
 import type { FuseData } from '@/features/Search/types'
-import { extractParameters, extractRequestBody } from '@/helpers/openapi'
+import {
+  extractBodyDescriptions,
+  extractBodyFieldNames,
+  extractParameterDescriptions,
+  extractParameterNames,
+} from '@/helpers/openapi'
 
 function responseExampleValueToString(value: unknown): string {
   if (typeof value === 'string') {
@@ -104,8 +109,10 @@ function addEntryToIndex(entry: TraversedEntry, index: FuseData[], document?: Op
       parameters: combineParams(pathItem?.parameters, operation.parameters),
     }
 
-    const parameters = extractParameters(operationWithPathParams.parameters ?? [])
-    const body = extractRequestBody(operationWithPathParams)
+    const parameters = extractParameterNames(operationWithPathParams.parameters ?? [])
+    const parameterDescriptions = extractParameterDescriptions(operationWithPathParams.parameters ?? [])
+    const body = extractBodyFieldNames(operationWithPathParams)
+    const bodyDescriptions = extractBodyDescriptions(operationWithPathParams)
     const responseExamples = extractResponseExamples(operationWithPathParams.responses)
 
     index.push({
@@ -115,8 +122,10 @@ function addEntryToIndex(entry: TraversedEntry, index: FuseData[], document?: Op
       description: operationWithPathParams.description || '',
       method: entry.method,
       path: entry.path,
-      body: body || '',
-      parameters: parameters ?? '',
+      body,
+      bodyDescriptions,
+      parameters,
+      parameterDescriptions,
       responseExamples,
       operationId: operationWithPathParams.operationId,
       entry,
@@ -128,6 +137,7 @@ function addEntryToIndex(entry: TraversedEntry, index: FuseData[], document?: Op
   // Webhook
   if (entry.type === 'webhook') {
     const webhook = getResolvedRef(document?.webhooks?.[entry.name]?.[entry.method]) ?? {}
+    const webhookDescription = webhook.description || ''
 
     index.push({
       id: entry.id,
@@ -135,7 +145,8 @@ function addEntryToIndex(entry: TraversedEntry, index: FuseData[], document?: Op
       title: entry.title,
       description: 'Webhook',
       method: entry.method,
-      body: webhook.description || '',
+      body: '',
+      bodyDescriptions: webhookDescription ? [webhookDescription] : [],
       operationId: webhook.operationId,
       entry,
     })
@@ -146,15 +157,15 @@ function addEntryToIndex(entry: TraversedEntry, index: FuseData[], document?: Op
   // Model
   if (entry.type === 'model') {
     const schema = getResolvedRef(document?.components?.schemas?.[entry.name])
-
-    const description = schema?.description ?? ''
+    const schemaDescription = schema?.description ?? ''
 
     index.push({
       type: 'model',
       title: entry.title,
       description: 'Model',
       id: entry.id,
-      body: description,
+      body: '',
+      bodyDescriptions: schemaDescription ? [schemaDescription] : [],
       entry,
     })
 

--- a/packages/api-reference/src/features/Search/helpers/create-search-index.ts
+++ b/packages/api-reference/src/features/Search/helpers/create-search-index.ts
@@ -14,6 +14,8 @@ import {
   extractBodyFieldNames,
   extractParameterDescriptions,
   extractParameterNames,
+  extractSchemaDescriptions,
+  extractSchemaFieldNames,
 } from '@/helpers/openapi'
 
 function responseExampleValueToString(value: unknown): string {
@@ -158,14 +160,16 @@ function addEntryToIndex(entry: TraversedEntry, index: FuseData[], document?: Op
   if (entry.type === 'model') {
     const schema = getResolvedRef(document?.components?.schemas?.[entry.name])
     const schemaDescription = schema?.description ?? ''
+    const propertyNames = extractSchemaFieldNames(schema)
+    const propertyDescriptions = extractSchemaDescriptions(schema)
 
     index.push({
       type: 'model',
       title: entry.title,
       description: 'Model',
       id: entry.id,
-      body: '',
-      bodyDescriptions: schemaDescription ? [schemaDescription] : [],
+      body: propertyNames,
+      bodyDescriptions: schemaDescription ? [schemaDescription, ...propertyDescriptions] : propertyDescriptions,
       entry,
     })
 

--- a/packages/api-reference/src/features/Search/search-quality.test.ts
+++ b/packages/api-reference/src/features/Search/search-quality.test.ts
@@ -881,6 +881,31 @@ describe('search quality', () => {
     expect(search('integer', document)).toHaveLength(0)
   })
 
+  it('finds a model entry by one of its property names', () => {
+    // Mirrors the Galaxy spec's `Satellite` model — a standalone component schema with a
+    // top-level `diameter` property. Searching `diameter` should surface the model.
+    const document = {
+      components: {
+        schemas: {
+          Satellite: {
+            type: 'object',
+            description: 'Every satellite in the Scalar Galaxy',
+            properties: {
+              id: { type: 'integer' },
+              name: { type: 'string' },
+              diameter: { type: 'number', description: 'Diameter in kilometers' },
+            },
+          },
+        },
+      },
+    } as unknown as Partial<OpenApiDocument>
+
+    const result = search('diameter', document)
+
+    expect(result[0]?.item?.type).toEqual('model')
+    expect(result[0]?.item?.title).toEqual('Satellite')
+  })
+
   it('finds operations whose body schema is a oneOf of $ref-ed object schemas', () => {
     // Mirrors the Galaxy spec's "Create a celestial body" endpoint: the request body schema is a
     // top-level `oneOf` of two `$ref`-ed object schemas. A property defined inside one branch

--- a/packages/api-reference/src/features/Search/search-quality.test.ts
+++ b/packages/api-reference/src/features/Search/search-quality.test.ts
@@ -781,4 +781,103 @@ describe('search quality', () => {
     expect(result[0]?.item?.type).toEqual('operation')
     expect(result[0]?.item?.title).toEqual('Upload file')
   })
+
+  it('ranks an operation that defines a parameter above one that mentions it in prose', () => {
+    const query = 'limit'
+
+    const document: Partial<OpenApiDocument> = {
+      paths: {
+        '/users': {
+          get: {
+            summary: 'List users',
+            operationId: 'listUsers',
+            parameters: [
+              {
+                in: 'query',
+                name: 'limit',
+                description: 'Maximum number of results',
+                schema: { type: 'integer' },
+              },
+            ],
+          },
+        },
+        '/rate-info': {
+          get: {
+            summary: 'Rate info',
+            description: 'Returns the current API rate limit window for the caller.',
+            operationId: 'getRateInfo',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result[0]?.item?.title).toEqual('List users')
+  })
+
+  it('ranks an operation that defines a body field above one that mentions it in prose', () => {
+    const query = 'email'
+
+    const document: Partial<OpenApiDocument> = {
+      paths: {
+        '/users': {
+          post: {
+            summary: 'Create user',
+            operationId: 'createUser',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['email'],
+                    properties: {
+                      email: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/notifications': {
+          get: {
+            summary: 'List notifications',
+            description: 'Returns notifications including any pending email delivery confirmations.',
+            operationId: 'listNotifications',
+          },
+        },
+      },
+    }
+
+    const result = search(query, document)
+
+    expect(result[0]?.item?.title).toEqual('Create user')
+  })
+
+  it('does not match parameter filter metadata like "query" or "REQUIRED"', () => {
+    // These filter-style tokens used to be packed into the indexed parameter string and
+    // produced false-positive matches. They should no longer be searchable.
+    const document: Partial<OpenApiDocument> = {
+      paths: {
+        '/users': {
+          get: {
+            summary: 'List users',
+            operationId: 'listUsers',
+            parameters: [
+              {
+                in: 'query',
+                name: 'limit',
+                required: true,
+                schema: { type: 'integer' },
+              },
+            ],
+          },
+        },
+      },
+    }
+
+    expect(search('REQUIRED', document)).toHaveLength(0)
+    expect(search('integer', document)).toHaveLength(0)
+  })
 })

--- a/packages/api-reference/src/features/Search/search-quality.test.ts
+++ b/packages/api-reference/src/features/Search/search-quality.test.ts
@@ -880,4 +880,51 @@ describe('search quality', () => {
     expect(search('REQUIRED', document)).toHaveLength(0)
     expect(search('integer', document)).toHaveLength(0)
   })
+
+  it('finds operations whose body schema is a oneOf of $ref-ed object schemas', () => {
+    // Mirrors the Galaxy spec's "Create a celestial body" endpoint: the request body schema is a
+    // top-level `oneOf` of two `$ref`-ed object schemas. A property defined inside one branch
+    // (e.g. `failureCallbackUrl` on `Planet`) should still surface the operation in search.
+    const planet = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        failureCallbackUrl: { type: 'string' },
+      },
+    }
+    const satellite = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        orbitalPeriod: { type: 'number' },
+      },
+    }
+
+    const document = {
+      paths: {
+        '/celestial-bodies': {
+          post: {
+            summary: 'Create a celestial body',
+            operationId: 'createCelestialBody',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    oneOf: [
+                      { $ref: '#/components/schemas/Planet', '$ref-value': planet },
+                      { $ref: '#/components/schemas/Satellite', '$ref-value': satellite },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as Partial<OpenApiDocument>
+
+    const result = search('failureCallbackUrl', document)
+
+    expect(result[0]?.item?.title).toEqual('Create a celestial body')
+  })
 })

--- a/packages/api-reference/src/features/Search/types.ts
+++ b/packages/api-reference/src/features/Search/types.ts
@@ -7,8 +7,14 @@ export type FuseData = {
   id: string
   title: string
   description: string
+  /** Top-level request-body property names (e.g. `email`, `username`). High-signal field for search. */
   body?: string | string[]
+  /** Descriptions of request-body properties. Verbose prose, weighted lower than `body`. */
+  bodyDescriptions?: string[]
+  /** Parameter names (e.g. `userId`, `limit`). High-signal field for search. */
   parameters?: string | string[]
+  /** Descriptions of parameters. Verbose prose, weighted lower than `parameters`. */
+  parameterDescriptions?: string[]
   responseExamples?: string[]
   method?: string
   path?: string

--- a/packages/api-reference/src/helpers/openapi.test.ts
+++ b/packages/api-reference/src/helpers/openapi.test.ts
@@ -1,4 +1,4 @@
-import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import type { OperationObject, SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -269,6 +269,166 @@ describe('openapi', () => {
       expect(result.join(' ')).not.toContain('optional')
       expect(result.join(' ')).not.toContain('string')
     })
+
+    it('collects properties from every branch of a oneOf', () => {
+      const operation = {
+        summary: 'Test',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                oneOf: [
+                  {
+                    type: 'object',
+                    properties: {
+                      planetName: { type: 'string' },
+                      failureCallbackUrl: { type: 'string' },
+                    },
+                  },
+                  {
+                    type: 'object',
+                    properties: {
+                      satelliteName: { type: 'string' },
+                      orbitalPeriod: { type: 'number' },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      } as unknown as OperationObject
+
+      expect(extractBodyFieldNames(operation)).toEqual([
+        'planetName',
+        'failureCallbackUrl',
+        'satelliteName',
+        'orbitalPeriod',
+      ])
+    })
+
+    it('resolves $ref schemas inside a oneOf', () => {
+      // Mirrors the Galaxy spec's CelestialBody shape: a oneOf of two $ref-ed object schemas.
+      const planetSchema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          failureCallbackUrl: { type: 'string' },
+        },
+      } as unknown as SchemaObject
+      const satelliteSchema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          orbitalPeriod: { type: 'number' },
+        },
+      } as unknown as SchemaObject
+      const operation = {
+        summary: 'Test',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                oneOf: [
+                  { $ref: '#/components/schemas/Planet', '$ref-value': planetSchema },
+                  { $ref: '#/components/schemas/Satellite', '$ref-value': satelliteSchema },
+                ],
+              },
+            },
+          },
+        },
+      } as unknown as OperationObject
+
+      expect(extractBodyFieldNames(operation)).toEqual(['name', 'failureCallbackUrl', 'orbitalPeriod'])
+    })
+
+    it('collects properties from every member of an allOf', () => {
+      const operation = {
+        summary: 'Test',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                allOf: [
+                  {
+                    type: 'object',
+                    properties: { id: { type: 'string' } },
+                  },
+                  {
+                    type: 'object',
+                    properties: { createdAt: { type: 'string' } },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      } as unknown as OperationObject
+
+      expect(extractBodyFieldNames(operation)).toEqual(['id', 'createdAt'])
+    })
+
+    it('descends through composition nested inside a property', () => {
+      const operation = {
+        summary: 'Test',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  payload: {
+                    oneOf: [
+                      {
+                        type: 'object',
+                        properties: {
+                          textValue: { type: 'string' },
+                        },
+                      },
+                      {
+                        type: 'object',
+                        properties: {
+                          numberValue: { type: 'number' },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as unknown as OperationObject
+
+      expect(extractBodyFieldNames(operation)).toEqual(['payload', 'textValue', 'numberValue'])
+    })
+
+    it('does not loop on a recursive schema', () => {
+      const treeProperties: Record<string, unknown> = {
+        value: { type: 'string' },
+      }
+      const treeSchema = {
+        type: 'object',
+        properties: treeProperties,
+      } as unknown as SchemaObject
+      // Wire up the recursive child after creation so both refer to the same object.
+      treeProperties.child = {
+        $ref: '#/components/schemas/Tree',
+        '$ref-value': treeSchema,
+      }
+
+      const operation = {
+        summary: 'Test',
+        requestBody: {
+          content: {
+            'application/json': { schema: treeSchema },
+          },
+        },
+      } as unknown as OperationObject
+
+      // Should terminate and emit each unique property name exactly once.
+      expect(extractBodyFieldNames(operation)).toEqual(['value', 'child'])
+    })
   })
 
   describe('extractBodyDescriptions', () => {
@@ -307,6 +467,36 @@ describe('openapi', () => {
         },
       }
       expect(extractBodyDescriptions(operation)).toEqual(['User display name', 'User email address'])
+    })
+
+    it('extracts descriptions from oneOf branches', () => {
+      const operation = {
+        summary: 'Test',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                oneOf: [
+                  {
+                    type: 'object',
+                    properties: {
+                      name: { type: 'string', description: 'Planet name' },
+                    },
+                  },
+                  {
+                    type: 'object',
+                    properties: {
+                      orbit: { type: 'number', description: 'Orbital period in days' },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      } as unknown as OperationObject
+
+      expect(extractBodyDescriptions(operation)).toEqual(['Planet name', 'Orbital period in days'])
     })
   })
 })

--- a/packages/api-reference/src/helpers/openapi.test.ts
+++ b/packages/api-reference/src/helpers/openapi.test.ts
@@ -7,6 +7,8 @@ import {
   extractBodyFieldNames,
   extractParameterDescriptions,
   extractParameterNames,
+  extractSchemaDescriptions,
+  extractSchemaFieldNames,
 } from './openapi'
 
 describe('openapi', () => {
@@ -342,6 +344,32 @@ describe('openapi', () => {
       expect(extractBodyFieldNames(operation)).toEqual(['name', 'failureCallbackUrl', 'orbitalPeriod'])
     })
 
+    it('collects properties from every branch of an anyOf', () => {
+      const operation = {
+        summary: 'Test',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                anyOf: [
+                  {
+                    type: 'object',
+                    properties: { emailAddress: { type: 'string' } },
+                  },
+                  {
+                    type: 'object',
+                    properties: { phoneNumber: { type: 'string' } },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      } as unknown as OperationObject
+
+      expect(extractBodyFieldNames(operation)).toEqual(['emailAddress', 'phoneNumber'])
+    })
+
     it('collects properties from every member of an allOf', () => {
       const operation = {
         summary: 'Test',
@@ -497,6 +525,62 @@ describe('openapi', () => {
       } as unknown as OperationObject
 
       expect(extractBodyDescriptions(operation)).toEqual(['Planet name', 'Orbital period in days'])
+    })
+  })
+
+  describe('extractSchemaFieldNames', () => {
+    it('returns empty array for an undefined schema', () => {
+      expect(extractSchemaFieldNames(undefined)).toEqual([])
+    })
+
+    it('extracts top-level property names from an object schema', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+          name: { type: 'string' },
+          diameter: { type: 'number' },
+        },
+      } as unknown as SchemaObject
+
+      expect(extractSchemaFieldNames(schema)).toEqual(['id', 'name', 'diameter'])
+    })
+
+    it('descends through a oneOf of $ref schemas', () => {
+      const planet = {
+        type: 'object',
+        properties: { name: { type: 'string' }, failureCallbackUrl: { type: 'string' } },
+      } as unknown as SchemaObject
+      const satellite = {
+        type: 'object',
+        properties: { name: { type: 'string' }, diameter: { type: 'number' } },
+      } as unknown as SchemaObject
+      const schema = {
+        oneOf: [
+          { $ref: '#/components/schemas/Planet', '$ref-value': planet },
+          { $ref: '#/components/schemas/Satellite', '$ref-value': satellite },
+        ],
+      } as unknown as SchemaObject
+
+      expect(extractSchemaFieldNames(schema)).toEqual(['name', 'failureCallbackUrl', 'diameter'])
+    })
+  })
+
+  describe('extractSchemaDescriptions', () => {
+    it('returns empty array for an undefined schema', () => {
+      expect(extractSchemaDescriptions(undefined)).toEqual([])
+    })
+
+    it('extracts top-level property descriptions', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          diameter: { type: 'number', description: 'Diameter in kilometers' },
+          name: { type: 'string' },
+        },
+      } as unknown as SchemaObject
+
+      expect(extractSchemaDescriptions(schema)).toEqual(['Diameter in kilometers'])
     })
   })
 })

--- a/packages/api-reference/src/helpers/openapi.test.ts
+++ b/packages/api-reference/src/helpers/openapi.test.ts
@@ -1,7 +1,13 @@
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { describe, expect, it } from 'vitest'
 
-import { deepMerge, extractParameters, extractRequestBody } from './openapi'
+import {
+  deepMerge,
+  extractBodyDescriptions,
+  extractBodyFieldNames,
+  extractParameterDescriptions,
+  extractParameterNames,
+} from './openapi'
 
 describe('openapi', () => {
   describe('deepMerge', () => {
@@ -48,7 +54,7 @@ describe('openapi', () => {
       })
     })
 
-    it("doesn't merge undefined properties", () => {
+    it('does not merge undefined properties', () => {
       expect(
         deepMerge(
           {
@@ -66,32 +72,94 @@ describe('openapi', () => {
     })
   })
 
-  describe('extractRequestBody', () => {
-    it('returns null for an operation without requestBody', () => {
-      const operation: OperationObject = {
-        summary: 'Test',
-        responses: {
-          200: {
-            description: 'Success',
-          },
-        },
-      }
-      const result = extractRequestBody(operation)
-      expect(result).toBeNull()
+  describe('extractParameterNames', () => {
+    it('returns empty array for empty parameters', () => {
+      expect(extractParameterNames([])).toEqual([])
     })
 
-    it('returns null for an operation with empty requestBody content', () => {
-      const operation: OperationObject = {
-        summary: 'Test',
-        requestBody: {
-          content: {},
-        },
-      }
-      const result = extractRequestBody(operation)
-      expect(result).toBeNull()
+    it('returns just the name for a path parameter', () => {
+      expect(extractParameterNames([{ in: 'path', name: 'userId', required: true }])).toEqual(['userId'])
     })
 
-    it('extracts application/json request body', () => {
+    it('returns just the name for a query parameter', () => {
+      expect(extractParameterNames([{ in: 'query', name: 'limit', schema: { type: 'integer' } }])).toEqual(['limit'])
+    })
+
+    it('drops filter-style metadata tokens', () => {
+      const result = extractParameterNames([
+        {
+          in: 'path',
+          name: 'userId',
+          required: true,
+          schema: { type: 'string' },
+          description: 'Unique user identifier',
+        },
+      ])
+      expect(result).toEqual(['userId'])
+      expect(result.join(' ')).not.toContain('REQUIRED')
+      expect(result.join(' ')).not.toContain('path')
+      expect(result.join(' ')).not.toContain('string')
+    })
+
+    it('extracts names across all parameter locations', () => {
+      const result = extractParameterNames([
+        { in: 'path', name: 'id', required: true },
+        { in: 'query', name: 'filter' },
+        { in: 'header', name: 'X-Api-Key', required: true },
+        { in: 'cookie', name: 'session' },
+      ])
+      expect(result).toEqual(['id', 'filter', 'X-Api-Key', 'session'])
+    })
+
+    it('deduplicates repeated names', () => {
+      const result = extractParameterNames([
+        { in: 'query', name: 'tag' },
+        { in: 'query', name: 'tag' },
+      ])
+      expect(result).toEqual(['tag'])
+    })
+  })
+
+  describe('extractParameterDescriptions', () => {
+    it('returns empty array when no descriptions are present', () => {
+      expect(extractParameterDescriptions([{ in: 'query', name: 'limit' }])).toEqual([])
+    })
+
+    it('returns the descriptions in order', () => {
+      const result = extractParameterDescriptions([
+        { in: 'query', name: 'limit', description: 'Maximum number of results' },
+        { in: 'path', name: 'userId', required: true, description: 'Unique user identifier' },
+      ])
+      expect(result).toEqual(['Maximum number of results', 'Unique user identifier'])
+    })
+
+    it('skips parameters without a description', () => {
+      const result = extractParameterDescriptions([
+        { in: 'query', name: 'limit' },
+        { in: 'query', name: 'offset', description: 'Number of records to skip' },
+      ])
+      expect(result).toEqual(['Number of records to skip'])
+    })
+  })
+
+  describe('extractBodyFieldNames', () => {
+    it('returns empty array for an operation without requestBody', () => {
+      const operation: OperationObject = {
+        summary: 'Test',
+        responses: { 200: { description: 'OK' } },
+      }
+      expect(extractBodyFieldNames(operation)).toEqual([])
+    })
+
+    it('returns empty array for empty requestBody content', () => {
+      const operation: OperationObject = {
+        summary: 'Test',
+        requestBody: { content: {} },
+      }
+      expect(extractBodyFieldNames(operation)).toEqual([])
+    })
+
+    it('extracts top-level property names from application/json', () => {
       const operation: OperationObject = {
         summary: 'Test',
         requestBody: {
@@ -101,39 +169,17 @@ describe('openapi', () => {
                 type: 'object',
                 properties: {
                   name: { type: 'string' },
+                  email: { type: 'string' },
                 },
               },
             },
           },
         },
       }
-      const result = extractRequestBody(operation)
-      expect(result).toContain('Body')
-      expect(result).toContain('name optional string')
+      expect(extractBodyFieldNames(operation)).toEqual(['name', 'email'])
     })
 
-    it('extracts application/xml request body', () => {
-      const operation: OperationObject = {
-        summary: 'Test',
-        requestBody: {
-          content: {
-            'application/xml': {
-              schema: {
-                type: 'object',
-                properties: {
-                  xmlField: { type: 'string' },
-                },
-              },
-            },
-          },
-        },
-      }
-      const result = extractRequestBody(operation)
-      expect(result).toContain('Body')
-      expect(result).toContain('xmlField optional string')
-    })
-
-    it('extracts multiple content types', () => {
+    it('extracts names across multiple content types and deduplicates', () => {
       const operation: OperationObject = {
         summary: 'Test',
         requestBody: {
@@ -143,6 +189,7 @@ describe('openapi', () => {
                 type: 'object',
                 properties: {
                   jsonField: { type: 'string' },
+                  shared: { type: 'string' },
                 },
               },
             },
@@ -151,58 +198,54 @@ describe('openapi', () => {
                 type: 'object',
                 properties: {
                   xmlField: { type: 'number' },
+                  shared: { type: 'number' },
                 },
               },
             },
           },
         },
       }
-      const result = extractRequestBody(operation)
-      expect(result).toContain('jsonField optional string')
-      expect(result).toContain('xmlField optional number')
+      expect(extractBodyFieldNames(operation)).toEqual(['jsonField', 'shared', 'xmlField'])
     })
 
-    it('extracts text/plain content type', () => {
+    it('extracts names from one level of nested objects', () => {
       const operation: OperationObject = {
         summary: 'Test',
         requestBody: {
           content: {
-            'text/plain': {
-              schema: {
-                type: 'string',
-              },
-            },
-          },
-        },
-      }
-      const result = extractRequestBody(operation)
-      expect(result).toEqual(['Body'])
-    })
-
-    it('extracts multipart/form-data content type', () => {
-      const operation: OperationObject = {
-        summary: 'Test',
-        requestBody: {
-          content: {
-            'multipart/form-data': {
+            'application/json': {
               schema: {
                 type: 'object',
                 properties: {
-                  file: { type: 'string', format: 'binary' },
-                  description: { type: 'string' },
+                  address: {
+                    type: 'object',
+                    properties: {
+                      street: { type: 'string' },
+                      city: { type: 'string' },
+                    },
+                  },
                 },
               },
             },
           },
         },
       }
-      const result = extractRequestBody(operation)
-      expect(result).toContain('Body')
-      expect(result).toContain('file optional string')
-      expect(result).toContain('description optional string')
+      expect(extractBodyFieldNames(operation)).toEqual(['address', 'street', 'city'])
     })
 
-    it('handles required properties', () => {
+    it('returns empty array for non-object schemas (e.g. text/plain)', () => {
+      const operation: OperationObject = {
+        summary: 'Test',
+        requestBody: {
+          content: {
+            'text/plain': { schema: { type: 'string' } },
+          },
+        },
+      }
+      expect(extractBodyFieldNames(operation)).toEqual([])
+    })
+
+    it('does not include filter-style metadata tokens', () => {
       const operation: OperationObject = {
         summary: 'Test',
         requestBody: {
@@ -220,70 +263,50 @@ describe('openapi', () => {
           },
         },
       }
-      const result = extractRequestBody(operation)
-      expect(result).toContain('name REQUIRED string')
-      expect(result).toContain('age optional number')
+      const result = extractBodyFieldNames(operation)
+      expect(result).toEqual(['name', 'age'])
+      expect(result.join(' ')).not.toContain('REQUIRED')
+      expect(result.join(' ')).not.toContain('optional')
+      expect(result.join(' ')).not.toContain('string')
     })
   })
 
-  describe('extractParameters', () => {
-    it('returns empty array for empty parameters', () => {
-      const result = extractParameters([])
-      expect(result).toEqual([])
-    })
-
-    it('formats a required path parameter', () => {
-      const result = extractParameters([{ in: 'path', name: 'userId', required: true }])
-      expect(result).toEqual(['userId REQUIRED path'])
-    })
-
-    it('formats an optional query parameter', () => {
-      const result = extractParameters([{ in: 'query', name: 'limit' }])
-      expect(result).toEqual(['limit optional query'])
-    })
-
-    it('includes parameter type from schema', () => {
-      const result = extractParameters([{ in: 'query', name: 'limit', schema: { type: 'integer' } }])
-      expect(result).toEqual(['limit optional query integer'])
-    })
-
-    it('includes parameter description', () => {
-      const result = extractParameters([{ in: 'query', name: 'limit', description: 'Maximum number of results' }])
-      expect(result).toEqual(['limit optional query Maximum number of results'])
-    })
-
-    it('formats parameter with schema and description', () => {
-      const result = extractParameters([
-        {
-          in: 'path',
-          name: 'userId',
-          required: true,
-          schema: { type: 'string' },
-          description: 'Unique user identifier',
+  describe('extractBodyDescriptions', () => {
+    it('returns empty array when no property has a description', () => {
+      const operation: OperationObject = {
+        summary: 'Test',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+              },
+            },
+          },
         },
-      ])
-      expect(result).toEqual(['userId REQUIRED path string Unique user identifier'])
+      }
+      expect(extractBodyDescriptions(operation)).toEqual([])
     })
 
-    it('extracts parameters from all categories', () => {
-      const result = extractParameters([
-        { in: 'path', name: 'id', required: true },
-        { in: 'query', name: 'filter' },
-        { in: 'header', name: 'X-Api-Key', required: true },
-        { in: 'cookie', name: 'session' },
-      ])
-      expect(result).toHaveLength(4)
-      expect(result).toEqual([
-        'id REQUIRED path',
-        'filter optional query',
-        'X-Api-Key REQUIRED header',
-        'session optional cookie',
-      ])
-    })
-
-    it('handles array type in schema', () => {
-      const result = extractParameters([{ in: 'query', name: 'tags', schema: { type: ['string', 'null'] } }])
-      expect(result).toEqual(['tags optional query string|null'])
+    it('extracts top-level property descriptions', () => {
+      const operation: OperationObject = {
+        summary: 'Test',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string', description: 'User display name' },
+                  email: { type: 'string', description: 'User email address' },
+                },
+              },
+            },
+          },
+        },
+      }
+      expect(extractBodyDescriptions(operation)).toEqual(['User display name', 'User email address'])
     })
   })
 })

--- a/packages/api-reference/src/helpers/openapi.ts
+++ b/packages/api-reference/src/helpers/openapi.ts
@@ -1,5 +1,6 @@
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type {
+  MediaTypeObject,
   OpenApiDocument,
   OperationObject,
   ParameterObject,
@@ -32,10 +33,45 @@ function pushUnique(target: string[], value: string | undefined): void {
   }
 }
 
+type CollectOptions = {
+  visit: (key: string, schema: SchemaObject | undefined) => void
+  visited: Set<SchemaObject>
+  maxPropertyDepth: number
+}
+
+/**
+ * Recursively visits every property of a schema, descending transparently through composition
+ * keywords (`oneOf`, `anyOf`, `allOf`) and one level into nested object properties.
+ *
+ * Composition is treated as transparent — a `oneOf` of two object variants is *the same level* as a
+ * single object, just expressed as multiple shapes. Property nesting is capped to keep the index
+ * focused on shallow, commonly-searched fields. A visited-set keyed by resolved-schema identity
+ * guards against recursive (`Tree → Tree`) schemas.
+ */
+function collectSchemaProperties(schema: SchemaObject | undefined, options: CollectOptions, propertyDepth = 0): void {
+  if (!schema || options.visited.has(schema)) {
+    return
+  }
+  options.visited.add(schema)
+
+  const variants = [...(schema.oneOf ?? []), ...(schema.anyOf ?? []), ...(schema.allOf ?? [])]
+  variants.forEach((variantRef) => {
+    collectSchemaProperties(resolveSchemaRef(variantRef), options, propertyDepth)
+  })
+
+  if (isObjectSchema(schema) && schema.properties) {
+    Object.entries(schema.properties).forEach(([key, propRef]) => {
+      const property = resolveSchemaRef(propRef)
+      options.visit(key, property)
+      if (propertyDepth + 1 < options.maxPropertyDepth) {
+        collectSchemaProperties(property, options, propertyDepth + 1)
+      }
+    })
+  }
+}
+
 /**
  * Walks the request body schemas of an operation and yields each property schema with its key.
- * Visits top-level properties plus one level of nested object properties — matching the depth that was
- * previously indexed for search.
  */
 function forEachRequestBodyProperty(
   operation: OperationObject,
@@ -46,25 +82,11 @@ function forEachRequestBodyProperty(
     return
   }
 
+  const visited = new Set<SchemaObject>()
   Object.values(content).forEach((media) => {
-    const resolvedMedia = getResolvedRef(media)
+    const resolvedMedia = getResolvedRef(media) as MediaTypeObject | undefined
     const schema = getResolvedRef(resolvedMedia?.schema)
-
-    if (!schema || !isObjectSchema(schema) || !schema.properties) {
-      return
-    }
-
-    Object.entries(schema.properties).forEach(([key, propRef]) => {
-      const property = resolveSchemaRef(propRef)
-      visit(key, property)
-
-      if (property && isObjectSchema(property) && property.properties) {
-        Object.entries(property.properties).forEach(([nestedKey, nestedRef]) => {
-          const nestedProperty = resolveSchemaRef(nestedRef)
-          visit(nestedKey, nestedProperty)
-        })
-      }
-    })
+    collectSchemaProperties(schema, { visit, visited, maxPropertyDepth: 2 })
   })
 }
 

--- a/packages/api-reference/src/helpers/openapi.ts
+++ b/packages/api-reference/src/helpers/openapi.ts
@@ -157,6 +157,39 @@ export function extractBodyDescriptions(operation: OperationObject): string[] {
 }
 
 /**
+ * Extracts the property names of a schema for the search index.
+ *
+ * Same depth and composition behavior as `extractBodyFieldNames` — descends transparently through
+ * `oneOf`/`anyOf`/`allOf`, walks one level into nested object properties, dedupes.
+ */
+export function extractSchemaFieldNames(schema: SchemaObject | undefined): string[] {
+  const names: string[] = []
+  collectSchemaProperties(schema, {
+    visit: (key) => pushUnique(names, key),
+    visited: new Set<SchemaObject>(),
+    maxPropertyDepth: 2,
+  })
+  return names
+}
+
+/**
+ * Extracts the property descriptions of a schema for the search index.
+ */
+export function extractSchemaDescriptions(schema: SchemaObject | undefined): string[] {
+  const descriptions: string[] = []
+  collectSchemaProperties(schema, {
+    visit: (_key, propertySchema) => {
+      if (propertySchema && 'description' in propertySchema && typeof propertySchema.description === 'string') {
+        pushUnique(descriptions, propertySchema.description)
+      }
+    },
+    visited: new Set<SchemaObject>(),
+    maxPropertyDepth: 2,
+  })
+  return descriptions
+}
+
+/**
  * Deep merge for objects
  */
 export function deepMerge(source: Record<any, any>, target: Record<any, any>) {

--- a/packages/api-reference/src/helpers/openapi.ts
+++ b/packages/api-reference/src/helpers/openapi.ts
@@ -1,5 +1,4 @@
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
-import type { MediaTypeObject } from '@scalar/workspace-store/schemas/v3.1/strict/media-type'
 import type {
   OpenApiDocument,
   OperationObject,
@@ -10,25 +9,7 @@ import type {
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { isObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
 
-/** Object schema shape with properties, used when logging request body. */
-type ObjectSchemaWithProperties = {
-  properties: Record<string, SchemaReferenceType<SchemaObject>>
-  required?: string[]
-}
-
 const isSchemaObject = (value: unknown): value is SchemaObject => typeof value === 'object' && value !== null
-
-const schemaTypeToString = (schema: SchemaObject): string => {
-  if (!('type' in schema)) {
-    return ''
-  }
-
-  if (typeof schema.type === 'string') {
-    return schema.type
-  }
-
-  return Array.isArray(schema.type) ? schema.type.join('|') : ''
-}
 
 /**
  * Resolves a schema reference from workspace-store to a SchemaObject.
@@ -42,116 +23,115 @@ function resolveSchemaRef(ref: SchemaReferenceType<SchemaObject>): SchemaObject 
   return ref
 }
 
-/**
- * Formats a property object into a string.
- */
-function formatProperty(key: string, obj: ObjectSchemaWithProperties): string {
-  let output = key
-  const isRequired = obj.required?.includes(key)
-  output += isRequired ? ' REQUIRED ' : ' optional '
-  const propRef = obj.properties[key]
-  if (!propRef) {
-    return output
+function pushUnique(target: string[], value: string | undefined): void {
+  if (!value) {
+    return
   }
-  const property = resolveSchemaRef(propRef)
-
-  if (property) {
-    output += schemaTypeToString(property)
-
-    if ('description' in property && typeof property.description === 'string') {
-      output += ` ${property.description}`
-    }
+  if (!target.includes(value)) {
+    target.push(value)
   }
-
-  return output
 }
 
 /**
- * Recursively logs the properties of an object.
+ * Walks the request body schemas of an operation and yields each property schema with its key.
+ * Visits top-level properties plus one level of nested object properties — matching the depth that was
+ * previously indexed for search.
  */
-function recursiveLogger(obj: MediaTypeObject): string[] {
-  const results: string[] = ['Body']
-  const schema = getResolvedRef(obj?.schema)
-
-  if (!schema || !isObjectSchema(schema) || !schema.properties) {
-    return results
+function forEachRequestBodyProperty(
+  operation: OperationObject,
+  visit: (key: string, schema: SchemaObject | undefined) => void,
+): void {
+  const content = getResolvedRef(operation?.requestBody)?.content
+  if (!content) {
+    return
   }
 
-  const properties = schema.properties
-  const schemaWithProps: ObjectSchemaWithProperties = {
-    properties,
-    required: schema.required,
-  }
-  Object.keys(properties).forEach((key) => {
-    if (!obj.schema) {
+  Object.values(content).forEach((media) => {
+    const resolvedMedia = getResolvedRef(media)
+    const schema = getResolvedRef(resolvedMedia?.schema)
+
+    if (!schema || !isObjectSchema(schema) || !schema.properties) {
       return
     }
 
-    results.push(formatProperty(key, schemaWithProps))
+    Object.entries(schema.properties).forEach(([key, propRef]) => {
+      const property = resolveSchemaRef(propRef)
+      visit(key, property)
 
-    const propRef = properties[key]
-    if (!propRef) {
-      return
-    }
-    const property = resolveSchemaRef(propRef)
-    if (property && isObjectSchema(property) && property.properties) {
-      const nestedProperties = property.properties
-      Object.keys(nestedProperties).forEach((subKey) => {
-        const ref = nestedProperties[subKey]
-        if (!ref) {
-          return
-        }
-        const nested = resolveSchemaRef(ref)
-        const typeStr = nested ? schemaTypeToString(nested) : ''
-        results.push(`${subKey} ${typeStr}`)
-      })
+      if (property && isObjectSchema(property) && property.properties) {
+        Object.entries(property.properties).forEach(([nestedKey, nestedRef]) => {
+          const nestedProperty = resolveSchemaRef(nestedRef)
+          visit(nestedKey, nestedProperty)
+        })
+      }
+    })
+  })
+}
+
+/**
+ * Extracts the names of every parameter on an operation.
+ *
+ * The returned strings contain only parameter names (e.g. `userId`, `limit`) so they can be indexed
+ * as a high-signal field for search. Filter-style metadata like `REQUIRED`, `optional`, `query` and
+ * the schema type are intentionally excluded — those tokens dilute fuzzy matches and produce false
+ * positives for queries like `query` or `integer`.
+ */
+export function extractParameterNames(parameters: ReferenceType<ParameterObject>[]): string[] {
+  const names: string[] = []
+
+  parameters.forEach((parameter) => {
+    const resolved = getResolvedRef(parameter)
+    pushUnique(names, resolved?.name)
+  })
+
+  return names
+}
+
+/**
+ * Extracts the descriptions of every parameter on an operation.
+ *
+ * Kept separate from parameter names so the search index can weight each independently.
+ */
+export function extractParameterDescriptions(parameters: ReferenceType<ParameterObject>[]): string[] {
+  const descriptions: string[] = []
+
+  parameters.forEach((parameter) => {
+    const resolved = getResolvedRef(parameter)
+    pushUnique(descriptions, resolved?.description)
+  })
+
+  return descriptions
+}
+
+/**
+ * Extracts the names of properties from the request body schema(s) of an operation.
+ *
+ * Walks every media type and includes both top-level and one level of nested property names so
+ * common fields like `email` or `username` surface in search regardless of how the body is shaped.
+ */
+export function extractBodyFieldNames(operation: OperationObject): string[] {
+  const names: string[] = []
+
+  forEachRequestBodyProperty(operation, (key) => {
+    pushUnique(names, key)
+  })
+
+  return names
+}
+
+/**
+ * Extracts the descriptions of properties from the request body schema(s) of an operation.
+ */
+export function extractBodyDescriptions(operation: OperationObject): string[] {
+  const descriptions: string[] = []
+
+  forEachRequestBodyProperty(operation, (_key, schema) => {
+    if (schema && 'description' in schema && typeof schema.description === 'string') {
+      pushUnique(descriptions, schema.description)
     }
   })
 
-  return results
-}
-
-/**
- * Extracts the request body from an operation.
- */
-export function extractRequestBody(operation: OperationObject): string[] | null {
-  const content = getResolvedRef(operation?.requestBody)?.content
-  const contentValue = Object.values(content ?? {})
-  if (contentValue.length === 0) {
-    // No content found
-    return null
-  }
-
-  return contentValue.flatMap((media) => recursiveLogger(media))
-}
-
-/**
- * Formats a parameter into a searchable string.
- */
-function formatParameter(param: ParameterObject): string {
-  const output = [param.name]
-  output.push(param.required ? 'REQUIRED' : 'optional')
-  output.push(param.in)
-
-  if ('schema' in param && param.schema) {
-    const schema = getResolvedRef(param.schema)
-    if (schema) {
-      output.push(schemaTypeToString(schema))
-    }
-  }
-
-  if (param.description) {
-    output.push(param.description)
-  }
-
-  return output.join(' ')
-}
-
-/**
- * Extracts parameters from an operation into searchable strings.
- */
-export function extractParameters(parameters: ReferenceType<ParameterObject>[]): string[] | null {
-  return parameters.map((parameter) => formatParameter(getResolvedRef(parameter)))
+  return descriptions
 }
 
 /**


### PR DESCRIPTION
Search couldn't find endpoints by parameter name reliably. A few things piled up:

- Parameter and body field names were buried inside a noisy string (`"limit optional query integer Maximum number of results"`) at the lowest weight, so any unrelated description would outrank an exact name match.
- The walker that builds the index didn't follow `oneOf` / `anyOf` / `allOf`, so polymorphic bodies (like Galaxy's `CelestialBody`) had zero properties indexed.
- Model entries didn't index their property names at all — searching `diameter` couldn't find the `Satellite` model.

This PR splits clean names into their own high-weight fields, drops the noise tokens, walks composition keywords (with `$ref` resolution and a cycle guard), and applies the same treatment to model schemas.

**Before**
<img width="588" height="178" alt="Screenshot 2026-05-08 at 14 48 31" src="https://github.com/user-attachments/assets/47cd5dd4-2c67-4b14-b981-dc02a507007c" />

**After**
<img width="584" height="280" alt="Screenshot 2026-05-08 at 14 43 13" src="https://github.com/user-attachments/assets/4d46148e-be66-4201-8329-65b8c0d87f15" />

**Before**
<img width="584" height="226" alt="Screenshot 2026-05-08 at 14 36 16" src="https://github.com/user-attachments/assets/e19d74c3-5640-4904-a4f4-36675f2edd6c" />

**After**
<img width="595" height="303" alt="Screenshot 2026-05-08 at 14 36 11" src="https://github.com/user-attachments/assets/80ed83d2-f601-4021-96fd-64d6688d3563" />

## Ticket

Closes #8937