### PR TITLE
fix(mock-server): correct security evaluation and validate credential shape

### DIFF
--- a/.changeset/mock-server-auth-evaluation.md
+++ b/.changeset/mock-server-auth-evaluation.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+Fix security checking: evaluate `security` as OR-of-ANDs, inherit document-level security when an operation defines none, and validate credential shape (well-formed Basic and Bearer)

--- a/packages/mock-server/src/create-mock-server.ts
+++ b/packages/mock-server/src/create-mock-server.ts
@@ -79,8 +79,12 @@ export async function createMockServer(configuration: MockServerOptions): Promis
       const route = honoRouteFromPath(path)
       const operation = pathItem?.[method] as OpenAPIV3_1.OperationObject
 
+      // Operation-level security overrides the global requirement, so fall back to the
+      // document-wide `security` when the operation does not define its own.
+      const effectiveSecurity = operation.security ?? schema?.security
+
       // Check if authentication is required for this operation
-      if (isAuthenticationRequired(operation.security)) {
+      if (isAuthenticationRequired(effectiveSecurity)) {
         app[method](route, handleAuthentication(schema, operation))
       }
 

--- a/packages/mock-server/src/utils/handle-authentication.test.ts
+++ b/packages/mock-server/src/utils/handle-authentication.test.ts
@@ -129,6 +129,18 @@ describe('handleAuthentication', () => {
 
       expect(response.status).toBe(200)
     })
+
+    it('stays unsatisfiable when a scheme name in the requirement is undefined', async () => {
+      // `missingScheme` is not defined in components.securitySchemes, so the AND group
+      // can never be satisfied even when the other credential is provided.
+      const server = await createMockServer({
+        document: documentWith({ operationSecurity: [{ bearerAuth: [], missingScheme: [] }] }),
+      })
+
+      const response = await server.request('/secret', { headers: { Authorization: 'Bearer token-123' } })
+
+      expect(response.status).toBe(401)
+    })
   })
 
   describe('OR semantics (multiple requirement objects)', () => {

--- a/packages/mock-server/src/utils/handle-authentication.test.ts
+++ b/packages/mock-server/src/utils/handle-authentication.test.ts
@@ -1,0 +1,185 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { describe, expect, it } from 'vitest'
+
+import { createMockServer } from '../create-mock-server'
+
+/** Helper to base64-encode `user:password` for Basic auth. */
+const basic = (credentials: string) => `Basic ${btoa(credentials)}`
+
+const securitySchemes: OpenAPIV3_1.ComponentsObject['securitySchemes'] = {
+  basicAuth: { type: 'http', scheme: 'basic' },
+  bearerAuth: { type: 'http', scheme: 'bearer' },
+  apiKeyHeader: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
+  apiKeyQuery: { type: 'apiKey', in: 'query', name: 'api_key' },
+}
+
+const okResponse: OpenAPIV3_1.ResponsesObject = {
+  '200': {
+    description: 'OK',
+    content: { 'application/json': { example: { ok: true } } },
+  },
+}
+
+/** Build a document with a single secured `GET /secret` operation. */
+const documentWith = ({
+  operationSecurity,
+  globalSecurity,
+}: {
+  operationSecurity?: OpenAPIV3_1.SecurityRequirementObject[]
+  globalSecurity?: OpenAPIV3_1.SecurityRequirementObject[]
+}): OpenAPIV3_1.Document => ({
+  openapi: '3.1.1',
+  info: { title: 'Test', version: '1.0.0' },
+  ...(globalSecurity ? { security: globalSecurity } : {}),
+  paths: {
+    '/secret': {
+      get: {
+        ...(operationSecurity ? { security: operationSecurity } : {}),
+        responses: okResponse,
+      },
+    },
+  },
+  components: { securitySchemes },
+})
+
+describe('handleAuthentication', () => {
+  it('rejects a request without credentials', async () => {
+    const server = await createMockServer({ document: documentWith({ operationSecurity: [{ bearerAuth: [] }] }) })
+
+    const response = await server.request('/secret')
+
+    expect(response.status).toBe(401)
+    expect(response.headers.get('WWW-Authenticate')).toContain('Bearer')
+  })
+
+  it('accepts a valid bearer token', async () => {
+    const server = await createMockServer({ document: documentWith({ operationSecurity: [{ bearerAuth: [] }] }) })
+
+    const response = await server.request('/secret', { headers: { Authorization: 'Bearer token-123' } })
+
+    expect(response.status).toBe(200)
+  })
+
+  it('rejects a bearer scheme with an empty token', async () => {
+    const server = await createMockServer({ document: documentWith({ operationSecurity: [{ bearerAuth: [] }] }) })
+
+    const response = await server.request('/secret', { headers: { Authorization: 'Bearer ' } })
+
+    expect(response.status).toBe(401)
+  })
+
+  it('accepts a well-formed basic credential', async () => {
+    const server = await createMockServer({ document: documentWith({ operationSecurity: [{ basicAuth: [] }] }) })
+
+    const response = await server.request('/secret', { headers: { Authorization: basic('user:password') } })
+
+    expect(response.status).toBe(200)
+  })
+
+  it('rejects a basic credential that is not valid base64', async () => {
+    const server = await createMockServer({ document: documentWith({ operationSecurity: [{ basicAuth: [] }] }) })
+
+    const response = await server.request('/secret', { headers: { Authorization: 'Basic not-base64!!' } })
+
+    expect(response.status).toBe(401)
+  })
+
+  it('rejects a basic credential without a colon', async () => {
+    const server = await createMockServer({ document: documentWith({ operationSecurity: [{ basicAuth: [] }] }) })
+
+    const response = await server.request('/secret', { headers: { Authorization: basic('useronly') } })
+
+    expect(response.status).toBe(401)
+  })
+
+  it('accepts an API key in a header', async () => {
+    const server = await createMockServer({ document: documentWith({ operationSecurity: [{ apiKeyHeader: [] }] }) })
+
+    const response = await server.request('/secret', { headers: { 'X-API-Key': 'abc' } })
+
+    expect(response.status).toBe(200)
+  })
+
+  it('accepts an API key in the query string', async () => {
+    const server = await createMockServer({ document: documentWith({ operationSecurity: [{ apiKeyQuery: [] }] }) })
+
+    const response = await server.request('/secret?api_key=abc')
+
+    expect(response.status).toBe(200)
+  })
+
+  describe('AND semantics (multiple schemes in one requirement)', () => {
+    const both: OpenAPIV3_1.SecurityRequirementObject[] = [{ bearerAuth: [], apiKeyHeader: [] }]
+
+    it('requires every scheme in the requirement', async () => {
+      const server = await createMockServer({ document: documentWith({ operationSecurity: both }) })
+
+      // Only the bearer token, missing the API key.
+      const response = await server.request('/secret', { headers: { Authorization: 'Bearer token-123' } })
+
+      expect(response.status).toBe(401)
+    })
+
+    it('passes when every scheme is satisfied', async () => {
+      const server = await createMockServer({ document: documentWith({ operationSecurity: both }) })
+
+      const response = await server.request('/secret', {
+        headers: { Authorization: 'Bearer token-123', 'X-API-Key': 'abc' },
+      })
+
+      expect(response.status).toBe(200)
+    })
+  })
+
+  describe('OR semantics (multiple requirement objects)', () => {
+    const either: OpenAPIV3_1.SecurityRequirementObject[] = [{ bearerAuth: [] }, { apiKeyHeader: [] }]
+
+    it('passes when any requirement is satisfied', async () => {
+      const server = await createMockServer({ document: documentWith({ operationSecurity: either }) })
+
+      const response = await server.request('/secret', { headers: { 'X-API-Key': 'abc' } })
+
+      expect(response.status).toBe(200)
+    })
+
+    it('advertises a challenge for each scheme', async () => {
+      const server = await createMockServer({ document: documentWith({ operationSecurity: either }) })
+
+      const response = await server.request('/secret')
+
+      const challenge = response.headers.get('WWW-Authenticate') ?? ''
+      expect(challenge).toContain('Bearer')
+      expect(challenge).toContain('ApiKey')
+    })
+  })
+
+  describe('global security inheritance', () => {
+    it('enforces document-level security when the operation defines none', async () => {
+      const server = await createMockServer({ document: documentWith({ globalSecurity: [{ bearerAuth: [] }] }) })
+
+      const response = await server.request('/secret')
+
+      expect(response.status).toBe(401)
+    })
+
+    it('lets an operation opt out of global security with an empty array', async () => {
+      const server = await createMockServer({
+        document: documentWith({ globalSecurity: [{ bearerAuth: [] }], operationSecurity: [] }),
+      })
+
+      const response = await server.request('/secret')
+
+      expect(response.status).toBe(200)
+    })
+  })
+
+  it('treats an empty requirement object as optional auth', async () => {
+    const server = await createMockServer({
+      document: documentWith({ operationSecurity: [{ bearerAuth: [] }, {}] }),
+    })
+
+    const response = await server.request('/secret')
+
+    expect(response.status).toBe(200)
+  })
+})

--- a/packages/mock-server/src/utils/handle-authentication.ts
+++ b/packages/mock-server/src/utils/handle-authentication.ts
@@ -149,15 +149,25 @@ export function handleAuthentication(schema?: OpenAPIV3_1.Document, operation?: 
     }
 
     const isAuthenticated = security.some((requirement: OpenAPIV3.SecurityRequirementObject) => {
+      const schemeNames = Object.keys(requirement)
+
       // An empty requirement object makes authentication optional.
-      if (Object.keys(requirement).length === 0) {
+      if (schemeNames.length === 0) {
         return true
       }
 
-      const schemes = resolveSchemes(requirement, schema)
+      // Every scheme listed in the requirement must resolve and be satisfied (AND).
+      // A name that does not resolve to a valid scheme makes the whole requirement
+      // unsatisfiable, so a missing scheme cannot be silently skipped.
+      return schemeNames.every((name) => {
+        const scheme = getResolvedRef(schema?.components?.securitySchemes?.[name])
 
-      // Every scheme in the requirement must be satisfied (AND).
-      return schemes.length > 0 && schemes.every((scheme) => isSchemeSatisfied(scheme, c))
+        if (!scheme || !('type' in scheme)) {
+          return false
+        }
+
+        return isSchemeSatisfied(scheme as OpenAPIV3_1.SecuritySchemeObject, c)
+      })
     })
 
     if (isAuthenticated) {

--- a/packages/mock-server/src/utils/handle-authentication.ts
+++ b/packages/mock-server/src/utils/handle-authentication.ts
@@ -1,130 +1,191 @@
-import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { OpenAPIV3, OpenAPIV3_1 } from '@scalar/openapi-types'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { Context } from 'hono'
 import { getCookie } from 'hono/cookie'
 
+/** Realm advertised in `WWW-Authenticate` challenges. */
+const REALM = 'Scalar Mock Server'
+
+/**
+ * Validate the shape of a `Basic` credential.
+ *
+ * Like Prism, we do not verify the credential against a user store (a mock server
+ * has no way to know valid credentials), but we do check that the header is a
+ * well-formed `Basic <base64(user:password)>` value.
+ */
+function isValidBasicAuth(authHeader?: string): boolean {
+  if (!authHeader?.startsWith('Basic ')) {
+    return false
+  }
+
+  const encoded = authHeader.slice('Basic '.length).trim()
+
+  if (!encoded) {
+    return false
+  }
+
+  try {
+    // A valid Basic credential decodes to `user:password`, so it must contain a colon.
+    return atob(encoded).includes(':')
+  } catch {
+    // `atob` throws on invalid base64.
+    return false
+  }
+}
+
+/**
+ * Validate the shape of a `Bearer` credential.
+ *
+ * We only check that a non-empty token is present after the scheme. Verifying the
+ * token itself (signature, expiry, scopes) is out of scope for a mock server.
+ */
+function isValidBearerAuth(authHeader?: string): boolean {
+  if (!authHeader?.startsWith('Bearer ')) {
+    return false
+  }
+
+  return authHeader.slice('Bearer '.length).trim().length > 0
+}
+
+/** Check whether a single security scheme is satisfied by the request. */
+function isSchemeSatisfied(scheme: OpenAPIV3_1.SecuritySchemeObject, c: Context): boolean {
+  switch (scheme.type) {
+    case 'http': {
+      const authHeader = c.req.header('Authorization')
+
+      if ('scheme' in scheme && scheme.scheme?.toLowerCase() === 'basic') {
+        return isValidBasicAuth(authHeader)
+      }
+
+      if ('scheme' in scheme && scheme.scheme?.toLowerCase() === 'bearer') {
+        return isValidBearerAuth(authHeader)
+      }
+
+      return false
+    }
+    case 'apiKey': {
+      if (!('name' in scheme) || !scheme.name || !('in' in scheme)) {
+        return false
+      }
+
+      const value =
+        scheme.in === 'header'
+          ? c.req.header(scheme.name)
+          : scheme.in === 'query'
+            ? c.req.query(scheme.name)
+            : scheme.in === 'cookie'
+              ? getCookie(c, scheme.name)
+              : undefined
+
+      return Boolean(value)
+    }
+    // OAuth 2.0 and OpenID Connect both carry a bearer token in the `Authorization` header.
+    case 'oauth2':
+    case 'openIdConnect':
+      return isValidBearerAuth(c.req.header('Authorization'))
+    default:
+      return false
+  }
+}
+
+/**
+ * Build the `WWW-Authenticate` challenge for a single security scheme.
+ *
+ * Returns `null` for schemes that do not map to an HTTP authentication challenge.
+ */
+function getChallenge(scheme: OpenAPIV3_1.SecuritySchemeObject): string | null {
+  switch (scheme.type) {
+    case 'http':
+      if ('scheme' in scheme && scheme.scheme?.toLowerCase() === 'basic') {
+        return `Basic realm="${REALM}", charset="UTF-8"`
+      }
+
+      if ('scheme' in scheme && scheme.scheme?.toLowerCase() === 'bearer') {
+        return `Bearer realm="${REALM}", error="invalid_token", error_description="The access token is invalid or has expired"`
+      }
+
+      return null
+    case 'apiKey':
+      if ('name' in scheme && scheme.name) {
+        return `ApiKey realm="${REALM}", error="invalid_token", error_description="Invalid or missing API key", name="${scheme.name}"`
+      }
+
+      return null
+    case 'oauth2':
+    case 'openIdConnect':
+      return `Bearer realm="${REALM}", error="invalid_token", error_description="The access token is invalid or has expired"`
+    default:
+      return null
+  }
+}
+
+/** Resolve all schemes referenced by a single security requirement object. */
+function resolveSchemes(
+  requirement: OpenAPIV3.SecurityRequirementObject,
+  schema?: OpenAPIV3_1.Document,
+): OpenAPIV3_1.SecuritySchemeObject[] {
+  return Object.keys(requirement)
+    .map((name) => getResolvedRef(schema?.components?.securitySchemes?.[name]))
+    .filter((scheme): scheme is OpenAPIV3_1.SecuritySchemeObject => Boolean(scheme) && 'type' in (scheme ?? {}))
+}
+
 /**
  * Handles authentication for incoming requests based on the OpenAPI document.
+ *
+ * The `security` array is evaluated as OR-of-ANDs: the request is authenticated if
+ * *any* requirement object is fully satisfied, and a requirement object is satisfied
+ * only when *every* scheme it lists is satisfied. An empty requirement object (`{}`)
+ * means authentication is optional and always passes.
  */
 export function handleAuthentication(schema?: OpenAPIV3_1.Document, operation?: OpenAPIV3_1.OperationObject) {
   return async (c: Context, next: () => Promise<void>): Promise<Response | void> => {
-    const operationSecuritySchemes = operation?.security || schema?.security
+    // Operation-level security overrides the global security requirement.
+    const security = operation?.security ?? schema?.security
 
-    if (operationSecuritySchemes && operationSecuritySchemes.length > 0) {
-      let isAuthenticated = false
-      let authScheme = ''
+    // Nothing to enforce.
+    if (!security || security.length === 0) {
+      await next()
+      return
+    }
 
-      for (const securityRequirement of operationSecuritySchemes) {
-        let securitySchemeAuthenticated = true
-
-        for (const [schemeName] of Object.entries(securityRequirement)) {
-          const scheme = getResolvedRef(schema?.components?.securitySchemes?.[schemeName])
-
-          if (scheme && 'type' in scheme) {
-            const securityScheme = scheme as OpenAPIV3_1.SecuritySchemeObject
-
-            switch (securityScheme.type) {
-              case 'http':
-                if ('scheme' in securityScheme && securityScheme.scheme === 'basic') {
-                  authScheme = 'Basic'
-                  const authHeader = c.req.header('Authorization')
-
-                  if (authHeader?.startsWith('Basic ')) {
-                    isAuthenticated = true
-                  }
-                } else if ('scheme' in securityScheme && securityScheme.scheme === 'bearer') {
-                  authScheme = 'Bearer'
-                  const authHeader = c.req.header('Authorization')
-
-                  if (authHeader?.startsWith('Bearer ')) {
-                    isAuthenticated = true
-                  }
-                }
-                break
-              case 'apiKey':
-                if ('name' in securityScheme && 'in' in securityScheme && securityScheme.name) {
-                  authScheme = `ApiKey ${securityScheme.name}`
-
-                  if (securityScheme.in === 'header') {
-                    const apiKey = c.req.header(securityScheme.name)
-                    if (apiKey) {
-                      isAuthenticated = true
-                    }
-                  } else if (securityScheme.in === 'query') {
-                    const apiKey = c.req.query(securityScheme.name)
-
-                    if (apiKey) {
-                      isAuthenticated = true
-                    }
-                  } else if (securityScheme.in === 'cookie') {
-                    const apiKey = getCookie(c, securityScheme.name)
-
-                    if (apiKey) {
-                      isAuthenticated = true
-                    }
-                  }
-                }
-                break
-              case 'oauth2':
-                authScheme = 'Bearer'
-                // Handle OAuth 2.0 flows, including password grant
-                if (c.req.header('Authorization')?.startsWith('Bearer ')) {
-                  isAuthenticated = true
-                }
-                break
-              case 'openIdConnect':
-                authScheme = 'Bearer'
-                // Handle OpenID Connect similar to OAuth2
-                if (c.req.header('Authorization')?.startsWith('Bearer ')) {
-                  isAuthenticated = true
-                }
-                break
-            }
-          }
-
-          if (!isAuthenticated) {
-            securitySchemeAuthenticated = false
-            break
-          }
-        }
-
-        if (securitySchemeAuthenticated) {
-          isAuthenticated = true
-          break
-        }
+    const isAuthenticated = security.some((requirement: OpenAPIV3.SecurityRequirementObject) => {
+      // An empty requirement object makes authentication optional.
+      if (Object.keys(requirement).length === 0) {
+        return true
       }
 
-      if (!isAuthenticated) {
-        let wwwAuthenticateValue = authScheme
+      const schemes = resolveSchemes(requirement, schema)
 
-        if (authScheme.startsWith('ApiKey')) {
-          wwwAuthenticateValue += ` realm="Scalar Mock Server", error="invalid_token", error_description="Invalid or missing API key"`
-        } else {
-          switch (authScheme) {
-            case 'Basic':
-              wwwAuthenticateValue += ' realm="Scalar Mock Server", charset="UTF-8"'
-              break
-            case 'Bearer':
-              wwwAuthenticateValue +=
-                ' realm="Scalar Mock Server", error="invalid_token", error_description="The access token is invalid or has expired"'
-              break
-            default:
-              wwwAuthenticateValue = 'Bearer realm="Scalar Mock Server"'
-          }
+      // Every scheme in the requirement must be satisfied (AND).
+      return schemes.length > 0 && schemes.every((scheme) => isSchemeSatisfied(scheme, c))
+    })
+
+    if (isAuthenticated) {
+      await next()
+      return
+    }
+
+    // Advertise a challenge for every scheme that could satisfy the request.
+    const challenges = new Set<string>()
+    for (const requirement of security) {
+      for (const scheme of resolveSchemes(requirement, schema)) {
+        const challenge = getChallenge(scheme)
+        if (challenge) {
+          challenges.add(challenge)
         }
-
-        c.header('WWW-Authenticate', wwwAuthenticateValue)
-        return c.json(
-          {
-            error: 'Unauthorized',
-            message: 'Authentication is required to access this resource.',
-          },
-          401,
-        )
       }
     }
 
-    // If all checks pass, continue to the next middleware
-    await next()
+    for (const challenge of challenges) {
+      c.header('WWW-Authenticate', challenge, { append: true })
+    }
+
+    return c.json(
+      {
+        error: 'Unauthorized',
+        message: 'Authentication is required to access this resource.',
+      },
+      401,
+    )
   }
 }


### PR DESCRIPTION
The mock server's auth checking had a couple of real holes. This tightens it up to behave the way Prism does (shape-checking, not credential verification — a mock can't know real credentials).

**What changed**

- **OR-of-ANDs evaluation.** A requirement object now only passes when *every* scheme in it is present. Before, a shared flag meant `{ bearer, apiKey }` was satisfied by just the bearer.
- **Global security is enforced.** Operations with no `security` of their own now inherit the document-level `security`. Before, the middleware was never attached, so globally-secured APIs let everything through.
- **Credential shape checks.** Basic must decode to `user:password`; Bearer must carry a non-empty token. Empty/garbage values are rejected.
- Emits a `WWW-Authenticate` challenge per relevant scheme.

Added `handle-authentication.test.ts` covering AND/OR semantics, inheritance, opt-out, and the shape checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication middleware behavior for all secured routes; stricter rules may break clients that relied on the previous incorrect OR/AND handling or missing global enforcement, but scope is limited to the mock server with broad test coverage.
> 
> **Overview**
> **Tightens mock-server auth** so OpenAPI `security` is enforced the way the spec describes, and routes pick up document-level requirements when an operation omits its own.
> 
> Route registration now uses **`operation.security ?? schema?.security`** when deciding whether to attach the auth middleware, so globally secured APIs are no longer left open when operations do not declare `security`.
> 
> **`handleAuthentication`** is reworked to evaluate the `security` array as **OR-of-ANDs** (any requirement object can pass; every scheme in that object must be satisfied). Undefined scheme names fail the whole AND group instead of being skipped. **Basic** and **Bearer** (plus OAuth/OIDC bearer-style) credentials must be well-formed—non-empty bearer token, valid base64 Basic with a `user:password` colon—without verifying real secrets. Failed requests emit **multiple `WWW-Authenticate` challenges** (one per relevant scheme) via appended headers.
> 
> Adds **`handle-authentication.test.ts`** for bearer/basic/apiKey, AND/OR semantics, global inheritance, opt-out with `security: []`, and optional `{}` requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca6efc77c726c43d2ccb41284abf43c8536f89f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->