### PR TITLE
fix(components): vertically center copy button for single-line code blocks

### DIFF
--- a/.changeset/codeblock-copy-center-single-line.md
+++ b/.changeset/codeblock-copy-center-single-line.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+fix(components): vertically center the copy button for single-line code blocks

--- a/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
+++ b/packages/components/src/components/ScalarCodeBlock/ScalarCodeBlock.vue
@@ -114,7 +114,7 @@ const { cx } = useBindCx()
       class="scalar-code-copy absolute"
       :class="[
         isOneLine
-          ? 'top-[calc(10px+0.5lh)] -translate-y-1/2 m-0 right-1'
+          ? 'top-1/2 -translate-y-1/2 m-0 right-1'
           : 'top-2.5 right-2.5',
         { 'opacity-100': copy === 'always' },
       ]"


### PR DESCRIPTION
For single-line code blocks the copy button was anchored to the first line with `calc(10px + 0.5lh)`. That `lh` is the button's own line-height, so in contexts with a taller code line-height (like api-reference) the icon ended up sitting above the text.

Now it centers against the box (`top-1/2 -translate-y-1/2`), so it stays aligned regardless of line-height.

**Before**

<img width="537" height="149" alt="Screenshot 2026-06-02 at 16 59 08" src="https://github.com/user-attachments/assets/52c50713-cbe8-4f9b-95dd-f05c0d8c416c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change for copy-button positioning on single-line code blocks only; no logic or API changes.
> 
> **Overview**
> Fixes misaligned copy controls on **single-line** `ScalarCodeBlock` instances by changing how the absolutely positioned copy button is vertically placed.
> 
> For `isOneLine` blocks, positioning moves from `top-[calc(10px+0.5lh)]` (which used the button’s own `lh` and could sit above taller code text in api-reference) to **`top-1/2 -translate-y-1/2`**, centering the icon within the code block container regardless of line-height. Multi-line layout (`top-2.5 right-2.5`) is unchanged. Patch changeset for `@scalar/components`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae5f5886449700809dc01a66ebf65c6f369440a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->