### PR TITLE
fix(docs): don’t duplicate page title

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -6,7 +6,6 @@
     "description": "Guides for Scalar, covering your favorite frameworks, languages and use cases."
   },
   "assetsDir": "documentation/assets",
-  "insertPageTitles": false,
   "siteConfig": {
     "subdomain": "scalar",
     "customDomain": "scalar.com",


### PR DESCRIPTION
## Problem

no more insertPageTitles!

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line site config cleanup with no application code changes; only possible impact is default page title rendering if the removed option still had effect in production.
> 
> **Overview**
> Removes the root-level **`insertPageTitles`** setting from **`scalar.config.json`**, which had been set to **`false`**.
> 
> That flag is no longer used in this project’s Docs config (per-page **`layout.pageTitle`** remains available where needed, e.g. on the Customers page). After this change, title behavior follows the current Scalar Docs defaults instead of the old global override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2fcd2aabf8a60b5ca29992b4ee9ed0e7a257679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->