### PR TITLE
fix(api-reference): clean up document listeners on destroy

### DIFF
--- a/.changeset/api-reference-destroy-listeners.md
+++ b/.changeset/api-reference-destroy-listeners.md
@@ -1,0 +1,16 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): clean up deprecated document listeners on destroy
+
+`createApiReference()` registered three document-level listeners
+(`scalar:reload-references`, `scalar:destroy-references`,
+`scalar:update-references-config`) but `destroy()` only unmounted the
+Vue app — the listeners stayed attached forever. In environments that
+mount and destroy instances repeatedly (notably the Astro integration's
+`renderMode="client"` with view transitions), each navigation leaked
+three permanent listeners on `document`.
+
+Tie the listeners to an `AbortController` and abort it from `destroy()`
+so they all come off in one shot.

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -170,7 +170,7 @@ describe('createApiReference', () => {
     const element = document.querySelector('#mount-point')
     const config = { _integration: 'html' }
 
-    const apiReference = createApiReference(element!, apiReferenceConfigurationSchema.parse(config))
+    const apiReference = createApiReference(element!, coerce(apiReferenceConfigurationSchema, config))
 
     consoleWarnSpy.mockClear()
     apiReference.destroy()

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -166,6 +166,26 @@ describe('createApiReference', () => {
     )
   })
 
+  it('removes the deprecated document listeners on destroy', () => {
+    const element = document.querySelector('#mount-point')
+    const config = { _integration: 'html' }
+
+    const apiReference = createApiReference(element!, apiReferenceConfigurationSchema.parse(config))
+
+    consoleWarnSpy.mockClear()
+    apiReference.destroy()
+
+    document.dispatchEvent(new Event('scalar:reload-references'))
+    document.dispatchEvent(new Event('scalar:destroy-references'))
+    document.dispatchEvent(new CustomEvent('scalar:update-references-config', { detail: {} }))
+
+    // Listeners are scoped to the instance's `AbortController`, so dispatching
+    // these events after `destroy()` must not run their deprecation warnings —
+    // otherwise each remount during Astro view transitions would leak three
+    // permanent listeners on `document`.
+    expect(consoleWarnSpy).not.toHaveBeenCalled()
+  })
+
   it('allows mounting after creation', async () => {
     const config = { _integration: 'html' }
     const app = createApiReference(coerce(apiReferenceConfigurationSchema, config))

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -215,6 +215,16 @@ export const createApiReference: CreateApiReference = (
     }
   }
 
+  // Tie the deprecated `document` listeners to an AbortController so `destroy`
+  // can remove them all at once. Without this, every `createApiReference()`
+  // call leaks three permanent listeners — visible during Astro view
+  // transitions where each navigation creates a new instance.
+  const abortController = new AbortController()
+  const listenerOptions: AddEventListenerOptions = {
+    capture: false,
+    signal: abortController.signal,
+  }
+
   /**
    * Reload the API Reference
    * @deprecated
@@ -249,11 +259,12 @@ export const createApiReference: CreateApiReference = (
       app = createReferenceApp()
       app.mount(currentElement)
     },
-    false,
+    listenerOptions,
   )
 
   /** Destroy the current API Reference instance */
   const destroy = () => {
+    abortController.abort()
     props.configuration = {}
     app.unmount()
   }
@@ -268,7 +279,7 @@ export const createApiReference: CreateApiReference = (
       console.warn('scalar:destroy-references event has been deprecated, please use scalarInstance.destroy instead.')
       destroy()
     },
-    false,
+    listenerOptions,
   )
 
   /**
@@ -285,7 +296,7 @@ export const createApiReference: CreateApiReference = (
         Object.assign(props, ev.detail)
       }
     },
-    false,
+    listenerOptions,
   )
 
   const instance = {


### PR DESCRIPTION
`createApiReference()` attached three document listeners for the deprecated `scalar:*-references` events but never removed them. Anything that mounts and unmounts repeatedly (Astro view transitions, for example) was leaking three listeners per navigation.

Now they all come off in `destroy()` via an `AbortController`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bug fix that only changes lifecycle cleanup for deprecated `document` event listeners; main risk is unexpected behavior if an environment lacks `AbortController`/event listener `signal` support.
> 
> **Overview**
> Fixes a listener leak in `createApiReference()` by scoping the three deprecated `document` event handlers (`scalar:reload-references`, `scalar:destroy-references`, `scalar:update-references-config`) to an `AbortController` and aborting it in `destroy()` so they’re removed when an instance is torn down.
> 
> Adds a regression test ensuring dispatching those deprecated events after `destroy()` no longer triggers deprecation warnings, and includes a patch changeset entry documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e8525f345f548f663197faaae7773ff649a25cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->