### PR TITLE
ci: use client-id for the release bot app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -27,7 +27,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           # Scope the token to the minimum the bot needs (push a branch + open a
           # PR). This token is handed to the third-party contributors action, so

--- a/.github/workflows/update-scalar-cli-documentation.yml
+++ b/.github/workflows/update-scalar-cli-documentation.yml
@@ -76,7 +76,7 @@ jobs:
         if: steps.check-changes.outputs.has-changes == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           # Scope the token to the minimum needed to open the docs PR.
           permission-contents: write


### PR DESCRIPTION
`actions/create-github-app-token` now warns that `app-id` is deprecated in favour of `client-id`. This switches the three workflows that mint the release-bot token to `client-id`.

> [!IMPORTANT]
> `client-id` and `app-id` are **different values**, so a new secret is required **before merging** or the token step will fail (and re-break the release):
>
> - Add **`RELEASE_BOT_CLIENT_ID`** = the GitHub App's *Client ID* (App settings → "Client ID", e.g. `Iv23li…`).
> - It must exist everywhere `RELEASE_BOT_APP_ID` does today — the repo/org secret scope **and** the `production-npm` environment (release.yml's `npm-publish` job is environment-scoped).
> - `RELEASE_BOT_APP_ID` can be deleted afterwards.

Files: `release.yml`, `update-contributors.yml`, `update-scalar-cli-documentation.yml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release and automation PR token path; merging without the new secret will break npm release and bot-opened PRs until `RELEASE_BOT_CLIENT_ID` is configured.
> 
> **Overview**
> Updates the **release-bot** GitHub App token step in three workflows to pass **`client-id`** instead of the deprecated **`app-id`** input on `actions/create-github-app-token`.
> 
> The change is the same in **`release.yml`**, **`update-contributors.yml`**, and **`update-scalar-cli-documentation.yml`**: only the secret reference switches from `RELEASE_BOT_APP_ID` to **`RELEASE_BOT_CLIENT_ID`**. **`RELEASE_BOT_PRIVATE_KEY`** and the scoped permissions are unchanged.
> 
> **Before merging**, add **`RELEASE_BOT_CLIENT_ID`** (the App’s Client ID, not the numeric App ID) wherever those jobs read secrets—especially **`production-npm`** for release and **`release-bot`** for the scheduled PR workflows—or the token step will fail and release/automation PRs will stop opening with CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9582f35131f58bb60e7370c0c3f9417787ba3fc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->