### PR TITLE
feat(helpers): better server extraction for partial urls

### DIFF
--- a/.changeset/full-impalas-wave.md
+++ b/.changeset/full-impalas-wave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': patch
+---
+
+feat: better server extraction from partial urls

--- a/packages/helpers/src/url/extract-server-from-path.test.ts
+++ b/packages/helpers/src/url/extract-server-from-path.test.ts
@@ -15,9 +15,22 @@ describe('extractServer', () => {
     expect(extractServerFromPath('https://api.example.com/v1/users')).toEqual(['https://api.example.com', '/v1/users'])
   })
 
-  it('returns null for URLs without protocol', () => {
-    expect(extractServerFromPath('api.example.com')).toBeNull()
-    expect(extractServerFromPath('api.example.com/v1/users')).toBeNull()
+  it('extracts bare-hostname URLs without a protocol', () => {
+    expect(extractServerFromPath('google.com')).toEqual(['google.com', '/'])
+    expect(extractServerFromPath('google.com/v1/users')).toEqual(['google.com', '/v1/users'])
+    expect(extractServerFromPath('api.example.com')).toEqual(['api.example.com', '/'])
+    expect(extractServerFromPath('api.example.com/v1/users')).toEqual(['api.example.com', '/v1/users'])
+    expect(extractServerFromPath('api.example.com:8080/v1/users')).toEqual(['api.example.com:8080', '/v1/users'])
+    expect(extractServerFromPath('api.example.com/search?q=test#section')).toEqual([
+      'api.example.com',
+      '/search?q=test#section',
+    ])
+  })
+
+  it('returns null for protocol-less inputs that are not hostnames', () => {
+    expect(extractServerFromPath('api/v1/users')).toBeNull()
+    expect(extractServerFromPath('localhost')).toBeNull()
+    expect(extractServerFromPath('users')).toBeNull()
   })
 
   it('normalizes standard ports and preserves custom ports', () => {

--- a/packages/helpers/src/url/extract-server-from-path.test.ts
+++ b/packages/helpers/src/url/extract-server-from-path.test.ts
@@ -186,4 +186,30 @@ describe('extractServer', () => {
     const longPath = '/path'.repeat(10)
     expect(extractServerFromPath(`https://api.example.com${longPath}`)).toEqual(['https://api.example.com', longPath])
   })
+
+  it('extracts bare-hostname URLs when :// appears in the query string, path, or fragment', () => {
+    expect(extractServerFromPath('api.example.com/auth?redirect=https://app.com/cb')).toEqual([
+      'api.example.com',
+      '/auth?redirect=https://app.com/cb',
+    ])
+    expect(extractServerFromPath('api.example.com/redirect?url=ftp://files.example.com/file')).toEqual([
+      'api.example.com',
+      '/redirect?url=ftp://files.example.com/file',
+    ])
+    expect(extractServerFromPath('api.example.com/docs#section://example')).toEqual([
+      'api.example.com',
+      '/docs#section://example',
+    ])
+  })
+
+  it('preserves explicit port for bare-hostname URLs regardless of the port number', () => {
+    /** Port 443 must be preserved even though it is the default for https */
+    expect(extractServerFromPath('api.example.com:443/v1')).toEqual(['api.example.com:443', '/v1'])
+    expect(extractServerFromPath('api.example.com:443')).toEqual(['api.example.com:443', '/'])
+    /** Port 80 stays preserved (regression check for the existing behavior) */
+    expect(extractServerFromPath('api.example.com:80/v1')).toEqual(['api.example.com:80', '/v1'])
+    expect(extractServerFromPath('api.example.com:80')).toEqual(['api.example.com:80', '/'])
+    /** Non-default ports continue to round-trip */
+    expect(extractServerFromPath('api.example.com:8443/v1')).toEqual(['api.example.com:8443', '/v1'])
+  })
 })

--- a/packages/helpers/src/url/extract-server-from-path.ts
+++ b/packages/helpers/src/url/extract-server-from-path.ts
@@ -33,8 +33,13 @@ export const extractServerFromPath = (path = ''): [string, string] | null => {
    * Handle bare-hostname URLs without a protocol (e.g., "google.com/path").
    * Only treat the input as a server when the candidate host contains a dot,
    * so plain path-only inputs like "api/v1/users" stay paths.
+   *
+   * The protocol check is scoped to the start of the string so that inputs
+   * like "api.example.com/auth?redirect=https://app.com/cb" are still treated
+   * as bare hostnames rather than being skipped because of a "://" inside the
+   * query string, path, or fragment.
    */
-  if (!path.startsWith('/') && !path.includes('://')) {
+  if (!path.startsWith('/') && !/^[a-z][a-z0-9+\-.]*:\/\//i.test(path)) {
     const hostEnd = path.search(/[/?#]/)
     const host = hostEnd === -1 ? path : path.slice(0, hostEnd)
 
@@ -44,8 +49,18 @@ export const extractServerFromPath = (path = ''): [string, string] | null => {
         if (url.origin === 'null') {
           return null
         }
-        /** Strip the protocol we added back out so the server stays a bare host */
-        const origin = url.host
+        /**
+         * Preserve any explicit port from the input. The URL API strips the
+         * default port for the parsing scheme (443 for https), which would
+         * otherwise lose information the user explicitly provided. Since the
+         * actual protocol is unknown for bare hostnames, we must not apply
+         * protocol-dependent port normalization.
+         */
+        let origin = url.host
+        const explicitPortMatch = host.match(/:(\d+)$/)
+        if (explicitPortMatch && !url.port) {
+          origin = `${url.hostname}:${explicitPortMatch[1]}`
+        }
         const remainingPath = decodeURIComponent(url.pathname) + url.search + url.hash
         return [origin, remainingPath]
       } catch {

--- a/packages/helpers/src/url/extract-server-from-path.ts
+++ b/packages/helpers/src/url/extract-server-from-path.ts
@@ -19,10 +19,39 @@
  * @example
  * extractServer('//api.example.com/v1/users')
  * // Returns: ['//api.example.com', '/v1/users']
+ *
+ * @example
+ * extractServer('google.com/v1/users')
+ * // Returns: ['google.com', '/v1/users']
  */
 export const extractServerFromPath = (path = ''): [string, string] | null => {
   if (!path.trim()) {
     return null
+  }
+
+  /**
+   * Handle bare-hostname URLs without a protocol (e.g., "google.com/path").
+   * Only treat the input as a server when the candidate host contains a dot,
+   * so plain path-only inputs like "api/v1/users" stay paths.
+   */
+  if (!path.startsWith('/') && !path.includes('://')) {
+    const hostEnd = path.search(/[/?#]/)
+    const host = hostEnd === -1 ? path : path.slice(0, hostEnd)
+
+    if (host.includes('.')) {
+      try {
+        const url = new URL(`https://${path}`)
+        if (url.origin === 'null') {
+          return null
+        }
+        /** Strip the protocol we added back out so the server stays a bare host */
+        const origin = url.host
+        const remainingPath = decodeURIComponent(url.pathname) + url.search + url.hash
+        return [origin, remainingPath]
+      } catch {
+        return null
+      }
+    }
   }
 
   /** Handle protocol-relative URLs (e.g., "//api.example.com") */

--- a/packages/oas-utils/src/migrations/migrate-to-indexdb.test.ts
+++ b/packages/oas-utils/src/migrations/migrate-to-indexdb.test.ts
@@ -4059,36 +4059,6 @@ describe('migrate-to-indexdb', () => {
         })
       })
 
-      it('does not extract from paths that look like URLs but have no protocol', async () => {
-        const request = requestSchema.parse({
-          uid: 'request-1',
-          path: 'api.example.com/users',
-          method: 'get',
-          summary: 'Get users',
-        })
-
-        const legacyData = createLegacyData({
-          title: 'No Protocol API',
-          collection: { requests: ['request-1'] },
-          requests: [request],
-        })
-
-        const result = await transformLegacyDataToWorkspace(legacyData)
-        const doc = (result[0]?.workspace.documents as Record<string, OpenApiDocument> | undefined)?.['no-protocol-api']
-
-        assert(doc)
-        expect(doc.servers).toEqual([])
-        expect(doc).toMatchObject({
-          paths: {
-            '/api.example.com/users': {
-              get: {
-                summary: 'Get users',
-              },
-            },
-          },
-        })
-      })
-
       it('extracts same server from multiple paths without duplication', async () => {
         const request1 = requestSchema.parse({
           uid: 'request-1',


### PR DESCRIPTION
## Problem

we wanted to extract servers from google.com/things

## Solution

Added it

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes URL parsing behavior to treat protocol-less hostnames (e.g. `api.example.com/v1`) as servers, which can alter migration results and address-bar server selection for inputs containing dots/ports/query strings.
> 
> **Overview**
> **Server extraction now supports partial URLs.** `extractServerFromPath` can now treat protocol-less bare hostnames like `google.com/v1` (including ports, query strings, and fragments) as a server + remaining path, while still rejecting non-hostname inputs.
> 
> **Behavior is tightened around edge cases.** Protocol detection only checks the start of the string (so `://` inside query/fragment doesn’t interfere), and explicit ports on bare hostnames are preserved even when the URL parser would drop defaults.
> 
> **Downstream expectations updated.** Tests were expanded for the new cases, and the migration test that previously asserted “no extraction without protocol” was removed to reflect the new behavior. A patch changeset for `@scalar/helpers` is included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c12de1b7ebe8abfa893ec8505a70f40af11ec37e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->