### PR TITLE
fix(docs): update sticker CDN URL

### DIFF
--- a/documentation/guides/app/getting-started.md
+++ b/documentation/guides/app/getting-started.md
@@ -221,7 +221,7 @@ Use [post-response scripts](./testing.md) to validate responses and automate che
     </div>
     <div class="relative">
       <div class="expander-hover-sticker">
-        <object class="sticker-clip-docs" width="113" height="143" data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/HLhbFqJ4vSzo4UDEZX2dq.svg"></object>
+        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.svg"></object>
       </div>
       <div class="expander-hover-title">API Docs</div>
       <div class="expander">

--- a/documentation/guides/app/getting-started.md
+++ b/documentation/guides/app/getting-started.md
@@ -221,7 +221,7 @@ Use [post-response scripts](./testing.md) to validate responses and automate che
     </div>
     <div class="relative">
       <div class="expander-hover-sticker">
-        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.svg"></object>
+        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.v3.svg"></object>
       </div>
       <div class="expander-hover-title">API Docs</div>
       <div class="expander">

--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -260,7 +260,7 @@ Put your content where you want: in your repository, any folder, or the Scalar E
     </div>
     <div class="relative">
       <div class="expander-hover-sticker">
-        <object class="sticker-clip-docs" width="113" height="143" data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/HLhbFqJ4vSzo4UDEZX2dq.svg"></object>
+        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.svg"></object>
       </div>
       <div class="expander-hover-title">Docs</div>
       <div class="expander">

--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -260,7 +260,7 @@ Put your content where you want: in your repository, any folder, or the Scalar E
     </div>
     <div class="relative">
       <div class="expander-hover-sticker">
-        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.svg"></object>
+        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.v3.svg"></object>
       </div>
       <div class="expander-hover-title">Docs</div>
       <div class="expander">

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -257,7 +257,7 @@
       </div>
     </div>
     <div class="draggable sticker-3">
-      <scalar-icon src="https://cdn.scalar.com/marketing/landing/sticker-3.svg"></scalar-icon>
+      <scalar-icon src="https://cdn.scalar.com/marketing/landing/sticker-3.v3.svg"></scalar-icon>
     </div>
   </div>
   <div class="product">
@@ -427,7 +427,7 @@
     </div>
     <div class="relative">
       <div class="expander-hover-sticker">
-        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.svg"></object>
+        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.v3.svg"></object>
       </div>
       <div class="expander-hover-title">API Docs</div>
       <div class="expander">

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -257,7 +257,7 @@
       </div>
     </div>
     <div class="draggable sticker-3">
-      <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/HLhbFqJ4vSzo4UDEZX2dq.svg"></scalar-icon>
+      <scalar-icon src="https://cdn.scalar.com/marketing/landing/sticker-3.svg"></scalar-icon>
     </div>
   </div>
   <div class="product">
@@ -427,7 +427,7 @@
     </div>
     <div class="relative">
       <div class="expander-hover-sticker">
-        <object class="sticker-clip-docs" width="113" height="143" data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/HLhbFqJ4vSzo4UDEZX2dq.svg"></object>
+        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.svg"></object>
       </div>
       <div class="expander-hover-title">API Docs</div>
       <div class="expander">

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -686,7 +686,7 @@
     </div>
     <div class="relative">
       <div class="expander-hover-sticker">
-        <object class="sticker-clip-docs" width="113" height="143" data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/HLhbFqJ4vSzo4UDEZX2dq.svg"></object>
+        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.svg"></object>
       </div>
       <div class="expander-hover-title">API Docs</div>
       <div class="expander">

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -686,7 +686,7 @@
     </div>
     <div class="relative">
       <div class="expander-hover-sticker">
-        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.svg"></object>
+        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.v3.svg"></object>
       </div>
       <div class="expander-hover-title">API Docs</div>
       <div class="expander">

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -202,7 +202,7 @@ All of this with just a couple clicks or a few API requests! You handle making y
     </div>
     <div class="relative">
       <div class="expander-hover-sticker">
-        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.svg"></object>
+        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.v3.svg"></object>
       </div>
       <div class="expander-hover-title">API Docs</div>
       <div class="expander">

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -202,7 +202,7 @@ All of this with just a couple clicks or a few API requests! You handle making y
     </div>
     <div class="relative">
       <div class="expander-hover-sticker">
-        <object class="sticker-clip-docs" width="113" height="143" data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/HLhbFqJ4vSzo4UDEZX2dq.svg"></object>
+        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.svg"></object>
       </div>
       <div class="expander-hover-title">API Docs</div>
       <div class="expander">

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -205,7 +205,7 @@ Once created, you will get redirected to the SDK Overview page where you can:
     </div>
     <div class="relative">
       <div class="expander-hover-sticker">
-        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.svg"></object>
+        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.v3.svg"></object>
       </div>
       <div class="expander-hover-title">API Docs</div>
       <div class="expander">

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -205,7 +205,7 @@ Once created, you will get redirected to the SDK Overview page where you can:
     </div>
     <div class="relative">
       <div class="expander-hover-sticker">
-        <object class="sticker-clip-docs" width="113" height="143" data="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/HLhbFqJ4vSzo4UDEZX2dq.svg"></object>
+        <object class="sticker-clip-docs" width="113" height="143" data="https://cdn.scalar.com/marketing/landing/sticker-3.svg"></object>
       </div>
       <div class="expander-hover-title">API Docs</div>
       <div class="expander">


### PR DESCRIPTION
fix for sticker in firefox 

old link: https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/HLhbFqJ4vSzo4UDEZX2dq.svg

new link: https://cdn.scalar.com/marketing/landing/sticker-3.svg