### PR TITLE
ci: remove Go setup and test servers from unit test shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,14 +272,6 @@ jobs:
       - name: Check built declaration alias imports
         if: matrix.shard-index == 1
         run: pnpm lint:check:dist-dts-aliases
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: projects/proxy-scalar-com/go.mod
-          cache: false
-      - name: Start test servers
-        run: pnpm script run test-servers & pnpm script wait -p 5051 5052
-        timeout-minutes: 1
       - name: Run tests
         run: |
           dirs=()
@@ -326,20 +318,6 @@ jobs:
         # For now we will integrate the E2E tests with the integrations tests as they are quite fast and this avoids another job.
       - name: Run e2e tests
         run: pnpm --filter @scalar/nuxt test:e2e
-
-  test-proxy-server:
-    needs: [build]
-    runs-on: blacksmith-2vcpu-ubuntu-2204
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: projects/proxy-scalar-com/go.mod
-          cache: false
-      - name: Run tests for the proxy server (Go)
-        run: cd projects/proxy-scalar-com && go test -v
 
   test-server-side-rendering:
     needs: [build]
@@ -1747,7 +1725,6 @@ jobs:
         knip,
         test-packages,
         test-integrations,
-        test-proxy-server,
         test-e2e-scalar-app,
         types,
       ]
@@ -1767,7 +1744,6 @@ jobs:
         test-server-side-rendering,
         test-packages,
         test-integrations,
-        test-proxy-server,
         test-e2e-scalar-app,
         types,
       ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,20 @@ jobs:
       - name: Run e2e tests
         run: pnpm --filter @scalar/nuxt test:e2e
 
+  test-proxy-server:
+    needs: [build]
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: projects/proxy-scalar-com/go.mod
+          cache: false
+      - name: Run tests for the proxy server (Go)
+        run: cd projects/proxy-scalar-com && go test -v
+
   test-server-side-rendering:
     needs: [build]
     runs-on: blacksmith-2vcpu-ubuntu-2204
@@ -1725,6 +1739,7 @@ jobs:
         knip,
         test-packages,
         test-integrations,
+        test-proxy-server,
         test-e2e-scalar-app,
         types,
       ]
@@ -1744,6 +1759,7 @@ jobs:
         test-server-side-rendering,
         test-packages,
         test-integrations,
+        test-proxy-server,
         test-e2e-scalar-app,
         types,
       ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the Go toolchain setup and proxy/void server startup from the `test-packages` shards, while keeping the dedicated `test-proxy-server` job intact.

**Changes:**
- Removed `Setup Go` step from `test-packages` job
- Removed `Start test servers` step (`pnpm script run test-servers & pnpm script wait -p 5051 5052`) from `test-packages` job
- `test-proxy-server` job is unchanged and remains a required gate for both PRs and main

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a6d49a3-4822-4789-97eb-f3f106f19080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a6d49a3-4822-4789-97eb-f3f106f19080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

