### PR TITLE
fix(scalar-app): csp policy

### DIFF
--- a/.changeset/goofy-geckos-sit.md
+++ b/.changeset/goofy-geckos-sit.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: csp issue

--- a/projects/scalar-app/entrypoints/web/index.html
+++ b/projects/scalar-app/entrypoints/web/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://cdn.vector.co https://api.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
+      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://*.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com https://*.vector.co; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob: https://*.vector.co; font-src https://fonts.scalar.com 'self'" />
     <link
       rel="icon"
       type="image/png"


### PR DESCRIPTION
## Problem

Just had one item in the wrong spot.


## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the static CSP meta tag and a patch changeset; impact should be confined to what external resources the web entrypoint can load.
> 
> **Overview**
> Updates `projects/scalar-app/entrypoints/web/index.html` Content-Security-Policy to consolidate `vector.co` hosts under `https://*.vector.co`, and to allow `vector.co` resources in `img-src` and `frame-src`.
> 
> Adds a patch changeset for `scalar-app` noting the CSP fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 909f843267e581871f520649e4bd4cc568094653. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->