### PR TITLE
refactor(api-reference): add in-house router for navigation ids

### DIFF
--- a/.changeset/in-house-router.md
+++ b/.changeset/in-house-router.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Introduce an internal routing helper that encapsulates URL ⇄ navigation-id translation and history writes for the active document. This is a behavior-preserving refactor that removes repeated routing boilerplate from `ApiReference.vue`.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -77,12 +77,7 @@ import DocumentSelector from '@/features/multiple-documents/DocumentSelector.vue
 import SearchButton from '@/features/Search/components/SearchButton.vue'
 import { getSystemModePreference } from '@/helpers/color-mode'
 import { downloadDocument } from '@/helpers/download'
-import {
-  getIdFromUrl,
-  makeUrlFromId,
-  matchesBasePath,
-  redirectLegacyModelUrl,
-} from '@/helpers/id-routing'
+import { getIdFromUrl, makeUrlFromId } from '@/helpers/id-routing'
 import {
   scrollToLazy as _scrollToLazy,
   addToPriorityQueue,
@@ -99,6 +94,7 @@ import {
   normalizeConfigurations,
   type NormalizedConfiguration,
 } from '@/helpers/normalize-configurations'
+import { createRouting, getDocumentSlugFromUrl } from '@/helpers/routing'
 import { safeDeepClone } from '@/helpers/safe-deep-clone'
 import { AGENT_CONTEXT_SYMBOL, useAgent } from '@/hooks/use-agent'
 import { useIntersection } from '@/hooks/use-intersection'
@@ -205,12 +201,10 @@ if (typeof window !== 'undefined') {
     (c) => c.config.pathRouting?.basePath,
   )
 
-  const initialId = getIdFromUrl(
-    url,
-    basePaths.find((p) => (p ? matchesBasePath(url, p) : false)),
-    isMultiDocument.value ? undefined : activeSlug.value,
-  )
-  const documentSlug = initialId.split('/')[0]
+  const documentSlug = getDocumentSlugFromUrl(url, basePaths, {
+    isMultiDocument: isMultiDocument.value,
+    activeSlug: activeSlug.value,
+  })
 
   if (documentSlug && configList.value[documentSlug]) {
     activeSlug.value = documentSlug
@@ -251,6 +245,24 @@ const mergedConfig = computed<ApiReferenceConfiguration>(() => {
 /** Convenience break out var to determine which routing mode we are using */
 const basePath = computed(() => mergedConfig.value.pathRouting?.basePath)
 
+/** Slug of the models section, used to redirect legacy `model/` bookmarks */
+const modelsSectionSlug = computed(() =>
+  slugify(
+    mergedConfig.value.modelsSectionLabel ?? DEFAULT_MODELS_SECTION_LABEL,
+  ),
+)
+
+/**
+ * In-house router for the active document: translates between the address bar and navigation ids
+ * and owns the history writes. Scrolling and intersection stay with this component.
+ */
+const routing = createRouting({
+  basePath,
+  isMultiDocument,
+  documentSlug: activeSlug,
+  modelsSectionSlug,
+})
+
 const themeStyle = computed(() =>
   getThemeStyles(mergedConfig.value.theme, {
     fonts: mergedConfig.value.withDefaultFonts,
@@ -274,15 +286,7 @@ watch(mergedConfig, (config) => pluginManager.notifyConfigChange(config))
 // Redirect legacy `/model/<name>` URLs to the current section's plural slug
 // so bookmarks from before the slug streamline keep resolving.
 if (typeof window !== 'undefined') {
-  const canonical = redirectLegacyModelUrl(
-    window.location.href,
-    slugify(
-      mergedConfig.value.modelsSectionLabel ?? DEFAULT_MODELS_SECTION_LABEL,
-    ),
-    activeSlug.value,
-    isMultiDocument.value,
-    mergedConfig.value.pathRouting?.basePath,
-  )
+  const canonical = routing.redirectLegacy(window.location.href)
   if (canonical) {
     window.history.replaceState({}, '', canonical.toString())
   }
@@ -784,14 +788,7 @@ onBeforeMount(async () => {
   // We read the client from the client store so we need to set it to the client store
   loadClientFromStorage(clientStore)
 
-  await changeSelectedDocument(
-    activeSlug.value,
-    getIdFromUrl(
-      window.location.href,
-      configList.value[activeSlug.value]?.config.pathRouting?.basePath,
-      isMultiDocument.value ? undefined : activeSlug.value,
-    ),
-  )
+  await changeSelectedDocument(activeSlug.value, routing.getId())
 })
 
 const documentUrl = computed(() => {
@@ -924,14 +921,10 @@ const handleSelectSidebarEntry = (id: string, caller?: 'sidebar') => {
 
   scrollToLazyElement(id)
 
-  const url = makeUrlFromId(id, basePath.value, isMultiDocument.value)
-  if (url) {
-    window.history.pushState({}, '', url)
-
+  const url = routing.push(id)
+  if (url && caller === 'sidebar') {
     // Trigger the onSidebarClick callback if the caller is sidebar
-    if (caller === 'sidebar') {
-      mergedConfig.value.onSidebarClick?.(url.toString())
-    }
+    mergedConfig.value.onSidebarClick?.(url.toString())
   }
 
   if (agent.showAgent.value) {
@@ -960,9 +953,8 @@ eventBus.on('intersecting:nav-item', ({ id }) => {
   // Scroll the sidebar to keep the selected element near the top
   scrollSidebarToTop(id)
 
-  const url = makeUrlFromId(id, basePath.value, isMultiDocument.value)
-  if (url && workspaceStore.workspace.activeDocument) {
-    window.history.replaceState({}, '', url.toString())
+  if (workspaceStore.workspace.activeDocument) {
+    routing.replace(id)
   }
 })
 
@@ -984,11 +976,7 @@ eventBus.on('toggle:nav-item', ({ id, open }) => {
 })
 
 eventBus.on('copy-url:nav-item', ({ id }) => {
-  const url = makeUrlFromId(
-    id,
-    basePath.value,
-    isMultiDocument.value,
-  )?.toString()
+  const url = routing.getUrl(id)?.toString()
   return url && copyToClipboard(url)
 })
 
@@ -1001,12 +989,7 @@ onBeforeMount(() => {
   addScalarClassesToHeadless()
 
   // When we detect a back button press we scroll to the new id
-  window.addEventListener('popstate', () => {
-    const id = getIdFromUrl(
-      window.location.href,
-      mergedConfig.value.pathRouting?.basePath,
-      isMultiDocument.value ? undefined : activeSlug.value,
-    )
+  routing.onNavigate((id) => {
     if (id) {
       scrollToLazyElement(id)
     }

--- a/packages/api-reference/src/helpers/routing.test.ts
+++ b/packages/api-reference/src/helpers/routing.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { createRouting, getDocumentSlugFromUrl } from './routing'
+
+const createLocationMock = (overrides: Partial<Location> = {}): Partial<Location> => ({
+  href: 'https://example.com/',
+  protocol: 'https:',
+  host: 'example.com',
+  pathname: '/',
+  search: '',
+  hash: '',
+  ...overrides,
+})
+
+const stubWindow = (overrides: Partial<Location> = {}, history: Partial<History> = {}) => {
+  vi.stubGlobal('window', {
+    location: createLocationMock(overrides) as Location,
+    history: { pushState: vi.fn(), replaceState: vi.fn(), ...history } as unknown as History,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })
+}
+
+describe('createRouting', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('getId', () => {
+    it('reads the id from the current location with hash routing', () => {
+      stubWindow({ href: 'https://example.com/#tag/users', hash: '#tag/users' })
+      const routing = createRouting({
+        basePath: undefined,
+        isMultiDocument: true,
+        documentSlug: 'default',
+        modelsSectionSlug: 'models',
+      })
+
+      expect(routing.getId()).toBe('tag/users')
+    })
+
+    it('prefixes the document slug in single-document mode', () => {
+      stubWindow({ href: 'https://example.com/#tag/users', hash: '#tag/users' })
+      const routing = createRouting({
+        basePath: undefined,
+        isMultiDocument: false,
+        documentSlug: 'default',
+        modelsSectionSlug: 'models',
+      })
+
+      expect(routing.getId()).toBe('default/tag/users')
+    })
+
+    it('reads the id from an explicit URL', () => {
+      stubWindow()
+      const routing = createRouting({
+        basePath: '/docs',
+        isMultiDocument: true,
+        documentSlug: 'default',
+        modelsSectionSlug: 'models',
+      })
+
+      expect(routing.getId('https://example.com/docs/default/tag/users')).toBe('default/tag/users')
+    })
+  })
+
+  describe('getUrl', () => {
+    it('builds a hash URL for an id', () => {
+      stubWindow()
+      const routing = createRouting({
+        basePath: undefined,
+        isMultiDocument: true,
+        documentSlug: 'default',
+        modelsSectionSlug: 'models',
+      })
+
+      expect(routing.getUrl('default/tag/users')?.hash).toBe('#default/tag/users')
+    })
+
+    it('returns undefined during SSR', () => {
+      vi.stubGlobal('window', undefined)
+      const routing = createRouting({
+        basePath: undefined,
+        isMultiDocument: true,
+        documentSlug: 'default',
+        modelsSectionSlug: 'models',
+      })
+
+      expect(routing.getUrl('default/tag/users')).toBeUndefined()
+    })
+  })
+
+  describe('push and replace', () => {
+    it('pushes a new history entry for an id', () => {
+      const pushState = vi.fn()
+      stubWindow({}, { pushState })
+      const routing = createRouting({
+        basePath: undefined,
+        isMultiDocument: true,
+        documentSlug: 'default',
+        modelsSectionSlug: 'models',
+      })
+
+      const url = routing.push('default/tag/users')
+
+      expect(url?.hash).toBe('#default/tag/users')
+      expect(pushState).toHaveBeenCalledWith({}, '', url)
+    })
+
+    it('replaces the current history entry for an id', () => {
+      const replaceState = vi.fn()
+      stubWindow({}, { replaceState })
+      const routing = createRouting({
+        basePath: undefined,
+        isMultiDocument: true,
+        documentSlug: 'default',
+        modelsSectionSlug: 'models',
+      })
+
+      const url = routing.replace('default/tag/users')
+
+      expect(replaceState).toHaveBeenCalledWith({}, '', url?.toString())
+    })
+  })
+
+  describe('redirectLegacy', () => {
+    it('canonicalizes a legacy model URL', () => {
+      stubWindow()
+      const routing = createRouting({
+        basePath: undefined,
+        isMultiDocument: true,
+        documentSlug: 'default',
+        modelsSectionSlug: 'models',
+      })
+
+      expect(routing.redirectLegacy('https://example.com/#default/model/User')?.hash).toBe('#default/models/User')
+    })
+
+    it('returns null when there is nothing to rewrite', () => {
+      stubWindow()
+      const routing = createRouting({
+        basePath: undefined,
+        isMultiDocument: true,
+        documentSlug: 'default',
+        modelsSectionSlug: 'models',
+      })
+
+      expect(routing.redirectLegacy('https://example.com/#default/tag/users')).toBeNull()
+    })
+  })
+
+  describe('onNavigate', () => {
+    it('forwards the current id on popstate and unsubscribes', () => {
+      const addEventListener = vi.fn()
+      const removeEventListener = vi.fn()
+      vi.stubGlobal('window', {
+        location: createLocationMock({ href: 'https://example.com/#tag/users', hash: '#tag/users' }) as Location,
+        addEventListener,
+        removeEventListener,
+      })
+      const routing = createRouting({
+        basePath: undefined,
+        isMultiDocument: true,
+        documentSlug: 'default',
+        modelsSectionSlug: 'models',
+      })
+      const handler = vi.fn()
+
+      const stop = routing.onNavigate(handler)
+      expect(addEventListener).toHaveBeenCalledWith('popstate', expect.any(Function))
+
+      // Invoke the registered listener as a popstate event would.
+      const listener = addEventListener.mock.calls[0]?.[1] as () => void
+      listener()
+      expect(handler).toHaveBeenCalledWith('tag/users')
+
+      stop()
+      expect(removeEventListener).toHaveBeenCalledWith('popstate', listener)
+    })
+
+    it('is a no-op during SSR', () => {
+      vi.stubGlobal('window', undefined)
+      const routing = createRouting({
+        basePath: undefined,
+        isMultiDocument: true,
+        documentSlug: 'default',
+        modelsSectionSlug: 'models',
+      })
+
+      expect(() => routing.onNavigate(vi.fn())()).not.toThrow()
+    })
+  })
+
+  it('reads reactive options on each call', () => {
+    stubWindow({ href: 'https://example.com/#tag/users', hash: '#tag/users' })
+    const isMultiDocument = ref(true)
+    const routing = createRouting({
+      basePath: undefined,
+      isMultiDocument,
+      documentSlug: 'default',
+      modelsSectionSlug: 'models',
+    })
+
+    expect(routing.getId()).toBe('tag/users')
+
+    isMultiDocument.value = false
+    expect(routing.getId()).toBe('default/tag/users')
+  })
+})
+
+describe('getDocumentSlugFromUrl', () => {
+  it('reads the slug from a matching base path in multi-document mode', () => {
+    const slug = getDocumentSlugFromUrl('https://example.com/docs/petstore/tag/users', ['/docs'], {
+      isMultiDocument: true,
+      activeSlug: 'default',
+    })
+
+    expect(slug).toBe('petstore')
+  })
+
+  it('reads the slug from the hash when no base path is configured', () => {
+    const slug = getDocumentSlugFromUrl('https://example.com/#petstore/tag/users', [undefined], {
+      isMultiDocument: true,
+      activeSlug: 'default',
+    })
+
+    expect(slug).toBe('petstore')
+  })
+
+  it('falls back to the active slug in single-document mode', () => {
+    const slug = getDocumentSlugFromUrl('https://example.com/#tag/users', [undefined], {
+      isMultiDocument: false,
+      activeSlug: 'default',
+    })
+
+    expect(slug).toBe('default')
+  })
+
+  it('returns an empty string when the URL has no id', () => {
+    const slug = getDocumentSlugFromUrl('https://example.com/', [undefined], {
+      isMultiDocument: true,
+      activeSlug: 'default',
+    })
+
+    expect(slug).toBe('')
+  })
+})

--- a/packages/api-reference/src/helpers/routing.ts
+++ b/packages/api-reference/src/helpers/routing.ts
@@ -1,0 +1,117 @@
+import { type MaybeRefOrGetter, toValue } from 'vue'
+
+import { getIdFromUrl, makeUrlFromId, matchesBasePath, redirectLegacyModelUrl } from './id-routing'
+
+/**
+ * Reactive routing context for the active document.
+ *
+ * Path routing, hash routing, and hash-base-path routing each store the navigation id in a
+ * different place, and single-document mode omits the document slug from the URL. These options
+ * capture that context once so call sites do not have to re-derive it.
+ */
+export type RoutingOptions = {
+  /** Base path for the active document (`config.pathRouting?.basePath`). Hash routing when undefined. */
+  basePath: MaybeRefOrGetter<string | undefined>
+  /** Whether the workspace renders multiple documents — controls whether the doc slug appears in the URL. */
+  isMultiDocument: MaybeRefOrGetter<boolean>
+  /** Slug of the active document; prefixes ids when the slug is omitted from single-document URLs. */
+  documentSlug: MaybeRefOrGetter<string>
+  /** Slug of the models section, for the legacy `model/` → `models/` redirect. */
+  modelsSectionSlug: MaybeRefOrGetter<string>
+}
+
+/**
+ * Translates between the address bar and navigation ids for the active document.
+ *
+ * This is the in-house router for `@scalar/api-reference`: it owns URL ⇄ id translation and the
+ * history writes, but deliberately not scrolling or intersection — reconciling the scroll position
+ * with the URL stays with the component that orchestrates it.
+ */
+export type Routing = {
+  /** The id encoded in `url` (defaults to the current location), normalized for the active document. */
+  getId: (url?: string | URL) => string
+  /** The URL that encodes `id`, or undefined during SSR. */
+  getUrl: (id: string) => URL | undefined
+  /** A canonicalized URL when `url` is a legacy `model/` link, otherwise null. */
+  redirectLegacy: (url: string | URL) => URL | null
+  /** Write `id` to the address bar with a new history entry; returns the new URL (undefined during SSR). */
+  push: (id: string) => URL | undefined
+  /** Write `id` to the address bar in place; returns the new URL (undefined during SSR). */
+  replace: (id: string) => URL | undefined
+  /** Subscribe to browser back/forward navigation. Returns an unsubscribe function. */
+  onNavigate: (handler: (id: string) => void) => () => void
+}
+
+export const createRouting = (options: RoutingOptions): Routing => {
+  // Multi-document URLs carry the slug already; single-document URLs need it added back.
+  const slugPrefix = () => (toValue(options.isMultiDocument) ? undefined : toValue(options.documentSlug))
+
+  const getId: Routing['getId'] = (url) => {
+    if (url === undefined && typeof window === 'undefined') {
+      return ''
+    }
+
+    return getIdFromUrl(url ?? window.location.href, toValue(options.basePath), slugPrefix())
+  }
+
+  const getUrl: Routing['getUrl'] = (id) =>
+    makeUrlFromId(id, toValue(options.basePath), toValue(options.isMultiDocument))
+
+  const redirectLegacy: Routing['redirectLegacy'] = (url) =>
+    redirectLegacyModelUrl(
+      url,
+      toValue(options.modelsSectionSlug),
+      toValue(options.documentSlug),
+      toValue(options.isMultiDocument),
+      toValue(options.basePath),
+    )
+
+  const push: Routing['push'] = (id) => {
+    const url = getUrl(id)
+    if (url) {
+      window.history.pushState({}, '', url)
+    }
+
+    return url
+  }
+
+  const replace: Routing['replace'] = (id) => {
+    const url = getUrl(id)
+    if (url) {
+      window.history.replaceState({}, '', url.toString())
+    }
+
+    return url
+  }
+
+  const onNavigate: Routing['onNavigate'] = (handler) => {
+    if (typeof window === 'undefined') {
+      return () => {}
+    }
+
+    const listener = () => handler(getId())
+    window.addEventListener('popstate', listener)
+
+    return () => window.removeEventListener('popstate', listener)
+  }
+
+  return { getId, getUrl, redirectLegacy, push, replace, onNavigate }
+}
+
+/**
+ * Determines which document a URL points to on initial load.
+ *
+ * Path routing does not tell us up front which base path to expect, so we try each document's base
+ * path until one matches, parse the id, and read the document slug from its first segment. Falls
+ * back to an empty string when no slug can be derived (for example with plain hash routing).
+ */
+export const getDocumentSlugFromUrl = (
+  url: string | URL,
+  basePaths: (string | undefined)[],
+  options: { isMultiDocument: boolean; activeSlug: string },
+): string => {
+  const matchedBasePath = basePaths.find((basePath) => (basePath ? matchesBasePath(url, basePath) : false))
+  const id = getIdFromUrl(url, matchedBasePath, options.isMultiDocument ? undefined : options.activeSlug)
+
+  return id.split('/')[0] ?? ''
+}


### PR DESCRIPTION
Builds on #9393. Wraps the `id-routing` helpers in a small `createRouting` so `ApiReference.vue` stops threading `basePath`/`isMultiDocument`/slug through every call site and hand-rolling `makeUrlFromId` + `history.pushState`.

The router owns URL ⇄ id translation, `push`/`replace`, the legacy redirect, and back/forward subscription. Scrolling and intersection stay in the component on purpose — reconciling scroll position with the URL is the component's job.

Behavior-preserving; the existing `id-routing.test.ts` and the `ApiReference` component test still pass, plus a new `routing.test.ts`.

> Stacked on `claude/refactor-legacy-model-redirect`; retarget to `main` once #9393 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)