### PR TITLE
fix(api-client): hide OAuth2 client secret when PKCE is enabled and omit it from token requests

### DIFF
--- a/.changeset/pkce-hide-client-secret.md
+++ b/.changeset/pkce-hide-client-secret.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): hide OAuth2 client secret when PKCE is enabled and omit it from token requests

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -302,6 +302,8 @@ To make authentication easier you can prefill the credentials for your users:
             tokenUrl: 'https://auth.example.com/oauth2/token',
             'x-scalar-redirect-uri': 'https://your-app.com/callback',
             // Use PKCE for additional security: 'SHA-256', 'plain', or 'no'
+            // With 'SHA-256' or 'plain', authorizationCode is treated as a public client.
+            // The Client Secret field is hidden and client_secret is not sent in token/refresh requests.
             'x-usePkce': 'SHA-256',
             // Preselected scopes
             selectedScopes: ['profile', 'email'],
@@ -362,6 +364,8 @@ To make authentication easier you can prefill the credentials for your users:
   }
 }
 ```
+
+For OAuth2 `authorizationCode` flows, when `x-usePkce` is set to `'SHA-256'` or `'plain'`, Scalar treats the flow as a public PKCE client. In that mode, the Client Secret input is hidden in the authentication form, and `client_secret` is not included in token exchange or refresh requests.
 
 The `authentication` configuration accepts:
 

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.test.ts
@@ -528,6 +528,73 @@ describe('OAuth2', () => {
     expect(emitted).toHaveBeenCalledTimes(1)
   })
 
+  it('hides Client Secret for authorization code when PKCE uses SHA-256', async () => {
+    const wrapper = mountWithProps({
+      flows: {
+        authorizationCode: {
+          authorizationUrl: 'https://example.com/auth',
+          tokenUrl: 'https://example.com/token',
+          refreshUrl: 'https://example.com/token',
+          'x-usePkce': 'SHA-256',
+          scopes: {},
+          'x-scalar-secret-client-id': 'client-id',
+          'x-scalar-secret-client-secret': 'stored-secret',
+          'x-scalar-secret-token': '',
+          'x-scalar-secret-redirect-uri': 'https://app.example/callback',
+        },
+      },
+    })
+
+    await nextTick()
+
+    expect(wrapper.text()).toContain('Client ID')
+    expect(wrapper.text()).not.toContain('Client Secret')
+  })
+
+  it('hides Client Secret for authorization code when PKCE uses plain', async () => {
+    const wrapper = mountWithProps({
+      flows: {
+        authorizationCode: {
+          authorizationUrl: 'https://example.com/auth',
+          tokenUrl: 'https://example.com/token',
+          refreshUrl: 'https://example.com/token',
+          'x-usePkce': 'plain',
+          scopes: {},
+          'x-scalar-secret-client-id': 'client-id',
+          'x-scalar-secret-client-secret': 'stored-secret',
+          'x-scalar-secret-token': '',
+          'x-scalar-secret-redirect-uri': 'https://app.example/callback',
+        },
+      },
+    })
+
+    await nextTick()
+
+    expect(wrapper.text()).not.toContain('Client Secret')
+  })
+
+  it('shows Client Secret for authorization code when PKCE is disabled', async () => {
+    const wrapper = mountWithProps({
+      flows: {
+        authorizationCode: {
+          authorizationUrl: 'https://example.com/auth',
+          tokenUrl: 'https://example.com/token',
+          refreshUrl: 'https://example.com/token',
+          'x-usePkce': 'no',
+          scopes: {},
+          'x-scalar-secret-client-id': 'client-id',
+          'x-scalar-secret-client-secret': '',
+          'x-scalar-secret-token': '',
+          'x-scalar-secret-redirect-uri': 'https://app.example/callback',
+        },
+      },
+    })
+
+    await nextTick()
+
+    expect(wrapper.text()).toContain('Client Secret')
+  })
+
   it('emits clear security scheme secrets for openIdConnect flow', async () => {
     const wrapper = mountWithProps({
       scheme: { type: 'openIdConnect' },

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
@@ -99,6 +99,24 @@ const selectedScopes = computed(() =>
   selectedScopesProp.filter((scope) => scope in (flow.value.scopes ?? {})),
 )
 
+/**
+ * PKCE public clients do not use a client_secret. Hide the field when the
+ * document enables PKCE so readers are not prompted for an unused secret.
+ */
+const showClientSecret = computed(() => {
+  if (!('x-scalar-secret-client-secret' in flow.value)) {
+    return false
+  }
+  const pkceMode =
+    'x-usePkce' in flow.value ? flow.value['x-usePkce'] : undefined
+  return pkceMode !== 'SHA-256' && pkceMode !== 'plain'
+})
+
+const clientSecretValue = computed((): string => {
+  const f = flow.value as { 'x-scalar-secret-client-secret'?: string }
+  return f['x-scalar-secret-client-secret'] ?? ''
+})
+
 /** Updates the security scheme base */
 const handleOauth2Update = (
   payload: Partial<OAuthFlow & XScalarCredentialsLocation>,
@@ -448,10 +466,10 @@ const handleSecretLocationUpdate = (value: string): void => {
       </RequestAuthDataTableInput>
     </DataTableRow>
 
-    <DataTableRow v-if="'x-scalar-secret-client-secret' in flow">
+    <DataTableRow v-if="showClientSecret">
       <RequestAuthDataTableInput
         :environment
-        :modelValue="flow['x-scalar-secret-client-secret']"
+        :modelValue="clientSecretValue"
         placeholder="XYZ123"
         type="password"
         @update:modelValue="

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
@@ -278,20 +278,25 @@ describe('oauth', () => {
       expect(error).toBe(null)
       expect(result).toEqual({ accessToken })
 
-      // Check fetch parameters
+      // Check fetch parameters — PKCE public clients omit client_secret and Basic auth
       expect(global.fetch).toHaveBeenCalledWith(tokenUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
-          'Authorization': `Basic ${secretAuth}`,
         },
-        body: new URLSearchParams({
-          redirect_uri: flows.authorizationCode['x-scalar-secret-redirect-uri'],
-          code,
-          grant_type: 'authorization_code',
-          code_verifier: 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8',
-        }),
+        body: expect.any(URLSearchParams),
       })
+
+      const pkceTokenArgs = vi.mocked(global.fetch).mock.calls[0]
+      expect(pkceTokenArgs).toBeDefined()
+      const pkceTokenBody = pkceTokenArgs![1]?.body as URLSearchParams
+      const pkceExpectedParams = new URLSearchParams()
+      pkceExpectedParams.set('client_id', flows.authorizationCode['x-scalar-secret-client-id'])
+      pkceExpectedParams.set('redirect_uri', flows.authorizationCode['x-scalar-secret-redirect-uri'])
+      pkceExpectedParams.set('code', code)
+      pkceExpectedParams.set('grant_type', 'authorization_code')
+      pkceExpectedParams.set('code_verifier', 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8')
+      expect(pkceTokenBody.toString()).toBe(pkceExpectedParams.toString())
     })
 
     it('should include x-scalar-security-body parameters in authorization code token request', async () => {
@@ -723,10 +728,9 @@ describe('oauth', () => {
       const callArgs = vi.mocked(global.fetch).mock.calls[0]
       expect(callArgs).toBeDefined()
       const body = callArgs![1]?.body as URLSearchParams
-      // Order matches implementation: client_id/client_secret, redirect_uri, code, grant_type, code_verifier
+      // PKCE + public client: client_id in body, no client_secret
       const expectedParams = new URLSearchParams()
       expectedParams.set('client_id', flows.authorizationCode['x-scalar-secret-client-id'])
-      expectedParams.set('client_secret', flows.authorizationCode['x-scalar-secret-client-secret'])
       expectedParams.set('redirect_uri', flows.authorizationCode['x-scalar-secret-redirect-uri'])
       expectedParams.set('code', code)
       expectedParams.set('grant_type', 'authorization_code')
@@ -1883,6 +1887,33 @@ describe('oauth', () => {
       expect(body.has('client_secret')).toBe(false)
       expect(body.get('grant_type')).toBe('refresh_token')
       expect(body.get('refresh_token')).toBe('refresh_token_123')
+    })
+
+    it('omits client_secret on refresh when PKCE mode is SHA-256 even if a secret is stored', async () => {
+      const pkcePublicScheme = {
+        authorizationCode: {
+          ...refreshScheme.authorizationCode,
+          'x-usePkce': 'SHA-256',
+          'x-scalar-secret-client-secret': clientSecret,
+        },
+      } satisfies OAuthFlowsObjectSecret
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        json: () =>
+          Promise.resolve({
+            access_token: 'new_access_token',
+          }),
+      })
+
+      await refreshOauth2Token(pkcePublicScheme, 'authorizationCode', '', mockServer)
+
+      const callArgs = vi.mocked(global.fetch).mock.calls[0]
+      const body = callArgs![1]?.body as URLSearchParams
+      expect(body.get('client_id')).toBe(refreshScheme.authorizationCode['x-scalar-secret-client-id'])
+      expect(body.has('client_secret')).toBe(false)
+      expect(callArgs![1]?.headers).toEqual({
+        'Content-Type': 'application/x-www-form-urlencoded',
+      })
     })
 
     it('omits client_id from the body for confidential clients using header credentials', async () => {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
@@ -13,6 +13,21 @@ import { getOAuthCallbackData } from './oauth-callback'
 /** Oauth2 security schemes which are not implicit */
 type NonImplicitFlows = Omit<OAuthFlowsObjectSecret, 'implicit'>
 
+const authorizationCodeUsesPkcePublicClient = (
+  flowType: keyof NonImplicitFlows,
+  flow: NonImplicitFlows[keyof NonImplicitFlows],
+): boolean => {
+  if (flowType !== 'authorizationCode') {
+    return false
+  }
+  const authCode = flow as OAuthFlowsObjectSecret['authorizationCode']
+  if (!authCode) {
+    return false
+  }
+  const pkceMode = authCode['x-usePkce']
+  return pkceMode === 'SHA-256' || pkceMode === 'plain'
+}
+
 type PKCEState = {
   codeVerifier: string
   codeChallenge: string
@@ -319,7 +334,8 @@ const authorizeServers = async (
 
   /** Where to add the credentials */
   const addCredentialsToBody = flow['x-scalar-credentials-location'] === 'body'
-  const hasClientSecret = Boolean(flow['x-scalar-secret-client-secret'])
+  const pkcePublicClient = authorizationCodeUsesPkcePublicClient(type, flow)
+  const hasClientSecret = Boolean(flow['x-scalar-secret-client-secret']) && !pkcePublicClient
   /**
    * Public authorization-code clients still need client_id in the token body.
    * We only send it implicitly for that case to avoid conflicting with Basic auth.
@@ -446,7 +462,8 @@ export const refreshOauth2Token = async (
   formData.set('refresh_token', refreshToken)
 
   const addCredentialsToBody = flow['x-scalar-credentials-location'] === 'body'
-  const hasClientSecret = Boolean(flow['x-scalar-secret-client-secret'])
+  const pkcePublicClient = authorizationCodeUsesPkcePublicClient(type, flow)
+  const hasClientSecret = Boolean(flow['x-scalar-secret-client-secret']) && !pkcePublicClient
   /**
    * Public authorization-code clients still need client_id in the refresh body per RFC 6749 Section 6.
    * We only send it implicitly for that case to avoid conflicting with Basic auth.


### PR DESCRIPTION
Fixes: #6848

When the OAuth2 authorization code flow sets `x-usePkce` to `SHA-256` or `plain`, we now treat it as a public PKCE profile: the Client Secret field is hidden in the auth UI, and `client_secret` is not sent on the code exchange or on refresh (including no Authorization: Basic … when credentials are in the header), so leftover stored secrets do not leak into requests.

If `x-usePkce` is no or omitted, behavior matches the previous confidential-style flow (secret field shown when the flow includes client secret fields, and secret sent when present).

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes OAuth2 `authorizationCode` token/refresh request construction (headers/body credentials) and could affect interoperability with providers expecting a client secret despite PKCE.
> 
> **Overview**
> For OAuth2 `authorizationCode` flows with `x-usePkce: 'SHA-256' | 'plain'`, the API client now treats the flow as a *public PKCE client*: the **Client Secret input is hidden** and `client_secret` (and `Authorization: Basic …`) is **omitted** from both token exchange and refresh requests even if a secret is stored.
> 
> Adds/updates tests covering the UI hiding behavior and the new request parameter/header expectations, and documents the PKCE public-client behavior in `documentation/configuration.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5fe0ff9b163c87cfa457cf37c0cc76bd7f6c625. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->