### PR TITLE
refactor(api-client): drop the cookie (CJS) dependency

### DIFF
--- a/.changeset/drop-cookie-dependency.md
+++ b/.changeset/drop-cookie-dependency.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/helpers': patch
+---
+
+Replace the CommonJS-only `cookie` dependency with an in-repo ESM `serializeCookie` helper

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -335,7 +335,6 @@
     "@types/har-format": "^1.2.16",
     "@vueuse/core": "catalog:*",
     "@vueuse/integrations": "catalog:*",
-    "cookie": "catalog:*",
     "focus-trap": "^7.8.0",
     "fuse.js": "catalog:*",
     "js-base64": "catalog:*",

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.ts
@@ -5,9 +5,9 @@ import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import { httpStatusCodes } from '@scalar/helpers/http/http-status-codes'
 import { normalizeHeaders } from '@scalar/helpers/http/normalize-headers'
 import { X_SCALAR_SET_COOKIE } from '@scalar/helpers/http/scalar-headers'
+import { serializeCookie } from '@scalar/helpers/http/serialize-cookie'
 import type { ClientPlugin } from '@scalar/oas-utils/helpers'
 import type { RequestPayload } from '@scalar/workspace-store/request-example'
-import * as cookie from 'cookie'
 import { parseSetCookie } from 'set-cookie-parser'
 
 import { getCookieHeaderKeys } from '@/v2/blocks/operation-block/helpers/get-cookie-header-keys'
@@ -148,18 +148,15 @@ export const sendRequest = async ({
 /**
  * Extracts and serializes custom cookies from the response using the custom cookie header.
  *
- * This function parses the custom cookie header (if present), serializes each cookie using the
- * 'cookie' library, and then deletes the custom cookie header from the response.
+ * This function parses the custom cookie header (if present), serializes each cookie using our
+ * in-repo `serializeCookie` helper, and then deletes the custom cookie header from the response.
  * Returns an array of serialized cookie strings, or null if no cookies were found.
- *
- * The @ts-expect-error is present due to a type mismatch between the 'cookie' parsing and serialization libraries.
  */
 const getCustomCookie = (response: Response): string[] | null => {
   const result = parseSetCookie(response.headers.get(X_SCALAR_SET_COOKIE) ?? '').map((c) =>
-    cookie.serialize(c.name, c.value, {
+    serializeCookie(c.name, c.value, {
       ...c,
       sameSite: c.sameSite as boolean | 'lax' | 'strict' | 'none' | undefined,
-      encode: (str: string) => str,
     }),
   )
 

--- a/packages/helpers/src/http/serialize-cookie.test.ts
+++ b/packages/helpers/src/http/serialize-cookie.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { serializeCookie } from './serialize-cookie'
+
+describe('serializeCookie', () => {
+  it('serializes a basic name/value pair', () => {
+    expect(serializeCookie('foo', 'bar')).toBe('foo=bar')
+  })
+
+  it('leaves the value raw and unencoded', () => {
+    // A space would normally be percent-encoded by `encodeURIComponent`; we keep the value as-is.
+    expect(serializeCookie('foo', 'bar%20baz')).toBe('foo=bar%20baz')
+  })
+
+  it('serializes an empty value', () => {
+    expect(serializeCookie('foo', '')).toBe('foo=')
+  })
+
+  it('adds the Path attribute', () => {
+    expect(serializeCookie('foo', 'bar', { path: '/' })).toBe('foo=bar; Path=/')
+  })
+
+  it('adds the Domain attribute', () => {
+    expect(serializeCookie('foo', 'bar', { domain: 'example.com' })).toBe('foo=bar; Domain=example.com')
+  })
+
+  it('renders expires as a UTC string', () => {
+    const expires = new Date('2026-06-08T00:00:00.000Z')
+    expect(serializeCookie('foo', 'bar', { expires })).toBe(`foo=bar; Expires=${expires.toUTCString()}`)
+  })
+
+  it('renders maxAge as Max-Age', () => {
+    expect(serializeCookie('foo', 'bar', { maxAge: 3600 })).toBe('foo=bar; Max-Age=3600')
+  })
+
+  it('adds HttpOnly and Secure flags', () => {
+    expect(serializeCookie('foo', 'bar', { httpOnly: true, secure: true })).toBe('foo=bar; HttpOnly; Secure')
+  })
+
+  it('renders sameSite as a string', () => {
+    expect(serializeCookie('foo', 'bar', { sameSite: 'lax' })).toBe('foo=bar; SameSite=Lax')
+    expect(serializeCookie('foo', 'bar', { sameSite: 'strict' })).toBe('foo=bar; SameSite=Strict')
+    expect(serializeCookie('foo', 'bar', { sameSite: 'none' })).toBe('foo=bar; SameSite=None')
+  })
+
+  it('treats sameSite true as Strict', () => {
+    expect(serializeCookie('foo', 'bar', { sameSite: true })).toBe('foo=bar; SameSite=Strict')
+  })
+
+  it('adds the Partitioned attribute', () => {
+    expect(serializeCookie('foo', 'bar', { partitioned: true })).toBe('foo=bar; Partitioned')
+  })
+
+  it('renders priority', () => {
+    expect(serializeCookie('foo', 'bar', { priority: 'high' })).toBe('foo=bar; Priority=High')
+  })
+
+  it('combines multiple attributes in order', () => {
+    const expires = new Date('2026-06-08T00:00:00.000Z')
+    expect(
+      serializeCookie('session', 'abc', {
+        maxAge: 60,
+        domain: 'example.com',
+        path: '/',
+        expires,
+        httpOnly: true,
+        secure: true,
+        sameSite: 'lax',
+      }),
+    ).toBe(
+      `session=abc; Max-Age=60; Domain=example.com; Path=/; Expires=${expires.toUTCString()}; HttpOnly; Secure; SameSite=Lax`,
+    )
+  })
+
+  it('throws for an invalid name', () => {
+    expect(() => serializeCookie('foo bar', 'baz')).toThrow(TypeError)
+  })
+})

--- a/packages/helpers/src/http/serialize-cookie.ts
+++ b/packages/helpers/src/http/serialize-cookie.ts
@@ -1,0 +1,145 @@
+/**
+ * RegExp to match cookie-name in RFC 6265 sec 4.1.1.
+ *
+ * Mirrors the `cookie` package so that names containing invalid characters are rejected.
+ */
+const cookieNameRegExp = /^[!-:<>-~]+$/
+
+/**
+ * RegExp to match cookie-value in RFC 6265 sec 4.1.1.
+ */
+const cookieValueRegExp = /^[!-:<-~]*$/
+
+/** RegExp to match domain-value in RFC 6265 sec 4.1.1. */
+const domainValueRegExp = /^([.]?[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)([.][a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$/i
+
+/** RegExp to match path-value in RFC 6265 sec 4.1.1. */
+const pathValueRegExp = /^[ -:=-~]*$/
+
+/** Options accepted when serializing a `Set-Cookie` header value. */
+export type SerializeCookieOptions = {
+  /** Number of seconds until the cookie expires, rendered as `Max-Age`. */
+  maxAge?: number
+  /** Domain the cookie is valid for, rendered as `Domain`. */
+  domain?: string
+  /** Path the cookie is valid for, rendered as `Path`. */
+  path?: string
+  /** Absolute expiry date, rendered as `Expires` using `Date.toUTCString()`. */
+  expires?: Date
+  /** Whether to add the `HttpOnly` attribute. */
+  httpOnly?: boolean
+  /** Whether to add the `Secure` attribute. */
+  secure?: boolean
+  /** Whether to add the `Partitioned` attribute. */
+  partitioned?: boolean
+  /** Cookie priority, rendered as `Priority=Low|Medium|High`. */
+  priority?: 'low' | 'medium' | 'high' | (string & {})
+  /**
+   * The `SameSite` attribute.
+   *
+   * `true` is treated as `Strict`, otherwise `strict`, `lax`, or `none`.
+   */
+  sameSite?: boolean | 'lax' | 'strict' | 'none' | (string & {})
+}
+
+/**
+ * Serialize a cookie name, value, and options into a `Set-Cookie` header string.
+ *
+ * This is a small, ESM-friendly drop-in for the `cookie` package's `serialize` (a.k.a.
+ * `stringifySetCookie`) function. The third-party package is CommonJS-only, which breaks
+ * Vite dev under pnpm's strict `node_modules` layout, so we reproduce just the behavior we
+ * need here.
+ *
+ * The value is intentionally left raw (not URL-encoded) to match how it was previously
+ * called with `encode: (str) => str`.
+ */
+export const serializeCookie = (name: string, value: string, options: SerializeCookieOptions = {}): string => {
+  if (!cookieNameRegExp.test(name)) {
+    throw new TypeError(`argument name is invalid: ${name}`)
+  }
+
+  if (!cookieValueRegExp.test(value)) {
+    throw new TypeError(`argument val is invalid: ${value}`)
+  }
+
+  let str = `${name}=${value}`
+
+  if (options.maxAge !== undefined) {
+    if (!Number.isInteger(options.maxAge)) {
+      throw new TypeError(`option maxAge is invalid: ${options.maxAge}`)
+    }
+    str += `; Max-Age=${options.maxAge}`
+  }
+
+  if (options.domain) {
+    if (!domainValueRegExp.test(options.domain)) {
+      throw new TypeError(`option domain is invalid: ${options.domain}`)
+    }
+    str += `; Domain=${options.domain}`
+  }
+
+  if (options.path) {
+    if (!pathValueRegExp.test(options.path)) {
+      throw new TypeError(`option path is invalid: ${options.path}`)
+    }
+    str += `; Path=${options.path}`
+  }
+
+  if (options.expires) {
+    if (!(options.expires instanceof Date) || !Number.isFinite(options.expires.valueOf())) {
+      throw new TypeError(`option expires is invalid: ${options.expires}`)
+    }
+    str += `; Expires=${options.expires.toUTCString()}`
+  }
+
+  if (options.httpOnly) {
+    str += '; HttpOnly'
+  }
+
+  if (options.secure) {
+    str += '; Secure'
+  }
+
+  if (options.partitioned) {
+    str += '; Partitioned'
+  }
+
+  if (options.priority) {
+    const priority = typeof options.priority === 'string' ? options.priority.toLowerCase() : undefined
+
+    switch (priority) {
+      case 'low':
+        str += '; Priority=Low'
+        break
+      case 'medium':
+        str += '; Priority=Medium'
+        break
+      case 'high':
+        str += '; Priority=High'
+        break
+      default:
+        throw new TypeError(`option priority is invalid: ${options.priority}`)
+    }
+  }
+
+  if (options.sameSite) {
+    const sameSite = typeof options.sameSite === 'string' ? options.sameSite.toLowerCase() : options.sameSite
+
+    switch (sameSite) {
+      case true:
+      case 'strict':
+        str += '; SameSite=Strict'
+        break
+      case 'lax':
+        str += '; SameSite=Lax'
+        break
+      case 'none':
+        str += '; SameSite=None'
+        break
+      default:
+        throw new TypeError(`option sameSite is invalid: ${options.sameSite}`)
+    }
+  }
+
+  return str
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,9 +138,6 @@ catalogs:
     concurrently:
       specifier: 9.1.2
       version: 9.1.2
-    cookie:
-      specifier: 1.1.1
-      version: 1.1.1
     cross-env:
       specifier: 10.1.0
       version: 10.1.0
@@ -1250,9 +1247,6 @@ importers:
       '@vueuse/integrations':
         specifier: catalog:*
         version: 13.9.0(axios@1.13.2)(change-case@5.4.4)(focus-trap@7.8.0)(fuse.js@7.1.0)(jwt-decode@4.0.0)(nprogress@0.2.0)(vue@3.5.30(typescript@5.9.3))
-      cookie:
-        specifier: catalog:*
-        version: 1.1.1
       focus-trap:
         specifier: ^7.8.0
         version: 7.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,7 +58,6 @@ catalogs:
     ai: 6.0.33
     ansis: 4.1.0
     astro: 5.18.1
-    cookie: 1.1.1
     commander: 13.1.0
     concurrently: 9.1.2
     cross-env: 10.1.0


### PR DESCRIPTION
The `cookie` package is CommonJS-only, which broke Vite dev under pnpm's strict node_modules layout. It was used in just one spot, so I replaced it with a small in-repo ESM `serializeCookie` helper.

## Ticket

Part of #9440

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cookie serialization on API responses; behavior is meant to match the old helper and is covered by new unit tests, but any subtle format difference could affect cookie display or downstream handling.
> 
> **Overview**
> Removes the **CommonJS-only `cookie` dependency** from `@scalar/api-client` and the workspace catalog so Vite dev works under pnpm’s strict layout.
> 
> Adds **`serializeCookie`** in `@scalar/helpers` as an ESM drop-in for `cookie.serialize`, with RFC-style validation and vitest coverage. **`send-request`** now uses it when turning Scalar’s custom set-cookie header into serialized cookie strings; the previous `encode: (str) => str` behavior is kept by leaving values unencoded, and the `@ts-expect-error` around the old library types is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cedd5bdbe0b88a24f03e9ea4fa8670aaa51e20dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->