### PR TITLE
fix(scalar-app): modify CSP on client

### DIFF
--- a/.changeset/five-gifts-visit.md
+++ b/.changeset/five-gifts-visit.md
@@ -2,4 +2,4 @@
 'scalar-app': patch
 ---
 
-chore: added scalar domain to csp
+chore: added scalar domain to csp; allow localhost img/media sources during Vite dev only

--- a/.changeset/five-gifts-visit.md
+++ b/.changeset/five-gifts-visit.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+chore: added scalar domain to csp

--- a/projects/scalar-app/dev-localhost-csp-plugin.ts
+++ b/projects/scalar-app/dev-localhost-csp-plugin.ts
@@ -1,0 +1,19 @@
+import type { Plugin } from 'vite'
+
+const LOCALHOST_MEDIA_SOURCES = 'http://127.0.0.1:* http://localhost:*'
+
+/**
+ * While the Vite dev server runs, allow images and media from localhost URLs in
+ * the HTML meta CSP (Electron uses file:// + remote assets; web dev uses another origin).
+ */
+export const devLocalhostCspPlugin = (): Plugin => ({
+  name: 'scalar-app-dev-localhost-csp',
+  transformIndexHtml(html, ctx) {
+    if (!ctx.server) {
+      return html
+    }
+    return html
+      .replace(/(img-src[^;]+);/g, `$1 ${LOCALHOST_MEDIA_SOURCES};`)
+      .replace(/(media-src[^;]+);/g, `$1 ${LOCALHOST_MEDIA_SOURCES};`)
+  },
+})

--- a/projects/scalar-app/electron.vite.config.ts
+++ b/projects/scalar-app/electron.vite.config.ts
@@ -5,6 +5,7 @@ import vue from '@vitejs/plugin-vue'
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import monacoEditorPlugin from 'vite-plugin-monaco-editor-esm'
 
+import { devLocalhostCspPlugin } from './dev-localhost-csp-plugin'
 import { scalarAppMonacoEditorPluginOptions } from './monaco-vite-plugin-options'
 import packageJson from './package.json' with { type: 'json' }
 
@@ -60,7 +61,7 @@ export default defineConfig({
       },
       dedupe: ['vue', 'monaco-editor', 'monaco-yaml'],
     },
-    plugins: [vue(), tailwindcss(), monacoEditorPlugin(scalarAppMonacoEditorPluginOptions)],
+    plugins: [vue(), tailwindcss(), monacoEditorPlugin(scalarAppMonacoEditorPluginOptions), devLocalhostCspPlugin()],
     optimizeDeps: {
       exclude: ['monaco-editor', 'monaco-yaml'],
     },

--- a/projects/scalar-app/entrypoints/electron/renderer/index.html
+++ b/projects/scalar-app/entrypoints/electron/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://cdn.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
   </head>
 
   <body class="scalar-app">

--- a/projects/scalar-app/entrypoints/electron/renderer/index.html
+++ b/projects/scalar-app/entrypoints/electron/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com; media-src 'self' data: blob:; object-src 'self' blob:; frame-src 'self' blob:; font-src 'self' https://fonts.scalar.com" />
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com" />
   </head>
 
   <body class="scalar-app">

--- a/projects/scalar-app/entrypoints/electron/renderer/index.html
+++ b/projects/scalar-app/entrypoints/electron/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com" />
+      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://cdn.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
   </head>
 
   <body class="scalar-app">

--- a/projects/scalar-app/entrypoints/web/index.html
+++ b/projects/scalar-app/entrypoints/web/index.html
@@ -2,6 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com" />
     <link
       rel="icon"
       type="image/png"

--- a/projects/scalar-app/entrypoints/web/index.html
+++ b/projects/scalar-app/entrypoints/web/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com" />
+      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://cdn.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
     <link
       rel="icon"
       type="image/png"

--- a/projects/scalar-app/vite.config.ts
+++ b/projects/scalar-app/vite.config.ts
@@ -5,6 +5,7 @@ import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 import monacoEditorPlugin from 'vite-plugin-monaco-editor-esm'
 
+import { devLocalhostCspPlugin } from './dev-localhost-csp-plugin'
 import { scalarAppMonacoEditorPluginOptions } from './monaco-vite-plugin-options'
 import packageJson from './package.json' with { type: 'json' }
 
@@ -29,7 +30,7 @@ export default defineConfig({
     exclude: ['monaco-editor', 'monaco-yaml'],
   },
   publicDir: resolve('public-web'),
-  plugins: [vue(), tailwindcss(), monacoEditorPlugin(scalarAppMonacoEditorPluginOptions)],
+  plugins: [vue(), tailwindcss(), monacoEditorPlugin(scalarAppMonacoEditorPluginOptions), devLocalhostCspPlugin()],
   build: {
     outDir: resolve('dist/web'),
     rolldownOptions: {


### PR DESCRIPTION
## Problem

Our CSP was missing our CDN.

## Solution

Added all *.scalar.com domains. Removed self from fonts

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Content Security Policy allowlists (including wildcard `*.scalar.com` and dev-time localhost media), which can weaken browser/Electron protections if misconfigured. Scope is limited to CSP strings and a dev-only Vite HTML transform plugin.
> 
> **Overview**
> Updates the app’s HTML meta **Content Security Policy** to allow loading `img-src`/`media-src` from `https://*.scalar.com` and `https://scalar.com`, and adds the same CSP meta tag to the web entrypoint.
> 
> Adds a small Vite plugin (`devLocalhostCspPlugin`) that, *only during `vite` dev*, appends `http://localhost:*` and `http://127.0.0.1:*` to `img-src` and `media-src`, and wires it into both `vite.config.ts` and `electron.vite.config.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 070c0d3e756668606008fbe0cffe9ad5620c6fc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->