### PR TITLE
feat(astro): client render mode for view transitions

### DIFF
--- a/.changeset/astro-starlight-support.md
+++ b/.changeset/astro-starlight-support.md
@@ -1,0 +1,7 @@
+---
+'@scalar/astro': minor
+---
+
+feat(astro): improve Starlight support
+
+Adds a `renderMode="client"` mode to `<ScalarComponent />` that mounts Scalar on the client and re-mounts around Astro view-transition events (`astro:before-swap`, `astro:page-load`). This fixes the "content appears only after a refresh" issue on Starlight pages and other Astro sites that use client-side navigation. A new `mountElementId` prop allows overriding the mount container id; if omitted, a unique `scalar-app-<uuid>` is generated per render so multiple components can coexist on one page. Function-valued config props (`content`, `plugins`, `onLoaded`, custom `fetch`, ...) are preserved through the same source-serialization that static mode already uses.

--- a/documentation/integrations/astro.md
+++ b/documentation/integrations/astro.md
@@ -90,3 +90,30 @@ import { ScalarComponent } from '@scalar/astro'
   proxyUrl: 'https://proxy.scalar.com',
 }} />
 ```
+
+### Starlight and View Transitions
+
+For a Starlight-specific guide, see [API Reference for Starlight](./starlight.md).
+
+If your Astro site uses client-side page transitions (for example Starlight with View Transitions),
+use `renderMode: 'client'` to mount Scalar after navigation events.
+
+This avoids the "content appears only after a refresh" issue on API reference pages.
+
+```astro
+---
+import { ScalarComponent } from '@scalar/astro'
+---
+
+<ScalarComponent
+  renderMode="client"
+  configuration={{
+    url: '/openapi.json',
+  }}
+/>
+```
+
+#### Client render mode options
+
+- `renderMode`: `'static' | 'client'` (defaults to `'static'`)
+- `mountElementId`: custom mount element id for client mode (defaults to a random `scalar-app-<uuid>` so multiple components on the same page do not collide)

--- a/documentation/integrations/starlight.md
+++ b/documentation/integrations/starlight.md
@@ -1,0 +1,40 @@
+# API Reference for Starlight (Astro)
+
+Starlight is built on Astro, so the Scalar integration for Starlight uses `@scalar/astro`.
+
+Use `renderMode="client"` so Scalar mounts correctly after Starlight navigation events.
+
+## Installation
+
+```bash
+npm install @scalar/astro
+```
+
+## Usage
+
+Use `ScalarComponent` in a Starlight page, and set `renderMode` to `client`:
+
+```astro
+---
+import { ScalarComponent } from '@scalar/astro'
+---
+
+<ScalarComponent
+  renderMode="client"
+  configuration={{
+    // Read more about configuration:
+    // https://scalar.com/products/api-references/configuration
+    url: '/openapi.json',
+  }}
+/>
+```
+
+## Why use `renderMode="client"` in Starlight
+
+Starlight commonly uses view transitions and client-side navigation. In this setup, static server-rendered HTML can appear empty after route changes until a full refresh.
+
+Client mode remounts Scalar on page transitions, which avoids that issue.
+
+## Related Astro guide
+
+For Astro usage outside of Starlight, see [API Reference for Astro](./astro.md).

--- a/integrations/astro/package.json
+++ b/integrations/astro/package.json
@@ -22,7 +22,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "dev": "cd playground && pnpm dev"
+    "dev": "cd playground && pnpm dev",
+    "test": "vitest --run"
   },
   "type": "module",
   "exports": {
@@ -51,7 +52,9 @@
     "@scalar/client-side-rendering": "workspace:*"
   },
   "devDependencies": {
-    "astro": "^4.0.0 || ^5.0.0 || ^6.0.0"
+    "astro": "^4.0.0 || ^5.0.0 || ^6.0.0",
+    "jsdom": "catalog:*",
+    "vitest": "catalog:*"
   },
   "peerDependencies": {
     "astro": "^4.0.0 || ^5.0.0"

--- a/integrations/astro/playground/src/pages/about.astro
+++ b/integrations/astro/playground/src/pages/about.astro
@@ -1,0 +1,10 @@
+---
+import { ClientRouter } from 'astro:transitions'
+---
+
+<ClientRouter />
+<h1>Astro playground page</h1>
+
+<p>
+  <a href="/client">Back to client mode example</a>
+</p>

--- a/integrations/astro/playground/src/pages/client.astro
+++ b/integrations/astro/playground/src/pages/client.astro
@@ -1,0 +1,16 @@
+---
+import { ScalarComponent } from '@scalar/astro'
+import { ClientRouter } from 'astro:transitions'
+---
+
+<ClientRouter />
+<h1>Client mode API reference</h1>
+<p><a href="/about">Go to another page</a></p>
+<p><a href="/">Back to static mode example</a></p>
+
+<ScalarComponent
+  renderMode="client"
+  configuration={{
+    url: 'https://registry.scalar.com/@scalar/apis/galaxy?format=json',
+  }}
+/>

--- a/integrations/astro/playground/src/pages/index.astro
+++ b/integrations/astro/playground/src/pages/index.astro
@@ -2,6 +2,8 @@
 import { ScalarComponent } from '@scalar/astro'
 ---
 
+<p><a href="/client">Client mode example</a></p>
+
 <ScalarComponent configuration={{
 	url: 'https://registry.scalar.com/@scalar/apis/galaxy?format=json',
 }} />

--- a/integrations/astro/src/ScalarComponent.astro
+++ b/integrations/astro/src/ScalarComponent.astro
@@ -1,8 +1,23 @@
 ---
-import { renderApiReference, type HtmlRenderingConfiguration } from '@scalar/client-side-rendering'
+import { getConfiguration, renderApiReference, type HtmlRenderingConfiguration } from '@scalar/client-side-rendering'
+
+import { serializeClientConfig } from './serialize-client-config'
 
 export interface Props {
   configuration: Partial<HtmlRenderingConfiguration>
+  /**
+   * Rendering strategy for Astro pages.
+   *
+   * - `static` renders pre-generated HTML (default)
+   * - `client` mounts Scalar on the client and re-mounts on `astro:page-load`
+   */
+  renderMode?: 'static' | 'client'
+  /**
+   * Element id used as the client mount point.
+   *
+   * Only used when `renderMode` is `client`.
+   */
+  mountElementId?: string
 }
 
 /**
@@ -13,18 +28,58 @@ const DEFAULT_CONFIGURATION: Partial<HtmlRenderingConfiguration> = {
   // _integration: 'astro',
 }
 
-const { configuration } = Astro.props
+// Generate a unique id per render so multiple `<ScalarComponent />` instances
+// on the same page do not collide on the default mount id.
+const {
+  configuration,
+  renderMode = 'static',
+  mountElementId = `scalar-app-${crypto.randomUUID()}`,
+}: Props = Astro.props
 
 const finalConfiguration = {
   ...DEFAULT_CONFIGURATION,
   ...configuration,
 }
 const { cdn, pageTitle, ...config } = finalConfiguration
-const html = renderApiReference({
-  config,
-  cdn,
-  pageTitle,
-})
+const html =
+  renderMode === 'static'
+    ? renderApiReference({
+        config,
+        cdn,
+        pageTitle,
+      })
+    : null
+
+// Run the config through the same normalization the static path applies via
+// `renderApiReference`, so client mode also drops `content` when `url` is set
+// and resolves function-valued `content`.
+const clientScript =
+  renderMode === 'client'
+    ? serializeClientConfig({
+        key: mountElementId,
+        configuration: getConfiguration(config as Record<string, unknown>),
+        cdn: cdn ?? null,
+      })
+    : null
 ---
 
-<div set:html={html}></div>
+{
+  renderMode === 'static' ? (
+    <div set:html={html ?? ''}></div>
+  ) : (
+    <>
+      <div id={mountElementId} data-scalar-mount></div>
+      {/*
+        Per-instance registration script. Emits raw JS (not JSON) so function-
+        valued config props (`content`, `plugins`, `onLoaded`, custom `fetch`,
+        ...) survive into the browser instead of being dropped by `JSON.stringify`.
+      */}
+      <script is:inline set:html={clientScript ?? ''}></script>
+      <script>
+        import { initScalarAstro } from './client'
+
+        initScalarAstro()
+      </script>
+    </>
+  )
+}

--- a/integrations/astro/src/client.test.ts
+++ b/integrations/astro/src/client.test.ts
@@ -1,0 +1,408 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getStyleHref, initScalarAstro } from './client'
+
+const STATE_KEY = '__scalarAstroState'
+const DEFAULT_STYLE_HREF = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/dist/style.css'
+
+type RegistryEntry = { configuration: unknown; cdn: string | null }
+type RegistryWindow = { __scalarAstro?: { configs?: Record<string, RegistryEntry> } }
+
+const registerConfig = (id: string, entry: RegistryEntry) => {
+  const win = window as unknown as RegistryWindow
+  win.__scalarAstro ??= { configs: {} }
+  win.__scalarAstro.configs ??= {}
+  win.__scalarAstro.configs[id] = entry
+}
+
+const addMountElement = (id: string, configuration: object | null, cdn: string | null = null): HTMLElement => {
+  const el = document.createElement('div')
+  el.id = id
+  el.setAttribute('data-scalar-mount', '')
+
+  if (configuration !== null) {
+    registerConfig(id, { configuration, cdn })
+  }
+
+  document.body.appendChild(el)
+  return el
+}
+
+const seedLoadedStylesheet = (href: string = DEFAULT_STYLE_HREF) => {
+  const link = document.createElement('link')
+  link.rel = 'stylesheet'
+  link.href = href
+  link.dataset.scalarAstroStyle = 'true'
+  link.dataset.loaded = 'true'
+  document.head.appendChild(link)
+}
+
+const seedLoadedCdnScript = (src: string = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference') => {
+  const script = document.createElement('script')
+  script.src = src
+  script.dataset.scalarAstroCdn = 'true'
+  script.dataset.loaded = 'true'
+  document.head.appendChild(script)
+}
+
+const stubScalarGlobal = () => {
+  const destroy = vi.fn()
+  const createApiReference = vi.fn(() => ({ destroy }))
+  ;(window as unknown as { Scalar: { createApiReference: typeof createApiReference } }).Scalar = {
+    createApiReference,
+  }
+  // Seed a matching loaded CDN script so `ensureCdnLoaded` short-circuits via
+  // the `dataset.loaded === 'true'` branch in `loadCdn`. Required because the
+  // loader no longer skips just because `window.Scalar` is set — that early
+  // return ignored the requested `cdn` URL and was the bug behind issue 6.
+  seedLoadedCdnScript()
+  return { createApiReference, destroy }
+}
+
+const resetEnvironment = () => {
+  document.body.replaceChildren()
+  document.head.replaceChildren()
+  delete (window as unknown as Record<string, unknown>)[STATE_KEY]
+  delete (window as unknown as Record<string, unknown>).Scalar
+  delete (window as unknown as Record<string, unknown>).__scalarAstro
+}
+
+const tick = async () => {
+  // Flush enough microtasks to cover the `await ensureStylesLoaded` and
+  // `await ensureCdnLoaded` chains plus any chained `.catch(...)` handlers.
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve()
+  }
+}
+
+describe('initScalarAstro', () => {
+  let scalar: { createApiReference: ReturnType<typeof vi.fn>; destroy: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    resetEnvironment()
+    seedLoadedStylesheet()
+    scalar = stubScalarGlobal()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('mounts each container on astro:page-load', async () => {
+    addMountElement('a', { url: '/a.json' })
+    addMountElement('b', { url: '/b.json' })
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(scalar.createApiReference).toHaveBeenCalledTimes(2)
+    expect(scalar.createApiReference).toHaveBeenCalledWith('#a', { url: '/a.json' })
+    expect(scalar.createApiReference).toHaveBeenCalledWith('#b', { url: '/b.json' })
+  })
+
+  it('destroys instances and clears the container on astro:before-swap', async () => {
+    const container = addMountElement('a', { url: '/a.json' })
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    // Simulate Scalar having rendered some children into the container.
+    container.appendChild(document.createElement('span'))
+    expect(container.children).toHaveLength(1)
+
+    document.dispatchEvent(new Event('astro:before-swap'))
+
+    expect(scalar.destroy).toHaveBeenCalledOnce()
+    expect(container.children).toHaveLength(0)
+  })
+
+  it('re-mounts on subsequent astro:page-load events', async () => {
+    addMountElement('a', { url: '/a.json' })
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+    document.dispatchEvent(new Event('astro:before-swap'))
+
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(scalar.createApiReference).toHaveBeenCalledTimes(2)
+    expect(scalar.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the config registry across navigations so revisited pages still mount', async () => {
+    // Astro's ClientRouter dedupes identical inline scripts during a session,
+    // so a previously-visited page's registration script may not re-run on
+    // revisit. The registry must persist across `astro:before-swap` for the
+    // mount to find its config.
+    addMountElement('a', { url: '/a.json' })
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    document.dispatchEvent(new Event('astro:before-swap'))
+
+    const registry = (window as unknown as RegistryWindow).__scalarAstro?.configs ?? {}
+    expect(registry.a).toEqual({ configuration: { url: '/a.json' }, cdn: null })
+
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(scalar.createApiReference).toHaveBeenCalledTimes(2)
+  })
+
+  it('is idempotent — calling initScalarAstro twice does not double-mount', async () => {
+    addMountElement('a', { url: '/a.json' })
+
+    initScalarAstro()
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(scalar.createApiReference).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips containers with no entry in the config registry', async () => {
+    const el = document.createElement('div')
+    el.id = 'a'
+    el.setAttribute('data-scalar-mount', '')
+    document.body.appendChild(el)
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(scalar.createApiReference).not.toHaveBeenCalled()
+  })
+
+  it('preserves function-valued config props through the registry', async () => {
+    const onLoaded = () => 'on-loaded'
+    const customFetch = (request: Request) => fetch(request)
+    addMountElement('a', { url: '/a.json', onLoaded, fetch: customFetch })
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(scalar.createApiReference).toHaveBeenCalledTimes(1)
+    const [, configurationPassed] = scalar.createApiReference.mock.calls[0] as [string, Record<string, unknown>]
+    expect(configurationPassed.onLoaded).toBe(onLoaded)
+    expect(configurationPassed.fetch).toBe(customFetch)
+  })
+
+  it.each([['javascript:alert(1)'], ['data:text/javascript,alert(1)'], ['vbscript:msgbox("x")']])(
+    'refuses to mount when cdn URL has unsafe scheme: %s',
+    async (cdn) => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      addMountElement('a', { url: '/a.json' }, cdn)
+
+      initScalarAstro()
+      document.dispatchEvent(new Event('astro:page-load'))
+      await tick()
+
+      expect(scalar.createApiReference).not.toHaveBeenCalled()
+      // Make sure no script tag was created for the unsafe scheme. The
+      // beforeEach seeds an unrelated default-cdn script, so check by URL
+      // scheme rather than by total count.
+      const scripts = Array.from(document.querySelectorAll<HTMLScriptElement>('script[data-scalar-astro-cdn="true"]'))
+      expect(scripts.some((script) => script.src === cdn || script.getAttribute('src') === cdn)).toBe(false)
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('unsafe URL scheme'))
+    },
+  )
+
+  it('escapes container ids that contain CSS metacharacters', async () => {
+    addMountElement('foo.bar:baz', { url: '/x.json' })
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(scalar.createApiReference).toHaveBeenCalledWith(`#${CSS.escape('foo.bar:baz')}`, { url: '/x.json' })
+  })
+
+  it('does not leak instance state across navigations', async () => {
+    initScalarAstro()
+
+    for (let i = 0; i < 100; i++) {
+      const id = `mount-${i}`
+      addMountElement(id, { url: `/${i}.json` })
+      document.dispatchEvent(new Event('astro:page-load'))
+      await tick()
+      document.dispatchEvent(new Event('astro:before-swap'))
+      // Simulate the next page's swap clearing out the old container.
+      document.getElementById(id)?.remove()
+    }
+
+    const state = (window as unknown as Record<string, { instances: Record<string, unknown> }>)[STATE_KEY]
+
+    expect(Object.keys(state.instances)).toHaveLength(0)
+  })
+
+  it('keeps unmounting other instances even if one destroy throws', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    addMountElement('a', { url: '/a.json' })
+    addMountElement('b', { url: '/b.json' })
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    // The first .destroy call throws, the second should still run.
+    scalar.destroy.mockImplementationOnce(() => {
+      throw new Error('boom')
+    })
+
+    document.dispatchEvent(new Event('astro:before-swap'))
+
+    expect(scalar.destroy).toHaveBeenCalledTimes(2)
+    expect(consoleSpy).toHaveBeenCalled()
+  })
+})
+
+describe('CDN and stylesheet deduplication', () => {
+  beforeEach(() => {
+    resetEnvironment()
+  })
+
+  it('attaches to a still-loading same-href stylesheet instead of removing it', async () => {
+    // Pre-place a Scalar-marked stylesheet that has not finished loading yet.
+    // The bug was that the loader would remove this element mid-load.
+    const existingLink = document.createElement('link')
+    existingLink.rel = 'stylesheet'
+    existingLink.href = DEFAULT_STYLE_HREF
+    existingLink.dataset.scalarAstroStyle = 'true'
+    document.head.appendChild(existingLink)
+
+    ;(window as unknown as { Scalar: unknown }).Scalar = {
+      createApiReference: vi.fn(() => ({ destroy: vi.fn() })),
+    }
+
+    addMountElement('a', { url: '/a.json' })
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await Promise.resolve()
+
+    // The pre-placed link must survive untouched.
+    const links = document.querySelectorAll('link[data-scalar-astro-style="true"]')
+    expect(links).toHaveLength(1)
+    expect(links[0]).toBe(existingLink)
+
+    // Once the original link's load fires, the mount can proceed.
+    existingLink.dispatchEvent(new Event('load'))
+    await tick()
+    expect(existingLink.dataset.loaded).toBe('true')
+  })
+
+  it('replaces a Scalar stylesheet whose href no longer matches', async () => {
+    const stale = document.createElement('link')
+    stale.rel = 'stylesheet'
+    stale.href = 'https://old.example.com/dist/style.css'
+    stale.dataset.scalarAstroStyle = 'true'
+    stale.dataset.loaded = 'true'
+    document.head.appendChild(stale)
+
+    addMountElement('a', { url: '/a.json' }, 'https://new.example.com/dist/api-reference.js')
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await Promise.resolve()
+
+    const links = document.querySelectorAll('link[data-scalar-astro-style="true"]')
+    expect(links).toHaveLength(1)
+    expect(links[0]).not.toBe(stale)
+    expect(links[0].getAttribute('href')).toBe('https://new.example.com/dist/style.css')
+  })
+
+  it('appends only one stylesheet link when many containers mount in parallel', async () => {
+    // No preloaded stylesheet — the first mount drives the actual load.
+    for (let i = 0; i < 5; i++) {
+      addMountElement(`c${i}`, { url: '/x.json' })
+    }
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await Promise.resolve()
+
+    expect(document.querySelectorAll('link[data-scalar-astro-style="true"]')).toHaveLength(1)
+  })
+
+  it('appends only one CDN script when many containers mount in parallel', async () => {
+    // Seed the stylesheet so `ensureStylesLoaded` resolves synchronously and we
+    // can observe the CDN loader behavior. `window.Scalar` stays undefined so
+    // the CDN loader actually runs.
+    seedLoadedStylesheet()
+
+    for (let i = 0; i < 5; i++) {
+      addMountElement(`c${i}`, { url: '/x.json' })
+    }
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    expect(document.querySelectorAll('script[data-scalar-astro-cdn="true"]')).toHaveLength(1)
+  })
+
+  it('loads a distinct CDN script when a later mount requests a different cdn', async () => {
+    // A previously-loaded Scalar bundle must not short-circuit a later mount
+    // whose `cdn` points at a different URL. The earlier code cached a single
+    // `cdnPromise` and returned early once any `window.Scalar` was set, so the
+    // second `cdn` was ignored — the wrong Scalar runtime would render against
+    // styles or version pins meant for the requested bundle.
+    const existingScript = document.createElement('script')
+    existingScript.dataset.scalarAstroCdn = 'true'
+    existingScript.dataset.loaded = 'true'
+    existingScript.src = 'https://cdn-a.example.com/api-reference.js'
+    document.head.appendChild(existingScript)
+    ;(window as unknown as { Scalar: unknown }).Scalar = {
+      createApiReference: vi.fn(() => ({ destroy: vi.fn() })),
+    }
+
+    seedLoadedStylesheet('https://cdn-b.example.com/style.css')
+    addMountElement('b', { url: '/b.json' }, 'https://cdn-b.example.com/api-reference.js')
+
+    initScalarAstro()
+    document.dispatchEvent(new Event('astro:page-load'))
+    await tick()
+
+    const sources = Array.from(
+      document.querySelectorAll<HTMLScriptElement>('script[data-scalar-astro-cdn="true"]'),
+    ).map((s) => s.src)
+
+    expect(sources).toContain('https://cdn-a.example.com/api-reference.js')
+    expect(sources).toContain('https://cdn-b.example.com/api-reference.js')
+  })
+})
+
+describe('getStyleHref', () => {
+  it.each([
+    [
+      'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
+      'https://cdn.jsdelivr.net/npm/@scalar/api-reference/dist/style.css',
+    ],
+    [
+      'https://cdn.jsdelivr.net/npm/@scalar/api-reference/dist/browser/standalone.js',
+      'https://cdn.jsdelivr.net/npm/@scalar/api-reference/dist/style.css',
+    ],
+    ['https://example.com/foo/bar.js', 'https://example.com/foo/style.css'],
+    ['https://example.com/pkg/dist', 'https://example.com/pkg/dist/style.css'],
+    ['https://example.com/pkg/', 'https://example.com/pkg/dist/style.css'],
+    [
+      'https://cdn.jsdelivr.net/npm/@scalar/api-reference/dist/browser/standalone.js?v=1',
+      'https://cdn.jsdelivr.net/npm/@scalar/api-reference/dist/style.css',
+    ],
+    ['https://example.com/foo/bar.js?v=2', 'https://example.com/foo/style.css'],
+  ])('resolves %s to %s', (cdn, expected) => {
+    expect(getStyleHref(cdn)).toBe(expected)
+  })
+
+  it('falls back to the default CDN when given null', () => {
+    expect(getStyleHref(null)).toBe(DEFAULT_STYLE_HREF)
+  })
+})

--- a/integrations/astro/src/client.ts
+++ b/integrations/astro/src/client.ts
@@ -1,0 +1,348 @@
+/**
+ * Client-side mounting logic for the Astro integration.
+ *
+ * Each `<ScalarComponent renderMode="client" />` renders a container marked
+ * with `data-scalar-mount` and emits a per-instance inline script that
+ * registers its config on `window.__scalarAstro.configs` keyed by mount id.
+ * The single hoisted script in the component calls `initScalarAstro` to wire
+ * up the Astro view-transition lifecycle once per page.
+ */
+
+const stateKey = '__scalarAstroState'
+const STYLE_MARKER = 'data-scalar-astro-style'
+const CDN_MARKER = 'data-scalar-astro-cdn'
+const DEFAULT_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
+const SAFE_PROTOCOLS = new Set(['http:', 'https:'])
+
+/**
+ * Reject CDN URLs that would let untrusted config execute code via
+ * `javascript:`, `data:`, or other non-http(s) schemes when assigned to
+ * `<script src>`. Defense in depth — the developer controls `cdn`, but a
+ * misconfiguration should fail closed rather than execute arbitrary code.
+ */
+const isSafeCdnUrl = (url: string): boolean => {
+  try {
+    return SAFE_PROTOCOLS.has(new URL(url, window.location.href).protocol)
+  } catch {
+    return false
+  }
+}
+
+type ScalarApiReferenceInstance = {
+  destroy?: () => void
+}
+
+type ScalarGlobal = {
+  createApiReference?: (selector: string, configuration: unknown) => ScalarApiReferenceInstance
+}
+
+type GlobalState = {
+  instances: Record<string, ScalarApiReferenceInstance | null>
+  initialized: boolean
+  cdnPromises: Record<string, Promise<void>>
+  stylePromise: Promise<void> | null
+  styleHref: string | null
+}
+
+type ClientConfigEntry = {
+  configuration?: unknown
+  cdn?: string | null
+}
+
+type AstroRegistry = {
+  configs?: Record<string, ClientConfigEntry>
+}
+
+type ScalarWindow = typeof window & {
+  Scalar?: ScalarGlobal
+  [stateKey]?: GlobalState
+  __scalarAstro?: AstroRegistry
+}
+
+type MountOptions = {
+  selector: string
+  configuration: unknown
+  cdn: string | null
+}
+
+const getGlobalState = (): GlobalState => {
+  const win = window as ScalarWindow
+  win[stateKey] ??= {
+    instances: {},
+    initialized: false,
+    cdnPromises: {},
+    stylePromise: null,
+    styleHref: null,
+  }
+  return win[stateKey]
+}
+
+/**
+ * Resolve the stylesheet URL for a given Scalar CDN script URL.
+ *
+ * Exported for unit testing.
+ */
+export const getStyleHref = (cdn: string | null): string => {
+  const cdnUrl = (cdn ?? DEFAULT_CDN).replace(/\/$/, '')
+
+  if (/\/dist\/browser\/[^/]+\.js(?:\?.*)?$/.test(cdnUrl)) {
+    return cdnUrl.replace(/\/dist\/browser\/[^/]+\.js(?:\?.*)?$/, '/dist/style.css')
+  }
+
+  if (/\.js(?:\?.*)?$/.test(cdnUrl)) {
+    return cdnUrl.replace(/\/[^/]+\.js(?:\?.*)?$/, '/style.css')
+  }
+
+  if (/\/dist$/.test(cdnUrl)) {
+    return `${cdnUrl}/style.css`
+  }
+
+  return `${cdnUrl}/dist/style.css`
+}
+
+const loadStylesheet = (styleHref: string): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    const existing = document.querySelector<HTMLLinkElement>(`link[${STYLE_MARKER}="true"]`)
+
+    if (existing?.getAttribute('href') === styleHref) {
+      if (existing.dataset.loaded === 'true') {
+        resolve()
+        return
+      }
+      // Same href, still loading: attach to the in-flight element instead of
+      // removing it, otherwise we orphan the partial download and race against
+      // anyone else awaiting that load.
+      existing.addEventListener(
+        'load',
+        () => {
+          existing.dataset.loaded = 'true'
+          resolve()
+        },
+        { once: true },
+      )
+      existing.addEventListener('error', () => reject(new Error('Failed to load Scalar CDN stylesheet')), {
+        once: true,
+      })
+      return
+    }
+
+    // Different href: replace the previous Scalar stylesheet entirely.
+    if (existing) {
+      existing.remove()
+    }
+
+    const link = document.createElement('link')
+    link.rel = 'stylesheet'
+    link.href = styleHref
+    link.dataset.scalarAstroStyle = 'true'
+    link.addEventListener(
+      'load',
+      () => {
+        link.dataset.loaded = 'true'
+        resolve()
+      },
+      { once: true },
+    )
+    link.addEventListener('error', () => reject(new Error('Failed to load Scalar CDN stylesheet')), { once: true })
+    document.head.appendChild(link)
+  })
+
+const ensureStylesLoaded = async (cdn: string | null): Promise<void> => {
+  const styleHref = getStyleHref(cdn)
+  const state = getGlobalState()
+
+  if (state.stylePromise && state.styleHref === styleHref) {
+    await state.stylePromise
+    return
+  }
+
+  // Different href requested: wait for any in-flight load to settle first so
+  // we do not race against an older `<link>` element being removed.
+  if (state.stylePromise) {
+    try {
+      await state.stylePromise
+    } catch {
+      // ignore — we are about to replace the stylesheet anyway
+    }
+  }
+
+  state.styleHref = styleHref
+  state.stylePromise = loadStylesheet(styleHref).catch((error) => {
+    state.stylePromise = null
+    state.styleHref = null
+    throw error
+  })
+
+  await state.stylePromise
+}
+
+const findExistingCdnScript = (src: string): HTMLScriptElement | null => {
+  const scripts = document.querySelectorAll<HTMLScriptElement>(`script[${CDN_MARKER}="true"]`)
+
+  for (const script of scripts) {
+    // Compare resolved hrefs so relative and absolute forms of the same URL match.
+    if (script.src === new URL(src, window.location.href).href) {
+      return script
+    }
+  }
+
+  return null
+}
+
+const loadCdn = (src: string): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    const existing = findExistingCdnScript(src)
+
+    if (existing?.dataset.loaded === 'true') {
+      resolve()
+      return
+    }
+
+    if (existing) {
+      existing.addEventListener('load', () => resolve(), { once: true })
+      existing.addEventListener('error', () => reject(new Error('Failed to load Scalar CDN script')), { once: true })
+      return
+    }
+
+    const script = document.createElement('script')
+    script.src = src
+    script.dataset.scalarAstroCdn = 'true'
+    script.addEventListener(
+      'load',
+      () => {
+        script.dataset.loaded = 'true'
+        resolve()
+      },
+      { once: true },
+    )
+    script.addEventListener('error', () => reject(new Error('Failed to load Scalar CDN script')), { once: true })
+    document.head.appendChild(script)
+  })
+
+const ensureCdnLoaded = async (cdn: string | null): Promise<void> => {
+  const src = cdn ?? DEFAULT_CDN
+  const state = getGlobalState()
+
+  // Track promises per resolved URL so a later mount with a different `cdn`
+  // (for example a version pin or a self-hosted bundle) actually loads its
+  // requested script instead of returning early because some other CDN
+  // already populated `window.Scalar`.
+  state.cdnPromises[src] ??= loadCdn(src).catch((error) => {
+    delete state.cdnPromises[src]
+    throw error
+  })
+
+  await state.cdnPromises[src]
+}
+
+const readMountOptions = (container: HTMLElement): MountOptions | null => {
+  if (!container.id) {
+    return null
+  }
+
+  const win = window as ScalarWindow
+  const entry = win.__scalarAstro?.configs?.[container.id]
+
+  if (!entry) {
+    return null
+  }
+
+  return {
+    // Escape the id so element ids containing CSS metacharacters (`.`, `:`,
+    // `[`, etc.) do not throw in `querySelector` or break selector-keyed state.
+    selector: `#${CSS.escape(container.id)}`,
+    configuration: entry.configuration ?? {},
+    cdn: entry.cdn ?? null,
+  }
+}
+
+const destroyInstance = (state: GlobalState, selector: string): void => {
+  const instance = state.instances[selector]
+
+  if (instance?.destroy) {
+    try {
+      instance.destroy()
+    } catch (error) {
+      console.error('[scalar/astro] failed to destroy instance', error)
+    }
+  }
+
+  // Callers either `delete` the key (`unmountAll`) or overwrite it with a
+  // fresh instance (`mountContainer`), so we do not need to null it here.
+
+  const container = document.querySelector(selector)
+
+  if (container) {
+    container.replaceChildren()
+  }
+}
+
+const mountContainer = async (container: HTMLElement): Promise<void> => {
+  const options = readMountOptions(container)
+
+  if (!options) {
+    return
+  }
+
+  const cdnUrl = options.cdn ?? DEFAULT_CDN
+
+  if (!isSafeCdnUrl(cdnUrl)) {
+    console.error(`[scalar/astro] Refusing to load CDN with unsafe URL scheme: ${cdnUrl}`)
+    return
+  }
+
+  const state = getGlobalState()
+  destroyInstance(state, options.selector)
+
+  await ensureStylesLoaded(options.cdn)
+  await ensureCdnLoaded(options.cdn)
+
+  const win = window as ScalarWindow
+
+  if (!win.Scalar?.createApiReference) {
+    return
+  }
+
+  state.instances[options.selector] = win.Scalar.createApiReference(options.selector, options.configuration)
+}
+
+const mountAll = (): void => {
+  const containers = document.querySelectorAll<HTMLElement>('[data-scalar-mount]')
+
+  for (const container of containers) {
+    void mountContainer(container)
+  }
+}
+
+const unmountAll = (): void => {
+  const state = getGlobalState()
+
+  for (const selector of Object.keys(state.instances)) {
+    destroyInstance(state, selector)
+    delete state.instances[selector]
+  }
+
+  // Intentionally do not clear `window.__scalarAstro.configs`. In static
+  // Starlight builds, Astro's ClientRouter executes identical inline scripts
+  // only once per session, so a previously-visited page's registration script
+  // does not re-run on revisit. Wiping the registry here would leave that
+  // page's mount with no entry and render blank until a full reload.
+}
+
+/**
+ * Wire up Astro view-transition listeners that mount and unmount Scalar
+ * instances around page navigations. Safe to call multiple times - listeners
+ * are only attached once per page lifecycle.
+ */
+export const initScalarAstro = (): void => {
+  const state = getGlobalState()
+
+  if (state.initialized) {
+    return
+  }
+
+  state.initialized = true
+
+  document.addEventListener('astro:before-swap', unmountAll)
+  document.addEventListener('astro:page-load', mountAll)
+}

--- a/integrations/astro/src/serialize-client-config.test.ts
+++ b/integrations/astro/src/serialize-client-config.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+
+import { serializeClientConfig } from './serialize-client-config'
+
+describe('serializeClientConfig', () => {
+  it('writes JSON-safe config as a JSON object literal', () => {
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: { url: '/a.json', theme: 'default' },
+      cdn: null,
+    })
+
+    expect(script).toContain('"mount-1"')
+    expect(script).toContain('configuration:{"url":"/a.json","theme":"default"}')
+    expect(script).toContain('cdn:null')
+  })
+
+  it('inlines top-level function-valued props as raw source', () => {
+    const onLoaded = function namedHandler() {
+      return 'hello'
+    }
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: { url: '/a.json', onLoaded },
+      cdn: null,
+    })
+
+    expect(script).toContain('"url":"/a.json"')
+    // The raw function source is present, not stripped to undefined like JSON.stringify would.
+    expect(script).toContain('"onLoaded":')
+    expect(script).toContain('namedHandler')
+    expect(script).toMatch(/return ['"]hello['"]/)
+  })
+
+  it('inlines arrays containing function entries', () => {
+    const plugin = function pluginFactory() {
+      return { name: 'fn-plugin' }
+    }
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: {
+        plugins: ['plain', plugin],
+      },
+      cdn: null,
+    })
+
+    expect(script).toContain('"plugins": ["plain", function pluginFactory')
+  })
+
+  it('emits a config object when every prop is a function', () => {
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: { onLoaded: function namedHandler() {} },
+      cdn: null,
+    })
+
+    // Should not produce `{}` and then drop the function — the object literal
+    // must contain the function entry.
+    expect(script).toContain('configuration:{ "onLoaded":')
+    expect(script).toContain('namedHandler')
+    expect(script).not.toContain('configuration:{}')
+  })
+
+  it('escapes </script> in string config values so it cannot break out of the script tag', () => {
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: { content: '</script><img src=x onerror=alert(1)>' },
+      cdn: null,
+    })
+
+    // The escaped `<\/script` is parsed as the same string by the JS engine
+    // but does not match the HTML parser's end-tag scanner.
+    expect(script).not.toContain('</script')
+    expect(script).toContain('<\\/script')
+  })
+
+  it('escapes </script> in function source', () => {
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: {
+        onLoaded: function leak() {
+          return '</script>'
+        },
+      },
+      cdn: null,
+    })
+
+    expect(script).not.toContain('</script')
+    expect(script).toContain('<\\/script')
+  })
+
+  it('escapes </script> in the cdn URL', () => {
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: {},
+      cdn: 'https://evil.example.com/</script><img src=x>',
+    })
+
+    expect(script).not.toContain('</script')
+    expect(script).toContain('<\\/script')
+  })
+
+  it('round-trips the cdn value via JSON', () => {
+    const script = serializeClientConfig({
+      key: 'mount-1',
+      configuration: {},
+      cdn: 'https://example.com/scalar.js',
+    })
+
+    expect(script).toContain('cdn:"https://example.com/scalar.js"')
+  })
+
+  it('keys entries by the provided id', () => {
+    const a = serializeClientConfig({ key: 'a', configuration: {}, cdn: null })
+    const b = serializeClientConfig({ key: 'b-with-dashes', configuration: {}, cdn: null })
+
+    expect(a).toContain('configs["a"]')
+    expect(b).toContain('configs["b-with-dashes"]')
+  })
+
+  it('initializes the registry idempotently', () => {
+    const script = serializeClientConfig({ key: 'a', configuration: {}, cdn: null })
+
+    // Uses `||` so a second emission does not clobber the existing registry.
+    expect(script).toContain('window.__scalarAstro=window.__scalarAstro||{configs:{}}')
+  })
+})

--- a/integrations/astro/src/serialize-client-config.ts
+++ b/integrations/astro/src/serialize-client-config.ts
@@ -1,0 +1,56 @@
+/**
+ * Build the inline-script body that registers a single Scalar mount config on
+ * the shared `window.__scalarAstro.configs` registry.
+ *
+ * Preserves top-level function-valued props (sorters, slug generators,
+ * lifecycle hooks) by emitting raw source via `Function#toString`. Then
+ * escapes any `</script` or `<!--` in the result because `key`, `cdn`, and
+ * arbitrary config string values are user-controlled and would otherwise let
+ * the value break out of the surrounding inline `<script>` tag.
+ */
+
+const escapeForInlineScript = (source: string): string =>
+  source.replace(/<\/(script)/gi, '<\\/$1').replace(/<!--/g, '<\\!--')
+
+const serializeArrayWithFunctions = (arr: readonly unknown[]): string =>
+  `[${arr.map((item) => (typeof item === 'function' ? item.toString() : JSON.stringify(item))).join(', ')}]`
+
+const serializeConfig = (config: Record<string, unknown>): string => {
+  const jsonSafe: Record<string, unknown> = { ...config }
+  const functionEntries: string[] = []
+
+  for (const [key, value] of Object.entries(config)) {
+    if (typeof value === 'function') {
+      functionEntries.push(`${JSON.stringify(key)}: ${(value as (...args: unknown[]) => unknown).toString()}`)
+      delete jsonSafe[key]
+    } else if (Array.isArray(value) && value.some((item) => typeof item === 'function')) {
+      functionEntries.push(`${JSON.stringify(key)}: ${serializeArrayWithFunctions(value)}`)
+      delete jsonSafe[key]
+    }
+  }
+
+  const json = JSON.stringify(jsonSafe)
+
+  if (functionEntries.length === 0) {
+    return escapeForInlineScript(json)
+  }
+  if (json === '{}') {
+    return escapeForInlineScript(`{ ${functionEntries.join(', ')} }`)
+  }
+  return escapeForInlineScript(`${json.slice(0, -1)}, ${functionEntries.join(', ')}}`)
+}
+
+type SerializeArgs = {
+  key: string
+  configuration: Record<string, unknown>
+  cdn: string | null
+}
+
+export const serializeClientConfig = ({ key, configuration, cdn }: SerializeArgs): string => {
+  const keyLiteral = JSON.stringify(key)
+  const configLiteral = serializeConfig(configuration)
+  const cdnLiteral = JSON.stringify(cdn)
+  return escapeForInlineScript(
+    `(window.__scalarAstro=window.__scalarAstro||{configs:{}}).configs[${keyLiteral}]={configuration:${configLiteral},cdn:${cdnLiteral}}`,
+  )
+}

--- a/integrations/astro/vitest.config.ts
+++ b/integrations/astro/vitest.config.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts'],
+    root: fileURLToPath(new URL('./', import.meta.url)),
+    setupFiles: ['./vitest.setup.ts'],
+  },
+})

--- a/integrations/astro/vitest.setup.ts
+++ b/integrations/astro/vitest.setup.ts
@@ -1,0 +1,54 @@
+// jsdom does not ship `CSS.escape`. Polyfill it for tests so code that relies
+// on it behaves as it would in any real browser.
+// Spec: https://drafts.csswg.org/cssom/#serialize-an-identifier
+const cssEscape = (value: string): string => {
+  const string = String(value)
+  const length = string.length
+  let result = ''
+
+  for (let index = 0; index < length; index++) {
+    const codeUnit = string.charCodeAt(index)
+
+    if (codeUnit === 0x0000) {
+      result += '�'
+      continue
+    }
+
+    if (
+      (codeUnit >= 0x0001 && codeUnit <= 0x001f) ||
+      codeUnit === 0x007f ||
+      (index === 0 && codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+      (index === 1 && codeUnit >= 0x0030 && codeUnit <= 0x0039 && string.charCodeAt(0) === 0x002d)
+    ) {
+      result += `\\${codeUnit.toString(16)} `
+      continue
+    }
+
+    if (index === 0 && length === 1 && codeUnit === 0x002d) {
+      result += `\\${string.charAt(index)}`
+      continue
+    }
+
+    if (
+      codeUnit >= 0x0080 ||
+      codeUnit === 0x002d ||
+      codeUnit === 0x005f ||
+      (codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+      (codeUnit >= 0x0041 && codeUnit <= 0x005a) ||
+      (codeUnit >= 0x0061 && codeUnit <= 0x007a)
+    ) {
+      result += string.charAt(index)
+      continue
+    }
+
+    result += `\\${string.charAt(index)}`
+  }
+
+  return result
+}
+
+if (typeof globalThis.CSS === 'undefined') {
+  ;(globalThis as unknown as { CSS: { escape: typeof cssEscape } }).CSS = { escape: cssEscape }
+} else if (typeof globalThis.CSS.escape !== 'function') {
+  globalThis.CSS.escape = cssEscape
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -779,6 +779,12 @@ importers:
       astro:
         specifier: ^4.0.0 || ^5.0.0 || ^6.0.0
         version: 5.15.9(@netlify/blobs@9.1.2)(@types/node@24.10.13)(db0@0.3.4)(ioredis@5.10.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      jsdom:
+        specifier: catalog:*
+        version: 27.4.0(@noble/hashes@1.8.0)
+      vitest:
+        specifier: catalog:*
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(jsdom@27.4.0(@noble/hashes@1.8.0))(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))
 
   integrations/astro/playground:
     dependencies:
@@ -18631,6 +18637,9 @@ packages:
   vue-component-type-helpers@3.2.7:
     resolution: {integrity: sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==}
 
+  vue-component-type-helpers@3.2.8:
+    resolution: {integrity: sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==}
+
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
     engines: {node: '>=12'}
@@ -25738,7 +25747,7 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.30(typescript@5.9.3)
-      vue-component-type-helpers: 3.2.7
+      vue-component-type-helpers: 3.2.8
 
   '@sveltejs/acorn-typescript@1.0.5(acorn@8.16.0)':
     dependencies:
@@ -38789,6 +38798,8 @@ snapshots:
   vue-component-type-helpers@2.2.10: {}
 
   vue-component-type-helpers@3.2.7: {}
+
+  vue-component-type-helpers@3.2.8: {}
 
   vue-demi@0.14.10(vue@3.5.30(typescript@5.9.3)):
     dependencies:

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -365,6 +365,10 @@
           "to": "/products/api-references/integrations/astro"
         },
         {
+          "from": "/scalar/scalar-api-references/integrations/starlight",
+          "to": "/products/api-references/integrations/starlight"
+        },
+        {
           "from": "/scalar/scalar-api-references/integrations/django",
           "to": "/products/api-references/integrations/django"
         },
@@ -1606,6 +1610,11 @@
                       "astro": {
                         "title": "Astro",
                         "filepath": "documentation/integrations/astro.md",
+                        "type": "page"
+                      },
+                      "starlight": {
+                        "title": "Starlight",
+                        "filepath": "documentation/integrations/starlight.md",
                         "type": "page"
                       },
                       "django": {


### PR DESCRIPTION
Adds a `renderMode="client"` to `<ScalarComponent />` so Scalar mounts on the client and re-mounts around Astro view transitions. Fixes the "page is blank until I refresh" thing you see on Starlight sites and any other Astro setup with client-side nav.

- Optional `mountElementId` — otherwise a unique id is generated per render so multiple Scalars can live on one page
- Function-valued config props (`content`, `plugins`, `onLoaded`, custom `fetch`, …) survive serialization
- Per-URL CDN registry so different components can use different CDNs without fighting
- Cleans up instance state and config registry on unmount
- New Starlight guide + playground routes for the static, client, and same-page-transition cases
- 36 tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new client-side mounting/unmounting logic and inline-script config serialization, which changes runtime behavior on navigations and introduces script/DOM loading paths (with some security guards) that could affect rendering or CDN loading.
> 
> **Overview**
> Adds a new `renderMode="client"` option to `@scalar/astro`’s `<ScalarComponent />` so Scalar mounts on the client and re-mounts around Astro view-transition events (`astro:page-load`, `astro:before-swap`), fixing blank/refresh-only rendering on Starlight and other client-navigated Astro sites.
> 
> Client mode now renders a dedicated mount container (optionally via `mountElementId`, otherwise a per-render `scalar-app-<uuid>`) and registers per-instance configs via an inline script that preserves function-valued config props while escaping inline-script breakouts.
> 
> Introduces a new `client.ts` runtime that dedupes stylesheet/CDN loading, supports per-URL CDN loading, escapes mount selectors, refuses unsafe CDN URL schemes, and cleans up instances on navigation; adds Vitest/jsdom coverage, playground routes demonstrating client navigation, and documentation updates including a new Starlight integration page and site routing entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb20f27c12d88f8d548bc05d7570cf9179785c7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->