### PR TITLE
fix(workspace-store): missing migration

### DIFF
--- a/.changeset/fix-indexdb-v3-repair-uid-schema.md
+++ b/.changeset/fix-indexdb-v3-repair-uid-schema.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Fixed a `NotFoundError: The specified index was not found` crash on startup for installs created by `@scalar/workspace-store@0.48.x`–`0.49.x`. The v2 IndexedDB migration was rewritten in place without bumping the schema version, so those installs were stranded on the superseded schema (no `teamSlug_slug` index) and never re-ran migrations. A new v3 migration brings them up to the current UID-based shape and is a no-op for installs already on it.

--- a/packages/workspace-store/src/persistence/index.ts
+++ b/packages/workspace-store/src/persistence/index.ts
@@ -4,6 +4,7 @@ import type { PathMethodHistory } from '@/entities/history/schema'
 import { createIndexDbConnection } from '@/persistence/indexdb'
 import { v1InitialMigration } from '@/persistence/migrations/v1-initial'
 import { v2TeamToLocalMigration } from '@/persistence/migrations/v2-team-to-local'
+import { v3RepairUidSchemaMigration } from '@/persistence/migrations/v3-repair-uid-schema'
 import type { InMemoryWorkspace } from '@/schemas/inmemory-workspace'
 import type { WorkspaceMeta } from '@/schemas/workspace'
 
@@ -64,7 +65,7 @@ export const createWorkspaceStorePersistence = async () => {
   // fresh installs and upgrades converge on exactly the same state.
   const connection = await createIndexDbConnection({
     name: 'scalar-workspace-store',
-    migrations: [v1InitialMigration, v2TeamToLocalMigration],
+    migrations: [v1InitialMigration, v2TeamToLocalMigration, v3RepairUidSchemaMigration],
     tables: {
       workspace: {
         schema: Type.Object({

--- a/packages/workspace-store/src/persistence/migrations/v3-repair-uid-schema.test.ts
+++ b/packages/workspace-store/src/persistence/migrations/v3-repair-uid-schema.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest'
+import 'fake-indexeddb/auto'
+
+import { createWorkspaceStorePersistence } from '@/persistence/index'
+
+const COMPOSITE_KEY_CHUNK_TABLES = [
+  'documents',
+  'originalDocuments',
+  'intermediateDocuments',
+  'overrides',
+  'history',
+  'auth',
+] as const
+
+describe('v3-repair-uid-schema', () => {
+  const dbName = 'scalar-workspace-store'
+
+  const cleanup = async (persistence: Awaited<ReturnType<typeof createWorkspaceStorePersistence>> | undefined) => {
+    persistence?.close()
+    const deleteRequest = indexedDB.deleteDatabase(dbName)
+    await new Promise((resolve, reject) => {
+      deleteRequest.onsuccess = () => resolve(undefined)
+      deleteRequest.onerror = () => reject(deleteRequest.error)
+    })
+  }
+
+  /**
+   * Builds a database in the superseded v2 shape: the `workspace` store keyed
+   * by `[teamSlug, slug]` with no indexes, and chunk stores still keyed by the
+   * legacy `workspaceId`. This is the exact state an install created by
+   * `@scalar/workspace-store@0.48.x`–`0.49.x` is stuck in.
+   */
+  const seedSupersededV2Database = async (
+    records: Array<{ slug: string; name: string; documents?: Record<string, unknown>; meta?: unknown }>,
+  ): Promise<void> => {
+    await new Promise<void>((resolve, reject) => {
+      const request = indexedDB.open(dbName, 2)
+      request.onupgradeneeded = () => {
+        const db = request.result
+        // The superseded v2 keyed the workspace store by [teamSlug, slug] and
+        // deliberately created no secondary indexes.
+        db.createObjectStore('workspace', { keyPath: ['teamSlug', 'slug'] })
+        db.createObjectStore('meta', { keyPath: 'workspaceId' })
+        for (const tableName of COMPOSITE_KEY_CHUNK_TABLES) {
+          db.createObjectStore(tableName, { keyPath: ['workspaceId', 'documentName'] })
+        }
+      }
+      request.onsuccess = () => {
+        const db = request.result
+        const tx = db.transaction(['workspace', 'meta', 'documents'], 'readwrite')
+        const workspaceStore = tx.objectStore('workspace')
+        const metaStore = tx.objectStore('meta')
+        const documentsStore = tx.objectStore('documents')
+
+        for (const record of records) {
+          workspaceStore.put({ name: record.name, teamSlug: 'local', slug: record.slug })
+
+          // The superseded v2 re-keyed every chunk to `${teamSlug}/${slug}`.
+          const workspaceId = `local/${record.slug}`
+          if (record.meta !== undefined) {
+            metaStore.put({ workspaceId, data: record.meta })
+          }
+          for (const [documentName, data] of Object.entries(record.documents ?? {})) {
+            documentsStore.put({ workspaceId, documentName, data })
+          }
+        }
+
+        tx.oncomplete = () => {
+          db.close()
+          resolve()
+        }
+        tx.onerror = () => reject(tx.error)
+      }
+      request.onerror = () => reject(request.error)
+    })
+  }
+
+  /**
+   * Builds a database in the current (UID-based) v2 shape, still pinned at
+   * version 2. This mirrors an install created by `@scalar/workspace-store`
+   * 0.50.0+, which v3 must recognise and leave completely untouched.
+   */
+  const seedCurrentV2Database = async (
+    records: Array<{ workspaceUid: string; slug: string; name: string; meta?: unknown }>,
+  ): Promise<void> => {
+    await new Promise<void>((resolve, reject) => {
+      const request = indexedDB.open(dbName, 2)
+      request.onupgradeneeded = () => {
+        const db = request.result
+        const workspace = db.createObjectStore('workspace', { keyPath: 'workspaceUid' })
+        workspace.createIndex('teamSlug_slug', ['teamSlug', 'slug'], { unique: true })
+        workspace.createIndex('teamUid', ['teamUid'])
+        db.createObjectStore('meta', { keyPath: 'workspaceUid' })
+        for (const tableName of COMPOSITE_KEY_CHUNK_TABLES) {
+          db.createObjectStore(tableName, { keyPath: ['workspaceUid', 'documentName'] })
+        }
+      }
+      request.onsuccess = () => {
+        const db = request.result
+        const tx = db.transaction(['workspace', 'meta'], 'readwrite')
+        const workspaceStore = tx.objectStore('workspace')
+        const metaStore = tx.objectStore('meta')
+
+        for (const record of records) {
+          workspaceStore.put({
+            workspaceUid: record.workspaceUid,
+            teamUid: 'local',
+            teamSlug: 'local',
+            slug: record.slug,
+            name: record.name,
+          })
+          if (record.meta !== undefined) {
+            metaStore.put({ workspaceUid: record.workspaceUid, data: record.meta })
+          }
+        }
+
+        tx.oncomplete = () => {
+          db.close()
+          resolve()
+        }
+        tx.onerror = () => reject(tx.error)
+      }
+      request.onerror = () => reject(request.error)
+    })
+  }
+
+  it('resolves a workspace by slug after repairing the superseded schema', async () => {
+    let persistence: Awaited<ReturnType<typeof createWorkspaceStorePersistence>> | undefined
+    try {
+      await seedSupersededV2Database([{ slug: 'api', name: 'Acme API' }])
+
+      // Opening the store runs v3, which recreates the workspace store with
+      // the missing `teamSlug_slug` index. Before the fix this lookup threw
+      // `NotFoundError: The specified index was not found`.
+      persistence = await createWorkspaceStorePersistence()
+
+      const workspace = await persistence.workspace.getItemBySlug({ slug: 'api' })
+      expect(workspace).toBeDefined()
+      expect(workspace?.workspaceUid).toEqual(expect.stringMatching(/^[0-9a-f-]{36}$/i))
+      expect(workspace?.teamSlug).toBe('local')
+      expect(workspace?.slug).toBe('api')
+      expect(workspace?.name).toBe('Acme API')
+    } finally {
+      await cleanup(persistence)
+    }
+  })
+
+  it('re-keys chunk records onto the new workspaceUid', async () => {
+    let persistence: Awaited<ReturnType<typeof createWorkspaceStorePersistence>> | undefined
+    try {
+      await seedSupersededV2Database([
+        {
+          slug: 'api',
+          name: 'Acme API',
+          meta: { 'x-scalar-color-mode': 'dark' },
+          documents: {
+            'doc-1': { openapi: '3.1.0', info: { title: 'API', version: '1.0.0' }, paths: {} },
+          },
+        },
+      ])
+
+      persistence = await createWorkspaceStorePersistence()
+
+      const bySlug = await persistence.workspace.getItemBySlug({ slug: 'api' })
+      const byUid = await persistence.workspace.getItem(bySlug!.workspaceUid)
+      expect(byUid?.workspace.meta).toEqual({ 'x-scalar-color-mode': 'dark' })
+      expect(byUid?.workspace.documents['doc-1']).toMatchObject({ openapi: '3.1.0' })
+    } finally {
+      await cleanup(persistence)
+    }
+  })
+
+  it('keeps every workspace and restores the teamUid index', async () => {
+    let persistence: Awaited<ReturnType<typeof createWorkspaceStorePersistence>> | undefined
+    try {
+      await seedSupersededV2Database([
+        { slug: 'one', name: 'One' },
+        { slug: 'two', name: 'Two' },
+        { slug: 'three', name: 'Three' },
+      ])
+
+      persistence = await createWorkspaceStorePersistence()
+
+      const all = await persistence.workspace.getAll()
+      expect(all.map((workspace) => workspace.slug).sort()).toEqual(['one', 'three', 'two'])
+
+      // getAllByTeamUid uses the `teamUid` index, which the superseded v2 also
+      // dropped — it must resolve again after the repair.
+      const local = await persistence.workspace.getAllByTeamUid('local')
+      expect(local).toHaveLength(3)
+    } finally {
+      await cleanup(persistence)
+    }
+  })
+
+  it('is a no-op for databases already on the UID-based schema', async () => {
+    let persistence: Awaited<ReturnType<typeof createWorkspaceStorePersistence>> | undefined
+    try {
+      await seedCurrentV2Database([
+        { workspaceUid: 'stable-uid', slug: 'api', name: 'Acme API', meta: { 'x-scalar-color-mode': 'dark' } },
+      ])
+
+      // v3 still runs (the database is at version 2), but it must detect the
+      // existing `teamSlug_slug` index and leave the data untouched — no
+      // regenerated UID, no orphaned chunks.
+      persistence = await createWorkspaceStorePersistence()
+
+      const workspace = await persistence.workspace.getItem('stable-uid')
+      expect(workspace?.workspaceUid).toBe('stable-uid')
+      expect(workspace?.slug).toBe('api')
+      expect(workspace?.workspace.meta).toEqual({ 'x-scalar-color-mode': 'dark' })
+    } finally {
+      await cleanup(persistence)
+    }
+  })
+})

--- a/packages/workspace-store/src/persistence/migrations/v3-repair-uid-schema.ts
+++ b/packages/workspace-store/src/persistence/migrations/v3-repair-uid-schema.ts
@@ -1,0 +1,205 @@
+import type { Migration } from '@/persistence/indexdb'
+
+/**
+ * v3 — repair installs left on the superseded v2 schema.
+ *
+ * The database version is derived from the number of migrations, so every
+ * position in the array is meant to be one immutable, shipped schema state.
+ * That contract was broken once: the v2 migration was rewritten in place
+ * between two releases instead of appending a new migration.
+ *
+ * As a result, "version 2" shipped as two different schemas:
+ *
+ * - Superseded v2 (`@scalar/workspace-store@0.48.x`–`0.49.x`): the `workspace`
+ *   store was keyed by the composite `[teamSlug, slug]` and had no secondary
+ *   indexes. Chunk stores kept the v1 `workspaceId` key path.
+ * - Current v2 (`@scalar/workspace-store@0.50.0`+): the `workspace` store is
+ *   keyed by `workspaceUid` and carries the `teamSlug_slug` (unique) and
+ *   `teamUid` indexes; every chunk store is keyed by `workspaceUid`.
+ *
+ * Both opened the database at version 2, so an install created by the
+ * superseded v2 never re-runs migrations on update — `onupgradeneeded` does
+ * not fire when the requested version already matches the existing one. The
+ * runtime then asks for the `teamSlug_slug` index that does not exist and
+ * slug-based lookups (`getItemBySlug`) throw `NotFoundError`.
+ *
+ * This migration brings those stranded installs up to the current shape:
+ * - The `workspace` store is recreated with `workspaceUid` as its primary key
+ *   and both indexes. A fresh UUID is generated for every record.
+ * - Every chunk store is recreated with the `workspaceUid` key path and its
+ *   records are re-keyed from the legacy `${teamSlug}/${slug}` id.
+ *
+ * It is a no-op for installs that already ran the current v2 (fresh installs
+ * and v1 upgrades): those carry the `teamSlug_slug` index, which is a reliable
+ * signal that the UID-based schema is already in place.
+ *
+ * Slug uniqueness needs no extra handling here: the superseded v2 keyed the
+ * `workspace` store by `[teamSlug, slug]`, so the pairs were already unique
+ * and the new unique index cannot collide.
+ */
+
+/** Tables that store per-workspace chunks keyed by a single workspace id. */
+const SINGLE_KEY_CHUNK_TABLES = ['meta'] as const
+
+/** Tables that store per-document chunks keyed by `[workspace id, documentName]`. */
+const COMPOSITE_KEY_CHUNK_TABLES = [
+  'documents',
+  'originalDocuments',
+  'intermediateDocuments',
+  'overrides',
+  'history',
+  'auth',
+] as const
+
+/**
+ * Workspace record as written by the superseded v2 migration: keyed by the
+ * composite `[teamSlug, slug]`, with no `workspaceUid` and no indexes.
+ */
+type SupersededWorkspaceRecord = {
+  name: string
+  teamSlug: string
+  slug: string
+}
+
+/** Workspace record in the current, UID-based shape. */
+type WorkspaceRecord = {
+  workspaceUid: string
+  teamUid: string
+  teamSlug: string
+  slug: string
+  name: string
+}
+
+/** A chunk record before re-keying — still carries the legacy `workspaceId`. */
+type LegacyChunkRecord = Record<string, unknown> & { workspaceId: string }
+
+/**
+ * Generates a UUID. Wrapped in a function so the migration fails loudly in
+ * environments where `crypto.randomUUID` is unavailable instead of writing
+ * records with an undefined primary key.
+ */
+const generateUid = (): string => {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID()
+  }
+  throw new Error('crypto.randomUUID is not available in this environment; cannot run v3 migration')
+}
+
+/** Wraps an IDB request so it can be awaited inside the upgrade transaction. */
+const requestAsPromise = <T>(req: IDBRequest<T>): Promise<T> =>
+  new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+
+/**
+ * Reads every record from a store, returning an empty array when the store
+ * does not exist. Queues the `getAll` request synchronously so the upgrade
+ * transaction stays alive across the await.
+ */
+const readAllRecords = async <T>(transaction: IDBTransaction, tableName: string): Promise<T[]> => {
+  if (!transaction.db.objectStoreNames.contains(tableName)) {
+    return []
+  }
+  const records = await requestAsPromise(transaction.objectStore(tableName).getAll())
+  return (records ?? []) as T[]
+}
+
+export const v3RepairUidSchemaMigration: Migration = {
+  description: 'Repair installs stranded on the superseded v2 schema (workspaceUid primary key + indexes)',
+  up: async ({ db, transaction }) => {
+    if (!db.objectStoreNames.contains('workspace')) {
+      // The workspace store must exist after v1; if it does not, something is
+      // very wrong and we should not silently paper over it here.
+      return
+    }
+
+    // Installs that ran the current v2 already have the UID-based schema. The
+    // `teamSlug_slug` index exists only on that shape, so its presence makes
+    // this migration a safe no-op for fresh installs and v1 upgrades.
+    if (transaction.objectStore('workspace').indexNames.contains('teamSlug_slug')) {
+      return
+    }
+
+    // Snapshot every record before dropping the old stores. The upgrade
+    // transaction stays alive while these `getAll` requests are pending, so
+    // the schema mutations below still run in versionchange mode — which is
+    // required for deleteObjectStore / createObjectStore.
+    const supersededWorkspaces = await readAllRecords<SupersededWorkspaceRecord>(transaction, 'workspace')
+
+    const legacySingleKeyChunks: Record<string, LegacyChunkRecord[]> = {}
+    for (const tableName of SINGLE_KEY_CHUNK_TABLES) {
+      legacySingleKeyChunks[tableName] = await readAllRecords<LegacyChunkRecord>(transaction, tableName)
+    }
+    const legacyCompositeKeyChunks: Record<string, LegacyChunkRecord[]> = {}
+    for (const tableName of COMPOSITE_KEY_CHUNK_TABLES) {
+      legacyCompositeKeyChunks[tableName] = await readAllRecords<LegacyChunkRecord>(transaction, tableName)
+    }
+
+    // Assign a stable UUID to every workspace and remember which legacy
+    // `${teamSlug}/${slug}` chunk id maps onto it.
+    const legacyIdToWorkspaceUid = new Map<string, string>()
+    const migratedWorkspaces: WorkspaceRecord[] = supersededWorkspaces.map((workspace) => {
+      const workspaceUid = generateUid()
+      legacyIdToWorkspaceUid.set(`${workspace.teamSlug}/${workspace.slug}`, workspaceUid)
+      return {
+        workspaceUid,
+        // The client now ships with a single local-team UX, and the
+        // superseded v2 had already collapsed every workspace into the
+        // local team — so both identifiers are forced to 'local'.
+        teamUid: 'local',
+        teamSlug: 'local',
+        slug: workspace.slug,
+        name: workspace.name,
+      }
+    })
+
+    // Recreate the workspace store with `workspaceUid` as the primary key,
+    // plus the indexes the runtime relies on. An object store's key path
+    // cannot be changed in place, so the store has to be dropped first.
+    db.deleteObjectStore('workspace')
+    const workspaceStore = db.createObjectStore('workspace', { keyPath: 'workspaceUid' })
+    workspaceStore.createIndex('teamSlug_slug', ['teamSlug', 'slug'], { unique: true })
+    workspaceStore.createIndex('teamUid', ['teamUid'])
+
+    // Recreate every chunk store with the `workspaceUid` key path.
+    for (const tableName of SINGLE_KEY_CHUNK_TABLES) {
+      if (transaction.db.objectStoreNames.contains(tableName)) {
+        db.deleteObjectStore(tableName)
+      }
+      db.createObjectStore(tableName, { keyPath: 'workspaceUid' })
+    }
+    for (const tableName of COMPOSITE_KEY_CHUNK_TABLES) {
+      if (transaction.db.objectStoreNames.contains(tableName)) {
+        db.deleteObjectStore(tableName)
+      }
+      db.createObjectStore(tableName, { keyPath: ['workspaceUid', 'documentName'] })
+    }
+
+    // Write the migrated workspace records into the fresh store.
+    for (const record of migratedWorkspaces) {
+      workspaceStore.put(record)
+    }
+
+    // Re-key every chunk record from its legacy `${teamSlug}/${slug}` id to
+    // the new `workspaceUid`. Orphans — chunks whose workspace no longer
+    // exists — are dropped; they have no meaning without their parent.
+    const rekeyChunks = (tableName: string, records: LegacyChunkRecord[]) => {
+      const store = transaction.objectStore(tableName)
+      for (const record of records) {
+        const workspaceUid = legacyIdToWorkspaceUid.get(record.workspaceId)
+        if (!workspaceUid) {
+          continue
+        }
+        const { workspaceId: _legacyId, ...rest } = record
+        store.put({ ...rest, workspaceUid })
+      }
+    }
+    for (const tableName of SINGLE_KEY_CHUNK_TABLES) {
+      rekeyChunks(tableName, legacySingleKeyChunks[tableName] ?? [])
+    }
+    for (const tableName of COMPOSITE_KEY_CHUNK_TABLES) {
+      rekeyChunks(tableName, legacyCompositeKeyChunks[tableName] ?? [])
+    }
+  },
+}


### PR DESCRIPTION
The v2 IndexedDB migration was rewritten in place between `@scalar/workspace-store@0.48.x` and `0.50.0` without bumping the schema version (the version is derived from `migrations.length`, which stayed at 2). Two different schemas shipped as "version 2":

- **Superseded v2** (0.48.x–0.49.x): `workspace` store keyed by `[teamSlug, slug]`, no indexes.
- **Current v2** (0.50.0+): `workspace` store keyed by `workspaceUid` with `teamSlug_slug` + `teamUid` indexes.

Installs created by the superseded v2 are stranded — `onupgradeneeded` never fires again because the requested version already matches. The runtime then asks for the `teamSlug_slug` index that does not exist and `getItemBySlug` crashes on startup with `NotFoundError: The specified index was not found`.

This adds a **v3 migration** that recreates the workspace and chunk stores in the current UID-based shape. It is a no-op for installs already on that shape, detected via the presence of the `teamSlug_slug` index — so fresh installs and v1 upgrades are untouched.

Tests cover the repair path, chunk re-keying, the restored `teamUid` index, and the no-op path for already-migrated databases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an IndexedDB repair migration that drops/recreates object stores and re-keys persisted data; mistakes could lead to data loss or broken workspace lookups on upgrade, though it’s guarded to no-op on already-correct schemas.
> 
> **Overview**
> Prevents a startup crash (`NotFoundError` on missing `teamSlug_slug` index) for installs created on the superseded “v2” schema by appending a new **v3 IndexedDB migration**.
> 
> The v3 migration detects the stranded schema (missing `teamSlug_slug`), then rebuilds the `workspace` store to the UID-based layout (new `workspaceUid` PK + `teamSlug_slug`/`teamUid` indexes) and re-keys all chunk tables (`meta`, `documents`, etc.) from legacy `workspaceId` to the new `workspaceUid`, dropping orphaned chunks. It explicitly no-ops when the UID-based indexes already exist, and adds comprehensive `fake-indexeddb` tests covering repair, chunk re-keying, index restoration, and no-op behavior.
> 
> Includes a patch changeset documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f14d3aae21d429f39df9ea6ab9054354b1e8d34c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->