### PR TITLE
ci: fix main workflow startup failure (release permissions)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -302,6 +302,15 @@ jobs:
       github.ref == 'refs/heads/main' &&
       needs.required-jobs-main.result == 'success'
     needs: [check-changes, required-jobs-main, integration-builds]
+    # A reusable workflow's jobs cannot request more token permissions than the
+    # calling job holds. release.yml's npm-publish and create-github-release
+    # jobs need write access, so grant it on this caller job — the workflow-level
+    # default of `contents: read` would otherwise reject the call at startup.
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
+      id-token: write
     uses: ./.github/workflows/release.yml
     with:
       docker_package_changed: ${{ needs.check-changes.outputs.docker_package_changed }}


### PR DESCRIPTION
We need this PR to fix the release process:

The **Main** workflow has failed at startup on every push to `main` since the ci.yml split (#9373, `c98698c1`).

`main.yml` sets a workflow-level default of `contents: read`, and the `release` caller job inherited it. 

But `release.yml`'s `npm-publish` and `create-github-release` jobs request write permissions (`contents`, `pull-requests`, `repository-projects`, `id-token`). A reusable workflow's jobs cannot exceed their caller's token, so GitHub rejected every run as an invalid workflow file before anything ran.

This grants those permissions on the `release` caller job. I checked the other caller jobs (`test-js`, `integration-builds`, `publish-integrations`, `todesktop`, `deploy-api-client`, `deploy-galaxy`). They only use read/none, so nothing else needs changing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission wiring on the release caller job; no application or runtime behavior changes.
> 
> **Overview**
> Fixes **Main** workflow startup failures by elevating the **`release`** job’s `GITHUB_TOKEN` permissions so it can call **`release.yml`**.
> 
> After the ci split, **`main.yml`** kept a workflow default of **`contents: read`**, which the **`release`** job inherited. Reusable workflows cannot run jobs with broader permissions than the caller, so runs were rejected before any jobs executed because **`release.yml`**’s **`npm-publish`** and **`create-github-release`** jobs need **`contents`**, **`pull-requests`**, **`repository-projects`**, and **`id-token`** write access.
> 
> The **`release`** caller job now explicitly sets those permissions; other reusable-workflow callers are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 095b85cbd11ab361f000eeacfc511c1919e5e7f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->