### PR TITLE
ci: install/build once

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -2,7 +2,7 @@ name: 'Build'
 description: |
   Install workspace deps and run a turbo build with the branch-scoped
   caches from setup-node. When `archive-output: true`, also tar up every
-  workspace `dist/` directory into `./workspace-dist.tar.gz` so downstream
+  workspace `dist/` directory into `./build-output.tar.gz` so downstream
   jobs can fan out via the `restore-build` composite instead of rebuilding.
 
   gzip rather than zstd because the `scalarapi/playwright-runner` container
@@ -12,7 +12,7 @@ inputs:
     description: 'Package glob pattern to build (e.g., "@scalar/api-reference" or "packages/*")'
     required: true
   archive-output:
-    description: 'When true, write ./workspace-dist.tar.gz alongside the build.'
+    description: 'When true, write ./build-output.tar.gz alongside the build.'
     required: false
     default: 'false'
 runs:
@@ -44,16 +44,16 @@ runs:
         set -euo pipefail
         find packages integrations projects \
           -mindepth 2 -maxdepth 2 -type d -name dist -print0 2>/dev/null \
-          | sort -zu > .workspace-dist.list
+          | sort -zu > .build-output.list
 
-        if [ ! -s .workspace-dist.list ]; then
+        if [ ! -s .build-output.list ]; then
           echo "No dist directories found to archive" >&2
           exit 1
         fi
 
         echo "Archiving:"
-        tr '\0' '\n' < .workspace-dist.list
+        tr '\0' '\n' < .build-output.list
 
-        tar --null -czf workspace-dist.tar.gz.tmp -T .workspace-dist.list
-        mv workspace-dist.tar.gz.tmp workspace-dist.tar.gz
-        ls -lh workspace-dist.tar.gz
+        tar --null -czf build-output.tar.gz.tmp -T .build-output.list
+        mv build-output.tar.gz.tmp build-output.tar.gz
+        ls -lh build-output.tar.gz

--- a/.github/actions/restore-build/action.yml
+++ b/.github/actions/restore-build/action.yml
@@ -1,0 +1,38 @@
+name: 'Restore Build'
+description: |
+  Restore a pre-built workspace produced by an earlier `build` job in the
+  same workflow run. Sets up pnpm + node, installs dependencies, downloads
+  the `workspace-dist` artifact, and extracts every `dist/` directory back
+  into place.
+
+  Intentionally never accepts a `run-id` input: artifacts must come from
+  the same run as the consumer, so a PR-produced artifact can never feed a
+  release job.
+runs:
+  using: 'composite'
+  steps:
+    - uses: ./.github/actions/setup-node
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile --prefer-offline
+
+    - name: Download workspace-dist artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: workspace-dist
+        path: .
+
+    - name: Extract workspace dist
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ ! -f workspace-dist.tar.gz ]; then
+          echo "Expected workspace-dist.tar.gz but it was not in the artifact" >&2
+          exit 1
+        fi
+        tar -xzf workspace-dist.tar.gz
+        rm workspace-dist.tar.gz
+        echo "Restored workspace dist directories:"
+        find packages integrations projects \
+          -mindepth 2 -maxdepth 2 -type d -name dist 2>/dev/null | sort

--- a/.github/actions/restore-build/action.yml
+++ b/.github/actions/restore-build/action.yml
@@ -2,7 +2,7 @@ name: 'Restore Build'
 description: |
   Restore a pre-built workspace produced by an earlier `build` job in the
   same workflow run. Sets up pnpm + node, installs dependencies, downloads
-  the `workspace-dist` artifact, and extracts every `dist/` directory back
+  the `build-output` artifact, and extracts every `dist/` directory back
   into place.
 
   Intentionally never accepts a `run-id` input: artifacts must come from
@@ -17,22 +17,22 @@ runs:
       shell: bash
       run: pnpm install --frozen-lockfile --prefer-offline
 
-    - name: Download workspace-dist artifact
+    - name: Download build-output artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
-        name: workspace-dist
+        name: build-output
         path: .
 
     - name: Extract workspace dist
       shell: bash
       run: |
         set -euo pipefail
-        if [ ! -f workspace-dist.tar.gz ]; then
-          echo "Expected workspace-dist.tar.gz but it was not in the artifact" >&2
+        if [ ! -f build-output.tar.gz ]; then
+          echo "Expected build-output.tar.gz but it was not in the artifact" >&2
           exit 1
         fi
-        tar -xzf workspace-dist.tar.gz
-        rm workspace-dist.tar.gz
+        tar -xzf build-output.tar.gz
+        rm build-output.tar.gz
         echo "Restored workspace dist directories:"
         find packages integrations projects \
           -mindepth 2 -maxdepth 2 -type d -name dist 2>/dev/null | sort

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,11 @@ jobs:
       # Tarball of every workspace dist/ produced above. Consumed by the
       # restore-build composite so downstream JS jobs can fan out without
       # rerunning the build.
-      - name: Upload workspace-dist artifact
+      - name: Upload build-output artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: workspace-dist
-          path: workspace-dist.tar.gz
+          name: build-output
+          path: build-output.tar.gz
           retention-days: 1
           # The tarball is already gzip-compressed; skip the upload action's
           # outer zip-compression pass.
@@ -801,7 +801,7 @@ jobs:
 
       # restore-build has already populated every workspace dependency's
       # dist directory, so this is a single-package build of the examples
-      # wrapper itself (examples/* are not part of the workspace-dist tarball).
+      # wrapper itself (examples/* are not part of the build-output tarball).
       - name: Build @scalar-examples/web
         run: pnpm --filter @scalar-examples/web build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         uses: ./.github/actions/build
         with:
           packages: './{packages,integrations}/**'
+          archive-output: 'true'
       - name: Copy and rename standalone.js to scalar.js
         run: |
           mkdir -p temp-artifacts
@@ -69,6 +70,18 @@ jobs:
           name: mock-server-docker-entrypoint
           path: packages/mock-server/docker/dist/docker-entrypoint.js
           retention-days: 3
+      # Tarball of every workspace dist/ produced above. Consumed by the
+      # restore-build composite so downstream JS jobs can fan out without
+      # rerunning the build.
+      - name: Upload workspace-dist artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: workspace-dist
+          path: workspace-dist.tar.gz
+          retention-days: 1
+          # The tarball is already gzip-compressed; skip the upload action's
+          # outer zip-compression pass.
+          compression-level: 0
       - if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
         name: Upload webpack stats to RelativeCI
         uses: relative-ci/agent-action@1707825cbfcc7452b2913d273414705415ae64d4 # v3
@@ -260,10 +273,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Build
-        uses: ./.github/actions/build
-        with:
-          packages: './{packages,integrations}/**'
+      - name: Restore pre-built workspace
+        uses: ./.github/actions/restore-build
       - name: Knip
         run: pnpm lint:knip
 
@@ -278,10 +289,8 @@ jobs:
         shard-total: [3]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Build packages
-        uses: ./.github/actions/build
-        with:
-          packages: './packages/**'
+      - name: Restore pre-built workspace
+        uses: ./.github/actions/restore-build
       - name: Check built declaration alias imports
         if: matrix.shard-index == 1
         run: pnpm lint:check:dist-dts-aliases
@@ -315,10 +324,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Build packages (workspace deps for projects)
-        uses: ./.github/actions/build
-        with:
-          packages: './packages/**'
+      - name: Restore pre-built workspace
+        uses: ./.github/actions/restore-build
       - name: Run project tests
         run: |
           args=()
@@ -352,10 +359,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Build packages
-        uses: ./.github/actions/build
-        with:
-          packages: './integrations/**'
+      - name: Restore pre-built workspace
+        uses: ./.github/actions/restore-build
       - name: Run tests
         run: pnpm turbo --filter './integrations/**' test
         # For now we will integrate the E2E tests with the integrations tests as they are quite fast and this avoids another job.
@@ -384,10 +389,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Build packages
-        uses: ./.github/actions/build
-        with:
-          packages: '@scalar/server-side-rendering...'
+      - name: Restore pre-built workspace
+        uses: ./.github/actions/restore-build
       - name: Start SSR playground and verify it responds
         run: |
           pnpm --filter @scalar/server-side-rendering dev &
@@ -415,10 +418,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Build packages
-        uses: ./.github/actions/build
-        with:
-          packages: '@scalar/api-reference...'
+      - name: Restore pre-built workspace
+        uses: ./.github/actions/restore-build
       - name: Generate new DEPLOY_ID
         run: echo "DEPLOY_ID=$(pnpx uuid)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
       - name: Run e2e tests (@scalar/api-reference)
@@ -465,10 +466,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Build scalar-app and dependencies
-        uses: ./.github/actions/build
-        with:
-          packages: 'scalar-app...'
+      - name: Restore pre-built workspace
+        uses: ./.github/actions/restore-build
       - name: Generate new DEPLOY_ID
         run: echo "DEPLOY_ID=$(pnpx uuid)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
       - name: Run e2e tests (scalar-app)
@@ -510,10 +509,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Build packages
-        uses: ./.github/actions/build
-        with:
-          packages: '@scalar/components...'
+      - name: Restore pre-built workspace
+        uses: ./.github/actions/restore-build
       - name: Generate new DEPLOY_ID
         run: echo "DEPLOY_ID=$(pnpx uuid)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
       - name: Build storybook
@@ -559,10 +556,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Build packages
-        uses: ./.github/actions/build
-        with:
-          packages: '@scalar/api-reference...'
+      - name: Restore pre-built workspace
+        uses: ./.github/actions/restore-build
       - name: Generate new DEPLOY_ID
         run: echo "DEPLOY_ID=$(pnpx uuid)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
       - name: Run snapshot tests (@scalar/api-reference)
@@ -801,10 +796,14 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Build
-        uses: ./.github/actions/build
-        with:
-          packages: '@scalar-examples/web...'
+      - name: Restore pre-built workspace
+        uses: ./.github/actions/restore-build
+
+      # restore-build has already populated every workspace dependency's
+      # dist directory, so this is a single-package build of the examples
+      # wrapper itself (examples/* are not part of the workspace-dist tarball).
+      - name: Build @scalar-examples/web
+        run: pnpm --filter @scalar-examples/web build
 
       - name: Generate DEPLOY_ID
         run: echo "DEPLOY_ID=$(pnpx uuid)" >> "$GITHUB_ENV"
@@ -846,10 +845,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Build workspace deps
-        uses: ./.github/actions/build
-        with:
-          packages: '@scalar/api-reference...'
+      - name: Restore pre-built workspace
+        uses: ./.github/actions/restore-build
 
       - name: Build package root app
         run: pnpm --filter @scalar/api-reference exec vite build . -c ./vite.previews.config.ts
@@ -891,10 +888,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Build
-        uses: ./.github/actions/build
-        with:
-          packages: './packages/**'
+      - name: Restore pre-built workspace
+        uses: ./.github/actions/restore-build
 
       - name: Generate DEPLOY_ID
         run: echo "DEPLOY_ID=$(pnpx uuid)" >> "$GITHUB_ENV"
@@ -1070,10 +1065,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Build @scalar/galaxy
-        uses: ./.github/actions/build
-        with:
-          packages: '@scalar/galaxy...'
+      - name: Restore pre-built workspace
+        uses: ./.github/actions/restore-build
 
       - name: Extract version and generate preview version
         id: preview-version


### PR DESCRIPTION
Right now every JS job in `ci.yml` re-runs `pnpm install` and `pnpm turbo build` even though the workspace it produces is identical. 

With this PR we build once, archive every `dist/` into `build-output.tar.gz`, and let downstream jobs pull it via a new `restore-build` composite.

Got this from #9233 with none of the other rewrites from that PR.

* Before: Build packages (cache hit) ~26s
* After: Restore pre-built workspace ~23s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Downstream jobs now depend on a single archived build matching the commit; a bad or incomplete tarball could break or mask failures across many CI jobs, though same-run-only artifact download limits cross-run misuse.
> 
> **Overview**
> CI now **builds packages and integrations once** in the `build` job, archives every workspace `dist/` into **`build-output.tar.gz`**, and uploads it as the **`build-output`** artifact (1-day retention, no extra zip compression).
> 
> A new **`restore-build`** composite action installs deps, downloads that artifact from the **same workflow run only** (no `run-id` input), and extracts the tarball so downstream jobs reuse the compiled output instead of running **`./.github/actions/build`** again.
> 
> **`ci.yml`** wires this into knip, package/project/integration tests, SSR and Playwright jobs, preview deploys, and galaxy registry preview. **`deploy-examples`** restores shared `dist/` trees then runs a **single** `pnpm --filter @scalar-examples/web build` because `examples/*` are outside the archive. The build composite renames the archive/list files from `workspace-dist` to **`build-output`**.
> 
> Jobs that still run a full or scoped build locally (e.g. **`types`**, **`npm-publish`**, **`todesktop-build`**) are unchanged by this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f74176ad2453d53951c11cda4682416a6560239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->