### PR TITLE
feat(asyncapi-upgrader): update 3.0 to 3.1

### DIFF
--- a/.changeset/asyncapi-3.0-to-3.1-message-refs.md
+++ b/.changeset/asyncapi-3.0-to-3.1-message-refs.md
@@ -1,0 +1,5 @@
+---
+'@scalar/asyncapi-upgrader': minor
+---
+
+feat: rewrite operation `messages` $refs from `#/components/messages/X` to `#/channels/{id}/messages/X` on 3.0 → 3.1 upgrade (the channel-scoped form 3.1 clarified as required)

--- a/packages/asyncapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
+++ b/packages/asyncapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
@@ -217,6 +217,62 @@ describe('upgradeFromThreeToThreeOne', () => {
     ).toEqual([{ $ref: '#/channels/userSignupReply/messages/userSignedUpReply' }])
   })
 
+  it('falls back to the operation channel when reply.channel is omitted', () => {
+    const document = upgradeFromThreeToThreeOne({
+      asyncapi: '3.0.0',
+      channels: {
+        ping: {
+          address: 'ping',
+          messages: {
+            ping: { $ref: '#/components/messages/ping' },
+            pong: { $ref: '#/components/messages/pong' },
+          },
+        },
+      },
+      operations: {
+        sendPing: {
+          action: 'send',
+          channel: { $ref: '#/channels/ping' },
+          messages: [{ $ref: '#/components/messages/ping' }],
+          reply: {
+            // No `channel` — reply runs on the parent operation's channel.
+            messages: [{ $ref: '#/components/messages/pong' }],
+          },
+        },
+      },
+    })
+
+    expect((document.operations as { sendPing: { reply: { messages: unknown } } }).sendPing.reply.messages).toEqual([
+      { $ref: '#/channels/ping/messages/pong' },
+    ])
+  })
+
+  it('dedupes operation messages when both forms point at the same message', () => {
+    const document = upgradeFromThreeToThreeOne({
+      asyncapi: '3.0.0',
+      channels: {
+        userSignedUp: {
+          address: 'user/signedup',
+          messages: { userSignedUp: { $ref: '#/components/messages/userSignedUp' } },
+        },
+      },
+      operations: {
+        onUserSignedUp: {
+          action: 'receive',
+          channel: { $ref: '#/channels/userSignedUp' },
+          messages: [
+            { $ref: '#/channels/userSignedUp/messages/userSignedUp' },
+            { $ref: '#/components/messages/userSignedUp' },
+          ],
+        },
+      },
+    })
+
+    expect((document.operations as { onUserSignedUp: { messages: unknown } }).onUserSignedUp.messages).toEqual([
+      { $ref: '#/channels/userSignedUp/messages/userSignedUp' },
+    ])
+  })
+
   it('leaves message refs alone when the operation has no channel ref', () => {
     const document = upgradeFromThreeToThreeOne({
       asyncapi: '3.0.0',

--- a/packages/asyncapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
+++ b/packages/asyncapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
@@ -14,4 +14,222 @@ describe('upgradeFromThreeToThreeOne', () => {
 
     expect(upgradeFromThreeToThreeOne(document)).toBe(document)
   })
+
+  // Carryover ---------------------------------------------------------------
+  //
+  // AsyncAPI 3.1 is backward-compatible with 3.0 — everything except the version string and the
+  // (technically-already-invalid) component-scope operation message refs should carry over verbatim.
+
+  it('leaves servers untouched', () => {
+    const document = upgradeFromThreeToThreeOne({
+      asyncapi: '3.0.0',
+      servers: {
+        production: {
+          host: 'broker.example.com',
+          protocol: 'mqtt',
+          security: [{ $ref: '#/components/securitySchemes/apiKey' }],
+        },
+      },
+    })
+
+    expect(document.servers).toEqual({
+      production: {
+        host: 'broker.example.com',
+        protocol: 'mqtt',
+        security: [{ $ref: '#/components/securitySchemes/apiKey' }],
+      },
+    })
+  })
+
+  it('leaves channels untouched', () => {
+    const document = upgradeFromThreeToThreeOne({
+      asyncapi: '3.0.0',
+      channels: {
+        userSignedUp: {
+          address: 'user/signedup',
+          messages: { userSignedUp: { $ref: '#/components/messages/userSignedUp' } },
+          parameters: { userId: { $ref: '#/components/parameters/userId' } },
+          bindings: { amqp: { is: 'queue' } },
+        },
+      },
+    })
+
+    expect(document.channels).toEqual({
+      userSignedUp: {
+        address: 'user/signedup',
+        messages: { userSignedUp: { $ref: '#/components/messages/userSignedUp' } },
+        parameters: { userId: { $ref: '#/components/parameters/userId' } },
+        bindings: { amqp: { is: 'queue' } },
+      },
+    })
+  })
+
+  it('leaves components untouched', () => {
+    const document = upgradeFromThreeToThreeOne({
+      asyncapi: '3.0.0',
+      components: {
+        messages: { userSignedUp: { payload: { type: 'object' } } },
+        schemas: { User: { type: 'object' } },
+        securitySchemes: { apiKey: { type: 'apiKey', in: 'user' } },
+      },
+    })
+
+    expect(document.components).toEqual({
+      messages: { userSignedUp: { payload: { type: 'object' } } },
+      schemas: { User: { type: 'object' } },
+      securitySchemes: { apiKey: { type: 'apiKey', in: 'user' } },
+    })
+  })
+
+  // Operation message refs --------------------------------------------------
+  //
+  // 3.0 *required* operation `messages` to ref `#/channels/{id}/messages/{name}`, but the spec's
+  // own examples used `#/components/messages/{name}` until 3.1 fixed them. Many real-world 3.0
+  // docs took the (incorrect) example form. We canonicalize on upgrade.
+
+  it('leaves operation messages refs alone when they are already channel-scoped', () => {
+    const document = upgradeFromThreeToThreeOne({
+      asyncapi: '3.0.0',
+      channels: {
+        userSignedUp: {
+          address: 'user/signedup',
+          messages: { userSignedUp: { $ref: '#/components/messages/userSignedUp' } },
+        },
+      },
+      operations: {
+        onUserSignedUp: {
+          action: 'receive',
+          channel: { $ref: '#/channels/userSignedUp' },
+          messages: [{ $ref: '#/channels/userSignedUp/messages/userSignedUp' }],
+        },
+      },
+    })
+
+    expect((document.operations as { onUserSignedUp: { messages: unknown } }).onUserSignedUp.messages).toEqual([
+      { $ref: '#/channels/userSignedUp/messages/userSignedUp' },
+    ])
+  })
+
+  it('rewrites operation messages refs from components scope to channel scope', () => {
+    const document = upgradeFromThreeToThreeOne({
+      asyncapi: '3.0.0',
+      channels: {
+        userSignedUp: {
+          address: 'user/signedup',
+          messages: { userSignedUp: { $ref: '#/components/messages/userSignedUp' } },
+        },
+      },
+      operations: {
+        onUserSignedUp: {
+          action: 'receive',
+          channel: { $ref: '#/channels/userSignedUp' },
+          messages: [{ $ref: '#/components/messages/userSignedUp' }],
+        },
+      },
+    })
+
+    expect((document.operations as { onUserSignedUp: { messages: unknown } }).onUserSignedUp.messages).toEqual([
+      { $ref: '#/channels/userSignedUp/messages/userSignedUp' },
+    ])
+  })
+
+  it('rewrites multiple operation message refs', () => {
+    const document = upgradeFromThreeToThreeOne({
+      asyncapi: '3.0.0',
+      channels: {
+        userEvents: {
+          address: 'user/events',
+          messages: {
+            signup: { $ref: '#/components/messages/signup' },
+            login: { $ref: '#/components/messages/login' },
+          },
+        },
+      },
+      operations: {
+        onUserEvent: {
+          action: 'receive',
+          channel: { $ref: '#/channels/userEvents' },
+          messages: [{ $ref: '#/components/messages/signup' }, { $ref: '#/components/messages/login' }],
+        },
+      },
+    })
+
+    expect((document.operations as { onUserEvent: { messages: unknown } }).onUserEvent.messages).toEqual([
+      { $ref: '#/channels/userEvents/messages/signup' },
+      { $ref: '#/channels/userEvents/messages/login' },
+    ])
+  })
+
+  it('adds the message to channel.messages when missing during rewrite', () => {
+    const document = upgradeFromThreeToThreeOne({
+      asyncapi: '3.0.0',
+      channels: {
+        userSignedUp: {
+          address: 'user/signedup',
+          messages: {},
+        },
+      },
+      operations: {
+        onUserSignedUp: {
+          action: 'receive',
+          channel: { $ref: '#/channels/userSignedUp' },
+          messages: [{ $ref: '#/components/messages/userSignedUp' }],
+        },
+      },
+    })
+
+    expect((document.channels as { userSignedUp: { messages: unknown } }).userSignedUp.messages).toEqual({
+      userSignedUp: { $ref: '#/components/messages/userSignedUp' },
+    })
+    expect((document.operations as { onUserSignedUp: { messages: unknown } }).onUserSignedUp.messages).toEqual([
+      { $ref: '#/channels/userSignedUp/messages/userSignedUp' },
+    ])
+  })
+
+  it('rewrites reply.messages refs the same way', () => {
+    const document = upgradeFromThreeToThreeOne({
+      asyncapi: '3.0.0',
+      channels: {
+        userSignup: {
+          address: 'user/signup',
+          messages: { userSignedUp: { $ref: '#/components/messages/userSignedUp' } },
+        },
+        userSignupReply: {
+          address: 'user/signup/reply',
+          messages: { userSignedUpReply: { $ref: '#/components/messages/userSignedUpReply' } },
+        },
+      },
+      operations: {
+        sendUserSignUp: {
+          action: 'send',
+          channel: { $ref: '#/channels/userSignup' },
+          messages: [{ $ref: '#/components/messages/userSignedUp' }],
+          reply: {
+            channel: { $ref: '#/channels/userSignupReply' },
+            messages: [{ $ref: '#/components/messages/userSignedUpReply' }],
+          },
+        },
+      },
+    })
+
+    expect(
+      (document.operations as { sendUserSignUp: { reply: { messages: unknown } } }).sendUserSignUp.reply.messages,
+    ).toEqual([{ $ref: '#/channels/userSignupReply/messages/userSignedUpReply' }])
+  })
+
+  it('leaves message refs alone when the operation has no channel ref', () => {
+    const document = upgradeFromThreeToThreeOne({
+      asyncapi: '3.0.0',
+      operations: {
+        orphan: {
+          action: 'send',
+          messages: [{ $ref: '#/components/messages/something' }],
+        },
+      },
+    })
+
+    expect((document.operations as { orphan: { messages: unknown } }).orphan.messages).toEqual([
+      { $ref: '#/components/messages/something' },
+    ])
+  })
 })

--- a/packages/asyncapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
+++ b/packages/asyncapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
@@ -48,7 +48,9 @@ function rewriteOperationMessageRefs(document: UnknownObject): void {
     rewriteMessageList(operation.messages, operation.channel, channels)
 
     if (isObject(operation.reply)) {
-      rewriteMessageList(operation.reply.messages, operation.reply.channel, channels)
+      // Reply's `channel` is optional in 3.0 — when omitted, the reply runs on the parent
+      // operation's channel.
+      rewriteMessageList(operation.reply.messages, operation.reply.channel ?? operation.channel, channels)
     }
   }
 }
@@ -78,15 +80,33 @@ function rewriteMessageList(messageList: unknown, channelRef: unknown, channels:
       continue
     }
 
-    const match = entry.$ref.match(COMPONENT_MESSAGE_REF)
-    if (!match) {
+    const [, messageName] = entry.$ref.match(COMPONENT_MESSAGE_REF) ?? []
+    if (!messageName) {
       continue
     }
 
-    const messageName = match[1]!
     registerChannelMessage(channel, messageName, entry.$ref)
     messageList[i] = { $ref: `#/channels/${channelId}/messages/${messageName}` }
   }
+
+  dedupeRefs(messageList)
+}
+
+/** Removes duplicate `{ $ref: 'X' }` entries (keeps the first occurrence). Mutates `list`. */
+function dedupeRefs(list: unknown[]): void {
+  const seen = new Set<string>()
+  let writeIndex = 0
+  for (const entry of list) {
+    if (isObject(entry) && typeof entry.$ref === 'string') {
+      if (seen.has(entry.$ref)) {
+        continue
+      }
+      seen.add(entry.$ref)
+    }
+    list[writeIndex] = entry
+    writeIndex += 1
+  }
+  list.length = writeIndex
 }
 
 /** Returns the channel id from a `{ $ref: '#/channels/{id}' }` value, or `undefined` for anything else. */

--- a/packages/asyncapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
+++ b/packages/asyncapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
@@ -4,21 +4,107 @@ import type { UnknownObject } from '@scalar/types/utils'
 /** The AsyncAPI version produced by this upgrade step. */
 const ASYNCAPI_VERSION = '3.1.0'
 
+const COMPONENT_MESSAGE_REF = /^#\/components\/messages\/(.+)$/
+
 /**
  * Upgrade an AsyncAPI 3.0 document to 3.1.0.
  *
- * For now this only bumps the `asyncapi` version string — no structural
- * transformations are applied yet.
+ * 3.1 is a clarification release — the only real schema rule it tightens is that operation
+ * `messages` $refs MUST use the channel-scoped form (`#/channels/{id}/messages/{name}`). The 3.0
+ * spec's own examples used the components-scoped form, so many real-world 3.0 documents do too.
+ * We canonicalize on upgrade and pull the referenced message into the channel's `messages` map if
+ * it isn't already there.
  */
 export function upgradeFromThreeToThreeOne(originalDocument: UnknownObject): UnknownObject {
   const document = originalDocument
 
-  // Skip anything that is not an AsyncAPI 3.0 document
   if (!isObject(document) || typeof document.asyncapi !== 'string' || !document.asyncapi.startsWith('3.0')) {
     return document
   }
 
   document.asyncapi = ASYNCAPI_VERSION
+  rewriteOperationMessageRefs(document)
 
   return document
+}
+
+/**
+ * For every operation with a channel `$ref`, rewrite any `#/components/messages/{name}` entry in
+ * its `messages` (and `reply.messages`) to `#/channels/{channelId}/messages/{name}`, registering
+ * the message on the channel if needed.
+ */
+function rewriteOperationMessageRefs(document: UnknownObject): void {
+  if (!isObject(document.operations) || !isObject(document.channels)) {
+    return
+  }
+
+  const channels = document.channels
+
+  for (const operation of Object.values(document.operations)) {
+    if (!isObject(operation)) {
+      continue
+    }
+
+    rewriteMessageList(operation.messages, operation.channel, channels)
+
+    if (isObject(operation.reply)) {
+      rewriteMessageList(operation.reply.messages, operation.reply.channel, channels)
+    }
+  }
+}
+
+/**
+ * Rewrites every `#/components/messages/{name}` entry in `messageList` in-place, given the channel
+ * reference that the surrounding operation/reply points at.
+ */
+function rewriteMessageList(messageList: unknown, channelRef: unknown, channels: UnknownObject): void {
+  if (!Array.isArray(messageList)) {
+    return
+  }
+
+  const channelId = extractChannelId(channelRef)
+  if (!channelId) {
+    return
+  }
+
+  const channel = channels[channelId]
+  if (!isObject(channel)) {
+    return
+  }
+
+  for (let i = 0; i < messageList.length; i += 1) {
+    const entry = messageList[i]
+    if (!isObject(entry) || typeof entry.$ref !== 'string') {
+      continue
+    }
+
+    const match = entry.$ref.match(COMPONENT_MESSAGE_REF)
+    if (!match) {
+      continue
+    }
+
+    const messageName = match[1]!
+    registerChannelMessage(channel, messageName, entry.$ref)
+    messageList[i] = { $ref: `#/channels/${channelId}/messages/${messageName}` }
+  }
+}
+
+/** Returns the channel id from a `{ $ref: '#/channels/{id}' }` value, or `undefined` for anything else. */
+function extractChannelId(channelRef: unknown): string | undefined {
+  if (!isObject(channelRef) || typeof channelRef.$ref !== 'string') {
+    return undefined
+  }
+  const match = channelRef.$ref.match(/^#\/channels\/([^/]+)$/)
+  return match ? match[1] : undefined
+}
+
+/** Ensures `channel.messages[name]` exists, defaulting to a `$ref` pointing at the original component message. */
+function registerChannelMessage(channel: UnknownObject, name: string, componentRef: string): void {
+  if (!isObject(channel.messages)) {
+    channel.messages = {}
+  }
+  const messages = channel.messages as UnknownObject
+  if (!(name in messages)) {
+    messages[name] = { $ref: componentRef }
+  }
 }


### PR DESCRIPTION
3.0 → 3.1 is mostly a clarification release. One change: operation `messages` $refs should use the channel-scoped form (`#/channels/{id}/messages/{name}`), not the components form. 

3.0 already required this but its own examples got it wrong. Most real-world 3.0 docs followed the bad examples. This upgrade fixes them in place and registers the message on the channel if it isn't already there. Reply messages too.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped document-transformation logic in asyncapi-upgrader with extensive tests; no auth, runtime API, or security-sensitive paths.
> 
> **Overview**
> Extends the AsyncAPI **3.0 → 3.1** upgrader so it no longer only bumps `asyncapi` to `3.1.0`. After the version change, it **rewrites** operation `messages` and `reply.messages` entries that use `#/components/messages/{name}` to the channel-scoped form `#/channels/{channelId}/messages/{name}`, using the operation (or reply) channel `$ref`. If that message name is missing on the channel, it **adds** `channel.messages[name]` pointing at the original component ref. **Reply** handling uses `reply.channel` when present, otherwise the parent operation’s channel. Duplicate `$ref` values in the same list are **deduped**; refs are left unchanged when there is no channel `$ref` or when they are already channel-scoped.
> 
> Adds a **minor** changeset for `@scalar/asyncapi-upgrader` and a broad **Vitest** suite (carryover for servers/channels/components, plus rewrite, multi-message, missing channel message, reply, dedupe, and orphan-operation cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6315af9cc434d7c41ffe768fc28e6e58afc8cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->