### PR TITLE
fix(api-reference): clean up injected head styles on destroy

### DIFF
--- a/.changeset/strong-rules-cheer.md
+++ b/.changeset/strong-rules-cheer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Clean up the standalone build's injected `<head>` styles on `destroy()` so they no longer linger after SPA-style navigation (Turbo Drive, htmx). The styles are re-attached when a new instance mounts.

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -186,6 +186,59 @@ describe('createApiReference', () => {
     expect(consoleWarnSpy).not.toHaveBeenCalled()
   })
 
+  // The standalone build injects all of its CSS into one <style> tag in <head>.
+  // Under SPA-style navigation (Turbo Drive, htmx) the host swaps the DOM without
+  // reloading the window, so these document-level styles would otherwise linger
+  // and bleed into the host app's next page. `destroy()` detaches them and a fresh
+  // mount re-attaches them. We simulate the injected tag since the bundle's
+  // runtime injection does not run in the test environment.
+  const injectStandaloneStyle = () => {
+    const style = document.createElement('style')
+    style.id = 'scalar-style'
+    style.textContent = ':root { --scalar-loaded-api-reference: true; }'
+    document.head.appendChild(style)
+
+    return style
+  }
+
+  it('detaches the injected standalone styles on destroy', () => {
+    injectStandaloneStyle()
+    const config = { _integration: 'html' }
+    const apiReference = createApiReference('#mount-point', coerce(apiReferenceConfigurationSchema, config))
+
+    expect(document.getElementById('scalar-style')).not.toBeNull()
+
+    apiReference.destroy()
+    expect(document.getElementById('scalar-style')).toBeNull()
+  })
+
+  it('re-attaches the injected styles when a new instance mounts', () => {
+    injectStandaloneStyle()
+    const config = { _integration: 'html' }
+
+    createApiReference('#mount-point', coerce(apiReferenceConfigurationSchema, config)).destroy()
+    expect(document.getElementById('scalar-style')).toBeNull()
+
+    createApiReference('#mount-point', coerce(apiReferenceConfigurationSchema, config))
+    expect(document.getElementById('scalar-style')).not.toBeNull()
+  })
+
+  it('keeps the styles until the last instance is destroyed', () => {
+    injectStandaloneStyle()
+    const second = document.createElement('div')
+    document.body.appendChild(second)
+
+    const config = { _integration: 'html' }
+    const first = createApiReference('#mount-point', coerce(apiReferenceConfigurationSchema, config))
+    const last = createApiReference(second, coerce(apiReferenceConfigurationSchema, config))
+
+    first.destroy()
+    expect(document.getElementById('scalar-style')).not.toBeNull()
+
+    last.destroy()
+    expect(document.getElementById('scalar-style')).toBeNull()
+  })
+
   it('allows mounting after creation', async () => {
     const config = { _integration: 'html' }
     const app = createApiReference(coerce(apiReferenceConfigurationSchema, config))

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -1,15 +1,76 @@
+import { apiReferenceConfigurationWithSourceSchema } from '@scalar/schemas/api-reference'
 import type {
   AnyApiReferenceConfiguration,
   ApiReferenceConfigurationWithSource,
   CreateApiReference,
 } from '@scalar/types/api-reference'
-import { apiReferenceConfigurationWithSourceSchema } from '@scalar/schemas/api-reference'
 import { createHead } from '@unhead/vue/client'
 import { createApp, createSSRApp, h, reactive } from 'vue'
 
 import { default as ApiReference } from '@/components/ApiReference.vue'
 
 const getSpecScriptTag = (doc: Document) => doc.getElementById('api-reference')
+
+/**
+ * The id given to the standalone build's single injected `<style>` tag.
+ * Keep in sync with `vite.standalone.config.ts`.
+ */
+const STANDALONE_STYLE_ID = 'scalar-style'
+
+/**
+ * Per-document bookkeeping for the standalone build's injected styles.
+ *
+ * The CDN build injects all of its CSS into one `<style>` tag in `<head>`. Under
+ * SPA-style navigation (Turbo Drive, htmx boost, Astro view transitions) the host
+ * swaps the DOM without reloading the window, so those document-level styles
+ * (`@layer scalar-base`, the `:root` theme variables) would otherwise linger and
+ * bleed into the host app's next page. We reference-count the live instances and
+ * detach the styles when the last one is destroyed, re-attaching them when a new
+ * instance mounts so navigating back to the reference is still styled.
+ *
+ * State is keyed by document so the counter survives navigations (the JS context
+ * persists) while staying isolated per page.
+ */
+const standaloneStyleState = new WeakMap<Document, { count: number; detachedStyle: HTMLStyleElement | null }>()
+
+const getStandaloneStyleState = (doc: Document): { count: number; detachedStyle: HTMLStyleElement | null } => {
+  const existing = standaloneStyleState.get(doc)
+  if (existing) {
+    return existing
+  }
+
+  const state = { count: 0, detachedStyle: null }
+  standaloneStyleState.set(doc, state)
+
+  return state
+}
+
+/** Track a freshly mounted instance and restore previously detached styles. */
+const retainStandaloneStyles = (doc: Document): void => {
+  const state = getStandaloneStyleState(doc)
+  state.count += 1
+
+  if (state.detachedStyle && !doc.getElementById(STANDALONE_STYLE_ID)) {
+    doc.head.appendChild(state.detachedStyle)
+    state.detachedStyle = null
+  }
+}
+
+/** Release an instance and detach the injected styles once the last one is gone. */
+const releaseStandaloneStyles = (doc: Document): void => {
+  const state = getStandaloneStyleState(doc)
+  state.count = Math.max(0, state.count - 1)
+
+  if (state.count > 0) {
+    return
+  }
+
+  const styleElement = doc.getElementById(STANDALONE_STYLE_ID)
+  if (styleElement instanceof HTMLStyleElement) {
+    state.detachedStyle = styleElement
+    styleElement.remove()
+  }
+}
 
 /**
  * Reading the configuration from the data-attributes.
@@ -207,9 +268,15 @@ export const createApiReference: CreateApiReference = (
   const shouldHydrate = !!optionalConfiguration && !!mountElement && mountElement.children.length > 0
   let app = createReferenceApp(shouldHydrate)
 
+  // Track whether this instance mounted so `destroy` only releases the shared
+  // standalone styles for instances that actually retained them.
+  let hasMounted = false
+
   if (optionalConfiguration) {
     if (mountElement) {
       app.mount(mountElement)
+      hasMounted = true
+      retainStandaloneStyles(document)
     } else {
       console.error('Could not find a mount point for API References:', elementOrSelectorOrConfig)
     }
@@ -267,6 +334,11 @@ export const createApiReference: CreateApiReference = (
     abortController.abort()
     props.configuration = {}
     app.unmount()
+
+    if (hasMounted) {
+      hasMounted = false
+      releaseStandaloneStyles(document)
+    }
   }
 
   /**

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -13,7 +13,7 @@ const getSpecScriptTag = (doc: Document) => doc.getElementById('api-reference')
 
 /**
  * The id given to the standalone build's single injected `<style>` tag.
- * Keep in sync with `vite.standalone.config.ts`.
+ * Keep in sync with `vite.standalone.config.ts` and `vite.standalone.esm.config.ts`.
  */
 const STANDALONE_STYLE_ID = 'scalar-style'
 

--- a/packages/api-reference/vite.standalone.config.ts
+++ b/packages/api-reference/vite.standalone.config.ts
@@ -45,7 +45,11 @@ export default defineConfig({
   plugins: [
     vue(),
     tailwindcss(),
-    cssInjectedByJsPlugin(),
+    // Tag the single injected <style> with a known id so the runtime can detach
+    // it on `destroy()`. Without this, the global styles linger in <head> after
+    // SPA-style navigation (Turbo Drive, htmx). Keep the id in sync with
+    // `STANDALONE_STYLE_ID` in `src/standalone/lib/html-api.ts`.
+    cssInjectedByJsPlugin({ attributes: { id: 'scalar-style' } }),
     webpackStats(),
     banner({
       outDir: 'dist/browser',

--- a/packages/api-reference/vite.standalone.esm.config.ts
+++ b/packages/api-reference/vite.standalone.esm.config.ts
@@ -45,7 +45,11 @@ export default defineConfig({
   plugins: [
     vue(),
     tailwindcss(),
-    cssInjectedByJsPlugin(),
+    // Tag the single injected <style> with a known id so the runtime can detach
+    // it on `destroy()`. Without this, the global styles linger in <head> after
+    // SPA-style navigation (Turbo Drive, htmx). Keep the id in sync with
+    // `STANDALONE_STYLE_ID` in `src/standalone/lib/html-api.ts`.
+    cssInjectedByJsPlugin({ attributes: { id: 'scalar-style' } }),
     webpackStats({ fileName: 'webpack-stats.esm.json' }),
     banner({
       outDir: 'dist/browser',


### PR DESCRIPTION
Standalone Scalar injects all its CSS into one `<style>` in `<head>`. With Turbo Drive / htmx the host swaps the DOM without a full reload, so those global styles stuck around and broke the next page.

`destroy()` now detaches the injected styles once the last instance is gone, and re-attaches them when a new instance mounts (so navigating back is still styled).

## Ticket

Fixes #9386

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to standalone HTML lifecycle and DOM head cleanup; refcounting is covered by new tests with no auth or data changes.
> 
> **Overview**
> Fixes global CSS from the standalone CDN build sticking in `document.head` after **Turbo Drive**, **htmx**, or similar navigation when hosts call `destroy()` without a full page reload.
> 
> The standalone Vite configs now give the injected `<style>` a fixed **`scalar-style`** id so runtime code can find it. **`html-api.ts`** reference-counts mounted instances per document: **`destroy()`** removes that tag only when the last mounted instance is torn down (keeping the node in memory so it can be re-appended), and a new mount restores it if styles were detached.
> 
> Tests cover detach on destroy, re-attach on remount, and multi-instance refcount behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2c95b8cf8892e97a5d72c511f752abaf2038c04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->