### PR TITLE
fix(helpers): "show schema" freezes on circular $refs

### DIFF
--- a/.changeset/pretty-print-shared-references.md
+++ b/.changeset/pretty-print-shared-references.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': patch
+---
+
+fix: prevent the browser from freezing when pretty-printing deeply shared object graphs (e.g. the "Show Schema" toggle on recursive OpenAPI schemas). `prettyPrintJson` now always collapses repeated references instead of fully expanding every shared subtree, which previously grew exponentially.

--- a/packages/helpers/src/json/pretty-print-json.test.ts
+++ b/packages/helpers/src/json/pretty-print-json.test.ts
@@ -26,4 +26,28 @@ describe('prettyPrintJson', () => {
 
     expect(prettyPrintJson(foo)).toMatch(`{\n  "foo": "[Circular]"\n}`)
   })
+
+  it('does not explode on heavily shared references', () => {
+    /*
+     * A deeply resolved, recursive OpenAPI schema (e.g. the "Show Schema" toggle on a
+     * self-referential type) produces a graph that reuses the same object reference in
+     * many places. True cycles are already cut to "[circular]" strings, so JSON.stringify
+     * never throws — instead it fully expands every shared subtree, which grows
+     * exponentially with depth and freezes the browser tab.
+     */
+    const buildDiamond = (depth: number) => {
+      let node: Record<string, unknown> = { leaf: true }
+      for (let level = 0; level < depth; level++) {
+        // Both branches point at the *same* object, doubling the expanded size per level
+        node = { left: node, right: node }
+      }
+      return node
+    }
+
+    const result = prettyPrintJson(buildDiamond(20))
+
+    // Collapsing repeated references keeps the output linear in the depth rather than 2^depth
+    expect(result.length).toBeLessThan(10_000)
+    expect(result).toContain('[Circular]')
+  })
 })

--- a/packages/helpers/src/json/pretty-print-json.ts
+++ b/packages/helpers/src/json/pretty-print-json.ts
@@ -18,18 +18,26 @@ export const prettyPrintJson = (value: string | number | any[] | Record<any, any
   }
 
   if (typeof value === 'object') {
-    try {
-      return JSON.stringify(value, null, 2)
-    } catch {
-      return replaceCircularDependencies(value)
-    }
+    /*
+     * Always serialize through the reference-aware path. A plain JSON.stringify only
+     * throws on *self*-referencing objects, but a structure that merely reuses the same
+     * object reference in many places (a "diamond" graph) serializes without error — by
+     * fully expanding every shared subtree. For a deeply shared graph that expansion grows
+     * exponentially and freezes the tab. This happens with deeply resolved, recursive
+     * OpenAPI schemas, where circular $refs are already cut to '[circular]' strings yet
+     * sibling types remain shared. Collapsing repeated references keeps the output linear.
+     */
+    return replaceCircularDependencies(value)
   }
 
   return value?.toString() ?? ''
 }
 
 /**
- * JSON.stringify, but with circular dependencies replaced with '[Circular]'
+ * JSON.stringify, but with repeated and circular references replaced with '[Circular]'.
+ *
+ * Note: parsing real JSON never yields shared references, so for ordinary parsed data
+ * this produces output identical to a plain JSON.stringify.
  */
 export function replaceCircularDependencies(content: any) {
   const cache = new Set()


### PR DESCRIPTION
Toggling **Show Schema** on a recursive/heavily cross-referenced OpenAPI schema froze the tab (e.g. "Get related OrgUnit" in the OData datawarehouse document).

The schema gets deep-resolved into a graph that reuses the same object in many places. `JSON.stringify` happily expands every shared subtree, which blows up exponentially (one real schema serialized to ~244 MB before the tab died). `prettyPrintJson` only fell back to the safe path when stringify *threw*, which never happens here.

Fix: 

always serialize through the reference-collapsing path. Repeated references become `[Circular]`, so output stays linear. Parsed JSON has no shared references, so normal pretty-printing is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to JSON pretty-printing in `@scalar/helpers`; normal objects and parsed JSON behavior stay equivalent, with safer handling for in-memory shared graphs.
> 
> **Overview**
> **Show Schema** and similar UI could freeze the browser when pretty-printing deeply resolved OpenAPI schemas that reuse the same object in many places (diamond graphs), because `prettyPrintJson` only used the safe serializer after `JSON.stringify` threw—which does not happen for shared references, only true self-cycles.
> 
> Object values now always go through `replaceCircularDependencies`, so the second visit to the same object becomes `[Circular]` and output size stays roughly linear in depth instead of exponential. Parsed JSON strings still use plain `JSON.stringify` (no shared refs after parse). A regression test builds a depth-20 diamond and asserts bounded output plus `[Circular]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7163021803d08b461b257d23bb6c332284b44024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->