### PR TITLE
fix(api-reference): preserve OAuth redirect URL when switching documents

### DIFF
--- a/.changeset/fix-redirect-url-cleared-on-document-switch.md
+++ b/.changeset/fix-redirect-url-cleared-on-document-switch.md
@@ -1,0 +1,9 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): preserve OAuth redirect URL when switching between OpenAPI documents
+
+Auth changes were being persisted under the wrong document slug and shared a single debounce queue across all documents. When switching documents quickly, the pending save for the first document could be overwritten or dropped by a save for the second document, causing the redirect URL (and other auth secrets) to appear cleared after switching back.
+
+The fix uses `event.documentName` as both the debounce key and the storage key, giving each document its own independent debounce queue.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -317,7 +317,6 @@ const clientStore = createWorkspaceStore({
   verbose: isDevelopment,
   plugins: [
     persistencePlugin({
-      prefix: () => activeSlug.value,
       persistAuth: () => mergedConfig.value.persistAuth ?? false,
     }),
   ],

--- a/packages/api-reference/src/plugins/persistance-plugin.test.ts
+++ b/packages/api-reference/src/plugins/persistance-plugin.test.ts
@@ -1,15 +1,14 @@
-import { REFERENCE_LS_KEYS, safeLocalStorage } from '@scalar/helpers/object/local-storage'
+import { REFERENCE_LS_KEYS } from '@scalar/helpers/object/local-storage'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { persistencePlugin } from './persistance-plugin'
 
 const AUTH_KEY = (slug: string) => `${REFERENCE_LS_KEYS.AUTH}-${slug}`
-const storage = safeLocalStorage()
 
 describe('persistance-plugin', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-    storage.clear()
+    localStorage.clear()
   })
 
   afterEach(() => {
@@ -24,7 +23,14 @@ describe('persistance-plugin', () => {
       documentName: 'doc-a',
       value: {
         secrets: {
-          oauth: { type: 'oauth2', flows: {}, 'x-scalar-secret-redirect-uri': 'https://a.example.com/callback' },
+          oauth: {
+            type: 'oauth2',
+            implicit: {
+              'x-scalar-secret-redirect-uri': 'https://a.example.com/callback',
+              'x-scalar-secret-client-id': '',
+              'x-scalar-secret-token': '',
+            },
+          },
         },
         selected: { document: undefined, path: undefined },
       },
@@ -32,8 +38,8 @@ describe('persistance-plugin', () => {
 
     await vi.runAllTimersAsync()
 
-    const saved = JSON.parse(storage.getItem(AUTH_KEY('doc-a')) ?? '{}')
-    expect(saved.secrets?.oauth?.['x-scalar-secret-redirect-uri']).toBe('https://a.example.com/callback')
+    const saved = JSON.parse(localStorage.getItem(AUTH_KEY('doc-a')) ?? '{}')
+    expect(saved.secrets?.oauth?.implicit?.['x-scalar-secret-redirect-uri']).toBe('https://a.example.com/callback')
   })
 
   it('keeps auth for each document isolated when both fire changes before debounce flushes', async () => {
@@ -44,7 +50,14 @@ describe('persistance-plugin', () => {
       documentName: 'doc-a',
       value: {
         secrets: {
-          oauth: { type: 'oauth2', flows: {}, 'x-scalar-secret-redirect-uri': 'https://a.example.com/callback' },
+          oauth: {
+            type: 'oauth2',
+            implicit: {
+              'x-scalar-secret-redirect-uri': 'https://a.example.com/callback',
+              'x-scalar-secret-client-id': '',
+              'x-scalar-secret-token': '',
+            },
+          },
         },
         selected: { document: undefined, path: undefined },
       },
@@ -55,7 +68,14 @@ describe('persistance-plugin', () => {
       documentName: 'doc-b',
       value: {
         secrets: {
-          oauth: { type: 'oauth2', flows: {}, 'x-scalar-secret-redirect-uri': 'https://b.example.com/callback' },
+          oauth: {
+            type: 'oauth2',
+            implicit: {
+              'x-scalar-secret-redirect-uri': 'https://b.example.com/callback',
+              'x-scalar-secret-client-id': '',
+              'x-scalar-secret-token': '',
+            },
+          },
         },
         selected: { document: undefined, path: undefined },
       },
@@ -63,13 +83,13 @@ describe('persistance-plugin', () => {
 
     await vi.runAllTimersAsync()
 
-    const savedA = JSON.parse(storage.getItem(AUTH_KEY('doc-a')) ?? '{}')
-    const savedB = JSON.parse(storage.getItem(AUTH_KEY('doc-b')) ?? '{}')
+    const savedA = JSON.parse(localStorage.getItem(AUTH_KEY('doc-a')) ?? '{}')
+    const savedB = JSON.parse(localStorage.getItem(AUTH_KEY('doc-b')) ?? '{}')
 
     // Both documents must be persisted independently — the second event must NOT
     // replace the pending write for the first.
-    expect(savedA.secrets?.oauth?.['x-scalar-secret-redirect-uri']).toBe('https://a.example.com/callback')
-    expect(savedB.secrets?.oauth?.['x-scalar-secret-redirect-uri']).toBe('https://b.example.com/callback')
+    expect(savedA.secrets?.oauth?.implicit?.['x-scalar-secret-redirect-uri']).toBe('https://a.example.com/callback')
+    expect(savedB.secrets?.oauth?.implicit?.['x-scalar-secret-redirect-uri']).toBe('https://b.example.com/callback')
   })
 
   it('does not persist auth when persistAuth is false', async () => {
@@ -86,7 +106,7 @@ describe('persistance-plugin', () => {
 
     await vi.runAllTimersAsync()
 
-    expect(storage.getItem(AUTH_KEY('doc-a'))).toBeNull()
+    expect(localStorage.getItem(AUTH_KEY('doc-a'))).toBeNull()
   })
 
   it('persists the latest auth value when the same document fires multiple rapid changes', async () => {
@@ -96,7 +116,16 @@ describe('persistance-plugin', () => {
       type: 'auth',
       documentName: 'doc-a',
       value: {
-        secrets: { oauth: { type: 'oauth2', flows: {}, 'x-scalar-secret-redirect-uri': 'https://first.example.com' } },
+        secrets: {
+          oauth: {
+            type: 'oauth2',
+            implicit: {
+              'x-scalar-secret-redirect-uri': 'https://first.example.com',
+              'x-scalar-secret-client-id': '',
+              'x-scalar-secret-token': '',
+            },
+          },
+        },
         selected: { document: undefined, path: undefined },
       },
     })
@@ -105,14 +134,23 @@ describe('persistance-plugin', () => {
       type: 'auth',
       documentName: 'doc-a',
       value: {
-        secrets: { oauth: { type: 'oauth2', flows: {}, 'x-scalar-secret-redirect-uri': 'https://latest.example.com' } },
+        secrets: {
+          oauth: {
+            type: 'oauth2',
+            implicit: {
+              'x-scalar-secret-redirect-uri': 'https://latest.example.com',
+              'x-scalar-secret-client-id': '',
+              'x-scalar-secret-token': '',
+            },
+          },
+        },
         selected: { document: undefined, path: undefined },
       },
     })
 
     await vi.runAllTimersAsync()
 
-    const saved = JSON.parse(storage.getItem(AUTH_KEY('doc-a')) ?? '{}')
-    expect(saved.secrets?.oauth?.['x-scalar-secret-redirect-uri']).toBe('https://latest.example.com')
+    const saved = JSON.parse(localStorage.getItem(AUTH_KEY('doc-a')) ?? '{}')
+    expect(saved.secrets?.oauth?.implicit?.['x-scalar-secret-redirect-uri']).toBe('https://latest.example.com')
   })
 })

--- a/packages/api-reference/src/plugins/persistance-plugin.test.ts
+++ b/packages/api-reference/src/plugins/persistance-plugin.test.ts
@@ -1,0 +1,118 @@
+import { REFERENCE_LS_KEYS, safeLocalStorage } from '@scalar/helpers/object/local-storage'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { persistencePlugin } from './persistance-plugin'
+
+const AUTH_KEY = (slug: string) => `${REFERENCE_LS_KEYS.AUTH}-${slug}`
+const storage = safeLocalStorage()
+
+describe('persistance-plugin', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    storage.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('persists auth changes to the correct document slug from the event', async () => {
+    const plugin = persistencePlugin({ persistAuth: true, debounceDelay: 0 })
+
+    plugin.hooks?.onWorkspaceStateChanges?.({
+      type: 'auth',
+      documentName: 'doc-a',
+      value: {
+        secrets: {
+          oauth: { type: 'oauth2', flows: {}, 'x-scalar-secret-redirect-uri': 'https://a.example.com/callback' },
+        },
+        selected: { document: undefined, path: undefined },
+      },
+    })
+
+    await vi.runAllTimersAsync()
+
+    const saved = JSON.parse(storage.getItem(AUTH_KEY('doc-a')) ?? '{}')
+    expect(saved.secrets?.oauth?.['x-scalar-secret-redirect-uri']).toBe('https://a.example.com/callback')
+  })
+
+  it('keeps auth for each document isolated when both fire changes before debounce flushes', async () => {
+    const plugin = persistencePlugin({ persistAuth: true, debounceDelay: 100 })
+
+    plugin.hooks?.onWorkspaceStateChanges?.({
+      type: 'auth',
+      documentName: 'doc-a',
+      value: {
+        secrets: {
+          oauth: { type: 'oauth2', flows: {}, 'x-scalar-secret-redirect-uri': 'https://a.example.com/callback' },
+        },
+        selected: { document: undefined, path: undefined },
+      },
+    })
+
+    plugin.hooks?.onWorkspaceStateChanges?.({
+      type: 'auth',
+      documentName: 'doc-b',
+      value: {
+        secrets: {
+          oauth: { type: 'oauth2', flows: {}, 'x-scalar-secret-redirect-uri': 'https://b.example.com/callback' },
+        },
+        selected: { document: undefined, path: undefined },
+      },
+    })
+
+    await vi.runAllTimersAsync()
+
+    const savedA = JSON.parse(storage.getItem(AUTH_KEY('doc-a')) ?? '{}')
+    const savedB = JSON.parse(storage.getItem(AUTH_KEY('doc-b')) ?? '{}')
+
+    // Both documents must be persisted independently — the second event must NOT
+    // replace the pending write for the first.
+    expect(savedA.secrets?.oauth?.['x-scalar-secret-redirect-uri']).toBe('https://a.example.com/callback')
+    expect(savedB.secrets?.oauth?.['x-scalar-secret-redirect-uri']).toBe('https://b.example.com/callback')
+  })
+
+  it('does not persist auth when persistAuth is false', async () => {
+    const plugin = persistencePlugin({ persistAuth: false, debounceDelay: 0 })
+
+    plugin.hooks?.onWorkspaceStateChanges?.({
+      type: 'auth',
+      documentName: 'doc-a',
+      value: {
+        secrets: {},
+        selected: { document: undefined, path: undefined },
+      },
+    })
+
+    await vi.runAllTimersAsync()
+
+    expect(storage.getItem(AUTH_KEY('doc-a'))).toBeNull()
+  })
+
+  it('persists the latest auth value when the same document fires multiple rapid changes', async () => {
+    const plugin = persistencePlugin({ persistAuth: true, debounceDelay: 100 })
+
+    plugin.hooks?.onWorkspaceStateChanges?.({
+      type: 'auth',
+      documentName: 'doc-a',
+      value: {
+        secrets: { oauth: { type: 'oauth2', flows: {}, 'x-scalar-secret-redirect-uri': 'https://first.example.com' } },
+        selected: { document: undefined, path: undefined },
+      },
+    })
+
+    plugin.hooks?.onWorkspaceStateChanges?.({
+      type: 'auth',
+      documentName: 'doc-a',
+      value: {
+        secrets: { oauth: { type: 'oauth2', flows: {}, 'x-scalar-secret-redirect-uri': 'https://latest.example.com' } },
+        selected: { document: undefined, path: undefined },
+      },
+    })
+
+    await vi.runAllTimersAsync()
+
+    const saved = JSON.parse(storage.getItem(AUTH_KEY('doc-a')) ?? '{}')
+    expect(saved.secrets?.oauth?.['x-scalar-secret-redirect-uri']).toBe('https://latest.example.com')
+  })
+})

--- a/packages/api-reference/src/plugins/persistance-plugin.ts
+++ b/packages/api-reference/src/plugins/persistance-plugin.ts
@@ -9,18 +9,11 @@ import { authStorage, clientStorage } from '@/helpers/storage'
 export const persistencePlugin = ({
   debounceDelay = 500,
   maxWait = 10000,
-  prefix = '',
   persistAuth = false,
 }: {
   debounceDelay?: number
   /** Maximum time in milliseconds to wait before forcing execution, even with continuous calls. */
   maxWait?: number
-  /**
-   * Prefix to use for local storage keys.
-   * This can be a string or a function returning a string.
-   * For example, to persist data per document, use the document name as the prefix.
-   */
-  prefix?: string | (() => string)
   /**
    * Determines whether authentication details should be persisted.
    * Accepts a boolean or a function that returns a boolean.
@@ -32,19 +25,6 @@ export const persistencePlugin = ({
   const { execute } = debounce({ delay: debounceDelay, maxWait })
   const authPersistence = authStorage()
   const clientPersistence = clientStorage()
-
-  /**
-   * Resolves the prefix to use for local storage keys.
-   * If 'prefix' is a string, returns it directly.
-   * If 'prefix' is a function, calls and returns its value.
-   */
-  const getPrefix = () => {
-    if (typeof prefix === 'string') {
-      return prefix
-    }
-
-    return prefix()
-  }
 
   const getPersistAuth = () => {
     if (typeof persistAuth === 'function') {
@@ -72,8 +52,11 @@ export const persistencePlugin = ({
         }
 
         // Persist auth and [server](TODO)
+        // Use event.documentName as both the debounce key and the storage key so that
+        // concurrent auth changes across multiple documents do not clobber each other and
+        // the correct slug is used even when the active document has already changed.
         if (getPersistAuth() && event.type === 'auth') {
-          execute('auth', () => authPersistence.setAuth(getPrefix(), event.value))
+          execute(`auth-${event.documentName}`, () => authPersistence.setAuth(event.documentName, event.value))
         }
 
         // No action for other event types


### PR DESCRIPTION
## Problem

When switching between OpenAPI documents quickly, OAuth redirect URLs (and other auth secrets) would appear cleared after switching back. This happened because:

1. Auth changes were being persisted under a shared debounce queue across all documents
2. The storage key was derived from a `prefix` parameter that could change when the active document changed
3. When switching documents, a pending save for the first document could be overwritten or dropped by a save for the second document

## Solution

Removed the `prefix` parameter from `persistencePlugin` and instead use `event.documentName` directly as both:
- The debounce queue key (ensuring each document has its own independent queue)
- The storage key (ensuring auth is persisted under the correct document slug)

This guarantees that concurrent auth changes across multiple documents do not interfere with each other, and the correct document slug is used even when the active document has already changed.

### Changes

- **`persistance-plugin.ts`**: Removed `prefix` parameter and `getPrefix()` function; changed auth persistence to use `event.documentName` for both debounce key and storage key
- **`ApiReference.vue`**: Removed `prefix: () => activeSlug.value` from plugin initialization
- **`persistance-plugin.test.ts`**: Added comprehensive test coverage for multi-document auth persistence scenarios

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

https://claude.ai/code/session_01VSmu3VNxWL6sDnZekNCp9a