### PR TITLE
feat(api-client): add WebSocket session transport and plugin hooks for AsyncAPI

### DIFF
--- a/.changeset/websocket-transport-api-client.md
+++ b/.changeset/websocket-transport-api-client.md
@@ -1,0 +1,8 @@
+---
+'@scalar/api-client': minor
+'@scalar/oas-utils': minor
+---
+
+feat: add WebSocket session transport and plugin hooks for AsyncAPI
+
+Add WebSocketSession with connect, send, and close helpers, plus connectWebSocket orchestration using Result-based errors. Extend ClientPlugin with optional webSocketHooks (beforeConnect, onWebSocketMessage, onWebSocketClose).

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -79,6 +79,7 @@
         "src/v2/workspace-events.ts",
         "src/v2/helpers/test-utils.ts",
         "src/v2/blocks/operation-block/index.ts",
+        "src/v2/blocks/channel-operation-block/index.ts",
         "src/v2/blocks/operation-code-sample/index.ts",
         "src/v2/blocks/request-block/index.ts",
         "src/v2/blocks/response-block/index.ts",

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/connect-websocket.test.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/connect-websocket.test.ts
@@ -290,4 +290,50 @@ describe('connectWebSocket', () => {
 
     expect(mock.constructorCalls[0]).toEqual({ url: 'wss://example.com', protocols: ['graphql-ws'] })
   })
+
+  it('returns failure when the session is destroyed while connecting', async () => {
+    const mock = createMockWebSocket()
+    const session = createWebSocketSession()
+
+    const promise = connectWebSocket({
+      connectionUrl: 'wss://example.com',
+      session,
+      customWebSocket: mock.MockWS,
+    })
+
+    await mock.waitForInstance()
+    session.destroy()
+
+    const result = await promise
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBe(WEBSOCKET_CONNECTION_FAILED)
+    }
+  })
+
+  it('returns failure when session.connect replaces an in-flight connection', async () => {
+    const mock = createMockWebSocket()
+    const session = createWebSocketSession()
+
+    const promise = connectWebSocket({
+      connectionUrl: 'wss://example.com',
+      session,
+      customWebSocket: mock.MockWS,
+    })
+
+    await mock.waitForInstance()
+
+    session.connect({
+      url: 'wss://example.com/other',
+      customWebSocket: mock.MockWS,
+    })
+
+    const result = await promise
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBe(WEBSOCKET_CONNECTION_FAILED)
+    }
+  })
 })

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/connect-websocket.test.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/connect-websocket.test.ts
@@ -202,6 +202,29 @@ describe('connectWebSocket', () => {
     )
   })
 
+  it('keeps session open after connect resolves when a later socket error fires', async () => {
+    const mock = createMockWebSocket()
+    const session = createWebSocketSession()
+    const onError = vi.fn()
+
+    const promise = connectWebSocket({
+      connectionUrl: 'wss://example.com',
+      session,
+      customWebSocket: mock.MockWS,
+      callbacks: { onError },
+    })
+
+    const ws = await mock.waitForInstance()
+    ws.onopen?.(new Event('open'))
+    const result = await promise
+
+    expect(result.ok).toBe(true)
+    ws.onerror?.(new Event('error'))
+
+    expect(session.state).toBe('open')
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+
   it('calls user callbacks alongside plugin hooks', async () => {
     const mock = createMockWebSocket()
     const session = createWebSocketSession()

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/connect-websocket.test.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/connect-websocket.test.ts
@@ -1,0 +1,293 @@
+import type { ClientPlugin } from '@scalar/oas-utils/helpers'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { WEBSOCKET_CONNECTION_FAILED, WEBSOCKET_CONNECTION_FAILED_MESSAGE, connectWebSocket } from './connect-websocket'
+import { createWebSocketSession } from './websocket-session'
+
+type MockSocketInstance = {
+  binaryType: string
+  onopen: ((ev: Event) => void) | null
+  onmessage: ((ev: MessageEvent) => void) | null
+  onerror: ((ev: Event) => void) | null
+  onclose: ((ev: CloseEvent) => void) | null
+  send: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+}
+
+const createMockWebSocket = () => {
+  let instance: MockSocketInstance | null = null
+  const constructorCalls: Array<{ url: string; protocols?: string | string[] }> = []
+  let onInstanceCreated: (() => void) | null = null
+
+  function MockWS(this: MockSocketInstance, url: string, protocols?: string | string[]) {
+    constructorCalls.push({ url, protocols })
+    this.binaryType = 'blob'
+    this.onopen = null
+    this.onmessage = null
+    this.onerror = null
+    this.onclose = null
+    this.send = vi.fn()
+    this.close = vi.fn()
+    instance = this
+    onInstanceCreated?.()
+  }
+
+  const waitForInstance = (): Promise<MockSocketInstance> =>
+    new Promise((resolve) => {
+      if (instance) {
+        resolve(instance)
+        return
+      }
+      onInstanceCreated = () => {
+        resolve(instance!)
+        onInstanceCreated = null
+      }
+    })
+
+  return {
+    MockWS: MockWS as unknown as typeof WebSocket,
+    get instance() {
+      return instance
+    },
+    get constructorCalls() {
+      return constructorCalls
+    },
+    waitForInstance,
+    reset: () => {
+      instance = null
+      constructorCalls.length = 0
+      onInstanceCreated = null
+    },
+  }
+}
+
+describe('connectWebSocket', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('resolves with session on successful connection', async () => {
+    const mock = createMockWebSocket()
+    const session = createWebSocketSession()
+
+    const promise = connectWebSocket({
+      connectionUrl: 'wss://example.com',
+      session,
+      customWebSocket: mock.MockWS,
+    })
+
+    const ws = await mock.waitForInstance()
+    ws.onopen?.(new Event('open'))
+
+    const result = await promise
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.session).toBe(session)
+    }
+    expect(session.state).toBe('open')
+  })
+
+  it('returns failure when connection fails before opening', async () => {
+    const mock = createMockWebSocket()
+    const session = createWebSocketSession()
+
+    const promise = connectWebSocket({
+      connectionUrl: 'wss://example.com',
+      session,
+      customWebSocket: mock.MockWS,
+    })
+
+    const ws = await mock.waitForInstance()
+    ws.onerror?.(new Event('error'))
+    ws.onclose?.(new CloseEvent('close', { code: 1006, reason: '', wasClean: false }))
+
+    const result = await promise
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBe(WEBSOCKET_CONNECTION_FAILED)
+      expect(result.message).toBe(WEBSOCKET_CONNECTION_FAILED_MESSAGE)
+    }
+  })
+
+  it('invokes beforeConnect plugin hook and uses modified URL', async () => {
+    const mock = createMockWebSocket()
+    const session = createWebSocketSession()
+
+    const plugin: ClientPlugin = {
+      webSocketHooks: {
+        beforeConnect: async ({ url }) => `${url}?token=abc`,
+      },
+    }
+
+    const promise = connectWebSocket({
+      connectionUrl: 'wss://example.com',
+      session,
+      plugins: [plugin],
+      customWebSocket: mock.MockWS,
+    })
+
+    const ws = await mock.waitForInstance()
+    ws.onopen?.(new Event('open'))
+    const result = await promise
+
+    expect(result.ok).toBe(true)
+    expect(mock.constructorCalls[0]!.url).toBe('wss://example.com?token=abc')
+  })
+
+  it('invokes onWebSocketMessage plugin hook for incoming frames', async () => {
+    const mock = createMockWebSocket()
+    const session = createWebSocketSession()
+    const messageHook = vi.fn()
+
+    const plugin: ClientPlugin = {
+      webSocketHooks: {
+        onWebSocketMessage: messageHook,
+      },
+    }
+
+    const promise = connectWebSocket({
+      connectionUrl: 'wss://example.com',
+      session,
+      plugins: [plugin],
+      customWebSocket: mock.MockWS,
+    })
+
+    const ws = await mock.waitForInstance()
+    ws.onopen?.(new Event('open'))
+    await promise
+
+    ws.onmessage?.(new MessageEvent('message', { data: '{"msg":"hi"}' }))
+
+    expect(messageHook).toHaveBeenCalledTimes(1)
+    expect(messageHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        frame: expect.objectContaining({
+          direction: 'incoming',
+          data: '{"msg":"hi"}',
+        }),
+      }),
+    )
+  })
+
+  it('invokes onWebSocketClose plugin hook when connection closes', async () => {
+    const mock = createMockWebSocket()
+    const session = createWebSocketSession()
+    const closeHook = vi.fn()
+
+    const plugin: ClientPlugin = {
+      webSocketHooks: {
+        onWebSocketClose: closeHook,
+      },
+    }
+
+    const promise = connectWebSocket({
+      connectionUrl: 'wss://example.com',
+      session,
+      plugins: [plugin],
+      customWebSocket: mock.MockWS,
+    })
+
+    const ws = await mock.waitForInstance()
+    ws.onopen?.(new Event('open'))
+    await promise
+
+    ws.onclose?.(new CloseEvent('close', { code: 1000, reason: 'done', wasClean: true }))
+
+    expect(closeHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        info: { code: 1000, reason: 'done', wasClean: true },
+      }),
+    )
+  })
+
+  it('calls user callbacks alongside plugin hooks', async () => {
+    const mock = createMockWebSocket()
+    const session = createWebSocketSession()
+    const onFrame = vi.fn()
+    const onOpen = vi.fn()
+
+    const promise = connectWebSocket({
+      connectionUrl: 'wss://example.com',
+      session,
+      customWebSocket: mock.MockWS,
+      callbacks: { onFrame, onOpen },
+    })
+
+    const ws = await mock.waitForInstance()
+    ws.onopen?.(new Event('open'))
+    await promise
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+
+    ws.onmessage?.(new MessageEvent('message', { data: 'test' }))
+    expect(onFrame).toHaveBeenCalledTimes(1)
+  })
+
+  it('chains multiple beforeConnect hooks', async () => {
+    const mock = createMockWebSocket()
+    const session = createWebSocketSession()
+
+    const plugin1: ClientPlugin = {
+      webSocketHooks: {
+        beforeConnect: async ({ url }) => `${url}?a=1`,
+      },
+    }
+    const plugin2: ClientPlugin = {
+      webSocketHooks: {
+        beforeConnect: async ({ url }) => `${url}&b=2`,
+      },
+    }
+
+    const promise = connectWebSocket({
+      connectionUrl: 'wss://example.com',
+      session,
+      plugins: [plugin1, plugin2],
+      customWebSocket: mock.MockWS,
+    })
+
+    const ws = await mock.waitForInstance()
+    ws.onopen?.(new Event('open'))
+    await promise
+
+    expect(mock.constructorCalls[0]!.url).toBe('wss://example.com?a=1&b=2')
+  })
+
+  it('returns failure when WebSocket constructor throws', async () => {
+    function ThrowingWS() {
+      throw new Error('Invalid URL')
+    }
+
+    const session = createWebSocketSession()
+
+    const result = await connectWebSocket({
+      connectionUrl: 'invalid',
+      session,
+      customWebSocket: ThrowingWS as unknown as typeof WebSocket,
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toBe(WEBSOCKET_CONNECTION_FAILED)
+    }
+  })
+
+  it('passes protocols to the session', async () => {
+    const mock = createMockWebSocket()
+    const session = createWebSocketSession()
+
+    const promise = connectWebSocket({
+      connectionUrl: 'wss://example.com',
+      protocols: ['graphql-ws'],
+      session,
+      customWebSocket: mock.MockWS,
+    })
+
+    const ws = await mock.waitForInstance()
+    ws.onopen?.(new Event('open'))
+    await promise
+
+    expect(mock.constructorCalls[0]).toEqual({ url: 'wss://example.com', protocols: ['graphql-ws'] })
+  })
+})

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/connect-websocket.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/connect-websocket.ts
@@ -1,0 +1,116 @@
+/**
+ * WebSocket connection orchestrator for AsyncAPI channel operations.
+ *
+ * Mirrors the `sendRequest` pattern: accepts a connection URL, optional plugins,
+ * and a session, then wires up the lifecycle. Plugin hooks (`beforeConnect`,
+ * `onWebSocketMessage`, `onWebSocketClose`) run at the appropriate points.
+ *
+ * Browser WebSocket cannot set arbitrary headers on the handshake, so auth is
+ * applied via query parameters. The proxy URL is intentionally unused here
+ * because WebSocket traffic does not go through an HTTP CORS proxy.
+ */
+import { type Result, err, ok } from '@scalar/helpers/types/result'
+import { safeRun } from '@scalar/helpers/types/safe-run'
+import type { ClientPlugin } from '@scalar/oas-utils/helpers'
+import { executeWebSocketHook } from '@scalar/oas-utils/helpers'
+
+import type { WebSocketCloseInfo, WebSocketFrame, WebSocketSession, WebSocketSessionState } from './websocket-session'
+
+export type ConnectWebSocketOptions = {
+  connectionUrl: string
+  protocols?: string | string[]
+  session: WebSocketSession
+  plugins?: ClientPlugin[]
+  callbacks?: {
+    onFrame?: (frame: WebSocketFrame) => void
+    onStateChange?: (state: WebSocketSessionState, previous: WebSocketSessionState) => void
+    onError?: (event: Event) => void
+    onClose?: (info: WebSocketCloseInfo) => void
+    onOpen?: () => void
+  }
+  /** Injectable WebSocket constructor for tests or Electron override */
+  customWebSocket?: typeof WebSocket
+}
+
+export type ConnectWebSocketData = {
+  session: WebSocketSession
+}
+
+/** Failure code when the WebSocket handshake or connection cannot be established. */
+export const WEBSOCKET_CONNECTION_FAILED = 'WEBSOCKET_CONNECTION_FAILED' as const
+
+export const WEBSOCKET_CONNECTION_FAILED_MESSAGE = 'The WebSocket connection could not be established' as const
+
+export type ConnectWebSocketFailureCode = typeof WEBSOCKET_CONNECTION_FAILED
+
+export type ConnectWebSocketResult = Result<ConnectWebSocketData, ConnectWebSocketFailureCode>
+
+const connectionFailed = (): ConnectWebSocketResult =>
+  err(WEBSOCKET_CONNECTION_FAILED, WEBSOCKET_CONNECTION_FAILED_MESSAGE)
+
+/**
+ * Connects a WebSocket session after running plugin `beforeConnect` hooks.
+ *
+ * Resolves once the socket opens, or returns a failure result on error or close
+ * before open. After the initial connect, the session stays alive and messages
+ * flow through `onFrame` until the caller (or the server) closes it.
+ */
+export const connectWebSocket = async ({
+  connectionUrl,
+  protocols,
+  session,
+  plugins = [],
+  callbacks,
+  customWebSocket,
+}: ConnectWebSocketOptions): Promise<ConnectWebSocketResult> => {
+  const guarded = await safeRun(async () => {
+    const beforeConnectResult = await executeWebSocketHook({ url: connectionUrl }, 'beforeConnect', plugins)
+    const url = beforeConnectResult.url
+
+    return new Promise<ConnectWebSocketResult>((resolve) => {
+      session.connect({
+        url,
+        protocols,
+        customWebSocket,
+        callbacks: {
+          onOpen: () => {
+            callbacks?.onOpen?.()
+            resolve(ok({ session }))
+          },
+          onFrame: (frame) => {
+            callbacks?.onFrame?.(frame)
+            void executeWebSocketHook({ frame }, 'onWebSocketMessage', plugins)
+          },
+          onStateChange: (state, previous) => {
+            callbacks?.onStateChange?.(state, previous)
+          },
+          onError: (event) => {
+            callbacks?.onError?.(event)
+
+            if (session.state === 'error' && session.frames.length === 0) {
+              resolve(connectionFailed())
+            }
+          },
+          onClose: (info) => {
+            callbacks?.onClose?.(info)
+            void executeWebSocketHook({ info }, 'onWebSocketClose', plugins)
+
+            if (session.state !== 'open') {
+              resolve(connectionFailed())
+            }
+          },
+        },
+      })
+
+      if (session.state === 'error') {
+        resolve(connectionFailed())
+      }
+    })
+  })
+
+  if (!guarded.ok) {
+    return err(WEBSOCKET_CONNECTION_FAILED, guarded.error)
+  }
+
+  return guarded.data
+}

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.test.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { WebSocketSessionState } from './websocket-session'
+import { createWebSocketSession } from './websocket-session'
+
+type MockSocketInstance = {
+  binaryType: string
+  onopen: ((ev: Event) => void) | null
+  onmessage: ((ev: MessageEvent) => void) | null
+  onerror: ((ev: Event) => void) | null
+  onclose: ((ev: CloseEvent) => void) | null
+  send: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+}
+
+const createMockWebSocket = () => {
+  let instance: MockSocketInstance | null = null
+  const sentMessages: string[] = []
+  let closedWith: { code?: number; reason?: string } | null = null
+  const constructorCalls: Array<{ url: string; protocols?: string | string[] }> = []
+
+  function MockWS(this: MockSocketInstance, url: string, protocols?: string | string[]) {
+    constructorCalls.push({ url, protocols })
+    this.binaryType = 'blob'
+    this.onopen = null
+    this.onmessage = null
+    this.onerror = null
+    this.onclose = null
+    this.send = vi.fn((data: string) => {
+      sentMessages.push(data)
+    })
+    this.close = vi.fn((code?: number, reason?: string) => {
+      closedWith = { code, reason }
+    })
+    instance = this
+  }
+
+  return {
+    MockWS: MockWS as unknown as typeof WebSocket,
+    get instance() {
+      return instance
+    },
+    get sentMessages() {
+      return sentMessages
+    },
+    get closedWith() {
+      return closedWith
+    },
+    get constructorCalls() {
+      return constructorCalls
+    },
+    reset: () => {
+      instance = null
+      sentMessages.length = 0
+      closedWith = null
+      constructorCalls.length = 0
+    },
+  }
+}
+
+describe('createWebSocketSession', () => {
+  let mock: ReturnType<typeof createMockWebSocket>
+
+  beforeEach(() => {
+    mock = createMockWebSocket()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('starts in idle state', () => {
+    const session = createWebSocketSession()
+    expect(session.state).toBe('idle')
+    expect(session.frames).toEqual([])
+    expect(session.closeInfo).toBeNull()
+    expect(session.url).toBeNull()
+  })
+
+  it('transitions to connecting then open', () => {
+    const session = createWebSocketSession()
+    const stateChanges: Array<{ state: WebSocketSessionState; previous: WebSocketSessionState }> = []
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+      callbacks: {
+        onStateChange: (state, previous) => {
+          stateChanges.push({ state, previous })
+        },
+      },
+    })
+
+    expect(session.state).toBe('connecting')
+    expect(stateChanges).toEqual([{ state: 'connecting', previous: 'idle' }])
+
+    mock.instance!.onopen?.(new Event('open'))
+
+    expect(session.state).toBe('open')
+    expect(stateChanges).toEqual([
+      { state: 'connecting', previous: 'idle' },
+      { state: 'open', previous: 'connecting' },
+    ])
+  })
+
+  it('stores the connection URL', () => {
+    const session = createWebSocketSession()
+    session.connect({
+      url: 'wss://example.com/chat',
+      customWebSocket: mock.MockWS,
+    })
+
+    expect(session.url).toBe('wss://example.com/chat')
+  })
+
+  it('passes protocols to the WebSocket constructor', () => {
+    const session = createWebSocketSession()
+    session.connect({
+      url: 'wss://example.com',
+      protocols: ['graphql-ws'],
+      customWebSocket: mock.MockWS,
+    })
+
+    expect(mock.constructorCalls[0]).toEqual({ url: 'wss://example.com', protocols: ['graphql-ws'] })
+  })
+
+  it('accumulates incoming frames', () => {
+    const session = createWebSocketSession()
+    const receivedFrames: unknown[] = []
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+      callbacks: {
+        onFrame: (frame) => receivedFrames.push(frame),
+      },
+    })
+
+    mock.instance!.onopen?.(new Event('open'))
+    mock.instance!.onmessage?.(new MessageEvent('message', { data: '{"hello":"world"}' }))
+
+    expect(session.frames).toHaveLength(1)
+    expect(session.frames[0]).toMatchObject({
+      direction: 'incoming',
+      data: '{"hello":"world"}',
+      opcode: 'text',
+    })
+    expect(session.frames[0]!.timestamp).toBeGreaterThan(0)
+    expect(receivedFrames).toHaveLength(1)
+  })
+
+  it('classifies ArrayBuffer messages as binary', () => {
+    const session = createWebSocketSession()
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+    })
+
+    mock.instance!.onopen?.(new Event('open'))
+    mock.instance!.onmessage?.(new MessageEvent('message', { data: new ArrayBuffer(4) }))
+
+    expect(session.frames[0]!.opcode).toBe('binary')
+  })
+
+  it('sends data and records outgoing frame', () => {
+    const session = createWebSocketSession()
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+    })
+
+    mock.instance!.onopen?.(new Event('open'))
+    session.send('{"type":"subscribe"}')
+
+    expect(mock.sentMessages).toEqual(['{"type":"subscribe"}'])
+    expect(session.frames).toHaveLength(1)
+    expect(session.frames[0]).toMatchObject({
+      direction: 'outgoing',
+      data: '{"type":"subscribe"}',
+      opcode: 'text',
+    })
+  })
+
+  it('ignores send when not in open state', () => {
+    const session = createWebSocketSession()
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+    })
+
+    session.send('should be ignored')
+
+    expect(session.state).toBe('connecting')
+    expect(mock.sentMessages).toEqual([])
+    expect(session.frames).toHaveLength(0)
+  })
+
+  it('transitions through closing to closed on close()', () => {
+    const session = createWebSocketSession()
+    const stateChanges: WebSocketSessionState[] = []
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+      callbacks: {
+        onStateChange: (state) => stateChanges.push(state),
+      },
+    })
+
+    mock.instance!.onopen?.(new Event('open'))
+    session.close(1000, 'done')
+
+    expect(session.state).toBe('closing')
+    expect(mock.closedWith).toEqual({ code: 1000, reason: 'done' })
+
+    mock.instance!.onclose?.(new CloseEvent('close', { code: 1000, reason: 'done', wasClean: true }))
+
+    expect(session.state).toBe('closed')
+    expect(session.closeInfo).toEqual({ code: 1000, reason: 'done', wasClean: true })
+    expect(stateChanges).toEqual(['connecting', 'open', 'closing', 'closed'])
+  })
+
+  it('calls onClose callback with close info', () => {
+    const session = createWebSocketSession()
+    const closeCallback = vi.fn()
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+      callbacks: { onClose: closeCallback },
+    })
+
+    mock.instance!.onopen?.(new Event('open'))
+    session.close()
+
+    mock.instance!.onclose?.(new CloseEvent('close', { code: 1000, reason: '', wasClean: true }))
+
+    expect(closeCallback).toHaveBeenCalledWith({ code: 1000, reason: '', wasClean: true })
+  })
+
+  it('transitions to error on socket error', () => {
+    const session = createWebSocketSession()
+    const errorCallback = vi.fn()
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+      callbacks: { onError: errorCallback },
+    })
+
+    mock.instance!.onerror?.(new Event('error'))
+
+    expect(session.state).toBe('error')
+    expect(errorCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('transitions to error when constructor throws', () => {
+    const session = createWebSocketSession()
+
+    function ThrowingWS() {
+      throw new Error('Invalid URL')
+    }
+
+    session.connect({
+      url: 'not-a-url',
+      customWebSocket: ThrowingWS as unknown as typeof WebSocket,
+    })
+
+    expect(session.state).toBe('error')
+  })
+
+  it('resets frames on reconnect', () => {
+    const session = createWebSocketSession()
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+    })
+
+    const firstInstance = mock.instance!
+    firstInstance.onopen?.(new Event('open'))
+    firstInstance.onmessage?.(new MessageEvent('message', { data: 'old message' }))
+    expect(session.frames).toHaveLength(1)
+
+    session.connect({
+      url: 'wss://example.com/v2',
+      customWebSocket: mock.MockWS,
+    })
+
+    expect(session.frames).toHaveLength(0)
+    expect(session.url).toBe('wss://example.com/v2')
+  })
+
+  it('calls onOpen callback', () => {
+    const session = createWebSocketSession()
+    const openCallback = vi.fn()
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+      callbacks: { onOpen: openCallback },
+    })
+
+    mock.instance!.onopen?.(new Event('open'))
+
+    expect(openCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('sets binaryType to arraybuffer', () => {
+    const session = createWebSocketSession()
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+    })
+
+    expect(mock.instance!.binaryType).toBe('arraybuffer')
+  })
+
+  it('destroy() closes an open connection and cleans up', () => {
+    const session = createWebSocketSession()
+    const stateChanges: WebSocketSessionState[] = []
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+      callbacks: {
+        onStateChange: (state) => stateChanges.push(state),
+      },
+    })
+
+    mock.instance!.onopen?.(new Event('open'))
+    session.destroy()
+
+    expect(session.state).toBe('closed')
+    expect(mock.closedWith).toEqual({ code: 1000, reason: '' })
+  })
+
+  it('uses default close code 1000 when close() is called without arguments', () => {
+    const session = createWebSocketSession()
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+    })
+
+    mock.instance!.onopen?.(new Event('open'))
+    session.close()
+
+    expect(mock.closedWith).toEqual({ code: 1000, reason: '' })
+  })
+})

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.test.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.test.ts
@@ -358,6 +358,40 @@ describe('createWebSocketSession', () => {
     expect(mock.closedWith).toEqual({ code: 1000, reason: '' })
   })
 
+  it('destroy() invokes onClose while connecting', () => {
+    const session = createWebSocketSession()
+    const closeCallback = vi.fn()
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+      callbacks: { onClose: closeCallback },
+    })
+
+    session.destroy()
+
+    expect(closeCallback).toHaveBeenCalledWith({ code: 1000, reason: '', wasClean: false })
+    expect(session.state).toBe('closed')
+  })
+
+  it('notifies previous callbacks when reconnecting during connecting', () => {
+    const session = createWebSocketSession()
+    const firstClose = vi.fn()
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+      callbacks: { onClose: firstClose },
+    })
+
+    session.connect({
+      url: 'wss://example.com/v2',
+      customWebSocket: mock.MockWS,
+    })
+
+    expect(firstClose).toHaveBeenCalledWith({ code: 1000, reason: '', wasClean: false })
+  })
+
   it('uses default close code 1000 when close() is called without arguments', () => {
     const session = createWebSocketSession()
 

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.test.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.test.ts
@@ -290,8 +290,28 @@ describe('createWebSocketSession', () => {
       customWebSocket: mock.MockWS,
     })
 
+    expect(firstInstance.close).toHaveBeenCalledWith(1000, '')
     expect(session.frames).toHaveLength(0)
     expect(session.url).toBe('wss://example.com/v2')
+  })
+
+  it('closes an in-progress connection when reconnecting', () => {
+    const session = createWebSocketSession()
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+    })
+
+    const firstInstance = mock.instance!
+    expect(session.state).toBe('connecting')
+
+    session.connect({
+      url: 'wss://example.com/v2',
+      customWebSocket: mock.MockWS,
+    })
+
+    expect(firstInstance.close).toHaveBeenCalledWith(1000, '')
   })
 
   it('calls onOpen callback', () => {

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.test.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.test.ts
@@ -241,7 +241,7 @@ describe('createWebSocketSession', () => {
     expect(closeCallback).toHaveBeenCalledWith({ code: 1000, reason: '', wasClean: true })
   })
 
-  it('transitions to error on socket error', () => {
+  it('transitions to error on socket error while connecting', () => {
     const session = createWebSocketSession()
     const errorCallback = vi.fn()
 
@@ -255,6 +255,33 @@ describe('createWebSocketSession', () => {
 
     expect(session.state).toBe('error')
     expect(errorCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps open state and allows send after socket error once connected', () => {
+    const session = createWebSocketSession()
+    const errorCallback = vi.fn()
+
+    session.connect({
+      url: 'wss://example.com',
+      customWebSocket: mock.MockWS,
+      callbacks: { onError: errorCallback },
+    })
+
+    mock.instance!.onopen?.(new Event('open'))
+    mock.instance!.onerror?.(new Event('error'))
+
+    expect(session.state).toBe('open')
+    expect(errorCallback).toHaveBeenCalledTimes(1)
+
+    session.send('still works')
+
+    expect(mock.sentMessages).toStrictEqual(['still works'])
+    expect(session.frames).toHaveLength(1)
+    expect(session.frames[0]).toMatchObject({
+      direction: 'outgoing',
+      data: 'still works',
+      opcode: 'text',
+    })
   })
 
   it('transitions to error when constructor throws', () => {

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.ts
@@ -51,6 +51,7 @@ export type WebSocketSession = {
   connect: (options: WebSocketConnectOptions) => void
   send: (data: string) => void
   close: (code?: number, reason?: string) => void
+  clearFrames: () => void
   destroy: () => void
 }
 
@@ -177,6 +178,10 @@ export const createWebSocketSession = (): WebSocketSession => {
     }
   }
 
+  const clearFrames = (): void => {
+    frames.length = 0
+  }
+
   const destroy = (): void => {
     releaseSocket()
     setState('closed')
@@ -198,6 +203,7 @@ export const createWebSocketSession = (): WebSocketSession => {
     connect,
     send,
     close,
+    clearFrames,
     destroy,
   }
 }

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.ts
@@ -151,7 +151,11 @@ export const createWebSocketSession = (): WebSocketSession => {
     }
 
     socket.onerror = (event: Event): void => {
-      setState('error')
+      // Errors after open are advisory; onclose owns terminal state. Transitioning
+      // to `error` here would block send() while the socket may still be connected.
+      if (currentState === 'connecting') {
+        setState('error')
+      }
       callbacks.onError?.(event)
     }
 

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.ts
@@ -1,0 +1,202 @@
+/**
+ * WebSocket session abstraction for the AsyncAPI channel operation transport.
+ *
+ * Manages the lifecycle of a single WebSocket connection: connect, send, close.
+ * The session tracks connection state transitions and bidirectional message frames,
+ * emitting callbacks so the UI can render a live message log.
+ *
+ * Browser WebSocket does not support custom headers on the handshake request.
+ * Auth is applied via query parameters or Sec-WebSocket-Protocol where applicable.
+ * In Electron, a richer handshake path may be used in the future.
+ */
+
+export type WebSocketSessionState = 'idle' | 'connecting' | 'open' | 'closing' | 'closed' | 'error'
+
+export type WebSocketFrameOpcode = 'text' | 'binary' | 'close'
+
+export type WebSocketFrame = {
+  direction: 'incoming' | 'outgoing'
+  timestamp: number
+  data: string | ArrayBuffer
+  opcode: WebSocketFrameOpcode
+}
+
+export type WebSocketCloseInfo = {
+  code: number
+  reason: string
+  wasClean: boolean
+}
+
+export type WebSocketSessionCallbacks = {
+  onFrame?: (frame: WebSocketFrame) => void
+  onStateChange?: (state: WebSocketSessionState, previous: WebSocketSessionState) => void
+  onError?: (event: Event) => void
+  onClose?: (info: WebSocketCloseInfo) => void
+  onOpen?: () => void
+}
+
+export type WebSocketConnectOptions = {
+  url: string
+  protocols?: string | string[]
+  callbacks?: WebSocketSessionCallbacks
+  /** Injectable WebSocket constructor for testing or Electron override */
+  customWebSocket?: typeof WebSocket
+}
+
+export type WebSocketSession = {
+  readonly state: WebSocketSessionState
+  readonly frames: WebSocketFrame[]
+  readonly closeInfo: WebSocketCloseInfo | null
+  readonly url: string | null
+  connect: (options: WebSocketConnectOptions) => void
+  send: (data: string) => void
+  close: (code?: number, reason?: string) => void
+  destroy: () => void
+}
+
+/**
+ * Creates a new WebSocket session with lifecycle management.
+ *
+ * The session starts in `idle` state and transitions through `connecting` -> `open`
+ * on success, or `connecting` -> `error` on failure. Calling `close()` transitions
+ * through `closing` -> `closed`. Frames are accumulated in the session for the UI
+ * message log.
+ */
+export const createWebSocketSession = (): WebSocketSession => {
+  let currentState: WebSocketSessionState = 'idle'
+  let socket: WebSocket | null = null
+  let callbacks: WebSocketSessionCallbacks = {}
+  const frames: WebSocketFrame[] = []
+  let closeInfo: WebSocketCloseInfo | null = null
+  let currentUrl: string | null = null
+
+  const setState = (next: WebSocketSessionState): void => {
+    const previous = currentState
+    if (previous === next) {
+      return
+    }
+    currentState = next
+    callbacks.onStateChange?.(next, previous)
+  }
+
+  const addFrame = (frame: WebSocketFrame): void => {
+    frames.push(frame)
+    callbacks.onFrame?.(frame)
+  }
+
+  const teardown = (): void => {
+    if (socket) {
+      socket.onopen = null
+      socket.onmessage = null
+      socket.onerror = null
+      socket.onclose = null
+      socket = null
+    }
+  }
+
+  const connect = (options: WebSocketConnectOptions): void => {
+    teardown()
+
+    frames.length = 0
+    closeInfo = null
+    currentUrl = options.url
+    callbacks = options.callbacks ?? {}
+
+    setState('connecting')
+
+    const WS = options.customWebSocket ?? globalThis.WebSocket
+
+    try {
+      socket = options.protocols ? new WS(options.url, options.protocols) : new WS(options.url)
+    } catch (_error) {
+      setState('error')
+      return
+    }
+
+    socket.binaryType = 'arraybuffer'
+
+    socket.onopen = (): void => {
+      setState('open')
+      callbacks.onOpen?.()
+    }
+
+    socket.onmessage = (event: MessageEvent): void => {
+      const isArrayBuffer = event.data instanceof ArrayBuffer
+      addFrame({
+        direction: 'incoming',
+        timestamp: Date.now(),
+        data: event.data as string | ArrayBuffer,
+        opcode: isArrayBuffer ? 'binary' : 'text',
+      })
+    }
+
+    socket.onerror = (event: Event): void => {
+      setState('error')
+      callbacks.onError?.(event)
+    }
+
+    socket.onclose = (event: CloseEvent): void => {
+      closeInfo = {
+        code: event.code,
+        reason: event.reason,
+        wasClean: event.wasClean,
+      }
+      setState('closed')
+      callbacks.onClose?.(closeInfo)
+      teardown()
+    }
+  }
+
+  const send = (data: string): void => {
+    if (!socket || currentState !== 'open') {
+      return
+    }
+
+    socket.send(data)
+
+    addFrame({
+      direction: 'outgoing',
+      timestamp: Date.now(),
+      data,
+      opcode: 'text',
+    })
+  }
+
+  const close = (code?: number, reason?: string): void => {
+    if (!socket) {
+      return
+    }
+
+    if (currentState === 'connecting' || currentState === 'open') {
+      setState('closing')
+      socket.close(code ?? 1000, reason ?? '')
+    }
+  }
+
+  const destroy = (): void => {
+    if (socket && (currentState === 'connecting' || currentState === 'open')) {
+      socket.close(1000, '')
+    }
+    teardown()
+    setState('closed')
+  }
+
+  return {
+    get state() {
+      return currentState
+    },
+    get frames() {
+      return frames
+    },
+    get closeInfo() {
+      return closeInfo
+    },
+    get url() {
+      return currentUrl
+    },
+    connect,
+    send,
+    close,
+    destroy,
+  }
+}

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.ts
@@ -99,8 +99,23 @@ export const createWebSocketSession = (): WebSocketSession => {
     activeSocket.close(1000, '')
   }
 
+  const isInFlight = (): boolean =>
+    currentState === 'connecting' || currentState === 'open' || currentState === 'closing'
+
+  const notifyAborted = (targetCallbacks: WebSocketSessionCallbacks): void => {
+    const info: WebSocketCloseInfo = { code: 1000, reason: '', wasClean: false }
+    targetCallbacks.onClose?.(info)
+  }
+
   const connect = (options: WebSocketConnectOptions): void => {
+    const previousCallbacks = callbacks
+    const wasInFlight = isInFlight()
+
     releaseSocket()
+
+    if (wasInFlight) {
+      notifyAborted(previousCallbacks)
+    }
 
     frames.length = 0
     closeInfo = null
@@ -183,7 +198,15 @@ export const createWebSocketSession = (): WebSocketSession => {
   }
 
   const destroy = (): void => {
+    const wasInFlight = isInFlight()
+
     releaseSocket()
+
+    if (wasInFlight) {
+      closeInfo = { code: 1000, reason: '', wasClean: false }
+      callbacks.onClose?.(closeInfo)
+    }
+
     setState('closed')
   }
 

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.ts
@@ -84,18 +84,22 @@ export const createWebSocketSession = (): WebSocketSession => {
     callbacks.onFrame?.(frame)
   }
 
-  const teardown = (): void => {
-    if (socket) {
-      socket.onopen = null
-      socket.onmessage = null
-      socket.onerror = null
-      socket.onclose = null
-      socket = null
+  const releaseSocket = (): void => {
+    if (!socket) {
+      return
     }
+
+    const activeSocket = socket
+    socket = null
+    activeSocket.onopen = null
+    activeSocket.onmessage = null
+    activeSocket.onerror = null
+    activeSocket.onclose = null
+    activeSocket.close(1000, '')
   }
 
   const connect = (options: WebSocketConnectOptions): void => {
-    teardown()
+    releaseSocket()
 
     frames.length = 0
     closeInfo = null
@@ -143,7 +147,7 @@ export const createWebSocketSession = (): WebSocketSession => {
       }
       setState('closed')
       callbacks.onClose?.(closeInfo)
-      teardown()
+      releaseSocket()
     }
   }
 
@@ -174,10 +178,7 @@ export const createWebSocketSession = (): WebSocketSession => {
   }
 
   const destroy = (): void => {
-    if (socket && (currentState === 'connecting' || currentState === 'open')) {
-      socket.close(1000, '')
-    }
-    teardown()
+    releaseSocket()
     setState('closed')
   }
 

--- a/packages/api-client/src/v2/blocks/channel-operation-block/index.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/index.ts
@@ -1,0 +1,19 @@
+export {
+  type ConnectWebSocketData,
+  type ConnectWebSocketFailureCode,
+  type ConnectWebSocketOptions,
+  type ConnectWebSocketResult,
+  WEBSOCKET_CONNECTION_FAILED,
+  WEBSOCKET_CONNECTION_FAILED_MESSAGE,
+  connectWebSocket,
+} from './helpers/connect-websocket'
+export {
+  type WebSocketCloseInfo,
+  type WebSocketConnectOptions,
+  type WebSocketFrame,
+  type WebSocketFrameOpcode,
+  type WebSocketSession,
+  type WebSocketSessionCallbacks,
+  type WebSocketSessionState,
+  createWebSocketSession,
+} from './helpers/websocket-session'

--- a/packages/oas-utils/src/helpers/client-plugins.ts
+++ b/packages/oas-utils/src/helpers/client-plugins.ts
@@ -29,6 +29,17 @@ export type ResponseBodyHandler = ResponseBodyHandlerBase &
 
 /** A type representing the hooks that a client plugin can define */
 type ClientPluginHooks = {
+  /**
+   * Runs when an operation view mounts, before any request is sent. Useful for warming up
+   * resources that would otherwise add latency to the first request (for example, lazily
+   * created sandboxes). Receives the current document and operation so plugins can decide
+   * whether the work is needed at all.
+   */
+  onRequestMount: (payload: { document: OpenApiDocument; operation: OperationObject }) => void | Promise<void>
+  /**
+   * Runs before a request is sent. Receives the current document and operation so plugins can
+   * modify the request before it is sent (for example, adding headers or modifying the body).
+   */
   beforeRequest: (payload: {
     /** Workspace-store request spec; mutable by pre-request scripts (headers, method). */
     requestBuilder: RequestFactory
@@ -36,6 +47,10 @@ type ClientPluginHooks = {
     operation: OperationObject
     variablesStore?: VariablesStore
   }) => void | Promise<void>
+  /**
+   * Runs after a response is received. Receives the current document and operation so plugins can
+   * modify the response after it is received (for example, adding headers or modifying the body).
+   */
   responseReceived: (payload: {
     response: Response
     /** Request builder object that was used to build the request. Mutating this object will not affect the request object. */

--- a/packages/oas-utils/src/helpers/client-plugins.ts
+++ b/packages/oas-utils/src/helpers/client-plugins.ts
@@ -29,13 +29,6 @@ export type ResponseBodyHandler = ResponseBodyHandlerBase &
 
 /** A type representing the hooks that a client plugin can define */
 type ClientPluginHooks = {
-  /**
-   * Runs when an operation view mounts, before any request is sent. Useful for warming up
-   * resources that would otherwise add latency to the first request (for example, lazily
-   * created sandboxes). Receives the current document and operation so plugins can decide
-   * whether the work is needed at all.
-   */
-  onRequestMount: (payload: { document: OpenApiDocument; operation: OperationObject }) => void | Promise<void>
   beforeRequest: (payload: {
     /** Workspace-store request spec; mutable by pre-request scripts (headers, method). */
     requestBuilder: RequestFactory
@@ -53,6 +46,43 @@ type ClientPluginHooks = {
     operation: OperationObject
     variablesStore?: VariablesStore
   }) => void | Promise<void>
+}
+
+/** Direction of a WebSocket message frame */
+export type WebSocketFrameDirection = 'incoming' | 'outgoing'
+
+/** Opcode classification for a WebSocket frame */
+export type WebSocketFrameType = 'text' | 'binary' | 'close'
+
+/** A single WebSocket message frame (sent or received) */
+export type WebSocketPluginFrame = {
+  direction: WebSocketFrameDirection
+  timestamp: number
+  data: string | ArrayBuffer
+  opcode: WebSocketFrameType
+}
+
+/** Close event metadata for WebSocket plugin hooks */
+export type WebSocketPluginCloseInfo = {
+  code: number
+  reason: string
+  wasClean: boolean
+}
+
+/**
+ * WebSocket-specific plugin hooks for AsyncAPI channel operations.
+ *
+ * These are intentionally separate from the HTTP `ClientPluginHooks` because
+ * the WebSocket lifecycle (long-lived connection, bidirectional frames) does
+ * not map onto request/response semantics.
+ */
+export type ClientPluginWebSocketHooks = {
+  /** Runs before the WebSocket handshake. Return a modified URL to override. */
+  beforeConnect: (payload: { url: string }) => string | void | Promise<string | void>
+  /** Runs for every incoming or outgoing frame on an open connection. */
+  onWebSocketMessage: (payload: { frame: WebSocketPluginFrame }) => void | Promise<void>
+  /** Runs when the connection closes (cleanly or due to error). */
+  onWebSocketClose: (payload: { info: WebSocketPluginCloseInfo }) => void | Promise<void>
 }
 
 /** A vue component which accepts the specified props */
@@ -125,6 +155,8 @@ type ClientPluginLifecycle = {
 
 export type ClientPlugin = {
   hooks?: Partial<ClientPluginHooks>
+  /** WebSocket-specific hooks for AsyncAPI channel operations */
+  webSocketHooks?: Partial<ClientPluginWebSocketHooks>
   components?: Partial<ClientPluginComponents>
   /** Lifecycle hooks for app-level concerns */
   lifecycle?: ClientPluginLifecycle
@@ -206,6 +238,37 @@ export const executeHook = async <K extends keyof HookPayloadMap>(
     if (hook) {
       const modifiedPayload = await hook(currentPayload as any)
       currentPayload = (modifiedPayload ?? currentPayload) as HookPayloadMap[K]
+    }
+  }
+
+  return currentPayload
+}
+
+type WebSocketHookPayloadMap = {
+  [K in keyof ClientPluginWebSocketHooks]: Parameters<ClientPluginWebSocketHooks[K]>[0]
+}
+
+/**
+ * Execute a WebSocket plugin hook across all plugins.
+ *
+ * For `beforeConnect`, the returned URL string (if any) is threaded through
+ * sequentially so each plugin can transform the URL. For fire-and-forget hooks
+ * (`onWebSocketMessage`, `onWebSocketClose`) the return value is ignored.
+ */
+export const executeWebSocketHook = async <K extends keyof WebSocketHookPayloadMap>(
+  payload: WebSocketHookPayloadMap[K],
+  hookName: K,
+  plugins: ClientPlugin[],
+): Promise<WebSocketHookPayloadMap[K]> => {
+  let currentPayload = payload
+
+  for (const plugin of plugins) {
+    const hook = plugin.webSocketHooks?.[hookName]
+    if (hook) {
+      const result = await (hook as (p: WebSocketHookPayloadMap[K]) => unknown)(currentPayload)
+      if (hookName === 'beforeConnect' && typeof result === 'string') {
+        currentPayload = { ...currentPayload, url: result } as WebSocketHookPayloadMap[K]
+      }
     }
   }
 

--- a/packages/oas-utils/src/helpers/index.ts
+++ b/packages/oas-utils/src/helpers/index.ts
@@ -1,2 +1,13 @@
-export { type ClientPlugin, type ResponseBodyHandler, executeHook, subscribePluginEvents } from './client-plugins'
+export {
+  type ClientPlugin,
+  type ClientPluginWebSocketHooks,
+  type ResponseBodyHandler,
+  type WebSocketFrameDirection,
+  type WebSocketFrameType,
+  type WebSocketPluginCloseInfo,
+  type WebSocketPluginFrame,
+  executeHook,
+  executeWebSocketHook,
+  subscribePluginEvents,
+} from './client-plugins'
 export { formatJsonOrYamlString, json, parseJsonOrYaml, transformToJson, yaml } from './parse'


### PR DESCRIPTION
Add WebSocketSession with connect, send, and close helpers, plus connectWebSocket orchestration using Result-based errors. Extend ClientPlugin with optional webSocketHooks (beforeConnect, onWebSocketMessage, onWebSocketClose).

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new WebSocket connection/session APIs and plugin hook surfaces that will be part of the client’s public behavior; incorrect lifecycle/error handling could cause connection leaks or inconsistent UI state.
> 
> **Overview**
> Adds an AsyncAPI WebSocket transport to `@scalar/api-client` via a new `WebSocketSession` abstraction (connect/send/close, state transitions, frame capture) plus a `connectWebSocket` orchestrator that runs `beforeConnect` and resolves with Result-based connection failures.
> 
> Extends `@scalar/oas-utils` `ClientPlugin` with optional `webSocketHooks` (`beforeConnect`, `onWebSocketMessage`, `onWebSocketClose`) and provides `executeWebSocketHook` to chain URL mutation and dispatch message/close events. Includes comprehensive Vitest coverage and exports the new channel-operation-block entry, with a small `knip.jsonc` entry update and a changeset bumping both packages (minor).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e857cff3067beeb5ed1cdd314b1c82124c58c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->