### PR TITLE
fix(aspnetcore): escape request path interpolated into initialize() JS string

### DIFF
--- a/.changeset/aspnetcore-initialize-xss-fix.md
+++ b/.changeset/aspnetcore-initialize-xss-fix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': patch
+---
+
+fix(aspnetcore): JSON-encode the request path and `JavaScriptConfiguration` option before interpolating them into the inline `initialize(...)` script, so a crafted request path cannot break out of the JS string literal

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -147,7 +147,10 @@ public static class ScalarEndpointRouteBuilderExtensions
             var title = options.Documents.Count == 1 ? options.Title?.Replace(DocumentName, options.Documents[0].Name) : options.Title;
             var standaloneResourceUrl = string.IsNullOrEmpty(options.BundleUrl) ? ScalarJavaScriptFile : options.BundleUrl;
 
-            var escapedRequestPath = Uri.EscapeDataString(httpContext.Request.Path);
+            // Uri.EscapeDataString protects URL semantics, but the value lands in an inline <script>
+            // string literal — JavaScriptEncoder.Default neutralizes quote-breakout payloads there.
+            var escapedRequestPath = JavaScriptEncoder.Default.Encode(Uri.EscapeDataString(httpContext.Request.Path));
+            var javaScriptConfiguration = JavaScriptEncoder.Default.Encode(options.JavaScriptConfiguration ?? string.Empty);
 
             // Auto-generated values win when both are set — a per-request nonce is the secure path.
             var effectiveNonce = options.DynamicNonce
@@ -183,10 +186,10 @@ public static class ScalarEndpointRouteBuilderExtensions
                       <script type="module"{{nonceAttribute}}>
                           import { initialize } from './{{ScalarJavaScriptHelperFile}}'
                           initialize(
-                          '{{escapedRequestPath}}',
+                          "{{escapedRequestPath}}",
                           {{options.DynamicBaseServerUrl.ToString().ToLowerInvariant()}},
                           {{serializedConfiguration}},
-                          '{{options.JavaScriptConfiguration}}')
+                          "{{javaScriptConfiguration}}")
                       </script>
                   </body>
                   </html>

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -54,6 +54,25 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
         content.Should().Match(expected);
     }
 
+    [Theory]
+    [InlineData("/scalar/robots.txt'-alert(1)-'")]
+    [InlineData("/scalar/scalar.js'-alert(1)-'")]
+    public async Task MapScalarApiReference_ShouldEscapeRequestPathForJavaScript_WhenPathContainsQuoteBreakout(string path)
+    {
+        // Arrange
+        var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync(path, TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        // The verbatim breakout pattern (literal apostrophe) must not survive into the rendered
+        // <script>. URL-encoding (%27) and JSON Unicode-escaping (') both prevent execution.
+        content.Should().NotContain("'-alert(1)-'");
+    }
+
     [Fact]
     public async Task MapScalarApiReference_ShouldRedirectToTrailingSlash_WhenRequestedWithoutTrailingSlash()
     {

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -42,7 +42,7 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
                                     <script type="module">
                                         import { initialize } from './scalar.aspnetcore.js'
                                         initialize(
-                                        '%2Fscalar%2F',
+                                        "%2Fscalar%2F",
                                         false,
                                         *)
                                     </script>


### PR DESCRIPTION
## Problem

The aspnetcore integration interpolates the request path into the inline `initialize('...')` call wrapped in single quotes, but only runs it through `Uri.EscapeDataString` — a URL encoder, not a JS-string encoder. A request like `/scalar/robots.txt'-alert(1)-'` could therefore land in the rendered `<script>` as a quote-breakout payload. The same defect was one line below, on the (developer-controlled) `JavaScriptConfiguration` option.

## Solution

Run both values through `JavaScriptEncoder.Default.Encode` — the same encoder we already use for the nonce on line 166 — and switch the surrounding quotes to double quotes so the style stays consistent. Added a small theory test pinning the two reported PoC paths.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches HTML generation for the ASP.NET Core endpoint and changes how values are encoded inside an inline script; small but security-sensitive because it mitigates a potential XSS vector and could affect initialization if encoding is wrong.
> 
> **Overview**
> Hardens the ASP.NET Core `MapScalarApiReference` HTML response against inline-script injection by JavaScript-encoding the request path and the `JavaScriptConfiguration` option before interpolating them into the `initialize(...)` call (and switching the string literals to double quotes).
> 
> Adds a regression test covering quote-breakout request paths and includes a patch changeset for `@scalar/aspnetcore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 153f1447e843b2cf212beb0d5b1bfdd06fe4ca9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->