### PR TITLE
fix(build-scripts): import resolve in release-notes-generator

### DIFF
--- a/tooling/scripts/src/commands/release-notes-generator/index.ts
+++ b/tooling/scripts/src/commands/release-notes-generator/index.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import { dirname } from 'node:path'
+import { dirname, resolve } from 'node:path'
 
 import { Command } from 'commander'
 


### PR DESCRIPTION
The `release-notes-generator` command used `resolve()` from `node:path` without importing it, which broke the changesets release workflow with a `ReferenceError`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single missing import fix in a tooling script to prevent a runtime `ReferenceError` in the release workflow.
> 
> **Overview**
> Fixes the `release-notes-generator` command by importing `resolve` from `node:path`, preventing runtime failures when it builds paths (e.g., locating adjacent `package.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1730c4218f990cee23179209670d8fa25fceb3a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->