### PR TITLE
build: use shx cp for cross-platform build:styles

### DIFF
--- a/.changeset/cross-platform-build-styles.md
+++ b/.changeset/cross-platform-build-styles.md
@@ -1,9 +1,0 @@
----
-'@scalar/agent-chat': patch
-'@scalar/api-client': patch
-'@scalar/api-reference': patch
-'@scalar/components': patch
-'@scalar/sidebar': patch
----
-
-build: use `shx cp` in `build:styles` so the styles directory copy works on Windows, matching the pattern already used in `@scalar/code-highlight` and `@scalar/blocks`.

--- a/.changeset/cross-platform-build-styles.md
+++ b/.changeset/cross-platform-build-styles.md
@@ -1,0 +1,9 @@
+---
+'@scalar/agent-chat': patch
+'@scalar/api-client': patch
+'@scalar/api-reference': patch
+'@scalar/components': patch
+'@scalar/sidebar': patch
+---
+
+build: use `shx cp` in `build:styles` so the styles directory copy works on Windows, matching the pattern already used in `@scalar/code-highlight` and `@scalar/blocks`.

--- a/packages/agent-chat/package.json
+++ b/packages/agent-chat/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "vite build && pnpm build:styles && vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && shx cp package.json dist",
-    "build:styles": "cp -r src/styles dist && tailwindcss --optimize -i src/style.css -o dist/style.css && cat dist/vue-styles.css >> dist/style.css",
+    "build:styles": "shx cp -r src/styles dist && tailwindcss --optimize -i src/style.css -o dist/style.css && cat dist/vue-styles.css >> dist/style.css",
     "build:watch": "vite build --watch",
     "dev": "pnpm playground",
     "playground": "cd playground && vite",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build": "vite build && pnpm build:styles && vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "build:styles": "cp -r src/styles dist && tailwindcss --optimize -i src/style.css -o dist/style.css && cat dist/vue-styles.css >> dist/style.css",
+    "build:styles": "shx cp -r src/styles dist && tailwindcss --optimize -i src/style.css -o dist/style.css && cat dist/vue-styles.css >> dist/style.css",
     "dev": "vite ./playground/modal -c ./vite.config.ts",
     "preview": "vite preview",
     "test": "vitest --run",

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -29,7 +29,7 @@
     "build:default": "vite build",
     "build:standalone": "vite build -c vite.standalone.config.ts",
     "build:standalone:esm": "vite build -c vite.standalone.esm.config.ts",
-    "build:styles": "cp -r src/styles dist && tailwindcss --optimize -i src/style.css -o dist/style.css && cat dist/vue-styles.css >> dist/style.css",
+    "build:styles": "shx cp -r src/styles dist && tailwindcss --optimize -i src/style.css -o dist/style.css && cat dist/vue-styles.css >> dist/style.css",
     "dev": "vite",
     "dev:standalone": "vite -c vite.standalone.config.ts",
     "playground:esm": "vite ./playground/esm -c ./playground/esm/vite.config.ts",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "pnpm typegen:icons && vite build && pnpm build:styles && vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:storybook": "storybook build",
-    "build:styles": "cp -r src/styles dist && tailwindcss --optimize -i src/style.css -o dist/style.css && cat dist/vue-styles.css >> dist/style.css",
+    "build:styles": "shx cp -r src/styles dist && tailwindcss --optimize -i src/style.css -o dist/style.css && cat dist/vue-styles.css >> dist/style.css",
     "build:watch": "concurrently \"vite build --watch\" \"vue-tsc --watch -p tsconfig.build.json\" \"tsc-alias -p tsconfig.build.json --watch\"",
     "clean:snapshots": "shx rm -rf \"**/snapshots\"",
     "dev": "storybook dev -p 5100 --ci",

--- a/packages/sidebar/package.json
+++ b/packages/sidebar/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "build": "vite build && pnpm build:styles && vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
-    "build:styles": "cp -r src/styles dist && tailwindcss --optimize -i src/style.css -o dist/style.css && cat dist/vue-styles.css >> dist/style.css",
+    "build:styles": "shx cp -r src/styles dist && tailwindcss --optimize -i src/style.css -o dist/style.css && cat dist/vue-styles.css >> dist/style.css",
     "dev": "vite ./playground -c ./vite.config.ts",
     "test": "vitest --run",
     "types:check": "vue-tsc --noEmit"


### PR DESCRIPTION
* `cp -r` is not available on Windows `cmd`/PowerShell
* use `shx cp -r` instead

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only build tooling change with no runtime or application logic impact.
> 
> **Overview**
> Updates the **`build:styles`** script in five UI packages (`agent-chat`, `api-client`, `api-reference`, `components`, `sidebar`) so the first step copies `src/styles` into `dist` with **`shx cp -r`** instead of **`cp -r`**.
> 
> That keeps the same Tailwind merge steps but makes style copying work on **Windows** shells where Unix `cp` is not available. **`shx`** is already used elsewhere in the monorepo (e.g. root and other package scripts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 667bd2905a2f4b76de5d0fd58739133999e37862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->