### PR TITLE
fix: simplify hero

### DIFF
--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -1,15 +1,15 @@
-<div class="flex flex-col gap-3 hero small-test">
+<div class="flex flex-col gap-3 hero small-test small-test-marc">
   <scalar-heading level="2" slug="introduction" class="text-balance">
-    Industry leading Developer Docs, SDKs & API Client
+    API interfaces built for developers and agents
   </scalar-heading>
   <p>
-    Purpose-built for the OpenAPI™ standard
+    Create beautiful docs, SDKs and secure MCP servers from your API. Scalar keeps every interface in sync as your API evolves.
   </p>
   <div class="flex gap-2">
     <a class="t-editor__button" href="https://dashboard.scalar.com/register">Get Started</a>
     <a class="t-editor__button" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a Demo</a>
   </div>
-  <div class="stickers">
+  <div class="stickers stickers-marc">
     <div class="draggable sticker-5">
       <scalar-icon src="https://api.scalar.com/cdn/images/LByt7m02eR-6wZrXUk5d5/SiTCkdsfi2287iQBEGzN2.svg"></scalar-icon>
     </div>
@@ -469,6 +469,14 @@
     text-wrap: balance;
     margin-top: 44px;
     position: relative;
+  }
+  .small-test-marc {
+    max-width: 680px;
+  }
+  @media only screen and (min-width: 1000px) {
+    .stickers-marc {
+      right: 240px;
+    }
   }
   .t-editor.page {
     margin-right: unset;


### PR DESCRIPTION
before:
<img width="1503" height="846" alt="image" src="https://github.com/user-attachments/assets/699613ce-ab70-4645-98d4-1394f6d8b5f6" />


after:
<img width="1498" height="850" alt="image" src="https://github.com/user-attachments/assets/a47504f6-aa1e-40e2-aae1-99a610b20946" />


## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only marketing copy and CSS on the introduction guide; no application or API behavior changes.
> 
> **Overview**
> **Introduction hero** on `documentation/guides/introduction.md` gets new marketing copy and small layout tweaks to match the simplified hero design (before/after screenshots in the PR).
> 
> The **headline** shifts from “Industry leading Developer Docs, SDKs & API Client” to **“API interfaces built for developers and agents”**, and the **subcopy** now highlights docs, SDKs, secure MCP servers, and keeping interfaces in sync as the API evolves (replacing the OpenAPI-only line).
> 
> **Layout:** the hero and sticker containers add modifier classes `small-test-marc` and `stickers-marc`. CSS widens the hero text block from **440px to 680px** and, on viewports **≥1000px**, nudges the sticker cluster with **`right: 240px`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 584951576bb597d831976b9283b731e9678de071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->