### PR TITLE
chore(codeowners): default to @scalar/engineers and add targeted package owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,53 +1,38 @@
-# Default code owner (overwritten by more specific entries)
-* @hanspagel @amritk @geoffgscott @marclave
+# Scalar OSS Codeowners
+#
+# By default most of the repository only requires review from a
+# member of the Scalar Engineering team. We want to keep this
+# open where possible to avoid blocking PRs unnecessarily.
 
-# Root level code owners
-/.github @hanspagel @geoffgscott
-/*.md @hanspagel @marclave
+# Base owners (overwritten by more specific entries)
+* @scalar/engineers
 
-# Renovate
-/.github/renovate.json @hanspagel
-
-# Documentation
-/documentation @hanspagel @marclave @hwkr @cameronrohani
-
-# Changesets
+# Changesets - no special review required
 /.changeset
 
-# Cursor rules
-/.cursor @hanspagel @amritk
+# Important repo & ci changes must be approved by Hans
+/.github/ @hanspagel
+/*.md @hanspagel
 
-# Packages
-/integrations/django-ninja @marclave
-/integrations/docusaurus @amritk @marclave
-/integrations/docker @marclave @hanspagel
-/integrations/dotnet @marclave @hanspagel
-/integrations/express @hanspagel @marclave
-/integrations/fastapi @marclave
-/integrations/fastify @hanspagel @marclave
-/integrations/hono @hanspagel @marclave
-/integrations/java @marclave @hanspagel
-/integrations/nestjs @marclave
-/integrations/nextjs @amritk @marclave
-/integrations/nuxt @amritk @marclave
-/packages/api-client @amritk @hanspagel @marclave @DemonHa
-/packages/api-client-react @amritk @marclave
-/packages/api-reference @hanspagel @marclave
-/packages/api-reference-editor @geoffgscott @marclave
-/packages/api-reference-react @amritk @marclave
-/packages/build-tooling @geoffgscott @marclave
-/packages/build-watch @geoffgscott @marclave
-/packages/code-highlight @geoffgscott @marclave
-/packages/components @hwkr @marclave
-/packages/draggable @amritk @marclave
-/packages/galaxy @hanspagel @marclave
+# Project & Package Specific Owners
+#
+# These should be added sparingly for portions of the
+# codebase where a small group of devs have specific
+# domain knowledge and need to be consulted on changes.
+/packages/api-client @amritk @hanspagel @DemonHa
+/packages/api-client-react @amritk
+/packages/api-reference @hanspagel
+/packages/api-reference-react @amritk
+/packages/components @hwkr
+/packages/core @hanspagel
 /packages/json-magic @DemonHa
-/packages/icons @hwkr @marclave
-/packages/mock-server @hanspagel @marclave
-/packages/oas-utils @amritk @hanspagel @marclave
-/packages/themes @hwkr @cameronrohani @marclave
-/packages/use-hooks @hwkr @hanspagel @marclave
-/packages/void-server @hanspagel @marclave
+/packages/icons @hwkr
+/packages/mock-server @hanspagel
+/packages/oas-utils @amritk @hanspagel
+/packages/openapi-parser @hanspagel @DemonHa
+/packages/pre-post-request-scripts @amritk @hanspagel @DemonHa
+/packages/sidebar @hwkr @hanspagel
+/packages/themes @hwkr @cameronrohani
+/packages/use-hooks @hwkr
+/packages/void-server @hanspagel
 /packages/workspace-store @DemonHa @amritk
-
-

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -17,9 +17,9 @@
       <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/JXS6tZ4EbKIkeGpjP6QKc.svg"></scalar-icon>
     </div>
     <div class="draggable sticker-6">
-      <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/sjRzU-qEfO5Y89jmLMyaF.svg"></scalar-icon>
+      <scalar-icon src="https://cdn.scalar.com/marketing/landing/sticker-6.svg"></scalar-icon>
     </div>
-    <div class="draggable sticker-7">
+    <div class="draggable sticker-7">s
       <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/-dJduqbPTJP5xwDRhB5VS.svg"></scalar-icon>
     </div>
   </div>


### PR DESCRIPTION
Simplifies CODEOWNERS so most of the repo routes to @scalar/engineers, with narrower overrides only where domain expertise still matters.


- **Default owner** is now `@scalar/engineers` (includes the whole dev team)
- **Removed** per-integration owners, documentation owners, `.cursor` rules, and several stale package entries (`build-tooling`, `api-reference-editor`, `galaxy`, etc.)
- **Kept** `@hanspagel` for `/.github/` and root `/*.md` (CI and top-level repo docs)
- **Kept** `/.changeset` with no owners (no code-owner gate on changesets)
- **Added** targeted package owners: `core`, `mock-server`, `openapi-parser`, `pre-post-request-scripts`, `sidebar`
- **Trimmed** redundant owners on existing package lines

Docs (`documentation/**`), `scalar.config.json`, integrations, and tooling fall through to `@scalar/engineers` so any engineer can review without a named maintainer bottleneck.

## Checklist

- [x] I explained why the change is needed.
- [x] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
