### PR TITLE
fix(openapi-types): support OpenAPI 3.2 schema forms

### DIFF
--- a/.changeset/openapi-32-schema-types.md
+++ b/.changeset/openapi-32-schema-types.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-types': patch
+---
+
+Allow OpenAPI 3.2 boolean schemas and media type schema references.

--- a/packages/openapi-types/3.2/media-type.d.ts
+++ b/packages/openapi-types/3.2/media-type.d.ts
@@ -16,9 +16,9 @@ export type MediaTypeObject = {
   examples?: Record<string, ExampleObject | ReferenceObject>
   description?: string
   /** A schema describing the complete content of the request, response, parameter, or header. */
-  schema?: SchemaObject
+  schema?: SchemaObject | ReferenceObject
   /** A schema describing each item within a [sequential media type](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md#sequential-media-types). */
-  itemSchema?: SchemaObject
+  itemSchema?: SchemaObject | ReferenceObject
   /** A map between a property name and its encoding information, as defined under [Encoding By Name](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md#encoding-by-name).  The `encoding` field SHALL only apply when the media type is `multipart` or `application/x-www-form-urlencoded`. If no Encoding Object is provided for a property, the behavior is determined by the default values documented for the Encoding Object. This field MUST NOT be present if `prefixEncoding` or `itemEncoding` are present. */
   encoding?: Record<string, EncodingObject>
   /** An array of positional encoding information, as defined under [Encoding By Position](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md#encoding-by-position).  The `prefixEncoding` field SHALL only apply when the media type is `multipart`. If no Encoding Object is provided for a property, the behavior is determined by the default values documented for the Encoding Object. This field MUST NOT be present if `encoding` is present. */

--- a/packages/openapi-types/3.2/schema.d.ts
+++ b/packages/openapi-types/3.2/schema.d.ts
@@ -148,6 +148,7 @@ export type MultiTypeObject = SharedProperties &
     format?: StringFormat | NumericFormat
   } & Extensions
 export type SchemaObject =
+  | boolean
   | UntypedObject
   | OtherTypes
   | NumericObject

--- a/packages/openapi-types/src/openapi-types.test-d.ts
+++ b/packages/openapi-types/src/openapi-types.test-d.ts
@@ -1,5 +1,10 @@
 import { describe, expectTypeOf, it } from 'vitest'
 
+import type {
+  Document as OpenAPIV3_2Document,
+  MediaTypeObject as OpenAPIV3_2MediaTypeObject,
+  SchemaObject as OpenAPIV3_2SchemaObject,
+} from '../3.2'
 import type { OpenAPI, OpenAPIV2, OpenAPIV3, OpenAPIV3_1, OpenAPIV3_2 } from './openapi-types'
 
 describe('OpenAPI', () => {
@@ -82,5 +87,51 @@ describe('OpenAPI', () => {
 
     // @ts-expect-error name is a string
     assertType('NOT_A_METHOD' as OpenAPI.HttpMethod)
+  })
+})
+
+describe('@scalar/openapi-types/3.2', () => {
+  it('allows boolean schemas anywhere a schema object is accepted', () => {
+    expectTypeOf<true>().toExtend<OpenAPIV3_2SchemaObject>()
+    expectTypeOf<false>().toExtend<OpenAPIV3_2SchemaObject>()
+
+    const schema: OpenAPIV3_2SchemaObject = {
+      type: 'object',
+      properties: {
+        anything: true,
+        nothing: false,
+      },
+      allOf: [true, false, { type: 'string' }],
+    }
+
+    const document: OpenAPIV3_2Document = {
+      openapi: '3.2.0',
+      info: {
+        title: 'Boolean schema test',
+        version: '1.0.0',
+      },
+      components: {
+        schemas: {
+          Anything: true,
+          Nothing: false,
+        },
+      },
+    }
+
+    expectTypeOf(schema).not.toBeAny()
+    expectTypeOf(document).not.toBeAny()
+  })
+
+  it('allows media type schemas to be references', () => {
+    const mediaType: OpenAPIV3_2MediaTypeObject = {
+      schema: {
+        $ref: '#/components/schemas/Pet',
+      },
+      itemSchema: {
+        $ref: '#/components/schemas/Pet',
+      },
+    }
+
+    expectTypeOf(mediaType).not.toBeAny()
   })
 })

--- a/projects/scalar-app/RELEASE_NOTES.schema.json
+++ b/projects/scalar-app/RELEASE_NOTES.schema.json
@@ -43,10 +43,7 @@
                   "description": "Plain-text paragraph copy. Use multiple paragraph blocks for multi-paragraph notes."
                 }
               },
-              "required": [
-                "type",
-                "text"
-              ],
+              "required": ["type", "text"],
               "additionalProperties": false,
               "description": "A free-form paragraph rendered between other content blocks."
             },
@@ -78,10 +75,7 @@
                   ]
                 }
               },
-              "required": [
-                "type",
-                "text"
-              ],
+              "required": ["type", "text"],
               "additionalProperties": false,
               "description": "A subsection heading inside a release entry."
             },
@@ -110,10 +104,7 @@
                   "type": "boolean"
                 }
               },
-              "required": [
-                "type",
-                "items"
-              ],
+              "required": ["type", "items"],
               "additionalProperties": false,
               "description": "A bullet (or numbered) list of single-sentence items."
             },
@@ -155,11 +146,7 @@
                   "maximum": 9007199254740991
                 }
               },
-              "required": [
-                "type",
-                "src",
-                "alt"
-              ],
+              "required": ["type", "src", "alt"],
               "additionalProperties": false,
               "description": "An inline image. Provide alt text for accessibility and an optional caption rendered beneath."
             },
@@ -204,10 +191,7 @@
                   "type": "boolean"
                 }
               },
-              "required": [
-                "type",
-                "src"
-              ],
+              "required": ["type", "src"],
               "additionalProperties": false,
               "description": "An inline video clip. Self-hosted MP4/WebM URLs work best - autoplay clips should also set `muted: true`."
             },
@@ -231,11 +215,7 @@
                   "description": "Accessible link text (for example \"Read full release notes\")."
                 }
               },
-              "required": [
-                "type",
-                "href",
-                "label"
-              ],
+              "required": ["type", "href", "label"],
               "additionalProperties": false,
               "description": "Call-to-action link (for example to full release notes on GitHub)."
             }
@@ -244,11 +224,7 @@
         }
       }
     },
-    "required": [
-      "version",
-      "date",
-      "title"
-    ],
+    "required": ["version", "date", "title"],
     "additionalProperties": false,
     "description": "A single curated release note rendered in the \"What's new\" modal."
   },


### PR DESCRIPTION
## Problem

`@scalar/openapi-types/3.2` rejects two valid OpenAPI 3.2 schema patterns reported in #9191 and #9190:

- boolean schemas (`true` / `false`) where a Schema Object is accepted
- media type `schema` and `itemSchema` values that are references

Fixes #9191.
Fixes #9190.

## Solution

- Include `boolean` in the OpenAPI 3.2 `SchemaObject` union.
- Allow `ReferenceObject` for OpenAPI 3.2 `MediaTypeObject.schema` and `MediaTypeObject.itemSchema`.
- Add compile-time regression coverage for the version-specific `@scalar/openapi-types/3.2` exports.
- Add a patch changeset for `@scalar/openapi-types`.
- Format `projects/scalar-app/RELEASE_NOTES.schema.json` so the repo-wide format check passes on the current base.

## Verification

- `pnpm format:check`
- `pnpm --filter @scalar/openapi-types types:check`
- `pnpm --filter @scalar/openapi-types test`
- `pnpm --filter @scalar/openapi-types build`
- `pnpm changeset status --since upstream/main`
- `git diff --check`

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [x] I updated the documentation. (Not applicable: type declaration fix.)
