### PR TITLE
fix(snippetz): curl URL query separator and shell quoting

### DIFF
--- a/.changeset/fix-curl-url-quoting.md
+++ b/.changeset/fix-curl-url-quoting.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+fix(snippetz): correct curl URL query separator and shell quoting

--- a/packages/snippetz/src/plugins/shell/curl/curl.test.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.test.ts
@@ -89,6 +89,28 @@ describe('shellCurl', () => {
     expect(result).toBe(`curl 'https://example.com?foo=bar&bar=foo'`)
   })
 
+  it('joins query string parameters with & when the URL already has a query string', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com/api?existing=1',
+      queryString: [
+        {
+          name: 'foo',
+          value: 'bar',
+        },
+      ],
+    })
+
+    expect(result).toBe(`curl 'https://example.com/api?existing=1&foo=bar'`)
+  })
+
+  it('quotes a URL whose query string has no other special characters', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com/api?param1=value1&param2=value2',
+    })
+
+    expect(result).toBe(`curl 'https://example.com/api?param1=value1&param2=value2'`)
+  })
+
   it('has cookies', () => {
     const result = shellCurl.generate({
       url: 'https://example.com',

--- a/packages/snippetz/src/plugins/shell/curl/curl.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.ts
@@ -36,9 +36,11 @@ export const shellCurl: Plugin = {
     // Build curl command parts
     const parts: string[] = ['curl']
 
-    // URL (quote if has query parameters or special characters)
+    // Build the URL, joining extra query parameters with `&` when the URL already carries a query string
+    const baseUrl = normalizedRequest.url ?? ''
+    const separator = baseUrl.includes('?') ? '&' : '?'
     const queryString = normalizedRequest.queryString?.length
-      ? '?' +
+      ? separator +
         normalizedRequest.queryString
           .map((param) => {
             // Ensure both name and value are fully URI encoded
@@ -46,9 +48,10 @@ export const shellCurl: Plugin = {
           })
           .join('&')
       : ''
-    const url = `${normalizedRequest.url}${queryString}`
-    const hasSpecialChars = /[\s<>[\]{}|\\^%$]/.test(url)
-    const urlPart = queryString || hasSpecialChars ? `'${url}'` : url
+    const url = `${baseUrl}${queryString}`
+    // Quote the URL whenever it contains anything the shell could interpret (spaces, query separators, globs, …)
+    const isShellSafe = /^[A-Za-z0-9._~:/%@+,=-]*$/.test(url)
+    const urlPart = isShellSafe ? url : `'${escapeSingleQuotes(url)}'`
     parts[0] = `curl ${urlPart}`
 
     // Method


### PR DESCRIPTION
The curl snippet generator had the same two latent issues that Bugbot flagged on the wget plugin in #9428:

- **Double `?`** — when the URL already carried a query string, extra `queryString` params were prefixed with `?`, producing `...?existing=1?foo=bar`. They now join with `&`.
- **Unquoted `?`/`&`** — the old special-character check did not include query separators, so a query-only URL like `https://example.com/api?a=1&b=2` was left unquoted and could be split or glob-expanded by the shell. The URL is now quoted whenever it contains anything outside a shell-safe set.

Added tests for both cases. All 44 curl tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to curl code-snippet output in snippetz with regression tests; no runtime API or auth behavior changes.
> 
> **Overview**
> Fixes **curl** snippet URL handling in `@scalar/snippetz` so generated commands are valid and safe to paste into a shell.
> 
> When the base URL already has a query string, extra `queryString` params are now appended with **`&`** instead of a second **`?`**. URL quoting no longer relies on a narrow “special character” regex; anything outside a **shell-safe** character set (including **`?`** and **`&`**) is wrapped in single quotes with existing single-quote escaping.
> 
> Two new tests cover merged query strings and query-only URLs that must be quoted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63266d76daef8b9c4a7aad8c6224fff55af29fb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->