### PR TITLE
chore(CODEOWNERS): fix scope for documentation and changeset

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,10 +9,10 @@
 /.github/renovate.json @hanspagel
 
 # Documentation
-/documentation/* @hanspagel @marclave @hwkr @cameronrohani
+/documentation @hanspagel @marclave @hwkr @cameronrohani
 
 # Changesets
-/.changeset/*
+/.changeset
 
 # Cursor rules
 /.cursor @hanspagel @amritk


### PR DESCRIPTION
The rule was only going one layer deep because of the `*` pattern.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
