### PR TITLE
fix(docker): hosting under a subpath via BASE_PATH

### DIFF
--- a/.changeset/docker-base-path-subpath.md
+++ b/.changeset/docker-base-path-subpath.md
@@ -1,0 +1,5 @@
+---
+'@scalarapi/docker-api-reference': patch
+---
+
+feat(docker): add `BASE_PATH` environment variable so the Docker image can be hosted under a subpath (for example, `/docs`). When set, the container prefixes the client-side `configuration.json` fetch URL and the generated `openapi/*` document URLs so they resolve correctly behind a reverse proxy or ingress that exposes Scalar under a non-root path.

--- a/documentation/integrations/docker.md
+++ b/documentation/integrations/docker.md
@@ -90,12 +90,27 @@ services:
     restart: unless-stopped
 ```
 
+## Hosting Under a Subpath
+
+When serving the API reference under a subpath (for example, behind a reverse proxy at `/docs`), set the `BASE_PATH` environment variable so the container generates URLs with the correct prefix:
+
+```bash
+docker run \
+  -p 8080:8080 \
+  -e BASE_PATH=/docs \
+  -e API_REFERENCE_CONFIG='{"pathRouting":{"basePath":"/docs"},"sources":[{"url":"https://api.example.com/openapi.json"}]}' \
+  scalarapi/api-reference:latest
+```
+
+`BASE_PATH` only changes the URLs the client requests (such as `/docs/configuration.json` and mounted document URLs). It does not change the internal Caddy routes, so your reverse proxy or ingress is still expected to strip the prefix before forwarding requests to the container.
+
 ## Environment Variables
 
-| Variable               | Description                                     | Default     |
-| ---------------------- | ----------------------------------------------- | ----------- |
-| `API_REFERENCE_CONFIG` | JSON configuration for the API Reference | -           |
-| `CDN_URL`              | URL for the API Reference CDN                   | `scalar.js` |
+| Variable               | Description                                                       | Default     |
+| ---------------------- | ----------------------------------------------------------------- | ----------- |
+| `API_REFERENCE_CONFIG` | JSON configuration for the API Reference                          | -           |
+| `BASE_PATH`            | URL prefix when serving under a subpath (for example, `/docs`)    | -           |
+| `CDN_URL`              | URL for the API Reference CDN                                     | `scalar.js` |
 
 **Note:** Either `API_REFERENCE_CONFIG` must be set OR documents must be mounted to `/docs`
 

--- a/integrations/docker/Dockerfile
+++ b/integrations/docker/Dockerfile
@@ -35,6 +35,9 @@ ENV API_REFERENCE_CONFIG=undefined
 # Environment variable for CDN URL
 ENV CDN_URL=scalar.js
 
+# Environment variable for the URL prefix when serving under a subpath (for example, "/docs")
+ENV BASE_PATH=""
+
 
 # Use the startup script as entrypoint
 ENTRYPOINT ["/usr/local/bin/start.sh"]

--- a/integrations/docker/assets/index.html
+++ b/integrations/docker/assets/index.html
@@ -14,7 +14,7 @@
     <script>
       // Optional URL prefix when serving under a subpath (for example, "/docs").
       // Strip any trailing slash so the prefix concatenates cleanly.
-      const basePath = '{{env "BASE_PATH"}}'.replace(/\/$/, '')
+      const basePath = '{{env "BASE_PATH" | js}}'.replace(/\/$/, '')
 
       async function init() {
         let mountedDocuments = []

--- a/integrations/docker/assets/index.html
+++ b/integrations/docker/assets/index.html
@@ -12,12 +12,16 @@
     <div id="app"></div>
     <script src="{{env "CDN_URL"}}"></script>
     <script>
+      // Optional URL prefix when serving under a subpath (for example, "/docs").
+      // Strip any trailing slash so the prefix concatenates cleanly.
+      const basePath = '{{env "BASE_PATH"}}'.replace(/\/$/, '')
+
       async function init() {
         let mountedDocuments = []
 
         // First, try to load the generated configuration
         try {
-          const response = await fetch('/configuration.json')
+          const response = await fetch(`${basePath}/configuration.json`)
 
           if (response.ok) {
             const mountedConfig = await response.json()

--- a/integrations/docker/scan-documents.sh
+++ b/integrations/docker/scan-documents.sh
@@ -4,7 +4,10 @@
 # Scans mounted directories for OpenAPI documents and generates configuration
 
 MOUNT_DIR="/docs"
-BASE_URL="/openapi"
+# Optional URL prefix when serving under a subpath (for example, "/docs").
+# Strip any trailing slash so the prefix concatenates cleanly.
+BASE_PATH="${BASE_PATH%/}"
+BASE_URL="${BASE_PATH}/openapi"
 CONFIG_FILE="/tmp/configuration.json"
 
 echo "Scanning for OpenAPI documents in: $MOUNT_DIR"


### PR DESCRIPTION
Hosting the Docker image under a subpath broke because `index.html` fetched `/configuration.json` and the generated config used absolute `/openapi/*` URLs — both ignored the subpath.

Adds a `BASE_PATH` env var that prefixes those URLs. Default behavior is unchanged.

## Ticket

Fixes #9225

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `BASE_PATH` prefix to generated/fetched URLs for the Docker image without changing default routing behavior. Main risk is misconfiguration causing broken asset/document links behind proxies.
> 
> **Overview**
> Adds a new optional `BASE_PATH` env var to the Docker API Reference image to support hosting behind a reverse proxy under a non-root URL prefix.
> 
> When set, the client now fetches `${BASE_PATH}/configuration.json`, and the document scanner generates mounted OpenAPI source URLs under `${BASE_PATH}/openapi/*` (trailing slash stripped). Docs are updated with subpath usage guidance and the new environment variable, and the Dockerfile exports `BASE_PATH` with an empty default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d7e915935ced522e44434ace83f22a16c6eb895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->