### PR TITLE
chore: add CODEOWNERS entry for scalar.config.json

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,4 +21,5 @@
 /packages/use-hooks @marclave @hanspagel @amritk @hwkr @cameronrohani
 /packages/use-toasts @marclave @hanspagel @amritk @hwkr @cameronrohani
 /documentation @marclave @hanspagel @hwkr @cameronrohani
+/scalar.config.json @marclave @hanspagel @hwkr @cameronrohani
 /*.md @marclave @hanspagel @hwkr @cameronrohani


### PR DESCRIPTION
Adds `scalar.config.json` to CODEOWNERS so docs config changes get reviewed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk administrative change that only affects review routing for `scalar.config.json` edits and does not modify runtime code or behavior.
> 
> **Overview**
> Adds a `CODEOWNERS` rule for `scalar.config.json`, ensuring changes to this docs/config file request review from the documentation owners rather than relying on the default owners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69f99013ca70ebb812b374088d583c9b7a9d1e7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->