### PR TITLE
ci: declare cloudflare secrets explicitly on deploy-api-client

### DIFF
--- a/.github/workflows/deploy-api-client.yml
+++ b/.github/workflows/deploy-api-client.yml
@@ -16,6 +16,11 @@ on:
         description: 'Commit SHA to deploy — PR head SHA for previews, git SHA for releases'
         type: string
         required: true
+    secrets:
+      CLOUDFLARE_API_TOKEN:
+        required: true
+      CLOUDFLARE_ACCOUNT_ID:
+        required: true
     outputs:
       preview-url:
         description: 'The Cloudflare Pages deployment URL (staging only)'


### PR DESCRIPTION
Documents the required secrets for the reusable `deploy-api-client` workflow. Non-breaking, `secrets: inherit` on existing callers continues to satisfy the explicit declaration.

Extracted from #9233.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only makes the reusable workflow’s required Cloudflare secrets explicit and does not change the deploy steps or behavior for callers already using `secrets: inherit`.
> 
> **Overview**
> The reusable `deploy-api-client` GitHub Actions workflow now **explicitly declares required secrets** (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) under `workflow_call`, documenting and enforcing the secret contract for Cloudflare Pages deployments.
> 
> No build/deploy logic changes; callers must provide these secrets (with existing `secrets: inherit` still satisfying the requirement).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 233b7bf9e99be660241f3958baaf0263db87a02c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->