### PR TITLE
feat(mock-server): validate requests against the OpenAPI contract

### DIFF
--- a/.changeset/mock-server-validate-request.md
+++ b/.changeset/mock-server-validate-request.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': minor
+---
+
+Validate incoming requests against the matched operation by default. Path/query parameters and the `application/json` request body are checked against their schema, and contract violations return a `422` with an `application/problem+json` body listing every violation. Set `validateRequest: false` to opt out and always return a mock response.

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -16,6 +16,7 @@ A powerful Node.js mock server that automatically generates realistic API respon
 - Supports Swagger 2.0 and OpenAPI 3.x documents
 - Write custom JavaScript handlers for dynamic responses
 - Automatically seed initial data on server startup
+- Validates incoming requests against your OpenAPI contract
 
 ## Quickstart
 
@@ -187,6 +188,48 @@ The given OpenAPI document is automatically exposed:
 - `/openapi.json` and `/openapi.yaml`
 
 ## Advanced Features
+
+### Request Validation
+
+The mock server enforces your OpenAPI contract by default. Each request is validated against the matched operation before a mock response is generated:
+
+- **Path and query parameters** declared in the operation are validated against their schema. Values arrive as strings, so `type: integer`/`boolean` are coerced before validation (for example `?limit=10` becomes the number `10`). Required parameters are enforced.
+- **JSON request bodies** are validated against `requestBody.content['application/json'].schema`, and `requestBody.required` is enforced.
+
+When a request violates the contract, the server responds with `422 Unprocessable Entity` and a `application/problem+json` body listing every violation, instead of a mock response.
+
+To turn this off and always return a mock response regardless of the request, set `validateRequest: false`:
+
+```ts
+import { createMockServer } from '@scalar/mock-server'
+
+const app = await createMockServer({
+  document,
+  // Opt out of request validation
+  validateRequest: false,
+})
+```
+
+A failing request (for example a missing required `limit` query parameter and a wrong-typed body field) returns:
+
+```http
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/problem+json
+```
+
+```json
+{
+  "error": "Request validation failed",
+  "violations": [
+    { "location": "query", "path": "/limit", "message": "limit must be integer" },
+    { "location": "body", "path": "/age", "message": "must be integer" }
+  ]
+}
+```
+
+Each violation reports its `location` (`path`, `query`, or `body`), a `path` pointing at the offending value, and a human-readable `message`. All violations are returned at once, not just the first.
+
+> This validates path/query parameters and JSON request bodies. Response validation, header/cookie parameters, non-JSON bodies, and proxy mode are planned follow-ups.
 
 ### Custom Request Handlers
 

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -62,6 +62,8 @@
     "@scalar/openapi-types": "workspace:*",
     "@scalar/openapi-upgrader": "workspace:*",
     "@scalar/workspace-store": "workspace:*",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "hono": "catalog:*",
     "yaml": "catalog:*"
   },

--- a/packages/mock-server/src/create-mock-server.ts
+++ b/packages/mock-server/src/create-mock-server.ts
@@ -13,6 +13,7 @@ import { isAuthenticationRequired } from '@/utils/is-authentication-required'
 import { logAuthenticationInstructions } from '@/utils/log-authentication-instructions'
 import { processOpenApiDocument } from '@/utils/process-openapi-document'
 import { setUpAuthenticationRoutes } from '@/utils/set-up-authentication-routes'
+import { validateRequest } from '@/utils/validate-request'
 
 import { store } from './libs/store'
 import { mockAnyResponse } from './routes/mock-any-response'
@@ -86,6 +87,13 @@ export async function createMockServer(configuration: MockServerOptions): Promis
       // Check if authentication is required for this operation
       if (isAuthenticationRequired(effectiveSecurity)) {
         app[method](route, handleAuthentication(schema, operation))
+      }
+
+      // Validate the incoming request against the operation contract (on by default;
+      // opt out with `validateRequest: false`). Runs after authentication but before the
+      // mock handler. Validators are compiled once here, so there is no per-request recompilation.
+      if (configuration.validateRequest !== false) {
+        app[method](route, validateRequest(operation))
       }
 
       // Check if operation has x-handler extension

--- a/packages/mock-server/src/create-mock-server.ts
+++ b/packages/mock-server/src/create-mock-server.ts
@@ -89,6 +89,15 @@ export async function createMockServer(configuration: MockServerOptions): Promis
         app[method](route, handleAuthentication(schema, operation))
       }
 
+      // Notify the `onRequest` callback before validation runs, so it fires for every request —
+      // including ones the validation middleware rejects with a `422`.
+      if (configuration.onRequest) {
+        app[method](route, async (c, next) => {
+          configuration.onRequest?.({ context: c, operation })
+          await next()
+        })
+      }
+
       // Validate the incoming request against the operation contract (on by default;
       // opt out with `validateRequest: false`). Runs after authentication but before the
       // mock handler. Validators are compiled once here, so there is no per-request recompilation.
@@ -103,9 +112,9 @@ export async function createMockServer(configuration: MockServerOptions): Promis
 
       // Route to appropriate handler
       if (hasHandler) {
-        app[method](route, (c) => mockHandlerResponse(c, operation, configuration))
+        app[method](route, (c) => mockHandlerResponse(c, operation))
       } else {
-        app[method](route, (c) => mockAnyResponse(c, operation, configuration))
+        app[method](route, (c) => mockAnyResponse(c, operation))
       }
     })
   })

--- a/packages/mock-server/src/create-mock-server.ts
+++ b/packages/mock-server/src/create-mock-server.ts
@@ -93,7 +93,7 @@ export async function createMockServer(configuration: MockServerOptions): Promis
       // opt out with `validateRequest: false`). Runs after authentication but before the
       // mock handler. Validators are compiled once here, so there is no per-request recompilation.
       if (configuration.validateRequest !== false) {
-        app[method](route, validateRequest(operation))
+        app[method](route, validateRequest(operation, pathItem?.parameters))
       }
 
       // Check if operation has x-handler extension

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -7,20 +7,14 @@ import type { Context } from 'hono'
 import { accepts } from 'hono/accepts'
 import type { StatusCode } from 'hono/utils/http-status'
 
-import type { MockServerOptions } from '@/types'
 import { findPreferredResponseKey } from '@/utils/find-preferred-response-key'
 
 /**
  * Mock any response
  */
-export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObject, options: MockServerOptions) {
-  // Call onRequest callback
-  if (options?.onRequest) {
-    options.onRequest({
-      context: c,
-      operation,
-    })
-  }
+export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObject) {
+  // Note: the `onRequest` callback runs as middleware (see `create-mock-server`) so it also fires
+  // for requests rejected before reaching this handler.
 
   // Response
   // default, 200, 201 …

--- a/packages/mock-server/src/routes/mock-handler-response.ts
+++ b/packages/mock-server/src/routes/mock-handler-response.ts
@@ -6,7 +6,6 @@ import type { Context } from 'hono'
 import { accepts } from 'hono/accepts'
 import type { StatusCode } from 'hono/utils/http-status'
 
-import type { MockServerOptions } from '@/types'
 import { buildHandlerContext } from '@/utils/build-handler-context'
 import { executeHandler } from '@/utils/execute-handler'
 
@@ -126,18 +125,9 @@ function determineStatusCode(tracking: {
  * Mock response using x-handler code.
  * Executes the handler and returns its result as the response.
  */
-export async function mockHandlerResponse(
-  c: Context,
-  operation: OpenAPIV3_1.OperationObject,
-  options: MockServerOptions,
-) {
-  // Call onRequest callback
-  if (options?.onRequest) {
-    options.onRequest({
-      context: c,
-      operation,
-    })
-  }
+export async function mockHandlerResponse(c: Context, operation: OpenAPIV3_1.OperationObject) {
+  // Note: the `onRequest` callback runs as middleware (see `create-mock-server`) so it also fires
+  // for requests rejected before reaching this handler.
 
   // Get x-handler code from operation
   const handlerCode = operation?.['x-handler']

--- a/packages/mock-server/src/types.ts
+++ b/packages/mock-server/src/types.ts
@@ -34,6 +34,20 @@ type BaseMockServerOptions = {
    * Callback function to be called before each request is processed.
    */
   onRequest?: (data: { context: Context; operation: OpenAPIV3_1.OperationObject }) => void
+
+  /**
+   * Validate the incoming request against the matched operation's schema. When the request
+   * violates the contract, the server responds with `422` and a `application/problem+json`
+   * body describing the violations, instead of returning a mock response.
+   *
+   * Validates path/query parameters and the `application/json` request body.
+   *
+   * @default true
+   *
+   * Enabled by default for Prism-style contract enforcement. Set to `false` to opt out and
+   * always return a mock response regardless of whether the request matches the contract.
+   */
+  validateRequest?: boolean
 }
 
 export type MockServerOptions = RequireAtLeastOne<BaseMockServerOptions, 'specification' | 'document'>

--- a/packages/mock-server/src/utils/build-handler-context.ts
+++ b/packages/mock-server/src/utils/build-handler-context.ts
@@ -95,7 +95,10 @@ export async function buildHandlerContext(
   let body: any = undefined
 
   try {
-    const contentType = c.req.header('content-type') ?? ''
+    // Compare case-insensitively, since media types are case-insensitive and request validation
+    // matches them the same way. Otherwise a body like `Application/JSON` could pass validation yet
+    // never reach the handler as `req.body`.
+    const contentType = (c.req.header('content-type') ?? '').toLowerCase()
     // An empty/absent Content-Type is treated as JSON to match request validation, so a headerless
     // JSON body that passes validation is still delivered to the handler as `req.body`.
     if (contentType === '' || contentType.includes('application/json')) {

--- a/packages/mock-server/src/utils/build-handler-context.ts
+++ b/packages/mock-server/src/utils/build-handler-context.ts
@@ -96,7 +96,9 @@ export async function buildHandlerContext(
 
   try {
     const contentType = c.req.header('content-type') ?? ''
-    if (contentType.includes('application/json')) {
+    // An empty/absent Content-Type is treated as JSON to match request validation, so a headerless
+    // JSON body that passes validation is still delivered to the handler as `req.body`.
+    if (contentType === '' || contentType.includes('application/json')) {
       body = await c.req.json().catch(() => undefined)
     } else if (contentType.includes('application/x-www-form-urlencoded')) {
       body = await c.req.parseBody().catch(() => undefined)

--- a/packages/mock-server/src/utils/validate-request.test.ts
+++ b/packages/mock-server/src/utils/validate-request.test.ts
@@ -318,4 +318,58 @@ describe('validate-request', () => {
     // Validation is skipped for this operation, so the request still resolves to the mock.
     expect(response.status).toBe(200)
   })
+
+  it('keeps working validators when only the body schema fails to compile', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const document = documentWith('/items', 'post', {
+      parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'integer' } }],
+      requestBody: {
+        required: true,
+        // A body schema that cannot compile must not disable the query validator above.
+        content: { 'application/json': { schema: { type: 'not-a-real-type' } as never } },
+      },
+    })
+
+    const server = await createMockServer({ document, validateRequest: true })
+
+    // The query validator still runs even though the body schema fell open.
+    const response = await server.request('/items', { method: 'POST' })
+    expect(response.status).toBe(422)
+    expect((await response.json()).violations[0]).toMatchObject({ location: 'query', path: '/limit' })
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('validates and delivers a JSON body sent without a Content-Type header', async () => {
+    const document = documentWith('/items', 'post', {
+      'x-handler': 'return { received: req.body };',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] },
+          },
+        },
+      },
+    })
+
+    const server = await createMockServer({ document, validateRequest: true })
+
+    // A string body would default to `text/plain`, so drop the header to exercise the absent case.
+    const withoutContentType = (body: string) => {
+      const request = new Request('http://localhost/items', { method: 'POST', body })
+      request.headers.delete('Content-Type')
+      return request
+    }
+
+    // No Content-Type header: validation must reject an invalid body...
+    const invalid = await server.request(withoutContentType(JSON.stringify({})))
+    expect(invalid.status).toBe(422)
+    expect((await invalid.json()).violations[0]).toMatchObject({ location: 'body' })
+
+    // ...and a valid body must still reach the handler as `req.body`.
+    const valid = await server.request(withoutContentType(JSON.stringify({ name: 'Alice' })))
+    expect((await valid.json()).received).toEqual({ name: 'Alice' })
+  })
 })

--- a/packages/mock-server/src/utils/validate-request.test.ts
+++ b/packages/mock-server/src/utils/validate-request.test.ts
@@ -119,6 +119,73 @@ describe('validate-request', () => {
     expect((await wrongType.json()).violations[0]).toMatchObject({ location: 'body', path: '/age' })
   })
 
+  it('returns 422 for unparseable JSON even when the body is optional', async () => {
+    const document = documentWith('/items', 'post', {
+      requestBody: {
+        required: false,
+        content: { 'application/json': { schema: { type: 'object', properties: { name: { type: 'string' } } } } },
+      },
+    })
+
+    const server = await createMockServer({ document, validateRequest: true })
+    const response = await server.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{not valid json',
+    })
+
+    expect(response.status).toBe(422)
+    expect((await response.json()).violations[0]).toMatchObject({ location: 'body' })
+  })
+
+  it('validates path-item-level parameters shared across operations', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: { title: 'Validation', version: '1.0.0' },
+      paths: {
+        '/items': {
+          // Declared on the path item, so it applies to every operation underneath.
+          parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'integer' } }],
+          get: {
+            responses: { '200': { description: 'OK', content: { 'application/json': { example: { ok: true } } } } },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document, validateRequest: true })
+
+    const missing = await server.request('/items')
+    expect(missing.status).toBe(422)
+    expect((await missing.json()).violations[0]).toMatchObject({ location: 'query', path: '/limit' })
+
+    const valid = await server.request('/items?limit=5')
+    expect(valid.status).toBe(200)
+  })
+
+  it('lets an operation parameter override a path-item parameter of the same name', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: { title: 'Validation', version: '1.0.0' },
+      paths: {
+        '/items': {
+          // Required on the path item, but the operation relaxes it to optional.
+          parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'integer' } }],
+          get: {
+            parameters: [{ name: 'limit', in: 'query', required: false, schema: { type: 'integer' } }],
+            responses: { '200': { description: 'OK', content: { 'application/json': { example: { ok: true } } } } },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document, validateRequest: true })
+
+    // The operation-level override wins, so a missing `limit` is allowed.
+    const response = await server.request('/items')
+    expect(response.status).toBe(200)
+  })
+
   it('returns 422 when a required body is missing, but passes when an optional body is missing', async () => {
     const requiredDoc = documentWith('/items', 'post', {
       requestBody: {

--- a/packages/mock-server/src/utils/validate-request.test.ts
+++ b/packages/mock-server/src/utils/validate-request.test.ts
@@ -372,4 +372,23 @@ describe('validate-request', () => {
     const valid = await server.request(withoutContentType(JSON.stringify({ name: 'Alice' })))
     expect((await valid.json()).received).toEqual({ name: 'Alice' })
   })
+
+  it('calls onRequest even when the request is rejected by validation', async () => {
+    const document = documentWith('/items', 'get', {
+      parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'integer' } }],
+    })
+
+    const onRequest = vi.fn()
+    const server = await createMockServer({ document, validateRequest: true, onRequest })
+
+    // A rejected request (missing required query param) must still trigger onRequest.
+    const rejected = await server.request('/items')
+    expect(rejected.status).toBe(422)
+    expect(onRequest).toHaveBeenCalledTimes(1)
+
+    // A valid request triggers it exactly once too (no double-invocation from the handler).
+    const ok = await server.request('/items?limit=5')
+    expect(ok.status).toBe(200)
+    expect(onRequest).toHaveBeenCalledTimes(2)
+  })
 })

--- a/packages/mock-server/src/utils/validate-request.test.ts
+++ b/packages/mock-server/src/utils/validate-request.test.ts
@@ -1,0 +1,208 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import Ajv2020 from 'ajv/dist/2020.js'
+import { describe, expect, it, vi } from 'vitest'
+
+import { createMockServer } from '../create-mock-server'
+
+/** Build a tiny document around a single operation for the route under test */
+const documentWith = (path: string, method: string, operation: OpenAPIV3_1.OperationObject) => ({
+  openapi: '3.1.0',
+  info: { title: 'Validation', version: '1.0.0' },
+  paths: {
+    [path]: {
+      [method]: {
+        responses: {
+          '200': {
+            description: 'OK',
+            content: { 'application/json': { example: { ok: true } } },
+          },
+        },
+        ...operation,
+      },
+    },
+  },
+})
+
+describe('validate-request', () => {
+  it('passes a valid request through to the normal mock response', async () => {
+    const document = documentWith('/items', 'get', {
+      parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'integer' } }],
+    })
+
+    const server = await createMockServer({ document, validateRequest: true })
+    const response = await server.request('/items?limit=10')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ ok: true })
+  })
+
+  it('returns 422 with a query violation for a missing required query param', async () => {
+    const document = documentWith('/items', 'get', {
+      parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'integer' } }],
+    })
+
+    const server = await createMockServer({ document, validateRequest: true })
+    const response = await server.request('/items')
+
+    expect(response.status).toBe(422)
+    expect(response.headers.get('Content-Type')).toContain('application/problem+json')
+
+    const body = await response.json()
+    expect(body.error).toBe('Request validation failed')
+    expect(body.violations).toEqual([expect.objectContaining({ location: 'query', path: '/limit' })])
+  })
+
+  it('returns 422 for a wrong-typed query param and coerces a correct one', async () => {
+    const document = documentWith('/items', 'get', {
+      parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'integer' } }],
+    })
+
+    const server = await createMockServer({ document, validateRequest: true })
+
+    const invalid = await server.request('/items?limit=abc')
+    expect(invalid.status).toBe(422)
+    expect((await invalid.json()).violations[0]).toMatchObject({ location: 'query' })
+
+    const valid = await server.request('/items?limit=42')
+    expect(valid.status).toBe(200)
+  })
+
+  it('returns 422 for a wrong-typed path param and coerces a correct one', async () => {
+    const document = documentWith('/items/{id}', 'get', {
+      parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+    })
+
+    const server = await createMockServer({ document, validateRequest: true })
+
+    const invalid = await server.request('/items/abc')
+    expect(invalid.status).toBe(422)
+    expect((await invalid.json()).violations[0]).toMatchObject({ location: 'path' })
+
+    const valid = await server.request('/items/123')
+    expect(valid.status).toBe(200)
+  })
+
+  it('returns 422 with body violations for an invalid JSON body', async () => {
+    const document = documentWith('/items', 'post', {
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              required: ['name'],
+              properties: { name: { type: 'string' }, age: { type: 'integer' } },
+            },
+          },
+        },
+      },
+    })
+
+    const server = await createMockServer({ document, validateRequest: true })
+
+    // Missing required field
+    const missingField = await server.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ age: 30 }),
+    })
+    expect(missingField.status).toBe(422)
+    expect((await missingField.json()).violations).toEqual([expect.objectContaining({ location: 'body' })])
+
+    // Wrong type
+    const wrongType = await server.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Jane', age: 'old' }),
+    })
+    expect(wrongType.status).toBe(422)
+    expect((await wrongType.json()).violations[0]).toMatchObject({ location: 'body', path: '/age' })
+  })
+
+  it('returns 422 when a required body is missing, but passes when an optional body is missing', async () => {
+    const requiredDoc = documentWith('/items', 'post', {
+      requestBody: {
+        required: true,
+        content: { 'application/json': { schema: { type: 'object', properties: { name: { type: 'string' } } } } },
+      },
+    })
+
+    const requiredServer = await createMockServer({ document: requiredDoc, validateRequest: true })
+    const requiredResponse = await requiredServer.request('/items', { method: 'POST' })
+    expect(requiredResponse.status).toBe(422)
+    expect((await requiredResponse.json()).violations[0]).toMatchObject({ location: 'body' })
+
+    const optionalDoc = documentWith('/items', 'post', {
+      requestBody: {
+        required: false,
+        content: { 'application/json': { schema: { type: 'object', properties: { name: { type: 'string' } } } } },
+      },
+    })
+
+    const optionalServer = await createMockServer({ document: optionalDoc, validateRequest: true })
+    const optionalResponse = await optionalServer.request('/items', { method: 'POST' })
+    expect(optionalResponse.status).toBe(200)
+  })
+
+  it('validates by default when validateRequest is unset', async () => {
+    const document = documentWith('/items', 'get', {
+      parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'integer' } }],
+    })
+
+    const server = await createMockServer({ document })
+    const response = await server.request('/items')
+
+    expect(response.status).toBe(422)
+  })
+
+  it('lets invalid requests pass when validateRequest is explicitly false', async () => {
+    const document = documentWith('/items', 'get', {
+      parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'integer' } }],
+    })
+
+    const server = await createMockServer({ document, validateRequest: false })
+    const response = await server.request('/items')
+
+    expect(response.status).toBe(200)
+  })
+
+  it('reuses the compiled validator across requests (no per-request recompilation)', async () => {
+    const document = documentWith('/items', 'get', {
+      parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'integer' } }],
+    })
+
+    // Validators are compiled once at route setup. Spy on Ajv's compile to prove that
+    // making requests does not trigger any further compilation.
+    const compileSpy = vi.spyOn(Ajv2020.prototype, 'compile')
+
+    const server = await createMockServer({ document, validateRequest: true })
+    const compilesAfterSetup = compileSpy.mock.calls.length
+    expect(compilesAfterSetup).toBeGreaterThan(0)
+
+    const first = await server.request('/items?limit=1')
+    const second = await server.request('/items?limit=2')
+    const third = await server.request('/items')
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+    expect(third.status).toBe(422)
+
+    // No additional compilation happened while serving requests.
+    expect(compileSpy.mock.calls.length).toBe(compilesAfterSetup)
+
+    compileSpy.mockRestore()
+  })
+
+  it('does not crash on a malformed schema and falls open', async () => {
+    const document = documentWith('/items', 'get', {
+      // `type` referencing an unknown keyword combination that cannot compile
+      parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'not-a-real-type' } as never }],
+    })
+
+    const server = await createMockServer({ document, validateRequest: true })
+    const response = await server.request('/items')
+
+    // Validation is skipped for this operation, so the request still resolves to the mock.
+    expect(response.status).toBe(200)
+  })
+})

--- a/packages/mock-server/src/utils/validate-request.test.ts
+++ b/packages/mock-server/src/utils/validate-request.test.ts
@@ -373,6 +373,31 @@ describe('validate-request', () => {
     expect((await valid.json()).received).toEqual({ name: 'Alice' })
   })
 
+  it('delivers a validated body to the handler for a mixed-case Content-Type', async () => {
+    const document = documentWith('/items', 'post', {
+      'x-handler': 'return { received: req.body };',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] },
+          },
+        },
+      },
+    })
+
+    const server = await createMockServer({ document, validateRequest: true })
+
+    // Media types are case-insensitive, so the validator and the handler must agree on `Application/JSON`.
+    const response = await server.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'Application/JSON' },
+      body: JSON.stringify({ name: 'Alice' }),
+    })
+
+    expect((await response.json()).received).toEqual({ name: 'Alice' })
+  })
+
   it('calls onRequest even when the request is rejected by validation', async () => {
     const document = documentWith('/items', 'get', {
       parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'integer' } }],

--- a/packages/mock-server/src/utils/validate-request.test.ts
+++ b/packages/mock-server/src/utils/validate-request.test.ts
@@ -144,6 +144,52 @@ describe('validate-request', () => {
     expect(optionalResponse.status).toBe(200)
   })
 
+  it('leaves the JSON body intact for a downstream x-handler', async () => {
+    const document = documentWith('/items', 'post', {
+      'x-handler': 'return { received: req.body };',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] },
+          },
+        },
+      },
+    })
+
+    const server = await createMockServer({ document, validateRequest: true })
+    const response = await server.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Alice' }),
+    })
+
+    // Validation reads the body, but the handler must still see it.
+    expect((await response.json()).received).toEqual({ name: 'Alice' })
+  })
+
+  it('leaves a form body intact for a downstream x-handler', async () => {
+    const document = documentWith('/form', 'post', {
+      'x-handler': 'return { received: req.body };',
+      requestBody: {
+        required: true,
+        content: {
+          'application/x-www-form-urlencoded': { schema: { type: 'object', properties: { name: { type: 'string' } } } },
+        },
+      },
+    })
+
+    const server = await createMockServer({ document, validateRequest: true })
+    const response = await server.request('/form', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: 'name=Alice&age=30',
+    })
+
+    // The body required check reads the stream; `parseBody` downstream must still reconstruct the form.
+    expect((await response.json()).received).toEqual({ name: 'Alice', age: '30' })
+  })
+
   it('validates by default when validateRequest is unset', async () => {
     const document = documentWith('/items', 'get', {
       parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'integer' } }],

--- a/packages/mock-server/src/utils/validate-request.ts
+++ b/packages/mock-server/src/utils/validate-request.ts
@@ -1,0 +1,201 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { getResolvedRefDeep } from '@scalar/workspace-store/helpers/get-resolved-ref-deep'
+import type { ErrorObject, ValidateFunction } from 'ajv'
+import Ajv2020 from 'ajv/dist/2020.js'
+import addFormats from 'ajv-formats'
+import type { Context, MiddlewareHandler } from 'hono'
+
+/** Where a validation violation was found in the request */
+type ViolationLocation = 'body' | 'query' | 'path'
+
+/** A single request validation violation, mapped from an Ajv error */
+type Violation = {
+  location: ViolationLocation
+  /** JSON pointer into the offending value (e.g. `/limit`), empty for top-level errors */
+  path: string
+  message: string
+}
+
+/** The validators compiled once per operation and reused across every request */
+type CompiledValidators = {
+  path: ValidateFunction | null
+  query: ValidateFunction | null
+  body: ValidateFunction | null
+  /** Whether the request body is required by the operation */
+  bodyRequired: boolean
+}
+
+/**
+ * Build a JSON Schema object for the parameters declared `in` the given location.
+ *
+ * Parameters arrive as strings, so the caller compiles these with `coerceTypes: true` to let
+ * `type: integer`/`boolean` validate correctly. Returns `null` when there is nothing to validate.
+ */
+const buildParameterSchema = (
+  parameters: OpenAPIV3_1.OperationObject['parameters'],
+  location: 'path' | 'query',
+): Record<string, unknown> | null => {
+  const properties: Record<string, unknown> = {}
+  const required: string[] = []
+
+  for (const parameterOrRef of parameters ?? []) {
+    const parameter = getResolvedRef(parameterOrRef)
+
+    if (parameter?.in !== location) {
+      continue
+    }
+
+    if (parameter.schema) {
+      properties[parameter.name] = getResolvedRefDeep(parameter.schema)
+    }
+
+    if (parameter.required) {
+      required.push(parameter.name)
+    }
+  }
+
+  if (Object.keys(properties).length === 0 && required.length === 0) {
+    return null
+  }
+
+  // Allow undeclared parameters to pass through; we only enforce what the operation declares.
+  return { type: 'object', properties, required, additionalProperties: true }
+}
+
+/**
+ * Compile the validators for a single operation once, so they can be reused on every request.
+ *
+ * A malformed or uncompilable schema must not crash the server: we log and fall open (skip
+ * validation for that part), consistent with how `x-seed` errors are swallowed during setup.
+ */
+const compileValidators = (operation: OpenAPIV3_1.OperationObject): CompiledValidators => {
+  const validators: CompiledValidators = { path: null, query: null, body: null, bodyRequired: false }
+
+  // Coerce string parameters to their declared types (integer, boolean, …).
+  const parameterAjv = new Ajv2020({ strict: false, allErrors: true, coerceTypes: true })
+  addFormats(parameterAjv)
+
+  // Do not coerce the JSON body; a JSON value already carries its type and coercion would mask errors.
+  const bodyAjv = new Ajv2020({ strict: false, allErrors: true })
+  addFormats(bodyAjv)
+
+  try {
+    const pathSchema = buildParameterSchema(operation.parameters, 'path')
+    if (pathSchema) {
+      validators.path = parameterAjv.compile(pathSchema)
+    }
+
+    const querySchema = buildParameterSchema(operation.parameters, 'query')
+    if (querySchema) {
+      validators.query = parameterAjv.compile(querySchema)
+    }
+
+    const requestBody = getResolvedRef(operation.requestBody)
+    validators.bodyRequired = requestBody?.required === true
+
+    const jsonSchema = getResolvedRef(requestBody?.content?.['application/json'])?.schema
+    if (jsonSchema) {
+      validators.body = bodyAjv.compile(getResolvedRefDeep(jsonSchema))
+    }
+  } catch (error) {
+    // Fail open: a broken schema should never take the mock server down.
+    console.error('Error compiling request validators, skipping validation for this operation:', error)
+    return { path: null, query: null, body: null, bodyRequired: false }
+  }
+
+  return validators
+}
+
+/**
+ * Map Ajv errors into our violation shape. For path/query parameters the offending parameter name
+ * is prepended to the message so the response is readable without cross-referencing the pointer.
+ */
+const mapErrors = (errors: ErrorObject[] | null | undefined, location: ViolationLocation): Violation[] =>
+  (errors ?? []).map((error) => {
+    const missingProperty =
+      typeof error.params === 'object' && error.params && 'missingProperty' in error.params
+        ? String((error.params as { missingProperty?: string }).missingProperty)
+        : ''
+    const path = error.instancePath || (missingProperty ? `/${missingProperty}` : '')
+
+    const name = error.instancePath.replace(/^\//, '') || missingProperty
+    const message = location !== 'body' && name ? `${name} ${error.message ?? ''}`.trim() : (error.message ?? '')
+
+    return { location, path, message }
+  })
+
+/**
+ * Detect whether the request body should be treated as JSON. We only validate JSON bodies in this
+ * slice; an empty/absent Content-Type is treated as JSON to stay forgiving.
+ */
+const isJsonRequest = (c: Context): boolean => {
+  const contentType = c.req.header('Content-Type')?.toLowerCase() ?? ''
+  return contentType === '' || contentType.includes('json')
+}
+
+/**
+ * Create a Hono middleware bound to a single resolved operation that enforces its request contract.
+ *
+ * Validators are compiled once here (at route-setup time) and reused on every request. On any
+ * violation the middleware short-circuits with a `422` and a `application/problem+json` body;
+ * otherwise it calls `next()` and the normal mock handler runs.
+ *
+ * TODO: Parity follow-ups, intentionally deferred in this slice — response validation,
+ * header/cookie parameter validation, non-JSON body validation, and validation proxy mode.
+ */
+export const validateRequest = (operation: OpenAPIV3_1.OperationObject): MiddlewareHandler => {
+  const validators = compileValidators(operation)
+
+  return async (c, next): Promise<Response | void> => {
+    const violations: Violation[] = []
+
+    // Path parameters (coerced from strings)
+    if (validators.path) {
+      const data: Record<string, unknown> = { ...c.req.param() }
+      if (!validators.path(data)) {
+        violations.push(...mapErrors(validators.path.errors, 'path'))
+      }
+    }
+
+    // Query parameters (coerced from strings)
+    if (validators.query) {
+      const data: Record<string, unknown> = { ...c.req.query() }
+      if (!validators.query(data)) {
+        violations.push(...mapErrors(validators.query.errors, 'query'))
+      }
+    }
+
+    // Request body — only `application/json` in this slice
+    if (validators.body || validators.bodyRequired) {
+      const raw = await c.req.text()
+
+      if (!raw) {
+        if (validators.bodyRequired) {
+          violations.push({ location: 'body', path: '', message: 'Request body is required' })
+        }
+      } else if (validators.body && isJsonRequest(c)) {
+        try {
+          const parsed: unknown = JSON.parse(raw)
+          if (!validators.body(parsed)) {
+            violations.push(...mapErrors(validators.body.errors, 'body'))
+          }
+        } catch {
+          if (validators.bodyRequired) {
+            violations.push({ location: 'body', path: '', message: 'Request body must be valid JSON' })
+          }
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      // Use `c.body` (not `c.json`) so the `application/problem+json` content type is preserved;
+      // `c.json` would force `application/json`.
+      return c.body(JSON.stringify({ error: 'Request validation failed', violations }), 422, {
+        'Content-Type': 'application/problem+json',
+      })
+    }
+
+    await next()
+  }
+}

--- a/packages/mock-server/src/utils/validate-request.ts
+++ b/packages/mock-server/src/utils/validate-request.ts
@@ -168,7 +168,10 @@ export const validateRequest = (operation: OpenAPIV3_1.OperationObject): Middlew
 
     // Request body — only `application/json` in this slice
     if (validators.body || validators.bodyRequired) {
-      const raw = await c.req.text()
+      // Read from a clone so the original request stream stays intact for the mock or `x-handler`
+      // downstream. Consuming `c.req.text()` directly would leave `c.req.parseBody()` (used for
+      // form bodies) unable to reconstruct the body, so handlers would see it as undefined.
+      const raw = await c.req.raw.clone().text()
 
       if (!raw) {
         if (validators.bodyRequired) {

--- a/packages/mock-server/src/utils/validate-request.ts
+++ b/packages/mock-server/src/utils/validate-request.ts
@@ -64,12 +64,45 @@ const buildParameterSchema = (
 }
 
 /**
+ * Merge path-item-level parameters with operation-level parameters.
+ *
+ * OpenAPI allows declaring `parameters` on the path item, where they apply to every operation under
+ * it. Operation-level parameters override path-item ones that share the same name and location.
+ */
+const mergeParameters = (
+  pathItemParameters: OpenAPIV3_1.PathItemObject['parameters'],
+  operationParameters: OpenAPIV3_1.OperationObject['parameters'],
+): OpenAPIV3_1.OperationObject['parameters'] => {
+  const byKey = new Map<string, NonNullable<OpenAPIV3_1.OperationObject['parameters']>[number]>()
+
+  // Guard against malformed documents where `parameters` is not an array.
+  const pathItemList = Array.isArray(pathItemParameters) ? pathItemParameters : []
+  const operationList = Array.isArray(operationParameters) ? operationParameters : []
+
+  // Path-item parameters come first so that operation-level entries overwrite them by identity.
+  for (const parameterOrRef of [...pathItemList, ...operationList]) {
+    const parameter = getResolvedRef(parameterOrRef)
+
+    if (!parameter?.name || !parameter.in) {
+      continue
+    }
+
+    byKey.set(`${parameter.in}:${parameter.name}`, parameterOrRef)
+  }
+
+  return [...byKey.values()]
+}
+
+/**
  * Compile the validators for a single operation once, so they can be reused on every request.
  *
  * A malformed or uncompilable schema must not crash the server: we log and fall open (skip
  * validation for that part), consistent with how `x-seed` errors are swallowed during setup.
  */
-const compileValidators = (operation: OpenAPIV3_1.OperationObject): CompiledValidators => {
+const compileValidators = (
+  operation: OpenAPIV3_1.OperationObject,
+  pathItemParameters: OpenAPIV3_1.PathItemObject['parameters'],
+): CompiledValidators => {
   const validators: CompiledValidators = { path: null, query: null, body: null, bodyRequired: false }
 
   // Coerce string parameters to their declared types (integer, boolean, …).
@@ -80,13 +113,16 @@ const compileValidators = (operation: OpenAPIV3_1.OperationObject): CompiledVali
   const bodyAjv = new Ajv2020({ strict: false, allErrors: true })
   addFormats(bodyAjv)
 
+  // Path-item parameters apply to every operation, so fold them in before building the schemas.
+  const parameters = mergeParameters(pathItemParameters, operation.parameters)
+
   try {
-    const pathSchema = buildParameterSchema(operation.parameters, 'path')
+    const pathSchema = buildParameterSchema(parameters, 'path')
     if (pathSchema) {
       validators.path = parameterAjv.compile(pathSchema)
     }
 
-    const querySchema = buildParameterSchema(operation.parameters, 'query')
+    const querySchema = buildParameterSchema(parameters, 'query')
     if (querySchema) {
       validators.query = parameterAjv.compile(querySchema)
     }
@@ -144,8 +180,11 @@ const isJsonRequest = (c: Context): boolean => {
  * TODO: Parity follow-ups, intentionally deferred in this slice — response validation,
  * header/cookie parameter validation, non-JSON body validation, and validation proxy mode.
  */
-export const validateRequest = (operation: OpenAPIV3_1.OperationObject): MiddlewareHandler => {
-  const validators = compileValidators(operation)
+export const validateRequest = (
+  operation: OpenAPIV3_1.OperationObject,
+  pathItemParameters?: OpenAPIV3_1.PathItemObject['parameters'],
+): MiddlewareHandler => {
+  const validators = compileValidators(operation, pathItemParameters)
 
   return async (c, next): Promise<Response | void> => {
     const violations: Violation[] = []
@@ -184,9 +223,9 @@ export const validateRequest = (operation: OpenAPIV3_1.OperationObject): Middlew
             violations.push(...mapErrors(validators.body.errors, 'body'))
           }
         } catch {
-          if (validators.bodyRequired) {
-            violations.push({ location: 'body', path: '', message: 'Request body must be valid JSON' })
-          }
+          // The client sent a non-empty JSON body that cannot be parsed, so it cannot satisfy the
+          // schema regardless of whether the body is required.
+          violations.push({ location: 'body', path: '', message: 'Request body must be valid JSON' })
         }
       }
     }

--- a/packages/mock-server/src/utils/validate-request.ts
+++ b/packages/mock-server/src/utils/validate-request.ts
@@ -94,17 +94,36 @@ const mergeParameters = (
 }
 
 /**
- * Compile the validators for a single operation once, so they can be reused on every request.
+ * Compile a single schema, failing open if it cannot compile.
  *
- * A malformed or uncompilable schema must not crash the server: we log and fall open (skip
- * validation for that part), consistent with how `x-seed` errors are swallowed during setup.
+ * A malformed or uncompilable schema must not crash the server: we log and skip validation for that
+ * part only, consistent with how `x-seed` errors are swallowed during setup. Each schema is compiled
+ * in isolation so one broken schema never disables the others.
+ */
+const compileSchema = (
+  ajv: Ajv2020,
+  schema: Record<string, unknown> | null,
+  label: string,
+): ValidateFunction | null => {
+  if (!schema) {
+    return null
+  }
+
+  try {
+    return ajv.compile(schema)
+  } catch (error) {
+    console.error(`Error compiling ${label} validator, skipping validation for it:`, error)
+    return null
+  }
+}
+
+/**
+ * Compile the validators for a single operation once, so they can be reused on every request.
  */
 const compileValidators = (
   operation: OpenAPIV3_1.OperationObject,
   pathItemParameters: OpenAPIV3_1.PathItemObject['parameters'],
 ): CompiledValidators => {
-  const validators: CompiledValidators = { path: null, query: null, body: null, bodyRequired: false }
-
   // Coerce string parameters to their declared types (integer, boolean, …).
   const parameterAjv = new Ajv2020({ strict: false, allErrors: true, coerceTypes: true })
   addFormats(parameterAjv)
@@ -116,31 +135,23 @@ const compileValidators = (
   // Path-item parameters apply to every operation, so fold them in before building the schemas.
   const parameters = mergeParameters(pathItemParameters, operation.parameters)
 
+  const requestBody = getResolvedRef(operation.requestBody)
+  // Build the body schema defensively; resolving a malformed `$ref` should not crash setup.
+  let bodySchema: Record<string, unknown> | null = null
   try {
-    const pathSchema = buildParameterSchema(parameters, 'path')
-    if (pathSchema) {
-      validators.path = parameterAjv.compile(pathSchema)
-    }
-
-    const querySchema = buildParameterSchema(parameters, 'query')
-    if (querySchema) {
-      validators.query = parameterAjv.compile(querySchema)
-    }
-
-    const requestBody = getResolvedRef(operation.requestBody)
-    validators.bodyRequired = requestBody?.required === true
-
     const jsonSchema = getResolvedRef(requestBody?.content?.['application/json'])?.schema
-    if (jsonSchema) {
-      validators.body = bodyAjv.compile(getResolvedRefDeep(jsonSchema))
-    }
+    bodySchema = jsonSchema ? (getResolvedRefDeep(jsonSchema) as Record<string, unknown>) : null
   } catch (error) {
-    // Fail open: a broken schema should never take the mock server down.
-    console.error('Error compiling request validators, skipping validation for this operation:', error)
-    return { path: null, query: null, body: null, bodyRequired: false }
+    console.error('Error resolving request body schema, skipping body validation:', error)
   }
 
-  return validators
+  return {
+    path: compileSchema(parameterAjv, buildParameterSchema(parameters, 'path'), 'path parameter'),
+    query: compileSchema(parameterAjv, buildParameterSchema(parameters, 'query'), 'query parameter'),
+    body: compileSchema(bodyAjv, bodySchema, 'request body'),
+    // Required-body enforcement is independent of whether the body schema compiles.
+    bodyRequired: requestBody?.required === true,
+  }
 }
 
 /**
@@ -163,11 +174,13 @@ const mapErrors = (errors: ErrorObject[] | null | undefined, location: Violation
 
 /**
  * Detect whether the request body should be treated as JSON. We only validate JSON bodies in this
- * slice; an empty/absent Content-Type is treated as JSON to stay forgiving.
+ * slice; an empty/absent Content-Type is treated as JSON to stay forgiving. This intentionally
+ * mirrors how `build-handler-context` parses the body, so we never validate a body the handler then
+ * fails to deliver as `req.body`.
  */
 const isJsonRequest = (c: Context): boolean => {
   const contentType = c.req.header('Content-Type')?.toLowerCase() ?? ''
-  return contentType === '' || contentType.includes('json')
+  return contentType === '' || contentType.includes('application/json')
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1868,6 +1868,12 @@ importers:
       '@scalar/workspace-store':
         specifier: workspace:*
         version: link:../workspace-store
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.17.1)
       hono:
         specifier: catalog:*
         version: 4.12.9


### PR DESCRIPTION
The mock server now checks incoming requests against your OpenAPI document and returns a `422` (`application/problem+json`) when they break the contract, instead of always handing back a mock response.

It validates path/query parameters (with string→type coercion, so `?limit=10` is a real integer) and `application/json` request bodies. Validators are compiled once per operation, and a bad schema fails open so the server never crashes.

This is on by default. Opt out with `validateRequest: false`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on validation changes behavior for existing clients that sent invalid requests and still got mocks; middleware ordering and body stream handling must stay correct for x-handler routes.
> 
> **Overview**
> **OpenAPI contract validation is now on by default** for `@scalar/mock-server`. Each matched operation runs new middleware (after auth, before mock/`x-handler`) that checks path/query params and `application/json` bodies with Ajv; failures return **422** and **`application/problem+json`** listing all violations instead of a mock response. Opt out with **`validateRequest: false`**.
> 
> Route setup compiles validators once per operation (string params coerced for integer/boolean). **`onRequest`** moved to middleware so it still runs for rejected requests; mock handlers no longer take `MockServerOptions`. **`build-handler-context`** aligns JSON body parsing with validation (case-insensitive `Content-Type`, treat missing type as JSON). Body reads use a cloned stream so downstream handlers still get JSON/form bodies. Uncompilable schemas fail open per validator slice.
> 
> Adds **`ajv`** / **`ajv-formats`**, docs, changeset, and broad integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2def411b816c788aa972e89f860ffcf9c318616d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->