### PR TITLE
feat(analytics): add save and sync analytics events

### DIFF
--- a/.changeset/add-sync-save-analytics.md
+++ b/.changeset/add-sync-save-analytics.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-client': patch
+---
+
+Add analytics events for document save and registry sync (pull/push) actions

--- a/packages/api-client/src/plugins/posthog/sanitize-event-payload.test.ts
+++ b/packages/api-client/src/plugins/posthog/sanitize-event-payload.test.ts
@@ -27,6 +27,9 @@ describe('sanitizeEventPayload', () => {
     expect(sanitize('log:login-click', {})).toEqual({})
     expect(sanitize('log:user-login', { uid: '123', email: 'test@example.com', teamUid: 't1' })).toEqual({})
     expect(sanitize('log:user-logout', undefined)).toEqual({})
+    expect(sanitize('log:save-document', undefined)).toEqual({})
+    expect(sanitize('log:sync-pull-document', undefined)).toEqual({})
+    expect(sanitize('log:sync-push-document', undefined)).toEqual({})
     expect(sanitize('hooks:on:request:sent', {})).toEqual({})
   })
 
@@ -199,6 +202,9 @@ describe('TRACKED_EVENTS', () => {
     'log:register-click',
     'log:user-login',
     'log:user-logout',
+    'log:save-document',
+    'log:sync-pull-document',
+    'log:sync-push-document',
   ]
 
   it('has an extractor function for every tracked event', () => {

--- a/packages/api-client/src/plugins/posthog/sanitize-event-payload.ts
+++ b/packages/api-client/src/plugins/posthog/sanitize-event-payload.ts
@@ -121,6 +121,11 @@ export const TRACKED_EVENTS: TrackedEventsMap = {
   'log:user-login': empty,
   'log:user-logout': empty,
 
+  // Document sync and save events
+  'log:save-document': empty,
+  'log:sync-pull-document': empty,
+  'log:sync-push-document': empty,
+
   // ---------------------------------------------------------------------------
   // Do not track — explicitly opted out so new events cause a type error
   // until they are consciously placed above with a payload

--- a/packages/workspace-store/src/events/definitions/log.ts
+++ b/packages/workspace-store/src/events/definitions/log.ts
@@ -14,4 +14,10 @@ export type LogEvents = {
   }
   /** Fired when the current user logs out */
   'log:user-logout': undefined
+  /** Fired when the user saves a document locally */
+  'log:save-document': undefined
+  /** Fired when the user initiates a pull from the registry */
+  'log:sync-pull-document': undefined
+  /** Fired when the user successfully pushes a document to the registry */
+  'log:sync-push-document': undefined
 }

--- a/projects/scalar-app/src/features/app/hooks/use-document-sync.ts
+++ b/projects/scalar-app/src/features/app/hooks/use-document-sync.ts
@@ -241,6 +241,7 @@ export const useDocumentSync = ({
       return
     }
     await app.store.value.saveDocument(slug)
+    app.eventBus.emit('log:save-document', undefined)
   }
 
   const handleRevertDocument = async (): Promise<void> => {
@@ -323,6 +324,8 @@ export const useDocumentSync = ({
     if (!meta || !slug || !registry || !store) {
       return
     }
+
+    app.eventBus.emit('log:sync-pull-document', undefined)
 
     const fetched = await registry.fetchDocument({
       namespace: meta.namespace,
@@ -545,6 +548,8 @@ export const useDocumentSync = ({
     })
 
     await store.saveDocument(slug)
+
+    app.eventBus.emit('log:sync-push-document', undefined)
 
     // Ask the host to refetch its registry listing so the cached
     // registry commit hash catches up with the one we just wrote

--- a/projects/scalar-app/src/features/app/hooks/use-document-sync.ts
+++ b/projects/scalar-app/src/features/app/hooks/use-document-sync.ts
@@ -325,8 +325,6 @@ export const useDocumentSync = ({
       return
     }
 
-    app.eventBus.emit('log:sync-pull-document', undefined)
-
     const fetched = await registry.fetchDocument({
       namespace: meta.namespace,
       slug: meta.slug,
@@ -366,6 +364,7 @@ export const useDocumentSync = ({
         app.eventBus.emit('hooks:on:rebase:document:complete', {
           meta: { documentName: slug },
         })
+        app.eventBus.emit('log:sync-pull-document', undefined)
         toast('Already up to date with the registry.', 'info')
         return
       }
@@ -410,6 +409,7 @@ export const useDocumentSync = ({
     app.eventBus.emit('hooks:on:rebase:document:complete', {
       meta: { documentName: slug },
     })
+    app.eventBus.emit('log:sync-pull-document', undefined)
 
     toast('Pulled latest changes from the registry.', 'info')
   }
@@ -445,6 +445,7 @@ export const useDocumentSync = ({
     app.eventBus.emit('hooks:on:rebase:document:complete', {
       meta: { documentName: pending.slug },
     })
+    app.eventBus.emit('log:sync-pull-document', undefined)
     pendingPullState.value = null
 
     toast('Pulled latest changes from the registry.', 'info')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds three new `log:` analytics events to track document save and registry sync activity, giving the team visibility into how many users are saving and syncing.

### New events

| Event | When it fires |
|-------|--------------|
| `log:save-document` | When a user saves a local document (via the Save button or Cmd/Ctrl+S) |
| `log:sync-pull-document` | When a user initiates a pull from the registry |
| `log:sync-push-document` | When a user successfully pushes a document to the registry |

### Changes

- **`packages/workspace-store/src/events/definitions/log.ts`** — declares the three new `LogEvents` entries
- **`packages/api-client/src/plugins/posthog/sanitize-event-payload.ts`** — adds them to the `TRACKED_EVENTS` allowlist with `empty` extractors (event fact only, no payload)
- **`projects/scalar-app/src/features/app/hooks/use-document-sync.ts`** — emits the events from `handleSaveDocument`, `handlePullDocument`, and `handlePushDocument`
- **`packages/api-client/src/plugins/posthog/sanitize-event-payload.test.ts`** — covers the new events in the existing test suite

### Why these events, why now

The existing `ui:save:local-document` event only fires from the keyboard shortcut handler — clicking the Save button in the header calls `handleSaveDocument` directly without emitting. Similarly, `hooks:on:rebase:document:complete` covers pull completion but there is no event for push. These gaps mean PostHog has no way to answer "how many people are saving?" or "how many people are pushing?".

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07RNPTKCB1/p1779482972517419?thread_ts=1779482972.517419&cid=C07RNPTKCB1)

<div><a href="https://cursor.com/agents/bc-315fcd17-305d-5131-a583-e8297ae80f00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-315fcd17-305d-5131-a583-e8297ae80f00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

