### PR TITLE
chore: deploy scalar app

### DIFF
--- a/.changeset/upset-shrimps-smell.md
+++ b/.changeset/upset-shrimps-smell.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+chore: deploy scalar app


### PR DESCRIPTION
The last deploy failed..

Adding the changeset again...

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds only a Changesets entry to trigger a patch release/deploy, with no runtime code changes.
> 
> **Overview**
> Adds a new Changesets file (`.changeset/upset-shrimps-smell.md`) that bumps `scalar-app` with a *patch* release labeled “chore: deploy scalar app”, effectively re-triggering the deploy pipeline after a failed release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63036913c1fbb2a1c161cceac27ef9515adea949. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->