### PR TITLE
docs: links with underlines

### DIFF
--- a/documentation/guides/enterprise/enterprise.md
+++ b/documentation/guides/enterprise/enterprise.md
@@ -169,8 +169,8 @@ Validate contracts early so exploration and testing stay tied to the same API de
 
 <style>
   :root {
-    --scalar-text-decoration: none;
-    --scalar-text-decoration-hover: none;
+    --scalar-text-decoration: underline;
+    --scalar-text-decoration-hover: underline;
   }
   .t-editor__anchor {
     --font-visited: none;

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -462,8 +462,8 @@
 
 <style>
   :root {
-    --scalar-text-decoration: none;
-    --scalar-text-decoration-hover: none;
+    --scalar-text-decoration: underline;
+    --scalar-text-decoration-hover: underline;
   }
   .t-editor__page-title,
   .t-editor__page-nav,


### PR DESCRIPTION
before:
<img width="1509" height="845" alt="image" src="https://github.com/user-attachments/assets/6ec5a838-7273-47ea-93dd-1c8cc242490a" />


after:
<img width="754" height="430" alt="image" src="https://github.com/user-attachments/assets/61baa19d-63d2-4e5a-b528-e902cb800761" />


## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only CSS on two marketing pages; no runtime or application logic changes.
> 
> **Overview**
> **Link styling** on the introduction and enterprise marketing guides now sets `--scalar-text-decoration` and `--scalar-text-decoration-hover` to `underline` instead of `none`, so in-page links (e.g. `t-editor__anchor` and other Scalar-themed anchors) read as links by default and on hover.
> 
> The change is limited to embedded `<style>` blocks in those two guide files; footer and button link rules that force no underline are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5bacedd7aae92b8276c1505019be2278730a068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->