### PR TITLE
chore: switch from tsc to tsgo

### DIFF
--- a/integrations/express/package.json
+++ b/integrations/express/package.json
@@ -21,7 +21,7 @@
     "docker:build": "docker build --build-arg BASE_IMAGE=scalar-base -t express-api-reference -f Dockerfile .",
     "docker:run": "docker run -p 5055:5055 express-api-reference",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/integrations/fastify/package.json
+++ b/integrations/fastify/package.json
@@ -28,7 +28,7 @@
     "docker:build": "docker build --build-arg BASE_IMAGE=scalar-base -t fastify-api-reference -f Dockerfile .",
     "docker:run": "docker run -p 5053:5053 fastify-api-reference",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/integrations/hono/package.json
+++ b/integrations/hono/package.json
@@ -20,7 +20,7 @@
     "docker:build": "docker buildx build --platform=linux/amd64 -t scalar-hono-reference --build-arg=\"BASE_IMAGE=scalar-base\" .",
     "docker:run": "docker run -t scalar-hono-reference",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/integrations/hono/tsconfig.json
+++ b/integrations/hono/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "types": ["node"],
     "paths": {
       "@/*": ["./src/*"],
       "@test/*": ["./test/*"]

--- a/integrations/nestjs/package.json
+++ b/integrations/nestjs/package.json
@@ -27,7 +27,7 @@
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/nextjs/package.json
+++ b/integrations/nextjs/package.json
@@ -26,7 +26,7 @@
     "build": "pnpm types:check && pnpm build-only",
     "build-only": "vite build",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit --skipLibCheck"
+    "types:check": "tsgo --noEmit --skipLibCheck"
   },
   "type": "module",
   "main": "./dist/index.cjs",

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -32,7 +32,9 @@
     // Used by root tsconfig.json
     "tsconfig-paths",
     //
-    "typescript-language-server"
+    "typescript-language-server",
+    // Provides the `tsgo` binary used by package `types:check` scripts; knip cannot map the binary to the package name
+    "@typescript/native-preview"
   ],
   "ignoreBinaries": ["netlify"],
   "ignoreIssues": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@playwright/test": "catalog:*",
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/node": "catalog:*",
+    "@typescript/native-preview": "7.0.0-dev.20260603.1",
     "cross-env": "catalog:*",
     "eslint": "^9.38.0",
     "eslint-plugin-vue": "^9.31.0",

--- a/packages/api-reference-react/package.json
+++ b/packages/api-reference-react/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "vite build && tsc -p tsconfig.build.json",
     "dev": "vite ./playground -c ./vite.config.ts",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/api-reference-react/src/shims.d.ts
+++ b/packages/api-reference-react/src/shims.d.ts
@@ -10,3 +10,7 @@ declare namespace globalThis {
 declare module 'vue/dist/vue.esm-bundler.js' {
   export * from 'vue'
 }
+
+// Side-effect CSS imports. tsc picks these up from `vite/client`, but tsgo does
+// not auto-include it here, so declare the module explicitly.
+declare module '*.css' {}

--- a/packages/asyncapi-upgrader/package.json
+++ b/packages/asyncapi-upgrader/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/client-side-rendering/package.json
+++ b/packages/client-side-rendering/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "exports": {

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -24,7 +24,7 @@
     "build": "vite build && tsc -p tsconfig.build.json --emitDeclarationOnly && tsc-alias -p tsconfig.build.json && shx cp -r src/css dist/css",
     "dev": "vite",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/code-highlight/shims.d.ts
+++ b/packages/code-highlight/shims.d.ts
@@ -1,0 +1,4 @@
+// Side-effect CSS imports (used by the playground). tsc picks these up from
+// `vite/client`, but tsgo does not auto-include it here, so declare the module
+// explicitly.
+declare module '*.css' {}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "exports": {

--- a/packages/galaxy/package.json
+++ b/packages/galaxy/package.json
@@ -26,7 +26,7 @@
     "dev:live": "cd src/documents && pnpx http-server --cors",
     "lint": "npx @scalar/cli document lint src/documents/3.1.yaml --rule ./galaxy.ruleset.yaml",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit",
+    "types:check": "tsgo --noEmit",
     "validate": "bash scripts/validate.sh"
   },
   "type": "module",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -22,7 +22,7 @@
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "vitest --run",
     "test:watch": "vitest",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -24,7 +24,7 @@
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "dev": "tsx watch playground/index.ts",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/import/tsconfig.json
+++ b/packages/import/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  }
 }

--- a/packages/json-magic/package.json
+++ b/packages/json-magic/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "exports": {

--- a/packages/mock-server/docker/package.json
+++ b/packages/mock-server/docker/package.json
@@ -22,7 +22,7 @@
     "docker:run:env": "docker run -e OPENAPI_DOCUMENT=\"$(cat ./documents/example.yaml)\" -p 3000:3000 --rm --init scalarapi/mock-server",
     "docker:run:url": "docker run -p 3000:3000 --rm --init scalarapi/mock-server --url https://raw.githubusercontent.com/OAI/OpenAPI-Specification/refs/heads/main/_archive_/schemas/v3.0/pass/petstore.yaml",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "dist/docker-entrypoint.js",

--- a/packages/mock-server/docker/tsconfig.json
+++ b/packages/mock-server/docker/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../tsconfig.json",
   "include": ["src"],
   "compilerOptions": {
+    "types": ["node"],
     "outDir": "./dist"
   }
 }

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/nextjs-openapi/package.json
+++ b/packages/nextjs-openapi/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "dev": "next dev playground -p 5066",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "exports": {

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/object-utils/package.json
+++ b/packages/object-utils/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "exports": {

--- a/packages/openapi-parser/package.json
+++ b/packages/openapi-parser/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "NODE_OPTIONS=--max_old_space_size=8192 vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/openapi-parser/tsconfig.json
+++ b/packages/openapi-parser/tsconfig.json
@@ -7,6 +7,7 @@
     "useUnknownInCatchVariables": false,
     "exactOptionalPropertyTypes": false,
     "allowJs": true,
+    "types": ["node"],
     "paths": {
       "@/*": ["./src/*"],
       "@test/*": ["./test/*"]

--- a/packages/openapi-types/package.json
+++ b/packages/openapi-types/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "exports": {

--- a/packages/openapi-upgrader/package.json
+++ b/packages/openapi-upgrader/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/postman-to-openapi/package.json
+++ b/packages/postman-to-openapi/package.json
@@ -27,7 +27,7 @@
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "evaluate": "tsx ./scripts/evaluate/run.ts",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/postman-to-openapi/tsconfig.json
+++ b/packages/postman-to-openapi/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "include": ["src", "test", "esbuild.ts", "env.d.ts"],
   "compilerOptions": {
+    "types": ["node"],
     "paths": {
       "@/*": ["./src/*"],
       "@test/*": ["./test/*"]

--- a/packages/server-side-rendering/package.json
+++ b/packages/server-side-rendering/package.json
@@ -19,7 +19,7 @@
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "dev": "tsx playground/server.ts",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "exports": {

--- a/packages/snippetz/package.json
+++ b/packages/snippetz/package.json
@@ -20,7 +20,7 @@
     "generate:markdown-docs": "tsx scripts/generate-markdown-docs.ts",
     "postbuild": "pnpm generate:dotnet-enums && pnpm generate:java-enums && pnpm generate:markdown-docs",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/snippetz/tsconfig.json
+++ b/packages/snippetz/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "include": ["src"],
   "compilerOptions": {
+    "types": ["node"],
     "paths": {
       "@/*": ["./src/*"],
       "@test/*": ["./test/*"]

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "vite build && tsc -p tsconfig.build.json",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/themes/tsconfig.json
+++ b/packages/themes/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["vite/client"],
-    "baseUrl": "."
+    "types": ["vite/client"]
   },
   "include": ["src", "env.d.ts"],
   "exclude": ["dist", "vite.config.ts", "node_modules"]

--- a/packages/ts-to-openapi/package.json
+++ b/packages/ts-to-openapi/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "exports": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "types": "dist/index.d.ts",

--- a/packages/void-server/package.json
+++ b/packages/void-server/package.json
@@ -23,7 +23,7 @@
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "dev": "tsx playground/index.ts",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "main": "dist/index.js",

--- a/packages/workspace-store/package.json
+++ b/packages/workspace-store/package.json
@@ -26,7 +26,7 @@
     "generate-openapi-types": "tsx ./scripts/generate-openapi-types.ts",
     "test": "vitest --run",
     "test:watch": "vitest",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,9 @@ importers:
       '@types/node':
         specifier: ^24.1.0
         version: 24.10.13
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260603.1
+        version: 7.0.0-dev.20260603.1
       cross-env:
         specifier: catalog:*
         version: 10.1.0
@@ -9053,6 +9056,53 @@ packages:
   '@typescript-eslint/visitor-keys@8.53.0':
     resolution: {integrity: sha512-LZ2NqIHFhvFwxG0qZeLL9DvdNAHPGCY5dIRwBhyYeU+LfLhcStE1ImjsuTG/WaVh3XysGaeLW8Rqq7cGkPCFvw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-BvaaQAHWaHA0nl26DsWTsXsKkCHqUTm7f5FMuNDyCU83Hvo7zHx0vpSTrzL+1KEWeWLUVVGA7U224dk+3yIosQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-a2JJezvJAqWXgTAD1tKdWs7iA/4s3EakLcCYx4rg3ptEbBF6ADWv7A9ySHxT/+CQWYCD0DYIb9du1JUWL85fRw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-MQ0JcRucLdcR6MT14wlrGNz9HaxJrFF8Axmo0IN6e5gSou2UrKKUvvAH1i8zU5Gm7jl8CWCLzzX/qGCi1TsinA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-GLsTfJQiGfTN+r1ezlxMcTd5MNYRB/tADD6Y1j1jfLjZsFYSVkNfCnDQA/jwUG6GddBBF+0Um7tBUP16emej9w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-u6gvCiVGSDagdR2+GI5VJLPxJbGevATJgjZ2QFLKBLWI3re7liTGlPAuaINNDq/r0m9rUPj2rEn0zwqtcLK0nQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-slxm6HBYs+jk0GpIBC2o03uY5qHgW7wIH+OTjK8JHbd2sUCgYV7P7bfZHUVZYi/cJZcVrnDW6MxXx734TuFn+w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-G7SDZJn2Z9+c1qsAFzI/JL0OsRjJ18diQ39ycWKmJikilZZeL7iS7j933bemWY4ODaLTfxhMRKPMHf9292gpDA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-CO519Ccw5rji4JIG0DGVMR5owraCeQhm94jM53eRhMdlzz0nAJcAZ63Y6m1u3dUwqGssqlYxh4CcwTFPxTpMYw==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -26555,6 +26605,37 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.53.0
       eslint-visitor-keys: 4.2.1
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260603.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260603.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260603.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260603.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260603.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260603.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260603.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260603.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260603.1
 
   '@ungap/structured-clone@1.2.0': {}
 

--- a/projects/galaxy-scalar-com/package.json
+++ b/projects/galaxy-scalar-com/package.json
@@ -26,7 +26,7 @@
     "deploy": "wrangler pages deploy dist --project-name=galaxy-scalar-com",
     "dev": "pnpm build && wrangler pages dev dist --compatibility-date=2026-04-28 --compatibility-flags=nodejs_compat",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "type": "module",
   "devDependencies": {

--- a/tooling/changelog-generator/package.json
+++ b/tooling/changelog-generator/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "test": "vitest --run",
-    "types:check": "tsc --noEmit"
+    "types:check": "tsgo --noEmit"
   },
   "dependencies": {
     "@changesets/get-github-info": "^0.7.0",


### PR DESCRIPTION
Swaps `tsc --noEmit` for `tsgo --noEmit` (the TypeScript 7 native port, `@typescript/native-preview`) on the 32 pure-TypeScript packages where it is a clean drop-in.

**Why:** type checking is roughly **5–10x faster**. On a built tree the 16 slowest-checking packages drop from ~20s to ~3.6s combined, and it is consistently 4–10x per package — e.g. `oas-utils` 3.0s→0.8s, `server-side-rendering` 3.2s→0.5s, `helpers` 1.8s→0.3s.

**Left on `tsc` / `vue-tsc` on purpose:**
- All Vue packages — tsgo has no `.vue` support yet.
- `schemas` and `validation` — they rely on mutually-recursive schema type inference the beta can't resolve (`TS7022/7024`, plus `TS2589` "excessively deep").
- `docusaurus` — tsgo removes `baseUrl` and `moduleResolution: node`; too risky to migrate here.

**Small fixes to satisfy tsgo's stricter resolution:** `"types": ["node"]` where Node globals are used, ambient `*.css` declarations for side-effect CSS imports, and dropping the now-removed `baseUrl` from `themes`.

Heads-up: `tsgo` is still a beta (`7.0.0-dev`, pinned exactly), so this is worth treating as a trial run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Beta native checker could diverge from `tsc` on edge cases, but changes are limited to dev type-check scripts and small tsconfig/shim fixes—no runtime or build emit changes.
> 
> **Overview**
> Replaces **`tsc --noEmit`** with **`tsgo --noEmit`** on the monorepo workspaces where it is a drop-in (integrations, most packages, galaxy project, changelog tooling). **Build output still uses `tsc`**; only the type-check script changes.
> 
> Adds **`@typescript/native-preview`** at the repo root (pinned dev preview) so CI and `pnpm types:check` invoke the native TypeScript 7 checker. **`knip.jsonc`** ignores that dependency because it only exposes the `tsgo` binary.
> 
> **tsgo-specific config fixes:** several **`tsconfig.json`** files set **`"types": ["node"]`** where Node globals were implicit before; **`declare module '*.css' {}`** is added where Vite’s client types no longer apply; **`packages/themes`** drops **`baseUrl`** while keeping **`vite/client`**.
> 
> Vue packages, **`schemas`**, **`validation`**, and **`docusaurus`** are unchanged and still use **`tsc`** / **`vue-tsc`** per the PR scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd46d238cfe301b000e4771dd6f6daaf7bd79a5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->