### PR TITLE
fix(components): add hover highlight to workspace dropdown menu items

### DIFF
--- a/.changeset/fix-workspace-dropdown-highlight.md
+++ b/.changeset/fix-workspace-dropdown-highlight.md
@@ -1,0 +1,5 @@
+---
+"@scalar/components": patch
+---
+
+fix(components): add `data-[highlighted]` styling to ScalarDropdownButton for Radix keyboard navigation highlight in workspace and team picker dropdowns

--- a/.changeset/fix-workspace-dropdown-highlight.md
+++ b/.changeset/fix-workspace-dropdown-highlight.md
@@ -1,5 +1,8 @@
 ---
 "@scalar/components": patch
+"@scalar/themes": patch
 ---
 
-fix(components): add `data-[highlighted]` styling to ScalarDropdownButton for Radix keyboard navigation highlight in workspace and team picker dropdowns
+fix(components): add `highlighted` Tailwind variant for Radix menu item highlight state
+
+Adds a new `highlighted` custom Tailwind variant (matching `[data-highlighted]`) to `@scalar/themes` and uses it in `ScalarDropdownButton` to restore the hover and keyboard-navigation highlight in the workspace and team picker dropdowns.

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdownButton.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdownButton.vue
@@ -32,9 +32,9 @@ const variants = cva({
     'block h-8 min-w-0 gap-1.5 rounded px-2.5 py-1.5 text-left',
     // Text / background style
     'truncate  no-underline text-sm text-c-1',
-    // Interaction — hover:bg-b-2 handles mouse, data-[highlighted]:bg-b-2 handles
+    // Interaction — hover:bg-b-2 handles mouse, highlighted:bg-b-2 handles
     // Radix keyboard navigation and mouse-hover within Radix menu items
-    'cursor-pointer hover:bg-b-2 data-[highlighted]:bg-b-2',
+    'cursor-pointer hover:bg-b-2 highlighted:bg-b-2',
   ],
   variants: {
     disabled: { true: 'pointer-events-none text-c-3' },

--- a/packages/components/src/components/ScalarDropdown/ScalarDropdownButton.vue
+++ b/packages/components/src/components/ScalarDropdown/ScalarDropdownButton.vue
@@ -32,8 +32,9 @@ const variants = cva({
     'block h-8 min-w-0 gap-1.5 rounded px-2.5 py-1.5 text-left',
     // Text / background style
     'truncate  no-underline text-sm text-c-1',
-    // Interaction
-    'cursor-pointer hover:bg-b-2',
+    // Interaction — hover:bg-b-2 handles mouse, data-[highlighted]:bg-b-2 handles
+    // Radix keyboard navigation and mouse-hover within Radix menu items
+    'cursor-pointer hover:bg-b-2 data-[highlighted]:bg-b-2',
   ],
   variants: {
     disabled: { true: 'pointer-events-none text-c-3' },
@@ -53,7 +54,8 @@ const variants = cva({
   </component>
 </template>
 <style scoped>
-.dark-mode .scalar-dropdown-item:hover {
+.dark-mode .scalar-dropdown-item:hover,
+.dark-mode .scalar-dropdown-item[data-highlighted] {
   filter: brightness(1.1);
 }
 </style>

--- a/packages/themes/src/tailwind/variants.css
+++ b/packages/themes/src/tailwind/variants.css
@@ -28,3 +28,13 @@
  */
 @custom-variant hocus (&:hover, &:focus-visible);
 @custom-variant hocus-within (&:hover, &:focus-within);
+
+/**
+ * Radix UI highlighted variant
+ *
+ * Matches elements that have the `data-highlighted` attribute set by Radix UI
+ * when they are the currently highlighted item in a menu (via keyboard or mouse).
+ *
+ * @see https://www.radix-ui.com/primitives/docs/components/dropdown-menu#item
+ */
+@custom-variant highlighted (&[data-highlighted]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the missing hover and keyboard-navigation highlight in the API client workspace (and team) picker dropdown.

### Root Cause

The workspace/team picker dropdowns use Radix UI's `DropdownMenu.RadioItem` with `ScalarDropdownButton` passed as the `:as` prop. When a menu item is highlighted (via mouse hover within a Radix-managed menu, or via keyboard arrow-key navigation), Radix applies the `data-highlighted` attribute to that element.

`ScalarDropdownButton` only had `hover:bg-b-2` which handles plain CSS `:hover` but not the Radix `data-highlighted` state. As a result, keyboard navigation produced no visible highlight, and mouse hover was unreliable within the menu context.

### Fix

1. Added a `highlighted` custom Tailwind variant (`&[data-highlighted]`) to `@scalar/themes/src/tailwind/variants.css`, alongside the existing `hocus` and `dark` variants. This is consistent with the existing pattern for shared variants across the codebase.
2. Used `highlighted:bg-b-2` in `ScalarDropdownButton`'s base Tailwind classes.
3. Updated the dark-mode scoped style to apply `filter: brightness(1.1)` on `[data-highlighted]` as well.

## Visual

<a href="https://cursor.com/agents/bc-e9fe3c69-4d5f-4b8b-b5ca-2a78d3cea93f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworkspace_dropdown_highlight_demo.mp4"><img src="https://cursor.com/artifacts/c/art-245b9e34-e75e-4924-bd7b-07dfa07c860d" alt="workspace_dropdown_highlight_demo.mp4" /></a>

The video demonstrates:
- Hovering over workspace items now shows the expected background highlight
- Arrow-key navigation through the workspace submenu now correctly highlights the focused item

## Ticket

Fixes DOC-5409

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-5409](https://linear.app/api-docs/issue/DOC-5409/api-client-workspace-dropdown-lacks-highlight)

<div><a href="https://cursor.com/agents/bc-e9fe3c69-4d5f-4b8b-b5ca-2a78d3cea93f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9fe3c69-4d5f-4b8b-b5ca-2a78d3cea93f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

