### PR TITLE
feat(api-reference): add `expandAllSchemaProperties` config option

### DIFF
--- a/.changeset/expand-all-schema-properties.md
+++ b/.changeset/expand-all-schema-properties.md
@@ -1,0 +1,10 @@
+---
+'@scalar/api-reference': minor
+'@scalar/schemas': minor
+'@scalar/types': minor
+---
+
+feat(api-reference): add `expandAllSchemaProperties` config option.
+
+When enabled, this removes the "Show/Hide Child Attributes" button, making
+all properties visible by default.

--- a/.changeset/expand-all-schema-properties.md
+++ b/.changeset/expand-all-schema-properties.md
@@ -6,5 +6,7 @@
 
 feat(api-reference): add `expandAllSchemaProperties` config option.
 
-When enabled, this removes the "Show/Hide Child Attributes" button, making
-all properties visible by default.
+When enabled, this removes the "Show/Hide Child Attributes" button, making all
+nested schema properties visible by default. Expansion is cycle-safe: every
+finite branch is expanded fully, and self-referential ($ref or inline) schemas
+stop at the point they would otherwise recurse forever.

--- a/.changeset/expand-all-schema-properties.md
+++ b/.changeset/expand-all-schema-properties.md
@@ -6,7 +6,7 @@
 
 feat(api-reference): add `expandAllSchemaProperties` config option.
 
-When enabled, this removes the "Show/Hide Child Attributes" button, making all
-nested schema properties visible by default. Expansion is cycle-safe: every
-finite branch is expanded fully, and self-referential ($ref or inline) schemas
-stop at the point they would otherwise recurse forever.
+When enabled, nested schema properties are expanded by default while keeping the
+"Show/Hide Child Attributes" button available for manual collapsing. Expansion
+is cycle-safe: every finite branch is expanded fully, and self-referential
+($ref or inline) schemas stop at the point they would otherwise recurse forever.

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -541,6 +541,25 @@ By default response sections are closed in the operations. This flag will open t
 }
 ```
 
+
+#### expandAllSchemaProperties
+
+**Type:** `boolean`
+
+When true, the Show/Hide Child Attributes toggle is not rendered for nested
+schemas and child properties are always visible. There is no UI to collapse
+them.
+
+Warning: this can cause performance issues on big documents.
+
+**Default:** `false`
+
+```javascript
+{
+  expandAllSchemaProperties: true
+}
+```
+
 #### favicon
 
 **Type:** `string`

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -546,8 +546,9 @@ By default response sections are closed in the operations. This flag will open t
 
 **Type:** `boolean`
 
-When true, the "Show/Hide Child Attributes" toggle is not rendered for nested
-schemas. Child properties are always visible and there is no UI to collapse them.
+When true, nested child properties are expanded by default. The
+"Show/Hide Child Attributes" toggle stays available so users can collapse
+sections manually.
 
 Warning: this can cause performance issues on big documents.
 

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -546,9 +546,8 @@ By default response sections are closed in the operations. This flag will open t
 
 **Type:** `boolean`
 
-When true, the Show/Hide Child Attributes toggle is not rendered for nested
-schemas and child properties are always visible. There is no UI to collapse
-them.
+When true, the "Show/Hide Child Attributes" toggle is not rendered for nested
+schemas. Child properties are always visible and there is no UI to collapse them.
 
 Warning: this can cause performance issues on big documents.
 

--- a/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.test.ts
@@ -49,6 +49,7 @@ describe('AsyncApiTraversedEntry', () => {
         options: {
           layout: 'modern',
           hideModels: false,
+          expandAllSchemaProperties: false,
           orderSchemaPropertiesBy: 'preserve',
           orderRequiredPropertiesFirst: true,
         },

--- a/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.vue
@@ -37,6 +37,7 @@ const {
   options: Pick<
     ApiReferenceConfigurationRaw,
     | 'layout'
+    | 'expandAllSchemaProperties'
     | 'orderRequiredPropertiesFirst'
     | 'orderSchemaPropertiesBy'
     | 'hideModels'

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -62,6 +62,7 @@ const {
     | 'oauth2RedirectUri'
     | 'orderRequiredPropertiesFirst'
     | 'orderSchemaPropertiesBy'
+    | 'expandAllSchemaProperties'
     | 'persistAuth'
     | 'proxyUrl'
     | 'servers'

--- a/packages/api-reference/src/components/Content/Models/Model.test.ts
+++ b/packages/api-reference/src/components/Content/Models/Model.test.ts
@@ -53,6 +53,7 @@ describe('Model', () => {
     hideModels: false,
     orderRequiredPropertiesFirst: false,
     orderSchemaPropertiesBy: 'alpha' as const,
+    expandAllSchemaProperties: false,
   }
 
   const mockConfigModern = {
@@ -60,6 +61,7 @@ describe('Model', () => {
     hideModels: false,
     orderRequiredPropertiesFirst: false,
     orderSchemaPropertiesBy: 'alpha' as const,
+    expandAllSchemaProperties: false,
   }
 
   describe('layout rendering', () => {

--- a/packages/api-reference/src/components/Content/Models/Model.vue
+++ b/packages/api-reference/src/components/Content/Models/Model.vue
@@ -20,6 +20,7 @@ const { schema, isCollapsed, id, options, eventBus, document } = defineProps<{
     | 'layout'
     | 'orderRequiredPropertiesFirst'
     | 'orderSchemaPropertiesBy'
+    | 'expandAllSchemaProperties'
     | 'hideModels'
   >
   schema: SchemaObject | undefined

--- a/packages/api-reference/src/components/Content/Models/components/ClassicLayout.vue
+++ b/packages/api-reference/src/components/Content/Models/components/ClassicLayout.vue
@@ -22,7 +22,10 @@ const { eventBus, id, options, document } = defineProps<{
   document?: OpenApiDocument
   options: Pick<
     ApiReferenceConfigurationRaw,
-    'orderRequiredPropertiesFirst' | 'orderSchemaPropertiesBy' | 'hideModels'
+    | 'orderRequiredPropertiesFirst'
+    | 'orderSchemaPropertiesBy'
+    | 'expandAllSchemaProperties'
+    | 'hideModels'
   >
 }>()
 </script>

--- a/packages/api-reference/src/components/Content/Models/components/ModernLayout.vue
+++ b/packages/api-reference/src/components/Content/Models/components/ModernLayout.vue
@@ -22,6 +22,7 @@ const { schema, options, document } = defineProps<{
     orderRequiredPropertiesFirst: boolean | undefined
     orderSchemaPropertiesBy: 'alpha' | 'preserve' | undefined
     hideModels: boolean | undefined
+    expandAllSchemaProperties: boolean | undefined
   }
 }>()
 </script>

--- a/packages/api-reference/src/components/Content/Operations/TraversedEntry.vue
+++ b/packages/api-reference/src/components/Content/Operations/TraversedEntry.vue
@@ -51,6 +51,7 @@ const {
     | 'layout'
     | 'orderRequiredPropertiesFirst'
     | 'orderSchemaPropertiesBy'
+    | 'expandAllSchemaProperties'
     | 'showOperationId'
     | 'hideModels'
     | 'modelsSectionLabel'

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -734,7 +734,7 @@ describe('Schema', () => {
     })
   })
   describe('expandAllSchemaProperties', () => {
-    it('does not render the toggle and shows nested properties when expandAllSchemaProperties is true', () => {
+    it('renders the toggle and shows nested properties by default when expandAllSchemaProperties is true', () => {
       const wrapper = mount(Schema, {
         props: {
           schema: {
@@ -754,7 +754,7 @@ describe('Schema', () => {
         },
       })
 
-      expect(wrapper.find('button').exists()).toBe(false)
+      expect(wrapper.find('button').exists()).toBe(true)
       expect(wrapper.text()).toContain('bar')
     })
 
@@ -886,9 +886,9 @@ describe('Schema', () => {
         },
       })
 
-      // The deepest property is visible and no collapse toggle is rendered.
+      // The deepest property is visible and the collapse toggle remains available.
       expect(wrapper.text()).toContain('leaf')
-      expect(wrapper.find('button').exists()).toBe(false)
+      expect(wrapper.find('button').exists()).toBe(true)
     })
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -1,5 +1,5 @@
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
-import { SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { type SchemaObject, SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 
@@ -731,6 +731,77 @@ describe('Schema', () => {
 
       // Check that the oneOf schema is inheiriting the description correctly
       expect(text).toContain('The date the object was closed in YYYY-MM-DD or ISO 8601 format.')
+    })
+  })
+  describe('expandAllSchemaProperties', () => {
+    it('does not render the toggle and shows nested properties when expandAllSchemaProperties is true', () => {
+      const wrapper = mount(Schema, {
+        props: {
+          schema: {
+            type: 'object',
+            properties: {
+              foo: {
+                type: 'object',
+                properties: {
+                  bar: { type: 'string' },
+                },
+              },
+            },
+          },
+          level: 1,
+          eventBus: null,
+          options: { expandAllSchemaProperties: true },
+        },
+      })
+
+      expect(wrapper.find('button').exists()).toBe(false)
+      expect(wrapper.text()).toContain('bar')
+    })
+
+    it('renders the toggle when expandAllSchemaProperties is false', () => {
+      const wrapper = mount(Schema, {
+        props: {
+          schema: {
+            type: 'object',
+            properties: {
+              foo: {
+                type: 'object',
+                properties: {
+                  bar: { type: 'string' },
+                },
+              },
+            },
+          },
+          level: 1,
+          eventBus: null,
+          options: {},
+        },
+      })
+
+      expect(wrapper.find('button').exists()).toBe(true)
+    })
+
+    it('does not infinitely expand circular schema references when expandAllSchemaProperties is true', () => {
+      const circularSchema = {
+        type: 'object',
+        properties: {},
+      } as Extract<SchemaObject, { type: 'object' }>
+
+      circularSchema.properties = {
+        self: circularSchema,
+      }
+
+      const wrapper = mount(Schema, {
+        props: {
+          schema: circularSchema,
+          level: 1,
+          eventBus: null,
+          options: { expandAllSchemaProperties: true },
+        },
+      })
+
+      expect(wrapper.text()).toContain('self')
+      expect(wrapper.find('button').exists()).toBe(true)
     })
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -803,5 +803,92 @@ describe('Schema', () => {
       expect(wrapper.text()).toContain('self')
       expect(wrapper.find('button').exists()).toBe(true)
     })
+
+    it('does not infinitely expand $ref-based circular schemas when expandAllSchemaProperties is true', () => {
+      // Mirror how the workspace store bundles a self-referential $ref: the
+      // property is a wrapper carrying both the ref string and the resolved node.
+      const node: any = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+      }
+      node.properties.child = {
+        $ref: '#/components/schemas/Node',
+        '$ref-value': node,
+      }
+
+      const wrapper = mount(Schema, {
+        props: {
+          schema: node,
+          level: 1,
+          eventBus: null,
+          options: { expandAllSchemaProperties: true },
+        },
+      })
+
+      // The first level of the cycle is expanded...
+      expect(wrapper.text()).toContain('child')
+      // ...but the recursion stops with a toggle instead of expanding forever.
+      expect(wrapper.find('button').exists()).toBe(true)
+    })
+
+    it('expands deeply nested finite schemas fully when enabled', () => {
+      // Eight levels deep to verify finite branches are not artificially truncated.
+      const schema = {
+        type: 'object',
+        properties: {
+          l1: {
+            type: 'object',
+            properties: {
+              l2: {
+                type: 'object',
+                properties: {
+                  l3: {
+                    type: 'object',
+                    properties: {
+                      l4: {
+                        type: 'object',
+                        properties: {
+                          l5: {
+                            type: 'object',
+                            properties: {
+                              l6: {
+                                type: 'object',
+                                properties: {
+                                  l7: {
+                                    type: 'object',
+                                    properties: {
+                                      leaf: { type: 'string' },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as Extract<SchemaObject, { type: 'object' }>
+
+      const wrapper = mount(Schema, {
+        props: {
+          schema,
+          level: 0,
+          eventBus: null,
+          options: { expandAllSchemaProperties: true },
+        },
+      })
+
+      // The deepest property is visible and no collapse toggle is rendered.
+      expect(wrapper.text()).toContain('leaf')
+      expect(wrapper.find('button').exists()).toBe(false)
+    })
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -80,8 +80,8 @@ const {
  * treated as cyclic when its key is already present in the ancestor set, which
  * indicates that rendering has looped back onto a self-referential schema.
  *
- * This lets us force-expand finite branches while stopping automatic expansion
- * only at cycle boundaries, preventing infinite recursion.
+ * This lets us default-expand finite branches while stopping automatic
+ * expansion only at cycle boundaries, preventing infinite recursion.
  */
 const ancestors = inject(SCHEMA_ANCESTORS_SYMBOL, undefined)
 
@@ -105,18 +105,13 @@ const shouldForceExpand = computed(
  * Determines whether to show the collapse/expand toggle button.
  * We hide the toggle for non-collapsible schemas and root-level schemas.
  */
-const shouldShowToggle = computed((): boolean => {
-  if (shouldForceExpand.value) {
-    return false
-  }
-
-  return !noncollapsible && level > 0
-})
+const shouldShowToggle = computed((): boolean => !noncollapsible && level > 0)
 
 /**
  * Whether the disclosure starts expanded. Non-collapsible schemas are always
- * open, and when child properties are always shown there is no toggle to expand
- * them, so they must start open too.
+ * open. When `expandAllSchemaProperties` is enabled, finite branches start
+ * expanded by default while cyclic branches remain collapsed to avoid recursion
+ * loops.
  */
 const defaultOpen = computed(
   (): boolean => noncollapsible || shouldForceExpand.value,
@@ -156,9 +151,9 @@ const schemaDescription = computed(() => {
   return schema.description
 })
 
-// Prevent click action if noncollapsible or child properties are always shown
+// Prevent click action if noncollapsible
 const handleClick = (e: MouseEvent) => {
-  if (noncollapsible || shouldForceExpand.value) {
+  if (noncollapsible) {
     e.stopPropagation()
   }
 }

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -64,14 +64,43 @@ const {
   /** Internal path used to sync nested request body compositions with the code sample */
   compositionPath?: string[]
 }>()
+/**
+ * Safety cap for `expandAllSchemaProperties`.
+ *
+ * We still auto-expand common schema nesting levels, but stop forcing nested
+ * disclosures open once we get deep in the tree. Deep levels are where
+ * recursive/circular schemas can explode render depth and hide sections.
+ *
+ * `6` is a pragmatic threshold: high enough to cover normal API payload
+ * structures while preventing runaway expansion on self-referential models.
+ */
+const MAX_AUTO_EXPAND_DEPTH = 6
+
+const shouldForceExpand = computed(
+  (): boolean =>
+    !!options.expandAllSchemaProperties && level < MAX_AUTO_EXPAND_DEPTH,
+)
 
 /**
  * Determines whether to show the collapse/expand toggle button.
  * We hide the toggle for non-collapsible schemas and root-level schemas.
  */
 const shouldShowToggle = computed((): boolean => {
+  if (shouldForceExpand.value) {
+    return false
+  }
+
   return !noncollapsible && level > 0
 })
+
+/**
+ * Whether the disclosure starts expanded. Non-collapsible schemas are always
+ * open, and when child properties are always shown there is no toggle to expand
+ * them, so they must start open too.
+ */
+const defaultOpen = computed(
+  (): boolean => noncollapsible || shouldForceExpand.value,
+)
 
 /** Gets the description to show for the schema */
 const schemaDescription = computed(() => {
@@ -107,14 +136,18 @@ const schemaDescription = computed(() => {
   return schema.description
 })
 
-// Prevent click action if noncollapsible
-const handleClick = (e: MouseEvent) => noncollapsible && e.stopPropagation()
+// Prevent click action if noncollapsible or child properties are always shown
+const handleClick = (e: MouseEvent) => {
+  if (noncollapsible || shouldForceExpand.value) {
+    e.stopPropagation()
+  }
+}
 </script>
 <template>
   <Disclosure
     v-if="typeof schema === 'object' && Object.keys(schema).length"
     v-slot="{ open }"
-    :defaultOpen="noncollapsible">
+    :defaultOpen="defaultOpen">
     <div
       class="schema-card"
       :class="[

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -7,13 +7,14 @@ import type {
   DiscriminatorObject,
   SchemaObject,
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-import { computed } from 'vue'
+import { computed, inject, provide } from 'vue'
 
 import type { SchemaOptions } from '@/components/Content/Schema/types'
 import ScreenReader from '@/components/ScreenReader.vue'
 
 import { isEmptySchemaObject } from './helpers/is-empty-schema-object'
 import { isTypeObject } from './helpers/is-type-object'
+import { SCHEMA_ANCESTORS_SYMBOL } from './helpers/schema-cycle'
 import SchemaHeading from './SchemaHeading.vue'
 import SchemaObjectProperties from './SchemaObjectProperties.vue'
 import SchemaProperty from './SchemaProperty.vue'
@@ -33,6 +34,7 @@ const {
   options,
   schemaContext,
   compositionPath,
+  cycleKey,
 } = defineProps<{
   schema?: SchemaObject
   /** Track how deep we've gone */
@@ -63,22 +65,40 @@ const {
   schemaContext?: string
   /** Internal path used to sync nested request body compositions with the code sample */
   compositionPath?: string[]
+  /**
+   * Stable identity of this schema node, derived from its raw (unresolved)
+   * value by the parent. Used to detect self-referential cycles. See
+   * {@link getCycleKey}.
+   */
+  cycleKey?: unknown
 }>()
+
 /**
- * Safety cap for `expandAllSchemaProperties`.
+ * Cycle-safe `expandAllSchemaProperties`.
  *
- * We still auto-expand common schema nesting levels, but stop forcing nested
- * disclosures open once we get deep in the tree. Deep levels are where
- * recursive/circular schemas can explode render depth and hide sections.
+ * We track ancestor schema keys along the current render path. A node is
+ * treated as cyclic when its key is already present in the ancestor set, which
+ * indicates that rendering has looped back onto a self-referential schema.
  *
- * `6` is a pragmatic threshold: high enough to cover normal API payload
- * structures while preventing runaway expansion on self-referential models.
+ * This lets us force-expand finite branches while stopping automatic expansion
+ * only at cycle boundaries, preventing infinite recursion.
  */
-const MAX_AUTO_EXPAND_DEPTH = 6
+const ancestors = inject(SCHEMA_ANCESTORS_SYMBOL, undefined)
+
+const isCyclic = computed(
+  (): boolean => cycleKey != null && !!ancestors?.has(cycleKey),
+)
+
+// Re-provide the ancestor set augmented with this node so descendants can
+// detect cycles back to it. Built once at setup; a node's key is stable.
+const childAncestors = new Set<unknown>(ancestors ?? [])
+if (cycleKey != null) {
+  childAncestors.add(cycleKey)
+}
+provide(SCHEMA_ANCESTORS_SYMBOL, childAncestors)
 
 const shouldForceExpand = computed(
-  (): boolean =>
-    !!options.expandAllSchemaProperties && level < MAX_AUTO_EXPAND_DEPTH,
+  (): boolean => !!options.expandAllSchemaProperties && !isCyclic.value,
 )
 
 /**

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -22,6 +22,7 @@ import {
 import { getSchemaType } from './helpers/get-schema-type'
 import { mergeAllOfSchemas } from './helpers/merge-all-of-schemas'
 import { type CompositionKeyword } from './helpers/schema-composition'
+import { getCycleKey } from './helpers/schema-cycle'
 import { getModelNameFromSchema } from './helpers/schema-name'
 import Schema from './Schema.vue'
 
@@ -149,8 +150,23 @@ const selectedComposition = computed(
   () => composition.value[Number(selectedOption.value?.id ?? '0')]?.value,
 )
 
-/** Controls whether the nested schema is displayed */
-const showNestedSchema = ref(false)
+/**
+ * Cycle key for the selected composition member, derived from its raw
+ * (unresolved) value so a member that references an ancestor is detected as a
+ * cycle.
+ */
+const selectedCompositionCycleKey = computed(() =>
+  getCycleKey(
+    composition.value[Number(selectedOption.value?.id ?? '0')]?.original,
+  ),
+)
+
+/**
+ * Controls whether the nested schema is displayed. When expanding all schema
+ * properties we open it by default; the nested Schema handles cycle detection,
+ * so finite compositions render fully while recursive ones still stop.
+ */
+const showNestedSchema = ref(!!props.options.expandAllSchemaProperties)
 
 if (
   requestBodyCompositionSelectionRef &&
@@ -232,9 +248,11 @@ if (
         <!-- Render the selected schema if it has content to display -->
         <Schema
           v-else
+          :key="selectedOption?.id ?? '0'"
           :breadcrumb="breadcrumb"
           :compact="compact"
           :compositionPath="compositionPath"
+          :cycleKey="selectedCompositionCycleKey"
           :discriminator="discriminator"
           :eventBus="eventBus"
           :hideHeading="hideHeading"

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
@@ -9,6 +9,7 @@ import type {
 import { computed } from 'vue'
 
 import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
+import { getCycleKey } from '@/components/Content/Schema/helpers/schema-cycle'
 import { sortPropertyNames } from '@/components/Content/Schema/helpers/sort-property-names'
 import type { SchemaOptions } from '@/components/Content/Schema/types'
 
@@ -182,6 +183,7 @@ const getAdditionalPropertiesValue = (
       :compact
       :compositionPath="compositionPath"
       :compositionPathSegment="property"
+      :cycleKey="getCycleKey(schema.properties[property])"
       :description="getPropertyDescription(schema.properties[property])"
       :discriminator
       :eventBus="eventBus"
@@ -204,6 +206,7 @@ const getAdditionalPropertiesValue = (
       :compact
       :compositionPath="compositionPath"
       :compositionPathSegment="key"
+      :cycleKey="getCycleKey(property)"
       :description="getPropertyDescription(property)"
       :discriminator
       :eventBus="eventBus"
@@ -228,6 +231,7 @@ const getAdditionalPropertiesValue = (
           schema.propertyNames,
         )
       "
+      :cycleKey="getCycleKey(schema.additionalProperties)"
       :discriminator
       :eventBus="eventBus"
       :hideHeading

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -12,6 +12,7 @@ import { computed, type Component } from 'vue'
 
 import { WithBreadcrumb } from '@/components/Anchor'
 import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
+import { getCycleKey } from '@/components/Content/Schema/helpers/schema-cycle'
 import type { SchemaOptions } from '@/components/Content/Schema/types'
 import { SpecificationExtension } from '@/features/specification-extension'
 
@@ -61,6 +62,8 @@ const props = withDefaults(
     compositionPath?: string[]
     /** Internal path segment for this property when building nested composition keys */
     compositionPathSegment?: string
+    /** Stable identity of this property's schema, used for cycle detection. */
+    cycleKey?: unknown
   }>(),
   {
     level: 0,
@@ -168,6 +171,18 @@ const resolvedArrayItems = computed(() => {
   return resolve.schema(value.items)
 })
 
+/**
+ * Cycle key for the array items schema, derived from the raw (unresolved) items
+ * so a self-referential array element is detected as a cycle.
+ */
+const arrayItemsCycleKey = computed(() => {
+  const value = optimizedValue.value
+  if (!value || !isArraySchema(value)) {
+    return undefined
+  }
+  return getCycleKey(value.items)
+})
+
 /** Check if discriminator matches current property */
 const isDiscriminatorProperty = computed(() =>
   Boolean(props.name && props.discriminator?.propertyName === props.name),
@@ -255,6 +270,7 @@ const isDiscriminatorProperty = computed(() =>
         :breadcrumb="childBreadcrumb"
         :compact="compact"
         :compositionPath="currentCompositionPath"
+        :cycleKey="cycleKey"
         :eventBus="eventBus"
         :hideModelNames
         :level="level + 1"
@@ -272,6 +288,7 @@ const isDiscriminatorProperty = computed(() =>
       <Schema
         :compact="compact"
         :compositionPath="arrayItemsCompositionPath"
+        :cycleKey="arrayItemsCycleKey"
         :eventBus="eventBus"
         :hideModelNames
         :level="level + 1"

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-cycle.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-cycle.ts
@@ -1,0 +1,41 @@
+import type { InjectionKey } from 'vue'
+
+/**
+ * The set of schema "cycle keys" for every ancestor on the current render path.
+ *
+ * Each `Schema` component injects this set, adds its own key, and re-provides
+ * it to its descendants. When a node's key is already present in the ancestor
+ * set we've hit a cycle (a self-referential schema) and must stop force
+ * expanding to avoid rendering forever.
+ *
+ * See {@link getCycleKey} for how a node's key is derived.
+ */
+export const SCHEMA_ANCESTORS_SYMBOL: InjectionKey<ReadonlySet<unknown>> = Symbol('schema-ancestors')
+
+/**
+ * Derive a stable identity for a schema node from its *raw* (unresolved) value.
+ *
+ * Cycle detection needs a key that is identical every time the same schema is
+ * reached along a path, and that survives the shallow copies/merges performed
+ * while rendering (which break object identity of the resolved schema).
+ *
+ * - For `$ref` nodes we use the ref string. Two branches that reference the
+ *   same component share the string, so a schema that (transitively) references
+ *   itself is detected as a cycle, while sibling references are not.
+ * - For inline schemas there is no ref, so we fall back to the raw object
+ *   reference. A self-referential inline schema reuses the same object, so
+ *   object identity catches the cycle.
+ *
+ * Returns `undefined` for primitives/booleans (e.g. `additionalProperties: true`)
+ * which can never form a cycle.
+ */
+export const getCycleKey = (raw: unknown): unknown => {
+  if (raw && typeof raw === 'object') {
+    if ('$ref' in raw && typeof (raw as { $ref?: unknown }).$ref === 'string') {
+      return (raw as { $ref: string }).$ref
+    }
+    return raw
+  }
+
+  return undefined
+}

--- a/packages/api-reference/src/components/Content/Schema/types.ts
+++ b/packages/api-reference/src/components/Content/Schema/types.ts
@@ -15,7 +15,7 @@ export type SchemaOptions = {
   orderSchemaPropertiesBy?: ApiReferenceConfiguration['orderSchemaPropertiesBy']
   /** Order required properties first */
   orderRequiredPropertiesFirst?: ApiReferenceConfiguration['orderRequiredPropertiesFirst']
-  /** Expand all nested schema properties (no Show/Hide toggle is rendered) */
+  /** Expand all nested schema properties by default while keeping the toggle available */
   expandAllSchemaProperties?: ApiReferenceConfiguration['expandAllSchemaProperties']
   /**
    * The document the schema belongs to.

--- a/packages/api-reference/src/components/Content/Schema/types.ts
+++ b/packages/api-reference/src/components/Content/Schema/types.ts
@@ -15,6 +15,8 @@ export type SchemaOptions = {
   orderSchemaPropertiesBy?: ApiReferenceConfiguration['orderSchemaPropertiesBy']
   /** Order required properties first */
   orderRequiredPropertiesFirst?: ApiReferenceConfiguration['orderRequiredPropertiesFirst']
+  /** Expand all nested schema properties (no Show/Hide toggle is rendered) */
+  expandAllSchemaProperties?: ApiReferenceConfiguration['expandAllSchemaProperties']
   /**
    * The document the schema belongs to.
    *

--- a/packages/api-reference/src/features/Operation/Operation.test.ts
+++ b/packages/api-reference/src/features/Operation/Operation.test.ts
@@ -1,5 +1,6 @@
 import { enableConsoleError, enableConsoleWarn } from '@scalar/helpers/testing/console-spies'
 import { apiReferenceConfigurationSchema } from '@scalar/schemas/api-reference'
+import { coerce } from '@scalar/validation'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
@@ -11,7 +12,6 @@ import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import Operation from './Operation.vue'
-import { coerce } from '@scalar/validation'
 
 type ExtractComponentProps<TComponent> = TComponent extends new () => { $props: infer P } ? P : never
 
@@ -58,6 +58,7 @@ const mountOperationWithConfig = (
     showOperationId: false,
     hideTestRequestButton: false,
     expandAllResponses: false,
+    expandAllSchemaProperties: false,
     orderRequiredPropertiesFirst: false,
     orderSchemaPropertiesBy: 'alpha',
     ...overrides.options,

--- a/packages/api-reference/src/features/Operation/Operation.vue
+++ b/packages/api-reference/src/features/Operation/Operation.vue
@@ -16,6 +16,7 @@ export type OperationProps = {
     | 'layout'
     | 'orderRequiredPropertiesFirst'
     | 'orderSchemaPropertiesBy'
+    | 'expandAllSchemaProperties'
     | 'showOperationId'
   >
   /** Document object */

--- a/packages/api-reference/src/features/Operation/components/Header.vue
+++ b/packages/api-reference/src/features/Operation/components/Header.vue
@@ -8,7 +8,15 @@ import type {
 
 import SchemaProperty from '@/components/Content/Schema/SchemaProperty.vue'
 
-const { name, header, breadcrumb, document } = defineProps<{
+const {
+  name,
+  header,
+  breadcrumb,
+  document,
+  orderSchemaPropertiesBy,
+  orderRequiredPropertiesFirst,
+  expandAllSchemaProperties,
+} = defineProps<{
   header: HeaderObject
   name: string
   breadcrumb?: string[]
@@ -17,6 +25,7 @@ const { name, header, breadcrumb, document } = defineProps<{
   document?: OpenApiDocument
   orderSchemaPropertiesBy: 'alpha' | 'preserve' | undefined
   orderRequiredPropertiesFirst: boolean | undefined
+  expandAllSchemaProperties: boolean | undefined
 }>()
 </script>
 <template>
@@ -29,6 +38,7 @@ const { name, header, breadcrumb, document } = defineProps<{
     :options="{
       orderRequiredPropertiesFirst: orderRequiredPropertiesFirst,
       orderSchemaPropertiesBy: orderSchemaPropertiesBy,
+      expandAllSchemaProperties: expandAllSchemaProperties,
       document,
     }"
     :schema="getResolvedRef(header.schema)" />

--- a/packages/api-reference/src/features/Operation/components/Headers.vue
+++ b/packages/api-reference/src/features/Operation/components/Headers.vue
@@ -18,6 +18,7 @@ const { headers, breadcrumb } = defineProps<{
   document?: OpenApiDocument
   orderRequiredPropertiesFirst: boolean | undefined
   orderSchemaPropertiesBy: 'alpha' | 'preserve' | undefined
+  expandAllSchemaProperties: boolean | undefined
 }>()
 </script>
 <template>
@@ -52,7 +53,8 @@ const { headers, breadcrumb } = defineProps<{
               :header="getResolvedRef(header)"
               :name="key"
               :orderRequiredPropertiesFirst="orderRequiredPropertiesFirst"
-              :orderSchemaPropertiesBy="orderSchemaPropertiesBy" />
+              :orderSchemaPropertiesBy="orderSchemaPropertiesBy"
+              :expandAllSchemaProperties="expandAllSchemaProperties" />
           </template>
         </DisclosurePanel>
       </div>

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.test.ts
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.test.ts
@@ -11,6 +11,7 @@ describe('OperationParameters', () => {
     hideModels: false,
     orderRequiredPropertiesFirst: false,
     orderSchemaPropertiesBy: 'alpha' as const,
+    expandAllSchemaProperties: false,
   }
 
   describe('path parameters', () => {

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.vue
@@ -25,7 +25,10 @@ const { parameters = [], requestBody } = defineProps<{
   document?: OpenApiDocument
   options: Pick<
     OperationProps['options'],
-    'hideModels' | 'orderRequiredPropertiesFirst' | 'orderSchemaPropertiesBy'
+    | 'hideModels'
+    | 'orderRequiredPropertiesFirst'
+    | 'orderSchemaPropertiesBy'
+    | 'expandAllSchemaProperties'
   >
 }>()
 

--- a/packages/api-reference/src/features/Operation/components/OperationResponses.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationResponses.vue
@@ -19,7 +19,10 @@ const { responses } = defineProps<{
   document?: OpenApiDocument
   options: Pick<
     OperationProps['options'],
-    'hideModels' | 'orderRequiredPropertiesFirst' | 'orderSchemaPropertiesBy'
+    | 'hideModels'
+    | 'orderRequiredPropertiesFirst'
+    | 'orderSchemaPropertiesBy'
+    | 'expandAllSchemaProperties'
   >
 }>()
 </script>

--- a/packages/api-reference/src/features/Operation/components/ParameterList.test.ts
+++ b/packages/api-reference/src/features/Operation/components/ParameterList.test.ts
@@ -12,6 +12,7 @@ describe('ParameterList', () => {
     hideModels: false,
     orderRequiredPropertiesFirst: true,
     orderSchemaPropertiesBy: 'alpha' as const,
+    expandAllSchemaProperties: false,
   }
 
   const createParameter = (name: string, overrides?: Partial<ParameterObject>): ParameterObject => ({
@@ -94,6 +95,7 @@ describe('ParameterList', () => {
       hideModels: false,
       orderRequiredPropertiesFirst: false,
       orderSchemaPropertiesBy: 'preserve' as const,
+      expandAllSchemaProperties: false,
     }
 
     const wrapper = mount(ParameterList, {

--- a/packages/api-reference/src/features/Operation/components/ParameterList.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterList.vue
@@ -19,7 +19,10 @@ const { parameters } = defineProps<{
   document?: OpenApiDocument
   options: Pick<
     OperationProps['options'],
-    'hideModels' | 'orderRequiredPropertiesFirst' | 'orderSchemaPropertiesBy'
+    | 'hideModels'
+    | 'orderRequiredPropertiesFirst'
+    | 'orderSchemaPropertiesBy'
+    | 'expandAllSchemaProperties'
   >
 }>()
 

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.test.ts
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.test.ts
@@ -18,6 +18,7 @@ describe('ParameterListItem', () => {
           hideModels: true,
           orderRequiredPropertiesFirst: false,
           orderSchemaPropertiesBy: 'alpha',
+          expandAllSchemaProperties: false,
         },
         parameter: {
           in: 'query',

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -34,7 +34,10 @@ const { name, parameter, options, collapsableItems, document } = defineProps<{
   document?: OpenApiDocument
   options: Pick<
     OperationProps['options'],
-    'hideModels' | 'orderRequiredPropertiesFirst' | 'orderSchemaPropertiesBy'
+    | 'hideModels'
+    | 'orderRequiredPropertiesFirst'
+    | 'orderSchemaPropertiesBy'
+    | 'expandAllSchemaProperties'
   >
 }>()
 
@@ -166,6 +169,7 @@ const shouldCollapse = computed<boolean>(() =>
           :breadcrumb="breadcrumb"
           :document="document"
           :eventBus="eventBus"
+          :expandAllSchemaProperties="options.expandAllSchemaProperties"
           :headers="headers"
           :orderRequiredPropertiesFirst="options.orderRequiredPropertiesFirst"
           :orderSchemaPropertiesBy="options.orderSchemaPropertiesBy" />
@@ -185,6 +189,7 @@ const shouldCollapse = computed<boolean>(() =>
             hideWriteOnly: true,
             orderRequiredPropertiesFirst: options.orderRequiredPropertiesFirst,
             orderSchemaPropertiesBy: options.orderSchemaPropertiesBy,
+            expandAllSchemaProperties: options.expandAllSchemaProperties,
             document,
           }"
           :required="'required' in parameter && parameter.required"

--- a/packages/api-reference/src/features/Operation/components/RequestBody.test.ts
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.test.ts
@@ -12,6 +12,7 @@ describe('RequestBody', () => {
     hideModels: false,
     orderRequiredPropertiesFirst: false,
     orderSchemaPropertiesBy: 'alpha' as const,
+    expandAllSchemaProperties: false,
   }
 
   it('renders request body with schema properties', () => {

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -29,6 +29,7 @@ const { requestBody, options, document } = defineProps<{
     orderRequiredPropertiesFirst: boolean | undefined
     orderSchemaPropertiesBy: 'alpha' | 'preserve' | undefined
     hideModels: boolean | undefined
+    expandAllSchemaProperties: boolean | undefined
   }
 }>()
 
@@ -184,6 +185,7 @@ const shouldRenderRequestBody = computed(
           hideReadOnly: true,
           orderRequiredPropertiesFirst: options.orderRequiredPropertiesFirst,
           orderSchemaPropertiesBy: options.orderSchemaPropertiesBy,
+          expandAllSchemaProperties: options.expandAllSchemaProperties,
           document,
         }"
         :schema="partitionedSchema.visibleProperties"
@@ -201,6 +203,7 @@ const shouldRenderRequestBody = computed(
           hideReadOnly: true,
           orderRequiredPropertiesFirst: options.orderRequiredPropertiesFirst,
           orderSchemaPropertiesBy: options.orderSchemaPropertiesBy,
+          expandAllSchemaProperties: options.expandAllSchemaProperties,
           document,
         }"
         :schema="partitionedSchema.collapsedProperties"
@@ -223,6 +226,7 @@ const shouldRenderRequestBody = computed(
           hideReadOnly: true,
           orderRequiredPropertiesFirst: options.orderRequiredPropertiesFirst,
           orderSchemaPropertiesBy: options.orderSchemaPropertiesBy,
+          expandAllSchemaProperties: options.expandAllSchemaProperties,
           document,
         }"
         :schema="schema"

--- a/packages/api-reference/src/features/Operation/components/callbacks/Callback.vue
+++ b/packages/api-reference/src/features/Operation/components/callbacks/Callback.vue
@@ -23,7 +23,10 @@ const { method, name, url, options, document } = defineProps<{
   document?: OpenApiDocument
   options: Pick<
     OperationProps['options'],
-    'hideModels' | 'orderRequiredPropertiesFirst' | 'orderSchemaPropertiesBy'
+    | 'hideModels'
+    | 'orderRequiredPropertiesFirst'
+    | 'orderSchemaPropertiesBy'
+    | 'expandAllSchemaProperties'
   >
 }>()
 </script>

--- a/packages/api-reference/src/features/Operation/components/callbacks/Callbacks.test.ts
+++ b/packages/api-reference/src/features/Operation/components/callbacks/Callbacks.test.ts
@@ -71,6 +71,7 @@ describe('Callbacks', () => {
           hideModels: false,
           orderRequiredPropertiesFirst: false,
           orderSchemaPropertiesBy: 'alpha',
+          expandAllSchemaProperties: false,
         },
       },
     })

--- a/packages/api-reference/src/features/Operation/components/callbacks/Callbacks.vue
+++ b/packages/api-reference/src/features/Operation/components/callbacks/Callbacks.vue
@@ -23,7 +23,10 @@ const { path, callbacks, options } = defineProps<{
   document?: OpenApiDocument
   options: Pick<
     OperationProps['options'],
-    'hideModels' | 'orderRequiredPropertiesFirst' | 'orderSchemaPropertiesBy'
+    | 'hideModels'
+    | 'orderRequiredPropertiesFirst'
+    | 'orderSchemaPropertiesBy'
+    | 'expandAllSchemaProperties'
   >
 }>()
 

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.test.ts
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.test.ts
@@ -124,6 +124,7 @@ const props: ExtractComponentProps<typeof ClassicLayout> = {
   operation,
   options: {
     expandAllResponses: false,
+    expandAllSchemaProperties: false,
     hideModels: false,
     hideTestRequestButton: true,
     layout: 'classic',

--- a/packages/schemas/src/api-reference/api-reference-configuration.ts
+++ b/packages/schemas/src/api-reference/api-reference-configuration.ts
@@ -218,7 +218,7 @@ export const apiReferenceConfigurationSchema = intersection([
     expandAllSchemaProperties: boolean({
       default: false,
       typeComment:
-        'Whether to expand all nested schema properties. When true, the Show/Hide Child Attributes toggle is not rendered and nested object properties are always visible. Warning: this can cause performance issues on big documents',
+        'Whether to expand all nested schema properties by default. The Show/Hide Child Attributes toggle remains available so nested sections can still be collapsed manually. Warning: this can cause performance issues on big documents',
     }),
     tagsSorter: optional(union([literal('alpha'), fn<(a: any, b: any) => number>()]), {
       typeComment: 'Function to sort tags',

--- a/packages/schemas/src/api-reference/api-reference-configuration.ts
+++ b/packages/schemas/src/api-reference/api-reference-configuration.ts
@@ -215,6 +215,11 @@ export const apiReferenceConfigurationSchema = intersection([
       typeComment:
         'Whether to expand all responses by default. Warning: this can cause performance issues on big documents',
     }),
+    expandAllSchemaProperties: boolean({
+      default: false,
+      typeComment:
+        'Whether to expand all nested schema properties. When true, the Show/Hide Child Attributes toggle is not rendered and nested object properties are always visible. Warning: this can cause performance issues on big documents',
+    }),
     tagsSorter: optional(union([literal('alpha'), fn<(a: any, b: any) => number>()]), {
       typeComment: 'Function to sort tags',
     }),

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -378,9 +378,9 @@ export const apiReferenceConfigurationSchema = baseConfigurationSchema.extend({
    */
   expandAllResponses: z.boolean().optional().default(false).catch(false),
   /**
-   * Whether to expand all nested schema properties. When true, the
-   * Show/Hide Child Attributes toggle is not rendered and nested object
-   * properties are always visible.
+   * Whether to expand all nested schema properties by default. The
+   * Show/Hide Child Attributes toggle remains available so nested sections can
+   * still be collapsed manually.
    *
    * Warning: this can cause performance issues on big documents
    * @default false

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -359,24 +359,33 @@ export const apiReferenceConfigurationSchema = baseConfigurationSchema.extend({
   /**
    * Whether to expand all tags by default
    *
-   * Warning this can cause performance issues on big documents
+   * Warning: this can cause performance issues on big documents
    * @default false
    */
   defaultOpenAllTags: z.boolean().optional().default(false).catch(false),
   /**
    * Whether to expand all models by default
    *
-   * Warning this can cause performance issues on big documents
+   * Warning: this can cause performance issues on big documents
    * @default false
    */
   expandAllModelSections: z.boolean().optional().default(false).catch(false),
   /**
    * Whether to expand all responses by default
    *
-   * Warning this can cause performance issues on big documents
+   * Warning: this can cause performance issues on big documents
    * @default false
    */
   expandAllResponses: z.boolean().optional().default(false).catch(false),
+  /**
+   * Whether to expand all nested schema properties. When true, the
+   * Show/Hide Child Attributes toggle is not rendered and nested object
+   * properties are always visible.
+   *
+   * Warning: this can cause performance issues on big documents
+   * @default false
+   */
+  expandAllSchemaProperties: z.boolean().optional().default(false).catch(false),
   /**
    * Function to sort tags
    * @default 'alpha' for alphabetical sorting

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -448,6 +448,8 @@ type ExtendedConfiguration = {
   expandAllModelSections: boolean
   /** Whether to expand all responses by default. Warning: this can cause performance issues on big documents */
   expandAllResponses: boolean
+  /** Whether to expand all nested schema properties. Warning: this can cause performance issues on big documents */
+  expandAllSchemaProperties: boolean
   /** Function to sort tags */
   tagsSorter?: 'alpha' | ((a: any, b: any) => number)
   /** Function to sort operations */


### PR DESCRIPTION
Adds a new boolean configuration option, `expandAllSchemaProperties`. When enabled, the "Show/Hide Child Attributes" toggle is expanded by default for all nested schema properties (the button is still available to hide them). The option defaults to `false` to preserve existing behavior (collapsed by default).

This is similar in behavior to `expandAllModelSections`: when enabled, sections start expanded by default and controls remain available to collapse them.

NOTE: The original version of this PR removed the show/hide button entirely. I restored it to be more reasonable toward user expectations.

Fixes https://github.com/scalar/scalar/issues/6293

What is included:

- Define `expandAllSchemaProperties` in both configuration schemas (`@scalar/schemas` and `@scalar/types`) and in `ExtendedConfiguration`.
- Thread the option through `Schema` and the relevant render trees (operations, models, headers, callbacks, request/response schemas, and AsyncAPI traversed entries).
- Add/adjust docs and changeset copy for the final behavior.
- Add unit coverage for enabled/disabled behavior, recursion safety, and deep finite expansion.
- Update affected test fixtures so typed options remain valid.

Recursion safety (latest refactor):

My first attempt to implement `expandAllSchemaProperties` encountered a problem: the renderer would keep opening the same schema chain forever when a model references itself (directly or transitively via `$ref`). That unbounded expansion can blow the call stack and leave parts of the reference UI missing or unresponsive. So, a cycle guard is necessary so finite schema branches still open fully, while self-referential branches expand only up to the point where they loop back on themselves.

- Each schema node gets a cycle identity key derived from its raw schema value (`$ref` string for references, object identity for inline schemas).
- Ancestor keys are propagated via provide/inject through the schema tree.
- If a node key already exists in the current ancestor set, that node is marked cyclic and automatic expansion stops at that boundary (toggle stays available for manual exploration).
- Finite branches continue expanding fully; only true cycles are guarded.
- This follows the same core pattern already used in `packages/api-reference/src/helpers/openapi.ts` (`collectSchemaProperties`), which uses a `visited` set to guard recursive schema walks.

This ensures the UI does not recurse indefinitely on self-referential schemas while still delivering the "expanded child properties" experience on normal schema trees.

## BEFORE

<img width="1426" height="1194" alt="Screenshot 2026-06-03 at 6 57 26 PM" src="https://github.com/user-attachments/assets/8e35ab12-598b-400d-a05b-b655fdb94532" />

## AFTER

<img width="1426" height="1194" alt="Screenshot 2026-06-03 at 6 56 58 PM" src="https://github.com/user-attachments/assets/b6b3752b-a7bc-4656-a77a-18a17c1225c4" />

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation.

Co-authored-by: Cursor <cursoragent@cursor.com>