### PR TITLE
fix(api-client): send nested object multipart parts as JSON

### DIFF
--- a/.changeset/api-client-urlencoded-encoding-content-type.md
+++ b/.changeset/api-client-urlencoded-encoding-content-type.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): ignore `encoding.contentType` on `application/x-www-form-urlencoded` request bodies
+
+Per OAS 3.1.x Encoding Object, `contentType` SHALL be ignored when the request body media type is not a multipart. After the recent change that lifted the multipart gate on `encoding.style`/`explode`/`allowReserved`, the `encoding` map started being passed for urlencoded bodies too. As a side effect, a urlencoded encoding entry that only set `contentType` would JSON-stringify object values into a single part instead of keeping the spec-default dotted-key flattening. Suppress `contentType` for non-multipart bodies so the flattening branch is restored.

--- a/.changeset/curl-multipart-json-pretty.md
+++ b/.changeset/curl-multipart-json-pretty.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+feat(snippetz): pretty-print JSON values inside cURL `--form` multipart parts so multipart requests stay readable, matching the existing `--data` JSON behavior

--- a/.changeset/curl-multipart-json-pretty.md
+++ b/.changeset/curl-multipart-json-pretty.md
@@ -2,4 +2,4 @@
 '@scalar/snippetz': patch
 ---
 
-feat(snippetz): pretty-print JSON values inside cURL `--form` multipart parts so multipart requests stay readable, matching the existing `--data` JSON behavior
+feat(snippetz): pretty-print JSON values inside cURL `--data` bodies and `--form` multipart parts, including RFC 6839 `+json` structured-syntax types (e.g. `application/vnd.api+json`) and parameterized variants (e.g. `application/json;charset=utf-8`)

--- a/.changeset/encoding-object-style-fields.md
+++ b/.changeset/encoding-object-style-fields.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+feat(workspace-store): expose `style`, `explode`, and `allowReserved` on the multipart Encoding Object schema and type, matching OpenAPI 3.1.1

--- a/.changeset/fix-multipart-nested-object-json-4834.md
+++ b/.changeset/fix-multipart-nested-object-json-4834.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): encode nested object properties in multipart/form-data as a single JSON part instead of flattening them with dotted keys

--- a/.changeset/multipart-encoding-style-precedence.md
+++ b/.changeset/multipart-encoding-style-precedence.md
@@ -1,5 +1,0 @@
----
-'@scalar/api-client': patch
----
-
-fix(api-client): honor `encoding.style` / `explode` / `allowReserved` on multipart parts so an explicit `style: form` opts back into flattened form-style serialization (and ignores `contentType`), per OpenAPI 3.1.1

--- a/.changeset/multipart-encoding-style-precedence.md
+++ b/.changeset/multipart-encoding-style-precedence.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): honor `encoding.style` / `explode` / `allowReserved` on multipart parts so an explicit `style: form` opts back into flattened form-style serialization (and ignores `contentType`), per OpenAPI 3.1.1

--- a/.changeset/multipart-encoding-style-routing.md
+++ b/.changeset/multipart-encoding-style-routing.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): serialize multipart parts with form / spaceDelimited / pipeDelimited / deepObject styles per RFC6570, matching how query parameters are already serialized. Replaces the dotted-key flattening previously emitted for `style: form, explode: true`.

--- a/.changeset/multipart-encoding-style-routing.md
+++ b/.changeset/multipart-encoding-style-routing.md
@@ -2,4 +2,4 @@
 '@scalar/api-client': patch
 ---
 
-fix(api-client): serialize multipart parts with form / spaceDelimited / pipeDelimited / deepObject styles per RFC6570, matching how query parameters are already serialized. Replaces the dotted-key flattening previously emitted for `style: form, explode: true`.
+fix(api-client): serialize `multipart/form-data` and `application/x-www-form-urlencoded` parts with form / spaceDelimited / pipeDelimited / deepObject styles per RFC6570 when `encoding.style` / `explode` / `allowReserved` is set, matching how query parameters are already serialized. Replaces the dotted-key flattening previously emitted for `style: form, explode: true`.

--- a/.changeset/multipart-form-style-nested-object-json.md
+++ b/.changeset/multipart-form-style-nested-object-json.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): JSON-stringify nested object/array values under `style: form` instead of emitting `[object Object]` in `multipart/form-data` and `application/x-www-form-urlencoded` bodies. RFC 6570 form-style serialization only addresses one level of nesting and OpenAPI 3.1 leaves deeper structures undefined; readable JSON is more useful than `String(value)` garble. The documented escape hatch for cleaner output remains `style: deepObject` with `explode: true`.

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
@@ -1350,6 +1350,44 @@ describe('processBody', () => {
   })
 
   describe('application/x-www-form-urlencoded', () => {
+    it('serializes encoding.style "form" with explode: true on an object using inner property names', () => {
+      const content = {
+        'application/x-www-form-urlencoded': {
+          encoding: {
+            props: {
+              style: 'form',
+              explode: true,
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              props: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string', example: 'widget' },
+                  count: { type: 'integer', example: 3 },
+                },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'application/x-www-form-urlencoded',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'application/x-www-form-urlencoded',
+        params: [
+          { name: 'name', value: 'widget' },
+          { name: 'count', value: '3' },
+        ],
+      })
+    })
+
     it('extracts examples from form data schema', () => {
       const content = {
         'application/x-www-form-urlencoded': {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
@@ -1200,6 +1200,43 @@ describe('processBody', () => {
       })
     })
 
+    it('falls back to repeated-name parts when style: deepObject is set on an array', () => {
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            tags: {
+              style: 'deepObject',
+              explode: true,
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              tags: {
+                type: 'array',
+                example: ['a', 'b', 'c'],
+                items: { type: 'string' },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [
+          { name: 'tags', value: 'a' },
+          { name: 'tags', value: 'b' },
+          { name: 'tags', value: 'c' },
+        ],
+      })
+    })
+
     it('falls back to per-file parts when style is set on an array of Files', () => {
       const content = {
         'multipart/form-data': {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
@@ -1200,6 +1200,43 @@ describe('processBody', () => {
       })
     })
 
+    it('falls back to per-file parts when style is set on an array of Files', () => {
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            attachments: {
+              style: 'form',
+              explode: true,
+            },
+          },
+          examples: {
+            default: {
+              value: {
+                attachments: [
+                  new File(['a'], 'a.txt', { type: 'text/plain' }),
+                  new File(['b'], 'b.txt', { type: 'text/plain' }),
+                ],
+              },
+            },
+          },
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+        example: 'default',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [
+          { name: 'attachments', value: '@a.txt' },
+          { name: 'attachments', value: '@b.txt' },
+        ],
+      })
+    })
+
     it('respects an explicit encoding.contentType over the application/json default', () => {
       const content = {
         'multipart/form-data': {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
@@ -1200,11 +1200,11 @@ describe('processBody', () => {
       })
     })
 
-    it('stringifies nested objects to "[object Object]" under style: form (spec-undefined fallback)', () => {
+    it('JSON-stringifies nested objects under style: form (spec-undefined fallback)', () => {
       // RFC6570 form-style serialization only addresses one level of nesting.
-      // Deeper structures are spec-undefined; we surface the degenerate String(value)
-      // output as a pinned regression test so future refactors notice if the contract
-      // changes. The documented escape hatch is style: deepObject + explode: true.
+      // Deeper structures are spec-undefined; we JSON-stringify them so authors get
+      // readable output instead of the degenerate "[object Object]" from String(value).
+      // The cleaner documented alternative is style: deepObject + explode: true.
       const content = {
         'multipart/form-data': {
           encoding: {
@@ -1242,7 +1242,7 @@ describe('processBody', () => {
         mimeType: 'multipart/form-data',
         params: [
           { name: 'name', value: 'widget' },
-          { name: 'meta', value: '[object Object]' },
+          { name: 'meta', value: '{"region":"eu"}' },
         ],
       })
     })

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
@@ -1,5 +1,5 @@
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
-import { SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { EncodingObjectSchema, SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { describe, expect, it } from 'vitest'
 
 import { processBody } from './process-body'
@@ -387,9 +387,9 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            user: {
+            user: coerceValue(EncodingObjectSchema, {
               contentType: 'application/json;charset=utf-8',
-            },
+            }),
           },
           examples: {
             default: {
@@ -469,9 +469,9 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            user: {
+            user: coerceValue(EncodingObjectSchema, {
               contentType: 'application/json;charset=utf-8',
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -819,10 +819,10 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            props: {
+            props: coerceValue(EncodingObjectSchema, {
               style: 'form',
               explode: true,
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -857,9 +857,9 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            props: {
+            props: coerceValue(EncodingObjectSchema, {
               explode: true,
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -890,10 +890,10 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            props: {
+            props: coerceValue(EncodingObjectSchema, {
               style: 'form',
               contentType: 'application/json',
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -924,10 +924,10 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            props: {
+            props: coerceValue(EncodingObjectSchema, {
               style: 'form',
               explode: false,
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -959,10 +959,10 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            tags: {
+            tags: coerceValue(EncodingObjectSchema, {
               style: 'form',
               explode: true,
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -996,10 +996,10 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            tags: {
+            tags: coerceValue(EncodingObjectSchema, {
               style: 'form',
               explode: false,
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -1029,9 +1029,9 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            tags: {
+            tags: coerceValue(EncodingObjectSchema, {
               style: 'spaceDelimited',
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -1061,9 +1061,9 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            props: {
+            props: coerceValue(EncodingObjectSchema, {
               style: 'spaceDelimited',
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -1095,9 +1095,9 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            tags: {
+            tags: coerceValue(EncodingObjectSchema, {
               style: 'pipeDelimited',
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -1127,9 +1127,9 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            props: {
+            props: coerceValue(EncodingObjectSchema, {
               style: 'pipeDelimited',
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -1161,10 +1161,10 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            props: {
+            props: coerceValue(EncodingObjectSchema, {
               style: 'deepObject',
               explode: true,
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -1208,10 +1208,10 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            props: {
+            props: coerceValue(EncodingObjectSchema, {
               style: 'form',
               explode: true,
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -1251,10 +1251,10 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            tags: {
+            tags: coerceValue(EncodingObjectSchema, {
               style: 'deepObject',
               explode: true,
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -1288,10 +1288,10 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            attachments: {
+            attachments: coerceValue(EncodingObjectSchema, {
               style: 'form',
               explode: true,
-            },
+            }),
           },
           examples: {
             default: {
@@ -1325,9 +1325,9 @@ describe('processBody', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
-            settings: {
+            settings: coerceValue(EncodingObjectSchema, {
               contentType: 'application/vnd.custom+json',
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -1401,10 +1401,10 @@ describe('processBody', () => {
       const content = {
         'application/x-www-form-urlencoded': {
           encoding: {
-            props: {
+            props: coerceValue(EncodingObjectSchema, {
               style: 'form',
               explode: true,
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',
@@ -1764,9 +1764,9 @@ describe('processBody', () => {
       const content = {
         'application/x-www-form-urlencoded': {
           encoding: {
-            user: {
+            user: coerceValue(EncodingObjectSchema, {
               contentType: 'application/json;charset=utf-8',
-            },
+            }),
           },
           schema: coerceValue(SchemaObjectSchema, {
             type: 'object',

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
@@ -1200,6 +1200,53 @@ describe('processBody', () => {
       })
     })
 
+    it('stringifies nested objects to "[object Object]" under style: form (spec-undefined fallback)', () => {
+      // RFC6570 form-style serialization only addresses one level of nesting.
+      // Deeper structures are spec-undefined; we surface the degenerate String(value)
+      // output as a pinned regression test so future refactors notice if the contract
+      // changes. The documented escape hatch is style: deepObject + explode: true.
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            props: {
+              style: 'form',
+              explode: true,
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              props: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string', example: 'widget' },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      region: { type: 'string', example: 'eu' },
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [
+          { name: 'name', value: 'widget' },
+          { name: 'meta', value: '[object Object]' },
+        ],
+      })
+    })
+
     it('falls back to repeated-name parts when style: deepObject is set on an array', () => {
       const content = {
         'multipart/form-data': {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
@@ -815,7 +815,7 @@ describe('processBody', () => {
       })
     })
 
-    it('respects encoding.style "form" with explode: true by flattening nested objects', () => {
+    it('serializes style: form + explode: true on an object using inner property names as part names', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
@@ -847,13 +847,13 @@ describe('processBody', () => {
       expect(result).toEqual({
         mimeType: 'multipart/form-data',
         params: [
-          { name: 'props.name', value: 'widget' },
-          { name: 'props.count', value: '3' },
+          { name: 'name', value: 'widget' },
+          { name: 'count', value: '3' },
         ],
       })
     })
 
-    it('treats explode: true alone as an opt-in to form-style flattening', () => {
+    it('defaults style to form when only explode: true is set', () => {
       const content = {
         'multipart/form-data': {
           encoding: {
@@ -882,7 +882,7 @@ describe('processBody', () => {
 
       expect(result).toEqual({
         mimeType: 'multipart/form-data',
-        params: [{ name: 'props.name', value: 'widget' }],
+        params: [{ name: 'name', value: 'widget' }],
       })
     })
 
@@ -916,7 +916,287 @@ describe('processBody', () => {
 
       expect(result).toEqual({
         mimeType: 'multipart/form-data',
-        params: [{ name: 'props.name', value: 'widget' }],
+        params: [{ name: 'name', value: 'widget' }],
+      })
+    })
+
+    it('serializes style: form + explode: false on an object as a single comma-joined part', () => {
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            props: {
+              style: 'form',
+              explode: false,
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              props: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string', example: 'widget' },
+                  count: { type: 'integer', example: 3 },
+                },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [{ name: 'props', value: 'name,widget,count,3' }],
+      })
+    })
+
+    it('serializes style: form + explode: true on an array as repeated parts', () => {
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            tags: {
+              style: 'form',
+              explode: true,
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              tags: {
+                type: 'array',
+                example: ['a', 'b', 'c'],
+                items: { type: 'string' },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [
+          { name: 'tags', value: 'a' },
+          { name: 'tags', value: 'b' },
+          { name: 'tags', value: 'c' },
+        ],
+      })
+    })
+
+    it('serializes style: form + explode: false on an array as a single comma-joined part', () => {
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            tags: {
+              style: 'form',
+              explode: false,
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              tags: {
+                type: 'array',
+                example: ['a', 'b', 'c'],
+                items: { type: 'string' },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [{ name: 'tags', value: 'a,b,c' }],
+      })
+    })
+
+    it('serializes style: spaceDelimited on an array', () => {
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            tags: {
+              style: 'spaceDelimited',
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              tags: {
+                type: 'array',
+                example: ['a', 'b', 'c'],
+                items: { type: 'string' },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [{ name: 'tags', value: 'a b c' }],
+      })
+    })
+
+    it('serializes style: spaceDelimited on an object', () => {
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            props: {
+              style: 'spaceDelimited',
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              props: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string', example: 'widget' },
+                  count: { type: 'integer', example: 3 },
+                },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [{ name: 'props', value: 'name widget count 3' }],
+      })
+    })
+
+    it('serializes style: pipeDelimited on an array', () => {
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            tags: {
+              style: 'pipeDelimited',
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              tags: {
+                type: 'array',
+                example: ['a', 'b', 'c'],
+                items: { type: 'string' },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [{ name: 'tags', value: 'a|b|c' }],
+      })
+    })
+
+    it('serializes style: pipeDelimited on an object', () => {
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            props: {
+              style: 'pipeDelimited',
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              props: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string', example: 'widget' },
+                  count: { type: 'integer', example: 3 },
+                },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [{ name: 'props', value: 'name|widget|count|3' }],
+      })
+    })
+
+    it('serializes style: deepObject + explode: true on a nested object', () => {
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            props: {
+              style: 'deepObject',
+              explode: true,
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              props: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string', example: 'widget' },
+                  meta: {
+                    type: 'object',
+                    properties: {
+                      region: { type: 'string', example: 'eu' },
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [
+          { name: 'props[name]', value: 'widget' },
+          { name: 'props[meta][region]', value: 'eu' },
+        ],
       })
     })
 

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
@@ -815,6 +815,111 @@ describe('processBody', () => {
       })
     })
 
+    it('respects encoding.style "form" with explode: true by flattening nested objects', () => {
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            props: {
+              style: 'form',
+              explode: true,
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              props: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string', example: 'widget' },
+                  count: { type: 'integer', example: 3 },
+                },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [
+          { name: 'props.name', value: 'widget' },
+          { name: 'props.count', value: '3' },
+        ],
+      })
+    })
+
+    it('treats explode: true alone as an opt-in to form-style flattening', () => {
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            props: {
+              explode: true,
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              props: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string', example: 'widget' },
+                },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [{ name: 'props.name', value: 'widget' }],
+      })
+    })
+
+    it('ignores encoding.contentType when style is set', () => {
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            props: {
+              style: 'form',
+              contentType: 'application/json',
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              props: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string', example: 'widget' },
+                },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [{ name: 'props.name', value: 'widget' }],
+      })
+    })
+
     it('respects an explicit encoding.contentType over the application/json default', () => {
       const content = {
         'multipart/form-data': {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
@@ -576,8 +576,11 @@ describe('processBody', () => {
         mimeType: 'multipart/form-data',
         params: [
           { name: 'files', value: 'SGVsbG8gV29ybGQ=' },
-          { name: 'metadata.uploadDate', value: '2024-01-01' },
-          { name: 'metadata.category', value: 'images' },
+          {
+            name: 'metadata',
+            value: JSON.stringify({ uploadDate: '2024-01-01', category: 'images' }),
+            contentType: 'application/json',
+          },
         ],
       })
     })
@@ -630,8 +633,11 @@ describe('processBody', () => {
           { name: 'title', value: 'My Image' },
           { name: 'description', value: 'A beautiful image' },
           { name: 'tags', value: 'photo' },
-          { name: 'settings.public', value: 'true' },
-          { name: 'settings.quality', value: 'high' },
+          {
+            name: 'settings',
+            value: JSON.stringify({ public: true, quality: 'high' }),
+            contentType: 'application/json',
+          },
         ],
       })
     })
@@ -706,8 +712,11 @@ describe('processBody', () => {
           { name: 'file', value: '@mars.jpg' },
           { name: 'name', value: 'Mars Rover Photo' },
           { name: 'category', value: 'space' },
-          { name: 'metadata.location', value: 'Mars' },
-          { name: 'metadata.date', value: '2024-01-15' },
+          {
+            name: 'metadata',
+            value: JSON.stringify({ location: 'Mars', date: '2024-01-15' }),
+            contentType: 'application/json',
+          },
         ],
       })
     })
@@ -758,6 +767,89 @@ describe('processBody', () => {
           { name: 'text', value: 'Simple text' },
           { name: 'number', value: '42' },
           { name: 'boolean', value: 'true' },
+        ],
+      })
+    })
+
+    it('encodes nested object property as a single JSON part (issue #4834)', () => {
+      const content = {
+        'multipart/form-data': {
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            required: ['file', 'props'],
+            properties: {
+              file: {
+                description: 'File to upload',
+                type: 'string',
+                format: 'binary',
+              },
+              props: {
+                type: 'object',
+                required: ['name', 'description'],
+                properties: {
+                  name: { type: 'string' },
+                  description: { type: 'string' },
+                  created_at: { type: ['string', 'null'], format: 'date-time' },
+                },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [
+          { name: 'file', value: '@filename' },
+          {
+            name: 'props',
+            value: JSON.stringify({ name: '', description: '', created_at: null }),
+            contentType: 'application/json',
+          },
+        ],
+      })
+    })
+
+    it('respects an explicit encoding.contentType over the application/json default', () => {
+      const content = {
+        'multipart/form-data': {
+          encoding: {
+            settings: {
+              contentType: 'application/vnd.custom+json',
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              settings: {
+                type: 'object',
+                properties: {
+                  enabled: { type: 'boolean', example: true },
+                },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [
+          {
+            name: 'settings',
+            value: JSON.stringify({ enabled: true }),
+            contentType: 'application/vnd.custom+json',
+          },
         ],
       })
     })

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.test.ts
@@ -1755,6 +1755,47 @@ describe('processBody', () => {
         ],
       })
     })
+
+    // Per OAS 3.1.x Encoding Object, `contentType` SHALL be ignored when the request body
+    // media type is not a multipart. An object value with a `contentType`-only encoding
+    // entry should still fall through to the dotted-key flattening default, not be
+    // JSON-stringified into a single part.
+    it('ignores encoding.contentType on urlencoded bodies and keeps dotted-key flattening', () => {
+      const content = {
+        'application/x-www-form-urlencoded': {
+          encoding: {
+            user: {
+              contentType: 'application/json;charset=utf-8',
+            },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              user: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string', example: 'Scalar' },
+                  role: { type: 'string', example: 'maintainer' },
+                },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'application/x-www-form-urlencoded',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'application/x-www-form-urlencoded',
+        params: [
+          { name: 'user.name', value: 'Scalar' },
+          { name: 'user.role', value: 'maintainer' },
+        ],
+      })
+    })
   })
 
   describe('binary files', () => {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
@@ -26,6 +26,18 @@ type ProcessBodyProps = Pick<OperationToHarProps, 'contentType' | 'example' | 'r
 type MultipartEncodingMap = MediaTypeObject['encoding']
 
 /**
+ * Stringify a value emitted by `serializeFormStyle` into a HAR param value.
+ *
+ * Form-style serialization only addresses one level of nesting per RFC6570;
+ * deeper structures (an object or array still sitting in `entry.value`) are
+ * spec-undefined. JSON-stringify them so authors get readable output instead
+ * of `String(value)` returning `"[object Object]"`. Primitives pass through
+ * `String()` to preserve the existing wire shape (e.g. `true` → `"true"`).
+ */
+const stringifyEntryValue = (value: unknown): string =>
+  value !== null && typeof value === 'object' ? JSON.stringify(value) : String(value)
+
+/**
  * Converts a form-data body into HAR `Param[]` entries for `multipart/form-data`
  * and `application/x-www-form-urlencoded` requests.
  *
@@ -109,7 +121,7 @@ const objectToFormParams = (
           const serialized = serializeFormStyle(unpacked, true)
           if (Array.isArray(serialized)) {
             for (const entry of serialized) {
-              params.push({ name: entry.key || key, value: String(entry.value) })
+              params.push({ name: entry.key || key, value: stringifyEntryValue(entry.value) })
             }
           } else {
             params.push({ name: key, value: String(serialized) })
@@ -131,7 +143,11 @@ const objectToFormParams = (
           for (const entry of serialized) {
             // Arrays: entry.key === '' → fall back to the outer name.
             // Objects: entry.key is the inner property name (spec strips the outer name).
-            params.push({ name: entry.key || key, value: String(entry.value) })
+            // Nested objects/arrays inside entry.value are spec-undefined (RFC6570 form-style
+            // only addresses one level of nesting); JSON-stringify them instead of letting
+            // String() emit "[object Object]". The escape hatch for cleaner output is
+            // style: deepObject + explode: true.
+            params.push({ name: entry.key || key, value: stringifyEntryValue(entry.value) })
           }
         } else {
           params.push({ name: key, value: String(serialized) })

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
@@ -27,6 +27,7 @@ const objectToFormParams = (
   obj: object | { name: string; value: unknown; isDisabled: boolean }[],
   encoding?: MultipartEncodingMap,
   parentKey?: string,
+  isMultipart = false,
 ): Param[] => {
   const params: Param[] = []
 
@@ -40,19 +41,33 @@ const objectToFormParams = (
       continue
     }
 
-    const partContentType = parentKey ? undefined : encoding?.[key]?.contentType
+    const explicitContentType = parentKey ? undefined : encoding?.[key]?.contentType
 
     // Handle File objects by converting them to 'BINARY'
     if (value instanceof File) {
       const file = unpackProxyObject(value)
-      params.push({ name: key, value: `@${file.name}`, ...(partContentType ? { contentType: partContentType } : {}) })
+      params.push({
+        name: key,
+        value: `@${file.name}`,
+        ...(explicitContentType ? { contentType: explicitContentType } : {}),
+      })
     }
     // Multipart encodings can override the entire top-level part payload
-    else if (partContentType && typeof value === 'object') {
+    else if (explicitContentType && typeof value === 'object') {
       params.push({
         name: key,
         value: JSON.stringify(unpackProxyObject(value)),
-        contentType: partContentType,
+        contentType: explicitContentType,
+      })
+    }
+    // Per OpenAPI 3.x: a top-level multipart property whose value is an object (and not a File)
+    // defaults to a single part encoded as application/json, rather than being flattened
+    // into multiple parts with dotted keys.
+    else if (isMultipart && !parentKey && typeof value === 'object' && !Array.isArray(value)) {
+      params.push({
+        name: key,
+        value: JSON.stringify(unpackProxyObject(value)),
+        contentType: 'application/json',
       })
     }
     // Handle arrays by adding each item with the same key
@@ -62,6 +77,15 @@ const objectToFormParams = (
         if (item instanceof File) {
           const file = unpackProxyObject(item)
           params.push({ name: key, value: `@${file.name}` })
+        }
+        // Per OpenAPI 3.x: a top-level multipart array of complex items defaults each part
+        // to application/json, instead of flattening object items into dotted keys.
+        else if (isMultipart && !parentKey && typeof item === 'object' && item !== null) {
+          params.push({
+            name: key,
+            value: JSON.stringify(unpackProxyObject(item)),
+            contentType: 'application/json',
+          })
         } else {
           params.push({ name: key, value: String(item) })
         }
@@ -75,7 +99,11 @@ const objectToFormParams = (
         params.push({ name: `${key}.${param.name}`, value: param.value })
       }
     } else {
-      params.push({ name: key, value: String(value), ...(partContentType ? { contentType: partContentType } : {}) })
+      params.push({
+        name: key,
+        value: String(value),
+        ...(explicitContentType ? { contentType: explicitContentType } : {}),
+      })
     }
   }
 
@@ -117,7 +145,12 @@ export const processBody = ({
     if (isFormData && typeof exampleValue === 'object' && exampleValue !== null) {
       return {
         mimeType: harMimeType,
-        params: objectToFormParams(exampleValue, _contentType === 'multipart/form-data' ? encoding : undefined),
+        params: objectToFormParams(
+          exampleValue,
+          _contentType === 'multipart/form-data' ? encoding : undefined,
+          undefined,
+          _contentType === 'multipart/form-data',
+        ),
       }
     }
 
@@ -161,7 +194,12 @@ export const processBody = ({
       if (isFormData && typeof extractedExample === 'object' && extractedExample !== null) {
         return {
           mimeType: harMimeType,
-          params: objectToFormParams(extractedExample, _contentType === 'multipart/form-data' ? encoding : undefined),
+          params: objectToFormParams(
+            extractedExample,
+            _contentType === 'multipart/form-data' ? encoding : undefined,
+            undefined,
+            _contentType === 'multipart/form-data',
+          ),
         }
       }
 

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
@@ -77,32 +77,40 @@ const objectToFormParams = (
     }
 
     const partEncoding = parentKey ? undefined : encoding?.[key]
-    // Per OpenAPI 3.1.1: when style, explode, or allowReserved is explicitly set on the
-    // encoding entry, contentType (implicit or explicit) is ignored and the value is
-    // serialized as if it were a query-style parameter.
-const hasFormStyle = partEncoding && (
-  partEncoding.style !== undefined ||
-  partEncoding.explode !== undefined ||
-  partEncoding.allowReserved !== undefined
-)
-    // Per OAS 3.1.x Encoding Object: `contentType` SHALL be ignored if the request body
-    // media type is not a multipart. For `application/x-www-form-urlencoded` we still
-    // honor `style`/`explode`/`allowReserved` (handled above), but a `contentType`-only
-    // entry has no effect — values fall through to the dotted-key flattening default.
+    /**
+     * Per OpenAPI 3.1.1: when style, explode, or allowReserved is explicitly set on the
+     * encoding entry, contentType (implicit or explicit) is ignored and the value is
+     * serialized as if it were a query-style parameter.
+     */
+    const hasFormStyle =
+      partEncoding &&
+      (partEncoding.style !== undefined ||
+        partEncoding.explode !== undefined ||
+        partEncoding.allowReserved !== undefined)
+    /**
+     * Per OAS 3.1.x Encoding Object: `contentType` SHALL be ignored if the request body
+     * media type is not a multipart. For `application/x-www-form-urlencoded` we still
+     * honor `style`/`explode`/`allowReserved` (handled above), but a `contentType`-only
+     * entry has no effect — values fall through to the dotted-key flattening default.
+     */
     const explicitContentType = hasFormStyle || !isMultipart ? undefined : partEncoding?.contentType
 
-    // Per OpenAPI 3.1.x Encoding Object: when style/explode/allowReserved is set on a
-    // `multipart/form-data` or `application/x-www-form-urlencoded` part, the value is
-    // serialized as if it were a query-style parameter and contentType is ignored. For
-    // multipart the query delimiters are stripped per §Appendix C; HAR represents both
-    // content types via `PostData.params`, so the same shape works for both.
-    // Primitives skip this branch and fall through to the String(value) path below since
-    // style is a no-op for primitives. Files skip too, as do arrays containing Files —
-    // RFC6570 expansion of binary data is undefined per §Appendix C, and the array branch
-    // below already emits one `@filename` part per File.
-    // allowReserved only affects percent-encoding, which is a no-op at the HAR layer per
-    // OAS 3.1.2 ("`allowReserved` has no effect" for multipart); its presence still opts
-    // into this branch per spec.
+    /**
+     * Per OpenAPI 3.1.x Encoding Object: when style/explode/allowReserved is set on a
+     * `multipart/form-data` or `application/x-www-form-urlencoded` part, the value is
+     * serialized as if it were a query-style parameter and contentType is ignored. For
+     * multipart the query delimiters are stripped per §Appendix C; HAR represents both
+     * content types via `PostData.params`, so the same shape works for both.
+     *
+     * Primitives skip this branch and fall through to the String(value) path below since
+     * style is a no-op for primitives. Files skip too, as do arrays containing Files —
+     * RFC6570 expansion of binary data is undefined per §Appendix C, and the array branch
+     * below already emits one `@filename` part per File.
+     *
+     * allowReserved only affects percent-encoding, which is a no-op at the HAR layer per
+     * OAS 3.1.2 ("`allowReserved` has no effect" for multipart); its presence still opts
+     * into this branch per spec.
+     */
     if (
       !parentKey &&
       hasFormStyle &&
@@ -112,16 +120,20 @@ const hasFormStyle = partEncoding && (
       !(Array.isArray(value) && value.some((item) => item instanceof File))
     ) {
       const unpacked = unpackProxyObject(value)
-      // OAS 3.1.x Encoding Object: encoding follows query-parameter defaults — when no
-      // `style` is set, the default is "form"; when no `explode` is set, the default is
-      // `true` for "form" and `false` for every other style.
+      /**
+       * OAS 3.1.x Encoding Object: encoding follows query-parameter defaults — when no
+       * `style` is set, the default is "form"; when no `explode` is set, the default is
+       * `true` for "form" and `false` for every other style.
+       */
       const style = partEncoding?.style ?? 'form'
       const explode = partEncoding?.explode ?? style === 'form'
 
       if (style === 'deepObject') {
         if (Array.isArray(unpacked)) {
-          // OAS 3.1.1 marks deepObject-on-array as n/a; fall back to the form/explode:true
-          // shape so the array still reaches the wire instead of being silently dropped.
+          /**
+           * OAS 3.1.1 marks deepObject-on-array as n/a; fall back to the form/explode:true
+           * shape so the array still reaches the wire instead of being silently dropped.
+           */
           const serialized = serializeFormStyle(unpacked, true)
           if (Array.isArray(serialized)) {
             for (const entry of serialized) {
@@ -131,8 +143,10 @@ const hasFormStyle = partEncoding && (
             params.push({ name: key, value: String(serialized) })
           }
         } else {
-          // explode:false with deepObject is undefined per spec; we invoke the serializer
-          // either way so authors get useful output instead of nothing.
+          /**
+           * explode:false with deepObject is undefined per spec; we invoke the serializer
+           * either way so authors get useful output instead of nothing.
+           */
           for (const entry of serializeDeepObjectStyle(key, unpacked)) {
             params.push({ name: entry.key, value: String(entry.value) })
           }
@@ -145,61 +159,65 @@ const hasFormStyle = partEncoding && (
         const serialized = serializeFormStyle(unpacked, explode)
         if (Array.isArray(serialized)) {
           for (const entry of serialized) {
-            // Arrays: entry.key === '' → fall back to the outer name.
-            // Objects: entry.key is the inner property name (spec strips the outer name).
-            // Nested objects/arrays inside entry.value are spec-undefined (RFC6570 form-style
-            // only addresses one level of nesting); JSON-stringify them instead of letting
-            // String() emit "[object Object]". The escape hatch for cleaner output is
-            // style: deepObject + explode: true.
+            /**
+             * Arrays: entry.key === '' → fall back to the outer name.
+             * Objects: entry.key is the inner property name (spec strips the outer name).
+             *
+             * Nested objects/arrays inside entry.value are spec-undefined (RFC6570 form-style
+             * only addresses one level of nesting); JSON-stringify them instead of letting
+             * String() emit "[object Object]". The escape hatch for cleaner output is
+             * style: deepObject + explode: true.
+             */
             params.push({ name: entry.key || key, value: stringifyEntryValue(entry.value) })
           }
         } else {
           params.push({ name: key, value: String(serialized) })
         }
       }
-    }
-    // File values render as `@filename` references, the conventional cURL syntax for an
-    // attached file. Picked up by snippet renderers downstream (e.g. `--form 'x=@file.png'`).
-    else if (value instanceof File) {
+    } else if (value instanceof File) {
+      /**
+       * File values render as `@filename` references, the conventional cURL syntax for an
+       * attached file. Picked up by snippet renderers downstream (e.g. `--form 'x=@file.png'`).
+       */
       const file = unpackProxyObject(value)
       params.push({
         name: key,
         value: `@${file.name}`,
         ...(explicitContentType ? { contentType: explicitContentType } : {}),
       })
-    }
-    // Per OAS 3.1.x Encoding Object: an explicit `encoding[key].contentType` on a
-    // complex value overrides the default and emits a single part containing the value
-    // JSON-stringified into that media type. Only reachable when style/explode/allowReserved
-    // are unset (otherwise contentType is ignored — see the style branch above).
-    else if (explicitContentType && typeof value === 'object') {
+    } else if (explicitContentType && typeof value === 'object') {
+      /**
+       * Per OAS 3.1.x Encoding Object: an explicit `encoding[key].contentType` on a
+       * complex value overrides the default and emits a single part containing the value
+       * JSON-stringified into that media type. Only reachable when style/explode/allowReserved
+       * are unset (otherwise contentType is ignored — see the style branch above).
+       */
       params.push({
         name: key,
         value: JSON.stringify(unpackProxyObject(value)),
         contentType: explicitContentType,
       })
-    }
-    // Per OpenAPI 3.x: a top-level multipart property whose value is an object (and not a File)
-    // defaults to a single part encoded as application/json, rather than being flattened
-    // into multiple parts with dotted keys.
-    else if (isMultipart && !parentKey && !hasFormStyle && typeof value === 'object' && !Array.isArray(value)) {
+    } else if (isMultipart && !parentKey && !hasFormStyle && typeof value === 'object' && !Array.isArray(value)) {
+      /**
+       * Per OpenAPI 3.x: a top-level multipart property whose value is an object (and not a File)
+       * defaults to a single part encoded as application/json, rather than being flattened
+       * into multiple parts with dotted keys.
+       */
       params.push({
         name: key,
         value: JSON.stringify(unpackProxyObject(value)),
         contentType: 'application/json',
       })
-    }
-    // Handle arrays by adding each item with the same key
-    else if (Array.isArray(value)) {
+    } else if (Array.isArray(value)) {
       for (const item of value) {
-        // Check if array item is a File
         if (item instanceof File) {
           const file = unpackProxyObject(item)
           params.push({ name: key, value: `@${file.name}` })
-        }
-        // Per OpenAPI 3.x: a top-level multipart array of complex items defaults each part
-        // to application/json, instead of flattening object items into dotted keys.
-        else if (isMultipart && !parentKey && !hasFormStyle && typeof item === 'object' && item !== null) {
+        } else if (isMultipart && !parentKey && !hasFormStyle && typeof item === 'object' && item !== null) {
+          /**
+           * Per OpenAPI 3.x: a top-level multipart array of complex items defaults each part
+           * to application/json, instead of flattening object items into dotted keys.
+           */
           params.push({
             name: key,
             value: JSON.stringify(unpackProxyObject(item)),
@@ -209,14 +227,15 @@ const hasFormStyle = partEncoding && (
           params.push({ name: key, value: String(item) })
         }
       }
-    }
-    // Legacy fallback: flatten nested objects into dotted-key parts. Reached when the
-    // multipart JSON-default branches above don't apply — i.e. either inside a recursive
-    // call (`parentKey` set) or on `application/x-www-form-urlencoded` bodies without an
-    // explicit encoding entry. Strict OAS 3.1.x would use `style: form, explode: true` as
-    // the urlencoded default (inner keys become top-level params); we keep dotted keys for
-    // backwards compatibility with consumers that already parse this shape.
-    else if (typeof value === 'object') {
+    } else if (typeof value === 'object') {
+      /**
+       * Legacy fallback: flatten nested objects into dotted-key parts. Reached when the
+       * multipart JSON-default branches above don't apply — i.e. either inside a recursive
+       * call (`parentKey` set) or on `application/x-www-form-urlencoded` bodies without an
+       * explicit encoding entry. Strict OAS 3.1.x would use `style: form, explode: true` as
+       * the urlencoded default (inner keys become top-level params); we keep dotted keys for
+       * backwards compatibility with consumers that already parse this shape.
+       */
       const nestedParams = objectToFormParams(value, undefined, key)
 
       for (const param of nestedParams) {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
@@ -85,7 +85,11 @@ const objectToFormParams = (
       (partEncoding.style !== undefined ||
         partEncoding.explode !== undefined ||
         partEncoding.allowReserved !== undefined)
-    const explicitContentType = hasFormStyle ? undefined : partEncoding?.contentType
+    // Per OAS 3.1.x Encoding Object: `contentType` SHALL be ignored if the request body
+    // media type is not a multipart. For `application/x-www-form-urlencoded` we still
+    // honor `style`/`explode`/`allowReserved` (handled above), but a `contentType`-only
+    // entry has no effect — values fall through to the dotted-key flattening default.
+    const explicitContentType = hasFormStyle || !isMultipart ? undefined : partEncoding?.contentType
 
     // Per OpenAPI 3.1.x Encoding Object: when style/explode/allowReserved is set on a
     // `multipart/form-data` or `application/x-www-form-urlencoded` part, the value is

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
@@ -59,17 +59,18 @@ const objectToFormParams = (
         partEncoding.allowReserved !== undefined)
     const explicitContentType = hasFormStyle ? undefined : partEncoding?.contentType
 
-    // Per OpenAPI 3.1.1 §Encoding Object: when style/explode/allowReserved is set, the part
-    // value is serialized as if it were a query-style parameter and contentType is ignored.
-    // The query delimiters are stripped per Appendix C, so part names/values come straight
-    // from the serializer. Primitives skip this branch and fall through to the String(value)
-    // path below since style is a no-op for primitives. Files skip too, as do arrays
-    // containing Files — RFC6570 expansion of binary data is undefined per spec line 4181,
-    // and the array branch below already emits one `@filename` part per File.
-    // allowReserved only affects percent-encoding, which is a no-op at the HAR layer (values
-    // are raw bytes in part bodies); its presence still opts into this branch per spec.
+    // Per OpenAPI 3.1.1 §Encoding Object: when style/explode/allowReserved is set on a
+    // `multipart/form-data` or `application/x-www-form-urlencoded` part, the value is
+    // serialized as if it were a query-style parameter and contentType is ignored. For
+    // multipart the query delimiters are stripped per Appendix C; HAR represents both
+    // content types via `PostData.params`, so the same shape works for both.
+    // Primitives skip this branch and fall through to the String(value) path below since
+    // style is a no-op for primitives. Files skip too, as do arrays containing Files —
+    // RFC6570 expansion of binary data is undefined per spec line 4181, and the array
+    // branch below already emits one `@filename` part per File.
+    // allowReserved only affects percent-encoding, which is a no-op at the HAR layer
+    // (values are raw bytes); its presence still opts into this branch per spec.
     if (
-      isMultipart &&
       !parentKey &&
       hasFormStyle &&
       typeof value === 'object' &&
@@ -220,12 +221,7 @@ export const processBody = ({
     if (isFormData && typeof exampleValue === 'object' && exampleValue !== null) {
       return {
         mimeType: harMimeType,
-        params: objectToFormParams(
-          exampleValue,
-          _contentType === 'multipart/form-data' ? encoding : undefined,
-          undefined,
-          _contentType === 'multipart/form-data',
-        ),
+        params: objectToFormParams(exampleValue, encoding, undefined, _contentType === 'multipart/form-data'),
       }
     }
 
@@ -269,12 +265,7 @@ export const processBody = ({
       if (isFormData && typeof extractedExample === 'object' && extractedExample !== null) {
         return {
           mimeType: harMimeType,
-          params: objectToFormParams(
-            extractedExample,
-            _contentType === 'multipart/form-data' ? encoding : undefined,
-            undefined,
-            _contentType === 'multipart/form-data',
-          ),
+          params: objectToFormParams(extractedExample, encoding, undefined, _contentType === 'multipart/form-data'),
         }
       }
 

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
@@ -41,7 +41,16 @@ const objectToFormParams = (
       continue
     }
 
-    const explicitContentType = parentKey ? undefined : encoding?.[key]?.contentType
+    const partEncoding = parentKey ? undefined : encoding?.[key]
+    // Per OpenAPI 3.1.1: when style, explode, or allowReserved is explicitly set on the
+    // encoding entry, contentType (implicit or explicit) is ignored and the value is
+    // serialized as if it were a query-style parameter.
+    const hasFormStyle =
+      !!partEncoding &&
+      (partEncoding.style !== undefined ||
+        partEncoding.explode !== undefined ||
+        partEncoding.allowReserved !== undefined)
+    const explicitContentType = hasFormStyle ? undefined : partEncoding?.contentType
 
     // Handle File objects by converting them to 'BINARY'
     if (value instanceof File) {
@@ -63,7 +72,7 @@ const objectToFormParams = (
     // Per OpenAPI 3.x: a top-level multipart property whose value is an object (and not a File)
     // defaults to a single part encoded as application/json, rather than being flattened
     // into multiple parts with dotted keys.
-    else if (isMultipart && !parentKey && typeof value === 'object' && !Array.isArray(value)) {
+    else if (isMultipart && !parentKey && !hasFormStyle && typeof value === 'object' && !Array.isArray(value)) {
       params.push({
         name: key,
         value: JSON.stringify(unpackProxyObject(value)),
@@ -80,7 +89,7 @@ const objectToFormParams = (
         }
         // Per OpenAPI 3.x: a top-level multipart array of complex items defaults each part
         // to application/json, instead of flattening object items into dotted keys.
-        else if (isMultipart && !parentKey && typeof item === 'object' && item !== null) {
+        else if (isMultipart && !parentKey && !hasFormStyle && typeof item === 'object' && item !== null) {
           params.push({
             name: key,
             value: JSON.stringify(unpackProxyObject(item)),

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
@@ -63,8 +63,9 @@ const objectToFormParams = (
     // value is serialized as if it were a query-style parameter and contentType is ignored.
     // The query delimiters are stripped per Appendix C, so part names/values come straight
     // from the serializer. Primitives skip this branch and fall through to the String(value)
-    // path below since style is a no-op for primitives. Files skip too — RFC6570 expansion
-    // of binary data is undefined per spec line 4181.
+    // path below since style is a no-op for primitives. Files skip too, as do arrays
+    // containing Files — RFC6570 expansion of binary data is undefined per spec line 4181,
+    // and the array branch below already emits one `@filename` part per File.
     // allowReserved only affects percent-encoding, which is a no-op at the HAR layer (values
     // are raw bytes in part bodies); its presence still opts into this branch per spec.
     if (
@@ -73,7 +74,8 @@ const objectToFormParams = (
       hasFormStyle &&
       typeof value === 'object' &&
       value !== null &&
-      !(value instanceof File)
+      !(value instanceof File) &&
+      !(Array.isArray(value) && value.some((item) => item instanceof File))
     ) {
       const unpacked = unpackProxyObject(value)
       const style = partEncoding?.style ?? 'form'

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
@@ -80,11 +80,11 @@ const objectToFormParams = (
     // Per OpenAPI 3.1.1: when style, explode, or allowReserved is explicitly set on the
     // encoding entry, contentType (implicit or explicit) is ignored and the value is
     // serialized as if it were a query-style parameter.
-    const hasFormStyle =
-      !!partEncoding &&
-      (partEncoding.style !== undefined ||
-        partEncoding.explode !== undefined ||
-        partEncoding.allowReserved !== undefined)
+const hasFormStyle = partEncoding && (
+  partEncoding.style !== undefined ||
+  partEncoding.explode !== undefined ||
+  partEncoding.allowReserved !== undefined
+)
     // Per OAS 3.1.x Encoding Object: `contentType` SHALL be ignored if the request body
     // media type is not a multipart. For `application/x-www-form-urlencoded` we still
     // honor `style`/`explode`/`allowReserved` (handled above), but a `contentType`-only

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
@@ -83,10 +83,23 @@ const objectToFormParams = (
       const explode = partEncoding?.explode ?? style === 'form'
 
       if (style === 'deepObject') {
-        // explode:false with deepObject is undefined per spec; we invoke the serializer
-        // either way so authors get useful output instead of nothing.
-        for (const entry of serializeDeepObjectStyle(key, unpacked)) {
-          params.push({ name: entry.key, value: String(entry.value) })
+        if (Array.isArray(unpacked)) {
+          // OAS 3.1.1 marks deepObject-on-array as n/a; fall back to the form/explode:true
+          // shape so the array still reaches the wire instead of being silently dropped.
+          const serialized = serializeFormStyle(unpacked, true)
+          if (Array.isArray(serialized)) {
+            for (const entry of serialized) {
+              params.push({ name: entry.key || key, value: String(entry.value) })
+            }
+          } else {
+            params.push({ name: key, value: String(serialized) })
+          }
+        } else {
+          // explode:false with deepObject is undefined per spec; we invoke the serializer
+          // either way so authors get useful output instead of nothing.
+          for (const entry of serializeDeepObjectStyle(key, unpacked)) {
+            params.push({ name: entry.key, value: String(entry.value) })
+          }
         }
       } else if (style === 'spaceDelimited') {
         params.push({ name: key, value: String(serializeSpaceDelimitedStyle(unpacked)) })

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
@@ -1,7 +1,14 @@
 import { json2xml } from '@scalar/helpers/file/json2xml'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import { unpackProxyObject } from '@scalar/workspace-store/helpers/unpack-proxy'
-import { getExample, getExampleFromSchema } from '@scalar/workspace-store/request-example'
+import {
+  getExample,
+  getExampleFromSchema,
+  serializeDeepObjectStyle,
+  serializeFormStyle,
+  serializePipeDelimitedStyle,
+  serializeSpaceDelimitedStyle,
+} from '@scalar/workspace-store/request-example'
 import type {
   MediaTypeObject,
   RequestBodyObject,
@@ -52,8 +59,52 @@ const objectToFormParams = (
         partEncoding.allowReserved !== undefined)
     const explicitContentType = hasFormStyle ? undefined : partEncoding?.contentType
 
+    // Per OpenAPI 3.1.1 §Encoding Object: when style/explode/allowReserved is set, the part
+    // value is serialized as if it were a query-style parameter and contentType is ignored.
+    // The query delimiters are stripped per Appendix C, so part names/values come straight
+    // from the serializer. Primitives skip this branch and fall through to the String(value)
+    // path below since style is a no-op for primitives. Files skip too — RFC6570 expansion
+    // of binary data is undefined per spec line 4181.
+    // allowReserved only affects percent-encoding, which is a no-op at the HAR layer (values
+    // are raw bytes in part bodies); its presence still opts into this branch per spec.
+    if (
+      isMultipart &&
+      !parentKey &&
+      hasFormStyle &&
+      typeof value === 'object' &&
+      value !== null &&
+      !(value instanceof File)
+    ) {
+      const unpacked = unpackProxyObject(value)
+      const style = partEncoding?.style ?? 'form'
+      // OAS defaults: explode is true for "form", false for everything else.
+      const explode = partEncoding?.explode ?? style === 'form'
+
+      if (style === 'deepObject') {
+        // explode:false with deepObject is undefined per spec; we invoke the serializer
+        // either way so authors get useful output instead of nothing.
+        for (const entry of serializeDeepObjectStyle(key, unpacked)) {
+          params.push({ name: entry.key, value: String(entry.value) })
+        }
+      } else if (style === 'spaceDelimited') {
+        params.push({ name: key, value: String(serializeSpaceDelimitedStyle(unpacked)) })
+      } else if (style === 'pipeDelimited') {
+        params.push({ name: key, value: String(serializePipeDelimitedStyle(unpacked)) })
+      } else {
+        const serialized = serializeFormStyle(unpacked, explode)
+        if (Array.isArray(serialized)) {
+          for (const entry of serialized) {
+            // Arrays: entry.key === '' → fall back to the outer name.
+            // Objects: entry.key is the inner property name (spec strips the outer name).
+            params.push({ name: entry.key || key, value: String(entry.value) })
+          }
+        } else {
+          params.push({ name: key, value: String(serialized) })
+        }
+      }
+    }
     // Handle File objects by converting them to 'BINARY'
-    if (value instanceof File) {
+    else if (value instanceof File) {
       const file = unpackProxyObject(value)
       params.push({
         name: key,

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
@@ -26,9 +26,25 @@ type ProcessBodyProps = Pick<OperationToHarProps, 'contentType' | 'example' | 'r
 type MultipartEncodingMap = MediaTypeObject['encoding']
 
 /**
- * Converts an object to an array of form parameters
- * @param obj - The object to convert
- * @returns Array of form parameters with name and value properties
+ * Converts a form-data body into HAR `Param[]` entries for `multipart/form-data`
+ * and `application/x-www-form-urlencoded` requests.
+ *
+ * Per OpenAPI 3.1.x Encoding Object, each property's serialization is governed
+ * by an optional Encoding entry. When `style` / `explode` / `allowReserved` is
+ * set, the value is serialized RFC6570-style and `contentType` is ignored.
+ * When only `contentType` is set, the property becomes a single part with that
+ * type. Otherwise spec defaults apply (object → `application/json` for multipart,
+ * primitives → `text/plain`).
+ *
+ * @param obj - The form-data payload, either an object keyed by property name
+ *   or a HAR-style `{ name, value, isDisabled }[]` array.
+ * @param encoding - The `encoding` map from the Media Type Object, if any.
+ *   Used only at the top level (`parentKey` undefined).
+ * @param parentKey - When set, we are flattening a nested object inside another
+ *   property; encoding is ignored and keys are joined with `.` (legacy default).
+ * @param isMultipart - True for `multipart/form-data`. Gates the spec defaults
+ *   for object/array properties that should become a single `application/json`
+ *   part. Urlencoded bodies skip those branches and fall through to flattening.
  */
 const objectToFormParams = (
   obj: object | { name: string; value: unknown; isDisabled: boolean }[],
@@ -59,17 +75,18 @@ const objectToFormParams = (
         partEncoding.allowReserved !== undefined)
     const explicitContentType = hasFormStyle ? undefined : partEncoding?.contentType
 
-    // Per OpenAPI 3.1.1 §Encoding Object: when style/explode/allowReserved is set on a
+    // Per OpenAPI 3.1.x Encoding Object: when style/explode/allowReserved is set on a
     // `multipart/form-data` or `application/x-www-form-urlencoded` part, the value is
     // serialized as if it were a query-style parameter and contentType is ignored. For
-    // multipart the query delimiters are stripped per Appendix C; HAR represents both
+    // multipart the query delimiters are stripped per §Appendix C; HAR represents both
     // content types via `PostData.params`, so the same shape works for both.
     // Primitives skip this branch and fall through to the String(value) path below since
     // style is a no-op for primitives. Files skip too, as do arrays containing Files —
-    // RFC6570 expansion of binary data is undefined per spec line 4181, and the array
-    // branch below already emits one `@filename` part per File.
-    // allowReserved only affects percent-encoding, which is a no-op at the HAR layer
-    // (values are raw bytes); its presence still opts into this branch per spec.
+    // RFC6570 expansion of binary data is undefined per §Appendix C, and the array branch
+    // below already emits one `@filename` part per File.
+    // allowReserved only affects percent-encoding, which is a no-op at the HAR layer per
+    // OAS 3.1.2 ("`allowReserved` has no effect" for multipart); its presence still opts
+    // into this branch per spec.
     if (
       !parentKey &&
       hasFormStyle &&
@@ -79,8 +96,10 @@ const objectToFormParams = (
       !(Array.isArray(value) && value.some((item) => item instanceof File))
     ) {
       const unpacked = unpackProxyObject(value)
+      // OAS 3.1.x Encoding Object: encoding follows query-parameter defaults — when no
+      // `style` is set, the default is "form"; when no `explode` is set, the default is
+      // `true` for "form" and `false` for every other style.
       const style = partEncoding?.style ?? 'form'
-      // OAS defaults: explode is true for "form", false for everything else.
       const explode = partEncoding?.explode ?? style === 'form'
 
       if (style === 'deepObject') {
@@ -119,7 +138,8 @@ const objectToFormParams = (
         }
       }
     }
-    // Handle File objects by converting them to 'BINARY'
+    // File values render as `@filename` references, the conventional cURL syntax for an
+    // attached file. Picked up by snippet renderers downstream (e.g. `--form 'x=@file.png'`).
     else if (value instanceof File) {
       const file = unpackProxyObject(value)
       params.push({
@@ -128,7 +148,10 @@ const objectToFormParams = (
         ...(explicitContentType ? { contentType: explicitContentType } : {}),
       })
     }
-    // Multipart encodings can override the entire top-level part payload
+    // Per OAS 3.1.x Encoding Object: an explicit `encoding[key].contentType` on a
+    // complex value overrides the default and emits a single part containing the value
+    // JSON-stringified into that media type. Only reachable when style/explode/allowReserved
+    // are unset (otherwise contentType is ignored — see the style branch above).
     else if (explicitContentType && typeof value === 'object') {
       params.push({
         name: key,
@@ -167,7 +190,12 @@ const objectToFormParams = (
         }
       }
     }
-    // Handle nested objects by flattening them
+    // Legacy fallback: flatten nested objects into dotted-key parts. Reached when the
+    // multipart JSON-default branches above don't apply — i.e. either inside a recursive
+    // call (`parentKey` set) or on `application/x-www-form-urlencoded` bodies without an
+    // explicit encoding entry. Strict OAS 3.1.x would use `style: form, explode: true` as
+    // the urlencoded default (inner keys become top-level params); we keep dotted keys for
+    // backwards compatibility with consumers that already parse this shape.
     else if (typeof value === 'object') {
       const nestedParams = objectToFormParams(value, undefined, key)
 

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-parameters.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-parameters.test.ts
@@ -719,6 +719,58 @@ describe('parameter styles', () => {
         { name: 'color[B]', value: '150' },
       ])
     })
+
+    it('falls back to bracket notation when deepObject is used without explode', () => {
+      const result = runProcessParameters({
+        harRequest: createHarRequest('/api/users'),
+        parameters: [
+          {
+            name: 'color',
+            in: 'query',
+            required: true,
+            style: 'deepObject',
+            schema: coerceValue(SchemaObjectSchema, {
+              type: 'object',
+              properties: {
+                R: { type: 'integer' },
+              },
+              example: { R: 100 },
+            }),
+          },
+        ],
+      })
+
+      // explode:false with deepObject is spec-undefined; we still emit bracket notation
+      // instead of silently dropping the parameter (mirrors process-body).
+      expect(result.queryString).toEqual([{ name: 'color[R]', value: '100' }])
+    })
+
+    it('falls back to repeated-name parts when deepObject is used on an array', () => {
+      const result = runProcessParameters({
+        harRequest: createHarRequest('/api/users'),
+        parameters: [
+          {
+            name: 'tags',
+            in: 'query',
+            required: true,
+            style: 'deepObject',
+            explode: true,
+            schema: coerceValue(SchemaObjectSchema, {
+              type: 'array',
+              items: { type: 'string' },
+              example: ['a', 'b', 'c'],
+            }),
+          },
+        ],
+      })
+
+      // deepObject-on-array is spec-undefined; fall back to form/explode:true repeated parts.
+      expect(result.queryString).toEqual([
+        { name: 'tags', value: 'a' },
+        { name: 'tags', value: 'b' },
+        { name: 'tags', value: 'c' },
+      ])
+    })
   })
 
   describe('header parameters', () => {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-parameters.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-parameters.ts
@@ -196,7 +196,21 @@ export const processParameters = ({
             break
           }
           case 'deepObject': {
-            if (explode) {
+            // OAS marks deepObject-on-array and deepObject+explode:false as undefined.
+            // Mirror process-body: fall back to form/explode:true for arrays and always
+            // invoke the serializer for objects so authors get useful output instead of
+            // a silently-dropped parameter.
+            if (Array.isArray(paramValue)) {
+              const serialized = serializeFormStyle(paramValue, true)
+              if (Array.isArray(serialized)) {
+                for (const entry of serialized) {
+                  const key = entry.key || param.name
+                  newQueryString.push({ name: key, value: encodeQueryValue(String(entry.value), param) })
+                }
+              } else {
+                newQueryString.push({ name: param.name, value: encodeQueryValue(String(serialized), param) })
+              }
+            } else {
               const entries = serializeDeepObjectStyle(param.name, paramValue)
               for (const entry of entries) {
                 newQueryString.push({ name: entry.key, value: encodeQueryValue(entry.value, param) })

--- a/packages/snippetz/package.json
+++ b/packages/snippetz/package.json
@@ -247,6 +247,7 @@
     "CHANGELOG"
   ],
   "dependencies": {
+    "@scalar/helpers": "workspace:*",
     "@scalar/types": "workspace:*",
     "js-base64": "catalog:*",
     "stringify-object": "^6.0.0"

--- a/packages/snippetz/src/plugins/shell/curl/curl.test.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.test.ts
@@ -247,7 +247,67 @@ describe('shellCurl', () => {
 
     expect(result).toBe(`curl https://example.com \\
   --request POST \\
-  --form 'user={"name":"scalar"};type=application/json;charset=utf-8'`)
+  --form 'user={
+  "name": "scalar"
+};type=application/json;charset=utf-8'`)
+  })
+
+  it('pretty-prints JSON multipart parts alongside file parts', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com/widget/v1/widgets',
+      method: 'POST',
+      headers: [
+        {
+          name: 'Content-Type',
+          value: 'multipart/form-data',
+        },
+      ],
+      postData: {
+        mimeType: 'multipart/form-data',
+        params: [
+          {
+            name: 'file',
+            fileName: 'filename',
+          },
+          {
+            name: 'props',
+            value: '{"name":"","description":"","created_at":null}',
+            contentType: 'application/json',
+          },
+        ],
+      },
+    })
+
+    expect(result).toBe(`curl https://example.com/widget/v1/widgets \\
+  --request POST \\
+  --header 'Content-Type: multipart/form-data' \\
+  --form 'file=@filename' \\
+  --form 'props={
+  "name": "",
+  "description": "",
+  "created_at": null
+};type=application/json'`)
+  })
+
+  it('leaves non-JSON multipart values untouched when contentType claims JSON', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com',
+      method: 'POST',
+      postData: {
+        mimeType: 'multipart/form-data',
+        params: [
+          {
+            name: 'props',
+            value: 'not json',
+            contentType: 'application/json',
+          },
+        ],
+      },
+    })
+
+    expect(result).toBe(`curl https://example.com \\
+  --request POST \\
+  --form 'props=not json;type=application/json'`)
   })
 
   it('handles multipart form data content types on files', () => {

--- a/packages/snippetz/src/plugins/shell/curl/curl.test.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.test.ts
@@ -670,6 +670,63 @@ describe('shellCurl', () => {
     expect(result).toBe(`curl 'https://example.com/api$v1/prices?amount=%2450.00'`)
   })
 
+  it('pretty-prints --data bodies whose mimeType uses a +json suffix', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com',
+      method: 'POST',
+      postData: {
+        mimeType: 'application/vnd.api+json',
+        text: JSON.stringify({ a: 1 }),
+      },
+    })
+
+    expect(result).toBe(`curl https://example.com \\
+  --request POST \\
+  --data '{
+  "a": 1
+}'`)
+  })
+
+  it('pretty-prints --data bodies whose mimeType includes a charset parameter', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com',
+      method: 'POST',
+      postData: {
+        mimeType: 'application/json;charset=utf-8',
+        text: JSON.stringify({ a: 1 }),
+      },
+    })
+
+    expect(result).toBe(`curl https://example.com \\
+  --request POST \\
+  --data '{
+  "a": 1
+}'`)
+  })
+
+  it('pretty-prints --form parts whose contentType uses a +json suffix', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com',
+      method: 'POST',
+      postData: {
+        mimeType: 'multipart/form-data',
+        params: [
+          {
+            name: 'props',
+            value: '{"a":1}',
+            contentType: 'application/vnd.custom+json',
+          },
+        ],
+      },
+    })
+
+    expect(result).toBe(`curl https://example.com \\
+  --request POST \\
+  --form 'props={
+  "a": 1
+};type=application/vnd.custom+json'`)
+  })
+
   it('escapes single quotes in JSON body', () => {
     const result = shellCurl.generate({
       url: 'https://editor.scalar.com/test',

--- a/packages/snippetz/src/plugins/shell/curl/curl.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.ts
@@ -115,7 +115,19 @@ export const shellCurl: Plugin = {
             const escapedFileName = escapeSingleQuotes(`${param.fileName}${multipartValueSuffix}`)
             parts.push(`--form '${escapedName}=@${escapedFileName}'`)
           } else {
-            const escapedValue = escapeSingleQuotes(`${param.value ?? ''}${multipartValueSuffix}`)
+            const rawValue = param.value ?? ''
+            // Pretty-print parts whose contentType is JSON so the snippet stays readable,
+            // mirroring what we already do for `--data` JSON bodies above.
+            const isJsonPart = !!param.contentType && /^application\/json\b/i.test(param.contentType)
+            let displayValue = rawValue
+            if (isJsonPart && rawValue) {
+              try {
+                displayValue = JSON.stringify(JSON.parse(rawValue), null, 2)
+              } catch {
+                // Fall back to the raw value if it is not valid JSON.
+              }
+            }
+            const escapedValue = escapeSingleQuotes(`${displayValue}${multipartValueSuffix}`)
             parts.push(`--form '${escapedName}=${escapedValue}'`)
           }
         })

--- a/packages/snippetz/src/plugins/shell/curl/curl.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.ts
@@ -1,6 +1,20 @@
+import { parseMimeType } from '@scalar/helpers/http/mime-type'
 import type { Plugin } from '@scalar/types/snippetz'
 
 import { escapeSingleQuotes } from '@/libs/shell'
+
+/**
+ * True for `application/json`, any RFC 6839 `+json` structured-syntax suffix
+ * (e.g. `application/vnd.api+json`), and parameterized variants
+ * (e.g. `application/json;charset=utf-8`). Case-insensitive.
+ */
+const isJsonContentType = (value: string | undefined): boolean => {
+  if (!value) {
+    return false
+  }
+  const { subtype } = parseMimeType(value)
+  return subtype === 'json' || subtype.endsWith('+json')
+}
 
 /**
  * shell/curl
@@ -78,7 +92,7 @@ export const shellCurl: Plugin = {
 
     // Body
     if (normalizedRequest.postData) {
-      if (normalizedRequest.postData.mimeType === 'application/json') {
+      if (isJsonContentType(normalizedRequest.postData.mimeType)) {
         // Pretty print JSON data
         if (normalizedRequest.postData.text) {
           try {
@@ -118,7 +132,7 @@ export const shellCurl: Plugin = {
             const rawValue = param.value ?? ''
             // Pretty-print parts whose contentType is JSON so the snippet stays readable,
             // mirroring what we already do for `--data` JSON bodies above.
-            const isJsonPart = !!param.contentType && /^application\/json\b/i.test(param.contentType)
+            const isJsonPart = isJsonContentType(param.contentType)
             let displayValue = rawValue
             if (isJsonPart && rawValue) {
               try {

--- a/packages/workspace-store/src/schemas/v3.1/strict/encoding.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/encoding.ts
@@ -16,6 +16,12 @@ export const EncodingObjectSchemaDefinition = Type.Object({
   contentType: Type.Optional(Type.String()),
   /** A map allowing additional information to be provided as headers. Content-Type is described separately and SHALL be ignored in this section. This field SHALL be ignored if the request body media type is not a multipart. */
   headers: Type.Optional(Type.Record(Type.String(), Type.Union([HeaderObjectRef, reference(HeaderObjectRef)]))),
+  /** Describes how a specific property value will be serialized depending on its type. See the Parameter Object for details on the style field. The behavior follows the same values as query parameters, including default values. Valid values are "form", "spaceDelimited", "pipeDelimited", and "deepObject". This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */
+  style: Type.Optional(Type.String()),
+  /** When this is true, property values of type array or object generate separate parameters for each value of the array, or key-value-pair of the map. For other types of properties this field has no effect. When style is "form", the default value is true. For all other styles, the default value is false. This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */
+  explode: Type.Optional(Type.Boolean()),
+  /** When this is true, parameter values are serialized using reserved expansion, as defined by RFC6570, which allows RFC3986's reserved character set, as well as percent-encoded triples, to pass through unchanged, while still percent-encoding all other disallowed characters (including % outside of percent-encoded triples). The default value is false. This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */
+  allowReserved: Type.Optional(Type.Boolean()),
 })
 
 /**
@@ -30,4 +36,10 @@ export type EncodingObject = {
   contentType?: string
   /** A map allowing additional information to be provided as headers. Content-Type is described separately and SHALL be ignored in this section. This field SHALL be ignored if the request body media type is not a multipart. */
   headers?: Record<string, ReferenceType<HeaderObject>>
+  /** Describes how a specific property value will be serialized depending on its type. See the Parameter Object for details on the style field. The behavior follows the same values as query parameters, including default values. Valid values are "form", "spaceDelimited", "pipeDelimited", and "deepObject". This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */
+  style?: string
+  /** When this is true, property values of type array or object generate separate parameters for each value of the array, or key-value-pair of the map. For other types of properties this field has no effect. When style is "form", the default value is true. For all other styles, the default value is false. This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */
+  explode?: boolean
+  /** When this is true, parameter values are serialized using reserved expansion, as defined by RFC6570, which allows RFC3986's reserved character set, as well as percent-encoded triples, to pass through unchanged, while still percent-encoding all other disallowed characters (including % outside of percent-encoded triples). The default value is false. This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */
+  allowReserved?: boolean
 }

--- a/packages/workspace-store/src/schemas/v3.1/strict/encoding.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/encoding.ts
@@ -17,12 +17,14 @@ export const EncodingObjectSchemaDefinition = Type.Object({
   /** A map allowing additional information to be provided as headers. Content-Type is described separately and SHALL be ignored in this section. This field SHALL be ignored if the request body media type is not a multipart. */
   headers: Type.Optional(Type.Record(Type.String(), Type.Union([HeaderObjectRef, reference(HeaderObjectRef)]))),
   /** Describes how a specific property value will be serialized depending on its type. See the Parameter Object for details on the style field. The behavior follows the same values as query parameters, including default values. Valid values are "form", "spaceDelimited", "pipeDelimited", and "deepObject". This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */
-style: Type.Optional(Type.Union([
-  Type.Literal('form'),
-  Type.Literal('spaceDelimited'),
-  Type.Literal('pipeDelimited'),
-  Type.Literal('deepObject')
-])),
+  style: Type.Optional(
+    Type.Union([
+      Type.Literal('form'),
+      Type.Literal('spaceDelimited'),
+      Type.Literal('pipeDelimited'),
+      Type.Literal('deepObject'),
+    ]),
+  ),
   /** When this is true, property values of type array or object generate separate parameters for each value of the array, or key-value-pair of the map. For other types of properties this field has no effect. When style is "form", the default value is true. For all other styles, the default value is false. This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */
   explode: Type.Optional(Type.Boolean()),
   /** When this is true, parameter values are serialized using reserved expansion, as defined by RFC6570, which allows RFC3986's reserved character set, as well as percent-encoded triples, to pass through unchanged, while still percent-encoding all other disallowed characters (including % outside of percent-encoded triples). The default value is false. This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */
@@ -42,7 +44,7 @@ export type EncodingObject = {
   /** A map allowing additional information to be provided as headers. Content-Type is described separately and SHALL be ignored in this section. This field SHALL be ignored if the request body media type is not a multipart. */
   headers?: Record<string, ReferenceType<HeaderObject>>
   /** Describes how a specific property value will be serialized depending on its type. See the Parameter Object for details on the style field. The behavior follows the same values as query parameters, including default values. Valid values are "form", "spaceDelimited", "pipeDelimited", and "deepObject". This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */
-  style?: string
+  style?: 'form' | 'spaceDelimited' | 'pipeDelimited' | 'deepObject' | undefined
   /** When this is true, property values of type array or object generate separate parameters for each value of the array, or key-value-pair of the map. For other types of properties this field has no effect. When style is "form", the default value is true. For all other styles, the default value is false. This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */
   explode?: boolean
   /** When this is true, parameter values are serialized using reserved expansion, as defined by RFC6570, which allows RFC3986's reserved character set, as well as percent-encoded triples, to pass through unchanged, while still percent-encoding all other disallowed characters (including % outside of percent-encoded triples). The default value is false. This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */

--- a/packages/workspace-store/src/schemas/v3.1/strict/encoding.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/encoding.ts
@@ -17,7 +17,12 @@ export const EncodingObjectSchemaDefinition = Type.Object({
   /** A map allowing additional information to be provided as headers. Content-Type is described separately and SHALL be ignored in this section. This field SHALL be ignored if the request body media type is not a multipart. */
   headers: Type.Optional(Type.Record(Type.String(), Type.Union([HeaderObjectRef, reference(HeaderObjectRef)]))),
   /** Describes how a specific property value will be serialized depending on its type. See the Parameter Object for details on the style field. The behavior follows the same values as query parameters, including default values. Valid values are "form", "spaceDelimited", "pipeDelimited", and "deepObject". This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */
-  style: Type.Optional(Type.String()),
+style: Type.Optional(Type.Union([
+  Type.Literal('form'),
+  Type.Literal('spaceDelimited'),
+  Type.Literal('pipeDelimited'),
+  Type.Literal('deepObject')
+])),
   /** When this is true, property values of type array or object generate separate parameters for each value of the array, or key-value-pair of the map. For other types of properties this field has no effect. When style is "form", the default value is true. For all other styles, the default value is false. This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */
   explode: Type.Optional(Type.Boolean()),
   /** When this is true, parameter values are serialized using reserved expansion, as defined by RFC6570, which allows RFC3986's reserved character set, as well as percent-encoded triples, to pass through unchanged, while still percent-encoding all other disallowed characters (including % outside of percent-encoded triples). The default value is false. This field SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data. If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2353,6 +2353,9 @@ importers:
 
   packages/snippetz:
     dependencies:
+      '@scalar/helpers':
+        specifier: workspace:*
+        version: link:../helpers
       '@scalar/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
When a `multipart/form-data` request body had a property of type `object` (like a `props` field with sub-fields), we were flattening it into multiple parts with dotted keys (`props.name`, `props.description`, …). Servers don't expect that — the OpenAPI spec says complex properties in multipart should be sent as a single JSON-encoded part.

Now we send one part per object, encoded as JSON. So instead of three garbled `props.*` form fields, you get one clean `props={"name":"…","description":"…"}` part with `Content-Type: application/json`.

**Before**

```bash
curl /widget/v1/widgets \
  --request POST \
  --header 'Content-Type: multipart/form-data' \
  --form 'file=@filename' \
  --form 'props.name=' \
  --form 'props.description='
```

**After**

```bash
curl https://void.scalar.com/widget/v1/widgets \
  --request POST \
  --header 'Content-Type: multipart/form-data' \
  --form 'file=@filename' \
  --form 'props={
  "name": "",
  "description": "",
  "created_at": null
};type=application/json'
```

## More examples

While fixing the original report we noticed `process-body.ts` ignored the Encoding Object's `style` / `explode` / `allowReserved` and `contentType` fields almost entirely. The PR now implements them per OAS 3.1.x §Encoding Object for both `multipart/form-data` and `application/x-www-form-urlencoded`. A few representative cases:

### 1. `encoding.style: form` + `explode: true` on a nested object

Many real-world specs use `style: form, explode: true` to declare that an object property should be split into one form field per inner key (no parent prefix), mirroring how query parameters expand.

```yaml
content:
  multipart/form-data:
    schema:
      type: object
      properties:
        props:
          type: object
          properties:
            name: { type: string, example: widget }
            count: { type: integer, example: 3 }
    encoding:
      props:
        style: form
        explode: true
```

Generates:

```bash
curl https://example.com/widgets \
  --request POST \
  --header 'Content-Type: multipart/form-data' \
  --form 'name=widget' \
  --form 'count=3'
```

Inner keys become part names; the outer `props` name disappears, matching the Style Examples table (`?R=100&G=200&B=150`).

### 2. `encoding.style: deepObject` for nested settings

A common pattern for "settings" or "filter" objects where the API wants `parent[child]` bracket notation:

```yaml
content:
  multipart/form-data:
    schema:
      type: object
      properties:
        props:
          type: object
          properties:
            name: { type: string, example: widget }
            meta:
              type: object
              properties:
                region: { type: string, example: eu }
    encoding:
      props:
        style: deepObject
        explode: true
```

Generates:

```bash
curl https://example.com/widgets \
  --request POST \
  --header 'Content-Type: multipart/form-data' \
  --form 'props[name]=widget' \
  --form 'props[meta][region]=eu'
```

Arbitrary nesting via brackets — the spec only defines one level, but we recurse so deeper structures still reach the wire (everything beyond level one is implementation-defined per OAS §Appendix C).

### 3. `encoding.contentType` with a `+json` vendor media type

JSON:API, HAL, and other API styles use `application/vnd.*+json` (RFC 6839). When an author overrides the part's contentType to such a type, the request goes out with that header **and** the cURL snippet now pretty-prints the body.

```yaml
content:
  multipart/form-data:
    schema:
      type: object
      properties:
        settings:
          type: object
          properties:
            enabled: { type: boolean, example: true }
    encoding:
      settings:
        contentType: application/vnd.api+json
```

Generates:

```bash
curl https://example.com \
  --request POST \
  --header 'Content-Type: multipart/form-data' \
  --form 'settings={
  "enabled": true
};type=application/vnd.api+json'
```

Previously the `--form` value would have stayed on one line because the cURL plugin only matched the exact string `application/json`. The detection now follows RFC 6839 `+json` and parameterized variants like `application/json;charset=utf-8`.

### 4. `style` on `application/x-www-form-urlencoded`

Per spec, `encoding.style` applies to urlencoded bodies just as it does to multipart. Previously this was a silent no-op; we now route through the same RFC6570 serializers used for multipart and query parameters.

```yaml
content:
  application/x-www-form-urlencoded:
    schema:
      type: object
      properties:
        props:
          type: object
          properties:
            name: { type: string, example: widget }
            count: { type: integer, example: 3 }
    encoding:
      props:
        style: form
        explode: true
```

Generates:

```bash
curl https://example.com \
  --request POST \
  --header 'Content-Type: application/x-www-form-urlencoded' \
  --data-urlencode 'name=widget' \
  --data-urlencode 'count=3'
```

Without an explicit `encoding` block, urlencoded bodies still use the legacy dotted-key flattening (`props.name=widget`) for backwards compatibility — opt into spec-correct behavior by declaring `style`.

### 5. `style: form, explode: false` on an array

The "single comma-joined part" form, which some Rails / PHP backends parse natively:

```yaml
content:
  multipart/form-data:
    schema:
      type: object
      properties:
        tags:
          type: array
          items: { type: string }
          example: [a, b, c]
    encoding:
      tags:
        style: form
        explode: false
```

Generates:

```bash
curl https://example.com \
  --request POST \
  --header 'Content-Type: multipart/form-data' \
  --form 'tags=a,b,c'
```

## Ticket

See #4834


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-body and query parameter serialization for `multipart/form-data` and `application/x-www-form-urlencoded`, which can alter the wire shape sent to servers and generated snippets. Risk is mitigated by extensive new test coverage, but regressions are possible for consumers relying on the previous dotted-key flattening behavior.
> 
> **Overview**
> **Aligns form body serialization with OpenAPI 3.1 Encoding Object rules.** `process-body` now (1) emits top-level multipart object/complex array values as a single JSON part (defaulting to `application/json`), (2) supports `encoding.style`/`explode`/`allowReserved` for both multipart and urlencoded bodies by routing through RFC6570 serializers, and (3) ignores `encoding.contentType` on `application/x-www-form-urlencoded` when it’s the only encoding hint.
> 
> **Improves generated cURL snippets for JSON bodies/parts.** The cURL plugin now detects JSON via `application/*+json` and parameterized JSON media types and pretty-prints JSON for both `--data` bodies and multipart `--form` parts when the value parses as JSON.
> 
> **Schema/types updated.** The workspace-store `EncodingObject` schema/type now exposes `style`, `explode`, and `allowReserved`, with new/updated tests covering the new serialization behavior and deepObject fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dafb4b0a4e027a1f2f1dec2089b14a428399fd1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

