### PR TITLE
fix(api-reference): don't fight for the tab title at scroll-top

### DIFF
--- a/.changeset/fix-page-title-scroll-top-race.md
+++ b/.changeset/fix-page-title-scroll-top-race.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: stabilize the tab title at the top of the document
+
+The document-start sentinel and the Introduction section both fire an intersection event at scroll-top. They resolved to different entries, so the tab title raced between the section title and the document title. The sentinel now emits the Introduction entry, so both agree.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -1024,11 +1024,15 @@ const documentStartRef = useTemplateRef<HTMLElement>('documentStartRef')
  * observer are intersecting simultaneously, so the section observer does not re-fire on its own.
  * The `onExit` callback bridges that gap by finding whichever section is at the viewport center
  * and re-emitting the nav event for it.
+ *
+ * We emit the Introduction entry rather than the document slug so this sentinel and the Introduction
+ * section's own intersection observer resolve to the same entry. Otherwise the two race at the top of
+ * the document and the tab title flickers between the section title and the document title.
  */
 useIntersection(
   documentStartRef,
   () => {
-    eventBus.emit('intersecting:nav-item', { id: activeSlug.value })
+    eventBus.emit('intersecting:nav-item', { id: infoSectionId.value })
   },
   {
     onExit: () => {


### PR DESCRIPTION
At the top of the document, two intersection observers fire at once: the document-start sentinel and the Introduction section. 

They resolved to different entries, so whichever ran last won `document.title`. The tab title raced between `Galaxy API › Introduction` and `Galaxy API › Galaxy API`. It now emits the Introduction entry, so both agree.

Verified locally with `pnpm test:e2e configuration/set-page-title --repeat-each=8`: 4/8 failures before, 8/8 pass after.

## Ticket

Fixes DOC-5503

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single emission change in scroll intersection handling; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **tab title flicker** when readers are at the top of the doc and `setPageTitle` is enabled.
> 
> At scroll-top, the **document-start sentinel** and the **Introduction** section both trigger intersection handling, but they used different nav ids (document slug vs Introduction). Whichever `intersecting:nav-item` ran last won `document.title`, so the tab alternated between the document name and the Introduction title.
> 
> The sentinel now emits **`infoSectionId`** (the Introduction sidebar entry) instead of **`activeSlug`**, matching the Introduction section observer. Comments and a patch changeset document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a7aee816fa7cbd4b9a254edf8569d5ea37d1479. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->