### PR TITLE
ci: run CI on the release PR via a GitHub App token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: CI
 
 # This workflow runs on:
 # 1. Push events to the main branch
-# 2. Pull request events
+# 2. Pull request events — including the "chore: release" PR opened by
+#    changesets/action. That PR is created with a GitHub App token (see the
+#    npm-publish job) instead of the default GITHUB_TOKEN, so GitHub does not
+#    suppress its workflow events and CI runs on it like any other PR.
 on:
   push:
     branches:
@@ -486,7 +489,7 @@ jobs:
           report-tag: test-scalar-app-e2e
 
   test-component-snapshots:
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.head_ref == 'changeset-release/main' || github.head_ref == 'main'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.head_ref == 'main'
     needs: [build]
     runs-on: blacksmith-4vcpu-ubuntu-2204
     container:
@@ -533,7 +536,7 @@ jobs:
           report-tag: test-components-snapshots
 
   test-cdn-snapshots:
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.head_ref == 'changeset-release/main' || github.head_ref == 'main'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.head_ref == 'main'
     needs: [build]
     runs-on: blacksmith-8vcpu-ubuntu-2204
     container:
@@ -677,10 +680,25 @@ jobs:
       # when no public packages were published in the same commit.
       scalar_app_released: ${{ steps.scalar-app-release.outputs.released }}
     steps:
+      # Mint a short-lived GitHub App token so the "chore: release" PR is opened
+      # by our app instead of the default GITHUB_TOKEN. Pull requests created with
+      # GITHUB_TOKEN do not trigger workflow events, which is why the release PR
+      # used to get no CI; an app token lifts that restriction. The credentials
+      # live in the production-npm environment so they inherit its branch
+      # protection rules.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
+          # Persist the app token so the branch push that opens the release PR is
+          # attributed to the app, which is what lets CI run on that PR.
+          token: ${{ steps.app-token.outputs.token }}
       - name: Detect scalar-app version bump
         id: scalar-app-release
         run: |
@@ -723,7 +741,9 @@ jobs:
           # The command to use to build and publish packages.
           publish: 'pnpm -r publish --access public --no-git-checks'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The app token (not GITHUB_TOKEN) is what makes the release PR
+          # trigger CI — see the "Generate GitHub App token" step above.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # https://www.npmjs.com/settings/YOUR_ACCOUNT_HANDLE/tokens/granular-access-tokens/new
           # Custom Expiration: 01-01-2100
           # Permissions: Read and Write


### PR DESCRIPTION
The `chore: release` PR is created by `changesets/action`. While it used the default `GITHUB_TOKEN`, GitHub [suppressed the PR's workflow events](https://github.com/changesets/action/issues/187#issuecomment-1228413850), so the release PR never got CI.

This mints a GitHub App token in `npm-publish` and hands it to `changesets/action`, so the release PR triggers CI like any normal PR. The push-branch workaround is removed.

The app credentials live in the existing `production-npm` environment, so they inherit its branch protection (`main` only).

### Before merging
- [x] Create/install a GitHub App with `contents: write` + `pull requests: write`
- [x] Add `RELEASE_BOT_APP_ID` and `RELEASE_BOT_PRIVATE_KEY` to the `production-npm` environment


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release automation credential path on `main` (app token with write access to contents/PRs); publish behavior is unchanged but a misconfigured app or secret would block or break release PR creation.
> 
> **Overview**
> The **`chore: release`** PR from `changesets/action` no longer skips CI. **`npm-publish`** mints a short-lived **GitHub App token** (`actions/create-github-app-token` with `RELEASE_BOT_*` secrets in `production-npm`) and passes it to **checkout** and **`changesets/action`** as `GITHUB_TOKEN`, so the release PR is opened by the app instead of the default token—which GitHub would not use to fire **`pull_request`** workflows.
> 
> The old workaround is removed: **`test-component-snapshots`** and **`test-cdn-snapshots`** no longer special-case **`changeset-release/main`** in their `if` conditions; the release PR is expected to run like any other PR. The workflow header comment documents this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a13059b2e377a8cf0368222ddf368105aa7160dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->