### PR TITLE
fix(workspace-store): preserve large integer parameter values

### DIFF
--- a/.changeset/fix-parameter-large-integer-deserialize.md
+++ b/.changeset/fix-parameter-large-integer-deserialize.md
@@ -1,0 +1,7 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: preserve large integer parameter values
+
+Stop JSON-parsing primitive parameter values when building requests. Integer and number path, query, and header fields keep the exact string from the editor so values larger than Number.MAX_SAFE_INTEGER are not rounded. Array and object parameters are still parsed for OpenAPI style serialization.

--- a/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.test.ts
+++ b/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.test.ts
@@ -88,7 +88,7 @@ describe('de-serialize-parameter', () => {
       expect(result).toEqual({ data: 'value' })
     })
 
-    it('parses boolean string when schema type is boolean', () => {
+    it('keeps boolean strings unchanged when schema type is boolean', () => {
       const param: ParameterWithSchemaObject = {
         name: 'test',
         in: 'query',
@@ -100,10 +100,10 @@ describe('de-serialize-parameter', () => {
 
       const result = deSerializeParameter(example, param)
 
-      expect(result).toBe(true)
+      expect(result).toBe('true')
     })
 
-    it('parses number string when schema type is number', () => {
+    it('keeps number strings unchanged when schema type is number', () => {
       const param: ParameterWithSchemaObject = {
         name: 'test',
         in: 'query',
@@ -115,10 +115,10 @@ describe('de-serialize-parameter', () => {
 
       const result = deSerializeParameter(example, param)
 
-      expect(result).toBe(42.5)
+      expect(result).toBe('42.5')
     })
 
-    it('parses integer string when schema type is integer', () => {
+    it('keeps integer strings unchanged when schema type is integer', () => {
       const param: ParameterWithSchemaObject = {
         name: 'test',
         in: 'query',
@@ -130,10 +130,25 @@ describe('de-serialize-parameter', () => {
 
       const result = deSerializeParameter(example, param)
 
-      expect(result).toBe(123)
+      expect(result).toBe('123')
     })
 
-    it('parses null string when schema type is null', () => {
+    it('keeps integers larger than Number.MAX_SAFE_INTEGER as strings', () => {
+      const param: ParameterWithSchemaObject = {
+        name: 'id',
+        in: 'path',
+        schema: {
+          type: 'integer',
+        },
+      }
+      const example = '1507323546366377984'
+
+      const result = deSerializeParameter(example, param)
+
+      expect(result).toBe('1507323546366377984')
+    })
+
+    it('keeps null keyword strings unchanged when schema type is null', () => {
       const param: ParameterWithSchemaObject = {
         name: 'test',
         in: 'query',
@@ -145,7 +160,7 @@ describe('de-serialize-parameter', () => {
 
       const result = deSerializeParameter(example, param)
 
-      expect(result).toBe(null)
+      expect(result).toBe('null')
     })
 
     it('does not parse string when schema type is string', () => {

--- a/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.ts
+++ b/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.ts
@@ -4,7 +4,10 @@ import type {
   ParameterWithSchemaObject,
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
-/** Helper that de-serializes the example value based on the parameter type */
+/**
+ * Coerces a parameter example from the UI (always a string from CodeInput) into a value
+ * request building can serialize. Only structured types are parsed; primitives stay as strings.
+ */
 export const deSerializeParameter = (example: unknown, param: ParameterObject) => {
   if ('content' in param) {
     return deSerializeContentExample(example, Object.keys(param.content ?? {})[0] ?? '')
@@ -16,41 +19,44 @@ export const deSerializeParameter = (example: unknown, param: ParameterObject) =
   return example
 }
 
-/** De-serialize the example value based on the content type */
+/**
+ * Content-based parameters (e.g. `application/json`) may hold full JSON payloads;
+ * parse those so nested structure is available to serializers.
+ */
 const deSerializeContentExample = (example: unknown, contentType: string) => {
   if (typeof example === 'string' && contentType.includes('json')) {
     try {
       return JSON.parse(example)
     } catch {
-      // Ignore the error and return the original example
+      return example
     }
   }
   return example
 }
 
-/** Create a set of all the types we wish to parse as JSON */
-const parseableTypesSet = new Set(['array', 'object', 'boolean', 'number', 'integer', 'null'])
+/** Schema types that must become arrays/objects — serializers branch on `Array.isArray` / objects. */
+const structuredSchemaTypes = new Set(['array', 'object'])
 
-/** De-serialize the example value based on the schema type */
+/**
+ * Schema-based parameters from the request editor.
+ *
+ * Primitives (`string`, `integer`, `number`, `boolean`, `null`) are left as the typed string
+ * Only `array` and `object` values are parsed so OpenAPI style serialization can expand them.
+ */
 const deSerializeSchemaExample = (example: unknown, schema: ParameterWithSchemaObject['schema']) => {
   const resolvedSchema = getResolvedRef(schema)
 
   if (typeof example === 'string' && resolvedSchema && 'type' in resolvedSchema) {
     const type = Array.isArray(resolvedSchema.type) ? resolvedSchema.type[0] : resolvedSchema.type
 
-    if (type && parseableTypesSet.has(type)) {
+    if (type && structuredSchemaTypes.has(type)) {
       try {
         return JSON.parse(example)
       } catch {
-        // For array types, fall back to splitting comma-separated values.
-        // Users commonly enter array values as "foo,bar" or "foo, bar" in the UI
-        // text field, which is not valid JSON. Per the OpenAPI spec, the default
-        // serialization for query array parameters is style=form + explode=true,
-        // meaning each value should be sent as a separate query parameter.
+        // Arrays: users often type `foo,bar` instead of JSON — split to match default form+explode query style.
         if (type === 'array') {
           return example.split(/,\s?/).filter((v) => v !== '')
         }
-        // Ignore the error and return the original example for other types
       }
     }
   }


### PR DESCRIPTION
Fixes: #9343 

Stop JSON-parsing primitive parameter values when building requests. Integer and number path, query, and header fields keep the exact string from the editor so values larger than Number.MAX_SAFE_INTEGER are not rounded. Array and object parameters are still parsed for OpenAPI style serialization.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted request-building coercion change with tests; serializers already handle string primitives for HTTP output.
> 
> **Overview**
> **`deSerializeParameter`** in `@scalar/workspace-store` no longer runs **`JSON.parse`** on primitive schema types (`integer`, `number`, `boolean`, `null`). Path, query, and header values from the request editor stay as the exact strings the user typed, so integers beyond **`Number.MAX_SAFE_INTEGER`** are not rounded when requests are built.
> 
> **Array** and **object** parameters are still parsed (including comma-split fallback for arrays) so OpenAPI style serialization keeps working. JSON **content**-based parameters are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35c46de08d4ff3a4e58fc065cc3caf3a21fd2a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->