### PR TITLE
ci: format release notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "types:build": "turbo types:build",
     "renovate:validate": "pnpm dlx --package renovate renovate-config-validator",
     "script": "pnpm --filter @scalar-internal/build-scripts start",
-    "release:version": "changeset version && pnpm --filter @scalar/helpers build && pnpm --filter @scalar-internal/build-scripts start release-notes-generator --package scalar-app --changelog projects/scalar-app/CHANGELOG.md --output projects/scalar-app/RELEASE_NOTES.json --markdown projects/scalar-app/RELEASE_NOTES.md --dependency-changelog packages/api-client/CHANGELOG.md"
+    "release:version": "changeset version && pnpm --filter @scalar/helpers build && pnpm --filter @scalar-internal/build-scripts start release-notes-generator --package scalar-app --changelog projects/scalar-app/CHANGELOG.md --output projects/scalar-app/RELEASE_NOTES.json --markdown projects/scalar-app/RELEASE_NOTES.md --dependency-changelog packages/api-client/CHANGELOG.md && pnpm format"
   },
   "remarkConfig": {
     "plugins": [

--- a/projects/scalar-app/RELEASE_NOTES.schema.json
+++ b/projects/scalar-app/RELEASE_NOTES.schema.json
@@ -43,10 +43,7 @@
                   "description": "Plain-text paragraph copy. Use multiple paragraph blocks for multi-paragraph notes."
                 }
               },
-              "required": [
-                "type",
-                "text"
-              ],
+              "required": ["type", "text"],
               "additionalProperties": false,
               "description": "A free-form paragraph rendered between other content blocks."
             },
@@ -78,10 +75,7 @@
                   ]
                 }
               },
-              "required": [
-                "type",
-                "text"
-              ],
+              "required": ["type", "text"],
               "additionalProperties": false,
               "description": "A subsection heading inside a release entry."
             },
@@ -110,10 +104,7 @@
                   "type": "boolean"
                 }
               },
-              "required": [
-                "type",
-                "items"
-              ],
+              "required": ["type", "items"],
               "additionalProperties": false,
               "description": "A bullet (or numbered) list of single-sentence items."
             },
@@ -155,11 +146,7 @@
                   "maximum": 9007199254740991
                 }
               },
-              "required": [
-                "type",
-                "src",
-                "alt"
-              ],
+              "required": ["type", "src", "alt"],
               "additionalProperties": false,
               "description": "An inline image. Provide alt text for accessibility and an optional caption rendered beneath."
             },
@@ -204,10 +191,7 @@
                   "type": "boolean"
                 }
               },
-              "required": [
-                "type",
-                "src"
-              ],
+              "required": ["type", "src"],
               "additionalProperties": false,
               "description": "An inline video clip. Self-hosted MP4/WebM URLs work best - autoplay clips should also set `muted: true`."
             },
@@ -231,11 +215,7 @@
                   "description": "Accessible link text (for example \"Read full release notes\")."
                 }
               },
-              "required": [
-                "type",
-                "href",
-                "label"
-              ],
+              "required": ["type", "href", "label"],
               "additionalProperties": false,
               "description": "Call-to-action link (for example to full release notes on GitHub)."
             }
@@ -244,11 +224,7 @@
         }
       }
     },
-    "required": [
-      "version",
-      "date",
-      "title"
-    ],
+    "required": ["version", "date", "title"],
     "additionalProperties": false,
     "description": "A single curated release note rendered in the \"What's new\" modal."
   },


### PR DESCRIPTION
not-biome-formatted release notes broke CI in all PRs

this PR formats the release notes, and adds "pnpm format" to the `release:version` script

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to formatting-only updates in the release notes JSON schema and adding an automatic `pnpm format` step to the release version script.
> 
> **Overview**
> Keeps release-note artifacts formatter-compliant by appending `pnpm format` to the `release:version` script after generating release notes.
> 
> Reformats `projects/scalar-app/RELEASE_NOTES.schema.json` (e.g., inlining `required` arrays) without altering schema meaning, preventing CI failures due to unformatted JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35d70c4c5e0d9478796ffb689d5d0808c0edd04a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->