### PR TITLE
fix(api-reference): show request example below operation details on narrow viewports

### DIFF
--- a/.changeset/section-columns-column-reverse.md
+++ b/.changeset/section-columns-column-reverse.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: reverse section column stack order on narrow viewports (≤900px)

--- a/packages/api-reference/src/components/Section/SectionColumns.vue
+++ b/packages/api-reference/src/components/Section/SectionColumns.vue
@@ -11,7 +11,7 @@
 }
 @container narrow-references-container (max-width: 900px) {
   .section-columns {
-    flex-direction: column;
+    flex-direction: column-reverse;
     gap: 24px;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On narrow viewports (≤900px), the request block (HTTP method + URL / curl) should appear below the operation title and description, not above path parameters and related schema content.

Implemented by setting flex-direction: column-reverse on .section-columns in SectionColumns.vue.


<img width="586" height="702" alt="image" src="https://github.com/user-attachments/assets/4c741c35-7b25-4c27-bca6-0dc70247892f" />
