### PR TITLE
feat(types,schemas,api-client): move customFetch to baseConfigurationSchema

### DIFF
--- a/.changeset/customfetch-base-config.md
+++ b/.changeset/customfetch-base-config.md
@@ -1,0 +1,7 @@
+---
+'@scalar/types': patch
+'@scalar/schemas': patch
+'@scalar/api-client': patch
+---
+
+Move `customFetch` from `apiReferenceConfigurationSchema` to `baseConfigurationSchema` so it is shared between the API Reference and the API Client

--- a/packages/api-client/src/v2/types/options.ts
+++ b/packages/api-client/src/v2/types/options.ts
@@ -1,8 +1,6 @@
 import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
 import type { Ref } from 'vue'
 
-import type { CustomFetch } from '@/v2/blocks/operation-block/helpers/send-request'
-
 /**
  * Configuration options for the API Client (app and modal).
  */
@@ -11,18 +9,13 @@ export type ApiClientOptions = Partial<
     ApiReferenceConfigurationRaw,
     | 'authentication'
     | 'baseServerURL'
+    | 'customFetch'
     | 'hideClientButton'
     | 'hiddenClients'
     | 'oauth2RedirectUri'
     | 'proxyUrl'
     | 'servers'
   >
-> & {
-  /**
-   * Custom fetch implementation used for all outgoing API requests.
-   * When provided, replaces the global fetch in the request execution engine (sendRequest).
-   */
-  customFetch?: CustomFetch
-}
+>
 
 export type ApiClientOptionsRef = Ref<ApiClientOptions>

--- a/packages/schemas/src/api-reference/api-reference-configuration.ts
+++ b/packages/schemas/src/api-reference/api-reference-configuration.ts
@@ -32,10 +32,6 @@ export const apiReferenceConfigurationSchema = intersection([
     fetch: optional(fn<typeof fetch>(), {
       typeComment: '@deprecated Use `customFetch` instead.',
     }),
-    customFetch: optional(fn<typeof fetch>(), {
-      typeComment:
-        "Custom fetch function used both when loading the OpenAPI document and when sending requests from the API client. Can be used to add custom headers, attach credentials (for example `credentials: 'include'`), handle auth, etc.",
-    }),
     plugins: optional(array(apiReferencePluginSchema), {
       typeComment: 'Plugins for the API reference',
     }),

--- a/packages/schemas/src/api-reference/base-configuration.ts
+++ b/packages/schemas/src/api-reference/base-configuration.ts
@@ -1,5 +1,7 @@
 import { any, array, boolean, fn, literal, nullable, object, optional, string, union } from '@scalar/validation'
 
+type FetchFunction = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+
 const externalUrlsSchema = object(
   {
     dashboardUrl: string({ default: 'https://dashboard.scalar.com' }),
@@ -148,4 +150,8 @@ export const baseConfigurationSchema = object({
     typeComment: 'Enables / disables telemetry',
   }),
   externalUrls: externalUrlsSchema,
+  customFetch: optional(fn<FetchFunction>(), {
+    typeComment:
+      "Custom fetch function used both when loading the OpenAPI document and when sending requests from the API client. Can be used to add custom headers, attach credentials (for example `credentials: 'include'`), handle auth, etc.",
+  }),
 })

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -8,6 +8,7 @@ import { type SourceConfiguration, sourceConfigurationSchema } from './source-co
 import { DEFAULT_MODELS_SECTION_LABEL } from './types'
 
 // Zod Schemas don't work well with async functions, so we use a custom type instead.
+// Note: `fetch` is the deprecated alias kept here for migration; `customFetch` lives in the base configuration.
 const fetchLikeSchema = z.custom<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>()
 
 /**
@@ -39,12 +40,6 @@ export const apiReferenceConfigurationSchema = baseConfigurationSchema.extend({
    * @deprecated Use `customFetch` instead.
    */
   fetch: fetchLikeSchema.optional(),
-  /**
-   * Custom fetch function used both when loading the OpenAPI document and when sending requests from the API client.
-   *
-   * Can be used to add custom headers, attach credentials (for example `credentials: 'include'`), handle auth, etc.
-   */
-  customFetch: fetchLikeSchema.optional(),
   /**
    * Plugins for the API reference
    */

--- a/packages/types/src/api-reference/base-configuration.ts
+++ b/packages/types/src/api-reference/base-configuration.ts
@@ -2,6 +2,9 @@ import z from 'zod'
 
 import { apiClientPluginSchema } from './api-client-plugin'
 
+// Zod doesn't work well with async functions, so we use a custom type instead.
+const fetchLikeSchema = z.custom<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>()
+
 const externalUrlsSchema = z.object({
   dashboardUrl: z.string().prefault('https://dashboard.scalar.com'),
   registryUrl: z.string().prefault('https://registry.scalar.com'),
@@ -170,6 +173,12 @@ export const baseConfigurationSchema = z.object({
   telemetry: z.boolean().optional().default(true),
   /** A bunch of external URLs to Scalar's services. */
   externalUrls: externalUrlsSchema.prefault({}),
+  /**
+   * Custom fetch function used both when loading the OpenAPI document and when sending requests from the API client.
+   *
+   * Can be used to add custom headers, attach credentials (for example `credentials: 'include'`), handle auth, etc.
+   */
+  customFetch: fetchLikeSchema.optional(),
 })
 
 /** Shared configuration for the API Reference and API Client */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`customFetch` was only defined in `apiReferenceConfigurationSchema` (specific to the API Reference), not in `baseConfigurationSchema` (shared between the API Reference and the API Client). This meant consumers who wanted to route all requests — including OAuth2 token exchanges, OIDC discovery, and API requests — through a custom fetch implementation had to wire it separately for each surface, rather than configuring it in one place.

## Solution

Move `customFetch` from `apiReferenceConfigurationSchema` into `baseConfigurationSchema` so it is part of the shared configuration inherited by both the API Reference and the API Client.

### Changes

- **`packages/types/src/api-reference/base-configuration.ts`**: Added `customFetch` to `baseConfigurationSchema` (zod-based)
- **`packages/types/src/api-reference/api-reference-configuration.ts`**: Removed `customFetch` from `apiReferenceConfigurationSchema` (now inherited from base)
- **`packages/schemas/src/api-reference/base-configuration.ts`**: Added `customFetch` to `baseConfigurationSchema` (`@scalar/validation`-based)
- **`packages/schemas/src/api-reference/api-reference-configuration.ts`**: Removed `customFetch` from the api-reference-specific schema (now inherited from base)
- **`packages/api-client/src/v2/types/options.ts`**: Updated `ApiClientOptions` to pick `customFetch` from `ApiReferenceConfigurationRaw` instead of declaring it as a separate standalone field

The deprecated `fetch` alias remains in `apiReferenceConfigurationSchema` for backwards compatibility and continues to migrate to `customFetch` during configuration coercion.

## Ticket

Related to discussion in #support thread (2026-05-14)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C088YUN719S/p1778750144344099?thread_ts=1778750144.344099&cid=C088YUN719S)

<div><a href="https://cursor.com/agents/bc-a37a3ffc-b277-562e-9ca0-d40188f86350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a37a3ffc-b277-562e-9ca0-d40188f86350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

