### PR TITLE
fix: open products sidebar default and hide page actions customers

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -806,7 +806,9 @@
             "filepath": "documentation/guides/customers/customers.md",
             "type": "page",
             "layout": {
-              "toc": false
+              "toc": false,
+              "pageTitle": false,
+              "pageActions": false
             },
             "head": {
               "links": [
@@ -840,6 +842,7 @@
             "title": "Products",
             "icon": "phosphor/regular/compass",
             "mode": "folder",
+            "open": true,
             "children": {
               "/docs": {
                 "title": "Docs",


### PR DESCRIPTION
before:
<img width="1506" height="857" alt="image" src="https://github.com/user-attachments/assets/b1332411-03bd-4c33-ab0d-990f712979a6" />

after:

<img width="1506" height="836" alt="image" src="https://github.com/user-attachments/assets/aeb88604-77e6-4072-b420-5fa1be760d47" />


## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes to marketing site navigation and per-page layout flags; no application logic or auth/data paths affected.
> 
> **Overview**
> Updates **scalar.com** site navigation and page chrome in `scalar.config.json`.
> 
> The **Products** sidebar group (`mode: "folder"`) now sets **`open: true`** so that section is **expanded by default** instead of starting collapsed.
> 
> The **`/customers`** route keeps **`toc: false`** and additionally disables the default page chrome with **`pageTitle: false`** and **`pageActions: false`**, so the marketing Customers page renders without the standard title and action controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd75a780f8d72461a4dbeda4559217b1a97ba1c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->