### PR TITLE
test(api-client): add comprehensive CodeInputLite test coverage

### DIFF
--- a/packages/api-client/src/v2/components/code-input/CodeInputLite.test.ts
+++ b/packages/api-client/src/v2/components/code-input/CodeInputLite.test.ts
@@ -787,7 +787,25 @@ describe('CodeInputLite', () => {
   describe('required indicator', () => {
     it('renders the required indicator when required is true', () => {
       const wrapper = mountInput({ modelValue: '', required: true })
-      expect(wrapper.find('.required').exists()).toBe(true)
+      const indicator = wrapper.find('.required')
+      expect(indicator.exists()).toBe(true)
+      expect(indicator.text()).toBe('Required')
+    })
+
+    it('sets aria-required on the editor when required is true', () => {
+      const wrapper = mountInput({ modelValue: '', required: true })
+      expect(wrapper.get('.code-input-lite__editor').attributes('aria-required')).toBe('true')
+    })
+
+    it('does not render the required indicator when required is false', () => {
+      const wrapper = mountInput({ modelValue: '', required: false })
+      expect(wrapper.find('.required').exists()).toBe(false)
+    })
+
+    it('does not render the required indicator by default', () => {
+      const wrapper = mountInput({ modelValue: '' })
+      expect(wrapper.find('.required').exists()).toBe(false)
+      expect(wrapper.get('.code-input-lite__editor').attributes('aria-required')).toBeUndefined()
     })
 
     it('hides the required indicator while the editor is focused', () => {
@@ -795,6 +813,17 @@ describe('CodeInputLite', () => {
       // assert the focus-hiding class is wired up rather than the computed style.
       const wrapper = mountInput({ modelValue: '', required: true })
       expect(wrapper.find('.required').classes()).toContain('peer-has-[.code-input-lite__editor:focus]:opacity-0')
+    })
+
+    it('still renders the required indicator alongside select mode', () => {
+      const wrapper = mountInput({
+        modelValue: 'a',
+        required: true,
+        enum: ['a', 'b'],
+      })
+      // The indicator is a sibling of the mode wrappers so it shows in every mode.
+      expect(wrapper.find('.required').exists()).toBe(true)
+      expect(wrapper.findComponent({ name: 'DataTableInputSelect' }).exists()).toBe(true)
     })
   })
 

--- a/packages/api-client/src/v2/components/code-input/CodeInputLite.test.ts
+++ b/packages/api-client/src/v2/components/code-input/CodeInputLite.test.ts
@@ -212,6 +212,24 @@ describe('CodeInputLite', () => {
     expect(wrapper.findComponent({ name: 'EnvironmentVariablesDropdown' }).exists()).toBe(false)
   })
 
+  it('does not open the dropdown when withVariables is false', async () => {
+    const wrapper = mountInput({ modelValue: '', withVariables: false })
+    api(wrapper).setContent('{{')
+    api(wrapper).focus('end')
+    await wrapper.get('.code-input-lite__editor').trigger('input')
+    await nextTick()
+    expect(wrapper.findComponent({ name: 'EnvironmentVariablesDropdown' }).exists()).toBe(false)
+  })
+
+  it('does not open the dropdown when no environment is provided and fake data is off', async () => {
+    const wrapper = mountInput({ modelValue: '', environment: undefined })
+    api(wrapper).setContent('{{')
+    api(wrapper).focus('end')
+    await wrapper.get('.code-input-lite__editor').trigger('input')
+    await nextTick()
+    expect(wrapper.findComponent({ name: 'EnvironmentVariablesDropdown' }).exists()).toBe(false)
+  })
+
   it('closes the dropdown after the closing `}}`', async () => {
     const wrapper = mountInput({ modelValue: '' })
     api(wrapper).setContent('{{baseUrl}}')
@@ -255,6 +273,13 @@ describe('CodeInputLite', () => {
 
   it('skips submit on blur when emitOnBlur is false', async () => {
     const wrapper = mountInput({ modelValue: '/users', emitOnBlur: false })
+    await wrapper.get('.code-input-lite__editor').trigger('blur')
+    expect(wrapper.emitted('submit')).toBeUndefined()
+    expect(wrapper.emitted('blur')).toBeTruthy()
+  })
+
+  it('does not emit submit on blur when the model value is empty', async () => {
+    const wrapper = mountInput({ modelValue: '', emitOnBlur: true })
     await wrapper.get('.code-input-lite__editor').trigger('blur')
     expect(wrapper.emitted('submit')).toBeUndefined()
     expect(wrapper.emitted('blur')).toBeTruthy()
@@ -515,6 +540,37 @@ describe('CodeInputLite', () => {
       expect(select.props('value')).toEqual(['a', 'b'])
     })
 
+    it('prefers the boolean select over examples when both are set', () => {
+      const wrapper = mountInput({
+        modelValue: 'true',
+        type: 'boolean',
+        examples: ['example1', 'example2'],
+      })
+      const select = wrapper.findComponent({ name: 'DataTableInputSelect' })
+      // Boolean wins — value array is true/false, not the examples
+      expect(select.props('value')).toEqual(['true', 'false'])
+    })
+
+    it('prioritizes the disabled label over enum select mode', () => {
+      const wrapper = mountInput({
+        modelValue: 'a',
+        disabled: true,
+        enum: ['a', 'b', 'c'],
+      })
+      expect(wrapper.find('[data-testid="code-input-lite-disabled"]').exists()).toBe(true)
+      expect(wrapper.findComponent({ name: 'DataTableInputSelect' }).exists()).toBe(false)
+    })
+
+    it('falls back to string for a tuple type containing only null in enum mode', () => {
+      const wrapper = mountInput({
+        modelValue: 'x',
+        enum: ['x', 'y'],
+        type: ['null'],
+      })
+      const select = wrapper.findComponent({ name: 'DataTableInputSelect' })
+      expect(select.props('type')).toBe('string')
+    })
+
     it('renders an examples select when examples are provided and no enum/boolean apply', () => {
       const wrapper = mountInput({
         modelValue: 'foo',
@@ -626,11 +682,57 @@ describe('CodeInputLite', () => {
     })
   })
 
+  describe('error state', () => {
+    it('applies the error class and aria-invalid when error is true', () => {
+      const wrapper = mountInput({ modelValue: 'test', error: true })
+      expect(wrapper.find('.code-input-lite').classes()).toContain('code-input-lite--error')
+      expect(wrapper.get('.code-input-lite__editor').attributes('aria-invalid')).toBe('true')
+    })
+
+    it('does not apply error styling by default', () => {
+      const wrapper = mountInput({ modelValue: 'test' })
+      expect(wrapper.find('.code-input-lite').classes()).not.toContain('code-input-lite--error')
+      expect(wrapper.get('.code-input-lite__editor').attributes('aria-invalid')).toBeUndefined()
+    })
+  })
+
+  describe('component id', () => {
+    it('uses a consumer-supplied id attribute on the editor wrapper', () => {
+      const wrapper = mount(CodeInputLite, {
+        attachTo: document.body,
+        props: {
+          modelValue: 'test',
+          environment: env,
+        } as InstanceType<typeof CodeInputLite>['$props'],
+        attrs: { id: 'custom-id' },
+      })
+      expect(wrapper.find('#custom-id').exists()).toBe(true)
+    })
+
+    it('does not assign an id to the editor wrapper before the first focus', () => {
+      const wrapper = mountInput({ modelValue: 'test' })
+      expect(wrapper.find('.code-input-lite').attributes('id')).toBeUndefined()
+    })
+
+    it('generates an id once the editor is focused', async () => {
+      const wrapper = mountInput({ modelValue: 'test' })
+      await wrapper.get('.code-input-lite__editor').trigger('focus')
+      await nextTick()
+      expect(wrapper.find('.code-input-lite').attributes('id')).toMatch(/^id-/)
+    })
+  })
+
   describe('serialization for non-string model values', () => {
     it('renders a number model value as its string form in the editor', async () => {
       const wrapper = mountInput({ modelValue: 42 as unknown as string })
       await nextTick()
       expect(api(wrapper).getValue()).toBe('42')
+    })
+
+    it('renders a zero model value as "0"', async () => {
+      const wrapper = mountInput({ modelValue: 0 as unknown as string })
+      await nextTick()
+      expect(api(wrapper).getValue()).toBe('0')
     })
 
     it('renders a boolean model value as its string form in the editor', async () => {


### PR DESCRIPTION
## Problem

The CodeInputLite component test suite had gaps in coverage for several important behaviors:
- Environment variables dropdown behavior under different conditions
- Submit event emission on blur with empty values
- Type precedence when multiple input modes are available (boolean vs examples, disabled vs enum)
- Error state styling and accessibility attributes
- Dynamic ID assignment behavior
- Edge cases in value serialization (zero values)

These gaps meant potential regressions could slip through undetected.

## Solution

Added 13 new test cases to `CodeInputLite.test.ts` covering:

1. **Dropdown behavior** (2 tests)
   - Verifies dropdown doesn't open when `withVariables` is false
   - Verifies dropdown doesn't open when environment is undefined

2. **Blur/submit behavior** (1 test)
   - Ensures submit event is not emitted on blur when model value is empty

3. **Type/mode precedence** (3 tests)
   - Boolean type takes precedence over examples when both are set
   - Disabled state takes precedence over enum select mode
   - Tuple type containing only null falls back to string in enum mode

4. **Error state** (2 tests)
   - Applies error class and aria-invalid when error prop is true
   - Confirms no error styling by default

5. **Component ID handling** (3 tests)
   - Respects consumer-supplied id attribute
   - Does not assign ID before first focus
   - Generates ID on first focus

6. **Value serialization** (1 test)
   - Correctly renders zero as "0" (edge case for falsy values)

All tests follow existing patterns in the suite and use the `mountInput` helper for consistency.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. (Test-only changes don't require changesets)
- [x] I added tests.
- [ ] I updated the documentation. (N/A for test additions)

https://claude.ai/code/session_016ayrC4vBkdBPvjBQNSW3zE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add assertions around edge cases and accessibility attributes without modifying production logic.
> 
> **Overview**
> Adds missing `CodeInputLite` test coverage for environment-variable dropdown gating (`withVariables`, missing `environment`), blur/submit behavior for empty values, and select-mode precedence (boolean vs examples, disabled vs enum, tuple type fallback).
> 
> Extends assertions around accessibility/styling (`error` → `aria-invalid`, `required` indicator text + `aria-required`), dynamic `id` assignment on focus, and value serialization edge cases (e.g. `0` → "0").
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ca8ce4734785b34deeffcf122dbd394d70650c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->