### PR TITLE
fix(aspire): store boolean env vars as strings for ACA publish

### DIFF
--- a/.changeset/aspire-bool-env-vars.md
+++ b/.changeset/aspire-bool-env-vars.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspire': patch
+---
+
+fix(aspire): store boolean environment variables as strings so `aspire publish` to Azure Container Apps no longer fails with "Unsupported value type System.Boolean"

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/ScalarResourceConfigurator.cs
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/ScalarResourceConfigurator.cs
@@ -30,9 +30,13 @@ internal static class ScalarResourceConfigurator
         var environmentVariables = context.EnvironmentVariables;
         environmentVariables.Add(ApiReferenceConfig, configurations);
         environmentVariables.Add(CdnUrl, scalarAspireOptions.BundleUrl);
-        environmentVariables.Add(AllowSelfSignedCertificates, scalarAspireOptions.AllowSelfSignedCertificates);
-        environmentVariables.Add(ForwardOriginalHostHeader, scalarAspireOptions.ForwardOriginalHostHeader);
-        environmentVariables.Add(DefaultProxy, scalarAspireOptions.DefaultProxy);
+        // Booleans must be stored as strings. Aspire's Azure Container Apps publisher only serializes
+        // strings and a few reference types, so a raw bool aborts `aspire publish` with
+        // "Unsupported value type System.Boolean". The container reads these back with GetValue<bool>,
+        // which parses case-insensitively, so this is a no-op for runtime behavior.
+        environmentVariables.Add(AllowSelfSignedCertificates, scalarAspireOptions.AllowSelfSignedCertificates ? "true" : "false");
+        environmentVariables.Add(ForwardOriginalHostHeader, scalarAspireOptions.ForwardOriginalHostHeader ? "true" : "false");
+        environmentVariables.Add(DefaultProxy, scalarAspireOptions.DefaultProxy ? "true" : "false");
     }
 
     private static async IAsyncEnumerable<ScalarOptions> CreateConfigurationsAsync(string scalarResourceName, IServiceProvider serviceProvider, IEnumerable<ScalarAnnotation> annotations, [EnumeratorCancellation] CancellationToken cancellationToken)

--- a/integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/ScalarResourceConfiguratorTests.cs
+++ b/integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/ScalarResourceConfiguratorTests.cs
@@ -419,6 +419,37 @@ public class ScalarResourceConfiguratorTests
         JsonDocument.Parse(decoded).RootElement.ValueKind.Should().Be(JsonValueKind.Array);
     }
 
+    [Fact]
+    public async Task EnvironmentVariables_AreAllStrings_SoAzureContainerAppsPublishCanSerializeThem()
+    {
+        // Aspire's Azure Container Apps publisher only serializes strings and a few reference types.
+        // A raw bool env var aborts `aspire publish` with "Unsupported value type System.Boolean",
+        // so every value the configurator adds must be a string. See scalar/scalar#9308.
+        var scalarResource = new ScalarResource(ScalarResourceName);
+        scalarResource.Annotations.Add(DefaultAnnotation(HttpApiResource()));
+
+        var services = new ServiceCollection();
+        services.AddOptions<ScalarAspireOptions>(ScalarResourceName);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var executionContext = new DistributedApplicationExecutionContext(
+            new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Publish)
+            {
+                ServiceProvider = serviceProvider
+            });
+
+        var envVars = new Dictionary<string, object>();
+        await ScalarResourceConfigurator.ConfigureScalarResourceAsync(
+            new EnvironmentCallbackContext(executionContext, scalarResource, envVars));
+
+        envVars.Values.Should().AllBeOfType<string>();
+
+        // The three boolean options are serialized as lowercase strings the container parses back.
+        envVars[EnvironmentVariables.DefaultProxy].Should().Be("true");
+        envVars[EnvironmentVariables.AllowSelfSignedCertificates].Should().Be("false");
+        envVars[EnvironmentVariables.ForwardOriginalHostHeader].Should().Be("false");
+    }
+
     // ---------------------------------------------------------------------------
     // Service-discovery environment variable tests
     //


### PR DESCRIPTION
`aspire publish` / `azd deploy` to Azure Container Apps crashed with `Unsupported value type System.Boolean` before any Bicep was emitted.

The cause: `ScalarResourceConfigurator` added three options (`AllowSelfSignedCertificates`, `ForwardOriginalHostHeader`, `DefaultProxy`) to `EnvironmentVariables` as raw `bool`. Aspire's ACA publisher only serializes strings and a few reference types, so anything else throws.

Fix is to store them as `"true"`/`"false"`. The container already reads them with `GetValue<bool>` (case-insensitive), so runtime behavior is unchanged.

## Ticket

Fixes #9308

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes how three boolean Aspire options are written into environment variables to satisfy Azure Container Apps publisher serialization; runtime behavior should remain the same aside from string casing.
> 
> **Overview**
> Fixes `aspire publish`/`azd deploy` failures to Azure Container Apps by ensuring `ScalarResourceConfigurator` stores the boolean options `ALLOW_SELF_SIGNED_CERTIFICATES`, `FORWARD_ORIGINAL_HOST_HEADER`, and `DEFAULT_PROXY` as lowercase string values (`"true"`/`"false"`) instead of raw `bool`.
> 
> Adds a regression test asserting all configurator-provided environment variable values are strings in publish mode, and includes a patch changeset for `@scalar/aspire`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc9f0a099c7be3c42877026c9d325f4f63ff7b23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->