### PR TITLE
ci: rename todesktop-build environment from production to production-todesktop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -971,7 +971,7 @@ jobs:
     needs: [required-jobs-main, build, check-changes, npm-publish]
     runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 15
-    environment: production
+    environment: production-todesktop
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Renames the `todesktop-build` job's environment from the generic `production` to a dedicated `production-todesktop`. Same scoping, narrower name — `TODESKTOP_ACCESS_TOKEN` / `TODESKTOP_EMAIL` no longer share an environment with anything else.

Before merging:
- [x] Create `production-todesktop` environment in repo settings → Environments
- [x] Set Deployment branches → `main` only
- [x] Add `TODESKTOP_ACCESS_TOKEN` and `TODESKTOP_EMAIL` to the environment (copy from the existing `production` env)
- [x] Mark this PR ready for review
- [ ] Once the existing `production` environment has no other consumers, delete its `TODESKTOP_*` secrets

Part of an incremental migration of repo-level secrets to environment-scoped secrets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI configuration-only change, but it affects the `todesktop-build` job’s environment-scoped secrets/approvals and could break releases if the new environment isn’t configured correctly.
> 
> **Overview**
> Updates the GitHub Actions `todesktop-build` job to run under a dedicated `production-todesktop` environment instead of the shared `production` environment, isolating ToDesktop credentials and environment settings from other production workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dd8f54b2e802255c848c66cdbfd2ca736a5261f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->