### PR TITLE
docs(galaxy): describe the Create a celestial body operation

### DIFF
--- a/.changeset/galaxy-celestial-body-description.md
+++ b/.changeset/galaxy-celestial-body-description.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+Add a description to the `Create a celestial body` operation

--- a/packages/galaxy/src/documents/3.1.yaml
+++ b/packages/galaxy/src/documents/3.1.yaml
@@ -424,6 +424,8 @@ paths:
       tags:
         - Celestial Bodies
       summary: Create a celestial body
+      description: Stars, moons, comets, the occasional rogue asteroid — if it
+        glows or drifts through the void, you can add it here.
       operationId: createCelestialBody
       requestBody:
         description: Celestial body to create


### PR DESCRIPTION
The `POST /celestial-bodies` operation had a summary but no description, which tripped the galaxy lint warning. Added one in the same playful tone as its neighbours, so the lint is clean again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the example OpenAPI spec; no runtime or API behavior changes.
> 
> **Overview**
> Adds an OpenAPI **description** to `POST /celestial-bodies` (`Create a celestial body`) in `packages/galaxy/src/documents/3.1.yaml`, matching the playful tone used on nearby operations so galaxy lint no longer flags a missing operation description.
> 
> Includes a **patch** changeset for `@scalar/galaxy` noting the doc update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 899cfd30dc68555c9561c18e02159e437a5ba670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->