### PR TITLE
chore: add @bgrcs as a wildcard codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,22 +5,22 @@
 /.changeset
 
 # Amrit + Redis
-/packages/api-client @marclave @hanspagel @amritk @DemonHa
-/packages/json-magic @marclave @hanspagel @amritk @DemonHa
-/packages/pre-post-request-scripts @marclave @hanspagel @amritk @DemonHa
-/packages/schemas @marclave @hanspagel @amritk @DemonHa
-/packages/types @marclave @hanspagel @amritk @DemonHa
-/packages/validation @marclave @hanspagel @amritk @DemonHa
-/packages/workspace-store @marclave @hanspagel @amritk @DemonHa
-/projects/scalar-app @marclave @hanspagel @amritk @DemonHa
+/packages/api-client @marclave @hanspagel @amritk @bgrcs @DemonHa
+/packages/json-magic @marclave @hanspagel @amritk @bgrcs @DemonHa
+/packages/pre-post-request-scripts @marclave @hanspagel @amritk @bgrcs @DemonHa
+/packages/schemas @marclave @hanspagel @amritk @bgrcs @DemonHa
+/packages/types @marclave @hanspagel @amritk @bgrcs @DemonHa
+/packages/validation @marclave @hanspagel @amritk @bgrcs @DemonHa
+/packages/workspace-store @marclave @hanspagel @amritk @bgrcs @DemonHa
+/projects/scalar-app @marclave @hanspagel @amritk @bgrcs @DemonHa
 
 # Brynn + Cam
-/packages/components @marclave @hanspagel @amritk @hwkr @cameronrohani
-/packages/icons @marclave @hanspagel @amritk @hwkr @cameronrohani
-/packages/sidebar @marclave @hanspagel @amritk @hwkr @cameronrohani @DemonHa
-/packages/themes @marclave @hanspagel @amritk @hwkr @cameronrohani
-/packages/use-hooks @marclave @hanspagel @amritk @hwkr @cameronrohani
-/packages/use-toasts @marclave @hanspagel @amritk @hwkr @cameronrohani
-/documentation @marclave @hanspagel @hwkr @cameronrohani
-/scalar.config.json @marclave @hanspagel @hwkr @cameronrohani
-/*.md @marclave @hanspagel @hwkr @cameronrohani
+/packages/components @marclave @hanspagel @amritk @bgrcs @hwkr @cameronrohani
+/packages/icons @marclave @hanspagel @amritk @bgrcs @hwkr @cameronrohani
+/packages/sidebar @marclave @hanspagel @amritk @bgrcs @hwkr @cameronrohani @DemonHa
+/packages/themes @marclave @hanspagel @amritk @bgrcs @hwkr @cameronrohani
+/packages/use-hooks @marclave @hanspagel @amritk @bgrcs @hwkr @cameronrohani
+/packages/use-toasts @marclave @hanspagel @amritk @bgrcs @hwkr @cameronrohani
+/documentation @marclave @hanspagel @bgrcs @hwkr @cameronrohani
+/scalar.config.json @marclave @hanspagel @bgrcs @hwkr @cameronrohani
+/*.md @marclave @hanspagel @bgrcs @hwkr @cameronrohani

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owners (overwritten by more specific entries)
-* @marclave @hanspagel @amritk
+* @marclave @hanspagel @amritk @bgrcs
 
 # Changesets
 /.changeset


### PR DESCRIPTION
Added Bruno as a wildcard codeowner for the EU timezone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repository ownership metadata only; no product code, auth, or data paths are affected.
> 
> **Overview**
> Adds **@bgrcs** as a code owner across `CODEOWNERS`, including the default `*` rule and every listed path group (Amrit/Redis packages, Brynn/Cam UI/docs paths).
> 
> This only changes who gets auto-requested on PRs; it does not modify application code or runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba9500b54c61d4b0441df794108485512645037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->