### PR TITLE
perf(api-reference): add benchmark suite for search, helpers, and configuration

### DIFF
--- a/.changeset/add-api-reference-benchmarks.md
+++ b/.changeset/add-api-reference-benchmarks.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+Add performance benchmarks for search index build, search queries, OpenAPI extraction helpers, and configuration normalization. Includes baseline comparison tooling via `pnpm test:benchmark:save` / `pnpm test:benchmark:compare`.

--- a/packages/api-reference/src/features/Search/search.bench.ts
+++ b/packages/api-reference/src/features/Search/search.bench.ts
@@ -1,0 +1,172 @@
+import galaxy from '@scalar/galaxy/3.1.json'
+import { createNavigation } from '@scalar/workspace-store/navigation'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { bench, describe } from 'vitest'
+
+import { createFuseInstance } from './helpers/create-fuse-instance'
+import { createSearchIndex } from './helpers/create-search-index'
+
+/**
+ * Attaches the scalar navigation tree to a document in-place so that
+ * createSearchIndex can traverse it.
+ */
+function withNavigation(doc: OpenApiDocument): OpenApiDocument {
+  doc['x-scalar-navigation'] = createNavigation('bench', doc, { hideModels: false })
+  return doc
+}
+
+/**
+ * Generates a synthetic OpenAPI document with `operationCount` operations spread
+ * across multiple tags. Used to stress-test the search pipeline at a realistic
+ * large-API scale without needing a real fixture file.
+ */
+function buildLargeSpec(operationCount: number): OpenApiDocument {
+  const paths: Record<string, Record<string, unknown>> = {}
+  const schemas: Record<string, unknown> = {}
+  const tags: { name: string; description: string }[] = []
+
+  const tagCount = Math.ceil(operationCount / 5)
+
+  for (let t = 0; t < tagCount; t++) {
+    tags.push({ name: `Service${t}`, description: `Operations for Service${t}` })
+  }
+
+  const methods: string[] = ['get', 'post', 'put', 'delete', 'patch']
+  let count = 0
+
+  for (let t = 0; t < tagCount && count < operationCount; t++) {
+    const tagName = `Service${t}`
+
+    for (let m = 0; m < methods.length && count < operationCount; m++) {
+      const method = methods[m] as string
+      const path = `/service${t}/${method === 'get' ? 'list' : method === 'post' ? 'create' : `item-${m}`}`
+      const hasBody = method !== 'get' && method !== 'delete'
+
+      paths[path] = {
+        ...paths[path],
+        [method]: {
+          operationId: `${tagName}_${method}_${count}`,
+          summary: `${method.toUpperCase()} ${tagName} operation ${count}`,
+          description: `Performs ${method} on ${tagName}. Operation number ${count} in the benchmark suite.`,
+          tags: [tagName],
+          parameters: [
+            {
+              in: 'query',
+              name: `param${count}`,
+              description: `Query parameter for operation ${count}`,
+              schema: { type: 'string' },
+            },
+            {
+              in: 'header',
+              name: 'X-Request-ID',
+              description: 'Unique request identifier',
+              schema: { type: 'string' },
+            },
+          ],
+          ...(hasBody && {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      [`field${count}A`]: { type: 'string', description: `First field for operation ${count}` },
+                      [`field${count}B`]: { type: 'number', description: `Second field for operation ${count}` },
+                    },
+                  },
+                },
+              },
+            },
+          }),
+          responses: {
+            200: {
+              description: 'Success',
+              content: { 'application/json': { example: { id: count, status: 'ok', service: tagName } } },
+            },
+            400: { description: 'Bad request' },
+          },
+        },
+      }
+
+      count++
+    }
+
+    schemas[`${tagName}Model`] = {
+      type: 'object',
+      title: `${tagName}Model`,
+      description: `Data model for ${tagName}`,
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string', description: 'Display name' },
+        createdAt: { type: 'string', format: 'date-time' },
+        serviceTag: { type: 'string', description: `Identifies the ${tagName}` },
+      },
+    }
+  }
+
+  return {
+    openapi: '3.1.0',
+    info: {
+      title: 'Large Benchmark API',
+      version: '1.0.0',
+      description: '# Introduction\nA large synthetic API used for benchmarking the search pipeline.',
+    },
+    tags,
+    paths,
+    components: { schemas },
+  } as unknown as OpenApiDocument
+}
+
+const galaxyDoc = withNavigation(galaxy as unknown as OpenApiDocument)
+const largeDoc = withNavigation(buildLargeSpec(100))
+
+const galaxyIndex = createSearchIndex(galaxyDoc)
+const largeIndex = createSearchIndex(largeDoc)
+
+const galaxyFuse = createFuseInstance()
+galaxyFuse.setCollection(galaxyIndex)
+
+const largeFuse = createFuseInstance()
+largeFuse.setCollection(largeIndex)
+
+describe('search index build', () => {
+  bench('galaxy spec', () => {
+    createSearchIndex(galaxyDoc)
+  })
+
+  bench('large spec (~100 operations)', () => {
+    createSearchIndex(largeDoc)
+  })
+})
+
+describe('search queries – galaxy spec', () => {
+  bench('short term ("user")', () => {
+    galaxyFuse.search('user')
+  })
+
+  bench('multi-word phrase ("create user account")', () => {
+    galaxyFuse.search('create user account')
+  })
+
+  bench('path segment ("/planets")', () => {
+    galaxyFuse.search('/planets')
+  })
+
+  bench('no match (term absent from index)', () => {
+    galaxyFuse.search('zzz_nonexistent_xyz_abc')
+  })
+})
+
+describe('search queries – large spec (~100 operations)', () => {
+  bench('short term ("service")', () => {
+    largeFuse.search('service')
+  })
+
+  bench('multi-word phrase ("create service operation")', () => {
+    largeFuse.search('create service operation')
+  })
+
+  bench('no match (term absent from index)', () => {
+    largeFuse.search('zzz_nonexistent_xyz_abc')
+  })
+})

--- a/packages/api-reference/src/helpers/normalize-configurations.bench.ts
+++ b/packages/api-reference/src/helpers/normalize-configurations.bench.ts
@@ -1,0 +1,68 @@
+import type { AnyApiReferenceConfiguration } from '@scalar/types/api-reference'
+import { bench, describe } from 'vitest'
+
+import { normalizeConfigurations, normalizeContent } from './normalize-configurations'
+
+const minimalObjectContent = {
+  openapi: '3.1.0',
+  info: { title: 'Minimal API', version: '1.0.0' },
+  paths: {
+    '/users': {
+      get: { summary: 'List Users', responses: { '200': { description: 'OK' } } },
+      post: { summary: 'Create User', responses: { '201': { description: 'Created' } } },
+    },
+    '/users/{id}': {
+      get: { summary: 'Get User', responses: { '200': { description: 'OK' } } },
+      put: { summary: 'Update User', responses: { '200': { description: 'OK' } } },
+      delete: { summary: 'Delete User', responses: { '204': { description: 'No Content' } } },
+    },
+  },
+}
+
+const jsonStringContent = JSON.stringify(minimalObjectContent)
+
+/** A sources-style config with 20 independent API documents — typical of a developer portal. */
+const multiSourceConfig = {
+  sources: Array.from({ length: 20 }, (_, i) => ({
+    url: `https://api.example.com/v${i}/openapi.json`,
+    title: `Microservice API ${i}`,
+    slug: `service-${i}`,
+  })),
+} as unknown as AnyApiReferenceConfiguration
+
+describe('normalizeConfigurations', () => {
+  bench('single URL config', () => {
+    normalizeConfigurations({ url: 'https://api.example.com/openapi.json' })
+  })
+
+  bench('single content config (object)', () => {
+    normalizeConfigurations({ content: minimalObjectContent })
+  })
+
+  bench('multi-source config (20 sources)', () => {
+    normalizeConfigurations(multiSourceConfig)
+  })
+
+  bench('array of 10 URL configs', () => {
+    normalizeConfigurations(
+      Array.from({ length: 10 }, (_, i) => ({
+        url: `https://api.example.com/service${i}/openapi.json`,
+        title: `Service ${i}`,
+      })) as unknown as AnyApiReferenceConfiguration,
+    )
+  })
+})
+
+describe('normalizeContent', () => {
+  bench('JSON string (parse + return)', () => {
+    normalizeContent(jsonStringContent)
+  })
+
+  bench('plain object (pass-through)', () => {
+    normalizeContent(minimalObjectContent)
+  })
+
+  bench('function returning object (invoke + pass-through)', () => {
+    normalizeContent(() => minimalObjectContent)
+  })
+})

--- a/packages/api-reference/src/helpers/openapi.bench.ts
+++ b/packages/api-reference/src/helpers/openapi.bench.ts
@@ -1,0 +1,128 @@
+import type {
+  OperationObject,
+  ParameterObject,
+  ReferenceType,
+  SchemaObject,
+} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { bench, describe } from 'vitest'
+
+import {
+  extractBodyDescriptions,
+  extractBodyFieldNames,
+  extractParameterDescriptions,
+  extractParameterNames,
+  extractSchemaDescriptions,
+  extractSchemaFieldNames,
+} from './openapi'
+
+/** 20 query parameters with descriptions — a realistic upper bound for heavily-parameterised endpoints. */
+const manyParameters: ReferenceType<ParameterObject>[] = Array.from({ length: 20 }, (_, i) => ({
+  in: 'query' as const,
+  name: `param${i}`,
+  description: `Description for parameter ${i}. Explains what this query field controls and its valid range.`,
+  required: i % 2 === 0,
+  schema: { type: 'string' as const },
+}))
+
+/**
+ * A schema with 15 top-level object properties, each containing 5 nested
+ * properties. Exercises the two-level recursion in collectSchemaProperties.
+ */
+const deepBodySchema: SchemaObject = {
+  type: 'object',
+  properties: Object.fromEntries(
+    Array.from({ length: 15 }, (_, i) => [
+      `field${i}`,
+      {
+        type: 'object',
+        description: `Top-level description for field ${i}`,
+        properties: Object.fromEntries(
+          Array.from({ length: 5 }, (_, j) => [
+            `nestedField${j}`,
+            { type: 'string', description: `Nested description ${j} under field ${i}` },
+          ]),
+        ),
+      },
+    ]),
+  ),
+} as unknown as SchemaObject
+
+const operationWithDeepBody: OperationObject = {
+  summary: 'Create Item',
+  requestBody: {
+    content: {
+      'application/json': { schema: deepBodySchema },
+    },
+  },
+  responses: {},
+}
+
+/**
+ * A schema that uses oneOf/anyOf composition, which triggers recursive
+ * traversal of variant schemas in extractSchemaFieldNames.
+ */
+const compositionSchema: SchemaObject = {
+  title: 'ComposedModel',
+  oneOf: [
+    {
+      type: 'object',
+      properties: {
+        typeAField: { type: 'string', description: 'Field only in variant A' },
+        sharedField: { type: 'string', description: 'Shared across variants' },
+      },
+    },
+    {
+      type: 'object',
+      properties: {
+        typeBField: { type: 'number', description: 'Field only in variant B' },
+        sharedField: { type: 'string', description: 'Shared across variants' },
+      },
+    },
+    {
+      anyOf: [
+        {
+          type: 'object',
+          properties: {
+            nestedVariantField: { type: 'boolean', description: 'Field inside a nested anyOf' },
+          },
+        },
+      ],
+    },
+  ],
+} as unknown as SchemaObject
+
+describe('extractParameterNames', () => {
+  bench('20 parameters', () => {
+    extractParameterNames(manyParameters)
+  })
+})
+
+describe('extractParameterDescriptions', () => {
+  bench('20 parameters', () => {
+    extractParameterDescriptions(manyParameters)
+  })
+})
+
+describe('extractBodyFieldNames', () => {
+  bench('deep schema (15 top-level × 5 nested properties)', () => {
+    extractBodyFieldNames(operationWithDeepBody)
+  })
+})
+
+describe('extractBodyDescriptions', () => {
+  bench('deep schema (15 top-level × 5 nested properties)', () => {
+    extractBodyDescriptions(operationWithDeepBody)
+  })
+})
+
+describe('extractSchemaFieldNames', () => {
+  bench('composition schema (oneOf + anyOf variants)', () => {
+    extractSchemaFieldNames(compositionSchema)
+  })
+})
+
+describe('extractSchemaDescriptions', () => {
+  bench('composition schema (oneOf + anyOf variants)', () => {
+    extractSchemaDescriptions(compositionSchema)
+  })
+})

--- a/packages/api-reference/src/standalone.bench.ts
+++ b/packages/api-reference/src/standalone.bench.ts
@@ -1,9 +1,42 @@
 import galaxy from '@scalar/galaxy/3.1.json'
 import { bench, describe, expect, vi } from 'vitest'
 
+/**
+ * A minimal one-operation spec used to isolate the framework startup cost
+ * from document-loading/parsing cost.
+ */
+const minimalSpec = {
+  openapi: '3.1.0',
+  info: { title: 'Minimal API', version: '1.0.0' },
+  paths: {
+    '/health': {
+      get: {
+        summary: 'Health Check',
+        description: 'Returns OK when the service is running.',
+        responses: { '200': { description: 'OK' } },
+      },
+    },
+  },
+}
+
 describe('standalone', () => {
   bench(
-    'first operation is rendered',
+    'render minimal spec (1 operation)',
+    async () => {
+      vi.resetModules()
+      const mountPoint = document.createElement('div')
+      document.body.appendChild(mountPoint)
+
+      const { createApiReference } = await import('@/standalone/lib/html-api')
+      createApiReference(mountPoint, { content: minimalSpec })
+
+      await vi.waitFor(() => expect(mountPoint.textContent).toContain('Health Check'))
+    },
+    { iterations: 1, warmupIterations: 1 },
+  )
+
+  bench(
+    'render galaxy spec (first operation visible)',
     async () => {
       // We need the reset modules here otherwise they get cached, for some reason doesn't work in the beforeEach
       vi.resetModules()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a formal Vitest benchmark suite to `@scalar/api-reference`, covering the most performance-critical code paths in the package.

## New benchmarks

### `src/standalone.bench.ts` (expanded)

| Benchmark | What it measures |
|-----------|-----------------|
| render minimal spec (1 operation) | Vue app startup + first operation painted (baseline overhead) |
| render galaxy spec (first operation visible) | Full doc load + first paint on a realistic medium-size spec |

### `src/features/Search/search.bench.ts` (new)

| Benchmark | What it measures |
|-----------|-----------------|
| `createSearchIndex` – galaxy spec | Index build time for a realistic ~20-operation API |
| `createSearchIndex` – large spec (~100 ops) | Index build time at scale (stress test) |
| `fuse.search` – short term, multi-word, path, no-match | Query latency on the galaxy index |
| `fuse.search` – short term, multi-word, no-match (large) | Query latency on a 100-operation index |

### `src/helpers/openapi.bench.ts` (new)

| Benchmark | What it measures |
|-----------|-----------------|
| `extractParameterNames` / `extractParameterDescriptions` | 20 parameters per operation |
| `extractBodyFieldNames` / `extractBodyDescriptions` | 15 top-level × 5 nested schema properties |
| `extractSchemaFieldNames` / `extractSchemaDescriptions` | `oneOf` + `anyOf` composition traversal |

### `src/helpers/normalize-configurations.bench.ts` (new)

| Benchmark | What it measures |
|-----------|-----------------|
| `normalizeConfigurations` – single URL/object/array/multi-source | Config processing at various scales |
| `normalizeContent` – JSON string, plain object, function | Content normalization code paths |

## How to run

```bash
# Run all benchmarks once (report to terminal)
cd packages/api-reference && pnpm test:benchmark

# Save a baseline for future comparison
pnpm test:benchmark:save

# Compare against a saved baseline
pnpm test:benchmark:compare
```

## Sample results (from this machine)

```
render minimal spec (1 operation)   5.07× faster than render galaxy spec

galaxy spec (search index build)   10.45× faster than large spec (~100 ops)

short term ("user") (galaxy search)  2.71× faster than no-match query

plain object (normalizeContent)    43.97× faster than JSON string parse

single URL (normalizeConfigurations) 21.76× faster than 20-source config
```
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07SWER07G9/p1778779400952399?thread_ts=1778779400.952399&cid=C07SWER07G9)

<div><a href="https://cursor.com/agents/bc-787d2d1b-2d69-57c4-a225-751321ded151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-787d2d1b-2d69-57c4-a225-751321ded151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

