### PR TITLE
test(api-reference): add classic layout AsyncAPI galaxy events source

### DIFF
--- a/packages/api-reference/test/utils/sources.ts
+++ b/packages/api-reference/test/utils/sources.ts
@@ -33,6 +33,12 @@ export const sources = [
     url: 'https://registry.scalar.com/@scalar/schemas/asyncapi?format=json',
   },
   {
+    title: 'Scalar Galaxy Events (AsyncAPI, Classic Layout)',
+    slug: 'scalar-galaxy-events-classic',
+    url: 'https://registry.scalar.com/@scalar/schemas/asyncapi?format=json',
+    layout: 'classic',
+  },
+  {
     title: 'Tag Groups',
     slug: 'tag-groups',
     content: {


### PR DESCRIPTION
Adds a classic-layout copy of the Scalar Galaxy Events (AsyncAPI) playground source, so we can test AsyncAPI rendering in the classic layout too.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture change in playground sources; no production API or auth behavior is modified.
> 
> **Overview**
> Adds a **classic layout** playground source for **Scalar Galaxy Events (AsyncAPI)**, using the same registry URL as the default-layout entry but with `layout: 'classic'`.
> 
> This mirrors the existing **Scalar Galaxy (Classic Layout)** pattern so api-reference tests can cover AsyncAPI rendering in the classic layout, not only the modern layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a90446b7e148aa8439d0749477b8420ccd7284ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->