### PR TITLE
fix(api-client): addressbar padding when no servers

### DIFF
--- a/.changeset/large-trams-post.md
+++ b/.changeset/large-trams-post.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: padding on addressbar with no servers

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -433,7 +433,7 @@ defineExpose({
         narrower than `@3xl`) and the duplicate buttons in the trailing
         mobile actions row take over at that point.
       -->
-      <div class="hidden gap-0.5 @3xl:flex">
+      <div class="hidden @3xl:flex">
         <HttpMethod
           :isEditable="layout !== 'modal'"
           isSquare
@@ -443,7 +443,7 @@ defineExpose({
       </div>
 
       <div
-        class="scroll-timeline-x scroll-timeline-x-hidden relative flex w-full gap-1 bg-blend-normal">
+        class="scroll-timeline-x scroll-timeline-x-hidden relative flex w-full bg-blend-normal">
         <!-- Servers -->
         <ServerDropdown
           v-if="servers.length"
@@ -466,7 +466,7 @@ defineExpose({
           ref="addressBarRef"
           alwaysEmitChange
           aria-label="Path"
-          class="min-w-fit pl-px outline-none"
+          class="ml-1 min-w-fit pl-px outline-none"
           disableCloseBrackets
           :disabled="layout === 'modal'"
           disableEnter


### PR DESCRIPTION
## Problem

Some padding was missed when there's no servers.

## Solution

Added a little `ml-1` + the gaps were useless

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only spacing tweaks plus a patch changeset; no logic or data flow changes.
> 
> **Overview**
> Fixes a visual spacing issue in `AddressBar.vue` when the servers dropdown is absent by removing unused `gap` classes and adding a small left margin (`ml-1`) to the path `CodeInput`.
> 
> Adds a changeset to publish `@scalar/api-client` as a patch release for this UI fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fae9af1e5cf297fae5a4809bdfccb7526b0c3b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->