### PR TITLE
fix(proxy-scalar-com): improve scalar_url validation messages

### DIFF
--- a/projects/proxy-scalar-com/main.go
+++ b/projects/proxy-scalar-com/main.go
@@ -151,15 +151,15 @@ var forbiddenHeadersForProxy = []forbiddenHeaderRewrite{
 var scalarURLValidationErrors = []proxyValidationError{
 	{
 		statusCode: http.StatusBadRequest,
-		message:    "The `scalar_url` query parameter is required. Try to add `?scalar_url=https%3A%2F%2Fgalaxy.scalar.com%2Fplanets` to the URL.",
+		message:    "Bad Request: The `scalar_url` query parameter is required. Try to add `?scalar_url=https%3A%2F%2Fgalaxy.scalar.com%2Fplanets` to the URL.",
 	},
 	{
 		statusCode: http.StatusBadRequest,
-		message:    "The `scalar_url` query parameter must be an absolute URL. Relative URLs like `/foobar` are not supported.",
+		message:    "Bad Request: The `scalar_url` query parameter must be an absolute URL. Relative URLs like `/foobar` are not supported.",
 	},
 	{
 		statusCode: http.StatusForbidden,
-		message:    "Forbidden: access to private addresses is not allowed",
+		message:    "Forbidden: Access to private addresses is not allowed. Please use a public domain name.",
 	},
 }
 

--- a/projects/proxy-scalar-com/main.go
+++ b/projects/proxy-scalar-com/main.go
@@ -136,11 +136,31 @@ type forbiddenHeaderRewrite struct {
 	scalarHeader string
 }
 
+type proxyValidationError struct {
+	statusCode int
+	message    string
+}
+
 var forbiddenHeadersForProxy = []forbiddenHeaderRewrite{
 	{header: "date", scalarHeader: "x-scalar-date"},
 	{header: "dnt", scalarHeader: "x-scalar-dnt"},
 	{header: "referer", scalarHeader: "x-scalar-referer"},
 	{header: "user-agent", scalarHeader: "x-scalar-user-agent"},
+}
+
+var scalarURLValidationErrors = []proxyValidationError{
+	{
+		statusCode: http.StatusBadRequest,
+		message:    "The `scalar_url` query parameter is required. Try to add `?scalar_url=https%3A%2F%2Fgalaxy.scalar.com%2Fplanets` to the URL.",
+	},
+	{
+		statusCode: http.StatusBadRequest,
+		message:    "The `scalar_url` query parameter must be an absolute URL. Relative URLs like `/foobar` are not supported.",
+	},
+	{
+		statusCode: http.StatusForbidden,
+		message:    "Forbidden: access to private addresses is not allowed",
+	},
 }
 
 type streamingResponseWriter struct {
@@ -287,22 +307,10 @@ func (ps *ProxyServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 	// Get and validate the target URL from the `scalar_url` query parameter
 	target := r.URL.Query().Get("scalar_url")
 
-	// Show an error if the scalar_url is missing
-	if target == "" {
-		http.Error(w, "The `scalar_url` query parameter is required. Try to add `?scalar_url=https%3A%2F%2Fgalaxy.scalar.com%2Fplanets` to the URL.", http.StatusBadRequest)
-		return
-	}
-
-	// Validate the URL
-	remote, err := url.Parse(target)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
-		return
-	}
-
-	// Deny any private, link-local, or loopback addresses
-	if !ps.bypassCidr && isBlockedHost(remote.Host) {
-		http.Error(w, "Forbidden: access to private addresses is not allowed", http.StatusForbidden)
+	remote, validationErrors := ps.validateScalarURL(target)
+	if len(validationErrors) > 0 {
+		firstError := validationErrors[0]
+		http.Error(w, firstError.message, firstError.statusCode)
 		return
 	}
 
@@ -311,6 +319,38 @@ func (ps *ProxyServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 		// Log any errors
 		log.Printf("[Proxy Error:] %v\n", err)
 	}
+}
+
+func (ps *ProxyServer) validateScalarURL(target string) (*url.URL, []proxyValidationError) {
+	errors := []proxyValidationError{}
+
+	if target == "" {
+		errors = append(errors, scalarURLValidationErrors[0])
+		return nil, errors
+	}
+
+	remote, err := url.Parse(target)
+	if err != nil {
+		errors = append(errors, proxyValidationError{
+			statusCode: http.StatusServiceUnavailable,
+			message:    err.Error(),
+		})
+
+		return nil, errors
+	}
+
+	if !remote.IsAbs() || remote.Host == "" {
+		errors = append(errors, scalarURLValidationErrors[1])
+		return nil, errors
+	}
+
+	// Deny any private, link-local, or loopback addresses
+	if !ps.bypassCidr && isBlockedHost(remote.Host) {
+		errors = append(errors, scalarURLValidationErrors[2])
+		return nil, errors
+	}
+
+	return remote, errors
 }
 
 // executeProxyRequest handles the proxying logic

--- a/projects/proxy-scalar-com/main_test.go
+++ b/projects/proxy-scalar-com/main_test.go
@@ -95,7 +95,7 @@ func TestBasicEndpoints(t *testing.T) {
 			t.Errorf("Expected status code %d, got %d", http.StatusBadRequest, w.Code)
 		}
 
-		expectedError := "The `scalar_url` query parameter is required. Try to add `?scalar_url=https%3A%2F%2Fgalaxy.scalar.com%2Fplanets` to the URL."
+		expectedError := scalarURLValidationErrors[0].message
 		if w.Body.String() != expectedError+"\n" {
 			t.Errorf("Expected error message about missing scalar_url parameter")
 		}
@@ -114,9 +114,25 @@ func TestBasicEndpoints(t *testing.T) {
 			t.Errorf("Expected status code %d, got %d", http.StatusBadRequest, w.Code)
 		}
 
-		expectedError := "The `scalar_url` query parameter is required. Try to add `?scalar_url=https%3A%2F%2Fgalaxy.scalar.com%2Fplanets` to the URL."
+		expectedError := scalarURLValidationErrors[0].message
 		if w.Body.String() != expectedError+"\n" {
 			t.Errorf("Expected error message about missing scalar_url parameter")
+		}
+	})
+
+	t.Run("Returns a descriptive error when scalar_url is relative", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?scalar_url=/foobar", nil)
+		w := httptest.NewRecorder()
+
+		proxyServer.handleRequest(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("Expected status code %d, got %d", http.StatusBadRequest, w.Code)
+		}
+
+		expectedError := scalarURLValidationErrors[1].message
+		if w.Body.String() != expectedError+"\n" {
+			t.Errorf("Expected relative URL validation error message")
 		}
 	})
 }
@@ -737,7 +753,7 @@ func TestSSEStreaming(t *testing.T) {
 func TestCidrPolicy(t *testing.T) {
 	proxyServer := NewProxyServer(false)
 
-	t.Run("Should not authorize localhost", func(t *testing.T) {
+	t.Run("Returns relative URL error for localhost without scheme", func(t *testing.T) {
 		// Create a new request
 		req := httptest.NewRequest(http.MethodGet, "/?scalar_url=localhost", nil)
 		w := httptest.NewRecorder()
@@ -746,8 +762,13 @@ func TestCidrPolicy(t *testing.T) {
 		proxyServer.handleRequest(w, req)
 
 		// Check the response
-		if w.Code != http.StatusForbidden {
-			t.Errorf("Expected status code %d, got %d", http.StatusForbidden, w.Code)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("Expected status code %d, got %d", http.StatusBadRequest, w.Code)
+		}
+
+		expectedError := scalarURLValidationErrors[1].message
+		if w.Body.String() != expectedError+"\n" {
+			t.Errorf("Expected relative URL validation error message")
 		}
 	})
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`projects/proxy-scalar-com` had duplicated inline `scalar_url` validation messages, and relative URLs like `/foobar` produced a forbidden/internal-address style error that did not explain the actual issue.

## Solution

- Centralized `scalar_url` validation messages into a single typed validation error array.
- Added `validateScalarURL` to return parsed URL data plus validation errors from one place.
- Added explicit handling for non-absolute/relative `scalar_url` values with a dedicated message.
- Updated tests to assert against centralized messages and added relative URL coverage.

**Before**

`?scalar_url=/foobar` (relative URL)

```
Forbidden: access to private addresses is not allowed
```

<img width="3028" height="690" alt="image" src="https://github.com/user-attachments/assets/99598201-c336-4396-80ec-674da94b87d5" />

**After**

```
Bad Request: The `scalar_url` query parameter must be an absolute URL. Relative URLs like `/foobar` are not supported.
```

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf95652c-1cb8-4bfa-a445-4c904872d3d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf95652c-1cb8-4bfa-a445-4c904872d3d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

