### PR TITLE
fix(docs): add missing tailwind class

### DIFF
--- a/documentation/assets/styles.css
+++ b/documentation/assets/styles.css
@@ -11,6 +11,10 @@
   display: none;
 }
 
+.w-1\/2 {
+  width: 50%;
+}
+
 /* TODO: Remove these styles after cleaning up the docs pages */
 
 /* Make adjacent buttons have secondary styles*/


### PR DESCRIPTION
Long term plan is to add a lightweight Tailwind implementation for our docs so this can't happen but for now this hotfixes the issue.

Before / After

<img width="522" height="462" alt="CleanShot 2026-05-29 at 10 05 35" src="https://github.com/user-attachments/assets/797a0fc6-569c-437e-ac64-3d365b31ec62" />
<img width="543" height="465" alt="CleanShot 2026-05-29 at 10 04 58" src="https://github.com/user-attachments/assets/9d035f8e-bf7c-4c22-9fba-9f7bfd52b44f" />


## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
