### PR TITLE
feat(asyncapi-upgrader): actually upgrade 1.x documents to 2.x

### DIFF
--- a/.changeset/asyncapi-1x-to-2x-transformation.md
+++ b/.changeset/asyncapi-1x-to-2x-transformation.md
@@ -1,0 +1,5 @@
+---
+'@scalar/asyncapi-upgrader': minor
+---
+
+feat: actually upgrade AsyncAPI 1.x documents to 2.x (servers, channels, parameters, stream, events) instead of only bumping the version string

--- a/packages/asyncapi-upgrader/src/1.2-to-2.6/upgrade-from-one-to-two.test.ts
+++ b/packages/asyncapi-upgrader/src/1.2-to-2.6/upgrade-from-one-to-two.test.ts
@@ -137,6 +137,35 @@ describe('upgradeFromOneToTwo', () => {
     })
   })
 
+  it('wraps publish/subscribe oneOf with inline messages in a message object', () => {
+    const document = upgradeFromOneToTwo({
+      asyncapi: '1.2.0',
+      topics: {
+        'user.events': {
+          publish: {
+            oneOf: [
+              { summary: 'Signup', payload: { type: 'object', properties: { id: { type: 'string' } } } },
+              { summary: 'Login', payload: { type: 'object', properties: { token: { type: 'string' } } } },
+            ],
+          },
+        },
+      },
+    })
+
+    expect(document.channels).toEqual({
+      'user.events': {
+        publish: {
+          message: {
+            oneOf: [
+              { summary: 'Signup', payload: { type: 'object', properties: { id: { type: 'string' } } } },
+              { summary: 'Login', payload: { type: 'object', properties: { token: { type: 'string' } } } },
+            ],
+          },
+        },
+      },
+    })
+  })
+
   it('wraps inline publish/subscribe message in a message object', () => {
     const document = upgradeFromOneToTwo({
       asyncapi: '1.2.0',

--- a/packages/asyncapi-upgrader/src/1.2-to-2.6/upgrade-from-one-to-two.test.ts
+++ b/packages/asyncapi-upgrader/src/1.2-to-2.6/upgrade-from-one-to-two.test.ts
@@ -14,4 +14,376 @@ describe('upgradeFromOneToTwo', () => {
 
     expect(upgradeFromOneToTwo(document)).toBe(document)
   })
+
+  it('converts the servers array to a keyed map', () => {
+    const document = upgradeFromOneToTwo({
+      asyncapi: '1.2.0',
+      servers: [
+        { url: 'api.example.com', scheme: 'mqtt', description: 'Production' },
+        { url: 'staging.example.com', scheme: 'mqtt', description: 'Staging' },
+      ],
+    })
+
+    expect(document.servers).toEqual({
+      production: { url: 'api.example.com', protocol: 'mqtt', description: 'Production' },
+      staging: { url: 'staging.example.com', protocol: 'mqtt', description: 'Staging' },
+    })
+  })
+
+  it('renames scheme to protocol and schemeVersion to protocolVersion', () => {
+    const document = upgradeFromOneToTwo({
+      asyncapi: '1.2.0',
+      servers: [{ url: 'api.example.com', scheme: 'amqp', schemeVersion: '0.9.1' }],
+    })
+
+    expect(document.servers).toEqual({
+      'server-0': { url: 'api.example.com', protocol: 'amqp', protocolVersion: '0.9.1' },
+    })
+  })
+
+  it('slugifies description to generate server keys, falling back to server-N when absent', () => {
+    const document = upgradeFromOneToTwo({
+      asyncapi: '1.2.0',
+      servers: [
+        { url: 'a.example.com', scheme: 'mqtt', description: 'My Production!' },
+        { url: 'b.example.com', scheme: 'mqtt' },
+        { url: 'c.example.com', scheme: 'mqtt', description: 'My Production!' },
+      ],
+    })
+
+    expect(document.servers).toEqual({
+      'my-production': { url: 'a.example.com', protocol: 'mqtt', description: 'My Production!' },
+      'server-1': { url: 'b.example.com', protocol: 'mqtt' },
+      'my-production-2': { url: 'c.example.com', protocol: 'mqtt', description: 'My Production!' },
+    })
+  })
+
+  it('renames topics to channels', () => {
+    const document = upgradeFromOneToTwo({
+      asyncapi: '1.2.0',
+      topics: {
+        'user.signup': {
+          publish: { $ref: '#/components/messages/userSignedUp' },
+        },
+      },
+    })
+
+    expect(document.topics).toBeUndefined()
+    expect(document.channels).toEqual({
+      'user.signup': {
+        publish: { message: { $ref: '#/components/messages/userSignedUp' } },
+      },
+    })
+  })
+
+  it('prepends baseTopic to every channel name and removes baseTopic', () => {
+    const document = upgradeFromOneToTwo({
+      asyncapi: '1.2.0',
+      baseTopic: 'smartylighting.streetlights.1.0',
+      topics: {
+        'event.lighting.measured': {
+          publish: { $ref: '#/components/messages/lightMeasured' },
+        },
+      },
+    })
+
+    expect(document.baseTopic).toBeUndefined()
+    expect(document.channels).toEqual({
+      'smartylighting.streetlights.1.0.event.lighting.measured': {
+        publish: { message: { $ref: '#/components/messages/lightMeasured' } },
+      },
+    })
+  })
+
+  it('wraps publish/subscribe $ref in a message object', () => {
+    const document = upgradeFromOneToTwo({
+      asyncapi: '1.2.0',
+      topics: {
+        'user.signup': {
+          publish: { $ref: '#/components/messages/userSignedUp' },
+          subscribe: { $ref: '#/components/messages/userConfirmation' },
+        },
+      },
+    })
+
+    expect(document.channels).toEqual({
+      'user.signup': {
+        publish: { message: { $ref: '#/components/messages/userSignedUp' } },
+        subscribe: { message: { $ref: '#/components/messages/userConfirmation' } },
+      },
+    })
+  })
+
+  it('wraps publish/subscribe oneOf in a message object', () => {
+    const document = upgradeFromOneToTwo({
+      asyncapi: '1.2.0',
+      topics: {
+        'user.events': {
+          publish: {
+            oneOf: [{ $ref: '#/components/messages/signup' }, { $ref: '#/components/messages/login' }],
+          },
+        },
+      },
+    })
+
+    expect(document.channels).toEqual({
+      'user.events': {
+        publish: {
+          message: {
+            oneOf: [{ $ref: '#/components/messages/signup' }, { $ref: '#/components/messages/login' }],
+          },
+        },
+      },
+    })
+  })
+
+  it('wraps inline publish/subscribe message in a message object', () => {
+    const document = upgradeFromOneToTwo({
+      asyncapi: '1.2.0',
+      topics: {
+        'user.signup': {
+          publish: {
+            summary: 'A user signed up.',
+            payload: { type: 'object', properties: { id: { type: 'string' } } },
+          },
+        },
+      },
+    })
+
+    expect(document.channels).toEqual({
+      'user.signup': {
+        publish: {
+          message: {
+            summary: 'A user signed up.',
+            payload: { type: 'object', properties: { id: { type: 'string' } } },
+          },
+        },
+      },
+    })
+  })
+
+  it('converts channel parameters array to a name-keyed map', () => {
+    const document = upgradeFromOneToTwo({
+      asyncapi: '1.2.0',
+      topics: {
+        'user.{userId}.signup': {
+          parameters: [{ name: 'userId', description: 'Id of the user.', schema: { type: 'string' } }],
+          publish: { $ref: '#/components/messages/userSignedUp' },
+        },
+      },
+    })
+
+    expect(document.channels).toEqual({
+      'user.{userId}.signup': {
+        parameters: {
+          userId: { description: 'Id of the user.', schema: { type: 'string' } },
+        },
+        publish: { message: { $ref: '#/components/messages/userSignedUp' } },
+      },
+    })
+  })
+
+  it('migrates stream to a single "/" channel and drops framing', () => {
+    const document = upgradeFromOneToTwo({
+      asyncapi: '1.2.0',
+      stream: {
+        framing: { type: 'chunked', delimiter: '\r\n' },
+        read: [{ $ref: '#/components/messages/chatMessage' }],
+        write: [{ $ref: '#/components/messages/outgoing' }],
+      },
+    })
+
+    expect(document.stream).toBeUndefined()
+    expect(document.channels).toEqual({
+      '/': {
+        subscribe: { message: { oneOf: [{ $ref: '#/components/messages/chatMessage' }] } },
+        publish: { message: { oneOf: [{ $ref: '#/components/messages/outgoing' }] } },
+      },
+    })
+  })
+
+  it('migrates events to a single "/" channel', () => {
+    const document = upgradeFromOneToTwo({
+      asyncapi: '1.2.0',
+      events: {
+        receive: [{ $ref: '#/components/messages/incoming' }],
+        send: [{ $ref: '#/components/messages/outgoing' }],
+      },
+    })
+
+    expect(document.events).toBeUndefined()
+    expect(document.channels).toEqual({
+      '/': {
+        subscribe: { message: { oneOf: [{ $ref: '#/components/messages/incoming' }] } },
+        publish: { message: { oneOf: [{ $ref: '#/components/messages/outgoing' }] } },
+      },
+    })
+  })
+
+  it('leaves info, components, and security untouched', () => {
+    const document = upgradeFromOneToTwo({
+      asyncapi: '1.2.0',
+      info: { title: 'Example', version: '1.0.0', description: 'A sample.' },
+      security: [{ apiKey: [] }],
+      components: {
+        schemas: { User: { type: 'object', properties: { id: { type: 'string' } } } },
+        messages: { userSignUp: { payload: { $ref: '#/components/schemas/User' } } },
+        parameters: { userId: { name: 'userId', schema: { type: 'string' } } },
+        securitySchemes: { apiKey: { type: 'apiKey', in: 'user' } },
+      },
+    })
+
+    expect(document.info).toEqual({ title: 'Example', version: '1.0.0', description: 'A sample.' })
+    expect(document.security).toEqual([{ apiKey: [] }])
+    expect(document.components).toEqual({
+      schemas: { User: { type: 'object', properties: { id: { type: 'string' } } } },
+      messages: { userSignUp: { payload: { $ref: '#/components/schemas/User' } } },
+      parameters: { userId: { name: 'userId', schema: { type: 'string' } } },
+      securitySchemes: { apiKey: { type: 'apiKey', in: 'user' } },
+    })
+  })
+
+  it('upgrades the official 1.2 streetlights sample to its 2.0 shape', () => {
+    // Input: AsyncAPI 1.2 streetlights sample.
+    // Source: github.com/asyncapi/spec, tag 1.2.0, test/docs/sample.yml
+    const input = {
+      asyncapi: '1.2.0',
+      info: {
+        title: 'Streetlights API',
+        version: '1.0.0',
+        description: 'The Smartylighting Streetlights API allows you to remotely manage the city lights.\n',
+        license: { name: 'Apache 2.0', url: 'https://www.apache.org/licenses/LICENSE-2.0' },
+      },
+      baseTopic: 'smartylighting.streetlights.1.0',
+      servers: [
+        {
+          url: 'api.streetlights.smartylighting.com:{port}',
+          scheme: 'mqtt',
+          description: 'Test broker',
+          variables: {
+            port: {
+              description: 'Secure connection (TLS) is available through port 8883.',
+              default: '1883',
+              enum: ['1883', '8883'],
+            },
+          },
+        },
+      ],
+      security: [{ apiKey: [] }],
+      topics: {
+        'event.{streetlightId}.lighting.measured': {
+          parameters: [{ $ref: '#/components/parameters/streetlightId' }],
+          publish: { $ref: '#/components/messages/lightMeasured' },
+        },
+        'action.{streetlightId}.turn.on': {
+          parameters: [{ $ref: '#/components/parameters/streetlightId' }],
+          subscribe: { $ref: '#/components/messages/turnOnOff' },
+        },
+      },
+      components: {
+        messages: {
+          lightMeasured: {
+            summary: 'Inform about environmental lighting conditions for a particular streetlight.',
+            payload: { $ref: '#/components/schemas/lightMeasuredPayload' },
+          },
+          turnOnOff: {
+            summary: 'Command a particular streetlight to turn the lights on or off.',
+            payload: { $ref: '#/components/schemas/turnOnOffPayload' },
+          },
+        },
+        schemas: {
+          lightMeasuredPayload: {
+            type: 'object',
+            properties: { lumens: { type: 'integer', minimum: 0 } },
+          },
+          turnOnOffPayload: {
+            type: 'object',
+            properties: { command: { type: 'string', enum: ['on', 'off'] } },
+          },
+        },
+        securitySchemes: {
+          apiKey: { type: 'apiKey', in: 'user', description: 'Provide your API key as the user.' },
+        },
+        parameters: {
+          streetlightId: {
+            name: 'streetlightId',
+            description: 'The ID of the streetlight.',
+            schema: { type: 'string' },
+          },
+        },
+      },
+    }
+
+    const expected = {
+      asyncapi: '2.6.0',
+      info: {
+        title: 'Streetlights API',
+        version: '1.0.0',
+        description: 'The Smartylighting Streetlights API allows you to remotely manage the city lights.\n',
+        license: { name: 'Apache 2.0', url: 'https://www.apache.org/licenses/LICENSE-2.0' },
+      },
+      servers: {
+        'test-broker': {
+          url: 'api.streetlights.smartylighting.com:{port}',
+          protocol: 'mqtt',
+          description: 'Test broker',
+          variables: {
+            port: {
+              description: 'Secure connection (TLS) is available through port 8883.',
+              default: '1883',
+              enum: ['1883', '8883'],
+            },
+          },
+        },
+      },
+      security: [{ apiKey: [] }],
+      channels: {
+        // Channel-level parameters were a `[{ $ref: '#/components/parameters/streetlightId' }]` array
+        // in 1.x. The map key is derived from the last segment of the $ref so the parameter still
+        // resolves to the same component.
+        'smartylighting.streetlights.1.0.event.{streetlightId}.lighting.measured': {
+          parameters: { streetlightId: { $ref: '#/components/parameters/streetlightId' } },
+          publish: { message: { $ref: '#/components/messages/lightMeasured' } },
+        },
+        'smartylighting.streetlights.1.0.action.{streetlightId}.turn.on': {
+          parameters: { streetlightId: { $ref: '#/components/parameters/streetlightId' } },
+          subscribe: { message: { $ref: '#/components/messages/turnOnOff' } },
+        },
+      },
+      components: {
+        messages: {
+          lightMeasured: {
+            summary: 'Inform about environmental lighting conditions for a particular streetlight.',
+            payload: { $ref: '#/components/schemas/lightMeasuredPayload' },
+          },
+          turnOnOff: {
+            summary: 'Command a particular streetlight to turn the lights on or off.',
+            payload: { $ref: '#/components/schemas/turnOnOffPayload' },
+          },
+        },
+        schemas: {
+          lightMeasuredPayload: {
+            type: 'object',
+            properties: { lumens: { type: 'integer', minimum: 0 } },
+          },
+          turnOnOffPayload: {
+            type: 'object',
+            properties: { command: { type: 'string', enum: ['on', 'off'] } },
+          },
+        },
+        securitySchemes: {
+          apiKey: { type: 'apiKey', in: 'user', description: 'Provide your API key as the user.' },
+        },
+        parameters: {
+          streetlightId: {
+            name: 'streetlightId',
+            description: 'The ID of the streetlight.',
+            schema: { type: 'string' },
+          },
+        },
+      },
+    }
+
+    expect(upgradeFromOneToTwo(input)).toEqual(expected)
+  })
 })

--- a/packages/asyncapi-upgrader/src/1.2-to-2.6/upgrade-from-one-to-two.ts
+++ b/packages/asyncapi-upgrader/src/1.2-to-2.6/upgrade-from-one-to-two.ts
@@ -1,4 +1,5 @@
 import { isObject } from '@scalar/helpers/object/is-object'
+import { slugify } from '@scalar/helpers/string/slugify'
 import type { UnknownObject } from '@scalar/types/utils'
 
 /** The AsyncAPI version produced by this upgrade step. */
@@ -73,13 +74,6 @@ function uniqueServerKey(description: string, index: number, usedKeys: Set<strin
     suffix += 1
   }
   return `${base}-${suffix}`
-}
-
-function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
 }
 
 /** topics → channels, with operation/parameter shape changes and `baseTopic` prepending. */

--- a/packages/asyncapi-upgrader/src/1.2-to-2.6/upgrade-from-one-to-two.ts
+++ b/packages/asyncapi-upgrader/src/1.2-to-2.6/upgrade-from-one-to-two.ts
@@ -4,21 +4,193 @@ import type { UnknownObject } from '@scalar/types/utils'
 /** The AsyncAPI version produced by this upgrade step. */
 const ASYNCAPI_VERSION = '2.6.0'
 
+/** The synthetic channel name used when consolidating a 1.x `stream` or `events` object. */
+const ROOT_CHANNEL = '/'
+
 /**
  * Upgrade an AsyncAPI 1.x document to 2.6.0.
  *
- * For now this only bumps the `asyncapi` version string — no structural
- * transformations are applied yet.
+ * Each transformation is the smallest change needed to bring the 1.x shape in line with 2.x.
+ * See `upgrade-from-one-to-two.test.ts` for the source of truth — every rule is one test.
  */
 export function upgradeFromOneToTwo(originalDocument: UnknownObject): UnknownObject {
   const document = originalDocument
 
-  // Skip anything that is not an AsyncAPI 1.x document
   if (!isObject(document) || typeof document.asyncapi !== 'string' || !document.asyncapi.startsWith('1.')) {
     return document
   }
 
   document.asyncapi = ASYNCAPI_VERSION
+  upgradeServers(document)
+  upgradeChannels(document)
+  upgradeStream(document)
+  upgradeEvents(document)
 
   return document
+}
+
+/** Servers: array of { url, scheme, schemeVersion, ... } → map { key: { url, protocol, protocolVersion, ... } }. */
+function upgradeServers(document: UnknownObject): void {
+  if (!Array.isArray(document.servers)) {
+    return
+  }
+
+  const result: Record<string, UnknownObject> = {}
+  const usedKeys = new Set<string>()
+
+  document.servers.forEach((server, index) => {
+    if (!isObject(server)) {
+      return
+    }
+
+    const upgraded: UnknownObject = {}
+    for (const [field, value] of Object.entries(server)) {
+      if (field === 'scheme') {
+        upgraded.protocol = value
+      } else if (field === 'schemeVersion') {
+        upgraded.protocolVersion = value
+      } else {
+        upgraded[field] = value
+      }
+    }
+
+    const key = uniqueServerKey(typeof server.description === 'string' ? server.description : '', index, usedKeys)
+    usedKeys.add(key)
+    result[key] = upgraded
+  })
+
+  document.servers = result
+}
+
+/** Slugify a description; fall back to `server-{index}`; dedupe collisions with `-2`, `-3`, … */
+function uniqueServerKey(description: string, index: number, usedKeys: Set<string>): string {
+  const base = slugify(description) || `server-${index}`
+  if (!usedKeys.has(base)) {
+    return base
+  }
+  let suffix = 2
+  while (usedKeys.has(`${base}-${suffix}`)) {
+    suffix += 1
+  }
+  return `${base}-${suffix}`
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+/** topics → channels, with operation/parameter shape changes and `baseTopic` prepending. */
+function upgradeChannels(document: UnknownObject): void {
+  if (!isObject(document.topics)) {
+    if (typeof document.baseTopic === 'string') {
+      delete document.baseTopic
+    }
+    return
+  }
+
+  const baseTopic = typeof document.baseTopic === 'string' ? document.baseTopic : ''
+  const channels: Record<string, UnknownObject> = {}
+
+  for (const [topic, item] of Object.entries(document.topics)) {
+    if (!isObject(item)) {
+      continue
+    }
+
+    const channelName = baseTopic ? `${baseTopic}.${topic}` : topic
+    const channel: UnknownObject = {}
+
+    for (const [field, value] of Object.entries(item)) {
+      if (field === 'parameters') {
+        const parameters = upgradeChannelParameters(value)
+        if (parameters) {
+          channel.parameters = parameters
+        }
+      } else if (field === 'publish' || field === 'subscribe') {
+        channel[field] = { message: value }
+      } else {
+        channel[field] = value
+      }
+    }
+
+    channels[channelName] = channel
+  }
+
+  document.channels = channels
+  delete document.topics
+  delete document.baseTopic
+}
+
+/** `parameters: [{ name, ... }]` → `parameters: { name: { ... } }`. Also handles `$ref` items. */
+function upgradeChannelParameters(parameters: unknown): Record<string, UnknownObject> | undefined {
+  if (!Array.isArray(parameters)) {
+    return undefined
+  }
+
+  const result: Record<string, UnknownObject> = {}
+
+  for (const parameter of parameters) {
+    if (!isObject(parameter)) {
+      continue
+    }
+
+    if (typeof parameter.$ref === 'string') {
+      const key = parameter.$ref.split('/').pop() ?? ''
+      if (key) {
+        result[key] = { $ref: parameter.$ref }
+      }
+      continue
+    }
+
+    if (typeof parameter.name !== 'string') {
+      continue
+    }
+
+    const { name, ...rest } = parameter
+    result[name] = rest
+  }
+
+  return result
+}
+
+/** `stream: { framing, read, write }` → `channels['/']` with subscribe/publish. Framing is dropped. */
+function upgradeStream(document: UnknownObject): void {
+  if (!isObject(document.stream)) {
+    return
+  }
+
+  const channel: UnknownObject = {}
+  if (Array.isArray(document.stream.read)) {
+    channel.subscribe = { message: { oneOf: document.stream.read } }
+  }
+  if (Array.isArray(document.stream.write)) {
+    channel.publish = { message: { oneOf: document.stream.write } }
+  }
+
+  const channels = isObject(document.channels) ? document.channels : {}
+  channels[ROOT_CHANNEL] = channel
+  document.channels = channels
+  delete document.stream
+}
+
+/** `events: { receive, send }` → `channels['/']` with subscribe/publish. */
+function upgradeEvents(document: UnknownObject): void {
+  if (!isObject(document.events)) {
+    return
+  }
+
+  const channel: UnknownObject = {}
+  if (Array.isArray(document.events.receive)) {
+    channel.subscribe = { message: { oneOf: document.events.receive } }
+  }
+  if (Array.isArray(document.events.send)) {
+    channel.publish = { message: { oneOf: document.events.send } }
+  }
+
+  const channels = isObject(document.channels) ? document.channels : {}
+  channels[ROOT_CHANNEL] = channel
+  document.channels = channels
+  delete document.events
 }

--- a/packages/asyncapi-upgrader/src/1.2-to-2.6/upgrade-from-one-to-two.ts
+++ b/packages/asyncapi-upgrader/src/1.2-to-2.6/upgrade-from-one-to-two.ts
@@ -38,9 +38,9 @@ function upgradeServers(document: UnknownObject): void {
   const result: Record<string, UnknownObject> = {}
   const usedKeys = new Set<string>()
 
-  document.servers.forEach((server, index) => {
+  for (const [index, server] of document.servers.entries()) {
     if (!isObject(server)) {
-      return
+      continue
     }
 
     const upgraded: UnknownObject = {}
@@ -57,7 +57,7 @@ function upgradeServers(document: UnknownObject): void {
     const key = uniqueServerKey(typeof server.description === 'string' ? server.description : '', index, usedKeys)
     usedKeys.add(key)
     result[key] = upgraded
-  })
+  }
 
   document.servers = result
 }
@@ -155,7 +155,13 @@ function upgradeChannelParameters(parameters: unknown): Record<string, UnknownOb
   return result
 }
 
-/** `stream: { framing, read, write }` → `channels['/']` with subscribe/publish. Framing is dropped. */
+/**
+ * `stream: { framing, read, write }` → `channels['/']` with subscribe/publish. Framing is dropped.
+ *
+ * AsyncAPI 1.x makes `topics`, `stream`, and `events` mutually exclusive at the document root, so a
+ * collision on the `/` channel between this transform, `upgradeEvents`, and any user-defined topic
+ * cannot happen in valid input.
+ */
 function upgradeStream(document: UnknownObject): void {
   if (!isObject(document.stream)) {
     return


### PR DESCRIPTION
The 1.x → 2.x step used to only bump the version string. 

Now it actually transforms the document: 

* servers array → keyed map
* `scheme`/`schemeVersion` → `protocol`/`protocolVersion`
* `topics` → `channels`
* `baseTopic` folded into channel names
* operations wrapped in `message`
* channel parameters from array to map
* `stream`/`events` consolidated into a single `/` channel

Rules come from the official AsyncAPI 1.2 and 2.0 specs. Each rule has a dedicated test, plus an end-to-end test on the 1.2 streetlights sample.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> In-place document transforms can mis-shape edge-case specs (server key collisions, $ref parameter keys, dropped stream framing), though behavior is spec-driven and heavily tested including streetlights e2e.
> 
> **Overview**
> The **1.x → 2.6** step in `@scalar/asyncapi-upgrader` no longer only sets `asyncapi` to `2.6.0`; it **mutates in place** (still only for `asyncapi` starting with `1.`) to match AsyncAPI 2.x layout.
> 
> **Servers** become a map: keys from slugified `description` (with `server-N` fallback and deduping), `scheme` → `protocol`, `schemeVersion` → `protocolVersion`.
> 
> **Topics** become **channels**: `baseTopic` is prefixed onto names and removed; `publish` / `subscribe` bodies are wrapped as `{ message: … }`; channel **parameters** go from an array to a map (by `name` or last `$ref` segment).
> 
> **Stream** and **events** root objects are removed and folded into a single **`/`** channel (`read`/`receive` → subscribe, `write`/`send` → publish, with `oneOf` where needed); stream **framing** is dropped.
> 
> Coverage is a large expansion of `upgrade-from-one-to-two.test.ts`, including the official 1.2 streetlights sample, plus a minor changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e6fd4945099bd944793ac8e27ac83a4c1b59f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->