### PR TITLE
feat(workspace-store): resolve `$dynamicRef` in generated examples

### DIFF
--- a/.changeset/resolve-dynamic-ref.md
+++ b/.changeset/resolve-dynamic-ref.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Resolve JSON Schema 2020-12 `$dynamicRef` against the active `$dynamicAnchor` when generating examples, so generic patterns like `PaginatedResponse<T>` and recursive trees produce concrete example data instead of empty placeholders

--- a/packages/workspace-store/src/helpers/dynamic-ref.test.ts
+++ b/packages/workspace-store/src/helpers/dynamic-ref.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SchemaObject } from '../schemas/v3.1/strict/schema'
+import { collectDynamicAnchors, isDynamicRef, pushDynamicScope, resolveDynamicRef } from './dynamic-ref'
+
+/** Cast a plain object to a SchemaObject so tests can use the untyped 2020-12 keywords (`$defs`). */
+const schema = (value: Record<string, unknown>) => value as unknown as SchemaObject
+
+describe('dynamic-ref', () => {
+  describe('isDynamicRef', () => {
+    it('matches a schema carrying $dynamicRef', () => {
+      expect(isDynamicRef({ $dynamicRef: '#itemType' })).toBe(true)
+    })
+
+    it('rejects schemas without a string $dynamicRef', () => {
+      expect(isDynamicRef({ type: 'string' })).toBe(false)
+      expect(isDynamicRef({ $dynamicRef: 42 })).toBe(false)
+      expect(isDynamicRef(null)).toBe(false)
+    })
+  })
+
+  describe('collectDynamicAnchors', () => {
+    it('collects an anchor declared at the resource root', () => {
+      const anchors = collectDynamicAnchors(schema({ $dynamicAnchor: 'category', type: 'object' }))
+      expect(anchors.has('category')).toBe(true)
+      expect(anchors.get('category')).toMatchObject({ type: 'object' })
+    })
+
+    it('collects anchors declared inside $defs', () => {
+      const anchors = collectDynamicAnchors(
+        schema({
+          $defs: { itemType: { $dynamicAnchor: 'itemType', type: 'string' } },
+          type: 'object',
+        }),
+      )
+      expect(anchors.get('itemType')).toMatchObject({ type: 'string' })
+    })
+
+    it('dereferences an anchor that binds through a sibling $ref', () => {
+      const anchors = collectDynamicAnchors(
+        schema({
+          $defs: {
+            itemType: { $dynamicAnchor: 'itemType', '$ref': '#/x', '$ref-value': { type: 'string' } },
+          },
+        }),
+      )
+      expect(anchors.get('itemType')).toMatchObject({ type: 'string' })
+    })
+
+    it('returns an empty map when there are no dynamic anchors', () => {
+      expect(collectDynamicAnchors(schema({ type: 'object' })).size).toBe(0)
+    })
+  })
+
+  describe('pushDynamicScope', () => {
+    it('appends schemas that can hold a dynamic anchor', () => {
+      const anchored = schema({ $dynamicAnchor: 'category' })
+      const withId = schema({ $id: 'urn:a' })
+      const withDefs = schema({ $defs: {} })
+
+      expect(pushDynamicScope([], anchored)).toEqual([anchored])
+      expect(pushDynamicScope([], withId)).toEqual([withId])
+      expect(pushDynamicScope([], withDefs)).toEqual([withDefs])
+    })
+
+    it('leaves the scope unchanged for plain subschemas', () => {
+      const scope = [schema({ $id: 'urn:a' })]
+      expect(pushDynamicScope(scope, schema({ type: 'string' }))).toBe(scope)
+    })
+
+    it('does not mutate the input scope', () => {
+      const scope = [schema({ $id: 'urn:a' })]
+      pushDynamicScope(scope, schema({ $id: 'urn:b' }))
+      expect(scope).toHaveLength(1)
+    })
+  })
+
+  describe('resolveDynamicRef', () => {
+    const outer = schema({ $id: 'urn:outer', $defs: { itemType: { $dynamicAnchor: 'itemType', type: 'string' } } })
+    const inner = schema({ $id: 'urn:inner', $defs: { itemType: { $dynamicAnchor: 'itemType', not: {} } } })
+
+    it('binds to the outermost matching anchor in the scope', () => {
+      // Scope is outermost-first, so the outer resource wins over the inner fallback.
+      expect(resolveDynamicRef('#itemType', [outer, inner])).toMatchObject({ type: 'string' })
+    })
+
+    it('falls back to an inner anchor when no outer one matches', () => {
+      expect(resolveDynamicRef('#itemType', [schema({ $id: 'urn:empty' }), inner])).toMatchObject({ not: {} })
+    })
+
+    it('returns undefined when no anchor matches', () => {
+      expect(resolveDynamicRef('#missing', [outer])).toBeUndefined()
+    })
+
+    it('ignores non-fragment and JSON-pointer references', () => {
+      expect(resolveDynamicRef('urn:outer', [outer])).toBeUndefined()
+      expect(resolveDynamicRef('#/$defs/itemType', [outer])).toBeUndefined()
+    })
+  })
+})

--- a/packages/workspace-store/src/helpers/dynamic-ref.ts
+++ b/packages/workspace-store/src/helpers/dynamic-ref.ts
@@ -1,0 +1,114 @@
+import { getResolvedRef, mergeSiblingReferences } from '@/helpers/get-resolved-ref'
+import { unpackProxyObject } from '@/helpers/unpack-proxy'
+import type { SchemaObject } from '@/schemas/v3.1/strict/schema'
+
+/**
+ * Resolution of JSON Schema 2020-12 `$dynamicRef` / `$dynamicAnchor`.
+ *
+ * Unlike `$ref`, a `$dynamicRef` does not resolve to a fixed location. It is resolved against the
+ * "dynamic scope" — the chain of schema resources entered to reach the reference. The same
+ * `{ "$dynamicRef": "#itemType" }` inside a shared generic template therefore resolves to different
+ * targets depending on which schema you entered through (e.g. `User` via `PaginatedUserResponse`,
+ * `Group` via `PaginatedGroupResponse`). Because the result depends on the traversal path, resolution
+ * cannot be pre-computed like `$ref`; it has to happen while walking the schema tree, with the scope
+ * threaded through the walk. See https://github.com/scalar/scalar/issues/9414.
+ */
+
+/** A schema that may carry the JSON Schema 2020-12 `$defs` keyword (not part of the strict type). */
+type SchemaWithDefs = SchemaObject & { $defs?: Record<string, SchemaObject> }
+
+/**
+ * The dynamic scope, ordered outermost-first.
+ *
+ * Each entry is a schema resource on the current evaluation path. When a `$dynamicRef` is resolved,
+ * the outermost entry that declares a matching `$dynamicAnchor` wins.
+ */
+export type DynamicScope = SchemaObject[]
+
+/** Narrow a schema to one that carries a `$dynamicRef`. */
+export const isDynamicRef = (schema: unknown): schema is SchemaObject & { $dynamicRef: string } =>
+  typeof schema === 'object' &&
+  schema !== null &&
+  '$dynamicRef' in schema &&
+  typeof (schema as { $dynamicRef?: unknown }).$dynamicRef === 'string'
+
+/**
+ * Whether a schema introduces something a `$dynamicRef` could later bind to.
+ *
+ * We only grow the dynamic scope with schemas that could hold a `$dynamicAnchor`: those declaring one
+ * directly, or resource boundaries (`$id`) / definition containers (`$defs`) that may hold one. Plain
+ * subschemas are skipped to keep the scope small.
+ */
+const carriesDynamicAnchor = (schema: SchemaObject): boolean =>
+  '$dynamicAnchor' in schema || '$id' in schema || '$defs' in (schema as SchemaWithDefs)
+
+/**
+ * Collect the `$dynamicAnchor` declarations of a single schema resource, keyed by anchor name.
+ *
+ * Anchors are looked for at the resource root and inside `$defs` — the two placements used by the
+ * common generic and recursive patterns. Anchors nested deeper are not collected (a documented v1
+ * limitation). Each target is dereferenced so callers receive the concrete schema the anchor points to.
+ */
+const anchorCache = new WeakMap<object, Map<string, SchemaObject>>()
+
+export const collectDynamicAnchors = (resource: SchemaObject): Map<string, SchemaObject> => {
+  // Cache per raw schema object so repeated lookups during a walk stay cheap.
+  const cacheTarget = unpackProxyObject(resource, { depth: 1 }) as object
+  const cached = anchorCache.get(cacheTarget)
+  if (cached) {
+    return cached
+  }
+
+  const anchors = new Map<string, SchemaObject>()
+
+  const add = (node: SchemaObject | undefined) => {
+    if (!node || typeof node !== 'object') {
+      return
+    }
+    const anchor = (node as { $dynamicAnchor?: unknown }).$dynamicAnchor
+    if (typeof anchor === 'string' && !anchors.has(anchor)) {
+      // Resolve any sibling `$ref` so the stored target is the concrete schema (e.g. `User`).
+      anchors.set(anchor, getResolvedRef(node, mergeSiblingReferences) as SchemaObject)
+    }
+  }
+
+  add(resource)
+
+  const defs = (resource as SchemaWithDefs).$defs
+  if (defs && typeof defs === 'object') {
+    for (const key of Object.keys(defs)) {
+      add(defs[key])
+    }
+  }
+
+  anchorCache.set(cacheTarget, anchors)
+  return anchors
+}
+
+/** Append a schema to the dynamic scope when it could hold a `$dynamicAnchor`, otherwise return it unchanged. */
+export const pushDynamicScope = (scope: DynamicScope, schema: SchemaObject): DynamicScope =>
+  carriesDynamicAnchor(schema) ? [...scope, schema] : scope
+
+/**
+ * Resolve a `$dynamicRef` fragment against the dynamic scope.
+ *
+ * Scans the scope outermost-first and returns the first resource that declares a `$dynamicAnchor` with
+ * the referenced name. Returns `undefined` when nothing matches, in which case callers should leave the
+ * reference unresolved (the schema renders as it did before, with no regression).
+ */
+export const resolveDynamicRef = (dynamicRef: string, scope: DynamicScope): SchemaObject | undefined => {
+  // Only plain-name fragments (`#itemType`) are supported; a non-fragment URI is not a dynamic anchor.
+  const name = dynamicRef.startsWith('#') ? dynamicRef.slice(1) : undefined
+  if (!name || name.startsWith('/')) {
+    return undefined
+  }
+
+  for (const resource of scope) {
+    const match = collectDynamicAnchors(resource).get(name)
+    if (match) {
+      return match
+    }
+  }
+
+  return undefined
+}

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
@@ -2104,6 +2104,47 @@ describe('getExampleFromSchema', () => {
       expect(Array.isArray(example.children)).toBe(true)
       expect(example.children[0]).toHaveProperty('displayName')
       expect(example.children[0]).toHaveProperty('locale')
+      // The recursive child is the full bound type, so it keeps the base fields (id, children) too —
+      // re-entering the same anchor must not be blocked by the cycle guard from the outer walk.
+      expect(example.children[0]).toHaveProperty('id')
+      expect(example.children[0]).toHaveProperty('children')
+      // The recursion descends at least one level deeper, still carrying the localized fields.
+      const grandchildren = example.children[0]!.children as Record<string, unknown>[]
+      expect(Array.isArray(grandchildren)).toBe(true)
+      expect(grandchildren[0]).toHaveProperty('displayName')
+    })
+
+    it('resolves a recursive $dynamicRef behind an object property', () => {
+      // Same recursion as above, but the self-reference is a plain object property (a linked-list `next`)
+      // rather than array items, so it exercises the main resolver branch instead of the array path.
+      const baseNode = {
+        $id: 'urn:node-base',
+        $dynamicAnchor: 'node',
+        type: 'object',
+        required: ['value', 'next'],
+        properties: {
+          value: { type: 'string' },
+          next: { $dynamicRef: '#node' },
+        },
+      }
+      const timestampedNode = dyn({
+        $id: 'urn:node-timestamped',
+        $dynamicAnchor: 'node',
+        allOf: [baseNode, { type: 'object', required: ['createdAt'], properties: { createdAt: { type: 'string' } } }],
+      })
+
+      const example = getExampleFromSchema(timestampedNode) as {
+        value: unknown
+        createdAt: unknown
+        next: Record<string, unknown>
+      }
+
+      expect(example).toHaveProperty('value')
+      expect(example).toHaveProperty('createdAt')
+      // `next` binds to the timestamped type, so it keeps both the base and the extended fields.
+      expect(example.next).toHaveProperty('value')
+      expect(example.next).toHaveProperty('createdAt')
+      expect(example.next).toHaveProperty('next')
     })
   })
 })

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
@@ -2015,4 +2015,95 @@ describe('getExampleFromSchema', () => {
       expect(Object.keys(getExampleFromSchema(schema) as object)).toEqual(['c', 'b', 'a'])
     })
   })
+
+  describe('$dynamicRef resolution', () => {
+    // Cast helper so tests can use the untyped 2020-12 keywords ($defs) and a magic-proxy-style $ref-value.
+    const dyn = (value: Record<string, unknown>) => value as unknown as SchemaObject
+
+    // A shared generic pagination template. Its item type is a $dynamicRef whose fallback matches nothing.
+    const paginatedTemplate = {
+      $id: 'urn:template',
+      $defs: { itemType: { $dynamicAnchor: 'itemType', not: {} } },
+      type: 'object',
+      required: ['items', 'total'],
+      properties: {
+        items: { type: 'array', items: { $dynamicRef: '#itemType' } },
+        total: { type: 'integer', minimum: 0 },
+      },
+    }
+
+    // A response specializing the template by binding itemType through a sibling $ref (as the magic proxy stores it).
+    const responseBinding = (itemSchema: Record<string, unknown>) =>
+      dyn({
+        $id: 'urn:response',
+        $defs: { itemType: { $dynamicAnchor: 'itemType', ...itemSchema } },
+        '$ref': 'urn:template',
+        '$ref-value': paginatedTemplate,
+      })
+
+    it('binds the dynamic item type to the specializing schema', () => {
+      const example = getExampleFromSchema(
+        responseBinding({ type: 'object', required: ['id', 'email'], properties: { id: {}, email: {} } }),
+      ) as { items: Record<string, unknown>[] }
+
+      expect(Array.isArray(example.items)).toBe(true)
+      expect(example.items).toHaveLength(1)
+      expect(example.items[0]).toHaveProperty('id')
+      expect(example.items[0]).toHaveProperty('email')
+    })
+
+    it('resolves the same template to different item types per binding', () => {
+      const groups = getExampleFromSchema(responseBinding({ type: 'object', properties: { name: {} } })) as {
+        items: Record<string, unknown>[]
+      }
+
+      expect(groups.items[0]).toHaveProperty('name')
+      expect(groups.items[0]).not.toHaveProperty('email')
+    })
+
+    it('falls back to the template anchor when no binding is in scope', () => {
+      // Rendering the template directly leaves the dynamic items unresolvable, so the array stays empty.
+      const example = getExampleFromSchema(dyn(paginatedTemplate)) as { items: unknown[] }
+      expect(example.items).toEqual([])
+    })
+
+    it('resolves recursive $dynamicRef to the active extended type', () => {
+      const baseCategory = {
+        $id: 'urn:base',
+        $dynamicAnchor: 'category',
+        type: 'object',
+        required: ['id', 'children'],
+        properties: {
+          id: { type: 'string' },
+          children: { type: 'array', items: { $dynamicRef: '#category' } },
+        },
+      }
+      const localizedCategory = dyn({
+        $id: 'urn:localized',
+        $dynamicAnchor: 'category',
+        allOf: [
+          baseCategory,
+          {
+            type: 'object',
+            required: ['displayName', 'locale'],
+            properties: { displayName: { type: 'string' }, locale: { type: 'string' } },
+          },
+        ],
+      })
+
+      const example = getExampleFromSchema(localizedCategory) as {
+        id: unknown
+        displayName: unknown
+        children: Record<string, unknown>[]
+      }
+
+      // The top level carries both the base and the localized fields.
+      expect(example).toHaveProperty('id')
+      expect(example).toHaveProperty('displayName')
+      // children bind to the localized type (it has displayName/locale), not the bare base type.
+      expect(Array.isArray(example.children)).toBe(true)
+      expect(example.children[0]).toHaveProperty('displayName')
+      expect(example.children[0]).toHaveProperty('locale')
+    })
+  })
 })

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
@@ -1,5 +1,6 @@
 import { isDefined } from '@scalar/helpers/array/is-defined'
 
+import { type DynamicScope, isDynamicRef, pushDynamicScope, resolveDynamicRef } from '@/helpers/dynamic-ref'
 import { unpackProxyObject } from '@/helpers/unpack-proxy'
 import { resolve } from '@/resolve'
 import type { SchemaObject } from '@/schemas/v3.1/strict/openapi-document'
@@ -132,9 +133,13 @@ const getRequiredNames = (parentSchema: SchemaObject | undefined): ReadonlySet<s
  * Cache the result for a schema if it is an object type.
  * Primitive values are not cached to avoid unnecessary WeakMap operations.
  * Stores a map of cacheKey strings which is made up of the options object.
+ *
+ * Skips the cache while a dynamic scope is active: the same shared schema node can resolve to
+ * different examples depending on the dynamic scope it was reached through, so caching it by object
+ * identity would leak one scope's result into another.
  */
-const cache = (schema: SchemaObject, result: unknown, cacheKey: string) => {
-  if (typeof result !== 'object' || result === null) {
+const cache = (schema: SchemaObject, result: unknown, cacheKey: string, skip = false) => {
+  if (skip || typeof result !== 'object' || result === null) {
     return result
   }
   const rawSchema = getSchemaCacheTarget(schema)
@@ -406,8 +411,12 @@ const handleObjectSchema = (
   seen: WeakSet<object>,
   cacheKey: string,
   schemaPath: string[],
+  dynamicScope: DynamicScope,
 ): unknown => {
   const response: Record<string, unknown> = {}
+  // Children are evaluated with this schema added to the dynamic scope so nested `$dynamicRef`s bind here.
+  const childScope = pushDynamicScope(dynamicScope, schema)
+  const skipCache = dynamicScope.length > 0
 
   if ('properties' in schema && schema.properties) {
     const properties = schema.properties
@@ -428,6 +437,7 @@ const handleObjectSchema = (
         name: propertyName,
         schemaPath: [...schemaPath, propertyName],
         seen,
+        dynamicScope: childScope,
       })
 
       if (typeof value !== 'undefined') {
@@ -448,6 +458,7 @@ const handleObjectSchema = (
         name: pattern,
         schemaPath: [...schemaPath, pattern],
         seen,
+        dynamicScope: childScope,
       })
     }
   }
@@ -482,6 +493,7 @@ const handleObjectSchema = (
             level: level + 1,
             schemaPath: [...schemaPath, additionalName],
             seen,
+            dynamicScope: childScope,
           })
         : 'anything'
 
@@ -505,6 +517,7 @@ const handleObjectSchema = (
           level: level + 1,
           schemaPath,
           seen,
+          dynamicScope: childScope,
         }),
       )
     }
@@ -517,6 +530,7 @@ const handleObjectSchema = (
         level: level + 1,
         parentSchema: schema,
         seen,
+        dynamicScope: childScope,
       })
       merged = mergeExamples(merged, ex)
     }
@@ -528,10 +542,10 @@ const handleObjectSchema = (
   if (options?.xml && 'xml' in schema && schema.xml?.name && level === 0) {
     const wrapped: Record<string, unknown> = {}
     wrapped[schema.xml.name] = response
-    return cache(schema, wrapped, cacheKey)
+    return cache(schema, wrapped, cacheKey, skipCache)
   }
 
-  return cache(schema, response, cacheKey)
+  return cache(schema, response, cacheKey, skipCache)
 }
 
 /** Build an example for an array schema, including items, allOf, oneOf/anyOf, and XML wrapping */
@@ -542,14 +556,27 @@ const handleArraySchema = (
   seen: WeakSet<object>,
   cacheKey: string,
   schemaPath: string[],
+  dynamicScope: DynamicScope,
 ) => {
-  const items = 'items' in schema ? resolve.schema(schema.items) : undefined
+  const childScope = pushDynamicScope(dynamicScope, schema)
+  const skipCache = dynamicScope.length > 0
+
+  let items = 'items' in schema ? resolve.schema(schema.items) : undefined
+  // Bind a dynamic item type (e.g. the generic `PaginatedResponse<T>` pattern) before inspecting it.
+  if (items && isDynamicRef(items)) {
+    items = resolveDynamicRef(items.$dynamicRef, childScope) ?? items
+  }
   const itemsSchemaPath = [...schemaPath, 'items']
   const itemsXmlTagName = items && typeof items === 'object' && 'xml' in items ? items.xml?.name : undefined
   const wrapItems = !!(options?.xml && 'xml' in schema && schema.xml?.wrapped && itemsXmlTagName)
 
   if (schema.example !== undefined) {
-    return cache(schema, wrapItems ? { [itemsXmlTagName as string]: schema.example } : schema.example, cacheKey)
+    return cache(
+      schema,
+      wrapItems ? { [itemsXmlTagName as string]: schema.example } : schema.example,
+      cacheKey,
+      skipCache,
+    )
   }
 
   if (items && typeof items === 'object') {
@@ -564,8 +591,9 @@ const handleArraySchema = (
           parentSchema: schema,
           schemaPath: itemsSchemaPath,
           seen,
+          dynamicScope: childScope,
         })
-        return cache(schema, wrapItems ? [{ [itemsXmlTagName as string]: merged }] : [merged], cacheKey)
+        return cache(schema, wrapItems ? [{ [itemsXmlTagName as string]: merged }] : [merged], cacheKey, skipCache)
       }
 
       const examples = allOf
@@ -575,6 +603,7 @@ const handleArraySchema = (
             parentSchema: schema,
             schemaPath: itemsSchemaPath,
             seen,
+            dynamicScope: childScope,
           }),
         )
         .filter(isDefined)
@@ -582,6 +611,7 @@ const handleArraySchema = (
         schema,
         wrapItems ? (examples as unknown[]).map((e) => ({ [itemsXmlTagName as string]: e })) : examples,
         cacheKey,
+        skipCache,
       )
     }
 
@@ -596,8 +626,9 @@ const handleArraySchema = (
         parentSchema: schema,
         schemaPath: itemsSchemaPath,
         seen,
+        dynamicScope: childScope,
       })
-      return cache(schema, wrapItems ? [{ [itemsXmlTagName as string]: ex }] : [ex], cacheKey)
+      return cache(schema, wrapItems ? [{ [itemsXmlTagName as string]: ex }] : [ex], cacheKey, skipCache)
     }
   }
 
@@ -611,11 +642,12 @@ const handleArraySchema = (
       level: level + 1,
       schemaPath: itemsSchemaPath,
       seen,
+      dynamicScope: childScope,
     })
-    return cache(schema, wrapItems ? [{ [itemsXmlTagName as string]: ex }] : [ex], cacheKey)
+    return cache(schema, wrapItems ? [{ [itemsXmlTagName as string]: ex }] : [ex], cacheKey, skipCache)
   }
 
-  return cache(schema, [], cacheKey)
+  return cache(schema, [], cacheKey, skipCache)
 }
 
 /** Return primitive example value for single-type schemas, or undefined if not primitive */
@@ -719,6 +751,7 @@ export const getExampleFromSchema = (
     name,
     seen = new WeakSet(),
     schemaPath = [],
+    dynamicScope = [],
   }: Partial<{
     level: number
     parentSchema: SchemaObject
@@ -726,6 +759,8 @@ export const getExampleFromSchema = (
     seen: WeakSet<object>
     /** Internal traversal path used to resolve nested composition selections. */
     schemaPath: string[]
+    /** Chain of schema resources entered so far, used to resolve `$dynamicRef` (JSON Schema 2020-12). */
+    dynamicScope: DynamicScope
   }> = {},
 ): unknown => {
   // Resolve any $ref references to get the actual schema
@@ -733,6 +768,27 @@ export const getExampleFromSchema = (
   if (!isDefined(_schema)) {
     return undefined
   }
+
+  // Resolve a `$dynamicRef` against the active dynamic scope, then continue with the bound schema.
+  // When nothing matches, fall through and render the reference as before (no regression).
+  if (isDynamicRef(_schema)) {
+    const resolvedDynamic = resolveDynamicRef(_schema.$dynamicRef, dynamicScope)
+    if (resolvedDynamic) {
+      return getExampleFromSchema(resolvedDynamic, options, {
+        level: level + 1,
+        parentSchema,
+        name,
+        seen,
+        schemaPath,
+        dynamicScope,
+      })
+    }
+  }
+
+  // Grow the scope with this schema so nested references can bind to its `$dynamicAnchor`s.
+  const childScope = pushDynamicScope(dynamicScope, _schema)
+  // The same shared node can resolve differently per scope, so skip the result cache under a scope.
+  const skipCache = dynamicScope.length > 0
 
   // Unpack from all proxies to get the raw schema object for cycle detection
   const targetValue = getSchemaCacheTarget(_schema)
@@ -744,11 +800,13 @@ export const getExampleFromSchema = (
   /** Make the cache key unique per options and schema path */
   const cacheKey = createOptionsCacheKey(options) + (schemaPath.length > 0 ? `:path:${schemaPath.join('.')}` : '')
 
-  // Check cache first for performance - avoid recomputing the same schema
-  const cached = resultCache.get(targetValue)?.get(cacheKey)
-  if (typeof cached !== 'undefined') {
-    seen.delete(targetValue)
-    return cached
+  // Check cache first for performance - avoid recomputing the same schema (skipped under a dynamic scope)
+  if (!skipCache) {
+    const cached = resultCache.get(targetValue)?.get(cacheKey)
+    if (typeof cached !== 'undefined') {
+      seen.delete(targetValue)
+      return cached
+    }
   }
 
   // Prevent infinite recursion in circular references
@@ -773,49 +831,49 @@ export const getExampleFromSchema = (
       // Type coercion for numeric types
       if ('type' in _schema && (_schema.type === 'number' || _schema.type === 'integer')) {
         seen.delete(targetValue)
-        return cache(_schema, Number(value), cacheKey)
+        return cache(_schema, Number(value), cacheKey, skipCache)
       }
       seen.delete(targetValue)
-      return cache(_schema, value, cacheKey)
+      return cache(_schema, value, cacheKey, skipCache)
     }
   }
 
   // Priority order: examples > example > default > const > enum
   if (Array.isArray(_schema.examples) && _schema.examples.length > 0) {
     seen.delete(targetValue)
-    return cache(_schema, _schema.examples[0], cacheKey)
+    return cache(_schema, _schema.examples[0], cacheKey, skipCache)
   }
   if (_schema.example !== undefined) {
     seen.delete(targetValue)
-    return cache(_schema, _schema.example, cacheKey)
+    return cache(_schema, _schema.example, cacheKey, skipCache)
   }
   if (_schema.default !== undefined) {
     const normalizedDefault = normalizeSchemaDefault(_schema)
 
     if (normalizedDefault !== INVALID_DEFAULT) {
       seen.delete(targetValue)
-      return cache(_schema, normalizedDefault, cacheKey)
+      return cache(_schema, normalizedDefault, cacheKey, skipCache)
     }
   }
   if (_schema.const !== undefined) {
     seen.delete(targetValue)
-    return cache(_schema, _schema.const, cacheKey)
+    return cache(_schema, _schema.const, cacheKey, skipCache)
   }
   if (Array.isArray(_schema.enum) && _schema.enum.length > 0) {
     seen.delete(targetValue)
-    return cache(_schema, _schema.enum[0], cacheKey)
+    return cache(_schema, _schema.enum[0], cacheKey, skipCache)
   }
 
   // Handle object types - check for properties to identify objects
   if ('properties' in _schema || ('type' in _schema && _schema.type === 'object')) {
-    const result = handleObjectSchema(_schema, options, level, seen, cacheKey, schemaPath)
+    const result = handleObjectSchema(_schema, options, level, seen, cacheKey, schemaPath, dynamicScope)
     seen.delete(targetValue)
     return result
   }
 
   // Handle array types
   if (('type' in _schema && _schema.type === 'array') || 'items' in _schema) {
-    const result = handleArraySchema(_schema, options, level, seen, cacheKey, schemaPath)
+    const result = handleArraySchema(_schema, options, level, seen, cacheKey, schemaPath, dynamicScope)
     seen.delete(targetValue)
     return result
   }
@@ -824,7 +882,7 @@ export const getExampleFromSchema = (
   const primitive = getPrimitiveValue(_schema, makeUpRandomData, options?.emptyString)
   if (primitive !== undefined) {
     seen.delete(targetValue)
-    return cache(_schema, primitive, cacheKey)
+    return cache(_schema, primitive, cacheKey, skipCache)
   }
 
   // Handle composition schemas (oneOf, anyOf)
@@ -849,13 +907,15 @@ export const getExampleFromSchema = (
             level: level + 1,
             schemaPath,
             seen,
+            dynamicScope: childScope,
           }),
           cacheKey,
+          skipCache,
         )
       }
     }
     seen.delete(targetValue)
-    return cache(_schema, null, cacheKey)
+    return cache(_schema, null, cacheKey, skipCache)
   }
 
   // Handle allOf at root level (non-object/array schemas)
@@ -868,6 +928,7 @@ export const getExampleFromSchema = (
         parentSchema: _schema,
         schemaPath,
         seen,
+        dynamicScope: childScope,
       })
       if (merged === undefined) {
         merged = ex
@@ -879,17 +940,17 @@ export const getExampleFromSchema = (
       }
     }
     seen.delete(targetValue)
-    return cache(_schema, merged ?? null, cacheKey)
+    return cache(_schema, merged ?? null, cacheKey, skipCache)
   }
 
   // Handle union types (array of types)
   const unionPrimitive = getUnionPrimitiveValue(_schema, makeUpRandomData, options?.emptyString)
   if (unionPrimitive !== undefined) {
     seen.delete(targetValue)
-    return cache(_schema, unionPrimitive, cacheKey)
+    return cache(_schema, unionPrimitive, cacheKey, skipCache)
   }
 
   // Default fallback
   seen.delete(targetValue)
-  return cache(_schema, null, cacheKey)
+  return cache(_schema, null, cacheKey, skipCache)
 }

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
@@ -563,8 +563,17 @@ const handleArraySchema = (
 
   let items = 'items' in schema ? resolve.schema(schema.items) : undefined
   // Bind a dynamic item type (e.g. the generic `PaginatedResponse<T>` pattern) before inspecting it.
+  // Crossing a `$dynamicRef` leaves the static schema graph, so the cycle guard built up by the outer
+  // walk no longer applies to the bound type. Restart `seen` for the item recursion so recursive trees
+  // (e.g. a category whose children reference the same anchor) render their nested levels instead of
+  // tripping the shared guard. Depth stays bounded by `MAX_LEVELS_DEEP`.
+  let itemsSeen = seen
   if (items && isDynamicRef(items)) {
-    items = resolveDynamicRef(items.$dynamicRef, childScope) ?? items
+    const resolvedDynamic = resolveDynamicRef(items.$dynamicRef, childScope)
+    if (resolvedDynamic) {
+      items = resolvedDynamic
+      itemsSeen = new WeakSet()
+    }
   }
   const itemsSchemaPath = [...schemaPath, 'items']
   const itemsXmlTagName = items && typeof items === 'object' && 'xml' in items ? items.xml?.name : undefined
@@ -590,7 +599,7 @@ const handleArraySchema = (
           level: level + 1,
           parentSchema: schema,
           schemaPath: itemsSchemaPath,
-          seen,
+          seen: itemsSeen,
           dynamicScope: childScope,
         })
         return cache(schema, wrapItems ? [{ [itemsXmlTagName as string]: merged }] : [merged], cacheKey, skipCache)
@@ -602,7 +611,7 @@ const handleArraySchema = (
             level: level + 1,
             parentSchema: schema,
             schemaPath: itemsSchemaPath,
-            seen,
+            seen: itemsSeen,
             dynamicScope: childScope,
           }),
         )
@@ -625,7 +634,7 @@ const handleArraySchema = (
         level: level + 1,
         parentSchema: schema,
         schemaPath: itemsSchemaPath,
-        seen,
+        seen: itemsSeen,
         dynamicScope: childScope,
       })
       return cache(schema, wrapItems ? [{ [itemsXmlTagName as string]: ex }] : [ex], cacheKey, skipCache)
@@ -641,7 +650,7 @@ const handleArraySchema = (
     const ex = getExampleFromSchema(items as SchemaObject, options, {
       level: level + 1,
       schemaPath: itemsSchemaPath,
-      seen,
+      seen: itemsSeen,
       dynamicScope: childScope,
     })
     return cache(schema, wrapItems ? [{ [itemsXmlTagName as string]: ex }] : [ex], cacheKey, skipCache)
@@ -774,11 +783,15 @@ export const getExampleFromSchema = (
   if (isDynamicRef(_schema)) {
     const resolvedDynamic = resolveDynamicRef(_schema.$dynamicRef, dynamicScope)
     if (resolvedDynamic) {
+      // The `seen` set guards against cycles in the static schema graph, but a `$dynamicRef` is resolved
+      // per evaluation path and intentionally points outside that graph. Re-entering the bound type with a
+      // fresh `seen` lets recursive examples (e.g. a category tree) render their nested levels instead of
+      // bailing out on the shared cycle guard. Depth stays bounded by `MAX_LEVELS_DEEP`.
       return getExampleFromSchema(resolvedDynamic, options, {
         level: level + 1,
         parentSchema,
         name,
-        seen,
+        seen: new WeakSet(),
         schemaPath,
         dynamicScope,
       })


### PR DESCRIPTION
OpenAPI 3.1 schemas using JSON Schema 2020-12 `$dynamicRef` / `$dynamicAnchor` loaded fine but the keywords did nothing, so generic patterns like `PaginatedResponse<T>` and recursive trees rendered empty examples.

This resolves `$dynamicRef` against the active `$dynamicAnchor` while walking the schema, so `items` get the concrete bound type (`User[]`, `Group[]`, …) instead of empty placeholders. Continues what we started in #9419.

Rendering in `@scalar/api-reference` is a separate walk and comes in a follow-up — it can reuse the exported resolver.

## Example

`UserPage` binds the generic `Page` template's item type to `User` via `$dynamicAnchor`:

```yaml
components:
  schemas:
    User:
      type: object
      properties:
        id: { type: string }
        email: { type: string, format: email }
    Page:
      $id: https://example.com/Page
      $defs:
        itemType: { $dynamicAnchor: itemType, not: {} }
      type: object
      properties:
        items:
          type: array
          items:
            $dynamicRef: '#itemType'
        total: { type: integer }
    UserPage:
      $id: https://example.com/UserPage
      $defs:
        itemType: { $dynamicAnchor: itemType, $ref: '#/components/schemas/User' }
      $ref: '#/components/schemas/Page'
```

Generated example for `UserPage` — `items` is now `User`, not empty:

```json
{
  "items": [{ "id": "", "email": "" }],
  "total": 1
}
```

## Ticket

Part of #9414


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core example-generation caching and recursion guards; incorrect scope or cache behavior could change examples for OpenAPI 3.1 schemas, though unmatched `$dynamicRef` is unchanged.
> 
> **Overview**
> Adds **JSON Schema 2020-12 `$dynamicRef` / `$dynamicAnchor` resolution** for request/response example generation, so generic templates (e.g. paginated `items`) and recursive schemas produce concrete examples instead of empty arrays or placeholders.
> 
> A reusable resolver is introduced in **`@scalar/json-magic/magic-proxy`** (`collectDynamicAnchors`, `pushDynamicScope`, `resolveDynamicRef`, plus magic-proxy `$ref-value` handling). **`getExampleFromSchema`** threads a **dynamic scope** through object/array walks, resolves `$dynamicRef` at entry and for array `items`, and **disables result caching** while a scope is active so the same schema node cannot return the wrong binding. After a dynamic jump it **resets the cycle `seen` set** (depth still capped) so recursive dynamic trees can nest without false cycle cuts.
> 
> Unmatched refs keep prior behavior (no regression). API reference rendering is out of scope here; the exported resolver is meant for reuse later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 638890a3f2dd839dcd3913b2a9e55050f4a3b5f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->