### PR TITLE
feat(api-reference): render AsyncAPI operations in the content

### DIFF
--- a/.changeset/asyncapi-operation-sections.md
+++ b/.changeset/asyncapi-operation-sections.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': minor
+'@scalar/types': patch
+---
+
+Render AsyncAPI operations as sections in the content area, each with a box listing the operation's messages

--- a/packages/api-reference/src/components/Badge/Badge.vue
+++ b/packages/api-reference/src/components/Badge/Badge.vue
@@ -50,6 +50,10 @@ const badgeStyle = computed(() =>
   background: color-mix(in srgb, var(--scalar-color-purple), transparent 90%);
   border: transparent;
 }
+:where(.badge).text-blue {
+  background: color-mix(in srgb, var(--scalar-color-blue), transparent 90%);
+  border: transparent;
+}
 :where(.badge).text-green {
   background: color-mix(in srgb, var(--scalar-color-green), transparent 90%);
   border: transparent;

--- a/packages/api-reference/src/components/Content/AsyncApi/MessagesList.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/MessagesList.vue
@@ -17,7 +17,8 @@ defineProps<{
 
 <template>
   <template v-if="messages.length > 0">
-    <ScalarCard class="messages-card">
+    <ScalarCard
+      class="sticky top-[calc(var(--refs-viewport-offset)+24px)] text-base">
       <ScalarCardHeader muted>
         <ScreenReader>{{ title }}</ScreenReader>
         Messages
@@ -25,11 +26,11 @@ defineProps<{
       <ScalarCardSection class="custom-scroll max-h-[60vh]">
         <ul
           :aria-label="`${title} messages`"
-          class="messages">
+          class="bg-b-2 w-full overflow-auto px-3 py-2.5">
           <li
             v-for="message in messages"
             :key="message.id"
-            class="message">
+            class="text-c-1 font-code flex text-[length:var(--scalar-small)] leading-[1.55] whitespace-nowrap">
             {{ message.label }}
           </li>
         </ul>
@@ -37,25 +38,3 @@ defineProps<{
     </ScalarCard>
   </template>
 </template>
-
-<style scoped>
-.messages-card {
-  position: sticky;
-  top: calc(var(--refs-viewport-offset) + 24px);
-  font-size: var(--scalar-font-size-3);
-}
-.messages {
-  overflow: auto;
-  background: var(--scalar-background-2);
-  padding: 10px 12px;
-  width: 100%;
-}
-.message {
-  display: flex;
-  white-space: nowrap;
-  color: var(--scalar-color-1);
-  line-height: 1.55;
-  font-family: var(--scalar-font-code);
-  font-size: var(--scalar-small);
-}
-</style>

--- a/packages/api-reference/src/components/Content/AsyncApi/MessagesList.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/MessagesList.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import {
+  ScalarCard,
+  ScalarCardHeader,
+  ScalarCardSection,
+} from '@scalar/components'
+
+import ScreenReader from '@/components/ScreenReader.vue'
+
+defineProps<{
+  /** Title of the operation, used for the screen reader and aria labels */
+  title: string
+  /** The messages to list, already resolved to a name and a stable id */
+  messages: { id: string; label: string }[]
+}>()
+</script>
+
+<template>
+  <template v-if="messages.length > 0">
+    <ScalarCard class="messages-card">
+      <ScalarCardHeader muted>
+        <ScreenReader>{{ title }}</ScreenReader>
+        Messages
+      </ScalarCardHeader>
+      <ScalarCardSection class="custom-scroll max-h-[60vh]">
+        <ul
+          :aria-label="`${title} messages`"
+          class="messages">
+          <li
+            v-for="message in messages"
+            :key="message.id"
+            class="message">
+            {{ message.label }}
+          </li>
+        </ul>
+      </ScalarCardSection>
+    </ScalarCard>
+  </template>
+</template>
+
+<style scoped>
+.messages-card {
+  position: sticky;
+  top: calc(var(--refs-viewport-offset) + 24px);
+  font-size: var(--scalar-font-size-3);
+}
+.messages {
+  overflow: auto;
+  background: var(--scalar-background-2);
+  padding: 10px 12px;
+  width: 100%;
+}
+.message {
+  display: flex;
+  white-space: nowrap;
+  color: var(--scalar-color-1);
+  line-height: 1.55;
+  font-family: var(--scalar-font-code);
+  font-size: var(--scalar-small);
+}
+</style>

--- a/packages/api-reference/src/components/Content/AsyncApi/OperationSection.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/OperationSection.test.ts
@@ -1,0 +1,104 @@
+import type { AsyncApiOperationObject } from '@scalar/types/asyncapi/3.1'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import OperationSection from './OperationSection.vue'
+
+/** Build a $ref wrapper as produced by the workspace store after bundling */
+const ref = <T>(value: T) => ({ $ref: '#/mock', '$ref-value': value })
+
+const createOperation = (overrides: Partial<AsyncApiOperationObject> = {}): AsyncApiOperationObject =>
+  ({
+    action: 'send',
+    channel: ref({ messages: {} }),
+    title: 'Send light measurement',
+    description: 'Publishes a light measurement.',
+    ...overrides,
+  }) as AsyncApiOperationObject
+
+describe('OperationSection', () => {
+  it('renders the operation title and description', () => {
+    const wrapper = mount(OperationSection, {
+      props: {
+        eventBus: null,
+        operationId: 'sendLightMeasurement',
+        operation: createOperation(),
+      },
+    })
+
+    expect(wrapper.text()).toContain('Send light measurement')
+    expect(wrapper.text()).toContain('Publishes a light measurement.')
+  })
+
+  it('falls back to the operation id when there is no title', () => {
+    const wrapper = mount(OperationSection, {
+      props: {
+        eventBus: null,
+        operationId: 'sendLightMeasurement',
+        operation: createOperation({ title: undefined }),
+      },
+    })
+
+    expect(wrapper.text()).toContain('sendLightMeasurement')
+  })
+
+  it('lists the messages referenced directly by the operation', () => {
+    const wrapper = mount(OperationSection, {
+      props: {
+        eventBus: null,
+        operationId: 'sendLightMeasurement',
+        operation: createOperation({
+          messages: [ref({ title: 'Light measured' }), ref({ name: 'turnOn' })] as AsyncApiOperationObject['messages'],
+        }),
+      },
+    })
+
+    expect(wrapper.text()).toContain('Light measured')
+    expect(wrapper.text()).toContain('turnOn')
+  })
+
+  it('falls back to the channel messages when the operation omits them', () => {
+    const wrapper = mount(OperationSection, {
+      props: {
+        eventBus: null,
+        operationId: 'sendLightMeasurement',
+        operation: createOperation({
+          channel: ref({
+            messages: {
+              lightMeasured: { title: 'Light measured' },
+              turnOn: { name: 'turnOn' },
+            },
+          }) as AsyncApiOperationObject['channel'],
+        }),
+      },
+    })
+
+    expect(wrapper.text()).toContain('Light measured')
+    expect(wrapper.text()).toContain('turnOn')
+  })
+
+  it('does not render the messages box when there are no messages', () => {
+    const wrapper = mount(OperationSection, {
+      props: {
+        eventBus: null,
+        operationId: 'sendLightMeasurement',
+        operation: createOperation({ messages: [] }),
+      },
+    })
+
+    expect(wrapper.text()).not.toContain('Messages')
+  })
+
+  it('renders the section with a deep-link id derived from the operation id', () => {
+    const wrapper = mount(OperationSection, {
+      props: {
+        eventBus: null,
+        operationId: 'sendLightMeasurement',
+        operation: createOperation(),
+      },
+    })
+
+    const section = wrapper.findComponent({ name: 'Section' })
+    expect(section.element.id).toBe('operation/sendlightmeasurement')
+  })
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/OperationSection.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/OperationSection.test.ts
@@ -89,6 +89,30 @@ describe('OperationSection', () => {
     expect(wrapper.text()).not.toContain('Messages')
   })
 
+  it('shows a Send badge for send operations', () => {
+    const wrapper = mount(OperationSection, {
+      props: {
+        eventBus: null,
+        operationId: 'sendLightMeasurement',
+        operation: createOperation({ action: 'send' }),
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'Badge' }).text()).toBe('Send')
+  })
+
+  it('shows a Receive badge for receive operations', () => {
+    const wrapper = mount(OperationSection, {
+      props: {
+        eventBus: null,
+        operationId: 'receiveLightMeasurement',
+        operation: createOperation({ action: 'receive' }),
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'Badge' }).text()).toBe('Receive')
+  })
+
   it('renders the section with a deep-link id derived from the operation id', () => {
     const wrapper = mount(OperationSection, {
       props: {

--- a/packages/api-reference/src/components/Content/AsyncApi/OperationSection.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/OperationSection.vue
@@ -95,7 +95,7 @@ const messages = computed(() => {
           </SectionHeaderTag>
         </Anchor>
         <Badge
-          class="action-badge font-code uppercase"
+          class="font-code ml-2 align-middle uppercase"
           :class="actionBadge.class">
           {{ actionBadge.label }}
         </Badge>
@@ -117,11 +117,3 @@ const messages = computed(() => {
     </Section>
   </SectionContainer>
 </template>
-
-<style scoped>
-/* Sit the action badge inline next to the heading, centered against the text */
-.action-badge {
-  margin-left: 8px;
-  vertical-align: middle;
-}
-</style>

--- a/packages/api-reference/src/components/Content/AsyncApi/OperationSection.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/OperationSection.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { ScalarMarkdown } from '@scalar/components'
+import { slugify } from '@scalar/helpers/string/slugify'
+import type {
+  AsyncApiChannelObject,
+  AsyncApiMessageObject,
+  AsyncApiOperationObject,
+} from '@scalar/types/asyncapi/3.1'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { computed, useId } from 'vue'
+
+import { Anchor } from '@/components/Anchor'
+import {
+  Section,
+  SectionColumn,
+  SectionColumns,
+  SectionContainer,
+  SectionContent,
+  SectionHeader,
+  SectionHeaderTag,
+} from '@/components/Section'
+
+import MessagesList from './MessagesList.vue'
+
+const { operationId, operation } = defineProps<{
+  /** The key of the operation in the AsyncAPI `operations` map */
+  operationId: string
+  operation: AsyncApiOperationObject
+  eventBus: WorkspaceEventBus | null
+}>()
+
+/** Id of the heading element, used to label the section for screen readers */
+const headerId = useId()
+
+/** Stable id for the section element, used for deep links */
+const id = computed(() => `operation/${slugify(operationId)}`)
+
+/** Human-friendly heading, falling back to the operation key */
+const title = computed(() => operation.title ?? operationId)
+
+const toMessage = (key: string, message: AsyncApiMessageObject) => ({
+  id: key,
+  label: message.title ?? message.name ?? key,
+})
+
+/**
+ * The messages listed in the box.
+ *
+ * An operation MAY reference a subset of its channel's messages. When the
+ * `messages` key is omitted entirely, the AsyncAPI spec says every message
+ * defined on the referenced channel is used, so we fall back to those.
+ */
+const messages = computed(() => {
+  if (operation.messages) {
+    return operation.messages.map((entry, index) => {
+      const message = getResolvedRef(entry) as AsyncApiMessageObject
+      return toMessage(message.name ?? `message-${index}`, message)
+    })
+  }
+
+  const channel = getResolvedRef(operation.channel) as AsyncApiChannelObject
+  return Object.entries(channel.messages ?? {}).map(([key, entry]) =>
+    toMessage(key, getResolvedRef(entry) as AsyncApiMessageObject),
+  )
+})
+</script>
+
+<template>
+  <SectionContainer
+    :aria-labelledby="headerId"
+    role="region">
+    <Section
+      :id="id"
+      role="none"
+      @intersecting="() => eventBus?.emit('intersecting:nav-item', { id })">
+      <SectionHeader>
+        <Anchor
+          @copyAnchorUrl="() => eventBus?.emit('copy-url:nav-item', { id })">
+          <SectionHeaderTag
+            :id="headerId"
+            :level="2">
+            {{ title }}
+          </SectionHeaderTag>
+        </Anchor>
+      </SectionHeader>
+      <SectionContent>
+        <SectionColumns>
+          <SectionColumn>
+            <ScalarMarkdown
+              :value="operation.description ?? ''"
+              withImages />
+          </SectionColumn>
+          <SectionColumn>
+            <MessagesList
+              :messages="messages"
+              :title="title" />
+          </SectionColumn>
+        </SectionColumns>
+      </SectionContent>
+    </Section>
+  </SectionContainer>
+</template>

--- a/packages/api-reference/src/components/Content/AsyncApi/OperationSection.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/OperationSection.vue
@@ -11,6 +11,7 @@ import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref
 import { computed, useId } from 'vue'
 
 import { Anchor } from '@/components/Anchor'
+import { Badge } from '@/components/Badge'
 import {
   Section,
   SectionColumn,
@@ -38,6 +39,16 @@ const id = computed(() => `operation/${slugify(operationId)}`)
 
 /** Human-friendly heading, falling back to the operation key */
 const title = computed(() => operation.title ?? operationId)
+
+/**
+ * Badge describing the operation's action, mirroring the HTTP method badge on
+ * OpenAPI operations. `receive` is read-like (blue), `send` is write-like (green).
+ */
+const actionBadge = computed(() =>
+  operation.action === 'send'
+    ? { label: 'Send', class: 'text-green' }
+    : { label: 'Receive', class: 'text-blue' },
+)
 
 const toMessage = (key: string, message: AsyncApiMessageObject) => ({
   id: key,
@@ -83,6 +94,11 @@ const messages = computed(() => {
             {{ title }}
           </SectionHeaderTag>
         </Anchor>
+        <Badge
+          class="action-badge font-code uppercase"
+          :class="actionBadge.class">
+          {{ actionBadge.label }}
+        </Badge>
       </SectionHeader>
       <SectionContent>
         <SectionColumns>
@@ -101,3 +117,11 @@ const messages = computed(() => {
     </Section>
   </SectionContainer>
 </template>
+
+<style scoped>
+/* Sit the action badge inline next to the heading, centered against the text */
+.action-badge {
+  margin-left: 8px;
+  vertical-align: middle;
+}
+</style>

--- a/packages/api-reference/src/components/Content/AsyncApi/index.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/index.ts
@@ -1,0 +1,1 @@
+export { default as OperationSection } from './OperationSection.vue'

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -3,9 +3,11 @@ import { generateClientOptions } from '@scalar/api-client/blocks/operation-code-
 import { mapHiddenClientsConfig } from '@scalar/api-client/modal'
 import { ScalarErrorBoundary } from '@scalar/components'
 import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
+import type { AsyncApiOperationObject } from '@scalar/types/asyncapi/3.1'
 import type { Heading } from '@scalar/types/legacy'
 import type { AuthStore } from '@scalar/workspace-store/entities/auth'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import {
   getSelectedServer,
   getServers,
@@ -28,6 +30,7 @@ import { ClientSelector } from '@/blocks/scalar-client-selector-block'
 import { InfoBlock } from '@/blocks/scalar-info-block'
 import { IntroductionCardItem } from '@/blocks/scalar-info-block/'
 import { ServerSelector } from '@/blocks/scalar-server-selector-block'
+import { OperationSection } from '@/components/Content/AsyncApi'
 import { Auth } from '@/components/Content/Auth'
 import TraversedEntry from '@/components/Content/Operations/TraversedEntry.vue'
 import { RenderPlugins } from '@/components/RenderPlugins'
@@ -102,6 +105,24 @@ const specificationVersion = computed(() => {
   }
   return openApiDocument.value?.['x-original-oas-version']
 })
+
+/**
+ * Narrow to an AsyncAPI document. AsyncAPI operations render as their own
+ * content sections; the rest of the content area stays OpenAPI-only for now.
+ */
+const asyncApiDocument = computed(() =>
+  isAsyncApiDocument(document) ? document : undefined,
+)
+
+/** AsyncAPI operations, resolved and ready to render as content sections */
+const asyncApiOperations = computed(() =>
+  Object.entries(asyncApiDocument.value?.operations ?? {}).map(
+    ([id, operation]) => ({
+      id,
+      operation: getResolvedRef(operation) as AsyncApiOperationObject,
+    }),
+  ),
+)
 
 /** Computed property to get all OpenAPI extension fields from the root document object */
 const documentExtensions = computed(() => getXKeysFromObject(document))
@@ -225,6 +246,16 @@ onMounted(() => {
       :selectedClient="xScalarDefaultClient"
       :selectedServer>
     </TraversedEntry>
+
+    <!-- Render AsyncAPI operations as content sections -->
+    <template v-if="asyncApiDocument">
+      <OperationSection
+        v-for="{ id, operation } in asyncApiOperations"
+        :key="id"
+        :eventBus
+        :operation
+        :operationId="id" />
+    </template>
 
     <!-- Render plugins at content.end view -->
     <RenderPlugins

--- a/packages/types/src/asyncapi/3.1/index.ts
+++ b/packages/types/src/asyncapi/3.1/index.ts
@@ -1,1 +1,8 @@
-export type { AsyncApiDocument, AsyncApiInfoObject, AsyncApiLicenseObject } from './index.generated'
+export type {
+  AsyncApiChannelObject,
+  AsyncApiDocument,
+  AsyncApiInfoObject,
+  AsyncApiLicenseObject,
+  AsyncApiMessageObject,
+  AsyncApiOperationObject,
+} from './index.generated'


### PR DESCRIPTION
don't even look at it, it's not good yet

Just a small addition, renders AsyncAPI operations in the content

Preview: https://pr-9305.scalar-api-reference-preview.pages.dev/#scalar-galaxy-events

<img width="1148" height="1097" alt="Screenshot 2026-05-21 at 15 52 29" src="https://github.com/user-attachments/assets/199ad3f9-0210-49ba-80f6-47552811ea7a" />
