### PR TITLE
fix(api-client): remove chevron on operation sidebar entry

### DIFF
--- a/.changeset/fruity-grapes-create.md
+++ b/.changeset/fruity-grapes-create.md
@@ -1,0 +1,5 @@
+---
+'@scalar/sidebar': patch
+---
+
+fix: remove chevron

--- a/packages/sidebar/src/components/SidebarItem.test.ts
+++ b/packages/sidebar/src/components/SidebarItem.test.ts
@@ -1,5 +1,6 @@
 import {
   ScalarSidebarGroup,
+  ScalarSidebarGroupToggle,
   ScalarSidebarItem,
   ScalarSidebarItem as ScalarSidebarItemComponent,
   ScalarSidebarSection,
@@ -1103,6 +1104,32 @@ describe('SidebarItem', () => {
 
       // In client layout, operations/webhooks with children should render as groups
       expect(wrapper.findComponent(ScalarSidebarGroup).exists()).toBe(true)
+    })
+
+    it('does not render the chevron beside the HTTP method badge', () => {
+      const item: Item = {
+        id: '1',
+        title: 'Operation with examples',
+        type: 'operation',
+        ref: 'ref-1',
+        method: 'post',
+        path: '/users',
+        children: [{ id: '2', title: 'Example 1', type: 'example', name: 'example1' }],
+      }
+
+      const wrapper = mount(SidebarItem, {
+        props: {
+          ...baseProps,
+          layout: 'client',
+          item,
+          isExpanded: () => true,
+        },
+      })
+
+      // The HTTP badge is rendered for items with a method
+      expect(wrapper.findComponent(SidebarHttpBadge).exists()).toBe(true)
+      // The chevron toggle should be hidden when the item has a method
+      expect(wrapper.findComponent(ScalarSidebarGroupToggle).exists()).toBe(false)
     })
 
     it('handles missing optional props gracefully', () => {

--- a/packages/sidebar/src/components/SidebarItem.vue
+++ b/packages/sidebar/src/components/SidebarItem.vue
@@ -254,7 +254,7 @@ const children = computed(() =>
     <template
       v-if="'method' in item"
       #toggle>
-      <!-- Nothing -->
+      <span class="hidden"></span>
     </template>
     <template
       v-if="slots.decorator"


### PR DESCRIPTION
## Problem

I accidentally didn't remove the chevron

## Solution

Went back to this code that actually removes it 😄 + added a test so it doesn't sneak back in

| Before | After |
|--------|--------|
| <img width="289" height="256" alt="image" src="https://github.com/user-attachments/assets/64a94484-6577-47c9-810a-baec5711b43f" /> | <img width="285" height="276" alt="image" src="https://github.com/user-attachments/assets/da09a65a-60e9-45dc-bda6-346f63622b88" /> |


## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts sidebar rendering for items with an HTTP method and adds a unit test to prevent regression.
> 
> **Overview**
> Operation/sidebar entries that have a `method` now suppress the `ScalarSidebarGroup` chevron toggle so it doesn’t appear beside the HTTP method badge (implemented via an empty hidden `#toggle` slot in `SidebarItem.vue`).
> 
> Adds a regression test asserting the group toggle (`ScalarSidebarGroupToggle`) is not rendered for method-based items in `client` layout, and includes a patch changeset for `@scalar/sidebar`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c70fd939e68d6d6c027040b8c32fc828accb2165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->