### PR TITLE
chore: update CSP and changeset documentation for projects

### DIFF
--- a/.changeset/csp-allow-https-images.md
+++ b/.changeset/csp-allow-https-images.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: allow images from any HTTPS source in CSP

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,7 +329,7 @@ If both a Linear ticket and a GitHub issue are provided, include both.
 
 ### Changesets
 
-For code changes in `packages/*` and `integrations/*`, include a changeset using `patch` or `minor` (do not use `major`).
+For code changes in `packages/*`, `integrations/*`, and `projects/*`, include a changeset using `patch` or `minor` (do not use `major`).
 
 Before opening or updating a PR, run:
 

--- a/projects/scalar-app/entrypoints/electron/renderer/index.html
+++ b/projects/scalar-app/entrypoints/electron/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
   </head>
 
   <body class="scalar-app">

--- a/projects/scalar-app/entrypoints/electron/renderer/index.html
+++ b/projects/scalar-app/entrypoints/electron/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
   </head>
 
   <body class="scalar-app">

--- a/projects/scalar-app/entrypoints/web/index.html
+++ b/projects/scalar-app/entrypoints/web/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://*.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob: https://*.vector.co; font-src https://fonts.scalar.com 'self'" />
+      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://*.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob: https://*.vector.co; font-src https://fonts.scalar.com 'self'" />
     <link
       rel="icon"
       type="image/png"

--- a/projects/scalar-app/entrypoints/web/index.html
+++ b/projects/scalar-app/entrypoints/web/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://*.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com https://*.vector.co; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob: https://*.vector.co; font-src https://fonts.scalar.com 'self'" />
+      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://*.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob: https://*.vector.co; font-src https://fonts.scalar.com 'self'" />
     <link
       rel="icon"
       type="image/png"


### PR DESCRIPTION
## Problem

The Content Security Policy (CSP) headers in the Electron and web entry points were overly restrictive for image sources, and the changeset documentation did not account for changes in the `projects/` directory.

## Solution

1. **CSP Updates**: Relaxed the `img-src` directive from `'self' data: blob: https://cdn.usefathom.com https://*.scalar.com https://scalar.com` to `'self' https:` to allow loading images from any HTTPS source. This simplifies the policy and reduces maintenance burden when new image sources are added.

2. **Documentation**: Updated `AGENTS.md` to clarify that changesets are required for code changes in `packages/*`, `integrations/*`, and `projects/*` directories.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. (Not applicable—documentation and configuration updates)
- [ ] I added tests. (Not applicable—configuration changes)
- [ ] I updated the documentation. (Yes—updated AGENTS.md)

https://claude.ai/code/session_012ofys5AedhWgkf9z9hqdry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes CSP `img-src` in both Electron and web entrypoints to allow any `https:` images, which may increase exposure to loading unintended remote content if other controls are lacking. Otherwise changes are small and localized (plus documentation/changeset updates).
> 
> **Overview**
> Updates the Scalar App Content Security Policy in both `projects/scalar-app` web and Electron entrypoints by changing `img-src` to allow loading images from any `https:` origin (instead of a hardcoded allowlist).
> 
> Adds a `scalar-app` patch changeset for the CSP adjustment and updates `AGENTS.md` to require changesets for code changes under `projects/*` in addition to `packages/*` and `integrations/*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2df32b3803773d097d762b8feb32ee253f4a774f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->