### PR TITLE
feat(workspace-store): type $dynamicRef / $dynamicAnchor on 3.1 Schema Objects

### DIFF
--- a/.changeset/dynamicref-schema-types.md
+++ b/.changeset/dynamicref-schema-types.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+feat(workspace-store): keep JSON Schema 2020-12 `$id`, `$anchor`, `$dynamicAnchor`, and `$dynamicRef` on Schema Objects so they survive parsing

--- a/packages/workspace-store/src/schemas/v3.1/strict/schema.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/schema.ts
@@ -87,6 +87,22 @@ type Extensions = XScalarIgnore &
   XTags
 
 const CorePropertiesWithSchema = Type.Object({
+  /**
+   * JSON Schema 2020-12 core reference keywords.
+   *
+   * OpenAPI 3.1 adopts the JSON Schema 2020-12 dialect for Schema Objects, which means a schema may carry an
+   * identifier (`$id`), a plain-name anchor (`$anchor`), and the dynamic binding keywords (`$dynamicAnchor` /
+   * `$dynamicRef`) used for generic and recursive patterns such as `PaginatedResponse<T>`. We keep these typed so
+   * the keywords survive parsing instead of being dropped as unknown properties. Resolution of `$dynamicRef`
+   * against the active `$dynamicAnchor` is tracked separately, see https://github.com/scalar/scalar/issues/9414.
+   */
+  $id: Type.Optional(Type.String()),
+  /** Plain-name anchor that other schemas can reference with `#anchor`. */
+  $anchor: Type.Optional(Type.String()),
+  /** Dynamic anchor, the target a matching `$dynamicRef` resolves to within the dynamic scope. */
+  $dynamicAnchor: Type.Optional(Type.String()),
+  /** Dynamic reference, resolved against the outermost matching `$dynamicAnchor` in the dynamic scope. */
+  $dynamicRef: Type.Optional(Type.String()),
   name: Type.Optional(Type.String()),
   /** A title for the schema. */
   title: Type.Optional(Type.String()),
@@ -138,6 +154,22 @@ const CorePropertiesWithSchema = Type.Object({
 })
 
 type CoreProperties = {
+  /**
+   * JSON Schema 2020-12 core reference keywords.
+   *
+   * OpenAPI 3.1 adopts the JSON Schema 2020-12 dialect for Schema Objects, which means a schema may carry an
+   * identifier (`$id`), a plain-name anchor (`$anchor`), and the dynamic binding keywords (`$dynamicAnchor` /
+   * `$dynamicRef`) used for generic and recursive patterns such as `PaginatedResponse<T>`. We keep these typed so
+   * the keywords survive parsing instead of being dropped as unknown properties. Resolution of `$dynamicRef`
+   * against the active `$dynamicAnchor` is tracked separately, see https://github.com/scalar/scalar/issues/9414.
+   */
+  $id?: string
+  /** Plain-name anchor that other schemas can reference with `#anchor`. */
+  $anchor?: string
+  /** Dynamic anchor, the target a matching `$dynamicRef` resolves to within the dynamic scope. */
+  $dynamicAnchor?: string
+  /** Dynamic reference, resolved against the outermost matching `$dynamicAnchor` in the dynamic scope. */
+  $dynamicRef?: string
   name?: string
   /** A title for the schema. */
   title?: string


### PR DESCRIPTION
Groundwork for `$dynamicRef` support. OpenAPI 3.1 docs using JSON Schema 2020-12 `$dynamicRef` / `$dynamicAnchor` load without error today, but the keywords get dropped as unknown properties and the schemas render empty.

This PR does the boring type plumbing so the keywords survive parsing. No resolution logic yet — that's the fast-follow.

- Add `$id`, `$anchor`, `$dynamicAnchor`, `$dynamicRef` to the 3.1 Schema Object types

Actual dynamic-scope resolution (the part that makes `items` render as `User[]`) comes in a follow-up.

## Ticket

Part of #9414

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema typing and parse retention only; no reference resolution or runtime behavior changes beyond not dropping these properties.
> 
> **Overview**
> Adds **JSON Schema 2020-12** core reference keywords (`$id`, `$anchor`, `$dynamicAnchor`, `$dynamicRef`) to the OpenAPI **3.1** strict Schema Object in `@scalar/workspace-store`, in both the TypeBox runtime schema (`CorePropertiesWithSchema`) and the TypeScript `CoreProperties` type.
> 
> Previously those fields were treated as unknown and **stripped during parse**, which could leave docs that use dynamic refs with empty-looking schemas even when loading succeeded. This change only preserves the keywords through parsing and typing; **`$dynamicRef` resolution is explicitly out of scope** (follow-up, #9414).
> 
> A **changeset** records a patch release for `@scalar/workspace-store`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b49404f788b5f70cf8816e51be708c37331a8794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->