### PR TITLE
docs(changeset): bumping release

### DIFF
--- a/.changeset/slick-doors-stick.md
+++ b/.changeset/slick-doors-stick.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'scalar-app': patch
+---
+
+chore: bumping release


### PR DESCRIPTION
Bumping changeset

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only a Changesets entry to trigger patch releases for `@scalar/api-client` and `scalar-app`, with no runtime or behavioral code changes.
> 
> **Overview**
> Adds a new Changesets file (`.changeset/slick-doors-stick.md`) that marks `@scalar/api-client` and `scalar-app` for a **patch** release with the note “chore: bumping release”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55b1c9ea4ecb0f90403204542cb2faf3f59a5a1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->