### PR TITLE
fix(openapi-types): allow boolean schemas in OpenAPI 3.1 types

### DIFF
--- a/.changeset/openapi-types-3-1-boolean-schema.md
+++ b/.changeset/openapi-types-3-1-boolean-schema.md
@@ -1,0 +1,7 @@
+---
+'@scalar/openapi-types': patch
+---
+
+fix: allow boolean schemas in OpenAPI 3.1 types
+
+OpenAPI 3.1 schemas are JSON Schema, where `true` and `false` are valid schemas (`true` allows any instance, `false` allows none). The `SchemaObject` type now accepts booleans anywhere a schema is expected, matching the existing 3.2 behavior.

--- a/packages/openapi-types/3.1/schema.d.ts
+++ b/packages/openapi-types/3.1/schema.d.ts
@@ -153,6 +153,7 @@ export type MultiTypeObject = SharedProperties &
     format?: StringFormat | NumericFormat
   } & Extensions
 export type SchemaObject =
+  | boolean
   | UntypedObject
   | OtherTypes
   | NumericObject

--- a/packages/openapi-types/src/openapi-types.test-d.ts
+++ b/packages/openapi-types/src/openapi-types.test-d.ts
@@ -1,5 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest'
 
+import type { Document as OpenAPIV3_1Document, SchemaObject as OpenAPIV3_1SchemaObject } from '../3.1'
 import type {
   Document as OpenAPIV3_2Document,
   MediaTypeObject as OpenAPIV3_2MediaTypeObject,
@@ -87,6 +88,39 @@ describe('OpenAPI', () => {
 
     // @ts-expect-error name is a string
     assertType('NOT_A_METHOD' as OpenAPI.HttpMethod)
+  })
+})
+
+describe('@scalar/openapi-types/3.1', () => {
+  it('allows boolean schemas anywhere a schema object is accepted', () => {
+    expectTypeOf<true>().toExtend<OpenAPIV3_1SchemaObject>()
+    expectTypeOf<false>().toExtend<OpenAPIV3_1SchemaObject>()
+
+    const schema: OpenAPIV3_1SchemaObject = {
+      type: 'object',
+      properties: {
+        anything: true,
+        nothing: false,
+      },
+      allOf: [true, false, { type: 'string' }],
+    }
+
+    const document: OpenAPIV3_1Document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Boolean schema test',
+        version: '1.0.0',
+      },
+      components: {
+        schemas: {
+          Anything: true,
+          Nothing: false,
+        },
+      },
+    }
+
+    expectTypeOf(schema).not.toBeAny()
+    expectTypeOf(document).not.toBeAny()
   })
 })
 


### PR DESCRIPTION
OpenAPI 3.1 schemas are JSON Schema, so `true` and `false` are valid schemas (`true` allows anything, `false` allows nothing). The 3.1 `SchemaObject` type rejected them, so legal documents failed to type-check.

This adds `boolean` to the 3.1 `SchemaObject` union, matching what 3.2 already does. The example from the report now type-checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only widening for valid OpenAPI 3.1 documents; no runtime or security impact.
> 
> **Overview**
> OpenAPI 3.1 `SchemaObject` now includes **`boolean`**, so `true`/`false` JSON Schema shorthand type-checks in properties, combinators, and `components.schemas`—aligned with **3.2** and the spec.
> 
> Adds **compile-time tests** for 3.1 (mirroring existing 3.2 coverage) and a **patch changeset** for `@scalar/openapi-types`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec5c4e0f818586d33a03b9e0dce5f1b1596f472c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->