### PR TITLE
ci: branch-scope persistent caches and add weekly refresh

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,31 +1,39 @@
 name: 'Setup Node'
-description: 'Setup pnpm, Node.js, and persistent turbo cache (stickydisk)'
-inputs:
-  node-version:
-    description: 'Node.js version to use (optional, defaults to reading from .nvmrc)'
-    required: false
+description: |
+  Set up pnpm, Node.js, and the branch-scoped caches used by every JS job
+  in this repo. Cache keys include `github.ref_name` so a PR can never
+  overwrite the cache a main-branch run will read.
 runs:
   using: 'composite'
   steps:
     - name: Install pnpm
       uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+
     - name: Read Node.js version from .nvmrc
       id: node-version
       shell: bash
-      run: |
-        if [ -n "${{ inputs.node-version }}" ]; then
-          echo "version=${{ inputs.node-version }}" >> $GITHUB_OUTPUT
-        else
-          echo "version=$(cat .nvmrc | tr -d 'v')" >> $GITHUB_OUTPUT
-        fi
+      run: echo "version=$(tr -d 'v' < .nvmrc)" >> "$GITHUB_OUTPUT"
+
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: ${{ steps.node-version.outputs.version }}
         cache: 'pnpm'
+
+    # Branch-scoped persistent turbo cache.
+    # Bump the `v1` suffix in both keys below to invalidate every cache.
     - if: startsWith(runner.name, 'blacksmith')
       name: Setup persistent turbo cache
       uses: useblacksmith/stickydisk@41873b1513bb679f9c115504cbd13d3660432504 # v1
       with:
-        key: ${{ github.repository }}-${{ github.ref_name }}-turbo-cache-${{ steps.node-version.outputs.version }}
+        key: ${{ github.repository }}-${{ github.ref_name }}-turbo-cache-${{ steps.node-version.outputs.version }}-v1
         path: ./.turbo
+
+    # Branch-scoped pnpm store cache. pnpm verifies tarball integrity at
+    # install time, so a poisoned tarball with a mismatched hash is rejected.
+    - if: startsWith(runner.name, 'blacksmith')
+      name: Setup persistent pnpm store cache
+      uses: useblacksmith/stickydisk@41873b1513bb679f9c115504cbd13d3660432504 # v1
+      with:
+        key: ${{ github.repository }}-${{ github.ref_name }}-pnpm-store-${{ steps.node-version.outputs.version }}-${{ hashFiles('pnpm-lock.yaml') }}-v1
+        path: ~/.local/share/pnpm/store

--- a/.github/workflows/cache-refresh.yml
+++ b/.github/workflows/cache-refresh.yml
@@ -1,0 +1,75 @@
+name: Cache Refresh
+
+# Weekly cold rebuild of the main-branch turbo and pnpm-store caches.
+# Wipe the disks, run a full install + build, and let the stickydisk
+# mechanism snapshot the resulting fresh state. Bounds how long a stale
+# or poisoned cache entry can survive on the main stickydisks.
+
+on:
+  schedule:
+    # Sundays 03:00 UTC. Quiet time, no overlap with usual release flow.
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cache-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          ref: main
+
+      - uses: ./.github/actions/setup-node
+
+      # Empty cache contents (do NOT `rm -rf` the directory itself: that
+      # is the stickydisk mount point and removing it can break the
+      # persistence binding).
+      - name: Clear existing cache contents
+        run: |
+          set -euo pipefail
+          echo "Cache state before clear:"
+          du -sh ./.turbo 2>/dev/null || echo "  ./.turbo: missing"
+          du -sh ~/.local/share/pnpm/store 2>/dev/null || echo "  pnpm store: missing"
+
+          if [ -d ./.turbo ]; then
+            find ./.turbo -mindepth 1 -delete
+          fi
+          if [ -d ~/.local/share/pnpm/store ]; then
+            find ~/.local/share/pnpm/store -mindepth 1 -delete
+          fi
+
+      - name: Install dependencies (cold)
+        run: pnpm install --frozen-lockfile
+
+      # `TURBO_FLAGS` MUST stay templated (`${{ env.TURBO_FLAGS }}`), not
+      # shell-expanded: its value embeds literal quotes around filter
+      # patterns and only the GHA templater handles those correctly.
+      - name: Build all packages (cold)
+        env:
+          TURBO_FLAGS: '--concurrency=100% --filter "!./integrations/{java,rust,dotnet,docker,fastapi,django-ninja}/**" --filter "!./projects/proxy-scalar-com/**"'
+        run: pnpm turbo ${{ env.TURBO_FLAGS }} --filter './{packages,integrations}/**' build
+
+      - name: Report cache footprints
+        run: |
+          {
+            echo "## Cache refresh summary"
+            echo ''
+            echo '| Path | Size |'
+            echo '|---|---|'
+            for p in ./.turbo ~/.local/share/pnpm/store; do
+              if [ -d "$p" ]; then
+                echo "| $p | $(du -sh "$p" | cut -f1) |"
+              fi
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cache-refresh.yml
+++ b/.github/workflows/cache-refresh.yml
@@ -25,6 +25,19 @@ jobs:
     permissions:
       contents: read
     steps:
+      # Refuse non-main dispatches. setup-node scopes its stickydisk keys
+      # by `github.ref_name`, so a run dispatched from another branch
+      # would wipe and repopulate the WRONG branch's caches with main's
+      # build output. Fail loudly instead of silently corrupting state.
+      - name: Refuse non-main refs
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          if [ "$REF" != "refs/heads/main" ]; then
+            echo "::error::cache-refresh must run on main, got '$REF'"
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false

--- a/.github/workflows/cache-refresh.yml
+++ b/.github/workflows/cache-refresh.yml
@@ -15,7 +15,19 @@ permissions:
   contents: read
 
 concurrency:
-  group: cache-refresh
+  # Share CI's main-branch concurrency group. This job wipes and rebuilds
+  # the branch-scoped stickydisks that `CI` also mounts for main (keyed by
+  # `github.ref_name` in .github/actions/setup-node). A refresh overlapping
+  # a CI run lets the last job to finish persist a partial or empty cache
+  # snapshot, so the two must never run at the same time. Both this job and
+  # CI-on-main use `cancel-in-progress: false`, so they queue instead of
+  # cancelling each other.
+  #
+  # This must stay equal to CI's group, which is
+  # `${{ github.workflow }}-${{ github.ref_name }}-base-ci` in ci.yml.
+  # cache-refresh only ever runs on main (see the "Refuse non-main refs"
+  # guard below), so the value is hardcoded rather than templated.
+  group: CI-main-base-ci
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Scopes the persistent turbo cache and a new pnpm-store stickydisk by branch + node version + lockfile, with a `-v1` suffix you can bump to invalidate everything. A new `cache-refresh.yml` runs every Sunday (and on demand) to wipe the main-branch caches and rebuild from cold, so a stale or poisoned entry cannot survive forever.

Extracted from #9233.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI caching behavior by introducing branch-scoped stickydisk caches and an automated cache wipe/rebuild workflow; mistakes could slow CI or cause flaky builds if caches are cleared or keyed incorrectly.
> 
> **Overview**
> Updates the composite `setup-node` action to make stickydisk caches **branch-scoped** (keyed by `github.ref_name`) and adds a `-v1` suffix for explicit cache invalidation. It also adds a persistent pnpm store stickydisk keyed by Node version and `pnpm-lock.yaml` hash, and simplifies Node version resolution to always read from `.nvmrc`.
> 
> Adds a new scheduled/on-demand `Cache Refresh` workflow that runs only on `main`, clears the turbo and pnpm-store stickydisk contents, performs a cold `pnpm install` + `turbo build`, and reports cache sizes, using CI’s main-branch concurrency group to avoid overlapping with normal CI runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdcccad68c50f92087763c86768a209ca7121e3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->