### PR TITLE
feat(helpers): add `normalizationForm` and `stripAccents` options to `slugify`

### DIFF
--- a/.changeset/slugify-normalization-options.md
+++ b/.changeset/slugify-normalization-options.md
@@ -1,0 +1,8 @@
+---
+'@scalar/helpers': patch
+---
+
+feat(helpers): add `normalizationForm` and `stripAccents` options to `slugify` and `slugger`
+
+- `normalizationForm` (`'NFC' | 'NFD' | 'NFKC' | 'NFKD'`, default `'NFC'`) passes the chosen form to `String.prototype.normalize()` before slugifying.
+- `stripAccents` (`boolean`, default `false`) decomposes accented letters via NFD and removes all Unicode combining marks so e.g. `"Crème Brûlée"` becomes `"creme-brulee"`. Takes precedence over `normalizationForm`.

--- a/packages/helpers/src/string/slugger.test.ts
+++ b/packages/helpers/src/string/slugger.test.ts
@@ -97,4 +97,21 @@ describe('slugger', () => {
     slug('MyAPI v1.2')
     expect(slug('MyAPI v1.2')).toBe('myapi-v1.2-1')
   })
+
+  it('strips accents when stripAccents is configured', () => {
+    const { slug } = slugger({ stripAccents: true })
+    expect(slug('Crème Brûlée')).toBe('creme-brulee')
+  })
+
+  it('tracks collisions for accent-stripped slugs', () => {
+    const { slug } = slugger({ stripAccents: true })
+    slug('Crème')
+    expect(slug('Creme')).toBe('creme-1')
+  })
+
+  it('applies normalizationForm when configured', () => {
+    const { slug } = slugger({ normalizationForm: 'NFKC' })
+    // fi ligature normalizes to "fi" under NFKC
+    expect(slug('\uFB01le')).toBe('file')
+  })
 })

--- a/packages/helpers/src/string/slugify.test.ts
+++ b/packages/helpers/src/string/slugify.test.ts
@@ -82,4 +82,56 @@ describe('slugify', () => {
   it('keeps allowed special chars while preserving case when configured', () => {
     expect(slugify('MyAPI v1.2', { preserveCase: true, allowedSpecialChars: '.' })).toBe('MyAPI-v1.2')
   })
+
+  // normalizationForm
+
+  it('uses NFC normalization by default', () => {
+    // Café written as NFD (e + combining acute) should round-trip to NFC form.
+    expect(slugify('cafe\u0301')).toBe('café')
+  })
+
+  it('preserves NFD decomposed form when normalizationForm is NFD', () => {
+    // With NFD output, the combining acute stays as a separate code point.
+    const result = slugify('café', { normalizationForm: 'NFD' })
+    // The result should be NFD-normalized, so the é is decomposed.
+    expect(result).toBe('cafe\u0301')
+  })
+
+  it('applies NFKC normalization to compatibility equivalents', () => {
+    // The fi ligature (U+FB01) decomposes to "fi" under NFKC/NFKD.
+    expect(slugify('\uFB01le', { normalizationForm: 'NFKC' })).toBe('file')
+  })
+
+  it('applies NFKD normalization to compatibility equivalents', () => {
+    expect(slugify('\uFB01le', { normalizationForm: 'NFKD' })).toBe('file')
+  })
+
+  // stripAccents
+
+  it('strips accent marks from Latin letters', () => {
+    expect(slugify('Crème Brûlée', { stripAccents: true })).toBe('creme-brulee')
+  })
+
+  it('strips accents from a variety of diacritics', () => {
+    expect(slugify('naïve résumé façade', { stripAccents: true })).toBe('naive-resume-facade')
+  })
+
+  it('strips accents while preserving case', () => {
+    expect(slugify('Héllo Wörld', { stripAccents: true, preserveCase: true })).toBe('Hello-World')
+  })
+
+  it('strips accents from non-Latin scripts with diacritics', () => {
+    // Vietnamese uses combining diacritics; stripping them degrades but does not break slugging.
+    const result = slugify('Hà Nội', { stripAccents: true })
+    expect(result).toBe('ha-noi')
+  })
+
+  it('stripAccents takes precedence over normalizationForm', () => {
+    // Even if normalizationForm is set to NFKC, stripAccents forces NFD internally.
+    expect(slugify('Crème', { stripAccents: true, normalizationForm: 'NFKC' })).toBe('creme')
+  })
+
+  it('leaves plain ASCII unchanged when stripAccents is true', () => {
+    expect(slugify('Hello World', { stripAccents: true })).toBe('hello-world')
+  })
 })

--- a/packages/helpers/src/string/slugify.ts
+++ b/packages/helpers/src/string/slugify.ts
@@ -2,8 +2,18 @@ const RE_NON_WORD = /[^\p{L}\p{M}\p{N}\s_-]/gu
 const RE_SPACES = /[\s_-]+/g
 const RE_TRIM_HYPHENS = /^-+|-+$/g
 
+/**
+ * Matches all Unicode combining marks (accents, diacritics, etc.).
+ * Used with NFD-decomposed text so base letters and their marks are
+ * separate code points and the marks can be dropped cleanly.
+ */
+const RE_COMBINING_MARKS = /\p{M}/gu
+
 /** Cache of compiled non-word regexes keyed by their `allowedSpecialChars` string. */
 const reNonWordCache = new Map<string, RegExp>()
+
+/** Unicode normalization form identifiers as defined by the ECMAScript specification. */
+export type NormalizationForm = 'NFC' | 'NFD' | 'NFKC' | 'NFKD'
 
 export type SlugifyOptions = {
   /**
@@ -19,6 +29,26 @@ export type SlugifyOptions = {
    * @example slugify('MyAPI', { preserveCase: true }) // 'MyAPI'
    */
   preserveCase?: boolean
+  /**
+   * Unicode normalization form applied to the input before slugifying.
+   * Has no effect when `stripAccents` is `true`, which always uses NFD
+   * internally to decompose accented letters before stripping them.
+   * @default 'NFC'
+   * @example slugify('ﬁle', { normalizationForm: 'NFKC' }) // 'file' (ligature → two letters)
+   */
+  normalizationForm?: NormalizationForm
+  /**
+   * When `true`, strips combining diacritical marks (accents) from letters,
+   * producing ASCII-friendly slugs from accented text.
+   *
+   * Internally normalizes to NFD so that base letters and their accent marks
+   * become separate code points, then removes all Unicode combining marks
+   * (`\p{M}`). This takes precedence over `normalizationForm`.
+   *
+   * @default false
+   * @example slugify('Crème Brûlée', { stripAccents: true }) // 'creme-brulee'
+   */
+  stripAccents?: boolean
 }
 
 /**
@@ -30,13 +60,15 @@ export type SlugifyOptions = {
  *
  * Pass {@link SlugifyOptions} to adjust this behaviour.
  *
- * | Option               | Type       | Default | Description                                                                                  |
- * |----------------------|------------|---------|----------------------------------------------------------------------------------------------|
- * | `allowedSpecialChars`| `string`   | `""`    | Extra characters that should survive the non-word filter (e.g. `"."` keeps dots so `"v1.2"` → `"v1.2"` instead of `"v12"`). |
- * | `preserveCase`       | `boolean`  | `false` | When `true`, the case is preserved. By default we lowercase the string |
+ * | Option               | Type                | Default | Description                                                                                                             |
+ * |----------------------|---------------------|---------|------------------------------------------------------------------------------------------------------------------------ |
+ * | `allowedSpecialChars`| `string`            | `""`    | Extra characters that should survive the non-word filter (e.g. `"."` keeps dots so `"v1.2"` → `"v1.2"` instead of `"v12"`). |
+ * | `preserveCase`       | `boolean`           | `false` | When `true`, the case is preserved. By default we lowercase the string.                                                 |
+ * | `normalizationForm`  | `NormalizationForm` | `'NFC'` | Unicode normalization form to apply. Ignored when `stripAccents` is `true`.                                             |
+ * | `stripAccents`       | `boolean`           | `false` | When `true`, strips diacritical marks so e.g. `"Crème"` → `"creme"`. Takes precedence over `normalizationForm`.        |
  */
 export const slugify = (v: string, options: SlugifyOptions = {}) => {
-  const { allowedSpecialChars = '', preserveCase = false } = options
+  const { allowedSpecialChars = '', preserveCase = false, normalizationForm = 'NFC', stripAccents = false } = options
 
   // Compile the non-word regex once and cache it for future use.
   const reNonWord = (() => {
@@ -57,8 +89,14 @@ export const slugify = (v: string, options: SlugifyOptions = {}) => {
     return reNonWordWithAllowedSpecialChars
   })()
 
-  // Normalize before filtering so equivalent Unicode forms produce the same slug.
-  const normalized = v.slice(0, 255).trim().normalize('NFC')
+  const trimmed = v.slice(0, 255).trim()
+
+  // NFD decomposes accented letters into base letter + combining mark, so the
+  // marks can be stripped cleanly with a single regex pass.
+  const normalized = stripAccents
+    ? trimmed.normalize('NFD').replace(RE_COMBINING_MARKS, '')
+    : trimmed.normalize(normalizationForm)
+
   const result = preserveCase ? normalized : normalized.toLowerCase()
 
   return result.replace(reNonWord, '').replace(RE_SPACES, '-').replace(RE_TRIM_HYPHENS, '')

--- a/packages/helpers/src/string/slugify.ts
+++ b/packages/helpers/src/string/slugify.ts
@@ -12,7 +12,13 @@ const RE_COMBINING_MARKS = /\p{M}/gu
 /** Cache of compiled non-word regexes keyed by their `allowedSpecialChars` string. */
 const reNonWordCache = new Map<string, RegExp>()
 
-/** Unicode normalization form identifiers as defined by the ECMAScript specification. */
+/**
+ * Unicode normalization forms used by `String.prototype.normalize()`:
+ * - `NFC`: canonical decomposition followed by recomposition (default for most text).
+ * - `NFD`: canonical decomposition (splits accents from base letters).
+ * - `NFKC`: compatibility decomposition followed by recomposition (folds ligatures and width variants).
+ * - `NFKD`: compatibility decomposition (like `NFKC` without recomposition).
+ */
 export type NormalizationForm = 'NFC' | 'NFD' | 'NFKC' | 'NFKD'
 
 export type SlugifyOptions = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds two new options to `SlugifyOptions` (and therefore `slugger`) in `@scalar/helpers`:

### `normalizationForm?: NormalizationForm`

Controls which Unicode normalization form (`'NFC' | 'NFD' | 'NFKC' | 'NFKD'`) is applied before slugifying. Defaults to `'NFC'` (the existing hardcoded behaviour). Ignored when `stripAccents` is `true`.

```ts
slugify('\uFB01le', { normalizationForm: 'NFKC' }) // 'file' (ﬁ ligature → fi)
```

### `stripAccents?: boolean`

When `true`, decomposes accented letters via NFD and strips all Unicode combining marks (`\p{M}`), producing ASCII-friendly slugs. Takes precedence over `normalizationForm`. Defaults to `false`.

```ts
slugify('Crème Brûlée', { stripAccents: true }) // 'creme-brulee'
slugify('Héllo Wörld', { stripAccents: true, preserveCase: true }) // 'Hello-World'
```

## Changes

- `packages/helpers/src/string/slugify.ts` — new `NormalizationForm` type, two new fields on `SlugifyOptions`, updated JSDoc table, updated `slugify()` implementation, plus reviewer-requested explanations for each normalization form value
- `packages/helpers/src/string/slugify.test.ts` — 10 new test cases covering both options and their interaction
- `packages/helpers/src/string/slugger.test.ts` — 3 new test cases confirming the options thread through `slugger()`
- `.changeset/slugify-normalization-options.md` — patch changeset for `@scalar/helpers`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fc967b0-2972-4d2b-816e-2739b4eabe74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fc967b0-2972-4d2b-816e-2739b4eabe74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

