### PR TITLE
fix(scalar-app): some analytics events not firing

### DIFF
--- a/.changeset/smooth-plants-open.md
+++ b/.changeset/smooth-plants-open.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'scalar-app': patch
+---
+
+fix: some analytics events not firing

--- a/packages/api-client/src/plugins/posthog/sanitize-event-payload.test.ts
+++ b/packages/api-client/src/plugins/posthog/sanitize-event-payload.test.ts
@@ -15,7 +15,8 @@ const sanitize = sanitizeEventPayload as (
 describe('sanitizeEventPayload', () => {
   it('returns null for an untracked event', () => {
     expect(sanitize('unknown:event' as keyof ApiReferenceEvents, {})).toBeNull()
-    expect(sanitize('log:user-login', { uid: '123' })).toBeNull()
+    // Opted-out event: known to the event bus but explicitly excluded from analytics.
+    expect(sanitize('auth:update:security-scheme-secrets', {})).toBeNull()
   })
 
   it('returns empty object for tracked events that extract no properties', () => {
@@ -24,6 +25,8 @@ describe('sanitizeEventPayload', () => {
     expect(sanitize('operation:send:request:hotkey', null)).toEqual({})
     expect(sanitize('ui:open:command-palette', { secret: 'abc' })).toEqual({})
     expect(sanitize('log:login-click', {})).toEqual({})
+    expect(sanitize('log:user-login', { uid: '123', email: 'test@example.com', teamUid: 't1' })).toEqual({})
+    expect(sanitize('log:user-logout', undefined)).toEqual({})
     expect(sanitize('hooks:on:request:sent', {})).toEqual({})
   })
 
@@ -194,6 +197,8 @@ describe('TRACKED_EVENTS', () => {
     'update:selected-client',
     'log:login-click',
     'log:register-click',
+    'log:user-login',
+    'log:user-logout',
   ]
 
   it('has an extractor function for every tracked event', () => {

--- a/packages/api-client/src/plugins/posthog/sanitize-event-payload.ts
+++ b/packages/api-client/src/plugins/posthog/sanitize-event-payload.ts
@@ -118,6 +118,8 @@ export const TRACKED_EVENTS: TrackedEventsMap = {
   // Account funnel events
   'log:login-click': empty,
   'log:register-click': empty,
+  'log:user-login': empty,
+  'log:user-logout': empty,
 
   // ---------------------------------------------------------------------------
   // Do not track — explicitly opted out so new events cause a type error
@@ -127,8 +129,6 @@ export const TRACKED_EVENTS: TrackedEventsMap = {
   'analytics:on:show-more': undefined,
   'analytics:on:loaded': undefined,
   'document:update:extension': undefined,
-  'log:user-login': undefined,
-  'log:user-logout': undefined,
   'operation:update:meta': undefined,
   'operation:update:extension': undefined,
   'operation:upsert:parameter': undefined,

--- a/projects/scalar-app/src/App.vue
+++ b/projects/scalar-app/src/App.vue
@@ -56,6 +56,7 @@ const {
 } = useTeams()
 
 const { handleLogin, handleRegister } = useAuthHandlers({
+  eventBus: app.eventBus,
   // Lets go to the team workspace on login
   onAuthenticated: async () => {
     await teamsSuspense()

--- a/projects/scalar-app/src/features/app/App.vue
+++ b/projects/scalar-app/src/features/app/App.vue
@@ -91,7 +91,7 @@ const registryDocuments = computed<RegistryDocumentsState>(
   () => registry?.documents ?? { status: 'success', documents: [] },
 )
 
-const slots = defineSlots<{
+defineSlots<{
   /**
    * Replaces the Scalar logo inside the header menu button. Typically used by
    * team-aware consumers (e.g. Scalar Cloud) to render a team avatar so the

--- a/projects/scalar-app/src/features/app/App.vue
+++ b/projects/scalar-app/src/features/app/App.vue
@@ -41,6 +41,7 @@ import { useDocumentWatcher } from '@/features/app/hooks/use-document-watcher'
 import type { CommandPaletteState } from '@/features/command-palette/hooks/use-command-palette-state'
 import TheCommandPalette from '@/features/command-palette/TheCommandPalette.vue'
 import { useMonacoEditorConfiguration } from '@/features/editor'
+import { useAuth } from '@/hooks/use-auth'
 import { useColorMode } from '@/hooks/use-color-mode'
 import { useTeams } from '@/hooks/use-teams'
 import { useThemes } from '@/hooks/use-themes'
@@ -90,7 +91,7 @@ const registryDocuments = computed<RegistryDocumentsState>(
   () => registry?.documents ?? { status: 'success', documents: [] },
 )
 
-defineSlots<{
+const slots = defineSlots<{
   /**
    * Replaces the Scalar logo inside the header menu button. Typically used by
    * team-aware consumers (e.g. Scalar Cloud) to render a team avatar so the
@@ -138,6 +139,21 @@ watch(app.telemetry, () => {
     plugin.lifecycle?.onConfigChange?.({
       config: { telemetry: app.telemetry.value },
     })
+  }
+})
+
+const { tokenData } = useAuth()
+
+/** Notify logging in/out */
+watch(tokenData, async (newTokenData, oldTokenData) => {
+  if (newTokenData && !oldTokenData) {
+    app.eventBus.emit('log:user-login', {
+      uid: newTokenData.userUid,
+      email: newTokenData.email,
+      teamUid: newTokenData.teamUid,
+    })
+  } else if (!newTokenData && oldTokenData) {
+    app.eventBus.emit('log:user-logout')
   }
 })
 

--- a/projects/scalar-app/src/hooks/use-auth-handlers.test.ts
+++ b/projects/scalar-app/src/hooks/use-auth-handlers.test.ts
@@ -1,3 +1,4 @@
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAuthHandlers } from './use-auth-handlers'
@@ -32,6 +33,34 @@ const stubLocation = () => {
   return location
 }
 
+/**
+ * Build a minimal mock event bus that records `emit` calls.
+ * We only need `emit` for these tests, so the rest of the interface is stubbed.
+ */
+const createMockEventBus = () => {
+  const emit = vi.fn()
+  const noop = () => undefined
+  const bus = {
+    emit,
+    on: vi.fn(() => noop),
+    once: vi.fn(() => noop),
+    off: vi.fn(),
+    onAny: vi.fn(() => noop),
+  } as unknown as WorkspaceEventBus
+  return { bus, emit }
+}
+
+/** Default args factory so each test gets a fresh mock event bus and `onAuthenticated`. */
+const createArgs = (overrides: Partial<Parameters<typeof useAuthHandlers>[0]> = {}) => {
+  const { bus, emit } = createMockEventBus()
+  const onAuthenticated = vi.fn()
+  return {
+    args: { eventBus: bus, onAuthenticated, ...overrides },
+    emit,
+    onAuthenticated,
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -53,7 +82,8 @@ describe('useAuthHandlers', () => {
         vi.stubGlobal('electron', false)
         const location = stubLocation()
 
-        const { handleLogin } = useAuthHandlers()
+        const { args } = createArgs()
+        const { handleLogin } = useAuthHandlers(args)
         await handleLogin()
 
         expect(location.href).toBe('https://dashboard.test/login')
@@ -66,10 +96,22 @@ describe('useAuthHandlers', () => {
         const getExchangeToken = vi.fn()
         vi.stubGlobal('api', { getExchangeToken })
 
-        const { handleLogin } = useAuthHandlers()
+        const { args } = createArgs()
+        const { handleLogin } = useAuthHandlers(args)
         await handleLogin()
 
         expect(getExchangeToken).not.toHaveBeenCalled()
+      })
+
+      it('emits log:login-click on the event bus', async () => {
+        vi.stubGlobal('electron', false)
+        stubLocation()
+
+        const { args, emit } = createArgs()
+        const { handleLogin } = useAuthHandlers(args)
+        await handleLogin()
+
+        expect(emit).toHaveBeenCalledWith('log:login-click', undefined)
       })
     })
 
@@ -83,7 +125,8 @@ describe('useAuthHandlers', () => {
         const getExchangeToken = vi.fn().mockResolvedValue(null)
         vi.stubGlobal('api', { getExchangeToken })
 
-        const { handleLogin } = useAuthHandlers()
+        const { args } = createArgs()
+        const { handleLogin } = useAuthHandlers(args)
         await handleLogin()
 
         expect(getExchangeToken).toHaveBeenCalledWith('login')
@@ -93,7 +136,8 @@ describe('useAuthHandlers', () => {
         const tokens = { accessToken: 'access.tok', refreshToken: 'refresh.tok' }
         vi.stubGlobal('api', { getExchangeToken: vi.fn().mockResolvedValue(tokens) })
 
-        const { handleLogin } = useAuthHandlers()
+        const { args } = createArgs()
+        const { handleLogin } = useAuthHandlers(args)
         await handleLogin()
 
         expect(mockSetTokens).toHaveBeenCalledWith(tokens.accessToken, tokens.refreshToken)
@@ -103,7 +147,8 @@ describe('useAuthHandlers', () => {
       it('shows an error toast and does not store tokens when exchange returns null', async () => {
         vi.stubGlobal('api', { getExchangeToken: vi.fn().mockResolvedValue(null) })
 
-        const { handleLogin } = useAuthHandlers()
+        const { args } = createArgs()
+        const { handleLogin } = useAuthHandlers(args)
         await handleLogin()
 
         expect(mockSetTokens).not.toHaveBeenCalled()
@@ -116,10 +161,21 @@ describe('useAuthHandlers', () => {
         const location = stubLocation()
         vi.stubGlobal('api', { getExchangeToken: vi.fn().mockResolvedValue(null) })
 
-        const { handleLogin } = useAuthHandlers()
+        const { args } = createArgs()
+        const { handleLogin } = useAuthHandlers(args)
         await handleLogin()
 
         expect(location.href).toBe('')
+      })
+
+      it('emits log:login-click on the event bus', async () => {
+        vi.stubGlobal('api', { getExchangeToken: vi.fn().mockResolvedValue(null) })
+
+        const { args, emit } = createArgs()
+        const { handleLogin } = useAuthHandlers(args)
+        await handleLogin()
+
+        expect(emit).toHaveBeenCalledWith('log:login-click', undefined)
       })
     })
   })
@@ -130,7 +186,8 @@ describe('useAuthHandlers', () => {
         vi.stubGlobal('electron', false)
         const location = stubLocation()
 
-        const { handleRegister } = useAuthHandlers()
+        const { args } = createArgs()
+        const { handleRegister } = useAuthHandlers(args)
         await handleRegister()
 
         expect(location.href).toBe('https://dashboard.test/register')
@@ -143,10 +200,22 @@ describe('useAuthHandlers', () => {
         const getExchangeToken = vi.fn()
         vi.stubGlobal('api', { getExchangeToken })
 
-        const { handleRegister } = useAuthHandlers()
+        const { args } = createArgs()
+        const { handleRegister } = useAuthHandlers(args)
         await handleRegister()
 
         expect(getExchangeToken).not.toHaveBeenCalled()
+      })
+
+      it('emits log:register-click on the event bus', async () => {
+        vi.stubGlobal('electron', false)
+        stubLocation()
+
+        const { args, emit } = createArgs()
+        const { handleRegister } = useAuthHandlers(args)
+        await handleRegister()
+
+        expect(emit).toHaveBeenCalledWith('log:register-click', undefined)
       })
     })
 
@@ -160,7 +229,8 @@ describe('useAuthHandlers', () => {
         const getExchangeToken = vi.fn().mockResolvedValue(null)
         vi.stubGlobal('api', { getExchangeToken })
 
-        const { handleRegister } = useAuthHandlers()
+        const { args } = createArgs()
+        const { handleRegister } = useAuthHandlers(args)
         await handleRegister()
 
         expect(getExchangeToken).toHaveBeenCalledWith('register')
@@ -170,7 +240,8 @@ describe('useAuthHandlers', () => {
         const tokens = { accessToken: 'access.tok', refreshToken: 'refresh.tok' }
         vi.stubGlobal('api', { getExchangeToken: vi.fn().mockResolvedValue(tokens) })
 
-        const { handleRegister } = useAuthHandlers()
+        const { args } = createArgs()
+        const { handleRegister } = useAuthHandlers(args)
         await handleRegister()
 
         expect(mockSetTokens).toHaveBeenCalledWith(tokens.accessToken, tokens.refreshToken)
@@ -180,7 +251,8 @@ describe('useAuthHandlers', () => {
       it('shows an error toast and does not store tokens when exchange returns null', async () => {
         vi.stubGlobal('api', { getExchangeToken: vi.fn().mockResolvedValue(null) })
 
-        const { handleRegister } = useAuthHandlers()
+        const { args } = createArgs()
+        const { handleRegister } = useAuthHandlers(args)
         await handleRegister()
 
         expect(mockSetTokens).not.toHaveBeenCalled()
@@ -193,10 +265,21 @@ describe('useAuthHandlers', () => {
         const location = stubLocation()
         vi.stubGlobal('api', { getExchangeToken: vi.fn().mockResolvedValue(null) })
 
-        const { handleRegister } = useAuthHandlers()
+        const { args } = createArgs()
+        const { handleRegister } = useAuthHandlers(args)
         await handleRegister()
 
         expect(location.href).toBe('')
+      })
+
+      it('emits log:register-click on the event bus', async () => {
+        vi.stubGlobal('api', { getExchangeToken: vi.fn().mockResolvedValue(null) })
+
+        const { args, emit } = createArgs()
+        const { handleRegister } = useAuthHandlers(args)
+        await handleRegister()
+
+        expect(emit).toHaveBeenCalledWith('log:register-click', undefined)
       })
     })
   })

--- a/projects/scalar-app/src/hooks/use-auth-handlers.ts
+++ b/projects/scalar-app/src/hooks/use-auth-handlers.ts
@@ -1,4 +1,5 @@
 import { useToasts } from '@scalar/use-toasts'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 
 import { loginUrl, registerUrl } from '@/helpers/auth/login-url'
 import { useAuth } from '@/hooks/use-auth'
@@ -8,9 +9,14 @@ import { useAuth } from '@/hooks/use-auth'
  *
  * Normally a good candiate for a helper but it touches state so must be a hook
  */
-export const useAuthHandlers = (options?: {
+export const useAuthHandlers = ({
+  eventBus,
+  onAuthenticated,
+}: {
+  /** Workspace event bus, used to emit analytics events for auth button clicks. */
+  eventBus: WorkspaceEventBus
   /** Called after a successful login or register (Electron only — web redirects to the dashboard). */
-  onAuthenticated?: () => void | Promise<void>
+  onAuthenticated: () => void | Promise<void>
 }) => {
   const { toast } = useToasts()
   const { setTokens } = useAuth()
@@ -22,6 +28,8 @@ export const useAuthHandlers = (options?: {
    * On web, redirects to the dashboard login page.
    */
   const handleLogin = async (): Promise<void> => {
+    eventBus.emit('log:login-click', undefined)
+
     if (window.electron !== true) {
       window.location.href = loginUrl()
       return
@@ -35,7 +43,7 @@ export const useAuthHandlers = (options?: {
     } else {
       toast('Logged in successfully', 'info')
       setTokens(result.accessToken, result.refreshToken)
-      await options?.onAuthenticated?.()
+      await onAuthenticated?.()
     }
   }
 
@@ -46,6 +54,8 @@ export const useAuthHandlers = (options?: {
    * On web, redirects to the dashboard registration page.
    */
   const handleRegister = async (): Promise<void> => {
+    eventBus.emit('log:register-click', undefined)
+
     if (window.electron !== true) {
       window.location.href = registerUrl()
       return
@@ -59,7 +69,7 @@ export const useAuthHandlers = (options?: {
     } else {
       toast('Registered successfully', 'info')
       setTokens(result.accessToken, result.refreshToken)
-      await options?.onAuthenticated?.()
+      await onAuthenticated?.()
     }
   }
 


### PR DESCRIPTION
## Problem

We weren't properly triggering login/out

## Solution

Fixed those plus added some differentiation between electron and web, we can already do this but this will add it explicitly.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-related UI hooks and adds new login/logout event emissions; while behavior is mostly additive, the `useAuthHandlers` signature change could break other call sites and the new watcher-driven events need to avoid unintended double-firing.
> 
> **Overview**
> Fixes missing auth analytics by **emitting explicit event-bus events** for `log:login-click`/`log:register-click` from `useAuthHandlers`, and `log:user-login`/`log:user-logout` when auth token state changes in the main app component.
> 
> Updates the PostHog payload sanitizer allowlist so `log:user-login`/`log:user-logout` are **tracked (but with no properties forwarded)**, and adds/updates tests to cover the new tracking and event-bus emissions. Adds a changeset bumping `@scalar/api-client` and `scalar-app` as patch releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e55b2c8df8f6ca597e41f3c50bdcded4db5835f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->