### PR TITLE
feat(api-client): replace AddressBar's CodeInput with a lightweight CodeInputLite

### DIFF
--- a/packages/api-client/src/v2/components/code-input/CodeInputLite.test.ts
+++ b/packages/api-client/src/v2/components/code-input/CodeInputLite.test.ts
@@ -239,6 +239,54 @@ describe('CodeInputLite', () => {
     expect(wrapper.findComponent({ name: 'EnvironmentVariablesDropdown' }).exists()).toBe(false)
   })
 
+  describe('combobox accessibility', () => {
+    it('exposes combobox semantics on the editor when variables are enabled', () => {
+      const editor = mountInput({ modelValue: '' }).get('.code-input-lite__editor')
+      expect(editor.attributes('role')).toBe('combobox')
+      expect(editor.attributes('aria-autocomplete')).toBe('list')
+    })
+
+    it('falls back to a plain textbox role when variables are disabled', () => {
+      const editor = mountInput({ modelValue: '', withVariables: false }).get('.code-input-lite__editor')
+      expect(editor.attributes('role')).toBe('textbox')
+      expect(editor.attributes('aria-autocomplete')).toBeUndefined()
+    })
+
+    it('wires aria-controls and aria-activedescendant to a real listbox and option', async () => {
+      const wrapper = mountInput({ modelValue: '' })
+      api(wrapper).setContent('{{')
+      api(wrapper).focus('end')
+      await wrapper.get('.code-input-lite__editor').trigger('input')
+      await nextTick()
+      await nextTick()
+
+      const editor = wrapper.get('.code-input-lite__editor')
+
+      // aria-controls must reference an element that exists and is a listbox.
+      const listboxId = editor.attributes('aria-controls')
+      expect(listboxId).toBeTruthy()
+      const listbox = document.getElementById(listboxId as string)
+      expect(listbox?.getAttribute('role')).toBe('listbox')
+
+      // Every row is exposed as an option.
+      const options = listbox?.querySelectorAll('[role="option"]') ?? []
+      expect(options.length).toBeGreaterThan(0)
+
+      // aria-activedescendant must point at the highlighted, existing option.
+      const activeId = editor.attributes('aria-activedescendant')
+      expect(activeId).toBeTruthy()
+      const activeOption = document.getElementById(activeId as string)
+      expect(activeOption).not.toBeNull()
+      expect(activeOption?.getAttribute('aria-selected')).toBe('true')
+    })
+
+    it('does not set aria-controls or aria-activedescendant while the dropdown is closed', () => {
+      const editor = mountInput({ modelValue: '/users' }).get('.code-input-lite__editor')
+      expect(editor.attributes('aria-controls')).toBeUndefined()
+      expect(editor.attributes('aria-activedescendant')).toBeUndefined()
+    })
+  })
+
   it('exposes focus(), getValue(), setContent(), and cursorPosition()', () => {
     const wrapper = mountInput({ modelValue: 'hello' })
     const exposed = api(wrapper)

--- a/packages/api-client/src/v2/components/code-input/CodeInputLite.vue
+++ b/packages/api-client/src/v2/components/code-input/CodeInputLite.vue
@@ -139,6 +139,19 @@ const dropdownRef = ref<InstanceType<
   typeof EnvironmentVariableDropdown
 > | null>(null)
 
+/** Id of the dropdown's `role="listbox"` element, for the combobox wiring. */
+const listboxId = computed((): string | undefined =>
+  componentId.value ? `${componentId.value}-listbox` : undefined,
+)
+
+/**
+ * Id of the option the dropdown currently highlights. Mirrors the dropdown's
+ * own selection so the editor can expose it via `aria-activedescendant`.
+ */
+const activeOptionId = computed(
+  (): string | undefined => dropdownRef.value?.activeOptionId,
+)
+
 const isFocused = ref(false)
 const isEmpty = ref(true)
 
@@ -819,12 +832,10 @@ defineExpose({
     <div
       ref="editorRef"
       :aria-activedescendant="
-        displayVariablesDropdown ? `${componentId}-listbox` : undefined
+        displayVariablesDropdown ? activeOptionId : undefined
       "
       :aria-autocomplete="withVariables ? 'list' : undefined"
-      :aria-controls="
-        displayVariablesDropdown ? `${componentId}-listbox` : undefined
-      "
+      :aria-controls="displayVariablesDropdown ? listboxId : undefined"
       :aria-expanded="displayVariablesDropdown ? 'true' : undefined"
       :aria-invalid="error ? 'true' : undefined"
       :aria-label="attrs['aria-label']"
@@ -871,6 +882,7 @@ defineExpose({
     :contextFunctionItems="contextFunctionDropdownItems"
     :dropdownPosition="dropdownPosition"
     :environment="environment"
+    :listboxId="listboxId"
     :query="dropdownQuery"
     @redirect="emit('navigate', { page: 'document', path: 'environment' })"
     @select="handleDropdownSelect" />

--- a/packages/api-client/src/v2/features/environments/components/EnvironmentVariablesDropdown.vue
+++ b/packages/api-client/src/v2/features/environments/components/EnvironmentVariablesDropdown.vue
@@ -16,12 +16,19 @@ const {
   environment,
   dropdownPosition,
   contextFunctionItems = [],
+  listboxId,
 } = defineProps<{
   query: string
   environment?: XScalarEnvironment
   dropdownPosition?: { left: number; top: number }
   /** Runtime placeholders such as `{{$guid}}`, shown with environment variables */
   contextFunctionItems?: { key: string; description: string }[]
+  /**
+   * Id for the `role="listbox"` element. When set, each option also receives a
+   * stable id so the owning combobox input can reference the active option via
+   * `aria-activedescendant` (W3C combobox pattern).
+   */
+  listboxId?: string
 }>()
 
 const emit = defineEmits<{
@@ -140,6 +147,19 @@ const filteredVariables = computed((): DropdownRow[] => {
   return [...envMatches, ...contextMatches]
 })
 
+const optionId = (index: number): string | undefined =>
+  listboxId ? `${listboxId}-option-${index}` : undefined
+
+/**
+ * Id of the currently highlighted option, for the combobox's
+ * `aria-activedescendant`. Undefined when there is no list to point at.
+ */
+const activeOptionId = computed((): string | undefined =>
+  filteredVariables.value.length
+    ? optionId(selectedVariableIndex.value)
+    : undefined,
+)
+
 const selectVariable = (variableKey: string): void => {
   emit('select', variableKey)
 }
@@ -169,6 +189,7 @@ const handleSelect = () => {
 defineExpose({
   handleArrowKey,
   handleSelect,
+  activeOptionId,
 })
 
 onMounted(() => {
@@ -202,13 +223,19 @@ onClickOutside(
       :style="dropdownStyle">
       <ul
         v-if="filteredVariables.length"
-        class="gap-1/2 flex flex-col">
+        :id="listboxId"
+        aria-label="Variable suggestions"
+        class="gap-1/2 flex flex-col"
+        role="listbox">
         <template
           v-for="(item, index) in filteredVariables"
           :key="`${item.kind}-${item.key}`">
           <li
+            :id="optionId(index)"
+            :aria-selected="index === selectedVariableIndex"
             class="font-code text-xxs hover:bg-b-3 flex h-8 cursor-pointer items-center justify-between gap-1.5 rounded p-1.5 transition-colors duration-150"
             :class="{ 'bg-b-3': index === selectedVariableIndex }"
+            role="option"
             @click="selectVariable(item.key)">
             <div class="flex items-center gap-2 whitespace-nowrap">
               <span


### PR DESCRIPTION
Adds a new single-line CodeInputLite component and uses it in the
AddressBar in place of the CodeMirror-backed CodeInput. CodeInputLite
pairs a native <input> (source of truth — native cursor, IME, selection,
paste, undo) with an absolutely positioned overlay div that mirrors the
value with `{{varname}}` matches rendered as styled pills. The {{
autocomplete dropdown is anchored via a hidden text-measuring span
instead of CodeMirror's coordsAtPos.

Highlights:

- Clean focus()/getValue()/setContent()/cursorPosition() API — no
  CodeMirror compatibility shims.
- Full ARIA combobox semantics (role, aria-controls, aria-expanded,
  aria-activedescendant, aria-autocomplete) when the autocomplete
  dropdown is wired, plus aria-required / aria-invalid from props.
- Per-pill hover/focus tooltips via the existing PillTooltipHost
  refactored to be renderless and accept a `target: HTMLElement` prop.
  The legacy CodeMirror widget pipeline (code-variable-widget.ts) and
  the new CodeInputLite overlay both mount the same component and only
  attach behaviour through @scalar/components' useTooltip.
- Click-to-position-caret: pills are interactive (pointer-events: auto)
  while the rest of the overlay stays inert; pill clicks are forwarded
  back to the input via a delegated handler that places the caret at
  the pill's end offset.
- Render-key cache dedupes overlay rebuilds and includes each variable's
  resolved value so env updates correctly invalidate.

26 new tests cover pill rendering, env / context-function variants,
backspace `}}` pair deletion, Enter / Escape / Arrow handling, dropdown
open/close/select/redirect, ARIA, modal-layout suppression, undefined-
variable fading, HTML escaping, prop sync, click forwarding, and tooltip
attach.

https://claude.ai/code/session_018RspZY32XxM9Nb5ea9zVV6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces several user-facing editors with a new `contenteditable`-based input and refactors tooltip/dropdown wiring, which could affect keyboard/IME behavior and accessibility in request/environment tables.
> 
> **Overview**
> Introduces a new lightweight single-line editor, `CodeInputLite`, to replace the CodeMirror-backed `CodeInput` in request table rows, `DataTableInput`, and the environment variables table, along with updated styling selectors.
> 
> Refactors pill tooltips to mount `PillTooltipHost` as a renderless behavior layer targeting an existing pill element (used by both `CodeInputLite` and the legacy CodeMirror widget), and enhances `EnvironmentVariablesDropdown` with proper listbox/option ids to support `aria-controls`/`aria-activedescendant` combobox semantics.
> 
> Adds extensive unit coverage for `CodeInputLite` plus updates existing tests to assert against `CodeInputLite`, and includes a changeset bumping `@scalar/api-client` (patch) for the new component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea1b7a79abe3a98f547fc087be299fcdc558eabd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->