### PR TITLE
feat(api-client): edit nested multipart object properties as individual form rows

### DIFF
--- a/.changeset/multipart-nested-form-rows.md
+++ b/.changeset/multipart-nested-form-rows.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/workspace-store': patch
+---
+
+feat(api-client): expand nested object properties of multipart form-data schemas into individual editable rows (e.g. `props.name`, `props.description`); the wire still sends one `application/json` multipart part per top-level object property — both for the initial schema-derived example and for edited form rows

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
@@ -68,7 +68,7 @@ const objectToFormParams = (
 
   /** Ensure we do not include disabled items */
   const entries: [string, unknown][] = Array.isArray(obj)
-    ? obj.filter((item) => !item.isDisabled).map((item) => [String(item.name), item.value] as [string, unknown])
+    ? obj.filter((item) => !item.isDisabled).map((item) => [String(item.name), item.value])
     : Object.entries(obj)
 
   for (const [key, value] of entries) {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-body.ts
@@ -67,8 +67,8 @@ const objectToFormParams = (
   const params: Param[] = []
 
   /** Ensure we do not include disabled items */
-  const entries = Array.isArray(obj)
-    ? obj.filter((item) => !item.isDisabled).map((item) => [item.name, item.value])
+  const entries: [string, unknown][] = Array.isArray(obj)
+    ? obj.filter((item) => !item.isDisabled).map((item) => [String(item.name), item.value] as [string, unknown])
     : Object.entries(obj)
 
   for (const [key, value] of entries) {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.test.ts
@@ -394,6 +394,47 @@ describe('getFormBodyRows', () => {
       expect(result[0]?.isRequired).toBe(false)
     })
 
+    it('keeps the leaf schema + required flag on dotted-name array rows (after edits)', () => {
+      // Once the user edits any row, `example.value` is stored as a flat row array. The
+      // dotted name still needs to resolve to its nested leaf in the schema so the
+      // `Required` badge and per-field schema metadata survive across re-renders.
+      const example: ExampleObject = {
+        value: [
+          { name: 'file', value: '@filename', isDisabled: false },
+          { name: 'props.name', value: 'edited', isDisabled: false },
+          { name: 'props.description', value: '', isDisabled: false },
+          { name: 'props.created_at', value: '', isDisabled: false },
+        ],
+      }
+      const formBodySchema: SchemaObject = {
+        type: 'object',
+        required: ['file', 'props'],
+        properties: {
+          file: { type: 'string', format: 'binary' },
+          props: {
+            type: 'object',
+            required: ['name', 'description'],
+            properties: {
+              name: { type: 'string' },
+              description: { type: 'string' },
+              created_at: { type: 'string', format: 'date-time' },
+            },
+          },
+        },
+      }
+
+      const result = getFormBodyRows(example, 'multipart/form-data', formBodySchema)
+
+      expect(result.map((row) => [row.name, row.isRequired])).toEqual([
+        ['file', true],
+        ['props.name', true],
+        ['props.description', true],
+        ['props.created_at', false],
+      ])
+      expect(result[1]?.schema).toBeDefined()
+      expect(result[2]?.schema).toBeDefined()
+    })
+
     it('preserves File values when walking nested schema', () => {
       const file = new File([''], 'avatar.png', { type: 'image/png' })
       const example: ExampleObject = {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.test.ts
@@ -435,6 +435,38 @@ describe('getFormBodyRows', () => {
       expect(result[2]?.schema).toBeDefined()
     })
 
+    it('does not expand nested object properties into dotted rows for urlencoded bodies', () => {
+      // Urlencoded has no spec-defined way to serialize one nested object across multiple
+      // dotted-name keys (and `buildRequestBody` only regroups dotted rows for multipart),
+      // so emitting `props.name`-style leaves here would round-trip into flat fields on send.
+      // Stay on a single top-level row per property; the inner object is JSON-stringified
+      // by the array branch when the example is saved back as a row array.
+      const example: ExampleObject = {
+        value: {
+          token: 'abc',
+          props: { name: 'Widget', description: 'A useful widget' },
+        },
+      }
+      const formBodySchema: SchemaObject = {
+        type: 'object',
+        properties: {
+          token: { type: 'string' },
+          props: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              description: { type: 'string' },
+            },
+          },
+        },
+      }
+
+      const result = getFormBodyRows(example, 'application/x-www-form-urlencoded', formBodySchema)
+
+      expect(result.map((row) => row.name)).toEqual(['token', 'props'])
+      expect(result[1]?.value).toBe(JSON.stringify({ name: 'Widget', description: 'A useful widget' }))
+    })
+
     it('preserves File values when walking nested schema', () => {
       const file = new File([''], 'avatar.png', { type: 'image/png' })
       const example: ExampleObject = {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.test.ts
@@ -435,6 +435,37 @@ describe('getFormBodyRows', () => {
       expect(result[2]?.schema).toBeDefined()
     })
 
+    it('emits example properties that are not declared in the schema', () => {
+      // A schema-derived example can carry keys the schema does not declare — either at
+      // the top level or inside a nested object. Those rows still need to be visible and
+      // editable; otherwise the user has no way to inspect or change them from the UI.
+      const example: ExampleObject = {
+        value: {
+          file: '',
+          props: { name: 'Widget', extra: 'undeclared-inner' },
+          top_extra: 'undeclared-top',
+        },
+      }
+      const formBodySchema: SchemaObject = {
+        type: 'object',
+        properties: {
+          file: { type: 'string', format: 'binary' },
+          props: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+          },
+        },
+      }
+
+      const result = getFormBodyRows(example, 'multipart/form-data', formBodySchema)
+
+      expect(result.map((row) => row.name)).toEqual(['file', 'props.name', 'props.extra', 'top_extra'])
+      expect(result.find((row) => row.name === 'props.extra')?.value).toBe('undeclared-inner')
+      expect(result.find((row) => row.name === 'top_extra')?.value).toBe('undeclared-top')
+    })
+
     it('does not expand nested object properties into dotted rows for urlencoded bodies', () => {
       // Urlencoded has no spec-defined way to serialize one nested object across multiple
       // dotted-name keys (and `buildRequestBody` only regroups dotted rows for multipart),

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.test.ts
@@ -302,6 +302,121 @@ describe('getFormBodyRows', () => {
       expect(result[1].isRequired).toBe(true)
     })
 
+    it('expands nested object properties into dotted rows (widget #4834 example)', () => {
+      const example: ExampleObject = {
+        value: {
+          file: '',
+          props: { name: '', description: '', created_at: null },
+        },
+      }
+      const formBodySchema: SchemaObject = {
+        type: 'object',
+        required: ['file', 'props'],
+        properties: {
+          file: {
+            description: 'File to upload',
+            type: 'string',
+            format: 'binary',
+          },
+          props: {
+            type: 'object',
+            required: ['name', 'description'],
+            properties: {
+              name: { type: 'string' },
+              description: { type: 'string' },
+              created_at: { type: 'string', format: 'date-time' },
+            },
+          },
+        },
+      }
+
+      const result = getFormBodyRows(example, 'multipart/form-data', formBodySchema)
+
+      expect(result.map((row) => row.name)).toEqual(['file', 'props.name', 'props.description', 'props.created_at'])
+      expect(result[0]?.description).toBe('File to upload')
+      expect(result[0]?.isRequired).toBe(true)
+      expect(result[1]?.isRequired).toBe(true)
+      expect(result[2]?.isRequired).toBe(true)
+      expect(result[3]?.isRequired).toBe(false)
+      expect(result[1]?.value).toBe('')
+      // `created_at` is null in the example (its schema allows `null`); the row should
+      // render as an empty input rather than the literal string "null".
+      expect(result[3]?.value).toBe('')
+      expect(result[3]?.schema).toBeDefined()
+    })
+
+    it('walks deeper than one level of nesting', () => {
+      const example: ExampleObject = {
+        value: { a: { b: { c: 'leaf' } } },
+      }
+      const formBodySchema: SchemaObject = {
+        type: 'object',
+        properties: {
+          a: {
+            type: 'object',
+            properties: {
+              b: {
+                type: 'object',
+                properties: {
+                  c: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const result = getFormBodyRows(example, 'multipart/form-data', formBodySchema)
+      expect(result).toHaveLength(1)
+      expect(result[0]?.name).toBe('a.b.c')
+      expect(result[0]?.value).toBe('leaf')
+    })
+
+    it('cascades required: a leaf is required only when every ancestor is required', () => {
+      const formBodySchema: SchemaObject = {
+        type: 'object',
+        required: [],
+        properties: {
+          props: {
+            type: 'object',
+            required: ['name'],
+            properties: {
+              name: { type: 'string' },
+            },
+          },
+        },
+      }
+      const example: ExampleObject = { value: { props: { name: '' } } }
+
+      const result = getFormBodyRows(example, 'multipart/form-data', formBodySchema)
+      expect(result).toHaveLength(1)
+      // `props` is not required, so `props.name` cannot be required either
+      expect(result[0]?.isRequired).toBe(false)
+    })
+
+    it('preserves File values when walking nested schema', () => {
+      const file = new File([''], 'avatar.png', { type: 'image/png' })
+      const example: ExampleObject = {
+        value: { upload: { file } },
+      }
+      const formBodySchema: SchemaObject = {
+        type: 'object',
+        properties: {
+          upload: {
+            type: 'object',
+            properties: {
+              file: { type: 'string', format: 'binary' },
+            },
+          },
+        },
+      }
+
+      const result = getFormBodyRows(example, 'multipart/form-data', formBodySchema)
+      expect(result).toHaveLength(1)
+      expect(result[0]?.name).toBe('upload.file')
+      expect(result[0]?.value).toBe(file)
+    })
+
     it('handles empty required array', () => {
       const example: ExampleObject = {
         value: [{ name: 'optionalField', value: 'x', isDisabled: false }],

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
@@ -117,8 +117,10 @@ export const getFormBodyRows = (
 
   // Schema-driven path: when the form body schema describes nested objects, emit one row
   // per leaf so users can edit individual fields. The dotted name (`props.name`) is folded
-  // back into a single JSON multipart part by `process-body.ts` before the request is sent.
-  if (leafByDottedName.size > 0 && typeof example.value === 'object') {
+  // back into a single JSON multipart part by `build-request-body.ts` before the request is
+  // sent. Gated to `multipart/form-data` because urlencoded has no regrouping step on send,
+  // so dotted leaves would otherwise reach the wire as separate `props.name`-style fields.
+  if (contentType === 'multipart/form-data' && leafByDottedName.size > 0 && typeof example.value === 'object') {
     return Array.from(leafByDottedName.values()).map(({ path }) => {
       const rawValue = getValueAtPath(example.value, path)
       // Missing values and explicit `null` (e.g. for a nullable schema) render as empty

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
@@ -32,21 +32,33 @@ type LeafRow = {
  * (`file` + `props.{name,description,created_at}`) yields four leaves.
  */
 const collectLeafProperties = (schema: SchemaObject, parentPath: string[] = [], parentRequired = true): LeafRow[] => {
+  // Nothing to walk if this is not an object schema or has no declared properties.
   if (!isObjectSchema(schema) || !schema.properties) {
     return []
   }
+
+  // `required` is a list of property names on *this* schema, so build it once per level.
   const requiredSet = new Set(schema.required ?? [])
   const leaves: LeafRow[] = []
+
   for (const [key, rawChildSchema] of objectEntries(schema.properties)) {
     const childSchema = resolve.schema(rawChildSchema)
     const path = [...parentPath, String(key)]
+
+    // A leaf is only required when *every* ancestor was also required — a non-required
+    // parent makes the whole subtree optional regardless of inner `required` lists.
     const isRequired = parentRequired && requiredSet.has(String(key))
+
+    // Nested objects with named properties recurse so each leaf gets its own row;
+    // everything else (primitives, arrays, files, additionalProperties placeholders)
+    // is treated as a leaf and stops the descent.
     if (childSchema && isObjectSchema(childSchema) && childSchema.properties) {
       leaves.push(...collectLeafProperties(childSchema, path, isRequired))
     } else {
       leaves.push({ path, schema: childSchema, isRequired })
     }
   }
+
   return leaves
 }
 

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
@@ -79,30 +79,37 @@ export const getFormBodyRows = (
   const schemaWithProperties = formBodySchema && isObjectSchema(formBodySchema) ? formBodySchema : undefined
   const requiredSet = schemaWithProperties ? new Set(schemaWithProperties.required ?? []) : undefined
 
+  // Pre-compute the leaf-by-dotted-name index up front so both the array and the
+  // schema-driven branches can pull each row's leaf schema and required flag without
+  // re-walking the schema. Without this, edited rows lose the per-leaf `Required`
+  // badge because a top-level `properties[name]` lookup misses dotted names.
+  const leafByDottedName = new Map<string, LeafRow>()
+  if (schemaWithProperties) {
+    for (const leaf of collectLeafProperties(schemaWithProperties)) {
+      leafByDottedName.set(leaf.path.join('.'), leaf)
+    }
+  }
+
   const mapRow = ({
     name,
     value,
     isDisabled = false,
-    leafSchema,
-    isRequiredOverride,
   }: {
     name: string
     value: string | File
     isDisabled?: boolean
-    leafSchema?: SchemaObject
-    isRequiredOverride?: boolean
   }): TableRow => {
     const row: TableRow = { name, value, isDisabled }
-    // Recursive walker can supply the resolved leaf schema and required flag directly;
-    // for flat inputs we fall back to the top-level property lookup.
-    const usingRecursive = leafSchema !== undefined || isRequiredOverride !== undefined
-    if (!usingRecursive && (!schemaWithProperties || !name)) {
+    if (!schemaWithProperties || !name) {
       return row
     }
-    const propSchema = leafSchema ?? resolve.schema(schemaWithProperties?.properties?.[name])
+    // Prefer the pre-resolved leaf (handles dotted names like `props.name`); fall back
+    // to a top-level property lookup so user-added rows keep working.
+    const leaf = leafByDottedName.get(name)
+    const propSchema = leaf?.schema ?? resolve.schema(schemaWithProperties.properties?.[name])
     row.schema = propSchema
     row.description = propSchema?.description
-    row.isRequired = isRequiredOverride ?? requiredSet?.has(name) ?? false
+    row.isRequired = leaf?.isRequired ?? requiredSet?.has(name) ?? false
     return row
   }
 
@@ -122,27 +129,19 @@ export const getFormBodyRows = (
   // Schema-driven path: when the form body schema describes nested objects, emit one row
   // per leaf so users can edit individual fields. The dotted name (`props.name`) is folded
   // back into a single JSON multipart part by `process-body.ts` before the request is sent.
-  if (schemaWithProperties && typeof example.value === 'object') {
-    const leaves = collectLeafProperties(schemaWithProperties)
-    if (leaves.length > 0) {
-      return leaves.map(({ path, schema: leafSchema, isRequired }) => {
-        const rawValue = getValueAtPath(example.value, path)
-        // Missing values and explicit `null` (e.g. for a nullable schema) render as empty
-        // inputs so the user can type a value rather than seeing the string "null".
-        const value =
-          rawValue instanceof File
-            ? rawValue
-            : rawValue === undefined || rawValue === null
-              ? ''
-              : stringifyValue(rawValue)
-        return mapRow({
-          name: path.join('.'),
-          value,
-          leafSchema,
-          isRequiredOverride: isRequired,
-        })
-      })
-    }
+  if (leafByDottedName.size > 0 && typeof example.value === 'object') {
+    return Array.from(leafByDottedName.values()).map(({ path }) => {
+      const rawValue = getValueAtPath(example.value, path)
+      // Missing values and explicit `null` (e.g. for a nullable schema) render as empty
+      // inputs so the user can type a value rather than seeing the string "null".
+      const value =
+        rawValue instanceof File
+          ? rawValue
+          : rawValue === undefined || rawValue === null
+            ? ''
+            : stringifyValue(rawValue)
+      return mapRow({ name: path.join('.'), value })
+    })
   }
 
   // We got an object try to convert it to an array of rows

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
@@ -1,4 +1,3 @@
-import { getValueAtPath } from '@scalar/helpers/object/get-value-at-path'
 import { isObject } from '@scalar/helpers/object/is-object'
 import { objectEntries } from '@scalar/helpers/object/object-entries'
 import { resolve } from '@scalar/workspace-store/resolve'
@@ -60,6 +59,58 @@ const collectLeafProperties = (schema: SchemaObject, parentPath: string[] = [], 
   }
 
   return leaves
+}
+
+/**
+ * Walk a schema + example together and collect one row per leaf, including example-only
+ * keys that the schema does not declare. Schema-declared properties come first in schema
+ * order; extras present in the example follow in example order at each level.
+ *
+ * Unlike `collectLeafProperties` (which is schema-only and feeds the dotted-name index),
+ * this walker drives what the user actually sees in the form: a row for every leaf the
+ * example contains, even when the schema is partial or out of date.
+ */
+const collectExampleRows = (
+  example: unknown,
+  schema: SchemaObject | undefined,
+  parentPath: string[] = [],
+): { path: string[]; value: unknown }[] => {
+  const rows: { path: string[]; value: unknown }[] = []
+  const exampleEntries = isObject(example) ? objectEntries(example as Record<string, unknown>) : []
+  const exampleByKey = new Map<string, unknown>(exampleEntries.map(([key, value]) => [String(key), value]))
+  const declaredKeys = new Set<string>()
+  const schemaProperties = schema && isObjectSchema(schema) ? (schema.properties ?? {}) : {}
+
+  // Schema-declared properties first, in schema order. Nested object schemas recurse so
+  // each leaf gets its own row; otherwise the schema-declared key is a leaf and uses the
+  // matching example value (or `undefined` when the example does not provide one).
+  for (const [key, rawChildSchema] of objectEntries(schemaProperties)) {
+    const keyStr = String(key)
+    declaredKeys.add(keyStr)
+    const childSchema = resolve.schema(rawChildSchema)
+    const path = [...parentPath, keyStr]
+    const exampleSubvalue = exampleByKey.get(keyStr)
+
+    if (childSchema && isObjectSchema(childSchema) && childSchema.properties) {
+      rows.push(...collectExampleRows(exampleSubvalue, childSchema, path))
+    } else {
+      rows.push({ path, value: exampleSubvalue })
+    }
+  }
+
+  // Example-only properties at this level (preserve example order). Their inner shape is
+  // not descended into — without a schema saying "this is a nested object" we have no
+  // signal to flatten, so an object value becomes a single JSON-stringified row, matching
+  // the schema-less fallback below.
+  for (const [key, value] of exampleEntries) {
+    const keyStr = String(key)
+    if (declaredKeys.has(keyStr)) {
+      continue
+    }
+    rows.push({ path: [...parentPath, keyStr], value })
+  }
+
+  return rows
 }
 
 /** Build the table rows for the form data, optionally enriched with schema (e.g. enum) per property */
@@ -132,18 +183,17 @@ export const getFormBodyRows = (
   // back into a single JSON multipart part by `build-request-body.ts` before the request is
   // sent. Gated to `multipart/form-data` because urlencoded has no regrouping step on send,
   // so dotted leaves would otherwise reach the wire as separate `props.name`-style fields.
-  if (contentType === 'multipart/form-data' && leafByDottedName.size > 0 && typeof example.value === 'object') {
-    return Array.from(leafByDottedName.values()).map(({ path }) => {
-      const rawValue = getValueAtPath(example.value, path)
+  //
+  // We walk the example alongside the schema so example-only properties (top-level extras
+  // or undeclared keys inside a nested object) are still visible and editable instead of
+  // being silently dropped to whatever the schema happens to declare.
+  if (contentType === 'multipart/form-data' && schemaWithProperties && typeof example.value === 'object') {
+    return collectExampleRows(example.value, schemaWithProperties).map(({ path, value }) => {
       // Missing values and explicit `null` (e.g. for a nullable schema) render as empty
       // inputs so the user can type a value rather than seeing the string "null".
-      const value =
-        rawValue instanceof File
-          ? rawValue
-          : rawValue === undefined || rawValue === null
-            ? ''
-            : stringifyValue(rawValue)
-      return mapRow({ name: path.join('.'), value })
+      const rendered =
+        value instanceof File ? value : value === undefined || value === null ? '' : stringifyValue(value)
+      return mapRow({ name: path.join('.'), value: rendered })
     })
   }
 

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
@@ -1,3 +1,4 @@
+import { getValueAtPath } from '@scalar/helpers/object/get-value-at-path'
 import { isObject } from '@scalar/helpers/object/is-object'
 import { objectEntries } from '@scalar/helpers/object/object-entries'
 import { resolve } from '@scalar/workspace-store/resolve'
@@ -14,18 +15,6 @@ const stringifyValue = (value: unknown) => {
     return JSON.stringify(value)
   }
   return String(value)
-}
-
-/** Look up a nested value in the example by walking the path. Returns `undefined` if any segment is missing. */
-const getValueAtPath = (root: unknown, path: string[]): unknown => {
-  let cursor: unknown = root
-  for (const segment of path) {
-    if (cursor instanceof File || !isObject(cursor)) {
-      return undefined
-    }
-    cursor = (cursor as Record<string, unknown>)[segment]
-  }
-  return cursor
 }
 
 type LeafRow = {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
@@ -16,6 +16,51 @@ const stringifyValue = (value: unknown) => {
   return String(value)
 }
 
+/** Look up a nested value in the example by walking the path. Returns `undefined` if any segment is missing. */
+const getValueAtPath = (root: unknown, path: string[]): unknown => {
+  let cursor: unknown = root
+  for (const segment of path) {
+    if (cursor instanceof File || !isObject(cursor)) {
+      return undefined
+    }
+    cursor = (cursor as Record<string, unknown>)[segment]
+  }
+  return cursor
+}
+
+type LeafRow = {
+  path: string[]
+  schema: SchemaObject | undefined
+  isRequired: boolean
+}
+
+/**
+ * Walk a (possibly nested) object schema and collect one entry per leaf property.
+ *
+ * A "leaf" is any property whose resolved schema is not an `{ type: 'object' }` schema
+ * with named `properties` — i.e. primitives, arrays, files, and `additionalProperties`
+ * placeholders all stop the recursion. Object properties recurse, so the widget example
+ * (`file` + `props.{name,description,created_at}`) yields four leaves.
+ */
+const collectLeafProperties = (schema: SchemaObject, parentPath: string[] = [], parentRequired = true): LeafRow[] => {
+  if (!isObjectSchema(schema) || !schema.properties) {
+    return []
+  }
+  const requiredSet = new Set(schema.required ?? [])
+  const leaves: LeafRow[] = []
+  for (const [key, rawChildSchema] of objectEntries(schema.properties)) {
+    const childSchema = resolve.schema(rawChildSchema)
+    const path = [...parentPath, String(key)]
+    const isRequired = parentRequired && requiredSet.has(String(key))
+    if (childSchema && isObjectSchema(childSchema) && childSchema.properties) {
+      leaves.push(...collectLeafProperties(childSchema, path, isRequired))
+    } else {
+      leaves.push({ path, schema: childSchema, isRequired })
+    }
+  }
+  return leaves
+}
+
 /** Build the table rows for the form data, optionally enriched with schema (e.g. enum) per property */
 export const getFormBodyRows = (
   example: ExampleObject | undefined | null,
@@ -38,20 +83,26 @@ export const getFormBodyRows = (
     name,
     value,
     isDisabled = false,
+    leafSchema,
+    isRequiredOverride,
   }: {
     name: string
     value: string | File
     isDisabled?: boolean
+    leafSchema?: SchemaObject
+    isRequiredOverride?: boolean
   }): TableRow => {
     const row: TableRow = { name, value, isDisabled }
-    if (!schemaWithProperties || !name) {
+    // Recursive walker can supply the resolved leaf schema and required flag directly;
+    // for flat inputs we fall back to the top-level property lookup.
+    const usingRecursive = leafSchema !== undefined || isRequiredOverride !== undefined
+    if (!usingRecursive && (!schemaWithProperties || !name)) {
       return row
     }
-    const propSchema = resolve.schema(schemaWithProperties.properties?.[name])
+    const propSchema = leafSchema ?? resolve.schema(schemaWithProperties?.properties?.[name])
     row.schema = propSchema
     row.description = propSchema?.description
-    row.isRequired = requiredSet?.has(name)
-    row.isDisabled = isDisabled
+    row.isRequired = isRequiredOverride ?? requiredSet?.has(name) ?? false
     return row
   }
 
@@ -66,6 +117,32 @@ export const getFormBodyRows = (
       }
       return { name: '', value: exampleValue, isDisabled: false }
     })
+  }
+
+  // Schema-driven path: when the form body schema describes nested objects, emit one row
+  // per leaf so users can edit individual fields. The dotted name (`props.name`) is folded
+  // back into a single JSON multipart part by `process-body.ts` before the request is sent.
+  if (schemaWithProperties && typeof example.value === 'object') {
+    const leaves = collectLeafProperties(schemaWithProperties)
+    if (leaves.length > 0) {
+      return leaves.map(({ path, schema: leafSchema, isRequired }) => {
+        const rawValue = getValueAtPath(example.value, path)
+        // Missing values and explicit `null` (e.g. for a nullable schema) render as empty
+        // inputs so the user can type a value rather than seeing the string "null".
+        const value =
+          rawValue instanceof File
+            ? rawValue
+            : rawValue === undefined || rawValue === null
+              ? ''
+              : stringifyValue(rawValue)
+        return mapRow({
+          name: path.join('.'),
+          value,
+          leafSchema,
+          isRequiredOverride: isRequired,
+        })
+      })
+    }
   }
 
   // We got an object try to convert it to an array of rows

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
@@ -631,4 +631,74 @@ describe('buildRequestBody', () => {
     assert(result?.value === 'null')
     expect(typeof result?.value).toBe('string')
   })
+
+  it('regroups dotted multipart rows back into a single JSON-stringified text part', () => {
+    const requestBody = {
+      content: {
+        'multipart/form-data': {
+          examples: {
+            default: {
+              value: [
+                { name: 'file', value: '@filename' },
+                { name: 'props.name', value: 'Widget' },
+                { name: 'props.description', value: 'A useful widget' },
+                { name: 'props.created_at', value: '2026-01-02T03:04:05Z' },
+                { name: 'props.note', value: 'ignored', isDisabled: true },
+              ],
+            },
+          },
+        },
+      },
+    }
+
+    const result = buildRequestBody(requestBody, 'default')
+    expect(result?.mode).toBe('formdata')
+    assert(result?.mode === 'formdata')
+
+    // The wire sends one `props` part (not three `props.*` parts), so the wire shape is
+    // consistent between the initial schema-derived example and edited form rows. The
+    // part is plain text because browser FormData adds a `filename="blob"` header to
+    // every Blob, which generic multipart parsers then misinterpret as a file upload.
+    expect(result.value).toEqual([
+      { type: 'text', key: 'file', value: '@filename' },
+      {
+        type: 'text',
+        key: 'props',
+        value: JSON.stringify({
+          name: 'Widget',
+          description: 'A useful widget',
+          created_at: '2026-01-02T03:04:05Z',
+        }),
+      },
+    ])
+  })
+
+  it('keeps a flat multipart row whose name happens to contain dots (filename)', () => {
+    const requestBody = {
+      content: {
+        'multipart/form-data': {
+          examples: {
+            default: {
+              value: [
+                {
+                  name: 'scalar.jpeg',
+                  value: new File(['scalar'], 'scalar.jpeg', { type: 'image/jpeg' }),
+                },
+                { name: 'caption', value: 'logo' },
+              ],
+            },
+          },
+        },
+      },
+    }
+
+    const result = buildRequestBody(requestBody, 'default')
+    expect(result?.mode).toBe('formdata')
+    assert(result?.mode === 'formdata')
+
+    expect(result.value).toHaveLength(2)
+    expect(result.value[0]?.type).toBe('file')
+    expect(result.value[0]?.key).toBe('scalar.jpeg')
+    expect(result.value[1]).toEqual({ type: 'text', key: 'caption', value: 'logo' })
+  })
 })

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
@@ -673,6 +673,43 @@ describe('buildRequestBody', () => {
     ])
   })
 
+  it('emits the regrouped multipart object at the position of its first dotted row', () => {
+    const requestBody = {
+      content: {
+        'multipart/form-data': {
+          examples: {
+            default: {
+              value: [
+                { name: 'before', value: 'first' },
+                { name: 'props.name', value: 'Widget' },
+                { name: 'middle', value: 'second' },
+                { name: 'props.description', value: 'A useful widget' },
+                { name: 'after', value: 'third' },
+              ],
+            },
+          },
+        },
+      },
+    }
+
+    const result = buildRequestBody(requestBody, 'default')
+    expect(result?.mode).toBe('formdata')
+    assert(result?.mode === 'formdata')
+
+    // The regrouped `props` part stays where the user placed its first dotted row,
+    // so flat rows around it keep their relative order.
+    expect(result.value).toEqual([
+      { type: 'text', key: 'before', value: 'first' },
+      {
+        type: 'text',
+        key: 'props',
+        value: JSON.stringify({ name: 'Widget', description: 'A useful widget' }),
+      },
+      { type: 'text', key: 'middle', value: 'second' },
+      { type: 'text', key: 'after', value: 'third' },
+    ])
+  })
+
   it('keeps a flat multipart row whose name happens to contain dots (filename)', () => {
     const requestBody = {
       content: {

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
@@ -633,9 +633,24 @@ describe('buildRequestBody', () => {
   })
 
   it('regroups dotted multipart rows back into a single JSON-stringified text part', () => {
-    const requestBody = {
+    const requestBody = coerceValue(RequestBodyObjectSchema, {
       content: {
         'multipart/form-data': {
+          schema: {
+            type: 'object',
+            properties: {
+              file: { type: 'string' },
+              props: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                  description: { type: 'string' },
+                  created_at: { type: 'string' },
+                  note: { type: 'string' },
+                },
+              },
+            },
+          },
           examples: {
             default: {
               value: [
@@ -649,7 +664,7 @@ describe('buildRequestBody', () => {
           },
         },
       },
-    }
+    })
 
     const result = buildRequestBody(requestBody, 'default')
     expect(result?.mode).toBe('formdata')
@@ -674,9 +689,24 @@ describe('buildRequestBody', () => {
   })
 
   it('emits the regrouped multipart object at the position of its first dotted row', () => {
-    const requestBody = {
+    const requestBody = coerceValue(RequestBodyObjectSchema, {
       content: {
         'multipart/form-data': {
+          schema: {
+            type: 'object',
+            properties: {
+              before: { type: 'string' },
+              middle: { type: 'string' },
+              after: { type: 'string' },
+              props: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                  description: { type: 'string' },
+                },
+              },
+            },
+          },
           examples: {
             default: {
               value: [
@@ -690,7 +720,7 @@ describe('buildRequestBody', () => {
           },
         },
       },
-    }
+    })
 
     const result = buildRequestBody(requestBody, 'default')
     expect(result?.mode).toBe('formdata')
@@ -737,5 +767,68 @@ describe('buildRequestBody', () => {
     expect(result.value[0]?.type).toBe('file')
     expect(result.value[0]?.key).toBe('scalar.jpeg')
     expect(result.value[1]).toEqual({ type: 'text', key: 'caption', value: 'logo' })
+  })
+
+  it('keeps non-File multipart rows whose names contain literal dots when the schema does not declare them as nested objects', () => {
+    const requestBody = {
+      content: {
+        'multipart/form-data': {
+          examples: {
+            default: {
+              value: [
+                { name: 'user.email', value: 'foo@bar.com' },
+                { name: 'config.json', value: '{"k":1}' },
+                { name: 'image.url', value: 'https://example.com/a.png' },
+              ],
+            },
+          },
+        },
+      },
+    }
+
+    const result = buildRequestBody(requestBody, 'default')
+    expect(result?.mode).toBe('formdata')
+    assert(result?.mode === 'formdata')
+
+    // Without a schema declaring `user`/`config`/`image` as nested object properties,
+    // these names are literal and must be sent as-is — not folded into nested objects.
+    expect(result.value).toEqual([
+      { type: 'text', key: 'user.email', value: 'foo@bar.com' },
+      { type: 'text', key: 'config.json', value: '{"k":1}' },
+      { type: 'text', key: 'image.url', value: 'https://example.com/a.png' },
+    ])
+  })
+
+  it('keeps multipart rows with literal dots flat when the schema declares the dotted name as a top-level property', () => {
+    const requestBody = coerceValue(RequestBodyObjectSchema, {
+      content: {
+        'multipart/form-data': {
+          schema: {
+            type: 'object',
+            properties: {
+              'user.email': { type: 'string' },
+              caption: { type: 'string' },
+            },
+          },
+          examples: {
+            default: {
+              value: [
+                { name: 'user.email', value: 'foo@bar.com' },
+                { name: 'caption', value: 'profile' },
+              ],
+            },
+          },
+        },
+      },
+    })
+
+    const result = buildRequestBody(requestBody, 'default')
+    expect(result?.mode).toBe('formdata')
+    assert(result?.mode === 'formdata')
+
+    expect(result.value).toEqual([
+      { type: 'text', key: 'user.email', value: 'foo@bar.com' },
+      { type: 'text', key: 'caption', value: 'profile' },
+    ])
   })
 })

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -1,8 +1,11 @@
 // import { replaceEnvVariables } from '@scalar/helpers/regex/replace-variables'
 import { isObject } from '@scalar/helpers/object/is-object'
 import { setValueAtPath } from '@scalar/helpers/object/set-value-at-path'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import { unpackProxyObject } from '@scalar/workspace-store/helpers/unpack-proxy'
+import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import type { RequestBodyObject } from '@scalar/workspace-store/schemas/v3.1/strict/request-body'
+import { isObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
 
 import { getExampleFromBody } from './get-request-body-example'
 import { getSelectedBodyContentType } from './get-selected-body-content-type'
@@ -50,11 +53,32 @@ const getMultipartEncodingContentType = (requestBody: RequestBodyObject, bodyCon
   requestBody.content[bodyContentType]?.encoding?.[fieldName]?.contentType
 
 /**
- * A multipart row name carries a dotted path into a nested object when it contains a
- * dot AND its value is not a File. Filenames in flat rows (e.g. `scalar.jpeg`) keep
- * their literal name and stay flat.
+ * Build a predicate that recognizes multipart rows whose dotted name encodes a path
+ * into a nested object property of the multipart schema. Without a schema (or when
+ * the dotted prefix is not declared as a nested object), a row like `user.email`
+ * is treated as a literal name and stays flat — only schema-derived leaves emitted
+ * by `get-form-body-rows.ts` are folded back via `foldDottedRowsToObject`.
  */
-const isDottedNestedRow = (name: string, value: unknown): boolean => !(value instanceof File) && name.includes('.')
+const buildDottedNestedRowPredicate = (schema: unknown) => {
+  const resolved = schema ? (getResolvedRef(schema) as SchemaObject | undefined) : undefined
+  if (!resolved || !isObjectSchema(resolved) || !resolved.properties) {
+    return (_name: string, _value: unknown) => false
+  }
+  const nestedTopKeys = new Set<string>()
+  for (const [key, child] of Object.entries(resolved.properties)) {
+    const childResolved = child ? (getResolvedRef(child) as SchemaObject | undefined) : undefined
+    if (childResolved && isObjectSchema(childResolved) && childResolved.properties) {
+      nestedTopKeys.add(key)
+    }
+  }
+  return (name: string, value: unknown) => {
+    if (value instanceof File || !name.includes('.')) {
+      return false
+    }
+    const head = name.split('.', 1)[0]
+    return !!head && nestedTopKeys.has(head)
+  }
+}
 
 /**
  * Fold dotted-name row entries (e.g. `props.name`, `props.description`) back into a
@@ -118,7 +142,9 @@ export const buildRequestBody = (
     // rows with dotted names (e.g. `props.name`). Regroup them so the wire still gets
     // one JSON multipart part per top-level object property — matching the
     // OpenAPI 3.x multipart-as-JSON default. Url-encoded forms do not nest, so we
-    // skip this for them.
+    // skip this for them. The predicate is schema-driven, so a user-named row like
+    // `user.email` whose top-level prefix is not a nested object stays flat.
+    const isDottedNestedRow = buildDottedNestedRowPredicate(requestBody.content[bodyContentType]?.schema)
     const shouldRegroupDotted =
       result.mode === 'formdata' && exampleValue.some(({ name, value }) => isDottedNestedRow(name, value))
 

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -125,13 +125,24 @@ export const buildRequestBody = (
     type Entry = { name: string; value: unknown }
     let entries: Entry[]
     if (shouldRegroupDotted) {
-      const flatRows: Entry[] = []
-      const dottedRows: Entry[] = []
-      for (const row of exampleValue) {
-        ;(isDottedNestedRow(row.name, row.value) ? dottedRows : flatRows).push(row)
-      }
+      // Emit the regrouped top-level object at the position of its first dotted row so
+      // interleaved flat rows stay in the order the user arranged them.
+      const dottedRows = exampleValue.filter(({ name, value }) => isDottedNestedRow(name, value))
       const regrouped = foldDottedRowsToObject(dottedRows)
-      entries = [...flatRows, ...Object.entries(regrouped).map(([name, value]) => ({ name, value }))]
+      const emittedTopKeys = new Set<string>()
+      entries = []
+      for (const row of exampleValue) {
+        if (!isDottedNestedRow(row.name, row.value)) {
+          entries.push(row)
+          continue
+        }
+        const topKey = row.name.split('.')[0]
+        if (!topKey || emittedTopKeys.has(topKey)) {
+          continue
+        }
+        emittedTopKeys.add(topKey)
+        entries.push({ name: topKey, value: regrouped[topKey] })
+      }
     } else {
       entries = exampleValue
     }

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -1,5 +1,6 @@
 // import { replaceEnvVariables } from '@scalar/helpers/regex/replace-variables'
 import { isObject } from '@scalar/helpers/object/is-object'
+import { setValueAtPath } from '@scalar/helpers/object/set-value-at-path'
 import { unpackProxyObject } from '@scalar/workspace-store/helpers/unpack-proxy'
 import type { RequestBodyObject } from '@scalar/workspace-store/schemas/v3.1/strict/request-body'
 
@@ -49,6 +50,26 @@ const getMultipartEncodingContentType = (requestBody: RequestBodyObject, bodyCon
   requestBody.content[bodyContentType]?.encoding?.[fieldName]?.contentType
 
 /**
+ * A multipart row name carries a dotted path into a nested object when it contains a
+ * dot AND its value is not a File. Filenames in flat rows (e.g. `scalar.jpeg`) keep
+ * their literal name and stay flat.
+ */
+const isDottedNestedRow = (name: string, value: unknown): boolean => !(value instanceof File) && name.includes('.')
+
+/**
+ * Fold dotted-name row entries (e.g. `props.name`, `props.description`) back into a
+ * single nested object so the wire shape stays one JSON multipart part per top-level
+ * object property — even though the form UI displays one row per leaf.
+ */
+const foldDottedRowsToObject = (rows: { name: string; value: unknown }[]): Record<string, unknown> => {
+  const root: Record<string, unknown> = {}
+  for (const { name, value } of rows) {
+    setValueAtPath(root, name.split('.'), value)
+  }
+  return root
+}
+
+/**
  * Create the fetch request body
  */
 export const buildRequestBody = (
@@ -93,8 +114,30 @@ export const buildRequestBody = (
             value: [],
           }
 
+    // When a multipart form was built from a nested object schema the UI emits leaf
+    // rows with dotted names (e.g. `props.name`). Regroup them so the wire still gets
+    // one JSON multipart part per top-level object property — matching the
+    // OpenAPI 3.x multipart-as-JSON default. Url-encoded forms do not nest, so we
+    // skip this for them.
+    const shouldRegroupDotted =
+      result.mode === 'formdata' && exampleValue.some(({ name, value }) => isDottedNestedRow(name, value))
+
+    type Entry = { name: string; value: unknown }
+    let entries: Entry[]
+    if (shouldRegroupDotted) {
+      const flatRows: Entry[] = []
+      const dottedRows: Entry[] = []
+      for (const row of exampleValue) {
+        ;(isDottedNestedRow(row.name, row.value) ? dottedRows : flatRows).push(row)
+      }
+      const regrouped = foldDottedRowsToObject(dottedRows)
+      entries = [...flatRows, ...Object.entries(regrouped).map(([name, value]) => ({ name, value }))]
+    } else {
+      entries = exampleValue
+    }
+
     // Loop over all entries and add them to the form
-    exampleValue.forEach(({ name, value }) => {
+    entries.forEach(({ name, value }) => {
       if (!name) {
         return
       }

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -81,19 +81,6 @@ const buildDottedNestedRowPredicate = (schema: unknown) => {
 }
 
 /**
- * Fold dotted-name row entries (e.g. `props.name`, `props.description`) back into a
- * single nested object so the wire shape stays one JSON multipart part per top-level
- * object property — even though the form UI displays one row per leaf.
- */
-const foldDottedRowsToObject = (rows: { name: string; value: unknown }[]): Record<string, unknown> => {
-  const root: Record<string, unknown> = {}
-  for (const { name, value } of rows) {
-    setValueAtPath(root, name.split('.'), value)
-  }
-  return root
-}
-
-/**
  * Create the fetch request body
  */
 export const buildRequestBody = (
@@ -144,33 +131,36 @@ export const buildRequestBody = (
     // OpenAPI 3.x multipart-as-JSON default. Url-encoded forms do not nest, so we
     // skip this for them. The predicate is schema-driven, so a user-named row like
     // `user.email` whose top-level prefix is not a nested object stays flat.
-    const isDottedNestedRow = buildDottedNestedRowPredicate(requestBody.content[bodyContentType]?.schema)
-    const shouldRegroupDotted =
-      result.mode === 'formdata' && exampleValue.some(({ name, value }) => isDottedNestedRow(name, value))
+    //
+    // Single pass: flat rows go into `entries` as-is; for each dotted-nested row, we
+    // lazily allocate the regrouped object for its top-level key and push it into
+    // `entries` at the position of the *first* matching row, then keep folding leaves
+    // into the same live object reference so interleaved flat rows keep their order.
+    const isDottedNestedRow =
+      result.mode === 'formdata'
+        ? buildDottedNestedRowPredicate(requestBody.content[bodyContentType]?.schema)
+        : () => false
 
-    type Entry = { name: string; value: unknown }
-    let entries: Entry[]
-    if (shouldRegroupDotted) {
-      // Emit the regrouped top-level object at the position of its first dotted row so
-      // interleaved flat rows stay in the order the user arranged them.
-      const dottedRows = exampleValue.filter(({ name, value }) => isDottedNestedRow(name, value))
-      const regrouped = foldDottedRowsToObject(dottedRows)
-      const emittedTopKeys = new Set<string>()
-      entries = []
-      for (const row of exampleValue) {
-        if (!isDottedNestedRow(row.name, row.value)) {
-          entries.push(row)
-          continue
-        }
-        const topKey = row.name.split('.')[0]
-        if (!topKey || emittedTopKeys.has(topKey)) {
-          continue
-        }
-        emittedTopKeys.add(topKey)
-        entries.push({ name: topKey, value: regrouped[topKey] })
+    const entries: { name: string; value: unknown }[] = []
+    const regroupedByTopKey = new Map<string, Record<string, unknown>>()
+
+    for (const row of exampleValue) {
+      if (!isDottedNestedRow(row.name, row.value)) {
+        entries.push(row)
+        continue
       }
-    } else {
-      entries = exampleValue
+      const segments = row.name.split('.')
+      const topKey = segments[0]
+      if (!topKey) {
+        continue
+      }
+      let target = regroupedByTopKey.get(topKey)
+      if (!target) {
+        target = {}
+        regroupedByTopKey.set(topKey, target)
+        entries.push({ name: topKey, value: target })
+      }
+      setValueAtPath(target, segments.slice(1), row.value)
     }
 
     // Loop over all entries and add them to the form


### PR DESCRIPTION
Nested object properties in `multipart/form-data` schemas used to collapse into a single JSON-stringified field. Now each leaf gets its own editable row (`props.name`, `props.description`, `props.created_at`), and dotted rows are regrouped into one `props` multipart part on send.

cURL preview also pretty-prints JSON inside `--form` parts, matching what we already do for `--data`.

**Before**
<img width="712" height="177" alt="Screenshot 2026-05-11 at 11 26 02" src="https://github.com/user-attachments/assets/e4476806-2bb4-4e2b-97d9-bdd89e594ef3" />

**After**
<img width="717" height="249" alt="Screenshot 2026-05-11 at 12 35 08" src="https://github.com/user-attachments/assets/35d5e87d-8296-440a-8f1d-d214996ba9f4" />

Fixes #4834

## OpenAPI Document

```yaml
openapi: 3.1.0
info:
  title: Multipart Nested Rows Test
  version: 1.0.0
paths:
  /widgets:
    post:
      summary: Create widget (multipart)
      requestBody:
        required: true
        content:
          multipart/form-data:
            schema:
              type: object
              required: [file, props]
              properties:
                file:
                  type: string
                  format: binary
                  description: File to upload
                props:
                  type: object
                  required: [name, description]
                  properties:
                    name: { type: string }
                    description: { type: string }
                    created_at: { type: string, format: date-time }
      responses:
        '200': { description: OK }

  /widgets-url:
    post:
      summary: Create widget (urlencoded) — same schema as multipart
      requestBody:
        required: true
        content:
          application/x-www-form-urlencoded:
            schema:
              type: object
              required: [token, props]
              properties:
                token: { type: string}
                props:
                  type: object
                  properties:
                    name: { type: string}
                    description: { type: string}
      responses:
        '200': { description: OK}
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how multipart form rows are generated and serialized, including schema-driven regrouping of dotted keys into JSON parts; mistakes could alter request payload shape or field ordering.
> 
> **Overview**
> Enables **nested `multipart/form-data` object properties** to be edited as individual dotted-name rows (e.g. `props.name`) by walking the request-body schema + example and emitting one row per leaf, while preserving per-leaf schema metadata and *cascading* `required` semantics.
> 
> Updates request-body building for multipart so **edited dotted rows are regrouped back into a single top-level JSON text part** (one part per top-level object property), preserving row order and avoiding accidental folding of literal dotted names (e.g. `user.email`) unless the schema declares a nested object. Adds comprehensive tests for nesting depth, null/file handling, undeclared example keys, urlencoded non-expansion, and dotted-name edge cases; also tightens HAR param building by normalizing row-array names to strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 352faf2678c76db3caf7d55cddbfdc62f3c1a9ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->