### PR TITLE
feat(api-client): support testing webhooks

### DIFF
--- a/.changeset/api-client-webhook-testing.md
+++ b/.changeset/api-client-webhook-testing.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': minor
+'@scalar/api-client': minor
+---
+
+feat: support testing webhooks in the API client. `getRequestExampleContext` now resolves operations from `document.webhooks` when `isWebhook: true` is passed in `RequestExampleMeta`, and the modal sidebar routes webhook selections through the same operation pipeline used for paths.

--- a/packages/api-client/src/v2/features/modal/Modal.vue
+++ b/packages/api-client/src/v2/features/modal/Modal.vue
@@ -12,6 +12,8 @@ export type ModalProps = {
   method: ComputedRef<HttpMethod | undefined>
   /** The example name must be initialized and passed in */
   exampleName: ComputedRef<string | undefined>
+  /** When true, the current route refers to a webhook from `document.webhooks` */
+  isWebhook?: ComputedRef<boolean>
   /** Selected anyOf/oneOf request-body variants keyed by schema path */
   requestBodyCompositionSelection: Ref<Record<string, number>>
   /** Controls the visibility of the modal */
@@ -183,6 +185,7 @@ defineExpose({
         :environment
         :eventBus
         :exampleName="exampleName?.value"
+        :isWebhook="isWebhook?.value ?? false"
         layout="modal"
         :method="method?.value"
         :options

--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
@@ -67,6 +67,7 @@ export const createApiClientModal = ({
     method: 'default',
     example: 'default',
     documentSlug: workspaceStore.workspace['x-scalar-active-document'] || 'default',
+    isWebhook: false,
   }
 
   const parameters = reactive<DefaultEntities>({ ...defaultEntities })
@@ -82,6 +83,7 @@ export const createApiClientModal = ({
   const path = computed(() => resolvedParameters.value.path)
   const method = computed(() => resolvedParameters.value.method)
   const exampleName = computed(() => resolvedParameters.value.example)
+  const isWebhook = computed(() => resolvedParameters.value.isWebhook ?? false)
   /** The document from the workspace store. Modal is OpenAPI-only; AsyncAPI docs surface as null. */
   const document = computed(() => {
     const doc = workspaceStore.workspace.documents[documentSlug.value ?? '']
@@ -95,6 +97,7 @@ export const createApiClientModal = ({
     path: path,
     method: method,
     exampleName: exampleName,
+    isWebhook,
     route,
   })
 
@@ -104,6 +107,7 @@ export const createApiClientModal = ({
     document,
     eventBus,
     exampleName,
+    isWebhook,
     method,
     modalState,
     path,

--- a/packages/api-client/src/v2/features/modal/helpers/resolve-route-parameters.test.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/resolve-route-parameters.test.ts
@@ -495,6 +495,7 @@ describe('resolve-route-parameters', () => {
       path: '/users',
       method: 'get',
       example: 'default',
+      isWebhook: false,
     })
   })
 
@@ -517,6 +518,7 @@ describe('resolve-route-parameters', () => {
       path: '/pets',
       method: 'post',
       example: 'default',
+      isWebhook: false,
     })
   })
 
@@ -553,6 +555,7 @@ describe('resolve-route-parameters', () => {
       path: undefined,
       method: undefined,
       example: 'default',
+      isWebhook: false,
     })
   })
 
@@ -575,6 +578,7 @@ describe('resolve-route-parameters', () => {
       path: undefined,
       method: undefined,
       example: 'default',
+      isWebhook: false,
     })
   })
 
@@ -600,5 +604,55 @@ describe('resolve-route-parameters', () => {
     expect(result.documentSlug).toBe('active-doc')
     expect(result.path).toBe('/new')
     expect(result.method).toBe('post')
+  })
+
+  describe('webhooks', () => {
+    it('resolves "default" path to the first webhook name when isWebhook is true', async () => {
+      const store = createWorkspaceStore()
+      await store.addDocument({
+        name: 'my-doc',
+        document: getDocument({
+          webhooks: { newPet: { post: { summary: 'New pet webhook' } } },
+        }),
+      })
+
+      const result = resolveRouteParameters(store, {
+        documentSlug: 'my-doc',
+        path: 'default',
+        method: 'default',
+        example: 'default',
+        isWebhook: true,
+      })
+
+      expect(result.path).toBe('newPet')
+      expect(result.method).toBe('post')
+      expect(result.isWebhook).toBe(true)
+    })
+
+    it('preserves an explicit webhook name and method', async () => {
+      const store = createWorkspaceStore()
+      await store.addDocument({
+        name: 'my-doc',
+        document: getDocument({
+          webhooks: { orderShipped: { post: { summary: 'Shipped' } } },
+        }),
+      })
+
+      const result = resolveRouteParameters(store, {
+        documentSlug: 'my-doc',
+        path: 'orderShipped',
+        method: 'post',
+        example: 'default',
+        isWebhook: true,
+      })
+
+      expect(result).toEqual({
+        documentSlug: 'my-doc',
+        path: 'orderShipped',
+        method: 'post',
+        example: 'default',
+        isWebhook: true,
+      })
+    })
   })
 })

--- a/packages/api-client/src/v2/features/modal/helpers/resolve-route-parameters.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/resolve-route-parameters.ts
@@ -7,14 +7,23 @@ import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 
 /** Payload for routing and opening the API client modal. */
 export type RoutePayload = {
+  /** API path for operations, or webhook name when `isWebhook` is true. */
   path: string
   method: HttpMethod
   example?: string
   documentSlug?: string
+  /** When true, resolve `path` against `document.webhooks` instead of `document.paths`. */
+  isWebhook?: boolean
 }
 
 /** Raw input values that may contain "default" placeholders. */
-export type DefaultEntities = Record<keyof RoutePayload, string>
+export type DefaultEntities = {
+  path: string
+  method: string
+  example: string
+  documentSlug: string
+  isWebhook?: boolean
+}
 
 /** Context for resolving route parameters from the workspace store. */
 type ResolverContext = {
@@ -69,7 +78,7 @@ export const resolveDocumentSlug = (store: WorkspaceStore, slug: string | undefi
  * When "default" is specified, returns the first available path in the document.
  * This is useful for initial navigation when no specific path is requested.
  */
-export const resolvePath = (ctx: ResolverContext, path: string | undefined): string | undefined => {
+export const resolvePath = (ctx: ResolverContext, path: string | undefined, isWebhook = false): string | undefined => {
   const document = getDocument(ctx)
 
   if (!document) {
@@ -77,7 +86,8 @@ export const resolvePath = (ctx: ResolverContext, path: string | undefined): str
   }
 
   if (path === 'default') {
-    return Object.keys(document.paths ?? {})[0]
+    const bag = isWebhook ? document.webhooks : document.paths
+    return Object.keys(bag ?? {})[0]
   }
 
   return path
@@ -93,6 +103,7 @@ export const resolveMethod = (
   ctx: ResolverContext,
   path: string | undefined,
   method: string | undefined,
+  isWebhook = false,
 ): HttpMethod | undefined => {
   const document = getDocument(ctx)
 
@@ -101,7 +112,8 @@ export const resolveMethod = (
   }
 
   if (method === 'default') {
-    const pathMethods = Object.keys(document.paths?.[path] ?? {})
+    const bag = isWebhook ? document.webhooks : document.paths
+    const pathMethods = Object.keys(bag?.[path] ?? {})
     return pathMethods.find(isHttpMethod)
   }
 
@@ -148,19 +160,22 @@ export const resolveExampleName = (
 export const resolveRouteParameters = (store: WorkspaceStore, params: DefaultEntities): Partial<RoutePayload> => {
   const documentSlug = resolveDocumentSlug(store, params.documentSlug)
   const ctx: ResolverContext = { store, documentSlug }
+  const isWebhook = params.isWebhook ?? false
 
-  const path = resolvePath(ctx, params.path)
-  const method = resolveMethod(ctx, path, params.method)
+  const path = resolvePath(ctx, params.path, isWebhook)
+  const method = resolveMethod(ctx, path, params.method, isWebhook)
 
   const traversedDocument = getDocument(ctx)?.['x-scalar-navigation']
 
   if (!traversedDocument) {
-    return { documentSlug, path, method, example: 'default' }
+    return { documentSlug, path, method, example: 'default', isWebhook }
   }
 
-  const operations = getOperationEntries(traversedDocument)
-  const operation = operations.get(`${path}|${method}`)?.find((entry) => entry.type === 'operation')
+  // getOperationEntries keys both operations (path|method) and webhooks (name|method) the same way.
+  const entries = getOperationEntries(traversedDocument)
+  const expectedType = isWebhook ? 'webhook' : 'operation'
+  const operation = entries.get(`${path}|${method}`)?.find((entry) => entry.type === expectedType)
   const example = resolveExampleName(ctx, operation, params.example)
 
-  return { documentSlug, path, method, example }
+  return { documentSlug, path, method, example, isWebhook }
 }

--- a/packages/api-client/src/v2/features/modal/hooks/use-modal-sidebar.ts
+++ b/packages/api-client/src/v2/features/modal/hooks/use-modal-sidebar.ts
@@ -17,6 +17,7 @@ export type UseModalSidebarReturn = {
     path?: string
     method?: HttpMethod
     example?: string
+    isWebhook?: boolean
   }) => TraversedEntry | undefined
 }
 
@@ -43,6 +44,7 @@ export const useModalSidebar = ({
   path,
   method,
   exampleName,
+  isWebhook,
   route,
 }: {
   workspaceStore: WorkspaceStore | null
@@ -50,6 +52,7 @@ export const useModalSidebar = ({
   path: ComputedRef<string | undefined>
   method: ComputedRef<HttpMethod | undefined>
   exampleName: ComputedRef<string | undefined>
+  isWebhook?: ComputedRef<boolean>
   route: (payload: RoutePayload) => void
 }): UseModalSidebarReturn => {
   const entries = computed<TraversedEntry[]>(() => {
@@ -69,8 +72,18 @@ export const useModalSidebar = ({
     generateReverseIndex({
       items: entries.value,
       nestedKey: 'children',
-      filter: (node) => node.type === 'operation' || node.type === 'example',
+      filter: (node) => node.type === 'operation' || node.type === 'example' || node.type === 'webhook',
       getId: (node) => {
+        // For webhooks, use the webhook's `name` as the location id's path slot — webhooks have
+        // no examples, so this branch is straightforward.
+        if (node.type === 'webhook') {
+          return generateLocationId({
+            document: toValue(documentSlug) ?? '',
+            path: node.name,
+            method: node.method,
+            isWebhook: true,
+          })
+        }
         const operation = getParentEntry('operation', node)
         return generateLocationId({
           document: toValue(documentSlug) ?? '',
@@ -107,6 +120,7 @@ export const useModalSidebar = ({
         path: location.path,
         method: location.method,
         example: location.example,
+        isWebhook: location.isWebhook,
       }),
     )
 
@@ -120,6 +134,7 @@ export const useModalSidebar = ({
         document: location.document,
         path: location.path,
         method: location.method,
+        isWebhook: location.isWebhook,
       }),
     )
   }
@@ -168,14 +183,27 @@ export const useModalSidebar = ({
       })
     }
 
+    // Webhooks have no examples; the webhook name fills the route's `path` slot and `isWebhook`
+    // tells downstream resolvers to look in `document.webhooks`.
+    if (entry.type === 'webhook') {
+      state.setSelected(id)
+      return route({
+        documentSlug: toValue(documentSlug),
+        path: entry.name,
+        method: entry.method,
+        example: 'default',
+        isWebhook: true,
+      })
+    }
+
     state.setExpanded(id, !state.isExpanded(id))
     return
   }
 
   /** Keep the sidebar state in sync with the modal parameters */
   watch(
-    [documentSlug, path, method, exampleName],
-    ([newDocument, newPath, newMethod, newExample]) => {
+    [documentSlug, path, method, exampleName, () => toValue(isWebhook) ?? false],
+    ([newDocument, newPath, newMethod, newExample, newIsWebhook]) => {
       if (!newDocument) {
         // Reset selection if no document is selected
         state.setSelected(null)
@@ -187,6 +215,7 @@ export const useModalSidebar = ({
         path: newPath,
         method: newMethod,
         example: newExample,
+        isWebhook: newIsWebhook,
       })
 
       if (entry) {

--- a/packages/api-client/src/v2/features/operation/Operation.vue
+++ b/packages/api-client/src/v2/features/operation/Operation.vue
@@ -18,12 +18,14 @@ export type OperationProps = {
   eventBus: WorkspaceEventBus
   /** The layout of the client */
   layout: ClientLayout
-  /** The API path currently selected (e.g. "/users/{id}") */
+  /** The API path currently selected (e.g. "/users/{id}"), or webhook name when `isWebhook` is true */
   path?: string
   /** The HTTP method for the currently selected API path (e.g. GET, POST) */
   method?: HttpMethod
   /** The name of the currently selected example (for examples within an endpoint) */
   exampleName?: string
+  /** When true, `path` is treated as a webhook name and resolved from `document.webhooks` */
+  isWebhook?: boolean
   /** The currently active environment */
   environment: XScalarEnvironment
   /** The workspace store */
@@ -67,6 +69,7 @@ const {
   workspaceStore,
   plugins,
   documentSlug,
+  isWebhook,
 } = defineProps<
   OperationProps & {
     /** Selected anyOf/oneOf request-body variants keyed by schema path */
@@ -86,7 +89,7 @@ const requestExample = computed(() => {
   const result = getRequestExampleContext(
     workspaceStore,
     documentSlug,
-    { path, method, exampleName },
+    { path, method, exampleName, isWebhook },
     {
       baseServerUrl: toValue(options)?.baseServerURL,
       fallbackDocument: document,

--- a/packages/api-client/src/v2/helpers/generate-location-id.ts
+++ b/packages/api-client/src/v2/helpers/generate-location-id.ts
@@ -17,11 +17,15 @@ export const generateLocationId = ({
   path,
   method,
   example,
+  isWebhook,
 }: {
   document: string
   path?: string
   method?: HttpMethod
   example?: string
+  /** When true, the id is namespaced so a webhook does not collide with an operation that shares its path. */
+  isWebhook?: boolean
 }) => {
-  return JSON.stringify([document, path, method, example].filter(isDefined))
+  const prefix = isWebhook ? 'webhook' : 'operation'
+  return JSON.stringify([prefix, document, path, method, example].filter(isDefined))
 }

--- a/packages/workspace-store/src/request-example/context/get-request-example-context.test.ts
+++ b/packages/workspace-store/src/request-example/context/get-request-example-context.test.ts
@@ -230,4 +230,118 @@ describe('getRequestExampleContext', () => {
       }),
     ])
   })
+
+  describe('webhooks', () => {
+    const createDocumentWithWebhook = (): OpenApiDocument =>
+      createMinimalDocument({
+        webhooks: {
+          newPet: {
+            post: {
+              operationId: 'newPetWebhook',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: { type: 'object', properties: { name: { type: 'string' } } },
+                  },
+                },
+              },
+              responses: {
+                '200': { description: 'Acknowledged' },
+              },
+            },
+          },
+        },
+      })
+
+    it('resolves the operation from document.webhooks when isWebhook is true', async () => {
+      const workspaceStore = createWorkspaceStore()
+      await workspaceStore.addDocument({
+        name: 'scalar-galaxy',
+        document: createDocumentWithWebhook(),
+      })
+
+      const result = getRequestExampleContext(workspaceStore, 'scalar-galaxy', {
+        path: 'newPet',
+        method: 'post',
+        exampleName: 'default',
+        isWebhook: true,
+      })
+
+      expect(result.ok).toBe(true)
+      assert(result.ok)
+      expect(result.data.operation.operationId).toBe('newPetWebhook')
+    })
+
+    it('falls back to fallbackDocument webhooks when the document is not in the workspace', () => {
+      const workspaceStore = createWorkspaceStore()
+      const fallbackDocument = createDocumentWithWebhook()
+
+      const result = getRequestExampleContext(
+        workspaceStore,
+        'not-in-workspace',
+        { path: 'newPet', method: 'post', exampleName: 'default', isWebhook: true },
+        { fallbackDocument },
+      )
+
+      expect(result.ok).toBe(true)
+      assert(result.ok)
+      expect(result.data.operation.operationId).toBe('newPetWebhook')
+    })
+
+    it('returns a webhook-specific error when the webhook name is unknown', async () => {
+      const workspaceStore = createWorkspaceStore()
+      await workspaceStore.addDocument({
+        name: 'scalar-galaxy',
+        document: createDocumentWithWebhook(),
+      })
+
+      const result = getRequestExampleContext(workspaceStore, 'scalar-galaxy', {
+        path: 'unknownWebhook',
+        method: 'post',
+        exampleName: 'default',
+        isWebhook: true,
+      })
+
+      expect(result.ok).toBe(false)
+      assert(!result.ok)
+      expect(result.error).toContain('Webhook unknownWebhook not found')
+    })
+
+    it('returns a webhook-specific error when the method is missing on the webhook', async () => {
+      const workspaceStore = createWorkspaceStore()
+      await workspaceStore.addDocument({
+        name: 'scalar-galaxy',
+        document: createDocumentWithWebhook(),
+      })
+
+      const result = getRequestExampleContext(workspaceStore, 'scalar-galaxy', {
+        path: 'newPet',
+        method: 'get',
+        exampleName: 'default',
+        isWebhook: true,
+      })
+
+      expect(result.ok).toBe(false)
+      assert(!result.ok)
+      expect(result.error).toContain('Method get not found on webhook newPet')
+    })
+
+    it('does not match a webhook name when isWebhook is false (default)', async () => {
+      const workspaceStore = createWorkspaceStore()
+      await workspaceStore.addDocument({
+        name: 'scalar-galaxy',
+        document: createDocumentWithWebhook(),
+      })
+
+      const result = getRequestExampleContext(workspaceStore, 'scalar-galaxy', {
+        path: 'newPet',
+        method: 'post',
+        exampleName: 'default',
+      })
+
+      expect(result.ok).toBe(false)
+      assert(!result.ok)
+      expect(result.error).toContain('Path newPet not found')
+    })
+  })
 })

--- a/packages/workspace-store/src/request-example/context/get-request-example-context.ts
+++ b/packages/workspace-store/src/request-example/context/get-request-example-context.ts
@@ -73,7 +73,7 @@ export const getRequestExampleContext = (
     fallbackDocument: WorkspaceDocument | null
   }> = {},
 ): Result<BuildRequestExampleContext> => {
-  const { path, method, exampleName } = requestExampleMeta
+  const { path, method, exampleName, isWebhook } = requestExampleMeta
   const document = workspaceStore.workspace.documents[documentName] ?? options.fallbackDocument ?? undefined
   if (!document) {
     return {
@@ -88,11 +88,13 @@ export const getRequestExampleContext = (
     }
   }
 
-  const pathItem = getResolvedRef(document.paths?.[path])
+  // Webhooks are modeled as PathItem objects under `document.webhooks` and are keyed by
+  // their webhook name rather than a URL path. Operations live under `document.paths`.
+  const pathItem = isWebhook ? getResolvedRef(document.webhooks?.[path]) : getResolvedRef(document.paths?.[path])
   if (!pathItem) {
     return {
       ok: false,
-      error: `Path ${path} not found`,
+      error: isWebhook ? `Webhook ${path} not found` : `Path ${path} not found`,
     }
   }
 
@@ -100,7 +102,7 @@ export const getRequestExampleContext = (
   if (!resolvedOperation) {
     return {
       ok: false,
-      error: `Method ${method} not found on path ${path}`,
+      error: isWebhook ? `Method ${method} not found on webhook ${path}` : `Method ${method} not found on path ${path}`,
     }
   }
 

--- a/packages/workspace-store/src/request-example/types.ts
+++ b/packages/workspace-store/src/request-example/types.ts
@@ -8,7 +8,18 @@ import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 export type { Result } from '@scalar/helpers/types/result'
 
 export type RequestExampleMeta = {
+  /**
+   * For operations, the request path (e.g. `/pets`). For webhooks, the webhook name
+   * from `document.webhooks` (e.g. `newPet`). Disambiguated by `isWebhook`.
+   */
   path: string
   method: HttpMethod
   exampleName: string
+  /**
+   * When true, `path` is treated as a webhook name and the operation is resolved from
+   * `document.webhooks` instead of `document.paths`. Webhooks describe outbound requests
+   * the API server makes; the destination URL comes from the operation's servers or a
+   * user-supplied URL, not from the webhook name itself.
+   */
+  isWebhook?: boolean
 }


### PR DESCRIPTION
Webhooks were already parsed into the workspace store and shown in the
sidebar, but the request-context pipeline only resolved operations from
`document.paths`. This change lets the API client send webhook requests:

- `getRequestExampleContext` accepts `isWebhook` on `RequestExampleMeta`
  and resolves the operation from `document.webhooks[name][method]`
- `resolveRouteParameters` forwards and respects `isWebhook` for both
  explicit and "default" path/method placeholders
- The modal sidebar selects webhook entries and routes them through
  the operation view; `generateLocationId` namespaces ids so a webhook
  name does not collide with an operation path
- `Operation.vue` and `Modal.vue` plumb `isWebhook` through to the
  request-context builder

Fixes #6880

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `isWebhook` routing mode that changes how operations are resolved (from `document.webhooks`) and how sidebar location IDs are generated, which could affect navigation/selection behavior across the modal and any consumers relying on the previous ID format.
> 
> **Overview**
> Enables testing OpenAPI webhooks in the API client by plumbing an `isWebhook` flag from modal routing/selection into the operation view and request-example context builder.
> 
> When `isWebhook` is true, route parameter resolution and `getRequestExampleContext` resolve against `document.webhooks` (with webhook-specific error messages), and the modal sidebar can select `webhook` entries and navigate them through the same operation pipeline. Sidebar location IDs are now namespaced (`operation` vs `webhook`) to prevent collisions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55ddf37f54c5a6eb675549e124a140fc899ae4a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->