### PR TITLE
feat(api-reference): hide client selector for AsyncAPI documents

### DIFF
--- a/.changeset/asyncapi-hide-client-selector.md
+++ b/.changeset/asyncapi-hide-client-selector.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Hide the client selector for AsyncAPI documents

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -202,7 +202,7 @@ onMounted(() => {
           </IntroductionCardItem>
         </ScalarErrorBoundary>
 
-        <!-- Client selector (not relevant for AsyncAPI) -->
+        <!-- Client selector -->
         <ScalarErrorBoundary>
           <IntroductionCardItem
             v-if="clientOptions.length && !asyncApiDocument"

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -202,10 +202,10 @@ onMounted(() => {
           </IntroductionCardItem>
         </ScalarErrorBoundary>
 
-        <!-- Client selector -->
+        <!-- Client selector (not relevant for AsyncAPI) -->
         <ScalarErrorBoundary>
           <IntroductionCardItem
-            v-if="clientOptions.length"
+            v-if="clientOptions.length && !asyncApiDocument"
             class="introduction-card-item scalar-reference-intro-clients">
             <ClientSelector
               class="introduction-card-item scalar-reference-intro-clients"


### PR DESCRIPTION
HTTP clients can't interact with the APIs described in AsyncAPI documents, so the client selector doesn't make sense there. This hides it.

<img width="546" height="125" alt="Screenshot 2026-06-05 at 13 34 49" src="https://github.com/user-attachments/assets/95cd1120-448f-4f5e-91c0-8606893fe8fc" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single template guard on an existing computed; no auth, data, or OpenAPI client flows change.
> 
> **Overview**
> The introduction **Client selector** no longer renders when the loaded spec is AsyncAPI, by tightening the `Content.vue` `v-if` to require `clientOptions.length && !asyncApiDocument`.
> 
> OpenAPI docs keep the existing HTTP client picker; AsyncAPI views already use `AsyncApiTraversedEntry` without operation-level client snippets, so this only removes a misleading intro control. Patch noted in `@scalar/api-reference` changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2170b00d17cbef98f3ad814ff74a955370fa254f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->