### PR TITLE
fix(api-reference): restore response content type selector when expandAllResponses is enabled

### DIFF
--- a/.changeset/fix-expand-all-responses-content-type.md
+++ b/.changeset/fix-expand-all-responses-content-type.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: restore response content type selector when expandAllResponses is enabled
+
+Move the content type picker after the disclosure panel so it stacks above expanded response content and remains clickable when `expandAllResponses` is true.

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -150,19 +150,6 @@ const shouldCollapse = computed<boolean>(() =>
           v-else
           class="flex-1" />
       </component>
-      <div
-        v-if="shouldCollapse && content"
-        class="absolute top-[calc(10px+0.5lh)] right-0 z-0 flex -translate-y-1/2 items-center text-base"
-        :class="{
-          'opacity-0 group-focus-within/parameter-item:opacity-100 group-hover/parameter-item:opacity-100':
-            !open,
-        }">
-        <div
-          class="from-b-1 absolute inset-y-0 -left-6 -z-1 w-8 bg-linear-to-l from-40% to-transparent" />
-        <ContentTypeSelect
-          v-model="selectedContentType"
-          :content="content" />
-      </div>
       <DisclosurePanel
         class="parameter-item-container parameter-item-container-markdown"
         :static="!collapsableItems">
@@ -198,6 +185,19 @@ const shouldCollapse = computed<boolean>(() =>
           :required="'required' in parameter && parameter.required"
           :schema="value" />
       </DisclosurePanel>
+      <div
+        v-if="shouldCollapse && content"
+        class="absolute top-[calc(10px+0.5lh)] right-0 z-0 flex -translate-y-1/2 items-center text-base"
+        :class="{
+          'opacity-0 group-focus-within/parameter-item:opacity-100 group-hover/parameter-item:opacity-100':
+            !open,
+        }">
+        <div
+          class="from-b-1 absolute inset-y-0 -left-6 -z-1 w-8 bg-linear-to-l from-40% to-transparent" />
+        <ContentTypeSelect
+          v-model="selectedContentType"
+          :content="content" />
+      </div>
     </Disclosure>
   </li>
 </template>


### PR DESCRIPTION
This PR fixes:  #9251

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that reorders elements in `ParameterListItem.vue` to fix layering/clickability; no data, auth, or API logic changes.
> 
> **Overview**
> Fixes a UI regression where the response content-type selector became unclickable when `expandAllResponses` expanded the disclosure content.
> 
> The `ContentTypeSelect` block in `ParameterListItem.vue` is moved to render *after* the `DisclosurePanel`, ensuring it stacks above the expanded content, and a patch changeset is added for `@scalar/api-reference`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e068500f93228c71f52888e1fbb30b3bdb262cd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->