### PR TITLE
perf(pre-post-request-scripts): warm up script sandbox on mount

### DIFF
--- a/.changeset/warm-sandbox-on-mount.md
+++ b/.changeset/warm-sandbox-on-mount.md
@@ -1,0 +1,7 @@
+---
+'@scalar/pre-post-request-scripts': patch
+'@scalar/oas-utils': patch
+'@scalar/api-client': patch
+---
+
+perf: warm up the request scripts sandbox on mount when scripts are present, so the first request no longer pays the sandbox cold-start cost

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -364,6 +364,10 @@ onMounted(() => {
   eventBus.on('operation:send:request:hotkey', handleExecute)
   eventBus.on('operation:cancel:request', cancelRequest)
   eventBus.on('copy-url:address-bar', copyAddressBarUrl)
+
+  // Let plugins warm up per-operation resources (e.g. the scripts sandbox) so the first request
+  // does not pay their cold-start cost.
+  void executeHook({ document, operation }, 'onRequestMount', plugins)
 })
 onBeforeUnmount(() => {
   eventBus.off('operation:send:request:hotkey', handleExecute)

--- a/packages/oas-utils/src/helpers/client-plugins.ts
+++ b/packages/oas-utils/src/helpers/client-plugins.ts
@@ -29,6 +29,13 @@ export type ResponseBodyHandler = ResponseBodyHandlerBase &
 
 /** A type representing the hooks that a client plugin can define */
 type ClientPluginHooks = {
+  /**
+   * Runs when an operation view mounts, before any request is sent. Useful for warming up
+   * resources that would otherwise add latency to the first request (for example, lazily
+   * created sandboxes). Receives the current document and operation so plugins can decide
+   * whether the work is needed at all.
+   */
+  onRequestMount: (payload: { document: OpenApiDocument; operation: OperationObject }) => void | Promise<void>
   beforeRequest: (payload: {
     /** Workspace-store request spec; mutable by pre-request scripts (headers, method). */
     requestBuilder: RequestFactory

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/index.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/index.ts
@@ -1,2 +1,3 @@
 export { type TestResult, executePostResponseScript } from './execute-post-response-script'
 export { executePreRequestScript } from './execute-pre-request-script'
+export { prewarmSandboxFrame } from './postman-adapter/sandbox-adapter'

--- a/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.ts
+++ b/packages/pre-post-request-scripts/src/libs/execute-scripts/postman-adapter/sandbox-adapter.ts
@@ -283,6 +283,27 @@ export const setSandboxTransport = (next: SandboxTransport): void => {
   transport = next
 }
 
+/**
+ * Eagerly creates the sandbox iframe so the first script execution does not pay the cold-start
+ * cost of loading `sandbox.html` and the `postman-sandbox` bundle (noticeably slow on Electron).
+ *
+ * This is a best-effort optimization: it only runs in a DOM context, reuses the same module-cached
+ * frame {@link executeInPostmanSandbox} later awaits, and swallows failures so a warm-up problem can
+ * never surface to the caller — the real execution path retries and reports errors on its own.
+ *
+ * Call this only when scripts are actually present; warming the sandbox for a request without
+ * scripts would defeat the lazy creation that keeps script-free requests cheap.
+ */
+export const prewarmSandboxFrame = (): void => {
+  if (typeof document === 'undefined') {
+    return
+  }
+
+  ensureSandboxFrame().catch(() => {
+    // Ignored on purpose: warm-up is opportunistic and the execution path handles real errors.
+  })
+}
+
 let nextExecutionId = 0
 
 export const executeInPostmanSandbox = async ({

--- a/packages/pre-post-request-scripts/src/plugins/request-scripts/request-scripts-plugin.test.ts
+++ b/packages/pre-post-request-scripts/src/plugins/request-scripts/request-scripts-plugin.test.ts
@@ -1,12 +1,19 @@
 import type { RequestFactory, VariableEntry, VariablesStore } from '@scalar/workspace-store/request-example'
-import { beforeAll, describe, expect, it } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Ref } from 'vue'
 
-import type { TestResult } from '@/libs/execute-scripts'
+import { type TestResult, prewarmSandboxFrame } from '@/libs/execute-scripts'
 import { executePostResponseScript } from '@/libs/execute-scripts/execute-post-response-script'
 import { executePreRequestScript } from '@/libs/execute-scripts/execute-pre-request-script'
 import { registerInProcessSandbox } from '@/libs/execute-scripts/postman-adapter/in-process-transport'
 import { requestScriptsPlugin } from '@/plugins/request-scripts/request-scripts-plugin'
+
+// Keep the real execute functions; only stub the warm-up so we can assert the mount hook's
+// decision without creating a real sandbox iframe.
+vi.mock('@/libs/execute-scripts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/libs/execute-scripts')>()
+  return { ...actual, prewarmSandboxFrame: vi.fn() }
+})
 
 beforeAll(() => {
   registerInProcessSandbox()
@@ -74,6 +81,42 @@ const createVariablesStore = (): VariablesStore => {
 }
 
 describe('request-scripts-plugin', () => {
+  describe('onRequestMount', () => {
+    beforeEach(() => {
+      vi.mocked(prewarmSandboxFrame).mockClear()
+    })
+
+    it('warms up the sandbox when the operation defines scripts', () => {
+      const plugin = requestScriptsPlugin()
+
+      plugin.hooks?.onRequestMount?.({
+        document: {},
+        operation: { 'x-post-response': 'pm.test("noop", () => pm.expect(true).to.be.true)' },
+      } as never)
+
+      expect(prewarmSandboxFrame).toHaveBeenCalledTimes(1)
+    })
+
+    it('warms up the sandbox when only the document defines scripts', () => {
+      const plugin = requestScriptsPlugin()
+
+      plugin.hooks?.onRequestMount?.({
+        document: { 'x-pre-request': 'pm.environment.set("ready", "yes")' },
+        operation: {},
+      } as never)
+
+      expect(prewarmSandboxFrame).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not warm up the sandbox when there are no scripts', () => {
+      const plugin = requestScriptsPlugin()
+
+      plugin.hooks?.onRequestMount?.({ document: {}, operation: {} } as never)
+
+      expect(prewarmSandboxFrame).not.toHaveBeenCalled()
+    })
+  })
+
   it('persists pm.globals between pre-request and post-response scripts', async () => {
     const variablesStore = createVariablesStore()
     const requestBuilder = createRequestBuilder()

--- a/packages/pre-post-request-scripts/src/plugins/request-scripts/request-scripts-plugin.ts
+++ b/packages/pre-post-request-scripts/src/plugins/request-scripts/request-scripts-plugin.ts
@@ -2,7 +2,12 @@ import type { ClientPlugin } from '@scalar/oas-utils/helpers'
 import { ref } from 'vue'
 
 import { getScript } from '@/helpers/get-script'
-import { type TestResult, executePostResponseScript, executePreRequestScript } from '@/libs/execute-scripts'
+import {
+  type TestResult,
+  executePostResponseScript,
+  executePreRequestScript,
+  prewarmSandboxFrame,
+} from '@/libs/execute-scripts'
 import { TestResults } from '@/plugins/request-scripts/components/TestResults'
 
 import ScriptsSection from './components/ScriptsSection.vue'
@@ -32,6 +37,21 @@ export const requestScriptsPlugin = (): ClientPlugin => {
     },
 
     hooks: {
+      onRequestMount: ({ document, operation }) => {
+        // Only warm up the sandbox when this operation actually has scripts. Requests without
+        // scripts never touch the sandbox, so creating the iframe for them would waste work.
+        const script = getScript(
+          document['x-pre-request'],
+          operation['x-pre-request'],
+          document['x-post-response'],
+          operation['x-post-response'],
+        )
+
+        if (script) {
+          prewarmSandboxFrame()
+        }
+      },
+
       beforeRequest: async ({ requestBuilder, document, operation, variablesStore }) => {
         // Reset test results when a new request is sent
         results.value = []


### PR DESCRIPTION
This is a little perf boost, I noticed the first request when you have scripts on prod electron was a bit slow, this pre-warms the sandbox a bit so you don't get that bit of lag.

## Summary

Follow-up to #9332. After fixing script execution on Electron, the **first** request after opening the app was noticeably slow whenever scripts were involved, because the sandbox iframe (`sandbox.html` + the `postman-sandbox` bundle) is created lazily on the first execution.

This PR warms up the sandbox on mount, but **only when the operation actually has scripts** — script-free requests still skip the sandbox entirely (the existing `if (!script) return` guards are unchanged).

- Add `prewarmSandboxFrame()` to the sandbox adapter — best-effort, DOM-guarded, reuses the same module-cached frame the executor later awaits, and swallows errors so warm-up can never surface to the caller.
- Add an optional `onRequestMount({ document, operation })` plugin hook.
- `OperationBlock.vue` fires `onRequestMount` in `onMounted`.
- The request scripts plugin implements the hook: it detects `x-pre-request` / `x-post-response` on the document or operation via `getScript`, and only prewarms when a script is present.

Because the warmed iframe is a module-level singleton, navigating to any script-bearing operation warms it for the rest of the session.

## Test plan

- [x] `pnpm vitest packages/pre-post-request-scripts --run` (54 passed) — includes new tests for the `onRequestMount` decision logic
- [x] `pnpm vitest packages/api-client` operation-block suite (152 passed)
- [x] `pnpm vitest packages/oas-utils` client-plugins suite (6 passed)
- [x] `types:check` clean for `pre-post-request-scripts`, `oas-utils`, `api-client`
- [x] biome + prettier clean
- [ ] Manual: open the Electron app, confirm the first request with a script is no longer slow

## Ticket

See #9332


---
_Generated by [Claude Code](https://claude.ai/code/session_01LXWdXPKzqkSmSGebhSoFRK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new client-plugin hook invoked on operation mount and eagerly creates the scripts sandbox iframe; while guarded/best-effort, it changes operation lifecycle behavior and could affect performance or error surfaces in DOM/Electron environments.
> 
> **Overview**
> Reduces first-request latency for script-enabled operations by introducing a new client-plugin hook, `onRequestMount`, that runs when an operation view mounts.
> 
> `OperationBlock` now executes this hook on mount, and the request-scripts plugin uses it to detect `x-pre-request`/`x-post-response` and opportunistically prewarm the Postman sandbox via a new `prewarmSandboxFrame()` helper (DOM-guarded and failure-swallowing). Tests were added to ensure warm-up only occurs when scripts are present, and a changeset bumps `@scalar/pre-post-request-scripts`, `@scalar/oas-utils`, and `@scalar/api-client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0347d2ad3c1cad45500f7771658aa3cf4bdb28a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->