### PR TITLE
fix(api-client): group custom x-codeSamples by language in dropdown

### DIFF
--- a/.changeset/group-code-samples-by-language.md
+++ b/.changeset/group-code-samples-by-language.md
@@ -1,0 +1,9 @@
+---
+'@scalar/api-client': patch
+---
+
+Group custom x-codeSamples by language in the code samples dropdown
+
+Previously, custom code samples from `x-codeSamples` were displayed in a single flat "Code Examples" group. This change groups them by language, similar to how auto-generated snippetz clients are grouped.
+
+For example, if an operation has two Python code samples (sync and async variants), they will now appear under a "Python" group with both options selectable, instead of appearing as separate top-level items.

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/find-client.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/find-client.test.ts
@@ -228,8 +228,8 @@ describe('findClient', () => {
     it('returns first option when first option is custom', () => {
       const customGroups: CustomClientOptionGroup[] = [
         {
-          label: 'Custom',
-          key: 'custom',
+          label: 'JavaScript',
+          key: 'custom-js',
           options: [
             {
               id: 'custom/example',

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/get-clients.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/get-clients.test.ts
@@ -7,11 +7,11 @@ import { getClients } from './get-clients'
 
 describe('getClients', () => {
   /**
-   * Test 1: Verifies that custom code samples are properly transformed and prepended
-   * This is critical because it ensures custom examples appear first in the UI
-   * and are correctly structured with all required properties.
+   * Test 1: Verifies that custom code samples are properly transformed and grouped by language
+   * This is critical because it ensures custom examples appear first in the UI,
+   * are correctly structured with all required properties, and are grouped by language.
    */
-  it('should merge custom code samples with client options and prepend them as a group', () => {
+  it('groups custom code samples by language and prepends them', () => {
     const customCodeSamples: XCodeSample[] = [
       {
         lang: 'python',
@@ -45,13 +45,13 @@ describe('getClients', () => {
 
     const result = getClients(customCodeSamples, clientOptions)
 
-    // Should have one more group than the original client options
-    expect(result).toHaveLength(2)
+    // Should have language groups + original client options
+    expect(result).toHaveLength(3)
 
-    // First group should be the custom code examples
+    // First group should be Python (first language encountered)
     expect(result[0]).toEqual({
-      label: 'Code Examples',
-      key: 'custom',
+      label: 'Python',
+      key: 'custom-python',
       options: [
         {
           id: 'custom/0',
@@ -60,6 +60,14 @@ describe('getClients', () => {
           title: 'Custom Python Example',
           label: 'Custom Python Example',
         },
+      ] satisfies CustomClientOption[],
+    })
+
+    // Second group should be Js (capitalized)
+    expect(result[1]).toEqual({
+      label: 'Js',
+      key: 'custom-js',
+      options: [
         {
           id: 'custom/1',
           lang: 'js',
@@ -71,7 +79,7 @@ describe('getClients', () => {
     })
 
     // Original client options should follow
-    expect(result[1]).toEqual(clientOptions[0])
+    expect(result[2]).toEqual(clientOptions[0])
   })
 
   /**
@@ -79,7 +87,7 @@ describe('getClients', () => {
    * This is critical because the OpenAPI spec allows lang and label to be optional,
    * and we need to handle these cases gracefully without breaking the UI.
    */
-  it('should handle custom code samples with missing lang and label fields', () => {
+  it('handles custom code samples with missing lang and label fields', () => {
     const customCodeSamples: XCodeSample[] = [
       {
         source: 'echo "test"',
@@ -98,40 +106,45 @@ describe('getClients', () => {
 
     const result = getClients(customCodeSamples, clientOptions)
 
-    expect(result).toHaveLength(1)
-    const firstGroup = result[0]
-    expect(firstGroup).toBeDefined()
-    expect(firstGroup?.label).toBe('Code Examples')
-    expect(firstGroup?.options).toHaveLength(3)
+    // Should have 2 groups: plaintext (samples 0 and 2) and ruby (sample 1)
+    expect(result).toHaveLength(2)
 
-    // When both lang and label are missing, should use the generated ID
-    const firstOption = result[0]?.options[0]
-    expect(firstOption).toBeDefined()
-    expect(firstOption).toMatchObject({
+    // First group is plaintext (first sample without lang defaults to plaintext)
+    const plaintextGroup = result[0]
+    expect(plaintextGroup).toBeDefined()
+    expect(plaintextGroup?.label).toBe('Plaintext')
+    expect(plaintextGroup?.key).toBe('custom-plaintext')
+    expect(plaintextGroup?.options).toHaveLength(2)
+
+    // When both lang and label are missing, should use the generated ID as label
+    expect(plaintextGroup?.options[0]).toMatchObject({
       id: 'custom/0',
       lang: 'plaintext',
       title: 'custom/0',
       label: 'custom/0',
     })
 
-    // When label is missing, should use lang
-    const secondOption = result[0]?.options[1]
-    expect(secondOption).toBeDefined()
-    expect(secondOption).toMatchObject({
-      id: 'custom/1',
-      lang: 'ruby',
-      title: 'ruby',
-      label: 'ruby',
-    })
-
     // When lang is missing, should use label and default to plaintext
-    const thirdOption = result[0]?.options[2]
-    expect(thirdOption).toBeDefined()
-    expect(thirdOption).toMatchObject({
+    expect(plaintextGroup?.options[1]).toMatchObject({
       id: 'custom/2',
       lang: 'plaintext',
       title: 'Special Example',
       label: 'Special Example',
+    })
+
+    // Second group is ruby
+    const rubyGroup = result[1]
+    expect(rubyGroup).toBeDefined()
+    expect(rubyGroup?.label).toBe('Ruby')
+    expect(rubyGroup?.key).toBe('custom-ruby')
+    expect(rubyGroup?.options).toHaveLength(1)
+
+    // When label is missing, should use lang
+    expect(rubyGroup?.options[0]).toMatchObject({
+      id: 'custom/1',
+      lang: 'ruby',
+      title: 'ruby',
+      label: 'ruby',
     })
   })
 
@@ -194,11 +207,12 @@ describe('getClients', () => {
   })
 
   /**
-   * Test 4: Verifies correct handling of edge cases with duplicate languages and special characters
-   * This is critical because real-world OpenAPI specs may contain duplicate custom examples
-   * or unusual language identifiers, and the function must handle these without errors.
+   * Test 4: Verifies correct handling of duplicate languages and special characters
+   * This is critical because real-world OpenAPI specs may contain multiple custom examples
+   * for the same language (e.g., sync and async Python clients), and they should be
+   * grouped together under one language group while maintaining distinct IDs.
    */
-  it('should handle duplicate languages and special characters in custom code samples', () => {
+  it('groups duplicate languages together while keeping distinct IDs', () => {
     const customCodeSamples: XCodeSample[] = [
       {
         lang: 'python',
@@ -242,21 +256,24 @@ describe('getClients', () => {
 
     const result = getClients(customCodeSamples, clientOptions)
 
-    expect(result).toHaveLength(2)
-    expect(result[0]?.label).toBe('Code Examples')
-    expect(result[0]?.options).toHaveLength(4)
+    // Should have 3 custom groups (python, c++, objective-c) + 1 original (shell)
+    expect(result).toHaveLength(4)
 
-    // Both python examples must get distinct IDs so they stay individually selectable
-    const firstPythonOption = result[0]?.options[0]
-    expect(firstPythonOption).toBeDefined()
+    // First group is Python with both samples
+    const pythonGroup = result[0]
+    expect(pythonGroup?.label).toBe('Python')
+    expect(pythonGroup?.key).toBe('custom-python')
+    expect(pythonGroup?.options).toHaveLength(2)
+
+    // Both python examples must have distinct IDs so they stay individually selectable
+    const firstPythonOption = pythonGroup?.options[0]
     expect(firstPythonOption).toMatchObject({
       id: 'custom/0',
       lang: 'python',
       label: 'Python Example 1',
     })
 
-    const secondPythonOption = result[0]?.options[1]
-    expect(secondPythonOption).toBeDefined()
+    const secondPythonOption = pythonGroup?.options[1]
     expect(secondPythonOption).toMatchObject({
       id: 'custom/1',
       lang: 'python',
@@ -265,24 +282,29 @@ describe('getClients', () => {
 
     expect(firstPythonOption?.id).not.toBe(secondPythonOption?.id)
 
-    // Languages with special characters should still produce unique IDs
-    const cppOption = result[0]?.options[2]
-    expect(cppOption).toBeDefined()
-    expect(cppOption).toMatchObject({
+    // Second group is C++
+    const cppGroup = result[1]
+    expect(cppGroup?.label).toBe('C++')
+    expect(cppGroup?.key).toBe('custom-c++')
+    expect(cppGroup?.options).toHaveLength(1)
+    expect(cppGroup?.options[0]).toMatchObject({
       id: 'custom/2',
       lang: 'c++',
       label: 'C++ Example',
     })
 
-    const objcOption = result[0]?.options[3]
-    expect(objcOption).toBeDefined()
-    expect(objcOption).toMatchObject({
+    // Third group is Objective-c (capitalized)
+    const objcGroup = result[2]
+    expect(objcGroup?.label).toBe('Objective-c')
+    expect(objcGroup?.key).toBe('custom-objective-c')
+    expect(objcGroup?.options).toHaveLength(1)
+    expect(objcGroup?.options[0]).toMatchObject({
       id: 'custom/3',
       lang: 'objective-c',
       label: 'Objective-C Example',
     })
 
-    // Original client options should still be present
-    expect(result[1]).toEqual(clientOptions[0])
+    // Original client options should still be present at the end
+    expect(result[3]).toEqual(clientOptions[0])
   })
 })

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/get-clients.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/get-clients.ts
@@ -1,3 +1,4 @@
+import { capitalize } from '@scalar/helpers/string/capitalize'
 import type { TargetId } from '@scalar/types/snippetz'
 import type { XCodeSample } from '@scalar/workspace-store/schemas/extensions/operation'
 
@@ -6,7 +7,11 @@ import { generateCustomId } from '@/v2/blocks/operation-code-sample/helpers/gene
 import type { CustomClientOptionGroup } from '@/v2/blocks/operation-code-sample/types'
 
 /**
- * Merges custom code samples with the client options
+ * Merges custom code samples with the client options, grouping them by language.
+ *
+ * Custom code samples with the same `lang` are grouped together under a single
+ * language group (e.g., two python samples become a "Python" group with both options).
+ * This matches the grouping behavior of auto-generated snippetz clients.
  *
  * @param customCodeSamples - The custom code samples from the operation to merge with the client options
  * @param clientOptions - The client options to merge with the custom code samples
@@ -16,31 +21,40 @@ export const getClients = (
   customCodeSamples: XCodeSample[],
   clientOptions: ClientOptionGroup[],
 ): CustomClientOptionGroup[] => {
-  // Handle custom code examples
-  if (customCodeSamples.length) {
-    const customClients = customCodeSamples.map((sample, index) => {
-      const id = generateCustomId(index)
-      const label = sample.label || sample.lang || id
-      const lang = (sample.lang as TargetId) || 'plaintext'
-
-      return {
-        id,
-        lang,
-        title: label,
-        label,
-        clientKey: 'custom',
-      } satisfies CustomClientOption
-    })
-
-    return [
-      {
-        label: 'Code Examples',
-        key: 'custom',
-        options: customClients,
-      },
-      ...clientOptions,
-    ]
+  if (!customCodeSamples.length) {
+    return clientOptions
   }
 
-  return clientOptions
+  // Group custom code samples by language
+  const groupedByLang = new Map<string, CustomClientOption[]>()
+
+  customCodeSamples.forEach((sample, index) => {
+    const id = generateCustomId(index)
+    const lang = (sample.lang as TargetId) || 'plaintext'
+    const label = sample.label || sample.lang || id
+
+    const option: CustomClientOption = {
+      id,
+      lang,
+      title: label,
+      label,
+      clientKey: 'custom',
+    }
+
+    const existing = groupedByLang.get(lang)
+    if (existing) {
+      existing.push(option)
+    } else {
+      groupedByLang.set(lang, [option])
+    }
+  })
+
+  // Convert grouped samples to client option groups
+  const customGroups: CustomClientOptionGroup[] = Array.from(groupedByLang.entries()).map(([lang, options]) => ({
+    label: capitalize(lang),
+    key: `custom-${lang}`,
+    options,
+  }))
+
+  return [...customGroups, ...clientOptions]
 }

--- a/packages/api-client/src/v2/blocks/operation-code-sample/types.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/types.ts
@@ -45,6 +45,6 @@ export type CustomOrDefaultClientOption = ClientOption | CustomClientOption
 
 /** Augments the base combobox option group with CustomClientOptions */
 export type CustomClientOptionGroup = ScalarComboboxOptionGroup<CustomOrDefaultClientOption> & {
-  /** Key of the group */
-  key: 'custom' | TargetId
+  /** Key of the group - can be a TargetId for auto-generated clients, or custom-{lang} for custom code samples grouped by language */
+  key: TargetId | `custom-${string}`
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes the code samples dropdown to group custom `x-codeSamples` by language, matching the grouping behavior of auto-generated snippetz clients.

## Problem

Previously, custom code samples from `x-codeSamples` were displayed in a single flat "Code Examples" group:

```
Code Examples
  ├── requests (sync)     ← lang: python
  ├── httpx (async)       ← lang: python  
  ├── fetch               ← lang: javascript
  └── axios               ← lang: javascript
```

This made it difficult for users to find related code samples when there were multiple examples for the same language (e.g., sync vs async Python clients).

## Solution

Custom code samples are now grouped by their `lang` field:

```
Python
  ├── requests (sync)
  └── httpx (async)
Javascript
  ├── fetch
  └── axios
Typescript
  └── TypeScript SDK
```

## Changes

- **`get-clients.ts`**: Updated `getClients()` to group custom samples by `lang` field using a Map, then convert to client option groups
- **`types.ts`**: Updated `CustomClientOptionGroup` type to support `custom-{lang}` keys for the new language groups
- **`get-clients.test.ts`**: Updated tests to verify new grouping behavior
- **`find-client.test.ts`**: Updated test data to use new key format

## Testing

- Unit tests verify correct grouping for:
  - Multiple samples with the same language (e.g., two Python samples)
  - Samples with different languages (creates separate groups)
  - Missing `lang` field (defaults to "plaintext" group)
  - Special characters in language names (e.g., "c++", "objective-c")
  - Samples maintain unique IDs (`custom/0`, `custom/1`, etc.) for code snippet lookup

## Example

With this `x-codeSamples` configuration:

```yaml
x-codeSamples:
  - lang: python
    label: requests (sync)
    source: |
      import requests
      r = requests.get("https://api.example.com/widgets/42")
  - lang: python
    label: httpx (async)
    source: |
      import asyncio, httpx
      async def main():
          async with httpx.AsyncClient() as client:
              r = await client.get("https://api.example.com/widgets/42")
```

Both Python samples will now appear under a single "Python" group in the dropdown, making it easy for users to find and compare different client options for the same language.

## Ticket

Fixes DOC-5487
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07SWER07G9/p1779927953042959?thread_ts=1779927953.042959&cid=C07SWER07G9)

<div><a href="https://cursor.com/agents/bc-1a17e4da-e592-5eea-8cd4-6f51ea8373f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a17e4da-e592-5eea-8cd4-6f51ea8373f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

