### PR TITLE
feat(galaxy): lint the example document with a Scalar ruleset

### DIFF
--- a/.changeset/galaxy-lint-ruleset.md
+++ b/.changeset/galaxy-lint-ruleset.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+Add a `lint` script and a local Spectral ruleset (`galaxy.ruleset.yaml`) so the example document can be linted with `@scalar/cli document lint`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
             | sed '/^[[:space:]]*$/d')
           warnings=$(printf '%s\n' "$clean" | grep -c '^Severity: Warning' || true)
           {
-            echo '### 🪐 Galaxy document lint'
+            echo '**Scalar Galaxy Lint**'
             echo ''
             if [ "${{ steps.lint.outputs.exit_code }}" != '0' ]; then
               echo '❌ Linting failed.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,8 @@ jobs:
     needs: [check-changes]
     permissions:
       contents: read
+      # Required so the lint results can be posted back to the PR.
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
@@ -270,8 +272,55 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
+      # Capture the lint output (warnings do not fail the command) so we can
+      # both surface it in the job log and post it to the PR. continue-on-error
+      # keeps the comment step running even when spectral:oas reports errors;
+      # the captured exit code is replayed at the end to set the job status.
       - name: Lint the Galaxy example document
-        run: pnpm --filter @scalar/galaxy lint
+        id: lint
+        run: |
+          set +e
+          pnpm --filter @scalar/galaxy lint > lint-output.txt 2>&1
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          cat lint-output.txt
+      # Only PRs from the same repository have a writable token for comments.
+      - name: Build lint comment
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
+        run: |
+          # Strip ANSI escape codes, npm noise, and the pnpm script echo, then
+          # collapse blank lines so the comment shows just the lint findings.
+          clean=$(sed -r 's/\x1b\[[0-9;?]*[a-zA-Z]//g' lint-output.txt \
+            | grep -v '^npm warn' \
+            | grep -v '^> ' \
+            | sed '/^[[:space:]]*$/d')
+          warnings=$(printf '%s\n' "$clean" | grep -c '^Severity: Warning' || true)
+          {
+            echo '### 🪐 Galaxy document lint'
+            echo ''
+            if [ "${{ steps.lint.outputs.exit_code }}" != '0' ]; then
+              echo '❌ Linting failed.'
+            elif [ "$warnings" -gt 0 ]; then
+              echo "⚠️ ${warnings} warning(s) found."
+            else
+              echo '✅ No issues found.'
+            fi
+            echo ''
+            echo '```'
+            printf '%s\n' "$clean"
+            echo '```'
+          } > lint-comment.md
+      - name: Post lint results to the PR
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
+        with:
+          file-path: lint-comment.md
+          # Reuse (update) the same comment on every new commit instead of
+          # posting a new one.
+          comment-tag: galaxy-lint
+      # Replay the lint exit code so the job fails on real (error-level) issues.
+      - name: Report lint status
+        if: ${{ !cancelled() }}
+        run: exit ${{ steps.lint.outputs.exit_code }}
 
   types:
     needs: [build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,8 +260,6 @@ jobs:
     needs: [check-changes]
     permissions:
       contents: read
-      # Required so the lint results can be posted back to the PR.
-      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
@@ -273,9 +271,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       # Capture the lint output (warnings do not fail the command) so we can
-      # both surface it in the job log and post it to the PR. continue-on-error
-      # keeps the comment step running even when spectral:oas reports errors;
-      # the captured exit code is replayed at the end to set the job status.
+      # both surface it in the job log and turn each finding into a check
+      # annotation. The captured exit code is replayed at the end to set the
+      # job status, so spectral:oas errors still fail the job.
       - name: Lint the Galaxy example document
         id: lint
         run: |
@@ -283,40 +281,34 @@ jobs:
           pnpm --filter @scalar/galaxy lint > lint-output.txt 2>&1
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
           cat lint-output.txt
-      # Only PRs from the same repository have a writable token for comments.
-      - name: Build lint comment
-        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
+      # Emit each finding as a GitHub check annotation. Annotations attach to
+      # the check run (and show inline on the diff when the linted file is part
+      # of the PR's changes); they regenerate every run, so there is nothing to
+      # dedupe. No token write is needed — contents:read is enough.
+      - name: Annotate lint findings
+        if: ${{ !cancelled() }}
         run: |
-          # Strip ANSI escape codes, npm noise, and the pnpm script echo, then
-          # collapse blank lines so the comment shows just the lint findings.
-          clean=$(sed -r 's/\x1b\[[0-9;?]*[a-zA-Z]//g' lint-output.txt \
-            | grep -v '^npm warn' \
-            | grep -v '^> ' \
-            | sed '/^[[:space:]]*$/d')
-          warnings=$(printf '%s\n' "$clean" | grep -c '^Severity: Warning' || true)
-          {
-            echo '**Scalar Galaxy Lint**'
-            echo ''
-            if [ "${{ steps.lint.outputs.exit_code }}" != '0' ]; then
-              echo '❌ Linting failed.'
-            elif [ "$warnings" -gt 0 ]; then
-              echo "⚠️ ${warnings} warning(s) found."
-            else
-              echo '✅ No issues found.'
-            fi
-            echo ''
-            echo '```'
-            printf '%s\n' "$clean"
-            echo '```'
-          } > lint-comment.md
-      - name: Post lint results to the PR
-        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
-        with:
-          file-path: lint-comment.md
-          # Reuse (update) the same comment on every new commit instead of
-          # posting a new one.
-          comment-tag: galaxy-lint
+          file='packages/galaxy/src/documents/3.1.yaml'
+          clean=$(sed -r 's/\x1b\[[0-9;?]*[a-zA-Z]//g' lint-output.txt | grep -v '^npm warn')
+          msg=''; sev=''; loc=''
+          emit() {
+            [ -z "$loc" ] && return
+            line="${loc%%:*}"
+            rest="${loc#*:}"
+            col="${rest%% *}"
+            level='warning'
+            [ "$sev" = 'Error' ] && level='error'
+            echo "::${level} file=${file},line=${line},col=${col},title=Scalar Galaxy Lint::${msg}"
+          }
+          while IFS= read -r l; do
+            case "$l" in
+              'Rule: '*) emit; msg=''; sev=''; loc='' ;;
+              'Message: '*) msg="${l#Message: }" ;;
+              'Severity: '*) sev="${l#Severity: }" ;;
+              'Location: '*) loc="${l#Location: }" ;;
+            esac
+          done <<< "$clean"
+          emit
       # Replay the lint exit code so the job fails on real (error-level) issues.
       - name: Report lint status
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,26 @@ jobs:
       - name: Lint Icon Library Icons
         run: pnpm --filter icons lint:icons
 
+  lint-galaxy:
+    if: needs.check-changes.outputs.galaxy_changed == 'true'
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    timeout-minutes: 10
+    needs: [check-changes]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Lint the Galaxy example document
+        run: pnpm --filter @scalar/galaxy lint
+
   types:
     needs: [build]
     runs-on: blacksmith-4vcpu-ubuntu-2204

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,8 @@ jobs:
     needs: [check-changes]
     permissions:
       contents: read
+      # Required so the lint results can be posted back to the PR.
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
@@ -271,9 +273,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       # Capture the lint output (warnings do not fail the command) so we can
-      # both surface it in the job log and turn each finding into a check
-      # annotation. The captured exit code is replayed at the end to set the
-      # job status, so spectral:oas errors still fail the job.
+      # both surface it in the job log and post it to the PR. continue-on-error
+      # keeps the comment step running even when spectral:oas reports errors;
+      # the captured exit code is replayed at the end to set the job status.
       - name: Lint the Galaxy example document
         id: lint
         run: |
@@ -281,34 +283,40 @@ jobs:
           pnpm --filter @scalar/galaxy lint > lint-output.txt 2>&1
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
           cat lint-output.txt
-      # Emit each finding as a GitHub check annotation. Annotations attach to
-      # the check run (and show inline on the diff when the linted file is part
-      # of the PR's changes); they regenerate every run, so there is nothing to
-      # dedupe. No token write is needed — contents:read is enough.
-      - name: Annotate lint findings
-        if: ${{ !cancelled() }}
+      # Only PRs from the same repository have a writable token for comments.
+      - name: Build lint comment
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         run: |
-          file='packages/galaxy/src/documents/3.1.yaml'
-          clean=$(sed -r 's/\x1b\[[0-9;?]*[a-zA-Z]//g' lint-output.txt | grep -v '^npm warn')
-          msg=''; sev=''; loc=''
-          emit() {
-            [ -z "$loc" ] && return
-            line="${loc%%:*}"
-            rest="${loc#*:}"
-            col="${rest%% *}"
-            level='warning'
-            [ "$sev" = 'Error' ] && level='error'
-            echo "::${level} file=${file},line=${line},col=${col},title=Scalar Galaxy Lint::${msg}"
-          }
-          while IFS= read -r l; do
-            case "$l" in
-              'Rule: '*) emit; msg=''; sev=''; loc='' ;;
-              'Message: '*) msg="${l#Message: }" ;;
-              'Severity: '*) sev="${l#Severity: }" ;;
-              'Location: '*) loc="${l#Location: }" ;;
-            esac
-          done <<< "$clean"
-          emit
+          # Strip ANSI escape codes, npm noise, and the pnpm script echo, then
+          # collapse blank lines so the comment shows just the lint findings.
+          clean=$(sed -r 's/\x1b\[[0-9;?]*[a-zA-Z]//g' lint-output.txt \
+            | grep -v '^npm warn' \
+            | grep -v '^> ' \
+            | sed '/^[[:space:]]*$/d')
+          warnings=$(printf '%s\n' "$clean" | grep -c '^Severity: Warning' || true)
+          {
+            echo '**Scalar Galaxy Lint**'
+            echo ''
+            if [ "${{ steps.lint.outputs.exit_code }}" != '0' ]; then
+              echo '❌ Linting failed.'
+            elif [ "$warnings" -gt 0 ]; then
+              echo "⚠️ ${warnings} warning(s) found."
+            else
+              echo '✅ No issues found.'
+            fi
+            echo ''
+            echo '```'
+            printf '%s\n' "$clean"
+            echo '```'
+          } > lint-comment.md
+      - name: Post lint results to the PR
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
+        with:
+          file-path: lint-comment.md
+          # Reuse (update) the same comment on every new commit instead of
+          # posting a new one.
+          comment-tag: galaxy-lint
       # Replay the lint exit code so the job fails on real (error-level) issues.
       - name: Report lint status
         if: ${{ !cancelled() }}

--- a/packages/galaxy/galaxy.ruleset.yaml
+++ b/packages/galaxy/galaxy.ruleset.yaml
@@ -1,0 +1,26 @@
+# Scalar ruleset for the Galaxy example document.
+#
+# Extends Spectral's built-in OpenAPI ruleset (spectral:oas) and layers on a few
+# Scalar opinions. The custom rules are kept at "warn" so they surface issues
+# without breaking the build; spectral:oas errors still fail the lint.
+#
+# Run it with:
+#   pnpm --filter @scalar/galaxy lint
+extends: spectral:oas
+rules:
+  # Every operation should carry a human-readable description, not just a summary.
+  operation-description:
+    description: Operations should have a description.
+    given: $.paths[*][get,put,post,delete,patch,options,head]
+    severity: warn
+    then:
+      field: description
+      function: truthy
+  # Every operation should be tagged so it groups nicely in the API reference.
+  operation-tags:
+    description: Operations should have at least one tag.
+    given: $.paths[*][get,put,post,delete,patch,options,head]
+    severity: warn
+    then:
+      field: tags
+      function: truthy

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -24,6 +24,7 @@
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && tsx scripts/post-build.ts",
     "dev": "pnpx @scalar/cli document serve ./src/documents/3.1.yaml --watch",
     "dev:live": "cd src/documents && pnpx http-server --cors",
+    "lint": "npx @scalar/cli document lint src/documents/3.1.yaml --rule ./galaxy.ruleset.yaml",
     "test": "vitest --run",
     "types:check": "tsc --noEmit",
     "validate": "bash scripts/validate.sh"


### PR DESCRIPTION
Galaxy is our example OpenAPI document, but nothing was linting it. This adds a `lint` script that runs `@scalar/cli document lint` against a small committed Spectral ruleset (`galaxy.ruleset.yaml`) — extending `spectral:oas` plus a couple of Scalar opinions. Nice side effect: it dogfoods our own Rules feature.

Run it with `pnpm --filter @scalar/galaxy lint`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and example-document quality only; no runtime product or auth/data paths change.
> 
> **Overview**
> Adds **OpenAPI linting** for the Galaxy example via a new `lint` script that runs `@scalar/cli document lint` on `src/documents/3.1.yaml` using a committed **`galaxy.ruleset.yaml`** (extends **`spectral:oas`** plus warn-only rules for operation **description** and **tags**).
> 
> **CI** gains a **`lint-galaxy`** job when `packages/galaxy/**` changes: it runs the lint, **posts/updates a PR comment** (`galaxy-lint`) with cleaned output, and **fails the job** on Spectral error-level findings while still surfacing warnings. A **changeset** records a patch release for `@scalar/galaxy`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5d2d3b5d1fbe4662813edd3fad9f36da72d971f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->