### PR TITLE
feat(galaxy): add tags and channel titles to AsyncAPI sample

### DIFF
--- a/.changeset/asyncapi-galaxy-tags.md
+++ b/.changeset/asyncapi-galaxy-tags.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+Tag channels, operations, and messages in the AsyncAPI 3.0 sample so they group consistently with the OpenAPI document.

--- a/packages/galaxy/src/documents/asyncapi/3.0.yaml
+++ b/packages/galaxy/src/documents/asyncapi/3.0.yaml
@@ -62,6 +62,7 @@ defaultContentType: application/json
 channels:
   planetEvents:
     address: 'planets/{planetId}/events'
+    title: Planet Events
     description: |
       Real-time events related to specific planets. Subscribe to get notified about:
 
@@ -107,6 +108,7 @@ channels:
               description: Filter by specific event types
   userEvents:
     address: 'users/{userId}/events'
+    title: User Events
     description: |
       User-related events including authentication, profile changes, and activity tracking.
 
@@ -132,6 +134,7 @@ channels:
         method: GET
   systemEvents:
     address: 'system/events'
+    title: System Events
     description: |
       System-wide events including maintenance notifications, rate limit alerts, and security events.
 
@@ -152,6 +155,7 @@ channels:
         method: GET
   celestialBodyEvents:
     address: 'celestial-bodies/events'
+    title: Celestial Body Events
     description: |
       Events related to all types of celestial bodies (planets, satellites, asteroids, comets).
 

--- a/packages/galaxy/src/documents/asyncapi/3.0.yaml
+++ b/packages/galaxy/src/documents/asyncapi/3.0.yaml
@@ -27,6 +27,18 @@ info:
   externalDocs:
     description: Documentation
     url: https://github.com/scalar/scalar
+  tags:
+    - name: Planets
+      description: Real-time planet events including creation, updates, deletions, atmospheric changes, and cosmic events
+    - name: Users
+      description: User authentication, registration, profile updates, and login events
+      externalDocs:
+        description: User documentation
+        url: https://github.com/scalar/scalar
+    - name: Celestial Bodies
+      description: Events for satellites, asteroids, comets, and other celestial objects in the galaxy
+    - name: System
+      description: System-wide events including maintenance, rate limits, security alerts, and API deprecations
 servers:
   production:
     host: galaxy.scalar.com
@@ -76,6 +88,8 @@ channels:
         $ref: '#/components/messages/AtmosphereChanged'
       imageUploaded:
         $ref: '#/components/messages/ImageUploaded'
+    tags:
+      - name: Planets
     bindings:
       ws:
         method: GET
@@ -111,6 +125,8 @@ channels:
         $ref: '#/components/messages/UserDeleted'
       loginAttempt:
         $ref: '#/components/messages/LoginAttempt'
+    tags:
+      - name: Users
     bindings:
       ws:
         method: GET
@@ -129,6 +145,8 @@ channels:
         $ref: '#/components/messages/SecurityAlert'
       apiVersionDeprecated:
         $ref: '#/components/messages/ApiVersionDeprecated'
+    tags:
+      - name: System
     bindings:
       ws:
         method: GET
@@ -147,6 +165,8 @@ channels:
         $ref: '#/components/messages/OrbitalCollision'
       newDiscovery:
         $ref: '#/components/messages/NewDiscovery'
+    tags:
+      - name: Celestial Bodies
     bindings:
       ws:
         method: GET
@@ -171,6 +191,8 @@ operations:
     description: Subscribe to real-time events for a specific planet
     traits:
       - $ref: '#/components/operationTraits/authenticated'
+    tags:
+      - name: Planets
     bindings:
       ws:
         bindingVersion: 0.1.0
@@ -184,6 +206,8 @@ operations:
     traits:
       - $ref: '#/components/operationTraits/authenticated'
       - $ref: '#/components/operationTraits/rateLimited'
+    tags:
+      - name: Users
     bindings:
       ws:
         bindingVersion: 0.1.0
@@ -194,6 +218,8 @@ operations:
       $ref: '#/channels/systemEvents'
     title: Subscribe to System Events
     description: Subscribe to system-wide notifications and alerts
+    tags:
+      - name: System
     bindings:
       ws:
         bindingVersion: 0.1.0
@@ -206,6 +232,8 @@ operations:
     description: Subscribe to events for all celestial bodies in the galaxy
     traits:
       - $ref: '#/components/operationTraits/rateLimited'
+    tags:
+      - name: Celestial Bodies
     bindings:
       ws:
         bindingVersion: 0.1.0
@@ -272,6 +300,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/PlanetCreatedEvent'
+      tags:
+        - name: Planets
       examples:
         - name: Mars Discovery
           summary: Mars was just added to the galaxy
@@ -324,6 +354,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/PlanetUpdatedEvent'
+      tags:
+        - name: Planets
       examples:
         - name: Mars Atmosphere Update
           summary: Mars atmosphere composition was updated
@@ -365,6 +397,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/PlanetDeletedEvent'
+      tags:
+        - name: Planets
       examples:
         - name: Planet Destruction
           summary: A planet was deleted (hopefully by accident!)
@@ -393,6 +427,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/PlanetExplodedEvent'
+      tags:
+        - name: Planets
       examples:
         - name: Supernova Event
           summary: A planet went supernova
@@ -431,6 +467,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/SatelliteDiscoveredEvent'
+      tags:
+        - name: Planets
       examples:
         - name: New Moon Discovery
           summary: A new moon was discovered around Mars
@@ -464,6 +502,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/AtmosphereChangedEvent'
+      tags:
+        - name: Planets
       examples:
         - name: Terraforming Progress
           summary: Mars atmosphere is being terraformed
@@ -499,6 +539,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/ImageUploadedEvent'
+      tags:
+        - name: Planets
       examples:
         - name: Mars Photo Upload
           summary: A new photo of Mars was uploaded
@@ -531,6 +573,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/UserSignedUpEvent'
+      tags:
+        - name: Users
       examples:
         - name: New User Registration
           summary: A new user joined the galaxy
@@ -560,6 +604,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/UserAuthenticatedEvent'
+      tags:
+        - name: Users
       examples:
         - name: Successful Login
           summary: User logged in successfully
@@ -592,6 +638,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/UserProfileUpdatedEvent'
+      tags:
+        - name: Users
       examples:
         - name: Profile Update
           summary: User updated their profile
@@ -621,6 +669,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/UserDeletedEvent'
+      tags:
+        - name: Users
       examples:
         - name: Account Deletion
           summary: A user deleted their account
@@ -649,6 +699,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/LoginAttemptEvent'
+      tags:
+        - name: Users
       examples:
         - name: Failed Login
           summary: Someone tried to log in with wrong credentials
@@ -679,6 +731,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/SystemMaintenanceEvent'
+      tags:
+        - name: System
       examples:
         - name: Scheduled Maintenance
           summary: System maintenance is starting
@@ -712,6 +766,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/RateLimitExceededEvent'
+      tags:
+        - name: System
       examples:
         - name: API Rate Limit Hit
           summary: A user hit the API rate limit
@@ -744,6 +800,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/SecurityAlertEvent'
+      tags:
+        - name: System
       examples:
         - name: Suspicious Activity
           summary: Suspicious login pattern detected
@@ -779,6 +837,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/ApiVersionDeprecatedEvent'
+      tags:
+        - name: System
       examples:
         - name: Version Deprecation
           summary: API version 1.0 is being deprecated
@@ -810,6 +870,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/CelestialBodyCreatedEvent'
+      tags:
+        - name: Celestial Bodies
       examples:
         - name: New Asteroid
           summary: A new asteroid was discovered
@@ -841,6 +903,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/CelestialBodyUpdatedEvent'
+      tags:
+        - name: Celestial Bodies
       examples:
         - name: Orbit Update
           summary: A satellite's orbit was recalculated
@@ -877,6 +941,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/OrbitalCollisionEvent'
+      tags:
+        - name: Celestial Bodies
       examples:
         - name: Asteroid Impact
           summary: An asteroid collided with a planet
@@ -914,6 +980,8 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/NewDiscoveryEvent'
+      tags:
+        - name: Celestial Bodies
       examples:
         - name: Habitable Planet
           summary: A potentially habitable planet was discovered


### PR DESCRIPTION
Adds tags and channel titles to the AsyncAPI example so it groups and reads like the OpenAPI one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample YAML and changeset only; no runtime or API behavior changes.
> 
> **Overview**
> The **@scalar/galaxy** AsyncAPI 3.0 sample is updated so its navigation matches the OpenAPI Scalar Galaxy doc.
> 
> **`info.tags`** now defines **Planets**, **Users**, **Celestial Bodies**, and **System** (with descriptions aligned to those domains). Each channel gets a **`title`** and a **`tags`** entry; subscribe operations and every message component get the same tag names. A patch **changeset** records the `@scalar/galaxy` release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f6170ba7154491bc4dbd1babb5691559b8cc72d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->