### PR TITLE
refactor(mock-server): use workspace-store for $ref resolution

### DIFF
--- a/.changeset/mock-server-workspace-store-refs.md
+++ b/.changeset/mock-server-workspace-store-refs.md
@@ -1,0 +1,7 @@
+---
+'@scalar/mock-server': patch
+---
+
+chore(mock-server): resolve OpenAPI references with `@scalar/workspace-store` instead of `@scalar/openapi-parser`
+
+The mock server no longer eagerly dereferences the whole document. It now keeps `$ref` nodes intact via the `@scalar/json-magic` magic proxy and resolves them lazily with `getResolvedRef`/`getResolvedRefDeep` from `@scalar/workspace-store`. The `/openapi.{json,yaml}` endpoints use `@scalar/json-magic` and `yaml` for normalization and serialization. This drops the `@scalar/openapi-parser` dependency. Behavior is unchanged.

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -59,11 +59,11 @@
     "@faker-js/faker": "catalog:*",
     "@scalar/helpers": "workspace:*",
     "@scalar/json-magic": "workspace:*",
-    "@scalar/openapi-parser": "workspace:*",
     "@scalar/openapi-types": "workspace:*",
     "@scalar/openapi-upgrader": "workspace:*",
     "@scalar/workspace-store": "workspace:*",
-    "hono": "catalog:*"
+    "hono": "catalog:*",
+    "yaml": "catalog:*"
   },
   "devDependencies": {
     "@types/node": "catalog:*",

--- a/packages/mock-server/src/create-mock-server.ts
+++ b/packages/mock-server/src/create-mock-server.ts
@@ -1,5 +1,5 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
-import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { getResolvedRef, mergeSiblingReferences } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 
@@ -33,7 +33,8 @@ export async function createMockServer(configuration: MockServerOptions): Promis
   const schemas = schema?.components?.schemas
   if (schemas) {
     for (const [schemaName, schemaObject] of Object.entries(schemas)) {
-      const seedCode = (getResolvedRef(schemaObject) as any)?.['x-seed']
+      // Merge `$ref` siblings so an `x-seed` placed next to a `$ref` is preserved (OpenAPI 3.1 semantics)
+      const seedCode = (getResolvedRef(schemaObject, mergeSiblingReferences) as any)?.['x-seed']
 
       if (seedCode && typeof seedCode === 'string') {
         try {

--- a/packages/mock-server/src/create-mock-server.ts
+++ b/packages/mock-server/src/create-mock-server.ts
@@ -1,4 +1,5 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 
@@ -32,7 +33,7 @@ export async function createMockServer(configuration: MockServerOptions): Promis
   const schemas = schema?.components?.schemas
   if (schemas) {
     for (const [schemaName, schemaObject] of Object.entries(schemas)) {
-      const seedCode = (schemaObject as any)?.['x-seed']
+      const seedCode = (getResolvedRef(schemaObject) as any)?.['x-seed']
 
       if (seedCode && typeof seedCode === 'string') {
         try {
@@ -68,12 +69,14 @@ export async function createMockServer(configuration: MockServerOptions): Promis
   const paths = schema?.paths ?? {}
 
   Object.keys(paths).forEach((path) => {
-    const methods = Object.keys(getOperations(paths[path])) as HttpMethod[]
+    // A path item may itself be a `$ref`, so resolve it before reading its operations.
+    const pathItem = getResolvedRef(paths[path])
+    const methods = Object.keys(getOperations(pathItem)) as HttpMethod[]
 
     /** Keys for all operations of a specified path */
     methods.forEach((method) => {
       const route = honoRouteFromPath(path)
-      const operation = schema?.paths?.[path]?.[method] as OpenAPIV3_1.OperationObject
+      const operation = pathItem?.[method] as OpenAPIV3_1.OperationObject
 
       // Check if authentication is required for this operation
       if (isAuthenticationRequired(operation.security)) {

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -1,5 +1,7 @@
 import { json2xml } from '@scalar/helpers/file/json2xml'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { getResolvedRefDeep } from '@scalar/workspace-store/helpers/get-resolved-ref-deep'
 import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
 import type { Context } from 'hono'
 import { accepts } from 'hono/accepts'
@@ -23,7 +25,7 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
   // Response
   // default, 200, 201 …
   const preferredResponseKey = findPreferredResponseKey(Object.keys(operation.responses ?? {}))
-  const preferredResponse = preferredResponseKey ? operation.responses?.[preferredResponseKey] : null
+  const preferredResponse = preferredResponseKey ? getResolvedRef(operation.responses?.[preferredResponseKey]) : null
 
   if (!preferredResponse) {
     c.status(500)
@@ -40,7 +42,8 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
   // Headers
   const headers = preferredResponse?.headers ?? {}
   Object.keys(headers).forEach((header) => {
-    const value = headers[header].schema ? (getExampleFromSchema(headers[header].schema) as string) : null
+    const headerObject = getResolvedRef(headers[header])
+    const value = headerObject.schema ? (getExampleFromSchema(getResolvedRefDeep(headerObject.schema)) as string) : null
     if (value !== null) {
       c.header(header, value)
     }
@@ -77,7 +80,7 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
   const body = acceptedResponse?.example
     ? acceptedResponse.example
     : acceptedResponse?.schema
-      ? getExampleFromSchema(acceptedResponse.schema, {
+      ? getExampleFromSchema(getResolvedRefDeep(acceptedResponse.schema), {
           emptyString: 'string',
           variables: c.req.param(),
           mode: 'read',

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -43,7 +43,9 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
   const headers = preferredResponse?.headers ?? {}
   Object.keys(headers).forEach((header) => {
     const headerObject = getResolvedRef(headers[header])
-    const value = headerObject.schema ? (getExampleFromSchema(getResolvedRefDeep(headerObject.schema)) as string) : null
+    const value = headerObject?.schema
+      ? (getExampleFromSchema(getResolvedRefDeep(headerObject.schema)) as string)
+      : null
     if (value !== null) {
       c.header(header, value)
     }

--- a/packages/mock-server/src/routes/mock-handler-response.ts
+++ b/packages/mock-server/src/routes/mock-handler-response.ts
@@ -1,4 +1,6 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { getResolvedRefDeep } from '@scalar/workspace-store/helpers/get-resolved-ref-deep'
 import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
 import type { Context } from 'hono'
 import { accepts } from 'hono/accepts'
@@ -22,7 +24,7 @@ function getExampleFromResponse(
   }
 
   const statusCodeStr = statusCode.toString()
-  const response = responses[statusCodeStr] || responses.default
+  const response = getResolvedRef(responses[statusCodeStr] || responses.default)
 
   if (!response) {
     return null
@@ -54,7 +56,7 @@ function getExampleFromResponse(
   return acceptedResponse.example !== undefined
     ? acceptedResponse.example
     : acceptedResponse.schema
-      ? getExampleFromSchema(acceptedResponse.schema, {
+      ? getExampleFromSchema(getResolvedRefDeep(acceptedResponse.schema), {
           emptyString: 'string',
           variables: c.req.param(),
           mode: 'read',

--- a/packages/mock-server/src/routes/respond-with-openapi-document.ts
+++ b/packages/mock-server/src/routes/respond-with-openapi-document.ts
@@ -1,5 +1,6 @@
-import { normalize, toYaml } from '@scalar/openapi-parser'
+import { normalize } from '@scalar/json-magic/helpers/normalize'
 import type { Context } from 'hono'
+import { stringify as toYaml } from 'yaml'
 
 /**
  * OpenAPI endpoints

--- a/packages/mock-server/src/utils/build-handler-context.ts
+++ b/packages/mock-server/src/utils/build-handler-context.ts
@@ -1,5 +1,7 @@
 import { faker } from '@faker-js/faker'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { getResolvedRefDeep } from '@scalar/workspace-store/helpers/get-resolved-ref-deep'
 import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
 import type { Context } from 'hono'
 import { accepts } from 'hono/accepts'
@@ -43,7 +45,7 @@ function getExampleFromResponse(
     return null
   }
 
-  const response = responses[statusCode] || responses.default
+  const response = getResolvedRef(responses[statusCode] || responses.default)
 
   if (!response) {
     return null
@@ -75,7 +77,7 @@ function getExampleFromResponse(
   return acceptedResponse.example !== undefined
     ? acceptedResponse.example
     : acceptedResponse.schema
-      ? getExampleFromSchema(acceptedResponse.schema, {
+      ? getExampleFromSchema(getResolvedRefDeep(acceptedResponse.schema), {
           emptyString: 'string',
           variables: c.req.param(),
           mode: 'read',

--- a/packages/mock-server/src/utils/get-open-auth-token-urls.ts
+++ b/packages/mock-server/src/utils/get-open-auth-token-urls.ts
@@ -48,7 +48,8 @@ export function getOpenAuthTokenUrls(schema?: OpenAPI.Document): string[] {
   for (const rawScheme of Object.values(securitySchemes)) {
     const scheme = getResolvedRef(rawScheme)
 
-    if (!isOAuth2Scheme(scheme)) {
+    // Skip schemes that could not be resolved (e.g. a `$ref` to a missing component)
+    if (!scheme || !isOAuth2Scheme(scheme)) {
       continue
     }
 

--- a/packages/mock-server/src/utils/get-open-auth-token-urls.ts
+++ b/packages/mock-server/src/utils/get-open-auth-token-urls.ts
@@ -1,4 +1,5 @@
 import type { OpenAPI, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 
 /**
  * Extract path from URL
@@ -44,7 +45,9 @@ export function getOpenAuthTokenUrls(schema?: OpenAPI.Document): string[] {
   const oauthUrls = new Set<string>()
 
   // Iterate through all security schemes
-  for (const scheme of Object.values(securitySchemes)) {
+  for (const rawScheme of Object.values(securitySchemes)) {
+    const scheme = getResolvedRef(rawScheme)
+
     if (!isOAuth2Scheme(scheme)) {
       continue
     }

--- a/packages/mock-server/src/utils/handle-authentication.ts
+++ b/packages/mock-server/src/utils/handle-authentication.ts
@@ -1,4 +1,5 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { Context } from 'hono'
 import { getCookie } from 'hono/cookie'
 
@@ -17,12 +18,7 @@ export function handleAuthentication(schema?: OpenAPIV3_1.Document, operation?: 
         let securitySchemeAuthenticated = true
 
         for (const [schemeName] of Object.entries(securityRequirement)) {
-          const scheme = schema?.components?.securitySchemes?.[schemeName]
-
-          // Skip if scheme is a reference object (should be dereferenced already, but check to be safe)
-          if (scheme && '$ref' in scheme) {
-            continue
-          }
+          const scheme = getResolvedRef(schema?.components?.securitySchemes?.[schemeName])
 
           if (scheme && 'type' in scheme) {
             const securityScheme = scheme as OpenAPIV3_1.SecuritySchemeObject

--- a/packages/mock-server/src/utils/log-authentication-instructions.ts
+++ b/packages/mock-server/src/utils/log-authentication-instructions.ts
@@ -1,4 +1,5 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 
 import { getPathFromUrl } from './get-open-auth-token-urls'
 
@@ -13,7 +14,9 @@ export function logAuthenticationInstructions(securitySchemes: Record<string, Op
   console.log('Authentication:')
   console.log()
 
-  Object.entries(securitySchemes).forEach(([_, scheme]) => {
+  Object.entries(securitySchemes).forEach(([_, rawScheme]) => {
+    const scheme = getResolvedRef(rawScheme)
+
     switch (scheme.type) {
       case 'apiKey':
         if (scheme.in === 'header') {

--- a/packages/mock-server/src/utils/log-authentication-instructions.ts
+++ b/packages/mock-server/src/utils/log-authentication-instructions.ts
@@ -17,6 +17,11 @@ export function logAuthenticationInstructions(securitySchemes: Record<string, Op
   Object.entries(securitySchemes).forEach(([_, rawScheme]) => {
     const scheme = getResolvedRef(rawScheme)
 
+    // Skip schemes that could not be resolved (e.g. a `$ref` to a missing component)
+    if (!scheme) {
+      return
+    }
+
     switch (scheme.type) {
       case 'apiKey':
         if (scheme.in === 'header') {

--- a/packages/mock-server/src/utils/process-openapi-document.ts
+++ b/packages/mock-server/src/utils/process-openapi-document.ts
@@ -1,18 +1,20 @@
 import { bundle } from '@scalar/json-magic/bundle'
-import { parseJson } from '@scalar/json-magic/bundle/plugins/node'
-import { parseYaml } from '@scalar/json-magic/bundle/plugins/node'
-import { readFiles } from '@scalar/json-magic/bundle/plugins/node'
-import { fetchUrls } from '@scalar/json-magic/bundle/plugins/node'
-import { dereference } from '@scalar/openapi-parser'
+import { fetchUrls, parseJson, parseYaml, readFiles } from '@scalar/json-magic/bundle/plugins/node'
+import { createMagicProxy } from '@scalar/json-magic/magic-proxy'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { upgrade } from '@scalar/openapi-upgrader'
 
 /**
  * Processes an OpenAPI document by bundling external references, upgrading to OpenAPI 3.1,
- * and dereferencing the document.
+ * and wrapping it so internal references stay intact but resolve lazily.
+ *
+ * Unlike a full dereference, the returned document keeps `$ref` nodes in place. Consumers
+ * resolve them on demand with `getResolvedRef` from `@scalar/workspace-store`, which reads the
+ * `$ref-value` exposed by the magic proxy. This avoids eagerly flattening (and duplicating)
+ * the whole document up front.
  *
  * @param document - The OpenAPI document to process. Can be a string (URL/path) or an object.
- * @returns A promise that resolves to the dereferenced OpenAPI 3.1 document.
+ * @returns A promise that resolves to the OpenAPI 3.1 document with lazily resolvable references.
  * @throws Error if the document cannot be processed or is invalid.
  */
 export async function processOpenApiDocument(
@@ -63,26 +65,7 @@ export async function processOpenApiDocument(
     throw new Error('Upgraded document is invalid: upgrade returned null or undefined')
   }
 
-  // Dereference the document
-  const dereferenceResult = dereference(upgraded)
-
-  // Check for dereference errors
-  if (dereferenceResult.errors && dereferenceResult.errors.length > 0) {
-    const errorMessages = dereferenceResult.errors.map((err) => err.message).join(', ')
-    throw new Error(`Failed to dereference OpenAPI document: ${errorMessages}`)
-  }
-
-  // Extract the schema from the dereference result
-  const schema = dereferenceResult.schema
-
-  if (!schema) {
-    throw new Error('Dereference result does not contain a schema')
-  }
-
-  // Ensure the schema is a valid OpenAPI 3.1 document
-  if (typeof schema !== 'object') {
-    throw new Error('Dereferenced schema is invalid: expected an object')
-  }
-
-  return schema as OpenAPIV3_1.Document
+  // Wrap the document in a magic proxy so internal references resolve lazily via `$ref-value`.
+  // External references were already pulled inline by `bundle` above, so only local `$ref`s remain.
+  return createMagicProxy(upgraded) as OpenAPIV3_1.Document
 }

--- a/packages/mock-server/src/utils/set-up-authentication-routes.ts
+++ b/packages/mock-server/src/utils/set-up-authentication-routes.ts
@@ -45,6 +45,11 @@ export function setUpAuthenticationRoutes(app: Hono, schema?: OpenAPI.Document) 
   Object.entries(securitySchemes).forEach(([_, rawScheme]) => {
     const scheme = getResolvedRef(rawScheme)
 
+    // Skip schemes that could not be resolved (e.g. a `$ref` to a missing component)
+    if (!scheme) {
+      return
+    }
+
     if (scheme.type === 'oauth2') {
       if (scheme.flows?.authorizationCode) {
         const authorizeRoute = scheme.flows.authorizationCode.authorizationUrl ?? '/oauth/authorize'

--- a/packages/mock-server/src/utils/set-up-authentication-routes.ts
+++ b/packages/mock-server/src/utils/set-up-authentication-routes.ts
@@ -1,4 +1,5 @@
 import type { OpenAPI, OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { Hono } from 'hono'
 
 import { respondWithAuthorizePage } from '@/routes/respond-with-authorize-page'
@@ -41,7 +42,9 @@ export function setUpAuthenticationRoutes(app: Hono, schema?: OpenAPI.Document) 
   const authorizeUrls = new Set<string>()
   const tokenUrls = new Set<string>()
 
-  Object.entries(securitySchemes).forEach(([_, scheme]) => {
+  Object.entries(securitySchemes).forEach(([_, rawScheme]) => {
+    const scheme = getResolvedRef(rawScheme)
+
     if (scheme.type === 'oauth2') {
       if (scheme.flows?.authorizationCode) {
         const authorizeRoute = scheme.flows.authorizationCode.authorizationUrl ?? '/oauth/authorize'

--- a/packages/mock-server/test/openapi.test.ts
+++ b/packages/mock-server/test/openapi.test.ts
@@ -1,5 +1,6 @@
-import { normalize, toYaml } from '@scalar/openapi-parser'
+import { normalize } from '@scalar/json-magic/helpers/normalize'
 import { describe, expect, it } from 'vitest'
+import { stringify as toYaml } from 'yaml'
 
 import { createMockServer } from '../src/create-mock-server'
 

--- a/packages/mock-server/test/unresolved-references.test.ts
+++ b/packages/mock-server/test/unresolved-references.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { createMockServer } from '../src'
+
+/**
+ * With lazy reference resolution, a `$ref` that cannot be resolved yields `undefined` at the
+ * point of use instead of failing during processing. These tests make sure the mock server
+ * degrades gracefully (skips the broken bit) rather than crashing at startup or per request.
+ */
+describe('unresolved references', () => {
+  it('starts when a security scheme is an unresolvable $ref', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: { title: 'Broken refs', version: '1.0.0' },
+      components: {
+        // Points at a component that does not exist
+        securitySchemes: { broken: { $ref: '#/components/securitySchemes/Missing' } },
+      },
+      paths: {
+        '/planets': {
+          get: {
+            responses: { '200': { description: 'OK', content: { 'application/json': { example: { id: 1 } } } } },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+    const response = await server.request('/planets')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ id: 1 })
+  })
+
+  it('responds when a response header is an unresolvable $ref', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: { title: 'Broken header ref', version: '1.0.0' },
+      paths: {
+        '/planets': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                headers: { 'X-Broken': { $ref: '#/components/headers/Missing' } },
+                content: { 'application/json': { example: { id: 1 } } },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+    const response = await server.request('/planets')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ id: 1 })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1868,9 +1868,6 @@ importers:
       '@scalar/json-magic':
         specifier: workspace:*
         version: link:../json-magic
-      '@scalar/openapi-parser':
-        specifier: workspace:*
-        version: link:../openapi-parser
       '@scalar/openapi-types':
         specifier: workspace:*
         version: link:../openapi-types
@@ -1883,6 +1880,9 @@ importers:
       hono:
         specifier: catalog:*
         version: 4.12.9
+      yaml:
+        specifier: catalog:*
+        version: 2.8.3
     devDependencies:
       '@types/node':
         specifier: ^24.1.0


### PR DESCRIPTION
Switches the mock server from `@scalar/openapi-parser` to `@scalar/workspace-store` + `@scalar/json-magic` for OpenAPI reference handling.

Instead of eagerly dereferencing the whole document up front, it now keeps `$ref`s in place (via the json-magic magic proxy) and resolves them lazily with `getResolvedRef` where consumers actually read responses, schemas, and security schemes. 

Example generation deep-resolves the relevant schema first (`getResolvedRefDeep`), matching how workspace-store does it internally. Without it, a ref nested under another ref (like galaxy's `Planet.creator → User`) renders as `null`. The `/openapi.{json,yaml}` endpoints now use `@scalar/json-magic`'s `normalize` and the `yaml` package.

No behavior change, all 193 mock-server tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every mock route reads OpenAPI (responses, auth, OAuth setup); behavior is intended to stay the same but ref edge cases and example generation paths shifted.
> 
> **Overview**
> Replaces eager full-document dereferencing (`@scalar/openapi-parser`) with **lazy** `$ref` handling: after bundle + upgrade, the spec is wrapped in `@scalar/json-magic`'s magic proxy and resolved at read time via `getResolvedRef` / `getResolvedRefDeep` from `@scalar/workspace-store`.
> 
> Routing, mocks, auth, and seeding now resolve refs where they read the spec—path items, responses, headers, schemas (with deep resolve for examples), and security schemes—including **`mergeSiblingReferences`** for `x-seed` next to a `$ref`. Broken refs are skipped instead of failing document processing; new tests cover startup and responses with missing components.
> 
> **`/openapi.json`** and **`/openapi.yaml`** serialize with `@scalar/json-magic` **`normalize`** and the **`yaml`** package instead of openapi-parser helpers. Dependency swap drops **`@scalar/openapi-parser`**, adds **`yaml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1a5a149681356a4aab883787abf9e943adb4f7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->