### PR TITLE
fix(api-reference): break cycles in mergeAllOfSchemas

### DIFF
--- a/.changeset/merge-cyclic-recursive-schemas.md
+++ b/.changeset/merge-cyclic-recursive-schemas.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): break cycles in `mergeAllOfSchemas` for self-referencing schemas (e.g. a schema whose array items `$ref` back to itself), which previously crashed the docs preview with "too much recursion"

--- a/.changeset/merge-cyclic-recursive-schemas.md
+++ b/.changeset/merge-cyclic-recursive-schemas.md
@@ -2,4 +2,4 @@
 '@scalar/api-reference': patch
 ---
 
-fix(api-reference): break cycles in `mergeAllOfSchemas` for self-referencing schemas (e.g. a schema whose array items `$ref` back to itself), which previously crashed the docs preview with "too much recursion"
+fix(api-reference): break cycles in `mergeAllOfSchemas` for self-referencing schemas (whether they `$ref` back to themselves through array items or through a plain object property), which previously crashed the docs preview with "too much recursion"

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
@@ -1105,4 +1105,31 @@ describe('mergeAllOfSchemas', () => {
 
     expect(() => mergeAllOfSchemas({ allOf: [issue, issue] } as any)).not.toThrow()
   })
+
+  it('does not infinitely recurse on schemas with a self-referencing $ref object property', () => {
+    // The sibling case of the array-items cycle above: a schema that points
+    // back at itself through a plain object property rather than array items.
+    //
+    //   TreeNode:
+    //     type: object
+    //     properties:
+    //       value: { type: string }
+    //       parent: { $ref: '#/components/schemas/TreeNode' }
+    //
+    // Here the recursion lives entirely inside mergePropertiesIntoResult's
+    // object-merge branch and never passes through mergeItems, so it needs its
+    // own cycle guard keyed on the property's $ref.
+    const node: any = {
+      type: 'object',
+      properties: {
+        value: { type: 'string' },
+      },
+    }
+    node.properties.parent = {
+      $ref: '#/components/schemas/TreeNode',
+      '$ref-value': node,
+    }
+
+    expect(() => mergeAllOfSchemas({ allOf: [node, node] } as any)).not.toThrow()
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
@@ -1072,4 +1072,37 @@ describe('mergeAllOfSchemas', () => {
       'x-enum-varnames': ['VALUE_ONE', 'VALUE_TWO'],
     })
   })
+
+  it('does not infinitely recurse on schemas with self-referencing $ref items', () => {
+    // Reproduces a real crash observed against schemas like:
+    //
+    //   ValidationIssue:
+    //     type: object
+    //     properties:
+    //       code: { type: string }
+    //       children:
+    //         type: array
+    //         items: { $ref: '#/components/schemas/ValidationIssue' }
+    //
+    // The recursive $ref drives mergeItems ↔ mergePropertiesIntoResult into
+    // infinite mutual recursion. The workspace-store dereferencer exposes
+    // resolved refs as `{ $ref, '$ref-value': <node> }` so we mirror that
+    // shape here to exercise the resolve.schema() path that the production
+    // bug took.
+    const issue: any = {
+      type: 'object',
+      properties: {
+        code: { type: 'string' },
+      },
+    }
+    issue.properties.children = {
+      type: 'array',
+      items: {
+        $ref: '#/components/schemas/ValidationIssue',
+        '$ref-value': issue,
+      },
+    }
+
+    expect(() => mergeAllOfSchemas({ allOf: [issue, issue] } as any)).not.toThrow()
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
@@ -241,15 +241,27 @@ const mergePropertiesIntoResult = (
     // Merge existing property
     const existing = resolve.schema(result[key])
 
+    // Break self-referential cycles: when this property's `$ref` is already
+    // being merged higher in the call stack, keep the partially merged existing
+    // schema instead of recursing into it again. This mirrors the guard in
+    // `mergeItems` and covers schemas that point back at themselves through a
+    // plain object property (e.g. a tree node whose `parent` $refs the node).
+    const schemaRef = (schema as { $ref?: string }).$ref
+    if (typeof schemaRef === 'string' && seenRefs.has(schemaRef)) {
+      result[key] = existing
+      continue
+    }
+    const nextSeenRefs = typeof schemaRef === 'string' ? new Set(seenRefs).add(schemaRef) : seenRefs
+
     if (schema.allOf) {
-      result[key] = mergeAllOfSchemas({ allOf: [existing, ...schema.allOf] } as SchemaObject, undefined, seenRefs)
+      result[key] = mergeAllOfSchemas({ allOf: [existing, ...schema.allOf] } as SchemaObject, undefined, nextSeenRefs)
     } else if (isArraySchema(schema) && isArraySchema(existing) && schema.items) {
       const existingItems = resolve.schema(existing.items)
       result[key] = {
         ...existing,
         type: 'array',
         items: existingItems
-          ? mergeItems(existingItems, resolve.schema(schema.items), seenRefs)
+          ? mergeItems(existingItems, resolve.schema(schema.items), nextSeenRefs)
           : resolve.schema(schema.items),
       }
     } else {
@@ -257,7 +269,7 @@ const mergePropertiesIntoResult = (
       if ('properties' in existing && 'properties' in schema) {
         const merged = { ...existing, ...schema }
         merged.properties = { ...existing.properties }
-        mergePropertiesIntoResult(merged.properties, schema.properties, seenRefs)
+        mergePropertiesIntoResult(merged.properties, schema.properties, nextSeenRefs)
         result[key] = merged
       }
       // Simple merge without property recursion

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
@@ -10,9 +10,14 @@ import { isArraySchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-
  *
  * @param schemas - Array of OpenAPI schema objects to merge
  * @param rootSchema - Optional root schema to merge with the result
+ * @param seenRefs - `$ref` strings already being merged higher in the call stack
  * @returns Merged schema object
  */
-export const mergeAllOfSchemas = (schemas: SchemaObject | undefined, rootSchema?: SchemaObject): SchemaObject => {
+export const mergeAllOfSchemas = (
+  schemas: SchemaObject | undefined,
+  rootSchema?: SchemaObject,
+  seenRefs: Set<string> = new Set(),
+): SchemaObject => {
   // Handle max depth, empty or invalid input
   if (!schemas?.allOf?.length || !Array.isArray(schemas.allOf)) {
     return rootSchema || ({} as SchemaObject)
@@ -35,26 +40,26 @@ export const mergeAllOfSchemas = (schemas: SchemaObject | undefined, rootSchema?
 
     // Handle nested allOf recursively
     if (schema.allOf) {
-      const nestedMerged = mergeAllOfSchemas(schema)
-      mergeSchemaIntoResult(result, nestedMerged)
+      const nestedMerged = mergeAllOfSchemas(schema, undefined, seenRefs)
+      mergeSchemaIntoResult(result, nestedMerged, false, seenRefs)
       continue
     }
 
-    mergeSchemaIntoResult(result, schema)
+    mergeSchemaIntoResult(result, schema, false, seenRefs)
   }
 
   // Apply base schema properties with precedence over allOf properties
   if (Object.keys(baseSchema).length > 0) {
-    mergeSchemaIntoResult(result, baseSchema, true)
+    mergeSchemaIntoResult(result, baseSchema, true, seenRefs)
   }
 
   // Process root schema last if provided
   if (rootSchema && typeof rootSchema === 'object') {
     if (rootSchema.allOf) {
-      const nestedMerged = mergeAllOfSchemas(rootSchema)
-      mergeSchemaIntoResult(result, nestedMerged, true)
+      const nestedMerged = mergeAllOfSchemas(rootSchema, undefined, seenRefs)
+      mergeSchemaIntoResult(result, nestedMerged, true, seenRefs)
     } else {
-      mergeSchemaIntoResult(result, rootSchema, true)
+      mergeSchemaIntoResult(result, rootSchema, true, seenRefs)
     }
   }
 
@@ -69,7 +74,12 @@ export const mergeAllOfSchemas = (schemas: SchemaObject | undefined, rootSchema?
  * @param schema - The source schema object to merge from
  * @param override - Whether to override existing properties (default: false)
  */
-const mergeSchemaIntoResult = (result: SchemaObject, schema: SchemaObject, override: boolean = false): void => {
+const mergeSchemaIntoResult = (
+  result: SchemaObject,
+  schema: SchemaObject,
+  override: boolean = false,
+  seenRefs: Set<string> = new Set(),
+): void => {
   // Early return if schema is empty
   const schemaKeys = objectKeys(schema)
   if (schemaKeys.length === 0) {
@@ -109,7 +119,7 @@ const mergeSchemaIntoResult = (result: SchemaObject, schema: SchemaObject, overr
         }
 
         // @ts-expect-error
-        mergePropertiesIntoResult(result.properties, value)
+        mergePropertiesIntoResult(result.properties, value, seenRefs)
       }
     }
     // Items
@@ -126,24 +136,24 @@ const mergeSchemaIntoResult = (result: SchemaObject, schema: SchemaObject, overr
 
           // Handle allOf within array items
           if (items.allOf) {
-            const mergedItems = mergeAllOfSchemas(items)
+            const mergedItems = mergeAllOfSchemas(items, undefined, seenRefs)
             // @ts-expect-error
             Object.assign(result.items, mergedItems)
           } else {
             // @ts-expect-error
-            mergeItemsIntoResult(getResolvedRef(result.items), items)
+            mergeItemsIntoResult(getResolvedRef(result.items), items, seenRefs)
           }
         }
         // For non-array types with items.allOf, merge into properties
         else if (items.allOf) {
-          const mergedItems = mergeAllOfSchemas(items)
+          const mergedItems = mergeAllOfSchemas(items, undefined, seenRefs)
           if ('properties' in mergedItems) {
             if (!('properties' in result)) {
               // @ts-expect-error
               result.properties = {}
             }
 
-            'properties' in result && mergePropertiesIntoResult(result.properties, mergedItems.properties)
+            'properties' in result && mergePropertiesIntoResult(result.properties, mergedItems.properties, seenRefs)
           }
         }
         // For non-array types without allOf, still set items if not already set
@@ -170,7 +180,7 @@ const mergeSchemaIntoResult = (result: SchemaObject, schema: SchemaObject, overr
         for (const _option of value) {
           const option = resolve.schema(_option)
           if (option && 'properties' in option && 'properties' in result) {
-            mergePropertiesIntoResult(result.properties, option.properties)
+            mergePropertiesIntoResult(result.properties, option.properties, seenRefs)
           }
         }
       }
@@ -194,6 +204,7 @@ const mergeSchemaIntoResult = (result: SchemaObject, schema: SchemaObject, overr
 const mergePropertiesIntoResult = (
   result: Extract<SchemaObject, { type: 'object' }>['properties'],
   properties: Extract<SchemaObject, { type: 'object' }>['properties'],
+  seenRefs: Set<string> = new Set(),
 ): void => {
   const propertyKeys = Object.keys(properties ?? {})
   if (!properties || !result || propertyKeys.length === 0) {
@@ -215,11 +226,11 @@ const mergePropertiesIntoResult = (
     if (!result[key]) {
       // Handle new property with allOf
       if (schema.allOf) {
-        result[key] = mergeAllOfSchemas(schema)
+        result[key] = mergeAllOfSchemas(schema, undefined, seenRefs)
       } else if (isArraySchema(schema) && resolve.schema(schema.items)?.allOf) {
         result[key] = {
           ...schema,
-          items: mergeAllOfSchemas(resolve.schema(schema.items)),
+          items: mergeAllOfSchemas(resolve.schema(schema.items), undefined, seenRefs),
         }
       } else if (properties[key]) {
         result[key] = properties[key]
@@ -231,20 +242,22 @@ const mergePropertiesIntoResult = (
     const existing = resolve.schema(result[key])
 
     if (schema.allOf) {
-      result[key] = mergeAllOfSchemas({ allOf: [existing, ...schema.allOf] } as SchemaObject)
+      result[key] = mergeAllOfSchemas({ allOf: [existing, ...schema.allOf] } as SchemaObject, undefined, seenRefs)
     } else if (isArraySchema(schema) && isArraySchema(existing) && schema.items) {
       const existingItems = resolve.schema(existing.items)
       result[key] = {
         ...existing,
         type: 'array',
-        items: existingItems ? mergeItems(existingItems, resolve.schema(schema.items)) : resolve.schema(schema.items),
+        items: existingItems
+          ? mergeItems(existingItems, resolve.schema(schema.items), seenRefs)
+          : resolve.schema(schema.items),
       }
     } else {
       // Create merged object with properties handled separately
       if ('properties' in existing && 'properties' in schema) {
         const merged = { ...existing, ...schema }
         merged.properties = { ...existing.properties }
-        mergePropertiesIntoResult(merged.properties, schema.properties)
+        mergePropertiesIntoResult(merged.properties, schema.properties, seenRefs)
         result[key] = merged
       }
       // Simple merge without property recursion
@@ -258,7 +271,7 @@ const mergePropertiesIntoResult = (
 /**
  * Efficiently merges array items into a result object.
  */
-const mergeItemsIntoResult = (result: SchemaObject, items: SchemaObject): void => {
+const mergeItemsIntoResult = (result: SchemaObject, items: SchemaObject, seenRefs: Set<string> = new Set()): void => {
   // Handle allOf in items
   if (items.allOf || result.allOf) {
     // Build array without spreads for better performance
@@ -280,7 +293,7 @@ const mergeItemsIntoResult = (result: SchemaObject, items: SchemaObject): void =
       allOfSchemas.push(items)
     }
 
-    const merged = mergeAllOfSchemas({ allOf: allOfSchemas } as SchemaObject)
+    const merged = mergeAllOfSchemas({ allOf: allOfSchemas } as SchemaObject, undefined, seenRefs)
     Object.assign(result, merged)
     return
   }
@@ -290,49 +303,35 @@ const mergeItemsIntoResult = (result: SchemaObject, items: SchemaObject): void =
 
   // Merge properties if both have them
   if ('properties' in result && 'properties' in items) {
-    mergePropertiesIntoResult(result.properties, items.properties)
+    mergePropertiesIntoResult(result.properties, items.properties, seenRefs)
   }
 }
-
-/**
- * Tracks `$ref` strings currently being merged so {@link mergeItems} can break
- * cycles caused by self-referencing schemas (e.g. a tree node whose `children`
- * array items `$ref` back to the node itself). Without this guard, mergeItems
- * and mergePropertiesIntoResult drive each other into infinite mutual
- * recursion: each call to `mergeItems(node, node)` walks `properties.children`,
- * whose items resolve back to `node`, which calls `mergeItems(node, node)`
- * again, ad infinitum.
- *
- * Reference equality can't catch the cycle because `resolve.schema()` returns
- * a fresh (coerced) object on every call, but the resolved object preserves
- * the original `$ref` string via `mergeSiblingReferences`, so `$ref` is a
- * stable identity we can track.
- */
-const inFlightRefs = new Set<string>()
 
 /**
  * Helper function for merging items that returns a new object.
  */
-const mergeItems = (existing: SchemaObject, incoming: SchemaObject): SchemaObject => {
+const mergeItems = (
+  existing: SchemaObject,
+  incoming: SchemaObject,
+  seenRefs: Set<string> = new Set(),
+): SchemaObject => {
   const incomingRef = (incoming as { $ref?: string }).$ref
-  if (typeof incomingRef === 'string' && inFlightRefs.has(incomingRef)) {
-    // Cycle: we are already merging this referenced schema higher in the call
-    // stack. Return the partially merged `existing` as-is.
-    return existing
-  }
+
   if (typeof incomingRef === 'string') {
-    inFlightRefs.add(incomingRef)
-  }
-  try {
-    return mergeItemsInner(existing, incoming)
-  } finally {
-    if (typeof incomingRef === 'string') {
-      inFlightRefs.delete(incomingRef)
+    if (seenRefs.has(incomingRef)) {
+      return existing
     }
+    return mergeItemsInner(existing, incoming, new Set(seenRefs).add(incomingRef))
   }
+
+  return mergeItemsInner(existing, incoming, seenRefs)
 }
 
-const mergeItemsInner = (existing: SchemaObject, incoming: SchemaObject): SchemaObject => {
+const mergeItemsInner = (
+  existing: SchemaObject,
+  incoming: SchemaObject,
+  seenRefs: Set<string> = new Set(),
+): SchemaObject => {
   // Handle allOf in either schema
   if (existing.allOf || incoming.allOf) {
     // Build array without spreads for better performance
@@ -354,7 +353,7 @@ const mergeItemsInner = (existing: SchemaObject, incoming: SchemaObject): Schema
       allOfSchemas.push(incoming)
     }
 
-    return mergeAllOfSchemas({ allOf: allOfSchemas } as SchemaObject)
+    return mergeAllOfSchemas({ allOf: allOfSchemas } as SchemaObject, undefined, seenRefs)
   }
 
   const merged = { ...existing, ...incoming }
@@ -364,7 +363,7 @@ const mergeItemsInner = (existing: SchemaObject, incoming: SchemaObject): Schema
     // @ts-expect-error
     merged.properties = { ...existing.properties }
     // @ts-expect-error
-    mergePropertiesIntoResult(merged.properties, incoming.properties)
+    mergePropertiesIntoResult(merged.properties, incoming.properties, seenRefs)
   }
 
   return merged as SchemaObject

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
@@ -295,9 +295,44 @@ const mergeItemsIntoResult = (result: SchemaObject, items: SchemaObject): void =
 }
 
 /**
+ * Tracks `$ref` strings currently being merged so {@link mergeItems} can break
+ * cycles caused by self-referencing schemas (e.g. a tree node whose `children`
+ * array items `$ref` back to the node itself). Without this guard, mergeItems
+ * and mergePropertiesIntoResult drive each other into infinite mutual
+ * recursion: each call to `mergeItems(node, node)` walks `properties.children`,
+ * whose items resolve back to `node`, which calls `mergeItems(node, node)`
+ * again, ad infinitum.
+ *
+ * Reference equality can't catch the cycle because `resolve.schema()` returns
+ * a fresh (coerced) object on every call, but the resolved object preserves
+ * the original `$ref` string via `mergeSiblingReferences`, so `$ref` is a
+ * stable identity we can track.
+ */
+const inFlightRefs = new Set<string>()
+
+/**
  * Helper function for merging items that returns a new object.
  */
 const mergeItems = (existing: SchemaObject, incoming: SchemaObject): SchemaObject => {
+  const incomingRef = (incoming as { $ref?: string }).$ref
+  if (typeof incomingRef === 'string' && inFlightRefs.has(incomingRef)) {
+    // Cycle: we are already merging this referenced schema higher in the call
+    // stack. Return the partially merged `existing` as-is.
+    return existing
+  }
+  if (typeof incomingRef === 'string') {
+    inFlightRefs.add(incomingRef)
+  }
+  try {
+    return mergeItemsInner(existing, incoming)
+  } finally {
+    if (typeof incomingRef === 'string') {
+      inFlightRefs.delete(incomingRef)
+    }
+  }
+}
+
+const mergeItemsInner = (existing: SchemaObject, incoming: SchemaObject): SchemaObject => {
   // Handle allOf in either schema
   if (existing.allOf || incoming.allOf) {
     // Build array without spreads for better performance


### PR DESCRIPTION
## Problem

Rendering a schema whose array items $ref back to the schema itself (e.g. ValidationIssue with `children: { items: { $ref: '...ValidationIssue' } }`) crashed the docs preview with "too much recursion" (Firefox) / "Maximum call stack size exceeded" (Chrome/Node). mergeItems and mergePropertiesIntoResult mutually recursed without any cycle detection.

## Solution

Track in-flight $ref strings in mergeItems; when the incoming schema's $ref is already being processed higher up the call stack, return the partially merged existing schema. $ref is a stable identity even across resolve.schema() calls (which coerce into fresh objects) because mergeSiblingReferences preserves the original $ref on the resolved value.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
