### PR TITLE
refactor(api-reference): generic redirects

### DIFF
--- a/.changeset/fast-rules-redirect.md
+++ b/.changeset/fast-rules-redirect.md
@@ -2,4 +2,4 @@
 '@scalar/api-reference': patch
 ---
 
-Refactor URL redirects into a routing-agnostic, list-driven engine. Redirects now operate on the bare navigation id, so each rule works across hash, hash-base-path, and path routing automatically. Behavior is unchanged.
+Refactor URL redirects into a routing-agnostic, list-driven engine. Redirects now operate on the bare navigation id, so each rule works across hash, hash-base-path, and path routing automatically. Also redirect old `models/<name>` bookmarks to the configured models section slug when the section label is customized (e.g. `schemas/`).

--- a/.changeset/fast-rules-redirect.md
+++ b/.changeset/fast-rules-redirect.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Refactor URL redirects into a routing-agnostic, list-driven engine. Redirects now operate on the bare navigation id, so each rule works across hash, hash-base-path, and path routing automatically. Behavior is unchanged.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -85,7 +85,7 @@ import {
   getIdFromUrl,
   makeUrlFromId,
   matchesBasePath,
-  redirectLegacyModelUrl,
+  redirectUrl,
 } from '@/helpers/id-routing'
 import {
   scrollToLazy as _scrollToLazy,
@@ -275,10 +275,10 @@ watch(mergedConfig, (config) => pluginManager.notifyConfigChange(config))
 // ---------------------------------------------------------------------------
 /** Navigation State Handling */
 
-// Redirect legacy `/model/<name>` URLs to the current section's plural slug
-// so bookmarks from before the slug streamline keep resolving.
+// Rewrite outdated `model/` and `models/` schema URLs to the current models
+// section slug so bookmarks from before the slug changed keep resolving.
 if (typeof window !== 'undefined') {
-  const canonical = redirectLegacyModelUrl(
+  const canonical = redirectUrl(
     window.location.href,
     slugify(
       mergedConfig.value.modelsSectionLabel ?? DEFAULT_MODELS_SECTION_LABEL,

--- a/packages/api-reference/src/helpers/id-routing.test.ts
+++ b/packages/api-reference/src/helpers/id-routing.test.ts
@@ -944,6 +944,58 @@ describe('redirectLegacyModelUrl', () => {
     })
   })
 
+  describe('customized models section slug', () => {
+    it('rewrites a `models` segment to the customized slug', () => {
+      const result = redirectLegacyModelUrl('https://example.com/#default/models/User', 'schemas', 'default', true)
+      expect(result?.hash).toBe('#default/schemas/User')
+    })
+
+    it('rewrites a tagged `models` segment to the customized slug', () => {
+      const result = redirectLegacyModelUrl(
+        'https://example.com/#default/tag/pets/models/Pet',
+        'schemas',
+        'default',
+        true,
+      )
+      expect(result?.hash).toBe('#default/tag/pets/schemas/Pet')
+    })
+
+    it('rewrites a `models` pathname to the customized slug', () => {
+      const result = redirectLegacyModelUrl(
+        'https://example.com/docs/default/models/User',
+        'schemas',
+        'default',
+        true,
+        '/docs',
+      )
+      expect(result?.pathname).toBe('/docs/default/schemas/User')
+    })
+
+    it('rewrites a top-level `models` segment in single-doc mode', () => {
+      const result = redirectLegacyModelUrl('https://example.com/#models/User', 'schemas', 'default', false)
+      expect(result?.hash).toBe('#schemas/User')
+    })
+
+    it('still rewrites the singular `model` segment to the customized slug', () => {
+      const result = redirectLegacyModelUrl('https://example.com/#default/model/User', 'schemas', 'default', true)
+      expect(result?.hash).toBe('#default/schemas/User')
+    })
+
+    it('leaves the `models` segment alone when the slug is the default', () => {
+      expect(redirectLegacyModelUrl('https://example.com/#default/models/User', 'models', 'default', true)).toBeNull()
+    })
+
+    it('leaves operation paths containing `/models/` untouched', () => {
+      expect(
+        redirectLegacyModelUrl('https://example.com/#default/POST/models/train', 'schemas', 'default', true),
+      ).toBeNull()
+    })
+
+    it('leaves a tagged `models` segment alone without a doc slug (ambiguous)', () => {
+      expect(redirectLegacyModelUrl('https://example.com/#tag/pets/models/Pet', 'schemas', 'default', false)).toBeNull()
+    })
+  })
+
   it('returns null when the document slug is empty', () => {
     expect(redirectLegacyModelUrl('https://example.com/#default/model/User', 'models', '', true)).toBeNull()
   })

--- a/packages/api-reference/src/helpers/id-routing.test.ts
+++ b/packages/api-reference/src/helpers/id-routing.test.ts
@@ -930,6 +930,20 @@ describe('redirectUrl', () => {
     })
   })
 
+  describe('hash base path routing', () => {
+    it('rewrites a legacy segment behind the hash base path', () => {
+      const result = redirectUrl('https://example.com/#/docs/default/model/User', 'models', 'default', true, '#/docs')
+      expect(result?.hash).toBe('#/docs/default/models/User')
+    })
+
+    it('still rewrites a legacy hash bookmark left over from before the base path was configured', () => {
+      // A bare `#default/model/User` fragment can linger from before the hash base path was set.
+      // The base-stripping carrier yields no id, so we fall back to the bare hash.
+      const result = redirectUrl('https://example.com/#default/model/User', 'models', 'default', true, '#/docs')
+      expect(result?.hash).toBe('#default/models/User')
+    })
+  })
+
   describe('customized models section slug', () => {
     it('rewrites a `models` segment to the customized slug', () => {
       const result = redirectUrl('https://example.com/#default/models/User', 'schemas', 'default', true)

--- a/packages/api-reference/src/helpers/id-routing.test.ts
+++ b/packages/api-reference/src/helpers/id-routing.test.ts
@@ -928,6 +928,20 @@ describe('redirectUrl', () => {
       const result = redirectUrl('https://example.com/docs/#default/model/User', 'models', 'default', true, '/docs')
       expect(result?.hash).toBe('#default/models/User')
     })
+
+    it('rewrites both the legacy pathname and a stale legacy hash in one pass', () => {
+      // When the id is legacy in both the pathname and a leftover hash, neither should survive the
+      // redirect — otherwise the address bar shows a corrected path next to an outdated hash.
+      const result = redirectUrl(
+        'https://example.com/docs/default/model/User#default/model/User',
+        'models',
+        'default',
+        true,
+        '/docs',
+      )
+      expect(result?.pathname).toBe('/docs/default/models/User')
+      expect(result?.hash).toBe('#default/models/User')
+    })
   })
 
   describe('hash base path routing', () => {

--- a/packages/api-reference/src/helpers/id-routing.test.ts
+++ b/packages/api-reference/src/helpers/id-routing.test.ts
@@ -8,7 +8,7 @@ import {
   getSchemaParamsFromId,
   makeUrlFromId,
   matchesBasePath,
-  redirectLegacyModelUrl,
+  redirectUrl,
   sanitizeBasePath,
 } from './id-routing'
 
@@ -828,25 +828,20 @@ describe('makeUrlFromId', () => {
   })
 })
 
-describe('redirectLegacyModelUrl', () => {
+describe('redirectUrl', () => {
   describe('multi-document hash routing', () => {
     it('rewrites a top-level legacy hash', () => {
-      const result = redirectLegacyModelUrl('https://example.com/#default/model/User', 'models', 'default', true)
+      const result = redirectUrl('https://example.com/#default/model/User', 'models', 'default', true)
       expect(result?.hash).toBe('#default/models/User')
     })
 
     it('rewrites a tagged legacy hash', () => {
-      const result = redirectLegacyModelUrl(
-        'https://example.com/#default/tag/pets/model/Pet',
-        'models',
-        'default',
-        true,
-      )
+      const result = redirectUrl('https://example.com/#default/tag/pets/model/Pet', 'models', 'default', true)
       expect(result?.hash).toBe('#default/tag/pets/models/Pet')
     })
 
     it('rewrites a tag-group legacy hash', () => {
-      const result = redirectLegacyModelUrl(
+      const result = redirectUrl(
         'https://example.com/#default/tag-group/0/tag/pets/model/Pet',
         'models',
         'default',
@@ -856,147 +851,117 @@ describe('redirectLegacyModelUrl', () => {
     })
 
     it('uses a custom slug when the label is not the default', () => {
-      const result = redirectLegacyModelUrl('https://example.com/#default/model/User', 'schemas', 'default', true)
+      const result = redirectUrl('https://example.com/#default/model/User', 'schemas', 'default', true)
       expect(result?.hash).toBe('#default/schemas/User')
     })
 
     it('preserves schema sub-paths after the model name', () => {
-      const result = redirectLegacyModelUrl(
-        'https://example.com/#default/model/User.body.id',
-        'models',
-        'default',
-        true,
-      )
+      const result = redirectUrl('https://example.com/#default/model/User.body.id', 'models', 'default', true)
       expect(result?.hash).toBe('#default/models/User.body.id')
     })
 
     it('returns null when the URL has no legacy segment', () => {
-      expect(redirectLegacyModelUrl('https://example.com/#default/models/User', 'models', 'default', true)).toBeNull()
-      expect(redirectLegacyModelUrl('https://example.com/#default/tag/pets', 'models', 'default', true)).toBeNull()
+      expect(redirectUrl('https://example.com/#default/models/User', 'models', 'default', true)).toBeNull()
+      expect(redirectUrl('https://example.com/#default/tag/pets', 'models', 'default', true)).toBeNull()
     })
 
     it('does not touch the section-level `/models` hash', () => {
-      expect(redirectLegacyModelUrl('https://example.com/#default/models', 'models', 'default', true)).toBeNull()
+      expect(redirectUrl('https://example.com/#default/models', 'models', 'default', true)).toBeNull()
     })
 
     it('leaves operation paths whose raw path contains `/model/` untouched', () => {
       // POST /model/train — common AI/ML endpoint
-      expect(
-        redirectLegacyModelUrl('https://example.com/#default/POST/model/train', 'models', 'default', true),
-      ).toBeNull()
+      expect(redirectUrl('https://example.com/#default/POST/model/train', 'models', 'default', true)).toBeNull()
       // POST /v1/model/train — `/model/` deeper in the path
-      expect(
-        redirectLegacyModelUrl('https://example.com/#default/POST/v1/model/train', 'models', 'default', true),
-      ).toBeNull()
+      expect(redirectUrl('https://example.com/#default/POST/v1/model/train', 'models', 'default', true)).toBeNull()
     })
 
     it('leaves operations under a tag named "model" untouched', () => {
-      expect(
-        redirectLegacyModelUrl('https://example.com/#default/tag/model/POST/foo', 'models', 'default', true),
-      ).toBeNull()
+      expect(redirectUrl('https://example.com/#default/tag/model/POST/foo', 'models', 'default', true)).toBeNull()
     })
   })
 
   describe('single-document hash routing', () => {
     it('rewrites a top-level legacy hash', () => {
-      const result = redirectLegacyModelUrl('https://example.com/#model/User', 'models', 'default', false)
+      const result = redirectUrl('https://example.com/#model/User', 'models', 'default', false)
       expect(result?.hash).toBe('#models/User')
     })
 
     it('rewrites a legacy hash that still includes the doc slug', () => {
       // Old bookmarks (or hand-typed URLs) sometimes include the doc slug even in single-doc mode.
-      const result = redirectLegacyModelUrl('https://example.com/#default/model/User', 'models', 'default', false)
+      const result = redirectUrl('https://example.com/#default/model/User', 'models', 'default', false)
       expect(result?.hash).toBe('#default/models/User')
     })
 
     it('returns null for tagged legacy hashes (ambiguous with tag named "model")', () => {
       // We cannot tell `#tag/<slug>/model/<name>` apart from an operation under a tag named "model"
       // once the document slug is stripped, so we leave these alone.
-      expect(redirectLegacyModelUrl('https://example.com/#tag/pets/model/Pet', 'models', 'default', false)).toBeNull()
+      expect(redirectUrl('https://example.com/#tag/pets/model/Pet', 'models', 'default', false)).toBeNull()
     })
 
     it('leaves operation paths containing `/model/` untouched', () => {
-      expect(redirectLegacyModelUrl('https://example.com/#POST/model/train', 'models', 'default', false)).toBeNull()
+      expect(redirectUrl('https://example.com/#POST/model/train', 'models', 'default', false)).toBeNull()
     })
   })
 
   describe('path routing', () => {
     it('rewrites a legacy pathname in multi-doc mode', () => {
-      const result = redirectLegacyModelUrl(
-        'https://example.com/docs/default/model/User',
-        'models',
-        'default',
-        true,
-        '/docs',
-      )
+      const result = redirectUrl('https://example.com/docs/default/model/User', 'models', 'default', true, '/docs')
       expect(result?.pathname).toBe('/docs/default/models/User')
     })
 
     it('rewrites a legacy pathname in single-doc mode', () => {
-      const result = redirectLegacyModelUrl('https://example.com/docs/model/User', 'models', 'default', false, '/docs')
+      const result = redirectUrl('https://example.com/docs/model/User', 'models', 'default', false, '/docs')
       expect(result?.pathname).toBe('/docs/models/User')
     })
 
     it('leaves operation pathnames untouched', () => {
       expect(
-        redirectLegacyModelUrl('https://example.com/docs/default/POST/model/train', 'models', 'default', true, '/docs'),
+        redirectUrl('https://example.com/docs/default/POST/model/train', 'models', 'default', true, '/docs'),
       ).toBeNull()
     })
   })
 
   describe('customized models section slug', () => {
     it('rewrites a `models` segment to the customized slug', () => {
-      const result = redirectLegacyModelUrl('https://example.com/#default/models/User', 'schemas', 'default', true)
+      const result = redirectUrl('https://example.com/#default/models/User', 'schemas', 'default', true)
       expect(result?.hash).toBe('#default/schemas/User')
     })
 
     it('rewrites a tagged `models` segment to the customized slug', () => {
-      const result = redirectLegacyModelUrl(
-        'https://example.com/#default/tag/pets/models/Pet',
-        'schemas',
-        'default',
-        true,
-      )
+      const result = redirectUrl('https://example.com/#default/tag/pets/models/Pet', 'schemas', 'default', true)
       expect(result?.hash).toBe('#default/tag/pets/schemas/Pet')
     })
 
     it('rewrites a `models` pathname to the customized slug', () => {
-      const result = redirectLegacyModelUrl(
-        'https://example.com/docs/default/models/User',
-        'schemas',
-        'default',
-        true,
-        '/docs',
-      )
+      const result = redirectUrl('https://example.com/docs/default/models/User', 'schemas', 'default', true, '/docs')
       expect(result?.pathname).toBe('/docs/default/schemas/User')
     })
 
     it('rewrites a top-level `models` segment in single-doc mode', () => {
-      const result = redirectLegacyModelUrl('https://example.com/#models/User', 'schemas', 'default', false)
+      const result = redirectUrl('https://example.com/#models/User', 'schemas', 'default', false)
       expect(result?.hash).toBe('#schemas/User')
     })
 
     it('still rewrites the singular `model` segment to the customized slug', () => {
-      const result = redirectLegacyModelUrl('https://example.com/#default/model/User', 'schemas', 'default', true)
+      const result = redirectUrl('https://example.com/#default/model/User', 'schemas', 'default', true)
       expect(result?.hash).toBe('#default/schemas/User')
     })
 
     it('leaves the `models` segment alone when the slug is the default', () => {
-      expect(redirectLegacyModelUrl('https://example.com/#default/models/User', 'models', 'default', true)).toBeNull()
+      expect(redirectUrl('https://example.com/#default/models/User', 'models', 'default', true)).toBeNull()
     })
 
     it('leaves operation paths containing `/models/` untouched', () => {
-      expect(
-        redirectLegacyModelUrl('https://example.com/#default/POST/models/train', 'schemas', 'default', true),
-      ).toBeNull()
+      expect(redirectUrl('https://example.com/#default/POST/models/train', 'schemas', 'default', true)).toBeNull()
     })
 
     it('leaves a tagged `models` segment alone without a doc slug (ambiguous)', () => {
-      expect(redirectLegacyModelUrl('https://example.com/#tag/pets/models/Pet', 'schemas', 'default', false)).toBeNull()
+      expect(redirectUrl('https://example.com/#tag/pets/models/Pet', 'schemas', 'default', false)).toBeNull()
     })
   })
 
   it('returns null when the document slug is empty', () => {
-    expect(redirectLegacyModelUrl('https://example.com/#default/model/User', 'models', '', true)).toBeNull()
+    expect(redirectUrl('https://example.com/#default/model/User', 'models', '', true)).toBeNull()
   })
 })

--- a/packages/api-reference/src/helpers/id-routing.test.ts
+++ b/packages/api-reference/src/helpers/id-routing.test.ts
@@ -920,6 +920,14 @@ describe('redirectUrl', () => {
         redirectUrl('https://example.com/docs/default/POST/model/train', 'models', 'default', true, '/docs'),
       ).toBeNull()
     })
+
+    it('still rewrites a legacy hash bookmark left over from before path routing', () => {
+      // A `#default/model/User` fragment can linger from when the docs used hash routing. Path
+      // routing reads the id from the pathname, but we fall back to the hash so the old bookmark
+      // is still canonicalized.
+      const result = redirectUrl('https://example.com/docs/#default/model/User', 'models', 'default', true, '/docs')
+      expect(result?.hash).toBe('#default/models/User')
+    })
   })
 
   describe('customized models section slug', () => {

--- a/packages/api-reference/src/helpers/id-routing.ts
+++ b/packages/api-reference/src/helpers/id-routing.ts
@@ -170,22 +170,30 @@ type IdCarrier = {
   write: (next: string) => void
 }
 
+/** Carrier for an id that lives in the bare hash fragment (`#<id>`). */
+const bareHashCarrier = (url: URL): IdCarrier => ({
+  value: decodeURIComponent(url.hash.slice(1)),
+  write: (next) => {
+    url.hash = next
+  },
+})
+
 /**
  * Locates the navigation id inside a URL regardless of the routing mode.
  *
  * The id can live in three places — the bare hash, a hash base path (`#<base>/<id>`), or the
- * pathname after a path base path. Returning the decoded id alongside a `write` callback lets
+ * pathname after a path base path. Each carrier pairs the decoded id with a `write` callback, so
  * callers edit ids in id-space without re-deriving the routing chrome for each mode.
+ *
+ * Multiple carriers are returned in priority order: the canonical location for the active routing
+ * mode comes first, followed by any legacy fallback. Path routing falls back to the bare hash so a
+ * stale `#default/model/User` bookmark (left over from before path routing was enabled) is still
+ * canonicalized — the previous implementation rewrote both the path and the hash on every load.
  */
-const locateIdCarrier = (url: URL, basePath: string | undefined): IdCarrier => {
+const locateIdCarriers = (url: URL, basePath: string | undefined): IdCarrier[] => {
   // Hash routing: the id is the bare fragment.
   if (typeof basePath !== 'string') {
-    return {
-      value: decodeURIComponent(url.hash.slice(1)),
-      write: (next) => {
-        url.hash = next
-      },
-    }
+    return [bareHashCarrier(url)]
   }
 
   // Hash base path routing: the id follows a `#<base>/` prefix.
@@ -193,25 +201,31 @@ const locateIdCarrier = (url: URL, basePath: string | undefined): IdCarrier => {
     const base = sanitizeHashBasePath(basePath)
     const hash = decodeURIComponent(url.hash.slice(1))
 
-    return {
-      value: stripBasePathPrefix(hash, base) ?? '',
-      write: (next) => {
-        url.hash = [base, next].filter(Boolean).join('/')
+    return [
+      {
+        value: stripBasePathPrefix(hash, base) ?? '',
+        write: (next) => {
+          url.hash = [base, next].filter(Boolean).join('/')
+        },
       },
-    }
+    ]
   }
 
   // Path routing: the id follows the (URL-encoded) base path in the pathname.
   const base = sanitizeBasePath(basePath)
   const remainder = stripBasePathPrefix(url.pathname, encodeBasePath(base))
 
-  return {
-    value: remainder === null ? '' : decodeURIComponent(remainder),
-    write: (next) => {
-      // Assigning to `pathname` re-encodes characters, so we splice with the decoded base.
-      url.pathname = base ? `/${base}/${next}` : `/${next}`
+  return [
+    {
+      value: remainder === null ? '' : decodeURIComponent(remainder),
+      write: (next) => {
+        // Assigning to `pathname` re-encodes characters, so we splice with the decoded base.
+        url.pathname = base ? `/${base}/${next}` : `/${next}`
+      },
     },
-  }
+    // Legacy fallback: an old hash-routing bookmark may still carry the id in the fragment.
+    bareHashCarrier(url),
+  ]
 }
 
 /**
@@ -306,7 +320,7 @@ const buildRedirects = ({ modelsSectionSlug, documentSlug, isMultiDocument }: Re
 /**
  * Rewrites navigation ids in a URL to their current form.
  *
- * The URL is reduced to its routing-agnostic id (see {@link locateIdCarrier}), each redirect rule
+ * The URL is reduced to its routing-agnostic id (see {@link locateIdCarriers}), each redirect rule
  * is applied in id-space (see {@link buildRedirects}), and the result is spliced back into the
  * original location. This handles hash, hash-base-path, and path routing uniformly, so a new
  * redirect only has to be added to the list once.
@@ -325,18 +339,18 @@ export const redirectUrl = (
   }
 
   const target = new URL(typeof url === 'string' ? url : url.toString())
-  const carrier = locateIdCarrier(target, basePath)
-  const rewritten = applyIdRedirects(
-    carrier.value,
-    buildRedirects({ modelsSectionSlug, documentSlug, isMultiDocument }),
-  )
+  const redirects = buildRedirects({ modelsSectionSlug, documentSlug, isMultiDocument })
 
-  if (rewritten === carrier.value) {
-    return null
+  // Try each place the id might live, in priority order, and apply the first rewrite that sticks.
+  for (const carrier of locateIdCarriers(target, basePath)) {
+    const rewritten = applyIdRedirects(carrier.value, redirects)
+    if (rewritten !== carrier.value) {
+      carrier.write(rewritten)
+      return target
+    }
   }
 
-  carrier.write(rewritten)
-  return target
+  return null
 }
 
 /** Extracts the schema parameters from the id if they are present */

--- a/packages/api-reference/src/helpers/id-routing.ts
+++ b/packages/api-reference/src/helpers/id-routing.ts
@@ -186,9 +186,10 @@ const bareHashCarrier = (url: URL): IdCarrier => ({
  * callers edit ids in id-space without re-deriving the routing chrome for each mode.
  *
  * Multiple carriers are returned in priority order: the canonical location for the active routing
- * mode comes first, followed by any legacy fallback. Path routing falls back to the bare hash so a
- * stale `#default/model/User` bookmark (left over from before path routing was enabled) is still
- * canonicalized — the previous implementation rewrote both the path and the hash on every load.
+ * mode comes first, followed by a legacy bare-hash fallback. Both path and hash-base-path routing
+ * fall back to the bare hash so a stale `#default/model/User` bookmark (left over from before the
+ * base path was configured) is still canonicalized — the previous implementation rewrote such
+ * doc-slug-anchored hashes on every load regardless of the routing mode.
  */
 const locateIdCarriers = (url: URL, basePath: string | undefined): IdCarrier[] => {
   // Hash routing: the id is the bare fragment.
@@ -208,6 +209,8 @@ const locateIdCarriers = (url: URL, basePath: string | undefined): IdCarrier[] =
           url.hash = [base, next].filter(Boolean).join('/')
         },
       },
+      // Legacy fallback: an old bookmark may carry the id in the fragment without the base prefix.
+      bareHashCarrier(url),
     ]
   }
 

--- a/packages/api-reference/src/helpers/id-routing.ts
+++ b/packages/api-reference/src/helpers/id-routing.ts
@@ -24,6 +24,23 @@ const stripBasePathPrefix = (value: string, basePath: string) => {
   return null
 }
 
+/**
+ * Builds the URL-encoded, slash-prefixed form of a sanitized base path.
+ *
+ * Each segment is encoded separately so the result matches how the browser stores
+ * `location.pathname` (which encodes within segments but leaves the slashes between them).
+ */
+const encodeBasePath = (sanitized: string) => {
+  if (!sanitized) {
+    return ''
+  }
+
+  return `/${sanitized
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')}`
+}
+
 /** Extracts an element id from the hash when using hash routing */
 export const getIdFromHash = (location: string | URL, slugPrefix: string | undefined) => {
   const url = typeof location === 'string' ? new URL(location) : location
@@ -35,16 +52,7 @@ export const getIdFromHash = (location: string | URL, slugPrefix: string | undef
 /** Extracts an element id from the path when using path routing */
 export const getIdFromPath = (location: string | URL, basePath: string, slugPrefix: string | undefined) => {
   const url = typeof location === 'string' ? new URL(location) : location
-  const sanitized = sanitizeBasePath(basePath)
-
-  // Construct the full basePath with leading slash and encode it for matching
-  // We need to encode each segment separately to match how URLs encode pathnames
-  const basePathWithSlash = sanitized
-    ? `/${sanitized
-        .split('/')
-        .map((segment) => encodeURIComponent(segment))
-        .join('/')}`
-    : ''
+  const basePathWithSlash = encodeBasePath(sanitizeBasePath(basePath))
 
   // Extract the portion after the basePath
   if (url.pathname.startsWith(basePathWithSlash)) {
@@ -79,13 +87,7 @@ export const matchesBasePath = (location: string | URL, basePath: string) => {
     return hash === basePath || hash.startsWith(`${basePath}/`)
   }
 
-  const sanitized = sanitizeBasePath(basePath)
-  const basePathWithSlash = sanitized
-    ? `/${sanitized
-        .split('/')
-        .map((segment) => encodeURIComponent(segment))
-        .join('/')}`
-    : ''
+  const basePathWithSlash = encodeBasePath(sanitizeBasePath(basePath))
 
   return url.pathname === basePathWithSlash || url.pathname.startsWith(`${basePathWithSlash}/`)
 }
@@ -159,19 +161,143 @@ export const makeUrlFromId = (_id: string, basePath: string | undefined, isMulti
 const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 /**
- * Rewrite legacy `/model/<name>` URL segments to the current section's slug.
+ * A located navigation id: the decoded id plus a way to write a rewritten id back.
+ */
+type IdCarrier = {
+  /** The decoded navigation id with all routing chrome (`#`, base path) removed. */
+  value: string
+  /** Splices `next` back into the location this id came from, preserving the URL shape. */
+  write: (next: string) => void
+}
+
+/**
+ * Locates the navigation id inside a URL regardless of the routing mode.
  *
- * Earlier versions hardcoded `model/` (singular) as the prefix for individual schema entries
- * even though the section itself was `models/`. We now use the same plural slug for both,
- * so old bookmarks like `#default/model/User` would 404. This rewrites them in place.
+ * The id can live in three places — the bare hash, a hash base path (`#<base>/<id>`), or the
+ * pathname after a path base path. Returning the decoded id alongside a `write` callback lets
+ * callers edit ids in id-space without re-deriving the routing chrome for each mode.
+ */
+const locateIdCarrier = (url: URL, basePath: string | undefined): IdCarrier => {
+  // Hash routing: the id is the bare fragment.
+  if (typeof basePath !== 'string') {
+    return {
+      value: decodeURIComponent(url.hash.slice(1)),
+      write: (next) => {
+        url.hash = next
+      },
+    }
+  }
+
+  // Hash base path routing: the id follows a `#<base>/` prefix.
+  if (isHashBasePath(basePath)) {
+    const base = sanitizeHashBasePath(basePath)
+    const hash = decodeURIComponent(url.hash.slice(1))
+
+    return {
+      value: stripBasePathPrefix(hash, base) ?? '',
+      write: (next) => {
+        url.hash = [base, next].filter(Boolean).join('/')
+      },
+    }
+  }
+
+  // Path routing: the id follows the (URL-encoded) base path in the pathname.
+  const base = sanitizeBasePath(basePath)
+  const remainder = stripBasePathPrefix(url.pathname, encodeBasePath(base))
+
+  return {
+    value: remainder === null ? '' : decodeURIComponent(remainder),
+    write: (next) => {
+      // Assigning to `pathname` re-encodes characters, so we splice with the decoded base.
+      url.pathname = base ? `/${base}/${next}` : `/${next}`
+    },
+  }
+}
+
+/**
+ * A single redirect rule, expressed in routing-agnostic id-space.
  *
- * The regex is anchored to the legacy structural shape so unrelated `/model/` occurrences
- * inside operation paths (e.g. `POST /model/train` for an AI/ML API → `default/POST/model/train`)
- * and a tag literally named "model" are left alone.
+ * Ids are navigation strings with all routing chrome (`#`, base path) stripped — see
+ * {@link locateIdCarrier}. A rule is just the shape of an id rewrite: `match` is tested against the
+ * id and `replace` follows the native `String.prototype.replace` contract, so a rule can be a plain
+ * segment swap or an arbitrary replacer function. A rule that does not match leaves the id alone.
+ */
+type IdRedirect = {
+  /** Pattern tested against the routing-agnostic id. */
+  match: RegExp
+  /** Replacement passed straight to `String.prototype.replace` (template string or replacer fn). */
+  replace: string | ((substring: string, ...groups: string[]) => string)
+}
+
+/**
+ * Applies redirect rules to an id and returns the first rewrite that changes it.
  *
- * Trade-off: in single-document mode the URL strips the document slug, which makes
- * `#tag/<slug>/model/<name>` ambiguous with an operation under a tag named "model".
- * Single-doc tagged-model bookmarks are not rewritten — only top-level models.
+ * Rules are tried in order and the search stops at the first match, so list more specific rules
+ * before more general ones. Returns the id unchanged when no rule applies.
+ */
+const applyIdRedirects = (id: string, redirects: IdRedirect[]): string => {
+  for (const { match, replace } of redirects) {
+    // The ternary narrows the union so each `String.prototype.replace` overload type-checks.
+    const next = typeof replace === 'string' ? id.replace(match, replace) : id.replace(match, replace)
+    if (next !== id) {
+      return next
+    }
+  }
+
+  return id
+}
+
+/** Optional `(tag-group/<n>/)?tag/<slug>/` chrome that may sit in front of a section segment. */
+const TAG_CHROME = '(?:(?:tag-group/[^/]+/)?tag/[^/]+/)?'
+
+/**
+ * Runtime values the redirect rules are built from.
+ *
+ * The rules are data, but a few entries depend on per-document values (the configurable models
+ * section slug, the active document slug, single- vs multi-document mode), so the list is built per
+ * call rather than declared as a static constant.
+ */
+type RedirectContext = {
+  /** Current (possibly customized) slug of the models section, e.g. `models` or `schemas`. */
+  modelsSectionSlug: string
+  /** Slug of the active document; legacy ids are anchored to it to avoid false positives. */
+  documentSlug: string
+  /** Multi-document ids always carry the doc slug; single-document bookmarks may omit it. */
+  isMultiDocument: boolean
+}
+
+/**
+ * Builds the list of id redirects for the current document.
+ *
+ * Add an entry here to support a new redirect. Each rule runs against every URL shape (hash, hash
+ * base path, path) for free, because rules operate on routing-agnostic ids.
+ */
+const buildRedirects = ({ modelsSectionSlug, documentSlug, isMultiDocument }: RedirectContext): IdRedirect[] => {
+  const escapedDoc = escapeRegex(documentSlug)
+  // Keeping the tag chrome inside the doc-slug group is deliberate: a slug-less
+  // `tag/<slug>/model/<name>` is left alone, since once the document slug is stripped it is
+  // ambiguous with an operation under a tag literally named "model".
+  const documentPrefix = isMultiDocument ? `${escapedDoc}/${TAG_CHROME}` : `(?:${escapedDoc}/${TAG_CHROME})?`
+
+  return [
+    {
+      // Earlier versions hardcoded a singular `model/` prefix for individual schema entries even
+      // though the section itself was plural, so old bookmarks like `default/model/User` would 404.
+      // Rewrite the leading segment to the current slug. The trailing `/` leaves an already-correct
+      // `models/` segment and operation paths such as `default/POST/model/train` untouched.
+      match: new RegExp(`^(${documentPrefix})model/`),
+      replace: (_match, prefix) => `${prefix}${modelsSectionSlug}/`,
+    },
+  ]
+}
+
+/**
+ * Rewrites navigation ids in a URL to their current form.
+ *
+ * The URL is reduced to its routing-agnostic id (see {@link locateIdCarrier}), each redirect rule
+ * is applied in id-space (see {@link buildRedirects}), and the result is spliced back into the
+ * original location. This handles hash, hash-base-path, and path routing uniformly, so a new
+ * redirect only has to be added to the list once.
  *
  * Returns the canonicalized URL when a rewrite happens, or null otherwise.
  */
@@ -186,41 +312,19 @@ export const redirectLegacyModelUrl = (
     return null
   }
 
-  const next = typeof url === 'string' ? new URL(url) : new URL(url.toString())
-  const escapedDoc = escapeRegex(documentSlug)
-  // Optional `(tag-group/<n>/)?tag/<slug>/` block in front of `model/`.
-  const tagPrefix = '(?:(?:tag-group\\/[^/]+\\/)?tag\\/[^/]+\\/)?'
-  const slugAnchoredHash = new RegExp(`^(#${escapedDoc}\\/${tagPrefix})model\\/`)
-  const replacement = `$1${modelsSectionSlug}/`
+  const target = new URL(typeof url === 'string' ? url : url.toString())
+  const carrier = locateIdCarrier(target, basePath)
+  const rewritten = applyIdRedirects(
+    carrier.value,
+    buildRedirects({ modelsSectionSlug, documentSlug, isMultiDocument }),
+  )
 
-  // Always try the slug-anchored form first — old bookmarks may include the doc slug
-  // even in single-document mode.
-  let newHash = next.hash.replace(slugAnchoredHash, replacement)
-  if (newHash === next.hash && !isMultiDocument) {
-    // Single-doc fallback: URL omits the doc slug (`#model/<name>`). We can only
-    // safely rewrite top-level models here — `#tag/<slug>/model/<name>` is
-    // ambiguous with an operation under a tag literally named "model".
-    newHash = next.hash.replace(/^(#)model\//, replacement)
-  }
-
-  let newPathname = next.pathname
-  if (basePath !== undefined && !basePath.startsWith('#')) {
-    const escapedBase = escapeRegex(sanitizeBasePath(basePath))
-    const basePrefix = escapedBase ? `\\/${escapedBase}` : ''
-    const slugAnchoredPath = new RegExp(`^(${basePrefix}\\/${escapedDoc}\\/${tagPrefix})model\\/`)
-    newPathname = next.pathname.replace(slugAnchoredPath, replacement)
-    if (newPathname === next.pathname && !isMultiDocument) {
-      newPathname = next.pathname.replace(new RegExp(`^(${basePrefix}\\/)model\\/`), replacement)
-    }
-  }
-
-  if (newHash === next.hash && newPathname === next.pathname) {
+  if (rewritten === carrier.value) {
     return null
   }
 
-  next.hash = newHash
-  next.pathname = newPathname
-  return next
+  carrier.write(rewritten)
+  return target
 }
 
 /** Extracts the schema parameters from the id if they are present */

--- a/packages/api-reference/src/helpers/id-routing.ts
+++ b/packages/api-reference/src/helpers/id-routing.ts
@@ -275,20 +275,32 @@ type RedirectContext = {
 const buildRedirects = ({ modelsSectionSlug, documentSlug, isMultiDocument }: RedirectContext): IdRedirect[] => {
   const escapedDoc = escapeRegex(documentSlug)
   // Keeping the tag chrome inside the doc-slug group is deliberate: a slug-less
-  // `tag/<slug>/model/<name>` is left alone, since once the document slug is stripped it is
-  // ambiguous with an operation under a tag literally named "model".
+  // `tag/<slug>/<segment>/<name>` is left alone, since once the document slug is stripped it is
+  // ambiguous with an operation under a tag literally named after the segment.
   const documentPrefix = isMultiDocument ? `${escapedDoc}/${TAG_CHROME}` : `(?:${escapedDoc}/${TAG_CHROME})?`
 
-  return [
-    {
-      // Earlier versions hardcoded a singular `model/` prefix for individual schema entries even
-      // though the section itself was plural, so old bookmarks like `default/model/User` would 404.
-      // Rewrite the leading segment to the current slug. The trailing `/` leaves an already-correct
-      // `models/` segment and operation paths such as `default/POST/model/train` untouched.
-      match: new RegExp(`^(${documentPrefix})model/`),
-      replace: (_match, prefix) => `${prefix}${modelsSectionSlug}/`,
-    },
+  // Rewrites a leading `<from>/` section segment to the current models section slug. The trailing
+  // `/` leaves an already-correct segment and operation paths such as `default/POST/model/train`
+  // untouched.
+  const renameSectionSegment = (from: string): IdRedirect => ({
+    match: new RegExp(`^(${documentPrefix})${escapeRegex(from)}/`),
+    replace: (_match, prefix) => `${prefix}${modelsSectionSlug}/`,
+  })
+
+  const redirects = [
+    // Earlier versions hardcoded a singular `model/` prefix for individual schema entries even
+    // though the section itself was plural, so old bookmarks like `default/model/User` would 404.
+    renameSectionSegment('model'),
   ]
+
+  // The models section used to live at the literal `models/`. Once a custom label moves it
+  // elsewhere (e.g. `schemas/`), older `models/<name>` bookmarks must follow it. When the slug is
+  // still the default `models` this would be a no-op, so only register it when it actually differs.
+  if (modelsSectionSlug !== 'models') {
+    redirects.push(renameSectionSegment('models'))
+  }
+
+  return redirects
 }
 
 /**

--- a/packages/api-reference/src/helpers/id-routing.ts
+++ b/packages/api-reference/src/helpers/id-routing.ts
@@ -313,7 +313,7 @@ const buildRedirects = ({ modelsSectionSlug, documentSlug, isMultiDocument }: Re
  *
  * Returns the canonicalized URL when a rewrite happens, or null otherwise.
  */
-export const redirectLegacyModelUrl = (
+export const redirectUrl = (
   url: string | URL,
   modelsSectionSlug: string,
   documentSlug: string,

--- a/packages/api-reference/src/helpers/id-routing.ts
+++ b/packages/api-reference/src/helpers/id-routing.ts
@@ -185,11 +185,12 @@ const bareHashCarrier = (url: URL): IdCarrier => ({
  * pathname after a path base path. Each carrier pairs the decoded id with a `write` callback, so
  * callers edit ids in id-space without re-deriving the routing chrome for each mode.
  *
- * Multiple carriers are returned in priority order: the canonical location for the active routing
- * mode comes first, followed by a legacy bare-hash fallback. Both path and hash-base-path routing
- * fall back to the bare hash so a stale `#default/model/User` bookmark (left over from before the
- * base path was configured) is still canonicalized — the previous implementation rewrote such
- * doc-slug-anchored hashes on every load regardless of the routing mode.
+ * Multiple carriers are returned: the canonical location for the active routing mode comes first,
+ * followed by a legacy bare-hash carrier. Both path and hash-base-path routing include the bare hash
+ * so a stale `#default/model/User` bookmark (left over from before the base path was configured) is
+ * still canonicalized — the previous implementation rewrote such doc-slug-anchored hashes on every
+ * load regardless of the routing mode. Callers rewrite every carrier that matches, not just the
+ * first, so a legacy id sitting in both the pathname and the hash is cleaned up in one pass.
  */
 const locateIdCarriers = (url: URL, basePath: string | undefined): IdCarrier[] => {
   // Hash routing: the id is the bare fragment.
@@ -344,16 +345,23 @@ export const redirectUrl = (
   const target = new URL(typeof url === 'string' ? url : url.toString())
   const redirects = buildRedirects({ modelsSectionSlug, documentSlug, isMultiDocument })
 
-  // Try each place the id might live, in priority order, and apply the first rewrite that sticks.
+  // Canonicalize every place the id might live. The carriers are distinct physical locations (the
+  // pathname and the bare hash), so a single page load can carry a legacy id in more than one — for
+  // example a path-routing URL whose stale hash still holds an old bookmark. Rewriting all of them
+  // avoids the address bar showing a corrected path next to an outdated hash. A redirect rule is
+  // anchored to the document slug, so it never matches the base-prefixed value of a fallback carrier,
+  // which keeps carriers that happen to share a location (hash base path + bare hash) from clobbering
+  // each other.
+  let didRedirect = false
   for (const carrier of locateIdCarriers(target, basePath)) {
     const rewritten = applyIdRedirects(carrier.value, redirects)
     if (rewritten !== carrier.value) {
       carrier.write(rewritten)
-      return target
+      didRedirect = true
     }
   }
 
-  return null
+  return didRedirect ? target : null
 }
 
 /** Extracts the schema parameters from the id if they are present */


### PR DESCRIPTION
Untangles the URL redirect logic in `id-routing.ts` and makes it list-driven, then adds a second redirect on top of it.

## How it works

A navigation id like `default/model/User` can sit in three different URL shapes depending on routing mode (bare `#hash`, `#base/hash`, or `/base/` path). The old code baked that routing chrome into every regex, so it needed a separate pattern per mode. The refactor splits *where the id lives* from *what it should become*:

- **`locateIdCarrier(url, basePath)`** — reduces any URL to its bare id plus a `write` callback that puts a new id back in the same shape. After this, nothing downstream cares about routing.
- **`IdRedirect` + `applyIdRedirects`** — a redirect is just `{ match, replace }` (the args to `String.replace`). Rules run in order against the bare id; first match wins. Because they only see the id, every rule works in all three routing modes for free.
- **`buildRedirects(context)`** — the list itself. The target slug is dynamic (`models`/`schemas`/custom), so the list is built per call from config values. Adding a redirect is a one-line list entry.

## Redirects in the list

1. `model/<name>` → current slug — old singular prefix that always 404'd against the plural section.
2. `models/<name>` → current slug — the section used to live at the literal `models/`; once a custom label moves it (e.g. `schemas/`), old bookmarks should follow. Registered **only when the slug differs from the default `models`**, so default setups are untouched.

The entry point `redirectUrl` (renamed from `redirectLegacyModelUrl`) keeps the same signature. 170 `id-routing` tests pass (8 new for the second redirect).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation URL canonicalization on load only; behavior is heavily tested and scoped to legacy model/models bookmarks without changing auth or data paths.
> 
> **Overview**
> Replaces **`redirectLegacyModelUrl`** with **`redirectUrl`**, backed by a routing-agnostic redirect engine in `id-routing.ts`. Navigation ids are extracted via **`locateIdCarriers`** (hash, hash-base-path, pathname, plus legacy bare-hash fallbacks), rewritten with ordered **`{ match, replace }`** rules in id-space, then written back through each carrier so pathname and stale hash can both be fixed in one load.
> 
> **`buildRedirects`** centralizes rules: legacy singular **`model/`** → current models section slug, and when the section label is customized, **`models/`** → that slug (skipped when the slug is still `models`). **`ApiReference.vue`** calls **`redirectUrl`** on init with the same arguments as before.
> 
> Shared path encoding moves into **`encodeBasePath`** (used by **`getIdFromPath`** and **`matchesBasePath`**). Tests rename the suite and add coverage for hash-base-path, path+hash dual rewrites, and customized section slugs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70625f0b2046effb405cd83e103c3a87fb43cbe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->