### PR TITLE
feat(api-reference): render AsyncAPI channels in the content area

### DIFF
--- a/.changeset/asyncapi-channel-sections.md
+++ b/.changeset/asyncapi-channel-sections.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Render AsyncAPI channels as sections in the content area, with the channel address as the heading and the channel description below. Channels are grouped under tags when the navigation tree groups them. Operations and messages are not rendered yet.

--- a/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.test.ts
@@ -1,0 +1,58 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import AsyncApiTraversedEntry from './AsyncApiTraversedEntry.vue'
+
+const document = {
+  asyncapi: '3.0.0',
+  info: { title: 'Streaming API', version: '1.0.0' },
+  'x-scalar-original-document-hash': '',
+  channels: {},
+} as unknown as AsyncApiDocument
+
+describe('AsyncApiTraversedEntry', () => {
+  /**
+   * Tag groups are rendered through the flatten branch in modern layout, so they
+   * must not count toward the sibling-tag total. If they did, a lone regular tag
+   * sitting next to a tag group would get `moreThanOneTag = true` and `ModernLayout`
+   * would hide its body behind a "Show more" button while collapsed.
+   */
+  it('does not count sibling tag groups when computing moreThanOneTag', () => {
+    const entries: TraversedEntry[] = [
+      {
+        id: 'tag',
+        type: 'tag',
+        title: 'Only Tag',
+        name: 'only-tag',
+        isGroup: false,
+        children: [],
+      },
+      {
+        id: 'group',
+        type: 'tag',
+        title: 'A Group',
+        name: 'a-group',
+        isGroup: true,
+        children: [],
+      },
+    ]
+
+    const wrapper = mount(AsyncApiTraversedEntry, {
+      props: {
+        entries,
+        document,
+        // `Lazy` only renders its slot when the entry is expanded; mark both
+        // so the assertion can see the rendered `<Tag>` for the regular tag.
+        expandedItems: { tag: true, group: true },
+        options: { layout: 'modern' },
+        eventBus: null as never,
+      },
+    })
+
+    const tagComponents = wrapper.findAllComponents({ name: 'Tag' })
+    expect(tagComponents).toHaveLength(1)
+    expect(tagComponents[0]?.props('moreThanOneTag')).toBe(false)
+  })
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import type {
+  TraversedAsyncApiChannel,
+  TraversedEntry,
+  TraversedTag,
+} from '@scalar/workspace-store/schemas/navigation'
+
+import { Tag } from '@/components/Content/Tags'
+import Lazy from '@/components/Lazy/Lazy.vue'
+
+import Channel from './Channel.vue'
+
+const {
+  entries,
+  document,
+  expandedItems,
+  options,
+  eventBus,
+  level = 0,
+} = defineProps<{
+  entries: TraversedEntry[]
+  document: AsyncApiDocument
+  expandedItems: Record<string, boolean>
+  options: { layout: 'classic' | 'modern' }
+  eventBus: WorkspaceEventBus
+  level?: number
+}>()
+
+const isTag = (entry: TraversedEntry): entry is TraversedTag =>
+  entry.type === 'tag'
+const isTagGroup = (
+  entry: TraversedEntry,
+): entry is TraversedTag & { isGroup: true } =>
+  entry.type === 'tag' && entry.isGroup === true
+const isChannel = (entry: TraversedEntry): entry is TraversedAsyncApiChannel =>
+  entry.type === 'asyncapi-channel'
+</script>
+
+<template>
+  <Lazy
+    v-for="entry in entries"
+    :id="entry.id"
+    :key="`${entry.id}-${options.layout}`"
+    :expanded="!!expandedItems[entry.id]">
+    <Channel
+      v-if="isChannel(entry)"
+      :channel="entry"
+      :document="document"
+      :eventBus="eventBus"
+      :isCollapsed="!expandedItems[entry.id]"
+      :layout="options.layout" />
+
+    <Tag
+      v-else-if="
+        isTag(entry) && (!isTagGroup(entry) || options.layout === 'classic')
+      "
+      :eventBus="eventBus"
+      :isCollapsed="!expandedItems[entry.id]"
+      :isLoading="false"
+      :layout="options.layout"
+      :moreThanOneTag="entries.filter(isTag).length > 1"
+      :tag="entry">
+      <template v-if="entry.children?.length">
+        <AsyncApiTraversedEntry
+          :document="document"
+          :entries="entry.children"
+          :eventBus="eventBus"
+          :expandedItems="expandedItems"
+          :level="level + 1"
+          :options="options" />
+      </template>
+    </Tag>
+
+    <AsyncApiTraversedEntry
+      v-else-if="isTagGroup(entry)"
+      :document="document"
+      :entries="entry.children ?? []"
+      :eventBus="eventBus"
+      :expandedItems="expandedItems"
+      :level="level + 1"
+      :options="options" />
+  </Lazy>
+</template>

--- a/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.vue
@@ -28,12 +28,20 @@ const {
   level?: number
 }>()
 
-const isTag = (entry: TraversedEntry): entry is TraversedTag =>
-  entry.type === 'tag'
 const isTagGroup = (
   entry: TraversedEntry,
 ): entry is TraversedTag & { isGroup: true } =>
   entry.type === 'tag' && entry.isGroup === true
+/**
+ * Narrow to a regular (non-group) tag. Tag groups go through a separate branch
+ * and must not inflate the sibling-tag count used for `moreThanOneTag`,
+ * otherwise `ModernLayout` shows a "Show more" button for a lone tag whenever
+ * it sits next to a tag group.
+ */
+const isTag = (
+  entry: TraversedEntry,
+): entry is TraversedTag & { isGroup: false } =>
+  entry.type === 'tag' && !isTagGroup(entry)
 const isChannel = (entry: TraversedEntry): entry is TraversedAsyncApiChannel =>
   entry.type === 'asyncapi-channel'
 </script>
@@ -54,7 +62,7 @@ const isChannel = (entry: TraversedEntry): entry is TraversedAsyncApiChannel =>
 
     <Tag
       v-else-if="
-        isTag(entry) && (!isTagGroup(entry) || options.layout === 'classic')
+        isTag(entry) || (isTagGroup(entry) && options.layout === 'classic')
       "
       :eventBus="eventBus"
       :isCollapsed="!expandedItems[entry.id]"

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
@@ -30,6 +30,15 @@ function createDocument(channelDescription?: string): AsyncApiDocument {
   } as AsyncApiDocument
 }
 
+function createDocumentWithChannel(channel: Record<string, unknown>): AsyncApiDocument {
+  return {
+    asyncapi: '3.0.0',
+    info: { title: 'Streaming API', version: '1.0.0' },
+    'x-scalar-original-document-hash': '',
+    channels: { userSignedUp: channel },
+  } as AsyncApiDocument
+}
+
 describe('Channel', () => {
   it('renders the channel address as the heading and the description below', () => {
     const wrapper = mount(Channel, {
@@ -60,6 +69,39 @@ describe('Channel', () => {
 
     const heading = wrapper.find('h2')
     expect(heading.text()).toContain('user/signedup')
+  })
+
+  it('prefers channel.title over the address when present', () => {
+    const wrapper = mount(Channel, {
+      props: {
+        channel: createChannel(),
+        document: createDocumentWithChannel({
+          address: 'user/signedup',
+          title: 'User signups',
+        }),
+        layout: 'modern',
+        isCollapsed: false,
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.find('h2').text()).toContain('User signups')
+    expect(wrapper.find('h2').text()).not.toContain('user/signedup')
+  })
+
+  it('falls back to the channel key when neither title nor address is set', () => {
+    const wrapper = mount(Channel, {
+      props: {
+        // Simulate the traversal fallback: address-less channels get `channelName` as `channelAddress`.
+        channel: createChannel({ channelAddress: 'userSignedUp' }),
+        document: createDocumentWithChannel({}),
+        layout: 'modern',
+        isCollapsed: false,
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.find('h2').text()).toContain('userSignedUp')
   })
 
   it('renders an accordion wrapper for the classic layout', () => {

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
@@ -1,0 +1,80 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import type { TraversedAsyncApiChannel } from '@scalar/workspace-store/schemas/navigation'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import Channel from './Channel.vue'
+
+function createChannel(overrides: Partial<TraversedAsyncApiChannel> = {}): TraversedAsyncApiChannel {
+  return {
+    type: 'asyncapi-channel',
+    id: 'doc/channel/userSignedUp',
+    title: 'User signups',
+    channelName: 'userSignedUp',
+    channelAddress: 'user/signedup',
+    ...overrides,
+  }
+}
+
+function createDocument(channelDescription?: string): AsyncApiDocument {
+  return {
+    asyncapi: '3.0.0',
+    info: { title: 'Streaming API', version: '1.0.0' },
+    'x-scalar-original-document-hash': '',
+    channels: {
+      userSignedUp: {
+        address: 'user/signedup',
+        description: channelDescription,
+      },
+    },
+  } as AsyncApiDocument
+}
+
+describe('Channel', () => {
+  it('renders the channel address as the heading and the description below', () => {
+    const wrapper = mount(Channel, {
+      props: {
+        channel: createChannel(),
+        document: createDocument('Fired whenever a user signs up.'),
+        layout: 'modern',
+        isCollapsed: false,
+        eventBus: null,
+      },
+    })
+
+    const heading = wrapper.find('h2')
+    expect(heading.text()).toContain('user/signedup')
+    expect(wrapper.text()).toContain('Fired whenever a user signs up.')
+  })
+
+  it('renders without a description when the channel has none', () => {
+    const wrapper = mount(Channel, {
+      props: {
+        channel: createChannel(),
+        document: createDocument(),
+        layout: 'modern',
+        isCollapsed: false,
+        eventBus: null,
+      },
+    })
+
+    const heading = wrapper.find('h2')
+    expect(heading.text()).toContain('user/signedup')
+  })
+
+  it('renders an accordion wrapper for the classic layout', () => {
+    const wrapper = mount(Channel, {
+      props: {
+        channel: createChannel(),
+        document: createDocument('Classic layout description.'),
+        layout: 'classic',
+        isCollapsed: false,
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'SectionContainerAccordion' }).exists()).toBe(true)
+    expect(wrapper.text()).toContain('user/signedup')
+    expect(wrapper.text()).toContain('Classic layout description.')
+  })
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { ScalarMarkdown } from '@scalar/components/markdown'
+import type {
+  AsyncApiChannelObject,
+  AsyncApiDocument,
+} from '@scalar/types/asyncapi/3.1'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import {
+  getResolvedRef,
+  mergeSiblingReferences,
+} from '@scalar/workspace-store/helpers/get-resolved-ref'
+import type { TraversedAsyncApiChannel } from '@scalar/workspace-store/schemas/navigation'
+import { computed, useId } from 'vue'
+
+import { Anchor } from '@/components/Anchor'
+import {
+  Section,
+  SectionContainer,
+  SectionContainerAccordion,
+  SectionContent,
+  SectionHeader,
+  SectionHeaderTag,
+} from '@/components/Section'
+
+const { channel, document, layout, isCollapsed, eventBus } = defineProps<{
+  channel: TraversedAsyncApiChannel
+  document: AsyncApiDocument
+  layout: 'classic' | 'modern'
+  isCollapsed: boolean
+  eventBus: WorkspaceEventBus | null
+}>()
+
+const headerId = useId()
+
+/**
+ * Resolve the channel from the document so we can read its description.
+ * The navigation entry only carries the address and identifying keys.
+ */
+const resolvedChannel = computed<AsyncApiChannelObject | undefined>(() => {
+  const node = document.channels?.[channel.channelName]
+  return node ? getResolvedRef(node, mergeSiblingReferences) : undefined
+})
+
+const description = computed(() => resolvedChannel.value?.description ?? '')
+</script>
+
+<template>
+  <SectionContainerAccordion
+    v-if="layout === 'classic'"
+    :aria-label="channel.channelAddress"
+    class="channel-section"
+    :modelValue="!isCollapsed"
+    @update:modelValue="
+      (value) =>
+        eventBus?.emit('toggle:nav-item', { id: channel.id, open: value })
+    ">
+    <template #title>
+      <SectionHeader class="channel-name">
+        <Anchor
+          @copyAnchorUrl="
+            () => eventBus?.emit('copy-url:nav-item', { id: channel.id })
+          ">
+          <SectionHeaderTag :level="2">
+            {{ channel.channelAddress }}
+          </SectionHeaderTag>
+        </Anchor>
+      </SectionHeader>
+      <ScalarMarkdown
+        class="channel-description"
+        :value="description"
+        withImages />
+    </template>
+  </SectionContainerAccordion>
+
+  <SectionContainer
+    v-else
+    :aria-labelledby="headerId"
+    role="region">
+    <Section
+      :id="channel.id"
+      role="none"
+      @intersecting="
+        () => eventBus?.emit('intersecting:nav-item', { id: channel.id })
+      ">
+      <SectionHeader>
+        <Anchor
+          @copyAnchorUrl="
+            () => eventBus?.emit('copy-url:nav-item', { id: channel.id })
+          ">
+          <SectionHeaderTag
+            :id="headerId"
+            :level="2">
+            {{ channel.channelAddress }}
+          </SectionHeaderTag>
+        </Anchor>
+      </SectionHeader>
+      <SectionContent>
+        <ScalarMarkdown
+          :value="description"
+          withImages />
+      </SectionContent>
+    </Section>
+  </SectionContainer>
+</template>
+
+<style scoped>
+.channel-section {
+  margin-bottom: 48px;
+}
+.channel-description {
+  padding-bottom: 4px;
+  text-align: left;
+}
+</style>

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
@@ -42,12 +42,25 @@ const resolvedChannel = computed<AsyncApiChannelObject | undefined>(() => {
 })
 
 const description = computed(() => resolvedChannel.value?.description ?? '')
+
+/**
+ * Heading shown above each channel section.
+ *
+ * Prefers the human-friendly `channel.title` when it is set, then falls back
+ * to `channel.address`, and finally to the channel map key.
+ * `channel.channelAddress` already encodes the address-or-key fallback during
+ * navigation traversal, so we only need to overlay `title` on top of it.
+ */
+const headingText = computed(() => {
+  const title = resolvedChannel.value?.title?.trim()
+  return title || channel.channelAddress
+})
 </script>
 
 <template>
   <SectionContainerAccordion
     v-if="layout === 'classic'"
-    :aria-label="channel.channelAddress"
+    :aria-label="headingText"
     class="channel-section"
     :modelValue="!isCollapsed"
     @update:modelValue="
@@ -61,7 +74,7 @@ const description = computed(() => resolvedChannel.value?.description ?? '')
             () => eventBus?.emit('copy-url:nav-item', { id: channel.id })
           ">
           <SectionHeaderTag :level="2">
-            {{ channel.channelAddress }}
+            {{ headingText }}
           </SectionHeaderTag>
         </Anchor>
       </SectionHeader>
@@ -90,7 +103,7 @@ const description = computed(() => resolvedChannel.value?.description ?? '')
           <SectionHeaderTag
             :id="headerId"
             :level="2">
-            {{ channel.channelAddress }}
+            {{ headingText }}
           </SectionHeaderTag>
         </Anchor>
       </SectionHeader>

--- a/packages/api-reference/src/components/Content/AsyncApi/index.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/index.ts
@@ -1,0 +1,2 @@
+export { default as AsyncApiTraversedEntry } from './AsyncApiTraversedEntry.vue'
+export { default as Channel } from './Channel.vue'

--- a/packages/api-reference/src/components/Content/AsyncApi/index.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/index.ts
@@ -1,2 +1,1 @@
 export { default as AsyncApiTraversedEntry } from './AsyncApiTraversedEntry.vue'
-export { default as Channel } from './Channel.vue'

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -28,6 +28,7 @@ import { ClientSelector } from '@/blocks/scalar-client-selector-block'
 import { InfoBlock } from '@/blocks/scalar-info-block'
 import { IntroductionCardItem } from '@/blocks/scalar-info-block/'
 import { ServerSelector } from '@/blocks/scalar-server-selector-block'
+import { AsyncApiTraversedEntry } from '@/components/Content/AsyncApi'
 import { Auth } from '@/components/Content/Auth'
 import TraversedEntry from '@/components/Content/Operations/TraversedEntry.vue'
 import { RenderPlugins } from '@/components/RenderPlugins'
@@ -92,6 +93,11 @@ const openApiDocument = computed(() =>
 )
 const openApiClientDocument = computed(() =>
   isOpenApiDocument(clientDocument) ? clientDocument : undefined,
+)
+
+/** AsyncAPI narrow, used to render the (currently channel-only) AsyncAPI content tree. */
+const asyncApiDocument = computed(() =>
+  isAsyncApiDocument(document) ? document : undefined,
 )
 
 const documentType = computed(() => getDocumentType(document))
@@ -225,6 +231,15 @@ onMounted(() => {
       :selectedClient="xScalarDefaultClient"
       :selectedServer>
     </TraversedEntry>
+
+    <!-- AsyncAPI: render channels grouped by tag, mirroring the sidebar order. -->
+    <AsyncApiTraversedEntry
+      v-else-if="items.length && asyncApiDocument"
+      :document="asyncApiDocument"
+      :entries="items"
+      :eventBus
+      :expandedItems
+      :options />
 
     <!-- Render plugins at content.end view -->
     <RenderPlugins


### PR DESCRIPTION
I saw the AsyncAPI channels appear in the sidebar already, so I started to build the rendering for it: 

Each channel renders as a section now. The heading shows 

1. `channel.title` if set (not set, see #9349)
2. otherwise the `address` (see screenshot), 
3. otherwise the channel key. 

Description below. Order and tag grouping follow the sidebar navigation. 

Operations and messages still aren't rendered. _But a marathon starts with just a single step, too._ :)

<img width="1209" height="1022" alt="Screenshot 2026-05-27 at 14 56 31" src="https://github.com/user-attachments/assets/d087fbe0-263d-4ed2-8eb6-26108cdc3c68" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI for AsyncAPI channel display only; follows existing OpenAPI traversal and section patterns with focused unit tests and no auth or data-path changes.
> 
> **Overview**
> **AsyncAPI docs** now show **channels in the main content pane**, not only in the sidebar. `Content.vue` routes AsyncAPI documents to a new **`AsyncApiTraversedEntry`** tree that follows the same navigation order and tag grouping as the sidebar (lazy-loaded, classic vs modern layout).
> 
> Each **`asyncapi-channel`** entry renders as a section via **`Channel`**: heading uses **`channel.title`**, then **address**, then the channel map key; **description** comes from the resolved channel object (markdown). Tag groups in **modern** layout are flattened without inflating **`moreThanOneTag`**, so a single tag beside a group does not get a spurious “Show more” state. **Operations and messages** are still not rendered in content.
> 
> Unit tests cover heading fallbacks, classic accordion, and the tag-group sibling count behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebebf70b3c2425ce84fcb80dbe6ab9a5af1b671f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->