### PR TITLE
test(workspace-store): add bundled path-item ref reproduction

### DIFF
--- a/.changeset/repro-sentry-bundled-empty-endpoints.md
+++ b/.changeset/repro-sentry-bundled-empty-endpoints.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+test(workspace-store): add reproduction for bundled path-item refs dropping operations from navigation

--- a/packages/workspace-store/src/navigation/helpers/traverse-paths.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-paths.test.ts
@@ -335,6 +335,43 @@ describe('traversePaths', () => {
     expect(tagsMap.get('Ignored')?.entries).toEqual([])
   })
 
+  it('reproduces empty operations for bundled path-item $ref wrappers', () => {
+    const document = createDocument()
+    document.paths = {
+      '/api/0/organizations/{organization_slug}/events/': {
+        $ref: '#/x-ext/sentry-path-item',
+        // biome-ignore lint/suspicious/noExplicitAny: simulating bundled path-item $ref-value
+        '$ref-value': {
+          get: {
+            tags: ['Events'],
+            summary: 'List organization events',
+            operationId: 'listOrganizationEvents',
+          },
+        },
+      } as any,
+    }
+
+    const tagsMap: TagsMap = new Map([
+      ['Events', { id: 'tag/events', parentId: 'doc-1', tag: { name: 'Events' }, entries: [] }],
+    ])
+
+    const result = traversePaths({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      generateId: (props) => {
+        if (props.type === 'operation') {
+          return `${props.method?.toUpperCase()}-${props.path}`
+        }
+        return 'unknown-id'
+      },
+    })
+
+    // Repro for DOC-5398: wrapped path-item refs are currently skipped, so no operations are discovered.
+    expect(tagsMap.get('Events')?.entries).toEqual([])
+    expect(result.untaggedOperations).toEqual([])
+  })
+
   it('should handle operations with missing summary', () => {
     const document = createDocument()
     document.paths = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Bundled API descriptions can include path-item `$ref` wrappers. In this shape, path traversal can miss HTTP methods and the served API description appears to have no endpoints.

## Solution

- Added a focused reproduction test in `traverse-paths.test.ts` that simulates a bundled path-item `$ref` wrapper with a resolved `$ref-value` operation.
- Asserted the current behavior (no discovered operations) so the failure mode is explicit and easy to target in a follow-up fix.
- Added a changeset for `@scalar/workspace-store`.

## Validation

- `pnpm --filter @scalar/workspace-store test -- src/navigation/helpers/traverse-paths.test.ts`
- `pnpm biome check --write --diagnostic-level=error --no-errors-on-unmatched --files-ignore-unknown=true packages/workspace-store/src/navigation/helpers/traverse-paths.test.ts .changeset/repro-sentry-bundled-empty-endpoints.md`
- `pnpm prettier --write packages/workspace-store/src/navigation/helpers/traverse-paths.test.ts .changeset/repro-sentry-bundled-empty-endpoints.md`
- `pnpm --filter @scalar/workspace-store types:check`
- `pnpm knip`

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Part of DOC-5398
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C087G9CGFRB/p1778622564316589?thread_ts=1778622564.316589&cid=C087G9CGFRB)

<div><a href="https://cursor.com/agents/bc-b79cd1ec-51b2-59c4-8bf0-b425ec484b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b79cd1ec-51b2-59c4-8bf0-b425ec484b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

