### PR TITLE
feat(galaxy-scalar-com): staging with @scalar/api-reference from the branch (not CDN)

### DIFF
--- a/.changeset/galaxy-staging-branch-bundle.md
+++ b/.changeset/galaxy-staging-branch-bundle.md
@@ -1,0 +1,5 @@
+---
+'galaxy-scalar-com': patch
+---
+
+Render staging and PR-preview deployments with the `@scalar/api-reference` bundle built from the current branch, so reference UI changes can be reviewed before they are released. Production keeps loading the published bundle from the jsDelivr CDN.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       mock_server_docker_package_changed: ${{ steps.set-outputs.outputs.mock_server_docker_package_changed }}
       icons_changed: ${{ steps.set-outputs.outputs.icons_changed }}
       galaxy_changed: ${{ steps.set-outputs.outputs.galaxy_changed }}
-      galaxy_app_changed: ${{ steps.set-outputs.outputs.galaxy_app_changed }}
+      galaxy_preview_changed: ${{ steps.set-outputs.outputs.galaxy_preview_changed }}
       api_client_changed: ${{ steps.set-outputs.outputs.api_client_changed }}
       api_reference_changed: ${{ steps.set-outputs.outputs.api_reference_changed }}
       scalar_app_package_changed: ${{ steps.set-outputs.outputs.scalar_app_package_changed }}
@@ -131,7 +131,11 @@ jobs:
               - packages/components/src/components/ScalarIcon/**
             galaxy_changed:
               - packages/galaxy/**
-            galaxy_app_changed:
+            # Any package can feed into the @scalar/api-reference bundle that
+            # galaxy serves, so a preview deploy is worthwhile for every package
+            # change, not just changes to galaxy itself.
+            galaxy_preview_changed:
+              - packages/**
               - projects/galaxy-scalar-com/**
             api_client_changed:
               - packages/api-client/**
@@ -182,7 +186,7 @@ jobs:
           echo "mock_server_docker_package_changed=${{ steps.changed-package-files.outputs.mock_server_docker_package_any_changed }}" >> $GITHUB_OUTPUT
           echo "icons_changed=${{ steps.changed-packages-files.outputs.icons_changed_any_changed }}" >> $GITHUB_OUTPUT
           echo "galaxy_changed=${{ steps.changed-packages-files.outputs.galaxy_changed_any_changed }}" >> $GITHUB_OUTPUT
-          echo "galaxy_app_changed=${{ steps.changed-packages-files.outputs.galaxy_app_changed_any_changed }}" >> $GITHUB_OUTPUT
+          echo "galaxy_preview_changed=${{ steps.changed-packages-files.outputs.galaxy_preview_changed_any_changed }}" >> $GITHUB_OUTPUT
           echo "api_client_changed=${{ steps.changed-packages-files.outputs.api_client_changed_any_changed }}" >> $GITHUB_OUTPUT
           echo "api_reference_changed=${{ steps.changed-packages-files.outputs.api_reference_changed_any_changed }}" >> $GITHUB_OUTPUT
           echo "scalar_app_package_changed=${{ steps.changed-packages-files.outputs.scalar_app_package_any_changed }}" >> $GITHUB_OUTPUT
@@ -969,12 +973,14 @@ jobs:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit
 
-  # Deploy galaxy-scalar-com to Cloudflare Pages. Like deploy-api-client, this
-  # runs for PR previews and every main push, and waits for npm-publish so it
-  # knows whether this commit released a dependency (-> production) or not
-  # (-> staging). `!cancelled()` lets it proceed when npm-publish is skipped
-  # (PRs); the explicit build/check-changes success gates are re-added because
-  # `!cancelled()` overrides the implicit `success()` check on `needs`.
+  # Deploy galaxy-scalar-com to Cloudflare Pages. On PRs it deploys a preview
+  # whenever any package — or galaxy itself — changed, so the branch-built
+  # @scalar/api-reference bundle galaxy serves can be reviewed; it also runs on
+  # every main push. Waits for npm-publish so it knows whether this commit
+  # released a dependency (-> production) or not (-> staging). `!cancelled()`
+  # lets it proceed when npm-publish is skipped (PRs); the explicit
+  # build/check-changes success gates are re-added because `!cancelled()`
+  # overrides the implicit `success()` check on `needs`.
   deploy-galaxy:
     if: |
       !cancelled() &&
@@ -986,7 +992,7 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
           !contains(github.actor, '[bot]') &&
-          needs.check-changes.outputs.galaxy_app_changed == 'true'
+          needs.check-changes.outputs.galaxy_preview_changed == 'true'
         ) ||
         github.ref == 'refs/heads/main'
       )

--- a/.github/workflows/deploy-galaxy.yml
+++ b/.github/workflows/deploy-galaxy.yml
@@ -35,6 +35,12 @@ jobs:
     # Setting environment here (not at the workflow level) is what grants access
     # to the environment-scoped vars.* and secrets.* for staging or production.
     environment: ${{ inputs.environment }}
+    env:
+      # Baked into the worker bundle by the galaxy build script. Production
+      # release deploys load the published @scalar/api-reference bundle from the
+      # jsDelivr CDN; staging and PR previews load the branch build that the
+      # build script copies into the deploy output.
+      GALAXY_IS_PRODUCTION: ${{ inputs.environment == 'production-galaxy-com' }}
     timeout-minutes: 15
     outputs:
       preview-url: ${{ steps.set-output.outputs.url }}

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -393,7 +393,10 @@
     "projects/galaxy-scalar-com": {
       // src/_worker.ts is the Cloudflare Pages worker entry, bundled by the
       // build script; knip cannot infer it without a wrangler config file.
-      "entry": ["src/_worker.ts"]
+      "entry": ["src/_worker.ts"],
+      // @scalar/api-reference is consumed by the build script (it copies the
+      // standalone bundle into the deploy output), not imported in source.
+      "ignoreDependencies": ["@scalar/api-reference"]
     },
     "projects/scalar-app": {
       "ignoreDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2632,6 +2632,9 @@ importers:
 
   projects/galaxy-scalar-com:
     devDependencies:
+      '@scalar/api-reference':
+        specifier: workspace:*
+        version: link:../../packages/api-reference
       '@scalar/galaxy':
         specifier: workspace:*
         version: link:../../packages/galaxy

--- a/projects/galaxy-scalar-com/package.json
+++ b/projects/galaxy-scalar-com/package.json
@@ -22,7 +22,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "wrangler deploy src/_worker.ts --dry-run --outdir dist --name galaxy-scalar-com --compatibility-date 2026-04-28 --compatibility-flags nodejs_compat",
+    "build": "wrangler deploy src/_worker.ts --dry-run --outdir dist --name galaxy-scalar-com --compatibility-date 2026-04-28 --compatibility-flags nodejs_compat --define GALAXY_IS_PRODUCTION:${GALAXY_IS_PRODUCTION:-false} && cp node_modules/@scalar/api-reference/dist/browser/standalone.js dist/scalar.js",
     "deploy": "wrangler pages deploy dist --project-name=galaxy-scalar-com",
     "dev": "pnpm build && wrangler pages dev dist --compatibility-date=2026-04-28 --compatibility-flags=nodejs_compat",
     "test": "vitest --run",
@@ -30,6 +30,7 @@
   },
   "type": "module",
   "devDependencies": {
+    "@scalar/api-reference": "workspace:*",
     "@scalar/galaxy": "workspace:*",
     "@scalar/helpers": "workspace:*",
     "@scalar/hono-api-reference": "workspace:*",

--- a/projects/galaxy-scalar-com/src/galaxy-scalar-com.test.ts
+++ b/projects/galaxy-scalar-com/src/galaxy-scalar-com.test.ts
@@ -88,14 +88,18 @@ describe('galaxy-scalar-com', () => {
           agent: expect.objectContaining({
             key: expect.any(String),
           }),
+          // Vitest builds run without the production `--define`, so the branch
+          // bundle is served from the local route.
+          cdn: '/scalar.js',
         }),
       )
     })
 
-    it('mounts the reference UI at the root path', () => {
+    it('mounts the reference UI and bundle routes', () => {
       configureApiReference(mockApp as Hono)
 
       expect(mockApp.get).toHaveBeenCalledWith('/', expect.any(Function))
+      expect(mockApp.get).toHaveBeenCalledWith('/scalar.js', expect.any(Function))
     })
   })
 })

--- a/projects/galaxy-scalar-com/src/galaxy-scalar-com.ts
+++ b/projects/galaxy-scalar-com/src/galaxy-scalar-com.ts
@@ -21,12 +21,47 @@ export const createApp = async (): Promise<Hono> =>
   })
 
 /**
+ * Path the branch-built `@scalar/api-reference` bundle is served from.
+ *
+ * The build script copies the standalone bundle into the deploy output as
+ * `scalar.js`; the route registered below serves it through the Cloudflare
+ * Pages `ASSETS` binding.
+ */
+const LOCAL_BUNDLE_PATH = '/scalar.js'
+
+/**
+ * Whether this is a production build.
+ *
+ * Wrangler's `--define` flag (see the `build` script) replaces this identifier
+ * with a literal `true` or `false` at build time, decided by the CI deploy
+ * environment. Production loads the published `@scalar/api-reference` bundle
+ * from the jsDelivr CDN; staging and PR previews load the bundle built from the
+ * current branch instead, so reference UI changes can be reviewed before they
+ * are released to npm.
+ *
+ * The `typeof` guard keeps this safe under Vitest and any other build that does
+ * not apply the define — the branch bundle is used by default.
+ */
+declare const GALAXY_IS_PRODUCTION: boolean
+const isProductionBuild = typeof GALAXY_IS_PRODUCTION !== 'undefined' && GALAXY_IS_PRODUCTION
+
+/**
+ * The Cloudflare Pages binding that serves files deployed alongside the worker.
+ */
+type AssetsBinding = { ASSETS: { fetch: (request: Request) => Promise<Response> } }
+
+/**
  * Mount the Scalar API reference UI at the root path.
  *
  * No `baseServerURL` is set: the mock endpoints and the reference UI share the
  * Worker origin, so Scalar resolves the document URL against the current origin.
  */
 export const configureApiReference = (app: Hono): void => {
+  // Serve the branch-built standalone bundle that the build step copied into
+  // the deploy output. Production never requests this route — it loads the
+  // reference UI from the CDN.
+  app.get(LOCAL_BUNDLE_PATH, (c) => (c.env as AssetsBinding).ASSETS.fetch(c.req.raw))
+
   app.get(
     '/',
     Scalar({
@@ -51,6 +86,9 @@ export const configureApiReference = (app: Hono): void => {
       agent: {
         key: 'eyJhbGciOiJFZERTQSJ9.eyJ1aWQiOiJKcWpjUkQ0aEZFRGpocGpCNDJEM24iLCJ0ZWFtVWlkIjoiSWxNbm05TXh5LVNhYm1MeEVfaTBMIiwiZXhwIjoxOTI4NTc4NDQ3LCJpYXQiOjE3NzA4OTg0NDd9.URUeP5n-RCTCHk8yJyAwlYZaLgJs0yAnOm6av-QoUD1vAuMd18eaSD3ziJFv9O5Vthcat7ICjJmq-qKe18EjBw',
       },
+      // Staging and PR previews render the reference UI built from this branch;
+      // production keeps the default jsDelivr CDN bundle.
+      ...(isProductionBuild ? {} : { cdn: LOCAL_BUNDLE_PATH }),
     }),
   )
 }

--- a/projects/galaxy-scalar-com/turbo.json
+++ b/projects/galaxy-scalar-com/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../node_modules/turbo/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      // The CI deploy workflow sets GALAXY_IS_PRODUCTION per environment; it is
+      // baked into the worker bundle, so it must be part of the build hash.
+      "env": ["GALAXY_IS_PRODUCTION"]
+    }
+  }
+}


### PR DESCRIPTION
Galaxy staging and PR previews loaded the API reference UI from jsDelivr, the published `@scalar/api-reference` release, so branch changes to it were never visible there.

Non-production deploys now serve the branch-built standalone bundle from `/scalar.js`. production keeps the CDN. 

CI sets `GALAXY_IS_PRODUCTION` per environment and the build bakes it into the worker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Cloudflare Pages worker build/deploy behavior and CI gating, which could affect preview/staging deployments (and potentially production if the new build flag or asset route is misconfigured). No direct user-data or auth logic changes.
> 
> **Overview**
> Staging and PR preview deployments of `galaxy-scalar-com` now render the API reference UI using the **branch-built** `@scalar/api-reference` standalone bundle served locally at `/scalar.js`, while production continues to use the published jsDelivr CDN bundle.
> 
> CI/deploy wiring is updated to support this: `deploy-galaxy` now triggers on `galaxy_preview_changed` (any package/project change), the deploy workflow sets `GALAXY_IS_PRODUCTION` per environment, and the galaxy build copies the standalone bundle into `dist` and registers a worker route to serve it via the Pages `ASSETS` binding. Related updates adjust tests, add per-project `turbo.json` env hashing, and suppress knip unused-dep warnings for the build-time-only dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a41cd1b5e34f661e6e53c4651d60fecacd468550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->