### PR TITLE
feat(api-client): no dropdown for a single client

### DIFF
--- a/.changeset/single-client-no-dropdown.md
+++ b/.changeset/single-client-no-dropdown.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Render the client library name as a plain label instead of a dropdown when only a single client is available

--- a/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.test.ts
@@ -615,6 +615,51 @@ describe('RequestExample', () => {
     })
   })
 
+  describe('Single Client', () => {
+    const singleClientOptions: ClientOptionGroup[] = [
+      {
+        label: 'JavaScript',
+        key: 'js',
+        options: [
+          {
+            id: 'js/fetch',
+            label: 'Fetch API',
+            lang: 'js',
+            title: 'JavaScript Fetch API',
+            targetKey: 'js',
+            targetTitle: 'JavaScript',
+            clientKey: 'fetch',
+          },
+        ],
+      },
+    ]
+
+    it('renders the client label without a dropdown when only one client is available', () => {
+      const wrapper = mount(RequestExample, {
+        props: {
+          ...defaultProps,
+          clientOptions: singleClientOptions,
+        },
+      })
+
+      // No dropdown should be rendered for a single client
+      expect(wrapper.findComponent({ name: 'ScalarCombobox' }).exists()).toBe(false)
+
+      // The client title should still be shown as a plain label
+      const label = wrapper.find('[data-testid="client-picker"]')
+      expect(label.exists()).toBe(true)
+      expect(label.text()).toContain('JavaScript Fetch API')
+    })
+
+    it('renders a dropdown when more than one client is available', () => {
+      const wrapper = mount(RequestExample, {
+        props: defaultProps,
+      })
+
+      expect(wrapper.findComponent({ name: 'ScalarCombobox' }).exists()).toBe(true)
+    })
+  })
+
   describe('Custom Examples', () => {
     it('handles x-custom-examples extension', () => {
       const wrapper = mount(RequestExample, {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.vue
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.vue
@@ -221,6 +221,11 @@ const clients = computed(() =>
   getClients(customCodeSamples.value, clientOptions),
 )
 
+/** Total number of available clients across all option groups */
+const clientCount = computed(() =>
+  clients.value.reduce((total, group) => total + group.options.length, 0),
+)
+
 /** The locally selected client which would include code samples from this operation only */
 const localSelectedClient = ref<ClientOption | CustomClientOption | undefined>(
   findClient(clients.value, selectedClient),
@@ -355,9 +360,11 @@ const id = useId()
       <slot name="header" />
       <!-- Client picker -->
       <template
-        v-if="!isWebhook && clients.length"
+        v-if="!isWebhook && clientCount"
         #actions>
+        <!-- Multiple clients: render a dropdown to switch between them -->
         <ScalarCombobox
+          v-if="clientCount > 1"
           class="max-h-80"
           :filterFn="filterClientsByQuery"
           :modelValue="localSelectedClient"
@@ -375,6 +382,13 @@ const id = useId()
               weight="bold" />
           </ScalarButton>
         </ScalarCombobox>
+        <!-- Single client: just show its label, no need for a dropdown -->
+        <span
+          v-else
+          class="text-c-2 flex h-full w-fit items-center px-0.5 py-0 text-base font-normal"
+          data-testid="client-picker">
+          {{ localSelectedClient?.title }}
+        </span>
       </template>
     </ScalarCardHeader>
 


### PR DESCRIPTION
When an operation only has one client library, we now just show its name instead of a dropdown you can't really use.

<img width="254" height="183" alt="Screenshot 2026-06-03 at 14 41 38" src="https://github.com/user-attachments/assets/f7d9bae9-345f-4ded-801a-4d50aed77806" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation change in OperationCodeSample; multi-client selection and snippet generation are unchanged.
> 
> **Overview**
> When an operation’s request example has **only one** HTTP client (after merging custom samples with `clientOptions`), the header no longer renders a `ScalarCombobox` with a caret. It shows the client title as a static label while keeping `data-testid="client-picker"`.
> 
> **Multiple clients** still use the existing combobox and `selectClient` / workspace client update behavior.
> 
> Visibility now keys off a new **`clientCount`** (total options across groups) instead of `clients.length`, so a single option in one group still shows the label. A patch changeset documents the `@scalar/api-client` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 102a7d30b04df555d0b88966efff41872b8d17c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->