### PR TITLE
chore: downgrade scalar-app changesets from minor to patch

### DIFF
--- a/.changeset/brave-squids-dream.md
+++ b/.changeset/brave-squids-dream.md
@@ -1,5 +1,5 @@
 ---
-'scalar-app': minor
+'scalar-app': patch
 ---
 
 feat(scalar-app): add a "What's new" modal accessible from the Get Started page so users can browse curated release notes inside the client. A small accent dot appears on the trigger when there are unseen releases. Release notes are bundled with the package via `RELEASE_NOTES.json` (the source of truth, imported directly so no runtime markdown parsing is needed) and filtered to the version the user has actually installed. The release-notes generator updates the JSON file during `pnpm changeset version` and regenerates a derived `RELEASE_NOTES.md` view alongside it.

--- a/.changeset/eleven-knives-fail.md
+++ b/.changeset/eleven-knives-fail.md
@@ -1,5 +1,5 @@
 ---
-'scalar-app': minor
+'scalar-app': patch
 '@scalar/helpers': minor
 ---
 

--- a/.changeset/khaki-clouds-search.md
+++ b/.changeset/khaki-clouds-search.md
@@ -1,5 +1,5 @@
 ---
-'scalar-app': minor
+'scalar-app': patch
 ---
 
 feat: integrate the new registry adapter

--- a/.changeset/neat-cows-divide.md
+++ b/.changeset/neat-cows-divide.md
@@ -1,5 +1,5 @@
 ---
-'scalar-app': minor
+'scalar-app': patch
 ---
 
 feat: handle workspace uid and slug reconciliation


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only changes Changeset metadata to reduce version bump magnitude for `scalar-app`, with no runtime code modifications.
> 
> **Overview**
> Adjusts several `.changeset/*.md` entries to bump `scalar-app` as a **patch** instead of a minor release for upcoming features (e.g., “What’s new” modal, changelog media attachments, registry adapter integration, and workspace UID/slug reconciliation).
> 
> No application code changes are included; this only affects package versioning/publishing semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37df55ec7656cc669dc0e49ab17bac0b9481a903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->