### PR TITLE
fix(api-reference): increase mobile sidebar z-index when open

### DIFF
--- a/.changeset/fix-mobile-sidebar-z-index.md
+++ b/.changeset/fix-mobile-sidebar-z-index.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix mobile sidebar z-index to ensure it appears above all content when open

--- a/packages/api-reference/src/components/MobileHeader.vue
+++ b/packages/api-reference/src/components/MobileHeader.vue
@@ -22,7 +22,7 @@ const variants = cva({
   base: 'lg:hidden items-center bg-b-1 sticky top-(--scalar-custom-header-height,0) z-10 [grid-area:header]',
   variants: {
     open: {
-      true: 'h-(--refs-sidebar-height) custom-scrollbar flex flex-col',
+      true: 'h-(--refs-sidebar-height) custom-scrollbar flex flex-col z-50',
     },
   },
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On scalar.com mobile view, the mobile navigation sidebar was appearing behind some content elements (product cards like API Client, SDKs, Registry, Developer Portals). This z-index issue made the mobile menu unusable when overlapping content was present on the page.

## Solution

Increased the z-index of the mobile sidebar from `z-10` to `z-50` when the sidebar is open. This ensures the mobile navigation always appears above all page content.

The fix is in `MobileHeader.vue` where the CVA variant for the open state now includes `z-50`:

```typescript
const variants = cva({
  base: '... z-10 ...',
  variants: {
    open: {
      true: 'h-(--refs-sidebar-height) custom-scrollbar flex flex-col z-50',
    },
  },
})
```

The z-index hierarchy in the Scalar theme:
- `z-10`: 10 (base state)
- `z-50`: 50 (open sidebar - now ensures it's above content)
- `z-context`: 1000 (for dropdowns/menus)
- `z-overlay`: 10000 (for modals)

## Visual

Mobile sidebar now stays on top of all content when open:

![Mobile sidebar open - properly layered above content](https://cursor.com/artifacts/c/art-3fb6d639-4017-48c6-bdc0-1b2da0f7a74d)

![Mobile sidebar stays on top while scrolling](https://cursor.com/artifacts/c/art-583f3405-a0f8-46b5-b6e3-1e72344e78b5)

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [ ] I added tests.
- [ ] I updated the documentation.

## Ticket

Fixes DOC-5389
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07SL9L6SJ0/p1778542842915359?thread_ts=1778542842.915359&cid=C07SL9L6SJ0)

<div><a href="https://cursor.com/agents/bc-d5c36b58-2e84-593b-a4d9-d15591b63839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5c36b58-2e84-593b-a4d9-d15591b63839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

