### PR TITLE
chore(ci): harden GitHub Actions workflows

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -16,7 +16,7 @@ runs:
         node-version: ${{ inputs.node-version }}
     - name: Install dependencies
       shell: bash
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
     - name: Build packages
       shell: bash
       run: pnpm turbo ${{ env.TURBO_FLAGS }} --filter '${{inputs.packages}}' build

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -363,6 +363,32 @@
     },
 
     {
+      "description": "Third-party GitHub Actions that receive secrets at runtime. Updates must be reviewed individually — never auto-merge, never group, never auto-approve via dependency dashboard.",
+      "matchDepTypes": ["action"],
+      "matchPackageNames": [
+        "relative-ci/agent-action",
+        "cloudflare/wrangler-action",
+        "changesets/action",
+        "peter-evans/create-pull-request",
+        "peter-evans/dockerhub-description",
+        "akhilmhdh/contributors-readme-action",
+        "daun/playwright-report-summary",
+        "thollander/actions-comment-pull-request",
+        "amannn/action-semantic-pull-request",
+        "fjogeleit/http-request-action",
+        "useblacksmith/build-push-action",
+        "docker/login-action"
+      ],
+      "groupName": null,
+      "automerge": false,
+      "dependencyDashboardApproval": true,
+      "labels": ["dependencies", "security-sensitive"],
+      "prBodyNotes": [
+        ":lock: **Security-sensitive update.** This action receives secrets at runtime. Review the diff between the current and target commit SHAs before merging. Check the action's changelog and any third-party dependencies it pulls in."
+      ]
+    },
+
+    {
       "description": "Disable engine updates like node, github runner, and uses-with",
       "matchDepTypes": ["engines", "github-runner", "uses-with"],
       "enabled": false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
       - main
   pull_request:
   workflow_dispatch: null
+# Workflow-level default: read-only. Individual jobs widen as needed.
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-base-ci
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -25,8 +28,13 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      # Required for build provenance attestation (scalar.js CDN artifact).
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Build
         uses: ./.github/actions/build
         with:
@@ -35,6 +43,15 @@ jobs:
         run: |
           mkdir -p temp-artifacts
           cp packages/api-reference/dist/browser/standalone.js temp-artifacts/scalar.js
+      # Build provenance for the CDN artifact: lets consumers verify with
+      # `gh attestation verify scalar.js --repo scalar/scalar` that the file
+      # was produced by this workflow on this commit. Only runs on main pushes
+      # so PR builds aren't signed with provenance.
+      - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        name: Attest scalar.js build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: temp-artifacts/scalar.js
       - name: Upload scalar.js artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -82,6 +99,8 @@ jobs:
       scalar_app_package_changed: ${{ steps.set-outputs.outputs.scalar_app_package_changed }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Check whether integration files were modified
         id: changed-integration-files

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Dependency Review
         uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4
         with:

--- a/.github/workflows/deploy-api-client.yml
+++ b/.github/workflows/deploy-api-client.yml
@@ -21,6 +21,9 @@ on:
         description: 'The Cloudflare Pages deployment URL (staging only)'
         value: ${{ jobs.deploy.outputs.preview-url }}
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: blacksmith-2vcpu-ubuntu-2204
@@ -34,6 +37,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       # Build
       - name: Build workspace deps

--- a/.github/workflows/renovate-config-validation.yml
+++ b/.github/workflows/renovate-config-validation.yml
@@ -15,6 +15,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/teardown-api-client-preview.yml
+++ b/.github/workflows/teardown-api-client-preview.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
+          persist-credentials: false
 
       - name: Delete PR preview deployments from Cloudflare Pages
         env:

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -5,6 +5,9 @@ on:
     # Run every Friday at 15:00 UTC
     - cron: '0 15 * * 5'
 
+permissions:
+  contents: read
+
 jobs:
   update-readme:
     name: Update the README

--- a/.github/workflows/update-scalar-cli-documentation.yml
+++ b/.github/workflows/update-scalar-cli-documentation.yml
@@ -7,6 +7,9 @@ on:
   # Allow manual triggering
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-cli-docs:
     name: Update CLI Documentation

--- a/.github/workflows/validate-scalar-configuration.yaml
+++ b/.github/workflows/validate-scalar-configuration.yaml
@@ -12,6 +12,9 @@ on:
       - 'scalar.config.json'
       - 'documentation/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate scalar.config.json
@@ -21,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6


### PR DESCRIPTION
1. Add top-level `permissions: contents: read` to ci.yml,
   update-contributors.yml, update-scalar-cli-documentation.yml,
   deploy-api-client.yml, and validate-scalar-configuration.yaml so that
   new jobs added without an explicit permissions block default to
   read-only.

4. Pin `pnpm install` to `--frozen-lockfile` in the build composite
   action. pnpm enables this on CI=true today, but making it explicit
   prevents silent regressions.

5. Add a Renovate packageRule for third-party GitHub Actions that
   receive secrets at runtime. These updates are excluded from grouping,
   require dependency-dashboard approval, never auto-merge, and are
   labelled `security-sensitive` so reviewers see the elevated risk.

6. Set `persist-credentials: false` on read-only checkouts in
   ci.yml (build, check-changes), deploy-api-client.yml, dependency-
   review.yml, renovate-config-validation.yml,
   teardown-api-client-preview.yml, and validate-scalar-configuration.yaml.
   Remaining ci.yml checkouts are left for a follow-up.

7. Add `actions/attest-build-provenance` for the scalar.js CDN artifact
   produced by the build job. Only runs on pushes to main. Consumers can
   verify with `gh attestation verify scalar.js --repo scalar/scalar`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple GitHub Actions workflows and permissions, so misconfiguration could break CI/build/deploy behavior. Changes are primarily hardening (least-privilege, locked installs, provenance attestation) with minimal impact on application code.
> 
> **Overview**
> **Hardens GitHub Actions security posture** by setting workflow-level `permissions: contents: read` defaults (with per-job widening where needed) and disabling `persist-credentials` on several `actions/checkout` steps.
> 
> Makes builds more deterministic by enforcing `pnpm install --frozen-lockfile` in the shared build composite action, and adds `actions/attest-build-provenance` for the `scalar.js` artifact on `main` pushes.
> 
> Updates Renovate rules so listed third-party actions that receive secrets are **never grouped or auto-merged**, require dependency-dashboard approval, and are labeled `security-sensitive` with reviewer guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59c357b50475e465654b76b9743859a9c359acdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->