### PR TITLE
fix(api-reference): prevent text wrapping in SecurityRequirementBadge

### DIFF
--- a/.changeset/fix-security-badge-wrapping.md
+++ b/.changeset/fix-security-badge-wrapping.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+Prevent text wrapping in SecurityRequirementBadge

--- a/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.vue
+++ b/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.vue
@@ -44,7 +44,7 @@ const isOrAlternatives = computed(
     v-if="requiredSecurity.state !== 'none'"
     placement="bottom-end">
     <button
-      class="security-requirement-badge inline-flex w-fit items-center justify-center gap-1 text-sm"
+      class="security-requirement-badge inline-flex w-fit items-center justify-center gap-1 text-sm whitespace-nowrap"
       :class="
         requiredSecurity.state === 'optional'
           ? 'text-c-2'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The "Auth Required" / "Auth Optional" text in the SecurityRequirementBadge was wrapping to multiple lines when the viewport was narrow, causing a poor visual appearance in the API reference.

## Solution

Added `whitespace-nowrap` Tailwind utility class to the button element in SecurityRequirementBadge.vue to prevent text wrapping. This ensures the badge label stays on a single line regardless of container width.

## Visual

![Auth Required badge at normal width](https://cursor.com/artifacts/c/art-fbc57ef6-06e4-45c3-9424-400d5b91e955)

![Auth Required badge at narrow width - text stays on single line](https://cursor.com/artifacts/c/art-464197b1-2294-4399-8828-2b626892b0b0)

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [ ] I added tests.
- [ ] I updated the documentation.

## Ticket

Fixes DOC-5358
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07SWER07G9/p1778775139448419?thread_ts=1778775139.448419&cid=C07SWER07G9)

<div><a href="https://cursor.com/agents/bc-d2a7128c-2065-5988-8af2-21bf70bef8b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2a7128c-2065-5988-8af2-21bf70bef8b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

