### PR TITLE
fix(scalar-app): align team switching with dashboard

### DIFF
--- a/.changeset/gold-paths-check.md
+++ b/.changeset/gold-paths-check.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: align team picker with dashboard

--- a/projects/scalar-app/src/App.vue
+++ b/projects/scalar-app/src/App.vue
@@ -15,7 +15,7 @@ export type AppProps = {
 
 <script setup lang="ts">
 import { PostHogClientPlugin } from '@scalar/api-client/plugins/posthog'
-import { ScalarHeaderButton } from '@scalar/components'
+import { ScalarHeaderButton, ScalarMenuTeamProfile } from '@scalar/components'
 import { safeRun } from '@scalar/helpers/types/safe-run'
 import { type LoaderPlugin } from '@scalar/json-magic/bundle'
 import { requestScriptsPlugin } from '@scalar/pre-post-request-scripts/plugins'
@@ -283,13 +283,9 @@ const registry = reactive({
 
       <!-- Team Logo -->
       <template
-        v-if="currentTeam?.imageUri"
+        v-if="currentTeam"
         #header-logo>
-        <img
-          :alt="currentTeam.name"
-          class="size-5 rounded"
-          role="presentation"
-          :src="currentTeam.imageUri" />
+        <ScalarMenuTeamProfile :team="currentTeam" />
       </template>
 
       <template

--- a/projects/scalar-app/src/App.vue
+++ b/projects/scalar-app/src/App.vue
@@ -285,7 +285,10 @@ const registry = reactive({
       <template
         v-if="currentTeam"
         #header-logo>
-        <ScalarMenuTeamProfile :team="currentTeam" />
+        <ScalarMenuTeamProfile
+          class="font-medium"
+          :label="currentTeam.name"
+          :src="currentTeam.imageUri" />
       </template>
 
       <template

--- a/projects/scalar-app/src/features/app/App.vue
+++ b/projects/scalar-app/src/features/app/App.vue
@@ -312,7 +312,6 @@ const routerViewProps = computed<RouteProps>(() => {
           :eventBus="app.eventBus"
           :tabs="app.tabs.state.value" />
         <AppHeader
-          :menuTitle="currentTeam?.name"
           @changed:team="emit('changed:team')"
           @navigate:to:settings="
             app.eventBus.emit('ui:navigate', {

--- a/projects/scalar-app/src/features/app/App.vue
+++ b/projects/scalar-app/src/features/app/App.vue
@@ -42,7 +42,6 @@ import type { CommandPaletteState } from '@/features/command-palette/hooks/use-c
 import TheCommandPalette from '@/features/command-palette/TheCommandPalette.vue'
 import { useMonacoEditorConfiguration } from '@/features/editor'
 import { useColorMode } from '@/hooks/use-color-mode'
-import { useTeams } from '@/hooks/use-teams'
 import { useThemes } from '@/hooks/use-themes'
 import type {
   RegistryAdapter,
@@ -114,8 +113,6 @@ defineSlots<{
 
 const app = getAppState()
 const paletteState = getCommandPaletteState()
-
-const { currentTeam } = useTeams()
 
 /** Expose workspace store to window for debugging purposes. */
 if (typeof window !== 'undefined') {

--- a/projects/scalar-app/src/features/app/components/AppHeader.test.ts
+++ b/projects/scalar-app/src/features/app/components/AppHeader.test.ts
@@ -29,31 +29,86 @@ describe('AppHeader', () => {
     expect(wrapper.find('[data-test="custom-logo"]').exists()).toBe(false)
   })
 
-  it('renders the `menuTitle` prop inline inside the menu trigger so consumers can label the active scope', () => {
-    // The menu trigger doubles as the leading breadcrumb segment by way of
-    // the `menuTitle` prop ("Team" / "Local"). A prop (rather than a slot)
-    // keeps consumers from having to thread a string through a slot just
-    // to communicate which workspace type is active.
+  it('renders the `breadcrumb` slot alongside the menu trigger so consumers can surface the active document and version', () => {
+    // The breadcrumb sits in the start section of the header next to the
+    // menu trigger. Hosts typically thread a document/version picker
+    // through this slot, so we just verify that arbitrary content reaches
+    // the DOM rather than coupling to picker internals.
     const wrapper = mount(AppHeader, {
-      props: {
-        menuTitle: 'Team',
+      slots: {
+        breadcrumb: '<span data-test="breadcrumb">overview / v1</span>',
       },
     })
 
-    // The button hosts the trigger - find it via the radix-set
-    // aria-expanded attribute so the assertion does not couple to the
-    // surrounding chrome.
-    const trigger = wrapper.find('button[aria-expanded]')
-    expect(trigger.text()).toContain('Team')
+    const breadcrumb = wrapper.find('[data-test="breadcrumb"]')
+    expect(breadcrumb.exists()).toBe(true)
+    expect(breadcrumb.text()).toBe('overview / v1')
   })
 
-  it('omits the menu trigger label when no `menuTitle` prop is provided', () => {
+  it('does not render the `breadcrumb` slot wrapper when no breadcrumb is provided', () => {
+    // Absence of the slot means the start section should only host the
+    // menu trigger - guarding against an empty wrapper that would otherwise
+    // affect layout and spacing.
     const wrapper = mount(AppHeader)
 
-    // Without a label the trigger should still mount cleanly (only the
-    // logo + caret) - the absence of stray text is the contract here.
-    const trigger = wrapper.find('button[aria-expanded]')
-    expect(trigger.text()).not.toContain('Team')
-    expect(trigger.text()).not.toContain('Local')
+    expect(wrapper.find('[data-test="breadcrumb"]').exists()).toBe(false)
+  })
+
+  it('renders the `end` slot in the trailing section of the header for consumer-controlled actions', () => {
+    // The end slot hosts things like the publish button or user menu in
+    // the team workspace. Verifying that arbitrary content reaches the DOM
+    // is the contract; the surrounding `ScalarHeader` chrome is covered
+    // by its own tests in `@scalar/components`.
+    const wrapper = mount(AppHeader, {
+      slots: {
+        end: '<button data-test="end-action">Publish</button>',
+      },
+    })
+
+    const endAction = wrapper.find('[data-test="end-action"]')
+    expect(endAction.exists()).toBe(true)
+    expect(endAction.text()).toBe('Publish')
+  })
+
+  it('overrides the default Settings menu item when the `menuItems` slot is provided', async () => {
+    // The default menu item is a "Settings" link. Consumers replace the
+    // whole section through `menuItems` rather than appending, so the
+    // default must be absent when the slot is filled. We open the menu
+    // first because the items only render once the popover is expanded.
+    const wrapper = mount(AppHeader, {
+      slots: {
+        menuItems: '<button data-test="custom-menu-item">Custom action</button>',
+      },
+      attachTo: document.body,
+    })
+
+    await wrapper.find('button[aria-expanded]').trigger('click')
+
+    const customItem = document.querySelector('[data-test="custom-menu-item"]')
+    expect(customItem).not.toBeNull()
+    expect(customItem?.textContent).toBe('Custom action')
+
+    // The default Settings entry should not appear when the slot wins.
+    expect(document.body.textContent).not.toContain('Settings')
+
+    wrapper.unmount()
+  })
+
+  it('emits `navigate:to:settings` when the default Settings menu item is activated', async () => {
+    // The default menu item exists so hosts that do not customize the
+    // menu still get a working settings entry point. Clicking it should
+    // bubble an intent (not a route) so the host owns navigation.
+    const wrapper = mount(AppHeader, { attachTo: document.body })
+
+    await wrapper.find('button[aria-expanded]').trigger('click')
+
+    const settings = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.includes('Settings'))
+    expect(settings).toBeDefined()
+    settings?.click()
+
+    expect(wrapper.emitted('navigate:to:settings')).toBeTruthy()
+    expect(wrapper.emitted('navigate:to:settings')?.length).toBe(1)
+
+    wrapper.unmount()
   })
 })

--- a/projects/scalar-app/src/features/app/components/AppHeader.vue
+++ b/projects/scalar-app/src/features/app/components/AppHeader.vue
@@ -15,17 +15,6 @@ import { computed } from 'vue'
 import { useAuth } from '@/hooks/use-auth'
 import { useTeams } from '@/hooks/use-teams'
 
-defineProps<{
-  /**
-   * Inline label rendered inside the menu trigger between the logo and the
-   * caret. Used to surface the active scope ("Team" / "Local") so the menu
-   * trigger doubles as the leading breadcrumb segment. Pass a plain string
-   * so consumers do not have to pierce through a slot pipeline just to
-   * tell the header which workspace type is active.
-   */
-  menuTitle?: string
-}>()
-
 const emit = defineEmits<{
   /** Emitted when the user wants to open the workspace settings */
   (e: 'navigate:to:settings'): void
@@ -92,13 +81,6 @@ const switchTeam = async (t?: ScalarMenuTeamOption) => {
           v-if="slots.logo"
           #logo>
           <slot name="logo" />
-        </template>
-        <template
-          v-if="menuTitle"
-          #title>
-          <span class="max-md:hidden">
-            {{ menuTitle }}
-          </span>
         </template>
         <template #products>
           <ScalarMenuProducts selected="client" />


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="286" height="287" alt="image" src="https://github.com/user-attachments/assets/a127cc03-a8f2-4860-abb0-d0acd03a55fc" /> | <img width="352" height="263" alt="image" src="https://github.com/user-attachments/assets/96801efc-82d0-4bee-bc5e-c26e8878eb9f" /> | 

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI composition change in the header/menu; main impact is potential layout/slot regressions around team branding and breadcrumbs.
> 
> **Overview**
> Aligns the app header’s team-switching/branding UI with the dashboard by swapping the simple team logo `img` for `ScalarMenuTeamProfile` and rendering it whenever a `currentTeam` exists.
> 
> Simplifies `AppHeader` integration by removing the `menuTitle` prop usage, relying on slots instead (notably `breadcrumb` and `end`), and updates/expands `AppHeader` tests to cover breadcrumb rendering, end-slot rendering, and default vs overridden Settings menu behavior.
> 
> Adds a changeset bump for `scalar-app` (patch) describing the alignment fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a48c0bf327f942e19ddfb25c2d1abac43108bec6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->