### PR TITLE
fix(fastify-api-reference): prefer fastify swagger source over url

### DIFF
--- a/.changeset/green-cars-taste.md
+++ b/.changeset/green-cars-taste.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+fix fallback to `fastify.swagger()` when `@fastify/swagger` is installed, even if `configuration.url` is set.

--- a/integrations/fastify/src/fastifyApiReference.test.ts
+++ b/integrations/fastify/src/fastifyApiReference.test.ts
@@ -365,6 +365,34 @@ describe('fastifyApiReference', () => {
     })
   })
 
+  it('prefers @fastify/swagger over configuration.url when both are configured', async () => {
+    const spec = exampleDocument()
+    fastify = Fastify({
+      logger: false,
+    })
+
+    await fastify.register(fastifySwagger, {
+      mode: 'static',
+      specification: {
+        document: spec,
+      },
+      exposeRoute: false,
+    })
+    await fastify.register(fastifyApiReference, {
+      configuration: {
+        url: '/openapi.yaml',
+      },
+    })
+
+    const address = await fastify.listen({ port: 0 })
+    const htmlResponse = await fetch(`${address}/reference/`)
+    const openApiDocumentResponse = await fetch(`${address}/reference/openapi.json`)
+
+    expect(openApiDocumentResponse.status).toBe(200)
+    expect(await openApiDocumentResponse.json()).toEqual(spec)
+    expect(await htmlResponse.text()).toContain('./openapi.json')
+  })
+
   it('has the default title', async () => {
     fastify = Fastify({
       logger: false,

--- a/integrations/fastify/src/fastifyApiReference.ts
+++ b/integrations/fastify/src/fastifyApiReference.ts
@@ -83,18 +83,18 @@ const fastifyApiReference = fp<
           },
         }
       }
-      if (url) {
-        return {
-          type: 'url' as const,
-          get: () => url,
-        }
-      }
-
       // Even if @fastify/swagger is loaded, when the `decorator` option is set, the `swagger` function is not available.
       if (fastify.hasPlugin('@fastify/swagger') && typeof fastify.swagger === 'function') {
         return {
           type: 'swagger' as const,
           get: () => fastify.swagger(),
+        }
+      }
+
+      if (url) {
+        return {
+          type: 'url' as const,
+          get: () => url,
         }
       }
 

--- a/integrations/fastify/src/types.ts
+++ b/integrations/fastify/src/types.ts
@@ -28,8 +28,8 @@ export type FastifyApiReferenceOptions = {
    *
    * The specification is sourced from, in order of precedence:
    * - `configuration.spec.content`
-   * - `configuration.spec.url` – fetched via `@scalar/openapi-parser/plugins/fetch-urls`
-   * - `@fastify/swagger` – if `configuration.spec` is not provided
+   * - `@fastify/swagger` – if `configuration.spec.content` is not provided
+   * - `configuration.spec.url`
    *
    * These endpoints can be used to fetch the OpenAPI specification for your own programmatic use.
    *


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When `@fastify/swagger` is registered in static mode and `configuration.url` is set to a local path that is not exposed, Scalar treats that URL string as OpenAPI content. This causes the generated `/reference/openapi.json` endpoint to fail and prevents the automatic Fastify Swagger integration fallback users expect.

## Solution

- Prefer `fastify.swagger()` over `configuration.url` whenever `@fastify/swagger` is installed and exposes the `swagger` decorator.
- Keep `configuration.content` as highest priority.
- Add a regression test that reproduces the issue and verifies the fallback now works.
- Add a changeset for `@scalar/fastify-api-reference`.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Fixes #9160
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13c0f93a-384f-4566-aa72-6363116c8c85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13c0f93a-384f-4566-aa72-6363116c8c85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

