### PR TITLE
fix(api-reference): avoid Nuxt @unhead/vue import warning

### DIFF
--- a/.changeset/api-reference-unhead-imports-warning.md
+++ b/.changeset/api-reference-unhead-imports-warning.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Stop triggering Nuxt's `Please import from #imports instead` warning by applying SEO meta through unhead's public head injection instead of importing the `useSeoMeta` composable directly

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -127,6 +127,7 @@
     "fuse.js": "catalog:*",
     "microdiff": "catalog:*",
     "nanoid": "catalog:*",
+    "unhead": "^2.1.4",
     "vue": "catalog:*",
     "yaml": "catalog:*"
   },

--- a/packages/api-reference/src/helpers/map-config-to-workspace-store.ts
+++ b/packages/api-reference/src/helpers/map-config-to-workspace-store.ts
@@ -1,9 +1,10 @@
 import { isClient } from '@scalar/api-client/blocks/operation-code-sample'
 import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
-import { useSeoMeta } from '@unhead/vue'
 import { useFavicon } from '@vueuse/core'
 import { type MaybeRefOrGetter, type Ref, computed, toValue, watch } from 'vue'
+
+import { useSeoMeta } from '@/helpers/unhead'
 
 export const mapConfigToWorkspaceStore = ({
   config,

--- a/packages/api-reference/src/helpers/unhead.test.ts
+++ b/packages/api-reference/src/helpers/unhead.test.ts
@@ -1,0 +1,53 @@
+import type { UseSeoMetaInput } from '@unhead/vue'
+import { useSeoMeta as unheadUseSeoMeta } from '@unhead/vue'
+import { createHead, renderSSRHead } from '@unhead/vue/server'
+import { describe, expect, it } from 'vitest'
+import { createApp } from 'vue'
+
+import { useSeoMeta } from './unhead'
+
+const sampleInput: UseSeoMetaInput = {
+  title: 'Scalar',
+  titleTemplate: '%s | API Reference',
+  description: 'Beautiful API references',
+  ogTitle: 'Scalar API Reference',
+  ogDescription: 'Beautiful API references',
+  ogImage: 'https://example.com/preview.png',
+  twitterCard: 'summary_large_image',
+}
+
+/** Apply some SEO meta with the given composable and render the resulting head as SSR markup. */
+const renderHeadWith = async (apply: (input: UseSeoMetaInput) => void) => {
+  const head = createHead()
+  const app = createApp({ render: () => null })
+  app.use(head)
+
+  app.runWithContext(() => apply(sampleInput))
+
+  return await renderSSRHead(head)
+}
+
+describe('useSeoMeta', () => {
+  it('produces the same head tags as @unhead/vue useSeoMeta', async () => {
+    const ours = await renderHeadWith(useSeoMeta)
+    const reference = await renderHeadWith(unheadUseSeoMeta)
+
+    expect(ours.headTags).toBe(reference.headTags)
+  })
+
+  it('renders the expected SEO meta tags', async () => {
+    const { headTags } = await renderHeadWith(useSeoMeta)
+
+    expect(headTags).toContain('<title>Scalar | API Reference</title>')
+    expect(headTags).toContain('name="description" content="Beautiful API references"')
+    expect(headTags).toContain('property="og:title" content="Scalar API Reference"')
+  })
+
+  it('does nothing when no head is provided', () => {
+    const app = createApp({ render: () => null })
+
+    // Without an installed head there is no injection context to push tags into, so this should
+    // simply be a no-op instead of throwing.
+    expect(() => app.runWithContext(() => useSeoMeta(sampleInput))).not.toThrow()
+  })
+})

--- a/packages/api-reference/src/helpers/unhead.ts
+++ b/packages/api-reference/src/helpers/unhead.ts
@@ -1,0 +1,46 @@
+import type { UseSeoMetaInput, VueHeadClient } from '@unhead/vue'
+import { headSymbol } from '@unhead/vue'
+import { FlatMetaPlugin } from 'unhead/plugins'
+import { inject, onScopeDispose } from 'vue'
+
+/**
+ * Apply SEO meta tags to the active unhead instance.
+ *
+ * This mirrors `@unhead/vue`'s `useSeoMeta`, but resolves the head instance through the public
+ * `headSymbol` injection instead of importing the `useSeoMeta` composable directly.
+ *
+ * Nuxt's `unhead` module rewrites any direct `import { useSeoMeta } from '@unhead/vue'` to its
+ * own `#imports` composable and logs a warning whenever it finds such an import in application
+ * code (anything resolved outside of `node_modules`). Because this package is linked into Nuxt
+ * apps as a workspace dependency, Vite resolves its built files to their real path under
+ * `packages/`, so Nuxt treats them as application code and prints:
+ *
+ *   You are importing from `@unhead/vue` in `.../map-config-to-workspace-store.js`.
+ *   Please import from `#imports` instead for full type safety.
+ *
+ * `headSymbol` is not one of the composables Nuxt rewrites, so importing it keeps the warning
+ * away while staying framework-agnostic for every other integration. The head is provided under
+ * `headSymbol` by both Nuxt and our own standalone setup (`createHead()` + `app.use(head)`).
+ */
+export const useSeoMeta = (input: UseSeoMetaInput) => {
+  const head = inject<VueHeadClient | null>(headSymbol, null)
+
+  // The head is only missing when the reference renders without an unhead context, for example
+  // inside a host app that never installed it. There is nothing to update in that case.
+  if (!head) {
+    return
+  }
+
+  head.use(FlatMetaPlugin)
+
+  const { title, titleTemplate, ...meta } = input
+
+  // `_flatMeta` is the internal input key `FlatMetaPlugin` expands into individual SEO meta tags.
+  // This is exactly what `@unhead/vue`'s `useSeoMeta` pushes under the hood.
+  const entry = head.push({ title, titleTemplate, _flatMeta: meta } as Parameters<typeof head.push>[0])
+
+  // Remove the entry again when the surrounding effect scope is disposed, matching `useSeoMeta`.
+  // `failSilently` keeps this safe when called outside of a component setup (for example on the
+  // server), where there is no scope to attach to.
+  onScopeDispose(() => entry.dispose(), true)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1432,6 +1432,9 @@ importers:
       nanoid:
         specifier: catalog:*
         version: 5.1.6
+      unhead:
+        specifier: ^2.1.4
+        version: 2.1.12
       vue:
         specifier: catalog:*
         version: 3.5.30(typescript@5.9.3)


### PR DESCRIPTION
Using `@scalar/api-reference` inside a Nuxt app logs this on dev:

```
[warn] [nuxt] You are importing from `@unhead/vue` in `.../packages/api-reference/dist/helpers/map-config-to-workspace-store.js`. Please import from `#imports` instead for full type safety.
```

Nuxt's unhead module rewrites direct `useSeoMeta`/`useHead`/… imports from `@unhead/vue` to its own `#imports` composable, and warns whenever it finds such an import in application code (anything resolved outside of `node_modules`). When this package is linked into a Nuxt app as a workspace dependency, Vite resolves its built files to their real path under `packages/`, so Nuxt treats them as app code and warns.

Instead of importing the `useSeoMeta` composable directly, the SEO meta is now applied through unhead's public `headSymbol` injection — which is the same head instance both Nuxt and our own standalone setup provide. `headSymbol` is not one of the composables Nuxt rewrites, so the warning is gone while every other integration keeps working unchanged.

A test renders the head via SSR and asserts the output is identical to `@unhead/vue`'s own `useSeoMeta`, so the inline stays faithful if unhead's internals change.