### PR TITLE
feat(scalar-app): correctly land on an operation when jumping from api-reference

### DIFF
--- a/.changeset/open-api-client-selected-operation.md
+++ b/.changeset/open-api-client-selected-operation.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'scalar-app': patch
+---
+
+feat: open the API client on the selected operation when launching from API Reference. The modal "Open API Client" link now includes `operation_path` and `operation_method` query params; scalar-app reads them after import and navigates to that request. Also fixes address bar blur replay when focus moves programmatically on first navigation into a draft operation.

--- a/packages/api-client/src/v2/blocks/operation-block/components/Header.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/components/Header.test.ts
@@ -52,6 +52,19 @@ describe('Header', () => {
     expect(emitted?.length).toBe(1)
   })
 
+  it('passes current path and method to OpenApiClientButton in modal layout', () => {
+    const modalWithUrl = render({
+      layout: 'modal',
+      documentUrl: 'https://example.com/openapi.json',
+      path: '/users/{id}',
+      method: 'post',
+    })
+    const button = modalWithUrl.getComponent(OpenApiClientButton)
+
+    expect(button.props('operationPath')).toBe('/users/{id}')
+    expect(button.props('operationMethod')).toBe('post')
+  })
+
   it('renders OpenApiClientButton only in modal layout with documentUrl when not hidden', () => {
     const modalWithUrl = render({ layout: 'modal', documentUrl: 'https://example.com/openapi.json' })
     expect(modalWithUrl.findComponent(OpenApiClientButton).exists()).toBe(true)

--- a/packages/api-client/src/v2/blocks/operation-block/components/Header.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/components/Header.vue
@@ -149,6 +149,8 @@ const handleAddEnvironment = () => {
         buttonSource="modal"
         class="!w-fit lg:-mr-1"
         :integration="integration ?? null"
+        :operationMethod="method"
+        :operationPath="path"
         :source="source ?? 'api-reference'"
         :url="documentUrl" />
 

--- a/packages/api-client/src/v2/blocks/operation-block/components/OpenApiClientButton.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/components/OpenApiClientButton.test.ts
@@ -1,0 +1,40 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import OpenApiClientButton from './OpenApiClientButton.vue'
+
+describe('OpenApiClientButton', () => {
+  it('adds operation_path and operation_method query params when provided', () => {
+    const wrapper = mount(OpenApiClientButton, {
+      props: {
+        buttonSource: 'modal',
+        url: 'https://example.com/openapi.json',
+        operationPath: '/pets/{id}',
+        operationMethod: 'GET',
+      },
+      attachTo: document.body,
+    })
+
+    const link = wrapper.get('a')
+    const href = new URL(link.attributes('href')!)
+    expect(href.searchParams.get('url')).toBe('https://example.com/openapi.json')
+    expect(href.searchParams.get('operation_path')).toBe('/pets/{id}')
+    expect(href.searchParams.get('operation_method')).toBe('get')
+  })
+
+  it('does not add operation query params when path or method is missing', () => {
+    const wrapper = mount(OpenApiClientButton, {
+      props: {
+        buttonSource: 'modal',
+        url: 'https://example.com/openapi.json',
+        operationPath: '/pets',
+      },
+      attachTo: document.body,
+    })
+
+    const href = new URL(wrapper.get('a').attributes('href')!)
+
+    expect(href.searchParams.has('operation_path')).toBe(false)
+    expect(href.searchParams.has('operation_method')).toBe(false)
+  })
+})

--- a/packages/api-client/src/v2/blocks/operation-block/components/OpenApiClientButton.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/components/OpenApiClientButton.vue
@@ -7,6 +7,8 @@ const {
   integration,
   isDevelopment,
   url,
+  operationPath,
+  operationMethod,
   buttonSource,
   source = 'api-reference',
 } = defineProps<{
@@ -15,6 +17,10 @@ const {
   isDevelopment?: boolean
   integration?: string | null
   url?: string
+  /** Operation path to open in the client after import */
+  operationPath?: string
+  /** HTTP method for the operation to open in the client after import */
+  operationMethod?: string
 }>()
 
 /** Link to import an OpenAPI document */
@@ -43,6 +49,11 @@ const href = computed((): string | undefined => {
 
   // URL that we'd like to import
   link.searchParams.set('url', absoluteUrl)
+
+  if (operationPath?.length && operationMethod?.length) {
+    link.searchParams.set('operation_path', operationPath)
+    link.searchParams.set('operation_method', operationMethod.toLowerCase())
+  }
 
   // Integration identifier
   if (integration !== null) {

--- a/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
+++ b/packages/api-client/src/v2/blocks/scalar-address-bar-block/components/AddressBar.vue
@@ -307,12 +307,29 @@ const handleMethodChange = (newMethod: HttpMethodType): void =>
 /**
  * Save the path on blur and replay the click that caused the blur (so e.g. a
  * click on the Send button still fires after the async update resolves).
- * Tab-outs explicitly do not replay — tabbing to a button should not trigger
- * its click.
+ *
+ * Tab-outs do not replay — tabbing to a button should not trigger its click
+ * (`tabbedOut` is set on `@keydown.tab`).
+ *
+ * Programmatic focus moves also do not replay. On first navigation into a
+ * draft operation, `usePathMasking` focuses and clears the address bar while
+ * `ScalarSidebarNestedItems` focuses the drilled-in Back button in
+ * `nextTick`. That steals focus from CodeMirror, fires blur with a
+ * `relatedTarget` (the Back button), and without a guard we would treat it
+ * like a user click: capture the selector, then `refocusBlurTarget` would
+ * synthesize `.click()` on Back and navigate away.
+ *
+ * `FocusEvent.sourceCapabilities` is null when no input device caused the
+ * focus change (e.g. `element.focus()`). A real pointer click sets it on the
+ * blur that precedes the click, so we still replay Send and other buttons.
  */
 const handlePathBlur = (newPath: string, event: FocusEvent): void => {
   const relatedTarget = event.relatedTarget as Element | null
-  const blurTargetSelector = tabbedOut.value ? null : getSelector(relatedTarget)
+  const blurTargetSelector =
+    tabbedOut.value ||
+    ('sourceCapabilities' in event && event.sourceCapabilities === null)
+      ? null
+      : getSelector(relatedTarget)
   tabbedOut.value = false
 
   emitPathMethodUpdate(

--- a/projects/scalar-app/src/App.vue
+++ b/projects/scalar-app/src/App.vue
@@ -31,6 +31,7 @@ import { groupWorkspacesByTeam } from '@/features/app/helpers/group-workspaces'
 import type { useCommandPaletteState } from '@/features/command-palette/hooks/use-command-palette-state'
 import AppMenuItems from '@/features/header/AppMenuItems.vue'
 import { ImportListener } from '@/features/import-listener'
+import type { NavigateToDocumentPayload } from '@/features/import-listener/types'
 import { deleteRegistryDocument } from '@/helpers/delete-registry-document'
 import { deleteRegistryVersion } from '@/helpers/delete-registry-version'
 import { fetchRegistryDocument } from '@/helpers/fetch-registry-document'
@@ -169,7 +170,22 @@ const handleCreateWorkspaceFromMenu = () => {
   app.eventBus.emit('ui:open:create-workspace')
 }
 
-const navigateToDocument = (slug: string) => {
+const navigateToDocument = ({
+  slug,
+  operationPath,
+  operationMethod,
+}: NavigateToDocumentPayload) => {
+  if (operationPath && operationMethod) {
+    app.eventBus.emit('ui:navigate', {
+      page: 'operation',
+      path: 'overview',
+      documentSlug: slug,
+      operationPath,
+      method: operationMethod,
+    })
+    return
+  }
+
   app.eventBus.emit('ui:navigate', {
     page: 'document',
     path: 'overview',

--- a/projects/scalar-app/src/App.vue
+++ b/projects/scalar-app/src/App.vue
@@ -177,11 +177,11 @@ const navigateToDocument = ({
 }: NavigateToDocumentPayload) => {
   if (operationPath && operationMethod) {
     app.eventBus.emit('ui:navigate', {
-      page: 'operation',
-      path: 'overview',
+      page: 'example',
       documentSlug: slug,
-      operationPath,
+      path: operationPath,
       method: operationMethod,
+      exampleName: 'default',
     })
     return
   }

--- a/projects/scalar-app/src/features/import-listener/ImportListener.vue
+++ b/projects/scalar-app/src/features/import-listener/ImportListener.vue
@@ -17,11 +17,12 @@ import { loadDocumentFromSource } from '@/features/import-listener/helpers/load-
 import {
   type CreateWorkspacePayload,
   type ImportEventData,
+  type NavigateToDocumentPayload,
 } from '@/features/import-listener/types'
 
 import DropEventListener from './components/DropEventListener.vue'
 import ImportModal from './components/ImportModal.vue'
-import { getUrlQueryParameter } from './helpers/get-url-query-parameter'
+import { getImportFromQuery } from './helpers/get-import-from-query'
 import { importDocumentToWorkspace } from './helpers/import-document-to-workspace'
 import { waitForCondition } from './helpers/wait-for-condition'
 
@@ -54,8 +55,8 @@ const { workspaceStore, darkMode, fileLoader, isOnlyOneWorkspace } =
   }>()
 
 const emit = defineEmits<{
-  /** Emitted when the user wants to navigate to a document. */
-  (e: 'navigateToDocument', slug: string): void
+  /** Emitted when the user wants to navigate to a document (and optionally an operation). */
+  (e: 'navigateToDocument', payload: NavigateToDocumentPayload): void
   /** Emitted when the user wants to set the active workspace */
   (e: 'set:workspace', id: string): void
   /** Emitted when the user wants to create a new workspace */
@@ -113,7 +114,7 @@ const directImport = async (
     return
   }
 
-  await handleImportDocument(draftStore.exportWorkspace(), 'drafts')
+  await handleImportDocument(draftStore.exportWorkspace(), 'drafts', importEventData)
 }
 
 /**
@@ -157,6 +158,7 @@ const handleInput = async (importEventData: ImportEventData): Promise<void> => {
 const handleImportDocument = async (
   workspaceState: InMemoryWorkspace,
   name: string,
+  importContext?: ImportEventData | null,
 ): Promise<void> => {
   const result = await importDocumentToWorkspace({
     workspaceStore,
@@ -169,7 +171,13 @@ const handleImportDocument = async (
     return
   }
 
-  emit('navigateToDocument', result.slug)
+  const pendingOperation = importContext ?? data.value
+
+  emit('navigateToDocument', {
+    slug: result.slug,
+    operationPath: pendingOperation?.operationPath,
+    operationMethod: pendingOperation?.operationMethod,
+  })
   modalState.hide()
 }
 
@@ -178,18 +186,10 @@ const handleImportDocument = async (
  * If a URL is found, automatically triggers the import flow.
  */
 onMounted(() => {
-  const urlQueryParameter = getUrlQueryParameter('url')
+  const importFromQuery = getImportFromQuery({ darkMode })
 
-  const logo = darkMode
-    ? getUrlQueryParameter('dark_logo')
-    : getUrlQueryParameter('light_logo')
-
-  if (urlQueryParameter) {
-    void handleInput({
-      source: urlQueryParameter,
-      type: 'url',
-      companyLogo: logo,
-    })
+  if (importFromQuery) {
+    void handleInput(importFromQuery)
   }
 
   if (window.electron === true) {

--- a/projects/scalar-app/src/features/import-listener/ImportListener.vue
+++ b/projects/scalar-app/src/features/import-listener/ImportListener.vue
@@ -114,7 +114,11 @@ const directImport = async (
     return
   }
 
-  await handleImportDocument(draftStore.exportWorkspace(), 'drafts', importEventData)
+  await handleImportDocument(
+    draftStore.exportWorkspace(),
+    'drafts',
+    importEventData,
+  )
 }
 
 /**

--- a/projects/scalar-app/src/features/import-listener/helpers/get-import-from-query.test.ts
+++ b/projects/scalar-app/src/features/import-listener/helpers/get-import-from-query.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getImportFromQuery } from './get-import-from-query'
+
+describe('getImportFromQuery', () => {
+  const mockLocation = (search: string): void => {
+    vi.stubGlobal('window', {
+      location: { search },
+    })
+  }
+
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns undefined when url query param is missing', () => {
+    mockLocation('?operation_path=/users&operation_method=get')
+
+    expect(getImportFromQuery({ darkMode: false })).toBeUndefined()
+  })
+
+  it('returns url import data with light logo in light mode', () => {
+    mockLocation('?url=https%3A%2F%2Fexample.com%2Fopenapi.json&light_logo=https%3A%2F%2Flogo')
+
+    expect(getImportFromQuery({ darkMode: false })).toEqual({
+      type: 'url',
+      source: 'https://example.com/openapi.json',
+      companyLogo: 'https://logo',
+    })
+  })
+
+  it('returns url import data with dark logo in dark mode', () => {
+    mockLocation('?url=https%3A%2F%2Fexample.com%2Fopenapi.json&dark_logo=https%3A%2F%2Fdark-logo')
+
+    expect(getImportFromQuery({ darkMode: true })).toEqual({
+      type: 'url',
+      source: 'https://example.com/openapi.json',
+      companyLogo: 'https://dark-logo',
+    })
+  })
+
+  it('includes operation path and method when query params are valid', () => {
+    mockLocation(
+      '?url=https%3A%2F%2Fexample.com%2Fopenapi.json&operation_path=%2Fusers%2F%7Bid%7D&operation_method=GET',
+    )
+
+    expect(getImportFromQuery({ darkMode: false })).toEqual({
+      type: 'url',
+      source: 'https://example.com/openapi.json',
+      companyLogo: null,
+      operationPath: '/users/{id}',
+      operationMethod: 'get',
+    })
+  })
+
+  it('omits operation fields when operation_method is invalid', () => {
+    mockLocation('?url=https%3A%2F%2Fexample.com%2Fopenapi.json&operation_path=/users&operation_method=INVALID')
+
+    expect(getImportFromQuery({ darkMode: false })).toEqual({
+      type: 'url',
+      source: 'https://example.com/openapi.json',
+      companyLogo: null,
+    })
+  })
+})

--- a/projects/scalar-app/src/features/import-listener/helpers/get-import-from-query.ts
+++ b/projects/scalar-app/src/features/import-listener/helpers/get-import-from-query.ts
@@ -1,0 +1,58 @@
+import { isHttpMethod } from '@scalar/helpers/http/is-http-method'
+
+import type { ImportEventData } from '@/features/import-listener/types'
+
+import { getUrlQueryParameter } from './get-url-query-parameter'
+
+type ImportFromQueryOptions = {
+  darkMode: boolean
+}
+
+const getImportOperationFromQuery = ():
+  | Pick<ImportEventData, 'operationPath' | 'operationMethod'>
+  | undefined => {
+  const operationPath = getUrlQueryParameter('operation_path')
+  const operationMethodRaw = getUrlQueryParameter('operation_method')
+
+  if (!operationPath?.length || !operationMethodRaw?.length) {
+    return undefined
+  }
+
+  const operationMethod = operationMethodRaw.toLowerCase()
+
+  if (!isHttpMethod(operationMethod)) {
+    return undefined
+  }
+
+  return {
+    operationPath,
+    operationMethod,
+  }
+}
+
+/**
+ * Reads import-related URL query parameters (document URL, logos, operation target)
+ * set when opening the client from API Reference or other integrations.
+ */
+export const getImportFromQuery = ({
+  darkMode,
+}: ImportFromQueryOptions): ImportEventData | undefined => {
+  const source = getUrlQueryParameter('url')
+
+  if (!source?.length) {
+    return undefined
+  }
+
+  const companyLogo = darkMode
+    ? getUrlQueryParameter('dark_logo')
+    : getUrlQueryParameter('light_logo')
+
+  const operation = getImportOperationFromQuery()
+
+  return {
+    type: 'url',
+    source,
+    companyLogo,
+    ...operation,
+  }
+}

--- a/projects/scalar-app/src/features/import-listener/helpers/get-import-from-query.ts
+++ b/projects/scalar-app/src/features/import-listener/helpers/get-import-from-query.ts
@@ -8,9 +8,7 @@ type ImportFromQueryOptions = {
   darkMode: boolean
 }
 
-const getImportOperationFromQuery = ():
-  | Pick<ImportEventData, 'operationPath' | 'operationMethod'>
-  | undefined => {
+const getImportOperationFromQuery = (): Pick<ImportEventData, 'operationPath' | 'operationMethod'> | undefined => {
   const operationPath = getUrlQueryParameter('operation_path')
   const operationMethodRaw = getUrlQueryParameter('operation_method')
 
@@ -34,18 +32,14 @@ const getImportOperationFromQuery = ():
  * Reads import-related URL query parameters (document URL, logos, operation target)
  * set when opening the client from API Reference or other integrations.
  */
-export const getImportFromQuery = ({
-  darkMode,
-}: ImportFromQueryOptions): ImportEventData | undefined => {
+export const getImportFromQuery = ({ darkMode }: ImportFromQueryOptions): ImportEventData | undefined => {
   const source = getUrlQueryParameter('url')
 
   if (!source?.length) {
     return undefined
   }
 
-  const companyLogo = darkMode
-    ? getUrlQueryParameter('dark_logo')
-    : getUrlQueryParameter('light_logo')
+  const companyLogo = darkMode ? getUrlQueryParameter('dark_logo') : getUrlQueryParameter('light_logo')
 
   const operation = getImportOperationFromQuery()
 

--- a/projects/scalar-app/src/features/import-listener/types.ts
+++ b/projects/scalar-app/src/features/import-listener/types.ts
@@ -1,7 +1,19 @@
+import type { HttpMethod } from '@scalar/helpers/http/http-methods'
+
 export type ImportEventData = {
   type: 'url' | 'file' | 'raw'
   source: string
   companyLogo?: string | null
+  /** OpenAPI path to open after a successful import (from API Reference modal) */
+  operationPath?: string
+  /** HTTP method for the operation to open after import */
+  operationMethod?: HttpMethod
+}
+
+export type NavigateToDocumentPayload = {
+  slug: string
+  operationPath?: string
+  operationMethod?: HttpMethod
 }
 
 export type CreateWorkspacePayload = {


### PR DESCRIPTION
When user opens the client from the modal we want it to land on the same operation.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the import/navigation flow between API Reference and `scalar-app` and adds a blur-click replay guard in the address bar, which could affect routing and focus behavior across clients.
> 
> **Overview**
> Enables **deep-linking into a specific operation** when opening the standalone API client from API Reference: the modal `OpenApiClientButton` now appends `operation_path`/`operation_method` query params, and `scalar-app` reads/validates them during import to navigate directly to the imported operation’s default example.
> 
> Also tightens `AddressBar` blur handling to avoid replaying clicks when focus changes are **programmatic** (via `FocusEvent.sourceCapabilities === null`), fixing an initial-navigation edge case where focus juggling could inadvertently trigger the Back button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62def46a475f17f0c49b3d2c12a5e5c31113ecca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->