### PR TITLE
fix(workspace-store, api-client): share executable URL build for copy and buildRequest

### DIFF
--- a/.changeset/floppy-houses-prove.md
+++ b/.changeset/floppy-houses-prove.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-client': patch
+---
+
+fix(workspace-store, api-client): share executable URL build for copy and buildRequest

--- a/.changeset/floppy-houses-prove.md
+++ b/.changeset/floppy-houses-prove.md
@@ -3,4 +3,6 @@
 '@scalar/api-client': patch
 ---
 
-fix(workspace-store, api-client): share executable URL build for copy and buildRequest
+fix: share executable URL build for copy and buildRequest
+
+Copy URL from the operation address bar now matches the URL that is actually sent: path parameters, operation query string, environment substitution, and security schemes that use in: query are all applied the same way as Send.

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -199,12 +199,6 @@ const cancelRequest = () => abortController.value?.abort(ERRORS.REQUEST_ABORTED)
  * `resolveExecutableRequestUrl`), including security query params.
  */
 const copyAddressBarUrl = async (): Promise<void> => {
-  const variablesStore = createVariablesStoreForRequest()
-  const envVariables = {
-    ...getEnvironmentVariables(environment),
-    ...variablesStore.getVariables(),
-  }
-
   const { request } = requestFactory({
     defaultHeaders,
     environment,
@@ -220,7 +214,7 @@ const copyAddressBarUrl = async (): Promise<void> => {
     requestBodyCompositionSelection,
   })
 
-  await copyToClipboard(resolveExecutableRequestUrl(request, envVariables))
+  await copyToClipboard(resolveExecutableRequestUrl(request, getEnvironmentVariables(environment)))
 }
 
 /** Execute the current operation example */

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -97,6 +97,7 @@ import {
   AVAILABLE_CLIENTS,
   type AvailableClients,
 } from '@scalar/types/snippetz'
+import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { useToasts } from '@scalar/use-toasts'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { SelectedSecurity } from '@scalar/workspace-store/entities/auth'
@@ -111,6 +112,7 @@ import {
   createVariablesStoreForRequest,
   getEnvironmentVariables,
   requestFactory,
+  resolveExecutableRequestUrl,
   type MergedSecuritySchemes,
   type RequestPayload,
   type SecuritySchemeObjectSecret,
@@ -182,6 +184,7 @@ const {
 const clientOptions = computed(() => generateClientOptions(httpClients))
 
 const { toast } = useToasts()
+const { copyToClipboard } = useClipboard()
 
 // Refs
 const abortController = ref<AbortController | null>(null)
@@ -190,6 +193,35 @@ const requestPayload = ref<RequestPayload | null>(null)
 
 /** Cancel the request */
 const cancelRequest = () => abortController.value?.abort(ERRORS.REQUEST_ABORTED)
+
+/**
+ * Copy the executable URL — same pipeline as Send (`requestFactory` +
+ * `resolveExecutableRequestUrl`), including security query params.
+ */
+const copyAddressBarUrl = async (): Promise<void> => {
+  const variablesStore = createVariablesStoreForRequest()
+  const envVariables = {
+    ...getEnvironmentVariables(environment),
+    ...variablesStore.getVariables(),
+  }
+
+  const { request } = requestFactory({
+    defaultHeaders,
+    environment,
+    exampleName: exampleKey,
+    globalCookies: [...workspaceCookies, ...documentCookies],
+    method,
+    operation,
+    path,
+    proxyUrl,
+    server,
+    selectedSecuritySchemes,
+    isElectron: isElectron(),
+    requestBodyCompositionSelection,
+  })
+
+  await copyToClipboard(resolveExecutableRequestUrl(request, envVariables))
+}
 
 /** Execute the current operation example */
 const handleExecute = async () => {
@@ -347,10 +379,12 @@ const handleExecute = async () => {
 onMounted(() => {
   eventBus.on('operation:send:request:hotkey', handleExecute)
   eventBus.on('operation:cancel:request', cancelRequest)
+  eventBus.on('copy-url:address-bar', copyAddressBarUrl)
 })
 onBeforeUnmount(() => {
   eventBus.off('operation:send:request:hotkey', handleExecute)
   eventBus.off('operation:cancel:request', cancelRequest)
+  eventBus.off('copy-url:address-bar', copyAddressBarUrl)
 })
 
 const operationHistory = computed<History[]>(() =>

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -214,7 +214,9 @@ const copyAddressBarUrl = async (): Promise<void> => {
     requestBodyCompositionSelection,
   })
 
-  await copyToClipboard(resolveExecutableRequestUrl(request, getEnvironmentVariables(environment)))
+  await copyToClipboard(
+    resolveExecutableRequestUrl(request, getEnvironmentVariables(environment)),
+  )
 }
 
 /** Execute the current operation example */

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -41,20 +41,14 @@ import {
 import { getSelector } from '@scalar/helpers/dom/get-selector'
 import { REQUEST_METHODS } from '@scalar/helpers/http/http-info'
 import type { HttpMethod as HttpMethodType } from '@scalar/helpers/http/http-methods'
-import { replaceEnvVariables } from '@scalar/helpers/regex/replace-variables'
 import { extractServerFromPath } from '@scalar/helpers/url/extract-server-from-path'
 import { ScalarIconCopy, ScalarIconWarningCircle } from '@scalar/icons'
 import { EditorView } from '@scalar/use-codemirror'
-import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import type {
   ApiReferenceEvents,
   ServerMeta,
   WorkspaceEventBus,
 } from '@scalar/workspace-store/events'
-import {
-  getEnvironmentVariables,
-  getResolvedUrl,
-} from '@scalar/workspace-store/request-example'
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
 import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import {
@@ -339,17 +333,9 @@ const handlePathBackspace = (event: KeyboardEvent): void => {
   }
 }
 
-// ───────────────────────────────────────────────────────────────────
-// Clipboard
-// ───────────────────────────────────────────────────────────────────
-
-const { copyToClipboard } = useClipboard()
-
-/** Copy the fully resolved URL (with environment variables applied) */
-const copyUrl = async (): Promise<void> => {
-  const resolvedUrl = getResolvedUrl({ server, path })
-  const variables = getEnvironmentVariables(environment)
-  await copyToClipboard(replaceEnvVariables(resolvedUrl, variables))
+/** Address bar copy is handled in OperationBlock (same URL as Send). */
+const requestCopyUrl = (): void => {
+  eventBus.emit('copy-url:address-bar')
 }
 
 // ───────────────────────────────────────────────────────────────────
@@ -380,7 +366,6 @@ onMounted(() => {
   unsubscribes.push(
     eventBus.on('ui:focus:address-bar', handleFocusAddressBar),
     eventBus.on('ui:focus:send-button', handleFocusSendButton),
-    eventBus.on('copy-url:address-bar', copyUrl),
     eventBus.on('hooks:on:request:sent', startLoading),
     eventBus.on('hooks:on:request:complete', stopLoading),
   )
@@ -479,7 +464,7 @@ defineExpose({
         class="hover:bg-b-3 mx-1"
         size="xs"
         variant="ghost"
-        @click="copyUrl">
+        @click="requestCopyUrl">
         <ScalarIconCopy />
         <span class="sr-only">Copy URL</span>
       </ScalarButton>

--- a/packages/workspace-store/src/request-example/builder/build-request.test.ts
+++ b/packages/workspace-store/src/request-example/builder/build-request.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { RequestFactory } from '@/request-example/builder/request-factory'
 
-import { buildRequest } from './build-request'
+import { buildRequest, resolveExecutableRequestUrl } from './build-request'
 
 const createFactory = (overrides: Partial<RequestFactory> = {}): RequestFactory => ({
   options: {},
@@ -708,5 +708,25 @@ describe('buildRequest', () => {
     const values = (requestInit.headers as Headers).get('X-Custom')
     expect(values).toContain('existing')
     expect(values).toContain('from-security')
+  })
+})
+
+describe('resolveExecutableRequestUrl', () => {
+  it('includes security query params in the URL like buildRequest', () => {
+    const url = resolveExecutableRequestUrl(
+      createFactory({
+        security: [{ in: 'query', name: 'api_key', value: 'secret' }],
+      }),
+      {},
+    )
+    expect(new URL(url).searchParams.get('api_key')).toBe('secret')
+  })
+
+  it('matches buildRequest URL when the request is not proxied', () => {
+    const factory = createFactory({
+      path: { raw: '/users/{id}', variables: { id: '7' } },
+      proxyUrl: '',
+    })
+    expect(resolveExecutableRequestUrl(factory, {})).toBe(buildRequest(factory, { envVariables: {} }).requestPayload[0])
   })
 })

--- a/packages/workspace-store/src/request-example/builder/build-request.ts
+++ b/packages/workspace-store/src/request-example/builder/build-request.ts
@@ -7,6 +7,7 @@ import { buildRequestCookieHeader } from '@/request-example/builder/header/build
 import { applyAllowReservedToUrl } from '@/request-example/builder/helpers/apply-allow-reserved-to-url'
 import type { RequestFactory } from '@/request-example/builder/request-factory'
 import { resolveRequestFactoryUrl } from '@/request-example/builder/resolve-request-factory-url'
+import type { BuildRequestSecurityResult } from '@/request-example/builder/security/build-request-security'
 import { contextFunctions, isContextFunctionName } from '@/request-example/functions'
 import type { XScalarCookie } from '@/schemas/extensions/general/x-scalar-cookies'
 
@@ -26,6 +27,58 @@ const FORBIDDEN_HEADERS: ForbiddenHeaderRewrite[] = [
   { header: 'referer', scalarHeader: X_SCALAR_REFERER },
   { header: 'user-agent', scalarHeader: X_SCALAR_USER_AGENT },
 ]
+
+const formatSecurityValue = (
+  security: BuildRequestSecurityResult,
+  replace: (value: string) => string | null,
+): string => {
+  const substitutedValue = replaceEnvVariables(security.value, replace)
+  if (security.format === 'basic') {
+    return `Basic ${encodeBase64(substitutedValue)}`
+  }
+
+  if (security.format === 'bearer') {
+    return `Bearer ${substitutedValue}`
+  }
+
+  return substitutedValue
+}
+
+const createEnvReplaceFn = (envVariables: Record<string, string>): ((value: string) => string | null) => {
+  return (value: string): string | null => {
+    if (isContextFunctionName(value)) {
+      return contextFunctions[value].fn() ?? null
+    }
+    return envVariables[value] ?? null
+  }
+}
+
+/**
+ * Resolved request URL string (path vars, operation query, **security query**
+ * params, env substitution, reserved-query rules) without proxy rewriting —
+ * aligned with {@link buildRequest} before `redirectToProxy`.
+ */
+export const resolveExecutableRequestUrl = (request: RequestFactory, envVariables: Record<string, string>): string => {
+  const replace = createEnvReplaceFn(envVariables)
+
+  const securityQueryParams = new URLSearchParams()
+  if (!request.options?.disableSecurity) {
+    request.security.forEach((security) => {
+      if (security.in !== 'query') {
+        return
+      }
+      const name = replaceEnvVariables(security.name, replace)
+      securityQueryParams.append(name, formatSecurityValue(security, replace))
+    })
+  }
+
+  const requestUrl = resolveRequestFactoryUrl(request, {
+    envVariables: replace,
+    securityQueryParams,
+  })
+
+  return applyAllowReservedToUrl(requestUrl, request.allowedReservedQueryParameters ?? new Set())
+}
 
 /**
  * Built request response
@@ -49,12 +102,7 @@ export const buildRequest = (
   },
 ): BuildRequestResponse => {
   /** Replace the value with the environment variable or context function */
-  const replace = (value: string): string | null => {
-    if (isContextFunctionName(value)) {
-      return contextFunctions[value].fn() ?? null
-    }
-    return options.envVariables[value] ?? null
-  }
+  const replace = createEnvReplaceFn(options.envVariables)
 
   /** Create a new abort controller */
   const controller = new AbortController()
@@ -116,18 +164,7 @@ export const buildRequest = (
       // - For 'basic': prefix with 'Basic' and base64-encode the value (username:password).
       // - For 'bearer': prefix with 'Bearer'.
       // - Otherwise: use the substituted value as is (for API keys, etc).
-      const securityValue = (() => {
-        const substitutedValue = replaceEnvVariables(security.value, replace)
-        if (security.format === 'basic') {
-          return `Basic ${encodeBase64(substitutedValue)}`
-        }
-
-        if (security.format === 'bearer') {
-          return `Bearer ${substitutedValue}`
-        }
-
-        return substitutedValue
-      })()
+      const securityValue = formatSecurityValue(security, replace)
 
       if (security.in === 'header') {
         // Set the header (use replaced header name so {{ env }} placeholders work)

--- a/packages/workspace-store/src/request-example/builder/index.ts
+++ b/packages/workspace-store/src/request-example/builder/index.ts
@@ -1,6 +1,10 @@
 export { getExampleFromBody } from './body/get-request-body-example'
 export { getSelectedBodyContentType } from './body/get-selected-body-content-type'
-export { type RequestPayload, buildRequest } from './build-request'
+export {
+  type RequestPayload,
+  buildRequest,
+  resolveExecutableRequestUrl,
+} from './build-request'
 export { deSerializeParameter } from './header/de-serialize-parameter'
 export { filterGlobalCookie } from './header/filter-global-cookies'
 export {
@@ -19,6 +23,7 @@ export { getResolvedUrl } from './helpers/get-resolved-url'
 export { getServerVariables } from './helpers/get-server-variables'
 export type { RequestFactory } from './request-factory'
 export { requestFactory } from './request-factory'
+export { resolveRequestFactoryUrl } from './resolve-request-factory-url'
 export { buildRequestSecurity } from './security/build-request-security'
 export type {
   ApiKeyObjectSecret,

--- a/packages/workspace-store/src/request-example/index.ts
+++ b/packages/workspace-store/src/request-example/index.ts
@@ -25,6 +25,8 @@ export {
   getSelectedBodyContentType,
   getServerVariables,
   requestFactory,
+  resolveExecutableRequestUrl,
+  resolveRequestFactoryUrl,
   serializeContentValue,
   serializeDeepObjectStyle,
   serializeFormStyle,


### PR DESCRIPTION
Copy URL from the operation address bar now matches the URL that is actually sent: path parameters, operation query string, environment substitution, and security schemes that use in: query are all applied the same way as Send.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the copied URL is constructed by reusing the request-building pipeline (including security query params and env substitution); risk is moderate because it affects user-visible URL sharing and request URL generation behavior.
> 
> **Overview**
> Fixes the address-bar **Copy URL** action to use the same URL-resolution pipeline as **Send**, so the copied link matches the actual executed request (path params, operation query, environment/context substitution, and `in: query` security schemes).
> 
> Adds `resolveExecutableRequestUrl` in `@scalar/workspace-store` to compute the pre-proxy executable URL and refactors shared env/security formatting logic; exports this helper and adds tests to ensure parity with `buildRequest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04a1a040787e8f189da5aaa077c48a7bdb5a1ed7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->