### PR TITLE
fix(api-reference): resolve $refs in additional properties

### DIFF
--- a/.changeset/crisp-queens-glow.md
+++ b/.changeset/crisp-queens-glow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: resolve $ref in additionalProperties before rendering schema

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.test.ts
@@ -149,6 +149,28 @@ describe('SchemaObjectProperties', () => {
     expect(prop.attributes('data-name')).toBe('propertyName')
   })
 
+  it('resolves $ref in additionalProperties and passes the resolved schema to SchemaProperty', () => {
+    const schema = {
+      type: 'object',
+      additionalProperties: {
+        $ref: '#/components/schemas/Resource',
+        '$ref-value': { type: 'object', properties: { id: { type: 'string' } } },
+      },
+    } as SchemaObject
+
+    const wrapper = mount(SchemaObjectProperties, {
+      props: { schema, options: {}, eventBus: null },
+    })
+
+    const prop = wrapper.findComponent({ name: 'SchemaProperty' })
+    expect(prop.exists()).toBe(true)
+    // The resolved schema should be passed, not { type: 'anything' }
+    expect(prop.props('schema')).toMatchObject({
+      type: 'object',
+      properties: { id: { type: 'string' } },
+    })
+  })
+
   it('does not render anything if schema has no properties, patternProperties, or additionalProperties', () => {
     const schema = coerceValue(SchemaObjectSchema, {
       type: 'object',

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
@@ -147,6 +147,7 @@ const getPropertyDescription = (
  * Get the value for additional properties.
  *
  * When additionalProperties is true or an empty object, it should render as { type: 'anything' }.
+ * $ref values are resolved before the type check so the referenced schema is rendered correctly.
  */
 const getAdditionalPropertiesValue = (
   additionalProperties: Extract<
@@ -154,21 +155,26 @@ const getAdditionalPropertiesValue = (
     { type: 'object' }
   >['additionalProperties'],
 ): SchemaObject => {
+  // Resolve $ref first so the type check below works on the actual schema
+  const resolved =
+    typeof additionalProperties === 'boolean'
+      ? additionalProperties
+      : resolve.schema(additionalProperties)
+
   if (
-    additionalProperties === true ||
-    (typeof additionalProperties === 'object' &&
-      Object.keys(additionalProperties).length === 0) ||
-    typeof additionalProperties !== 'object' ||
-    !('type' in additionalProperties)
+    resolved === true ||
+    (typeof resolved === 'object' && Object.keys(resolved).length === 0) ||
+    typeof resolved !== 'object' ||
+    !('type' in resolved)
   ) {
     return {
       // @ts-expect-error - ask hans
       type: 'anything',
-      ...(typeof additionalProperties === 'object' ? additionalProperties : {}),
+      ...(typeof resolved === 'object' ? resolved : {}),
     }
   }
 
-  return additionalProperties
+  return resolved
 }
 </script>
 


### PR DESCRIPTION
Addresses #6257.

## Problem

When `additionalProperties` contains a `$ref` (e.g. pointing to an external schema file), the referenced schema's contents were not rendered — only "propertyName" was shown with no type information.

The root cause was in `getAdditionalPropertiesValue`: it checked for a `type` key on the raw `$ref` object, which never has one, causing it to always return `{ type: 'anything' }` instead of the actual referenced schema.

The fix resolves the schema via `resolve.schema()` before the type check, consistent with how `getAdditionalPropertiesName` already handles the same input.

## Changes
- `packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue` — resolve `$ref` before checking for `type` in `getAdditionalPropertiesValue`
- `packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.test.ts` — regression test for `additionalProperties` with a `$ref` value