### PR TITLE
docs(agents): always scope test runs to the affected package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,39 @@ If the helper you need already exists there, import it from `@scalar/helpers`. O
 - **E2E**: Playwright in `packages/api-reference` and `packages/components`
 - **Integration tests**: `pnpm vitest integrations/*`
 
+### Running Tests
+
+**Always scope test runs to the package you modified.** Do not run `pnpm test` from the repo root when working on a single package — it runs the entire monorepo test suite, which is slow, noisy, and can surface unrelated pre-existing failures that obscure real problems.
+
+**Preferred: run from repo root with a path filter (single run)**
+
+```bash
+# Run all tests for a specific package once and exit
+pnpm vitest packages/<name> --run
+
+# Examples
+pnpm vitest packages/helpers --run
+pnpm vitest packages/oas-utils --run
+pnpm vitest integrations/fastify --run
+```
+
+**Alternative: run from inside the package directory**
+
+```bash
+cd packages/<name>
+pnpm test --run   # or: pnpm vitest --run
+```
+
+**Watch mode (while actively developing)**
+
+```bash
+pnpm vitest packages/<name>          # from repo root
+# or
+cd packages/<name> && pnpm test      # from package directory
+```
+
+Only use the root `pnpm test` (no path argument) when you intentionally want to verify the full monorepo — for example, as a final pre-merge sanity check.
+
 ### Testing Standards
 
 - Always import `describe`, `it`, and `expect` explicitly from `vitest` (no globals)
@@ -327,7 +360,19 @@ pnpm biome check --write --diagnostic-level=error --no-errors-on-unmatched --fil
 pnpm prettier --write $CHANGED
 ```
 
-**2. Type-check only the affected package(s):**
+**2. Run tests only for the affected package(s):**
+
+```bash
+# Replace <package-name> with the actual package directory name (e.g. helpers, oas-utils, api-client)
+pnpm vitest packages/<package-name> --run
+
+# For integrations
+pnpm vitest integrations/<integration-name> --run
+```
+
+Do not run `pnpm test` from the repo root — scope it to the package you changed.
+
+**3. Type-check only the affected package(s):**
 
 ```bash
 # Replace <package-name> with the actual package (e.g. api-client, helpers, oas-utils)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds explicit guidance to `AGENTS.md` so that LLMs always run tests scoped to the package/folder they modified, rather than triggering the full monorepo test suite from the repo root.

## Changes

Two additions to `AGENTS.md`:

1. **New `### Running Tests` subsection** (under `## Testing`) — explains the preferred patterns with concrete examples:
   - `pnpm vitest packages/<name> --run` from repo root (preferred)
   - `cd packages/<name> && pnpm test --run` from inside the package
   - Watch-mode equivalents
   - When root-level `pnpm test` is acceptable (intentional full-suite check before merge)

2. **New step 2 in `### After-change checklist`** — makes scoped test runs a required step alongside lint, format, and type-check; the existing type-check step becomes step 3.

The root-cause motivation: running `pnpm test` from the repo root is slow, noisy, and surfaces pre-existing failures in unrelated packages that obscure the real signal from the change at hand.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6c20204-6308-48a6-8a60-67303b1f7663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6c20204-6308-48a6-8a60-67303b1f7663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

