### PR TITLE
feat(aspnetcore): cryptographic nonce for script tags

### DIFF
--- a/.changeset/silver-masks-punch.md
+++ b/.changeset/silver-masks-punch.md
@@ -2,4 +2,4 @@
 '@scalar/aspnetcore': minor
 ---
 
-Support cryptographic nonce for script tags
+Support cryptographic nonce for script tags, with automatic per-request generation via the parameterless `WithNonce()` extension.

--- a/.changeset/silver-masks-punch.md
+++ b/.changeset/silver-masks-punch.md
@@ -1,5 +1,5 @@
 ---
-'@scalar/aspnetcore': patch
+'@scalar/aspnetcore': minor
 ---
 
 Support cryptographic nonce for script tags

--- a/.changeset/silver-masks-punch.md
+++ b/.changeset/silver-masks-punch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+Support cryptographic nonce for script tags

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -152,6 +152,12 @@ public static class ScalarEndpointRouteBuilderExtensions
                 ? string.Empty
                 : $" nonce=\"{HtmlEncoder.Default.Encode(options.Nonce)}\"";
 
+            if (!string.IsNullOrWhiteSpace(options.Nonce))
+            {
+                // Prevent intermediaries and browsers from replaying a one-time nonce to another client.
+                httpContext.Response.Headers.CacheControl = "no-store";
+            }
+
             return Results.Content(
                 $$"""
                   <!doctype html>

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -259,7 +259,11 @@ public static class ScalarEndpointRouteBuilderExtensions
     {
         Span<byte> bytes = stackalloc byte[32];
         RandomNumberGenerator.Fill(bytes);
-        return Convert.ToBase64String(bytes);
+        // Base64url avoids '+' and '/', which HtmlEncoder.Default would otherwise escape as numeric entities.
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
     }
 
     private static bool ShouldRedirectToTrailingSlash(HttpContext httpContext, string? documentName, [NotNullWhen(true)] out string? redirectUrl)

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -147,6 +147,13 @@ public static class ScalarEndpointRouteBuilderExtensions
 
             var escapedRequestPath = Uri.EscapeDataString(httpContext.Request.Path);
 
+            var nonceAttribute = string.Empty;
+
+            if (!string.IsNullOrWhiteSpace(options.Nonce))
+            {
+                nonceAttribute = $" nonce=\"{options.Nonce}\"";
+            }
+
             return Results.Content(
                 $$"""
                   <!doctype html>
@@ -160,9 +167,9 @@ public static class ScalarEndpointRouteBuilderExtensions
                   <body>
                       {{options.HeaderContent}}
                       <div id="app"></div>
-                      <script src="{{standaloneResourceUrl}}"></script>
-                      <script type="module" src="{{ScalarJavaScriptHelperFile}}"></script>
-                      <script type="module">
+                      <script src="{{standaloneResourceUrl}}"{{nonceAttribute}}></script>
+                      <script type="module" src="{{ScalarJavaScriptHelperFile}}"{{nonceAttribute}}></script>
+                      <script type="module"{{nonceAttribute}}>
                           import { initialize } from './{{ScalarJavaScriptHelperFile}}'
                           initialize(
                           '{{escapedRequestPath}}',

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Net.Mime;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -147,12 +148,9 @@ public static class ScalarEndpointRouteBuilderExtensions
 
             var escapedRequestPath = Uri.EscapeDataString(httpContext.Request.Path);
 
-            var nonceAttribute = string.Empty;
-
-            if (!string.IsNullOrWhiteSpace(options.Nonce))
-            {
-                nonceAttribute = $" nonce=\"{options.Nonce}\"";
-            }
+            var nonceAttribute = string.IsNullOrWhiteSpace(options.Nonce)
+                ? string.Empty
+                : $" nonce=\"{HtmlEncoder.Default.Encode(options.Nonce)}\"";
 
             return Results.Content(
                 $$"""

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Net.Mime;
+using System.Security.Cryptography;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
@@ -148,15 +149,21 @@ public static class ScalarEndpointRouteBuilderExtensions
 
             var escapedRequestPath = Uri.EscapeDataString(httpContext.Request.Path);
 
-            var nonceAttribute = string.IsNullOrWhiteSpace(options.Nonce)
-                ? string.Empty
-                : $" nonce=\"{HtmlEncoder.Default.Encode(options.Nonce)}\"";
+            // Auto-generated values win when both are set — a per-request nonce is the secure path.
+            var effectiveNonce = options.DynamicNonce
+                ? GenerateNonce()
+                : options.Nonce;
 
-            if (!string.IsNullOrWhiteSpace(options.Nonce))
+            if (!string.IsNullOrWhiteSpace(effectiveNonce))
             {
+                httpContext.Items[ScalarOptions.NonceHttpContextItemKey] = effectiveNonce;
                 // Prevent intermediaries and browsers from replaying a one-time nonce to another client.
                 httpContext.Response.Headers.CacheControl = "no-store";
             }
+
+            var nonceAttribute = string.IsNullOrWhiteSpace(effectiveNonce)
+                ? string.Empty
+                : $" nonce=\"{HtmlEncoder.Default.Encode(effectiveNonce)}\"";
 
             return Results.Content(
                 $$"""
@@ -246,6 +253,13 @@ public static class ScalarEndpointRouteBuilderExtensions
         // We don't have pre-compress files in Debug builds
         return resourceFile.CreateReadStream();
 #endif
+    }
+
+    private static string GenerateNonce()
+    {
+        Span<byte> bytes = stackalloc byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes);
     }
 
     private static bool ShouldRedirectToTrailingSlash(HttpContext httpContext, string? documentName, [NotNullWhen(true)] out string? redirectUrl)

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -284,4 +284,21 @@ public static partial class ScalarOptionsExtensions
         options.Nonce = nonce;
         return options;
     }
+
+    /// <summary>
+    /// Configures Scalar to generate a fresh cryptographically random nonce on every request and emit it on each script tag.
+    /// </summary>
+    /// <param name="options">The <see cref="ScalarOptions" /> to configure.</param>
+    /// <returns>The configured <see cref="ScalarOptions" />.</returns>
+    /// <remarks>
+    /// The generated value is also stored on <c>HttpContext.Items</c> under the key
+    /// <see cref="ScalarOptions.NonceHttpContextItemKey" /> so downstream middleware can read it and emit a matching
+    /// <c>Content-Security-Policy: script-src 'nonce-{value}'</c> header (typically via <c>HttpResponse.OnStarting</c>, since this
+    /// endpoint runs at the end of the request pipeline).
+    /// </remarks>
+    public static ScalarOptions WithNonce(this ScalarOptions options)
+    {
+        options.DynamicNonce = true;
+        return options;
+    }
 }

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -277,8 +277,18 @@ public static partial class ScalarOptionsExtensions
     }
 
     /// <summary>
-    /// Controls whether to add a cryptographic nonce as an attribute to the script tags.
+    /// Sets a static cryptographic nonce to emit on the rendered script tags.
     /// </summary>
+    /// <param name="options">The <see cref="ScalarOptions" /> to configure.</param>
+    /// <param name="nonce">The nonce value to emit on each script tag.</param>
+    /// <returns>The configured <see cref="ScalarOptions" />.</returns>
+    /// <remarks>
+    /// A matching <c>Content-Security-Policy: script-src 'nonce-{value}'</c> header must be sent on the same response for the nonce
+    /// to have any effect. Because nonces must be unpredictable and used only once, prefer the parameterless
+    /// <see cref="WithNonce(ScalarOptions)" /> overload for automatic per-request generation, or compute a value from your own CSP
+    /// middleware via the <c>MapScalarApiReference(Action&lt;ScalarOptions, HttpContext&gt;)</c> overload. Passing a static value
+    /// at startup defeats CSP protection and is only appropriate when the value comes from a per-request source.
+    /// </remarks>
     public static ScalarOptions WithNonce(this ScalarOptions options, string nonce)
     {
         options.Nonce = nonce;

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -275,4 +275,13 @@ public static partial class ScalarOptionsExtensions
         options.JavaScriptConfiguration = javaScriptConfiguration;
         return options;
     }
+
+    /// <summary>
+    /// Controls whether to add a cryptographic nonce as an attribute to the script tags.
+    /// </summary>
+    public static ScalarOptions WithNonce(this ScalarOptions options, string nonce)
+    {
+        options.Nonce = nonce;
+        return options;
+    }
 }

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarOptionsExtensions.cs
@@ -288,6 +288,8 @@ public static partial class ScalarOptionsExtensions
     /// <see cref="WithNonce(ScalarOptions)" /> overload for automatic per-request generation, or compute a value from your own CSP
     /// middleware via the <c>MapScalarApiReference(Action&lt;ScalarOptions, HttpContext&gt;)</c> overload. Passing a static value
     /// at startup defeats CSP protection and is only appropriate when the value comes from a per-request source.
+    /// Emitting a nonce also sets <c>Cache-Control: no-store</c> on the response, overriding any prior value, since a nonced
+    /// response cannot be safely cached.
     /// </remarks>
     public static ScalarOptions WithNonce(this ScalarOptions options, string nonce)
     {
@@ -304,7 +306,8 @@ public static partial class ScalarOptionsExtensions
     /// The generated value is also stored on <c>HttpContext.Items</c> under the key
     /// <see cref="ScalarOptions.NonceHttpContextItemKey" /> so downstream middleware can read it and emit a matching
     /// <c>Content-Security-Policy: script-src 'nonce-{value}'</c> header (typically via <c>HttpResponse.OnStarting</c>, since this
-    /// endpoint runs at the end of the request pipeline).
+    /// endpoint runs at the end of the request pipeline). Emitting a nonce also sets <c>Cache-Control: no-store</c> on the response,
+    /// overriding any prior value, since a nonced response cannot be safely cached.
     /// </remarks>
     public static ScalarOptions WithNonce(this ScalarOptions options)
     {

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -77,10 +77,14 @@ public partial class ScalarOptions
     [StringSyntax(StringSyntaxAttribute.Uri)]
     public string? JavaScriptConfiguration { get; set; }
 
-
     /// <summary>
-    /// A cryptographic nonce to be added as an attribute to the script tags.
+    /// A cryptographic nonce emitted as an attribute on the rendered script tags.
     /// </summary>
+    /// <remarks>
+    /// A matching <c>Content-Security-Policy: script-src 'nonce-{value}'</c> header must be sent on the same response. Reusing a
+    /// static value defeats CSP — for safe per-request generation, set <see cref="DynamicNonce" /> (via the parameterless
+    /// <c>WithNonce()</c> extension) instead.
+    /// </remarks>
     public string? Nonce { get; set; }
 
     /// <summary>

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -83,7 +83,8 @@ public partial class ScalarOptions
     /// <remarks>
     /// A matching <c>Content-Security-Policy: script-src 'nonce-{value}'</c> header must be sent on the same response. Reusing a
     /// static value defeats CSP — for safe per-request generation, set <see cref="DynamicNonce" /> (via the parameterless
-    /// <c>WithNonce()</c> extension) instead.
+    /// <c>WithNonce()</c> extension) instead. When <see cref="DynamicNonce" /> is also enabled, the generated value takes
+    /// precedence and this static value is ignored.
     /// </remarks>
     public string? Nonce { get; set; }
 

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -76,4 +76,10 @@ public partial class ScalarOptions
     /// </remarks>
     [StringSyntax(StringSyntaxAttribute.Uri)]
     public string? JavaScriptConfiguration { get; set; }
+
+
+    /// <summary>
+    /// A cryptographic nonce to be added as an attribute to the script tags. 
+    /// </summary>
+    public string? Nonce { get; set; }
 }

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Options/ScalarOptions.cs
@@ -79,7 +79,21 @@ public partial class ScalarOptions
 
 
     /// <summary>
-    /// A cryptographic nonce to be added as an attribute to the script tags. 
+    /// A cryptographic nonce to be added as an attribute to the script tags.
     /// </summary>
     public string? Nonce { get; set; }
+
+    /// <summary>
+    /// Controls whether Scalar generates a fresh cryptographically random nonce on every request.
+    /// </summary>
+    /// <remarks>
+    /// When set to <c>true</c>, a new value is created per request and emitted on each script tag. The generated value is also
+    /// written to <c>HttpContext.Items</c> under the key <see cref="NonceHttpContextItemKey" /> so a CSP middleware can pick it up.
+    /// </remarks>
+    public bool DynamicNonce { get; set; }
+
+    /// <summary>
+    /// The key used to store the active nonce on <c>HttpContext.Items</c> when <see cref="DynamicNonce" /> is enabled.
+    /// </summary>
+    public const string NonceHttpContextItemKey = "Scalar.Nonce";
 }

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -336,7 +336,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         var indexContent = await index.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         indexContent.Should().NotContain(" nonce=\"");
-        (index.Headers.CacheControl?.NoStore).Should().NotBe(true);
+        index.Headers.CacheControl.Should().BeNull();
     }
 
     [Fact]

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -380,6 +380,37 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         Regex.Count(secondHtml, $" nonce=\"{Regex.Escape(secondNonce!)}\"").Should().Be(3);
     }
 
+    [Fact]
+    public async Task MapScalarApiReference_ShouldPreferDynamicNonceOverStaticValue_WhenBothAreSet()
+    {
+        // Arrange
+        const string staticNonce = "static-nonce-should-not-be-rendered";
+        var localFactory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.Configure(options =>
+            {
+                options.UseRouting();
+                options.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapScalarApiReference(o => o.WithNonce(staticNonce).WithNonce());
+                });
+            });
+        });
+        var client = localFactory.CreateClient();
+
+        // Act
+        var index = await client.GetAsync("/scalar", TestContext.Current.CancellationToken);
+
+        // Assert
+        index.StatusCode.Should().Be(HttpStatusCode.OK);
+        var indexContent = await index.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        indexContent.Should().NotContain(staticNonce);
+        var rendered = ExtractNonce(indexContent);
+        rendered.Should().NotBeNullOrEmpty();
+        rendered.Should().NotBe(staticNonce);
+    }
+
     private static string? ExtractNonce(string html)
     {
         var match = Regex.Match(html, " nonce=\"([^\"]+)\"");

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -1,6 +1,7 @@
 using System.IO.Compression;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Security.Cryptography;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -286,5 +287,42 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         content.Should().Contain("<title>Scalar API Reference | v1</title>");
+    }
+
+    [Fact]
+    public async Task MapScalarApiReference_ShouldUseNonce_WhenRequested()
+    {
+        // Arrange
+        var nonce = GenerateNounce();
+        var localFactory = factory.WithWebHostBuilder(builder =>
+        {
+            // builder.ConfigureTestServices(services => services.Configure<ScalarOptions>(o => o.WithTheme(ScalarTheme.Mars)));
+            builder.Configure(options =>
+            {
+                options.UseRouting();
+                options.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapScalarApiReference(o => o.WithNonce(nonce));
+                });
+            });
+        });
+        var client = localFactory.CreateClient();
+
+        // Act
+        var index = await client.GetAsync("/scalar", TestContext.Current.CancellationToken);
+
+        // Assert
+        index.StatusCode.Should().Be(HttpStatusCode.OK);
+        var indexContent = await index.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        indexContent.Should().Contain($" nonce=\"{nonce}\"");
+    }
+
+    private static string GenerateNounce()
+    {
+        using var rng = RandomNumberGenerator.Create();
+        var nonceBytes = new byte[32];
+        rng.GetBytes(nonceBytes);
+        return Convert.ToBase64String(nonceBytes);
     }
 }

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -2,6 +2,7 @@ using System.IO.Compression;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
+using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -315,7 +316,9 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         index.StatusCode.Should().Be(HttpStatusCode.OK);
         var indexContent = await index.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
-        Regex.Matches(indexContent, $" nonce=\"{Regex.Escape(nonce)}\"").Count.Should().Be(3);
+        // HtmlEncoder escapes characters such as '+' (common in base64) as numeric entities, so match the encoded form.
+        var encodedNonce = HtmlEncoder.Default.Encode(nonce);
+        Regex.Count(indexContent, $" nonce=\"{Regex.Escape(encodedNonce)}\"").Should().Be(3);
         index.Headers.CacheControl!.NoStore.Should().BeTrue();
     }
 
@@ -373,8 +376,8 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         secondNonce.Should().NotBeNullOrEmpty();
         firstNonce.Should().NotBe(secondNonce);
 
-        Regex.Matches(firstHtml, $" nonce=\"{Regex.Escape(firstNonce!)}\"").Count.Should().Be(3);
-        Regex.Matches(secondHtml, $" nonce=\"{Regex.Escape(secondNonce!)}\"").Count.Should().Be(3);
+        Regex.Count(firstHtml, $" nonce=\"{Regex.Escape(firstNonce!)}\"").Should().Be(3);
+        Regex.Count(secondHtml, $" nonce=\"{Regex.Escape(secondNonce!)}\"").Should().Be(3);
     }
 
     private static string? ExtractNonce(string html)

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -419,9 +419,8 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
 
     private static string GenerateNonce()
     {
-        using var rng = RandomNumberGenerator.Create();
-        var nonceBytes = new byte[32];
-        rng.GetBytes(nonceBytes);
-        return Convert.ToBase64String(nonceBytes);
+        Span<byte> bytes = stackalloc byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes);
     }
 }

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -294,7 +294,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
     public async Task MapScalarApiReference_ShouldUseNonce_WhenRequested()
     {
         // Arrange
-        var nonce = GenerateNounce();
+        var nonce = GenerateNonce();
         var localFactory = factory.WithWebHostBuilder(builder =>
         {
             builder.Configure(options =>
@@ -383,7 +383,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         return match.Success ? match.Groups[1].Value : null;
     }
 
-    private static string GenerateNounce()
+    private static string GenerateNonce()
     {
         using var rng = RandomNumberGenerator.Create();
         var nonceBytes = new byte[32];

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -315,7 +315,25 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         index.StatusCode.Should().Be(HttpStatusCode.OK);
         var indexContent = await index.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
-        indexContent.Should().Contain($" nonce=\"{nonce}\"");
+        Regex.Matches(indexContent, $" nonce=\"{Regex.Escape(nonce)}\"").Count.Should().Be(3);
+        index.Headers.CacheControl!.NoStore.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task MapScalarApiReference_ShouldNotEmitNonceAttribute_WhenNonceNotConfigured()
+    {
+        // Arrange
+        var client = factory.CreateClient();
+
+        // Act
+        var index = await client.GetAsync("/scalar", TestContext.Current.CancellationToken);
+
+        // Assert
+        index.StatusCode.Should().Be(HttpStatusCode.OK);
+        var indexContent = await index.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        indexContent.Should().NotContain(" nonce=\"");
+        (index.Headers.CacheControl?.NoStore).Should().NotBe(true);
     }
 
     [Fact]

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -296,7 +296,6 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         var nonce = GenerateNounce();
         var localFactory = factory.WithWebHostBuilder(builder =>
         {
-            // builder.ConfigureTestServices(services => services.Configure<ScalarOptions>(o => o.WithTheme(ScalarTheme.Mars)));
             builder.Configure(options =>
             {
                 options.UseRouting();

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -2,6 +2,7 @@ using System.IO.Compression;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -315,6 +316,53 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         var indexContent = await index.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         indexContent.Should().Contain($" nonce=\"{nonce}\"");
+    }
+
+    [Fact]
+    public async Task MapScalarApiReference_ShouldGenerateNoncePerRequest_WhenWithNonceCalledWithoutArgs()
+    {
+        // Arrange
+        var localFactory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.Configure(options =>
+            {
+                options.UseRouting();
+                options.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapScalarApiReference(o => o.WithNonce());
+                });
+            });
+        });
+        var client = localFactory.CreateClient();
+
+        // Act
+        var first = await client.GetAsync("/scalar", TestContext.Current.CancellationToken);
+        var second = await client.GetAsync("/scalar", TestContext.Current.CancellationToken);
+
+        // Assert
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        first.Headers.CacheControl!.NoStore.Should().BeTrue();
+        second.Headers.CacheControl!.NoStore.Should().BeTrue();
+
+        var firstHtml = await first.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var secondHtml = await second.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        var firstNonce = ExtractNonce(firstHtml);
+        var secondNonce = ExtractNonce(secondHtml);
+
+        firstNonce.Should().NotBeNullOrEmpty();
+        secondNonce.Should().NotBeNullOrEmpty();
+        firstNonce.Should().NotBe(secondNonce);
+
+        Regex.Matches(firstHtml, $" nonce=\"{Regex.Escape(firstNonce!)}\"").Count.Should().Be(3);
+        Regex.Matches(secondHtml, $" nonce=\"{Regex.Escape(secondNonce!)}\"").Count.Should().Be(3);
+    }
+
+    private static string? ExtractNonce(string html)
+    {
+        var match = Regex.Match(html, " nonce=\"([^\"]+)\"");
+        return match.Success ? match.Groups[1].Value : null;
     }
 
     private static string GenerateNounce()


### PR DESCRIPTION
It's not uncommon for APIs to apply a CSP policy globally to all responses. This change will allow conforming to such a CSP policy by applying a nonce to the script tags. 

An alternative to this change is to add exceptions for Scalar to the CSP policy, which also works OK. But I would like to avoid exceptions if possible.