### PR TITLE
fix(scalar-app): csp problem

### DIFF
--- a/.changeset/few-weeks-juggle.md
+++ b/.changeset/few-weeks-juggle.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix(scalar-app): csp issue

--- a/projects/scalar-app/entrypoints/web/index.html
+++ b/projects/scalar-app/entrypoints/web/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://cdn.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
+      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://cdn.vector.co https://api.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
     <link
       rel="icon"
       type="image/png"


### PR DESCRIPTION
## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small static HTML change that only relaxes the `script-src` CSP to include one additional domain, plus a patch changeset.
> 
> **Overview**
> Fixes a CSP violation in `scalar-app` by adding `https://api.vector.co` to the `script-src` allowlist in the web entrypoint `index.html`.
> 
> Adds a patch changeset to release the CSP fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7d2ee53f10c49ff58f8f1aa460ccf9c6b0ead22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->