### PR TITLE
feat(api-reference): AsyncAPI `info.description` headings in search

### DIFF
--- a/.changeset/asyncapi-search-headings.md
+++ b/.changeset/asyncapi-search-headings.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Surface AsyncAPI `info.description` headings in the search modal, mirroring the sidebar behaviour. AsyncAPI channels, operations, and messages are not indexed yet.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -332,15 +332,14 @@ const { toggleColorMode, isDarkMode } = useColorMode({
 })
 
 /**
- * The active document narrowed to an OpenAPI document.
- *
- * api-reference is OpenAPI-native, so AsyncAPI documents are surfaced as
- * undefined to downstream components.
+ * The active document passed to the search modal. Both OpenAPI and AsyncAPI
+ * documents are surfaced so the search index can pick up info.description
+ * headings from either spec; AsyncAPI-specific entries (channels, operations,
+ * messages) are not indexed yet.
  */
-const activeOpenApiDocument = computed(() => {
-  const doc = workspaceStore.workspace.activeDocument
-  return isOpenApiDocument(doc) ? doc : undefined
-})
+const activeSearchableDocument = computed(
+  () => workspaceStore.workspace.activeDocument,
+)
 
 /**
  * Create top level sidebar entries for each document
@@ -1060,7 +1059,7 @@ const showMCPButton = computed(() => {
           <SearchButton
             v-if="!mergedConfig.hideSearch"
             class="my-2"
-            :document="activeOpenApiDocument"
+            :document="activeSearchableDocument"
             :eventBus="eventBus"
             :hideModels="mergedConfig.hideModels"
             :searchHotKey="mergedConfig.searchHotKey"
@@ -1096,7 +1095,7 @@ const showMCPButton = computed(() => {
                 v-if="!mergedConfig.hideSearch"
                 class="flex gap-1.5 px-3 pt-3">
                 <SearchButton
-                  :document="activeOpenApiDocument"
+                  :document="activeSearchableDocument"
                   :eventBus="eventBus"
                   :hideModels="mergedConfig.hideModels"
                   :searchHotKey="mergedConfig.searchHotKey" />
@@ -1190,7 +1189,7 @@ const showMCPButton = computed(() => {
               <SearchButton
                 v-if="!mergedConfig.hideSearch"
                 class="t-doc__sidebar max-w-64"
-                :document="activeOpenApiDocument"
+                :document="activeSearchableDocument"
                 :eventBus="eventBus"
                 :hideModels="mergedConfig.hideModels"
                 :searchHotKey="mergedConfig.searchHotKey" />

--- a/packages/api-reference/src/features/Search/components/SearchButton.vue
+++ b/packages/api-reference/src/features/Search/components/SearchButton.vue
@@ -4,6 +4,7 @@ import { useModal } from '@scalar/components/modal'
 import { ScalarSidebarSearchButton } from '@scalar/components/sidebar'
 import { isMacOS } from '@scalar/helpers/general/is-mac-os'
 import { ScalarIconMagnifyingGlass } from '@scalar/icons'
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
@@ -14,7 +15,7 @@ const { searchHotKey = 'k', hideModels = false } = defineProps<{
   forceIcon?: boolean
   searchHotKey?: string
   hideModels?: boolean
-  document?: OpenApiDocument
+  document?: OpenApiDocument | AsyncApiDocument
   eventBus: WorkspaceEventBus
 }>()
 

--- a/packages/api-reference/src/features/Search/components/SearchModal.vue
+++ b/packages/api-reference/src/features/Search/components/SearchModal.vue
@@ -2,6 +2,7 @@
 import { ScalarModal, type ModalState } from '@scalar/components/modal'
 import { ScalarSearchInput } from '@scalar/components/search-input'
 import { ScalarSearchResultList } from '@scalar/components/search-results'
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { nanoid } from 'nanoid'
@@ -13,7 +14,7 @@ import SearchResult from './SearchResult.vue'
 
 const props = defineProps<{
   modalState: ModalState
-  document: OpenApiDocument | undefined
+  document: OpenApiDocument | AsyncApiDocument | undefined
   eventBus: WorkspaceEventBus
 }>()
 

--- a/packages/api-reference/src/features/Search/helpers/create-search-index.test.ts
+++ b/packages/api-reference/src/features/Search/helpers/create-search-index.test.ts
@@ -1,4 +1,5 @@
-import { createNavigation } from '@scalar/workspace-store/navigation'
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import { createNavigation, traverseAsyncApiDocument } from '@scalar/workspace-store/navigation'
 import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { describe, expect, it } from 'vitest'
 
@@ -20,6 +21,7 @@ const introductionSearchEntry = {
 
 function createMockDocument(document: Partial<OpenApiDocument>) {
   const doc = {
+    openapi: '3.1.0',
     info: {
       title: 'Test API',
       version: '1.0.0',
@@ -909,6 +911,27 @@ describe('createSearchIndex', () => {
       expect(tagEntries.length).toBeGreaterThanOrEqual(2)
       expect(operationEntries.length).toBeGreaterThanOrEqual(3)
       expect(modelEntries.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe('AsyncAPI documents', () => {
+    it('indexes the Introduction entry and headings from info.description', () => {
+      const document = {
+        asyncapi: '3.0.0',
+        info: {
+          title: 'Streaming API',
+          version: '1.0.0',
+          description: 'Welcome to the streaming API.\n\n## Getting started\n\nConnect to a channel and subscribe.',
+        },
+        'x-scalar-original-document-hash': '',
+      } as AsyncApiDocument
+
+      document['x-scalar-navigation'] = traverseAsyncApiDocument('test', document)
+
+      const index = createSearchIndex(document)
+
+      const headings = index.filter((item) => item.type === 'heading')
+      expect(headings.map((item) => item.title)).toEqual(expect.arrayContaining(['Introduction', 'Getting started']))
     })
   })
 })

--- a/packages/api-reference/src/features/Search/helpers/create-search-index.ts
+++ b/packages/api-reference/src/features/Search/helpers/create-search-index.ts
@@ -1,6 +1,8 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import { combineParams } from '@scalar/workspace-store/request-example'
 import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
+import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import type {
   MediaTypeObject,
   OpenApiDocument,
@@ -17,6 +19,9 @@ import {
   extractSchemaDescriptions,
   extractSchemaFieldNames,
 } from '@/helpers/openapi'
+
+/** Documents the search index can ingest. AsyncAPI is supported for headings and tags; channels/operations/messages are not indexed yet. */
+type SearchableDocument = OpenApiDocument | AsyncApiDocument
 
 function responseExampleValueToString(value: unknown): string {
   if (typeof value === 'string') {
@@ -76,7 +81,7 @@ function extractResponseExamples(responses: ResponsesObject | undefined): string
 /**
  * Create a search index from a list of entries.
  */
-export function createSearchIndex(document: OpenApiDocument | undefined): FuseData[] {
+export function createSearchIndex(document: SearchableDocument | undefined): FuseData[] {
   const index: FuseData[] = []
 
   /**
@@ -100,11 +105,18 @@ export function createSearchIndex(document: OpenApiDocument | undefined): FuseDa
 
 /**
  * Adds a single entry to the search index, handling all entry types recursively.
+ *
+ * AsyncAPI documents only contribute heading/tag entries here. Their channels,
+ * operations, and messages are not indexed yet.
  */
-function addEntryToIndex(entry: TraversedEntry, index: FuseData[], document?: OpenApiDocument): void {
+function addEntryToIndex(entry: TraversedEntry, index: FuseData[], document?: SearchableDocument): void {
+  // OpenAPI-only branches read fields that do not exist on AsyncAPI documents (paths, webhooks,
+  // components.schemas). Narrow once here so each branch can dereference safely.
+  const openApiDocument = isOpenApiDocument(document) ? document : undefined
+
   // Operation
   if (entry.type === 'operation') {
-    const pathItem = getResolvedRef(document?.paths?.[entry.path])
+    const pathItem = getResolvedRef(openApiDocument?.paths?.[entry.path])
     const operation = (getResolvedRef(pathItem?.[entry.method]) ?? {}) as OperationObject
     const operationWithPathParams = {
       ...operation,
@@ -138,7 +150,7 @@ function addEntryToIndex(entry: TraversedEntry, index: FuseData[], document?: Op
 
   // Webhook
   if (entry.type === 'webhook') {
-    const webhook = getResolvedRef(document?.webhooks?.[entry.name]?.[entry.method]) ?? {}
+    const webhook = getResolvedRef(openApiDocument?.webhooks?.[entry.name]?.[entry.method]) ?? {}
     const webhookDescription = webhook.description || ''
 
     index.push({
@@ -158,7 +170,7 @@ function addEntryToIndex(entry: TraversedEntry, index: FuseData[], document?: Op
 
   // Model
   if (entry.type === 'model') {
-    const schema = getResolvedRef(document?.components?.schemas?.[entry.name])
+    const schema = getResolvedRef(openApiDocument?.components?.schemas?.[entry.name])
     const schemaDescription = schema?.description ?? ''
     const propertyNames = extractSchemaFieldNames(schema)
     const propertyDescriptions = extractSchemaDescriptions(schema)

--- a/packages/api-reference/src/features/Search/hooks/useSearchIndex.ts
+++ b/packages/api-reference/src/features/Search/hooks/useSearchIndex.ts
@@ -1,3 +1,4 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import type { FuseResult } from 'fuse.js'
 import { type MaybeRefOrGetter, computed, ref, toValue } from 'vue'
@@ -9,9 +10,9 @@ import type { FuseData } from '../types'
 const MAX_SEARCH_RESULTS = 25
 
 /**
- * Creates the search index from an OpenAPI document.
+ * Creates the search index from an OpenAPI or AsyncAPI document.
  */
-export function useSearchIndex(document: MaybeRefOrGetter<OpenApiDocument | undefined>) {
+export function useSearchIndex(document: MaybeRefOrGetter<OpenApiDocument | AsyncApiDocument | undefined>) {
   const searchIndex = computed<FuseData[]>(() => createSearchIndex(toValue(document)))
 
   /** When the document changes we replace the search index */

--- a/packages/api-reference/src/features/Search/search-quality.test.ts
+++ b/packages/api-reference/src/features/Search/search-quality.test.ts
@@ -7,6 +7,7 @@ import { createSearchIndex } from './helpers/create-search-index'
 
 function search(query: string, document: Partial<OpenApiDocument>) {
   const doc = {
+    openapi: '3.1.0',
     info: {
       title: 'Test API',
       version: '1.0.0',


### PR DESCRIPTION
Follow-up to #9255 — the sidebar already shows AsyncAPI `info.description` headings, now the search modal picks them up too. Channels, operations, and messages still aren't indexed.

<img width="570" height="269" alt="Screenshot 2026-05-27 at 14 32 06" src="https://github.com/user-attachments/assets/a16d4a24-d4d8-46b4-bee5-7dcfec61322b" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to search indexing and document typing; OpenAPI paths are unchanged behind a type guard, with no auth or data-handling changes.
> 
> **Overview**
> **AsyncAPI docs can use reference search for intro headings**, matching the sidebar: the active workspace document (OpenAPI or AsyncAPI) is passed into search instead of dropping non-OpenAPI specs.
> 
> Search indexing accepts **`OpenApiDocument | AsyncApiDocument`**. OpenAPI-only enrichment (paths, webhooks, models) is gated with **`isOpenApiDocument`** so AsyncAPI navigation still contributes **`text` / heading** entries from **`info.description`**. Channels, operations, and messages are **not** indexed yet.
> 
> Types and wiring were updated in **`ApiReference.vue`**, **`SearchButton`**, **`SearchModal`**, **`useSearchIndex`**, and **`create-search-index`**, with a new AsyncAPI test in **`create-search-index.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b965f823b9c54e90e55a47c8b4091ca0e93f969. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->