### PR TITLE
docs(pricing): add Agent Scalar credits to Pro and Enterprise overview cards

### DIFF
--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -56,11 +56,11 @@
         </li>
         <li>
           <scalar-icon src="phosphor/bold/check"></scalar-icon>
-          SDKs in every supported language
+          500 Agent Scalar credits
         </li>
         <li>
           <scalar-icon src="phosphor/bold/check"></scalar-icon>
-          Hosted MCP servers
+          SDKs and hosted MCP servers
         </li>
         <li>
           <scalar-icon src="phosphor/bold/check"></scalar-icon>
@@ -86,7 +86,7 @@
         </li>
         <li>
           <scalar-icon src="phosphor/bold/check"></scalar-icon>
-          Priority support and SLAs
+          Custom Agent Scalar credits
         </li>
         <li>
           <scalar-icon src="phosphor/bold/check"></scalar-icon>
@@ -94,7 +94,7 @@
         </li>
         <li>
           <scalar-icon src="phosphor/bold/check"></scalar-icon>
-          Dedicated Slack/Teams channel
+          Priority support with dedicated channel
         </li>
       </ul>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The pricing overview cards on the pricing page were missing Agent Scalar credits information for the Pro and Enterprise plans. The Free plan showed "50 Agent Scalar credits" but Pro and Enterprise cards did not display their respective credit allocations, even though the detailed pricing table below had this information.

## Solution

Added Agent Scalar credits to the overview cards:
- **Pro plan**: Added "500 Agent Scalar credits" and combined "SDKs in every supported language" with "Hosted MCP servers" into "SDKs and hosted MCP servers" to maintain the 5-item layout
- **Enterprise plan**: Added "Custom Agent Scalar credits" and combined "Priority support and SLAs" with "Dedicated Slack/Teams channel" into "Priority support with dedicated channel"

This ensures the overview cards are consistent with the detailed pricing table and highlights the Agent Scalar credits feature prominently for all plan tiers.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed for documentation content changes -->
- [ ] I added tests. <!-- Not applicable for documentation content -->
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07SL9L6SJ0/p1781039234087379?thread_ts=1781039234.087379&cid=C07SL9L6SJ0)

<div><a href="https://cursor.com/agents/bc-91f4a2ab-fc2b-540e-aec6-abcc2a81d3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91f4a2ab-fc2b-540e-aec6-abcc2a81d3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

