### PR TITLE
chore(agent-chat): update neverpanic to 0.0.8

### DIFF
--- a/.changeset/update-neverpanic.md
+++ b/.changeset/update-neverpanic.md
@@ -1,0 +1,5 @@
+---
+'@scalar/agent-chat': patch
+---
+
+Update neverpanic to 0.0.8, which drops the TypeScript peer dependency and removes the unmet peer warning on install

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,8 +199,8 @@ catalogs:
       specifier: ^5.1.6
       version: 5.1.6
     neverpanic:
-      specifier: 0.0.7
-      version: 0.0.7
+      specifier: 0.0.8
+      version: 0.0.8
     next:
       specifier: ^15.5.14
       version: 15.5.15
@@ -1149,7 +1149,7 @@ importers:
         version: 3.7.8
       neverpanic:
         specifier: catalog:*
-        version: 0.0.7(typescript@5.9.3)
+        version: 0.0.8
       truncate-json:
         specifier: catalog:*
         version: 3.0.1
@@ -14335,10 +14335,8 @@ packages:
     resolution: {integrity: sha512-Nc3loyVASW59W+8fLDZT1lncpG7llffyZ2o0UQLx/Fr20i7P8oP+lE7+TEcFvXj9IUWU6LjB9P3BH+iFGyp+mg==}
     engines: {node: ^14.16.0 || >=16.0.0}
 
-  neverpanic@0.0.7:
-    resolution: {integrity: sha512-GFRTSX2JAEATOCQYlyFkR+9FJPl0pD24toE1foqYAsL6aPLlRKn6L0UFOtJhZCxEbDv+SUsiW4AcPs9cIFwkFw==}
-    peerDependencies:
-      typescript: '5'
+  neverpanic@0.0.8:
+    resolution: {integrity: sha512-vVdkelrLxaow/fdWDumzNBO+jwm6X8bxeLJc34THtpj70u0C5QBkcV6CRCu2X726km7XD45N0A3QtYCla4RvKw==}
 
   next@15.5.15:
     resolution: {integrity: sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==}
@@ -33212,9 +33210,7 @@ snapshots:
       qs: 6.14.1
     optional: true
 
-  neverpanic@0.0.7(typescript@5.9.3):
-    dependencies:
-      typescript: 5.9.3
+  neverpanic@0.0.8: {}
 
   next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -80,7 +80,7 @@ catalogs:
     monaco-yaml: 5.4.1
     nanoid: ^5.1.6
     next: ^15.5.14
-    neverpanic: 0.0.7
+    neverpanic: 0.0.8
     picomatch: ^4.0.4
     postcss: ^8.4.38
     radix-vue: ^1.9.17


### PR DESCRIPTION
Bumps `neverpanic` 0.0.7 → 0.0.8. The new version drops its `typescript@5` peer dependency, so installs no longer warn when the project is on TypeScript 6.

## Ticket

Fixes #9245

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bump with no runtime code changes; low risk aside from routine third-party patch behavior.
> 
> **Overview**
> Bumps the workspace catalog **`neverpanic`** dependency from **0.0.7** to **0.0.8** and refreshes **`pnpm-lock.yaml`**. **`@scalar/agent-chat`** still consumes it via **`catalog:*`**; no application source changes.
> 
> The new release removes **`neverpanic`**’s **`typescript@5`** peer dependency, so installs should no longer emit unmet-peer warnings when the monorepo uses a different TypeScript version (e.g. 5.9.3 or 6.x). A patch **changeset** records the bump for **`@scalar/agent-chat`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22728c18954cc9ce719a296687bbb3fe8a66ed50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->