### PR TITLE
chore(themes): change default font stack to match tailwind's

### DIFF
--- a/.changeset/four-moons-judge.md
+++ b/.changeset/four-moons-judge.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+Use the correct system fonts when withDefaultFonts is set to false

--- a/packages/themes/src/base/variables.css
+++ b/packages/themes/src/base/variables.css
@@ -6,7 +6,8 @@
 
   /* TYPOGRAPHY ------------------------------------ */
   --scalar-font:
-    "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji";
   --scalar-font-code:
     "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 

--- a/packages/themes/src/base/variables.css
+++ b/packages/themes/src/base/variables.css
@@ -6,13 +6,9 @@
 
   /* TYPOGRAPHY ------------------------------------ */
   --scalar-font:
-    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans",
-    "Helvetica Neue", sans-serif;
+    "Inter", ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --scalar-font-code:
-    "JetBrains Mono", ui-monospace, Menlo, Monaco,
-    "Cascadia Mono", "Segoe UI Mono", "Roboto Mono", "Oxygen Mono",
-    "Ubuntu Monospace", "Source Code Pro", "Fira Mono", "Droid Sans Mono",
-    "Courier New", monospace;
+    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 
   /** Font sizes for rendered text content (editor styles or static content) */
   --scalar-heading-1: 24px; /* Editor Page heading */

--- a/packages/themes/src/base/variables.css
+++ b/packages/themes/src/base/variables.css
@@ -6,9 +6,9 @@
 
   /* TYPOGRAPHY ------------------------------------ */
   --scalar-font:
-    "Inter", ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+    "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --scalar-font-code:
-    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 
   /** Font sizes for rendered text content (editor styles or static content) */
   --scalar-heading-1: 24px; /* Editor Page heading */

--- a/packages/themes/src/presets/custom-theme-starter.css
+++ b/packages/themes/src/presets/custom-theme-starter.css
@@ -13,9 +13,9 @@
 
   /* Typography */
   --scalar-font:
-    "Inter", ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+    "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --scalar-font-code:
-    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 
   /* Font sizes */
   --scalar-heading-1: 24px; /* Page headings */

--- a/packages/themes/src/presets/custom-theme-starter.css
+++ b/packages/themes/src/presets/custom-theme-starter.css
@@ -13,7 +13,8 @@
 
   /* Typography */
   --scalar-font:
-    "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji";
   --scalar-font-code:
     "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 

--- a/packages/themes/src/presets/custom-theme-starter.css
+++ b/packages/themes/src/presets/custom-theme-starter.css
@@ -13,9 +13,9 @@
 
   /* Typography */
   --scalar-font:
-    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans",
-    "Helvetica Neue", sans-serif;
-  --scalar-font-code: "JetBrains Mono";
+    "Inter", ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --scalar-font-code:
+    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 
   /* Font sizes */
   --scalar-heading-1: 24px; /* Page headings */


### PR DESCRIPTION
- **chore(themes): change default font stack to match tailwind's**
- **docs(changeset): Use the correct system fonts when withDefaultFonts is set to false**

## Problem

<!--
  What problem does the PR solve?
  WHY did you submit the PR?

  We are interested in the WHY (LLMs won't know).
-->

When withDefaultFonts is set to false, scalar would display a random font instead of my configured system font

## Solution

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

Changed the default font stack to match tailwind's" https://tailwindcss.com/docs/font-family

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
