### PR TITLE
fix(scalar-app): make CSP more permissive for cross-origin content

### DIFF
--- a/.changeset/csp-more-permissive.md
+++ b/.changeset/csp-more-permissive.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: make CSP more permissive to allow loading JSON/YAML, scripts, frames, and media from any HTTPS source

--- a/projects/scalar-app/entrypoints/electron/renderer/index.html
+++ b/projects/scalar-app/entrypoints/electron/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
+      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src * data: blob:; media-src * data: blob:; object-src 'self' blob:; frame-src * blob:; font-src 'self' https:" />
   </head>
 
   <body class="scalar-app">

--- a/projects/scalar-app/entrypoints/electron/renderer/index.html
+++ b/projects/scalar-app/entrypoints/electron/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src * data: blob:; media-src * data: blob:; object-src 'self' blob:; frame-src * blob:; font-src 'self' https:" />
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://*.vector.co https://*.liadm.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src * data: blob:; media-src * data: blob:; object-src 'self' blob:; frame-src * blob:; font-src 'self' https:" />
   </head>
 
   <body class="scalar-app">

--- a/projects/scalar-app/entrypoints/web/index.html
+++ b/projects/scalar-app/entrypoints/web/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src * data: blob:; media-src * data: blob:; object-src 'self' blob:; frame-src * blob:; font-src 'self' https:" />
+      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://*.vector.co https://*.liadm.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src * data: blob:; media-src * data: blob:; object-src 'self' blob:; frame-src * blob:; font-src 'self' https:" />
     <link
       rel="icon"
       type="image/png"

--- a/projects/scalar-app/entrypoints/web/index.html
+++ b/projects/scalar-app/entrypoints/web/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://*.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob: https://*.vector.co; font-src https://fonts.scalar.com 'self'" />
+      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src * data: blob:; media-src * data: blob:; object-src 'self' blob:; frame-src * blob:; font-src 'self' https:" />
     <link
       rel="icon"
       type="image/png"


### PR DESCRIPTION
Allow scripts, frames, images, media, and fonts from any HTTPS source so
users can load JSON/YAML from any domain and trackers (vector.co, liadm.com,
apollo.io, etc.) load without CSP errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This significantly broadens the app’s Content Security Policy (e.g., `img-src`, `media-src`, and `frame-src` to `*`, and looser `font-src`), increasing exposure to malicious third-party content and XSS/embedding risks if any injection or untrusted URLs exist.
> 
> **Overview**
> Relaxes the `Content-Security-Policy` meta tag in both the web and Electron renderer entrypoints to **allow loading images, media, and frames from any origin (`*`)**, and to permit fonts from any HTTPS source.
> 
> Extends `script-src` allowlists to include additional third-party domains (e.g., `*.liadm.com`) so external trackers/assets load without CSP errors, and adds a patch changeset documenting the CSP loosening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f536f62f8d45c6f0848038c78c4ada2a07c01fbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->