### PR TITLE
chore(scalar-app): add e2e tests for pre/post request scripts + iframe sandbox for scripts

### DIFF
--- a/.changeset/ready-singers-chew.md
+++ b/.changeset/ready-singers-chew.md
@@ -1,5 +1,8 @@
 ---
+'@scalar/pre-post-request-scripts': patch
 'scalar-app': patch
 ---
 
-chore: add unsafe-eval to the electron csp for pre-post scripts
+chore: remove `'unsafe-eval'` from the desktop/web app CSP
+
+Pre-request and post-response scripts run through `postman-sandbox`, which relies on `eval`. Instead of allowing `'unsafe-eval'` in the main application CSP, script execution now happens inside an isolated sandbox iframe (`sandbox.html`) that is loaded from a real same-origin URL and carries its own permissive CSP. The host talks to it over `postMessage`, so the main `script-src` no longer needs `'unsafe-eval'`.

--- a/.changeset/ready-singers-chew.md
+++ b/.changeset/ready-singers-chew.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+chore: add unsafe-eval to the electron csp for pre-post scripts

--- a/.changeset/short-moments-tease.md
+++ b/.changeset/short-moments-tease.md
@@ -1,5 +1,0 @@
----
-'scalar-app': patch
----
-
-fix: allow pre-request and post-response scripts in scalar app CSP

--- a/.changeset/short-moments-tease.md
+++ b/.changeset/short-moments-tease.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+chore: remove unsafe-eval from csp

--- a/.changeset/short-moments-tease.md
+++ b/.changeset/short-moments-tease.md
@@ -2,4 +2,4 @@
 'scalar-app': patch
 ---
 
-chore: remove unsafe-eval from csp
+fix: allow pre-request and post-response scripts in scalar app CSP

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -281,7 +281,13 @@
       ]
     },
     "packages/pre-post-request-scripts": {
-      "entry": ["src/index.ts", "src/plugins/index.ts"]
+      "entry": [
+        "src/index.ts",
+        "src/plugins/index.ts",
+        // Loaded by the sandbox iframe host page (sandbox.html) inside scalar-app.
+        // Exposed via the `./sandbox` subpath export, which knip cannot map back to src.
+        "src/libs/execute-scripts/postman-adapter/sandbox-frame-entry.ts"
+      ]
     },
     "packages/openapi-to-markdown": {
       "ignoreDependencies": ["vue"]
@@ -400,12 +406,16 @@
       "entry": [
         // Web app
         "entrypoints/web/src/main.ts",
+        // Web sandbox iframe entry (loaded by entrypoints/web/sandbox.html)
+        "entrypoints/web/src/sandbox.ts",
         // Electron main process
         "entrypoints/electron/main/index.ts",
         // Electron preload script
         "entrypoints/electron/preload/index.ts",
         // Electron renderer
         "entrypoints/electron/renderer/src/main.ts",
+        // Electron sandbox iframe entry (loaded by entrypoints/electron/renderer/sandbox.html)
+        "entrypoints/electron/renderer/src/sandbox.ts",
         // Vite configs
         "electron.vite.config.ts"
       ]

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ScalarIcon } from '@scalar/components'
+import { isObject } from '@scalar/helpers/object/is-object'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { computed } from 'vue'
 

--- a/packages/pre-post-request-scripts/package.json
+++ b/packages/pre-post-request-scripts/package.json
@@ -63,6 +63,7 @@
     "@codemirror/lang-javascript": "^6.2.5",
     "@headlessui/vue": "catalog:*",
     "@scalar/components": "workspace:*",
+    "@scalar/helpers": "workspace:*",
     "@scalar/oas-utils": "workspace:*",
     "@scalar/use-codemirror": "workspace:*",
     "@scalar/workspace-store": "workspace:*",

--- a/packages/pre-post-request-scripts/package.json
+++ b/packages/pre-post-request-scripts/package.json
@@ -48,6 +48,11 @@
       "import": "./dist/plugins/index.js",
       "types": "./dist/plugins/index.d.ts",
       "default": "./dist/plugins/index.js"
+    },
+    "./sandbox": {
+      "import": "./dist/libs/execute-scripts/postman-adapter/sandbox-frame-entry.js",
+      "types": "./dist/libs/execute-scripts/postman-adapter/sandbox-frame-entry.d.ts",
+      "default": "./dist/libs/execute-scripts/postman-adapter/sandbox-frame-entry.js"
     }
   },
   "files": [

--- a/packages/pre-post-request-scripts/src/consts/example-scripts.test.ts
+++ b/packages/pre-post-request-scripts/src/consts/example-scripts.test.ts
@@ -1,8 +1,13 @@
 import type { RequestFactory } from '@scalar/workspace-store/request-example'
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { type TestResult, executePostResponseScript } from '../libs/execute-scripts'
+import { registerInProcessSandbox } from '../libs/execute-scripts/postman-adapter/in-process-transport'
 import { EXAMPLE_SCRIPTS } from './example-scripts'
+
+beforeAll(() => {
+  registerInProcessSandbox()
+})
 
 const createRequestBuilder = (): RequestFactory => ({
   options: {},

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/build-sandbox-context.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/build-sandbox-context.ts
@@ -1,7 +1,7 @@
-import type { VariableEntry, VariablesStore } from '@scalar/workspace-store/request-example'
+import type { VariableEntry } from '@scalar/workspace-store/request-example'
 import { VariableList, VariableScope } from 'postman-collection'
 
-import { getVariableScopesFromStore } from './variables-store'
+import type { SerializableScopes } from './postman-adapter/sandbox-protocol'
 
 function toVariableList(entries: VariableEntry[]): VariableList {
   if (entries.length === 0) {
@@ -15,19 +15,23 @@ function toVariableList(entries: VariableEntry[]): VariableList {
   )
 }
 
-/**
- * Builds the Postman sandbox context object for variables (globals, environment,
- * collection, data, _variables) from a VariablesStore. Used so pm.variables.get/set
- * and precedence match Postman behavior.
- */
-export function buildSandboxContextFromStore(store: VariablesStore): {
+type SandboxVariableContext = {
   globals: VariableScope
   collectionVariables: VariableScope
   environment: VariableScope
   data: Record<string, string>
   _variables: VariableScope
-} {
-  const scopes = getVariableScopesFromStore(store)
+}
+
+/**
+ * Builds the Postman sandbox context object for variables (globals, environment,
+ * collection, data, _variables) from plain key/value scopes. Used so pm.variables.get/set
+ * and precedence match Postman behavior.
+ *
+ * This depends on postman-collection (`VariableScope`) but not on postman-sandbox, and is meant
+ * to run inside the sandbox iframe after the scopes have crossed the `postMessage` boundary.
+ */
+export function buildSandboxContextFromScopes(scopes: SerializableScopes): SandboxVariableContext {
   return {
     globals: new VariableScope(toVariableList(scopes.globals)),
     collectionVariables: new VariableScope(toVariableList(scopes.collectionVariables)),

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/execute-post-response-script.test.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/execute-post-response-script.test.ts
@@ -1,8 +1,13 @@
 import type { RequestFactory } from '@scalar/workspace-store/request-example'
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import type { TestResult } from './execute-post-response-script'
 import { executePostResponseScript } from './execute-post-response-script'
+import { registerInProcessSandbox } from './postman-adapter/in-process-transport'
+
+beforeAll(() => {
+  registerInProcessSandbox()
+})
 
 const createRequestBuilder = (): RequestFactory => ({
   options: {},

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/in-process-transport.test.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/in-process-transport.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { runSandboxExecutionMock, setSandboxTransportMock } = vi.hoisted(() => ({
+  runSandboxExecutionMock: vi.fn(),
+  setSandboxTransportMock: vi.fn(),
+}))
+
+vi.mock('./sandbox-frame-server', () => ({
+  runSandboxExecution: runSandboxExecutionMock,
+}))
+
+vi.mock('./sandbox-adapter', () => ({
+  setSandboxTransport: setSandboxTransportMock,
+}))
+
+import { registerInProcessSandbox } from './in-process-transport'
+import { SANDBOX_CHANNEL, type SandboxExecuteRequest, type SandboxOutboundMessage } from './sandbox-protocol'
+
+const baseRequest: SandboxExecuteRequest = {
+  channel: SANDBOX_CHANNEL,
+  kind: 'execute',
+  id: 'req-1',
+  listen: 'test',
+  script: 'pm.test("noop", () => {})',
+}
+
+/** Pull out the transport that `registerInProcessSandbox` installed so we can drive it directly. */
+const getTransport = () => {
+  registerInProcessSandbox()
+  expect(setSandboxTransportMock).toHaveBeenCalledTimes(1)
+  return setSandboxTransportMock.mock.calls[0]![0] as (
+    request: SandboxExecuteRequest,
+    onMessage: (message: SandboxOutboundMessage) => void,
+  ) => void
+}
+
+describe('registerInProcessSandbox', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('forwards messages from runSandboxExecution to onMessage on success', async () => {
+    runSandboxExecutionMock.mockImplementation((_request, emit) => {
+      emit({ channel: SANDBOX_CHANNEL, kind: 'done', id: 'req-1' })
+      return Promise.resolve()
+    })
+
+    const messages: SandboxOutboundMessage[] = []
+    getTransport()(baseRequest, (m) => messages.push(m))
+    // The transport returns synchronously; await a microtask so the mocked async work settles.
+    await Promise.resolve()
+
+    expect(messages).toEqual([{ channel: SANDBOX_CHANNEL, kind: 'done', id: 'req-1' }])
+  })
+
+  it('emits a done with the error message when runSandboxExecution rejects', async () => {
+    // Without the catch, the host promise in `executeInPostmanSandbox` would hang forever.
+    runSandboxExecutionMock.mockRejectedValueOnce(new Error('createContext failed'))
+
+    const messages: SandboxOutboundMessage[] = []
+    getTransport()(baseRequest, (m) => messages.push(m))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(messages).toEqual([
+      {
+        channel: SANDBOX_CHANNEL,
+        kind: 'done',
+        id: 'req-1',
+        error: 'createContext failed',
+      },
+    ])
+  })
+
+  it('stringifies non-Error rejections', async () => {
+    runSandboxExecutionMock.mockRejectedValueOnce('kaboom')
+
+    const messages: SandboxOutboundMessage[] = []
+    getTransport()(baseRequest, (m) => messages.push(m))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(messages).toEqual([
+      {
+        channel: SANDBOX_CHANNEL,
+        kind: 'done',
+        id: 'req-1',
+        error: 'kaboom',
+      },
+    ])
+  })
+})

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/in-process-transport.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/in-process-transport.ts
@@ -1,5 +1,6 @@
 import { setSandboxTransport } from './sandbox-adapter'
 import { runSandboxExecution } from './sandbox-frame-server'
+import { SANDBOX_CHANNEL } from './sandbox-protocol'
 
 /**
  * Routes the host adapter to run scripts in-process via {@link runSandboxExecution} instead of an
@@ -8,6 +9,16 @@ import { runSandboxExecution } from './sandbox-frame-server'
  */
 export const registerInProcessSandbox = (): void => {
   setSandboxTransport((request, onMessage) => {
-    void runSandboxExecution(request, onMessage)
+    // Mirror the iframe transport: a rejection from `runSandboxExecution` (for example a failed
+    // `createContext`) must surface as a `done` message, otherwise the host's awaiting promise
+    // in `executeInPostmanSandbox` hangs forever.
+    runSandboxExecution(request, onMessage).catch((error: unknown) => {
+      onMessage({
+        channel: SANDBOX_CHANNEL,
+        kind: 'done',
+        id: request.id,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    })
   })
 }

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/in-process-transport.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/in-process-transport.ts
@@ -1,0 +1,13 @@
+import { setSandboxTransport } from './sandbox-adapter'
+import { runSandboxExecution } from './sandbox-frame-server'
+
+/**
+ * Routes the host adapter to run scripts in-process via {@link runSandboxExecution} instead of an
+ * iframe. Used by node tests so the real postman-sandbox pipeline (which needs no DOM in node) can be
+ * exercised end-to-end. Never call this in production: it pulls `postman-sandbox` into the host.
+ */
+export const registerInProcessSandbox = (): void => {
+  setSandboxTransport((request, onMessage) => {
+    void runSandboxExecution(request, onMessage)
+  })
+}

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.test.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { sandboxFrameUrl, toPostmanResponse } from './sandbox-adapter'
+import { createConsoleContext } from '../context/console'
+import { executeInPostmanSandbox, sandboxFrameUrl, toPostmanResponse } from './sandbox-adapter'
 
 describe('sandbox-adapter', () => {
   it('serializes a Response into a Postman response definition with header objects', async () => {
@@ -128,5 +129,35 @@ describe('sandboxFrameUrl', () => {
     stubLocation('http://localhost:5066/')
 
     expect(sandboxFrameUrl()).toBe('http://localhost:5066/sandbox.html')
+  })
+})
+
+describe('executeInPostmanSandbox', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    document.querySelectorAll('iframe').forEach((frame) => frame.remove())
+  })
+
+  it('recovers instead of hanging when the sandbox iframe never reports readiness', async () => {
+    // jsdom never loads the iframe `src`, so the frame neither posts `ready` nor fires an `error`
+    // event — exactly the silent failure (bundle 404, CSP block, boot crash) the readiness timeout
+    // guards against. Without that timeout these promises would never settle and the test would
+    // time out.
+    vi.useFakeTimers()
+
+    const runOnce = async () => {
+      const execution = executeInPostmanSandbox({
+        script: 'pm.test("noop", () => {})',
+        type: 'pre-request',
+        context: { scriptConsole: createConsoleContext() },
+      })
+      await vi.runAllTimersAsync()
+      await expect(execution).resolves.toBeUndefined()
+    }
+
+    await runOnce()
+    // A second call must retry with a fresh frame: the timeout clears the cached frame promise, so
+    // one broken boot does not freeze script execution for the rest of the session.
+    await runOnce()
   })
 })

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.test.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.test.ts
@@ -1,158 +1,40 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
-const { sandboxContextMock, createContextMock } = vi.hoisted(() => {
-  const sandboxContext = {
-    on: vi.fn(),
-    off: vi.fn(),
-    execute: vi.fn(),
-    dispose: vi.fn(),
-  }
+import { toPostmanResponse } from './sandbox-adapter'
 
-  return {
-    sandboxContextMock: sandboxContext,
-    createContextMock: vi.fn((callback: (error: unknown, context: typeof sandboxContext) => void) =>
-      callback(null, sandboxContext),
-    ),
-  }
-})
-
-vi.mock('postman-sandbox', () => ({
-  default: {
-    createContext: createContextMock,
-  },
-}))
-
-import { executeInPostmanSandbox } from './sandbox-adapter'
-
-describe('postman-sandbox-adapter', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  it('passes response headers as Postman header objects', async () => {
-    sandboxContextMock.execute.mockImplementation((_target, _options, callback) => callback(undefined))
-
+describe('sandbox-adapter', () => {
+  it('serializes a Response into a Postman response definition with header objects', async () => {
     const response = new Response('{"ok":true}', {
-      status: 200,
+      status: 201,
+      statusText: 'Created',
       headers: {
         'content-type': 'application/json',
         'x-request-id': 'req-123',
       },
     })
 
-    await executeInPostmanSandbox({
-      script: 'pm.test("noop", () => {})',
-      type: 'post-response',
-      context: {
-        response,
-        scriptConsole: {
-          log: vi.fn(),
-          error: vi.fn(),
-          warn: vi.fn(),
-          info: vi.fn(),
-          debug: vi.fn(),
-          trace: vi.fn(),
-          table: vi.fn(),
-        },
-      },
-    })
+    const result = await toPostmanResponse(response)
 
-    expect(sandboxContextMock.execute).toHaveBeenCalledWith(
-      expect.objectContaining({ listen: 'test' }),
-      expect.objectContaining({
-        context: expect.objectContaining({
-          response: expect.objectContaining({
-            header: expect.arrayContaining([
-              expect.objectContaining({ key: 'content-type', value: 'application/json' }),
-              expect.objectContaining({ key: 'x-request-id', value: 'req-123' }),
-            ]),
-          }),
-        }),
-      }),
-      expect.any(Function),
+    expect(result.code).toBe(201)
+    expect(result.status).toBe('Created')
+    expect(result.header).toEqual(
+      expect.arrayContaining([
+        { key: 'content-type', value: 'application/json' },
+        { key: 'x-request-id', value: 'req-123' },
+      ]),
     )
+    expect(result.stream).toEqual({ type: 'Buffer', data: Array.from(new TextEncoder().encode('{"ok":true}')) })
   })
 
-  it('uses prerequest listener for pre-request scripts and test listener for post-response', async () => {
-    sandboxContextMock.execute.mockImplementation((_target, _options, callback) => callback(undefined))
-
-    await executeInPostmanSandbox({
-      script: 'pm.globals.set("a", "1")',
-      type: 'pre-request',
-      context: {
-        scriptConsole: {
-          log: vi.fn(),
-          error: vi.fn(),
-          warn: vi.fn(),
-          info: vi.fn(),
-          debug: vi.fn(),
-          trace: vi.fn(),
-          table: vi.fn(),
-        },
-      },
-    })
-
-    expect(sandboxContextMock.execute).toHaveBeenCalledWith(
-      expect.objectContaining({ listen: 'prerequest' }),
-      expect.any(Object),
-      expect.any(Function),
-    )
-
-    vi.clearAllMocks()
-    sandboxContextMock.execute.mockImplementation((_target, _options, callback) => callback(undefined))
-
-    await executeInPostmanSandbox({
-      script: 'pm.test("noop", () => {})',
-      type: 'post-response',
-      context: {
-        response: new Response('{}', { status: 200 }),
-        scriptConsole: {
-          log: vi.fn(),
-          error: vi.fn(),
-          warn: vi.fn(),
-          info: vi.fn(),
-          debug: vi.fn(),
-          trace: vi.fn(),
-          table: vi.fn(),
-        },
-      },
-    })
-
-    expect(sandboxContextMock.execute).toHaveBeenCalledWith(
-      expect.objectContaining({ listen: 'test' }),
-      expect.any(Object),
-      expect.any(Function),
-    )
+  it('falls back to the numeric status when statusText is empty', async () => {
+    const result = await toPostmanResponse(new Response(null, { status: 204 }))
+    expect(result.status).toBe('204')
   })
 
-  it('cleans up sandbox listeners and context when response conversion fails', async () => {
+  it('rejects when the response body cannot be read', async () => {
     const response = new Response('payload', { status: 200 })
     response.text = () => Promise.reject(new Error('Body already used'))
 
-    await expect(
-      executeInPostmanSandbox({
-        script: 'pm.test("noop", () => {})',
-        type: 'post-response',
-        context: {
-          response,
-          scriptConsole: {
-            log: vi.fn(),
-            error: vi.fn(),
-            warn: vi.fn(),
-            info: vi.fn(),
-            debug: vi.fn(),
-            trace: vi.fn(),
-            table: vi.fn(),
-          },
-        },
-      }),
-    ).rejects.toThrow('Body already used')
-
-    expect(sandboxContextMock.on).toHaveBeenCalledWith('execution.assertion', expect.any(Function))
-    expect(sandboxContextMock.on).toHaveBeenCalledWith('console', expect.any(Function))
-    expect(sandboxContextMock.off).toHaveBeenCalledWith('execution.assertion', expect.any(Function))
-    expect(sandboxContextMock.off).toHaveBeenCalledWith('console', expect.any(Function))
-    expect(sandboxContextMock.execute).not.toHaveBeenCalled()
-    expect(sandboxContextMock.dispose).toHaveBeenCalledTimes(1)
+    await expect(toPostmanResponse(response)).rejects.toThrow('Body already used')
   })
 })

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.test.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.test.ts
@@ -33,8 +33,21 @@ describe('sandbox-adapter', () => {
 
   it('rejects when the response body cannot be read', async () => {
     const response = new Response('payload', { status: 200 })
-    response.text = () => Promise.reject(new Error('Body already used'))
+    response.arrayBuffer = () => Promise.reject(new Error('Body already used'))
 
     await expect(toPostmanResponse(response)).rejects.toThrow('Body already used')
+  })
+
+  it('preserves binary payloads byte-for-byte', async () => {
+    // PDF magic bytes (0x25 0x50 0x44 0x46 … “%PDF”) followed by a byte sequence that is not
+    // valid UTF-8 (0xC0 is never a valid lead byte). Round-tripping through `response.text()` +
+    // `TextEncoder` would replace 0xC0 with the U+FFFD replacement character and corrupt the
+    // signature; `arrayBuffer()` must keep every byte intact.
+    const bytes = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0xc0, 0x80, 0xff, 0x00])
+    const response = new Response(bytes, { status: 200 })
+
+    const result = await toPostmanResponse(response)
+
+    expect(result.stream).toEqual({ type: 'Buffer', data: Array.from(bytes) })
   })
 })

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.test.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
 
-import { toPostmanResponse } from './sandbox-adapter'
+import { sandboxFrameUrl, toPostmanResponse } from './sandbox-adapter'
 
 describe('sandbox-adapter', () => {
   it('serializes a Response into a Postman response definition with header objects', async () => {
@@ -49,5 +50,83 @@ describe('sandbox-adapter', () => {
     const result = await toPostmanResponse(response)
 
     expect(result.stream).toEqual({ type: 'Buffer', data: Array.from(bytes) })
+  })
+})
+
+describe('sandboxFrameUrl', () => {
+  // `isElectron()` checks for `window.electron` (preload-injected). Tests drive that flag plus
+  // `window.location`/`<base href>` to simulate each environment.
+  const originalLocationDescriptor = Object.getOwnPropertyDescriptor(window, 'location')
+
+  const stubLocation = (href: string) => {
+    const url = new URL(href)
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...window.location,
+        href: url.href,
+        origin: url.origin,
+        protocol: url.protocol,
+        host: url.host,
+        hostname: url.hostname,
+        pathname: url.pathname,
+        search: url.search,
+        hash: url.hash,
+      },
+    })
+    // jsdom mirrors `document.baseURI` from `<base href>`, so update one to match.
+    let base = document.querySelector('base')
+    if (!base) {
+      base = document.createElement('base')
+      document.head.appendChild(base)
+    }
+    base.href = href
+  }
+
+  const setElectron = (present: boolean) => {
+    if (present) {
+      ;(window as unknown as { electron?: boolean }).electron = true
+    } else {
+      delete (window as unknown as { electron?: boolean }).electron
+    }
+  }
+
+  afterEach(() => {
+    if (originalLocationDescriptor) {
+      Object.defineProperty(window, 'location', originalLocationDescriptor)
+    }
+    document.querySelector('base')?.remove()
+    setElectron(false)
+  })
+
+  it('anchors to the origin root on the web so SPA route segments do not break resolution', () => {
+    // Relative URLs would land under the active SPA route and hit the history fallback.
+    setElectron(false)
+    stubLocation('https://client.scalar.com/@team/workspace/get-started')
+
+    expect(sandboxFrameUrl()).toBe('https://client.scalar.com/sandbox.html')
+  })
+
+  it('keeps the origin-root anchor on the web at the application root', () => {
+    setElectron(false)
+    stubLocation('https://client.scalar.com/')
+
+    expect(sandboxFrameUrl()).toBe('https://client.scalar.com/sandbox.html')
+  })
+
+  it('resolves a sibling in packaged Electron (`file://`)', () => {
+    // The document path is literal on disk; the `file://` origin alone would drop the directory.
+    setElectron(true)
+    stubLocation('file:///Applications/Scalar.app/Contents/Resources/renderer/index.html')
+
+    expect(sandboxFrameUrl()).toBe('file:///Applications/Scalar.app/Contents/Resources/renderer/sandbox.html')
+  })
+
+  it('resolves a sibling in Electron dev mode where the renderer is served over http(s)', () => {
+    // Dev-mode Electron looks like a web URL; only `window.electron` distinguishes it.
+    setElectron(true)
+    stubLocation('http://localhost:5066/')
+
+    expect(sandboxFrameUrl()).toBe('http://localhost:5066/sandbox.html')
   })
 })

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.ts
@@ -83,6 +83,20 @@ type SandboxTransport = (request: SandboxExecuteRequest, onMessage: (message: Sa
 
 let framePromise: Promise<Window> | undefined
 
+/**
+ * Maximum time we wait for a freshly created sandbox iframe to post its `ready` handshake.
+ *
+ * The iframe `error` event fires only when the `.html` document itself fails to load. If the
+ * document loads (HTTP 200) but the script inside never reaches `startSandboxFrameServer` — a
+ * 404 on the bundle, an import error, a CSP block, a crash during boot — no `ready` message is
+ * posted and no `error` event fires. Without this ceiling the readiness promise hangs forever;
+ * because it is module-cached, every later call awaits the same dead promise and all script
+ * execution freezes for the session. The window is generous: readiness only requires loading one
+ * same-origin HTML file plus the sandbox bundle, so timing out means the bundle is genuinely
+ * broken rather than slow.
+ */
+const SANDBOX_READY_TIMEOUT_MS = 30 * 1000
+
 /** Lazily creates a single hidden sandbox iframe and resolves once it reports readiness. */
 const ensureSandboxFrame = (): Promise<Window> => {
   if (framePromise) {
@@ -97,6 +111,14 @@ const ensureSandboxFrame = (): Promise<Window> => {
 
     const expectedOrigin = sandboxOrigin()
 
+    // Cleanup shared by the success, load-error, and readiness-timeout paths: cancel the timer and
+    // drop the window listener so exactly one of the three settles the promise without leaking.
+    let readyTimeoutId: ReturnType<typeof setTimeout>
+    const stopWaiting = () => {
+      clearTimeout(readyTimeoutId)
+      window.removeEventListener('message', onReady)
+    }
+
     const onReady = (event: MessageEvent) => {
       // Same-origin iframe: reject anything that does not come from our own origin and our own frame.
       if (event.origin !== expectedOrigin || event.source !== iframe.contentWindow) {
@@ -106,7 +128,7 @@ const ensureSandboxFrame = (): Promise<Window> => {
       if (!data || data.channel !== SANDBOX_CHANNEL || data.kind !== 'ready') {
         return
       }
-      window.removeEventListener('message', onReady)
+      stopWaiting()
       if (!iframe.contentWindow) {
         // Tear the orphaned node down so a retry can append a fresh frame without piling up.
         iframe.remove()
@@ -118,7 +140,7 @@ const ensureSandboxFrame = (): Promise<Window> => {
     }
 
     iframe.addEventListener('error', () => {
-      window.removeEventListener('message', onReady)
+      stopWaiting()
       // Drop the broken iframe from the DOM. Without this, a transient failure (network blip, bad
       // bundle path, etc.) leaves a dead `<iframe>` attached, and every retry appends another one,
       // growing the DOM unboundedly across the session.
@@ -126,6 +148,16 @@ const ensureSandboxFrame = (): Promise<Window> => {
       framePromise = undefined
       reject(new Error('Failed to load the script sandbox iframe'))
     })
+
+    // Catch the silent failure mode the `error` event cannot see: the document loaded but its
+    // script never announced readiness. Drop the dead frame and clear the cache so the next call
+    // retries with a fresh iframe instead of awaiting this one forever.
+    readyTimeoutId = setTimeout(() => {
+      window.removeEventListener('message', onReady)
+      iframe.remove()
+      framePromise = undefined
+      reject(new Error(`Sandbox iframe did not report readiness within ${SANDBOX_READY_TIMEOUT_MS}ms`))
+    }, SANDBOX_READY_TIMEOUT_MS)
 
     window.addEventListener('message', onReady)
     document.body.appendChild(iframe)

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.ts
@@ -63,10 +63,7 @@ const sandboxOrigin = (): string => window.location.origin
  * unit tests can run the real execution in-process (`runSandboxExecution`) without a DOM, and without
  * the production host bundle ever importing `postman-sandbox`.
  */
-export type SandboxTransport = (
-  request: SandboxExecuteRequest,
-  onMessage: (message: SandboxOutboundMessage) => void,
-) => void
+type SandboxTransport = (request: SandboxExecuteRequest, onMessage: (message: SandboxOutboundMessage) => void) => void
 
 let framePromise: Promise<Window> | undefined
 

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.ts
@@ -1,22 +1,27 @@
 import type { RequestFactory, VariablesStore } from '@scalar/workspace-store/request-example'
-import type { ExecutionResult, SandboxContext } from 'postman-sandbox'
-import Sandbox from 'postman-sandbox'
 
-import { buildSandboxContextFromStore } from '../build-sandbox-context'
 import type { ConsoleContext } from '../context/console'
 import type { TestResult } from '../execute-post-response-script'
-import { toVariableEntries } from '../variables-store'
+import { getVariableScopesFromStore, toVariableEntries } from '../variables-store'
 import { createPostmanRequestFromFactory, syncPlainPostmanRequestToRequestFactory } from './request-factory-adapter'
+import {
+  type PostmanResponseDefinition,
+  SANDBOX_CHANNEL,
+  type SandboxExecuteRequest,
+  type SandboxOutboundMessage,
+} from './sandbox-protocol'
 
-type AssertionEvent = {
-  name: string
-  index: number
-  passed: boolean
-  skipped: boolean
-  error: { message?: string } | null
-}
+/**
+ * Host-side adapter for pre/post-request scripts.
+ *
+ * The actual script execution happens in `postman-sandbox`, which requires `eval`. To keep
+ * `'unsafe-eval'` out of the main application CSP, that execution is delegated to an iframe loaded
+ * from a real same-origin `.html` file with its own permissive CSP (see `sandbox-frame-server.ts`).
+ * This module therefore must NOT import `postman-sandbox`; it only serializes inputs, talks to the
+ * iframe over `postMessage`, and applies the results back to the live store/request.
+ */
 
-const toPostmanResponse = async (response: Response) => {
+export const toPostmanResponse = async (response: Response): Promise<PostmanResponseDefinition> => {
   const responseText = await response.text()
   const responseBytes = Array.from(new TextEncoder().encode(responseText))
 
@@ -31,45 +36,103 @@ const toPostmanResponse = async (response: Response) => {
   }
 }
 
-const createContext = (): Promise<SandboxContext> =>
-  new Promise((resolve, reject) => {
-    Sandbox.createContext((error: unknown, context: SandboxContext) => {
-      if (error) {
-        reject(error)
+/** Resolves the sandbox iframe URL relative to the current document so it works for web and Electron `file://`. */
+const sandboxFrameUrl = (): string => new URL('sandbox.html', document.baseURI).href
+
+/**
+ * Delivers a single execute request to the sandbox and forwards every message it produces (test
+ * results, console output, and the final `done`) to `onMessage`.
+ *
+ * The default transport is the iframe (see {@link iframeTransport}). It is injectable so that node
+ * unit tests can run the real execution in-process (`runSandboxExecution`) without a DOM, and without
+ * the production host bundle ever importing `postman-sandbox`.
+ */
+export type SandboxTransport = (
+  request: SandboxExecuteRequest,
+  onMessage: (message: SandboxOutboundMessage) => void,
+) => void
+
+let framePromise: Promise<Window> | undefined
+
+/** Lazily creates a single hidden sandbox iframe and resolves once it reports readiness. */
+const ensureSandboxFrame = (): Promise<Window> => {
+  if (framePromise) {
+    return framePromise
+  }
+
+  framePromise = new Promise<Window>((resolve, reject) => {
+    const iframe = document.createElement('iframe')
+    iframe.setAttribute('aria-hidden', 'true')
+    iframe.style.display = 'none'
+    iframe.src = sandboxFrameUrl()
+
+    const onReady = (event: MessageEvent) => {
+      if (event.source !== iframe.contentWindow) {
         return
       }
+      const data = event.data as SandboxOutboundMessage | null
+      if (!data || data.channel !== SANDBOX_CHANNEL || data.kind !== 'ready') {
+        return
+      }
+      window.removeEventListener('message', onReady)
+      if (!iframe.contentWindow) {
+        reject(new Error('Sandbox iframe has no content window'))
+        return
+      }
+      resolve(iframe.contentWindow)
+    }
 
-      resolve(context)
+    iframe.addEventListener('error', () => {
+      window.removeEventListener('message', onReady)
+      framePromise = undefined
+      reject(new Error('Failed to load the script sandbox iframe'))
     })
+
+    window.addEventListener('message', onReady)
+    document.body.appendChild(iframe)
   })
 
-const toErrorMessage = (error: unknown): string => {
-  if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string') {
-    return error.message
-  }
-
-  return String(error)
+  return framePromise
 }
 
-const upsertTestResult = (testResults: TestResult[], assertion: AssertionEvent, duration: number): void => {
-  const title = assertion.name || `Assertion ${assertion.index + 1}`
+const iframeTransport: SandboxTransport = (request, onMessage) => {
+  ensureSandboxFrame()
+    .then((frame) => {
+      const handleMessage = (event: MessageEvent) => {
+        if (event.source !== frame) {
+          return
+        }
+        const data = event.data as SandboxOutboundMessage | null
+        if (!data || data.channel !== SANDBOX_CHANNEL || !('id' in data) || data.id !== request.id) {
+          return
+        }
+        if (data.kind === 'done') {
+          window.removeEventListener('message', handleMessage)
+        }
+        onMessage(data)
+      }
 
-  const nextResult: TestResult = {
-    title,
-    passed: assertion.passed,
-    duration,
-    error: assertion.error?.message,
-    status: assertion.passed ? 'passed' : 'failed',
-  }
-
-  const existingResultIndex = testResults.findIndex((result) => result.title === title)
-  if (existingResultIndex === -1) {
-    testResults.push(nextResult)
-    return
-  }
-
-  testResults[existingResultIndex] = nextResult
+      window.addEventListener('message', handleMessage)
+      frame.postMessage(request, '*')
+    })
+    .catch((error: unknown) => {
+      onMessage({
+        channel: SANDBOX_CHANNEL,
+        kind: 'done',
+        id: request.id,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    })
 }
+
+let transport: SandboxTransport = iframeTransport
+
+/** Override how the host reaches the sandbox (e.g. an in-process transport for tests). */
+export const setSandboxTransport = (next: SandboxTransport): void => {
+  transport = next
+}
+
+let nextExecutionId = 0
 
 export const executeInPostmanSandbox = async ({
   script,
@@ -88,118 +151,63 @@ export const executeInPostmanSandbox = async ({
   }
   onTestResultsUpdate?: ((results: TestResult[]) => void) | undefined
 }): Promise<VariablesStore | undefined> => {
-  const testResults: TestResult[] = []
-  let lastAssertionTime = 0
-  let scriptExecutionStartedAt = 0
-  const sandboxContext = await createContext()
+  // Serialize everything that crosses the iframe boundary on the host, so the iframe only deals with
+  // plain, structured-cloneable data. The response body is read here (it requires the live Response).
+  const requestDefinition = requestBuilder ? createPostmanRequestFromFactory(requestBuilder).toJSON() : undefined
+  const responseDefinition = response ? await toPostmanResponse(response) : undefined
+  const scopes = variablesStore ? getVariableScopesFromStore(variablesStore) : undefined
 
-  const handleAssertion = (_cursor: unknown, assertions: AssertionEvent[]) => {
-    assertions.forEach((assertion) => {
-      const duration = Number((performance.now() - lastAssertionTime).toFixed(2))
-      lastAssertionTime = performance.now()
-      upsertTestResult(testResults, assertion, duration)
-    })
-    onTestResultsUpdate?.([...testResults])
+  const request: SandboxExecuteRequest = {
+    channel: SANDBOX_CHANNEL,
+    kind: 'execute',
+    id: String(nextExecutionId++),
+    listen: type === 'pre-request' ? 'prerequest' : 'test',
+    script,
+    scopes,
+    request: requestDefinition,
+    response: responseDefinition,
   }
 
-  const variablesContext = variablesStore ? buildSandboxContextFromStore(variablesStore) : undefined
+  await new Promise<void>((resolve) => {
+    const onMessage = (data: SandboxOutboundMessage) => {
+      if (data.kind === 'test-results') {
+        onTestResultsUpdate?.(data.results)
+        return
+      }
 
-  const handleConsole = (_cursor: unknown, level: keyof ConsoleContext, ...args: unknown[]) => {
-    const consoleMethod = scriptConsole[level] ?? scriptConsole.log
-    ;(consoleMethod as (...params: unknown[]) => void)(...args)
-  }
+      if (data.kind === 'console') {
+        const consoleMethod = scriptConsole[data.level] ?? scriptConsole.log
+        ;(consoleMethod as (...params: unknown[]) => void)(...data.args)
+        return
+      }
 
-  try {
-    sandboxContext.on('execution.assertion', handleAssertion)
-    sandboxContext.on('console', handleConsole)
+      if (data.kind === 'done') {
+        if (variablesStore && data.variables) {
+          const { local, collection, globals, environment } = data.variables
+          if (local) {
+            variablesStore.setLocalVariables(toVariableEntries(local))
+          }
+          if (collection) {
+            variablesStore.setCollectionVariables?.(toVariableEntries(collection))
+          }
+          if (globals) {
+            variablesStore.setGlobals?.(toVariableEntries(globals))
+          }
+          if (environment) {
+            variablesStore.setEnvironment?.(toVariableEntries(environment))
+          }
+        }
 
-    const postmanRequest = requestBuilder ? createPostmanRequestFromFactory(requestBuilder) : undefined
-    const postmanResponse = response ? await toPostmanResponse(response) : undefined
+        if (!data.error && type === 'pre-request' && requestBuilder && data.request !== undefined) {
+          syncPlainPostmanRequestToRequestFactory(data.request, requestBuilder)
+        }
 
-    scriptExecutionStartedAt = performance.now()
-    lastAssertionTime = scriptExecutionStartedAt
-
-    /**
-     * Lodash `_.has(context, 'response')` is true even when the value is `undefined`,
-     * which makes the sandbox run `new Response(undefined)` and breaks `pm.request`.
-     * Only set keys that are actually present.
-     */
-    const context: Record<string, unknown> = {
-      ...(variablesContext ?? {}),
+        resolve()
+      }
     }
 
-    // We need to pass the postman request to the sandbox so it can be mutated by the script.
-    if (postmanRequest !== undefined) {
-      context.request = postmanRequest
-    }
-    // We need to pass the postman response to the sandbox so it can be used by the script.
-    if (postmanResponse !== undefined) {
-      context.response = postmanResponse
-    }
-
-    /** Pre-request scripts must use the prerequest listener so pm.globals / pm.environment / collection mutations appear on ExecutionResult. */
-    const listen = type === 'pre-request' ? 'prerequest' : 'test'
-
-    await new Promise<void>((resolve) => {
-      sandboxContext.execute(
-        {
-          listen,
-          script: {
-            exec: [script],
-          },
-        },
-        {
-          disableLegacyAPIs: true,
-          context,
-        },
-        (error: unknown, execution?: ExecutionResult) => {
-          if (variablesStore && execution) {
-            if (execution._variables?.values) {
-              const localVariables = toVariableEntries(execution._variables.values)
-              variablesStore.setLocalVariables(localVariables)
-            }
-            if (execution.collectionVariables?.values) {
-              const collectionVariables = toVariableEntries(execution.collectionVariables.values)
-              variablesStore.setCollectionVariables?.(collectionVariables)
-            }
-            if (execution.globals?.values) {
-              const globals = toVariableEntries(execution.globals.values)
-              variablesStore.setGlobals?.(globals)
-            }
-            if (execution.environment?.values) {
-              const environmentVariables = toVariableEntries(execution.environment.values)
-              variablesStore.setEnvironment?.(environmentVariables)
-            }
-          }
-
-          if (!error && type === 'pre-request' && requestBuilder && execution?.request !== undefined) {
-            syncPlainPostmanRequestToRequestFactory(execution.request, requestBuilder)
-          }
-          if (error) {
-            const duration = Number((performance.now() - scriptExecutionStartedAt).toFixed(2))
-            const errorMessage = toErrorMessage(error)
-
-            scriptConsole.error(`[${type.toUpperCase()} Script] Error (${duration}ms):`, errorMessage)
-
-            testResults.push({
-              title: 'Script Execution',
-              passed: false,
-              duration,
-              error: errorMessage,
-              status: 'failed',
-            })
-            onTestResultsUpdate?.([...testResults])
-          }
-
-          resolve()
-        },
-      )
-    })
-  } finally {
-    sandboxContext.off('execution.assertion', handleAssertion)
-    sandboxContext.off('console', handleConsole)
-    sandboxContext.dispose()
-  }
+    transport(request, onMessage)
+  })
 
   return variablesStore
 }

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.ts
@@ -20,10 +20,13 @@ import {
  * This module therefore must NOT import `postman-sandbox`; it only serializes inputs, talks to the
  * iframe over `postMessage`, and applies the results back to the live store/request.
  */
-
 export const toPostmanResponse = async (response: Response): Promise<PostmanResponseDefinition> => {
-  const responseText = await response.text()
-  const responseBytes = Array.from(new TextEncoder().encode(responseText))
+  // Read as ArrayBuffer (not text) so binary payloads — gzipped JSON, images, PDFs, protobuf —
+  // survive the trip through `postMessage` byte-for-byte. Round-tripping through `response.text()`
+  // + `TextEncoder` corrupts any sequence that is not valid UTF-8 because the decoder replaces
+  // invalid units with U+FFFD before we ever encode them back to bytes.
+  const buffer = await response.arrayBuffer()
+  const responseBytes = Array.from(new Uint8Array(buffer))
 
   return {
     code: response.status,
@@ -38,6 +41,19 @@ export const toPostmanResponse = async (response: Response): Promise<PostmanResp
 
 /** Resolves the sandbox iframe URL relative to the current document so it works for web and Electron `file://`. */
 const sandboxFrameUrl = (): string => new URL('sandbox.html', document.baseURI).href
+
+/**
+ * Origin we pin `postMessage` exchanges to.
+ *
+ * The sandbox iframe is served from the same origin as the host (see `sandbox.html`), so we lock
+ * every send and receive to `window.location.origin`. Pinning the send origin prevents the payload
+ * from leaking if the frame is ever navigated away to another origin; pinning the receive origin
+ * prevents another window (for example a cross-origin opener) from spoofing sandbox messages.
+ *
+ * For `file://` documents (Electron), `window.location.origin` is the string `'file://'`, which is
+ * the same value `postMessage` reports on `event.origin`, so the pin still holds.
+ */
+const sandboxOrigin = (): string => window.location.origin
 
 /**
  * Delivers a single execute request to the sandbox and forwards every message it produces (test
@@ -66,8 +82,11 @@ const ensureSandboxFrame = (): Promise<Window> => {
     iframe.style.display = 'none'
     iframe.src = sandboxFrameUrl()
 
+    const expectedOrigin = sandboxOrigin()
+
     const onReady = (event: MessageEvent) => {
-      if (event.source !== iframe.contentWindow) {
+      // Same-origin iframe: reject anything that does not come from our own origin and our own frame.
+      if (event.origin !== expectedOrigin || event.source !== iframe.contentWindow) {
         return
       }
       const data = event.data as SandboxOutboundMessage | null
@@ -76,6 +95,9 @@ const ensureSandboxFrame = (): Promise<Window> => {
       }
       window.removeEventListener('message', onReady)
       if (!iframe.contentWindow) {
+        // Tear the orphaned node down so a retry can append a fresh frame without piling up.
+        iframe.remove()
+        framePromise = undefined
         reject(new Error('Sandbox iframe has no content window'))
         return
       }
@@ -84,6 +106,10 @@ const ensureSandboxFrame = (): Promise<Window> => {
 
     iframe.addEventListener('error', () => {
       window.removeEventListener('message', onReady)
+      // Drop the broken iframe from the DOM. Without this, a transient failure (network blip, bad
+      // bundle path, etc.) leaves a dead `<iframe>` attached, and every retry appends another one,
+      // growing the DOM unboundedly across the session.
+      iframe.remove()
       framePromise = undefined
       reject(new Error('Failed to load the script sandbox iframe'))
     })
@@ -95,11 +121,39 @@ const ensureSandboxFrame = (): Promise<Window> => {
   return framePromise
 }
 
+/**
+ * Maximum time we wait for the iframe to emit `kind: 'done'` for a given execute request.
+ *
+ * postman-sandbox enforces its own per-script timeout inside the sandbox, so reaching this ceiling
+ * means the iframe itself wedged (renderer OOM, hard crash, blocking infinite loop in a worker,
+ * messages dropped). The default is generous on purpose — this is a circuit-breaker for crashes,
+ * not a budget for user scripts.
+ */
+const SANDBOX_EXECUTION_TIMEOUT_MS = 5 * 60 * 1000
+
 const iframeTransport: SandboxTransport = (request, onMessage) => {
   ensureSandboxFrame()
     .then((frame) => {
+      const expectedOrigin = sandboxOrigin()
+
+      // Defensive circuit-breaker: if the iframe dies mid-execution we would otherwise wait on a
+      // `done` message that will never arrive, leaking the listener and leaving the caller's
+      // promise unresolved. The timer is cancelled the moment `done` is observed below.
+      const timeoutId = setTimeout(() => {
+        window.removeEventListener('message', handleMessage)
+        onMessage({
+          channel: SANDBOX_CHANNEL,
+          kind: 'done',
+          id: request.id,
+          error: `Script execution timed out after ${SANDBOX_EXECUTION_TIMEOUT_MS}ms`,
+        })
+      }, SANDBOX_EXECUTION_TIMEOUT_MS)
+
       const handleMessage = (event: MessageEvent) => {
-        if (event.source !== frame) {
+        // Reject anything that is not from our own origin and our own frame. Without this guard,
+        // any window in the same browsing context group could send fabricated `done`/`test-results`
+        // messages and trick the host into applying attacker-controlled variables and requests.
+        if (event.origin !== expectedOrigin || event.source !== frame) {
           return
         }
         const data = event.data as SandboxOutboundMessage | null
@@ -107,13 +161,16 @@ const iframeTransport: SandboxTransport = (request, onMessage) => {
           return
         }
         if (data.kind === 'done') {
+          clearTimeout(timeoutId)
           window.removeEventListener('message', handleMessage)
         }
         onMessage(data)
       }
 
       window.addEventListener('message', handleMessage)
-      frame.postMessage(request, '*')
+      // Pin the target origin: the execute payload contains environments, headers, secrets, and
+      // potentially auth tokens, so we must never broadcast it with `'*'`.
+      frame.postMessage(request, expectedOrigin)
     })
     .catch((error: unknown) => {
       onMessage({
@@ -124,7 +181,6 @@ const iframeTransport: SandboxTransport = (request, onMessage) => {
       })
     })
 }
-
 let transport: SandboxTransport = iframeTransport
 
 /** Override how the host reaches the sandbox (e.g. an in-process transport for tests). */

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.ts
@@ -1,3 +1,4 @@
+import { isElectron } from '@scalar/helpers/general/is-electron'
 import type { RequestFactory, VariablesStore } from '@scalar/workspace-store/request-example'
 
 import type { ConsoleContext } from '../context/console'
@@ -39,8 +40,23 @@ export const toPostmanResponse = async (response: Response): Promise<PostmanResp
   }
 }
 
-/** Resolves the sandbox iframe URL relative to the current document so it works for web and Electron `file://`. */
-const sandboxFrameUrl = (): string => new URL('sandbox.html', document.baseURI).href
+/**
+ * Resolves the sandbox iframe URL.
+ *
+ * On the web we anchor to the origin root because the SPA router owns the current path: a
+ * relative `sandbox.html` would resolve under the active route and get rewritten to `index.html`
+ * by the history fallback. In Electron the document path is literal, so a sibling resolution
+ * works — and we use the `isElectron` helper rather than a `file://` check because Electron's
+ * dev mode is served over `http://localhost`.
+ *
+ * Exported for tests; production code reaches it through `ensureSandboxFrame`.
+ */
+export const sandboxFrameUrl = (): string => {
+  if (isElectron()) {
+    return new URL('sandbox.html', document.baseURI).href
+  }
+  return new URL('/sandbox.html', window.location.origin).href
+}
 
 /**
  * Origin we pin `postMessage` exchanges to.

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-frame-entry.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-frame-entry.ts
@@ -1,0 +1,9 @@
+import { startSandboxFrameServer } from './sandbox-frame-server'
+
+/**
+ * Entry point loaded by the sandbox iframe host page (`sandbox.html`).
+ *
+ * Importing this module pulls in `postman-sandbox`, so it must only ever be loaded inside the sandbox
+ * iframe (which has its own permissive CSP) — never from the main application bundle.
+ */
+startSandboxFrameServer()

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-frame-server.test.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-frame-server.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { sandboxContextMock, createContextMock } = vi.hoisted(() => {
+  const sandboxContext = {
+    on: vi.fn(),
+    off: vi.fn(),
+    execute: vi.fn(),
+    dispose: vi.fn(),
+  }
+
+  return {
+    sandboxContextMock: sandboxContext,
+    createContextMock: vi.fn((callback: (error: unknown, context: typeof sandboxContext) => void) =>
+      callback(null, sandboxContext),
+    ),
+  }
+})
+
+vi.mock('postman-sandbox', () => ({
+  default: {
+    createContext: createContextMock,
+  },
+}))
+
+import { runSandboxExecution } from './sandbox-frame-server'
+import { SANDBOX_CHANNEL, type SandboxExecuteRequest, type SandboxOutboundMessage } from './sandbox-protocol'
+
+const baseRequest = (overrides: Partial<SandboxExecuteRequest>): SandboxExecuteRequest => ({
+  channel: SANDBOX_CHANNEL,
+  kind: 'execute',
+  id: '1',
+  listen: 'test',
+  script: 'pm.test("noop", () => {})',
+  ...overrides,
+})
+
+describe('sandbox-frame-server', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes the plain response through to the sandbox context', async () => {
+    sandboxContextMock.execute.mockImplementation((_target, _options, callback) => callback(undefined))
+
+    await runSandboxExecution(
+      baseRequest({
+        response: {
+          code: 200,
+          status: '200',
+          header: [
+            { key: 'content-type', value: 'application/json' },
+            { key: 'x-request-id', value: 'req-123' },
+          ],
+          stream: { type: 'Buffer', data: [] },
+        },
+      }),
+      vi.fn(),
+    )
+
+    expect(sandboxContextMock.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ listen: 'test' }),
+      expect.objectContaining({
+        context: expect.objectContaining({
+          response: expect.objectContaining({
+            header: expect.arrayContaining([
+              expect.objectContaining({ key: 'content-type', value: 'application/json' }),
+              expect.objectContaining({ key: 'x-request-id', value: 'req-123' }),
+            ]),
+          }),
+        }),
+      }),
+      expect.any(Function),
+    )
+  })
+
+  it('uses the prerequest listener for pre-request and the test listener for post-response', async () => {
+    sandboxContextMock.execute.mockImplementation((_target, _options, callback) => callback(undefined))
+
+    await runSandboxExecution(baseRequest({ listen: 'prerequest', script: 'pm.globals.set("a", "1")' }), vi.fn())
+    expect(sandboxContextMock.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ listen: 'prerequest' }),
+      expect.any(Object),
+      expect.any(Function),
+    )
+
+    vi.clearAllMocks()
+    sandboxContextMock.execute.mockImplementation((_target, _options, callback) => callback(undefined))
+
+    await runSandboxExecution(baseRequest({ listen: 'test' }), vi.fn())
+    expect(sandboxContextMock.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ listen: 'test' }),
+      expect.any(Object),
+      expect.any(Function),
+    )
+  })
+
+  it('removes listeners and disposes the context after execution', async () => {
+    sandboxContextMock.execute.mockImplementation((_target, _options, callback) => callback(undefined))
+
+    await runSandboxExecution(baseRequest({}), vi.fn())
+
+    expect(sandboxContextMock.on).toHaveBeenCalledWith('execution.assertion', expect.any(Function))
+    expect(sandboxContextMock.on).toHaveBeenCalledWith('console', expect.any(Function))
+    expect(sandboxContextMock.off).toHaveBeenCalledWith('execution.assertion', expect.any(Function))
+    expect(sandboxContextMock.off).toHaveBeenCalledWith('console', expect.any(Function))
+    expect(sandboxContextMock.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards variable scopes from the execution result in the done message', async () => {
+    sandboxContextMock.execute.mockImplementation((_target, _options, callback) =>
+      callback(undefined, {
+        _variables: { values: [{ key: 'local', value: 'l' }] },
+        globals: { values: [{ key: 'g', value: '1' }] },
+      }),
+    )
+
+    const messages: SandboxOutboundMessage[] = []
+    await runSandboxExecution(baseRequest({ id: '7' }), (message) => messages.push(message))
+
+    const done = messages.find((message) => message.kind === 'done')
+    expect(done).toEqual(
+      expect.objectContaining({
+        id: '7',
+        variables: expect.objectContaining({
+          local: [{ key: 'local', value: 'l' }],
+          globals: [{ key: 'g', value: '1' }],
+        }),
+      }),
+    )
+  })
+
+  it('emits a failed test result and a done error when the script throws', async () => {
+    sandboxContextMock.execute.mockImplementation((_target, _options, callback) => callback(new Error('kaboom')))
+
+    const messages: SandboxOutboundMessage[] = []
+    await runSandboxExecution(baseRequest({}), (message) => messages.push(message))
+
+    const lastResults = messages.filter((message) => message.kind === 'test-results').at(-1)
+    expect(lastResults?.kind === 'test-results' && lastResults.results).toEqual(
+      expect.arrayContaining([expect.objectContaining({ title: 'Script Execution', passed: false, error: 'kaboom' })]),
+    )
+
+    const done = messages.find((message) => message.kind === 'done')
+    expect(done?.kind === 'done' && done.error).toBe('kaboom')
+  })
+})

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-frame-server.test.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-frame-server.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { sandboxContextMock, createContextMock } = vi.hoisted(() => {
@@ -22,7 +23,7 @@ vi.mock('postman-sandbox', () => ({
   },
 }))
 
-import { runSandboxExecution } from './sandbox-frame-server'
+import { runSandboxExecution, startSandboxFrameServer } from './sandbox-frame-server'
 import { SANDBOX_CHANNEL, type SandboxExecuteRequest, type SandboxOutboundMessage } from './sandbox-protocol'
 
 const baseRequest = (overrides: Partial<SandboxExecuteRequest>): SandboxExecuteRequest => ({
@@ -142,5 +143,120 @@ describe('sandbox-frame-server', () => {
 
     const done = messages.find((message) => message.kind === 'done')
     expect(done?.kind === 'done' && done.error).toBe('kaboom')
+  })
+})
+
+describe('startSandboxFrameServer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  /**
+   * `startSandboxFrameServer` posts a `ready` message and registers a `message` listener. We
+   * stub the bare minimum off `window.parent` (target of `postMessage`) and dispatch synthetic
+   * `MessageEvent`s with controlled `origin`/`source` so we can prove the listener enforces the
+   * same-origin pin without spinning up a real iframe.
+   *
+   * We rely on the teardown returned by `startSandboxFrameServer` so each test cleans up its
+   * own listener; without that, listeners from earlier tests would still see dispatched events
+   * and call into the parent stub of the current test, contaminating assertions.
+   */
+  const setupServer = () => {
+    const parentPostMessage = vi.fn()
+    const originalParentDescriptor = Object.getOwnPropertyDescriptor(window, 'parent')
+
+    // Replace `window.parent` with our stub. Captured here so the teardown can restore exactly
+    // what was there before, even if the original was the engine-provided non-configurable
+    // descriptor (in which case `originalParentDescriptor` is `undefined` and `delete` is the
+    // correct restore).
+    Object.defineProperty(window, 'parent', {
+      configurable: true,
+      get: () =>
+        ({
+          postMessage: parentPostMessage,
+        }) as unknown as Window,
+    })
+
+    const teardown = startSandboxFrameServer()
+
+    return {
+      parentPostMessage,
+      restore: () => {
+        teardown()
+        if (originalParentDescriptor) {
+          Object.defineProperty(window, 'parent', originalParentDescriptor)
+        } else {
+          // No own descriptor existed (the property came from the prototype chain) — drop ours
+          // so the original lookup path is re-exposed.
+          delete (window as unknown as { parent?: unknown }).parent
+        }
+      },
+    }
+  }
+
+  const dispatchExecute = (overrides: Partial<MessageEventInit<unknown>>) => {
+    const request: SandboxExecuteRequest = {
+      channel: SANDBOX_CHANNEL,
+      kind: 'execute',
+      id: '1',
+      listen: 'test',
+      script: 'pm.test("noop", () => {})',
+    }
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: request,
+        origin: window.location.origin,
+        source: window.parent,
+        ...overrides,
+      }),
+    )
+  }
+
+  it('announces readiness to the parent pinned to the current origin (not wildcard)', () => {
+    const { parentPostMessage, restore } = setupServer()
+
+    try {
+      expect(parentPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ channel: SANDBOX_CHANNEL, kind: 'ready' }),
+        window.location.origin,
+      )
+      expect(parentPostMessage).not.toHaveBeenCalledWith(expect.anything(), '*')
+    } finally {
+      restore()
+    }
+  })
+
+  it('ignores execute messages from a foreign origin', () => {
+    const { parentPostMessage, restore } = setupServer()
+
+    try {
+      parentPostMessage.mockClear()
+
+      // Synthetic message from `https://evil.example`. The server must drop it without invoking
+      // the sandbox, so no `test-results`/`done` are ever posted back.
+      dispatchExecute({ origin: 'https://evil.example' })
+
+      expect(createContextMock).not.toHaveBeenCalled()
+      expect(parentPostMessage).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
+  it('ignores execute messages whose source is not the parent window', () => {
+    const { parentPostMessage, restore } = setupServer()
+
+    try {
+      parentPostMessage.mockClear()
+
+      // Correct origin but a different window object (for example a sibling frame).
+      dispatchExecute({ source: window as unknown as MessageEventSource })
+
+      expect(createContextMock).not.toHaveBeenCalled()
+      expect(parentPostMessage).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
   })
 })

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-frame-server.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-frame-server.ts
@@ -194,14 +194,40 @@ export const runSandboxExecution = async (
 /**
  * Boots the sandbox bridge: listens for {@link SandboxExecuteRequest} messages from the host window
  * and announces readiness. Called by the sandbox `.html` entry point.
+ *
+ * Returns a teardown function that removes the `message` listener it registered. Production code
+ * does not need to call it (the iframe lives for the lifetime of the document), but tests and any
+ * future hot-reload path can use it to avoid leaking listeners across reboots.
  */
-export const startSandboxFrameServer = (): void => {
+export const startSandboxFrameServer = (): (() => void) => {
+  /**
+   * Origin we pin `postMessage` exchanges to.
+   *
+   * The iframe is loaded same-origin with its host (see `sandbox.html`), so both the parent we
+   * post to and the parent we accept from are pinned to `window.location.origin`. This prevents
+   * a hostile cross-origin opener from feeding fake execute requests into the sandbox, and stops
+   * sandbox output (which can include user secrets returned via `pm.environment`) from leaking
+   * to a different origin if the parent is ever swapped out.
+   *
+   * For `file://` documents (Electron) this resolves to `'file://'`, which is the same value
+   * `postMessage` exposes on `event.origin`, so the pin still holds.
+   */
+  const expectedOrigin = window.location.origin
+
   const post = (message: SandboxOutboundMessage) => {
-    // The host validates `event.source`; the iframe content is our own served file, so target '*'.
-    window.parent?.postMessage(message, '*')
+    // Always target the host's origin explicitly instead of `'*'`. The host also validates
+    // `event.source` and `event.origin`, but defense-in-depth is cheap here.
+    window.parent?.postMessage(message, expectedOrigin)
   }
 
-  window.addEventListener('message', (event: MessageEvent) => {
+  const handleMessage = (event: MessageEvent) => {
+    // Reject anything that is not from our parent on our own origin. Without this guard, any
+    // window that obtains a reference to this iframe could send fabricated execute payloads and
+    // run arbitrary scripts inside the eval-permitted realm.
+    if (event.origin !== expectedOrigin || event.source !== window.parent) {
+      return
+    }
+
     const data = event.data as Partial<SandboxExecuteRequest> | null
     if (!data || data.channel !== SANDBOX_CHANNEL || data.kind !== 'execute') {
       return
@@ -215,7 +241,10 @@ export const startSandboxFrameServer = (): void => {
         error: toErrorMessage(error),
       })
     })
-  })
+  }
 
+  window.addEventListener('message', handleMessage)
   post({ channel: SANDBOX_CHANNEL, kind: 'ready' })
+
+  return () => window.removeEventListener('message', handleMessage)
 }

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-frame-server.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-frame-server.ts
@@ -1,0 +1,221 @@
+import { Request as PostmanRequest } from 'postman-collection'
+import type { ExecutionResult, SandboxContext } from 'postman-sandbox'
+import Sandbox from 'postman-sandbox'
+
+import { buildSandboxContextFromScopes } from '../build-sandbox-context'
+import type { ConsoleContext } from '../context/console'
+import type { TestResult } from '../execute-post-response-script'
+import { SANDBOX_CHANNEL, type SandboxExecuteRequest, type SandboxOutboundMessage } from './sandbox-protocol'
+
+/**
+ * Iframe-side sandbox bridge.
+ *
+ * This is the ONLY module that imports `postman-sandbox` (and therefore the only place that performs
+ * `eval`/`new Function`). It is loaded exclusively by the sandbox `.html` host page, which carries its
+ * own permissive CSP. The main application bundle never imports this file, so it stays eval-free and
+ * its CSP can drop `'unsafe-eval'`.
+ */
+
+type AssertionEvent = {
+  name: string
+  index: number
+  passed: boolean
+  skipped: boolean
+  error: { message?: string } | null
+}
+
+const toErrorMessage = (error: unknown): string => {
+  if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string') {
+    return error.message
+  }
+
+  return String(error)
+}
+
+const upsertTestResult = (testResults: TestResult[], assertion: AssertionEvent, duration: number): void => {
+  const title = assertion.name || `Assertion ${assertion.index + 1}`
+
+  const nextResult: TestResult = {
+    title,
+    passed: assertion.passed,
+    duration,
+    error: assertion.error?.message,
+    status: assertion.passed ? 'passed' : 'failed',
+  }
+
+  const existingResultIndex = testResults.findIndex((result) => result.title === title)
+  if (existingResultIndex === -1) {
+    testResults.push(nextResult)
+    return
+  }
+
+  testResults[existingResultIndex] = nextResult
+}
+
+const createContext = (): Promise<SandboxContext> =>
+  new Promise((resolve, reject) => {
+    Sandbox.createContext((error: unknown, context: SandboxContext) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve(context)
+    })
+  })
+
+/**
+ * Runs a single script in the postman-sandbox and reports progress/results via {@link emit}.
+ *
+ * Inputs arrive as plain, structured-cloneable data (already converted on the host) and are rebuilt
+ * into postman-collection objects here. Variable mutations and the mutated request are sent back as
+ * plain values; the host applies them to the live `VariablesStore`/`RequestFactory`.
+ */
+export const runSandboxExecution = async (
+  request: SandboxExecuteRequest,
+  emit: (message: SandboxOutboundMessage) => void,
+): Promise<void> => {
+  const { id, listen, script, scopes, request: requestDefinition, response } = request
+
+  const testResults: TestResult[] = []
+  let lastAssertionTime = 0
+  let scriptExecutionStartedAt = 0
+
+  const sandboxContext = await createContext()
+
+  const handleAssertion = (_cursor: unknown, assertions: AssertionEvent[]) => {
+    assertions.forEach((assertion) => {
+      const duration = Number((performance.now() - lastAssertionTime).toFixed(2))
+      lastAssertionTime = performance.now()
+      upsertTestResult(testResults, assertion, duration)
+    })
+    emit({ channel: SANDBOX_CHANNEL, kind: 'test-results', id, results: [...testResults] })
+  }
+
+  const handleConsole = (_cursor: unknown, level: string, ...args: unknown[]) => {
+    emit({ channel: SANDBOX_CHANNEL, kind: 'console', id, level: level as keyof ConsoleContext, args })
+  }
+
+  try {
+    sandboxContext.on('execution.assertion', handleAssertion)
+    sandboxContext.on('console', handleConsole)
+
+    const variablesContext = scopes ? buildSandboxContextFromScopes(scopes) : undefined
+
+    scriptExecutionStartedAt = performance.now()
+    lastAssertionTime = scriptExecutionStartedAt
+
+    /**
+     * Lodash `_.has(context, 'response')` is true even when the value is `undefined`,
+     * which makes the sandbox run `new Response(undefined)` and breaks `pm.request`.
+     * Only set keys that are actually present.
+     */
+    const context: Record<string, unknown> = {
+      ...(variablesContext ?? {}),
+    }
+
+    if (requestDefinition !== undefined) {
+      context.request = new PostmanRequest(requestDefinition as ConstructorParameters<typeof PostmanRequest>[0])
+    }
+    if (response !== undefined) {
+      context.response = response
+    }
+
+    await new Promise<void>((resolve) => {
+      sandboxContext.execute(
+        {
+          listen,
+          script: {
+            exec: [script],
+          },
+        },
+        {
+          disableLegacyAPIs: true,
+          context,
+        },
+        (error: unknown, execution?: ExecutionResult) => {
+          const done: SandboxOutboundMessage = {
+            channel: SANDBOX_CHANNEL,
+            kind: 'done',
+            id,
+          }
+
+          if (execution) {
+            done.variables = {
+              local: execution._variables?.values,
+              collection: execution.collectionVariables?.values,
+              globals: execution.globals?.values,
+              environment: execution.environment?.values,
+            }
+          }
+
+          if (!error && listen === 'prerequest' && execution?.request !== undefined) {
+            done.request = execution.request
+          }
+
+          if (error) {
+            const duration = Number((performance.now() - scriptExecutionStartedAt).toFixed(2))
+            const errorMessage = toErrorMessage(error)
+            done.error = errorMessage
+
+            emit({
+              channel: SANDBOX_CHANNEL,
+              kind: 'console',
+              id,
+              level: 'error',
+              args: [
+                `[${listen === 'prerequest' ? 'PRE-REQUEST' : 'POST-RESPONSE'} Script] Error (${duration}ms):`,
+                errorMessage,
+              ],
+            })
+
+            testResults.push({
+              title: 'Script Execution',
+              passed: false,
+              duration,
+              error: errorMessage,
+              status: 'failed',
+            })
+            emit({ channel: SANDBOX_CHANNEL, kind: 'test-results', id, results: [...testResults] })
+          }
+
+          emit(done)
+          resolve()
+        },
+      )
+    })
+  } finally {
+    sandboxContext.off('execution.assertion', handleAssertion)
+    sandboxContext.off('console', handleConsole)
+    sandboxContext.dispose()
+  }
+}
+
+/**
+ * Boots the sandbox bridge: listens for {@link SandboxExecuteRequest} messages from the host window
+ * and announces readiness. Called by the sandbox `.html` entry point.
+ */
+export const startSandboxFrameServer = (): void => {
+  const post = (message: SandboxOutboundMessage) => {
+    // The host validates `event.source`; the iframe content is our own served file, so target '*'.
+    window.parent?.postMessage(message, '*')
+  }
+
+  window.addEventListener('message', (event: MessageEvent) => {
+    const data = event.data as Partial<SandboxExecuteRequest> | null
+    if (!data || data.channel !== SANDBOX_CHANNEL || data.kind !== 'execute') {
+      return
+    }
+
+    void runSandboxExecution(data as SandboxExecuteRequest, post).catch((error: unknown) => {
+      post({
+        channel: SANDBOX_CHANNEL,
+        kind: 'done',
+        id: (data as SandboxExecuteRequest).id,
+        error: toErrorMessage(error),
+      })
+    })
+  })
+
+  post({ channel: SANDBOX_CHANNEL, kind: 'ready' })
+}

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-protocol.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-protocol.ts
@@ -1,0 +1,97 @@
+import type { VariableEntry } from '@scalar/workspace-store/request-example'
+
+import type { ConsoleContext } from '../context/console'
+import type { TestResult } from '../execute-post-response-script'
+
+/**
+ * Message channel shared between the host (main app realm) and the sandbox iframe.
+ *
+ * Pre/post-request scripts are executed by `postman-sandbox`, which relies on `eval`/`new Function`.
+ * To keep `'unsafe-eval'` out of the main application CSP, that execution is relocated into an
+ * iframe loaded from a real, same-origin `.html` file that carries its own (permissive) CSP. The
+ * host and the iframe talk over `postMessage` using the messages defined here. Everything that
+ * crosses the boundary must be structured-cloneable, so postman-collection objects are serialized
+ * to their plain JSON form (`VariableScope`/`Request` definitions) and rebuilt inside the iframe.
+ */
+export const SANDBOX_CHANNEL = 'scalar-pre-post-request-scripts-sandbox'
+
+/** Plain, serializable representation of a postman-collection `Request` (`Request.prototype.toJSON()`). */
+export type PostmanRequestDefinition = unknown
+
+/** Plain response shape consumed by `pm.response` inside the sandbox. */
+export type PostmanResponseDefinition = {
+  code: number
+  status: string
+  header: { key: string; value: string }[]
+  stream: { type: 'Buffer'; data: number[] }
+}
+
+/** Variable scopes serialized as key/value arrays so the iframe can rebuild postman `VariableScope`s. */
+export type SerializableScopes = {
+  environment: VariableEntry[]
+  globals: VariableEntry[]
+  collectionVariables: VariableEntry[]
+  data: Record<string, string>
+  local: VariableEntry[]
+}
+
+/** Plain variable values as returned on a postman `ExecutionResult` scope (`{ values }`). */
+export type SerializableVariableValues = Array<{ key: string; value: string; type?: string }>
+
+/** Host → iframe: run a single pre-request or post-response script. */
+export type SandboxExecuteRequest = {
+  channel: typeof SANDBOX_CHANNEL
+  kind: 'execute'
+  id: string
+  /** Maps to the postman-sandbox listener: `'prerequest'` for pre-request, `'test'` for post-response. */
+  listen: 'prerequest' | 'test'
+  script: string
+  scopes?: SerializableScopes
+  request?: PostmanRequestDefinition
+  response?: PostmanResponseDefinition
+}
+
+/** iframe → host: the sandbox bridge has loaded and is ready to receive `execute` requests. */
+export type SandboxReadyMessage = {
+  channel: typeof SANDBOX_CHANNEL
+  kind: 'ready'
+}
+
+/** iframe → host: incremental test results (assertions + script execution errors). */
+export type SandboxTestResultsMessage = {
+  channel: typeof SANDBOX_CHANNEL
+  kind: 'test-results'
+  id: string
+  results: TestResult[]
+}
+
+/** iframe → host: a console call made by the script. */
+export type SandboxConsoleMessage = {
+  channel: typeof SANDBOX_CHANNEL
+  kind: 'console'
+  id: string
+  level: keyof ConsoleContext
+  args: unknown[]
+}
+
+/** iframe → host: the script finished (successfully or with an error). */
+export type SandboxDoneMessage = {
+  channel: typeof SANDBOX_CHANNEL
+  kind: 'done'
+  id: string
+  variables?: {
+    local?: SerializableVariableValues
+    collection?: SerializableVariableValues
+    globals?: SerializableVariableValues
+    environment?: SerializableVariableValues
+  }
+  /** Mutated postman request (`execution.request`) for pre-request scripts. */
+  request?: PostmanRequestDefinition
+  error?: string
+}
+
+export type SandboxOutboundMessage =
+  | SandboxReadyMessage
+  | SandboxTestResultsMessage
+  | SandboxConsoleMessage
+  | SandboxDoneMessage

--- a/packages/pre-post-request-scripts/src/plugins/request-scripts/request-scripts-plugin.test.ts
+++ b/packages/pre-post-request-scripts/src/plugins/request-scripts/request-scripts-plugin.test.ts
@@ -1,11 +1,16 @@
 import type { RequestFactory, VariableEntry, VariablesStore } from '@scalar/workspace-store/request-example'
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 import type { Ref } from 'vue'
 
 import type { TestResult } from '@/libs/execute-scripts'
 import { executePostResponseScript } from '@/libs/execute-scripts/execute-post-response-script'
 import { executePreRequestScript } from '@/libs/execute-scripts/execute-pre-request-script'
+import { registerInProcessSandbox } from '@/libs/execute-scripts/postman-adapter/in-process-transport'
 import { requestScriptsPlugin } from '@/plugins/request-scripts/request-scripts-plugin'
+
+beforeAll(() => {
+  registerInProcessSandbox()
+})
 
 const createRequestBuilder = (): RequestFactory => ({
   options: {},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1082,7 +1082,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: ^4.0.0
-        version: 4.3.1(magicast@0.3.5)
+        version: 4.3.1(magicast@0.5.2)
       '@scalar/api-client':
         specifier: workspace:*
         version: link:../../packages/api-client
@@ -1101,7 +1101,7 @@ importers:
     devDependencies:
       '@nuxt/module-builder':
         specifier: ^1.0.1
-        version: 1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))
       '@types/node':
         specifier: ^24.1.0
         version: 24.10.13
@@ -1110,7 +1110,7 @@ importers:
         version: 10.1.0
       nuxt:
         specifier: ^4.1.0
-        version: 4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3)
+        version: 4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3)
       shx:
         specifier: catalog:*
         version: 0.4.0
@@ -2186,6 +2186,9 @@ importers:
       '@scalar/components':
         specifier: workspace:*
         version: link:../components
+      '@scalar/helpers':
+        specifier: workspace:*
+        version: link:../helpers
       '@scalar/oas-utils':
         specifier: workspace:*
         version: link:../oas-utils
@@ -23635,11 +23638,11 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)':
+  '@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.1)(commander@13.1.0)
       '@clack/prompts': 1.1.0
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
       citty: 0.2.1
       confbox: 0.2.4
       consola: 3.4.2
@@ -23847,9 +23850,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/kit@4.1.2(magicast@0.3.5)':
+  '@nuxt/kit@4.1.2(magicast@0.5.2)':
     dependencies:
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -23870,31 +23873,6 @@ snapshots:
       ufo: 1.6.3
       unctx: 2.5.0
       unimport: 5.7.0
-      untyped: 2.0.0
-    transitivePeerDependencies:
-      - magicast
-
-  '@nuxt/kit@4.3.1(magicast@0.3.5)':
-    dependencies:
-      c12: 3.3.3(magicast@0.3.5)
-      consola: 3.4.2
-      defu: 6.1.4
-      destr: 2.0.5
-      errx: 0.1.0
-      exsolve: 1.0.8
-      ignore: 7.0.5
-      jiti: 2.6.1
-      klona: 2.0.6
-      mlly: 1.8.1
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      rc9: 3.0.0
-      scule: 1.3.0
-      semver: 7.7.4
-      tinyglobby: 0.2.15
-      ufo: 1.6.3
-      unctx: 2.5.0
       untyped: 2.0.0
     transitivePeerDependencies:
       - magicast
@@ -23924,9 +23902,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/module-builder@1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))':
+  '@nuxt/module-builder@1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
       citty: 0.1.6
       consola: 3.4.2
       defu: 6.1.4
@@ -24041,9 +24019,9 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.1.2(magicast@0.3.5))':
+  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.1.2(magicast@0.5.2))':
     dependencies:
-      '@nuxt/kit': 4.1.2(magicast@0.3.5)
+      '@nuxt/kit': 4.1.2(magicast@0.5.2)
       citty: 0.2.1
       consola: 3.4.2
       ofetch: 2.0.0-alpha.3
@@ -24113,9 +24091,9 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)':
+  '@nuxt/vite-builder@4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)':
     dependencies:
-      '@nuxt/kit': 4.1.2(magicast@0.3.5)
+      '@nuxt/kit': 4.1.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
       '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 5.1.4(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
@@ -33930,18 +33908,18 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3):
+  nuxt@4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3):
     dependencies:
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
       '@nuxt/devalue': 2.0.2
       '@nuxt/devtools': 2.7.0(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
-      '@nuxt/kit': 4.1.2(magicast@0.3.5)
+      '@nuxt/kit': 4.1.2(magicast@0.5.2)
       '@nuxt/schema': 4.1.2
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.1.2(magicast@0.3.5))
-      '@nuxt/vite-builder': 4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.1.2(magicast@0.5.2))
+      '@nuxt/vite-builder': 4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
       chokidar: 4.0.3
       compatx: 0.2.0
       consola: 3.4.2

--- a/projects/scalar-app/electron.vite.config.ts
+++ b/projects/scalar-app/electron.vite.config.ts
@@ -69,7 +69,11 @@ export default defineConfig({
       minify: true,
       outDir: 'dist/renderer',
       rollupOptions: {
-        input: resolve('entrypoints/electron/renderer/index.html'),
+        input: {
+          index: resolve('entrypoints/electron/renderer/index.html'),
+          // Isolated realm that runs pre/post-request scripts (postman-sandbox) with its own CSP.
+          sandbox: resolve('entrypoints/electron/renderer/sandbox.html'),
+        },
         output: {
           format: 'es',
         },

--- a/projects/scalar-app/entrypoints/electron/renderer/index.html
+++ b/projects/scalar-app/entrypoints/electron/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
   </head>
 
   <body class="scalar-app">

--- a/projects/scalar-app/entrypoints/electron/renderer/index.html
+++ b/projects/scalar-app/entrypoints/electron/renderer/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
+      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob:; font-src https://fonts.scalar.com 'self'" />
   </head>
 
   <body class="scalar-app">

--- a/projects/scalar-app/entrypoints/electron/renderer/sandbox.html
+++ b/projects/scalar-app/entrypoints/electron/renderer/sandbox.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <!--
+      Isolated realm for executing user pre/post-request scripts via postman-sandbox.
+
+      Loaded in an iframe from a real file:// URL so it does NOT inherit the renderer's CSP. It carries
+      its own permissive CSP that allows 'unsafe-eval' (postman-sandbox/uvm needs it, and runs the
+      script in a nested blob worker that inherits this policy). Keeping eval confined here is what lets
+      the renderer drop 'unsafe-eval'. The realm has no DOM access to the parent and no privileged bridge.
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' blob:; worker-src 'self' blob:; connect-src 'self' ws: wss:; style-src 'self' 'unsafe-inline'; img-src 'self' data:" />
+    <title>Scalar Script Sandbox</title>
+  </head>
+  <body>
+    <script
+      type="module"
+      src="./src/sandbox.ts"></script>
+  </body>
+</html>

--- a/projects/scalar-app/entrypoints/electron/renderer/src/sandbox.ts
+++ b/projects/scalar-app/entrypoints/electron/renderer/src/sandbox.ts
@@ -1,0 +1,7 @@
+/**
+ * Bootstraps the script sandbox inside its isolated iframe realm.
+ *
+ * Importing this pulls in postman-sandbox (which uses eval), so it must only run in `sandbox.html`,
+ * never in the main application bundle.
+ */
+import '@scalar/pre-post-request-scripts/sandbox'

--- a/projects/scalar-app/entrypoints/web/index.html
+++ b/projects/scalar-app/entrypoints/web/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://*.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob: https://*.vector.co; font-src https://fonts.scalar.com 'self'" />
+      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://*.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob: https://*.vector.co; font-src https://fonts.scalar.com 'self'" />
     <link
       rel="icon"
       type="image/png"

--- a/projects/scalar-app/entrypoints/web/index.html
+++ b/projects/scalar-app/entrypoints/web/index.html
@@ -5,7 +5,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src *; script-src 'self' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://*.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob: https://*.vector.co; font-src https://fonts.scalar.com 'self'" />
+      content="default-src 'self'; connect-src *; script-src 'self' 'unsafe-eval' https://cdn.usefathom.com https://magic.scalar.com https://assets.apollo.io https://*.vector.co; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data: blob:; media-src 'self' data: blob: https://*.scalar.com https://scalar.com; object-src 'self' blob:; frame-src 'self' blob: https://*.vector.co; font-src https://fonts.scalar.com 'self'" />
     <link
       rel="icon"
       type="image/png"

--- a/projects/scalar-app/entrypoints/web/sandbox.html
+++ b/projects/scalar-app/entrypoints/web/sandbox.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <!--
+      Isolated realm for executing user pre/post-request scripts via postman-sandbox.
+
+      This page is intentionally loaded in an iframe from a real (network-scheme) URL so it does NOT
+      inherit the main application's CSP. It carries its own permissive CSP that allows 'unsafe-eval'
+      (postman-sandbox/uvm needs it, and runs the script in a nested blob worker that inherits this
+      policy). Keeping eval confined here is what lets the main app drop 'unsafe-eval'. The realm has
+      no DOM access to the parent and no privileged bridge.
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' blob:; worker-src 'self' blob:; connect-src 'self' ws: wss:; style-src 'self' 'unsafe-inline'; img-src 'self' data:" />
+    <title>Scalar Script Sandbox</title>
+  </head>
+  <body>
+    <script
+      type="module"
+      src="./src/sandbox.ts"></script>
+  </body>
+</html>

--- a/projects/scalar-app/entrypoints/web/src/sandbox.ts
+++ b/projects/scalar-app/entrypoints/web/src/sandbox.ts
@@ -1,0 +1,7 @@
+/**
+ * Bootstraps the script sandbox inside its isolated iframe realm.
+ *
+ * Importing this pulls in postman-sandbox (which uses eval), so it must only run in `sandbox.html`,
+ * never in the main application bundle.
+ */
+import '@scalar/pre-post-request-scripts/sandbox'

--- a/projects/scalar-app/test/electron.e2e.ts
+++ b/projects/scalar-app/test/electron.e2e.ts
@@ -77,9 +77,11 @@ test.describe('Electron', () => {
   test('launch app', async () => {
     const app = await launchElectronApp()
 
-    await waitForMainWindow(app)
-
-    await app.close()
+    try {
+      await waitForMainWindow(app)
+    } finally {
+      await app.close()
+    }
   })
 
   test('pre-request and post-response scripts run under the Electron content security policy', async () => {

--- a/projects/scalar-app/test/electron.e2e.ts
+++ b/projects/scalar-app/test/electron.e2e.ts
@@ -1,7 +1,10 @@
-import { statSync } from 'node:fs'
+import { mkdtempSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { _electron, expect, test } from '@playwright/test'
+
+import { runRequestScriptsCspScenario } from './helpers/request-scripts-csp-scenario'
 
 /**
  * Helper function to find the frontend build
@@ -24,60 +27,69 @@ const findFolder = () => {
   throw new Error('Could not find Electron app entry point')
 }
 
+const launchElectronApp = async () => {
+  const cwd = findFolder()
+  const entryPoint = join(cwd, 'dist/main/index.js')
+  const userDataDir = mkdtempSync(join(tmpdir(), 'scalar-app-electron-e2e-'))
+
+  statSync(entryPoint)
+
+  return await _electron.launch({
+    args: [`--user-data-dir=${userDataDir}`, entryPoint],
+    cwd,
+  })
+}
+
+const waitForMainWindow = async (app: Awaited<ReturnType<typeof launchElectronApp>>) => {
+  await expect
+    .poll(
+      () => {
+        const mainWindow = app.windows().find((win) => win.url().includes('index.html'))
+        return mainWindow ? mainWindow.url() : ''
+      },
+      {
+        message: 'Main window should contain index.html',
+        timeout: 4_000,
+      },
+    )
+    .toMatch(/projects\/scalar-app\/dist\/renderer\/index.html/)
+
+  return app.windows().find((win) => win.url().includes('index.html')) ?? (await app.firstWindow())
+}
+
 test.describe('Electron', () => {
+  test.setTimeout(120_000)
+
   // Chromium-only, ignore mobile
   test.skip(
     ({ browserName, isMobile }) => browserName !== 'chromium' || isMobile,
     'Electron tests require Chromium and cannot run on mobile',
   )
 
-  test('launch app', async () => {
+  test.beforeEach(() => {
     // GitHub Actions and the Playwright Docker image are headless Linux: Electron needs X11/Wayland.
     test.skip(
       Boolean(process.env.CI),
       'Electron needs a display server. Run locally: pnpm --filter scalar-app exec playwright test test/electron.e2e.ts',
     )
+  })
 
-    // Check whether the build was found
-    const cwd = findFolder()
+  test('launch app', async () => {
+    const app = await launchElectronApp()
 
-    console.log()
-    console.log('=== DEBUG ===')
-    console.log()
-    console.log('CWD:        ', process.cwd())
-    console.log('App folder: ', cwd)
-    console.log('Entry point:', join(cwd, 'dist/main/index.js'))
-    console.log()
-
-    // Verify the entry point file exists
-    try {
-      const entryPoint = join(cwd, 'dist/main/index.js')
-      statSync(entryPoint)
-      console.log('✅ Entry point exists.')
-    } catch (error) {
-      console.error('❌ Entry point not found:', error)
-    }
-
-    // Launch the Electron app with absolute path
-    const app = await _electron.launch({
-      args: [join(cwd, 'dist/main/index.js')],
-      cwd,
-    })
-
-    // Wait for the main window to load `index.html`
-    await expect
-      .poll(
-        () => {
-          const mainWindow = app.windows().find((win) => win.url().includes('index.html'))
-          return mainWindow ? mainWindow.url() : ''
-        },
-        {
-          message: 'Main window should contain index.html',
-          timeout: 4_000,
-        },
-      )
-      .toMatch(/projects\/scalar-app\/dist\/renderer\/index.html$/)
+    await waitForMainWindow(app)
 
     await app.close()
+  })
+
+  test('pre-request and post-response scripts run under the Electron content security policy', async () => {
+    const app = await launchElectronApp()
+
+    try {
+      const page = await waitForMainWindow(app)
+      await runRequestScriptsCspScenario(page)
+    } finally {
+      await app.close()
+    }
   })
 })

--- a/projects/scalar-app/test/helpers/request-scripts-csp-scenario.ts
+++ b/projects/scalar-app/test/helpers/request-scripts-csp-scenario.ts
@@ -1,0 +1,178 @@
+import { type Server, createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { type Page, expect } from '@playwright/test'
+
+import { waitForScalarAppShellReady } from './wait-for-scalar-app-shell-ready'
+
+const SCRIPT_TEST_DOCUMENT = 'e2e-request-scripts-csp'
+const SCRIPT_DOCUMENT_SIDEBAR_TITLE = 'E2E request scripts CSP'
+const SCRIPT_OPERATION_SIDEBAR_TITLE = 'Run scripts under CSP'
+const DOCUMENT_DRAFTS_OVERVIEW = '/@local/default/document/drafts/overview'
+const MOCK_SERVER_HOST = '127.0.0.1'
+
+type ScriptMockServer = {
+  server: Server
+  origin: string
+}
+
+const startScriptMockServer = async (): Promise<ScriptMockServer> => {
+  const server = createServer((request, response) => {
+    response.setHeader('access-control-allow-origin', '*')
+
+    if (request.method === 'OPTIONS') {
+      response.writeHead(204, {
+        'access-control-allow-methods': 'GET, HEAD, OPTIONS',
+        'access-control-allow-headers': '*',
+      })
+      response.end()
+      return
+    }
+
+    if (request.method === 'GET' && request.url?.startsWith('/scripts')) {
+      response.writeHead(200, { 'content-type': 'application/json' })
+      response.end(JSON.stringify({ ok: true }))
+      return
+    }
+
+    response.writeHead(404, { 'content-type': 'text/plain' })
+    response.end('not found')
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, MOCK_SERVER_HOST, () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+
+  const address = server.address() as AddressInfo | null
+
+  if (!address) {
+    throw new Error('Mock server did not bind to a port')
+  }
+
+  return {
+    server,
+    origin: `http://${MOCK_SERVER_HOST}:${address.port}`,
+  }
+}
+
+const stopScriptMockServer = async (server: Server): Promise<void> => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve()
+    })
+  })
+}
+
+const seedScriptDocument = async (page: Page, serverUrl: string): Promise<void> => {
+  await page.evaluate(
+    async ({ documentName, serverUrl }: { documentName: string; serverUrl: string }) => {
+      const store = window.dumpAppState().store.value
+
+      if (!store) {
+        throw new Error('Workspace store is not ready')
+      }
+
+      const ok = await store.addDocument({
+        name: documentName,
+        document: {
+          openapi: '3.1.0',
+          info: {
+            title: 'E2E request scripts CSP',
+            version: '1.0.0',
+          },
+          servers: [{ url: serverUrl }],
+          paths: {
+            '/scripts': {
+              get: {
+                summary: 'Run scripts under CSP',
+                'x-pre-request': 'pm.environment.set("preRequestRan", "yes")',
+                'x-post-response': `
+                  pm.test("pre-request script ran", () => {
+                    pm.expect(pm.environment.get("preRequestRan")).to.eq("yes")
+                  })
+                  pm.test("post-response script ran", () => {
+                    pm.response.to.have.status(200)
+                    pm.expect(pm.response.json()).to.deep.equal({ ok: true })
+                  })
+                `,
+                responses: {
+                  '200': {
+                    description: 'Script execution response',
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      if (!ok) {
+        throw new Error('store.addDocument returned false')
+      }
+    },
+    { documentName: SCRIPT_TEST_DOCUMENT, serverUrl },
+  )
+}
+
+const navigateToDraftsOverview = async (page: Page): Promise<void> => {
+  if (page.url().startsWith('file:')) {
+    await page.evaluate((path) => {
+      window.location.hash = path
+    }, DOCUMENT_DRAFTS_OVERVIEW)
+    await page.waitForURL(/#\/@local\/default\/document\/drafts\/overview/, { timeout: 60_000 })
+    return
+  }
+
+  await page.goto(DOCUMENT_DRAFTS_OVERVIEW, { waitUntil: 'load', timeout: 60_000 })
+  await expect(page).toHaveURL(/\/document\/drafts\//)
+}
+
+export const runRequestScriptsCspScenario = async (page: Page): Promise<void> => {
+  const mockServer = await startScriptMockServer()
+
+  try {
+    const cspErrors: string[] = []
+    page.on('console', (message) => {
+      if (message.type() === 'error' && /content security policy|unsafe-eval|script-src/i.test(message.text())) {
+        cspErrors.push(message.text())
+      }
+    })
+
+    await navigateToDraftsOverview(page)
+    await waitForScalarAppShellReady(page)
+
+    await seedScriptDocument(page, mockServer.origin)
+
+    await page.evaluate((documentName) => {
+      const path = `/@local/default/document/${documentName}/path/%252Fscripts/method/get/example/default`
+      if (window.location.href.startsWith('file:')) {
+        window.location.hash = path
+        return
+      }
+
+      window.location.assign(path)
+    }, SCRIPT_TEST_DOCUMENT)
+    await expect(page).toHaveURL(new RegExp(`/document/${SCRIPT_TEST_DOCUMENT}/.*example/default`))
+
+    const sendButton = page.locator('[data-addressbar-action="send"]:visible').first()
+    await sendButton.click()
+    await expect(sendButton).not.toBeDisabled({ timeout: 60_000 })
+
+    const main = page.locator('main')
+    await expect(main.getByText('pre-request script ran', { exact: true })).toBeVisible({ timeout: 30_000 })
+    await expect(main.getByText('post-response script ran', { exact: true })).toBeVisible()
+    await expect(main.getByText('2/2', { exact: true })).toBeVisible()
+    expect(cspErrors, cspErrors.join('\n')).toEqual([])
+  } finally {
+    await stopScriptMockServer(mockServer.server)
+  }
+}

--- a/projects/scalar-app/test/helpers/request-scripts-csp-scenario.ts
+++ b/projects/scalar-app/test/helpers/request-scripts-csp-scenario.ts
@@ -6,8 +6,6 @@ import { type Page, expect } from '@playwright/test'
 import { waitForScalarAppShellReady } from './wait-for-scalar-app-shell-ready'
 
 const SCRIPT_TEST_DOCUMENT = 'e2e-request-scripts-csp'
-const SCRIPT_DOCUMENT_SIDEBAR_TITLE = 'E2E request scripts CSP'
-const SCRIPT_OPERATION_SIDEBAR_TITLE = 'Run scripts under CSP'
 const DOCUMENT_DRAFTS_OVERVIEW = '/@local/default/document/drafts/overview'
 const MOCK_SERVER_HOST = '127.0.0.1'
 

--- a/projects/scalar-app/test/request-scripts-csp.e2e.ts
+++ b/projects/scalar-app/test/request-scripts-csp.e2e.ts
@@ -3,6 +3,8 @@ import { test } from '@playwright/test'
 import { runRequestScriptsCspScenario } from './helpers/request-scripts-csp-scenario'
 
 test.describe('request-scripts-csp.e2e', () => {
+  test.setTimeout(120_000)
+
   test('pre-request and post-response scripts run under the app content security policy', async ({ page }) => {
     await runRequestScriptsCspScenario(page)
   })

--- a/projects/scalar-app/test/request-scripts-csp.e2e.ts
+++ b/projects/scalar-app/test/request-scripts-csp.e2e.ts
@@ -1,0 +1,9 @@
+import { test } from '@playwright/test'
+
+import { runRequestScriptsCspScenario } from './helpers/request-scripts-csp-scenario'
+
+test.describe('request-scripts-csp.e2e', () => {
+  test('pre-request and post-response scripts run under the app content security policy', async ({ page }) => {
+    await runRequestScriptsCspScenario(page)
+  })
+})

--- a/projects/scalar-app/vite.config.ts
+++ b/projects/scalar-app/vite.config.ts
@@ -34,7 +34,11 @@ export default defineConfig({
   build: {
     outDir: resolve('dist/web'),
     rolldownOptions: {
-      input: resolve('entrypoints/web/index.html'),
+      input: {
+        index: resolve('entrypoints/web/index.html'),
+        // Isolated realm that runs pre/post-request scripts (postman-sandbox) with its own CSP.
+        sandbox: resolve('entrypoints/web/sandbox.html'),
+      },
     },
   },
   server: {


### PR DESCRIPTION
## Problem

Originally I wanted to remove unsafe-eval from our CSP.

## Solution

To do this we need to execute the scripts in an iframe, so this is what we do.

-----

Relocated postman-sandbox execution to an isolated iframe with its own permissive CSP, allowing the main application to drop 'unsafe-eval' entirely. The changes:

Split execution into two realms:

Host adapter (sandbox-adapter.ts): Serializes inputs (request, response, variables) and communicates with the iframe via postMessage
Iframe server (sandbox-frame-server.ts): The ONLY module that imports postman-sandbox; receives serialized data, executes scripts, and sends results back
Message protocol (sandbox-protocol.ts): Defines structured, cloneable message types for host↔iframe communication (execute requests, test results, console output, variable mutations)

Transport abstraction (sandbox-adapter.ts): Injected SandboxTransport allows tests to run scripts in-process without a DOM, while production uses iframe transport

Sandbox HTML pages: Added sandbox.html entry points for both web and Electron that load the iframe with a permissive CSP ('unsafe-eval', 'unsafe-inline', blob:)

Build configuration: Updated Vite configs to build both index.html and sandbox.html as separate entry points

Updated tests: Refactored test suite to use the new in-process transport for unit testing without mocking the sandbox

The main application bundle no longer imports postman-sandbox, so 'unsafe-eval' can be removed from its CSP. Script execution is confined to the iframe realm, which has its own isolated CSP.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes script execution architecture and CSP handling by moving `postman-sandbox` into a dedicated iframe and introducing `postMessage` transport/timeouts; regressions could break request scripts or variable/request mutation syncing across web and Electron.
> 
> **Overview**
> **Removes `'unsafe-eval'` from the Scalar app CSP** by relocating pre-request/post-response script execution (`postman-sandbox`) into a new same-origin `sandbox.html` iframe with its own permissive CSP, for both web and Electron builds.
> 
> Refactors `@scalar/pre-post-request-scripts` to split a host-side adapter (serializes request/response/variable scopes, uses pinned-origin `postMessage`, adds readiness/execution timeouts) from an iframe-side server that is now the only place importing `postman-sandbox`, and defines a new structured message protocol plus an injectable in-process transport for unit tests.
> 
> Updates build/test scaffolding to ship the new sandbox entrypoints and adds Playwright E2E coverage to ensure scripts run without CSP violations; includes a small `api-reference` example unwrapping fix and related dependency/export/knip adjustments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab840a1093312d9f481852b654f8e00b49843e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->