### PR TITLE
fix(docs): remove underlines from anchors

### DIFF
--- a/documentation/guides/app/getting-started.md
+++ b/documentation/guides/app/getting-started.md
@@ -273,12 +273,19 @@ Use [post-response scripts](./testing.md) to validate responses and automate che
   </div>
 </div>
 <style>
-    .resources-cta-container {
-      border-radius: var(--scalar-radius-lg);
-      border: var(--scalar-border-width) solid var(--scalar-border-color);
-      width: 100%;
-      padding: 12px 8px;
-    }
+  :root {
+    --scalar-text-decoration: none;
+    --scalar-text-decoration-hover: none;
+  }
+  .t-editor__anchor {
+    --font-visited: none;
+  }
+  .resources-cta-container {
+    border-radius: var(--scalar-radius-lg);
+    border: var(--scalar-border-width) solid var(--scalar-border-color);
+    width: 100%;
+    padding: 12px 8px;
+  }
   .resources-cta {
     max-height: fit-content;
     width: 100%;

--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -312,12 +312,19 @@ Put your content where you want: in your repository, any folder, or the Scalar E
   </div>
 </div>
 <style>
-    .resources-cta-container {
-      border-radius: var(--scalar-radius-lg);
-      border: var(--scalar-border-width) solid var(--scalar-border-color);
-      width: 100%;
-      padding: 12px 8px;
-    }
+  :root {
+    --scalar-text-decoration: none;
+    --scalar-text-decoration-hover: none;
+  }
+  .t-editor__anchor {
+    --font-visited: none;
+  }
+  .resources-cta-container {
+    border-radius: var(--scalar-radius-lg);
+    border: var(--scalar-border-width) solid var(--scalar-border-color);
+    width: 100%;
+    padding: 12px 8px;
+  }
   .resources-cta {
     max-height: fit-content;
     width: 100%;

--- a/documentation/guides/enterprise/enterprise.md
+++ b/documentation/guides/enterprise/enterprise.md
@@ -154,6 +154,13 @@ Validate contracts early so exploration and testing stay tied to the same API de
 </div>
 
 <style>
+  :root {
+    --scalar-text-decoration: none;
+    --scalar-text-decoration-hover: none;
+  }
+  .t-editor__anchor {
+    --font-visited: none;
+  }
   .enterprise-features-copy {
     max-width: 680px;
   }

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -484,6 +484,10 @@
 </div>
 
 <style>
+  :root {
+    --scalar-text-decoration: none;
+    --scalar-text-decoration-hover: none;
+  }
   .t-editor__page-title,
   .t-editor__page-nav,
   .notify-container,
@@ -498,6 +502,9 @@
   }
   .t-doc .layout-header {
     z-index: 10000;
+  }
+  .t-editor__anchor {
+    --font-visited: none;
   }
   .t-editor__button {
     min-width: 160px;

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -694,6 +694,13 @@
   <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/utn6gGF3Iucolqx4jmXmY.svg">
 </div>
 <style>
+:root {
+  --scalar-text-decoration: none;
+  --scalar-text-decoration-hover: none;
+}
+.t-editor__anchor {
+  --font-visited: none;
+}
 .mobiletabs input {
   position: absolute;
   left: -200vw;

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -254,12 +254,19 @@ All of this with just a couple clicks or a few API requests! You handle making y
   </div>
 </div>
 <style>
-    .resources-cta-container {
-      border-radius: var(--scalar-radius-lg);
-      border: var(--scalar-border-width) solid var(--scalar-border-color);
-      width: 100%;
-      padding: 12px 8px;
-    }
+  :root {
+    --scalar-text-decoration: none;
+    --scalar-text-decoration-hover: none;
+  }
+  .t-editor__anchor {
+    --font-visited: none;
+  }
+  .resources-cta-container {
+    border-radius: var(--scalar-radius-lg);
+    border: var(--scalar-border-width) solid var(--scalar-border-color);
+    width: 100%;
+    padding: 12px 8px;
+  }
   .resources-cta {
     max-height: fit-content;
     width: 100%;

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -257,12 +257,19 @@ Once created, you will get redirected to the SDK Overview page where you can:
   </div>
 </div>
 <style>
-    .resources-cta-container {
-      border-radius: var(--scalar-radius-lg);
-      border: var(--scalar-border-width) solid var(--scalar-border-color);
-      width: 100%;
-      padding: 12px 8px;
-    }
+  :root {
+    --scalar-text-decoration: none;
+    --scalar-text-decoration-hover: none;
+  }
+  .t-editor__anchor {
+    --font-visited: none;
+  }
+  .resources-cta-container {
+    border-radius: var(--scalar-radius-lg);
+    border: var(--scalar-border-width) solid var(--scalar-border-color);
+    width: 100%;
+    padding: 12px 8px;
+  }
   .resources-cta {
     max-height: fit-content;
     width: 100%;


### PR DESCRIPTION
Still need to move this to MDX but fixes the style regression for now.

Before

<img width="2202" height="832" alt="CleanShot 2026-05-19 at 16 41 54@2x" src="https://github.com/user-attachments/assets/3e190523-6173-4b02-ade8-43740e6a1cb2" />

After

<img width="2202" height="832" alt="CleanShot 2026-05-19 at 16 50 02@2x" src="https://github.com/user-attachments/assets/b0177e06-d79f-4728-bb5b-e9ea939cf577" />


## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
