### PR TITLE
ci: scope docker publish jobs to production-dockerhub environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1166,6 +1166,7 @@ jobs:
   docker-publish:
     if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.docker_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: production-dockerhub
     timeout-minutes: 10
     concurrency:
       group: docker-publish
@@ -1230,6 +1231,7 @@ jobs:
   mock-server-docker-publish:
     if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.mock_server_docker_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: production-dockerhub
     timeout-minutes: 10
     concurrency:
       group: mock-server-docker-publish


### PR DESCRIPTION
Adds `environment: production-dockerhub` to `docker-publish` and `mock-server-docker-publish` so the Docker Hub credentials are only readable from these jobs on `main`.

Before merging:
- [x] Create `production-dockerhub` environment in repo settings → Environments
- [x] Set Deployment branches → `main` only
- [x] Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` to the environment
- [ ] Mark this PR ready for review

Part of an incremental migration of repo-level secrets to environment-scoped secrets. Repo-level copies stay during the transition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the release/publish workflow for Docker images; misconfigured GitHub Environments or missing environment secrets could prevent DockerHub publishes on `main`. No product/runtime code paths are affected.
> 
> **Overview**
> Scopes DockerHub publishing to a GitHub Environment by adding `environment: production-dockerhub` to the `docker-publish` and `mock-server-docker-publish` jobs in `ci.yml`.
> 
> This restricts access to `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` to those publish jobs (and whatever branch restrictions are configured on the environment), tightening secret exposure during releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fb22a3d14373e1f6d2687cc1389ef968bf7f807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->