### PR TITLE
feat(api-client): add Cmd/Ctrl+S for  so hosts (e.g. scalar-app) can match the header Save control for local workspaces

### DIFF
--- a/.changeset/api-client-local-save-hotkey.md
+++ b/.changeset/api-client-local-save-hotkey.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-client': patch
+---
+
+feat: add Cmd/Ctrl+S for `ui:save:local-document` so hosts (e.g. scalar-app) can match the header Save control for local workspaces

--- a/documentation/guides/app/keyboard-shortcuts.md
+++ b/documentation/guides/app/keyboard-shortcuts.md
@@ -10,6 +10,7 @@ The API Client supports keyboard shortcuts to speed up your workflow. On macOS, 
 | ⌘ K | Open command palette |
 | ⌘ B | Toggle sidebar |
 | ⌘ L | Focus address bar |
+| ⌘ S | Save local workspace (same as the header Save control when it is shown) |
 | Escape | Close modal |
 
 ## Desktop Only

--- a/packages/api-client/src/v2/helpers/handle-hotkeys.test.ts
+++ b/packages/api-client/src/v2/helpers/handle-hotkeys.test.ts
@@ -359,4 +359,31 @@ describe('handle-hotkey-down', () => {
 
     expect(mockEventBus.emit).not.toHaveBeenCalled()
   })
+
+  it('fires ui:save:local-document on Cmd+S in web layout', () => {
+    vi.mocked(isMacOS).mockReturnValue(true)
+
+    const event = createKeyboardEvent('s', { metaKey: true })
+    handleHotkeys(event, mockEventBus, 'web')
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith('ui:save:local-document', { event }, { skipUnpackProxy: true })
+  })
+
+  it('fires ui:save:local-document on Ctrl+S in web layout on non-macOS', () => {
+    vi.mocked(isMacOS).mockReturnValue(false)
+
+    const event = createKeyboardEvent('s', { ctrlKey: true })
+    handleHotkeys(event, mockEventBus, 'web')
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith('ui:save:local-document', { event }, { skipUnpackProxy: true })
+  })
+
+  it('fires ui:save:local-document on Cmd+S in desktop layout', () => {
+    vi.mocked(isMacOS).mockReturnValue(true)
+
+    const event = createKeyboardEvent('s', { metaKey: true })
+    handleHotkeys(event, mockEventBus, 'desktop')
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith('ui:save:local-document', { event }, { skipUnpackProxy: true })
+  })
 })

--- a/packages/api-client/src/v2/helpers/handle-hotkeys.ts
+++ b/packages/api-client/src/v2/helpers/handle-hotkeys.ts
@@ -16,6 +16,7 @@ const DEFAULT_HOTKEYS: HotKeyConfig = {
   l: { event: 'ui:focus:address-bar', modifiers: ['default'] },
   j: { event: 'ui:focus:search', modifiers: ['default'] },
   i: { event: 'ui:open:settings', modifiers: ['default'] },
+  s: { event: 'ui:save:local-document', modifiers: ['default'] },
 }
 
 /** Hotkey map by layout, we can allow the user to override this later */

--- a/packages/workspace-store/src/events/definitions/ui.ts
+++ b/packages/workspace-store/src/events/definitions/ui.ts
@@ -225,6 +225,15 @@ export type UIEvents = {
    */
   'ui:open:command-palette': CommandPaletteAction | KeyboardEventPayload | undefined
 
+  /**
+   * Request persisting the active document from a keyboard shortcut (Cmd/Ctrl+S).
+   *
+   * Hosts that show a local-only Save control (for example scalar-app) should
+   * listen, call `event.preventDefault()` when they handle the shortcut, and
+   * run their save path only when a save is actually allowed.
+   */
+  'ui:save:local-document': KeyboardEventPayload
+
   // ────────────────────────────────────────────────────────────
   // Navigation Item Events
   // ────────────────────────────────────────────────────────────

--- a/projects/scalar-app/src/features/app/App.vue
+++ b/projects/scalar-app/src/features/app/App.vue
@@ -221,16 +221,19 @@ const {
 })
 
 /** Cmd/Ctrl+S matches the header Save control for local workspaces (see AppHeaderActions). */
-const unsubscribeSaveLocalDocumentHotkey = app.eventBus.on('ui:save:local-document', (payload) => {
-  if (!showLocalSaveActions.value) {
-    return
-  }
-  payload.event.preventDefault()
-  if (!isActiveDocumentDirty.value) {
-    return
-  }
-  void handleSaveDocument()
-})
+const unsubscribeSaveLocalDocumentHotkey = app.eventBus.on(
+  'ui:save:local-document',
+  (payload) => {
+    if (!showLocalSaveActions.value) {
+      return
+    }
+    payload.event.preventDefault()
+    if (!isActiveDocumentDirty.value) {
+      return
+    }
+    void handleSaveDocument()
+  },
+)
 
 /** Props to pass to the RouterView component. */
 const routerViewProps = computed<RouteProps>(() => {

--- a/projects/scalar-app/src/features/app/App.vue
+++ b/projects/scalar-app/src/features/app/App.vue
@@ -140,6 +140,7 @@ onBeforeUnmount(() => {
     plugin.lifecycle?.onDestroy?.()
   }
   unsubscribeOpenCreateWorkspace()
+  unsubscribeSaveLocalDocumentHotkey()
 })
 
 /** Register global hotkeys for the app, passing the workspace event bus and layout state */
@@ -217,6 +218,18 @@ const {
   app,
   registry,
   registryDocuments: () => registryDocuments.value,
+})
+
+/** Cmd/Ctrl+S matches the header Save control for local workspaces (see AppHeaderActions). */
+const unsubscribeSaveLocalDocumentHotkey = app.eventBus.on('ui:save:local-document', (payload) => {
+  if (!showLocalSaveActions.value) {
+    return
+  }
+  payload.event.preventDefault()
+  if (!isActiveDocumentDirty.value) {
+    return
+  }
+  void handleSaveDocument()
 })
 
 /** Props to pass to the RouterView component. */


### PR DESCRIPTION
## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new global Cmd/Ctrl+S binding and event-bus surface that hosts may handle and `preventDefault()`, which could interfere with the browser’s native Save behavior if misused. Scope is otherwise small and covered by unit tests.
> 
> **Overview**
> Adds a new Cmd/Ctrl+S hotkey that emits `ui:save:local-document` from the API client hotkey handler, with tests verifying behavior on macOS vs non-macOS and across layouts.
> 
> Extends workspace-store UI event definitions to include `ui:save:local-document`, and wires `scalar-app` to handle the event by preventing default and triggering save only when local save actions are shown and the active document is dirty.
> 
> Updates keyboard shortcut docs and adds a changeset bumping `@scalar/api-client` and `@scalar/workspace-store` (patch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a7fb14536b490fff56b0516169b4cd64e097b0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->