### PR TITLE
chore: add changelog back

### DIFF
--- a/.changeset/api-client-local-save-hotkey.md
+++ b/.changeset/api-client-local-save-hotkey.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-client': patch
+---
+
+feat: add Cmd/Ctrl+S for `ui:save:local-document` so hosts (e.g. scalar-app) can match the header Save control for local workspaces

--- a/.changeset/api-reference-destroy-listeners.md
+++ b/.changeset/api-reference-destroy-listeners.md
@@ -1,0 +1,16 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): clean up deprecated document listeners on destroy
+
+`createApiReference()` registered three document-level listeners
+(`scalar:reload-references`, `scalar:destroy-references`,
+`scalar:update-references-config`) but `destroy()` only unmounted the
+Vue app — the listeners stayed attached forever. In environments that
+mount and destroy instances repeatedly (notably the Astro integration's
+`renderMode="client"` with view transitions), each navigation leaked
+three permanent listeners on `document`.
+
+Tie the listeners to an `AbortController` and abort it from `destroy()`
+so they all come off in one shot.

--- a/.changeset/asyncapi-download-label.md
+++ b/.changeset/asyncapi-download-label.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: show "Download AsyncAPI Document" label for AsyncAPI documents

--- a/.changeset/asyncapi-rebase-no-coerce.md
+++ b/.changeset/asyncapi-rebase-no-coerce.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: stop coercing rebased documents against the strict OpenAPI schema so AsyncAPI documents survive a rebase without having OpenAPI fields injected

--- a/.changeset/asyncapi-version-badge.md
+++ b/.changeset/asyncapi-version-badge.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: rename the "OAS" version badge to "OpenAPI" and show an "AsyncAPI" badge for AsyncAPI documents

--- a/.changeset/block-send-without-server.md
+++ b/.changeset/block-send-without-server.md
@@ -1,0 +1,14 @@
+---
+'@scalar/api-client': patch
+'@scalar/api-reference': patch
+'@scalar/helpers': patch
+'@scalar/workspace-store': patch
+---
+
+fix(api-client): block invalid request URLs before send and surface `buildRequest` failures as results
+
+Request construction now treats a bad merged URL as a first-class failure instead of throwing deep inside helpers. After `mergeUrls`, `resolveRequestFactoryUrl` rejects incomplete targets when strict mode applies: relative URLs, an empty server base, or path strings that still contain unresolved `{{variable}}` placeholders. Callers may set `allowMissingRequestServerBase` where a full absolute URL is intentionally optional (for example the embedded modal layout in `OperationBlock`, or API Reference `onBeforeRequest` hooks that build against the document origin).
+
+`buildRequest` returns a `Result` (`ok` / `err`) with stable error codes such as `MISSING_REQUEST_SERVER_BASE`, `INVALID_REQUEST_FACTORY_URL`, and `BUILD_REQUEST_FAILED` for unexpected synchronous failures. Those failures are wrapped with `safeRun` from `@scalar/helpers`, which logs to `console.error` and maps throws to a string message on the result. The API Reference plugin path logs and skips `onBeforeRequest` when a preview request cannot be built, so user hooks never run against a half-built fetch payload.
+
+Downstream packages (`api-client`, `api-reference`, `scalar-app` where applicable) unwrap the result, show toasts or logs, and avoid calling `sendRequest` until the URL is valid.

--- a/.changeset/brave-squids-dream.md
+++ b/.changeset/brave-squids-dream.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+feat(scalar-app): add a "What's new" modal accessible from the Get Started page so users can browse curated release notes inside the client. A small accent dot appears on the trigger when there are unseen releases. Release notes are bundled with the package via `RELEASE_NOTES.json` (the source of truth, imported directly so no runtime markdown parsing is needed) and filtered to the version the user has actually installed. The release-notes generator updates the JSON file during `pnpm changeset version` and regenerates a derived `RELEASE_NOTES.md` view alongside it.

--- a/.changeset/breezy-worms-press.md
+++ b/.changeset/breezy-worms-press.md
@@ -1,0 +1,8 @@
+---
+'@scalar/workspace-store': minor
+'@scalar/oas-utils': minor
+---
+
+feat: UID-based workspaces and local-team migration
+
+IndexedDB v2 migrates existing data into the new shape, collapses all workspaces into the local team (aligned with a single team workspace on the client for now), resolves slug collisions deterministically, re-keys chunk stores by workspaceUid, and strips x-scalar-tabs and x-scalar-active-tab from meta chunks so routing does not follow stale paths after migration or slug changes.

--- a/.changeset/chatty-tips-accept.md
+++ b/.changeset/chatty-tips-accept.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+feat: added team switching and fixed up team redirection and workspace routing

--- a/.changeset/clean-trains-invite.md
+++ b/.changeset/clean-trains-invite.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+remove outdated Biome suppression in schema traversal loop

--- a/.changeset/clever-keys-rank.md
+++ b/.changeset/clever-keys-rank.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): improve search ranking for parameter, request-body, and model field names, including polymorphic (oneOf/anyOf/allOf) schemas

--- a/.changeset/common-cows-fall.md
+++ b/.changeset/common-cows-fall.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: monaco editor vite plugin

--- a/.changeset/crisp-queens-glow.md
+++ b/.changeset/crisp-queens-glow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: resolve $ref in additionalProperties before rendering schema

--- a/.changeset/cuddly-paws-remain.md
+++ b/.changeset/cuddly-paws-remain.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+chore: use the new schemas

--- a/.changeset/curly-sloths-jump.md
+++ b/.changeset/curly-sloths-jump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix urlencoded request body serialization for nested object and array values

--- a/.changeset/curvy-comics-run.md
+++ b/.changeset/curvy-comics-run.md
@@ -1,0 +1,9 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: OAuth scope CRUD mutators
+
+- New mutators **`upsertScope`** and **`deleteScope`** backed by new `AuthEvents` entries; **`updateSelectedScopes`** only updates selection state.
+- **Rename**: `upsertScope` rewrites the scope key in the flow and mirrors the new key in every document- and operation-level selected requirement for that scheme.
+- **Delete**: `deleteScope` removes the scope from the flow and drops it from matching selections.

--- a/.changeset/dirty-lines-retire.md
+++ b/.changeset/dirty-lines-retire.md
@@ -1,0 +1,9 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: OAuth scope CRUD UI
+
+- **Scope definitions vs selection**: adding, editing, or removing a scope on the OAuth flow now goes through dedicated workspace events `auth:upsert:scopes` and `auth:delete:scopes`, plumbed from `OAuth2` → `RequestAuthTab` → `RequestAuthDataTable` and registered in `initializeWorkspaceEventHandlers`. Updating checked scopes remains `auth:update:selected-scopes` without `newScopePayload`.
+- **OAuthScopesInput**: row hover actions to edit or delete a scope; one shared add/edit modal; when the flow defines no scopes, the summary shows **No Scopes Defined**, **Select All** / **Deselect All** and the expand chevron are hidden, the disclosure summary is disabled, and **Add Scope** stays outside so it remains clickable; the `–` before a description is omitted when the description is empty or missing.
+- **OAuthScopesAddModal**: supports edit mode (`scope` prop), inline errors for missing name and duplicate names (replacing toast-only validation), trims submitted names, and tests clean up teleported modal DOM between runs.

--- a/.changeset/dull-badgers-enter.md
+++ b/.changeset/dull-badgers-enter.md
@@ -1,0 +1,9 @@
+---
+'@scalar/workspace-store': minor
+'@scalar/api-reference': minor
+'@scalar/agent-chat': minor
+'@scalar/api-client': minor
+'@scalar/oas-utils': minor
+---
+
+feat: make `WorkspaceDocument` an union of OpenApiDocument and AsyncApiDocument

--- a/.changeset/early-needles-scream.md
+++ b/.changeset/early-needles-scream.md
@@ -1,0 +1,8 @@
+---
+'@scalar/api-client': patch
+'@scalar/components': patch
+'scalar-app': patch
+'@scalar/sidebar': patch
+---
+
+feat: some polish for the scalar-app

--- a/.changeset/eighty-doodles-mix.md
+++ b/.changeset/eighty-doodles-mix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': minor
+---
+
+feat: add compareVersions and serializeReleaseNotes helpers

--- a/.changeset/eleven-knives-fail.md
+++ b/.changeset/eleven-knives-fail.md
@@ -1,0 +1,6 @@
+---
+'scalar-app': patch
+'@scalar/helpers': minor
+---
+
+feat: support media attachments for the changelog modal

--- a/.changeset/every-seals-dream.md
+++ b/.changeset/every-seals-dream.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: format raw JSON responses with jsonc-parser
+
+Raw JSON response bodies in the API client are now formatted with `jsonc-parser` instead of `@scalar/helpers` `prettyPrintJson`. The previous path parsed with `JSON.parse` and re-stringified with `JSON.stringify`, which coerces every JSON number to a JavaScript `Number` and loses precision for integers beyond `Number.MAX_SAFE_INTEGER` (a common pain point for 64-bit IDs and other large values). `jsonc-parser` formats the document as text, so numeric literals stay identical to the response on the wire while indentation and line breaks are still normalized. JSON with Comments (JSONC) tokens also remain valid alongside CodeMirror’s JSON mode.

--- a/.changeset/fine-drinks-sin.md
+++ b/.changeset/fine-drinks-sin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': minor
+---
+
+feat: let the command palette pick a registry document version

--- a/.changeset/five-gifts-visit.md
+++ b/.changeset/five-gifts-visit.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+chore: added scalar domain to csp; allow localhost img/media sources during Vite dev only

--- a/.changeset/fix-9114-x-internal-on-ref-wrapper.md
+++ b/.changeset/fix-9114-x-internal-on-ref-wrapper.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix(workspace-store): respect x-internal and x-scalar-ignore on $ref wrapper schemas, operations, and webhooks in the sidebar

--- a/.changeset/fix-invalid-url-protocol-message.md
+++ b/.changeset/fix-invalid-url-protocol-message.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': patch
+---
+
+fix(helpers): show friendly error message for relative / non-http URLs in the API client

--- a/.changeset/fix-mobile-sidebar-z-index.md
+++ b/.changeset/fix-mobile-sidebar-z-index.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix mobile sidebar z-index to ensure it appears above all content when open

--- a/.changeset/fix-oauth-scope-scrollbar.md
+++ b/.changeset/fix-oauth-scope-scrollbar.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Remove unwanted scrollbar beside auth scope checkboxes

--- a/.changeset/fix-oauth2-scopes-preferred-scheme.md
+++ b/.changeset/fix-oauth2-scopes-preferred-scheme.md
@@ -1,0 +1,9 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: initialize selection when updating OAuth2 scopes with preferredSecurityScheme
+
+When preferredSecurityScheme is used, the selection is computed on-the-fly by getSelectedSecurity but not persisted to the auth store. This caused updateSelectedScopes to fail silently when users tried to select scopes, as it couldn't find a stored selection to update.
+
+The fix initializes the selection in the auth store when it doesn't exist, allowing scope updates to work correctly with preferredSecurityScheme.

--- a/.changeset/fix-workspace-dropdown-highlight.md
+++ b/.changeset/fix-workspace-dropdown-highlight.md
@@ -1,0 +1,8 @@
+---
+"@scalar/components": patch
+"@scalar/themes": patch
+---
+
+fix(components): add `highlighted` Tailwind variant for Radix menu item highlight state
+
+Adds a new `highlighted` custom Tailwind variant (matching `[data-highlighted]`) to `@scalar/themes` and uses it in `ScalarDropdownButton` to restore the hover and keyboard-navigation highlight in the workspace and team picker dropdowns.

--- a/.changeset/floppy-houses-prove.md
+++ b/.changeset/floppy-houses-prove.md
@@ -1,0 +1,8 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-client': patch
+---
+
+fix: share executable URL build for copy and buildRequest
+
+Copy URL from the operation address bar now matches the URL that is actually sent: path parameters, operation query string, environment substitution, and security schemes that use in: query are all applied the same way as Send.

--- a/.changeset/floppy-sails-hug.md
+++ b/.changeset/floppy-sails-hug.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: handle registry document and version deletion in document settings

--- a/.changeset/four-books-bet.md
+++ b/.changeset/four-books-bet.md
@@ -1,0 +1,6 @@
+---
+'@scalar/components': patch
+'scalar-app': patch
+---
+
+feat: add team switching to the scalar app

--- a/.changeset/frank-bottles-stand.md
+++ b/.changeset/frank-bottles-stand.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: rename default workspace labels to Local workspace and Team workspace

--- a/.changeset/fresh-trees-listen.md
+++ b/.changeset/fresh-trees-listen.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Avoid repeating request body schema descriptions above collapsed overflow properties.

--- a/.changeset/full-impalas-wave.md
+++ b/.changeset/full-impalas-wave.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': patch
+---
+
+feat: better server extraction from partial urls

--- a/.changeset/get-document-type-helper.md
+++ b/.changeset/get-document-type-helper.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+feat(workspace-store): add `getDocumentType` helper to identify OpenAPI vs AsyncAPI documents

--- a/.changeset/grumpy-lilies-heal.md
+++ b/.changeset/grumpy-lilies-heal.md
@@ -1,0 +1,5 @@
+---
+'@scalar/oas-utils': patch
+---
+
+refactor(oas-utils): drop local `migrations/semver` and use `isVersionLessThan` from `@scalar/helpers` in the workspace migrator. The previous `semverLessThan` export is removed from `@scalar/oas-utils/migrations`; import from `@scalar/helpers/general/compare-versions` instead.

--- a/.changeset/hot-rats-stare.md
+++ b/.changeset/hot-rats-stare.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: prevent address bar from stretching past max width

--- a/.changeset/hotkey-symbol-set-env.md
+++ b/.changeset/hotkey-symbol-set-env.md
@@ -1,0 +1,7 @@
+---
+'@scalar/components': patch
+---
+
+fix: respect optional `VITE_SCALAR_HOTKEY_SYMBOL_SET` on ScalarHotkey to override OS-based modifier
+
+This can be really useful when we want to have deterministic results on the CI

--- a/.changeset/hungry-buttons-matter.md
+++ b/.changeset/hungry-buttons-matter.md
@@ -1,0 +1,9 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+'scalar-app': patch
+'@scalar/oas-utils': patch
+---
+
+feat: add more analytics events

--- a/.changeset/itchy-flowers-tan.md
+++ b/.changeset/itchy-flowers-tan.md
@@ -1,0 +1,5 @@
+---
+'@scalar/client-side-rendering': patch
+---
+
+chore: use the new schemas from the new package

--- a/.changeset/json-response-preview-raw-tabs.md
+++ b/.changeset/json-response-preview-raw-tabs.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client': patch
+---
+
+feat: add Preview/Raw tabs for JSON responses with true raw body view
+
+JSON bodies now open on a formatted Preview tab (JSONC pretty-print without JSON.parse round-trip). The Raw tab shows the exact decoded response text. Other media types are unchanged; HTML, images, and other previews already used the same toggle pattern.

--- a/.changeset/khaki-clouds-search.md
+++ b/.changeset/khaki-clouds-search.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+feat: integrate the new registry adapter

--- a/.changeset/large-trams-post.md
+++ b/.changeset/large-trams-post.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: padding on addressbar with no servers

--- a/.changeset/lemon-falcons-hear.md
+++ b/.changeset/lemon-falcons-hear.md
@@ -1,0 +1,5 @@
+---
+'@scalar/json-magic': patch
+---
+
+fix: strip a leading UTF-8 BOM before JSON.parse in normalize so BOM-prefixed files parse correctly

--- a/.changeset/lemon-rules-itch.md
+++ b/.changeset/lemon-rules-itch.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: remove shortcuts label from the editor page

--- a/.changeset/light-banks-tap.md
+++ b/.changeset/light-banks-tap.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: history bug on operation switch

--- a/.changeset/lucky-lines-win.md
+++ b/.changeset/lucky-lines-win.md
@@ -1,0 +1,5 @@
+---
+'@scalar/schemas': minor
+---
+
+feat: write custom schemas for api-reference configuration

--- a/.changeset/narrow-request-table-tooltips.md
+++ b/.changeset/narrow-request-table-tooltips.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): narrow request table parameter info popover width

--- a/.changeset/neat-cows-divide.md
+++ b/.changeset/neat-cows-divide.md
@@ -1,0 +1,8 @@
+---
+'scalar-app': patch
+---
+
+feat: handle workspace uid and slug reconciliation
+
+App is updated to treat workspaceUid / teamUid as canonical, to reconcile server-driven team slug changes against persisted records (and clear stale tab metadata where needed), and to route workspace resume flows through a clearer resumeOrGetStarted API. migrate-to-indexdb (localStorage → IndexedDB) writes new records using the same UID + local team model.
+

--- a/.changeset/neat-queries-expand.md
+++ b/.changeset/neat-queries-expand.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/workspace-store': patch
+---
+
+fix(api-client): expand object query parameters in the request UI

--- a/.changeset/ninety-tires-obey.md
+++ b/.changeset/ninety-tires-obey.md
@@ -1,0 +1,5 @@
+---
+'@scalar/agent-chat': patch
+---
+
+chore: remove zod and use the custom validation library

--- a/.changeset/optimize-mobile-layout.md
+++ b/.changeset/optimize-mobile-layout.md
@@ -1,0 +1,19 @@
+---
+'@scalar/api-client': patch
+'@scalar/pre-post-request-scripts': patch
+'scalar-app': patch
+---
+
+feat: optimize layout for mobile
+
+- Hide the document breadcrumb on small screens and surface workspace
+  switching from the menu instead, so the top bar stays uncluttered.
+- Convert the document save / discard / pull / push / publish buttons to
+  header-button styling and only render the trailing divider when there
+  are actual cluster buttons next to it.
+- Stack the address bar onto two rows on small screens so the URL and
+  the action cluster (copy / history / send) each get a full row.
+- Hide the "Log in" affordance from the small-screen top bar (the menu
+  still owns it) and keep only the primary "Register" CTA there.
+- Give the pre-request and post-response script editors proper vertical
+  padding so the help text no longer clips when it wraps.

--- a/.changeset/perky-waves-decide.md
+++ b/.changeset/perky-waves-decide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: omit disabled default headers when building requests

--- a/.changeset/php-curl-custom-request-method.md
+++ b/.changeset/php-curl-custom-request-method.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+fix(snippetz): emit `CURLOPT_CUSTOMREQUEST` for PHP cURL snippets when the method is not GET or POST, so DELETE/PUT/PATCH requests render with the correct verb

--- a/.changeset/pkce-hide-client-secret.md
+++ b/.changeset/pkce-hide-client-secret.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix(api-client): hide OAuth2 client secret when PKCE is enabled and omit it from token requests

--- a/.changeset/plain-ravens-wish.md
+++ b/.changeset/plain-ravens-wish.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: agent scalar warnings

--- a/.changeset/pretty-tables-bake.md
+++ b/.changeset/pretty-tables-bake.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): lower badge style specificity

--- a/.changeset/proud-buses-start.md
+++ b/.changeset/proud-buses-start.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/api-client': patch
+---
+
+fix: posthog stream warning

--- a/.changeset/purple-garlics-jump.md
+++ b/.changeset/purple-garlics-jump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+refactor: remove the main import file since it was empty

--- a/.changeset/setvalueatpath-helper.md
+++ b/.changeset/setvalueatpath-helper.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': minor
+---
+
+feat(helpers): add `setValueAtPath` for path-array-based nested object writes

--- a/.changeset/silent-goats-cheat.md
+++ b/.changeset/silent-goats-cheat.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: keep splash until team loads so team workspace reloads stick

--- a/.changeset/silver-otters-knock.md
+++ b/.changeset/silver-otters-knock.md
@@ -1,0 +1,11 @@
+---
+'@scalar/api-client': patch
+'@scalar/helpers': patch
+'@scalar/workspace-store': patch
+---
+
+fix(api-client): request body content types — OpenAPI extras, MIME labels, and "Other" without auto Content-Type
+
+The request body dropdown lists built-in types first, then any additional media types from the OpenAPI operation. Labels use the MIME essence (no `charset` in the label). The **Other** option is available again for a raw body: it does **not** add an automatic `Content-Type` header (users can set one manually). Code snippets avoid injecting `Content-Type: other`.
+
+`getDefaultHeaders` and `filterDisabledDefaultHeaders` are exported from `@scalar/workspace-store/request-example`; the API client uses them for code snippets instead of a duplicate helper.

--- a/.changeset/six-bikes-check.md
+++ b/.changeset/six-bikes-check.md
@@ -1,0 +1,5 @@
+---
+'@scalar/validation': minor
+---
+
+feat: support default values for coersion

--- a/.changeset/six-teeth-hide.md
+++ b/.changeset/six-teeth-hide.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): remove tooltip when scope is disposed

--- a/.changeset/slimy-lobsters-doubt.md
+++ b/.changeset/slimy-lobsters-doubt.md
@@ -1,0 +1,5 @@
+---
+'@scalar/server-side-rendering': patch
+---
+
+Integrate Unhead server-side head rendering in SSR output so `metaData` and title tags are included in the server-rendered HTML document.

--- a/.changeset/slow-lobsters-juggle.md
+++ b/.changeset/slow-lobsters-juggle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix invalid Tailwind gap utility in the address bar

--- a/.changeset/slugify-normalization-options.md
+++ b/.changeset/slugify-normalization-options.md
@@ -1,0 +1,8 @@
+---
+'@scalar/helpers': patch
+---
+
+feat(helpers): add `normalizationForm` and `stripAccents` options to `slugify` and `slugger`
+
+- `normalizationForm` (`'NFC' | 'NFD' | 'NFKC' | 'NFKD'`, default `'NFC'`) passes the chosen form to `String.prototype.normalize()` before slugifying.
+- `stripAccents` (`boolean`, default `false`) decomposes accented letters via NFD and removes all Unicode combining marks so e.g. `"Crème Brûlée"` becomes `"creme-brulee"`. Takes precedence over `normalizationForm`.

--- a/.changeset/smart-bugs-take.md
+++ b/.changeset/smart-bugs-take.md
@@ -1,0 +1,7 @@
+---
+'scalar-app': patch
+---
+
+fix: enable transparent Electron window to reduce resize flash
+
+The desktop shell uses a dark-themed surface; Electron’s default backing color can show through briefly while the webview repaints during aggressive window resizing. A transparent window lets the renderer’s own background (CSS / theme) own what users see in those gaps.

--- a/.changeset/social-sails-juggle.md
+++ b/.changeset/social-sails-juggle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-hooks': patch
+---
+
+chore: remove zod

--- a/.changeset/sour-weeks-ask.md
+++ b/.changeset/sour-weeks-ask.md
@@ -1,0 +1,8 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/helpers': patch
+---
+
+fix: forward selected forbidden headers via `X-Scalar-*` when proxying
+
+Browsers strip selected forbidden headers from outgoing requests. When using the Scalar proxy (or running in Electron), we now rewrite a small allowlist (`Date`, `DNT`, and `Referer`) to `X-Scalar-*` headers so the proxy can forward the intended upstream headers without opening support for the full forbidden-header set.

--- a/.changeset/tall-buses-pump.md
+++ b/.changeset/tall-buses-pump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/types': minor
+---
+
+feat: write pure types without using the zod schemas

--- a/.changeset/tangy-ducks-hammer.md
+++ b/.changeset/tangy-ducks-hammer.md
@@ -1,0 +1,8 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: prevent stuck response overlay after overlapping sends
+
+Fixes a case where the response loading overlay could stay visible indefinitely and **Cancel** had no effect after opening an example and sending a request very quickly (or when multiple sends overlapped).
+The reason for that is that `ResponseLoadingOverlay` delays showing the spinner by 1s. Each `hooks:on:request:sent` scheduled a new `setTimeout` without clearing the previous one. Overlapping `sent` events could leave an orphaned timer that still called `loader.start()` after the request had already finished and `hooks:on:request:complete` had run—so the overlay turned on with no further `complete`, and **Cancel** targeted an `AbortController` that no longer matched the finished request.

--- a/.changeset/theme-helpers-extract.md
+++ b/.changeset/theme-helpers-extract.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': patch
+---
+
+Add `@scalar/helpers/theme/load-css-variables` for parsing Scalar theme CSS into light/dark custom property maps (moved from scalar-app).

--- a/.changeset/thirty-clowns-talk.md
+++ b/.changeset/thirty-clowns-talk.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'scalar-app': patch
+---
+
+build: switch Monaco Vite plugin to ESM and align workers

--- a/.changeset/tough-hornets-join.md
+++ b/.changeset/tough-hornets-join.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'scalar-app': patch
+---
+
+chore: move app files from client to scalar-app


### PR DESCRIPTION
The release broke so I am adding the changelogs back

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces an IndexedDB v2 migration that reshapes persisted workspace data and changes request URL/build semantics across `workspace-store`, `api-client`, and `api-reference`, which can impact routing and request sending in production.
> 
> **Overview**
> Introduces **UID-based workspaces** with an IndexedDB v2 migration that collapses legacy workspaces into a local team model, resolves slug collisions, re-keys chunk storage by `workspaceUid`, and clears stale tab metadata to avoid routing issues.
> 
> Hardens request construction by making `buildRequest` return a typed `Result` (with stable error codes) and rejecting incomplete/invalid merged URLs before send; downstream callers now unwrap failures, skip `onBeforeRequest` when the preview payload can’t be built, and align “Copy URL” with the actual executable URL.
> 
> Expands **OpenAPI + AsyncAPI** support (union `WorkspaceDocument`, AsyncAPI badges/labels, avoid OpenAPI coercion on rebase), improves API Reference behavior (cleans up deprecated document listeners on `destroy`, search ranking, schema `$ref` handling, mobile z-index), and adds Scalar app UX work (team switching/routing, “What’s new” release-notes modal, mobile layout polish, Monaco/Electron/CSP fixes) plus several helper/type/schema refactors (remove `zod`, new slugify/options, version compare, theme CSS parsing, forbidden-header forwarding via `X-Scalar-*`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 933ca33e43c0599175a1f30f8660f0dfdba8f524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->