### PR TITLE
feat(mock-server): `Prefer` header and named examples

### DIFF
--- a/.changeset/mock-server-prefer-header.md
+++ b/.changeset/mock-server-prefer-header.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+Add `Prefer` header support to control mock responses: use `code=<status>` to request a specific response status and `example=<name>` to pick a named example from the `examples` map. Also adds support for the OpenAPI `examples` map (previously only the singular `example` was used).

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -187,6 +187,67 @@ The given OpenAPI document is automatically exposed:
 
 - `/openapi.json` and `/openapi.yaml`
 
+### Selecting responses
+
+By default the mock server picks a response (and its status code) for you and returns the first example it can find. You can override both with the standard [`Prefer` header](https://www.rfc-editor.org/rfc/rfc7240), just like [Stoplight Prism](https://github.com/stoplightio/prism).
+
+Use `code=<status>` to request a specific response status:
+
+```bash
+# Returns the 404 response defined for the operation
+curl http://localhost:3000/users/1 -H 'Prefer: code=404'
+```
+
+Use `example=<name>` to pick a named example from the `examples` map:
+
+```bash
+# Returns the `bob` example from the response
+curl http://localhost:3000/users -H 'Prefer: example=bob'
+```
+
+Both directives are independent and can be combined. `code=` picks the response, then `example=` picks the example within it:
+
+```bash
+curl http://localhost:3000/users -H 'Prefer: code=422, example=missingEmail'
+```
+
+Unknown values fall back to the default behavior, so an undefined status code or example name never errors.
+
+To define multiple examples, use the `examples` map on the response media type:
+
+```typescript
+const document = {
+  openapi: '3.1.1',
+  info: {
+    title: 'Hello World',
+    version: '1.0.0',
+  },
+  paths: {
+    '/users': {
+      get: {
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                examples: {
+                  alice: {
+                    value: { name: 'Alice' },
+                  },
+                  bob: {
+                    value: { name: 'Bob' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
 ## Advanced Features
 
 ### Request Validation

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -96,13 +96,19 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
   c.status(statusCode)
 
   return c.body(
-    typeof body === 'object'
+    // `null` is `typeof 'object'` too, but it is not a valid XML/JSON object
+    // root — serialize it (and any non-string primitive) with `JSON.stringify`
+    // so a `null` example does not get fed into `json2xml`.
+    body !== null && typeof body === 'object'
       ? // XML
         acceptedContentType?.includes('xml')
         ? json2xml(body as Record<string, unknown>)
         : // JSON
           JSON.stringify(body, null, 2)
-      : // String
-        (body as string),
+      : typeof body === 'string'
+        ? // String
+          body
+        : // null / number / boolean
+          JSON.stringify(body),
   )
 }

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -8,6 +8,8 @@ import { accepts } from 'hono/accepts'
 import type { StatusCode } from 'hono/utils/http-status'
 
 import { findPreferredResponseKey } from '@/utils/find-preferred-response-key'
+import { parsePreferHeader } from '@/utils/parse-prefer-header'
+import { selectResponseExample } from '@/utils/select-response-example'
 
 /**
  * Mock any response
@@ -16,25 +18,30 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
   // Note: the `onRequest` callback runs as middleware (see `create-mock-server`) so it also fires
   // for requests rejected before reaching this handler.
 
-  // Response
-  // default, 200, 201 …
-  const preferredResponseKey = findPreferredResponseKey(Object.keys(operation.responses ?? {}))
-  const preferredResponse = preferredResponseKey ? getResolvedRef(operation.responses?.[preferredResponseKey]) : null
+  // Parse the Prefer header (RFC 7240) so clients can request a specific
+  // response status (`code=`) and named example (`example=`).
+  const prefer = parsePreferHeader(c.req.header('Prefer'))
 
-  if (!preferredResponse) {
+  // Response selection:
+  // 1. An explicit `Prefer: code=<status>` that matches a defined response
+  // 2. Otherwise the preferred key (default, 200, 201 …)
+  // An unknown `code=` is ignored and falls back to the preferred key.
+  const preferredResponseKey = findPreferredResponseKey(Object.keys(operation.responses ?? {}))
+  const responseKey = prefer.code && operation.responses?.[prefer.code] ? prefer.code : preferredResponseKey
+
+  const selectedResponse = responseKey ? getResolvedRef(operation.responses?.[responseKey]) : null
+
+  if (!selectedResponse) {
     c.status(500)
 
     return c.json({ error: 'No response defined for this operation.' })
   }
 
   // Status code
-  const statusCode = Number.parseInt(
-    preferredResponseKey === 'default' ? '200' : (preferredResponseKey ?? '200'),
-    10,
-  ) as StatusCode
+  const statusCode = Number.parseInt(responseKey === 'default' ? '200' : (responseKey ?? '200'), 10) as StatusCode
 
   // Headers
-  const headers = preferredResponse?.headers ?? {}
+  const headers = selectedResponse?.headers ?? {}
   Object.keys(headers).forEach((header) => {
     const headerObject = getResolvedRef(headers[header])
     const value = headerObject?.schema
@@ -51,7 +58,7 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
     return c.body(null)
   }
 
-  const supportedContentTypes = Object.keys(preferredResponse?.content ?? {})
+  const supportedContentTypes = Object.keys(selectedResponse?.content ?? {})
 
   // If no content types are defined, return the status with no body
   if (supportedContentTypes.length === 0) {
@@ -70,11 +77,14 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
 
   c.header('Content-Type', acceptedContentType)
 
-  const acceptedResponse = preferredResponse?.content?.[acceptedContentType]
+  const acceptedResponse = selectedResponse?.content?.[acceptedContentType]
 
-  // Body
-  const body = acceptedResponse?.example
-    ? acceptedResponse.example
+  // Body: a named/singular/first example if one is defined, otherwise generate
+  // a value from the schema. `Prefer: example=<name>` picks a named example.
+  const selectedExample = selectResponseExample(acceptedResponse, prefer.example)
+
+  const body = selectedExample
+    ? selectedExample.value
     : acceptedResponse?.schema
       ? getExampleFromSchema(getResolvedRefDeep(acceptedResponse.schema), {
           emptyString: 'string',
@@ -89,10 +99,10 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
     typeof body === 'object'
       ? // XML
         acceptedContentType?.includes('xml')
-        ? json2xml(body)
+        ? json2xml(body as Record<string, unknown>)
         : // JSON
           JSON.stringify(body, null, 2)
       : // String
-        body,
+        (body as string),
   )
 }

--- a/packages/mock-server/src/routes/mock-handler-response.ts
+++ b/packages/mock-server/src/routes/mock-handler-response.ts
@@ -8,15 +8,22 @@ import type { StatusCode } from 'hono/utils/http-status'
 
 import { buildHandlerContext } from '@/utils/build-handler-context'
 import { executeHandler } from '@/utils/execute-handler'
+import { parsePreferHeader } from '@/utils/parse-prefer-header'
+import { selectResponseExample } from '@/utils/select-response-example'
 
 /**
  * Get example response from OpenAPI spec for a given status code.
  * Returns the example value if found, or null if not available.
+ *
+ * Honors `Prefer: example=<name>` to pick a named example from the
+ * `examples` map; otherwise it falls back to the singular `example`, the
+ * first entry of the map, or a value generated from the schema.
  */
 function getExampleFromResponse(
   c: Context,
   statusCode: StatusCode,
   responses: OpenAPIV3_1.ResponsesObject | undefined,
+  exampleName?: string,
 ): any {
   if (!responses) {
     return null
@@ -51,9 +58,11 @@ function getExampleFromResponse(
     return null
   }
 
-  // Extract example from example property or generate from schema
-  return acceptedResponse.example !== undefined
-    ? acceptedResponse.example
+  // Extract example (named, singular, or first) or generate from schema
+  const selectedExample = selectResponseExample(acceptedResponse, exampleName)
+
+  return selectedExample
+    ? selectedExample.value
     : acceptedResponse.schema
       ? getExampleFromSchema(getResolvedRefDeep(acceptedResponse.schema), {
           emptyString: 'string',
@@ -162,10 +171,12 @@ export async function mockHandlerResponse(c: Context, operation: OpenAPIV3_1.Ope
     // Handle undefined/null results gracefully
     if (result === undefined || result === null) {
       // Try to pick up example response from OpenAPI spec if available
+      const prefer = parsePreferHeader(c.req.header('Prefer'))
       const exampleResponse = getExampleFromResponse(
         c,
         statusCode,
         operation.responses as OpenAPIV3_1.ResponsesObject | undefined,
+        prefer.example,
       )
       if (exampleResponse !== null) {
         return c.json(exampleResponse)

--- a/packages/mock-server/src/utils/parse-prefer-header.test.ts
+++ b/packages/mock-server/src/utils/parse-prefer-header.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { parsePreferHeader } from './parse-prefer-header'
+
+describe('parsePreferHeader', () => {
+  it('returns an empty object when the header is missing', () => {
+    expect(parsePreferHeader(undefined)).toEqual({})
+    expect(parsePreferHeader(null)).toEqual({})
+    expect(parsePreferHeader('')).toEqual({})
+  })
+
+  it('parses a single directive', () => {
+    expect(parsePreferHeader('code=404')).toEqual({ code: '404' })
+  })
+
+  it('parses multiple comma-separated directives', () => {
+    expect(parsePreferHeader('code=404, example=notFound')).toEqual({
+      code: '404',
+      example: 'notFound',
+    })
+  })
+
+  it('parses semicolon-separated parameters', () => {
+    expect(parsePreferHeader('code=201; example=created')).toEqual({
+      code: '201',
+      example: 'created',
+    })
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(parsePreferHeader('  code = 200 ')).toEqual({ code: '200' })
+  })
+
+  it('lower-cases directive keys', () => {
+    expect(parsePreferHeader('Code=200')).toEqual({ code: '200' })
+  })
+
+  it('strips quotes from values', () => {
+    expect(parsePreferHeader('example="not found"')).toEqual({ example: 'not found' })
+  })
+
+  it('ignores valueless tokens', () => {
+    expect(parsePreferHeader('respond-async, code=200')).toEqual({ code: '200' })
+  })
+})

--- a/packages/mock-server/src/utils/parse-prefer-header.ts
+++ b/packages/mock-server/src/utils/parse-prefer-header.ts
@@ -1,0 +1,46 @@
+/**
+ * Directives parsed from an HTTP `Prefer` header (RFC 7240).
+ *
+ * The mock server understands `code` (pick a response status) and `example`
+ * (pick a named example). The index signature keeps the shape open so future
+ * directives can be read without changing the parser.
+ */
+export type PreferDirectives = {
+  /** Requested response status code, e.g. `code=404`. */
+  code?: string
+  /** Requested named example from the `examples` map, e.g. `example=notFound`. */
+  example?: string
+  [directive: string]: string | undefined
+}
+
+/**
+ * Parse an HTTP `Prefer` header into its directives.
+ *
+ * The header is a comma- and semicolon-separated list of `key=value` tokens
+ * (RFC 7240). We treat every token uniformly, lower-case the keys, and strip
+ * optional surrounding quotes from the values. A missing header or a token
+ * without a value is simply ignored so callers always fall through to their
+ * default behavior instead of erroring.
+ */
+export const parsePreferHeader = (header: string | null | undefined): PreferDirectives => {
+  if (!header) {
+    return {}
+  }
+
+  const directives: PreferDirectives = {}
+
+  for (const token of header.split(/[,;]/)) {
+    const [rawKey, ...rest] = token.split('=')
+    const key = rawKey?.trim().toLowerCase()
+
+    // Skip tokens that have no key or no value (e.g. `respond-async`).
+    if (!key || rest.length === 0) {
+      continue
+    }
+
+    // Re-join in case the value itself contained an `=` and drop quotes.
+    directives[key] = rest.join('=').trim().replace(/^"|"$/g, '')
+  }
+
+  return directives
+}

--- a/packages/mock-server/src/utils/parse-prefer-header.ts
+++ b/packages/mock-server/src/utils/parse-prefer-header.ts
@@ -5,7 +5,7 @@
  * (pick a named example). The index signature keeps the shape open so future
  * directives can be read without changing the parser.
  */
-export type PreferDirectives = {
+type PreferDirectives = {
   /** Requested response status code, e.g. `code=404`. */
   code?: string
   /** Requested named example from the `examples` map, e.g. `example=notFound`. */

--- a/packages/mock-server/src/utils/select-response-example.test.ts
+++ b/packages/mock-server/src/utils/select-response-example.test.ts
@@ -1,0 +1,67 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { describe, expect, it } from 'vitest'
+
+import { selectResponseExample } from './select-response-example'
+
+describe('selectResponseExample', () => {
+  it('returns undefined when the media type is missing', () => {
+    expect(selectResponseExample(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined when nothing is defined', () => {
+    expect(selectResponseExample({ schema: { type: 'string' } })).toBeUndefined()
+  })
+
+  it('uses the singular example', () => {
+    expect(selectResponseExample({ example: { foo: 'bar' } })).toEqual({ value: { foo: 'bar' } })
+  })
+
+  it('treats a null singular example as a real value', () => {
+    expect(selectResponseExample({ example: null })).toEqual({ value: null })
+  })
+
+  it('uses the first entry of the examples map when there is no singular example', () => {
+    const mediaType: OpenAPIV3_1.MediaTypeObject = {
+      examples: {
+        first: { value: { id: 1 } },
+        second: { value: { id: 2 } },
+      },
+    }
+
+    expect(selectResponseExample(mediaType)).toEqual({ value: { id: 1 } })
+  })
+
+  it('prefers the singular example over the examples map without a name', () => {
+    const mediaType: OpenAPIV3_1.MediaTypeObject = {
+      example: { from: 'singular' },
+      examples: {
+        first: { value: { from: 'map' } },
+      },
+    }
+
+    expect(selectResponseExample(mediaType)).toEqual({ value: { from: 'singular' } })
+  })
+
+  it('selects a named example', () => {
+    const mediaType: OpenAPIV3_1.MediaTypeObject = {
+      example: { from: 'singular' },
+      examples: {
+        first: { value: { id: 1 } },
+        notFound: { value: { error: 'not found' } },
+      },
+    }
+
+    expect(selectResponseExample(mediaType, 'notFound')).toEqual({ value: { error: 'not found' } })
+  })
+
+  it('falls through to the singular example for an unknown name', () => {
+    const mediaType: OpenAPIV3_1.MediaTypeObject = {
+      example: { from: 'singular' },
+      examples: {
+        first: { value: { id: 1 } },
+      },
+    }
+
+    expect(selectResponseExample(mediaType, 'missing')).toEqual({ value: { from: 'singular' } })
+  })
+})

--- a/packages/mock-server/src/utils/select-response-example.test.ts
+++ b/packages/mock-server/src/utils/select-response-example.test.ts
@@ -64,4 +64,47 @@ describe('selectResponseExample', () => {
 
     expect(selectResponseExample(mediaType, 'missing')).toEqual({ value: { from: 'singular' } })
   })
+
+  it('skips a named example without a value so the caller can use the schema', () => {
+    const mediaType: OpenAPIV3_1.MediaTypeObject = {
+      schema: { type: 'string' },
+      examples: {
+        external: { externalValue: 'https://example.com/payload.json' },
+      },
+    }
+
+    expect(selectResponseExample(mediaType, 'external')).toBeUndefined()
+  })
+
+  it('falls through to the singular example when a named example has no value', () => {
+    const mediaType: OpenAPIV3_1.MediaTypeObject = {
+      example: { from: 'singular' },
+      examples: {
+        external: { externalValue: 'https://example.com/payload.json' },
+      },
+    }
+
+    expect(selectResponseExample(mediaType, 'external')).toEqual({ value: { from: 'singular' } })
+  })
+
+  it('skips the first examples entry when it has no value', () => {
+    const mediaType: OpenAPIV3_1.MediaTypeObject = {
+      schema: { type: 'string' },
+      examples: {
+        external: { externalValue: 'https://example.com/payload.json' },
+      },
+    }
+
+    expect(selectResponseExample(mediaType)).toBeUndefined()
+  })
+
+  it('treats a null named example value as a real value', () => {
+    const mediaType: OpenAPIV3_1.MediaTypeObject = {
+      examples: {
+        empty: { value: null },
+      },
+    }
+
+    expect(selectResponseExample(mediaType, 'empty')).toEqual({ value: null })
+  })
 })

--- a/packages/mock-server/src/utils/select-response-example.ts
+++ b/packages/mock-server/src/utils/select-response-example.ts
@@ -13,7 +13,10 @@ import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref
  * Returns a `{ value }` wrapper when an example is available — so a `null` or
  * otherwise falsy value is still treated as a real example — or `undefined`
  * to signal that the caller should fall back to generating a body from the
- * schema. An unknown `exampleName` simply falls through to the later steps.
+ * schema. An example whose resolved `value` is `undefined` (for example, an
+ * Example Object that only carries an `externalValue`) is skipped, so the
+ * caller still gets a schema-generated body. An unknown `exampleName` simply
+ * falls through to the later steps.
  */
 export const selectResponseExample = (
   mediaType: OpenAPIV3_1.MediaTypeObject | undefined,
@@ -27,7 +30,11 @@ export const selectResponseExample = (
 
   // 1. A named example requested via `Prefer: example=<name>`
   if (exampleName && examples && exampleName in examples) {
-    return { value: getResolvedRef(examples[exampleName])?.value }
+    const value = getResolvedRef(examples[exampleName])?.value
+
+    if (value !== undefined) {
+      return { value }
+    }
   }
 
   // 2. The singular `example` keyword
@@ -40,7 +47,11 @@ export const selectResponseExample = (
     const firstKey = Object.keys(examples)[0]
 
     if (firstKey !== undefined) {
-      return { value: getResolvedRef(examples[firstKey])?.value }
+      const value = getResolvedRef(examples[firstKey])?.value
+
+      if (value !== undefined) {
+        return { value }
+      }
     }
   }
 

--- a/packages/mock-server/src/utils/select-response-example.ts
+++ b/packages/mock-server/src/utils/select-response-example.ts
@@ -1,0 +1,49 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+
+/**
+ * Pick the example body for a response media type.
+ *
+ * Precedence (per the OpenAPI Media Type Object plus the `Prefer: example=`
+ * directive):
+ * 1. A named example explicitly requested via `exampleName`.
+ * 2. The singular `example` keyword.
+ * 3. The first entry of the `examples` map.
+ *
+ * Returns a `{ value }` wrapper when an example is available — so a `null` or
+ * otherwise falsy value is still treated as a real example — or `undefined`
+ * to signal that the caller should fall back to generating a body from the
+ * schema. An unknown `exampleName` simply falls through to the later steps.
+ */
+export const selectResponseExample = (
+  mediaType: OpenAPIV3_1.MediaTypeObject | undefined,
+  exampleName?: string,
+): { value: unknown } | undefined => {
+  if (!mediaType) {
+    return undefined
+  }
+
+  const { example, examples } = mediaType
+
+  // 1. A named example requested via `Prefer: example=<name>`
+  if (exampleName && examples && exampleName in examples) {
+    return { value: getResolvedRef(examples[exampleName])?.value }
+  }
+
+  // 2. The singular `example` keyword
+  if (example !== undefined) {
+    return { value: example }
+  }
+
+  // 3. The first entry of the `examples` map
+  if (examples) {
+    const firstKey = Object.keys(examples)[0]
+
+    if (firstKey !== undefined) {
+      return { value: getResolvedRef(examples[firstKey])?.value }
+    }
+  }
+
+  // 4. Nothing defined: let the caller generate a body from the schema
+  return undefined
+}

--- a/packages/mock-server/test/prefer.test.ts
+++ b/packages/mock-server/test/prefer.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest'
+
+import { createMockServer } from '../src/create-mock-server'
+
+const baseInfo = {
+  title: 'Prefer Header',
+  version: '1.0.0',
+}
+
+describe('Prefer header', () => {
+  describe('code directive', () => {
+    const document = {
+      openapi: '3.1.0',
+      info: baseInfo,
+      paths: {
+        '/things': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: { 'application/json': { example: { status: 'ok' } } },
+              },
+              '404': {
+                description: 'Not Found',
+                content: { 'application/json': { example: { error: 'not found' } } },
+              },
+              '204': {
+                description: 'No Content',
+              },
+            },
+          },
+        },
+      },
+    }
+
+    it('selects a defined non-default response and sets its status', async () => {
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/things', { headers: { Prefer: 'code=404' } })
+
+      expect(response.status).toBe(404)
+      expect(await response.json()).toEqual({ error: 'not found' })
+    })
+
+    it('falls back to the preferred key for an unknown code', async () => {
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/things', { headers: { Prefer: 'code=418' } })
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ status: 'ok' })
+    })
+
+    it('returns no body for a 204 selected via code', async () => {
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/things', { headers: { Prefer: 'code=204' } })
+
+      expect(response.status).toBe(204)
+      expect(await response.text()).toBe('')
+    })
+
+    it('uses the preferred response without a Prefer header', async () => {
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/things')
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ status: 'ok' })
+    })
+  })
+
+  describe('example directive', () => {
+    const documentWithExamples = {
+      openapi: '3.1.0',
+      info: baseInfo,
+      paths: {
+        '/users': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    examples: {
+                      alice: { value: { name: 'Alice' } },
+                      bob: { value: { name: 'Bob' } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    it('selects a named example', async () => {
+      const server = await createMockServer({ document: documentWithExamples })
+
+      const response = await server.request('/users', { headers: { Prefer: 'example=bob' } })
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ name: 'Bob' })
+    })
+
+    it('uses the first example when no name is given', async () => {
+      const server = await createMockServer({ document: documentWithExamples })
+
+      const response = await server.request('/users')
+
+      expect(await response.json()).toEqual({ name: 'Alice' })
+    })
+
+    it('falls back to the first example for an unknown name', async () => {
+      const server = await createMockServer({ document: documentWithExamples })
+
+      const response = await server.request('/users', { headers: { Prefer: 'example=carol' } })
+
+      expect(await response.json()).toEqual({ name: 'Alice' })
+    })
+
+    it('prefers the singular example over the examples map', async () => {
+      const document = {
+        openapi: '3.1.0',
+        info: baseInfo,
+        paths: {
+          '/users': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      example: { name: 'Singular' },
+                      examples: { alice: { value: { name: 'Alice' } } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/users')
+
+      expect(await response.json()).toEqual({ name: 'Singular' })
+    })
+
+    it('generates a body from the schema when nothing is defined', async () => {
+      const document = {
+        openapi: '3.1.0',
+        info: baseInfo,
+        paths: {
+          '/users': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: { name: { type: 'string', example: 'Generated' } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/users')
+
+      expect(await response.json()).toEqual({ name: 'Generated' })
+    })
+  })
+
+  describe('code and example combined', () => {
+    it('picks the response by code, then the example within it', async () => {
+      const document = {
+        openapi: '3.1.0',
+        info: baseInfo,
+        paths: {
+          '/users': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      examples: { ok: { value: { status: 'ok' } } },
+                    },
+                  },
+                },
+                '422': {
+                  description: 'Unprocessable Entity',
+                  content: {
+                    'application/json': {
+                      examples: {
+                        missingName: { value: { error: 'name is required' } },
+                        missingEmail: { value: { error: 'email is required' } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/users', {
+        headers: { Prefer: 'code=422, example=missingEmail' },
+      })
+
+      expect(response.status).toBe(422)
+      expect(await response.json()).toEqual({ error: 'email is required' })
+    })
+  })
+})

--- a/packages/mock-server/test/prefer.test.ts
+++ b/packages/mock-server/test/prefer.test.ts
@@ -183,6 +183,60 @@ describe('Prefer header', () => {
     })
   })
 
+  describe('null example', () => {
+    it('serializes a null JSON example as null', async () => {
+      const document = {
+        openapi: '3.1.0',
+        info: baseInfo,
+        paths: {
+          '/nothing': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: { 'application/json': { example: null } },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/nothing')
+
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('null')
+    })
+
+    it('does not feed a null example into json2xml for XML responses', async () => {
+      const document = {
+        openapi: '3.1.0',
+        info: baseInfo,
+        paths: {
+          '/nothing': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: { 'application/xml': { example: null } },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/nothing', { headers: { Accept: 'application/xml' } })
+
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('null')
+    })
+  })
+
   describe('code and example combined', () => {
     it('picks the response by code, then the example within it', async () => {
       const document = {


### PR DESCRIPTION
The mock server only ever returned the singular `example` and a fixed status. Now you can steer it with the `Prefer` header (same as Prism):

- `Prefer: code=404` → return that response/status
- `Prefer: example=bob` → return that named example from the `examples` map

They compose, and anything unknown just falls back to the old behavior. Also reads the OpenAPI `examples` map now, not just `example`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive mock-server behavior with fallbacks for invalid Prefer values; limited to dev/testing tooling, covered by new tests.
> 
> **Overview**
> Adds **RFC 7240 `Prefer` header** support so clients can steer mock responses (Prism-style): **`code=<status>`** selects a defined operation response when present, otherwise behavior is unchanged; **`example=<name>`** picks from the media type **`examples`** map. Directives can be combined (status first, then example). Unknown codes or names **fall back** without error.
> 
> Mock response building now uses shared **`selectResponseExample`** logic: named example → singular **`example`** → first **`examples`** entry → schema generation ( **`externalValue`-only** examples are skipped). **`mockAnyResponse`** applies both directives; **`mockHandlerResponse`** honors **`example=`** when falling back to spec examples for null/undefined handler results.
> 
> Fixes body serialization so **`null`** and other non-object primitives are not passed to **`json2xml`**. Docs and a changeset describe usage; unit and integration tests cover parsing, selection precedence, and end-to-end behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a9313680a8c49472f0de8a37941129615383b9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->