### PR TITLE
test(workspace-store): cover recursive $ref schema example generation

### DIFF
--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { createWorkspaceStore } from '@/client'
 import { coerceValue } from '@/schemas/typebox-coerce'
 import { type SchemaObject, SchemaObjectSchema } from '@/schemas/v3.1/strict/openapi-document'
 
@@ -1822,6 +1823,51 @@ describe('getExampleFromSchema', () => {
       // Circular references should be skipped entirely
       const example = getExampleFromSchema(schema)
       expect(example).toStrictEqual({})
+    })
+
+    // Regression test for https://github.com/scalar/scalar/issues/9442
+    // A schema that references itself through `allOf` + a nested array (resolved via
+    // the workspace store's magic proxy) used to overflow the stack while rendering the
+    // response example. The self-reference inside the array should resolve to an empty array.
+    it('handles $ref self-references through allOf without overflowing', async () => {
+      const store = createWorkspaceStore()
+      await store.addDocument({
+        name: 'default',
+        document: {
+          openapi: '3.1.0',
+          info: { title: 'Comments', version: '1.0.0' },
+          components: {
+            schemas: {
+              Dto: { type: 'object', properties: { id: { type: 'string' } } },
+              CommentDto: {
+                title: 'CommentDto',
+                allOf: [
+                  { $ref: '#/components/schemas/Dto' },
+                  {
+                    type: 'object',
+                    properties: {
+                      text: { type: 'string' },
+                      responses: {
+                        type: 'array',
+                        items: { $ref: '#/components/schemas/CommentDto' },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      })
+
+      const schema = (store.workspace.activeDocument as any).components.schemas.CommentDto as SchemaObject
+
+      expect(getExampleFromSchema(schema, { emptyString: 'string', mode: 'read' })).toStrictEqual({
+        id: 'string',
+        text: 'string',
+        // The self-reference is expanded once and then stopped, instead of recursing forever.
+        responses: [{}],
+      })
     })
   })
 


### PR DESCRIPTION
Verified #9442 (stack overflow on a self-referencing `CommentDto` via `allOf` + $ref) against current `main`: the response example now renders fine as `{ id, text, responses: [{}] }` with no console errors. The crash was fixed after 1.58.0 was published (recursive coerce #9262, allOf cycle-break #9194).

This adds a regression test so it stays fixed — the existing circular-reference tests only covered hand-built identity cycles, not the $ref/magic-proxy path that actually broke.

## Ticket

Closes #9442