### PR TITLE
chore(scalar-app): explicitly enable contextIsolation in Electron BrowserWindow

### DIFF
--- a/.changeset/scalar-app-context-isolation.md
+++ b/.changeset/scalar-app-context-isolation.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+chore: explicitly enable `contextIsolation` and `nodeIntegration: false` on the desktop app's BrowserWindow to satisfy the toDesktop static analysis check (these were already the secure Electron defaults at runtime)

--- a/projects/scalar-app/entrypoints/electron/main/application/window.ts
+++ b/projects/scalar-app/entrypoints/electron/main/application/window.ts
@@ -36,6 +36,11 @@ export function createWindow({ isDev }: { isDev?: boolean }): BrowserWindow {
     autoHideMenuBar: true,
     webPreferences: {
       preload: join(import.meta.dirname, '../preload/index.mjs'),
+      // Explicitly enable context isolation (the Electron default) so the renderer and preload
+      // run in separate JavaScript contexts. We already bridge APIs via contextBridge in the
+      // preload, so this is purely making the secure default visible to static analyzers.
+      contextIsolation: true,
+      nodeIntegration: false,
       sandbox: false,
     },
   })


### PR DESCRIPTION
## Problem

The desktop app's Electron `BrowserWindow` configuration was relying on Electron's secure defaults for `contextIsolation` and `nodeIntegration`, but these settings were not explicitly declared in the code. This causes static analysis tools (like toDesktop) to flag the configuration as potentially insecure, even though the runtime behavior was already secure.

## Solution

Explicitly set `contextIsolation: true` and `nodeIntegration: false` in the `webPreferences` configuration of the `BrowserWindow`. These settings were already the Electron defaults at runtime, so this change is purely making the secure configuration visible to static analyzers and improving code clarity.

The renderer and preload scripts already run in separate JavaScript contexts with APIs bridged via `contextBridge`, so this change has no functional impact—it only makes the existing secure setup explicit in the code.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [ ] I added tests. (N/A — configuration change with no functional impact)
- [ ] I updated the documentation. (N/A — internal configuration)

https://claude.ai/code/session_01WLxDZpSzZLbsiqyr6Xa9AK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only makes Electron `BrowserWindow` security defaults explicit (`contextIsolation: true`, `nodeIntegration: false`) to satisfy static analysis, with no intended runtime behavior change.
> 
> **Overview**
> Makes the desktop app’s Electron `BrowserWindow` configuration explicitly set `contextIsolation: true` and `nodeIntegration: false`, aligning the code with Electron’s secure defaults and silencing `toDesktop` static analysis warnings.
> 
> Adds a patch changeset documenting the non-functional security-clarity update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0461eab7ccc89d713708671d1a1f285206fd43f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->