### PR TITLE
feat(asyncapi-upgrader): actually upgrade 2.x documents to 3.0

### DIFF
--- a/.changeset/asyncapi-2x-to-3x-transformation.md
+++ b/.changeset/asyncapi-2x-to-3x-transformation.md
@@ -1,0 +1,5 @@
+---
+'@scalar/asyncapi-upgrader': minor
+---
+
+feat: actually upgrade AsyncAPI 2.x documents to 3.0 (servers, channels, operations, security/OAuth) instead of only bumping the version string

--- a/biome.json
+++ b/biome.json
@@ -4,6 +4,7 @@
     "includes": [
       "**",
       "!**/node_modules",
+      "!**/.claude/**",
       "!**/dist",
       "!**/.venv",
       "!**/.turbo",

--- a/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.test.ts
+++ b/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.test.ts
@@ -43,6 +43,19 @@ describe('upgradeFromTwoToThree', () => {
     })
   })
 
+  it('keeps the scheme on host when splitting a fully-qualified url', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      servers: {
+        production: { url: 'https://api.example.com/v2', protocol: 'http' },
+      },
+    })
+
+    expect(document.servers).toEqual({
+      production: { host: 'https://api.example.com', pathname: '/v2', protocol: 'http' },
+    })
+  })
+
   it('converts non-OAuth server security to $ref entries', () => {
     const document = upgradeFromTwoToThree({
       asyncapi: '2.6.0',
@@ -344,6 +357,83 @@ describe('upgradeFromTwoToThree', () => {
       messages: { ping: { payload: { type: 'object' } } },
       schemas: { Pong: { type: 'string' } },
     })
+  })
+
+  it('upgrades operation-level security like server security', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      channels: {
+        'user/signup': {
+          publish: {
+            operationId: 'onSignup',
+            security: [{ apiKey: [] }],
+            message: { $ref: '#/components/messages/userSignedUp' },
+          },
+        },
+      },
+      components: {
+        securitySchemes: { apiKey: { type: 'apiKey', in: 'user' } },
+      },
+    })
+
+    expect((document.operations as { onSignup: { security: unknown } }).onSignup.security).toEqual([
+      { $ref: '#/components/securitySchemes/apiKey' },
+    ])
+  })
+
+  it('dedupes channel ids that slugify to the same value', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      channels: {
+        'user/signedup': {
+          publish: {
+            operationId: 'fromSlash',
+            message: { $ref: '#/components/messages/a' },
+          },
+        },
+        'user.signedup': {
+          publish: {
+            operationId: 'fromDot',
+            message: { $ref: '#/components/messages/b' },
+          },
+        },
+      },
+    })
+
+    expect(Object.keys(document.channels as object)).toEqual(['user-signedup', 'user-signedup-2'])
+    expect(document.operations).toEqual({
+      fromSlash: {
+        action: 'receive',
+        channel: { $ref: '#/channels/user-signedup' },
+        messages: [{ $ref: '#/channels/user-signedup/messages/a' }],
+      },
+      fromDot: {
+        action: 'receive',
+        channel: { $ref: '#/channels/user-signedup-2' },
+        messages: [{ $ref: '#/channels/user-signedup-2/messages/b' }],
+      },
+    })
+  })
+
+  it('dedupes operation keys when an operationId collides with a generated one', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      channels: {
+        'user/welcome': {
+          // Generated key would be `send-user-welcome`.
+          subscribe: { message: { $ref: '#/components/messages/welcome' } },
+        },
+        'admin/welcome': {
+          // Hand-picked operationId collides with the auto-generated one above.
+          subscribe: {
+            operationId: 'send-user-welcome',
+            message: { $ref: '#/components/messages/adminWelcome' },
+          },
+        },
+      },
+    })
+
+    expect(Object.keys(document.operations as object)).toEqual(['send-user-welcome', 'send-user-welcome-2'])
   })
 
   // End-to-end ---------------------------------------------------------------

--- a/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.test.ts
+++ b/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.test.ts
@@ -43,7 +43,7 @@ describe('upgradeFromTwoToThree', () => {
     })
   })
 
-  it('keeps the scheme on host when splitting a fully-qualified url', () => {
+  it('strips the scheme from host when splitting a fully-qualified url', () => {
     const document = upgradeFromTwoToThree({
       asyncapi: '2.6.0',
       servers: {
@@ -52,7 +52,7 @@ describe('upgradeFromTwoToThree', () => {
     })
 
     expect(document.servers).toEqual({
-      production: { host: 'https://api.example.com', pathname: '/v2', protocol: 'http' },
+      production: { host: 'api.example.com', pathname: '/v2', protocol: 'http' },
     })
   })
 

--- a/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.test.ts
+++ b/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.test.ts
@@ -14,4 +14,447 @@ describe('upgradeFromTwoToThree', () => {
 
     expect(upgradeFromTwoToThree(document)).toBe(document)
   })
+
+  // Servers ------------------------------------------------------------------
+
+  it('splits server url into host and pathname when a path is present', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      servers: {
+        production: { url: 'broker.example.com:1883/v2', protocol: 'mqtt' },
+      },
+    })
+
+    expect(document.servers).toEqual({
+      production: { host: 'broker.example.com:1883', pathname: '/v2', protocol: 'mqtt' },
+    })
+  })
+
+  it('uses host only when the server url has no path', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      servers: {
+        production: { url: 'broker.example.com:1883', protocol: 'mqtt' },
+      },
+    })
+
+    expect(document.servers).toEqual({
+      production: { host: 'broker.example.com:1883', protocol: 'mqtt' },
+    })
+  })
+
+  it('converts non-OAuth server security to $ref entries', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      servers: {
+        production: {
+          url: 'broker.example.com',
+          protocol: 'mqtt',
+          security: [{ apiKey: [] }],
+        },
+      },
+      components: {
+        securitySchemes: { apiKey: { type: 'apiKey', in: 'user' } },
+      },
+    })
+
+    expect((document.servers as { production: { security: unknown } }).production.security).toEqual([
+      { $ref: '#/components/securitySchemes/apiKey' },
+    ])
+  })
+
+  it('inlines OAuth server security with a scopes array', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      servers: {
+        production: {
+          url: 'broker.example.com',
+          protocol: 'mqtt',
+          security: [{ supportedOauthFlows: ['streetlights:on', 'streetlights:off'] }],
+        },
+      },
+      components: {
+        securitySchemes: {
+          supportedOauthFlows: {
+            type: 'oauth2',
+            flows: {
+              implicit: {
+                authorizationUrl: 'https://example.com/auth',
+                scopes: {
+                  'streetlights:on': 'Switch on',
+                  'streetlights:off': 'Switch off',
+                  'streetlights:dim': 'Dim',
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect((document.servers as { production: { security: unknown } }).production.security).toEqual([
+      {
+        type: 'oauth2',
+        flows: {
+          implicit: {
+            authorizationUrl: 'https://example.com/auth',
+            availableScopes: {
+              'streetlights:on': 'Switch on',
+              'streetlights:off': 'Switch off',
+              'streetlights:dim': 'Dim',
+            },
+          },
+        },
+        scopes: ['streetlights:on', 'streetlights:off'],
+      },
+    ])
+  })
+
+  it('renames scopes to availableScopes in component OAuth flows', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      components: {
+        securitySchemes: {
+          oauth: {
+            type: 'oauth2',
+            flows: {
+              implicit: {
+                authorizationUrl: 'https://example.com/auth',
+                scopes: { read: 'Read', write: 'Write' },
+              },
+              password: {
+                tokenUrl: 'https://example.com/token',
+                scopes: { read: 'Read' },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect((document.components as { securitySchemes: { oauth: unknown } }).securitySchemes.oauth).toEqual({
+      type: 'oauth2',
+      flows: {
+        implicit: {
+          authorizationUrl: 'https://example.com/auth',
+          availableScopes: { read: 'Read', write: 'Write' },
+        },
+        password: {
+          tokenUrl: 'https://example.com/token',
+          availableScopes: { read: 'Read' },
+        },
+      },
+    })
+  })
+
+  // Channels & operations ----------------------------------------------------
+
+  it('moves the channel path to address and uses a slug as the channel id', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      channels: {
+        'user/signedup': {
+          publish: { message: { $ref: '#/components/messages/userSignedUp' } },
+        },
+      },
+    })
+
+    expect(document.channels).toEqual({
+      'user-signedup': {
+        address: 'user/signedup',
+        messages: { userSignedUp: { $ref: '#/components/messages/userSignedUp' } },
+      },
+    })
+  })
+
+  it('creates a receive operation from a publish operation', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      channels: {
+        'user/signedup': {
+          publish: {
+            operationId: 'onUserSignedUp',
+            summary: 'Receive sign-up events',
+            message: { $ref: '#/components/messages/userSignedUp' },
+          },
+        },
+      },
+    })
+
+    expect(document.operations).toEqual({
+      onUserSignedUp: {
+        action: 'receive',
+        channel: { $ref: '#/channels/user-signedup' },
+        summary: 'Receive sign-up events',
+        messages: [{ $ref: '#/channels/user-signedup/messages/userSignedUp' }],
+      },
+    })
+  })
+
+  it('creates a send operation from a subscribe operation', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      channels: {
+        'user/welcome': {
+          subscribe: {
+            operationId: 'sendWelcome',
+            message: { $ref: '#/components/messages/welcome' },
+          },
+        },
+      },
+    })
+
+    expect(document.operations).toEqual({
+      sendWelcome: {
+        action: 'send',
+        channel: { $ref: '#/channels/user-welcome' },
+        messages: [{ $ref: '#/channels/user-welcome/messages/welcome' }],
+      },
+    })
+  })
+
+  it('generates an operation key from the action and channel slug when operationId is missing', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      channels: {
+        'user/signedup': {
+          publish: { message: { $ref: '#/components/messages/userSignedUp' } },
+        },
+      },
+    })
+
+    expect(document.operations).toEqual({
+      'receive-user-signedup': {
+        action: 'receive',
+        channel: { $ref: '#/channels/user-signedup' },
+        messages: [{ $ref: '#/channels/user-signedup/messages/userSignedUp' }],
+      },
+    })
+  })
+
+  it('expands oneOf messages into multiple channel.messages entries', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      channels: {
+        'user/events': {
+          publish: {
+            operationId: 'onUserEvent',
+            message: {
+              oneOf: [{ $ref: '#/components/messages/signup' }, { $ref: '#/components/messages/login' }],
+            },
+          },
+        },
+      },
+    })
+
+    expect((document.channels as Record<string, unknown>)['user-events']).toEqual({
+      address: 'user/events',
+      messages: {
+        signup: { $ref: '#/components/messages/signup' },
+        login: { $ref: '#/components/messages/login' },
+      },
+    })
+    expect((document.operations as Record<string, unknown>).onUserEvent).toEqual({
+      action: 'receive',
+      channel: { $ref: '#/channels/user-events' },
+      messages: [{ $ref: '#/channels/user-events/messages/signup' }, { $ref: '#/channels/user-events/messages/login' }],
+    })
+  })
+
+  it('keeps channel description, parameters, bindings, and servers', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      channels: {
+        'user/{userId}/signedup': {
+          description: 'User signup channel.',
+          servers: ['production'],
+          parameters: {
+            userId: { $ref: '#/components/parameters/userId' },
+          },
+          bindings: { amqp: { is: 'queue' } },
+          publish: { message: { $ref: '#/components/messages/userSignedUp' } },
+        },
+      },
+    })
+
+    expect((document.channels as Record<string, unknown>)['user-userid-signedup']).toEqual({
+      address: 'user/{userId}/signedup',
+      description: 'User signup channel.',
+      servers: [{ $ref: '#/servers/production' }],
+      parameters: {
+        userId: { $ref: '#/components/parameters/userId' },
+      },
+      bindings: { amqp: { is: 'queue' } },
+      messages: { userSignedUp: { $ref: '#/components/messages/userSignedUp' } },
+    })
+  })
+
+  it('creates both a receive and a send operation when a channel has both publish and subscribe', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      channels: {
+        'chat/{roomId}': {
+          publish: {
+            operationId: 'sendMessage',
+            message: { $ref: '#/components/messages/userMessage' },
+          },
+          subscribe: {
+            operationId: 'receiveMessage',
+            message: { $ref: '#/components/messages/serverMessage' },
+          },
+        },
+      },
+    })
+
+    expect((document.channels as Record<string, unknown>)['chat-roomid']).toEqual({
+      address: 'chat/{roomId}',
+      messages: {
+        userMessage: { $ref: '#/components/messages/userMessage' },
+        serverMessage: { $ref: '#/components/messages/serverMessage' },
+      },
+    })
+    expect(document.operations).toEqual({
+      sendMessage: {
+        action: 'receive',
+        channel: { $ref: '#/channels/chat-roomid' },
+        messages: [{ $ref: '#/channels/chat-roomid/messages/userMessage' }],
+      },
+      receiveMessage: {
+        action: 'send',
+        channel: { $ref: '#/channels/chat-roomid' },
+        messages: [{ $ref: '#/channels/chat-roomid/messages/serverMessage' }],
+      },
+    })
+  })
+
+  it('leaves info, defaultContentType, and components.messages untouched', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      info: { title: 'Example', version: '1.0.0', description: 'A sample.' },
+      defaultContentType: 'application/json',
+      components: {
+        messages: { ping: { payload: { type: 'object' } } },
+        schemas: { Pong: { type: 'string' } },
+      },
+    })
+
+    expect(document.info).toEqual({ title: 'Example', version: '1.0.0', description: 'A sample.' })
+    expect(document.defaultContentType).toBe('application/json')
+    expect(document.components).toEqual({
+      messages: { ping: { payload: { type: 'object' } } },
+      schemas: { Pong: { type: 'string' } },
+    })
+  })
+
+  // End-to-end ---------------------------------------------------------------
+
+  it('upgrades a trimmed 2.6 streetlights-mqtt sample to its 3.0 shape', () => {
+    // Input adapted from github.com/asyncapi/spec, tag v2.6.0,
+    // examples/streetlights-mqtt.yml — trimmed to the parts the upgrader handles.
+    const input = {
+      asyncapi: '2.6.0',
+      info: { title: 'Streetlights MQTT API', version: '1.0.0' },
+      defaultContentType: 'application/json',
+      servers: {
+        production: {
+          url: 'test.mosquitto.org:{port}',
+          protocol: 'mqtt',
+          description: 'Test broker',
+          variables: { port: { default: '1883', enum: ['1883', '8883'] } },
+          security: [{ apiKey: [] }],
+        },
+      },
+      channels: {
+        'smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured': {
+          parameters: { streetlightId: { $ref: '#/components/parameters/streetlightId' } },
+          publish: {
+            operationId: 'receiveLightMeasurement',
+            summary: 'Inform about environmental lighting conditions.',
+            message: { $ref: '#/components/messages/lightMeasured' },
+          },
+        },
+        'smartylighting/streetlights/1/0/action/{streetlightId}/turn/on': {
+          parameters: { streetlightId: { $ref: '#/components/parameters/streetlightId' } },
+          subscribe: {
+            operationId: 'turnOn',
+            message: { $ref: '#/components/messages/turnOnOff' },
+          },
+        },
+      },
+      components: {
+        messages: {
+          lightMeasured: { name: 'lightMeasured', payload: { type: 'object' } },
+          turnOnOff: { name: 'turnOnOff', payload: { type: 'object' } },
+        },
+        parameters: {
+          streetlightId: { description: 'The ID of the streetlight.', schema: { type: 'string' } },
+        },
+        securitySchemes: {
+          apiKey: { type: 'apiKey', in: 'user' },
+        },
+      },
+    }
+
+    const expected = {
+      asyncapi: '3.0.0',
+      info: { title: 'Streetlights MQTT API', version: '1.0.0' },
+      defaultContentType: 'application/json',
+      servers: {
+        production: {
+          host: 'test.mosquitto.org:{port}',
+          protocol: 'mqtt',
+          description: 'Test broker',
+          variables: { port: { default: '1883', enum: ['1883', '8883'] } },
+          security: [{ $ref: '#/components/securitySchemes/apiKey' }],
+        },
+      },
+      channels: {
+        'smartylighting-streetlights-1-0-event-streetlightid-lighting-measured': {
+          address: 'smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured',
+          parameters: { streetlightId: { $ref: '#/components/parameters/streetlightId' } },
+          messages: { lightMeasured: { $ref: '#/components/messages/lightMeasured' } },
+        },
+        'smartylighting-streetlights-1-0-action-streetlightid-turn-on': {
+          address: 'smartylighting/streetlights/1/0/action/{streetlightId}/turn/on',
+          parameters: { streetlightId: { $ref: '#/components/parameters/streetlightId' } },
+          messages: { turnOnOff: { $ref: '#/components/messages/turnOnOff' } },
+        },
+      },
+      operations: {
+        receiveLightMeasurement: {
+          action: 'receive',
+          channel: { $ref: '#/channels/smartylighting-streetlights-1-0-event-streetlightid-lighting-measured' },
+          summary: 'Inform about environmental lighting conditions.',
+          messages: [
+            {
+              $ref: '#/channels/smartylighting-streetlights-1-0-event-streetlightid-lighting-measured/messages/lightMeasured',
+            },
+          ],
+        },
+        turnOn: {
+          action: 'send',
+          channel: { $ref: '#/channels/smartylighting-streetlights-1-0-action-streetlightid-turn-on' },
+          messages: [
+            {
+              $ref: '#/channels/smartylighting-streetlights-1-0-action-streetlightid-turn-on/messages/turnOnOff',
+            },
+          ],
+        },
+      },
+      components: {
+        messages: {
+          lightMeasured: { name: 'lightMeasured', payload: { type: 'object' } },
+          turnOnOff: { name: 'turnOnOff', payload: { type: 'object' } },
+        },
+        parameters: {
+          streetlightId: { description: 'The ID of the streetlight.', schema: { type: 'string' } },
+        },
+        securitySchemes: {
+          apiKey: { type: 'apiKey', in: 'user' },
+        },
+      },
+    }
+
+    expect(upgradeFromTwoToThree(input)).toEqual(expected)
+  })
 })

--- a/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.test.ts
+++ b/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.test.ts
@@ -340,6 +340,44 @@ describe('upgradeFromTwoToThree', () => {
     })
   })
 
+  it('keeps anonymous inline publish and subscribe messages separate', () => {
+    const document = upgradeFromTwoToThree({
+      asyncapi: '2.6.0',
+      channels: {
+        chat: {
+          publish: {
+            operationId: 'sendMessage',
+            message: { payload: { type: 'object', properties: { sent: { type: 'string' } } } },
+          },
+          subscribe: {
+            operationId: 'receiveMessage',
+            message: { payload: { type: 'object', properties: { received: { type: 'string' } } } },
+          },
+        },
+      },
+    })
+
+    expect((document.channels as Record<string, unknown>)['chat']).toEqual({
+      address: 'chat',
+      messages: {
+        'message-0': { payload: { type: 'object', properties: { sent: { type: 'string' } } } },
+        'message-1': { payload: { type: 'object', properties: { received: { type: 'string' } } } },
+      },
+    })
+    expect(document.operations).toEqual({
+      sendMessage: {
+        action: 'receive',
+        channel: { $ref: '#/channels/chat' },
+        messages: [{ $ref: '#/channels/chat/messages/message-0' }],
+      },
+      receiveMessage: {
+        action: 'send',
+        channel: { $ref: '#/channels/chat' },
+        messages: [{ $ref: '#/channels/chat/messages/message-1' }],
+      },
+    })
+  })
+
   it('leaves info, defaultContentType, and components.messages untouched', () => {
     const document = upgradeFromTwoToThree({
       asyncapi: '2.6.0',

--- a/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.ts
+++ b/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.ts
@@ -57,9 +57,7 @@ function upgradeServers(document: UnknownObject): void {
     }
 
     if (Array.isArray(server.security)) {
-      server.security = server.security
-        .map((requirement) => upgradeSecurityRequirement(requirement, securitySchemes))
-        .filter((entry): entry is UnknownObject => entry !== undefined)
+      server.security = upgradeSecurity(server.security, securitySchemes)
     }
   }
 }
@@ -67,21 +65,37 @@ function upgradeServers(document: UnknownObject): void {
 /** Splits a 2.x server URL into a 3.0 `host` (everything before the first `/` outside the scheme) and `pathname`. */
 function splitUrl(url: string): { host: string; pathname: string } {
   const schemeMatch = url.match(/^([a-zA-Z][a-zA-Z0-9+\-.]*:\/\/)(.*)$/)
-  const scheme = schemeMatch ? schemeMatch[1] : ''
-  const rest = schemeMatch ? schemeMatch[2]! : url
-  const slashIndex = rest.indexOf('/')
 
+  if (schemeMatch) {
+    const [, scheme, rest] = schemeMatch
+    const slashIndex = rest!.indexOf('/')
+    if (slashIndex === -1) {
+      return { host: url, pathname: '' }
+    }
+    return {
+      host: `${scheme}${rest!.slice(0, slashIndex)}`,
+      pathname: rest!.slice(slashIndex),
+    }
+  }
+
+  const slashIndex = url.indexOf('/')
   if (slashIndex === -1) {
     return { host: url, pathname: '' }
   }
-
-  return {
-    host: `${scheme}${rest.slice(0, slashIndex)}`,
-    pathname: rest.slice(slashIndex),
-  }
+  return { host: url.slice(0, slashIndex), pathname: url.slice(slashIndex) }
 }
 
-/** Rewrites one 2.x security requirement object into its 3.0 form. */
+/** Maps every 2.x security requirement to its 3.0 form (`$ref` or inline OAuth + `scopes`). */
+function upgradeSecurity(security: unknown[], securitySchemes: Record<string, UnknownObject>): UnknownObject[] {
+  return security
+    .map((requirement) => upgradeSecurityRequirement(requirement, securitySchemes))
+    .filter((entry): entry is UnknownObject => entry !== undefined)
+}
+
+/**
+ * Rewrites one 2.x security requirement object into its 3.0 form. 2.x security requirement objects
+ * have exactly one key (the scheme name) and an array of scope names — we read that single entry.
+ */
 function upgradeSecurityRequirement(
   requirement: unknown,
   securitySchemes: Record<string, UnknownObject>,
@@ -90,12 +104,11 @@ function upgradeSecurityRequirement(
     return undefined
   }
 
-  const entries = Object.entries(requirement)
-  if (entries.length === 0) {
+  const [entry] = Object.entries(requirement)
+  if (!entry) {
     return undefined
   }
-
-  const [name, scopes] = entries[0]!
+  const [name, scopes] = entry
   const scheme = securitySchemes[name]
 
   if (isObject(scheme) && scheme.type === 'oauth2' && Array.isArray(scopes)) {
@@ -159,15 +172,18 @@ function upgradeChannelsAndOperations(document: UnknownObject): void {
     return
   }
 
+  const securitySchemes = getSecuritySchemes(document)
   const channels: Record<string, UnknownObject> = {}
   const operations: Record<string, UnknownObject> = {}
+  const usedChannelIds = new Set<string>()
+  const usedOperationKeys = new Set<string>()
 
   for (const [path, channel] of Object.entries(document.channels)) {
     if (!isObject(channel)) {
       continue
     }
 
-    const channelId = slugify(path)
+    const channelId = uniqueKey(slugify(path), usedChannelIds)
     const newChannel: UnknownObject = { address: path }
     const messages: Record<string, UnknownObject> = {}
 
@@ -192,12 +208,12 @@ function upgradeChannelsAndOperations(document: UnknownObject): void {
     channels[channelId] = newChannel
 
     if (isObject(channel.publish)) {
-      const opKey = operationKey(channel.publish, 'receive', channelId)
-      operations[opKey] = buildOperation(channel.publish, 'receive', channelId, publishMessages)
+      const opKey = uniqueKey(operationKey(channel.publish, 'receive', channelId), usedOperationKeys)
+      operations[opKey] = buildOperation(channel.publish, 'receive', channelId, publishMessages, securitySchemes)
     }
     if (isObject(channel.subscribe)) {
-      const opKey = operationKey(channel.subscribe, 'send', channelId)
-      operations[opKey] = buildOperation(channel.subscribe, 'send', channelId, subscribeMessages)
+      const opKey = uniqueKey(operationKey(channel.subscribe, 'send', channelId), usedOperationKeys)
+      operations[opKey] = buildOperation(channel.subscribe, 'send', channelId, subscribeMessages, securitySchemes)
     }
   }
 
@@ -258,11 +274,16 @@ function buildOperation(
   action: 'send' | 'receive',
   channelId: string,
   messageIds: string[],
+  securitySchemes: Record<string, UnknownObject>,
 ): UnknownObject {
   const result: UnknownObject = { action, channel: { $ref: `#/channels/${channelId}` } }
 
   for (const [field, value] of Object.entries(operation)) {
     if (field === 'message' || field === 'operationId') {
+      continue
+    }
+    if (field === 'security' && Array.isArray(value)) {
+      result.security = upgradeSecurity(value, securitySchemes)
       continue
     }
     result[field] = value
@@ -281,4 +302,19 @@ function slugify(value: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
+}
+
+/** Returns the base key if unused, otherwise appends `-2`, `-3`, … until unique. Mutates `usedKeys`. */
+function uniqueKey(base: string, usedKeys: Set<string>): string {
+  if (!usedKeys.has(base)) {
+    usedKeys.add(base)
+    return base
+  }
+  let suffix = 2
+  while (usedKeys.has(`${base}-${suffix}`)) {
+    suffix += 1
+  }
+  const key = `${base}-${suffix}`
+  usedKeys.add(key)
+  return key
 }

--- a/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.ts
+++ b/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.ts
@@ -1,4 +1,5 @@
 import { isObject } from '@scalar/helpers/object/is-object'
+import { slugify } from '@scalar/helpers/string/slugify'
 import type { UnknownObject } from '@scalar/types/utils'
 
 /** The AsyncAPI version produced by this upgrade step. */
@@ -183,7 +184,7 @@ function upgradeChannelsAndOperations(document: UnknownObject): void {
       continue
     }
 
-    const channelId = uniqueKey(slugify(path), usedChannelIds)
+    const channelId = uniqueKey(slugifyChannelPath(path), usedChannelIds)
     const newChannel: UnknownObject = { address: path }
     const messages: Record<string, UnknownObject> = {}
 
@@ -294,14 +295,14 @@ function buildOperation(
 }
 
 /**
- * Slugify a channel path or other identifier source: lowercase, replace runs of non-alphanumerics
- * with `-`, strip `-` at the ends. Empty input collapses to an empty string — the caller falls back.
+ * Slugify a channel path (e.g. `user/{id}/signedup` → `user-id-signedup`).
+ *
+ * `@scalar/helpers/string/slugify` drops non-word characters outright, but channel paths use `/`,
+ * `.`, `{`, and `}` as logical separators we want preserved as hyphens — so we pre-replace any run
+ * of non-alphanumerics with a space and let the shared slugify collapse those into hyphens.
  */
-function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
+function slugifyChannelPath(value: string): string {
+  return slugify(value.replace(/[^a-zA-Z0-9]+/g, ' '))
 }
 
 /** Returns the base key if unused, otherwise appends `-2`, `-3`, … until unique. Mutates `usedKeys`. */

--- a/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.ts
+++ b/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.ts
@@ -7,18 +7,278 @@ const ASYNCAPI_VERSION = '3.0.0'
 /**
  * Upgrade an AsyncAPI 2.x document to 3.0.0.
  *
- * For now this only bumps the `asyncapi` version string — no structural
- * transformations are applied yet.
+ * Each transformation is the smallest change needed to bring the 2.x shape in line with 3.0.
+ * See `upgrade-from-two-to-three.test.ts` for the source of truth — every rule is one test.
  */
 export function upgradeFromTwoToThree(originalDocument: UnknownObject): UnknownObject {
   const document = originalDocument
 
-  // Skip anything that is not an AsyncAPI 2.x document
   if (!isObject(document) || typeof document.asyncapi !== 'string' || !document.asyncapi.startsWith('2.')) {
     return document
   }
 
   document.asyncapi = ASYNCAPI_VERSION
 
+  // OAuth flows must be rewritten before security requirements consult them.
+  upgradeComponentOAuthScopes(document)
+  upgradeServers(document)
+  upgradeChannelsAndOperations(document)
+
   return document
+}
+
+// ---------------------------------------------------------------------------
+// Servers
+// ---------------------------------------------------------------------------
+
+/**
+ * Servers: `url` becomes `host` (+ optional `pathname` when the URL contains a path).
+ * `security` entries become either `$ref` (non-OAuth) or inline scheme + scopes array (OAuth).
+ */
+function upgradeServers(document: UnknownObject): void {
+  if (!isObject(document.servers)) {
+    return
+  }
+
+  const securitySchemes = getSecuritySchemes(document)
+
+  for (const server of Object.values(document.servers)) {
+    if (!isObject(server)) {
+      continue
+    }
+
+    if (typeof server.url === 'string') {
+      const { host, pathname } = splitUrl(server.url)
+      server.host = host
+      if (pathname) {
+        server.pathname = pathname
+      }
+      delete server.url
+    }
+
+    if (Array.isArray(server.security)) {
+      server.security = server.security
+        .map((requirement) => upgradeSecurityRequirement(requirement, securitySchemes))
+        .filter((entry): entry is UnknownObject => entry !== undefined)
+    }
+  }
+}
+
+/** Splits a 2.x server URL into a 3.0 `host` (everything before the first `/` outside the scheme) and `pathname`. */
+function splitUrl(url: string): { host: string; pathname: string } {
+  const schemeMatch = url.match(/^([a-zA-Z][a-zA-Z0-9+\-.]*:\/\/)(.*)$/)
+  const scheme = schemeMatch ? schemeMatch[1] : ''
+  const rest = schemeMatch ? schemeMatch[2]! : url
+  const slashIndex = rest.indexOf('/')
+
+  if (slashIndex === -1) {
+    return { host: url, pathname: '' }
+  }
+
+  return {
+    host: `${scheme}${rest.slice(0, slashIndex)}`,
+    pathname: rest.slice(slashIndex),
+  }
+}
+
+/** Rewrites one 2.x security requirement object into its 3.0 form. */
+function upgradeSecurityRequirement(
+  requirement: unknown,
+  securitySchemes: Record<string, UnknownObject>,
+): UnknownObject | undefined {
+  if (!isObject(requirement)) {
+    return undefined
+  }
+
+  const entries = Object.entries(requirement)
+  if (entries.length === 0) {
+    return undefined
+  }
+
+  const [name, scopes] = entries[0]!
+  const scheme = securitySchemes[name]
+
+  if (isObject(scheme) && scheme.type === 'oauth2' && Array.isArray(scopes)) {
+    return { ...scheme, scopes }
+  }
+
+  return { $ref: `#/components/securitySchemes/${name}` }
+}
+
+function getSecuritySchemes(document: UnknownObject): Record<string, UnknownObject> {
+  if (!isObject(document.components) || !isObject(document.components.securitySchemes)) {
+    return {}
+  }
+  const schemes: Record<string, UnknownObject> = {}
+  for (const [name, value] of Object.entries(document.components.securitySchemes)) {
+    if (isObject(value)) {
+      schemes[name] = value
+    }
+  }
+  return schemes
+}
+
+// ---------------------------------------------------------------------------
+// OAuth scopes → availableScopes (in components.securitySchemes)
+// ---------------------------------------------------------------------------
+
+/** Renames `scopes` → `availableScopes` on every flow of every OAuth scheme in components. */
+function upgradeComponentOAuthScopes(document: UnknownObject): void {
+  if (!isObject(document.components) || !isObject(document.components.securitySchemes)) {
+    return
+  }
+
+  for (const scheme of Object.values(document.components.securitySchemes)) {
+    if (!isObject(scheme) || scheme.type !== 'oauth2' || !isObject(scheme.flows)) {
+      continue
+    }
+
+    for (const flow of Object.values(scheme.flows)) {
+      if (isObject(flow) && 'scopes' in flow) {
+        flow.availableScopes = flow.scopes
+        delete flow.scopes
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Channels & operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Channels become identifier-keyed with an `address` field. Each `publish`/`subscribe` operation is
+ * lifted to the top-level `operations` map with `action: 'receive' | 'send'`, and its message(s)
+ * move into `channel.messages` (keyed by message id derived from the `$ref` or `name`).
+ *
+ * The 2.x `publish` semantics — the application receives the message — maps to 3.0 `action: 'receive'`.
+ * The 2.x `subscribe` semantics — the application sends the message — maps to 3.0 `action: 'send'`.
+ */
+function upgradeChannelsAndOperations(document: UnknownObject): void {
+  if (!isObject(document.channels)) {
+    return
+  }
+
+  const channels: Record<string, UnknownObject> = {}
+  const operations: Record<string, UnknownObject> = {}
+
+  for (const [path, channel] of Object.entries(document.channels)) {
+    if (!isObject(channel)) {
+      continue
+    }
+
+    const channelId = slugify(path)
+    const newChannel: UnknownObject = { address: path }
+    const messages: Record<string, UnknownObject> = {}
+
+    for (const [field, value] of Object.entries(channel)) {
+      if (field === 'publish' || field === 'subscribe' || field === 'parameters') {
+        continue
+      }
+      if (field === 'servers' && Array.isArray(value)) {
+        newChannel.servers = value.map((name) => ({ $ref: `#/servers/${name}` }))
+        continue
+      }
+      newChannel[field] = value
+    }
+    if (isObject(channel.parameters)) {
+      newChannel.parameters = channel.parameters
+    }
+
+    const publishMessages = collectMessages(channel.publish, messages)
+    const subscribeMessages = collectMessages(channel.subscribe, messages)
+
+    newChannel.messages = messages
+    channels[channelId] = newChannel
+
+    if (isObject(channel.publish)) {
+      const opKey = operationKey(channel.publish, 'receive', channelId)
+      operations[opKey] = buildOperation(channel.publish, 'receive', channelId, publishMessages)
+    }
+    if (isObject(channel.subscribe)) {
+      const opKey = operationKey(channel.subscribe, 'send', channelId)
+      operations[opKey] = buildOperation(channel.subscribe, 'send', channelId, subscribeMessages)
+    }
+  }
+
+  document.channels = channels
+  document.operations = operations
+}
+
+/**
+ * Extracts each message reference from a 2.x operation's `message` field (single or `oneOf`) into
+ * the channel-level `messages` map; returns the message ids in order for use in `operation.messages`.
+ */
+function collectMessages(operation: unknown, channelMessages: Record<string, UnknownObject>): string[] {
+  if (!isObject(operation) || !isObject(operation.message)) {
+    return []
+  }
+
+  const message = operation.message
+  const items = Array.isArray(message.oneOf) ? message.oneOf : [message]
+  const ids: string[] = []
+
+  for (const item of items) {
+    if (!isObject(item)) {
+      continue
+    }
+    const id = messageId(item, ids.length)
+    channelMessages[id] = item
+    ids.push(id)
+  }
+
+  return ids
+}
+
+/** Derives a channel-message map key from a message: last `$ref` segment, `name`, or generated. */
+function messageId(message: UnknownObject, index: number): string {
+  if (typeof message.$ref === 'string') {
+    const last = message.$ref.split('/').pop()
+    if (last) {
+      return last
+    }
+  }
+  if (typeof message.name === 'string' && message.name) {
+    return message.name
+  }
+  return `message-${index}`
+}
+
+/** Reuses 2.x `operationId` when present; otherwise generates `${action}-${channelId}`. */
+function operationKey(operation: UnknownObject, action: 'send' | 'receive', channelId: string): string {
+  if (typeof operation.operationId === 'string' && operation.operationId) {
+    return operation.operationId
+  }
+  return `${action}-${channelId}`
+}
+
+/** Assembles the 3.0 Operation Object from the 2.x publish/subscribe shape. */
+function buildOperation(
+  operation: UnknownObject,
+  action: 'send' | 'receive',
+  channelId: string,
+  messageIds: string[],
+): UnknownObject {
+  const result: UnknownObject = { action, channel: { $ref: `#/channels/${channelId}` } }
+
+  for (const [field, value] of Object.entries(operation)) {
+    if (field === 'message' || field === 'operationId') {
+      continue
+    }
+    result[field] = value
+  }
+
+  result.messages = messageIds.map((id) => ({ $ref: `#/channels/${channelId}/messages/${id}` }))
+  return result
+}
+
+/**
+ * Slugify a channel path or other identifier source: lowercase, replace runs of non-alphanumerics
+ * with `-`, strip `-` at the ends. Empty input collapses to an empty string — the caller falls back.
+ */
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
 }

--- a/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.ts
+++ b/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.ts
@@ -233,7 +233,7 @@ function collectMessages(operation: unknown, channelMessages: Record<string, Unk
     if (!isObject(item)) {
       continue
     }
-    const id = messageId(item, ids.length)
+    const id = messageId(item, channelMessages)
     channelMessages[id] = item
     ids.push(id)
   }
@@ -241,8 +241,13 @@ function collectMessages(operation: unknown, channelMessages: Record<string, Unk
   return ids
 }
 
-/** Derives a channel-message map key from a message: last `$ref` segment, `name`, or generated. */
-function messageId(message: UnknownObject, index: number): string {
+/**
+ * Derives a channel-message map key from a message: last `$ref` segment, `name`, or a generated
+ * `message-N`. The generated fallback is checked against the keys already present in the shared
+ * channel-message map so that anonymous inline messages from `publish` and `subscribe` do not
+ * collide on `message-0` and overwrite each other.
+ */
+function messageId(message: UnknownObject, existingMessages: Record<string, UnknownObject>): string {
   if (typeof message.$ref === 'string') {
     const last = message.$ref.split('/').pop()
     if (last) {
@@ -251,6 +256,10 @@ function messageId(message: UnknownObject, index: number): string {
   }
   if (typeof message.name === 'string' && message.name) {
     return message.name
+  }
+  let index = 0
+  while (`message-${index}` in existingMessages) {
+    index += 1
   }
   return `message-${index}`
 }

--- a/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.ts
+++ b/packages/asyncapi-upgrader/src/2.6-to-3.0/upgrade-from-two-to-three.ts
@@ -63,27 +63,21 @@ function upgradeServers(document: UnknownObject): void {
   }
 }
 
-/** Splits a 2.x server URL into a 3.0 `host` (everything before the first `/` outside the scheme) and `pathname`. */
+/**
+ * Splits a 2.x server URL into a 3.0 `host` (hostname plus optional port) and `pathname`.
+ *
+ * The scheme is dropped because AsyncAPI 3.0 carries the protocol exclusively in the `protocol`
+ * field — keeping it on `host` would duplicate that information and violate the spec.
+ */
 function splitUrl(url: string): { host: string; pathname: string } {
-  const schemeMatch = url.match(/^([a-zA-Z][a-zA-Z0-9+\-.]*:\/\/)(.*)$/)
+  const schemeMatch = url.match(/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\/(.*)$/)
+  const rest = schemeMatch ? schemeMatch[1]! : url
 
-  if (schemeMatch) {
-    const [, scheme, rest] = schemeMatch
-    const slashIndex = rest!.indexOf('/')
-    if (slashIndex === -1) {
-      return { host: url, pathname: '' }
-    }
-    return {
-      host: `${scheme}${rest!.slice(0, slashIndex)}`,
-      pathname: rest!.slice(slashIndex),
-    }
-  }
-
-  const slashIndex = url.indexOf('/')
+  const slashIndex = rest.indexOf('/')
   if (slashIndex === -1) {
-    return { host: url, pathname: '' }
+    return { host: rest, pathname: '' }
   }
-  return { host: url.slice(0, slashIndex), pathname: url.slice(slashIndex) }
+  return { host: rest.slice(0, slashIndex), pathname: rest.slice(slashIndex) }
 }
 
 /** Maps every 2.x security requirement to its 3.0 form (`$ref` or inline OAuth + `scopes`). */


### PR DESCRIPTION
The 2.x → 3.0 step used to only bump the version string. Now it actually transforms the document: 

* server `url` → `host`/`pathname`
* server security to `$ref` (or inline OAuth + `scopes` array)
* channels restructured into `address` + `messages` map
* `publish`/`subscribe` lifted to top-level `operations` (`receive`/`send`)
* `scopes` → `availableScopes` in component OAuth flows

Rules come from the official AsyncAPI 2.6 and 3.0 specs. Each rule has a dedicated test, plus an end-to-end test on the 2.6 streetlights-mqtt sample.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, spec-sensitive document transforms (OAuth/security and publish/subscribe semantics) can mis-upgrade edge-case APIs; risk is mitigated by broad unit and E2E tests but output correctness still matters for downstream tooling.
> 
> **Overview**
> **`@scalar/asyncapi-upgrader`** now performs a real AsyncAPI **2.x → 3.0** migration instead of only setting `asyncapi` to `3.0.0`. Non-2.x documents are still returned unchanged.
> 
> **Servers:** `url` is split into `host` and optional `pathname` (scheme stripped when present). Server `security` becomes component `$ref`s for non-OAuth schemes, or inlined OAuth with a `scopes` array. Component OAuth flows rename `scopes` to `availableScopes` before security is rewritten.
> 
> **Channels & operations:** Channel map keys become slugified ids with the former path in `address`; `publish`/`subscribe` move to top-level `operations` with `receive`/`send` actions, channel refs, and channel-local message refs. Messages are collected on the channel (including `oneOf` and anonymous `message-N` ids). Channel `servers` become `$ref` objects; operation security follows the same rules as servers. Colliding channel and operation keys get `-2`, `-3`, … suffixes.
> 
> Coverage is a large Vitest suite plus a trimmed **streetlights-mqtt** end-to-end case. A minor changeset and excluding `**/.claude/**` from Biome are also included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9e8bfefcae696ec9d5866b08981e1c8f259ff6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->