### PR TITLE
fix(helpers): friendly error for non-http URLs in API client

### DIFF
--- a/.changeset/fix-invalid-url-protocol-message.md
+++ b/.changeset/fix-invalid-url-protocol-message.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': patch
+---
+
+fix(helpers): show friendly error message for relative / non-http URLs in the API client

--- a/packages/helpers/src/errors/normalize-error.test.ts
+++ b/packages/helpers/src/errors/normalize-error.test.ts
@@ -16,6 +16,19 @@ describe('normalize-error', () => {
       expect(result).toBe(ERRORS.INVALID_URL)
     })
 
+    it('returns INVALID_URL_PROTOCOL error for raw undici invalid protocol message', () => {
+      const message = 'Invalid URL protocol: the URL must start with `http:` or `https:`.'
+      const result = prettyErrorMessage(message)
+      expect(result).toBe(ERRORS.INVALID_URL_PROTOCOL)
+    })
+
+    it('returns INVALID_URL_PROTOCOL error for Electron-wrapped undici invalid protocol message', () => {
+      const message =
+        "Error invoking remote method 'customFetch': InvalidArgumentError: Invalid URL protocol: the URL must start with `http:` or `https:`."
+      const result = prettyErrorMessage(message)
+      expect(result).toBe(ERRORS.INVALID_URL_PROTOCOL)
+    })
+
     it('returns INVALID_HEADER error for fetch invalid name failure', () => {
       const message = `Failed to execute 'fetch' on 'Window': Invalid name`
       const result = prettyErrorMessage(message)

--- a/packages/helpers/src/errors/normalize-error.ts
+++ b/packages/helpers/src/errors/normalize-error.ts
@@ -10,6 +10,7 @@ export const ERRORS = {
   BUILDING_REQUEST_FAILED: 'An error occurred while building the request',
   DEFAULT: 'An unknown error has occurred.',
   INVALID_URL: 'The URL seems to be invalid. Try adding a valid URL.',
+  INVALID_URL_PROTOCOL: 'The URL must start with http:// or https://.',
   INVALID_HEADER: 'There is an invalid header present, please double check your params.',
   MISSING_FILE: 'File uploads are not saved in history, you must re-upload the file.',
   REQUEST_ABORTED: 'The request has been cancelled',
@@ -28,6 +29,14 @@ export const prettyErrorMessage = (message: string) => {
   // Invalid URL
   if (message === `Failed to construct 'URL': Invalid URL`) {
     return ERRORS.INVALID_URL
+  }
+
+  // Invalid URL protocol (thrown by undici in the Electron main process when
+  // a non-http(s) URL is sent — e.g. a relative path). The message may arrive
+  // wrapped by Electron's IPC layer (`Error invoking remote method ...`), so
+  // match on substring rather than equality.
+  if (message.includes('Invalid URL protocol')) {
+    return ERRORS.INVALID_URL_PROTOCOL
   }
 
   // Invalid Header


### PR DESCRIPTION
## Summary

Sending a request to a relative URL in the Electron API client surfaced a raw, cryptic error:

> Error invoking remote method 'customFetch': InvalidArgumentError: Invalid URL protocol: the URL must start with \`http:\` or \`https:\`.

The error originates from `undici` in the Electron main process and gets wrapped by Electron's IPC layer before reaching the UI. `prettyErrorMessage` did not recognize it and passed it through verbatim.

This adds a substring match in `prettyErrorMessage` (so it works for both the raw and Electron-wrapped forms) and maps it to a new `INVALID_URL_PROTOCOL` message: *"The URL must start with http:// or https://."*

**Before**

<img width="784" height="332" alt="image" src="https://github.com/user-attachments/assets/2efcb67c-f90a-41e2-8656-eddf4e3c484e" />

## Test plan

- [ ] `pnpm vitest packages/helpers/src/errors/normalize-error.test.ts --run` passes (18 tests, 2 new)
- [ ] In the API client (Electron), entering a relative URL like `/foo` and sending shows the friendly message instead of the IPC/undici stack


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to error-message normalization and tests, mapping a known undici/Electron error string to a friendlier message.
> 
> **Overview**
> Adds a new `ERRORS.INVALID_URL_PROTOCOL` message and teaches `prettyErrorMessage` to detect undici's "Invalid URL protocol" failures (including Electron IPC-wrapped variants) via substring matching, returning a friendly http/https guidance message.
> 
> Includes new unit tests covering both raw and Electron-wrapped error strings, plus a changeset bumping `@scalar/helpers` with a patch release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89384eb2ac27905b1604cfe4c9f2e8785ac0d512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->