### PR TITLE
fix(api-client): preserve nested multipart field types

### DIFF
--- a/.changeset/nested-multipart-types.md
+++ b/.changeset/nested-multipart-types.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Preserve nested multipart object field types after request body form edits.

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
@@ -879,6 +879,53 @@ describe('buildRequestBody', () => {
     ])
   })
 
+  it('coerces regrouped dotted multipart rows using their leaf schema types', () => {
+    const requestBody = coerceValue(RequestBodyObjectSchema, {
+      content: {
+        'multipart/form-data': {
+          schema: {
+            type: 'object',
+            properties: {
+              jsonField: {
+                type: 'object',
+                properties: {
+                  isSomething: { type: 'boolean' },
+                  mood: {
+                    type: 'array',
+                    items: { type: 'string' },
+                  },
+                },
+              },
+              stringField: { type: 'string' },
+            },
+          },
+          examples: {
+            default: {
+              value: [
+                { name: 'jsonField.isSomething', value: 'false' },
+                { name: 'jsonField.mood', value: '[]' },
+                { name: 'stringField', value: 'ciao2' },
+              ],
+            },
+          },
+        },
+      },
+    })
+
+    const result = buildRequestBody(requestBody, 'default')
+    expect(result?.mode).toBe('formdata')
+    assert(result?.mode === 'formdata')
+
+    expect(result.value).toEqual([
+      {
+        type: 'text',
+        key: 'jsonField',
+        value: JSON.stringify({ isSomething: false, mood: [] }),
+      },
+      { type: 'text', key: 'stringField', value: 'ciao2' },
+    ])
+  })
+
   it('emits the regrouped multipart object at the position of its first dotted row', () => {
     const requestBody = coerceValue(RequestBodyObjectSchema, {
       content: {

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -53,6 +53,83 @@ export type RequestBody = FormData | UrlEncoded | Raw
 const getMultipartEncodingContentType = (requestBody: RequestBodyObject, bodyContentType: string, fieldName: string) =>
   requestBody.content[bodyContentType]?.encoding?.[fieldName]?.contentType
 
+const getSchemaAtPath = (schema: unknown, path: string[]): SchemaObject | undefined => {
+  let current = schema ? (getResolvedRef(schema) as SchemaObject | undefined) : undefined
+
+  for (const segment of path) {
+    if (!current || !isObjectSchema(current) || !current.properties) {
+      return undefined
+    }
+
+    const next = current.properties[segment]
+    if (!next) {
+      return undefined
+    }
+
+    current = getResolvedRef(next) as SchemaObject | undefined
+  }
+
+  return current
+}
+
+const getSchemaTypes = (schema: SchemaObject | undefined): string[] => {
+  const type = schema && 'type' in schema ? schema.type : undefined
+
+  if (!type) {
+    return []
+  }
+
+  return Array.isArray(type) ? type : [type]
+}
+
+const coerceFormRowValue = (value: unknown, schema: SchemaObject | undefined): unknown => {
+  if (typeof value !== 'string') {
+    return value
+  }
+
+  const types = getSchemaTypes(schema)
+  if (!types.length || types.includes('string')) {
+    return value
+  }
+
+  if (types.includes('boolean')) {
+    if (value === 'true') {
+      return true
+    }
+
+    if (value === 'false') {
+      return false
+    }
+  }
+
+  const isInteger = types.includes('integer')
+  const isNumber = types.includes('number')
+  if ((isInteger || isNumber) && value.trim() !== '') {
+    const numericValue = Number(value)
+    if (Number.isFinite(numericValue) && (isNumber || Number.isInteger(numericValue))) {
+      return numericValue
+    }
+  }
+
+  if (types.includes('array') || types.includes('object')) {
+    try {
+      const parsedValue = JSON.parse(value)
+
+      if (types.includes('array') && Array.isArray(parsedValue)) {
+        return parsedValue
+      }
+
+      if (types.includes('object') && isObject(parsedValue)) {
+        return parsedValue
+      }
+    } catch {
+      return value
+    }
+  }
+
+  return value
+}
+
 /**
  * Build a predicate that recognizes multipart rows whose dotted name encodes a path
  * into a nested object property of the multipart schema. Without a schema (or when
@@ -137,10 +214,8 @@ export const buildRequestBody = (
     // lazily allocate the regrouped object for its top-level key and push it into
     // `entries` at the position of the *first* matching row, then keep folding leaves
     // into the same live object reference so interleaved flat rows keep their order.
-    const isDottedNestedRow =
-      result.mode === 'formdata'
-        ? buildDottedNestedRowPredicate(requestBody.content[bodyContentType]?.schema)
-        : () => false
+    const multipartSchema = requestBody.content[bodyContentType]?.schema
+    const isDottedNestedRow = result.mode === 'formdata' ? buildDottedNestedRowPredicate(multipartSchema) : () => false
 
     const entries: { name: string; value: unknown }[] = []
     const regroupedByTopKey = new Map<string, Record<string, unknown>>()
@@ -161,7 +236,11 @@ export const buildRequestBody = (
         regroupedByTopKey.set(topKey, target)
         entries.push({ name: topKey, value: target })
       }
-      setValueAtPath(target, segments.slice(1), row.value)
+      setValueAtPath(
+        target,
+        segments.slice(1),
+        coerceFormRowValue(row.value, getSchemaAtPath(multipartSchema, segments)),
+      )
     }
 
     // Loop over all entries and add them to the form


### PR DESCRIPTION
## Problem

Fixes #9416.

Nested multipart object fields are displayed as editable dotted rows in the request body form. After editing, those row values are strings, and the request builder folded them directly back into the grouped JSON multipart part. That made boolean and array leaves send as `"false"` and `"[]"` instead of `false` and `[]`.

## Solution

Resolve the multipart schema leaf for each dotted nested row before regrouping it, then coerce string row values only when the schema type does not allow `string`. The existing schema-driven dotted-row predicate still keeps literal dotted field names flat.

Added a regression test covering a nested multipart object with a boolean leaf and array leaf after form edits.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [x] I updated the documentation. Not applicable: this is a request-building bug fix with regression coverage and no docs surface change.
