### PR TITLE
fix(client-side-rendering): escape </script> in inline configs

### DIFF
--- a/.changeset/safe-stars-protect.md
+++ b/.changeset/safe-stars-protect.md
@@ -1,9 +1,12 @@
 ---
-'@scalar/client-side-rendering': patch
+'@scalar/client-side-rendering': minor
 ---
 
-fix(client-side-rendering): escape `</script>` and `<!--` in inline-script config
+fix(client-side-rendering): escape user-controlled values in the rendered HTML
 
-User-controlled values in the configuration (a `content` string, a custom callback's source, the CDN URL, etc.) used to be embedded into the inline `<script>` tag verbatim. A value containing `</script>` would terminate the surrounding script element early, breaking the API reference mount and letting any trailing characters be parsed as HTML.
+User-controlled values used to be embedded into the rendered page verbatim in two places:
 
-The serialization now goes through [`serialize-javascript`](https://github.com/yahoo/serialize-javascript), which preserves function-valued config props (instead of `JSON.stringify` silently dropping them) and applies HTML-safe escaping for `</script`, `<!--`, `<![CDATA[`, and the U+2028 / U+2029 line separators. The escape preserves the JavaScript string value while preventing the HTML parser from matching the dangerous sequence.
+- **Inline `<script>` body** — config props like `content`, a custom callback's source, etc. A value containing `</script>` would terminate the surrounding script element early, breaking the API reference mount and letting any trailing characters be parsed as HTML.
+- **`<script src="…">` attribute** — the CDN URL. A value containing `"` would close the attribute and let trailing markup be parsed as HTML.
+
+The config payload now goes through [`serialize-javascript`](https://github.com/yahoo/serialize-javascript), which preserves function-valued props (instead of `JSON.stringify` silently dropping them) and applies HTML-safe escaping for `</script`, `<!--`, `<![CDATA[`, and the U+2028 / U+2029 line separators. The CDN URL is now HTML-attribute-escaped (`&`, `<`, `>`, `"`, `'`) so it cannot break out of the `src` value.

--- a/.changeset/safe-stars-protect.md
+++ b/.changeset/safe-stars-protect.md
@@ -6,4 +6,4 @@ fix(client-side-rendering): escape `</script>` and `<!--` in inline-script confi
 
 User-controlled values in the configuration (a `content` string, a custom callback's source, the CDN URL, etc.) used to be embedded into the inline `<script>` tag verbatim. A value containing `</script>` would terminate the surrounding script element early, breaking the API reference mount and letting any trailing characters be parsed as HTML.
 
-The serialization now lives in a single `serializeConfigToScript` helper and applies HTML-safe escaping (`</script` → `<\/script`, `<!--` → `<\!--`). The escape preserves the JavaScript string value while preventing the HTML parser from matching the dangerous sequence.
+The serialization now goes through [`serialize-javascript`](https://github.com/yahoo/serialize-javascript), which preserves function-valued config props (instead of `JSON.stringify` silently dropping them) and applies HTML-safe escaping for `</script`, `<!--`, `<![CDATA[`, and the U+2028 / U+2029 line separators. The escape preserves the JavaScript string value while preventing the HTML parser from matching the dangerous sequence.

--- a/.changeset/safe-stars-protect.md
+++ b/.changeset/safe-stars-protect.md
@@ -1,0 +1,9 @@
+---
+'@scalar/client-side-rendering': patch
+---
+
+fix(client-side-rendering): escape `</script>` and `<!--` in inline-script config
+
+User-controlled values in the configuration (a `content` string, a custom callback's source, the CDN URL, etc.) used to be embedded into the inline `<script>` tag verbatim. A value containing `</script>` would terminate the surrounding script element early, breaking the API reference mount and letting any trailing characters be parsed as HTML.
+
+The serialization now lives in a single `serializeConfigToScript` helper and applies HTML-safe escaping (`</script` → `<\/script`, `<!--` → `<\!--`). The escape preserves the JavaScript string value while preventing the HTML parser from matching the dangerous sequence.

--- a/packages/client-side-rendering/package.json
+++ b/packages/client-side-rendering/package.json
@@ -35,9 +35,11 @@
   "dependencies": {
     "@scalar/schemas": "workspace:*",
     "@scalar/types": "workspace:*",
-    "@scalar/validation": "workspace:*"
+    "@scalar/validation": "workspace:*",
+    "serialize-javascript": "^7.0.5"
   },
   "devDependencies": {
+    "@types/serialize-javascript": "^5.0.4",
     "vite": "catalog:*"
   }
 }

--- a/packages/client-side-rendering/src/html-rendering.test.ts
+++ b/packages/client-side-rendering/src/html-rendering.test.ts
@@ -100,7 +100,7 @@ describe('html-rendering', () => {
           content: { foo: 'bar' },
         },
       })
-      expect(html).toContain('"url": "https://api.example.com/spec"')
+      expect(html).toContain('"url":"https://api.example.com/spec"')
       expect(html).not.toContain('"content"')
     })
 
@@ -174,8 +174,8 @@ describe('html-rendering', () => {
       }
 
       const tags = getScriptTags(config, 'https://example.com/script.js')
-      expect(tags).toContain('"tagsSorter": "alpha"')
-      expect(tags).toContain('"operationsSorter": "method"')
+      expect(tags).toContain('"tagsSorter":"alpha"')
+      expect(tags).toContain('"operationsSorter":"method"')
     })
 
     it('generates complete HTML document with configuration', () => {
@@ -209,7 +209,7 @@ describe('html-rendering', () => {
       expect(html).toContain('<script src="https://example.com/script.js"></script>')
 
       // Check that configuration is properly embedded
-      expect(html).toContain('"theme": "kepler"')
+      expect(html).toContain('"theme":"kepler"')
       expect(html).toContain('"tagsSorter": (a, b) => a.name.localeCompare(b.name)')
       // Check the onLoaded callback is included (whitespace may vary)
       expect(html).toContain('"onLoaded":')
@@ -226,7 +226,7 @@ describe('html-rendering', () => {
       const tags = getScriptTags(config, 'https://example.com/script.js')
 
       // Check that non-function properties are JSON stringified
-      expect(tags).toContain('"theme": "kepler"')
+      expect(tags).toContain('"theme":"kepler"')
       // Check that function properties are preserved
       expect(tags).toContain('"tagsSorter": (a, b) => a.name.localeCompare(b.name)')
       expect(tags).toContain('"onLoaded": () => console.log("loaded")')
@@ -263,11 +263,11 @@ describe('html-rendering', () => {
 
       const tags = getScriptTags(config, 'https://example.com/script.js')
 
-      expect(tags).toContain('"theme": "kepler"')
+      expect(tags).toContain('"theme":"kepler"')
       expect(tags).toContain('"onLoaded": () => console.log("loaded")')
-      expect(tags).toContain('{\n        "theme": "kepler",')
-      expect(tags).toContain('\n        "onLoaded": () => console.log("loaded")\n      }')
-      expect(tags).not.toContain('"theme": "kepler",,')
+      // Function entries are spliced before the closing brace of the JSON object literal.
+      expect(tags).toContain('{"theme":"kepler", "onLoaded": () => console.log("loaded")}')
+      expect(tags).not.toContain('"theme":"kepler",,')
     })
 
     it('preserves plugins array containing functions', () => {

--- a/packages/client-side-rendering/src/html-rendering.test.ts
+++ b/packages/client-side-rendering/src/html-rendering.test.ts
@@ -100,7 +100,7 @@ describe('html-rendering', () => {
           content: { foo: 'bar' },
         },
       })
-      expect(html).toContain('"url":"https://api.example.com/spec"')
+      expect(html).toContain('"url": "https://api.example.com/spec"')
       expect(html).not.toContain('"content"')
     })
 
@@ -174,8 +174,8 @@ describe('html-rendering', () => {
       }
 
       const tags = getScriptTags(config, 'https://example.com/script.js')
-      expect(tags).toContain('"tagsSorter":"alpha"')
-      expect(tags).toContain('"operationsSorter":"method"')
+      expect(tags).toContain('"tagsSorter": "alpha"')
+      expect(tags).toContain('"operationsSorter": "method"')
     })
 
     it('generates complete HTML document with configuration', () => {
@@ -209,7 +209,7 @@ describe('html-rendering', () => {
       expect(html).toContain('<script src="https://example.com/script.js"></script>')
 
       // Check that configuration is properly embedded
-      expect(html).toContain('"theme":"kepler"')
+      expect(html).toContain('"theme": "kepler"')
       expect(html).toContain('"tagsSorter": (a, b) => a.name.localeCompare(b.name)')
       // Check the onLoaded callback is included (whitespace may vary)
       expect(html).toContain('"onLoaded":')
@@ -226,7 +226,7 @@ describe('html-rendering', () => {
       const tags = getScriptTags(config, 'https://example.com/script.js')
 
       // Check that non-function properties are JSON stringified
-      expect(tags).toContain('"theme":"kepler"')
+      expect(tags).toContain('"theme": "kepler"')
       // Check that function properties are preserved
       expect(tags).toContain('"tagsSorter": (a, b) => a.name.localeCompare(b.name)')
       expect(tags).toContain('"onLoaded": () => console.log("loaded")')
@@ -263,11 +263,12 @@ describe('html-rendering', () => {
 
       const tags = getScriptTags(config, 'https://example.com/script.js')
 
-      expect(tags).toContain('"theme":"kepler"')
+      expect(tags).toContain('"theme": "kepler"')
       expect(tags).toContain('"onLoaded": () => console.log("loaded")')
-      // Function entries are spliced before the closing brace of the JSON object literal.
-      expect(tags).toContain('{"theme":"kepler", "onLoaded": () => console.log("loaded")}')
-      expect(tags).not.toContain('"theme":"kepler",,')
+      // The JSON prop and the function entry should both end up inside the
+      // same object literal, with no double commas left from the splice.
+      expect(tags).toMatch(/"theme": "kepler",\s+"onLoaded": \(\) => console\.log\("loaded"\)/)
+      expect(tags).not.toContain('"theme": "kepler",,')
     })
 
     it('preserves plugins array containing functions', () => {

--- a/packages/client-side-rendering/src/html-rendering.test.ts
+++ b/packages/client-side-rendering/src/html-rendering.test.ts
@@ -28,7 +28,7 @@ describe('html-rendering', () => {
     it('escapes HTML in page title', () => {
       const html = renderApiReference({ config: {}, pageTitle: '<script>alert("xss")</script>' })
       expect(html).not.toContain('<script>alert')
-      expect(html).toContain('<title>&lt;script&gt;alert("xss")&lt;/script&gt;</title>')
+      expect(html).toContain('<title>&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;</title>')
     })
 
     it('includes both custom CSS and custom theme when provided', () => {
@@ -125,6 +125,16 @@ describe('html-rendering', () => {
     it('uses custom CDN when provided', () => {
       const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}), 'https://example.com/script.js')
       expect(tags).toContain('https://example.com/script.js')
+    })
+
+    it('HTML-escapes the CDN URL so it cannot break out of the script src attribute', () => {
+      const malicious = 'https://example.com/x.js"><img src=x onerror=alert(1)>'
+      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}), malicious)
+
+      // The unescaped `"` would have closed the attribute and let the trailing
+      // markup be parsed as HTML; `&quot;` keeps it inside the attribute value.
+      expect(tags).not.toContain('"><img src=x onerror=alert(1)>')
+      expect(tags).toContain('&quot;&gt;&lt;img src=x onerror=alert(1)&gt;')
     })
 
     it('preserves function properties in configuration', () => {

--- a/packages/client-side-rendering/src/html-rendering.test.ts
+++ b/packages/client-side-rendering/src/html-rendering.test.ts
@@ -100,7 +100,8 @@ describe('html-rendering', () => {
           content: { foo: 'bar' },
         },
       })
-      expect(html).toContain('"url": "https://api.example.com/spec"')
+      // The serializer unicode-escapes `/` as `/` for inline-script safety.
+      expect(html).toContain('"url": "https:\\u002F\\u002Fapi.example.com\\u002Fspec"')
       expect(html).not.toContain('"content"')
     })
 
@@ -289,8 +290,11 @@ describe('html-rendering', () => {
 
       const tags = getScriptTags(config, 'https://example.com/script.js')
 
-      // Check that plugins array is preserved with function
-      expect(tags).toContain('"plugins": [() => ({')
+      // The function body comes from `Function#toString()` and contains the
+      // post-transpile source — assert on the substantive tokens, not on the
+      // exact line-wrapping that the pretty-printer produces.
+      expect(tags).toContain('"plugins":')
+      expect(tags).toContain('() => ({')
       expect(tags).toContain('name: "test-plugin"')
       expect(tags).toContain('extensions: [')
       expect(tags).toContain('name: "x-custom-extension"')

--- a/packages/client-side-rendering/src/html-rendering.ts
+++ b/packages/client-side-rendering/src/html-rendering.ts
@@ -1,17 +1,18 @@
 import type { AnyApiReferenceConfiguration, HtmlRenderingConfiguration } from '@scalar/types/api-reference'
 
-import { escapeForInlineScript, serializeConfigToScript } from './serialize-config'
+import { serializeConfigToScript } from './serialize-config'
 
 export type { AnyApiReferenceConfiguration, HtmlRenderingConfiguration }
 
 const DEFAULT_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
 
 /**
- * Escape HTML special characters in user-provided strings.
+ * Escape characters that could let a user-controlled string break out of any
+ * HTML context — element text content and single- or double-quoted attribute
+ * values both need `&`, `<`, `>`, `"`, and `'` neutralized.
  */
-const escapeHtml = (str: string): string => {
-  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-}
+const escapeHtml = (str: string): string =>
+  str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;')
 
 /**
  * Helper function to add consistent indentation to multiline strings
@@ -109,7 +110,7 @@ export function renderApiReference(
  */
 export function getScriptTags(configuration: Record<string, unknown>, cdn?: string): string {
   const configString = serializeConfigToScript(configuration)
-  const cdnUrl = escapeForInlineScript(cdn ?? DEFAULT_CDN)
+  const cdnUrl = escapeHtml(cdn ?? DEFAULT_CDN)
 
   return `
     <!-- Load the Script -->

--- a/packages/client-side-rendering/src/html-rendering.ts
+++ b/packages/client-side-rendering/src/html-rendering.ts
@@ -1,5 +1,7 @@
 import type { AnyApiReferenceConfiguration, HtmlRenderingConfiguration } from '@scalar/types/api-reference'
 
+import { escapeForInlineScript, serializeConfigToScript } from './serialize-config'
+
 export type { AnyApiReferenceConfiguration, HtmlRenderingConfiguration }
 
 const DEFAULT_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
@@ -103,50 +105,15 @@ export function renderApiReference(
 }
 
 /**
- * Helper function to serialize arrays that may contain functions
- */
-const serializeArrayWithFunctions = (arr: unknown[]): string => {
-  return `[${arr.map((item) => (typeof item === 'function' ? item.toString() : JSON.stringify(item))).join(', ')}]`
-}
-
-/**
  * The script tags to load the @scalar/api-reference package from the CDN.
  */
 export function getScriptTags(configuration: Record<string, unknown>, cdn?: string): string {
-  const restConfig = { ...configuration }
-
-  const functionProps: string[] = []
-
-  for (const [key, value] of Object.entries(configuration)) {
-    if (typeof value === 'function') {
-      functionProps.push(`"${key}": ${value.toString()}`)
-      delete restConfig[key]
-    } else if (Array.isArray(value) && value.some((item) => typeof item === 'function')) {
-      functionProps.push(`"${key}": ${serializeArrayWithFunctions(value)}`)
-      delete restConfig[key]
-    }
-  }
-
-  const jsonString = JSON.stringify(restConfig, null, 2)
-  const indentedJsonString = jsonString
-    .split('\n')
-    .map((line, index) => (index === 0 ? line : `      ${line}`))
-    .join('\n')
-
-  let configString = indentedJsonString
-
-  if (functionProps.length > 0) {
-    if (jsonString === '{}') {
-      configString = `{\n        ${functionProps.join(',\n        ')}\n      }`
-    } else {
-      const jsonWithoutClosingBrace = indentedJsonString.split('\n').slice(0, -1).join('\n')
-      configString = `${jsonWithoutClosingBrace},\n        ${functionProps.join(',\n        ')}\n      }`
-    }
-  }
+  const configString = serializeConfigToScript(configuration)
+  const cdnUrl = escapeForInlineScript(cdn ?? DEFAULT_CDN)
 
   return `
     <!-- Load the Script -->
-    <script src="${cdn ?? DEFAULT_CDN}"></script>
+    <script src="${cdnUrl}"></script>
 
     <!-- Initialize the Scalar API Reference -->
     <script type="text/javascript">

--- a/packages/client-side-rendering/src/index.ts
+++ b/packages/client-side-rendering/src/index.ts
@@ -5,4 +5,4 @@ export {
   getScriptTags,
   renderApiReference,
 } from './html-rendering'
-export { escapeForInlineScript, serializeConfigToScript } from './serialize-config'
+export { serializeConfigToScript } from './serialize-config'

--- a/packages/client-side-rendering/src/index.ts
+++ b/packages/client-side-rendering/src/index.ts
@@ -5,3 +5,4 @@ export {
   getScriptTags,
   renderApiReference,
 } from './html-rendering'
+export { escapeForInlineScript, serializeConfigToScript } from './serialize-config'

--- a/packages/client-side-rendering/src/serialize-config.test.ts
+++ b/packages/client-side-rendering/src/serialize-config.test.ts
@@ -28,7 +28,9 @@ describe('escapeForInlineScript', () => {
 
 describe('serializeConfigToScript', () => {
   it('returns a JSON-safe object literal when no functions are present', () => {
-    expect(serializeConfigToScript({ url: '/a.json', theme: 'kepler' })).toBe('{"url":"/a.json","theme":"kepler"}')
+    expect(serializeConfigToScript({ url: '/a.json', theme: 'kepler' })).toBe(
+      ['{', '        "url": "/a.json",', '        "theme": "kepler"', '      }'].join('\n'),
+    )
   })
 
   it('inlines function-valued props as raw source', () => {
@@ -39,7 +41,7 @@ describe('serializeConfigToScript', () => {
       },
     })
 
-    expect(result).toContain('"url":"/a.json"')
+    expect(result).toContain('"url": "/a.json"')
     expect(result).toContain('"onLoaded":')
     expect(result).toContain('namedHandler')
     expect(result).toMatch(/return ['"]hello['"]/)

--- a/packages/client-side-rendering/src/serialize-config.test.ts
+++ b/packages/client-side-rendering/src/serialize-config.test.ts
@@ -27,10 +27,13 @@ describe('escapeForInlineScript', () => {
 })
 
 describe('serializeConfigToScript', () => {
-  it('returns a JSON-safe object literal when no functions are present', () => {
-    expect(serializeConfigToScript({ url: '/a.json', theme: 'kepler' })).toBe(
-      ['{', '        "url": "/a.json",', '        "theme": "kepler"', '      }'].join('\n'),
-    )
+  it('serializes plain values as a valid JS object literal', () => {
+    const result = serializeConfigToScript({ url: '/a.json', theme: 'kepler' })
+
+    // serialize-javascript escapes `<`, `>`, and `/` as unicode escapes; the
+    // JS engine decodes them back to the original characters at runtime.
+    expect(result).toMatch(/"url":\s*"\\u002Fa\.json"/)
+    expect(result).toMatch(/"theme":\s*"kepler"/)
   })
 
   it('inlines function-valued props as raw source', () => {
@@ -41,7 +44,6 @@ describe('serializeConfigToScript', () => {
       },
     })
 
-    expect(result).toContain('"url": "/a.json"')
     expect(result).toContain('"onLoaded":')
     expect(result).toContain('namedHandler')
     expect(result).toMatch(/return ['"]hello['"]/)
@@ -54,7 +56,9 @@ describe('serializeConfigToScript', () => {
 
     const result = serializeConfigToScript({ plugins: ['plain', plugin] })
 
-    expect(result).toContain('"plugins": ["plain", function pluginFactory')
+    expect(result).toContain('"plugins":')
+    expect(result).toContain('"plain"')
+    expect(result).toContain('function pluginFactory')
   })
 
   it('emits a valid object literal when every prop is a function', () => {
@@ -67,23 +71,15 @@ describe('serializeConfigToScript', () => {
     expect(result).toContain('"onLoaded":')
     expect(result).toContain('namedHandler')
     expect(result).not.toContain('{,')
-    expect(result).not.toMatch(/^\{}$/)
-  })
-
-  it('drops `undefined` props from the JSON portion (matches JSON.stringify semantics)', () => {
-    const result = serializeConfigToScript({ customCss: undefined, onLoaded: () => 1 })
-    expect(result).not.toContain('customCss')
-    expect(result).toContain('"onLoaded":')
   })
 
   it('escapes </script> in string values so it cannot terminate the inline script', () => {
     const result = serializeConfigToScript({ content: '</script><img src=x onerror=alert(1)>' })
 
-    // Raw `</script` would close the surrounding <script> element. The escaped
-    // `<\/script` is parsed as the same string by the JS engine but does not
-    // match the HTML parser's end-tag scanner.
-    expect(result).not.toContain('</script')
-    expect(result).toContain('<\\/script')
+    // The HTML parser scans for a literal `</script` (case-insensitive). Any
+    // escape form (`</`, `<\/`) breaks the match while the JS engine
+    // still decodes back to the original string.
+    expect(result).not.toMatch(/<\/script/i)
   })
 
   it('escapes </script> inside function source', () => {
@@ -95,14 +91,12 @@ describe('serializeConfigToScript', () => {
 
     const result = serializeConfigToScript({ onLoaded })
 
-    expect(result).not.toContain('</script')
-    expect(result).toContain('<\\/script')
+    expect(result).not.toMatch(/<\/script/i)
   })
 
   it('escapes <!-- in user input', () => {
     const result = serializeConfigToScript({ content: 'a<!--b' })
 
     expect(result).not.toContain('<!--')
-    expect(result).toContain('<\\!--')
   })
 })

--- a/packages/client-side-rendering/src/serialize-config.test.ts
+++ b/packages/client-side-rendering/src/serialize-config.test.ts
@@ -1,30 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { escapeForInlineScript, serializeConfigToScript } from './serialize-config'
-
-describe('escapeForInlineScript', () => {
-  it('escapes lowercase </script>', () => {
-    expect(escapeForInlineScript('a</script>b')).toBe('a<\\/script>b')
-  })
-
-  it('escapes uppercase or mixed-case </script>', () => {
-    expect(escapeForInlineScript('a</SCRIPT>b')).toBe('a<\\/SCRIPT>b')
-    expect(escapeForInlineScript('a</ScRiPt>b')).toBe('a<\\/ScRiPt>b')
-  })
-
-  it('escapes <!-- so it cannot start an HTML comment', () => {
-    expect(escapeForInlineScript('a<!--b')).toBe('a<\\!--b')
-  })
-
-  it('leaves other content untouched', () => {
-    expect(escapeForInlineScript('regular text < > / \\')).toBe('regular text < > / \\')
-  })
-
-  it('is idempotent — escaping an already-escaped value does nothing', () => {
-    const once = escapeForInlineScript('</script><!--')
-    expect(escapeForInlineScript(once)).toBe(once)
-  })
-})
+import { serializeConfigToScript } from './serialize-config'
 
 describe('serializeConfigToScript', () => {
   it('serializes plain values as a valid JS object literal', () => {

--- a/packages/client-side-rendering/src/serialize-config.test.ts
+++ b/packages/client-side-rendering/src/serialize-config.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+
+import { escapeForInlineScript, serializeConfigToScript } from './serialize-config'
+
+describe('escapeForInlineScript', () => {
+  it('escapes lowercase </script>', () => {
+    expect(escapeForInlineScript('a</script>b')).toBe('a<\\/script>b')
+  })
+
+  it('escapes uppercase or mixed-case </script>', () => {
+    expect(escapeForInlineScript('a</SCRIPT>b')).toBe('a<\\/SCRIPT>b')
+    expect(escapeForInlineScript('a</ScRiPt>b')).toBe('a<\\/ScRiPt>b')
+  })
+
+  it('escapes <!-- so it cannot start an HTML comment', () => {
+    expect(escapeForInlineScript('a<!--b')).toBe('a<\\!--b')
+  })
+
+  it('leaves other content untouched', () => {
+    expect(escapeForInlineScript('regular text < > / \\')).toBe('regular text < > / \\')
+  })
+
+  it('is idempotent — escaping an already-escaped value does nothing', () => {
+    const once = escapeForInlineScript('</script><!--')
+    expect(escapeForInlineScript(once)).toBe(once)
+  })
+})
+
+describe('serializeConfigToScript', () => {
+  it('returns a JSON-safe object literal when no functions are present', () => {
+    expect(serializeConfigToScript({ url: '/a.json', theme: 'kepler' })).toBe('{"url":"/a.json","theme":"kepler"}')
+  })
+
+  it('inlines function-valued props as raw source', () => {
+    const result = serializeConfigToScript({
+      url: '/a.json',
+      onLoaded: function namedHandler() {
+        return 'hello'
+      },
+    })
+
+    expect(result).toContain('"url":"/a.json"')
+    expect(result).toContain('"onLoaded":')
+    expect(result).toContain('namedHandler')
+    expect(result).toMatch(/return ['"]hello['"]/)
+  })
+
+  it('preserves function entries inside arrays', () => {
+    const plugin = function pluginFactory() {
+      return { name: 'fn-plugin' }
+    }
+
+    const result = serializeConfigToScript({ plugins: ['plain', plugin] })
+
+    expect(result).toContain('"plugins": ["plain", function pluginFactory')
+  })
+
+  it('emits a valid object literal when every prop is a function', () => {
+    const result = serializeConfigToScript({
+      onLoaded: function namedHandler() {
+        return null
+      },
+    })
+
+    expect(result).toContain('"onLoaded":')
+    expect(result).toContain('namedHandler')
+    expect(result).not.toContain('{,')
+    expect(result).not.toMatch(/^\{}$/)
+  })
+
+  it('drops `undefined` props from the JSON portion (matches JSON.stringify semantics)', () => {
+    const result = serializeConfigToScript({ customCss: undefined, onLoaded: () => 1 })
+    expect(result).not.toContain('customCss')
+    expect(result).toContain('"onLoaded":')
+  })
+
+  it('escapes </script> in string values so it cannot terminate the inline script', () => {
+    const result = serializeConfigToScript({ content: '</script><img src=x onerror=alert(1)>' })
+
+    // Raw `</script` would close the surrounding <script> element. The escaped
+    // `<\/script` is parsed as the same string by the JS engine but does not
+    // match the HTML parser's end-tag scanner.
+    expect(result).not.toContain('</script')
+    expect(result).toContain('<\\/script')
+  })
+
+  it('escapes </script> inside function source', () => {
+    const onLoaded = function leak() {
+      // This source survives `Function#toString()` and would otherwise close
+      // the surrounding inline script.
+      return '</script><img src=x>'
+    }
+
+    const result = serializeConfigToScript({ onLoaded })
+
+    expect(result).not.toContain('</script')
+    expect(result).toContain('<\\/script')
+  })
+
+  it('escapes <!-- in user input', () => {
+    const result = serializeConfigToScript({ content: 'a<!--b' })
+
+    expect(result).not.toContain('<!--')
+    expect(result).toContain('<\\!--')
+  })
+})

--- a/packages/client-side-rendering/src/serialize-config.ts
+++ b/packages/client-side-rendering/src/serialize-config.ts
@@ -1,62 +1,32 @@
+import serialize from 'serialize-javascript'
+
 /**
  * Escape sequences that would let a value break out of an inline `<script>` tag.
  *
- * The HTML parser scans script bodies for `</script` (case-insensitive) and
- * `<!--`. A user-controlled string in the configuration (for example
- * `content`, a custom callback's source, or a CDN URL) that contains those
- * sequences would terminate the script element early — leaving the trailing
- * characters to be parsed as HTML and potentially executing injected markup.
- *
- * Inserting a backslash keeps the JavaScript string value identical (`\/` is
- * just `/` to the JS engine) while preventing the HTML parser from matching
- * the dangerous sequence.
+ * `serializeConfigToScript` already handles this for the config payload via
+ * `serialize-javascript`. This standalone helper is exposed for callers that
+ * splice other user-controlled strings into the same inline-script context
+ * (for example a CDN URL that downstream code interpolates into the
+ * surrounding HTML).
  */
 export const escapeForInlineScript = (source: string): string =>
   source.replace(/<\/(script)/gi, '<\\/$1').replace(/<!--/g, '<\\!--')
-
-const serializeArrayWithFunctions = (arr: readonly unknown[]): string =>
-  `[${arr.map((item) => (typeof item === 'function' ? item.toString() : JSON.stringify(item))).join(', ')}]`
 
 /**
  * Serialize a configuration object to a JavaScript expression string that can
  * be safely embedded inside an inline `<script>` tag.
  *
- * - Preserves top-level function-valued props (and arrays containing
- *   functions) by emitting raw source via `Function#toString` instead of
- *   silently dropping them (which `JSON.stringify` would do).
- * - Pretty-prints with 2-space indent and indents continuation lines with 6
- *   spaces so the output drops neatly into a `<script>` block.
- * - Escapes any `</script` or `<!--` sequences in the result.
+ * `serialize-javascript` preserves function-valued props (via
+ * `Function#toString`) instead of silently dropping them the way
+ * `JSON.stringify` does, and escapes `</script`, `<!--`, `<![CDATA[`, and the
+ * U+2028 / U+2029 line separators so the output cannot break out of the
+ * surrounding script element.
+ *
+ * Continuation lines are indented six spaces so the result drops neatly into
+ * the script template in `html-rendering.ts`.
  */
-export const serializeConfigToScript = (config: Record<string, unknown>): string => {
-  const jsonSafe: Record<string, unknown> = { ...config }
-  const functionEntries: string[] = []
-
-  for (const [key, value] of Object.entries(config)) {
-    if (typeof value === 'function') {
-      functionEntries.push(`"${key}": ${(value as (...args: unknown[]) => unknown).toString()}`)
-      delete jsonSafe[key]
-    } else if (Array.isArray(value) && value.some((item) => typeof item === 'function')) {
-      functionEntries.push(`"${key}": ${serializeArrayWithFunctions(value)}`)
-      delete jsonSafe[key]
-    }
-  }
-
-  const json = JSON.stringify(jsonSafe, null, 2)
-  const indented = json
+export const serializeConfigToScript = (config: Record<string, unknown>): string =>
+  serialize(config, { space: 2 })
     .split('\n')
     .map((line, index) => (index === 0 ? line : `      ${line}`))
     .join('\n')
-
-  let result: string
-  if (functionEntries.length === 0) {
-    result = indented
-  } else if (json === '{}') {
-    result = `{\n        ${functionEntries.join(',\n        ')}\n      }`
-  } else {
-    const withoutClose = indented.split('\n').slice(0, -1).join('\n')
-    result = `${withoutClose},\n        ${functionEntries.join(',\n        ')}\n      }`
-  }
-
-  return escapeForInlineScript(result)
-}

--- a/packages/client-side-rendering/src/serialize-config.ts
+++ b/packages/client-side-rendering/src/serialize-config.ts
@@ -1,0 +1,55 @@
+/**
+ * Escape sequences that would let a value break out of an inline `<script>` tag.
+ *
+ * The HTML parser scans script bodies for `</script` (case-insensitive) and
+ * `<!--`. A user-controlled string in the configuration (for example
+ * `content`, a custom callback's source, or a CDN URL) that contains those
+ * sequences would terminate the script element early — leaving the trailing
+ * characters to be parsed as HTML and potentially executing injected markup.
+ *
+ * Inserting a backslash keeps the JavaScript string value identical (`\/` is
+ * just `/` to the JS engine) while preventing the HTML parser from matching
+ * the dangerous sequence.
+ */
+export const escapeForInlineScript = (source: string): string =>
+  source.replace(/<\/(script)/gi, '<\\/$1').replace(/<!--/g, '<\\!--')
+
+const serializeArrayWithFunctions = (arr: readonly unknown[]): string =>
+  `[${arr.map((item) => (typeof item === 'function' ? item.toString() : JSON.stringify(item))).join(', ')}]`
+
+/**
+ * Serialize a configuration object to a JavaScript expression string that can
+ * be safely embedded inside an inline `<script>` tag.
+ *
+ * - Preserves top-level function-valued props (and arrays containing
+ *   functions) by emitting raw source via `Function#toString` instead of
+ *   silently dropping them (which `JSON.stringify` would do).
+ * - Escapes any `</script` or `<!--` sequences in the result.
+ */
+export const serializeConfigToScript = (config: Record<string, unknown>): string => {
+  const jsonSafe: Record<string, unknown> = { ...config }
+  const functionEntries: string[] = []
+
+  for (const [key, value] of Object.entries(config)) {
+    if (typeof value === 'function') {
+      functionEntries.push(`${JSON.stringify(key)}: ${(value as (...args: unknown[]) => unknown).toString()}`)
+      delete jsonSafe[key]
+    } else if (Array.isArray(value) && value.some((item) => typeof item === 'function')) {
+      functionEntries.push(`${JSON.stringify(key)}: ${serializeArrayWithFunctions(value)}`)
+      delete jsonSafe[key]
+    }
+  }
+
+  const json = JSON.stringify(jsonSafe)
+
+  let result: string
+  if (functionEntries.length === 0) {
+    result = json
+  } else if (json === '{}') {
+    result = `{ ${functionEntries.join(', ')} }`
+  } else {
+    result = `${json.slice(0, -1)}, ${functionEntries.join(', ')}}`
+  }
+
+  return escapeForInlineScript(result)
+}

--- a/packages/client-side-rendering/src/serialize-config.ts
+++ b/packages/client-side-rendering/src/serialize-config.ts
@@ -1,18 +1,6 @@
 import serialize from 'serialize-javascript'
 
 /**
- * Escape sequences that would let a value break out of an inline `<script>` tag.
- *
- * `serializeConfigToScript` already handles this for the config payload via
- * `serialize-javascript`. This standalone helper is exposed for callers that
- * splice other user-controlled strings into the same inline-script context
- * (for example a CDN URL that downstream code interpolates into the
- * surrounding HTML).
- */
-export const escapeForInlineScript = (source: string): string =>
-  source.replace(/<\/(script)/gi, '<\\/$1').replace(/<!--/g, '<\\!--')
-
-/**
  * Serialize a configuration object to a JavaScript expression string that can
  * be safely embedded inside an inline `<script>` tag.
  *

--- a/packages/client-side-rendering/src/serialize-config.ts
+++ b/packages/client-side-rendering/src/serialize-config.ts
@@ -24,6 +24,8 @@ const serializeArrayWithFunctions = (arr: readonly unknown[]): string =>
  * - Preserves top-level function-valued props (and arrays containing
  *   functions) by emitting raw source via `Function#toString` instead of
  *   silently dropping them (which `JSON.stringify` would do).
+ * - Pretty-prints with 2-space indent and indents continuation lines with 6
+ *   spaces so the output drops neatly into a `<script>` block.
  * - Escapes any `</script` or `<!--` sequences in the result.
  */
 export const serializeConfigToScript = (config: Record<string, unknown>): string => {
@@ -32,23 +34,28 @@ export const serializeConfigToScript = (config: Record<string, unknown>): string
 
   for (const [key, value] of Object.entries(config)) {
     if (typeof value === 'function') {
-      functionEntries.push(`${JSON.stringify(key)}: ${(value as (...args: unknown[]) => unknown).toString()}`)
+      functionEntries.push(`"${key}": ${(value as (...args: unknown[]) => unknown).toString()}`)
       delete jsonSafe[key]
     } else if (Array.isArray(value) && value.some((item) => typeof item === 'function')) {
-      functionEntries.push(`${JSON.stringify(key)}: ${serializeArrayWithFunctions(value)}`)
+      functionEntries.push(`"${key}": ${serializeArrayWithFunctions(value)}`)
       delete jsonSafe[key]
     }
   }
 
-  const json = JSON.stringify(jsonSafe)
+  const json = JSON.stringify(jsonSafe, null, 2)
+  const indented = json
+    .split('\n')
+    .map((line, index) => (index === 0 ? line : `      ${line}`))
+    .join('\n')
 
   let result: string
   if (functionEntries.length === 0) {
-    result = json
+    result = indented
   } else if (json === '{}') {
-    result = `{ ${functionEntries.join(', ')} }`
+    result = `{\n        ${functionEntries.join(',\n        ')}\n      }`
   } else {
-    result = `${json.slice(0, -1)}, ${functionEntries.join(', ')}}`
+    const withoutClose = indented.split('\n').slice(0, -1).join('\n')
+    result = `${withoutClose},\n        ${functionEntries.join(',\n        ')}\n      }`
   }
 
   return escapeForInlineScript(result)

--- a/packages/client-side-rendering/test/few-dependencies.test.ts
+++ b/packages/client-side-rendering/test/few-dependencies.test.ts
@@ -4,11 +4,16 @@ import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 describe('few-dependencies', () => {
-  it('has only `@scalar/types`, `@scalar/schemas`, and `@scalar/validation` as production dependencies', () => {
+  it('has only `@scalar/types`, `@scalar/schemas`, `@scalar/validation`, and `serialize-javascript` as production dependencies', () => {
     const packageJson = readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8')
     const dependencies = JSON.parse(packageJson).dependencies
 
     expect(dependencies).toBeDefined()
-    expect(Object.keys(dependencies)).toStrictEqual(['@scalar/schemas', '@scalar/types', '@scalar/validation'])
+    expect(Object.keys(dependencies)).toStrictEqual([
+      '@scalar/schemas',
+      '@scalar/types',
+      '@scalar/validation',
+      'serialize-javascript',
+    ])
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1082,7 +1082,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: ^4.0.0
-        version: 4.3.1(magicast@0.5.2)
+        version: 4.3.1(magicast@0.3.5)
       '@scalar/api-client':
         specifier: workspace:*
         version: link:../../packages/api-client
@@ -1101,7 +1101,7 @@ importers:
     devDependencies:
       '@nuxt/module-builder':
         specifier: ^1.0.1
-        version: 1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))
       '@types/node':
         specifier: ^24.1.0
         version: 24.10.13
@@ -1110,7 +1110,7 @@ importers:
         version: 10.1.0
       nuxt:
         specifier: ^4.1.0
-        version: 4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3)
+        version: 4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3)
       shx:
         specifier: catalog:*
         version: 0.4.0
@@ -1593,7 +1593,13 @@ importers:
       '@scalar/validation':
         specifier: workspace:*
         version: link:../validation
+      serialize-javascript:
+        specifier: ^7.0.5
+        version: 7.0.5
     devDependencies:
+      '@types/serialize-javascript':
+        specifier: ^5.0.4
+        version: 5.0.4
       vite:
         specifier: catalog:*
         version: 8.0.0(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3)
@@ -8997,6 +9003,9 @@ packages:
 
   '@types/send@0.17.4':
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
+
+  '@types/serialize-javascript@5.0.4':
+    resolution: {integrity: sha512-Z2R7UKFuNWCP8eoa2o9e5rkD3hmWxx/1L0CYz0k2BZzGh0PhEVMp9kfGiqEml/0IglwNERXZ2hwNzIrSz/KHTA==}
 
   '@types/serve-index@1.9.4':
     resolution: {integrity: sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==}
@@ -16744,6 +16753,10 @@ packages:
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+    engines: {node: '>=20.0.0'}
+
   seroval@1.5.1:
     resolution: {integrity: sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==}
     engines: {node: '>=10'}
@@ -23632,11 +23645,11 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)':
+  '@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.1)(commander@13.1.0)
       '@clack/prompts': 1.1.0
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.3.5)
       citty: 0.2.1
       confbox: 0.2.4
       consola: 3.4.2
@@ -23844,9 +23857,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/kit@4.1.2(magicast@0.5.2)':
+  '@nuxt/kit@4.1.2(magicast@0.3.5)':
     dependencies:
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.3.5)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -23867,6 +23880,31 @@ snapshots:
       ufo: 1.6.3
       unctx: 2.5.0
       unimport: 5.7.0
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@nuxt/kit@4.3.1(magicast@0.3.5)':
+    dependencies:
+      c12: 3.3.3(magicast@0.3.5)
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.0.8
+      ignore: 7.0.5
+      jiti: 2.6.1
+      klona: 2.0.6
+      mlly: 1.8.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      rc9: 3.0.0
+      scule: 1.3.0
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ufo: 1.6.3
+      unctx: 2.5.0
       untyped: 2.0.0
     transitivePeerDependencies:
       - magicast
@@ -23896,9 +23934,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/module-builder@1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))':
+  '@nuxt/module-builder@1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)
       citty: 0.1.6
       consola: 3.4.2
       defu: 6.1.4
@@ -24013,9 +24051,9 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.1.2(magicast@0.5.2))':
+  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.1.2(magicast@0.3.5))':
     dependencies:
-      '@nuxt/kit': 4.1.2(magicast@0.5.2)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       citty: 0.2.1
       consola: 3.4.2
       ofetch: 2.0.0-alpha.3
@@ -24085,9 +24123,9 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)':
+  '@nuxt/vite-builder@4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)':
     dependencies:
-      '@nuxt/kit': 4.1.2(magicast@0.5.2)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
       '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 5.1.4(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
@@ -26590,6 +26628,8 @@ snapshots:
     dependencies:
       '@types/mime': 1.3.5
       '@types/node': 24.10.13
+
+  '@types/serialize-javascript@5.0.4': {}
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -33908,18 +33948,18 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3):
+  nuxt@4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3):
     dependencies:
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
       '@nuxt/devtools': 2.7.0(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
-      '@nuxt/kit': 4.1.2(magicast@0.5.2)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       '@nuxt/schema': 4.1.2
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.1.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.1.2(magicast@0.3.5))
+      '@nuxt/vite-builder': 4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.3.5)
       chokidar: 4.0.3
       compatx: 0.2.0
       consola: 3.4.2
@@ -36568,6 +36608,8 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+
+  serialize-javascript@7.0.5: {}
 
   seroval@1.5.1: {}
 


### PR DESCRIPTION
A value like `</script>` inside a config string (content, callback source, CDN URL, …) used to get written into the inline `<script>` tag verbatim — terminating the script early and letting whatever followed get parsed as HTML.

The config serialization now lives in a shared `serializeConfigToScript` helper and escapes `</script` and `<!--` before they hit the page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches HTML generation and inline script serialization; while changes are well-tested, mistakes could break client-side mounting or reintroduce XSS vectors.
> 
> **Overview**
> **Escapes user-controlled values when generating the API reference HTML.** Inline config serialization is replaced with `serialize-javascript` via a new shared `serializeConfigToScript` helper to prevent `</script>`/`<!--`-style breakouts while preserving function-valued props.
> 
> **Hardens script loading and titles.** The CDN URL is now HTML-attribute-escaped before being inserted into `<script src="…">`, and page-title escaping is tightened (including quotes). Tests and dependencies are updated accordingly, and `serializeConfigToScript` is exported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47d25c6902cdf20fad2c506dcc8be13ab36173b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->