### PR TITLE
chore(api-reference): add AsyncAPI example to playground

### DIFF
--- a/packages/api-reference/test/snapshots/tag-groups.e2e.ts
+++ b/packages/api-reference/test/snapshots/tag-groups.e2e.ts
@@ -9,7 +9,7 @@ import { serveExample } from '@test/utils/serve-example'
 import { sources } from '../utils/sources'
 
 /** Tag groups source */
-const source = sources[2]
+const source = sources.find((s) => s.slug === 'tag-groups')!
 
 /** Options for the page screenshots */
 const getScreenshotOptions = (...mask: Locator[]) =>

--- a/packages/api-reference/test/utils/sources.ts
+++ b/packages/api-reference/test/utils/sources.ts
@@ -29,6 +29,7 @@ export const sources = [
   },
   {
     title: 'Scalar Galaxy Events (AsyncAPI)',
+    slug: 'scalar-galaxy-events',
     url: 'https://registry.scalar.com/@scalar/schemas/asyncapi?format=json',
   },
   {

--- a/packages/api-reference/test/utils/sources.ts
+++ b/packages/api-reference/test/utils/sources.ts
@@ -28,6 +28,10 @@ export const sources = [
     layout: 'classic',
   },
   {
+    title: 'Scalar Galaxy Events (AsyncAPI)',
+    url: 'https://registry.scalar.com/@scalar/schemas/asyncapi?format=json',
+  },
+  {
     title: 'Tag Groups',
     slug: 'tag-groups',
     content: {


### PR DESCRIPTION
Adds the Scalar Galaxy Events AsyncAPI document to the api-reference playground sources so we can test AsyncAPI rendering alongside the OpenAPI examples.

Makes it easier to review PRs. :)

See it here:
https://pr-9176.scalar-api-reference-preview.pages.dev/#scalar-galaxy-events


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test/playground fixtures and make an e2e test more robust by selecting sources by `slug` instead of array index.
> 
> **Overview**
> Adds a new playground/test source, **`scalar-galaxy-events`**, pointing to an AsyncAPI document URL so AsyncAPI rendering can be exercised alongside existing OpenAPI examples.
> 
> Updates `tag-groups.e2e.ts` to select the “Tag Groups” source via `sources.find((s) => s.slug === 'tag-groups')` instead of `sources[2]`, preventing the visual regression test from breaking when sources are reordered or new entries are inserted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a3f0b9e564c2156c4515b637b1275ed16cdccbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->