### PR TITLE
fix(api-reference): render schema examples (null, whitespace, value-shaped objects)

### DIFF
--- a/.changeset/schema-example-edge-cases.md
+++ b/.changeset/schema-example-edge-cases.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: render `null`, whitespace-only, and `value`/`externalValue`-shaped schema examples correctly

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.test.ts
@@ -39,13 +39,36 @@ describe('SchemaPropertyExamples', () => {
     expect(wrapper.find('.property-example-value span').text()).toBe('')
   })
 
-  it('does not render a single example when the value is null', () => {
+  it('renders a single example when the value is null', () => {
     const wrapper = mount(SchemaPropertyExamples, {
       props: {
         example: null,
       },
     })
 
+    expect(wrapper.find('.property-example').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Example')
+    expect(wrapper.text()).toContain('null')
+  })
+
+  it('does not render a single example when the value is undefined', () => {
+    const wrapper = mount(SchemaPropertyExamples, {
+      props: {
+        example: undefined,
+      },
+    })
+
     expect(wrapper.find('.property-example').exists()).toBe(false)
+  })
+
+  it('renders a single example when the value is a whitespace-only string', () => {
+    const wrapper = mount(SchemaPropertyExamples, {
+      props: {
+        example: ' ',
+      },
+    })
+
+    expect(wrapper.find('.property-example').exists()).toBe(true)
+    expect(wrapper.find('.property-example-value span').text()).toBe('')
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.test.ts
@@ -71,4 +71,42 @@ describe('SchemaPropertyExamples', () => {
     expect(wrapper.find('.property-example').exists()).toBe(true)
     expect(wrapper.find('.property-example-value span').text()).toBe('')
   })
+
+  it('renders a single example for an object value without unwrapping', () => {
+    const wrapper = mount(SchemaPropertyExamples, {
+      props: {
+        example: { testProperty: 'testValue' },
+      },
+    })
+
+    expect(wrapper.find('.property-example').exists()).toBe(true)
+    expect(wrapper.text()).toContain('{"testProperty":"testValue"}')
+  })
+
+  it('unwraps `value` from OpenAPI Example Objects in the `examples` map', () => {
+    const wrapper = mount(SchemaPropertyExamples, {
+      props: {
+        examples: {
+          first: { summary: 'A name', value: 'Alice' },
+          second: { value: 42 },
+        },
+      },
+    })
+
+    const buttons = wrapper.findAll('.property-example-value span')
+    expect(buttons[0]?.text()).toBe('Alice')
+    expect(buttons[1]?.text()).toBe('42')
+  })
+
+  it('unwraps `externalValue` from OpenAPI Example Objects in the `examples` map', () => {
+    const wrapper = mount(SchemaPropertyExamples, {
+      props: {
+        examples: {
+          remote: { externalValue: 'https://example.com/sample.json' },
+        },
+      },
+    })
+
+    expect(wrapper.find('.property-example-value span').text()).toBe('https://example.com/sample.json')
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
@@ -39,7 +39,7 @@ const multipleExamplesLabel = computed(() =>
  * to the actual sample. Plain values pass through untouched.
  */
 function unwrapExampleObject(value: unknown): unknown {
-  if (value && typeof value === 'object' && !Array.isArray(value)) {
+  if (isObject(value)) {
     if ('value' in value) {
       return value.value
     }

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
@@ -33,6 +33,22 @@ const hasMultipleExamples = computed(
 const multipleExamplesLabel = computed(() =>
   Object.keys(normalizedExamples.value).length === 1 ? 'Example' : 'Examples',
 )
+
+/**
+ * Unwrap an OpenAPI 3 Example Object (`{ value, externalValue, summary, description }`)
+ * to the actual sample. Plain values pass through untouched.
+ */
+function unwrapExampleObject(value: unknown): unknown {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    if ('value' in value) {
+      return (value as { value: unknown }).value
+    }
+    if ('externalValue' in value) {
+      return (value as { externalValue: unknown }).externalValue
+    }
+  }
+  return value
+}
 </script>
 <template>
   <!-- single example (deprecated) -->
@@ -68,8 +84,8 @@ const multipleExamplesLabel = computed(() =>
           :key="key"
           class="property-example-value group"
           type="button"
-          @click="copyToClipboard(formatExample(ex))">
-          <span>{{ formatExample(ex) }} </span>
+          @click="copyToClipboard(formatExample(unwrapExampleObject(ex)))">
+          <span>{{ formatExample(unwrapExampleObject(ex)) }} </span>
           <ScalarIcon
             class="text-c-3 group-hover:text-c-1 ml-auto min-h-3 min-w-3"
             icon="Clipboard"

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
@@ -41,7 +41,7 @@ const multipleExamplesLabel = computed(() =>
 function unwrapExampleObject(value: unknown): unknown {
   if (value && typeof value === 'object' && !Array.isArray(value)) {
     if ('value' in value) {
-      return (value as { value: unknown }).value
+      return value.value
     }
     if ('externalValue' in value) {
       return (value as { externalValue: unknown }).externalValue

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyExamples.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ScalarIcon } from '@scalar/components'
-import { isDefined } from '@scalar/helpers/array/is-defined'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { computed } from 'vue'
 
@@ -15,7 +14,9 @@ const { examples, example } = defineProps<{
 
 const { copyToClipboard } = useClipboard()
 
-const hasSingleExample = computed(() => isDefined(example))
+// `null` is a meaningful example value for nullable schemas, so only treat
+// `undefined` as "not provided".
+const hasSingleExample = computed(() => example !== undefined)
 
 const normalizedExamples = computed<Record<string, unknown>>(() => {
   if (examples && typeof examples === 'object') {

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -894,7 +894,7 @@ describe('SchemaPropertyHeading', () => {
       expect(examplesElement.props('example')).toBe(false)
     })
 
-    it('does not pass null from items.example when value.example is not available', () => {
+    it('passes null from items.example when value.example is not available', () => {
       const wrapper = mount(SchemaPropertyHeading, {
         props: {
           value: coerceValue(SchemaObjectSchema, {
@@ -906,7 +906,7 @@ describe('SchemaPropertyHeading', () => {
       })
 
       const examplesElement = wrapper.findComponent({ name: 'SchemaPropertyExamples' })
-      expect(examplesElement.props('example')).toBeUndefined()
+      expect(examplesElement.props('example')).toBeNull()
     })
   })
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -244,13 +244,24 @@ const displayType = computed(() => {
 })
 
 const exampleValue = computed(() => {
-  if (isDefined(props.value?.example)) {
+  // Treat only `undefined` as "not set" — `null` is a valid example value on a nullable schema.
+  if (
+    props.value &&
+    'example' in props.value &&
+    props.value.example !== undefined
+  ) {
     return props.value.example
   }
 
   if (props.value && isArraySchema(props.value)) {
-    const itemsExample = resolve.schema(props.value.items)?.example
-    return isDefined(itemsExample) ? itemsExample : undefined
+    const itemsSchema = resolve.schema(props.value.items)
+    if (
+      itemsSchema &&
+      'example' in itemsSchema &&
+      itemsSchema.example !== undefined
+    ) {
+      return itemsSchema.example
+    }
   }
 
   return undefined

--- a/packages/api-reference/src/components/Content/Schema/helpers/format-example.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/format-example.test.ts
@@ -92,19 +92,23 @@ describe('formatExample', () => {
     expect(result).toBe('123.456')
   })
 
-  it('handles external value', () => {
-    const input = {
-      externalValue: 'https://example.com',
-    }
+  it('stringifies objects with a `value` property', () => {
+    // `value`/`externalValue` are OpenAPI Example Object keys that callers should
+    // unwrap before passing here. `formatExample` itself treats them as plain object keys.
+    const input = { value: '123' }
     const result = formatExample(input)
-    expect(result).toBe('https://example.com')
+    expect(result).toBe('{"value":"123"}')
   })
 
-  it('handles object value', () => {
-    const input = {
-      value: '123',
-    }
+  it('stringifies objects with an `externalValue` property', () => {
+    const input = { externalValue: 'https://example.com' }
     const result = formatExample(input)
-    expect(result).toBe('123')
+    expect(result).toBe('{"externalValue":"https://example.com"}')
+  })
+
+  it('stringifies arbitrary objects', () => {
+    const input = { testProperty: 'testValue' }
+    const result = formatExample(input)
+    expect(result).toBe('{"testProperty":"testValue"}')
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/format-example.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/format-example.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import { formatExample } from './format-example'
 
 describe('formatExample', () => {
@@ -54,6 +55,17 @@ describe('formatExample', () => {
     const input = ['  leading', 'trailing  ', '  both  ']
     const result = formatExample(input)
     expect(result).toBe('["leading", "trailing", "both"]')
+  })
+
+  it('preserves whitespace-only strings inside arrays', () => {
+    const input = [' ', '  ']
+    const result = formatExample(input)
+    expect(result).toBe('[" ", "  "]')
+  })
+
+  it('preserves a whitespace-only string', () => {
+    const result = formatExample(' ')
+    expect(result).toBe(' ')
   })
 
   it('handles non-string/non-array input', () => {

--- a/packages/api-reference/src/components/Content/Schema/helpers/format-example.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/format-example.ts
@@ -40,14 +40,6 @@ export function formatExample(example: unknown): string | number {
   }
 
   if (typeof example === 'object') {
-    if ('value' in example) {
-      return example.value as string | number
-    }
-
-    if ('externalValue' in example) {
-      return example.externalValue as string | number
-    }
-
     return JSON.stringify(example)
   }
 

--- a/packages/api-reference/src/components/Content/Schema/helpers/format-example.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/format-example.ts
@@ -1,4 +1,13 @@
 /**
+ * Trims surrounding whitespace, but keeps the original string when trimming would empty it
+ * (so an intentional " " example is not silently turned into "").
+ */
+function preserveOrTrim(value: string): string {
+  const trimmed = value.trim()
+  return trimmed === '' ? value : trimmed
+}
+
+/**
  * Converts an example value to a string that can be displayed in the UI.
  */
 export function formatExample(example: unknown): string | number {
@@ -6,7 +15,7 @@ export function formatExample(example: unknown): string | number {
     return `[${example
       .map((item) => {
         if (typeof item === 'string') {
-          return `"${item.toString().trim()}"`
+          return `"${preserveOrTrim(item)}"`
         }
 
         if (typeof item === 'object') {
@@ -47,8 +56,8 @@ export function formatExample(example: unknown): string | number {
   }
 
   if (typeof example === 'string') {
-    return example.trim()
+    return preserveOrTrim(example)
   }
 
-  return example.toString().trim()
+  return preserveOrTrim(example.toString())
 }


### PR DESCRIPTION
Three small fixes to how a property's `example` is rendered:

- `" "` and other whitespace-only strings were trimmed to empty before display — kept as-is now.
- `null` examples were hidden entirely; they render as `null` now, which matters for nullable schemas.
- Plain user objects with a `value` or `externalValue` key were being unwrapped as if they were OpenAPI Example Objects. The unwrap moved to the multi-`examples` map where Example Objects actually live.

## OpenAPI Example

https://sandbox.scalar.com/e/OEoJ4

## Ticket

Closes #7508


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts example selection/formatting and adds tests; main risk is minor regression in how schema examples are displayed/copied.
> 
> **Overview**
> Fixes schema example rendering in `@scalar/api-reference` to **treat `null` as a real example value** (only `undefined` hides the example) and to **preserve whitespace-only examples** instead of trimming them to empty.
> 
> Moves OpenAPI Example Object (`{ value, externalValue }`) unwrapping out of the generic formatter and into the `examples` map rendering path, so plain objects with `value`/`externalValue` keys are displayed as JSON rather than being incorrectly unwrapped; updates/adds tests covering these edge cases and ships a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67b2d0c0ddade2b07f18a72dc5db418d045525cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->