### PR TITLE
fix(api-reference): make `x-tagGroups` titles navigable from search

### DIFF
--- a/.changeset/tag-group-search-navigation.md
+++ b/.changeset/tag-group-search-navigation.md
@@ -1,0 +1,9 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): make x-tagGroups titles navigable from search
+
+Tag group titles appeared as search results but clicking them did nothing,
+because the flattened modern layout rendered no element carrying the tag
+group id to scroll to. The group now exposes its id as a scroll anchor.

--- a/packages/api-reference/src/components/Content/Operations/TraversedEntry.test.ts
+++ b/packages/api-reference/src/components/Content/Operations/TraversedEntry.test.ts
@@ -311,6 +311,23 @@ describe('tag group rendering', () => {
     expect(wrapper.text()).toContain('Get Users')
   })
 
+  it('exposes the tag group id as a scroll anchor', () => {
+    // Modern layout flattens tag groups, so the group needs its own anchor
+    // element. Without it, selecting the group from search or the sidebar has
+    // nothing to scroll to.
+    const tagGroup = createMockTagGroup({
+      id: 'tag-group/auth',
+      children: [createMockOperation({ id: 'group-op-1', title: 'Get Users', path: '/users', method: 'get' })],
+    })
+    const entries: TraversedEntry[] = [tagGroup]
+
+    const wrapper = mount(TraversedEntryComponent, {
+      props: makeMockProps(entries),
+    })
+
+    expect(wrapper.find('#tag-group\\/auth').exists()).toBe(true)
+  })
+
   it('renders empty tag group correctly', () => {
     const tagGroup = createMockTagGroup({ children: [] })
     const entries: TraversedEntry[] = [tagGroup]

--- a/packages/api-reference/src/components/Content/Operations/TraversedEntry.vue
+++ b/packages/api-reference/src/components/Content/Operations/TraversedEntry.vue
@@ -157,21 +157,30 @@ function getPathValue(entry: TraversedOperation | TraversedWebhook) {
       </template>
     </Tag>
 
-    <!-- Display tag grop entries for modern layout (flattened) -->
-    <TraversedEntry
+    <!-- Display tag group entries for modern layout (flattened) -->
+    <!--
+      The wrapping element carries the tag group id so it remains a scroll
+      target. Modern layout flattens groups and renders no header of their own,
+      so without this anchor, selecting a tag group (from search or the sidebar)
+      would have nothing to scroll to.
+    -->
+    <div
       v-else-if="isTagGroup(entry)"
-      :authStore
-      :clientOptions
-      :document
-      :entries="entry.children || []"
-      :eventBus
-      :expandedItems
-      :level="level + 1"
-      :options
-      :securitySchemes
-      :selectedClient
-      :selectedServer>
-    </TraversedEntry>
+      :id="entry.id">
+      <TraversedEntry
+        :authStore
+        :clientOptions
+        :document
+        :entries="entry.children || []"
+        :eventBus
+        :expandedItems
+        :level="level + 1"
+        :options
+        :securitySchemes
+        :selectedClient
+        :selectedServer>
+      </TraversedEntry>
+    </div>
 
     <!-- Models -->
     <ModelTag


### PR DESCRIPTION
Tag group titles (from `x-tagGroups`) show up as search results, but clicking them did nothing.

In the default (modern) layout, tag groups are rendered flattened. The group's children render directly with no element carrying the group's own id.

Added a regression test that fails on the pre-fix code and passes with the fix.

## Ticket

Closes #9412