### PR TITLE
chore(ci): hotfix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -677,11 +677,7 @@ jobs:
           # The commit message to use.
           commit: 'chore: version packages'
           # The command to use to build and publish packages.
-          # --parallel 1 serializes publishes per package; npm's
-          # registry occasionally returns HTTP 409 "Failed to save packument"
-          # on near-simultaneous PUTs to the same packument (which `pnpm -r
-          # publish` does by default across the workspace).
-          publish: 'pnpm -r publish --access public --no-git-checks --parallel 1'
+          publish: 'pnpm -r publish --access public --no-git-checks'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # https://www.npmjs.com/settings/YOUR_ACCOUNT_HANDLE/tokens/granular-access-tokens/new

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -677,11 +677,11 @@ jobs:
           # The commit message to use.
           commit: 'chore: version packages'
           # The command to use to build and publish packages.
-          # --workspace-concurrency=1 serializes publishes per package; npm's
+          # --parallel 1 serializes publishes per package; npm's
           # registry occasionally returns HTTP 409 "Failed to save packument"
           # on near-simultaneous PUTs to the same packument (which `pnpm -r
           # publish` does by default across the workspace).
-          publish: 'pnpm -r --workspace-concurrency=1 publish --access public --no-git-checks'
+          publish: 'pnpm -r publish --access public --no-git-checks --parallel 1'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # https://www.npmjs.com/settings/YOUR_ACCOUNT_HANDLE/tokens/granular-access-tokens/new


### PR DESCRIPTION
## Problem

We are working on CI

## Solution

Fix as we go 

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes npm publishing behavior in the release workflow, which could affect reliability of main-branch releases if the registry can’t handle concurrent publishes.
> 
> **Overview**
> Updates the `npm-publish` job in `.github/workflows/ci.yml` to run `pnpm -r publish` without `--workspace-concurrency=1`, removing the previous serialization workaround for npm registry 409 errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e31def3071aba97c7f2ef707ac69c2da96945174. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->