### PR TITLE
fix(api-client): make code samples with the same language independently selectable

### DIFF
--- a/.changeset/fix-code-samples-shared-language.md
+++ b/.changeset/fix-code-samples-shared-language.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fixed `x-codeSamples` entries that share a `lang`: multiple code samples with the same language but different labels (e.g. separate sync and async examples) were all marked selected and showed the same snippet. Each sample is now keyed by its position, so every one stays individually selectable.

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-client-options.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-client-options.test.ts
@@ -1,5 +1,4 @@
 import { AVAILABLE_CLIENTS } from '@scalar/snippetz'
-import type { XCodeSample } from '@scalar/workspace-store/schemas/extensions/operation'
 import { describe, expect, it } from 'vitest'
 
 import { generateClientOptions, generateCustomId } from './generate-client-options'
@@ -228,25 +227,15 @@ describe('generateClientOptions', () => {
 })
 
 describe('generateCustomId', () => {
-  it('should generate correct custom ID for code samples', () => {
-    const sample: XCodeSample = {
-      lang: 'typescript',
-      label: 'TypeScript Example',
-      source: 'console.log("Hello World")',
-    }
-
-    const result = generateCustomId(sample)
-    expect(result).toBe('custom/typescript')
+  it('generates a custom ID from the sample index', () => {
+    expect(generateCustomId(0)).toBe('custom/0')
+    expect(generateCustomId(3)).toBe('custom/3')
   })
 
-  it('should handle different language types', () => {
-    const samples: XCodeSample[] = [
-      { lang: 'javascript', source: 'console.log("test")' },
-      { lang: 'python', source: 'print("test")' },
-      { lang: 'curl', source: 'curl -X GET https://api.example.com' },
-    ]
+  it('generates distinct IDs so samples sharing a language stay separate', () => {
+    const results = [0, 1, 2].map((index) => generateCustomId(index))
 
-    const results = samples.map((sample) => generateCustomId(sample))
-    expect(results).toEqual(['custom/javascript', 'custom/python', 'custom/curl'])
+    expect(results).toEqual(['custom/0', 'custom/1', 'custom/2'])
+    expect(new Set(results).size).toBe(results.length)
   })
 })

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-client-options.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-client-options.ts
@@ -1,5 +1,4 @@
 import { AVAILABLE_CLIENTS, type AvailableClients, snippetz } from '@scalar/snippetz'
-import type { XCodeSample } from '@scalar/workspace-store/schemas/extensions/operation'
 import { capitalize } from 'vue'
 
 import type { ClientOptionGroup } from '@/v2/blocks/operation-code-sample/types'
@@ -7,8 +6,14 @@ import type { ClientOptionGroup } from '@/v2/blocks/operation-code-sample/types'
 /** Type of custom code sample IDs */
 export type CustomCodeSampleId = `custom/${string}`
 
-/** Helper to generate an ID for custom code samples */
-export const generateCustomId = (example: XCodeSample): CustomCodeSampleId => `custom/${example.lang}`
+/**
+ * Generate a unique ID for a custom code sample.
+ *
+ * The ID is keyed by the sample's position in the operation's code samples, so multiple
+ * samples that share the same `lang` (e.g. separate sync and async examples) stay
+ * individually selectable.
+ */
+export const generateCustomId = (index: number): CustomCodeSampleId => `custom/${index}`
 
 /**
  * Generate client options for the request example block by filtering by allowed clients

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-code-snippet.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-code-snippet.test.ts
@@ -51,27 +51,27 @@ describe('generateCodeSnippet', () => {
     expect(result).toBe("fetch('https://api.example.com/users/{userId}')")
   })
 
-  it('returns custom code sample source when clientId starts with "custom"', () => {
+  it('resolves each custom code sample by its index, even when languages match', () => {
     const customCodeSamples: XCodeSample[] = [
       {
         lang: 'python',
-        label: 'Python Example',
-        source: 'import requests\nresponse = requests.get("https://api.example.com")',
+        label: 'Python',
+        source: 'response = svix.application.list()',
       },
       {
-        lang: 'javascript',
-        label: 'JavaScript Example',
-        source: 'fetch("https://api.example.com")',
+        lang: 'python',
+        label: 'Python (Async)',
+        source: 'response = await svix.application.list()',
       },
     ]
 
-    const result = generateCodeSnippet({
-      ...baseParams,
-      clientId: 'custom/python',
-      customCodeSamples,
-    })
-
-    expect(result).toBe('import requests\nresponse = requests.get("https://api.example.com")')
+    // Two samples share a language, but each index resolves to its own source
+    expect(generateCodeSnippet({ ...baseParams, clientId: 'custom/0', customCodeSamples })).toBe(
+      'response = svix.application.list()',
+    )
+    expect(generateCodeSnippet({ ...baseParams, clientId: 'custom/1', customCodeSamples })).toBe(
+      'response = await svix.application.list()',
+    )
   })
 
   it('returns "Custom example not found" when custom clientId does not match any custom code sample', () => {
@@ -85,7 +85,7 @@ describe('generateCodeSnippet', () => {
 
     const result = generateCodeSnippet({
       ...baseParams,
-      clientId: 'custom/ruby',
+      clientId: 'custom/99',
       customCodeSamples,
     })
 

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-code-snippet.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/generate-code-snippet.ts
@@ -63,8 +63,7 @@ export const generateCodeSnippet = ({
     // Use the selected custom example
     if (clientId.startsWith('custom')) {
       return (
-        customCodeSamples.find((example) => generateCustomId(example) === clientId)?.source ??
-        'Custom example not found'
+        customCodeSamples.find((_, index) => generateCustomId(index) === clientId)?.source ?? 'Custom example not found'
       )
     }
 

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/get-clients.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/get-clients.test.ts
@@ -54,14 +54,14 @@ describe('getClients', () => {
       key: 'custom',
       options: [
         {
-          id: 'custom/python',
+          id: 'custom/0',
           lang: 'python',
           clientKey: 'custom',
           title: 'Custom Python Example',
           label: 'Custom Python Example',
         },
         {
-          id: 'custom/js',
+          id: 'custom/1',
           lang: 'js',
           clientKey: 'custom',
           title: 'Custom JS Example',
@@ -108,17 +108,17 @@ describe('getClients', () => {
     const firstOption = result[0]?.options[0]
     expect(firstOption).toBeDefined()
     expect(firstOption).toMatchObject({
-      id: 'custom/undefined',
+      id: 'custom/0',
       lang: 'plaintext',
-      title: 'custom/undefined',
-      label: 'custom/undefined',
+      title: 'custom/0',
+      label: 'custom/0',
     })
 
     // When label is missing, should use lang
     const secondOption = result[0]?.options[1]
     expect(secondOption).toBeDefined()
     expect(secondOption).toMatchObject({
-      id: 'custom/ruby',
+      id: 'custom/1',
       lang: 'ruby',
       title: 'ruby',
       label: 'ruby',
@@ -128,7 +128,7 @@ describe('getClients', () => {
     const thirdOption = result[0]?.options[2]
     expect(thirdOption).toBeDefined()
     expect(thirdOption).toMatchObject({
-      id: 'custom/undefined',
+      id: 'custom/2',
       lang: 'plaintext',
       title: 'Special Example',
       label: 'Special Example',
@@ -246,11 +246,11 @@ describe('getClients', () => {
     expect(result[0]?.label).toBe('Code Examples')
     expect(result[0]?.options).toHaveLength(4)
 
-    // Both python examples should be included with the same ID but different labels
+    // Both python examples must get distinct IDs so they stay individually selectable
     const firstPythonOption = result[0]?.options[0]
     expect(firstPythonOption).toBeDefined()
     expect(firstPythonOption).toMatchObject({
-      id: 'custom/python',
+      id: 'custom/0',
       lang: 'python',
       label: 'Python Example 1',
     })
@@ -258,16 +258,18 @@ describe('getClients', () => {
     const secondPythonOption = result[0]?.options[1]
     expect(secondPythonOption).toBeDefined()
     expect(secondPythonOption).toMatchObject({
-      id: 'custom/python',
+      id: 'custom/1',
       lang: 'python',
       label: 'Python Example 2',
     })
 
-    // Special characters in language names should be preserved
+    expect(firstPythonOption?.id).not.toBe(secondPythonOption?.id)
+
+    // Languages with special characters should still produce unique IDs
     const cppOption = result[0]?.options[2]
     expect(cppOption).toBeDefined()
     expect(cppOption).toMatchObject({
-      id: 'custom/c++',
+      id: 'custom/2',
       lang: 'c++',
       label: 'C++ Example',
     })
@@ -275,7 +277,7 @@ describe('getClients', () => {
     const objcOption = result[0]?.options[3]
     expect(objcOption).toBeDefined()
     expect(objcOption).toMatchObject({
-      id: 'custom/objective-c',
+      id: 'custom/3',
       lang: 'objective-c',
       label: 'Objective-C Example',
     })

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/get-clients.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/get-clients.ts
@@ -18,8 +18,8 @@ export const getClients = (
 ): CustomClientOptionGroup[] => {
   // Handle custom code examples
   if (customCodeSamples.length) {
-    const customClients = customCodeSamples.map((sample) => {
-      const id = generateCustomId(sample)
+    const customClients = customCodeSamples.map((sample, index) => {
+      const id = generateCustomId(index)
       const label = sample.label || sample.lang || id
       const lang = (sample.lang as TargetId) || 'plaintext'
 


### PR DESCRIPTION
`x-codeSamples` entries that share a `lang` (e.g. Svix's `Python` and `Python (Async)`, both `lang: "Python"`) were keyed only by language. They all collapsed onto a single entry, clicking one marked every same-language sample as selected and always showed the same snippet.

Each custom code sample is now keyed by its position in the operation's samples, so every entry stays individually selectable regardless of language.

## Ticket

Fixes #9290

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to custom code-sample ID generation/lookup and is covered by updated unit tests; main impact is that previously language-keyed custom sample IDs are now index-keyed.
> 
> **Overview**
> Fixes custom `x-codeSamples` selection collisions by changing `generateCustomId` to key IDs by sample index (e.g. `custom/0`) instead of `lang`, so multiple samples with the same language remain independently selectable.
> 
> Updates `getClients` and `generateCodeSnippet` to generate/resolve custom sample IDs by index, and adjusts tests plus a changeset to reflect the new behavior and prevent regressions when languages/labels are duplicated or missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9871db65848a08372163c71f62451a69b8ef7060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->