### PR TITLE
fix(api-client): remove unwanted scrollbar beside auth scope checkboxes

### DIFF
--- a/.changeset/fix-oauth-scope-scrollbar.md
+++ b/.changeset/fix-oauth-scope-scrollbar.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Remove unwanted scrollbar beside auth scope checkboxes

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue
@@ -273,7 +273,7 @@ const handleDeleteScope = (scopeKey: string) => {
               v-model="searchQuery"
               class="flex items-center text-xs" />
             <table
-              class="grid max-h-40 auto-rows-auto overflow-x-hidden overflow-y-scroll"
+              class="grid max-h-40 auto-rows-auto overflow-x-hidden overflow-y-auto"
               :style="{ gridTemplateColumns: '1fr auto' }">
               <DataTableRow
                 v-for="{ id, label, description } in filteredScopes"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The OAuth scope list in the auth selector was using `overflow-y-scroll` on the scope list `<table>`, which forces a persistent vertical scrollbar to always be visible — even when the scope list is short and does not overflow the `max-h-40` constraint. This placed an unwanted scrollbar right next to the checkbox column.

**Fix:** Changed `overflow-y-scroll` → `overflow-y-auto` so the scrollbar only appears when the scope list actually overflows the max height.

## Visual

![OAuth scopes list after fix — no scrollbar next to checkboxes](https://cursor.com/artifacts/c/art-ea6fd82b-edc5-42fe-9f64-ea2baa8013a8)

No unwanted scrollbar appears beside the checkboxes when the list fits within the available height.

<a href="https://cursor.com/agents/bc-97cab85d-58cd-4147-bc93-ffcca211ed28/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foauth_scopes_no_scrollbar.mp4"><img src="https://cursor.com/artifacts/c/art-3a4e45e7-e271-42cd-916c-91a8cf5fcb88" alt="oauth_scopes_no_scrollbar.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97cab85d-58cd-4147-bc93-ffcca211ed28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97cab85d-58cd-4147-bc93-ffcca211ed28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

