### PR TITLE
fix: correctly detect changed packages

### DIFF
--- a/tooling/scripts/src/commands/release-notes-generator/detect-versioned-changelog-paths.ts
+++ b/tooling/scripts/src/commands/release-notes-generator/detect-versioned-changelog-paths.ts
@@ -59,16 +59,16 @@ export const shouldGenerateReleaseNotesForProduct = (
 }
 
 /**
- * Paths changed in the working tree since `HEAD`. Used right after
+ * Paths changed in the working tree compared to `main`. Used right after
  * `changeset version` inside `pnpm release:version` to detect which
  * packages were actually bumped in this release.
  *
  * Returns `null` when git is unavailable so callers fall back to
  * generating for every product rather than failing the release pipeline.
  */
-const getPathsChangedSinceHead = async (): Promise<Set<string> | null> => {
+const getPathsChangedSinceMain = async (): Promise<Set<string> | null> => {
   try {
-    const { stdout } = await execFileAsync('git', ['diff', '--name-only', 'HEAD'], {
+    const { stdout } = await execFileAsync('git', ['diff', '--name-only', 'main'], {
       cwd: getRepoRoot(),
     })
     const paths = stdout
@@ -98,7 +98,7 @@ const normalizeChangedPathsForComparison = (changedPaths: ReadonlySet<string>): 
  * for consistent set membership checks.
  */
 export const getChangedPathsForReleaseFiltering = async (): Promise<Set<string> | null> => {
-  const changed = await getPathsChangedSinceHead()
+  const changed = await getPathsChangedSinceMain()
   if (changed === null) {
     return null
   }


### PR DESCRIPTION

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to git diff baseline in release-notes tooling; no runtime product or security impact.
> 
> **Overview**
> Release-notes filtering now compares the working tree to **`main`** instead of **`HEAD`** when listing changed paths after `changeset version`.
> 
> The helper is renamed accordingly (`getPathsChangedSinceMain`), so only products whose changelogs or `package.json` files actually changed in this release get AI release notes instead of being mis-detected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c9534ff68c6cb9e35f2f19ae2258addbc06cf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->