### PR TITLE
docs: add documentation for group page property

### DIFF
--- a/.agents/skills/scalar-docs/SKILL.md
+++ b/.agents/skills/scalar-docs/SKILL.md
@@ -193,6 +193,22 @@ Collapsible section with children:
 
 Modes: `flat`, `nested`, `folder` (default).
 
+**Folder landing pages:** Add a `page` property to make clicking the folder navigate to a page:
+
+```json
+"/company": {
+  "type": "group",
+  "title": "Company",
+  "mode": "folder",
+  "page": { "type": "page", "title": "About Us", "filepath": "docs/company/index.md" },
+  "children": {
+    "/team": { "type": "page", "title": "Our Team", "filepath": "docs/company/team.md" }
+  }
+}
+```
+
+**Default open state:** Use `open: true` to expand a folder by default.
+
 #### Link (`type: "link"`)
 
 External URL:

--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -390,13 +390,15 @@ Groups allow you to organize related pages, API references, and links into colla
 
 ### Properties
 
-| Property   | Type                             | Required | Description                          |
-| ---------- | -------------------------------- | -------- | ------------------------------------ |
-| `type`     | `"group"`                        | Yes      | Must be `"group"`                    |
-| `title`    | `string`                         | No       | The display text in the navigation   |
-| `children` | `object`                         | Yes      | An object containing nested routes   |
-| `mode`     | `"flat" \| "nested" \| "folder"` | No       | How the group is displayed           |
-| `icon`     | `string`                         | No       | An icon to display next to the group |
+| Property   | Type                             | Required | Description                                                      |
+| ---------- | -------------------------------- | -------- | ---------------------------------------------------------------- |
+| `type`     | `"group"`                        | Yes      | Must be `"group"`                                                |
+| `title`    | `string`                         | No       | The display text in the navigation                               |
+| `children` | `object`                         | Yes      | An object containing nested routes                               |
+| `mode`     | `"flat" \| "nested" \| "folder"` | No       | How the group is displayed                                       |
+| `icon`     | `string`                         | No       | An icon to display next to the group                             |
+| `page`     | `object`                         | No       | A page to navigate to when clicking the folder (folder mode only) |
+| `open`     | `boolean`                        | No       | Whether the folder is expanded by default (folder mode only)     |
 
 ### Display Modes
 
@@ -440,6 +442,72 @@ Groups can contain other groups to create deep navigation hierarchies:
           }
         }
       }
+    }
+  }
+}
+```
+
+### Folder Landing Pages
+
+Folders can have an associated landing page using the `page` property. When a user clicks on the folder title in the sidebar, they navigate to this page instead of just expanding the folder. This is useful for sections that need both an overview page and child pages.
+
+```json
+"/company": {
+  "type": "group",
+  "title": "Company",
+  "mode": "folder",
+  "icon": "phosphor/regular/building",
+  "page": {
+    "type": "page",
+    "title": "About Us",
+    "filepath": "docs/company/index.md"
+  },
+  "children": {
+    "/team": {
+      "type": "page",
+      "title": "Our Team",
+      "filepath": "docs/company/team.md"
+    },
+    "/careers": {
+      "type": "page",
+      "title": "Careers",
+      "filepath": "docs/company/careers.md"
+    }
+  }
+}
+```
+
+In this example, clicking "Company" in the sidebar navigates to the "About Us" page (`docs/company/index.md`), while the folder can still be expanded to show "Our Team" and "Careers" as child pages.
+
+The `page` property accepts the same configuration as a regular page route:
+
+| Property      | Type      | Required | Description                        |
+| ------------- | --------- | -------- | ---------------------------------- |
+| `type`        | `"page"`  | Yes      | Must be `"page"`                   |
+| `title`       | `string`  | No       | The display text for the page      |
+| `filepath`    | `string`  | Yes      | Relative path to the markdown file |
+| `description` | `string`  | No       | A description for SEO and metadata |
+
+### Default Folder State
+
+By default, folders start in a collapsed state. Use the `open` property to have a folder expanded when the page loads:
+
+```json
+"/guides": {
+  "type": "group",
+  "title": "Guides",
+  "mode": "folder",
+  "open": true,
+  "children": {
+    "/quickstart": {
+      "type": "page",
+      "title": "Quickstart",
+      "filepath": "docs/guides/quickstart.md"
+    },
+    "/advanced": {
+      "type": "page",
+      "title": "Advanced Usage",
+      "filepath": "docs/guides/advanced.md"
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `page` property on `group` entries with `mode: "folder"` was not documented. This feature allows folders to have a landing page that opens when clicking the folder title, but users and developers were unaware of its existence.

Additionally, the `open` property for controlling whether folders are expanded by default was also undocumented.

## Solution

Added comprehensive documentation for both the `page` and `open` properties on group entries:

- **`page`**: Allows a folder to have a landing page that opens when clicking the folder title. Useful for sections like "Company" where clicking the folder should navigate to an "About Us" page while still allowing access to child pages like "Team" and "Careers".

- **`open`**: Controls whether a folder is expanded by default when the page loads.

### Changes

- `documentation/guides/docs/configuration/navigation.md`: Added `page` and `open` to the properties table, plus new sections explaining "Folder Landing Pages" and "Default Folder State" with examples.

- `.agents/skills/scalar-docs/SKILL.md`: Updated the group section to include information about the `page` and `open` properties for AI agent awareness.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed for docs-only changes -->
- [ ] I added tests. <!-- N/A for documentation -->
- [x] I updated the documentation.

## Ticket

Part of DOC-5381
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07SL9L6SJ0/p1778377123419199?thread_ts=1778377123.419199&cid=C07SL9L6SJ0)

<div><a href="https://cursor.com/agents/bc-e9e35c0d-3f72-5727-9cf0-773c6ad2ecfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9e35c0d-3f72-5727-9cf0-773c6ad2ecfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

