### PR TITLE
ci: fix required-jobs-pull-requests hanging on chore: release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,16 @@ name: CI
 
 # This workflow runs on:
 # 1. Push events to the main branch
-# 2. Pull request events
+# 2. Push events to changeset-release/main (the release PR branch created by
+#    changesets/action). Because changesets uses GITHUB_TOKEN to create/update
+#    the release PR, GitHub suppresses the pull_request event and the CI never
+#    runs unless we also listen for pushes to this branch directly.
+# 3. Pull request events
 on:
   push:
     branches:
       - main
+      - changeset-release/main
   pull_request:
   workflow_dispatch: null
 # Workflow-level default: read-only. Individual jobs widen as needed.
@@ -14,7 +19,7 @@ permissions:
   contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-base-ci
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/changeset-release/main' }}
 env:
   # Exclude these packages from turbo as they are handled by dedicated jobs
   TURBO_FLAGS: '--concurrency=100% --filter "!./integrations/{java,rust,dotnet,docker,fastapi,django-ninja}/**" --filter "!./projects/proxy-scalar-com/**"'
@@ -188,7 +193,7 @@ jobs:
           echo "scalar_app_package_changed=${{ steps.changed-packages-files.outputs.scalar_app_package_any_changed }}" >> $GITHUB_OUTPUT
 
   format:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/changeset-release/main')
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
     steps:
@@ -245,7 +250,7 @@ jobs:
         run: pnpm turbo ${{ env.TURBO_FLAGS }} types:check
 
   knip:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/changeset-release/main')
     needs: [build]
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
@@ -1865,7 +1870,7 @@ jobs:
   # Other jobs
 
   required-jobs-pull-requests:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/changeset-release/main')
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 1
     permissions: {}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `required-jobs-pull-requests` check is always stuck as **"Waiting for status to be reported"** on `chore: release` PRs, blocking them from being merged.

### Root cause

The `chore: release` PR is created and updated by `changesets/action` using `GITHUB_TOKEN`. GitHub deliberately suppresses `pull_request` events triggered by `GITHUB_TOKEN` to prevent recursive workflow loops. Because no `pull_request` event fires, the CI workflow **never runs** for the release PR, and `required-jobs-pull-requests` is never reported.

## Fix

Add `changeset-release/main` to the CI workflow's `push` trigger. When the changesets bot pushes a commit to `changeset-release/main`, the CI workflow now runs as a `push` event. GitHub surfaces push-triggered status checks on any open PR whose head branch received that push, so `required-jobs-pull-requests` is reported and branch protection is satisfied — with the tests actually running.

Four targeted changes in `.github/workflows/ci.yml`:

| Change | Why |
|--------|-----|
| Add `changeset-release/main` to push trigger | Make CI run when changesets bot pushes to the release branch |
| `format` condition: also run on push to `changeset-release/main` | `format` is in `required-jobs-pull-requests.needs`; if skipped it causes the gate to fail |
| `knip` condition: same | Same reason as `format` |
| `required-jobs-pull-requests` condition: also run on push to `changeset-release/main` | The gate job itself needs to run to report a status |
| `cancel-in-progress`: also cancel on push to `changeset-release/main` | Cancel stale runs when the bot pushes an updated release commit, matching existing PR behaviour |

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07SWER07G9/p1779489394879809?thread_ts=1779489394.879809&cid=C07SWER07G9)

<div><a href="https://cursor.com/agents/bc-bd8fa88c-20b2-5857-8d51-714f10019427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd8fa88c-20b2-5857-8d51-714f10019427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

