### PR TITLE
fix(themes): use pure white text for scalar button in dark themes

### DIFF
--- a/.changeset/fair-dingos-matter.md
+++ b/.changeset/fair-dingos-matter.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+fix button text color variables to use pure white instead of semi-transparent white in dark themes.

--- a/packages/themes/src/base/variables.css
+++ b/packages/themes/src/base/variables.css
@@ -81,7 +81,7 @@
   --scalar-scrollbar-color: rgba(0, 0, 0, 0.18);
   --scalar-button-1: rgba(0, 0, 0, 1);
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: #fff;
 
   --scalar-shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.11);
   --scalar-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px, rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 0.5px;

--- a/packages/themes/src/presets/alternate.css
+++ b/packages/themes/src/presets/alternate.css
@@ -76,7 +76,7 @@
 
   --scalar-button-1: rgba(0, 0, 0, 1);
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: #fff;
 }
 .dark-mode {
   --scalar-color-green: #00b648;

--- a/packages/themes/src/presets/bluePlanet.css
+++ b/packages/themes/src/presets/bluePlanet.css
@@ -65,7 +65,7 @@
 
   --scalar-button-1: rgba(0, 0, 0, 1);
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: #fff;
 }
 .dark-mode {
   --scalar-color-green: rgba(69, 255, 165, 0.823);

--- a/packages/themes/src/presets/deepSpace.css
+++ b/packages/themes/src/presets/deepSpace.css
@@ -64,7 +64,7 @@
 
   --scalar-button-1: rgba(0, 0, 0, 1);
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: #fff;
 }
 .dark-mode {
   --scalar-color-green: rgba(69, 255, 165, 0.823);

--- a/packages/themes/src/presets/default.css
+++ b/packages/themes/src/presets/default.css
@@ -66,7 +66,7 @@
 
   --scalar-button-1: rgba(0, 0, 0, 1);
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: #fff;
 
   --scalar-tooltip-background: color-mix(in srgb, #1a1a1a, transparent 10%);
   --scalar-tooltip-color: color-mix(in srgb, #fff, transparent 15%);

--- a/packages/themes/src/presets/kepler.css
+++ b/packages/themes/src/presets/kepler.css
@@ -67,7 +67,7 @@
 
   --scalar-button-1: rgba(0, 0, 0, 1);
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: #fff;
 }
 .dark-mode {
   --scalar-color-green: #00b648;

--- a/packages/themes/src/presets/mars.css
+++ b/packages/themes/src/presets/mars.css
@@ -64,7 +64,7 @@
 
   --scalar-button-1: rgba(0, 0, 0, 1);
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: #fff;
 }
 .dark-mode {
   --scalar-color-green: rgba(69, 255, 165, 0.823);

--- a/packages/themes/src/presets/purple.css
+++ b/packages/themes/src/presets/purple.css
@@ -57,7 +57,7 @@
 
   --scalar-button-1: rgba(0, 0, 0, 1);
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: #fff;
 }
 .dark-mode {
   --scalar-color-green: #30a159;

--- a/packages/themes/src/presets/saturn.css
+++ b/packages/themes/src/presets/saturn.css
@@ -55,7 +55,7 @@
 
   --scalar-button-1: rgba(0, 0, 0, 1);
   --scalar-button-1-hover: rgba(0, 0, 0, 0.8);
-  --scalar-button-1-color: rgba(255, 255, 255, 0.9);
+  --scalar-button-1-color: #fff;
 }
 .dark-mode {
   --scalar-color-green: #30a159;


### PR DESCRIPTION
### Motivation

- The scalar primary button text was specified as semi-transparent white which caused it to appear slightly opaque on scalar.com, so the token needs to render as pure white for correct legibility.

### Description

- Replaced `--scalar-button-1-color: rgba(255, 255, 255, 0.9);` with `--scalar-button-1-color: #fff;` in `packages/themes/src/base/variables.css` and the dark-theme presets `default`, `alternate`, `bluePlanet`, `deepSpace`, `kepler`, `mars`, `purple`, and `saturn`.
- Added a changeset file `.changeset/fair-dingos-matter.md` with a `patch` bump for `@scalar/themes` describing the fix.
- Committed the updates with message `fix(themes): use pure white scalar button text in dark presets`.

### Testing

- Ran Biome formatting and Prettier on changed files with `pnpm biome check --write --diagnostic-level=error --no-errors-on-unmatched --files-ignore-unknown=true $CHANGED` and `pnpm prettier --write $CHANGED`, which completed successfully.
- Ran unit test command `pnpm vitest packages/themes --run`, which exited successfully with no test files found.
- Type-checked the package with `pnpm --filter @scalar/themes types:check` (ran `tsc --noEmit`) and it succeeded.
- `pnpm changeset status` could not be completed in this environment because the tool could not determine where `HEAD` diverged from `main` (this is an environment limitation, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d2feea1248327b6bded5606becd04)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely changes CSS variable values for button text color and adds a patch changeset, with no runtime logic changes.
> 
> **Overview**
> Updates the `--scalar-button-1-color` token from semi-transparent white (`rgba(255, 255, 255, 0.9)`) to pure white (`#fff`) across the base theme variables and multiple preset theme files to improve button text legibility.
> 
> Adds a Changeset to publish this as a **patch** release of `@scalar/themes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72332444540480ce78e313afb53fd61104458cd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->