### PR TITLE
fix(fastify): annotate schemaToHideRoute as FastifySchema to prevent hook type mismatch

### DIFF
--- a/.changeset/fix-fastify-schema-hook-type.md
+++ b/.changeset/fix-fastify-schema-hook-type.md
@@ -1,0 +1,5 @@
+---
+"@scalar/fastify-api-reference": patch
+---
+
+Fix intermittent TypeScript error when hook handlers are spread into route options. Annotating the internal `schemaToHideRoute` constant as `FastifySchema` prevents TypeScript from narrowing its type to `{ hide: boolean }`, which caused incompatible hook-handler types with Fastify 5's `NoInfer<SchemaCompiler>`-based route definitions.

--- a/integrations/fastify/src/fastifyApiReference.ts
+++ b/integrations/fastify/src/fastifyApiReference.ts
@@ -2,7 +2,7 @@
 import { renderApiReference } from '@scalar/client-side-rendering'
 import { normalize, toJson, toYaml } from '@scalar/openapi-parser'
 import type { OpenAPI } from '@scalar/openapi-types'
-import type { FastifyBaseLogger, FastifyTypeProviderDefault, RawServerDefault } from 'fastify'
+import type { FastifyBaseLogger, FastifySchema, FastifyTypeProviderDefault, RawServerDefault } from 'fastify'
 import fp from 'fastify-plugin'
 import { slug } from 'github-slugger'
 
@@ -21,7 +21,10 @@ const RELATIVE_JAVASCRIPT_PATH = 'js/scalar.js'
  *
  * @see https://github.com/fastify/fastify-swagger#hide-a-route
  */
-const schemaToHideRoute = {
+// Typed as FastifySchema so route inference uses FastifySchema (not the narrow
+// literal { hide: boolean }), keeping hook handler types compatible across
+// Fastify v4 and v5 even when @fastify/swagger augments FastifySchema with `hide`.
+const schemaToHideRoute: FastifySchema = {
   hide: true,
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Annotate the internal `schemaToHideRoute` constant with an explicit `FastifySchema` type in `fastifyApiReference.ts`.

## Why this fixes the flaky CI failure

The CI failure was a TypeScript type error (`TS2345`) that appeared intermittently in the `test-integrations` job. Here is the chain of events:

1. **Root cause — schema type narrowing**: `schemaToHideRoute` was declared as a plain object literal without a type annotation, so TypeScript inferred its type as `{ hide: boolean }`.

2. **How Fastify 5.8+ triggered the error**: Fastify 5.8 introduced `RouteShorthandHook<T>` and started using `NoInfer<SchemaCompiler>` inside route-level hook handler types. When `fastify.route({ schema: schemaToHideRoute, ...hooks })` is called, TypeScript infers `SchemaCompiler = { hide: boolean }` from the schema literal. The hook handlers in `RouteShorthandOptions` then expect `RouteShorthandHook<onRequestHookHandler<..., NoInfer<{ hide: boolean }>, ...>>`. But the `hooks` object carries `onRequestHookHandler<..., FastifySchema, ...>` (the default). These two are structurally incompatible in a contravariant position (function parameter types), so tsc errors.

3. **Why it was flaky**: The workspace catalog pins `fastify: ^5.8.1`, while `integrations/fastify/package.json` declares `"fastify": "^4.0.0"` directly. Peer-dependency hoisting in pnpm can cause TypeScript to resolve the v5 types in some environments (e.g. after a fresh `pnpm install` that hoists the v5 peer required by `@fastify/http-proxy` or `@fastify/swagger`). When the v4 types were used, nothing broke. When the v5 types were resolved, the error appeared.

## Fix

Annotating `schemaToHideRoute: FastifySchema` forces TypeScript to infer `SchemaCompiler = FastifySchema` for all routes. `NoInfer<FastifySchema>` resolves to `FastifySchema`, which is exactly the schema type that `onRequestHookHandler` defaults to, making the types compatible again for both Fastify 4 and Fastify 5.

```diff
-const schemaToHideRoute = {
+const schemaToHideRoute: FastifySchema = {
   hide: true,
 }
```

## Testing

- ✅ `pnpm --filter @scalar/fastify-api-reference types:check` — passes (was failing with `TS2345` before the fix)
- ✅ `pnpm vitest integrations/fastify/src/fastifyApiReference.test.ts --run` — all 44 tests pass
- ✅ `pnpm vitest integrations/fastify/test/exports.test.ts --run` — passes
- ✅ `pnpm biome check` — no issues on changed file

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63b83685-fd43-4de4-9bae-6e2fa13a6b69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63b83685-fd43-4de4-9bae-6e2fa13a6b69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

