### PR TITLE
feat(api-reference): render AsyncAPI operations & messages

### DIFF
--- a/.changeset/asyncapi-channel-messages.md
+++ b/.changeset/asyncapi-channel-messages.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+feat: render AsyncAPI operations and their messages below each channel

--- a/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.test.ts
@@ -55,4 +55,72 @@ describe('AsyncApiTraversedEntry', () => {
     expect(tagComponents).toHaveLength(1)
     expect(tagComponents[0]?.props('moreThanOneTag')).toBe(false)
   })
+
+  it('renders a channel with its operation and nested message', () => {
+    const entries: TraversedEntry[] = [
+      {
+        id: 'channel',
+        type: 'asyncapi-channel',
+        title: 'User signup channel',
+        channelName: 'userSignedup',
+        channelAddress: 'user/signedup',
+        children: [
+          {
+            id: 'operation',
+            type: 'asyncapi-operation',
+            title: 'Consume user events',
+            operationName: 'receiveUserEvents',
+            action: 'receive',
+            channelName: 'userSignedup',
+            channelAddress: 'user/signedup',
+            children: [
+              {
+                id: 'message',
+                type: 'asyncapi-message',
+                title: 'User signed up',
+                messageName: 'userSignedUp',
+                channelName: 'userSignedup',
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const channelDocument = {
+      asyncapi: '3.0.0',
+      info: { title: 'Streaming API', version: '1.0.0' },
+      'x-scalar-original-document-hash': '',
+      channels: {
+        userSignedup: {
+          address: 'user/signedup',
+          messages: {
+            userSignedUp: {
+              title: 'User signed up',
+              summary: 'Inform about a new user.',
+            },
+          },
+        },
+      },
+    } as unknown as AsyncApiDocument
+
+    const wrapper = mount(AsyncApiTraversedEntry, {
+      props: {
+        entries,
+        document: channelDocument,
+        // `Lazy` only renders its slot when expanded, so mark every level.
+        expandedItems: { channel: true, operation: true, message: true },
+        options: { layout: 'modern' },
+        eventBus: null as never,
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'Channel' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'Operation' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'Message' }).exists()).toBe(true)
+    expect(wrapper.text()).toContain('Consume user events')
+    expect(wrapper.text()).toContain('receive')
+    expect(wrapper.text()).toContain('User signed up')
+    expect(wrapper.text()).toContain('Inform about a new user.')
+  })
 })

--- a/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.vue
@@ -3,6 +3,7 @@ import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type {
   TraversedAsyncApiChannel,
+  TraversedAsyncApiOperation,
   TraversedEntry,
   TraversedTag,
 } from '@scalar/workspace-store/schemas/navigation'
@@ -11,6 +12,7 @@ import { Tag } from '@/components/Content/Tags'
 import Lazy from '@/components/Lazy/Lazy.vue'
 
 import Channel from './Channel.vue'
+import Operation from './Operation.vue'
 
 const {
   entries,
@@ -44,6 +46,9 @@ const isTag = (
   entry.type === 'tag' && !isTagGroup(entry)
 const isChannel = (entry: TraversedEntry): entry is TraversedAsyncApiChannel =>
   entry.type === 'asyncapi-channel'
+const isOperation = (
+  entry: TraversedEntry,
+): entry is TraversedAsyncApiOperation => entry.type === 'asyncapi-operation'
 </script>
 
 <template>
@@ -52,13 +57,33 @@ const isChannel = (entry: TraversedEntry): entry is TraversedAsyncApiChannel =>
     :id="entry.id"
     :key="`${entry.id}-${options.layout}`"
     :expanded="!!expandedItems[entry.id]">
+    <!-- Channel: renders its own section, with operations nested below. -->
     <Channel
       v-if="isChannel(entry)"
       :channel="entry"
       :document="document"
       :eventBus="eventBus"
       :isCollapsed="!expandedItems[entry.id]"
-      :layout="options.layout" />
+      :layout="options.layout"
+      :level="level">
+      <AsyncApiTraversedEntry
+        v-if="entry.children?.length"
+        :document="document"
+        :entries="entry.children"
+        :eventBus="eventBus"
+        :expandedItems="expandedItems"
+        :level="level + 1"
+        :options="options" />
+    </Channel>
+
+    <!-- Operation: a single section that lists its messages as accordions. -->
+    <Operation
+      v-else-if="isOperation(entry)"
+      :document="document"
+      :eventBus="eventBus"
+      :expandedItems="expandedItems"
+      :level="level"
+      :operation="entry" />
 
     <Tag
       v-else-if="

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
@@ -22,12 +22,21 @@ import {
   SectionHeaderTag,
 } from '@/components/Section'
 
-const { channel, document, layout, isCollapsed, eventBus } = defineProps<{
+const {
+  channel,
+  document,
+  layout,
+  isCollapsed,
+  eventBus,
+  level = 0,
+} = defineProps<{
   channel: TraversedAsyncApiChannel
   document: AsyncApiDocument
   layout: 'classic' | 'modern'
   isCollapsed: boolean
   eventBus: WorkspaceEventBus | null
+  /** Nesting depth, used to skip the outer container padding when nested. */
+  level?: number
 }>()
 
 const headerId = useId()
@@ -61,14 +70,14 @@ const headingText = computed(() => {
   <SectionContainerAccordion
     v-if="layout === 'classic'"
     :aria-label="headingText"
-    class="channel-section"
+    class="mb-12"
     :modelValue="!isCollapsed"
     @update:modelValue="
       (value) =>
         eventBus?.emit('toggle:nav-item', { id: channel.id, open: value })
     ">
     <template #title>
-      <SectionHeader class="channel-name">
+      <SectionHeader>
         <Anchor
           @copyAnchorUrl="
             () => eventBus?.emit('copy-url:nav-item', { id: channel.id })
@@ -79,19 +88,24 @@ const headingText = computed(() => {
         </Anchor>
       </SectionHeader>
       <ScalarMarkdown
-        class="channel-description"
+        class="pb-1 text-left"
         :value="description"
         withImages />
     </template>
+
+    <!-- Operations (and their messages) render as their own sections below. -->
+    <div class="contents divide-y">
+      <slot />
+    </div>
   </SectionContainerAccordion>
 
   <SectionContainer
     v-else
-    :aria-labelledby="headerId"
-    role="region">
+    :omit="level !== 0">
     <Section
       :id="channel.id"
-      role="none"
+      :aria-labelledby="headerId"
+      role="region"
       @intersecting="
         () => eventBus?.emit('intersecting:nav-item', { id: channel.id })
       ">
@@ -113,15 +127,10 @@ const headingText = computed(() => {
           withImages />
       </SectionContent>
     </Section>
+
+    <!-- Operations (and their messages) render as their own sections below. -->
+    <div class="contents divide-y">
+      <slot />
+    </div>
   </SectionContainer>
 </template>
-
-<style scoped>
-.channel-section {
-  margin-bottom: 48px;
-}
-.channel-description {
-  padding-bottom: 4px;
-  text-align: left;
-}
-</style>

--- a/packages/api-reference/src/components/Content/AsyncApi/Message.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Message.test.ts
@@ -1,0 +1,139 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import type { TraversedAsyncApiMessage } from '@scalar/workspace-store/schemas/navigation'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import Message from './Message.vue'
+
+function createMessage(overrides: Partial<TraversedAsyncApiMessage> = {}): TraversedAsyncApiMessage {
+  return {
+    type: 'asyncapi-message',
+    id: 'doc/channel/userSignedUp/message/userSignedUp',
+    title: 'User signed up',
+    messageName: 'userSignedUp',
+    channelName: 'userSignedUp',
+    ...overrides,
+  }
+}
+
+function createDocument(message: Record<string, unknown>): AsyncApiDocument {
+  return {
+    asyncapi: '3.0.0',
+    info: { title: 'Streaming API', version: '1.0.0' },
+    'x-scalar-original-document-hash': '',
+    channels: {
+      userSignedUp: {
+        address: 'user/signedup',
+        messages: { userSignedUp: message },
+      },
+    },
+  } as AsyncApiDocument
+}
+
+describe('Message', () => {
+  it('renders the title on the accordion with the summary inside', () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({
+          title: 'User signed up',
+          summary: 'Notifies when a user signs up.',
+        }),
+        eventBus: null,
+        isCollapsed: false,
+      },
+    })
+
+    expect(wrapper.find('h3').text()).toContain('User signed up')
+    expect(wrapper.text()).toContain('Notifies when a user signs up.')
+  })
+
+  it('falls back to the message name when no title is set', () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({ name: 'UserSignedUp' }),
+        eventBus: null,
+        isCollapsed: false,
+      },
+    })
+
+    expect(wrapper.find('h3').text()).toContain('UserSignedUp')
+  })
+
+  it('falls back to the message map key when neither title nor name is set', () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({}),
+        eventBus: null,
+        isCollapsed: false,
+      },
+    })
+
+    expect(wrapper.find('h3').text()).toContain('userSignedUp')
+  })
+
+  it('renders the payload schema with the Schema component', () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({
+          title: 'User signed up',
+          payload: {
+            type: 'object',
+            properties: { userId: { type: 'string' } },
+          },
+        }),
+        eventBus: null,
+        isCollapsed: false,
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'Schema' }).exists()).toBe(true)
+    expect(wrapper.text()).toContain('userId')
+  })
+
+  it('unwraps a multi-format payload before rendering the schema', () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({
+          title: 'User signed up',
+          payload: {
+            schemaFormat: 'application/vnd.aai.asyncapi;version=3.0.0',
+            schema: {
+              type: 'object',
+              properties: { email: { type: 'string' } },
+            },
+          },
+        }),
+        eventBus: null,
+        isCollapsed: false,
+      },
+    })
+
+    expect(wrapper.text()).toContain('email')
+  })
+
+  it('keeps the payload collapsed when isCollapsed is true', () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({
+          title: 'User signed up',
+          payload: {
+            type: 'object',
+            properties: { userId: { type: 'string' } },
+          },
+        }),
+        eventBus: null,
+        isCollapsed: true,
+      },
+    })
+
+    // The heading is always visible, but the body (payload) stays hidden.
+    expect(wrapper.find('h3').text()).toContain('User signed up')
+    expect(wrapper.findComponent({ name: 'Schema' }).exists()).toBe(false)
+  })
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/Message.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Message.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import type {
+  AsyncApiDocument,
+  AsyncApiMessageObject,
+} from '@scalar/types/asyncapi/3.1'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import {
+  getResolvedRef,
+  mergeSiblingReferences,
+} from '@scalar/workspace-store/helpers/get-resolved-ref'
+import type { TraversedAsyncApiMessage } from '@scalar/workspace-store/schemas/navigation'
+import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { computed } from 'vue'
+
+import { Schema, SchemaHeading } from '@/components/Content/Schema'
+import { CompactSection, SectionHeaderTag } from '@/components/Section'
+
+const { message, document, eventBus, isCollapsed } = defineProps<{
+  message: TraversedAsyncApiMessage
+  document: AsyncApiDocument
+  eventBus: WorkspaceEventBus | null
+  isCollapsed: boolean
+}>()
+
+/**
+ * Resolve the message from the document so we can read its summary and payload.
+ * The navigation entry only carries the identifying keys.
+ */
+const resolvedMessage = computed<AsyncApiMessageObject | undefined>(() => {
+  const channelNode = document.channels?.[message.channelName]
+  const channel = channelNode
+    ? getResolvedRef(channelNode, mergeSiblingReferences)
+    : undefined
+
+  const messageNode = channel?.messages?.[message.messageName]
+  return messageNode
+    ? getResolvedRef(messageNode, mergeSiblingReferences)
+    : undefined
+})
+
+/**
+ * Heading shown on the accordion trigger.
+ *
+ * Prefers the human-friendly `title`, then falls back to the machine-friendly
+ * `name`, and finally to the message map key.
+ */
+const headingText = computed(() => {
+  const title = resolvedMessage.value?.title?.trim()
+  const name = resolvedMessage.value?.name?.trim()
+  return title || name || message.messageName
+})
+
+const summary = computed(() => resolvedMessage.value?.summary?.trim() ?? '')
+
+/**
+ * The message payload, rendered with the shared Schema component.
+ *
+ * AsyncAPI payloads may be a bare JSON Schema or a Multi Format Schema Object
+ * (`{ schemaFormat, schema }`), and either form may sit behind a `$ref`. We
+ * resolve the reference and unwrap the multi-format wrapper so the Schema
+ * component always receives a plain schema.
+ */
+const payloadSchema = computed<SchemaObject | undefined>(() => {
+  const payloadNode = resolvedMessage.value?.payload
+  if (!payloadNode) {
+    return undefined
+  }
+
+  const payload = getResolvedRef(payloadNode, mergeSiblingReferences)
+  const schema =
+    payload && typeof payload === 'object' && 'schema' in payload
+      ? payload.schema
+      : payload
+
+  return schema as SchemaObject | undefined
+})
+</script>
+
+<template>
+  <CompactSection
+    :id="message.id"
+    :label="headingText"
+    :modelValue="!isCollapsed"
+    @copyAnchorUrl="
+      () => eventBus?.emit('copy-url:nav-item', { id: message.id })
+    "
+    @update:modelValue="
+      (value) =>
+        eventBus?.emit('toggle:nav-item', { id: message.id, open: value })
+    ">
+    <template #heading>
+      <SectionHeaderTag :level="3">
+        <SchemaHeading
+          v-if="payloadSchema"
+          :name="headingText"
+          :value="payloadSchema" />
+        <template v-else>{{ headingText }}</template>
+      </SectionHeaderTag>
+    </template>
+
+    <p
+      v-if="summary"
+      class="mb-2">
+      {{ summary }}
+    </p>
+    <Schema
+      v-if="payloadSchema"
+      :eventBus="eventBus"
+      hideHeading
+      :level="1"
+      noncollapsible
+      :options="{}"
+      :schema="payloadSchema" />
+  </CompactSection>
+</template>

--- a/packages/api-reference/src/components/Content/AsyncApi/Operation.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Operation.test.ts
@@ -1,0 +1,82 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import type { TraversedAsyncApiOperation } from '@scalar/workspace-store/schemas/navigation'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import Operation from './Operation.vue'
+
+function createOperation(overrides: Partial<TraversedAsyncApiOperation> = {}): TraversedAsyncApiOperation {
+  return {
+    type: 'asyncapi-operation',
+    id: 'doc/channel/userSignedUp/operation/onUserSignedUp',
+    title: 'On user signed up',
+    operationName: 'onUserSignedUp',
+    action: 'receive',
+    channelName: 'userSignedUp',
+    channelAddress: 'user/signedup',
+    children: [
+      {
+        type: 'asyncapi-message',
+        id: 'doc/channel/userSignedUp/message/userSignedUp',
+        title: 'User signed up',
+        messageName: 'userSignedUp',
+        channelName: 'userSignedUp',
+      },
+    ],
+    ...overrides,
+  }
+}
+
+const document = {
+  asyncapi: '3.0.0',
+  info: { title: 'Streaming API', version: '1.0.0' },
+  'x-scalar-original-document-hash': '',
+  channels: {
+    userSignedUp: {
+      address: 'user/signedup',
+      messages: { userSignedUp: { title: 'User signed up' } },
+    },
+  },
+} as unknown as AsyncApiDocument
+
+describe('Operation', () => {
+  it('renders the operation title and its action', () => {
+    const wrapper = mount(Operation, {
+      props: {
+        operation: createOperation(),
+        document,
+        eventBus: null,
+        expandedItems: {},
+      },
+    })
+
+    expect(wrapper.find('h3').text()).toContain('On user signed up')
+    expect(wrapper.text()).toContain('receive')
+  })
+
+  it('lists its messages as accordions', () => {
+    const wrapper = mount(Operation, {
+      props: {
+        operation: createOperation(),
+        document,
+        eventBus: null,
+        expandedItems: {},
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'Message' }).exists()).toBe(true)
+  })
+
+  it('renders no message accordions when the operation has none', () => {
+    const wrapper = mount(Operation, {
+      props: {
+        operation: createOperation({ children: undefined }),
+        document,
+        eventBus: null,
+        expandedItems: {},
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'Message' }).exists()).toBe(false)
+  })
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/Operation.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Operation.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import type {
+  TraversedAsyncApiMessage,
+  TraversedAsyncApiOperation,
+  TraversedEntry,
+} from '@scalar/workspace-store/schemas/navigation'
+import { computed, useId } from 'vue'
+
+import { Anchor } from '@/components/Anchor'
+import { Badge } from '@/components/Badge'
+import {
+  Section,
+  SectionContainer,
+  SectionContent,
+  SectionHeader,
+  SectionHeaderTag,
+} from '@/components/Section'
+
+import Message from './Message.vue'
+
+const {
+  operation,
+  level = 0,
+  eventBus,
+  expandedItems,
+} = defineProps<{
+  operation: TraversedAsyncApiOperation
+  document: AsyncApiDocument
+  eventBus: WorkspaceEventBus | null
+  /** Used to determine which message accordions are open. */
+  expandedItems: Record<string, boolean>
+  /** Nesting depth, used to skip the outer container padding when nested. */
+  level?: number
+}>()
+
+const headerId = useId()
+
+/** Messages nested under this operation, rendered as accordions in the section. */
+const messages = computed(() =>
+  (operation.children ?? []).filter(
+    (entry: TraversedEntry): entry is TraversedAsyncApiMessage =>
+      entry.type === 'asyncapi-message',
+  ),
+)
+</script>
+
+<template>
+  <SectionContainer :omit="level !== 0">
+    <Section
+      :id="operation.id"
+      :aria-labelledby="headerId"
+      class="[--font-size:var(--scalar-heading-2)]"
+      role="region"
+      @intersecting="
+        () => eventBus?.emit('intersecting:nav-item', { id: operation.id })
+      ">
+      <SectionContent>
+        <!-- Badge row above the heading, mirroring the OpenAPI operation layout. -->
+        <div class="mb-1 flex gap-1">
+          <!-- send/receive tells the reader which direction the operation flows. -->
+          <Badge class="uppercase">{{ operation.action }}</Badge>
+        </div>
+        <SectionHeader removeMargin>
+          <Anchor
+            @copyAnchorUrl="
+              () => eventBus?.emit('copy-url:nav-item', { id: operation.id })
+            ">
+            <SectionHeaderTag
+              :id="headerId"
+              :level="3">
+              {{ operation.title }}
+            </SectionHeaderTag>
+          </Anchor>
+        </SectionHeader>
+      </SectionContent>
+
+      <!-- Messages listed as accordions, like the OpenAPI models section. -->
+      <Message
+        v-for="message in messages"
+        :key="message.id"
+        :document="document"
+        :eventBus="eventBus"
+        :isCollapsed="!expandedItems[message.id]"
+        :message="message" />
+    </Section>
+  </SectionContainer>
+</template>


### PR DESCRIPTION
Renders AsyncAPI messages in the API reference.

Each operation now gets its own section under its channel, and its messages are listed as model-style accordions — title (falling back to name, then key), summary, and the payload rendered with the existing `Schema` component.