### PR TITLE
fix(ci): deploy galaxy releases to staging and production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1019,6 +1019,7 @@ jobs:
       !cancelled() &&
       needs.build.result == 'success' &&
       needs.check-changes.result == 'success' &&
+      needs.npm-publish.result != 'failure' &&
       needs.npm-publish.outputs.published == 'true' &&
       github.ref == 'refs/heads/main'
     needs: [build, check-changes, npm-publish]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -978,14 +978,13 @@ jobs:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit
 
-  # Deploy galaxy-scalar-com to Cloudflare Pages. On PRs it deploys a preview
-  # whenever any package — or galaxy itself — changed, so the branch-built
-  # @scalar/api-reference bundle galaxy serves can be reviewed; it also runs on
-  # every main push. Waits for npm-publish so it knows whether this commit
-  # released a dependency (-> production) or not (-> staging). `!cancelled()`
-  # lets it proceed when npm-publish is skipped (PRs); the explicit
-  # build/check-changes success gates are re-added because `!cancelled()`
-  # overrides the implicit `success()` check on `needs`.
+  # Deploy galaxy-scalar-com to Cloudflare Pages staging. On PRs it deploys a
+  # preview whenever any package — or galaxy itself — changed, so the
+  # branch-built @scalar/api-reference bundle galaxy serves can be reviewed; it
+  # also runs on every main push. `!cancelled()` lets it proceed when
+  # npm-publish is skipped (PRs); the explicit build/check-changes success gates
+  # are re-added because `!cancelled()` overrides the implicit `success()`
+  # check on `needs`.
   deploy-galaxy:
     if: |
       !cancelled() &&
@@ -1007,12 +1006,29 @@ jobs:
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/deploy-galaxy.yml
     with:
-      # Release commits (npm publish) target the production-galaxy-com
-      # environment — galaxy's dependencies ship with every release. Ordinary
-      # merges to main and PR previews target staging-galaxy-com.
-      environment: ${{ needs.npm-publish.outputs.published == 'true' && 'production-galaxy-com' || 'staging-galaxy-com' }}
+      environment: staging-galaxy-com
       pr-number: ${{ github.event.pull_request.number }}
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
+    secrets: inherit
+
+  # Release commits also deploy galaxy-scalar-com to production. This runs in
+  # addition to the staging deployment above so release SHAs land in both
+  # environments.
+  deploy-galaxy-production:
+    if: |
+      !cancelled() &&
+      needs.build.result == 'success' &&
+      needs.check-changes.result == 'success' &&
+      needs.npm-publish.outputs.published == 'true' &&
+      github.ref == 'refs/heads/main'
+    needs: [build, check-changes, npm-publish]
+    concurrency:
+      group: deploy-galaxy-production-${{ github.ref }}
+      cancel-in-progress: false
+    uses: ./.github/workflows/deploy-galaxy.yml
+    with:
+      environment: production-galaxy-com
+      sha: ${{ github.sha }}
     secrets: inherit
 
   todesktop-build:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Release commits currently execute a single `deploy-galaxy` reusable workflow call that targets either staging or production. This means a release SHA can end up deployed to staging without a second production deployment in the same CI run.

## Solution

- Keep `deploy-galaxy` focused on staging + PR preview behavior.
- Add a dedicated `deploy-galaxy-production` job that runs on `main` when `npm-publish` reports a published release.
- Reuse the same deploy workflow with `production-galaxy-com`, so release commits deploy to both staging and production.

## Testing

- Parsed `.github/workflows/ci.yml` with Python + PyYAML.
- Asserted `deploy-galaxy` targets `staging-galaxy-com`.
- Asserted `deploy-galaxy-production` targets `production-galaxy-com`.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc7de41e-58c4-438c-8c1a-1a7a39fc9d65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc7de41e-58c4-438c-8c1a-1a7a39fc9d65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

