### PR TITLE
feat(api-reference): add an AsyncAPI server selector

### DIFF
--- a/.changeset/asyncapi-server-selector.md
+++ b/.changeset/asyncapi-server-selector.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': minor
+---
+
+feat(api-reference): add an AsyncAPI server selector
+
+Adds a server selector for AsyncAPI documents in the API reference introduction. It mirrors the OpenAPI server selector but works with the AsyncAPI server shape (a named map of `host`/`protocol`/`pathname`), labelling each server with its constructed connection URL. Selection is local for now and is not yet persisted to the workspace store.

--- a/.changeset/asyncapi-server-selector.md
+++ b/.changeset/asyncapi-server-selector.md
@@ -1,7 +1,12 @@
 ---
 '@scalar/api-reference': minor
+'@scalar/workspace-store': minor
+'@scalar/api-client': patch
+'@scalar/types': patch
 ---
 
 feat(api-reference): add an AsyncAPI server selector
 
-Adds a server selector for AsyncAPI documents in the API reference introduction. It mirrors the OpenAPI server selector but works with the AsyncAPI server shape (a named map of `host`/`protocol`/`pathname`), labelling each server with its constructed connection URL. Selection is local for now and is not yet persisted to the workspace store.
+Adds a server selector for AsyncAPI documents in the API reference introduction. It mirrors the OpenAPI server selector but works with the AsyncAPI server shape (a named map of `host`/`protocol`/`pathname`), labelling each server with its constructed connection URL.
+
+Server selection and variable changes are now persisted to the workspace store via new `asyncapi-server:update:selected` and `asyncapi-server:update:variables` events and their mutators, mirroring the OpenAPI wiring.

--- a/packages/api-client/src/plugins/posthog/sanitize-event-payload.ts
+++ b/packages/api-client/src/plugins/posthog/sanitize-event-payload.ts
@@ -147,6 +147,8 @@ export const TRACKED_EVENTS: TrackedEventsMap = {
   'server:update:variables': undefined,
   'server:update:selected': undefined,
   'server:clear:servers': undefined,
+  'asyncapi-server:update:selected': undefined,
+  'asyncapi-server:update:variables': undefined,
   'tabs:update:tabs': undefined,
   'tabs:close:tab': undefined,
   'tabs:close:other-tabs': undefined,

--- a/packages/api-client/src/v2/workspace-events.ts
+++ b/packages/api-client/src/v2/workspace-events.ts
@@ -230,6 +230,20 @@ export function initializeWorkspaceEventHandlers({
   eventBus.on('server:update:selected', (payload) =>
     withHook('server:update:selected', mutators.value.active().server.updateSelectedServer, hooks)(payload),
   )
+  eventBus.on('asyncapi-server:update:selected', (payload) =>
+    withHook(
+      'asyncapi-server:update:selected',
+      mutators.value.active().server.updateSelectedAsyncApiServer,
+      hooks,
+    )(payload),
+  )
+  eventBus.on('asyncapi-server:update:variables', (payload) =>
+    withHook(
+      'asyncapi-server:update:variables',
+      mutators.value.active().server.updateAsyncApiServerVariables,
+      hooks,
+    )(payload),
+  )
 
   //------------------------------------------------------------------------------------
   // Operation Related Event Handlers

--- a/packages/api-reference/src/blocks/index.ts
+++ b/packages/api-reference/src/blocks/index.ts
@@ -1,3 +1,4 @@
+export { AsyncApiServerSelector } from './scalar-asyncapi-server-selector-block'
 export { ClientSelector } from './scalar-client-selector-block'
 export { InfoBlock, IntroductionCardItem } from './scalar-info-block'
 export { ServerSelector } from './scalar-server-selector-block'

--- a/packages/api-reference/src/blocks/scalar-asyncapi-server-selector-block/components/AsyncApiServerSelector.test.ts
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-server-selector-block/components/AsyncApiServerSelector.test.ts
@@ -1,7 +1,7 @@
 import type { AsyncApiServerEntry } from '@scalar/workspace-store/channel-example'
+import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
-import { nextTick } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
 
 import AsyncApiServerSelector from './AsyncApiServerSelector.vue'
 
@@ -17,6 +17,8 @@ const createEntry = (
 })
 
 describe('AsyncApiServerSelector', () => {
+  const eventBus = createWorkspaceEventBus()
+
   const mockServers: AsyncApiServerEntry[] = [
     createEntry({ name: 'production', url: 'mqtt://broker.example.com', description: 'Production server' }),
     createEntry({ name: 'staging', url: 'mqtt://staging.example.com', description: 'Staging server' }),
@@ -25,7 +27,7 @@ describe('AsyncApiServerSelector', () => {
   const serverWithVariables: AsyncApiServerEntry[] = [
     createEntry({
       name: 'production',
-      url: 'mqtt://{environment}.example.com',
+      url: 'mqtt://prod.example.com',
       description: 'Server with variables',
       server: {
         host: '{environment}.example.com',
@@ -39,7 +41,7 @@ describe('AsyncApiServerSelector', () => {
 
   it('renders the server label', () => {
     const wrapper = mount(AsyncApiServerSelector, {
-      props: { servers: mockServers, selectedServer: mockServers[0]! },
+      props: { servers: mockServers, selectedServer: mockServers[0]!, eventBus },
     })
 
     expect(wrapper.text()).toContain('Server')
@@ -47,7 +49,7 @@ describe('AsyncApiServerSelector', () => {
 
   it('renders the selector when servers are available', () => {
     const wrapper = mount(AsyncApiServerSelector, {
-      props: { servers: mockServers, selectedServer: mockServers[0]! },
+      props: { servers: mockServers, selectedServer: mockServers[0]!, eventBus },
     })
 
     expect(wrapper.findComponent({ name: 'Selector' }).exists()).toBe(true)
@@ -55,7 +57,7 @@ describe('AsyncApiServerSelector', () => {
 
   it('does not render the selector when no servers are available', () => {
     const wrapper = mount(AsyncApiServerSelector, {
-      props: { servers: [], selectedServer: null },
+      props: { servers: [], selectedServer: null, eventBus },
     })
 
     expect(wrapper.findComponent({ name: 'Selector' }).exists()).toBe(false)
@@ -63,7 +65,7 @@ describe('AsyncApiServerSelector', () => {
 
   it('renders the selected server description', () => {
     const wrapper = mount(AsyncApiServerSelector, {
-      props: { servers: mockServers, selectedServer: mockServers[1]! },
+      props: { servers: mockServers, selectedServer: mockServers[1]!, eventBus },
     })
 
     expect(wrapper.text()).toContain('Staging server')
@@ -71,7 +73,7 @@ describe('AsyncApiServerSelector', () => {
 
   it('normalizes AsyncAPI variables for the variables form', () => {
     const wrapper = mount(AsyncApiServerSelector, {
-      props: { servers: serverWithVariables, selectedServer: serverWithVariables[0]! },
+      props: { servers: serverWithVariables, selectedServer: serverWithVariables[0]!, eventBus },
     })
 
     const variablesForm = wrapper.findComponent({ name: 'ServerVariablesForm' })
@@ -82,35 +84,39 @@ describe('AsyncApiServerSelector', () => {
     expect(variablesForm.props('layout')).toBe('reference')
   })
 
-  it('toggles the selection off when the active server is selected again', async () => {
+  it('emits the selected server name when a server is chosen', async () => {
+    const emit = vi.spyOn(eventBus, 'emit')
     const wrapper = mount(AsyncApiServerSelector, {
-      props: { servers: mockServers, selectedServer: mockServers[0]! },
-    })
-
-    expect(wrapper.text()).toContain('Production server')
-
-    const selector = wrapper.findComponent({ name: 'Selector' })
-    await selector.vm.$emit('update:modelValue', 'production')
-    await nextTick()
-
-    expect(wrapper.text()).not.toContain('Production server')
-  })
-
-  it('switches the active server when a different one is selected', async () => {
-    const wrapper = mount(AsyncApiServerSelector, {
-      props: { servers: mockServers, selectedServer: mockServers[0]! },
+      props: { servers: mockServers, selectedServer: mockServers[0]!, eventBus },
     })
 
     const selector = wrapper.findComponent({ name: 'Selector' })
     await selector.vm.$emit('update:modelValue', 'staging')
-    await nextTick()
 
-    expect(wrapper.text()).toContain('Staging server')
+    expect(emit).toHaveBeenCalledWith('asyncapi-server:update:selected', { name: 'staging' })
+    emit.mockRestore()
+  })
+
+  it('emits a variable update with the selected server name', async () => {
+    const emit = vi.spyOn(eventBus, 'emit')
+    const wrapper = mount(AsyncApiServerSelector, {
+      props: { servers: serverWithVariables, selectedServer: serverWithVariables[0]!, eventBus },
+    })
+
+    const variablesForm = wrapper.findComponent({ name: 'ServerVariablesForm' })
+    await variablesForm.vm.$emit('update:variable', 'environment', 'staging')
+
+    expect(emit).toHaveBeenCalledWith('asyncapi-server:update:variables', {
+      name: 'production',
+      key: 'environment',
+      value: 'staging',
+    })
+    emit.mockRestore()
   })
 
   it('handles a null selectedServer gracefully', () => {
     const wrapper = mount(AsyncApiServerSelector, {
-      props: { servers: mockServers, selectedServer: null },
+      props: { servers: mockServers, selectedServer: null, eventBus },
     })
 
     expect(wrapper.text()).toContain('Server')

--- a/packages/api-reference/src/blocks/scalar-asyncapi-server-selector-block/components/AsyncApiServerSelector.test.ts
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-server-selector-block/components/AsyncApiServerSelector.test.ts
@@ -1,0 +1,118 @@
+import type { AsyncApiServerEntry } from '@scalar/workspace-store/channel-example'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+
+import AsyncApiServerSelector from './AsyncApiServerSelector.vue'
+
+/** Build an AsyncAPI server entry with sensible defaults for tests. */
+const createEntry = (
+  overrides: Partial<AsyncApiServerEntry> & Pick<AsyncApiServerEntry, 'name' | 'url'>,
+): AsyncApiServerEntry => ({
+  host: 'broker.example.com',
+  protocol: 'mqtt',
+  isWebSocket: false,
+  server: { host: 'broker.example.com', protocol: 'mqtt' },
+  ...overrides,
+})
+
+describe('AsyncApiServerSelector', () => {
+  const mockServers: AsyncApiServerEntry[] = [
+    createEntry({ name: 'production', url: 'mqtt://broker.example.com', description: 'Production server' }),
+    createEntry({ name: 'staging', url: 'mqtt://staging.example.com', description: 'Staging server' }),
+  ]
+
+  const serverWithVariables: AsyncApiServerEntry[] = [
+    createEntry({
+      name: 'production',
+      url: 'mqtt://{environment}.example.com',
+      description: 'Server with variables',
+      server: {
+        host: '{environment}.example.com',
+        protocol: 'mqtt',
+        variables: {
+          environment: { default: 'prod', description: 'Environment name', enum: ['prod', 'staging', 'dev'] },
+        },
+      },
+    }),
+  ]
+
+  it('renders the server label', () => {
+    const wrapper = mount(AsyncApiServerSelector, {
+      props: { servers: mockServers, selectedServer: mockServers[0]! },
+    })
+
+    expect(wrapper.text()).toContain('Server')
+  })
+
+  it('renders the selector when servers are available', () => {
+    const wrapper = mount(AsyncApiServerSelector, {
+      props: { servers: mockServers, selectedServer: mockServers[0]! },
+    })
+
+    expect(wrapper.findComponent({ name: 'Selector' }).exists()).toBe(true)
+  })
+
+  it('does not render the selector when no servers are available', () => {
+    const wrapper = mount(AsyncApiServerSelector, {
+      props: { servers: [], selectedServer: null },
+    })
+
+    expect(wrapper.findComponent({ name: 'Selector' }).exists()).toBe(false)
+  })
+
+  it('renders the selected server description', () => {
+    const wrapper = mount(AsyncApiServerSelector, {
+      props: { servers: mockServers, selectedServer: mockServers[1]! },
+    })
+
+    expect(wrapper.text()).toContain('Staging server')
+  })
+
+  it('normalizes AsyncAPI variables for the variables form', () => {
+    const wrapper = mount(AsyncApiServerSelector, {
+      props: { servers: serverWithVariables, selectedServer: serverWithVariables[0]! },
+    })
+
+    const variablesForm = wrapper.findComponent({ name: 'ServerVariablesForm' })
+    expect(variablesForm.exists()).toBe(true)
+    expect(variablesForm.props('variables')).toEqual({
+      environment: { default: 'prod', description: 'Environment name', enum: ['prod', 'staging', 'dev'] },
+    })
+    expect(variablesForm.props('layout')).toBe('reference')
+  })
+
+  it('toggles the selection off when the active server is selected again', async () => {
+    const wrapper = mount(AsyncApiServerSelector, {
+      props: { servers: mockServers, selectedServer: mockServers[0]! },
+    })
+
+    expect(wrapper.text()).toContain('Production server')
+
+    const selector = wrapper.findComponent({ name: 'Selector' })
+    await selector.vm.$emit('update:modelValue', 'production')
+    await nextTick()
+
+    expect(wrapper.text()).not.toContain('Production server')
+  })
+
+  it('switches the active server when a different one is selected', async () => {
+    const wrapper = mount(AsyncApiServerSelector, {
+      props: { servers: mockServers, selectedServer: mockServers[0]! },
+    })
+
+    const selector = wrapper.findComponent({ name: 'Selector' })
+    await selector.vm.$emit('update:modelValue', 'staging')
+    await nextTick()
+
+    expect(wrapper.text()).toContain('Staging server')
+  })
+
+  it('handles a null selectedServer gracefully', () => {
+    const wrapper = mount(AsyncApiServerSelector, {
+      props: { servers: mockServers, selectedServer: null },
+    })
+
+    expect(wrapper.text()).toContain('Server')
+  })
+})

--- a/packages/api-reference/src/blocks/scalar-asyncapi-server-selector-block/components/AsyncApiServerSelector.vue
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-server-selector-block/components/AsyncApiServerSelector.vue
@@ -1,5 +1,7 @@
 <script lang="ts">
 type SelectorProps = {
+  /** The event bus to use for emitting events */
+  eventBus: WorkspaceEventBus
   /** The currently selected server */
   selectedServer: AsyncApiServerEntry | null
   /** Available servers */
@@ -13,8 +15,8 @@ type SelectorProps = {
  * OpenAPI ServerSelector, but works with the AsyncAPI server shape (a named map
  * of `host`/`protocol`/`pathname` rather than an array of `url`).
  *
- * Selection is tracked locally for now: the workspace-store server mutators
- * assume the OpenAPI server shape, so AsyncAPI selection is not yet persisted.
+ * @event asyncapi-server:update:selected - Emitted when the selected server changes
+ * @event asyncapi-server:update:variables - Emitted when a server variable changes
  */
 export default {}
 </script>
@@ -23,41 +25,22 @@ export default {}
 import { ServerVariablesForm } from '@scalar/api-client/components/Server'
 import { ScalarMarkdown } from '@scalar/components/markdown'
 import type { AsyncApiServerEntry } from '@scalar/workspace-store/channel-example'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
-import { computed, ref, useId, watch } from 'vue'
+import { computed, useId } from 'vue'
 
 import Selector from './Selector.vue'
 
-const { servers, selectedServer } = defineProps<SelectorProps>()
+const { eventBus, servers, selectedServer } = defineProps<SelectorProps>()
 
 const id = useId()
-
-/**
- * Local-only selection state, keyed by server name. AsyncAPI server selection is
- * not yet persisted to the workspace store, so we keep the choice in the
- * component while still letting users switch between servers.
- */
-const selectedName = ref(selectedServer?.name ?? null)
-
-// Re-sync the local selection when the incoming selection changes.
-watch(
-  () => selectedServer?.name,
-  (name) => {
-    selectedName.value = name ?? null
-  },
-)
-
-/** The server matching the local selection, falling back to none. */
-const activeServer = computed(
-  () => servers.find((server) => server.name === selectedName.value) ?? null,
-)
 
 /**
  * Normalize AsyncAPI server variables into the shape the shared
  * ServerVariablesForm expects (resolving references and defaulting `default`).
  */
 const serverVariables = computed(() => {
-  const variables = activeServer.value?.server.variables
+  const variables = selectedServer?.server.variables
   if (!variables) {
     return undefined
   }
@@ -77,9 +60,22 @@ const serverVariables = computed(() => {
   )
 })
 
-/** Toggle the selected server (selecting the active server clears it). */
+/** Update the selected server */
 const updateServer = (name: string) => {
-  selectedName.value = selectedName.value === name ? null : name
+  eventBus.emit('asyncapi-server:update:selected', { name })
+}
+
+/** Update a server variable on the selected server */
+const updateServerVariable = (key: string, value: string) => {
+  if (!selectedServer) {
+    return
+  }
+
+  eventBus.emit('asyncapi-server:update:variables', {
+    name: selectedServer.name,
+    key,
+    value,
+  })
 }
 </script>
 
@@ -92,22 +88,23 @@ const updateServer = (name: string) => {
     :id="id"
     class="border"
     :class="{
-      'rounded-b-xl': !activeServer?.description && !serverVariables,
+      'rounded-b-xl': !selectedServer?.description && !serverVariables,
     }">
     <Selector
       v-if="servers.length"
-      :selectedServer="activeServer"
+      :selectedServer
       :servers="servers"
       :target="id"
       @update:modelValue="updateServer" />
   </div>
   <ServerVariablesForm
     layout="reference"
-    :variables="serverVariables" />
+    :variables="serverVariables"
+    @update:variable="updateServerVariable" />
 
   <!-- Description -->
   <ScalarMarkdown
-    v-if="activeServer?.description"
+    v-if="selectedServer?.description"
     class="text-c-3 rounded-b-xl border-x border-b px-3 py-1.5"
-    :value="activeServer.description" />
+    :value="selectedServer.description" />
 </template>

--- a/packages/api-reference/src/blocks/scalar-asyncapi-server-selector-block/components/AsyncApiServerSelector.vue
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-server-selector-block/components/AsyncApiServerSelector.vue
@@ -1,0 +1,113 @@
+<script lang="ts">
+type SelectorProps = {
+  /** The currently selected server */
+  selectedServer: AsyncApiServerEntry | null
+  /** Available servers */
+  servers: AsyncApiServerEntry[]
+}
+
+/**
+ * AsyncApiServerSelector
+ *
+ * Core component for rendering an AsyncAPI server selector block. It mirrors the
+ * OpenAPI ServerSelector, but works with the AsyncAPI server shape (a named map
+ * of `host`/`protocol`/`pathname` rather than an array of `url`).
+ *
+ * Selection is tracked locally for now: the workspace-store server mutators
+ * assume the OpenAPI server shape, so AsyncAPI selection is not yet persisted.
+ */
+export default {}
+</script>
+
+<script lang="ts" setup>
+import { ServerVariablesForm } from '@scalar/api-client/components/Server'
+import { ScalarMarkdown } from '@scalar/components/markdown'
+import type { AsyncApiServerEntry } from '@scalar/workspace-store/channel-example'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { computed, ref, useId, watch } from 'vue'
+
+import Selector from './Selector.vue'
+
+const { servers, selectedServer } = defineProps<SelectorProps>()
+
+const id = useId()
+
+/**
+ * Local-only selection state, keyed by server name. AsyncAPI server selection is
+ * not yet persisted to the workspace store, so we keep the choice in the
+ * component while still letting users switch between servers.
+ */
+const selectedName = ref(selectedServer?.name ?? null)
+
+// Re-sync the local selection when the incoming selection changes.
+watch(
+  () => selectedServer?.name,
+  (name) => {
+    selectedName.value = name ?? null
+  },
+)
+
+/** The server matching the local selection, falling back to none. */
+const activeServer = computed(
+  () => servers.find((server) => server.name === selectedName.value) ?? null,
+)
+
+/**
+ * Normalize AsyncAPI server variables into the shape the shared
+ * ServerVariablesForm expects (resolving references and defaulting `default`).
+ */
+const serverVariables = computed(() => {
+  const variables = activeServer.value?.server.variables
+  if (!variables) {
+    return undefined
+  }
+
+  return Object.fromEntries(
+    Object.entries(variables).map(([name, variable]) => {
+      const resolved = getResolvedRef(variable)
+      return [
+        name,
+        {
+          default: resolved.default ?? '',
+          enum: resolved.enum,
+          description: resolved.description,
+        },
+      ]
+    }),
+  )
+})
+
+/** Toggle the selected server (selecting the active server clears it). */
+const updateServer = (name: string) => {
+  selectedName.value = selectedName.value === name ? null : name
+}
+</script>
+
+<template>
+  <label
+    class="bg-b-2 flex h-8 items-center rounded-t-xl border-x border-t px-3 py-2.5 font-medium">
+    Server
+  </label>
+  <div
+    :id="id"
+    class="border"
+    :class="{
+      'rounded-b-xl': !activeServer?.description && !serverVariables,
+    }">
+    <Selector
+      v-if="servers.length"
+      :selectedServer="activeServer"
+      :servers="servers"
+      :target="id"
+      @update:modelValue="updateServer" />
+  </div>
+  <ServerVariablesForm
+    layout="reference"
+    :variables="serverVariables" />
+
+  <!-- Description -->
+  <ScalarMarkdown
+    v-if="activeServer?.description"
+    class="text-c-3 rounded-b-xl border-x border-b px-3 py-1.5"
+    :value="activeServer.description" />
+</template>

--- a/packages/api-reference/src/blocks/scalar-asyncapi-server-selector-block/components/Selector.test.ts
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-server-selector-block/components/Selector.test.ts
@@ -1,0 +1,108 @@
+import type { AsyncApiServerEntry } from '@scalar/workspace-store/channel-example'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+
+import Selector from './Selector.vue'
+
+/** Build an AsyncAPI server entry with sensible defaults for tests. */
+const createEntry = (
+  overrides: Partial<AsyncApiServerEntry> & Pick<AsyncApiServerEntry, 'name' | 'url'>,
+): AsyncApiServerEntry => ({
+  host: 'broker.example.com',
+  protocol: 'mqtt',
+  isWebSocket: false,
+  server: { host: 'broker.example.com', protocol: 'mqtt' },
+  ...overrides,
+})
+
+describe('Selector', () => {
+  const mockServers: AsyncApiServerEntry[] = [
+    createEntry({ name: 'production', url: 'mqtt://broker.example.com', description: 'Production server' }),
+    createEntry({ name: 'staging', url: 'mqtt://staging.example.com', description: 'Staging server' }),
+    createEntry({ name: 'local', url: 'ws://localhost:3000', protocol: 'ws', isWebSocket: true }),
+  ]
+
+  const singleServer: AsyncApiServerEntry[] = [mockServers[0]!]
+
+  it('renders screen reader text for multiple servers', () => {
+    const wrapper = mount(Selector, {
+      props: { servers: mockServers, selectedServer: null, target: 'test-target' },
+    })
+
+    expect(wrapper.text()).toContain('Server:')
+  })
+
+  it('renders the constructed URL as the label', () => {
+    const wrapper = mount(Selector, {
+      props: { servers: mockServers, selectedServer: mockServers[0]!, target: 'test-target' },
+    })
+
+    expect(wrapper.text()).toContain('mqtt://broker.example.com')
+    expect(wrapper.vm.serverOptions.length).toBe(3)
+  })
+
+  it('renders a simple div when only one server is available', () => {
+    const wrapper = mount(Selector, {
+      props: { servers: singleServer, selectedServer: singleServer[0]!, target: 'test-target' },
+    })
+
+    expect(wrapper.text()).toContain('mqtt://broker.example.com')
+    expect(wrapper.vm.serverOptions.length).toBe(1)
+  })
+
+  it('handles an empty servers array', () => {
+    const wrapper = mount(Selector, {
+      props: { servers: [], selectedServer: null, target: 'test-target' },
+    })
+
+    expect(wrapper.vm.serverOptions.length).toBe(0)
+    expect(wrapper.vm.serverUrlWithoutTrailingSlash).toBe('')
+  })
+
+  it('removes the trailing slash from the server URL', () => {
+    const serversWithSlash: AsyncApiServerEntry[] = [
+      createEntry({ name: 'production', url: 'mqtt://broker.example.com/' }),
+    ]
+
+    const wrapper = mount(Selector, {
+      props: { servers: serversWithSlash, selectedServer: serversWithSlash[0]!, target: 'test-target' },
+    })
+
+    expect(wrapper.text()).toContain('mqtt://broker.example.com')
+    expect(wrapper.text()).not.toContain('broker.example.com/')
+  })
+
+  it('keys options by name and labels them by URL', () => {
+    const wrapper = mount(Selector, {
+      props: { servers: mockServers, selectedServer: null, target: 'test-target' },
+    })
+
+    const options = wrapper.vm.serverOptions
+    expect(options).toHaveLength(3)
+    expect(options[0]).toEqual({ id: 'production', label: 'mqtt://broker.example.com' })
+    expect(options[2]).toEqual({ id: 'local', label: 'ws://localhost:3000' })
+  })
+
+  it('updates the displayed server when the selection changes', async () => {
+    const wrapper = mount(Selector, {
+      props: { servers: mockServers, selectedServer: mockServers[0]!, target: 'test-target' },
+    })
+
+    expect(wrapper.text()).toContain('broker.example.com')
+
+    await wrapper.setProps({ selectedServer: mockServers[1] })
+    await nextTick()
+
+    expect(wrapper.text()).toContain('staging.example.com')
+  })
+
+  it('handles a null selectedServer', () => {
+    const wrapper = mount(Selector, {
+      props: { servers: mockServers, selectedServer: null, target: 'test-target' },
+    })
+
+    expect(wrapper.vm.selectedServer).toBeNull()
+    expect(wrapper.vm.serverUrlWithoutTrailingSlash).toBe('')
+  })
+})

--- a/packages/api-reference/src/blocks/scalar-asyncapi-server-selector-block/components/Selector.vue
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-server-selector-block/components/Selector.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { ScalarButton } from '@scalar/components/button'
+import { ScalarListbox } from '@scalar/components/listbox'
+import { ScalarIconCaretDown } from '@scalar/icons'
+import type { AsyncApiServerEntry } from '@scalar/workspace-store/channel-example'
+import { computed } from 'vue'
+
+const { target, servers, selectedServer } = defineProps<{
+  /** The selected server */
+  selectedServer: AsyncApiServerEntry | null
+  /** Available servers */
+  servers: AsyncApiServerEntry[]
+  /** The id of the target to use for the popover (e.g. address bar) */
+  target: string
+}>()
+
+const emit = defineEmits<{
+  /** Emitted with the server name when the selected server changes */
+  (e: 'update:modelValue', value: string): void
+}>()
+
+/**
+ * AsyncAPI servers are a named map without a single `url`, so we key options by
+ * the server name and label them with the constructed connection URL.
+ */
+const serverOptions = computed(() =>
+  servers.map((server) => ({
+    id: server.name,
+    label: server.url,
+  })),
+)
+
+const serverUrlWithoutTrailingSlash = computed(
+  () => selectedServer?.url?.replace(/\/$/, '') || '',
+)
+
+const selectedServerOption = computed(() =>
+  serverOptions.value.find((opt) => opt.id === selectedServer?.name),
+)
+
+// For testing
+defineExpose({
+  servers,
+  serverUrlWithoutTrailingSlash,
+  serverOptions,
+  selectedServer,
+})
+</script>
+<template>
+  <ScalarListbox
+    v-if="serverOptions.length > 1"
+    ref="elem"
+    class="group"
+    :modelValue="selectedServerOption"
+    :options="serverOptions"
+    placement="bottom-start"
+    resize
+    :target="target"
+    @update:modelValue="(e) => emit('update:modelValue', e.id)">
+    <ScalarButton
+      class="bg-b-1 text-c-1 h-auto w-full justify-start gap-1.5 overflow-x-auto rounded-t-none !rounded-b-xl px-3 py-1.5 text-base/5.25 font-normal whitespace-nowrap -outline-offset-1"
+      variant="ghost">
+      <span class="sr-only">Server:</span>
+      <span class="overflow-x-auto">{{
+        serverUrlWithoutTrailingSlash || 'Select a server'
+      }}</span>
+      <ScalarIconCaretDown
+        class="text-c-2 ui-open:rotate-180 mt-0.25 size-3 transition-transform duration-100"
+        weight="bold" />
+    </ScalarButton>
+  </ScalarListbox>
+  <div
+    v-else
+    class="text-c-1 flex h-auto w-full items-center gap-0.75 !rounded-b-xl px-3 py-1.5 text-base leading-[20px] whitespace-nowrap">
+    <span class="sr-only">Server:</span>
+    <span class="overflow-x-auto">{{ serverUrlWithoutTrailingSlash }}</span>
+  </div>
+</template>

--- a/packages/api-reference/src/blocks/scalar-asyncapi-server-selector-block/index.ts
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-server-selector-block/index.ts
@@ -1,0 +1,1 @@
+export { default as AsyncApiServerSelector } from './components/AsyncApiServerSelector.vue'

--- a/packages/api-reference/src/components/ApiReference.config.test.ts
+++ b/packages/api-reference/src/components/ApiReference.config.test.ts
@@ -771,3 +771,36 @@ describe('ApiReference custom fetch forwarding', () => {
     warn.mockRestore()
   })
 })
+
+describe('ApiReference AsyncAPI onServerChange', () => {
+  it('fires onServerChange with the connection URL when an AsyncAPI server is selected', async () => {
+    const onServerChange = vi.fn()
+
+    const wrapper = mountComponent({
+      props: {
+        configuration: {
+          onServerChange,
+          content: {
+            asyncapi: '3.0.0',
+            info: { title: 'Events API', version: '1.0.0' },
+            servers: {
+              production: { host: 'broker.example.com', protocol: 'wss' },
+              development: { host: 'localhost:8080', protocol: 'ws' },
+            },
+            channels: { events: { address: 'events' } },
+          },
+        },
+      },
+    })
+    await flushPromises()
+
+    const serverSelector = wrapper.findComponent({ name: 'Selector' })
+    expect(serverSelector.exists()).toBe(true)
+
+    await serverSelector.vm.$emit('update:modelValue', 'development')
+
+    expect(onServerChange).toHaveBeenCalledWith('ws://localhost:8080')
+
+    wrapper.unmount()
+  })
+})

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -38,6 +38,7 @@ import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { useColorMode } from '@scalar/use-hooks/useColorMode'
 import { ScalarToasts } from '@scalar/use-toasts'
 import { coerce } from '@scalar/validation'
+import { getAsyncApiServers } from '@scalar/workspace-store/channel-example'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import {
@@ -48,7 +49,10 @@ import type {
   TraversedEntry,
   TraversedTag,
 } from '@scalar/workspace-store/schemas/navigation'
-import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
+import {
+  isAsyncApiDocument,
+  isOpenApiDocument,
+} from '@scalar/workspace-store/schemas/type-guards'
 import { useScrollLock } from '@vueuse/core'
 import diff from 'microdiff'
 import {
@@ -869,6 +873,23 @@ onBeforeUnmount(() => {
 eventBus.on('server:update:selected', ({ url }) =>
   mergedConfig.value.onServerChange?.(url),
 )
+
+/**
+ * AsyncAPI servers are keyed by name, so resolve the selected name to its
+ * constructed connection URL before firing onServerChange, keeping the callback
+ * payload consistent with OpenAPI (a URL string).
+ */
+eventBus.on('asyncapi-server:update:selected', ({ name }) => {
+  const document = clientStore.workspace.activeDocument
+  if (!isAsyncApiDocument(document)) {
+    return
+  }
+
+  const server = getAsyncApiServers(document, { webSocketOnly: false }).find(
+    (s) => s.name === name,
+  )
+  mergedConfig.value.onServerChange?.(server?.url ?? name)
+})
 
 /** Download the document from the store */
 eventBus.on('ui:download:document', ({ format }) => {

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -4,6 +4,10 @@ import { mapHiddenClientsConfig } from '@scalar/api-client/modal/map-hidden-clie
 import { ScalarErrorBoundary } from '@scalar/components/error-boundary'
 import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
 import type { Heading } from '@scalar/types/legacy'
+import {
+  getAsyncApiServers,
+  getSelectedAsyncApiServer,
+} from '@scalar/workspace-store/channel-example'
 import type { AuthStore } from '@scalar/workspace-store/entities/auth'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import {
@@ -24,6 +28,7 @@ import type {
 } from '@scalar/workspace-store/schemas/workspace'
 import { computed, onMounted } from 'vue'
 
+import { AsyncApiServerSelector } from '@/blocks/scalar-asyncapi-server-selector-block'
 import { ClientSelector } from '@/blocks/scalar-client-selector-block'
 import { InfoBlock } from '@/blocks/scalar-info-block'
 import { IntroductionCardItem } from '@/blocks/scalar-info-block/'
@@ -136,6 +141,24 @@ const selectedServer = computed(() =>
   ),
 )
 
+/**
+ * Compute the AsyncAPI servers (all protocols, not just WebSocket) for the
+ * document-level server selector.
+ */
+const asyncApiServers = computed(() =>
+  asyncApiDocument.value
+    ? getAsyncApiServers(asyncApiDocument.value, { webSocketOnly: false })
+    : [],
+)
+
+/** Compute the selected AsyncAPI server for the document */
+const asyncApiSelectedServer = computed(() =>
+  getSelectedAsyncApiServer(
+    asyncApiDocument.value ?? null,
+    asyncApiServers.value,
+  ),
+)
+
 /** Merge authentication config with the document security schemes */
 const securitySchemes = computed(() =>
   mergeSecurity(
@@ -183,6 +206,17 @@ onMounted(() => {
               :eventBus
               :selectedServer
               :servers />
+          </IntroductionCardItem>
+        </ScalarErrorBoundary>
+
+        <!-- AsyncAPI Server Selector -->
+        <ScalarErrorBoundary>
+          <IntroductionCardItem
+            v-if="asyncApiServers.length"
+            class="scalar-reference-intro-server scalar-client introduction-card-item text-base leading-normal [--scalar-address-bar-height:0px]">
+            <AsyncApiServerSelector
+              :selectedServer="asyncApiSelectedServer"
+              :servers="asyncApiServers" />
           </IntroductionCardItem>
         </ScalarErrorBoundary>
 

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -108,6 +108,11 @@ const asyncApiDocument = computed(() =>
   isAsyncApiDocument(document) ? document : undefined,
 )
 
+/** AsyncAPI narrow of the client document, where server selection/variables are persisted. */
+const asyncApiClientDocument = computed(() =>
+  isAsyncApiDocument(clientDocument) ? clientDocument : undefined,
+)
+
 const documentType = computed(() => getDocumentType(document))
 
 const specificationVersion = computed(() => {
@@ -146,15 +151,15 @@ const selectedServer = computed(() =>
  * document-level server selector.
  */
 const asyncApiServers = computed(() =>
-  asyncApiDocument.value
-    ? getAsyncApiServers(asyncApiDocument.value, { webSocketOnly: false })
+  asyncApiClientDocument.value
+    ? getAsyncApiServers(asyncApiClientDocument.value, { webSocketOnly: false })
     : [],
 )
 
 /** Compute the selected AsyncAPI server for the document */
 const asyncApiSelectedServer = computed(() =>
   getSelectedAsyncApiServer(
-    asyncApiDocument.value ?? null,
+    asyncApiClientDocument.value ?? null,
     asyncApiServers.value,
   ),
 )
@@ -215,6 +220,7 @@ onMounted(() => {
             v-if="asyncApiServers.length"
             class="scalar-reference-intro-server scalar-client introduction-card-item text-base leading-normal [--scalar-address-bar-height:0px]">
             <AsyncApiServerSelector
+              :eventBus
               :selectedServer="asyncApiSelectedServer"
               :servers="asyncApiServers" />
           </IntroductionCardItem>

--- a/packages/api-reference/test/utils/sources.ts
+++ b/packages/api-reference/test/utils/sources.ts
@@ -39,6 +39,67 @@ export const sources = [
     layout: 'classic',
   },
   {
+    // Small inline AsyncAPI doc to exercise the server selector with multiple
+    // servers, server variables, and a server description.
+    title: 'AsyncAPI Server Selector Playground',
+    slug: 'asyncapi-server-selector',
+    content: {
+      asyncapi: '3.0.0',
+      info: {
+        title: 'Server Selector Playground',
+        version: '1.0.0',
+      },
+      servers: {
+        production: {
+          host: '{environment}.example.com:{port}',
+          protocol: 'wss',
+          pathname: '/ws',
+          description: 'Production WebSocket broker. Pick an environment and port to build the URL.',
+          variables: {
+            environment: {
+              default: 'api',
+              description: 'Subdomain to connect to',
+              enum: ['api', 'staging', 'dev'],
+            },
+            port: {
+              default: '443',
+            },
+          },
+        },
+        development: {
+          host: 'localhost:8080',
+          protocol: 'ws',
+          description: 'Local development broker',
+        },
+        mqtt: {
+          host: 'broker.example.com:1883',
+          protocol: 'mqtt',
+        },
+      },
+      channels: {
+        events: {
+          address: 'events',
+          messages: {
+            ping: {
+              payload: {
+                type: 'object',
+                properties: {
+                  message: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+      operations: {
+        sendEvent: {
+          action: 'send',
+          channel: { $ref: '#/channels/events' },
+        },
+      },
+    },
+  },
+  {
     title: 'Tag Groups',
     slug: 'tag-groups',
     content: {

--- a/packages/api-reference/test/utils/sources.ts
+++ b/packages/api-reference/test/utils/sources.ts
@@ -39,67 +39,6 @@ export const sources = [
     layout: 'classic',
   },
   {
-    // Small inline AsyncAPI doc to exercise the server selector with multiple
-    // servers, server variables, and a server description.
-    title: 'AsyncAPI Server Selector Playground',
-    slug: 'asyncapi-server-selector',
-    content: {
-      asyncapi: '3.0.0',
-      info: {
-        title: 'Server Selector Playground',
-        version: '1.0.0',
-      },
-      servers: {
-        production: {
-          host: '{environment}.example.com:{port}',
-          protocol: 'wss',
-          pathname: '/ws',
-          description: 'Production WebSocket broker. Pick an environment and port to build the URL.',
-          variables: {
-            environment: {
-              default: 'api',
-              description: 'Subdomain to connect to',
-              enum: ['api', 'staging', 'dev'],
-            },
-            port: {
-              default: '443',
-            },
-          },
-        },
-        development: {
-          host: 'localhost:8080',
-          protocol: 'ws',
-          description: 'Local development broker',
-        },
-        mqtt: {
-          host: 'broker.example.com:1883',
-          protocol: 'mqtt',
-        },
-      },
-      channels: {
-        events: {
-          address: 'events',
-          messages: {
-            ping: {
-              payload: {
-                type: 'object',
-                properties: {
-                  message: { type: 'string' },
-                },
-              },
-            },
-          },
-        },
-      },
-      operations: {
-        sendEvent: {
-          action: 'send',
-          channel: { $ref: '#/channels/events' },
-        },
-      },
-    },
-  },
-  {
     title: 'Tag Groups',
     slug: 'tag-groups',
     content: {

--- a/packages/types/src/asyncapi/3.1/index.ts
+++ b/packages/types/src/asyncapi/3.1/index.ts
@@ -8,5 +8,6 @@ export type {
   AsyncApiParameterObject,
   AsyncApiSecuritySchemeObject,
   AsyncApiServerObject,
+  AsyncApiServerVariableObject,
   AsyncApiWsBindingObject,
 } from './index.generated'

--- a/packages/workspace-store/src/events/definitions/server.ts
+++ b/packages/workspace-store/src/events/definitions/server.ts
@@ -80,4 +80,25 @@ export type ServerEvents = {
     /** The meta information for the server */
     meta: ServerMeta
   }
+  /**
+   * Update the selected server for an AsyncAPI document.
+   *
+   * AsyncAPI servers are a named map (rather than an array of `url`), so the
+   * selection is identified by the server name instead of an index or URL.
+   */
+  'asyncapi-server:update:selected': {
+    /** The name (key in `document.servers`) of the server to select */
+    name: string
+  }
+  /**
+   * Update a server variable for an AsyncAPI document, identified by server name.
+   */
+  'asyncapi-server:update:variables': {
+    /** The name (key in `document.servers`) of the server to update */
+    name: string
+    /** The key of the variable to update */
+    key: string
+    /** The new value of the variable */
+    value: string
+  }
 }

--- a/packages/workspace-store/src/mutators/server.test.ts
+++ b/packages/workspace-store/src/mutators/server.test.ts
@@ -1276,7 +1276,7 @@ describe('updateSelectedAsyncApiServer', () => {
     expect(document['x-scalar-selected-server']).toBe('development')
   })
 
-  it('clears the selection when the active server is selected again', () => {
+  it('keeps the server selected when it is selected again', () => {
     const document = createAsyncApiDocument({
       servers: { production: { host: 'broker.example.com', protocol: 'wss' } },
       'x-scalar-selected-server': 'production',
@@ -1284,8 +1284,8 @@ describe('updateSelectedAsyncApiServer', () => {
 
     const result = updateSelectedAsyncApiServer(document, { name: 'production' })
 
-    expect(result).toBe('')
-    expect(document['x-scalar-selected-server']).toBe('')
+    expect(result).toBe('production')
+    expect(document['x-scalar-selected-server']).toBe('production')
   })
 
   it('returns undefined for non-AsyncAPI documents', () => {

--- a/packages/workspace-store/src/mutators/server.test.ts
+++ b/packages/workspace-store/src/mutators/server.test.ts
@@ -1,3 +1,4 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import { describe, expect, it } from 'vitest'
 
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
@@ -8,6 +9,8 @@ import {
   clearServers,
   deleteServer,
   initializeServers,
+  updateAsyncApiServerVariables,
+  updateSelectedAsyncApiServer,
   updateSelectedServer,
   updateServer,
   updateServerVariables,
@@ -1244,5 +1247,106 @@ describe('x-scalar-selected-server tracking', () => {
       expect(document.servers).toHaveLength(0)
       expect(document['x-scalar-selected-server']).toBe('https://api.example.com')
     })
+  })
+})
+
+/**
+ * Helper to create a minimal AsyncApiDocument for testing.
+ */
+function createAsyncApiDocument(initial?: Partial<AsyncApiDocument>): AsyncApiDocument {
+  return {
+    asyncapi: '3.0.0',
+    info: { title: 'Test', version: '1.0.0' },
+    ...initial,
+  } as AsyncApiDocument
+}
+
+describe('updateSelectedAsyncApiServer', () => {
+  it('selects a server by name', () => {
+    const document = createAsyncApiDocument({
+      servers: {
+        production: { host: 'broker.example.com', protocol: 'wss' },
+        development: { host: 'localhost:8080', protocol: 'ws' },
+      },
+    })
+
+    const result = updateSelectedAsyncApiServer(document, { name: 'development' })
+
+    expect(result).toBe('development')
+    expect(document['x-scalar-selected-server']).toBe('development')
+  })
+
+  it('clears the selection when the active server is selected again', () => {
+    const document = createAsyncApiDocument({
+      servers: { production: { host: 'broker.example.com', protocol: 'wss' } },
+      'x-scalar-selected-server': 'production',
+    })
+
+    const result = updateSelectedAsyncApiServer(document, { name: 'production' })
+
+    expect(result).toBe('')
+    expect(document['x-scalar-selected-server']).toBe('')
+  })
+
+  it('returns undefined for non-AsyncAPI documents', () => {
+    const document = createDocument({ servers: [{ url: 'https://api.example.com' }] })
+
+    const result = updateSelectedAsyncApiServer(document, { name: 'production' })
+
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('updateAsyncApiServerVariables', () => {
+  it('updates a server variable default by server name', () => {
+    const document = createAsyncApiDocument({
+      servers: {
+        production: {
+          host: '{environment}.example.com',
+          protocol: 'wss',
+          variables: {
+            environment: { default: 'api', enum: ['api', 'staging', 'dev'] },
+          },
+        },
+      },
+    })
+
+    const result = updateAsyncApiServerVariables(document, {
+      name: 'production',
+      key: 'environment',
+      value: 'staging',
+    })
+
+    expect(result?.default).toBe('staging')
+    const environment = getResolvedRef(document.servers?.production)?.variables?.environment
+    expect(environment ? getResolvedRef(environment).default : undefined).toBe('staging')
+  })
+
+  it('returns undefined when the variable is not found', () => {
+    const document = createAsyncApiDocument({
+      servers: { production: { host: 'broker.example.com', protocol: 'wss' } },
+    })
+
+    const result = updateAsyncApiServerVariables(document, {
+      name: 'production',
+      key: 'environment',
+      value: 'staging',
+    })
+
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined for non-AsyncAPI documents', () => {
+    const document = createDocument({
+      servers: [{ url: 'https://{environment}.example.com', variables: { environment: { default: 'api' } } }],
+    })
+
+    const result = updateAsyncApiServerVariables(document, {
+      name: '0',
+      key: 'environment',
+      value: 'staging',
+    })
+
+    expect(result).toBeUndefined()
   })
 })

--- a/packages/workspace-store/src/mutators/server.ts
+++ b/packages/workspace-store/src/mutators/server.ts
@@ -1,9 +1,10 @@
 import { findVariables } from '@scalar/helpers/regex/find-variables'
+import type { AsyncApiServerVariableObject } from '@scalar/types/asyncapi/3.1'
 
 import type { ServerEvents, ServerMeta } from '@/events/definitions/server'
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
 import { unpackProxyObject } from '@/helpers/unpack-proxy'
-import { isOpenApiDocument } from '@/schemas/type-guards'
+import { isAsyncApiDocument, isOpenApiDocument } from '@/schemas/type-guards'
 import { coerceValue } from '@/schemas/typebox-coerce'
 import { type ServerObject, ServerObjectSchema } from '@/schemas/v3.1/strict/openapi-document'
 import type { WorkspaceDocument } from '@/schemas/workspace'
@@ -299,6 +300,57 @@ export const updateSelectedServer = (
   return target['x-scalar-selected-server']
 }
 
+/**
+ * Updates the selected server for an AsyncAPI document.
+ *
+ * AsyncAPI servers are a named map, so the selection is stored as the server
+ * name in `x-scalar-selected-server`. Selecting the already-selected server
+ * clears it (mirroring the OpenAPI selector toggle).
+ *
+ * @param document - The document to update the selected server in
+ * @param name - The name of the server to select
+ * @returns the name of the selected server or undefined if the document is not AsyncAPI
+ */
+export const updateSelectedAsyncApiServer = (
+  document: WorkspaceDocument | null,
+  { name }: ServerEvents['asyncapi-server:update:selected'],
+): string | undefined => {
+  if (!isAsyncApiDocument(document)) {
+    return undefined
+  }
+
+  document['x-scalar-selected-server'] = document['x-scalar-selected-server'] === name ? '' : name
+  return document['x-scalar-selected-server']
+}
+
+/**
+ * Updates a server variable for an AsyncAPI document, identified by server name.
+ *
+ * @param document - The document to update the server variables in
+ * @param name - The name of the server to update
+ * @param key - The key of the variable to update
+ * @param value - The new value of the variable
+ * @returns the updated variable or undefined if it is not found
+ */
+export const updateAsyncApiServerVariables = (
+  document: WorkspaceDocument | null,
+  { name, key, value }: ServerEvents['asyncapi-server:update:variables'],
+): AsyncApiServerVariableObject | undefined => {
+  if (!isAsyncApiDocument(document)) {
+    return undefined
+  }
+
+  const server = getResolvedRef(document.servers?.[name])
+  const variable = server?.variables?.[key] ? getResolvedRef(server.variables[key]) : undefined
+  if (!variable) {
+    console.error('Variable not found', key, name)
+    return undefined
+  }
+
+  variable.default = value
+  return variable
+}
+
 export const serverMutatorsFactory = ({ document }: { document: WorkspaceDocument | null }) => {
   return {
     initializeServers: (payload: ServerEvents['server:initialize:servers']) => initializeServers(document, payload),
@@ -309,5 +361,9 @@ export const serverMutatorsFactory = ({ document }: { document: WorkspaceDocumen
     updateServerVariables: (payload: ServerEvents['server:update:variables']) =>
       updateServerVariables(document, payload),
     updateSelectedServer: (payload: ServerEvents['server:update:selected']) => updateSelectedServer(document, payload),
+    updateSelectedAsyncApiServer: (payload: ServerEvents['asyncapi-server:update:selected']) =>
+      updateSelectedAsyncApiServer(document, payload),
+    updateAsyncApiServerVariables: (payload: ServerEvents['asyncapi-server:update:variables']) =>
+      updateAsyncApiServerVariables(document, payload),
   }
 }

--- a/packages/workspace-store/src/mutators/server.ts
+++ b/packages/workspace-store/src/mutators/server.ts
@@ -304,8 +304,9 @@ export const updateSelectedServer = (
  * Updates the selected server for an AsyncAPI document.
  *
  * AsyncAPI servers are a named map, so the selection is stored as the server
- * name in `x-scalar-selected-server`. Selecting the already-selected server
- * clears it (mirroring the OpenAPI selector toggle).
+ * name in `x-scalar-selected-server`. There is always an effective server
+ * (`getSelectedAsyncApiServer` falls back to the first one), so this simply sets
+ * the selection rather than toggling it off.
  *
  * @param document - The document to update the selected server in
  * @param name - The name of the server to select
@@ -319,7 +320,7 @@ export const updateSelectedAsyncApiServer = (
     return undefined
   }
 
-  document['x-scalar-selected-server'] = document['x-scalar-selected-server'] === name ? '' : name
+  document['x-scalar-selected-server'] = name
   return document['x-scalar-selected-server']
 }
 


### PR DESCRIPTION
Adds a server selector for AsyncAPI documents in the API reference, next to the OpenAPI one. It works with the AsyncAPI server shape (a named map of `host`/`protocol`/`pathname`) and labels each server with its constructed connection URL.

Selection and server variables persist to the workspace store via new `asyncapi-server:update:*` events and mutators, wired up the same way as OpenAPI.

<img width="548" height="214" alt="Screenshot 2026-06-05 at 14 00 42" src="https://github.com/user-attachments/assets/848a8c28-4f45-427f-bb50-2182f8c2db8a" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reuses `x-scalar-selected-server` for AsyncAPI server names (vs OpenAPI URLs) and mutates live client documents; scope is reference UI and store events, not auth or network.
> 
> **Overview**
> Adds an **AsyncAPI server selector** to the API reference introduction, parallel to the OpenAPI control. Options use server **names** from the spec map and show each entry’s **built connection URL**; a single server renders as read-only text, multiple servers use a listbox. Variable editing reuses `ServerVariablesForm` with AsyncAPI variables normalized via `getResolvedRef`.
> 
> **Persistence and wiring:** UI emits `asyncapi-server:update:selected` and `asyncapi-server:update:variables`; api-client event handlers call new workspace mutators that store selection in `x-scalar-selected-server` (by **name**) and update variable defaults on the named server. PostHog explicitly opts these events out of tracking.
> 
> **Integration:** `Content.vue` loads servers from the **client** AsyncAPI document (`webSocketOnly: false` for doc-level listing). `ApiReference.vue` maps AsyncAPI selection to `onServerChange` with a **URL string**, matching OpenAPI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c446bbe7062d5aaf0052894fda0f852b7006b7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->