### PR TITLE
fix(api-reference): SSR hydration mismatch in Search components

### DIFF
--- a/.changeset/ssr-hydration-shortcut-teleport.md
+++ b/.changeset/ssr-hydration-shortcut-teleport.md
@@ -1,0 +1,8 @@
+---
+'@scalar/api-reference': patch
+'@scalar/components': patch
+---
+
+fix(api-reference): avoid SSR hydration mismatch from the search shortcut and teleport ids
+
+The macOS search shortcut symbol was derived from `navigator` during render, so a Mac client hydrated `⌘` where the server sent `⌃`. The platform is now resolved after mount. Teleport target ids and the search modal ids also switched from `nanoid()` to Vue's SSR-stable `useId()`.

--- a/packages/api-reference/src/features/Search/components/SearchButton.ssr.test.ts
+++ b/packages/api-reference/src/features/Search/components/SearchButton.ssr.test.ts
@@ -1,0 +1,65 @@
+import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
+import { renderToString } from '@vue/server-renderer'
+import { flushPromises } from '@vue/test-utils'
+import { afterEach, expect, it } from 'vitest'
+import { createSSRApp, h } from 'vue'
+
+import SearchButton from './SearchButton.vue'
+
+/** Symbols used for the macOS and non-macOS keyboard shortcut */
+const COMMAND_SYMBOL = '⌘'
+const CONTROL_SYMBOL = '⌃'
+
+/**
+ * Overrides the reported platform so we can simulate a macOS client. The
+ * platform is read through `navigator`, which is unavailable during real SSR.
+ */
+const setUserAgent = (userAgent: string) =>
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: userAgent,
+    configurable: true,
+  })
+
+const originalUserAgent = window.navigator.userAgent
+
+afterEach(() => setUserAgent(originalUserAgent))
+
+const props = { eventBus: createWorkspaceEventBus(), document: undefined }
+
+/**
+ * The server has no `navigator`, so it always renders the non-macOS shortcut.
+ * If the client picked the shortcut from `navigator` during its first render,
+ * a macOS visitor would render `⌘` where the server sent `⌃`, which is exactly
+ * the hydration mismatch reported in the issue. The platform must therefore not
+ * influence the server-rendered markup.
+ */
+it('renders a platform-independent shortcut on the server', async () => {
+  // Pretend we are on macOS while producing the "server" markup.
+  setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+
+  const html = await renderToString(createSSRApp({ render: () => h(SearchButton, props) }))
+
+  expect(html).toContain(CONTROL_SYMBOL)
+  expect(html).not.toContain(COMMAND_SYMBOL)
+})
+
+/**
+ * Once mounted on the client, the macOS shortcut is resolved so the symbol is
+ * still correct for the user, just applied after hydration rather than during it.
+ */
+it('upgrades to the macOS shortcut after mounting on a macOS client', async () => {
+  const html = await renderToString(createSSRApp({ render: () => h(SearchButton, props) }))
+
+  setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+
+  const container = document.createElement('div')
+  container.innerHTML = html
+
+  const app = createSSRApp({ render: () => h(SearchButton, props) })
+  app.mount(container)
+  await flushPromises()
+
+  expect(container.textContent).toContain(COMMAND_SYMBOL)
+
+  app.unmount()
+})

--- a/packages/api-reference/src/features/Search/components/SearchButton.vue
+++ b/packages/api-reference/src/features/Search/components/SearchButton.vue
@@ -30,6 +30,19 @@ const {
 const button = ref<InstanceType<typeof ScalarSidebarSearchButton>>()
 const modalState = useModal()
 
+/**
+ * Whether the user is on macOS, used to show the correct shortcut symbol.
+ *
+ * This must default to `false` so the server-rendered markup and the first
+ * client render agree. Detecting the platform relies on `navigator`, which is
+ * unavailable during SSR, so we resolve it after mount to avoid a hydration
+ * mismatch.
+ */
+const isMac = ref(false)
+onMounted(() => {
+  isMac.value = isMacOS()
+})
+
 const handleHotKey = (e: KeyboardEvent) => {
   if ((isMacOS() ? e.metaKey : e.ctrlKey) && e.key === searchHotKey) {
     e.preventDefault()
@@ -83,7 +96,7 @@ function handleClick() {
       Search
     </span>
     <template #shortcut>
-      <template v-if="isMacOS()">
+      <template v-if="isMac">
         <span class="sr-only">Command</span>
         <span aria-hidden="true">⌘</span>
       </template>

--- a/packages/api-reference/src/features/Search/components/SearchModal.vue
+++ b/packages/api-reference/src/features/Search/components/SearchModal.vue
@@ -6,8 +6,7 @@ import type { ModelsSectionLabel } from '@scalar/types/api-reference'
 import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-import { nanoid } from 'nanoid'
-import { computed, ref, watch } from 'vue'
+import { computed, ref, useId, watch } from 'vue'
 
 import { useSearchIndex } from '@/features/Search/hooks/useSearchIndex'
 
@@ -21,7 +20,7 @@ const props = defineProps<{
 }>()
 
 /** Base id for the search form */
-const id = nanoid()
+const id = useId()
 /** An id for the results listbox */
 const listboxId = `${id}-search-result`
 /** An id for the results instructions */

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -235,7 +235,6 @@
     "@scalar/use-hooks": "workspace:*",
     "@vueuse/core": "catalog:*",
     "cva": "1.0.0-beta.4",
-    "nanoid": "catalog:*",
     "radix-vue": "catalog:*",
     "vue": "catalog:*",
     "vue-component-type-helpers": "^3.2.6"

--- a/packages/components/src/components/ScalarTeleport/useTeleport.test.ts
+++ b/packages/components/src/components/ScalarTeleport/useTeleport.test.ts
@@ -3,15 +3,11 @@ import { inject } from 'vue'
 
 import { useProvideTeleport, useTeleport } from './useTeleport'
 
-// Mock vue's inject
+// Mock vue's inject, provide and useId
 vi.mock('vue', () => ({
   inject: vi.fn(),
   provide: vi.fn(),
-}))
-
-// Mock nanoid
-vi.mock('nanoid', () => ({
-  nanoid: vi.fn().mockReturnValue('1234567890'),
+  useId: vi.fn().mockReturnValue('1234567890'),
 }))
 
 describe('useTeleport', () => {

--- a/packages/components/src/components/ScalarTeleport/useTeleport.ts
+++ b/packages/components/src/components/ScalarTeleport/useTeleport.ts
@@ -1,5 +1,4 @@
-import { nanoid } from 'nanoid'
-import { type InjectionKey, inject, provide } from 'vue'
+import { type InjectionKey, inject, provide, useId } from 'vue'
 
 /**
  * The teleport target
@@ -21,7 +20,9 @@ export const useTeleport = () => inject(TELEPORT_SYMBOL, 'body')
  * @see https://vuejs.org/guide/components/provide-inject.html#provide-inject
  */
 export const useProvideTeleport = (id?: string) => {
-  const targetId = id ?? `scalar-teleport-${nanoid()}`
+  // `useId` produces ids that are stable across SSR and client hydration,
+  // avoiding a mismatch on the teleport target id.
+  const targetId = id ?? `scalar-teleport-${useId()}`
   provide(TELEPORT_SYMBOL, `#${targetId}`)
   return targetId
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1037,7 +1037,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: ^4.0.0
-        version: 4.3.1(magicast@0.5.2)
+        version: 4.3.1(magicast@0.3.5)
       '@scalar/api-client':
         specifier: workspace:*
         version: link:../../packages/api-client
@@ -1056,7 +1056,7 @@ importers:
     devDependencies:
       '@nuxt/module-builder':
         specifier: ^1.0.1
-        version: 1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))
       '@types/node':
         specifier: ^24.1.0
         version: 24.10.13
@@ -1065,7 +1065,7 @@ importers:
         version: 10.1.0
       nuxt:
         specifier: ^4.1.0
-        version: 4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3)
+        version: 4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3)
       shx:
         specifier: catalog:*
         version: 0.4.0
@@ -1665,9 +1665,6 @@ importers:
       cva:
         specifier: 1.0.0-beta.4
         version: 1.0.0-beta.4(typescript@5.9.3)
-      nanoid:
-        specifier: catalog:*
-        version: 5.1.6
       radix-vue:
         specifier: catalog:*
         version: 1.9.17(vue@3.5.30(typescript@5.9.3))
@@ -23466,11 +23463,11 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)':
+  '@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.1)(commander@13.1.0)
       '@clack/prompts': 1.1.0
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.3.5)
       citty: 0.2.1
       confbox: 0.2.4
       consola: 3.4.2
@@ -23678,9 +23675,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/kit@4.1.2(magicast@0.5.2)':
+  '@nuxt/kit@4.1.2(magicast@0.3.5)':
     dependencies:
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.3.5)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -23701,6 +23698,31 @@ snapshots:
       ufo: 1.6.3
       unctx: 2.5.0
       unimport: 5.7.0
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@nuxt/kit@4.3.1(magicast@0.3.5)':
+    dependencies:
+      c12: 3.3.3(magicast@0.3.5)
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.0.8
+      ignore: 7.0.5
+      jiti: 2.6.1
+      klona: 2.0.6
+      mlly: 1.8.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      rc9: 3.0.0
+      scule: 1.3.0
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ufo: 1.6.3
+      unctx: 2.5.0
       untyped: 2.0.0
     transitivePeerDependencies:
       - magicast
@@ -23730,9 +23752,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/module-builder@1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))':
+  '@nuxt/module-builder@1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)
       citty: 0.1.6
       consola: 3.4.2
       defu: 6.1.4
@@ -23847,9 +23869,9 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.1.2(magicast@0.5.2))':
+  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.1.2(magicast@0.3.5))':
     dependencies:
-      '@nuxt/kit': 4.1.2(magicast@0.5.2)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       citty: 0.2.1
       consola: 3.4.2
       ofetch: 2.0.0-alpha.3
@@ -23919,9 +23941,9 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)':
+  '@nuxt/vite-builder@4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)':
     dependencies:
-      '@nuxt/kit': 4.1.2(magicast@0.5.2)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
       '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 5.1.4(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
@@ -33542,18 +33564,18 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3):
+  nuxt@4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3):
     dependencies:
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
       '@nuxt/devtools': 2.7.0(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
-      '@nuxt/kit': 4.1.2(magicast@0.5.2)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       '@nuxt/schema': 4.1.2
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.1.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.1.2(magicast@0.3.5))
+      '@nuxt/vite-builder': 4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.3.5)
       chokidar: 4.0.3
       compatx: 0.2.0
       consola: 3.4.2


### PR DESCRIPTION
The macOS search shortcut symbol was picked from `navigator` during render, so a Mac client hydrated `⌘` where the server sent `⌃`. Now resolved after mount. Also swapped a couple of `nanoid()` ids (search modal, teleport target) to Vue's SSR-stable `useId()`.

Includes an SSR regression test that fails without the fix.

## Ticket

Fixes #4458

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted SSR/hydration fixes with regression tests; macOS users may briefly see the wrong shortcut symbol before mount.
> 
> **Overview**
> Fixes SSR hydration mismatches in api-reference search and shared teleport targets.
> 
> **Search shortcut:** The sidebar search button no longer calls `isMacOS()` during render for the displayed symbol. It uses an `isMac` ref defaulting to `false` (non-macOS `⌃`) so server and initial client markup match, then sets `isMac` in `onMounted` so macOS users still see `⌘` after hydration. Keyboard handling still uses `isMacOS()` at event time.
> 
> **Stable ids:** `SearchModal` and `useProvideTeleport` replace `nanoid()` with Vue's `useId()` for form/listbox/instructions and auto-generated teleport target ids. `@scalar/components` drops the `nanoid` dependency.
> 
> **Tests:** Adds `SearchButton.ssr.test.ts` for server-only non-mac shortcut markup and post-mount macOS upgrade; updates teleport unit tests to mock `useId` instead of `nanoid`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e94f9bef064581c7c14d8d3d9cc94ad767153a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->