### PR TITLE
fix(ci): detect releases reliably so production deploys run

### DIFF
--- a/.github/workflows/publish-integrations.yml
+++ b/.github/workflows/publish-integrations.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
     inputs:
       published:
-        description: 'changesets/action outputs.published — gate for every publish'
+        description: "release.yml's package-release detection — gate for every publish"
         type: string
         required: true
       docker_package_changed:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,18 +103,25 @@ jobs:
       repository-projects: write
       # Required for npm provenance statements
       id-token: write
-    # Expose the changesets/action outputs so downstream jobs can gate on the
-    # actual publish result instead of parsing the commit message. `published`
-    # is 'true' only when changesets/action actually pushed at least one
-    # package to npm; `publishedPackages` is a JSON array of {name, version}.
+    # 'true' when this commit released at least one public package — every
+    # release-gated job downstream (production galaxy deploy, GitHub release,
+    # integration publishes, CDN purge, production web deploy) keys off this.
+    #
+    # We deliberately do NOT use changesets/action's own `published` output:
+    # that action only reports a package as published when the publish command
+    # prints changesets' `New tag:` lines, which only `changeset publish`
+    # emits. Our publish command is `pnpm -r publish`, whose output it cannot
+    # parse, so `steps.changesets.outputs.published` is always 'false' even
+    # though packages do reach npm. Instead we detect a release by diffing
+    # public package.json versions against the previous commit (see the
+    # "Detect package release" step).
     outputs:
-      published: ${{ steps.changesets.outputs.published }}
-      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+      published: ${{ steps.release-check.outputs.published }}
       # 'true' when this commit bumped projects/scalar-app/package.json's
-      # version. scalar-app is private, so it never appears in
-      # `publishedPackages` — this lets downstream jobs (web prod deploy,
+      # version. scalar-app is private, so it is excluded from the public
+      # detection above — this lets downstream jobs (web prod deploy,
       # ToDesktop build) treat a scalar-app version bump as a release even
-      # when no public packages were published in the same commit.
+      # when no public packages were released in the same commit.
       scalar_app_released: ${{ steps.scalar-app-release.outputs.released }}
       # Captured by the always()-step below so the caller can read the
       # npm-publish job result independently of sibling release jobs.
@@ -151,6 +158,35 @@ jobs:
             echo "scalar-app version unchanged: $CURRENT_VERSION"
             echo "released=false" >> "$GITHUB_OUTPUT"
           fi
+      # Detect whether this commit released any public package, by diffing the
+      # version field of every changed package.json against the previous commit.
+      # This is the reliable replacement for changesets/action's `published`
+      # output (see the outputs block above for why that one is unusable). A
+      # release commit is the merge of the "chore: version packages" PR, which
+      # bumps the version in each released package.json; ordinary commits bump
+      # nothing and so deploy to staging instead of production. Runs before the
+      # build/stash steps so it only ever sees committed versions.
+      - name: Detect package release
+        id: release-check
+        run: |
+          published=false
+          while IFS= read -r file; do
+            # Only care about package manifests that still exist in the tree.
+            case "$file" in */package.json) ;; *) continue ;; esac
+            [ -f "$file" ] || continue
+            # Private packages never publish to npm. scalar-app is the only one
+            # that gates a deploy, and it is handled by the step above.
+            if [ "$(jq -r '.private // false' "$file")" = "true" ]; then
+              continue
+            fi
+            CURRENT_VERSION=$(jq -r '.version // ""' "$file")
+            PREV_VERSION=$(git show "HEAD~1:$file" 2>/dev/null | jq -r '.version // ""' 2>/dev/null || echo "")
+            if [ -n "$CURRENT_VERSION" ] && [ "$CURRENT_VERSION" != "$PREV_VERSION" ]; then
+              echo "released: $file ($PREV_VERSION -> $CURRENT_VERSION)"
+              published=true
+            fi
+          done < <(git diff --name-only HEAD~1 HEAD)
+          echo "published=$published" >> "$GITHUB_OUTPUT"
       - name: Build
         uses: ./.github/actions/build
         with:
@@ -194,7 +230,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
       - name: Bust CDN cache
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.release-check.outputs.published == 'true'
         uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d # v1.16.4
         with:
           url: 'https://purge.jsdelivr.net/npm/@scalar/api-reference'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ on:
         required: true
     outputs:
       published:
-        description: "changesets/action published flag ('true' when a package shipped to npm)"
+        description: "'true' when this commit released at least one public package to npm"
         value: ${{ jobs.npm-publish.outputs.published }}
       scalar_app_released:
         description: "'true' when projects/scalar-app version bumped on this commit"
@@ -181,7 +181,12 @@ jobs:
             fi
             CURRENT_VERSION=$(jq -r '.version // ""' "$file")
             PREV_VERSION=$(git show "HEAD~1:$file" 2>/dev/null | jq -r '.version // ""' 2>/dev/null || echo "")
-            if [ -n "$CURRENT_VERSION" ] && [ "$CURRENT_VERSION" != "$PREV_VERSION" ]; then
+            # Require a non-empty PREV_VERSION so a brand-new package.json (added
+            # in an ordinary feature merge, where HEAD~1 has no such file) is not
+            # mistaken for a release — the same guard the scalar-app step uses. A
+            # real release only ever bumps the version of a package that already
+            # existed in the previous commit; changesets never adds manifests.
+            if [ -n "$PREV_VERSION" ] && [ "$CURRENT_VERSION" != "$PREV_VERSION" ]; then
               echo "released: $file ($PREV_VERSION -> $CURRENT_VERSION)"
               published=true
             fi


### PR DESCRIPTION
`deploy-galaxy-production` (and every other release-gated job) has been silently skipping on release commits.

### Why

All release gates key off `needs.release.outputs.published`, which we wired to changesets/action's `published` output. That action only marks a package as published when the publish command prints changesets' own `New tag:` lines — and only `changeset publish` emits those. Our publish command is `pnpm -r publish`, so the action never sees them: `published` is always `false`, even though packages do reach npm.

Introduced in #9222, which swapped the old `RELEASING:` commit-message gate for `published == 'true'`.

So on every release the following skipped or fell back to staging:

- `deploy-galaxy-production`
- `create-github-release`
- `push-to-scalar-registry`
- the integration publishes (Docker, NuGet, PyPI, crates, Maven)
- the CDN purge
- `deploy-galaxy` / `deploy-api-client` deployed to **staging** instead of production

Confirmed on the latest release run (`chore: release` #9453, `0efa0f327`): npm-publish succeeded and published 30 packages, but `deploy-galaxy-production`, `create-github-release`, and `push-to-scalar-registry` all show **skipped**.

### Fix

Derive `published` from a version diff of public `package.json` files against the previous commit, mirroring the existing scalar-app detection step right next to it — instead of trusting the changesets output. Verified against `0efa0f327` (→ `true`, 30 packages) and ordinary commits (→ `false`).

CI-only change, so no changeset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production and registry deploys are gated; incorrect detection could skip production or run it on non-release commits, though guards mirror the existing scalar-app logic.
> 
> **Overview**
> Release-gated CI (production deploys, GitHub releases, integration publishes, CDN purge) was wired to **changesets/action**’s `published` output, which stays **`false`** when publish runs via **`pnpm -r publish`** instead of **`changeset publish`**. That caused those jobs to skip on real release commits even though npm publish succeeded.
> 
> This PR sets **`published`** from a new **Detect package release** step: it scans changed **`package.json`** files, skips private packages, and marks a release when a public package’s **version** differs from **`HEAD~1`** (same pattern as the existing scalar-app bump check). The npm-publish job output and CDN purge **`if`** now use **`release-check`** instead of **`changesets`**, and workflow input descriptions are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 054575f7b1e7f770cc8bd0921713b62fee23fd5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->