### PR TITLE
ci: scope scalar-registry jobs to production-scalar-registry and staging-scalar-registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -739,6 +739,7 @@ jobs:
   push-to-scalar-registry:
     if: needs.npm-publish.outputs.published == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: production-scalar-registry
     timeout-minutes: 10
     needs: [build, test-packages, npm-publish]
 
@@ -1008,6 +1009,7 @@ jobs:
       needs.check-changes.outputs.galaxy_changed == 'true'
     needs: [build, check-changes]
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: staging-scalar-registry
     timeout-minutes: 10
     permissions:
       contents: read


### PR DESCRIPTION
Scopes both scalar-registry jobs:

- `push-to-scalar-registry` (runs on `main`) → `production-scalar-registry`
- `galaxy-registry-preview` (runs on PRs from this repo) → `staging-scalar-registry`

Both read `SCALAR_API_KEY`, but each environment can hold its own value if you want to use different tokens for production vs. previews.

Before merging:
- [x] Create `production-scalar-registry` environment in repo settings → Environments
  - [x] Deployment branches: `main` only
  - [x] Add `SCALAR_API_KEY`
- [x] Create `staging-scalar-registry` environment in repo settings → Environments
  - [x] Deployment branches: **not** `main` only (this job runs from PR branches). Either "All branches", or "Selected" with a pattern that matches your PR head refs. Fork PRs cannot access environment secrets without a reviewer-approval gate.
  - [x] Add `SCALAR_API_KEY`
- [x] Mark this PR ready for review

Part of an incremental migration of repo-level secrets to environment-scoped secrets. Repo-level copies stay during the transition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk CI configuration change, but misconfigured GitHub Environments/secrets could cause Scalar Registry publish/preview jobs to fail at runtime.
> 
> **Overview**
> Scopes Scalar Registry publishing in `.github/workflows/ci.yml` to GitHub Environments by assigning `push-to-scalar-registry` to **`production-scalar-registry`** and `galaxy-registry-preview` to **`staging-scalar-registry`**, enabling environment-specific `SCALAR_API_KEY` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ce73e54456536a8ee040508961ba3f231721880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->