### PR TITLE
ci: detect scalar-app version bumps for release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,11 +666,29 @@ jobs:
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+      # 'true' when this commit bumped projects/scalar-app/package.json's
+      # version. scalar-app is private, so it never appears in
+      # `publishedPackages` — this lets downstream jobs (web prod deploy,
+      # ToDesktop build) treat a scalar-app version bump as a release even
+      # when no public packages were published in the same commit.
+      scalar_app_released: ${{ steps.scalar-app-release.outputs.released }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
+      - name: Detect scalar-app version bump
+        id: scalar-app-release
+        run: |
+          CURRENT_VERSION=$(jq -r .version projects/scalar-app/package.json)
+          PREV_VERSION=$(git show HEAD~1:projects/scalar-app/package.json 2>/dev/null | jq -r .version || echo "")
+          if [ -n "$PREV_VERSION" ] && [ "$CURRENT_VERSION" != "$PREV_VERSION" ]; then
+            echo "scalar-app version changed: $PREV_VERSION -> $CURRENT_VERSION"
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "scalar-app version unchanged: $CURRENT_VERSION"
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Build
         uses: ./.github/actions/build
         with:
@@ -936,18 +954,20 @@ jobs:
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/deploy-api-client.yml
     with:
-      # 'production' only when npm-publish actually published at least one
-      # package on this commit; otherwise 'staging' (which is also what every
-      # PR preview uses).
-      environment: ${{ needs.npm-publish.outputs.published == 'true' && 'production' || 'staging' }}
+      # 'production' when this commit released at least one public package
+      # to npm OR bumped scalar-app's version. scalar-app is private so it
+      # never appears in `publishedPackages`; without the explicit version
+      # bump check, a release PR containing only scalar-app changesets would
+      # publish nothing and silently fall back to staging.
+      environment: ${{ (needs.npm-publish.outputs.published == 'true' || needs.npm-publish.outputs.scalar_app_released == 'true') && 'production' || 'staging' }}
       pr-number: ${{ github.event.pull_request.number }}
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit
 
   todesktop-build:
-    if: |
-      needs.npm-publish.outputs.published == 'true' &&
-      needs.check-changes.outputs.scalar_app_package_changed == 'true'
+    # Run whenever scalar-app's version was bumped on this commit. scalar-app
+    # is private, so `npm-publish.outputs.published` cannot be relied on here.
+    if: needs.npm-publish.outputs.scalar_app_released == 'true'
     needs: [required-jobs-main, build, check-changes, npm-publish]
     runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 15


### PR DESCRIPTION
This one is priority so we can release the client

## Problem

The CI/CD pipeline currently relies on `npm-publish.outputs.published` to determine whether a release occurred. However, `scalar-app` is a private package that never appears in the `publishedPackages` output, even when its version is bumped. This causes two issues:

1. **api-client deployments**: A release PR containing only scalar-app changesets would publish nothing to npm but should still trigger a production deployment
2. **ToDesktop builds**: The condition `published == 'true' && scalar_app_package_changed == 'true'` is fragile—it conflates two independent concerns and fails when only scalar-app is released

## Solution

Added explicit scalar-app version bump detection in the `npm-publish` job:

- New step `Detect scalar-app version bump` compares the current and previous commit's `projects/scalar-app/package.json` version
- Outputs `scalar_app_released` flag to job outputs
- Updated `deploy-api-client` environment selection to treat a scalar-app version bump as a release (production deployment)
- Simplified `todesktop-build` condition to rely solely on `scalar_app_released` instead of checking both `published` and `scalar_app_package_changed`

This decouples the scalar-app release signal from npm publishing and makes the intent explicit in the workflow.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- Not applicable: CI/workflow-only change -->
- [x] I added tests. <!-- Not applicable: CI/workflow configuration -->
- [x] I updated the documentation. <!-- Not applicable: CI/workflow configuration -->

https://claude.ai/code/session_01J64DdT6JU7K4Acsiz6SGUX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI release gating to treat `projects/scalar-app` version bumps as releases; mistakes could trigger or skip production deploys/ToDesktop builds unexpectedly.
> 
> **Overview**
> Adds a `Detect scalar-app version bump` step to the `npm-publish` job and exposes a new `scalar_app_released` output based on comparing the current commit’s `projects/scalar-app/package.json` version to `HEAD~1`.
> 
> Updates downstream gating to use this signal: `deploy-api-client` now selects *production* when either npm published packages **or** `scalar_app_released` is true, and `todesktop-build` now runs solely on `scalar_app_released` (instead of coupling to `published`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3818af07cd37df39c233b20b357077b23ecddc95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->