### PR TITLE
ci: scope npm-publish to production-npm environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,6 +644,7 @@ jobs:
     # 422 because the OIDC issuer is not in npm's trusted list. Always use a
     # github-hosted runner here, regardless of whether this run will publish.
     runs-on: ubuntu-22.04
+    environment: production-npm
     timeout-minutes: 15
     # Avoid running this job in parallel:
     # `changesets/action` creates/updates the release branch, which shouldn't happen in parallel.


### PR DESCRIPTION
Adds `environment: production-npm` to the `npm-publish` job so `NPM_TOKEN` is only readable from this job on `main`.

Before merging:
- [x] Create `production-npm` environment in repo settings → Environments
- [x] Set Deployment branches → `main` only
- [x] Add `NPM_TOKEN` to the environment
- [x] Mark this PR ready for review

Part of an incremental migration of repo-level secrets to environment-scoped secrets. Repo-level copies stay during the transition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow change that only affects the `npm-publish` job’s secret/approval context on `main`; main risk is misconfigured environment settings causing publishes to fail.
> 
> **Overview**
> Scopes the `npm-publish` GitHub Actions job to the `production-npm` environment by adding `environment: production-npm` in `.github/workflows/ci.yml`, so publishing on `main` can use environment-scoped secrets (e.g., `NPM_TOKEN`) and any configured environment protections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86225534f49765988ae5c359ecaa8c1d72075e38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->