### PR TITLE
fix(api-client-react): restore inline OpenAPI document support

### DIFF
--- a/.changeset/api-client-react-inline-content.md
+++ b/.changeset/api-client-react-inline-content.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client-react': patch
+---
+
+fix: restore inline OpenAPI document support via the `content` configuration field in `useApiClient`

--- a/packages/api-client-react/src/use-api-client.test.ts
+++ b/packages/api-client-react/src/use-api-client.test.ts
@@ -223,6 +223,19 @@ describe('use-api-client', () => {
     await waitFor(() => expect(mockWorkspaceStore.addDocument).toHaveBeenCalledWith({ name: 'default', url: '' }))
   })
 
+  it('does not register a content hash when url is an empty string', async () => {
+    const { useApiClient } = await import('./use-api-client')
+    const contentHashSlug = generateHash(JSON.stringify({}))
+
+    renderHook(() => useApiClient({ configuration: { url: '' } }))
+
+    await waitFor(() => expect(mockWorkspaceStore.addDocument).toHaveBeenCalled())
+
+    const registrationNames = mockWorkspaceStore.addDocument.mock.calls.map((call) => call[0].name)
+    expect(registrationNames).not.toContain(contentHashSlug)
+    expect(mockWorkspaceStore.addDocument).toHaveBeenCalledTimes(1)
+  })
+
   it('calls addDocument with "default" slug when configuration has no url or content', async () => {
     const { useApiClient } = await import('./use-api-client')
     renderHook(() => useApiClient({ configuration: { url: '' } }))

--- a/packages/api-client-react/src/use-api-client.test.ts
+++ b/packages/api-client-react/src/use-api-client.test.ts
@@ -1,7 +1,13 @@
+import { generateHash } from '@scalar/helpers/string/generate-hash'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ApiClientConfigurationReact } from './use-api-client'
+
+const inlineOpenApiContent = {
+  openapi: '3.1.0',
+  info: { title: 'Inline API', version: '1.0.0' },
+}
 
 // Mock the style import so it doesn't fail in jsdom
 vi.mock('./style.css', () => ({}))
@@ -149,6 +155,52 @@ describe('use-api-client', () => {
     expect(mockWorkspaceStore.addDocument).toHaveBeenCalledWith({
       name: 'https://api.example.com/openapi.json',
       url: 'https://api.example.com/openapi.json',
+    })
+  })
+
+  it('calls workspaceStore.addDocument with document when content is configured', async () => {
+    const { useApiClient } = await import('./use-api-client')
+    const slug = generateHash(JSON.stringify(inlineOpenApiContent))
+
+    renderHook(() => useApiClient({ configuration: { content: inlineOpenApiContent } }))
+
+    await waitFor(() => expect(mockWorkspaceStore.addDocument).toHaveBeenCalled())
+
+    expect(mockWorkspaceStore.addDocument).toHaveBeenCalledWith({
+      name: slug,
+      document: inlineOpenApiContent,
+    })
+  })
+
+  it('registers url documents without a document field', async () => {
+    const { useApiClient } = await import('./use-api-client')
+    renderHook(() => useApiClient({ configuration: { url: 'https://api.example.com/openapi.json' } }))
+
+    await waitFor(() => expect(mockWorkspaceStore.addDocument).toHaveBeenCalled())
+
+    const urlRegistrationCall = mockWorkspaceStore.addDocument.mock.calls.find(
+      (call) => call[0].name === 'https://api.example.com/openapi.json',
+    )?.[0]
+
+    expect(urlRegistrationCall).toStrictEqual({
+      name: 'https://api.example.com/openapi.json',
+      url: 'https://api.example.com/openapi.json',
+    })
+  })
+
+  it('registers inline content without a url field', async () => {
+    const { useApiClient } = await import('./use-api-client')
+    const slug = generateHash(JSON.stringify(inlineOpenApiContent))
+
+    renderHook(() => useApiClient({ configuration: { content: inlineOpenApiContent } }))
+
+    await waitFor(() => expect(mockWorkspaceStore.addDocument).toHaveBeenCalled())
+
+    const contentRegistrationCall = mockWorkspaceStore.addDocument.mock.calls.find((call) => call[0].name === slug)?.[0]
+
+    expect(contentRegistrationCall).toStrictEqual({
+      name: slug,
+      document: inlineOpenApiContent,
     })
   })
 

--- a/packages/api-client-react/src/use-api-client.ts
+++ b/packages/api-client-react/src/use-api-client.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import type { ApiClientModal, ApiClientOptions, RoutePayload } from '@scalar/api-client/modal'
+import { generateHash } from '@scalar/helpers/string/generate-hash'
 import { useEffect, useRef, useState } from 'react'
 
 import './style.css'
@@ -14,10 +15,17 @@ globalThis.__VUE_OPTIONS_API__ = true
 globalThis.__VUE_PROD_HYDRATION_MISMATCH_DETAILS__ = true
 globalThis.__VUE_PROD_DEVTOOLS__ = false
 
-export type ApiClientConfigurationReact = ApiClientOptions & {
-  // content?: Record<string, unknown>
-  url: string
-}
+export type ApiClientConfigurationReact = ApiClientOptions &
+  (
+    | {
+        content?: never
+        url: string
+      }
+    | {
+        content: Record<string, unknown>
+        url?: never
+      }
+  )
 
 export type UseApiClientModalProps = {
   /** Configuration for the Api Client (url or inline content) */
@@ -26,6 +34,13 @@ export type UseApiClientModalProps = {
 
 /** Tracks which documents are/have been loaded so we dont duplicate */
 const documentSet = new Set<string>()
+
+const getDocumentSlug = (configuration: ApiClientConfigurationReact) => {
+  if (configuration.url) {
+    return configuration.url
+  }
+  return generateHash(JSON.stringify(configuration.content ?? {}))
+}
 
 /**
  * Returns the singleton Api Client
@@ -52,16 +67,14 @@ export const useApiClient = ({
     let cancelled = false
 
     // Strip document-specific fields before passing to the modal constructor.
-    const { url, ...modalOptions } = configuration
+    const { url, content, ...modalOptions } = configuration
+
+    const slug = getDocumentSlug(configuration)
 
     void getOrCreateApiClient(modalOptions)?.then((_client) => {
       if (cancelled || !_client) {
         return
       }
-
-      // Compute the slug here so we can batch all three state updates into one render,
-      // preventing a render where `client` is set but `documentSlug` is still ''.
-      const slug = url || ''
 
       // React always provides the complete modal option set for this hook instance,
       // so we overwrite to clear options removed by consumers.
@@ -74,7 +87,11 @@ export const useApiClient = ({
 
       if (slug && !documentSet.has(slug)) {
         documentSet.add(slug)
-        void _client.workspaceStore.addDocument({ name: slug, url })
+        if (url !== undefined) {
+          void _client.workspaceStore.addDocument({ name: slug, url })
+        } else {
+          void _client.workspaceStore.addDocument({ name: slug, document: content })
+        }
       }
     })
 
@@ -99,8 +116,12 @@ export const useApiClient = ({
     }
     documentSet.add(slug)
 
-    void workspaceStore.addDocument({ name: slug, url: configuration.url })
-  }, [client, configuration.url, workspaceStore])
+    if (configuration.url !== undefined) {
+      void workspaceStore.addDocument({ name: slug, url: configuration.url })
+    } else {
+      void workspaceStore.addDocument({ name: slug, document: configuration.content })
+    }
+  }, [client, configuration.url, configuration.content, workspaceStore])
 
   // Update the modal options when the configuration changes
   useEffect(() => {
@@ -108,7 +129,7 @@ export const useApiClient = ({
       return
     }
 
-    const { url: _, ...modalOptions } = configuration
+    const { url: _url, content: _content, ...modalOptions } = configuration
     if (isObjectEqual(previousModalOptionsRef.current, modalOptions)) {
       return
     }

--- a/packages/api-client-react/src/use-api-client.ts
+++ b/packages/api-client-react/src/use-api-client.ts
@@ -36,10 +36,10 @@ export type UseApiClientModalProps = {
 const documentSet = new Set<string>()
 
 const getDocumentSlug = (configuration: ApiClientConfigurationReact) => {
-  if (configuration.url) {
-    return configuration.url
+  if (configuration.url !== undefined) {
+    return configuration.url || 'default'
   }
-  return generateHash(JSON.stringify(configuration.content ?? {}))
+  return generateHash(JSON.stringify(configuration.content))
 }
 
 /**
@@ -108,7 +108,7 @@ export const useApiClient = ({
       return
     }
 
-    const slug = configuration.url || 'default'
+    const slug = getDocumentSlug(configuration)
     documentSlugRef.current = slug
 
     if (documentSet.has(slug)) {


### PR DESCRIPTION
Looks like we did a breaking change on this PR: #8840

This PR restores support for passing config as a plain object

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `useApiClient` configuration typing and document registration logic to support inline OpenAPI objects, which may affect consumers and document de-duplication behavior (slug generation via JSON hashing). Test coverage reduces but does not eliminate risk around edge cases like object key ordering and rerenders.
> 
> **Overview**
> Restores support for passing an inline OpenAPI document to `useApiClient` via a `content` configuration (mutually exclusive with `url`), generating a stable document slug by hashing the serialized content.
> 
> Updates document registration to call `workspaceStore.addDocument` with either `{url}` or `{document}` accordingly, and expands the hook’s tests to cover inline-content registration, slug behavior, and ensuring URL-based registrations don’t accidentally include `document`/content-hash side effects.
> 
> Adds a patch changeset for `@scalar/api-client-react`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a378570b2365c6369771c5238fb6e2349e35b99e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->