### PR TITLE
feat(client-side-rendering): add nonce option for CSP

### DIFF
--- a/.changeset/csp-nonce-support.md
+++ b/.changeset/csp-nonce-support.md
@@ -14,12 +14,14 @@
 
 Add a `nonce` option for Content Security Policy support.
 
-When you pass a `nonce`, the rendered HTML stamps it onto the inline `<script>` and `<style>` tags (and the CDN `<script>` tag), and emits a matching `<meta property="csp-nonce">` tag so the standalone bundle applies the same nonce to the stylesheet it injects at runtime. This lets the API Reference render under a strict Content Security Policy without `unsafe-inline`.
+When you pass a `nonce`, the rendered HTML stamps it onto the inline `<script>` and the CDN `<script>` tag (and Scalar's own `<style>` tags, plus a matching `<meta property="csp-nonce">`). This lets the API Reference run under a strict `script-src` with no `unsafe-inline` and no `unsafe-eval`.
 
 ```ts
 ApiReference({
   url: '/openapi.json',
-  // Match this value in your `script-src` and `style-src` CSP directives.
+  // Match this value in your `script-src` CSP directive.
   nonce: 'r4nd0m',
 })
 ```
+
+Note: `style-src` still needs `'unsafe-inline'`. The reference renders inline `style="…"` attributes, which a CSP nonce can never authorize (nonces only apply to `<script>`, `<style>` and `<link>` elements), so a nonce-only `style-src` is not possible. The win is a fully strict `script-src`.

--- a/.changeset/csp-nonce-support.md
+++ b/.changeset/csp-nonce-support.md
@@ -1,0 +1,25 @@
+---
+'@scalar/client-side-rendering': minor
+'@scalar/api-reference': minor
+'@scalar/types': minor
+'@scalar/schemas': minor
+'@scalar/nextjs-api-reference': minor
+'@scalar/express-api-reference': minor
+'@scalar/fastify-api-reference': minor
+'@scalar/nestjs-api-reference': minor
+'@scalar/hono-api-reference': minor
+'@scalar/sveltekit': minor
+'@scalar/astro': minor
+---
+
+Add a `nonce` option for Content Security Policy support.
+
+When you pass a `nonce`, the rendered HTML stamps it onto the inline `<script>` and `<style>` tags (and the CDN `<script>` tag), and emits a matching `<meta property="csp-nonce">` tag so the standalone bundle applies the same nonce to the stylesheet it injects at runtime. This lets the API Reference render under a strict Content Security Policy without `unsafe-inline`.
+
+```ts
+ApiReference({
+  url: '/openapi.json',
+  // Match this value in your `script-src` and `style-src` CSP directives.
+  nonce: 'r4nd0m',
+})
+```

--- a/documentation/integrations/astro.md
+++ b/documentation/integrations/astro.md
@@ -47,6 +47,9 @@ import { ScalarComponent } from '@scalar/astro'
 
 In `client` mode the configuration is serialized into the page as JSON, so function-valued options (a custom `fetch`, `onLoaded`, plugins, …) are not carried over. Use the default `static` mode if you rely on those.
 
+> [!NOTE]
+> **Content Security Policy in `client` mode.** Passing a `nonce` stamps the CDN `<script>` Scalar injects at runtime and emits the `csp-nonce` meta tag for the styles it injects (see [the CSP guide](./html-js.md#content-security-policy-csp)). The small script that boots the client is generated and bundled by Astro itself, not by Scalar, so Scalar cannot put your nonce on it. Under a strict `script-src 'nonce-…'`, allow Astro's own scripts the way Astro recommends — enable [`experimental.csp`](https://docs.astro.build/en/reference/experimental-flags/csp/), which nonces every script Astro emits, or add `'self'` to `script-src`. The default `static` mode has no Astro-generated bootstrap and stays fully nonce-only.
+
 ### Themes
 
 You can use one of [our predefined themes](https://github.com/scalar/scalar/blob/main/packages/themes/src/index.ts#L15) (`alternate`, `default`, `moon`, `purple`, `solarized`) or overwrite it with `none`. All themes come with a light and dark color scheme.

--- a/documentation/integrations/html-js.md
+++ b/documentation/integrations/html-js.md
@@ -40,19 +40,19 @@ Check out the [Configuration](../configuration.md) page to learn more about cust
 
 ## Content Security Policy (CSP)
 
-If your page enforces a strict [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP), the inline initialization script and the stylesheet that the bundle injects at runtime are blocked unless you allow `unsafe-inline`.
+If your page enforces a strict [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP), the inline initialization script is blocked unless you allow `unsafe-inline`.
 
-To keep a strict policy instead, generate a per-request nonce, put it on the script tags, and add a `<meta property="csp-nonce">` so the injected stylesheet picks up the same nonce:
+To keep a strict `script-src` instead, generate a per-request nonce and put it on both script tags:
 
 ```html
 <head>
-  <!-- Use the same value as the `nonce-...` source in your CSP header -->
+  <!-- The reference also injects styles at runtime; this lets them carry the same nonce -->
   <meta property="csp-nonce" content="r4nd0m" />
 </head>
 <body>
   <div id="app"></div>
 
-  <!-- script-src 'nonce-r4nd0m' -->
+  <!-- script-src 'nonce-r4nd0m' — no unsafe-inline, no unsafe-eval -->
   <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference" nonce="r4nd0m"></script>
   <script nonce="r4nd0m">
     Scalar.createApiReference('#app', {
@@ -62,7 +62,10 @@ To keep a strict policy instead, generate a per-request nonce, put it on the scr
 </body>
 ```
 
-If you render the HTML through one of our server integrations (Next.js, Express, Fastify, NestJS, Hono, SvelteKit, Astro) you do not have to wire this up by hand: pass a `nonce` to the configuration and all of the above is added for you.
+> [!NOTE]
+> **`style-src` still needs `'unsafe-inline'`.** The reference renders inline `style="…"` attributes, and a CSP nonce can never authorize inline style attributes — only `<script>`, `<style>` and `<link>` elements. So a strict, nonce-only `style-src` is not possible today; keep `style-src 'unsafe-inline'`. The win here is `script-src`, which can stay fully strict.
+
+If you render the HTML through one of our server integrations (Next.js, Express, Fastify, NestJS, Hono, SvelteKit, Astro), pass a `nonce` to the configuration and the script tags and meta tag are added for you.
 
 ## Version
 

--- a/documentation/integrations/html-js.md
+++ b/documentation/integrations/html-js.md
@@ -38,6 +38,32 @@ This renders our `@scalar/galaxy` OpenAPI example, using the latest version of `
 
 Check out the [Configuration](../configuration.md) page to learn more about customizing your API reference.
 
+## Content Security Policy (CSP)
+
+If your page enforces a strict [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP), the inline initialization script and the stylesheet that the bundle injects at runtime are blocked unless you allow `unsafe-inline`.
+
+To keep a strict policy instead, generate a per-request nonce, put it on the script tags, and add a `<meta property="csp-nonce">` so the injected stylesheet picks up the same nonce:
+
+```html
+<head>
+  <!-- Use the same value as the `nonce-...` source in your CSP header -->
+  <meta property="csp-nonce" content="r4nd0m" />
+</head>
+<body>
+  <div id="app"></div>
+
+  <!-- script-src 'nonce-r4nd0m' -->
+  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference" nonce="r4nd0m"></script>
+  <script nonce="r4nd0m">
+    Scalar.createApiReference('#app', {
+      url: 'https://registry.scalar.com/@scalar/apis/galaxy?format=json',
+    })
+  </script>
+</body>
+```
+
+If you render the HTML through one of our server integrations (Next.js, Express, Fastify, NestJS, Hono, SvelteKit, Astro) you do not have to wire this up by hand: pass a `nonce` to the configuration and all of the above is added for you.
+
 ## Version
 
 It's recommended to use the latest version from jsdelivr. You'll get continuous updates, fixes and other improvements and that's also the one we're testing and monitoring continuously.

--- a/documentation/integrations/nextjs.md
+++ b/documentation/integrations/nextjs.md
@@ -104,9 +104,9 @@ export const GET = ApiReference(config)
 
 ### Content Security Policy (CSP)
 
-To render the reference, Scalar adds an inline `<script>` and inline `<style>` to the page, and the bundle injects its stylesheet at runtime. Under a strict [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) those are blocked unless you allow `unsafe-inline` (which defeats the purpose of a CSP).
+To boot the reference, Scalar adds an inline `<script>` to the page. Under a strict [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) that script is blocked unless you allow `unsafe-inline` (which defeats the purpose of a CSP).
 
-Instead, pass a `nonce`. Scalar stamps it onto the inline tags and emits a matching `<meta property="csp-nonce">` so the injected stylesheet picks up the same nonce. That way you can keep a strict policy without `unsafe-inline`.
+Instead, pass a `nonce`. Scalar stamps it onto the inline script and the CDN `<script>` tag, so you can keep a strict `script-src` with **no `unsafe-inline` and no `unsafe-eval`**.
 
 A nonce has to be generated fresh for every request, so generate it in `middleware.ts`, expose it to the route through a request header, and set the matching CSP response header:
 
@@ -120,8 +120,10 @@ export function middleware(request: NextRequest) {
 
   const csp = [
     `default-src 'self'`,
+    // Scripts are locked down to the nonce — no unsafe-inline, no unsafe-eval.
     `script-src 'nonce-${nonce}'`,
-    `style-src 'nonce-${nonce}'`,
+    // Styles still need 'unsafe-inline' (see the note below).
+    `style-src 'unsafe-inline'`,
     // Allow the OpenAPI document and any other resources you load.
     `connect-src 'self' https:`,
     `img-src 'self' data: https:`,
@@ -161,6 +163,9 @@ export async function GET() {
 ```
 
 The same `nonce` option is available in all of our HTML-rendering integrations (Express, Fastify, NestJS, Hono, SvelteKit and Astro).
+
+> [!NOTE]
+> **`style-src` still needs `'unsafe-inline'`.** The reference renders many inline `style="…"` attributes, and a CSP nonce can never authorize inline style attributes — only `<script>`, `<style>` and `<link>` elements. So `style-src` cannot be locked down to a nonce today. The `nonce` is still applied to Scalar's own style tags (and a matching `<meta property="csp-nonce">` is emitted), but `style-src 'unsafe-inline'` remains required. The important win is `script-src`, which you can keep fully strict.
 
 ## Guide
 

--- a/documentation/integrations/nextjs.md
+++ b/documentation/integrations/nextjs.md
@@ -102,6 +102,65 @@ const config = {
 export const GET = ApiReference(config)
 ```
 
+### Content Security Policy (CSP)
+
+To render the reference, Scalar adds an inline `<script>` and inline `<style>` to the page, and the bundle injects its stylesheet at runtime. Under a strict [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) those are blocked unless you allow `unsafe-inline` (which defeats the purpose of a CSP).
+
+Instead, pass a `nonce`. Scalar stamps it onto the inline tags and emits a matching `<meta property="csp-nonce">` so the injected stylesheet picks up the same nonce. That way you can keep a strict policy without `unsafe-inline`.
+
+A nonce has to be generated fresh for every request, so generate it in `middleware.ts`, expose it to the route through a request header, and set the matching CSP response header:
+
+```typescript
+// middleware.ts
+import { NextResponse, type NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  // A fresh nonce per request.
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
+
+  const csp = [
+    `default-src 'self'`,
+    `script-src 'nonce-${nonce}'`,
+    `style-src 'nonce-${nonce}'`,
+    // Allow the OpenAPI document and any other resources you load.
+    `connect-src 'self' https:`,
+    `img-src 'self' data: https:`,
+    `font-src 'self' https:`,
+  ].join('; ')
+
+  // Pass the nonce to the route handler via a request header.
+  const headers = new Headers(request.headers)
+  headers.set('x-nonce', nonce)
+
+  const response = NextResponse.next({ request: { headers } })
+  response.headers.set('Content-Security-Policy', csp)
+
+  return response
+}
+
+export const config = {
+  matcher: '/reference/:path*',
+}
+```
+
+Then read the nonce in the route handler and pass it to the configuration:
+
+```typescript
+// app/reference/route.ts
+import { ApiReference } from '@scalar/nextjs-api-reference'
+import { headers } from 'next/headers'
+
+export async function GET() {
+  const nonce = (await headers()).get('x-nonce') ?? undefined
+
+  return ApiReference({
+    url: '/openapi.json',
+    nonce,
+  })()
+}
+```
+
+The same `nonce` option is available in all of our HTML-rendering integrations (Express, Fastify, NestJS, Hono, SvelteKit and Astro).
 
 ## Guide
 

--- a/integrations/astro/src/ScalarClient.astro
+++ b/integrations/astro/src/ScalarClient.astro
@@ -4,12 +4,18 @@ import { getConfiguration, type HtmlRenderingConfiguration } from '@scalar/clien
 interface Props {
   config: Omit<Partial<HtmlRenderingConfiguration>, 'cdn' | 'pageTitle'>
   cdn?: string
+  /**
+   * A Content Security Policy nonce, forwarded to the client so it can stamp
+   * the dynamically injected CDN `<script>` and the `csp-nonce` meta tag that
+   * the standalone bundle reads when nonce-ing its runtime styles.
+   */
+  nonce?: string
 }
 
-const { config, cdn } = Astro.props
+const { config, cdn, nonce } = Astro.props
 ---
 
-<div data-scalar-client data-configuration={JSON.stringify(getConfiguration(config))} data-cdn={cdn}></div>
+<div data-scalar-client data-configuration={JSON.stringify(getConfiguration(config))} data-cdn={cdn} data-nonce={nonce}></div>
 
 <script>
   import { initScalarClient } from './client'

--- a/integrations/astro/src/ScalarClient.astro
+++ b/integrations/astro/src/ScalarClient.astro
@@ -8,6 +8,11 @@ interface Props {
    * A Content Security Policy nonce, forwarded to the client so it can stamp
    * the dynamically injected CDN `<script>` and the `csp-nonce` meta tag that
    * the standalone bundle reads when nonce-ing its runtime styles.
+   *
+   * Note: this does not nonce the bootstrap `<script>` below — Astro bundles
+   * and emits that tag itself, so its CSP handling is Astro's (see the comment
+   * on the script). Under a strict `script-src`, allow Astro's own scripts via
+   * its `experimental.csp` flag or `'self'`.
    */
   nonce?: string
 }
@@ -17,6 +22,15 @@ const { config, cdn, nonce } = Astro.props
 
 <div data-scalar-client data-configuration={JSON.stringify(getConfiguration(config))} data-cdn={cdn} data-nonce={nonce}></div>
 
+{/*
+  Astro bundles this script and resolves the `./client` import, but that also
+  means Astro — not Scalar — emits the final `<script>` tag, so we cannot stamp
+  the user's `nonce` on it: adding a `nonce` attribute opts the script out of
+  bundling and leaves the import unresolved. Under a strict `script-src`, allow
+  Astro's own scripts via its `experimental.csp` flag (which nonces them) or
+  `'self'`. The nonce still reaches what Scalar controls — the CDN script and
+  the runtime styles — applied from `client.ts` via `data-nonce`.
+*/}
 <script>
   import { initScalarClient } from './client'
 

--- a/integrations/astro/src/ScalarComponent.astro
+++ b/integrations/astro/src/ScalarComponent.astro
@@ -37,7 +37,7 @@ const { cdn, pageTitle, nonce, ...config } = finalConfiguration
 
 {
   renderMode === 'client' ? (
-    <ScalarClient config={config} cdn={cdn} />
+    <ScalarClient config={config} cdn={cdn} nonce={nonce} />
   ) : (
     <div set:html={renderApiReference({ config, cdn, pageTitle, nonce })} />
   )

--- a/integrations/astro/src/ScalarComponent.astro
+++ b/integrations/astro/src/ScalarComponent.astro
@@ -32,13 +32,13 @@ const finalConfiguration = {
   ...DEFAULT_CONFIGURATION,
   ...configuration,
 }
-const { cdn, pageTitle, ...config } = finalConfiguration
+const { cdn, pageTitle, nonce, ...config } = finalConfiguration
 ---
 
 {
   renderMode === 'client' ? (
     <ScalarClient config={config} cdn={cdn} />
   ) : (
-    <div set:html={renderApiReference({ config, cdn, pageTitle })} />
+    <div set:html={renderApiReference({ config, cdn, pageTitle, nonce })} />
   )
 }

--- a/integrations/astro/src/client.test.ts
+++ b/integrations/astro/src/client.test.ts
@@ -57,13 +57,17 @@ const installScalar = (cdn: string = DEFAULT_CDN): Created[] => {
 }
 
 /** Add an empty client-rendered container to the page, as the component does. */
-const createContainer = (configuration: unknown, cdn?: string): HTMLElement => {
+const createContainer = (configuration: unknown, cdn?: string, nonce?: string): HTMLElement => {
   const element = document.createElement('div')
   element.setAttribute('data-scalar-client', '')
   element.dataset.configuration = JSON.stringify(configuration)
 
   if (cdn) {
     element.dataset.cdn = cdn
+  }
+
+  if (nonce) {
+    element.dataset.nonce = nonce
   }
 
   document.body.appendChild(element)
@@ -213,6 +217,34 @@ describe('client', () => {
     // for the shared global.
     expect(mountedBy.get(elementA)).toBe('a')
     expect(mountedBy.get(elementB)).toBe('b')
+  })
+
+  it('stamps the nonce on the injected CDN script', async () => {
+    createContainer({}, 'https://cdn.example.com/api-reference', 'r4nd0m')
+
+    initScalarClient()
+    await flush()
+
+    expect(document.head.querySelector('script')?.nonce).toBe('r4nd0m')
+  })
+
+  it('emits a csp-nonce meta tag so the bundle can nonce its injected styles', async () => {
+    createContainer({}, undefined, 'r4nd0m')
+
+    initScalarClient()
+    await flush()
+
+    expect(document.head.querySelector('meta[property="csp-nonce"]')?.getAttribute('content')).toBe('r4nd0m')
+  })
+
+  it('does not stamp a nonce or meta tag when none is given', async () => {
+    createContainer({})
+
+    initScalarClient()
+    await flush()
+
+    expect(document.head.querySelector('script')?.nonce).toBe('')
+    expect(document.head.querySelector('meta[property="csp-nonce"]')).toBeNull()
   })
 
   it('mounts containers added by a client-side navigation', async () => {

--- a/integrations/astro/src/client.test.ts
+++ b/integrations/astro/src/client.test.ts
@@ -247,6 +247,21 @@ describe('client', () => {
     expect(document.head.querySelector('meta[property="csp-nonce"]')).toBeNull()
   })
 
+  it('stamps the nonce even when an earlier mount loaded the same CDN without one', async () => {
+    // A nonce-less container mounts first and injects an un-nonced script.
+    createContainer({}, 'https://cdn.example.com/api-reference')
+    // A second container on the same CDN needs the nonce to pass strict CSP.
+    createContainer({}, 'https://cdn.example.com/api-reference', 'r4nd0m')
+
+    initScalarClient()
+    await flush()
+
+    const scripts = Array.from(document.head.querySelectorAll('script'))
+    // The cache keys on the nonce, so the second mount gets its own stamped tag
+    // instead of reusing the un-nonced one.
+    expect(scripts.some((script) => script.nonce === 'r4nd0m')).toBe(true)
+  })
+
   it('mounts containers added by a client-side navigation', async () => {
     const created = installScalar()
 

--- a/integrations/astro/src/client.ts
+++ b/integrations/astro/src/client.ts
@@ -82,7 +82,7 @@ const getState = (): ClientState => {
  * here keeps the common single-CDN page correct and narrows the window for the
  * rest.)
  */
-const loadCdn = (cdn: string): Promise<ScalarGlobal | undefined> => {
+const loadCdn = (cdn: string, nonce?: string): Promise<ScalarGlobal | undefined> => {
   const { cdnLoads } = getState()
   const cached = cdnLoads.get(cdn)
 
@@ -93,6 +93,11 @@ const loadCdn = (cdn: string): Promise<ScalarGlobal | undefined> => {
   const load = new Promise<ScalarGlobal | undefined>((resolve, reject) => {
     const script = document.createElement('script')
     script.src = cdn
+    // Stamp the nonce so the injected bundle is allowed under a strict
+    // `script-src 'nonce-...'` policy.
+    if (nonce) {
+      script.nonce = nonce
+    }
     script.addEventListener('load', () => resolve((window as ScalarWindow).Scalar), { once: true })
     script.addEventListener(
       'error',
@@ -111,6 +116,29 @@ const loadCdn = (cdn: string): Promise<ScalarGlobal | undefined> => {
   cdnLoads.set(cdn, load)
 
   return load
+}
+
+/**
+ * Ensure a `<meta property="csp-nonce">` is present in `<head>`.
+ *
+ * The standalone bundle reads this meta tag (it is built with `useStrictCSP`)
+ * to nonce the stylesheet it injects at runtime, so a strict `style-src` lets
+ * the bundle's `<style>` through. The static render path emits this tag in the
+ * server-rendered HTML; in client mode we add it here instead. Astro replaces
+ * `<head>` on every view transition, so this is re-checked on each mount.
+ */
+const ensureCspNonceMeta = (nonce: string): void => {
+  const existing = document.head.querySelector('meta[property="csp-nonce"]')
+
+  if (existing) {
+    existing.setAttribute('content', nonce)
+    return
+  }
+
+  const meta = document.createElement('meta')
+  meta.setAttribute('property', 'csp-nonce')
+  meta.setAttribute('content', nonce)
+  document.head.appendChild(meta)
 }
 
 /** Mount a single container, unless it is already mounted or mounting. */
@@ -136,12 +164,19 @@ const mountContainer = (element: HTMLElement): void => {
   }
 
   const cdn = element.dataset.cdn || DEFAULT_CDN
+  const nonce = element.dataset.nonce
   // Remember which lifecycle this mount belongs to (see `ClientState`).
   const { generation } = state
 
+  // Expose the nonce to the bundle before it loads, so the styles it injects at
+  // runtime carry the nonce too.
+  if (nonce) {
+    ensureCspNonceMeta(nonce)
+  }
+
   state.pending.add(element)
 
-  void loadCdn(cdn)
+  void loadCdn(cdn, nonce)
     .then((Scalar) => {
       // Mount only if this page is still live (no view transition happened
       // while the CDN loaded) and the element is still in the document.

--- a/integrations/astro/src/client.ts
+++ b/integrations/astro/src/client.ts
@@ -81,10 +81,17 @@ const getState = (): ClientState => {
  * (Distinct bundles sharing one global is inherently last-one-wins; capturing
  * here keeps the common single-CDN page correct and narrows the window for the
  * rest.)
+ *
+ * The cache key also includes the nonce. A strict `script-src 'nonce-...'` only
+ * allows the `<script>` whose nonce matches the policy, so two mounts that want
+ * the same bundle under different nonces (or one with and one without) each need
+ * their own correctly-stamped tag — reusing the first load would leave the
+ * second blocked.
  */
 const loadCdn = (cdn: string, nonce?: string): Promise<ScalarGlobal | undefined> => {
   const { cdnLoads } = getState()
-  const cached = cdnLoads.get(cdn)
+  const key = nonce ? `${cdn}\n${nonce}` : cdn
+  const cached = cdnLoads.get(key)
 
   if (cached) {
     return cached
@@ -104,7 +111,7 @@ const loadCdn = (cdn: string, nonce?: string): Promise<ScalarGlobal | undefined>
       () => {
         // Drop the cached failure (and the dead tag) so a later mount or
         // navigation can retry, instead of replaying this rejection forever.
-        cdnLoads.delete(cdn)
+        cdnLoads.delete(key)
         script.remove()
         reject(new Error(`[@scalar/astro] Could not load ${cdn}`))
       },
@@ -113,7 +120,7 @@ const loadCdn = (cdn: string, nonce?: string): Promise<ScalarGlobal | undefined>
     document.head.appendChild(script)
   })
 
-  cdnLoads.set(cdn, load)
+  cdnLoads.set(key, load)
 
   return load
 }

--- a/integrations/express/src/apiReference.ts
+++ b/integrations/express/src/apiReference.ts
@@ -22,7 +22,7 @@ export function apiReference(givenConfiguration: Partial<ApiReferenceConfigurati
 
   // Respond with the HTML document
   return (_, res) => {
-    const { cdn, pageTitle, ...config } = configuration
-    res.type('text/html').send(renderApiReference({ config, pageTitle, cdn }))
+    const { cdn, pageTitle, nonce, ...config } = configuration
+    res.type('text/html').send(renderApiReference({ config, pageTitle, cdn, nonce }))
   }
 }

--- a/integrations/fastify/src/fastifyApiReference.ts
+++ b/integrations/fastify/src/fastifyApiReference.ts
@@ -229,13 +229,14 @@ const fastifyApiReference = fp<
         }
 
         // Respond with the HTML document
-        const { cdn, pageTitle, ...config } = configuration
+        const { cdn, pageTitle, nonce, ...config } = configuration
         return reply.header('Content-Type', 'text/html; charset=utf-8').send(
           renderApiReference({
             config,
             // We're using the bundled JS here by default, but the user can pass a CDN URL.
             cdn: cdn ?? RELATIVE_JAVASCRIPT_PATH,
             pageTitle,
+            nonce,
           }),
         )
       },

--- a/integrations/hono/src/scalar.ts
+++ b/integrations/hono/src/scalar.ts
@@ -89,7 +89,7 @@ export const Scalar = <E extends Env>(configOrResolver: Configuration<E>): Middl
     }
 
     // Respond with the HTML document
-    const { cdn, pageTitle, ...config } = configuration
-    return c.html(renderApiReference({ config, pageTitle, cdn }, customTheme))
+    const { cdn, pageTitle, nonce, ...config } = configuration
+    return c.html(renderApiReference({ config, pageTitle, cdn, nonce }, customTheme))
   }
 }

--- a/integrations/nestjs/src/nestJSApiReference.ts
+++ b/integrations/nestjs/src/nestJSApiReference.ts
@@ -92,8 +92,8 @@ export function apiReference(givenConfiguration: NestJSReferenceConfiguration) {
   }
 
   const content = () => {
-    const { cdn, pageTitle, ...config } = configuration
-    return renderApiReference({ config, pageTitle, cdn }, customThemeCSS)
+    const { cdn, pageTitle, nonce, ...config } = configuration
+    return renderApiReference({ config, pageTitle, cdn, nonce }, customThemeCSS)
   }
 
   if (givenConfiguration.withFastify) {

--- a/integrations/nextjs/src/ApiReference.ts
+++ b/integrations/nextjs/src/ApiReference.ts
@@ -26,8 +26,8 @@ export const ApiReference = (givenConfiguration: Partial<ApiReferenceConfigurati
   }
 
   return () => {
-    const { cdn, pageTitle, ...config } = configuration
-    const referenceDocument = renderApiReference({ config, pageTitle, cdn }, customTheme)
+    const { cdn, pageTitle, nonce, ...config } = configuration
+    const referenceDocument = renderApiReference({ config, pageTitle, cdn, nonce }, customTheme)
     return new Response(referenceDocument, {
       status: 200,
       headers: { 'Content-Type': 'text/html' },

--- a/integrations/sveltekit/src/scalar-api-reference.ts
+++ b/integrations/sveltekit/src/scalar-api-reference.ts
@@ -23,8 +23,8 @@ export const ScalarApiReference = (givenConfiguration: Partial<ApiReferenceConfi
   }
 
   return () => {
-    const { cdn, pageTitle, ...config } = configuration
-    const referenceDocument = renderApiReference({ config, pageTitle, cdn }, customTheme)
+    const { cdn, pageTitle, nonce, ...config } = configuration
+    const referenceDocument = renderApiReference({ config, pageTitle, cdn, nonce }, customTheme)
     return new Response(referenceDocument, {
       status: 200,
       headers: { 'Content-Type': 'text/html' },

--- a/packages/api-reference/vite.standalone.config.ts
+++ b/packages/api-reference/vite.standalone.config.ts
@@ -49,7 +49,11 @@ export default defineConfig({
     // it on `destroy()`. Without this, the global styles linger in <head> after
     // SPA-style navigation (Turbo Drive, htmx). Keep the id in sync with
     // `STANDALONE_STYLE_ID` in `src/standalone/lib/html-api.ts`.
-    cssInjectedByJsPlugin({ attributes: { id: 'scalar-style' } }),
+    //
+    // `useStrictCSP` makes the injected <style> read its nonce from a
+    // `<meta property="csp-nonce">` tag, so the bundle's CSS can be served under a strict
+    // Content Security Policy. See the `nonce` option in @scalar/client-side-rendering.
+    cssInjectedByJsPlugin({ attributes: { id: 'scalar-style' }, useStrictCSP: true }),
     webpackStats(),
     banner({
       outDir: 'dist/browser',

--- a/packages/api-reference/vite.standalone.esm.config.ts
+++ b/packages/api-reference/vite.standalone.esm.config.ts
@@ -49,7 +49,11 @@ export default defineConfig({
     // it on `destroy()`. Without this, the global styles linger in <head> after
     // SPA-style navigation (Turbo Drive, htmx). Keep the id in sync with
     // `STANDALONE_STYLE_ID` in `src/standalone/lib/html-api.ts`.
-    cssInjectedByJsPlugin({ attributes: { id: 'scalar-style' } }),
+    //
+    // `useStrictCSP` makes the injected <style> read its nonce from a
+    // `<meta property="csp-nonce">` tag, so the bundle's CSS can be served under a strict
+    // Content Security Policy. See the `nonce` option in @scalar/client-side-rendering.
+    cssInjectedByJsPlugin({ attributes: { id: 'scalar-style' }, useStrictCSP: true }),
     webpackStats({ fileName: 'webpack-stats.esm.json' }),
     banner({
       outDir: 'dist/browser',

--- a/packages/client-side-rendering/src/html-rendering.test.ts
+++ b/packages/client-side-rendering/src/html-rendering.test.ts
@@ -108,6 +108,37 @@ describe('html-rendering', () => {
       const html = renderApiReference({ config: {}, cdn: 'https://example.com/scalar.js' })
       expect(html).toContain('https://example.com/scalar.js')
     })
+
+    it('applies the nonce to the inline script, style and CDN script tags', () => {
+      const html = renderApiReference({ config: { customCss: 'body { color: red }' }, nonce: 'r4nd0m' })
+      // CDN script
+      expect(html).toContain(
+        '<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference" nonce="r4nd0m"></script>',
+      )
+      // Inline init script
+      expect(html).toContain('<script type="text/javascript" nonce="r4nd0m">')
+      // Inline style
+      expect(html).toContain('<style type="text/css" nonce="r4nd0m">')
+    })
+
+    it('emits a csp-nonce meta tag so the bundle can nonce its injected styles', () => {
+      const html = renderApiReference({ config: {}, nonce: 'r4nd0m' })
+      expect(html).toContain('<meta property="csp-nonce" content="r4nd0m" />')
+    })
+
+    it('does not emit nonce attributes or the meta tag when no nonce is provided', () => {
+      const html = renderApiReference({ config: { customCss: 'body { color: red }' } })
+      expect(html).not.toContain('nonce=')
+      expect(html).not.toContain('csp-nonce')
+      expect(html).toContain('<style type="text/css">')
+      expect(html).toContain('<script type="text/javascript">')
+    })
+
+    it('escapes the nonce to prevent attribute injection', () => {
+      const html = renderApiReference({ config: {}, nonce: '"><script>alert(1)</script>' })
+      expect(html).not.toContain('"><script>alert(1)')
+      expect(html).toContain('nonce="&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"')
+    })
   })
 
   describe('getScriptTags', () => {
@@ -124,6 +155,16 @@ describe('html-rendering', () => {
     it('uses custom CDN when provided', () => {
       const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}), 'https://example.com/script.js')
       expect(tags).toContain('https://example.com/script.js')
+    })
+
+    it('applies the nonce to both script tags when provided', () => {
+      const tags = getScriptTags(
+        apiReferenceConfigurationWithSourceSchema({}),
+        'https://example.com/script.js',
+        'abc123',
+      )
+      expect(tags).toContain('<script src="https://example.com/script.js" nonce="abc123"></script>')
+      expect(tags).toContain('<script type="text/javascript" nonce="abc123">')
     })
 
     it('preserves function properties in configuration', () => {

--- a/packages/client-side-rendering/src/html-rendering.ts
+++ b/packages/client-side-rendering/src/html-rendering.ts
@@ -92,8 +92,11 @@ export function renderApiReference(
      * tags (and the CDN `<script>` tag).
      *
      * When set, a `<meta property="csp-nonce">` tag is also emitted so the standalone bundle can apply
-     * the same nonce to the stylesheet it injects at runtime, allowing the API Reference to render
-     * under a strict CSP without `unsafe-inline`.
+     * the same nonce to the stylesheet it injects at runtime. This lets the API Reference run under a
+     * strict `script-src` with no `unsafe-inline` and no `unsafe-eval`.
+     *
+     * Note: `style-src` still needs `'unsafe-inline'`, because the reference renders inline
+     * `style="..."` attributes that a CSP nonce cannot authorize.
      */
     nonce?: string
   },

--- a/packages/client-side-rendering/src/html-rendering.ts
+++ b/packages/client-side-rendering/src/html-rendering.ts
@@ -13,6 +13,20 @@ const escapeHtml = (str: string): string => {
 }
 
 /**
+ * Escape a value for use inside a double-quoted HTML attribute.
+ *
+ * On top of the regular HTML escaping we also encode double quotes so the value cannot break out of
+ * the attribute. Used for the CSP nonce, which is attacker-influenced in some setups.
+ */
+const escapeHtmlAttribute = (str: string): string => escapeHtml(str).replace(/"/g, '&quot;')
+
+/**
+ * Build a ` nonce="..."` attribute (with a leading space) when a nonce is provided, otherwise an
+ * empty string. Returned ready to be interpolated into a tag.
+ */
+const nonceAttribute = (nonce?: string): string => (nonce ? ` nonce="${escapeHtmlAttribute(nonce)}"` : '')
+
+/**
  * Helper function to add consistent indentation to multiline strings
  * @param str The string to indent
  * @param spaces Number of spaces for each level
@@ -34,7 +48,7 @@ const addIndent = (str: string, spaces: number = 2, initialIndent: boolean = fal
 /**
  * Generate the style tag with custom theme if needed
  */
-const getStyles = (configuration: Record<string, unknown>, customTheme: string): string => {
+const getStyles = (configuration: Record<string, unknown>, customTheme: string, nonce?: string): string => {
   const styles: string[] = []
 
   if (configuration.customCss) {
@@ -52,7 +66,7 @@ const getStyles = (configuration: Record<string, unknown>, customTheme: string):
   }
 
   return `
-    <style type="text/css">
+    <style type="text/css"${nonceAttribute(nonce)}>
       ${addIndent(styles.join('\n\n'), 6)}
     </style>`
 }
@@ -73,10 +87,19 @@ export function renderApiReference(
     pageTitle?: string
     /** CDN URL for the standalone bundle. Defaults to jsDelivr. */
     cdn?: string
+    /**
+     * A Content Security Policy (CSP) nonce to apply to the generated inline `<script>` and `<style>`
+     * tags (and the CDN `<script>` tag).
+     *
+     * When set, a `<meta property="csp-nonce">` tag is also emitted so the standalone bundle can apply
+     * the same nonce to the stylesheet it injects at runtime, allowing the API Reference to render
+     * under a strict CSP without `unsafe-inline`.
+     */
+    nonce?: string
   },
   customTheme = '',
 ): string {
-  const { config: givenConfig, pageTitle, cdn } = options
+  const { config: givenConfig, pageTitle, cdn, nonce } = options
   const title = escapeHtml(pageTitle ?? 'Scalar API Reference')
 
   const unwrapped = Array.isArray(givenConfig) ? givenConfig[0] : givenConfig
@@ -88,6 +111,10 @@ export function renderApiReference(
     ...(customCss !== undefined ? { customCss } : {}),
   } as Record<string, unknown>)
 
+  // Expose the nonce to the standalone bundle so it can apply it to the stylesheet it injects at
+  // runtime (the bundle reads `meta[property=csp-nonce]` when built with `useStrictCSP`).
+  const cspNonceMeta = nonce ? `\n    <meta property="csp-nonce" content="${escapeHtmlAttribute(nonce)}" />` : ''
+
   return `<!doctype html>
 <html>
   <head>
@@ -95,10 +122,10 @@ export function renderApiReference(
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1" />${getStyles(configuration as Record<string, unknown>, customTheme)}
+      content="width=device-width, initial-scale=1" />${cspNonceMeta}${getStyles(configuration as Record<string, unknown>, customTheme, nonce)}
   </head>
   <body>
-    <div id="app"></div>${getScriptTags(configuration, cdn)}
+    <div id="app"></div>${getScriptTags(configuration, cdn, nonce)}
   </body>
 </html>`
 }
@@ -112,8 +139,11 @@ const serializeArrayWithFunctions = (arr: unknown[]): string => {
 
 /**
  * The script tags to load the @scalar/api-reference package from the CDN.
+ *
+ * When a `nonce` is provided it is applied to both script tags so they are allowed under a strict
+ * `script-src` Content Security Policy.
  */
-export function getScriptTags(configuration: Record<string, unknown>, cdn?: string): string {
+export function getScriptTags(configuration: Record<string, unknown>, cdn?: string, nonce?: string): string {
   const restConfig = { ...configuration }
 
   const functionProps: string[] = []
@@ -145,12 +175,14 @@ export function getScriptTags(configuration: Record<string, unknown>, cdn?: stri
     }
   }
 
+  const nonceAttr = nonceAttribute(nonce)
+
   return `
     <!-- Load the Script -->
-    <script src="${cdn ?? DEFAULT_CDN}"></script>
+    <script src="${cdn ?? DEFAULT_CDN}"${nonceAttr}></script>
 
     <!-- Initialize the Scalar API Reference -->
-    <script type="text/javascript">
+    <script type="text/javascript"${nonceAttr}>
       Scalar.createApiReference('#app', ${configString})
     </script>`
 }

--- a/packages/schemas/src/api-reference/html-rendering-configuration.ts
+++ b/packages/schemas/src/api-reference/html-rendering-configuration.ts
@@ -1,4 +1,4 @@
-import { object, string } from '@scalar/validation'
+import { object, optional, string } from '@scalar/validation'
 
 export const htmlRenderingConfigurationSchema = object({
   /**
@@ -16,4 +16,11 @@ export const htmlRenderingConfigurationSchema = object({
   pageTitle: string({
     default: 'Scalar API Reference',
   }),
+  /**
+   * A Content Security Policy (CSP) nonce to apply to the generated inline `<script>` and `<style>`
+   * tags so the API Reference can render under a strict CSP without `unsafe-inline`.
+   *
+   * Generate a fresh value per request and match it in your `script-src` and `style-src` directives.
+   */
+  nonce: optional(string()),
 })

--- a/packages/types/src/api-reference/html-rendering-configuration.ts
+++ b/packages/types/src/api-reference/html-rendering-configuration.ts
@@ -13,11 +13,15 @@ export type HtmlRenderingConfiguration = Partial<ApiReferenceConfigurationWithMu
    * tags (and the CDN `<script>` tag).
    *
    * When set, a `<meta property="csp-nonce">` tag is also emitted so the standalone bundle can apply
-   * the same nonce to the stylesheet it injects at runtime. This allows the API Reference to render
-   * under a strict CSP without `unsafe-inline`.
+   * the same nonce to the stylesheet it injects at runtime. This lets the API Reference run under a
+   * strict `script-src` with no `unsafe-inline` and no `unsafe-eval`.
    *
-   * The value must match the `nonce-...` source in your `script-src` and `style-src` directives, and
-   * a fresh nonce should be generated for every request.
+   * The value must match the `nonce-...` source in your `script-src` directive, and a fresh nonce
+   * should be generated for every request.
+   *
+   * Note: `style-src` still needs `'unsafe-inline'`. The reference renders inline `style="..."`
+   * attributes, which a CSP nonce can never authorize (nonces only apply to `<script>`, `<style>`
+   * and `<link>` elements).
    */
   nonce: string
 }

--- a/packages/types/src/api-reference/html-rendering-configuration.ts
+++ b/packages/types/src/api-reference/html-rendering-configuration.ts
@@ -8,4 +8,16 @@ import type { ApiReferenceConfigurationWithMultipleSources } from './types'
 export type HtmlRenderingConfiguration = Partial<ApiReferenceConfigurationWithMultipleSources> & {
   pageTitle: string
   cdn: string
+  /**
+   * A Content Security Policy (CSP) nonce to apply to the generated inline `<script>` and `<style>`
+   * tags (and the CDN `<script>` tag).
+   *
+   * When set, a `<meta property="csp-nonce">` tag is also emitted so the standalone bundle can apply
+   * the same nonce to the stylesheet it injects at runtime. This allows the API Reference to render
+   * under a strict CSP without `unsafe-inline`.
+   *
+   * The value must match the `nonce-...` source in your `script-src` and `style-src` directives, and
+   * a fresh nonce should be generated for every request.
+   */
+  nonce: string
 }


### PR DESCRIPTION
Adds a `nonce` option so the API Reference can run under a strict **`script-src`** — no `unsafe-inline`, no `unsafe-eval`. Pass a `nonce` and it gets stamped on the inline init `<script>` and the CDN `<script>` (and Scalar's own `<style>` tags, plus a `<meta property="csp-nonce">`).

```ts
ApiReference({ url: '/openapi.json', nonce: 'r4nd0m' })
```

Wired through next, express, fastify, nestjs, hono, sveltekit and astro. Docs include a Next.js middleware example for per-request nonces.

### Verified against the real bundle

Built the standalone bundle and loaded the Galaxy reference under `script-src 'nonce-x'; style-src 'unsafe-inline'`:

- **`script-src` fully strict** — zero violations, no `unsafe-eval` needed, reference boots and is interactive. This is the core of #3973.
- The main 234 KB stylesheet loads via the nonce.

### Honest caveat: `style-src` still needs `'unsafe-inline'`

The reference renders ~200 inline `style="…"` attributes (Vue `:style`), plus a few third-party `<style>` injections (CodeMirror, Sonner, highlight theme). A CSP nonce **cannot** authorize inline style attributes — only `<script>`/`<style>`/`<link>` elements — so a nonce-only `style-src` is not achievable today. Recommended policy: `script-src 'nonce-x'; style-src 'unsafe-inline'`. The meaningful win is locking down `script-src` (the dangerous vector + the issue's main complaint).

## Ticket

Closes #3973

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared HTML output and all server integrations; incorrect nonce wiring would break CSP-locked pages, though behavior is opt-in and covered by new tests.
> 
> **Overview**
> Adds an optional **`nonce`** on HTML-rendering config so API Reference pages can use a strict **`script-src`** (no `unsafe-inline` / `unsafe-eval`).
> 
> **Core rendering:** `renderApiReference` and `getScriptTags` stamp the nonce on the CDN script, inline init script, and inline `<style>` tags, emit `<meta property="csp-nonce">`, and escape nonce values for attribute safety. Types/schemas document the option; standalone Vite builds enable **`useStrictCSP`** on CSS injection so runtime styles pick up the meta nonce.
> 
> **Integrations:** Next.js, Express, Fastify, NestJS, Hono, SvelteKit, and Astro (static + client) plumb `nonce` into `renderApiReference`. Astro client mode forwards nonce via `data-nonce`, nonces injected CDN scripts, keys CDN cache by CDN+nonce, and ensures the CSP meta on mount.
> 
> **Docs/changeset:** CSP guides for HTML/JS, Next middleware example, and Astro client-mode caveats; **`style-src 'unsafe-inline'`** remains required for inline `style="…"` attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 178ed7645c5a3a716489702a9e4b506b79f67454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->