### PR TITLE
fix(api-client): array query params wrapped in anyOf/oneOf sent as repeated params

### DIFF
--- a/.changeset/array-anyof-query-params.md
+++ b/.changeset/array-anyof-query-params.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Fix `anyOf`/`oneOf` array query parameters (e.g. `Optional[List[str]]`) being sent as a single string instead of repeated query parameters

--- a/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.test.ts
+++ b/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.test.ts
@@ -375,6 +375,31 @@ describe('de-serialize-parameter', () => {
       expect(result).toEqual(['item1', 'item2'])
     })
 
+    it('splits comma-separated string into array when array type is wrapped in anyOf', () => {
+      const param: ParameterWithSchemaObject = {
+        name: 'id',
+        in: 'query',
+        schema: {
+          anyOf: [{ type: 'array', items: { type: 'string' } }, { type: 'null' }],
+        } as ParameterWithSchemaObject['schema'],
+      }
+
+      expect(deSerializeParameter('a,b', param)).toEqual(['a', 'b'])
+      expect(deSerializeParameter('["a","b"]', param)).toEqual(['a', 'b'])
+    })
+
+    it('parses JSON object when object type is wrapped in oneOf', () => {
+      const param: ParameterWithSchemaObject = {
+        name: 'filter',
+        in: 'query',
+        schema: {
+          oneOf: [{ type: 'object' }, { type: 'null' }],
+        } as ParameterWithSchemaObject['schema'],
+      }
+
+      expect(deSerializeParameter('{"a":1}', param)).toEqual({ a: 1 })
+    })
+
     it('handles complex nested JSON with content type', () => {
       const param: ParameterObject = {
         name: 'test',

--- a/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.ts
+++ b/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.ts
@@ -38,18 +38,54 @@ const deSerializeContentExample = (example: unknown, contentType: string) => {
 const structuredSchemaTypes = new Set(['array', 'object'])
 
 /**
+ * Find the structured (`array` or `object`) type a schema represents, looking through
+ * `anyOf`/`oneOf`/`allOf` composition.
+ *
+ * Optional array/object parameters are commonly described as `anyOf: [{ type: 'array' }, { type: 'null' }]`
+ * (e.g. FastAPI/Pydantic `Optional[List[str]]`). Without unwrapping these we would treat the value as a
+ * plain string and send a single `id=a,b` query parameter instead of repeating `id=a&id=b`.
+ */
+const getStructuredType = (schema: unknown): 'array' | 'object' | undefined => {
+  const resolved = getResolvedRef(schema)
+  if (!resolved || typeof resolved !== 'object') {
+    return undefined
+  }
+
+  if ('type' in resolved && resolved.type) {
+    const type = Array.isArray(resolved.type)
+      ? resolved.type.find((t: string) => structuredSchemaTypes.has(t))
+      : resolved.type
+    if (type === 'array' || type === 'object') {
+      return type
+    }
+  }
+
+  for (const key of ['anyOf', 'oneOf', 'allOf'] as const) {
+    const subSchemas = (resolved as Record<string, unknown>)[key]
+    if (Array.isArray(subSchemas)) {
+      for (const subSchema of subSchemas) {
+        const type = getStructuredType(subSchema)
+        if (type) {
+          return type
+        }
+      }
+    }
+  }
+
+  return undefined
+}
+
+/**
  * Schema-based parameters from the request editor.
  *
  * Primitives (`string`, `integer`, `number`, `boolean`, `null`) are left as the typed string
  * Only `array` and `object` values are parsed so OpenAPI style serialization can expand them.
  */
 const deSerializeSchemaExample = (example: unknown, schema: ParameterWithSchemaObject['schema']) => {
-  const resolvedSchema = getResolvedRef(schema)
+  if (typeof example === 'string') {
+    const type = getStructuredType(schema)
 
-  if (typeof example === 'string' && resolvedSchema && 'type' in resolvedSchema) {
-    const type = Array.isArray(resolvedSchema.type) ? resolvedSchema.type[0] : resolvedSchema.type
-
-    if (type && structuredSchemaTypes.has(type)) {
+    if (type) {
       try {
         return JSON.parse(example)
       } catch {


### PR DESCRIPTION
Optional array query params written as `anyOf: [{ type: array }, { type: null }]` (the shape FastAPI/Pydantic emit for `Optional[List[str]]`) weren't being recognized as arrays. So `?id=a&id=b` got flattened into a single `?id=a,b`, which APIs reject with a 422.

De-serialization now looks through `anyOf`/`oneOf`/`allOf` to find the array (or object) type.

Repro doc from the issue: https://sandbox.scalar.com/e/59AqE

## Ticket

Fixes #8938

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to parameter example parsing in workspace-store with new unit tests; no auth or data-layer impact.
> 
> **Overview**
> Fixes request building for optional array/object query parameters whose OpenAPI schema uses **`anyOf`/`oneOf`/`allOf`** (e.g. FastAPI `Optional[List[str]]` as `anyOf: [array, null]`). Those values were left as plain strings, so clients sent **`id=a,b`** instead of **`id=a&id=b`**, often causing 422s.
> 
> **`deSerializeSchemaExample`** now resolves the effective **`array` or `object`** type via a new **`getStructuredType`** helper that walks composition keywords and `$ref`, then applies the existing JSON parse / comma-split behavior. Tests cover **`anyOf`** arrays and **`oneOf`** objects; changeset records a patch for **`@scalar/workspace-store`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f54fe6de8fd7ed4e3c4f2287a59458e6bad206ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->