### PR TITLE
ci: scope deploy-components to production-netlify environment

### DIFF
--- a/.github/workflows/deploy-previews.yml
+++ b/.github/workflows/deploy-previews.yml
@@ -47,6 +47,7 @@ permissions:
 jobs:
   deploy-examples:
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: production-netlify
     timeout-minutes: 10
     concurrency:
       group: deploy-examples-${{ github.ref }}
@@ -127,6 +128,7 @@ jobs:
 
   deploy-components:
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: production-netlify
     timeout-minutes: 10
     concurrency:
       group: deploy-components-${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -338,6 +338,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: [build]
     runs-on: blacksmith-2vcpu-ubuntu-2204
+    environment: production-netlify
     timeout-minutes: 10
     concurrency:
       group: deploy-components-${{ github.ref }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -308,6 +308,7 @@ jobs:
   test-e2e-api-reference:
     needs: [build]
     runs-on: blacksmith-4vcpu-ubuntu-2204
+    environment: production-netlify
     container:
       image: scalarapi/playwright-runner:1.59.1
       options: --privileged
@@ -356,6 +357,7 @@ jobs:
   test-e2e-scalar-app:
     needs: [build]
     runs-on: blacksmith-4vcpu-ubuntu-2204
+    environment: production-netlify
     container:
       image: scalarapi/playwright-runner:1.59.1
       options: --privileged
@@ -400,6 +402,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.head_ref == 'main'
     needs: [build]
     runs-on: blacksmith-4vcpu-ubuntu-2204
+    environment: production-netlify
     container:
       image: scalarapi/playwright-runner:1.59.1
       options: --privileged
@@ -447,6 +450,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.head_ref == 'main'
     needs: [build]
     runs-on: blacksmith-8vcpu-ubuntu-2204
+    environment: production-netlify
     container:
       image: scalarapi/playwright-runner:1.59.1
       options: --privileged


### PR DESCRIPTION
Adds `environment: production-netlify` to `deploy-components` so `NETLIFY_AUTH_TOKEN` is only readable from this job.

Note: this job runs on **both** PR previews and `main` production deploys, so locking the environment to `Deployment branches: main only` will break PR-side preview deploys. Either widen the deployment-branches rule, or split the job into PR-preview vs. production in a follow-up.

Before merging:
- [x] Create `production-netlify` environment in repo settings → Environments
- [x] Deployment branches: choose one
  - `main` only (will break PR previews until the job is split)
  - "All branches" (job-scoping benefit but no branch restriction)
  - "Selected" with a pattern matching PR head refs in this repo
- [x] Add `NETLIFY_AUTH_TOKEN` to the environment
- [x] Mark this PR ready for review

Part of an incremental migration of repo-level secrets to environment-scoped secrets. Repo-level copies stay during the transition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI secret scoping for Netlify across PR previews, main deploys, and e2e report uploads; misconfigured environment deployment branches could break PR workflows until settings or job splits are adjusted.
> 
> **Overview**
> Adds **`environment: production-netlify`** to GitHub Actions jobs that call Netlify (`NETLIFY_AUTH_TOKEN`), so the token is read from the environment instead of repo-wide secrets.
> 
> **Preview and production deploys:** `deploy-examples` and `deploy-components` in `deploy-previews.yml`, plus main-branch `deploy-components` in `main.yml`.
> 
> **PR CI:** Playwright jobs that upload reports to Netlify in `pr.yml` (`test-e2e-api-reference`, `test-e2e-scalar-app`, `test-component-snapshots`, `test-cdn-snapshots`).
> 
> Repo-level secrets can stay during the migration; jobs must be allowed to use the environment (deployment branch rules affect PR previews and report uploads if restricted to `main` only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e57933743b6e71f512650d887d156dcdd8f5d6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->