### PR TITLE
fix(scalar-app): fail during build if the env variables are not set

### DIFF
--- a/.changeset/strict-scalar-app-env.md
+++ b/.changeset/strict-scalar-app-env.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+fix: fail Vite and electron-vite builds when required VITE_* environment variables are missing

--- a/projects/scalar-app/.env.example
+++ b/projects/scalar-app/.env.example
@@ -1,3 +1,4 @@
+VITE_ENV=development
 VITE_DASHBOARD_URL=http://localhost:3560
 VITE_API_URL=http://localhost:9999/access
 VITE_SERVICES_URL=http://localhost:9999

--- a/projects/scalar-app/.env.test
+++ b/projects/scalar-app/.env.test
@@ -1,0 +1,4 @@
+VITE_ENV=test
+VITE_API_URL=https://api.staging.scalar.com
+VITE_DASHBOARD_URL=https://dashboard.staging.scalar.com
+VITE_SERVICES_URL=https://services.staging.scalar.com

--- a/projects/scalar-app/assert-scalar-app-env-plugin.ts
+++ b/projects/scalar-app/assert-scalar-app-env-plugin.ts
@@ -1,0 +1,11 @@
+import { type Plugin, loadEnv } from 'vite'
+
+import { assertScalarAppEnv } from './assert-scalar-app-env'
+
+/** Fail Vite dev and build when required `VITE_*` variables are not set. */
+export const assertScalarAppEnvPlugin = (envDir: string): Plugin => ({
+  name: 'scalar-app-assert-env',
+  config(_config, { mode }) {
+    assertScalarAppEnv(loadEnv(mode, envDir, 'VITE_'))
+  },
+})

--- a/projects/scalar-app/assert-scalar-app-env.ts
+++ b/projects/scalar-app/assert-scalar-app-env.ts
@@ -1,4 +1,4 @@
-import { type Static, coerce, literal, object, string, union, validate } from '@scalar/validation'
+import { type Schema, type Static, coerce, literal, object, string, union, validate } from '@scalar/validation'
 
 const deployEnvironments = union([literal('development'), literal('test'), literal('staging'), literal('production')])
 
@@ -11,11 +11,46 @@ const environmentSchema = object({
 
 type ScalarAppEnv = Static<typeof environmentSchema>
 
-/** Throws when required `VITE_*` variables are missing or invalid. */
-export const assertScalarAppEnv = (env: unknown): ScalarAppEnv => {
-  if (!validate(environmentSchema, env)) {
-    throw new Error('Invalid environment variables')
+/** Human-readable description of what a property schema accepts, for error messages. */
+const describeExpected = (schema: Schema): string => {
+  if (schema.type === 'union') {
+    return schema.schemas.map((member) => ('value' in member ? JSON.stringify(member.value) : member.type)).join(' | ')
   }
 
-  return coerce(environmentSchema, env)
+  return `a ${schema.type}`
+}
+
+/** Collect a per-variable explanation for every property that fails validation. */
+const collectProblems = (env: Record<string, unknown>): string[] =>
+  Object.entries(environmentSchema.properties).flatMap(([key, schema]) => {
+    if (validate(schema, env[key])) {
+      return []
+    }
+
+    const reason =
+      env[key] === undefined ? 'is missing' : `is ${JSON.stringify(env[key])}, expected ${describeExpected(schema)}`
+
+    return [`${key} ${reason}`]
+  })
+
+/**
+ * Throws when required `VITE_*` variables are missing or invalid.
+ *
+ * The thrown error lists every offending variable (missing vs. wrong type/value)
+ * so a failed build or test run points straight at the `.env` file to fix.
+ */
+export const assertScalarAppEnv = (env: unknown): ScalarAppEnv => {
+  // `import.meta.env` and other host-provided env objects are not always plain
+  // objects — Vitest, for example, backs `import.meta.env` onto `process.env`
+  // via a custom prototype, which the schema's plain-object check rejects.
+  // Copy the own enumerable keys into a plain object so validation can read them.
+  const normalized: Record<string, unknown> = env && typeof env === 'object' ? { ...env } : {}
+
+  if (!validate(environmentSchema, normalized)) {
+    const problems = collectProblems(normalized)
+
+    throw new Error(`Invalid environment variables:\n${problems.map((problem) => `  - ${problem}`).join('\n')}`)
+  }
+
+  return coerce(environmentSchema, normalized)
 }

--- a/projects/scalar-app/assert-scalar-app-env.ts
+++ b/projects/scalar-app/assert-scalar-app-env.ts
@@ -1,0 +1,21 @@
+import { type Static, coerce, literal, object, string, union, validate } from '@scalar/validation'
+
+const deployEnvironments = union([literal('development'), literal('test'), literal('staging'), literal('production')])
+
+export const environmentSchema = object({
+  VITE_ENV: deployEnvironments,
+  VITE_API_URL: string(),
+  VITE_SERVICES_URL: string(),
+  VITE_DASHBOARD_URL: string(),
+})
+
+export type ScalarAppEnv = Static<typeof environmentSchema>
+
+/** Throws when required `VITE_*` variables are missing or invalid. */
+export const assertScalarAppEnv = (env: unknown): ScalarAppEnv => {
+  if (!validate(environmentSchema, env)) {
+    throw new Error('Invalid environment variables')
+  }
+
+  return coerce(environmentSchema, env)
+}

--- a/projects/scalar-app/assert-scalar-app-env.ts
+++ b/projects/scalar-app/assert-scalar-app-env.ts
@@ -2,14 +2,14 @@ import { type Static, coerce, literal, object, string, union, validate } from '@
 
 const deployEnvironments = union([literal('development'), literal('test'), literal('staging'), literal('production')])
 
-export const environmentSchema = object({
+const environmentSchema = object({
   VITE_ENV: deployEnvironments,
   VITE_API_URL: string(),
   VITE_SERVICES_URL: string(),
   VITE_DASHBOARD_URL: string(),
 })
 
-export type ScalarAppEnv = Static<typeof environmentSchema>
+type ScalarAppEnv = Static<typeof environmentSchema>
 
 /** Throws when required `VITE_*` variables are missing or invalid. */
 export const assertScalarAppEnv = (env: unknown): ScalarAppEnv => {

--- a/projects/scalar-app/electron.vite.config.ts
+++ b/projects/scalar-app/electron.vite.config.ts
@@ -5,14 +5,18 @@ import vue from '@vitejs/plugin-vue'
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import monacoEditorPlugin from 'vite-plugin-monaco-editor-esm'
 
+import { assertScalarAppEnvPlugin } from './assert-scalar-app-env-plugin'
 import { devLocalhostCspPlugin } from './dev-localhost-csp-plugin'
 import { scalarAppMonacoEditorPluginOptions } from './monaco-vite-plugin-options'
 import packageJson from './package.json' with { type: 'json' }
 
 const { version: scalarAppVersion } = packageJson
+const envDir = resolve('.')
 
 export default defineConfig({
   main: {
+    envDir,
+    plugins: [assertScalarAppEnvPlugin(envDir)],
     resolve: {
       alias: {
         '@electron': resolve('entrypoints/electron'),
@@ -47,6 +51,7 @@ export default defineConfig({
     },
   },
   renderer: {
+    envDir,
     root: resolve('entrypoints/electron/renderer'),
     define: {
       OVERRIDE_PACKAGE_VERSION: JSON.stringify(scalarAppVersion),
@@ -61,7 +66,13 @@ export default defineConfig({
       },
       dedupe: ['vue', 'monaco-editor', 'monaco-yaml'],
     },
-    plugins: [vue(), tailwindcss(), monacoEditorPlugin(scalarAppMonacoEditorPluginOptions), devLocalhostCspPlugin()],
+    plugins: [
+      assertScalarAppEnvPlugin(envDir),
+      vue(),
+      tailwindcss(),
+      monacoEditorPlugin(scalarAppMonacoEditorPluginOptions),
+      devLocalhostCspPlugin(),
+    ],
     optimizeDeps: {
       exclude: ['monaco-editor', 'monaco-yaml'],
     },

--- a/projects/scalar-app/src/environment.ts
+++ b/projects/scalar-app/src/environment.ts
@@ -1,12 +1,5 @@
-import { coerce, literal, object, string, union } from '@scalar/validation'
+import { type ScalarAppEnv, assertScalarAppEnv } from '../assert-scalar-app-env'
 
-const deployEnvironments = union([literal('development'), literal('test'), literal('staging'), literal('production')])
+export type { ScalarAppEnv }
 
-const environmentSchema = object({
-  VITE_ENV: deployEnvironments,
-  VITE_API_URL: string(),
-  VITE_SERVICES_URL: string(),
-  VITE_DASHBOARD_URL: string(),
-})
-
-export const env = coerce(environmentSchema, import.meta.env)
+export const env = assertScalarAppEnv(import.meta.env)

--- a/projects/scalar-app/src/environment.ts
+++ b/projects/scalar-app/src/environment.ts
@@ -1,5 +1,3 @@
-import { type ScalarAppEnv, assertScalarAppEnv } from '../assert-scalar-app-env'
-
-export type { ScalarAppEnv }
+import { assertScalarAppEnv } from '../assert-scalar-app-env'
 
 export const env = assertScalarAppEnv(import.meta.env)

--- a/projects/scalar-app/tsconfig.node.json
+++ b/projects/scalar-app/tsconfig.node.json
@@ -3,6 +3,8 @@
   "include": [
     "entrypoints/electron/shims.d.ts",
     "electron.vite.config.*",
+    "assert-scalar-app-env.ts",
+    "assert-scalar-app-env-plugin.ts",
     "monaco-vite-plugin-options.ts",
     "vite.config.ts",
     "entrypoints/electron/main/**/*",

--- a/projects/scalar-app/vite.config.ts
+++ b/projects/scalar-app/vite.config.ts
@@ -5,15 +5,17 @@ import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 import monacoEditorPlugin from 'vite-plugin-monaco-editor-esm'
 
+import { assertScalarAppEnvPlugin } from './assert-scalar-app-env-plugin'
 import { devLocalhostCspPlugin } from './dev-localhost-csp-plugin'
 import { scalarAppMonacoEditorPluginOptions } from './monaco-vite-plugin-options'
 import packageJson from './package.json' with { type: 'json' }
 
 const { version: scalarAppVersion } = packageJson
+const envDir = resolve('.')
 
 export default defineConfig({
   root: resolve('entrypoints/web'),
-  envDir: resolve('.'),
+  envDir,
   define: {
     OVERRIDE_PACKAGE_VERSION: JSON.stringify(scalarAppVersion),
   },
@@ -30,7 +32,13 @@ export default defineConfig({
     exclude: ['monaco-editor', 'monaco-yaml'],
   },
   publicDir: resolve('public-web'),
-  plugins: [vue(), tailwindcss(), monacoEditorPlugin(scalarAppMonacoEditorPluginOptions), devLocalhostCspPlugin()],
+  plugins: [
+    assertScalarAppEnvPlugin(envDir),
+    vue(),
+    tailwindcss(),
+    monacoEditorPlugin(scalarAppMonacoEditorPluginOptions),
+    devLocalhostCspPlugin(),
+  ],
   build: {
     outDir: resolve('dist/web'),
     rolldownOptions: {


### PR DESCRIPTION
Currently the build passes even if we don't provide the required variables.

This PR makes the whole build step to fail if user doesn't provide the env variables

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build/startup now hard-fails when required `VITE_*` variables are missing or invalid, which may break existing CI/dev setups relying on implicit defaults. Risk is limited to configuration validation and Vite/electron-vite config wiring.
> 
> **Overview**
> **Vite and electron-vite builds now fail fast on missing/invalid required environment variables.** A new `assertScalarAppEnv` validator enforces `VITE_ENV` (limited to `development|test|staging|production`) plus required URL vars and throws an error listing all problems.
> 
> Vite (`vite.config.ts`) and Electron (`electron.vite.config.ts` main/renderer) now run this check via a dedicated `assertScalarAppEnvPlugin` during config, and `src/environment.ts` switches from silent coercion to strict assertion. Adds `.env.test` and a changeset documenting the patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f0095e4699a253a1d3152fc2f56fadf9eec4b37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->