### PR TITLE
ci: scope aspire-publish to production-aspire environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1400,6 +1400,7 @@ jobs:
   aspire-publish:
     if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.aspire_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: production-aspire
     timeout-minutes: 10
     concurrency:
       group: aspire-publish


### PR DESCRIPTION
Adds `environment: production-aspire` to `aspire-publish` so its NuGet and Docker Hub credentials are only readable from this job on `main`.

This job pushes to NuGet **and** logs into Docker Hub. A job can only declare one environment, so `production-aspire` needs to carry the Docker Hub credentials too.

Before merging:
- [ ] Create `production-aspire` environment in repo settings → Environments
- [ ] Set Deployment branches → `main` only
- [ ] Add to the environment: `NUGET_TOKEN`, `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`
- [ ] Mark this PR ready for review

Part of an incremental migration of repo-level secrets to environment-scoped secrets. Repo-level copies stay during the transition.