### PR TITLE
fix(scalar-app): redirect to correct HTML file on logout in Electron

### DIFF
--- a/.changeset/clean-logout-electron-redirect.md
+++ b/.changeset/clean-logout-electron-redirect.md
@@ -1,0 +1,7 @@
+---
+'scalar-app': patch
+---
+
+fix(scalar-app): redirect to the correct HTML file on logout in Electron
+
+On Electron the app loads from a `file://` URL and uses hash-based routing, so the previous `window.location.href = '/'` resolved to the filesystem root and broke the app. Logout now resets the hash on the current HTML file and reloads on Electron, while the web build still hard routes to `/`.

--- a/projects/scalar-app/src/hooks/use-auth.test.ts
+++ b/projects/scalar-app/src/hooks/use-auth.test.ts
@@ -129,6 +129,35 @@ describe('useAuth', () => {
     // email: '' is falsy, so isLoggedIn should not be true
     expect(isLoggedIn.value).toBe(false)
   })
+
+  describe('logout redirect', () => {
+    afterEach(() => {
+      // Clean up the Electron flag so it does not leak into other tests
+      delete (window as unknown as { electron?: boolean }).electron
+      vi.unstubAllGlobals()
+    })
+
+    it('hard routes to the root path on web', () => {
+      const location = { pathname: '/some/team/workspace', href: '', reload: vi.fn() }
+      vi.stubGlobal('location', location)
+
+      useAuth().logout()
+
+      expect(location.href).toBe('/')
+      expect(location.reload).not.toHaveBeenCalled()
+    })
+
+    it('resets the hash on the current HTML file and reloads on Electron', () => {
+      ;(window as unknown as { electron?: boolean }).electron = true
+      const location = { pathname: '/path/to/index.html', href: '', reload: vi.fn() }
+      vi.stubGlobal('location', location)
+
+      useAuth().logout()
+
+      expect(location.href).toBe('/path/to/index.html#/')
+      expect(location.reload).toHaveBeenCalledOnce()
+    })
+  })
 })
 
 // Tokens returned by a successful /core/login/refresh response

--- a/projects/scalar-app/src/hooks/use-auth.ts
+++ b/projects/scalar-app/src/hooks/use-auth.ts
@@ -80,7 +80,15 @@ const logout = () => {
   queryClient.clear()
 
   // Lets hard route to ensure we are no longer on the team workspace
-  window.location.href = '/'
+  if (window.electron === true) {
+    // Electron loads from a file:// URL and uses hash routing, so navigating to
+    // '/' would resolve to the filesystem root. Reset the hash on the current
+    // HTML file instead and reload to drop any in-memory team workspace state.
+    window.location.href = `${window.location.pathname}#/`
+    window.location.reload()
+  } else {
+    window.location.href = '/'
+  }
 }
 
 /**


### PR DESCRIPTION
Electron loads from a file:// URL with hash routing, so navigating to '/' resolved to the filesystem root and broke the app. Reset the hash on the current HTML file and reload on Electron; keep the web hard route to '/'.

https://claude.ai/code/session_01At5Gk8aBH4JMaqgAWzKSRP

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated change to logout navigation behavior plus targeted unit tests; only affects redirect logic and cache clearing remains unchanged.
> 
> **Overview**
> Fixes logout navigation for Electron builds by **avoiding `window.location.href = '/'`** (which breaks on `file://` URLs) and instead redirecting to the current HTML file with `#/` and forcing a reload; web builds continue to hard-route to `/`.
> 
> Adds unit tests covering both web and Electron logout redirect behavior, and includes a patch changeset documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e37dbb953df80654a12bdfda0e15abbe0f53f836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->