### PR TITLE
fix(scalar-app): history bug + max width

### DIFF
--- a/.changeset/light-banks-tap.md
+++ b/.changeset/light-banks-tap.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: history bug on operation switch

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
@@ -960,4 +960,146 @@ describe('OperationBlock', () => {
     expect(restored && 'data' in restored ? restored.data : undefined).toBe('{"users": []}')
     expect(getResponseBlockProps(wrapper).requestPayload).not.toBeNull()
   })
+
+  it('falls back to the last history entry when the in-memory cache is empty', async () => {
+    // Simulates landing on an operation that has been called before in a
+    // previous session: `responseCache` is empty but the workspace store
+    // still holds the operation's history. The response panel should show
+    // the most recent historical response instead of an empty state.
+    const historyEntry = {
+      time: 250,
+      timestamp: Date.now(),
+      request: {
+        method: 'GET',
+        url: 'https://api.example.com/api/users',
+        httpVersion: 'HTTP/1.1',
+        headers: [],
+        queryString: [],
+        cookies: [],
+        headersSize: -1,
+        bodySize: -1,
+      },
+      response: {
+        status: 201,
+        statusText: 'Created',
+        httpVersion: 'HTTP/1.1',
+        headers: [{ name: 'Content-Type', value: 'application/json' }],
+        cookies: [],
+        content: {
+          size: 19,
+          mimeType: 'application/json',
+          text: '{"from":"history"}',
+        },
+        redirectURL: '',
+        headersSize: -1,
+        bodySize: 19,
+      },
+      meta: { example: 'default' },
+      requestMetadata: { variables: {} },
+    }
+
+    const wrapper = mount(OperationBlock, {
+      props: {
+        ...createDefaultProps(),
+        history: [historyEntry],
+      },
+    })
+
+    await wrapper.vm.$nextTick()
+
+    const restored = getResponseBlockProps(wrapper).response
+    expect(restored).not.toBeNull()
+    expect(restored?.status).toBe(201)
+    expect(restored && 'data' in restored ? restored.data : undefined).toBe('{"from":"history"}')
+  })
+
+  it('prefers the in-memory cache over history when both are available', async () => {
+    // After a fresh send, `responseCache` holds the live response (with
+    // streams, full body, etc.). The history fallback should only kick in
+    // when the cache misses — it must not overwrite a cache hit.
+    const liveResponse: ResponseInstance = {
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      cookieHeaderKeys: [],
+      duration: 100,
+      method: 'get',
+      path: '/api/users',
+      data: '{"from":"cache"}',
+      size: 16,
+      ok: true,
+      redirected: false,
+      type: 'basic',
+      url: 'https://api.example.com/api/users',
+      body: null,
+      bodyUsed: false,
+      arrayBuffer: vi.fn(),
+      blob: vi.fn(),
+      formData: vi.fn(),
+      json: vi.fn(),
+      text: vi.fn(),
+      clone: vi.fn(),
+      bytes: vi.fn(),
+    }
+
+    const historyEntry = {
+      time: 250,
+      timestamp: Date.now(),
+      request: {
+        method: 'GET',
+        url: 'https://api.example.com/api/users',
+        httpVersion: 'HTTP/1.1',
+        headers: [],
+        queryString: [],
+        cookies: [],
+        headersSize: -1,
+        bodySize: -1,
+      },
+      response: {
+        status: 201,
+        statusText: 'Created',
+        httpVersion: 'HTTP/1.1',
+        headers: [],
+        cookies: [],
+        content: { size: 19, mimeType: 'application/json', text: '{"from":"history"}' },
+        redirectURL: '',
+        headersSize: -1,
+        bodySize: 19,
+      },
+      meta: { example: 'default' },
+      requestMetadata: { variables: {} },
+    }
+
+    vi.mocked(buildRequest).mockReturnValue(
+      ok({
+        controller: new AbortController(),
+        requestPayload: ['https://api.example.com/api/users', { method: 'GET', headers: new Headers() }],
+        isUsingProxy: false,
+      }),
+    )
+    vi.mocked(sendRequest).mockResolvedValue([
+      null,
+      {
+        timestamp: Date.now(),
+        requestPayload: ['https://api.example.com/api/users', { method: 'GET', headers: new Headers() }],
+        response: liveResponse,
+        originalResponse: new Response(),
+      },
+    ])
+
+    const wrapper = mount(OperationBlock, {
+      props: { ...createDefaultProps(), history: [historyEntry] },
+    })
+
+    // Send a request so the cache is populated with the live response.
+    await triggerExecute(wrapper)
+    // Navigate away and back — the cache should win over history.
+    await wrapper.setProps({ path: '/api/posts' })
+    await wrapper.vm.$nextTick()
+    await wrapper.setProps({ path: '/api/users' })
+    await wrapper.vm.$nextTick()
+
+    const restored = getResponseBlockProps(wrapper).response
+    expect(restored && 'data' in restored ? restored.data : undefined).toBe('{"from":"cache"}')
+  })
 })

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
@@ -961,6 +961,56 @@ describe('OperationBlock', () => {
     expect(getResponseBlockProps(wrapper).requestPayload).not.toBeNull()
   })
 
+  it('only falls back to history entries that were created for the active example', async () => {
+    // Two history entries on the same path/method but for different
+    // example keys. The active example is `default`, so the response panel
+    // must show the `default` entry — not the most recent overall.
+    const buildEntry = (exampleKey: string, body: string, status: number) => ({
+      time: 100,
+      timestamp: Date.now(),
+      request: {
+        method: 'GET',
+        url: 'https://api.example.com/api/users',
+        httpVersion: 'HTTP/1.1',
+        headers: [],
+        queryString: [],
+        cookies: [],
+        headersSize: -1,
+        bodySize: -1,
+      },
+      response: {
+        status,
+        statusText: 'OK',
+        httpVersion: 'HTTP/1.1',
+        headers: [],
+        cookies: [],
+        content: { size: body.length, mimeType: 'application/json', text: body },
+        redirectURL: '',
+        headersSize: -1,
+        bodySize: body.length,
+      },
+      meta: { example: exampleKey },
+      requestMetadata: { variables: {} },
+    })
+
+    const wrapper = mount(OperationBlock, {
+      props: {
+        ...createDefaultProps(),
+        // Chronological order: `default` first, then `alternative` newer.
+        history: [
+          buildEntry('default', '{"from":"default"}', 200),
+          buildEntry('alternative', '{"from":"alternative"}', 201),
+        ],
+      },
+    })
+
+    await wrapper.vm.$nextTick()
+
+    const restored = getResponseBlockProps(wrapper).response
+    expect(restored?.status).toBe(200)
+    expect(restored && 'data' in restored ? restored.data : undefined).toBe('{"from":"default"}')
+  })
+
   it('falls back to the last history entry when the in-memory cache is empty', async () => {
     // Simulates landing on an operation that has been called before in a
     // previous session: `responseCache` is empty but the workspace store

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -460,35 +460,39 @@ watch(
     const cached = responseCache.get(
       getOperationExampleKey(newMethod, newPath, newExampleKey),
     )
-    // History is keyed only by document/path/method but each entry carries
-    // the example it came from, so we walk from the end and pick the most
-    // recent entry that matches the active example. Otherwise a cache miss
-    // on example B would restore example A's response.
-    const latest = (() => {
-      for (let i = history.length - 1; i >= 0; i--) {
-        const entry = history[i]
-        if (entry?.meta.example === newExampleKey) {
-          return entry
-        }
-      }
-      return undefined
-    })()
 
     if (cached) {
       response.value = cached.response
       requestPayload.value = cached.requestPayload
-    } else if (latest) {
-      response.value = harToFetchResponse({
-        harResponse: latest.response,
-        url: latest.request.url,
-        method: newMethod,
-        path: newPath,
-        duration: latest.time,
-      })
-      requestPayload.value = null
     } else {
-      response.value = null
-      requestPayload.value = null
+      // History is keyed only by document/path/method but each entry carries
+      // the example it came from, so we walk from the end and pick the most
+      // recent entry that matches the active example. Otherwise a cache miss
+      // on example B would restore example A's response. Only runs on a
+      // cache miss — the common case (in-session navigation) skips it.
+      const latest = (() => {
+        for (let i = history.length - 1; i >= 0; i--) {
+          const entry = history[i]
+          if (entry?.meta.example === newExampleKey) {
+            return entry
+          }
+        }
+        return undefined
+      })()
+
+      if (latest) {
+        response.value = harToFetchResponse({
+          harResponse: latest.response,
+          url: latest.request.url,
+          method: newMethod,
+          path: newPath,
+          duration: latest.time,
+        })
+        requestPayload.value = null
+      } else {
+        response.value = null
+        requestPayload.value = null
+      }
     }
 
     // Cancel any in-flight request

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -460,11 +460,19 @@ watch(
     const cached = responseCache.get(
       getOperationExampleKey(newMethod, newPath, newExampleKey),
     )
-    // `history` is chronological (oldest first), so the last element is the
-    // most recent response for this path + method. `.at(-1)` returns
-    // `undefined` for an empty array, which folds the "no history" and
-    // "history exists" branches together.
-    const latest = history.at(-1)
+    // History is keyed only by document/path/method but each entry carries
+    // the example it came from, so we walk from the end and pick the most
+    // recent entry that matches the active example. Otherwise a cache miss
+    // on example B would restore example A's response.
+    const latest = (() => {
+      for (let i = history.length - 1; i >= 0; i--) {
+        const entry = history[i]
+        if (entry?.meta.example === newExampleKey) {
+          return entry
+        }
+      }
+      return undefined
+    })()
 
     if (cached) {
       response.value = cached.response

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -457,28 +457,27 @@ const handleNavigateSettings = () => {
 watch(
   [() => path, () => method, () => exampleKey],
   ([newPath, newMethod, newExampleKey]) => {
-    const newKey = getOperationExampleKey(newMethod, newPath, newExampleKey)
-    const cached = responseCache.get(newKey)
+    const cached = responseCache.get(
+      getOperationExampleKey(newMethod, newPath, newExampleKey),
+    )
+    // `history` is chronological (oldest first), so the last element is the
+    // most recent response for this path + method. `.at(-1)` returns
+    // `undefined` for an empty array, which folds the "no history" and
+    // "history exists" branches together.
+    const latest = history.at(-1)
+
     if (cached) {
       response.value = cached.response
       requestPayload.value = cached.requestPayload
-    } else if (history.length > 0) {
-      // `history` is chronological (oldest first); the last element is the
-      // most recent response for this path + method.
-      const latest = history[history.length - 1]
-      if (latest) {
-        response.value = harToFetchResponse({
-          harResponse: latest.response,
-          url: latest.request.url,
-          method: newMethod,
-          path: newPath,
-          duration: latest.time,
-        })
-        requestPayload.value = null
-      } else {
-        response.value = null
-        requestPayload.value = null
-      }
+    } else if (latest) {
+      response.value = harToFetchResponse({
+        harResponse: latest.response,
+        url: latest.request.url,
+        method: newMethod,
+        path: newPath,
+        duration: latest.time,
+      })
+      requestPayload.value = null
     } else {
       response.value = null
       requestPayload.value = null

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -440,10 +440,19 @@ const handleNavigateSettings = () => {
 }
 
 /**
- * When the path, method, or example key changes: save current response to
- * cache (so it can be restored when navigating back), then restore from cache
- * for the new operation or clear if no cached response. Response is only
- * cleared on page refresh or when making a new request for that operation.
+ * When the path, method, or example key changes, restore the response panel
+ * for the new operation from the best available source:
+ *
+ *   1. `responseCache` — in-memory, populated on every successful send.
+ *      Has the live response object (including streams) so it wins.
+ *   2. `history` — persisted in the workspace store. Used as a fallback when
+ *      the in-memory cache is empty (page reload, fresh app session, etc.)
+ *      so navigating to an operation that has been called before shows the
+ *      last response instead of an empty panel.
+ *   3. Otherwise clear.
+ *
+ * Only the response is restored from history — the user's request inputs are
+ * left alone, so we never silently overwrite an in-progress draft.
  */
 watch(
   [() => path, () => method, () => exampleKey],
@@ -453,6 +462,23 @@ watch(
     if (cached) {
       response.value = cached.response
       requestPayload.value = cached.requestPayload
+    } else if (history.length > 0) {
+      // `history` is chronological (oldest first); the last element is the
+      // most recent response for this path + method.
+      const latest = history[history.length - 1]
+      if (latest) {
+        response.value = harToFetchResponse({
+          harResponse: latest.response,
+          url: latest.request.url,
+          method: newMethod,
+          path: newPath,
+          duration: latest.time,
+        })
+        requestPayload.value = null
+      } else {
+        response.value = null
+        requestPayload.value = null
+      }
     } else {
       response.value = null
       requestPayload.value = null

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -409,11 +409,11 @@ defineExpose({
     send button.
   -->
   <div
-    class="order-last flex h-auto w-full max-w-[48rem] grow-2 flex-wrap items-stretch [--scalar-address-bar-height:32px] @3xl:order-0 @3xl:w-auto @3xl:flex-nowrap">
+    class="order-last flex h-auto w-full max-w-3xl grow-3 flex-wrap items-stretch [--scalar-address-bar-height:32px] @3xl:order-0 @3xl:w-auto @3xl:flex-nowrap">
     <!-- Address Bar -->
     <div
       :id="id"
-      class="address-bar-bg-states text-xxs group relative flex h-(--scalar-address-bar-height) w-full max-w-[48rem] flex-1 flex-row items-stretch rounded-lg p-0.75 @3xl:w-auto"
+      class="address-bar-bg-states text-xxs group relative flex h-(--scalar-address-bar-height) w-full flex-1 flex-row items-stretch rounded-lg p-0.75 @3xl:w-auto"
       :class="{
         'outline-c-danger outline': hasConflict,
         'rounded-b-none': isDropdownOpen,

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -409,11 +409,11 @@ defineExpose({
     send button.
   -->
   <div
-    class="order-last flex h-auto w-full max-w-3xl grow-3 flex-wrap items-stretch [--scalar-address-bar-height:32px] @3xl:order-0 @3xl:w-auto @3xl:flex-nowrap">
+    class="order-last flex h-auto w-full max-w-3xl grow-3 flex-wrap items-stretch [--scalar-address-bar-height:32px] @3xl:order-0 @3xl:flex-nowrap">
     <!-- Address Bar -->
     <div
       :id="id"
-      class="address-bar-bg-states text-xxs group relative flex h-(--scalar-address-bar-height) w-full flex-1 flex-row items-stretch rounded-lg p-0.75 @3xl:w-auto"
+      class="address-bar-bg-states text-xxs group relative flex h-(--scalar-address-bar-height) w-full flex-1 flex-row items-stretch rounded-lg p-0.75"
       :class="{
         'outline-c-danger outline': hasConflict,
         'rounded-b-none': isDropdownOpen,


### PR DESCRIPTION
## Problem

When an operation has made a request and we go to another one and come back it shows a blank response area.

## Solution

We restore the last response like we used to.

Also fixed max width in address bar (again again)

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes response-restoration logic in `OperationBlock` to hydrate UI state from persisted history, which could affect what users see when navigating between operations/examples. Risk is limited to client-side state/UI behavior and is covered by new targeted tests.
> 
> **Overview**
> Prevents the response panel from showing empty when navigating back to an operation by adding a **history-based fallback** on cache misses in `OperationBlock.vue` (while still preferring `responseCache`).
> 
> The fallback selects the most recent history entry **matching the active `exampleKey`** and restores only the response (leaving request inputs untouched); new tests cover example-scoped selection, cache-vs-history precedence, and empty-cache behavior.
> 
> Also adjusts `AddressBar.vue` sizing classes (e.g., `max-w-3xl`/`grow-3`) to fix the address bar’s max-width behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2301e0c42d0ee113e72c9b6f39a3ab95fffe9ff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->