### PR TITLE
feat(api-reference): AsyncAPI `info.description` in sidebar

### DIFF
--- a/.changeset/asyncapi-info-description-navigation.md
+++ b/.changeset/asyncapi-info-description-navigation.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-reference': patch
+---
+
+Surface the Introduction entry and any headings extracted from `info.description` of AsyncAPI documents in the sidebar, mirroring how OpenAPI documents are handled.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -357,9 +357,8 @@ const itemsFromWorkspace = computed<TraversedEntry[]>(() => {
       description: document.info.description,
       name: document.info.title ?? slug,
       title: document.info.title ?? slug,
-      children: isOpenApiDocument(document)
-        ? (document['x-scalar-navigation']?.children ?? [])
-        : [],
+      // Both OpenAPI and AsyncAPI documents carry an `x-scalar-navigation` tree.
+      children: document['x-scalar-navigation']?.children ?? [],
     }),
   )
 })

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -3849,13 +3849,15 @@ describe('create-workspace-store', () => {
       })
       expect(document?.['x-scalar-original-document-hash']).not.toBe('')
       expect(document).not.toHaveProperty('openapi')
-      expect(document?.['x-scalar-navigation']).toEqual({
-        children: [],
-        icon: undefined,
+      // AsyncAPI docs always carry an `x-scalar-navigation` tree so the sidebar can
+      // surface `info.description`. Without channels, tags, or a description, the only
+      // entry is the default Introduction.
+      expect(document?.['x-scalar-navigation']).toMatchObject({
         id: 'streetlights',
         name: 'streetlights',
         title: 'Streetlights API',
         type: 'document',
+        children: [{ type: 'text', title: 'Introduction' }],
       })
     })
 
@@ -4072,6 +4074,11 @@ describe('create-workspace-store', () => {
       const navigation = document['x-scalar-navigation']
       expect(navigation).toEqual({
         'children': [
+          {
+            'id': 'chatapp/description/introduction',
+            'title': 'Introduction',
+            'type': 'text',
+          },
           {
             'channelAddress': '/chat',
             'channelName': 'chat',

--- a/packages/workspace-store/src/navigation/helpers/traverse-asyncapi-document.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-asyncapi-document.test.ts
@@ -127,7 +127,7 @@ const collectAsyncApiMessages = (children: TraversedEntry[] | undefined): Traver
   collectEntries(children, 'asyncapi-message')
 
 describe('traverseAsyncApiDocument', () => {
-  it('returns an empty document when there are no operations', () => {
+  it('emits only the default Introduction entry when there are no operations or description', () => {
     const document = {
       asyncapi: '3.0.0',
       info: { title: 'Streetlights API', version: '1.0.0' },
@@ -141,8 +141,30 @@ describe('traverseAsyncApiDocument', () => {
       type: 'document',
       title: 'Streetlights API',
       name: 'streetlights',
-      children: [],
+      children: [{ type: 'text', title: 'Introduction' }],
     })
+  })
+
+  it('extracts headings from info.description as children of Introduction', () => {
+    const document = {
+      asyncapi: '3.0.0',
+      info: {
+        title: 'Streetlights API',
+        version: '1.0.0',
+        description:
+          'Some leading text.\n\n## Event-Driven Features\n\n- bullet a\n- bullet b\n\n## Resources\n\n- link a\n',
+      },
+      'x-scalar-original-document-hash': 'streetlights-fixture',
+    } as unknown as AsyncApiDocument
+
+    const result = traverseAsyncApiDocument('streetlights', document, mockOptions)
+    const intro = result.children?.[0]
+
+    expect(intro).toMatchObject({ type: 'text', title: 'Introduction' })
+    expect('children' in (intro ?? {}) ? (intro as { children?: unknown }).children : undefined).toEqual([
+      { id: expect.any(String), title: 'Event-Driven Features', type: 'text', children: [] },
+      { id: expect.any(String), title: 'Resources', type: 'text', children: [] },
+    ])
   })
 
   it('lists Galaxy channels with operations and nests messages under operations', () => {
@@ -290,6 +312,7 @@ describe('traverseAsyncApiDocument', () => {
     const result = traverseAsyncApiDocument('tagged', document, mockOptions)
 
     expect(result.children).toEqual([
+      expect.objectContaining({ type: 'text', title: 'Introduction' }),
       expect.objectContaining({
         type: 'asyncapi-channel',
         channelName: 'events',

--- a/packages/workspace-store/src/navigation/helpers/traverse-asyncapi-document.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-asyncapi-document.ts
@@ -7,6 +7,7 @@ import { isHidden } from '@/helpers/is-hidden'
 import { unpackProxyObject } from '@/helpers/unpack-proxy'
 import { type NavigationOptions, getNavigationOptions } from '@/navigation/get-navigation-options'
 import { getTag } from '@/navigation/helpers/get-tag'
+import { traverseDescription } from '@/navigation/helpers/traverse-description'
 import type { TagsMap, TraverseSpecOptions } from '@/navigation/types'
 import type { XInternal } from '@/schemas/extensions/document/x-internal'
 import type { XScalarIgnore } from '@/schemas/extensions/document/x-scalar-ignore'
@@ -19,7 +20,7 @@ import type {
   TraversedEntry,
   TraversedTag,
 } from '@/schemas/navigation'
-import type { InfoObject, TagObject } from '@/schemas/v3.1/strict/openapi-document'
+import type { TagObject } from '@/schemas/v3.1/strict/openapi-document'
 
 /** Anything that may carry the navigation visibility extensions. */
 type Hideable = XInternal & XScalarIgnore
@@ -595,7 +596,7 @@ export const traverseAsyncApiDocument = (
 
   const documentId = generateId({
     type: 'document',
-    info: document.info as InfoObject,
+    info: document.info,
     name: documentName,
   })
 
@@ -649,7 +650,13 @@ export const traverseAsyncApiDocument = (
     }
   }
 
-  const entries: TraversedEntry[] = []
+  // Surface the Introduction entry plus any headings extracted from `info.description`
+  // before the channel/tag entries, mirroring how OpenAPI documents are traversed.
+  const entries: TraversedEntry[] = traverseDescription({
+    generateId,
+    parentId: documentId,
+    info: document.info,
+  })
 
   if (tagsMap.size > 0) {
     entries.push(

--- a/packages/workspace-store/src/navigation/helpers/traverse-description.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-description.ts
@@ -1,3 +1,5 @@
+import type { AsyncApiInfoObject } from '@scalar/types/asyncapi/3.1'
+
 import { getHeadingsFromMarkdown, getLowestHeadingLevel } from '@/navigation/helpers/utils'
 import type { TraverseSpecOptions } from '@/navigation/types'
 import type { TraversedDescription } from '@/schemas/navigation'
@@ -11,7 +13,7 @@ const DEFAULT_DESCRIPTION_ENTRY = {
 const getDefaultDescriptionEntry = (
   generateId: TraverseSpecOptions['generateId'],
   parentId: string,
-  info: InfoObject,
+  info: InfoObject | AsyncApiInfoObject,
 ) => {
   const id = generateId({
     type: 'text',
@@ -32,7 +34,7 @@ const getDefaultDescriptionEntry = (
 }
 
 /**
- * Creates a hierarchical navigation structure from markdown headings in an OpenAPI description.
+ * Creates a hierarchical navigation structure from markdown headings in an OpenAPI or AsyncAPI description.
  *
  * The function processes markdown headings to create a two-level navigation tree:
  * - Level 1: Main sections (based on the lowest heading level found)
@@ -44,7 +46,7 @@ const getDefaultDescriptionEntry = (
  * @param description - The markdown description text to process
  * @param generateId - Function to generate unique IDs for headings
  * @param parentId - The ID of the parent entry
- * @param info - OpenAPI Info Object
+ * @param info - OpenAPI or AsyncAPI Info Object
  *
  * @returns Array of TraversedDescription entries with their hierarchy
  */
@@ -55,7 +57,7 @@ export const traverseDescription = ({
 }: {
   generateId: TraverseSpecOptions['generateId']
   parentId: string
-  info: InfoObject
+  info: InfoObject | AsyncApiInfoObject
 }): TraversedDescription[] => {
   const description = info.description?.trim()
 

--- a/packages/workspace-store/src/schemas/navigation.ts
+++ b/packages/workspace-store/src/schemas/navigation.ts
@@ -1,5 +1,6 @@
 import { HTTP_METHODS, type HttpMethod } from '@scalar/helpers/http/http-methods'
 import { type TLiteral, Type } from '@scalar/typebox'
+import type { AsyncApiInfoObject } from '@scalar/types/asyncapi/3.1'
 
 import { compose } from '@/schemas/compose'
 import type { InfoObject } from '@/schemas/v3.1/strict/info'
@@ -297,12 +298,12 @@ export type WithParent<Entry extends TraversedEntry> = Entry & {
 
 export type DocumentIdProps = {
   name: string
-  info: InfoObject
+  info: InfoObject | AsyncApiInfoObject
   type: 'document'
 }
 
 type DescriptionIdProps = {
-  info: InfoObject
+  info: InfoObject | AsyncApiInfoObject
   type: 'text'
   slug?: string
   depth?: number


### PR DESCRIPTION
Puts `info.description` from AsyncAPI documents and the headings inside in the sidebar.

Preview: https://pr-9255.scalar-api-reference-preview.pages.dev/#scalar-galaxy-events

<img width="301" height="197" alt="Screenshot 2026-05-21 at 13 15 39" src="https://github.com/user-attachments/assets/7aa0d001-0db9-481f-8f07-240c564f6a4f" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and sidebar display changes only; no auth, security, or data-handling impact.
> 
> **Overview**
> AsyncAPI specs now get the same **Introduction** sidebar treatment as OpenAPI: workspace traversal prepends description navigation (default **Introduction**, plus markdown headings from `info.description`) ahead of channels/tags, and `traverseDescription` / navigation ID types accept **AsyncAPI** `info` objects.
> 
> **api-reference** no longer gates sidebar children on OpenAPI only—it always uses each document’s `x-scalar-navigation` tree, so AsyncAPI workspaces show those intro entries in the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f15cd6f98bcf32e941034a7028c1acb89559c7c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->