### PR TITLE
build(code-highlight): bundle dependencies into the output

### DIFF
--- a/.changeset/code-highlight-bundle-deps.md
+++ b/.changeset/code-highlight-bundle-deps.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+Bundle runtime dependencies into the build so CommonJS-only packages (like `extend` and `debug`) no longer leak to consumers and break Vite dev under pnpm

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -21,7 +21,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json && shx cp -r src/css dist/css",
+    "build": "vite build && tsc -p tsconfig.build.json --emitDeclarationOnly && tsc-alias -p tsconfig.build.json && shx cp -r src/css dist/css",
     "dev": "vite",
     "test": "vitest --run",
     "types:check": "tsc --noEmit"

--- a/packages/code-highlight/vite.config.ts
+++ b/packages/code-highlight/vite.config.ts
@@ -2,13 +2,46 @@ import { resolve } from 'node:path'
 
 import { defineConfig } from 'vite'
 
+import { createLibEntry, findEntryPoints } from '../../tooling/scripts/vite-lib-config'
+
+const entryPaths = await findEntryPoints()
+const entry = createLibEntry(entryPaths, import.meta.dirname)
+
+// https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [],
   resolve: {
     alias: { '@': resolve(import.meta.dirname, './src') },
     dedupe: ['vue'],
   },
   server: {
     port: 9000,
+  },
+  build: {
+    outDir: './dist',
+    minify: false,
+    sourcemap: true,
+    lib: {
+      formats: ['es'],
+      entry,
+    },
+    rolldownOptions: {
+      // Bundle all dependencies into the output.
+      //
+      // This package depends on the unified/remark/rehype/micromark/lowlight
+      // stack, which transitively pulls in CommonJS-only modules (`extend` via
+      // `unified`, `debug` via `micromark`) plus `highlight.js` (which uses
+      // `require()`). Externalizing them ships raw CJS to consumers, which
+      // breaks Vite dev under pnpm's strict node_modules layout
+      // (`exports is not defined`). By bundling, Rolldown converts the CJS to
+      // ESM at build time so consumers only ever see self-contained ESM.
+      external: [],
+      output: {
+        // Map each entry to the dist layout the `exports` map expects
+        // (e.g. `code/index` -> `dist/code/index.js`).
+        entryFileNames: '[name].js',
+        // Co-locate shared chunks under a predictable directory.
+        chunkFileNames: 'chunks/[name].js',
+      },
+    },
   },
 })

--- a/packages/code-highlight/vite.config.ts
+++ b/packages/code-highlight/vite.config.ts
@@ -1,14 +1,40 @@
 import { resolve } from 'node:path'
 
-import { defineConfig } from 'vite'
+import { type Plugin, defineConfig } from 'vite'
 
 import { createLibEntry, findEntryPoints } from '../../tooling/scripts/vite-lib-config'
 
 const entryPaths = await findEntryPoints()
 const entry = createLibEntry(entryPaths, import.meta.dirname)
 
+/**
+ * Force the universal build of `decode-named-character-reference`.
+ *
+ * The package ships a `browser` export (`index.dom.js`) that decodes entities
+ * via a `<textarea>` and touches `document` at module load. Because we bundle
+ * dependencies, Rolldown would inline that browser variant into the output and
+ * crash the moment the bundle is imported in Node/SSR (e.g. vitest:
+ * `ReferenceError: document is not defined`). The default `index.js` is a pure
+ * implementation that works everywhere, including the browser, so we rewrite
+ * the resolved id to it.
+ */
+const useUniversalDecodeNamedCharacterReference = (): Plugin => ({
+  name: 'use-universal-decode-named-character-reference',
+  enforce: 'pre',
+  async resolveId(source, importer, options) {
+    if (source !== 'decode-named-character-reference') {
+      return null
+    }
+
+    const resolved = await this.resolve(source, importer, { ...options, skipSelf: true })
+
+    return resolved ? resolved.id.replace(/index\.dom\.js$/, 'index.js') : null
+  },
+})
+
 // https://vitejs.dev/config/
 export default defineConfig({
+  plugins: [useUniversalDecodeNamedCharacterReference()],
   resolve: {
     alias: { '@': resolve(import.meta.dirname, './src') },
     dedupe: ['vue'],


### PR DESCRIPTION
`@scalar/code-highlight` now bundles its runtime dependencies into self-contained ESM at build time, so CommonJS-only packages (`extend`, `debug`) no longer leak to consumers and break Vite dev under pnpm.

## Ticket

Part of #9440

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build and dependency graph changes affect every consumer of the package; bundling the full markdown/highlight stack increases bundle size and could surface subtle runtime differences, though scope is limited to this library’s dist output.
> 
> **Overview**
> **`@scalar/code-highlight`** now builds with **Vite/Rolldown** instead of shipping transpiled source that still externalizes the unified/remark/rehype stack. The build **inlines all runtime dependencies** into self-contained ESM so CommonJS-only transitives (`extend`, `debug`, etc.) and `highlight.js` `require()` usage no longer reach consumers and trigger **`exports is not defined`** under pnpm + Vite dev.
> 
> The **`build` script** runs `vite build` first, then **`tsc --emitDeclarationOnly`** (plus `tsc-alias` and CSS copy) so `dist` layout still matches the existing **`exports`** map. Lib config uses shared **`findEntryPoints` / `createLibEntry`** tooling, ESM-only output, sourcemaps, and **`chunks/`** for shared chunks.
> 
> A **pre-resolve Vite plugin** forces the universal **`decode-named-character-reference`** entry instead of the browser build that touches **`document` at load**, avoiding SSR/Vitest failures after bundling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 391b54fd5f82423e7f5234ce3fcd070bc2f870fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->