### PR TITLE
ci: scope aspnetcore-publish and aspire-publish to production-nuget environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1401,6 +1401,7 @@ jobs:
   aspire-publish:
     if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.aspire_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: production-nuget
     timeout-minutes: 10
     concurrency:
       group: aspire-publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1339,6 +1339,7 @@ jobs:
   aspnetcore-publish:
     if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.aspnetcore_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: production-nuget
     timeout-minutes: 10
     # We don't want to run `nuget push` (publishing to NuGet) in parallel.
     concurrency:


### PR DESCRIPTION
Adds `environment: production-nuget` to both `aspnetcore-publish` and `aspire-publish` so their NuGet and Docker Hub credentials are only readable from these jobs on `main`.

Both jobs push to NuGet **and** log into Docker Hub, so the env carries both sets of credentials.

Before merging:
- [x] Create `production-nuget` environment in repo settings → Environments
- [x] Set Deployment branches → `main` only
- [x] Add to the environment: `NUGET_TOKEN`, `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`
- [x] Mark this PR ready for review

Part of an incremental migration of repo-level secrets to environment-scoped secrets. Repo-level copies stay during the transition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub Actions environment for NuGet/Docker publishing jobs, which can block releases if the `production-nuget` environment or its secrets/branch protections are misconfigured.
> 
> **Overview**
> Scopes the .NET release jobs `aspnetcore-publish` and `aspire-publish` in `ci.yml` to the `production-nuget` GitHub Actions environment, so their publish-time secrets are only accessible via that environment.
> 
> This tightens credential access for NuGet (and the Aspire job’s Docker Hub login) without changing build/test logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69d2ca3387f2e06175a1ba352bc43938f6c15422. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->