### PR TITLE
fix(api-reference): forward fetch to API client

### DIFF
--- a/.changeset/forward-custom-fetch-to-client.md
+++ b/.changeset/forward-custom-fetch-to-client.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: forward `configuration.fetch` to the API client so "Test Request" calls use the custom fetch (enabling things like `credentials: 'include'`), not only the OpenAPI document load

--- a/.changeset/forward-custom-fetch-to-client.md
+++ b/.changeset/forward-custom-fetch-to-client.md
@@ -1,5 +1,7 @@
 ---
 '@scalar/api-reference': patch
+'@scalar/schemas': patch
+'@scalar/types': patch
 ---
 
-fix: forward `configuration.fetch` to the API client so "Test Request" calls use the custom fetch (enabling things like `credentials: 'include'`), not only the OpenAPI document load
+feat: add `customFetch` to the api-reference configuration and forward it to the API client so requests (including "Test Request" calls) use the custom fetch — enabling things like `credentials: 'include'`. The previous `fetch` option is deprecated and migrated automatically with a console warning.

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -1106,12 +1106,12 @@ Custom functions to control specific behaviors and URL generation.
 
 **Type:** `(input: string | URL | globalThis.Request, init?: RequestInit) => Promise<Response>`
 
-Custom [fetch function](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to fetch documents with a custom logic. Can be used to add custom headers, handle auth, etc.
+Custom [fetch function](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) used both when loading the OpenAPI document and when sending "Test Request" calls from the API client. Can be used to add custom headers, attach credentials (for example `credentials: 'include'`), handle auth, etc.
 
 ```javascript
 {
   fetch: (input: string | URL | globalThis.Request, init?: RequestInit) => {
-    return window.fetch(input, init)
+    return window.fetch(input, { ...init, credentials: 'include' })
   }
 }
 ```

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -1102,7 +1102,7 @@ By default we're using Inter and JetBrains Mono, served from our fonts CDN at `h
 
 Custom functions to control specific behaviors and URL generation.
 
-#### fetch
+#### customFetch
 
 **Type:** `(input: string | URL | globalThis.Request, init?: RequestInit) => Promise<Response>`
 
@@ -1110,11 +1110,13 @@ Custom [fetch function](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_A
 
 ```javascript
 {
-  fetch: (input: string | URL | globalThis.Request, init?: RequestInit) => {
+  customFetch: (input: string | URL | globalThis.Request, init?: RequestInit) => {
     return window.fetch(input, { ...init, credentials: 'include' })
   }
 }
 ```
+
+> The previous `fetch` option is deprecated. It still works and is migrated automatically (with a console warning), but new code should use `customFetch`.
 
 #### generateHeadingSlug
 

--- a/packages/api-reference/src/components/ApiReference.config.test.ts
+++ b/packages/api-reference/src/components/ApiReference.config.test.ts
@@ -724,9 +724,32 @@ describe('ApiReference Configuration Tests', { timeout: 15_000 }, () => {
 })
 
 describe('ApiReference custom fetch forwarding', () => {
-  it('passes configuration.fetch to the API client modal as customFetch', async () => {
+  it('passes configuration.customFetch to the API client modal', async () => {
     const customFetch = vi.fn() as unknown as typeof fetch
     const spy = vi.spyOn(apiClientModalModule, 'createApiClientModal')
+
+    const wrapper = mountComponent({
+      props: {
+        configuration: {
+          content: createBasicDocument(),
+          customFetch,
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(spy).toHaveBeenCalled()
+    const passedOptions = toValue(spy.mock.calls.at(-1)?.[0].options)
+    expect(passedOptions?.customFetch).toBe(customFetch)
+
+    wrapper.unmount()
+    spy.mockRestore()
+  })
+
+  it('migrates the deprecated configuration.fetch to customFetch', async () => {
+    const customFetch = vi.fn() as unknown as typeof fetch
+    const spy = vi.spyOn(apiClientModalModule, 'createApiClientModal')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const wrapper = mountComponent({
       props: {
@@ -741,8 +764,10 @@ describe('ApiReference custom fetch forwarding', () => {
     expect(spy).toHaveBeenCalled()
     const passedOptions = toValue(spy.mock.calls.at(-1)?.[0].options)
     expect(passedOptions?.customFetch).toBe(customFetch)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(`deprecated 'fetch' attribute`))
 
     wrapper.unmount()
     spy.mockRestore()
+    warn.mockRestore()
   })
 })

--- a/packages/api-reference/src/components/ApiReference.config.test.ts
+++ b/packages/api-reference/src/components/ApiReference.config.test.ts
@@ -1,7 +1,9 @@
 import type { ClientOptionGroup } from '@scalar/api-client/blocks/operation-code-sample'
+import * as apiClientModalModule from '@scalar/api-client/modal'
 import type { TraversedTag } from '@scalar/workspace-store/schemas/navigation'
 import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { toValue } from 'vue'
 
 import ApiReference from './ApiReference.vue'
 
@@ -718,5 +720,29 @@ describe('ApiReference Configuration Tests', { timeout: 15_000 }, () => {
     await flushPromises()
     expect(document.body.classList.contains('dark-mode')).toBe(true)
     darkWrapper.unmount()
+  })
+})
+
+describe('ApiReference custom fetch forwarding', () => {
+  it('passes configuration.fetch to the API client modal as customFetch', async () => {
+    const customFetch = vi.fn() as unknown as typeof fetch
+    const spy = vi.spyOn(apiClientModalModule, 'createApiClientModal')
+
+    const wrapper = mountComponent({
+      props: {
+        configuration: {
+          content: createBasicDocument(),
+          fetch: customFetch,
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(spy).toHaveBeenCalled()
+    const passedOptions = toValue(spy.mock.calls.at(-1)?.[0].options)
+    expect(passedOptions?.customFetch).toBe(customFetch)
+
+    wrapper.unmount()
+    spy.mockRestore()
   })
 })

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -15,6 +15,7 @@ import { OpenApiClientButton } from '@scalar/api-client/blocks/operation-block'
 import {
   createApiClientModal,
   type ApiClientModal,
+  type ApiClientOptions,
 } from '@scalar/api-client/modal'
 import {
   addScalarClassesToHeadless,
@@ -238,6 +239,11 @@ const mergedConfig = computed<ApiReferenceConfiguration>(() => ({
   ...configList.value[activeSlug.value]?.config,
   // Any overrides from the localhost toolbar
   ...configurationOverrides.value,
+}))
+
+const apiClientOptions = computed<ApiClientOptions>(() => ({
+  ...mergedConfig.value,
+  customFetch: mergedConfig.value.fetch,
 }))
 
 /** Convenience break out var to determine which routing mode we are using */
@@ -790,7 +796,7 @@ onMounted(() => {
     el: modal.value,
     eventBus,
     workspaceStore: clientStore,
-    options: mergedConfig,
+    options: apiClientOptions,
     plugins: [
       ...pluginManager.getApiClientPlugins(),
       ...mapConfigPlugins(mergedConfig, environment),

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -15,7 +15,6 @@ import { OpenApiClientButton } from '@scalar/api-client/blocks/operation-block'
 import {
   createApiClientModal,
   type ApiClientModal,
-  type ApiClientOptions,
 } from '@scalar/api-client/modal'
 import {
   addScalarClassesToHeadless,
@@ -239,11 +238,6 @@ const mergedConfig = computed<ApiReferenceConfiguration>(() => ({
   ...configList.value[activeSlug.value]?.config,
   // Any overrides from the localhost toolbar
   ...configurationOverrides.value,
-}))
-
-const apiClientOptions = computed<ApiClientOptions>(() => ({
-  ...mergedConfig.value,
-  customFetch: mergedConfig.value.fetch,
 }))
 
 /** Convenience break out var to determine which routing mode we are using */
@@ -589,7 +583,7 @@ const changeSelectedDocument = async (
         ? {
             name: slug,
             url: normalized.source.url,
-            fetch: config.fetch,
+            fetch: config.customFetch,
           }
         : {
             name: slug,
@@ -677,7 +671,7 @@ watch(
           {
             name: updated.slug,
             url: updated.source.url,
-            fetch: updated.config.fetch,
+            fetch: updated.config.customFetch,
           },
           updated.config,
         )
@@ -796,7 +790,7 @@ onMounted(() => {
     el: modal.value,
     eventBus,
     workspaceStore: clientStore,
-    options: apiClientOptions,
+    options: mergedConfig,
     plugins: [
       ...pluginManager.getApiClientPlugins(),
       ...mapConfigPlugins(mergedConfig, environment),

--- a/packages/schemas/src/api-reference/api-referece-configuration.test.ts
+++ b/packages/schemas/src/api-reference/api-referece-configuration.test.ts
@@ -221,6 +221,34 @@ describe('api-reference-configuration', () => {
       expect(migratedConfig.proxy).toBeUndefined()
     })
 
+    it('migrates fetch to customFetch', () => {
+      const fetchFn = (() => Promise.resolve(new Response())) as typeof fetch
+
+      const config = {
+        fetch: fetchFn,
+      }
+
+      const migratedConfig = apiReferenceConfigurationWithSourceSchema(config)
+
+      expect(migratedConfig.customFetch).toBe(fetchFn)
+      expect(migratedConfig.fetch).toBeUndefined()
+    })
+
+    it('keeps customFetch if both fetch and customFetch are set', () => {
+      const fetchFn = (() => Promise.resolve(new Response())) as typeof fetch
+      const customFetchFn = (() => Promise.resolve(new Response())) as typeof fetch
+
+      const config = {
+        fetch: fetchFn,
+        customFetch: customFetchFn,
+      }
+
+      const migratedConfig = apiReferenceConfigurationWithSourceSchema(config)
+
+      expect(migratedConfig.customFetch).toBe(customFetchFn)
+      expect(migratedConfig.fetch).toBeUndefined()
+    })
+
     it('migrates spec.url to url', () => {
       const config = {
         spec: {

--- a/packages/schemas/src/api-reference/api-reference-configuration.ts
+++ b/packages/schemas/src/api-reference/api-reference-configuration.ts
@@ -29,7 +29,11 @@ export const apiReferenceConfigurationSchema = intersection([
       typeComment: '@deprecated Use proxyUrl instead',
     }),
     fetch: optional(fn<typeof fetch>(), {
-      typeComment: 'Custom fetch function for custom logic. Can be used to add custom headers, handle auth, etc.',
+      typeComment: '@deprecated Use `customFetch` instead.',
+    }),
+    customFetch: optional(fn<typeof fetch>(), {
+      typeComment:
+        "Custom fetch function used both when loading the OpenAPI document and when sending requests from the API client. Can be used to add custom headers, attach credentials (for example `credentials: 'include'`), handle auth, etc.",
     }),
     plugins: optional(array(apiReferencePluginSchema), {
       typeComment: 'Plugins for the API reference',
@@ -259,6 +263,16 @@ export const apiReferenceConfigurationWithSourceSchema = (rawInput: unknown) => 
     }
 
     delete input.proxy
+  }
+
+  if (input.fetch) {
+    console.warn(`[DEPRECATED] You're using the deprecated 'fetch' attribute. Use 'customFetch' instead.`)
+
+    if (!input.customFetch) {
+      input.customFetch = input.fetch
+    }
+
+    delete input.fetch
   }
 
   if (input.proxyUrl === OLD_PROXY_URL) {

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -34,8 +34,16 @@ export const apiReferenceConfigurationSchema = baseConfigurationSchema.extend({
    * Custom fetch function for custom logic
    *
    * Can be used to add custom headers, handle auth, etc.
+   *
+   * @deprecated Use `customFetch` instead.
    */
   fetch: fetchLikeSchema.optional(),
+  /**
+   * Custom fetch function used both when loading the OpenAPI document and when sending requests from the API client.
+   *
+   * Can be used to add custom headers, attach credentials (for example `credentials: 'include'`), handle auth, etc.
+   */
+  customFetch: fetchLikeSchema.optional(),
   /**
    * Plugins for the API reference
    */
@@ -480,6 +488,17 @@ export const apiReferenceConfigurationWithSourceSchema: ZodType<
     }
 
     delete configuration.proxy
+  }
+
+  // Migrate fetch to customFetch
+  if (configuration.fetch) {
+    console.warn(`[DEPRECATED] You're using the deprecated 'fetch' attribute. Use 'customFetch' instead.`)
+
+    if (!configuration.customFetch) {
+      configuration.customFetch = configuration.fetch
+    }
+
+    delete configuration.fetch
   }
 
   if (configuration.proxyUrl === OLD_PROXY_URL) {

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -333,8 +333,18 @@ type ExtendedConfiguration = {
   layout: 'modern' | 'classic'
   /** @deprecated Use proxyUrl instead */
   proxy?: string
-  /** Custom fetch function for custom logic. Can be used to add custom headers, handle auth, etc. */
+  /**
+   * Custom fetch function for custom logic. Can be used to add custom headers, handle auth, etc.
+   *
+   * @deprecated Use `customFetch` instead.
+   */
   fetch?: typeof fetch
+  /**
+   * Custom fetch function used both when loading the OpenAPI document and when sending requests from the API client.
+   *
+   * Can be used to add custom headers, attach credentials (for example `credentials: 'include'`), handle auth, etc.
+   */
+  customFetch?: typeof fetch
   /** Plugins for the API reference */
   plugins?: ApiReferencePlugin[]
   /** Allows the user to inject an editor for the spec */


### PR DESCRIPTION
 ## Problem

The configuration.fetch option was only used when fetching the OpenAPI document — the API client (which executes "Try Request") was reading a separate customFetch option that nothing in the api-reference layer set.

## Solution

Bridge the two so a user-supplied fetch is also used for outgoing API requests, enabling things like credentials: 'include'.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
