### PR TITLE
ci: scope java-publish to production-maven environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1759,6 +1759,7 @@ jobs:
     if: needs.npm-publish.outputs.published == 'true' && needs.check-changes.outputs.java_package_changed == 'true'
     needs: [required-jobs-main, java-build-test, check-changes, npm-publish]
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: production-maven
     concurrency:
       group: java-publish
       cancel-in-progress: false


### PR DESCRIPTION
Adds `environment: production-maven` to `java-publish` so the Maven and GPG signing credentials are only readable from this job on `main`.

Before merging:
- [ ] Create `production-maven` environment in repo settings → Environments
- [ ] Set Deployment branches → `main` only
- [ ] Add to the environment: `MAVEN_USERNAME`, `MAVEN_PASSWORD`, `GPG_KEY_ID`, `GPG_PASSPHRASE`, `GPG_PRIVATE_KEY`
- [ ] Mark this PR ready for review

Part of an incremental migration of repo-level secrets to environment-scoped secrets. Repo-level copies stay during the transition.