### PR TITLE
fix(workspace-store): keep nested multipart JSON types after form edit

### DIFF
--- a/.changeset/multipart-json-leaf-types.md
+++ b/.changeset/multipart-json-leaf-types.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Keep nested JSON multipart field types after editing the request body form. Editing a form row no longer turns a nested object's booleans, numbers, and arrays into strings on the wire.

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
@@ -1027,6 +1027,46 @@ describe('buildRequestBody', () => {
     ])
   })
 
+  it('follows $ref sibling overrides when coercing a regrouped leaf type', () => {
+    // OpenAPI 3.1 allows annotations alongside a $ref, and they take precedence over the
+    // referenced schema. Here the leaf references a boolean schema but a sibling `type: 'string'`
+    // overrides it, so the merged leaf is a string and the stringified value must stay a string
+    // instead of being parsed back into a boolean. Build the body raw so the $ref siblings survive.
+    const requestBody = {
+      content: {
+        'multipart/form-data': {
+          schema: {
+            type: 'object',
+            properties: {
+              jsonField: {
+                type: 'object',
+                properties: {
+                  overridden: {
+                    $ref: '#/components/schemas/Flag',
+                    '$ref-value': { type: 'boolean' },
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+          examples: {
+            default: {
+              value: [{ name: 'jsonField.overridden', value: 'false' }],
+            },
+          },
+        },
+      },
+    }
+
+    // The strict reference schema does not model annotations alongside a $ref, so cast the raw
+    // body — real workspace data can carry these siblings, which is what mergeSiblingReferences handles.
+    const result = buildRequestBody(requestBody as Parameters<typeof buildRequestBody>[0], 'default')
+    assert(result?.mode === 'formdata')
+
+    expect(result.value).toEqual([{ type: 'text', key: 'jsonField', value: JSON.stringify({ overridden: 'false' }) }])
+  })
+
   it('keeps a flat multipart row whose name happens to contain dots (filename)', () => {
     const requestBody = {
       content: {

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
@@ -931,6 +931,102 @@ describe('buildRequestBody', () => {
     ])
   })
 
+  it('restores leaf types when regrouping dotted multipart rows back into a JSON part', () => {
+    const requestBody = coerceValue(RequestBodyObjectSchema, {
+      content: {
+        'multipart/form-data': {
+          schema: {
+            type: 'object',
+            properties: {
+              jsonField: {
+                type: 'object',
+                properties: {
+                  isSomething: { type: 'boolean' },
+                  mood: { type: 'array', items: { type: 'string' } },
+                  count: { type: 'integer' },
+                  meta: { type: 'object' },
+                },
+              },
+              stringField: { type: 'string' },
+            },
+          },
+          examples: {
+            default: {
+              // The shape the store holds after the user edits a form row: dotted names with
+              // every value stringified for display.
+              value: [
+                { name: 'jsonField.isSomething', value: 'false' },
+                { name: 'jsonField.mood', value: '[]' },
+                { name: 'jsonField.count', value: '3' },
+                { name: 'jsonField.meta', value: '{"a":1}' },
+                { name: 'stringField', value: 'hi' },
+              ],
+            },
+          },
+        },
+      },
+    })
+
+    const result = buildRequestBody(requestBody, 'default')
+    expect(result?.mode).toBe('formdata')
+    assert(result?.mode === 'formdata')
+
+    // The nested JSON part keeps the schema-declared types instead of string-typing them.
+    expect(result.value).toEqual([
+      {
+        type: 'text',
+        key: 'jsonField',
+        value: JSON.stringify({ isSomething: false, mood: [], count: 3, meta: { a: 1 } }),
+      },
+      { type: 'text', key: 'stringField', value: 'hi' },
+    ])
+  })
+
+  it('keeps stringy leaf values as strings when the schema allows a string', () => {
+    const requestBody = coerceValue(RequestBodyObjectSchema, {
+      content: {
+        'multipart/form-data': {
+          schema: {
+            type: 'object',
+            properties: {
+              jsonField: {
+                type: 'object',
+                properties: {
+                  // String field whose value happens to look like a boolean.
+                  label: { type: 'string' },
+                  // Union allowing string keeps the raw text rather than guessing a type.
+                  nullableText: { type: ['string', 'null'] },
+                  // Non-string type but the value is not valid JSON for it: stay untouched.
+                  flag: { type: 'boolean' },
+                },
+              },
+            },
+          },
+          examples: {
+            default: {
+              value: [
+                { name: 'jsonField.label', value: 'false' },
+                { name: 'jsonField.nullableText', value: 'true' },
+                { name: 'jsonField.flag', value: 'yes' },
+              ],
+            },
+          },
+        },
+      },
+    })
+
+    const result = buildRequestBody(requestBody, 'default')
+    assert(result?.mode === 'formdata')
+
+    expect(result.value).toEqual([
+      {
+        type: 'text',
+        key: 'jsonField',
+        value: JSON.stringify({ label: 'false', nullableText: 'true', flag: 'yes' }),
+      },
+    ])
+  })
+
   it('keeps a flat multipart row whose name happens to contain dots (filename)', () => {
     const requestBody = {
       content: {

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
@@ -1027,6 +1027,52 @@ describe('buildRequestBody', () => {
     ])
   })
 
+  it('keeps a fractional value as a string for an integer-only leaf but coerces a whole number', () => {
+    const requestBody = coerceValue(RequestBodyObjectSchema, {
+      content: {
+        'multipart/form-data': {
+          schema: {
+            type: 'object',
+            properties: {
+              jsonField: {
+                type: 'object',
+                properties: {
+                  // Integer-only leaf: a whole number coerces, a fractional value does not.
+                  whole: { type: 'integer' },
+                  fractional: { type: 'integer' },
+                  // A leaf allowing `number` accepts the fractional value.
+                  ratio: { type: 'number' },
+                },
+              },
+            },
+          },
+          examples: {
+            default: {
+              value: [
+                { name: 'jsonField.whole', value: '3' },
+                { name: 'jsonField.fractional', value: '3.14' },
+                { name: 'jsonField.ratio', value: '3.14' },
+              ],
+            },
+          },
+        },
+      },
+    })
+
+    const result = buildRequestBody(requestBody, 'default')
+    assert(result?.mode === 'formdata')
+
+    // The fractional value stays a string under the integer-only leaf; the whole number and the
+    // number-typed leaf are coerced.
+    expect(result.value).toEqual([
+      {
+        type: 'text',
+        key: 'jsonField',
+        value: JSON.stringify({ whole: 3, fractional: '3.14', ratio: 3.14 }),
+      },
+    ])
+  })
+
   it('follows $ref sibling overrides when coercing a regrouped leaf type', () => {
     // OpenAPI 3.1 allows annotations alongside a $ref, and they take precedence over the
     // referenced schema. Here the leaf references a boolean schema but a sibling `type: 'string'`

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -119,7 +119,9 @@ const parsedValueMatchesSchemaType = (value: unknown, types: string[]): boolean 
     return types.includes('boolean')
   }
   if (typeof value === 'number') {
-    return types.includes('number') || types.includes('integer')
+    // A fractional value only satisfies `number`; `integer` requires a whole number so a
+    // string like "3.14" against an integer-only leaf stays untouched instead of being coerced.
+    return types.includes('number') || (types.includes('integer') && Number.isInteger(value))
   }
   if (typeof value === 'string') {
     return types.includes('string')

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -81,6 +81,76 @@ const buildDottedNestedRowPredicate = (schema: unknown) => {
   }
 }
 
+/** Normalize a schema's `type` (string | string[] | absent) into a plain string array. */
+const normalizeSchemaTypes = (schema: SchemaObject): string[] => {
+  const type = 'type' in schema ? schema.type : undefined
+  return Array.isArray(type) ? [...type] : type == null ? [] : [type]
+}
+
+/**
+ * Walk an object schema along a dotted-row path and return the resolved leaf schema,
+ * or undefined when any segment is not a declared object property.
+ */
+const resolveLeafSchema = (schema: SchemaObject | undefined, segments: string[]): SchemaObject | undefined => {
+  let current = schema
+  for (const segment of segments) {
+    if (!current || !isObjectSchema(current) || !current.properties) {
+      return undefined
+    }
+    current = getResolvedRef(current.properties[segment]) as SchemaObject | undefined
+  }
+  return current
+}
+
+/** True when a JSON-parsed value's runtime type is allowed by the schema's declared types. */
+const parsedValueMatchesSchemaType = (value: unknown, types: string[]): boolean => {
+  if (value === null) {
+    return types.includes('null')
+  }
+  if (Array.isArray(value)) {
+    return types.includes('array')
+  }
+  if (typeof value === 'object') {
+    return types.includes('object')
+  }
+  if (typeof value === 'boolean') {
+    return types.includes('boolean')
+  }
+  if (typeof value === 'number') {
+    return types.includes('number') || types.includes('integer')
+  }
+  if (typeof value === 'string') {
+    return types.includes('string')
+  }
+  return false
+}
+
+/**
+ * The form table stringifies every value for display, so an edited nested field comes back
+ * as a string (`false` -> "false", `[]` -> "[]"). When the leaf schema declares a non-string
+ * type, parse the string back to that type so the regrouped JSON part keeps its original
+ * shape instead of becoming string-typed (issue #9416).
+ *
+ * Coercion is deliberately conservative: schemas that allow `string` keep the raw text, and a
+ * value that does not parse as its declared type is left untouched so user input is never lost.
+ */
+const coerceLeafValueToSchemaType = (value: unknown, schema: SchemaObject | undefined): unknown => {
+  if (typeof value !== 'string' || !schema) {
+    return value
+  }
+  const types = normalizeSchemaTypes(schema)
+  // No declared type, or a string is allowed: keep the user's text as-is.
+  if (types.length === 0 || types.includes('string')) {
+    return value
+  }
+  try {
+    const parsed = JSON.parse(value)
+    return parsedValueMatchesSchemaType(parsed, types) ? parsed : value
+  } catch {
+    return value
+  }
+}
+
 /**
  * Create the fetch request body
  */
@@ -137,10 +207,11 @@ export const buildRequestBody = (
     // lazily allocate the regrouped object for its top-level key and push it into
     // `entries` at the position of the *first* matching row, then keep folding leaves
     // into the same live object reference so interleaved flat rows keep their order.
-    const isDottedNestedRow =
+    const multipartSchema =
       result.mode === 'formdata'
-        ? buildDottedNestedRowPredicate(requestBody.content[bodyContentType]?.schema)
-        : () => false
+        ? (getResolvedRef(requestBody.content[bodyContentType]?.schema) as SchemaObject | undefined)
+        : undefined
+    const isDottedNestedRow = result.mode === 'formdata' ? buildDottedNestedRowPredicate(multipartSchema) : () => false
 
     const entries: { name: string; value: unknown }[] = []
     const regroupedByTopKey = new Map<string, Record<string, unknown>>()
@@ -161,7 +232,13 @@ export const buildRequestBody = (
         regroupedByTopKey.set(topKey, target)
         entries.push({ name: topKey, value: target })
       }
-      setValueAtPath(target, segments.slice(1), row.value)
+      // The form table stringifies leaf values; restore the schema-declared type so the
+      // regrouped JSON part keeps booleans/numbers/arrays instead of string-typing them.
+      setValueAtPath(
+        target,
+        segments.slice(1),
+        coerceLeafValueToSchemaType(row.value, resolveLeafSchema(multipartSchema, segments)),
+      )
     }
 
     // Loop over all entries and add them to the form

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -1,7 +1,7 @@
 // import { replaceEnvVariables } from '@scalar/helpers/regex/replace-variables'
 import { isObject } from '@scalar/helpers/object/is-object'
 import { setValueAtPath } from '@scalar/helpers/object/set-value-at-path'
-import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { getResolvedRef, mergeSiblingReferences } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import { unpackProxyObject } from '@scalar/workspace-store/helpers/unpack-proxy'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import type { RequestBodyObject } from '@scalar/workspace-store/schemas/v3.1/strict/request-body'
@@ -61,13 +61,15 @@ const getMultipartEncodingContentType = (requestBody: RequestBodyObject, bodyCon
  * by `get-form-body-rows.ts` are folded back via `foldDottedRowsToObject`.
  */
 const buildDottedNestedRowPredicate = (schema: unknown) => {
-  const resolved = schema ? (getResolvedRef(schema) as SchemaObject | undefined) : undefined
+  const resolved = schema ? (getResolvedRef(schema, mergeSiblingReferences) as SchemaObject | undefined) : undefined
   if (!resolved || !isObjectSchema(resolved) || !resolved.properties) {
     return (_name: string, _value: unknown) => false
   }
   const nestedTopKeys = new Set<string>()
   for (const [key, child] of Object.entries(resolved.properties)) {
-    const childResolved = child ? (getResolvedRef(child) as SchemaObject | undefined) : undefined
+    const childResolved = child
+      ? (getResolvedRef(child, mergeSiblingReferences) as SchemaObject | undefined)
+      : undefined
     if (childResolved && isObjectSchema(childResolved) && childResolved.properties) {
       nestedTopKeys.add(key)
     }
@@ -97,7 +99,7 @@ const resolveLeafSchema = (schema: SchemaObject | undefined, segments: string[])
     if (!current || !isObjectSchema(current) || !current.properties) {
       return undefined
     }
-    current = getResolvedRef(current.properties[segment]) as SchemaObject | undefined
+    current = getResolvedRef(current.properties[segment], mergeSiblingReferences) as SchemaObject | undefined
   }
   return current
 }
@@ -209,7 +211,9 @@ export const buildRequestBody = (
     // into the same live object reference so interleaved flat rows keep their order.
     const multipartSchema =
       result.mode === 'formdata'
-        ? (getResolvedRef(requestBody.content[bodyContentType]?.schema) as SchemaObject | undefined)
+        ? (getResolvedRef(requestBody.content[bodyContentType]?.schema, mergeSiblingReferences) as
+            | SchemaObject
+            | undefined)
         : undefined
     const isDottedNestedRow = result.mode === 'formdata' ? buildDottedNestedRowPredicate(multipartSchema) : () => false
 


### PR DESCRIPTION
Editing any field in the multipart request body form turned a nested JSON field's booleans, numbers, and arrays into strings on the wire: `{"isSomething":false,"mood":[]}` became `{"isSomething":"false","mood":"[]"}`.

The form table stringifies every leaf value for display, so an edited nested field comes back as a string. When `buildRequestBody` regroups the dotted rows into a single JSON part, it now coerces each leaf back to its schema-declared type. Coercion is conservative: a schema that allows a string keeps the raw text, and anything that does not parse as its declared type is left untouched.

## Ticket

Fixes #9416

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-body serialization for multipart nested JSON after UI edits; logic is guarded and well-tested but affects wire payloads users send from the client.
> 
> **Overview**
> Fixes a bug where **editing nested fields in the multipart request body form** sent JSON parts with string-typed leaves (e.g. `"false"` instead of `false`) because the UI stores every cell as a string.
> 
> When `buildRequestBody` **regroups dotted rows** (e.g. `jsonField.isSomething`) back into one JSON multipart part, it now **coerces each leaf** using the resolved OpenAPI leaf schema: `JSON.parse` plus a type check against declared types (boolean, array, integer, number, object, null). Coercion is **conservative**—if the schema allows `string`, or parse/type check fails, the raw string is kept.
> 
> Schema resolution now uses **`mergeSiblingReferences`** when walking multipart schemas and leaf paths so **$ref sibling overrides** (OpenAPI 3.1) affect coercion. New tests cover the happy path, string unions, integer vs fractional numbers, and ref overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0802413cd48f6f2e3b5f8f5229da6ef64a10df4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->