### PR TITLE
fix(api-reference): avoid lh inside calc() to silence postcss-calc warnings

### DIFF
--- a/.changeset/enum-lh-calc-warning.md
+++ b/.changeset/enum-lh-calc-warning.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix(api-reference): stop `lh`-in-`calc()` PostCSS warnings during consumer builds
+
+The enum property decorator used `calc(0.5lh)` and `calc(0.5lh + 4px)`. Older `postcss-calc` versions (pulled in transitively by consumer builds via cssnano) cannot parse the `lh` unit inside `calc()` and emitted parse warnings. The redundant `calc()` is dropped, and the half-line value is kept in a custom property so the reducer skips it. The rendered output is unchanged.

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnumPropertyItem.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnumPropertyItem.vue
@@ -70,13 +70,20 @@ defineProps<{
 .property-enum-value:last-of-type::before,
 .property-enum-values:has(.enum-toggle-button)
   .property-enum-value:nth-last-child(2)::before {
-  height: calc(0.5lh + 4px);
+  /*
+   * The half-line is kept in a custom property so older `postcss-calc`
+   * versions (pulled in transitively by consumer builds via cssnano) skip
+   * reducing this expression instead of warning that they cannot parse the
+   * `lh` unit inside `calc()`.
+   */
+  --enum-decorator-height: 0.5lh;
+  height: calc(var(--enum-decorator-height) + 4px);
 }
 
 .property-enum-value-label::after {
   content: '';
   position: absolute;
-  top: calc(0.5lh);
+  top: 0.5lh;
   left: -12px;
   width: 8px;
   height: var(--decorator-width);


### PR DESCRIPTION
Consumer production builds that embed `@scalar/api-reference` (e.g. the Nuxt example) print PostCSS parse warnings during the build:

```
[warn] [vite:css][postcss] Parse error on line 1:
0.5lh + 4px
-^
Expecting end of input, "ADD", "SUB", "MUL", "DIV", got unexpected "UNKNOWN_DIMENSION"
```

The source is `SchemaEnumPropertyItem.vue`, which styled the enum decorator with `calc(0.5lh)` and `calc(0.5lh + 4px)`. Older `postcss-calc` versions (pulled in transitively via cssnano in those builds) cannot parse the `lh` unit inside `calc()`, so they warn and leave the value untouched.

The fix:
- Drop the redundant `calc()` from `top: calc(0.5lh)` → `top: 0.5lh`.
- Keep the half-line in a custom property (`--enum-decorator-height: 0.5lh`) so the reducer skips the expression instead of trying to parse the `lh` unit.

Rendered output is unchanged — both modern `postcss-calc` and the browser produce identical CSS.

Verified against the exact warning-producing version (`postcss-calc@9.0.1`): both `calc(0.5lh)` and `calc(0.5lh + 4px)` warn, while `top: 0.5lh` and `calc(var(--enum-decorator-height) + 4px)` produce no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)