### PR TITLE
ci: scope pypi publish jobs to production-pypi environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1526,6 +1526,7 @@ jobs:
   fastapi-publish:
     if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.fastapi_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: production-pypi
     timeout-minutes: 10
     concurrency:
       group: fastapi-publish
@@ -1588,6 +1589,7 @@ jobs:
   django-ninja-publish:
     if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.django_ninja_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: production-pypi
     timeout-minutes: 10
     concurrency:
       group: django-ninja-publish


### PR DESCRIPTION
Adds `environment: production-pypi` to `fastapi-publish` and `django-ninja-publish` in the reusable integration publishing workflow. Once the environment is configured, both jobs use its `PYPI_TOKEN` and follow its deployment restrictions. The workflow remains called from `main.yml` after a successful release, with each publisher gated by package changes and a passing integration build.

Before merging:
- [ ] Create or verify the `production-pypi` environment in repository settings → Environments
- [ ] Set deployment branches to `main` only
- [ ] Add `PYPI_TOKEN` to the environment
- [ ] Mark this PR ready for review

Part of an incremental migration of repository-level secrets to environment-scoped secrets. Repository-level copies stay during the transition, so this change does not yet restrict all access to `PYPI_TOKEN` to these jobs. The environment secret takes precedence for these jobs once configured.
