### PR TITLE
fix: update branding copy from 'The OpenAPI company' to 'The API company'

### DIFF
--- a/documentation/guides/app/getting-started.md
+++ b/documentation/guides/app/getting-started.md
@@ -239,7 +239,7 @@ Use [post-response scripts](./testing.md) to validate responses and automate che
         <span class="text-c-1">
           <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
         </span>
-        <p class="mt-10 text-c-3 text-sm text-balance">The OpenAPI company.</p>
+        <p class="mt-10 text-c-3 text-sm text-balance">The API company.</p>
         <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
       </div>
       <div class="flex text-sm">

--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -278,7 +278,7 @@ Put your content where you want: in your repository, any folder, or the Scalar E
         <span class="text-c-1">
           <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
         </span>
-        <p class="mt-10 text-c-3 text-sm text-balance">The OpenAPI company.</p>
+        <p class="mt-10 text-c-3 text-sm text-balance">The API company.</p>
         <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
       </div>
       <div class="flex text-sm">

--- a/documentation/guides/enterprise/enterprise.md
+++ b/documentation/guides/enterprise/enterprise.md
@@ -120,7 +120,7 @@ Validate contracts early so exploration and testing stay tied to the same API de
         <span class="text-c-1">
           <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
         </span>
-        <p class="mt-10 text-c-3 text-sm text-balance">The OpenAPI company.</p>
+        <p class="mt-10 text-c-3 text-sm text-balance">The API company.</p>
         <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
       </div>
       <div class="flex text-sm">

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -445,7 +445,7 @@
         <span class="text-c-1">
           <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
         </span>
-        <p class="mt-10 text-c-3 text-sm text-balance">The OpenAPI company.</p>
+        <p class="mt-10 text-c-3 text-sm text-balance">The API company.</p>
         <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
       </div>
       <div class="flex text-sm">

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -657,7 +657,7 @@
         <span class="text-c-1">
           <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
         </span>
-        <p class="mt-10 text-c-3 text-sm text-balance">The OpenAPI company.</p>
+        <p class="mt-10 text-c-3 text-sm text-balance">The API company.</p>
         <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
       </div>
       <div class="flex text-sm">

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -220,7 +220,7 @@ All of this with just a couple clicks or a few API requests! You handle making y
         <span class="text-c-1">
           <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
         </span>
-        <p class="mt-10 text-c-3 text-sm text-balance">The OpenAPI company.</p>
+        <p class="mt-10 text-c-3 text-sm text-balance">The API company.</p>
         <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
       </div>
       <div class="flex text-sm">

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -223,7 +223,7 @@ Once created, you will get redirected to the SDK Overview page where you can:
         <span class="text-c-1">
           <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/qlPkhjY7Ec6E5g3SHMjEp.svg"></scalar-icon>
         </span>
-        <p class="mt-10 text-c-3 text-sm text-balance">The OpenAPI company.</p>
+        <p class="mt-10 text-c-3 text-sm text-balance">The API company.</p>
         <p class="mt-5 text-c-3 text-sm text-balance">© API Documentation, Inc.</p>
       </div>
       <div class="flex text-sm">

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -52,7 +52,7 @@
         },
         {
           "property": "og:title",
-          "content": "Scalar - The OpenAPI Company"
+          "content": "Scalar - The API Company"
         },
         {
           "property": "og:description",
@@ -76,7 +76,7 @@
         },
         {
           "name": "twitter:title",
-          "content": "Scalar - The OpenAPI Company"
+          "content": "Scalar - The API Company"
         },
         {
           "name": "twitter:description",


### PR DESCRIPTION
### Motivation
- Standardize public-facing branding copy to refer to "The API company" instead of "The OpenAPI company" and update social/OG metadata accordingly.

### Description
- Replaced footer copy in multiple guide pages from `The OpenAPI company.` to `The API company.` across documentation files under `documentation/guides/*`.
- Updated Open Graph and Twitter meta titles in `scalar.config.json` from `Scalar - The OpenAPI Company` to `Scalar - The API Company`.
- Changes are content-only text updates and do not modify application logic or behavior.

### Testing
- No automated tests were run because this is a content-only change affecting documentation and meta text.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e7078ab508327b643819c6e351269)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content-only change affecting footer text and social (OG/Twitter) metadata titles; no application logic is modified.
> 
> **Overview**
> Updates public-facing branding copy across multiple documentation guide footers, replacing **"The OpenAPI company."** with **"The API company."**.
> 
> Also updates `scalar.config.json` social metadata (`og:title` and `twitter:title`) from **"Scalar - The OpenAPI Company"** to **"Scalar - The API Company"**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aabaa47cf54de83a43cbdd14ea5e12c5a5b05de1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->