### PR TITLE
chore(ci): stop relying on string checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1545,7 +1545,8 @@ jobs:
     concurrency:
       group: django-ninja-publish
       cancel-in-progress: false
-    needs: [required-jobs-main, django-ninja-build-test, check-changes, npm-publish]
+    needs:
+      [required-jobs-main, django-ninja-build-test, check-changes, npm-publish]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -887,12 +887,21 @@ jobs:
   deploy-api-client:
     # Run for PR previews and every main push. On main, we wait for npm-publish
     # so we know whether this commit actually released and should deploy to
-    # production (otherwise staging). `!cancelled()` lets this job proceed when
-    # npm-publish is skipped (PRs) or succeeded-without-publish (main pushes
-    # that only opened/updated the release PR). A failed npm-publish blocks
-    # deploys so a broken publish never silently lands on staging.
+    # production (otherwise staging).
+    #
+    # `!cancelled()` lets this job proceed when npm-publish is skipped (PRs) or
+    # succeeded-without-publish (main pushes that only opened/updated the
+    # release PR). Because `!cancelled()` overrides the implicit `success()`
+    # check that GitHub Actions normally applies to all `needs`, we must
+    # re-add explicit success gates for `build` and `check-changes` — otherwise
+    # a broken build on main would still deploy to staging. For `npm-publish`
+    # we keep the relaxed `!= 'failure'` check so a legitimate skip (PRs) or
+    # success-without-publish (no changesets to release) still allows deploy,
+    # but a failed publish blocks it.
     if: |
       !cancelled() &&
+      needs.build.result == 'success' &&
+      needs.check-changes.result == 'success' &&
       needs.npm-publish.result != 'failure' &&
       (
         (

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,12 +563,12 @@ jobs:
 
   # We use this job for automated changelog generation
   create-github-release:
-    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
+    if: needs.npm-publish.outputs.published == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 5
     permissions:
       contents: write
-    needs: [required-jobs-main]
+    needs: [required-jobs-main, npm-publish]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -617,8 +617,11 @@ jobs:
 
   npm-publish:
     if: github.ref == 'refs/heads/main'
-    # Use a GitHub-hosted runner for npm publish to ensure signed releases
-    runs-on: ${{ startsWith(github.event.head_commit.message, 'RELEASING:') && 'ubuntu-22.04' || 'blacksmith-4vcpu-ubuntu-2204' }}
+    # `npm publish --provenance` requires a GitHub-hosted runner. Self-hosted
+    # runners (including Blacksmith) are rejected by the npm registry with HTTP
+    # 422 because the OIDC issuer is not in npm's trusted list. Always use a
+    # github-hosted runner here, regardless of whether this run will publish.
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     # Avoid running this job in parallel:
     # `changesets/action` creates/updates the release branch, which shouldn't happen in parallel.
@@ -634,6 +637,13 @@ jobs:
       # Required for npm provenance statements
       id-token: write
     needs: [required-jobs-main]
+    # Expose the changesets/action outputs so downstream jobs can gate on the
+    # actual publish result instead of parsing the commit message. `published`
+    # is 'true' only when changesets/action actually pushed at least one
+    # package to npm; `publishedPackages` is a JSON array of {name, version}.
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -666,8 +676,12 @@ jobs:
           version: 'pnpm release:version'
           # The commit message to use.
           commit: 'chore: version packages'
-          # The command to use to build and publish packages
-          publish: 'pnpm -r publish --access public --no-git-checks'
+          # The command to use to build and publish packages.
+          # --workspace-concurrency=1 serializes publishes per package; npm's
+          # registry occasionally returns HTTP 409 "Failed to save packument"
+          # on near-simultaneous PUTs to the same packument (which `pnpm -r
+          # publish` does by default across the workspace).
+          publish: 'pnpm -r --workspace-concurrency=1 publish --access public --no-git-checks'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # https://www.npmjs.com/settings/YOUR_ACCOUNT_HANDLE/tokens/granular-access-tokens/new
@@ -687,10 +701,10 @@ jobs:
           method: 'GET'
 
   push-to-scalar-registry:
-    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:')
+    if: needs.npm-publish.outputs.published == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
-    needs: [build, test-packages]
+    needs: [build, test-packages, npm-publish]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -871,31 +885,43 @@ jobs:
   # - merges to main that are not a release commit (staging)
   # - merges to main that are a release commit (production)
   deploy-api-client:
+    # Run for PR previews and every main push. On main, we wait for npm-publish
+    # so we know whether this commit actually released and should deploy to
+    # production (otherwise staging). `!cancelled()` lets this job proceed when
+    # npm-publish is skipped (PRs) or succeeded-without-publish (main pushes
+    # that only opened/updated the release PR). A failed npm-publish blocks
+    # deploys so a broken publish never silently lands on staging.
     if: |
+      !cancelled() &&
+      needs.npm-publish.result != 'failure' &&
       (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        !contains(github.actor, '[bot]') &&
-        needs.check-changes.outputs.api_client_changed == 'true'
-      ) ||
-      github.ref == 'refs/heads/main'
-    needs: [build, check-changes]
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          !contains(github.actor, '[bot]') &&
+          needs.check-changes.outputs.api_client_changed == 'true'
+        ) ||
+        github.ref == 'refs/heads/main'
+      )
+    needs: [build, check-changes, npm-publish]
     concurrency:
       group: deploy-api-client-${{ github.ref }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/deploy-api-client.yml
     with:
-      environment: ${{ startsWith(github.event.head_commit.message, 'RELEASING:') && 'production' || 'staging' }}
+      # 'production' only when npm-publish actually published at least one
+      # package on this commit; otherwise 'staging' (which is also what every
+      # PR preview uses).
+      environment: ${{ needs.npm-publish.outputs.published == 'true' && 'production' || 'staging' }}
       pr-number: ${{ github.event.pull_request.number }}
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit
 
   todesktop-build:
     if: |
-      github.ref == 'refs/heads/main' &&
-      startsWith(github.event.head_commit.message, 'RELEASING:') &&
+      needs.npm-publish.outputs.published == 'true' &&
       needs.check-changes.outputs.scalar_app_package_changed == 'true'
-    needs: [required-jobs-main, build, check-changes]
+    needs: [required-jobs-main, build, check-changes, npm-publish]
     runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 15
     environment: production
@@ -1091,13 +1117,13 @@ jobs:
           tags: scalarapi/api-reference:latest
 
   docker-publish:
-    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:') && needs.check-changes.outputs.docker_package_changed == 'true'
+    if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.docker_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
     concurrency:
       group: docker-publish
       cancel-in-progress: false
-    needs: [required-jobs-main, docker-build, check-changes]
+    needs: [required-jobs-main, docker-build, check-changes, npm-publish]
     permissions:
       contents: read
     steps:
@@ -1155,13 +1181,13 @@ jobs:
           readme-filepath: ./integrations/docker/README.md
 
   mock-server-docker-publish:
-    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:') && needs.check-changes.outputs.mock_server_docker_package_changed == 'true'
+    if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.mock_server_docker_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
     concurrency:
       group: mock-server-docker-publish
       cancel-in-progress: false
-    needs: [required-jobs-main, check-changes]
+    needs: [required-jobs-main, check-changes, npm-publish]
     permissions:
       contents: read
     steps:
@@ -1264,14 +1290,14 @@ jobs:
         run: dotnet test -c Release --no-build
 
   aspnetcore-publish:
-    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:') && needs.check-changes.outputs.aspnetcore_package_changed == 'true'
+    if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.aspnetcore_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
     # We don't want to run `nuget push` (publishing to NuGet) in parallel.
     concurrency:
       group: aspnetcore-publish
       cancel-in-progress: false
-    needs: [required-jobs-main, dotnet-build-test, check-changes]
+    needs: [required-jobs-main, dotnet-build-test, check-changes, npm-publish]
     permissions:
       contents: read
     steps:
@@ -1325,13 +1351,13 @@ jobs:
         run: dotnet nuget push nupkgs/*.nupkg -k ${{ secrets.NUGET_TOKEN }} -s https://api.nuget.org/v3/index.json
 
   aspire-publish:
-    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:') && needs.check-changes.outputs.aspire_package_changed == 'true'
+    if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.aspire_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
     concurrency:
       group: aspire-publish
       cancel-in-progress: false
-    needs: [required-jobs-main, dotnet-build-test, check-changes]
+    needs: [required-jobs-main, dotnet-build-test, check-changes, npm-publish]
     permissions:
       contents: read
     steps:
@@ -1451,13 +1477,13 @@ jobs:
         run: python run_tests.py
 
   fastapi-publish:
-    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:') && needs.check-changes.outputs.fastapi_package_changed == 'true'
+    if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.fastapi_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
     concurrency:
       group: fastapi-publish
       cancel-in-progress: false
-    needs: [required-jobs-main, fastapi-build-test, check-changes]
+    needs: [required-jobs-main, fastapi-build-test, check-changes, npm-publish]
     permissions:
       contents: read
     steps:
@@ -1513,13 +1539,13 @@ jobs:
         run: python run_tests.py
 
   django-ninja-publish:
-    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:') && needs.check-changes.outputs.django_ninja_package_changed == 'true'
+    if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.django_ninja_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
     concurrency:
       group: django-ninja-publish
       cancel-in-progress: false
-    needs: [required-jobs-main, django-ninja-build-test, check-changes]
+    needs: [required-jobs-main, django-ninja-build-test, check-changes, npm-publish]
     permissions:
       contents: read
     steps:
@@ -1602,13 +1628,13 @@ jobs:
           cargo build --example warp --features warp
 
   rust-publish:
-    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:') && needs.check-changes.outputs.rust_package_changed == 'true'
+    if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.rust_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
     concurrency:
       group: rust-publish
       cancel-in-progress: false
-    needs: [required-jobs-main, rust-build-test, check-changes]
+    needs: [required-jobs-main, rust-build-test, check-changes, npm-publish]
     permissions:
       contents: read
     steps:
@@ -1682,8 +1708,8 @@ jobs:
         run: mvn clean test
 
   java-publish:
-    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'RELEASING:') && needs.check-changes.outputs.java_package_changed == 'true'
-    needs: [required-jobs-main, java-build-test, check-changes]
+    if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.java_package_changed == 'true'
+    needs: [required-jobs-main, java-build-test, check-changes, npm-publish]
     runs-on: blacksmith-2vcpu-ubuntu-2204
     concurrency:
       group: java-publish


### PR DESCRIPTION
## Problem

We were previously relying on string checks of "Releasing" to gate our prod releases. This broke a couple different ways and we couldn't release for a while.

## Solution

The plan is to eventually make this work off of releases but for now we switched to using an output. This should work better than the string (if it works)

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI/CD release gating logic for npm, Docker, NuGet, PyPI, Maven, and production deploys; misconfiguration could block releases or deploy the wrong environment.
> 
> **Overview**
> Stops using commit-message string checks (e.g. `RELEASING:`) to trigger production publishing/deployments, and instead gates downstream release jobs on `changesets/action`’s `published` output from the `npm-publish` job.
> 
> Makes `npm-publish` always run on a GitHub-hosted runner (required for `npm publish --provenance`), exposes `published`/`publishedPackages` as job outputs, serializes workspace publishing to reduce npm registry 409s, and updates `deploy-api-client` to choose *production vs staging* based on whether a publish actually occurred (with explicit `needs.*.result` safety checks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88f0c599dc2a1761535d13c4cd0942056a63846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->