### PR TITLE
chore: add scalar-app to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,7 @@
 /packages/types @marclave @hanspagel @amritk @DemonHa
 /packages/validation @marclave @hanspagel @amritk @DemonHa
 /packages/workspace-store @marclave @hanspagel @amritk @DemonHa
+/projects/scalar-app @marclave @hanspagel @amritk @DemonHa
 
 # Brynn + Cam
 /packages/components @marclave @hanspagel @amritk @hwkr @cameronrohani


### PR DESCRIPTION
The ol scalar-app was missing

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates repository ownership metadata only and does not affect runtime code or behavior.
> 
> **Overview**
> Adds `projects/scalar-app` to `CODEOWNERS`, assigning reviews for that directory to `@marclave`, `@hanspagel`, `@amritk`, and `@DemonHa`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 481cc98718cf815899cfc5e181966a91b1176199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->