### PR TITLE
feat(dotnet): add AsyncAPI document support with DocumentType discriminator

### DIFF
--- a/.changeset/async-api-documents-dotnet.md
+++ b/.changeset/async-api-documents-dotnet.md
@@ -1,0 +1,8 @@
+---
+'@scalar/aspnetcore': minor
+'@scalar/aspire': minor
+---
+
+feat(dotnet): add AsyncAPI document support
+
+Adds `AddAsyncApiDocument`, `AddAsyncApiDocuments`, and `WithAsyncApiRoutePattern` so AsyncAPI documents can be registered alongside OpenAPI documents in the same Scalar API Reference. AsyncAPI documents use a separate default route pattern (`/asyncapi/{documentName}.json`) that is resolved lazily at configuration time.

--- a/documentation/integrations/aspire.md
+++ b/documentation/integrations/aspire.md
@@ -114,6 +114,29 @@ scalar.WithApiReference(bookService, options =>
 });
 ```
 
+### AsyncAPI Documents
+
+Services can expose AsyncAPI documents next to their OpenAPI documents. Use `AddAsyncApiDocument` or `AddAsyncApiDocuments` to register them; both document types are rendered together in the same API Reference. AsyncAPI documents use a separate default route pattern (`/asyncapi/{documentName}.json`), which you can override with `WithAsyncApiRoutePattern`.
+
+```csharp
+scalar.WithApiReference(eventService, options =>
+{
+    // Add an AsyncAPI document with a custom title
+    options.AddAsyncApiDocument("events", "Event Stream");
+
+    // Mix AsyncAPI and OpenAPI documents in a single reference
+    options
+        .AddDocument("v1", "REST API")
+        .AddAsyncApiDocument("events", "Event Stream");
+
+    // Or add multiple AsyncAPI documents at once
+    options.AddAsyncApiDocuments("events", "commands");
+
+    // Customize the default AsyncAPI route pattern
+    options.WithAsyncApiRoutePattern("/messaging/{documentName}.json");
+});
+```
+
 ### Static OpenAPI Documents
 
 Use the file-based overload when a service does not expose a live OpenAPI endpoint—for example, when the description document is generated at build time or when documenting an external API from a local file. The file is mounted into the Scalar container and served at `/openapi/{folderPath}/{filename}`. When the optional `folderPath` parameter is not provided, the resource name is used as the folder, so the path is `/openapi/{resourceName}/{filename}`. You can pass an explicit `folderPath` to override the default folder or to avoid name collisions when multiple services serve static files. The document URL in the API Reference uses that path; the `resourceBuilder` is still used to configure the **Try It** server URL (the API base URL for requests).

--- a/documentation/integrations/aspnetcore/integration.md
+++ b/documentation/integrations/aspnetcore/integration.md
@@ -270,6 +270,18 @@ app.MapScalarApiReference(options =>
 });
 ```
 
+You can also pass `ScalarDocument` objects. They are always registered as AsyncAPI documents, regardless of the `DocumentType` set on the object:
+
+```csharp
+var documents = new[]
+{
+    new ScalarDocument("events", "Event Stream"),
+    new ScalarDocument("commands", "Commands", "/messaging/{documentName}.json")
+};
+
+app.MapScalarApiReference(options => options.AddAsyncApiDocuments(documents));
+```
+
 To change the default route pattern for all AsyncAPI documents that do not specify their own:
 
 ```csharp

--- a/documentation/integrations/aspnetcore/integration.md
+++ b/documentation/integrations/aspnetcore/integration.md
@@ -234,6 +234,53 @@ You can also specify a document name directly in the URL path (e.g., `/scalar/v1
 > [!NOTE]
 > **Note on case sensitivity**: Scalar forwards document names to the OpenAPI generator exactly as they appear in the URL path or as they are defined, preserving the case. The behavior depends on whether your OpenAPI generator treats document names as case-sensitive. To avoid issues, use consistent casing for document names (e.g., lowercase `"v1"`).
 
+### AsyncAPI Documents
+
+Scalar can render AsyncAPI documents alongside your OpenAPI documents in the same API Reference. Use the `AddAsyncApiDocument` or `AddAsyncApiDocuments` methods to register them. AsyncAPI documents are served from a separate default route pattern (`/asyncapi/{documentName}.json`), which you can customize with `WithAsyncApiRoutePattern`.
+
+```csharp
+app.MapScalarApiReference(options =>
+{
+    // Simple document name (uses the default /asyncapi/{documentName}.json pattern)
+    options.AddAsyncApiDocument("events");
+
+    // With a custom title
+    options.AddAsyncApiDocument("events", "Event Stream");
+
+    // With a custom route pattern
+    options.AddAsyncApiDocument("events", routePattern: "/messaging/{documentName}.json");
+
+    // External AsyncAPI document
+    options.AddAsyncApiDocument("payments",
+        "Payments Events", "https://api.example.com/asyncapi/payments.json");
+});
+```
+
+You can add several AsyncAPI documents at once and mix them freely with OpenAPI documents — both types are rendered together in a single API Reference:
+
+```csharp
+app.MapScalarApiReference(options =>
+{
+    options
+        .AddDocument("v1", "REST API")
+        .AddAsyncApiDocument("events", "Event Stream");
+
+    // Or add multiple AsyncAPI documents by name
+    options.AddAsyncApiDocuments("events", "commands");
+});
+```
+
+To change the default route pattern for all AsyncAPI documents that do not specify their own:
+
+```csharp
+app.MapScalarApiReference(options =>
+{
+    options.WithAsyncApiRoutePattern("/messaging/{documentName}.json");
+});
+```
+
+The `routePattern` parameter on `AddAsyncApiDocument` works like its OpenAPI counterpart: if not specified, it falls back to the global `AsyncApiRoutePattern`, and the pattern can include the `{documentName}` placeholder.
+
 ### Agent
 
 Agent adds an AI chat interface to your API reference. It is enabled by default on localhost with a limited free tier (10 messages). For production, you need an [Agent key](../../guides/agent/key.md).

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -324,4 +324,52 @@ public class ScalarOptionsMapperTests
         configuration.Mcp.Should().NotBeNull();
         configuration.Mcp!.Disabled.Should().BeTrue();
     }
+
+    [Fact]
+    public void GetSources_ShouldMapAsyncApiDocumentUrl_UsingDefaultPattern()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+        options.AddAsyncApiDocument("events");
+
+        // Act
+        var configuration = options.ToScalarConfiguration();
+
+        // Assert
+        configuration.Sources.Should().ContainSingle()
+            .Which.Url.Should().Be("asyncapi/events.json");
+    }
+
+    [Fact]
+    public void GetSources_ShouldMapAsyncApiDocumentUrl_UsingCustomPattern()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+        options.WithAsyncApiRoutePattern("/api/asyncapi/{documentName}.yaml")
+               .AddAsyncApiDocument("events");
+
+        // Act
+        var configuration = options.ToScalarConfiguration();
+
+        // Assert
+        configuration.Sources.Should().ContainSingle()
+            .Which.Url.Should().Be("api/asyncapi/events.yaml");
+    }
+
+    [Fact]
+    public void GetSources_ShouldIncludeBothOpenApiAndAsyncApiDocuments()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+        options.AddDocument("v1");
+        options.AddAsyncApiDocument("events");
+
+        // Act
+        var configuration = options.ToScalarConfiguration();
+
+        // Assert
+        configuration.Sources.Should().HaveCount(2);
+        configuration.Sources.Should().ContainSingle(s => s.Url == "openapi/v1.json");
+        configuration.Sources.Should().ContainSingle(s => s.Url == "asyncapi/events.json");
+    }
 }

--- a/integrations/dotnet/shared/src/Scalar.Shared/Enums/DocumentType.cs
+++ b/integrations/dotnet/shared/src/Scalar.Shared/Enums/DocumentType.cs
@@ -1,0 +1,21 @@
+#if SCALAR_ASPIRE
+namespace Scalar.Aspire;
+#else
+namespace Scalar.AspNetCore;
+#endif
+
+/// <summary>
+/// Specifies the type of an API document.
+/// </summary>
+public enum DocumentType
+{
+    /// <summary>
+    /// An OpenAPI document.
+    /// </summary>
+    OpenApi,
+
+    /// <summary>
+    /// An AsyncAPI document.
+    /// </summary>
+    AsyncApi
+}

--- a/integrations/dotnet/shared/src/Scalar.Shared/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/dotnet/shared/src/Scalar.Shared/Extensions/ScalarOptionsExtensions.cs
@@ -678,6 +678,21 @@ public static partial class ScalarOptionsExtensions
     }
 
     /// <summary>
+    /// Adds multiple AsyncAPI documents to the Scalar API Reference using document objects.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="documents">A list of <see cref="ScalarDocument" />s to add.</param>
+    /// <remarks>
+    /// When multiple documents are added, they will be displayed as selectable options in a dropdown menu.
+    /// Each document is treated as an AsyncAPI document regardless of its <see cref="ScalarDocument.DocumentType" />.
+    /// </remarks>
+    public static TOptions AddAsyncApiDocuments<TOptions>(this TOptions options, params IEnumerable<ScalarDocument> documents) where TOptions : ScalarOptions
+    {
+        options.Documents.AddRange(documents.Select(document => document with { DocumentType = DocumentType.AsyncApi }));
+        return options;
+    }
+
+    /// <summary>
     /// Controls whether to expose 'dotnet' flag to the configuration.
     /// </summary>
     /// <param name="options">The options to configure.</param>

--- a/integrations/dotnet/shared/src/Scalar.Shared/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/dotnet/shared/src/Scalar.Shared/Extensions/ScalarOptionsExtensions.cs
@@ -632,6 +632,54 @@ public static partial class ScalarOptionsExtensions
     }
 
     /// <summary>
+    /// Controls the route pattern of the AsyncAPI document.
+    /// Can also be a complete URL to a remote AsyncAPI document, just be aware of CORS restrictions in this case.
+    /// The pattern can include the '{documentName}' placeholder which will be replaced with the document name.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="pattern">The route pattern to set.</param>
+    public static TOptions WithAsyncApiRoutePattern<TOptions>(this TOptions options, [StringSyntax("Route")] string pattern) where TOptions : ScalarOptions
+    {
+        options.AsyncApiRoutePattern = pattern;
+        return options;
+    }
+
+    /// <summary>
+    /// Adds an AsyncAPI document to the Scalar API Reference.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="documentName">The name identifier for the AsyncAPI document. This value will be used to replace the '{documentName}' placeholder in the <see cref="ScalarOptions.AsyncApiRoutePattern"/>.</param>
+    /// <param name="title">Optional display title for the document. If not provided, the document name will be used as the title.</param>
+    /// <param name="routePattern">Optional route pattern for the AsyncAPI document. If not provided, the <see cref="ScalarOptions.AsyncApiRoutePattern"/> will be used. The pattern can include the '{documentName}' placeholder which will be replaced with the document name.</param>
+    /// <param name="isDefault">Indicates whether this document should be the default selection when multiple documents are available. Only one document should be marked as default.</param>
+    /// <param name="agentKey">Optional Agent Scalar key for this document.</param>
+    /// <remarks>
+    /// When multiple documents are added, they will be displayed as selectable options in a dropdown menu.
+    /// If no documents are explicitly added, a default document named 'v1' will be used.
+    /// </remarks>
+    public static TOptions AddAsyncApiDocument<TOptions>(this TOptions options, string documentName, string? title = null, string? routePattern = null, bool isDefault = false, string? agentKey = null) where TOptions : ScalarOptions
+    {
+        var agent = agentKey is null ? null : new ScalarAgentOptions { Key = agentKey };
+        options.Documents.Add(new ScalarDocument(documentName, title, routePattern, isDefault, agent, DocumentType.AsyncApi));
+        return options;
+    }
+
+    /// <summary>
+    /// Adds multiple AsyncAPI documents to the Scalar API Reference using document names.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="documentNames">The name identifiers for the AsyncAPI documents.</param>
+    /// <remarks>
+    /// When multiple documents are added, they will be displayed as selectable options in a dropdown menu.
+    /// If no documents are explicitly added, a default document named 'v1' will be used.
+    /// </remarks>
+    public static TOptions AddAsyncApiDocuments<TOptions>(this TOptions options, params IEnumerable<string> documentNames) where TOptions : ScalarOptions
+    {
+        options.Documents.AddRange(documentNames.Select(name => new ScalarDocument(name, DocumentType: DocumentType.AsyncApi)));
+        return options;
+    }
+
+    /// <summary>
     /// Controls whether to expose 'dotnet' flag to the configuration.
     /// </summary>
     /// <param name="options">The options to configure.</param>

--- a/integrations/dotnet/shared/src/Scalar.Shared/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/dotnet/shared/src/Scalar.Shared/Extensions/ScalarOptionsExtensions.cs
@@ -655,7 +655,6 @@ public static partial class ScalarOptionsExtensions
     /// <param name="agentKey">Optional Agent Scalar key for this document.</param>
     /// <remarks>
     /// When multiple documents are added, they will be displayed as selectable options in a dropdown menu.
-    /// If no documents are explicitly added, a default document named 'v1' will be used.
     /// </remarks>
     public static TOptions AddAsyncApiDocument<TOptions>(this TOptions options, string documentName, string? title = null, string? routePattern = null, bool isDefault = false, string? agentKey = null) where TOptions : ScalarOptions
     {
@@ -671,7 +670,6 @@ public static partial class ScalarOptionsExtensions
     /// <param name="documentNames">The name identifiers for the AsyncAPI documents.</param>
     /// <remarks>
     /// When multiple documents are added, they will be displayed as selectable options in a dropdown menu.
-    /// If no documents are explicitly added, a default document named 'v1' will be used.
     /// </remarks>
     public static TOptions AddAsyncApiDocuments<TOptions>(this TOptions options, params IEnumerable<string> documentNames) where TOptions : ScalarOptions
     {

--- a/integrations/dotnet/shared/src/Scalar.Shared/Mapper/ScalarOptionsMapper.cs
+++ b/integrations/dotnet/shared/src/Scalar.Shared/Mapper/ScalarOptionsMapper.cs
@@ -71,14 +71,16 @@ internal static partial class ScalarOptionsMapper
     private static IEnumerable<ScalarSource> GetSources(ScalarOptions options)
     {
         var trimmedOpenApiRoutePattern = options.OpenApiRoutePattern.TrimStart('/');
+        var trimmedAsyncApiRoutePattern = options.AsyncApiRoutePattern.TrimStart('/');
 
         foreach (var document in options.Documents)
         {
-            var openApiRoutePattern = document.RoutePattern is null ? trimmedOpenApiRoutePattern : document.RoutePattern.TrimStart('/');
+            var defaultPattern = document.DocumentType == DocumentType.AsyncApi ? trimmedAsyncApiRoutePattern : trimmedOpenApiRoutePattern;
+            var routePattern = document.RoutePattern is null ? defaultPattern : document.RoutePattern.TrimStart('/');
             yield return new ScalarSource
             {
                 Title = document.Title ?? document.Name,
-                Url = openApiRoutePattern.Replace(DocumentName, document.Name),
+                Url = routePattern.Replace(DocumentName, document.Name),
                 Default = document.IsDefault,
                 Agent = document.Agent
             };

--- a/integrations/dotnet/shared/src/Scalar.Shared/Options/ScalarDocument.cs
+++ b/integrations/dotnet/shared/src/Scalar.Shared/Options/ScalarDocument.cs
@@ -9,8 +9,12 @@ namespace Scalar.AspNetCore;
 /// </summary>
 /// <param name="Name">The name of the document.</param>
 /// <param name="Title">The optional title of the document.</param>
-/// <param name="RoutePattern">The optional OpenAPI route pattern of the document.</param>
+/// <param name="RoutePattern">
+/// The optional route pattern for the document. If not provided, the pattern from <see cref="ScalarOptions"/> is resolved at configuration time
+/// based on the <paramref name="DocumentType"/>: <see cref="ScalarOptions.OpenApiRoutePattern"/> for <see cref="DocumentType.OpenApi"/> documents
+/// and <see cref="ScalarOptions.AsyncApiRoutePattern"/> for <see cref="DocumentType.AsyncApi"/> documents.
+/// </param>
 /// <param name="IsDefault">Indicates whether this document is the default document.</param>
 /// <param name="Agent">Optional Agent Scalar options for this document (e.g. API key).</param>
-/// <remarks>By default, the <see cref="ScalarOptions.OpenApiRoutePattern"/> is used to determine the full OpenAPI document URL.</remarks>
-public sealed record ScalarDocument(string Name, string? Title = null, string? RoutePattern = null, bool IsDefault = false, ScalarAgentOptions? Agent = null);
+/// <param name="DocumentType">The type of the document (default: <see cref="DocumentType.OpenApi"/>).</param>
+public sealed record ScalarDocument(string Name, string? Title = null, string? RoutePattern = null, bool IsDefault = false, ScalarAgentOptions? Agent = null, DocumentType DocumentType = DocumentType.OpenApi);

--- a/integrations/dotnet/shared/src/Scalar.Shared/Options/ScalarOptions.cs
+++ b/integrations/dotnet/shared/src/Scalar.Shared/Options/ScalarOptions.cs
@@ -27,6 +27,13 @@ public partial class ScalarOptions
     public string OpenApiRoutePattern { get; set; } = "/openapi/{documentName}.json";
 
     /// <summary>
+    /// Controls the route pattern of the AsyncAPI document.
+    /// Can also be a complete URL to a remote AsyncAPI document, just be aware of CORS restrictions in this case.
+    /// The pattern can include the '{documentName}' placeholder which will be replaced with the document name.
+    /// </summary>
+    public string AsyncApiRoutePattern { get; set; } = "/asyncapi/{documentName}.json";
+
+    /// <summary>
     /// Controls the proxy URL for API requests.
     /// </summary>
     [StringSyntax(StringSyntaxAttribute.Uri)]

--- a/integrations/dotnet/shared/tests/Scalar.Shared.Tests/Extensions/ScalarOptionsExtensionsTests.cs
+++ b/integrations/dotnet/shared/tests/Scalar.Shared.Tests/Extensions/ScalarOptionsExtensionsTests.cs
@@ -93,6 +93,24 @@ public class ScalarOptionsExtensionsTests
     }
 
     [Fact]
+    public void AddAsyncApiDocuments_ShouldForceAsyncApiTypeOnDocumentObjects()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act — pass documents that default to DocumentType.OpenApi; the overload coerces them to AsyncApi
+        options.AddAsyncApiDocuments(
+            new ScalarDocument("events", "Event Stream"),
+            new ScalarDocument("commands", RoutePattern: "/messaging/{documentName}.json"));
+
+        // Assert
+        options.Documents.Should().HaveCount(2);
+        options.Documents.Should().AllSatisfy(d => d.DocumentType.Should().Be(DocumentType.AsyncApi));
+        options.Documents.Should().ContainSingle(d => d.Name == "events" && d.Title == "Event Stream");
+        options.Documents.Should().ContainSingle(d => d.Name == "commands" && d.RoutePattern == "/messaging/{documentName}.json");
+    }
+
+    [Fact]
     public void AddAsyncApiDocument_ShouldCoexistWithOpenApiDocuments()
     {
         // Arrange

--- a/integrations/dotnet/shared/tests/Scalar.Shared.Tests/Extensions/ScalarOptionsExtensionsTests.cs
+++ b/integrations/dotnet/shared/tests/Scalar.Shared.Tests/Extensions/ScalarOptionsExtensionsTests.cs
@@ -29,6 +29,87 @@ public class ScalarOptionsExtensionsTests
     }
 
     [Fact]
+    public void AddAsyncApiDocument_ShouldUseDefaultAsyncApiRoutePattern()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.AddAsyncApiDocument("events");
+
+        // Assert
+        var document = options.Documents.Should().ContainSingle().Subject;
+        document.RoutePattern.Should().BeNull();
+        document.DocumentType.Should().Be(DocumentType.AsyncApi);
+    }
+
+    [Fact]
+    public void AddAsyncApiDocument_ShouldUseCustomRoutePatternWhenProvided()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.AddAsyncApiDocument("events", routePattern: "/api/asyncapi/{documentName}.yaml");
+
+        // Assert
+        var document = options.Documents.Should().ContainSingle().Subject;
+        document.RoutePattern.Should().Be("/api/asyncapi/{documentName}.yaml");
+        document.DocumentType.Should().Be(DocumentType.AsyncApi);
+    }
+
+    [Fact]
+    public void AddAsyncApiDocument_ShouldUseUpdatedAsyncApiRoutePatternFromOptions()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options
+            .WithAsyncApiRoutePattern("/custom/{documentName}.json")
+            .AddAsyncApiDocument("events");
+
+        // Assert — the document stores no pattern; the mapper reads AsyncApiRoutePattern at configuration time
+        var document = options.Documents.Should().ContainSingle().Subject;
+        document.RoutePattern.Should().BeNull();
+        document.DocumentType.Should().Be(DocumentType.AsyncApi);
+        options.AsyncApiRoutePattern.Should().Be("/custom/{documentName}.json");
+    }
+
+    [Fact]
+    public void AddAsyncApiDocuments_ShouldAddAllDocumentsWithAsyncApiType()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options.AddAsyncApiDocuments("events", "commands");
+
+        // Assert
+        options.Documents.Should().HaveCount(2);
+        options.Documents.Should().AllSatisfy(d => d.DocumentType.Should().Be(DocumentType.AsyncApi));
+        options.Documents.Should().ContainSingle(d => d.Name == "events");
+        options.Documents.Should().ContainSingle(d => d.Name == "commands");
+    }
+
+    [Fact]
+    public void AddAsyncApiDocument_ShouldCoexistWithOpenApiDocuments()
+    {
+        // Arrange
+        var options = new ScalarOptions();
+
+        // Act
+        options
+            .AddDocument("v1")
+            .AddAsyncApiDocument("events");
+
+        // Assert
+        options.Documents.Should().HaveCount(2);
+        options.Documents.Should().ContainSingle(d => d.Name == "v1" && d.DocumentType == DocumentType.OpenApi);
+        options.Documents.Should().ContainSingle(d => d.Name == "events" && d.DocumentType == DocumentType.AsyncApi);
+    }
+
+    [Fact]
     public void WithMcpServer_ShouldPreserveDisabledFlag()
     {
         // Arrange


### PR DESCRIPTION
Introduces AsyncAPI document methods (AddAsyncApiDocument, AddAsyncApiDocuments, WithAsyncApiRoutePattern) and a DocumentType enum so OpenAPI and AsyncAPI documents share the same Documents collection but resolve their default route patterns lazily at configuration time. AddAsyncApiDocument now also accepts an agentKey parameter.

## Problem

The .NET integration only supported OpenAPI documents. There was no way to register AsyncAPI documents in the Scalar API Reference from a .NET application. Additionally, OpenAPI and AsyncAPI documents needed to coexist in the same document list (union type) so the Scalar frontend can render them together in a single reference.

## Solution

- Added `AsyncApiRoutePattern` property to `ScalarOptions` (default: `/asyncapi/{documentName}.json`).
- Added `AddAsyncApiDocument`, `AddAsyncApiDocuments`, and `WithAsyncApiRoutePattern` extension methods mirroring the existing OpenAPI document API.
- Introduced a `DocumentType` enum (`OpenApi` / `AsyncApi`) on `ScalarDocument` so the mapper knows which default route pattern to resolve when no explicit pattern is provided. This makes both document types behave consistently: the pattern is resolved lazily at configuration time rather than eagerly at add time.
- Added `agentKey` parameter to `AddAsyncApiDocument` to match the `AddDocument` signature.
- Both document types are stored in the same `Documents` collection — the Scalar frontend already treats sources as a union type.

Alternative considered: eagerly resolving and storing the AsyncAPI route pattern at call time (no `DocumentType` needed). Rejected because it creates an inconsistency — changing `AsyncApiRoutePattern` after adding documents would silently have no effect, unlike the OpenAPI equivalent.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.
