### PR TITLE
feat(api-reference): render AsyncAPI channel parameters

### DIFF
--- a/.changeset/asyncapi-channel-parameters.md
+++ b/.changeset/asyncapi-channel-parameters.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': minor
+---
+
+feat(api-reference): render AsyncAPI channel parameters
+
+Channel address parameters (the `{param}` placeholders in a channel address) are now shown in the API reference, reusing the same parameter list component as OpenAPI operations. Their `enum`, `default`, and `examples` are displayed on a string schema.

--- a/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.vue
@@ -98,7 +98,8 @@ const getModelSchema = (name: string) => getAsyncApiModelSchema(document, name)
       :document="document"
       :eventBus="eventBus"
       :isCollapsed="!expandedItems[entry.id]"
-      :layout="options.layout" />
+      :layout="options.layout"
+      :options="options" />
 
     <Tag
       v-else-if="

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
@@ -119,4 +119,39 @@ describe('Channel', () => {
     expect(wrapper.text()).toContain('user/signedup')
     expect(wrapper.text()).toContain('Classic layout description.')
   })
+
+  it('renders channel address parameters', () => {
+    const wrapper = mount(Channel, {
+      props: {
+        channel: createChannel({ channelAddress: 'user/{userId}/signedup' }),
+        document: createDocumentWithChannel({
+          address: 'user/{userId}/signedup',
+          parameters: {
+            userId: { description: 'The unique user identifier' },
+          },
+        }),
+        layout: 'modern',
+        isCollapsed: false,
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.text()).toContain('Parameters')
+    expect(wrapper.text()).toContain('userId')
+    expect(wrapper.text()).toContain('The unique user identifier')
+  })
+
+  it('does not render a parameters section when the channel has none', () => {
+    const wrapper = mount(Channel, {
+      props: {
+        channel: createChannel(),
+        document: createDocument(),
+        layout: 'modern',
+        isCollapsed: false,
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.text()).not.toContain('Parameters')
+  })
 })

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ScalarMarkdown } from '@scalar/components/markdown'
+import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
 import type {
   AsyncApiChannelObject,
   AsyncApiDocument,
@@ -21,14 +22,28 @@ import {
   SectionHeader,
   SectionHeaderTag,
 } from '@/components/Section'
+import ParameterList from '@/features/Operation/components/ParameterList.vue'
 
-const { channel, document, layout, isCollapsed, eventBus } = defineProps<{
-  channel: TraversedAsyncApiChannel
-  document: AsyncApiDocument
-  layout: 'classic' | 'modern'
-  isCollapsed: boolean
-  eventBus: WorkspaceEventBus | null
-}>()
+import { adaptAsyncApiParameters } from './helpers/adapt-async-api-parameters'
+
+/** Subset of the configuration the shared `ParameterList` renderer needs. */
+type ParameterListOptions = Pick<
+  ApiReferenceConfigurationRaw,
+  | 'hideModels'
+  | 'orderRequiredPropertiesFirst'
+  | 'orderSchemaPropertiesBy'
+  | 'expandAllSchemaProperties'
+>
+
+const { channel, document, layout, isCollapsed, eventBus, options } =
+  defineProps<{
+    channel: TraversedAsyncApiChannel
+    document: AsyncApiDocument
+    layout: 'classic' | 'modern'
+    isCollapsed: boolean
+    eventBus: WorkspaceEventBus | null
+    options?: Partial<ParameterListOptions>
+  }>()
 
 const headerId = useId()
 
@@ -55,6 +70,22 @@ const headingText = computed(() => {
   const title = resolvedChannel.value?.title?.trim()
   return title || channel.channelAddress
 })
+
+/**
+ * Channel address parameters mapped into the OpenAPI parameter shape so we can reuse the shared
+ * `ParameterList` component instead of building a dedicated AsyncAPI renderer.
+ */
+const parameters = computed(() =>
+  adaptAsyncApiParameters(resolvedChannel.value?.parameters),
+)
+
+/** Fill in defaults so the shared renderer always receives a complete options object. */
+const parameterListOptions = computed<ParameterListOptions>(() => ({
+  hideModels: options?.hideModels ?? false,
+  orderRequiredPropertiesFirst: options?.orderRequiredPropertiesFirst ?? false,
+  orderSchemaPropertiesBy: options?.orderSchemaPropertiesBy ?? 'preserve',
+  expandAllSchemaProperties: options?.expandAllSchemaProperties ?? false,
+}))
 </script>
 
 <template>
@@ -83,6 +114,13 @@ const headingText = computed(() => {
         :value="description"
         withImages />
     </template>
+    <ParameterList
+      v-if="parameters.length"
+      :eventBus="eventBus"
+      :options="parameterListOptions"
+      :parameters="parameters">
+      <template #title>Parameters</template>
+    </ParameterList>
   </SectionContainerAccordion>
 
   <SectionContainer
@@ -111,6 +149,13 @@ const headingText = computed(() => {
         <ScalarMarkdown
           :value="description"
           withImages />
+        <ParameterList
+          v-if="parameters.length"
+          :eventBus="eventBus"
+          :options="parameterListOptions"
+          :parameters="parameters">
+          <template #title>Parameters</template>
+        </ParameterList>
       </SectionContent>
     </Section>
   </SectionContainer>

--- a/packages/api-reference/src/components/Content/AsyncApi/helpers/adapt-async-api-parameters.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/helpers/adapt-async-api-parameters.test.ts
@@ -1,0 +1,78 @@
+import type { AsyncApiChannelObject } from '@scalar/types/asyncapi/3.1'
+import { describe, expect, it } from 'vitest'
+
+import { adaptAsyncApiParameters } from './adapt-async-api-parameters'
+
+describe('adaptAsyncApiParameters', () => {
+  it('returns an empty array when there are no parameters', () => {
+    expect(adaptAsyncApiParameters(undefined)).toEqual([])
+  })
+
+  it('maps a parameter to a required path parameter with a string schema', () => {
+    const parameters: AsyncApiChannelObject['parameters'] = {
+      userId: { description: 'The user id' },
+    }
+
+    expect(adaptAsyncApiParameters(parameters)).toEqual([
+      {
+        name: 'userId',
+        in: 'path',
+        required: true,
+        description: 'The user id',
+        schema: { type: 'string' },
+      },
+    ])
+  })
+
+  it('folds enum, default, and examples onto the schema', () => {
+    const parameters: AsyncApiChannelObject['parameters'] = {
+      env: {
+        enum: ['staging', 'production'],
+        default: 'production',
+        examples: ['staging'],
+      },
+    }
+
+    expect(adaptAsyncApiParameters(parameters)).toEqual([
+      {
+        name: 'env',
+        in: 'path',
+        required: true,
+        schema: {
+          type: 'string',
+          enum: ['staging', 'production'],
+          default: 'production',
+          examples: ['staging'],
+        },
+      },
+    ])
+  })
+
+  it('omits the description when it is missing', () => {
+    const parameters: AsyncApiChannelObject['parameters'] = {
+      userId: {},
+    }
+
+    const [parameter] = adaptAsyncApiParameters(parameters)
+    expect(parameter).not.toHaveProperty('description')
+  })
+
+  it('resolves $ref parameters', () => {
+    const parameters = {
+      userId: {
+        $ref: '#/components/parameters/userId',
+        '$ref-value': { description: 'Resolved user id' },
+      },
+    } as unknown as AsyncApiChannelObject['parameters']
+
+    expect(adaptAsyncApiParameters(parameters)).toEqual([
+      {
+        name: 'userId',
+        in: 'path',
+        required: true,
+        description: 'Resolved user id',
+        schema: { type: 'string' },
+      },
+    ])
+  })
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/helpers/adapt-async-api-parameters.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/helpers/adapt-async-api-parameters.ts
@@ -1,0 +1,47 @@
+import type { AsyncApiChannelObject } from '@scalar/types/asyncapi/3.1'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import type { ParameterObject, SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+
+/**
+ * Adapt AsyncAPI channel parameters into the OpenAPI `ParameterObject` shape so we can reuse the
+ * existing `ParameterList` rendering instead of building a separate component.
+ *
+ * AsyncAPI parameters are address placeholders (the `{param}` expressions in a channel address).
+ * They are string-only and, because every placeholder in the address must be supplied, always
+ * required. We therefore map them to `path` parameters (the closest OpenAPI analog) and fold the
+ * `enum`, `default`, and `examples` fields onto a synthetic string schema so the schema renderer
+ * can display them. The `location` runtime expression has no display equivalent and is dropped.
+ */
+export const adaptAsyncApiParameters = (parameters: AsyncApiChannelObject['parameters']): ParameterObject[] => {
+  if (!parameters) {
+    return []
+  }
+
+  return Object.entries(parameters).map(([name, value]) => {
+    // Fall back to an empty object so an unresolved `$ref` still renders the parameter name.
+    const parameter = getResolvedRef(value) ?? {}
+
+    const schema: SchemaObject = { type: 'string' }
+    if (parameter.enum) {
+      schema.enum = parameter.enum
+    }
+    if (parameter.default !== undefined) {
+      schema.default = parameter.default
+    }
+    if (parameter.examples) {
+      schema.examples = parameter.examples
+    }
+
+    const result: ParameterObject = {
+      name,
+      in: 'path',
+      required: true,
+      schema,
+    }
+    if (parameter.description) {
+      result.description = parameter.description
+    }
+
+    return result
+  })
+}


### PR DESCRIPTION
AsyncAPI channels can have address parameters (the `{param}` bits in the address). We now show them, reusing the same parameter list as OpenAPI operations via a small adapter that maps the AsyncAPI parameter onto a required string path parameter.

<img src="https://raw.githubusercontent.com/scalar/scalar/asyncapi-channel-parameters-assets/.github/pr-assets/asyncapi-channel-parameters.png" alt="AsyncAPI channel parameters" width="640" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only addition in AsyncAPI channel UI with dedicated tests; no auth, data, or shared OpenAPI operation behavior changes beyond reusing ParameterList.
> 
> **Overview**
> AsyncAPI channel views now show **address parameters** (the `{param}` segments in a channel address) when the spec defines them, using the same **Parameters** UI as OpenAPI operations.
> 
> A new **`adaptAsyncApiParameters`** helper maps each channel parameter to a required OpenAPI-style **path** parameter with a **string** schema, including **`enum`**, **`default`**, and **`examples`** when present, and resolves **`$ref`** entries. **`Channel.vue`** wires this into **`ParameterList`** for both classic and modern layouts; the section is omitted when there are no parameters. **`AsyncApiTraversedEntry`** passes through reference **options** (schema ordering, hide models, etc.) so parameter rendering stays consistent with the rest of the reference.
> 
> Unit tests cover the adapter and channel rendering (with and without parameters). The changeset bumps **`@scalar/api-reference`** as a minor feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b7a65101031dddbd313fad1ff385832649ad030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->