### PR TITLE
ci: scope rust-publish to production-crates environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1678,6 +1678,7 @@ jobs:
   rust-publish:
     if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.rust_package_changed == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: production-crates
     timeout-minutes: 10
     concurrency:
       group: rust-publish


### PR DESCRIPTION
Adds `environment: production-crates` to `rust-publish` so `CARGO_REGISTRY_TOKEN` is only readable from this job on `main`.

Before merging:
- [x] Create `production-crates` environment in repo settings → Environments
- [x] Set Deployment branches → `main` only
- [x] Add `CARGO_REGISTRY_TOKEN` to the environment
- [x] Mark this PR ready for review

Part of an incremental migration of repo-level secrets to environment-scoped secrets. Repo-level copies stay during the transition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions job configuration to use an environment, without changing build/test/publish commands. Main risk is misconfigured environment/branch protections causing the `rust-publish` job to lose access to `CARGO_REGISTRY_TOKEN` and fail publishing.
> 
> **Overview**
> Scopes the `rust-publish` GitHub Actions job to the `production-crates` environment by adding `environment: production-crates`, so the crates.io publish token can be environment-scoped rather than repository-wide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6843e4a52615320b084c03e3ec1001c7967276b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->