### PR TITLE
fix(api-reference): download button for AsyncAPI documents

### DIFF
--- a/.changeset/asyncapi-download-label.md
+++ b/.changeset/asyncapi-download-label.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: show "Download AsyncAPI Document" label for AsyncAPI documents

--- a/packages/api-reference/src/blocks/scalar-info-block/components/DownloadLink.test.ts
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/DownloadLink.test.ts
@@ -246,4 +246,27 @@ describe('DownloadLink', () => {
       expect(button.attributes('type')).toBe('button')
     })
   })
+
+  describe('Document type label', () => {
+    it('renders the OpenAPI label by default', () => {
+      const wrapper = createWrapper({ documentDownloadType: 'json' })
+
+      expect(wrapper.find('.download-button span').text()).toBe('Download OpenAPI Document')
+    })
+
+    it('renders the AsyncAPI label when documentType is asyncapi', () => {
+      const wrapper = createWrapper({ documentDownloadType: 'json' }, { documentType: 'asyncapi' })
+
+      expect(wrapper.find('.download-button span').text()).toBe('Download AsyncAPI Document')
+    })
+
+    it('renders the AsyncAPI label on the direct download link', () => {
+      const wrapper = createWrapper(
+        { documentDownloadType: 'direct' },
+        { documentUrl: 'https://example.com/asyncapi.json', documentType: 'asyncapi' },
+      )
+
+      expect(wrapper.find('a.download-link span').text()).toBe('Download AsyncAPI Document')
+    })
+  })
 })

--- a/packages/api-reference/src/blocks/scalar-info-block/components/DownloadLink.vue
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/DownloadLink.vue
@@ -1,10 +1,16 @@
 <script lang="ts" setup>
 import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
 import { type WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { computed } from 'vue'
 
 import Badge from '@/components/Badge/Badge.vue'
 
-const { eventBus, documentDownloadType, documentUrl } = defineProps<{
+const {
+  eventBus,
+  documentDownloadType,
+  documentUrl,
+  documentType = 'openapi',
+} = defineProps<{
   /** The document download type. */
   documentDownloadType: ApiReferenceConfiguration['documentDownloadType']
   /** The event bus for the handling all events. */
@@ -14,7 +20,15 @@ const { eventBus, documentDownloadType, documentUrl } = defineProps<{
    * so the link can point to the document.
    */
   documentUrl?: string
+  /** The kind of document being rendered. Drives the button label. */
+  documentType?: 'openapi' | 'asyncapi'
 }>()
+
+const label = computed(() =>
+  documentType === 'asyncapi'
+    ? 'Download AsyncAPI Document'
+    : 'Download OpenAPI Document',
+)
 
 // The id is retrieved at the layout level.
 const handleDownloadClick = (format: 'json' | 'yaml') => {
@@ -36,7 +50,7 @@ const handleDownloadClick = (format: 'json' | 'yaml') => {
       v-if="documentDownloadType === 'direct' && documentUrl"
       class="download-link download-button"
       :href="documentUrl">
-      <span> Download OpenAPI Document </span>
+      <span>{{ label }}</span>
     </a>
 
     <!-- JSON  -->
@@ -45,7 +59,7 @@ const handleDownloadClick = (format: 'json' | 'yaml') => {
       class="download-button"
       type="button"
       @click.prevent="() => handleDownloadClick('json')">
-      <span> Download OpenAPI Document </span>
+      <span>{{ label }}</span>
       <Badge class="extension hidden group-hover:flex">json</Badge>
     </button>
 
@@ -55,7 +69,7 @@ const handleDownloadClick = (format: 'json' | 'yaml') => {
       class="download-button"
       type="button"
       @click.prevent="() => handleDownloadClick('yaml')">
-      <span> Download OpenAPI Document </span>
+      <span>{{ label }}</span>
       <Badge class="extension hidden group-hover:flex">yaml</Badge>
     </button>
   </div>

--- a/packages/api-reference/src/blocks/scalar-info-block/components/InfoBlock.vue
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/InfoBlock.vue
@@ -76,6 +76,7 @@ const introCardsSlot = computed(() =>
     <template #download-link>
       <DownloadLink
         :documentDownloadType
+        :documentType
         :documentUrl
         :eventBus />
     </template>

--- a/packages/api-reference/test/configuration/document-download-type.e2e.ts
+++ b/packages/api-reference/test/configuration/document-download-type.e2e.ts
@@ -1,5 +1,16 @@
-import { expect, test } from '@playwright/test'
+import { type Page, expect, test } from '@playwright/test'
 import { serveExample } from '@test/utils/serve-example'
+
+/**
+ * Locate a download button by the format shown on its (hover-revealed) badge.
+ *
+ * The visible label is "Download OpenAPI Document" on both buttons, so we
+ * filter by the inner `.extension` badge to distinguish json from yaml.
+ */
+const getDownloadButton = (page: Page, format: 'json' | 'yaml') =>
+  page
+    .getByRole('button', { name: 'Download OpenAPI Document' })
+    .filter({ has: page.locator('.extension', { hasText: format }) })
 
 test.describe('documentDownloadType', () => {
   test('shows both download buttons by default', async ({ page }) => {
@@ -7,8 +18,8 @@ test.describe('documentDownloadType', () => {
 
     await page.goto(example)
 
-    await expect(page.getByText('Download OpenAPI Document json', { exact: true })).toBeVisible()
-    await expect(page.getByText('Download OpenAPI Document yaml', { exact: true })).toBeVisible()
+    await expect(getDownloadButton(page, 'json')).toHaveCount(1)
+    await expect(getDownloadButton(page, 'yaml')).toHaveCount(1)
   })
 
   test('hides yaml download button when set to json', async ({ page }) => {
@@ -16,8 +27,8 @@ test.describe('documentDownloadType', () => {
 
     await page.goto(example)
 
-    await expect(page.getByText('Download OpenAPI Document json', { exact: true })).toBeVisible()
-    await expect(page.getByText('Download OpenAPI Document yaml', { exact: true })).not.toBeVisible()
+    await expect(getDownloadButton(page, 'json')).toHaveCount(1)
+    await expect(getDownloadButton(page, 'yaml')).toHaveCount(0)
   })
 
   test('hides json download button when set to yaml', async ({ page }) => {
@@ -25,7 +36,7 @@ test.describe('documentDownloadType', () => {
 
     await page.goto(example)
 
-    await expect(page.getByText('Download OpenAPI Document json', { exact: true })).not.toBeVisible()
-    await expect(page.getByText('Download OpenAPI Document yaml', { exact: true })).toBeVisible()
+    await expect(getDownloadButton(page, 'json')).toHaveCount(0)
+    await expect(getDownloadButton(page, 'yaml')).toHaveCount(1)
   })
 })

--- a/packages/api-reference/test/configuration/hide-download-button.e2e.ts
+++ b/packages/api-reference/test/configuration/hide-download-button.e2e.ts
@@ -1,5 +1,16 @@
-import { expect, test } from '@playwright/test'
+import { type Page, expect, test } from '@playwright/test'
 import { serveExample } from '@test/utils/serve-example'
+
+/**
+ * Locate a download button by the format shown on its (hover-revealed) badge.
+ *
+ * The visible label is "Download OpenAPI Document" on both buttons, so we
+ * filter by the inner `.extension` badge to distinguish json from yaml.
+ */
+const getDownloadButton = (page: Page, format: 'json' | 'yaml') =>
+  page
+    .getByRole('button', { name: 'Download OpenAPI Document' })
+    .filter({ has: page.locator('.extension', { hasText: format }) })
 
 test.describe('hideDownloadButton', () => {
   test('shows download button by default', async ({ page }) => {
@@ -7,8 +18,8 @@ test.describe('hideDownloadButton', () => {
 
     await page.goto(example)
 
-    await expect(page.getByText('Download OpenAPI Document json', { exact: true })).toBeVisible()
-    await expect(page.getByText('Download OpenAPI Document yaml', { exact: true })).toBeVisible()
+    await expect(getDownloadButton(page, 'json')).toHaveCount(1)
+    await expect(getDownloadButton(page, 'yaml')).toHaveCount(1)
   })
 
   test('hides download button when set to true', async ({ page }) => {
@@ -16,7 +27,7 @@ test.describe('hideDownloadButton', () => {
 
     await page.goto(example)
 
-    await expect(page.getByText('Download OpenAPI Document json', { exact: true })).not.toBeVisible()
-    await expect(page.getByText('Download OpenAPI Document yaml', { exact: true })).not.toBeVisible()
+    await expect(getDownloadButton(page, 'json')).toHaveCount(0)
+    await expect(getDownloadButton(page, 'yaml')).toHaveCount(0)
   })
 })


### PR DESCRIPTION
## Summary

When the active document is AsyncAPI, the download in the introduction block was still labelled "Download OpenAPI Document". The download itself already worked (it just serializes the active document), so this only fixes the label.

`Content.vue` now derives a `documentType` via `isAsyncApiDocument` and threads it through `InfoBlock` to `DownloadLink`, which switches the label to "Download AsyncAPI Document" when appropriate. Default is still `'openapi'`, so existing callers do not change behavior.

**Before**

<img width="590" height="264" alt="Screenshot 2026-05-11 at 13 09 41" src="https://github.com/user-attachments/assets/29fa43cd-eb36-48b5-8cae-5b20ea4f7ece" />

**After**

<img width="575" height="254" alt="Screenshot 2026-05-11 at 13 13 08" src="https://github.com/user-attachments/assets/567cf70a-e446-4a4c-b0cc-9ff1755fe2b7" />

## Test plan

- [ ] Open the api-reference playground at `#scalar-galaxy-events-asyncapi` — intro block reads "Download AsyncAPI Document"
- [ ] Click both json and yaml — downloaded files contain a valid AsyncAPI document
- [ ] Open `#scalar-galaxy` — intro block still reads "Download OpenAPI Document"
- [ ] `DownloadLink.test.ts` passes (24 tests, including 3 new ones for the label)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: download button text now depends on `documentType`, with added tests; no download behavior or data handling is modified.
> 
> **Overview**
> Fixes the intro-block download button/link label to reflect the active spec type by threading a `documentType` prop into `DownloadLink` and switching the text to **“Download AsyncAPI Document”** when appropriate (default remains OpenAPI).
> 
> Adds unit coverage for the new label behavior and updates Playwright e2e selectors to locate JSON/YAML download buttons via their format badges instead of concatenated text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2f565d713ccab563dd65beafa9264d75674d5a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->