### PR TITLE
fix(workspace-store): `operationTitleSource` in navigation

### DIFF
--- a/.changeset/workspace-store-operation-title-source.md
+++ b/.changeset/workspace-store-operation-title-source.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Respect `operationTitleSource: 'path'` when building sidebar navigation so operation paths render instead of summaries.

--- a/packages/workspace-store/src/navigation/get-navigation-options.ts
+++ b/packages/workspace-store/src/navigation/get-navigation-options.ts
@@ -16,6 +16,7 @@ export type NavigationOptions =
         | 'operationsSorter'
         | 'tagsSorter'
         | 'hideModels'
+        | 'operationTitleSource'
       >
     >
   | undefined
@@ -136,6 +137,7 @@ export const getNavigationOptions = (documentName: string, options?: NavigationO
     hideModels: options?.hideModels ?? false,
     operationsSorter: options?.operationsSorter,
     tagsSorter: options?.tagsSorter,
+    operationTitleSource: options?.operationTitleSource,
     generateId,
   }
 }

--- a/packages/workspace-store/src/navigation/helpers/traverse-document.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-document.ts
@@ -20,7 +20,10 @@ import { traverseWebhooks } from './traverse-webhooks'
  * - Optional schema/model documentation
  */
 export const traverseDocument = (documentName: string, document: OpenApiDocument, options?: NavigationOptions) => {
-  const { hideModels, tagsSorter, operationsSorter, generateId } = getNavigationOptions(documentName, options)
+  const { hideModels, tagsSorter, operationsSorter, generateId, operationTitleSource } = getNavigationOptions(
+    documentName,
+    options,
+  )
 
   const documentId = generateId({
     type: 'document',
@@ -44,7 +47,13 @@ export const traverseDocument = (documentName: string, document: OpenApiDocument
   })
 
   /** Traverse all the document path  */
-  const { untaggedOperations } = traversePaths({ document, tagsMap, generateId, documentId })
+  const { untaggedOperations } = traversePaths({
+    document,
+    tagsMap,
+    generateId,
+    documentId,
+    operationTitleSource,
+  })
 
   const untaggedWebhooksParentId = generateId({
     type: 'webhook',

--- a/packages/workspace-store/src/navigation/helpers/traverse-paths.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-paths.test.ts
@@ -423,4 +423,97 @@ describe('traversePaths', () => {
     })
     expect(tagsMap.get('Test')?.entries[0]?.title).toBe('/test')
   })
+
+  it("uses the path when operationTitleSource is 'path' even if a summary is set", () => {
+    const document = createDocument()
+    document.paths = {
+      '/2fa/passkey/get-get-args': {
+        get: {
+          tags: ['Passkey'],
+          summary: 'Test passkey',
+        },
+      },
+    }
+
+    const tagsMap: TagsMap = new Map([
+      ['Passkey', { id: 'tag/passkey', parentId: 'doc-1', tag: { name: 'Passkey' }, entries: [] }],
+    ])
+
+    const result = traversePaths({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      operationTitleSource: 'path',
+      generateId: (props) => {
+        if (props.type === 'operation') {
+          return `${props.method?.toUpperCase()}-${props.path}`
+        }
+        return 'unknown-id'
+      },
+    })
+
+    expect(tagsMap.get('Passkey')?.entries[0]?.title).toBe('/2fa/passkey/get-get-args')
+    expect(result.untaggedOperations).toHaveLength(0)
+  })
+
+  it("falls back to the path when operationTitleSource is 'path' and there is no summary", () => {
+    const document = createDocument()
+    document.paths = {
+      '/widgets': {
+        get: {
+          tags: ['Widget'],
+        },
+      },
+    }
+
+    const tagsMap: TagsMap = new Map([
+      ['Widget', { id: 'tag/widget', parentId: 'doc-1', tag: { name: 'Widget' }, entries: [] }],
+    ])
+
+    traversePaths({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      operationTitleSource: 'path',
+      generateId: (props) => {
+        if (props.type === 'operation') {
+          return `${props.method?.toUpperCase()}-${props.path}`
+        }
+        return 'unknown-id'
+      },
+    })
+
+    expect(tagsMap.get('Widget')?.entries[0]?.title).toBe('/widgets')
+  })
+
+  it("uses the summary when operationTitleSource is 'summary' (default behavior preserved)", () => {
+    const document = createDocument()
+    document.paths = {
+      '/widgets': {
+        get: {
+          tags: ['Widget'],
+          summary: 'List widgets',
+        },
+      },
+    }
+
+    const tagsMap: TagsMap = new Map([
+      ['Widget', { id: 'tag/widget', parentId: 'doc-1', tag: { name: 'Widget' }, entries: [] }],
+    ])
+
+    traversePaths({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      operationTitleSource: 'summary',
+      generateId: (props) => {
+        if (props.type === 'operation') {
+          return `${props.method?.toUpperCase()}-${props.path}`
+        }
+        return 'unknown-id'
+      },
+    })
+
+    expect(tagsMap.get('Widget')?.entries[0]?.title).toBe('List widgets')
+  })
 })

--- a/packages/workspace-store/src/navigation/helpers/traverse-paths.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-paths.ts
@@ -6,7 +6,7 @@ import { escapeJsonPointer } from '@scalar/json-magic/helpers/escape-json-pointe
 import { getResolvedRef, mergeSiblingReferences } from '@/helpers/get-resolved-ref'
 import { isHidden } from '@/helpers/is-hidden'
 import { traverseOperationExamples } from '@/navigation/helpers/traverse-examples'
-import type { TagsMap, TraverseSpecOptions } from '@/navigation/types'
+import type { OperationTitleSource, TagsMap, TraverseSpecOptions } from '@/navigation/types'
 import { XScalarStabilityValues } from '@/schemas/extensions/operation'
 import type { ParentTag, TraversedExample, TraversedOperation } from '@/schemas/navigation'
 import type { OpenApiDocument, OperationObject } from '@/schemas/v3.1/strict/openapi-document'
@@ -37,6 +37,7 @@ const createOperationEntry = ({
   generateId,
   parentId,
   parentTag,
+  operationTitleSource,
 }: {
   ref: string
   operation: OperationObject
@@ -45,6 +46,7 @@ const createOperationEntry = ({
   parentTag?: ParentTag
   generateId: TraverseSpecOptions['generateId']
   parentId: string
+  operationTitleSource?: OperationTitleSource
 }): TraversedOperation => {
   const id = generateId({
     type: 'operation',
@@ -54,7 +56,7 @@ const createOperationEntry = ({
     path: path,
     parentId: parentId,
   })
-  const title = operation.summary?.trim() ? operation.summary : path
+  const title = operationTitleSource === 'path' ? path : operation.summary?.trim() ? operation.summary : path
 
   const isDeprecated = isDeprecatedOperation(operation)
 
@@ -105,6 +107,7 @@ export const traversePaths = ({
   tagsMap,
   generateId,
   documentId,
+  operationTitleSource,
 }: {
   document: OpenApiDocument
   /** Map of tags and their entries */
@@ -113,6 +116,8 @@ export const traversePaths = ({
   generateId: TraverseSpecOptions['generateId']
   /** Document ID */
   documentId: string
+  /** Whether to use the operation summary or the operation path for sidebar titles */
+  operationTitleSource?: OperationTitleSource
 }): { untaggedOperations: TraversedOperation[] } => {
   const untaggedOperations: TraversedOperation[] = []
 
@@ -152,6 +157,7 @@ export const traversePaths = ({
               parentTag: { tag, id: tagId },
               generateId,
               parentId: tagId,
+              operationTitleSource,
             }),
           )
         })
@@ -165,6 +171,7 @@ export const traversePaths = ({
             path,
             generateId,
             parentId: documentId,
+            operationTitleSource,
           }),
         )
       }

--- a/packages/workspace-store/src/navigation/types.ts
+++ b/packages/workspace-store/src/navigation/types.ts
@@ -12,6 +12,9 @@ type OperationSortValue = {
   httpVerb: string
 }
 
+/** Whether to use the operation summary or the operation path for sidebar and search titles */
+export type OperationTitleSource = 'summary' | 'path'
+
 /** Configuration options for traversing an OpenAPI specification document.
  *
  * These options control how the document is processed and organized, including:
@@ -28,6 +31,9 @@ export type TraverseSpecOptions = {
 
   /** Whether to hide model schemas from the navigation */
   hideModels: boolean
+
+  /** Whether to derive operation titles from the operation summary or the path */
+  operationTitleSource?: OperationTitleSource
 
   generateId: IdGenerator
 }


### PR DESCRIPTION
`operationTitleSource: 'path'` had no effect on sidebar titles generated by `@scalar/workspace-store` — the title was unconditionally set to `summary || path` in `traverse-paths.ts`. This thread the option through `traverseDocument` → `traversePaths` → `createOperationEntry` so the path is used when requested.

## Ticket

Closes #9246

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes how operation titles are derived for sidebar navigation, gated by an optional config flag, and adds targeted test coverage.
> 
> **Overview**
> **Navigation generation now respects `operationTitleSource`.** The option is plumbed from `getNavigationOptions` through `traverseDocument` into `traversePaths`, and `createOperationEntry` uses it to force operation titles to the OpenAPI path when set to `'path'` (otherwise preserving the existing `summary`-then-`path` behavior).
> 
> Adds `OperationTitleSource` typing and new `traversePaths` tests covering `'path'` vs `'summary'` behavior, plus a patch changeset for `@scalar/workspace-store`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5657016d64a646d209749203fcdfea0a9b739295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->