### PR TITLE
feat(workspace-store): order schema example properties by x-order

### DIFF
--- a/.changeset/workspace-store-x-order-examples.md
+++ b/.changeset/workspace-store-x-order-examples.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+feat: respect the `x-order` extension when building schema examples

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
@@ -1973,4 +1973,46 @@ describe('getExampleFromSchema', () => {
       expect((secondCall as any).user).toBe((thirdCall as any).user)
     })
   })
+
+  describe('x-order', () => {
+    it('orders properties by their x-order value', () => {
+      const schema = coerceValue(SchemaObjectSchema, {
+        type: 'object',
+        properties: {
+          name: { type: 'string', 'x-order': 1 },
+          description: { type: 'string', 'x-order': 3 },
+          diameter: { type: 'number', 'x-order': 2 },
+        },
+      })
+
+      expect(Object.keys(getExampleFromSchema(schema) as object)).toEqual(['name', 'diameter', 'description'])
+    })
+
+    it('places properties with x-order before those without, keeping insertion order for the rest', () => {
+      const schema = coerceValue(SchemaObjectSchema, {
+        type: 'object',
+        properties: {
+          alpha: { type: 'string' },
+          beta: { type: 'string', 'x-order': 2 },
+          gamma: { type: 'string' },
+          delta: { type: 'string', 'x-order': 1 },
+        },
+      })
+
+      expect(Object.keys(getExampleFromSchema(schema) as object)).toEqual(['delta', 'beta', 'alpha', 'gamma'])
+    })
+
+    it('sorts x-order numerically, not lexically', () => {
+      const schema = coerceValue(SchemaObjectSchema, {
+        type: 'object',
+        properties: {
+          a: { type: 'string', 'x-order': 10 },
+          b: { type: 'string', 'x-order': 2 },
+          c: { type: 'string', 'x-order': 1 },
+        },
+      })
+
+      expect(Object.keys(getExampleFromSchema(schema) as object)).toEqual(['c', 'b', 'a'])
+    })
+  })
 })

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
@@ -362,6 +362,40 @@ const getCompositionSelectionIndex = (
 }
 
 /**
+ * Read the numeric `x-order` extension value from a raw property entry, if present.
+ * The entry may be a schema or a `$ref` object, so we check membership before reading.
+ */
+const getXOrder = (property: unknown): number | undefined => {
+  if (property && typeof property === 'object' && 'x-order' in property) {
+    const order = Number((property as Record<string, unknown>)['x-order'])
+    return Number.isNaN(order) ? undefined : order
+  }
+  return undefined
+}
+
+/**
+ * Sort property names by the `x-order` extension.
+ * Properties with `x-order` come first, ascending by value; the rest keep their
+ * original insertion order thanks to a stable sort.
+ */
+const sortPropertyNamesByXOrder = (properties: Record<string, unknown>): string[] =>
+  Object.keys(properties).sort((a, b) => {
+    const aOrder = getXOrder(properties[a])
+    const bOrder = getXOrder(properties[b])
+
+    if (aOrder !== undefined && bOrder !== undefined) {
+      return aOrder - bOrder
+    }
+    if (aOrder !== undefined) {
+      return -1
+    }
+    if (bOrder !== undefined) {
+      return 1
+    }
+    return 0
+  })
+
+/**
  * Build an example for an object schema, including properties, patternProperties,
  * additionalProperties, and composition (allOf/oneOf/anyOf) merging.
  */
@@ -376,12 +410,13 @@ const handleObjectSchema = (
   const response: Record<string, unknown> = {}
 
   if ('properties' in schema && schema.properties) {
-    const propertyNames = Object.keys(schema.properties)
+    const properties = schema.properties
+    const propertyNames = sortPropertyNamesByXOrder(properties)
     const limit = propertyNames.length
 
     for (let i = 0; i < limit; i++) {
       const propertyName = propertyNames[i]!
-      const propertySchema = resolve.schema(schema.properties[propertyName])
+      const propertySchema = resolve.schema(properties[propertyName])
       if (!propertySchema) {
         continue
       }

--- a/packages/workspace-store/src/schemas/extensions/schema/x-order.ts
+++ b/packages/workspace-store/src/schemas/extensions/schema/x-order.ts
@@ -1,0 +1,32 @@
+import { Type } from '@scalar/typebox'
+import { number, object, optional } from '@scalar/validation'
+
+/**
+ * x-order
+ *
+ * Controls the display order of schema properties. Properties with `x-order` are
+ * sorted by their numeric value (ascending) and shown before properties without it.
+ */
+export const XOrderSchema = Type.Object({
+  'x-order': Type.Optional(Type.Number()),
+})
+
+export type XOrder = {
+  /**
+   * x-order
+   *
+   * Controls the display order of schema properties. Properties with `x-order` are
+   * sorted by their numeric value (ascending) and shown before properties without it.
+   */
+  'x-order'?: number
+}
+
+export const XOrder = object(
+  {
+    'x-order': optional(number()),
+  },
+  {
+    typeName: 'XOrder',
+    typeComment: 'Display order for a schema property',
+  },
+)

--- a/packages/workspace-store/src/schemas/v3.1/openapi/index.ts
+++ b/packages/workspace-store/src/schemas/v3.1/openapi/index.ts
@@ -43,6 +43,7 @@ import { XAdditionalPropertiesName } from '@/schemas/extensions/schema/x-additio
 import { XEnumDescriptions } from '@/schemas/extensions/schema/x-enum-descriptions'
 import { XEnumVarNames } from '@/schemas/extensions/schema/x-enum-varnames'
 import { XExamples } from '@/schemas/extensions/schema/x-examples'
+import { XOrder } from '@/schemas/extensions/schema/x-order'
 import { XVariable } from '@/schemas/extensions/schema/x-variable'
 import { XDefaultScopes } from '@/schemas/extensions/security/x-default-scopes'
 import { XScalarCredentialsLocation } from '@/schemas/extensions/security/x-scalar-credentials-location'
@@ -250,6 +251,7 @@ export const generateSchema = (maybeRef: (inner: Schema) => Schema) => {
     XEnumDescriptions,
     XEnumVarNames,
     XAdditionalPropertiesName,
+    XOrder,
     XTags,
   ] as const
 

--- a/packages/workspace-store/src/schemas/v3.1/strict/schema.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/schema.ts
@@ -11,6 +11,7 @@ import {
 import { type XEnumDescriptions, XEnumDescriptionsSchema } from '@/schemas/extensions/schema/x-enum-descriptions'
 import { type XEnumVarNames, XEnumVarNamesSchema } from '@/schemas/extensions/schema/x-enum-varnames'
 import { type XExamples, XExamplesSchema } from '@/schemas/extensions/schema/x-examples'
+import { type XOrder, XOrderSchema } from '@/schemas/extensions/schema/x-order'
 import { type XVariable, XVariableSchema } from '@/schemas/extensions/schema/x-variable'
 import type { ExternalDocumentationObject } from '@/schemas/v3.1/strict/external-documentation'
 import type { XMLObject } from '@/schemas/v3.1/strict/xml'
@@ -75,6 +76,7 @@ const Extensions = compose(
   XEnumDescriptionsSchema,
   XEnumVarNamesSchema,
   XAdditionalPropertiesNameSchema,
+  XOrderSchema,
   XTagsSchema,
 )
 
@@ -85,6 +87,7 @@ type Extensions = XScalarIgnore &
   XEnumVarNames &
   XExamples &
   XAdditionalPropertiesName &
+  XOrder &
   XTags
 
 const CorePropertiesWithSchema = Type.Object({


### PR DESCRIPTION
`getExampleFromSchema` ignored the `x-order` extension, so generated examples could list keys in a different order than the docs show. Now it sorts object properties by `x-order` (ascending; the rest keep insertion order), matching the API reference display.

Also adds a typed `x-order` schema extension alongside the existing ones.

```yaml
openapi: 3.1.0
info:
  title: x-order test
  version: 1.0.0
paths:
  /planets:
    post:
      summary: Create a planet
      requestBody:
        content:
          application/json:
            schema:
              type: object
              properties:
                description:
                  type: string
                  x-order: 3
                diameter:
                  type: number
                  x-order: 2
                name:
                  type: string
                  x-order: 1
                discovered:
                  type: boolean
      responses:
        '200':
          description: OK
```

<img width="539" height="288" alt="Screenshot 2026-05-22 at 22 17 50" src="https://github.com/user-attachments/assets/a9e8c053-14fb-4f50-a421-b4c06dcce4fc" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect the ordering of keys in generated schema examples and extend schema typing/validation for a new optional extension field.
> 
> **Overview**
> Generated object examples from `getExampleFromSchema` now **respect the `x-order` extension** when iterating schema `properties`, ordering `x-order`-annotated keys first (ascending numeric) while leaving the remaining keys in insertion order.
> 
> This PR also **adds a typed/validated `x-order` schema extension** and wires it into both the OpenAPI 3.1 schema generator and strict schema composition, with new tests covering ordering behavior (including numeric vs lexical sorting) and a changeset bump for `@scalar/workspace-store`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb8876f096f28d4617ee75bf02a7c38928e059b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->