### PR TITLE
feat(api-reference): add content.start plugin view slot and sidebar visibility option

### DIFF
--- a/.changeset/add-content-start-view-and-plugin-sidebar.md
+++ b/.changeset/add-content-start-view-and-plugin-sidebar.md
@@ -7,4 +7,4 @@
 Add `content.start` plugin view slot and `sidebar` visibility option for plugin view components.
 
 - **`content.start`**: A new view slot that renders custom plugin components **before** the Introduction/Info section (at the top of the content area).
-- **`sidebar` option on `ViewComponent`**: Plugins can now opt-in to display a sidebar entry for their custom views by providing `sidebar: { show: true, label: 'My Page' }`. Omitting `sidebar` or setting `show: false` hides the entry from the sidebar.
+- **`sidebar` option on `ViewComponent`**: Plugins can now opt-in to display a sidebar entry for their custom views by providing `sidebar: { show: true, label: 'My Page' }`. Omitting `sidebar` or setting `show: false` hides the entry from the sidebar. The entry hooks into the existing navigation, so clicking it scrolls to the plugin view and it highlights as it scrolls into view.

--- a/.changeset/add-content-start-view-and-plugin-sidebar.md
+++ b/.changeset/add-content-start-view-and-plugin-sidebar.md
@@ -1,0 +1,10 @@
+---
+'@scalar/api-reference': minor
+'@scalar/types': minor
+'@scalar/schemas': minor
+---
+
+Add `content.start` plugin view slot and `sidebar` visibility option for plugin view components.
+
+- **`content.start`**: A new view slot that renders custom plugin components **before** the Introduction/Info section (at the top of the content area).
+- **`sidebar` option on `ViewComponent`**: Plugins can now opt-in to display a sidebar entry for their custom views by providing `sidebar: { show: true, label: 'My Page' }`. Omitting `sidebar` or setting `show: false` hides the entry from the sidebar.

--- a/documentation/plugins.md
+++ b/documentation/plugins.md
@@ -125,7 +125,23 @@ Plugins can inject components at specific locations in the API Reference using v
 
 #### Available Views
 
+- `content.start` - Before the Introduction/Info section
 - `content.end` - After the Models section
+
+#### Sidebar Visibility
+
+View components can optionally appear in the sidebar. Add a `sidebar` configuration to control this:
+
+```typescript
+{
+  component: CustomComponent,
+  sidebar: {
+    show: true,       // true = visible in sidebar, false/omitted = hidden
+    label: 'My Page', // Display text in the sidebar
+    icon: 'book',     // Optional icon name
+  },
+}
+```
 
 #### Example
 
@@ -139,9 +155,20 @@ export const FeedbackPlugin = (): ApiReferencePlugin => {
       name: 'feedback-plugin',
       extensions: [],
       views: {
+        'content.start': [
+          {
+            component: CustomComponent,
+            // Show in sidebar
+            sidebar: {
+              show: true,
+              label: 'Getting Started',
+            },
+          },
+        ],
         'content.end': [
           {
             component: CustomComponent,
+            // Not shown in sidebar (omitted)
           },
         ],
       },
@@ -172,6 +199,34 @@ export const FeedbackPlugin = (): ApiReferencePlugin => {
           {
             component: CustomComponent,
             renderer: ReactRenderer,
+          },
+        ],
+      },
+    }
+  }
+}
+```
+
+With sidebar visibility:
+
+```typescript
+import { ReactRenderer } from '@scalar/react-renderer'
+import { CustomComponent } from './components/CustomComponent'
+
+export const FeedbackPlugin = (): ApiReferencePlugin => {
+  return () => {
+    return {
+      name: 'feedback-plugin',
+      extensions: [],
+      views: {
+        'content.start': [
+          {
+            component: CustomComponent,
+            renderer: ReactRenderer,
+            sidebar: {
+              show: true,
+              label: 'Support',
+            },
           },
         ],
       },

--- a/documentation/plugins.md
+++ b/documentation/plugins.md
@@ -130,7 +130,7 @@ Plugins can inject components at specific locations in the API Reference using v
 
 #### Sidebar Visibility
 
-View components can optionally appear in the sidebar. Add a `sidebar` configuration to control this:
+View components can optionally appear in the sidebar. Add a `sidebar` configuration to control this. Clicking the entry scrolls to the component, and the entry highlights as it scrolls into view, just like the built-in sections.
 
 ```typescript
 {
@@ -138,7 +138,6 @@ View components can optionally appear in the sidebar. Add a `sidebar` configurat
   sidebar: {
     show: true,       // true = visible in sidebar, false/omitted = hidden
     label: 'My Page', // Display text in the sidebar
-    icon: 'book',     // Optional icon name
   },
 }
 ```

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -379,19 +379,21 @@ const activeSearchableDocument = computed(
  * navigation and scroll-spy logic can scroll to and highlight it. Plugins are static for
  * the lifetime of the manager, so this only needs to be resolved once.
  */
-const pluginSidebarEntries = pluginManager
-  .getSidebarEntries()
-  .reduce<Record<'content.start' | 'content.end', TraversedEntry[]>>(
-    (grouped, entry) => {
-      grouped[entry.viewName].push({
-        id: entry.id,
-        title: entry.label,
-        type: 'text',
-      })
-      return grouped
-    },
-    { 'content.start': [], 'content.end': [] },
-  )
+const pluginSidebarEntries = computed(() =>
+  pluginManager
+    .getSidebarEntries(activeSlug.value)
+    .reduce<Record<'content.start' | 'content.end', TraversedEntry[]>>(
+      (grouped, entry) => {
+        grouped[entry.viewName].push({
+          id: entry.id,
+          title: entry.label,
+          type: 'text',
+        })
+        return grouped
+      },
+      { 'content.start': [], 'content.end': [] },
+    ),
+)
 
 /**
  * Create top level sidebar entries for each document
@@ -408,9 +410,9 @@ const itemsFromWorkspace = computed<TraversedEntry[]>(() => {
       const childrenWithPlugins =
         slug === activeSlug.value
           ? [
-              ...pluginSidebarEntries['content.start'],
+              ...pluginSidebarEntries.value['content.start'],
               ...children,
-              ...pluginSidebarEntries['content.end'],
+              ...pluginSidebarEntries.value['content.end'],
             ]
           : children
 
@@ -1276,6 +1278,7 @@ const showMCPButton = computed(() => {
           :authStore="clientStore.auth"
           :clientDocument="clientStore.workspace.activeDocument"
           :document="workspaceStore.workspace.activeDocument"
+          :documentSlug="activeSlug"
           :environment
           :eventBus
           :expandedItems="sidebarState.expandedItems.value"

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -373,20 +373,56 @@ const activeSearchableDocument = computed(
 )
 
 /**
+ * Sidebar entries contributed by plugin views (content.start / content.end).
+ *
+ * Each entry reuses the same id as the rendered plugin component, so the existing
+ * navigation and scroll-spy logic can scroll to and highlight it. Plugins are static for
+ * the lifetime of the manager, so this only needs to be resolved once.
+ */
+const pluginSidebarEntries = pluginManager
+  .getSidebarEntries()
+  .reduce<Record<'content.start' | 'content.end', TraversedEntry[]>>(
+    (grouped, entry) => {
+      grouped[entry.viewName].push({
+        id: entry.id,
+        title: entry.label,
+        type: 'text',
+      })
+      return grouped
+    },
+    { 'content.start': [], 'content.end': [] },
+  )
+
+/**
  * Create top level sidebar entries for each document
  * This allows sharing a single sidebar state for across the workspace
  */
 const itemsFromWorkspace = computed<TraversedEntry[]>(() => {
   return Object.entries(workspaceStore.workspace.documents).map(
-    ([slug, document]) => ({
-      id: slug,
-      type: 'document',
-      description: document.info.description,
-      name: document.info.title ?? slug,
-      title: document.info.title ?? slug,
+    ([slug, document]) => {
       // Both OpenAPI and AsyncAPI documents carry an `x-scalar-navigation` tree.
-      children: document['x-scalar-navigation']?.children ?? [],
-    }),
+      const children = document['x-scalar-navigation']?.children ?? []
+
+      // Plugin views render once for the active document, so only surface their sidebar
+      // entries there. `content.start` sits above the Introduction, `content.end` below.
+      const childrenWithPlugins =
+        slug === activeSlug.value
+          ? [
+              ...pluginSidebarEntries['content.start'],
+              ...children,
+              ...pluginSidebarEntries['content.end'],
+            ]
+          : children
+
+      return {
+        id: slug,
+        type: 'document',
+        description: document.info.description,
+        name: document.info.title ?? slug,
+        title: document.info.title ?? slug,
+        children: childrenWithPlugins,
+      }
+    },
   )
 })
 

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -199,6 +199,11 @@ onMounted(() => {
   <div class="narrow-references-container">
     <slot name="start" />
 
+    <!-- Render plugins at content.start view -->
+    <RenderPlugins
+      :options
+      viewName="content.start" />
+
     <!-- Introduction -->
 
     <InfoBlock

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -201,6 +201,7 @@ onMounted(() => {
 
     <!-- Render plugins at content.start view -->
     <RenderPlugins
+      :eventBus
       :options
       viewName="content.start" />
 
@@ -311,6 +312,7 @@ onMounted(() => {
 
     <!-- Render plugins at content.end view -->
     <RenderPlugins
+      :eventBus
       :options
       viewName="content.end" />
 

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -56,8 +56,11 @@ const {
   eventBus,
   options,
   authStore,
+  documentSlug,
 } = defineProps<{
   infoSectionId: string
+  /** Slug of the active document, used to scope plugin view ids for navigation and deep-linking */
+  documentSlug: string
   /** The subset of the configuration object required for the content component */
   options: Pick<
     ApiReferenceConfigurationRaw,
@@ -201,6 +204,7 @@ onMounted(() => {
 
     <!-- Render plugins at content.start view -->
     <RenderPlugins
+      :documentSlug
       :eventBus
       :options
       viewName="content.start" />
@@ -312,6 +316,7 @@ onMounted(() => {
 
     <!-- Render plugins at content.end view -->
     <RenderPlugins
+      :documentSlug
       :eventBus
       :options
       viewName="content.end" />

--- a/packages/api-reference/src/components/RenderPlugins/RenderPluginView.vue
+++ b/packages/api-reference/src/components/RenderPlugins/RenderPluginView.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { ScalarErrorBoundary } from '@scalar/components/error-boundary'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { useTemplateRef } from 'vue'
+
+import { useIntersection } from '@/hooks/use-intersection'
+import type { PluginViewComponent } from '@/plugins'
+
+const { item, options, eventBus } = defineProps<{
+  item: PluginViewComponent
+  options: Record<string, any>
+  eventBus?: WorkspaceEventBus
+}>()
+
+const el = useTemplateRef<HTMLElement>('el')
+
+/**
+ * Participate in the existing scroll-spy. We only emit when the view opts into a sidebar
+ * entry, because otherwise we would select a navigation item that does not exist and clear
+ * the currently active section as the user scrolls past the plugin view.
+ */
+useIntersection(el, () => {
+  if (item.sidebar?.show) {
+    eventBus?.emit('intersecting:nav-item', { id: item.id })
+  }
+})
+</script>
+
+<template>
+  <!-- The id mirrors the sidebar entry id so navigation can scroll to this element -->
+  <div
+    :id="item.id"
+    ref="el">
+    <ScalarErrorBoundary>
+      <template v-if="item.renderer">
+        <!-- Custom renderer (e.g. React) -->
+        <component
+          :is="item.renderer"
+          v-bind="{
+            component: item.component,
+            options,
+            ...item.props,
+          }" />
+      </template>
+      <template v-else>
+        <!-- Vue component -->
+        <component
+          :is="item.component"
+          v-bind="{ options, ...item.props }" />
+      </template>
+    </ScalarErrorBoundary>
+  </div>
+</template>

--- a/packages/api-reference/src/components/RenderPlugins/RenderPlugins.test.ts
+++ b/packages/api-reference/src/components/RenderPlugins/RenderPlugins.test.ts
@@ -32,6 +32,7 @@ describe('RenderPlugins', () => {
         props: {
           viewName: 'content.end',
           options: mockOptions,
+          documentSlug: 'my-doc',
         },
       })
 
@@ -64,6 +65,7 @@ describe('RenderPlugins', () => {
         props: {
           viewName: 'content.end',
           options: mockOptions,
+          documentSlug: 'my-doc',
         },
       })
 
@@ -100,6 +102,7 @@ describe('RenderPlugins', () => {
         props: {
           viewName: 'content.end',
           options: mockOptions,
+          documentSlug: 'my-doc',
         },
       })
 
@@ -141,6 +144,7 @@ describe('RenderPlugins', () => {
         props: {
           viewName: 'content.end',
           options: mockOptions,
+          documentSlug: 'my-doc',
         },
       })
 
@@ -184,6 +188,7 @@ describe('RenderPlugins', () => {
         props: {
           viewName: 'content.end',
           options: mockOptions,
+          documentSlug: 'my-doc',
         },
       })
 
@@ -232,6 +237,7 @@ describe('RenderPlugins', () => {
         props: {
           viewName: 'content.end',
           options: mockOptions,
+          documentSlug: 'my-doc',
         },
       })
 
@@ -281,6 +287,7 @@ describe('RenderPlugins', () => {
         props: {
           viewName: 'content.end',
           options: mockOptions,
+          documentSlug: 'my-doc',
         },
       })
 
@@ -324,6 +331,7 @@ describe('RenderPlugins', () => {
         props: {
           viewName: 'content.end',
           options: mockOptions,
+          documentSlug: 'my-doc',
         },
       })
 
@@ -355,6 +363,7 @@ describe('RenderPlugins', () => {
         props: {
           viewName: 'content.end',
           options: mockOptions,
+          documentSlug: 'my-doc',
         },
       })
 
@@ -386,10 +395,11 @@ describe('RenderPlugins', () => {
         props: {
           viewName: 'content.end',
           options: mockOptions,
+          documentSlug: 'my-doc',
         },
       })
 
-      expect(getViewComponentsMock).toHaveBeenCalledWith('content.end')
+      expect(getViewComponentsMock).toHaveBeenCalledWith('content.end', 'my-doc')
       expect(getViewComponentsMock).toHaveBeenCalledTimes(1)
     })
 
@@ -411,10 +421,11 @@ describe('RenderPlugins', () => {
           // @ts-expect-error just for the test
           viewName: 'custom.view.name',
           options: mockOptions,
+          documentSlug: 'my-doc',
         },
       })
 
-      expect(getViewComponentsMock).toHaveBeenCalledWith('custom.view.name')
+      expect(getViewComponentsMock).toHaveBeenCalledWith('custom.view.name', 'my-doc')
     })
   })
 
@@ -429,7 +440,7 @@ describe('RenderPlugins', () => {
       vi.mocked(usePluginManager).mockReturnValue({
         getViewComponents: vi.fn().mockReturnValue([
           {
-            id: 'plugin-view/my-plugin/content.start/0',
+            id: 'my-doc/plugin-view/my-plugin/content.start/0',
             component: TestComponent,
             sidebar: { show: true, label: 'Getting Started' },
           },
@@ -446,11 +457,12 @@ describe('RenderPlugins', () => {
         props: {
           viewName: 'content.start',
           options: mockOptions,
+          documentSlug: 'my-doc',
         },
       })
 
       // The wrapper id mirrors the sidebar entry id so scroll navigation can find it
-      expect(wrapper.find('[id="plugin-view/my-plugin/content.start/0"]').exists()).toBe(true)
+      expect(wrapper.find('[id="my-doc/plugin-view/my-plugin/content.start/0"]').exists()).toBe(true)
     })
   })
 
@@ -475,6 +487,7 @@ describe('RenderPlugins', () => {
         props: {
           viewName: 'content.end',
           options: mockOptions,
+          documentSlug: 'my-doc',
         },
       })
 
@@ -503,6 +516,7 @@ describe('RenderPlugins', () => {
         props: {
           viewName: 'content.end',
           options: {},
+          documentSlug: 'my-doc',
         },
       })
 
@@ -532,6 +546,7 @@ describe('RenderPlugins', () => {
         props: {
           viewName: 'content.end',
           options: mockOptions,
+          documentSlug: 'my-doc',
         },
       })
 

--- a/packages/api-reference/src/components/RenderPlugins/RenderPlugins.test.ts
+++ b/packages/api-reference/src/components/RenderPlugins/RenderPlugins.test.ts
@@ -25,6 +25,7 @@ describe('RenderPlugins', () => {
         notifyConfigChange: vi.fn(),
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -56,6 +57,7 @@ describe('RenderPlugins', () => {
         notifyConfigChange: vi.fn(),
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -91,6 +93,7 @@ describe('RenderPlugins', () => {
         notifyConfigChange: vi.fn(),
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -131,6 +134,7 @@ describe('RenderPlugins', () => {
         notifyConfigChange: vi.fn(),
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
       })
 
       mount(RenderPlugins, {
@@ -173,6 +177,7 @@ describe('RenderPlugins', () => {
         notifyConfigChange: vi.fn(),
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
       })
 
       mount(RenderPlugins, {
@@ -220,6 +225,7 @@ describe('RenderPlugins', () => {
         notifyConfigChange: vi.fn(),
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
       })
 
       mount(RenderPlugins, {
@@ -268,6 +274,7 @@ describe('RenderPlugins', () => {
         notifyConfigChange: vi.fn(),
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -310,6 +317,7 @@ describe('RenderPlugins', () => {
         notifyConfigChange: vi.fn(),
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -340,6 +348,7 @@ describe('RenderPlugins', () => {
         notifyConfigChange: vi.fn(),
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -370,6 +379,7 @@ describe('RenderPlugins', () => {
         notifyConfigChange: vi.fn(),
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
       })
 
       mount(RenderPlugins, {
@@ -393,6 +403,7 @@ describe('RenderPlugins', () => {
         notifyConfigChange: vi.fn(),
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
       })
 
       mount(RenderPlugins, {
@@ -421,6 +432,7 @@ describe('RenderPlugins', () => {
         notifyConfigChange: vi.fn(),
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -448,6 +460,7 @@ describe('RenderPlugins', () => {
         notifyConfigChange: vi.fn(),
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -476,6 +489,7 @@ describe('RenderPlugins', () => {
         notifyConfigChange: vi.fn(),
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
       })
 
       const wrapper = mount(RenderPlugins, {

--- a/packages/api-reference/src/components/RenderPlugins/RenderPlugins.test.ts
+++ b/packages/api-reference/src/components/RenderPlugins/RenderPlugins.test.ts
@@ -418,6 +418,42 @@ describe('RenderPlugins', () => {
     })
   })
 
+  describe('navigation wiring', () => {
+    it('renders each view with its id so navigation can scroll to it', () => {
+      const TestComponent = {
+        name: 'TestComponent',
+        template: '<div class="test-component">Test</div>',
+        props: ['options'],
+      }
+
+      vi.mocked(usePluginManager).mockReturnValue({
+        getViewComponents: vi.fn().mockReturnValue([
+          {
+            id: 'plugin-view/my-plugin/content.start/0',
+            component: TestComponent,
+            sidebar: { show: true, label: 'Getting Started' },
+          },
+        ]),
+        getSpecificationExtensions: vi.fn(),
+        notifyInit: vi.fn(),
+        notifyConfigChange: vi.fn(),
+        notifyDestroy: vi.fn(),
+        getApiClientPlugins: vi.fn().mockReturnValue([]),
+        getSidebarEntries: vi.fn().mockReturnValue([]),
+      })
+
+      const wrapper = mount(RenderPlugins, {
+        props: {
+          viewName: 'content.start',
+          options: mockOptions,
+        },
+      })
+
+      // The wrapper id mirrors the sidebar entry id so scroll navigation can find it
+      expect(wrapper.find('[id="plugin-view/my-plugin/content.start/0"]').exists()).toBe(true)
+    })
+  })
+
   describe('edge cases', () => {
     it('handles components with no props gracefully', () => {
       const TestComponent = {

--- a/packages/api-reference/src/components/RenderPlugins/RenderPlugins.vue
+++ b/packages/api-reference/src/components/RenderPlugins/RenderPlugins.vue
@@ -1,18 +1,21 @@
 <script setup lang="ts">
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { computed } from 'vue'
 
 import { usePluginManager } from '@/plugins'
 
 import RenderPluginView from './RenderPluginView.vue'
 
-const { viewName, options, eventBus } = defineProps<{
+const { viewName, options, eventBus, documentSlug } = defineProps<{
   viewName: 'content.start' | 'content.end'
   options: Record<string, any>
   eventBus?: WorkspaceEventBus
+  /** Slug of the active document, used to scope plugin view ids for navigation and deep-linking */
+  documentSlug: string
 }>()
 
 const { getViewComponents } = usePluginManager()
-const components = getViewComponents(viewName)
+const components = computed(() => getViewComponents(viewName, documentSlug))
 </script>
 
 <template>

--- a/packages/api-reference/src/components/RenderPlugins/RenderPlugins.vue
+++ b/packages/api-reference/src/components/RenderPlugins/RenderPlugins.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
-import { ScalarErrorBoundary } from '@scalar/components/error-boundary'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 
 import { usePluginManager } from '@/plugins'
 
-const { viewName, options } = defineProps<{
+import RenderPluginView from './RenderPluginView.vue'
+
+const { viewName, options, eventBus } = defineProps<{
   viewName: 'content.start' | 'content.end'
   options: Record<string, any>
+  eventBus?: WorkspaceEventBus
 }>()
 
 const { getViewComponents } = usePluginManager()
@@ -13,32 +16,14 @@ const components = getViewComponents(viewName)
 </script>
 
 <template>
-  <template v-if="components.length">
-    <div class="plugin-view">
-      <template
-        v-for="(item, _index) in components"
-        :key="_index">
-        <ScalarErrorBoundary>
-          <div :id="`plugin-view-${viewName}-${_index}`">
-            <template v-if="item.renderer">
-              <!-- Custom renderer (e.g. React) -->
-              <component
-                :is="item.renderer"
-                v-bind="{
-                  component: item.component,
-                  options,
-                  ...item.props,
-                }" />
-            </template>
-            <template v-else>
-              <!-- Vue component -->
-              <component
-                :is="item.component"
-                v-bind="{ options, ...item.props }" />
-            </template>
-          </div>
-        </ScalarErrorBoundary>
-      </template>
-    </div>
-  </template>
+  <div
+    v-if="components.length"
+    class="plugin-view">
+    <RenderPluginView
+      v-for="item in components"
+      :key="item.id"
+      :eventBus="eventBus"
+      :item="item"
+      :options="options" />
+  </div>
 </template>

--- a/packages/api-reference/src/components/RenderPlugins/RenderPlugins.vue
+++ b/packages/api-reference/src/components/RenderPlugins/RenderPlugins.vue
@@ -4,7 +4,7 @@ import { ScalarErrorBoundary } from '@scalar/components/error-boundary'
 import { usePluginManager } from '@/plugins'
 
 const { viewName, options } = defineProps<{
-  viewName: 'content.end'
+  viewName: 'content.start' | 'content.end'
   options: Record<string, any>
 }>()
 
@@ -19,22 +19,24 @@ const components = getViewComponents(viewName)
         v-for="(item, _index) in components"
         :key="_index">
         <ScalarErrorBoundary>
-          <template v-if="item.renderer">
-            <!-- Custom renderer (e.g. React) -->
-            <component
-              :is="item.renderer"
-              v-bind="{
-                component: item.component,
-                options,
-                ...item.props,
-              }" />
-          </template>
-          <template v-else>
-            <!-- Vue component -->
-            <component
-              :is="item.component"
-              v-bind="{ options, ...item.props }" />
-          </template>
+          <div :id="`plugin-view-${viewName}-${_index}`">
+            <template v-if="item.renderer">
+              <!-- Custom renderer (e.g. React) -->
+              <component
+                :is="item.renderer"
+                v-bind="{
+                  component: item.component,
+                  options,
+                  ...item.props,
+                }" />
+            </template>
+            <template v-else>
+              <!-- Vue component -->
+              <component
+                :is="item.component"
+                v-bind="{ options, ...item.props }" />
+            </template>
+          </div>
         </ScalarErrorBoundary>
       </template>
     </div>

--- a/packages/api-reference/src/plugins/index.ts
+++ b/packages/api-reference/src/plugins/index.ts
@@ -2,6 +2,7 @@ export { PLUGIN_MANAGER_SYMBOL, usePluginManager } from '@/plugins/hooks/usePlug
 export {
   type ApiReferencePlugin,
   type PluginManager,
+  type PluginViewComponent,
   createPluginManager,
 } from '@/plugins/plugin-manager'
 

--- a/packages/api-reference/src/plugins/plugin-manager.test.ts
+++ b/packages/api-reference/src/plugins/plugin-manager.test.ts
@@ -186,6 +186,166 @@ describe('plugin-manager', () => {
     })
   })
 
+  describe('getViewComponents - content.start', () => {
+    it('returns empty array when no plugins have content.start views', () => {
+      const mockPlugin: ApiReferencePlugin = () => ({
+        name: 'testPlugin',
+        extensions: [],
+        views: {
+          'content.end': [{ component: 'EndComponent' }],
+        },
+      })
+
+      const manager = createPluginManager({ plugins: [mockPlugin] })
+      const components = manager.getViewComponents('content.start')
+      expect(components).toEqual([])
+    })
+
+    it('returns components for content.start view', () => {
+      const mockComponent = 'StartComponent'
+      const mockPlugin: ApiReferencePlugin = () => ({
+        name: 'testPlugin',
+        extensions: [],
+        views: {
+          'content.start': [
+            {
+              component: mockComponent,
+              props: { title: 'My Custom Page' },
+            },
+          ],
+        },
+      })
+
+      const manager = createPluginManager({ plugins: [mockPlugin] })
+      const components = manager.getViewComponents('content.start')
+      expect(components).toEqual([
+        {
+          component: mockComponent,
+          props: { title: 'My Custom Page' },
+        },
+      ])
+    })
+
+    it('returns components from both content.start and content.end independently', () => {
+      const mockPlugin: ApiReferencePlugin = () => ({
+        name: 'testPlugin',
+        extensions: [],
+        views: {
+          'content.start': [{ component: 'StartComponent' }],
+          'content.end': [{ component: 'EndComponent' }],
+        },
+      })
+
+      const manager = createPluginManager({ plugins: [mockPlugin] })
+      expect(manager.getViewComponents('content.start')).toEqual([{ component: 'StartComponent' }])
+      expect(manager.getViewComponents('content.end')).toEqual([{ component: 'EndComponent' }])
+    })
+  })
+
+  describe('getSidebarEntries', () => {
+    it('returns empty array when no plugins have sidebar config', () => {
+      const mockPlugin: ApiReferencePlugin = () => ({
+        name: 'testPlugin',
+        extensions: [],
+        views: {
+          'content.start': [{ component: 'StartComponent' }],
+        },
+      })
+
+      const manager = createPluginManager({ plugins: [mockPlugin] })
+      expect(manager.getSidebarEntries()).toEqual([])
+    })
+
+    it('returns empty array when sidebar.show is false', () => {
+      const mockPlugin: ApiReferencePlugin = () => ({
+        name: 'testPlugin',
+        extensions: [],
+        views: {
+          'content.start': [
+            {
+              component: 'StartComponent',
+              sidebar: { show: false, label: 'Hidden Page' },
+            },
+          ],
+        },
+      })
+
+      const manager = createPluginManager({ plugins: [mockPlugin] })
+      expect(manager.getSidebarEntries()).toEqual([])
+    })
+
+    it('returns entries when sidebar.show is true', () => {
+      const mockPlugin: ApiReferencePlugin = () => ({
+        name: 'testPlugin',
+        extensions: [],
+        views: {
+          'content.start': [
+            {
+              component: 'StartComponent',
+              sidebar: { show: true, label: 'Getting Started' },
+            },
+          ],
+        },
+      })
+
+      const manager = createPluginManager({ plugins: [mockPlugin] })
+      expect(manager.getSidebarEntries()).toEqual([
+        { label: 'Getting Started', icon: undefined, viewName: 'content.start', index: 0 },
+      ])
+    })
+
+    it('returns entries with icon when provided', () => {
+      const mockPlugin: ApiReferencePlugin = () => ({
+        name: 'testPlugin',
+        extensions: [],
+        views: {
+          'content.end': [
+            {
+              component: 'EndComponent',
+              sidebar: { show: true, label: 'Changelog', icon: 'history' },
+            },
+          ],
+        },
+      })
+
+      const manager = createPluginManager({ plugins: [mockPlugin] })
+      expect(manager.getSidebarEntries()).toEqual([
+        { label: 'Changelog', icon: 'history', viewName: 'content.end', index: 0 },
+      ])
+    })
+
+    it('returns multiple sidebar entries from mixed views', () => {
+      const mockPlugin: ApiReferencePlugin = () => ({
+        name: 'testPlugin',
+        extensions: [],
+        views: {
+          'content.start': [
+            {
+              component: 'Page1',
+              sidebar: { show: true, label: 'Overview' },
+            },
+            {
+              component: 'Page2',
+              // No sidebar — should not appear
+            },
+          ],
+          'content.end': [
+            {
+              component: 'Footer',
+              sidebar: { show: true, label: 'Support' },
+            },
+          ],
+        },
+      })
+
+      const manager = createPluginManager({ plugins: [mockPlugin] })
+      expect(manager.getSidebarEntries()).toEqual([
+        { label: 'Overview', icon: undefined, viewName: 'content.start', index: 0 },
+        { label: 'Support', icon: undefined, viewName: 'content.end', index: 0 },
+      ])
+    })
+  })
+
   describe('lifecycle hooks', () => {
     it('notifyInit calls onInit on all plugins with config', () => {
       const onInit1 = vi.fn()

--- a/packages/api-reference/src/plugins/plugin-manager.test.ts
+++ b/packages/api-reference/src/plugins/plugin-manager.test.ts
@@ -64,7 +64,7 @@ describe('plugin-manager', () => {
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
-      const components = manager.getViewComponents('content.end')
+      const components = manager.getViewComponents('content.end', 'my-doc')
       expect(components).toEqual([])
     })
 
@@ -84,10 +84,10 @@ describe('plugin-manager', () => {
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
-      const components = manager.getViewComponents('content.end')
+      const components = manager.getViewComponents('content.end', 'my-doc')
       expect(components).toEqual([
         {
-          id: 'plugin-view/testPlugin/content.end/0',
+          id: 'my-doc/plugin-view/testPlugin/content.end/0',
           component: mockComponent,
           props: { customProp: 'test value' },
         },
@@ -125,15 +125,15 @@ describe('plugin-manager', () => {
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin1, mockPlugin2] })
-      const components = manager.getViewComponents('content.end')
+      const components = manager.getViewComponents('content.end', 'my-doc')
       expect(components).toEqual([
         {
-          id: 'plugin-view/testPlugin1/content.end/0',
+          id: 'my-doc/plugin-view/testPlugin1/content.end/0',
           component: mockComponent1,
           props: { value: 'first' },
         },
         {
-          id: 'plugin-view/testPlugin2/content.end/0',
+          id: 'my-doc/plugin-view/testPlugin2/content.end/0',
           component: mockComponent2,
           props: { value: 'second' },
         },
@@ -155,7 +155,7 @@ describe('plugin-manager', () => {
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
       // @ts-expect-error testing invalid view
-      const components = manager.getViewComponents('non-existent-view')
+      const components = manager.getViewComponents('non-existent-view', 'my-doc')
       expect(components).toEqual([])
     })
 
@@ -179,10 +179,10 @@ describe('plugin-manager', () => {
       const extensions = manager.getSpecificationExtensions('x-test')
       expect(extensions).toEqual([{ name: 'x-test', component: 'extensionComponent' }])
 
-      const components = manager.getViewComponents('content.end')
+      const components = manager.getViewComponents('content.end', 'my-doc')
       expect(components).toEqual([
         {
-          id: 'plugin-view/testPlugin/content.end/0',
+          id: 'my-doc/plugin-view/testPlugin/content.end/0',
           component: mockComponent,
           renderer: 'MockRenderer',
         },
@@ -201,7 +201,7 @@ describe('plugin-manager', () => {
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
-      const components = manager.getViewComponents('content.start')
+      const components = manager.getViewComponents('content.start', 'my-doc')
       expect(components).toEqual([])
     })
 
@@ -221,10 +221,10 @@ describe('plugin-manager', () => {
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
-      const components = manager.getViewComponents('content.start')
+      const components = manager.getViewComponents('content.start', 'my-doc')
       expect(components).toEqual([
         {
-          id: 'plugin-view/testPlugin/content.start/0',
+          id: 'my-doc/plugin-view/testPlugin/content.start/0',
           component: mockComponent,
           props: { title: 'My Custom Page' },
         },
@@ -242,11 +242,11 @@ describe('plugin-manager', () => {
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
-      expect(manager.getViewComponents('content.start')).toEqual([
-        { id: 'plugin-view/testPlugin/content.start/0', component: 'StartComponent' },
+      expect(manager.getViewComponents('content.start', 'my-doc')).toEqual([
+        { id: 'my-doc/plugin-view/testPlugin/content.start/0', component: 'StartComponent' },
       ])
-      expect(manager.getViewComponents('content.end')).toEqual([
-        { id: 'plugin-view/testPlugin/content.end/0', component: 'EndComponent' },
+      expect(manager.getViewComponents('content.end', 'my-doc')).toEqual([
+        { id: 'my-doc/plugin-view/testPlugin/content.end/0', component: 'EndComponent' },
       ])
     })
   })
@@ -262,7 +262,7 @@ describe('plugin-manager', () => {
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
-      expect(manager.getSidebarEntries()).toEqual([])
+      expect(manager.getSidebarEntries('my-doc')).toEqual([])
     })
 
     it('returns empty array when sidebar.show is false', () => {
@@ -280,7 +280,7 @@ describe('plugin-manager', () => {
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
-      expect(manager.getSidebarEntries()).toEqual([])
+      expect(manager.getSidebarEntries('my-doc')).toEqual([])
     })
 
     it('returns entries when sidebar.show is true', () => {
@@ -298,8 +298,8 @@ describe('plugin-manager', () => {
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
-      expect(manager.getSidebarEntries()).toEqual([
-        { id: 'plugin-view/testPlugin/content.start/0', label: 'Getting Started', viewName: 'content.start' },
+      expect(manager.getSidebarEntries('my-doc')).toEqual([
+        { id: 'my-doc/plugin-view/testPlugin/content.start/0', label: 'Getting Started', viewName: 'content.start' },
       ])
     })
 
@@ -318,8 +318,8 @@ describe('plugin-manager', () => {
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
-      expect(manager.getSidebarEntries()).toEqual([
-        { id: 'plugin-view/testPlugin/content.end/0', label: 'Changelog', viewName: 'content.end' },
+      expect(manager.getSidebarEntries('my-doc')).toEqual([
+        { id: 'my-doc/plugin-view/testPlugin/content.end/0', label: 'Changelog', viewName: 'content.end' },
       ])
     })
 
@@ -348,9 +348,9 @@ describe('plugin-manager', () => {
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
-      expect(manager.getSidebarEntries()).toEqual([
-        { id: 'plugin-view/testPlugin/content.start/0', label: 'Overview', viewName: 'content.start' },
-        { id: 'plugin-view/testPlugin/content.end/0', label: 'Support', viewName: 'content.end' },
+      expect(manager.getSidebarEntries('my-doc')).toEqual([
+        { id: 'my-doc/plugin-view/testPlugin/content.start/0', label: 'Overview', viewName: 'content.start' },
+        { id: 'my-doc/plugin-view/testPlugin/content.end/0', label: 'Support', viewName: 'content.end' },
       ])
     })
   })

--- a/packages/api-reference/src/plugins/plugin-manager.test.ts
+++ b/packages/api-reference/src/plugins/plugin-manager.test.ts
@@ -87,6 +87,7 @@ describe('plugin-manager', () => {
       const components = manager.getViewComponents('content.end')
       expect(components).toEqual([
         {
+          id: 'plugin-view/testPlugin/content.end/0',
           component: mockComponent,
           props: { customProp: 'test value' },
         },
@@ -127,10 +128,12 @@ describe('plugin-manager', () => {
       const components = manager.getViewComponents('content.end')
       expect(components).toEqual([
         {
+          id: 'plugin-view/testPlugin1/content.end/0',
           component: mockComponent1,
           props: { value: 'first' },
         },
         {
+          id: 'plugin-view/testPlugin2/content.end/0',
           component: mockComponent2,
           props: { value: 'second' },
         },
@@ -179,6 +182,7 @@ describe('plugin-manager', () => {
       const components = manager.getViewComponents('content.end')
       expect(components).toEqual([
         {
+          id: 'plugin-view/testPlugin/content.end/0',
           component: mockComponent,
           renderer: 'MockRenderer',
         },
@@ -220,6 +224,7 @@ describe('plugin-manager', () => {
       const components = manager.getViewComponents('content.start')
       expect(components).toEqual([
         {
+          id: 'plugin-view/testPlugin/content.start/0',
           component: mockComponent,
           props: { title: 'My Custom Page' },
         },
@@ -237,8 +242,12 @@ describe('plugin-manager', () => {
       })
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
-      expect(manager.getViewComponents('content.start')).toEqual([{ component: 'StartComponent' }])
-      expect(manager.getViewComponents('content.end')).toEqual([{ component: 'EndComponent' }])
+      expect(manager.getViewComponents('content.start')).toEqual([
+        { id: 'plugin-view/testPlugin/content.start/0', component: 'StartComponent' },
+      ])
+      expect(manager.getViewComponents('content.end')).toEqual([
+        { id: 'plugin-view/testPlugin/content.end/0', component: 'EndComponent' },
+      ])
     })
   })
 
@@ -290,11 +299,11 @@ describe('plugin-manager', () => {
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
       expect(manager.getSidebarEntries()).toEqual([
-        { label: 'Getting Started', icon: undefined, viewName: 'content.start', index: 0 },
+        { id: 'plugin-view/testPlugin/content.start/0', label: 'Getting Started', viewName: 'content.start' },
       ])
     })
 
-    it('returns entries with icon when provided', () => {
+    it('returns entries for content.end views', () => {
       const mockPlugin: ApiReferencePlugin = () => ({
         name: 'testPlugin',
         extensions: [],
@@ -302,7 +311,7 @@ describe('plugin-manager', () => {
           'content.end': [
             {
               component: 'EndComponent',
-              sidebar: { show: true, label: 'Changelog', icon: 'history' },
+              sidebar: { show: true, label: 'Changelog' },
             },
           ],
         },
@@ -310,7 +319,7 @@ describe('plugin-manager', () => {
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
       expect(manager.getSidebarEntries()).toEqual([
-        { label: 'Changelog', icon: 'history', viewName: 'content.end', index: 0 },
+        { id: 'plugin-view/testPlugin/content.end/0', label: 'Changelog', viewName: 'content.end' },
       ])
     })
 
@@ -340,8 +349,8 @@ describe('plugin-manager', () => {
 
       const manager = createPluginManager({ plugins: [mockPlugin] })
       expect(manager.getSidebarEntries()).toEqual([
-        { label: 'Overview', icon: undefined, viewName: 'content.start', index: 0 },
-        { label: 'Support', icon: undefined, viewName: 'content.end', index: 0 },
+        { id: 'plugin-view/testPlugin/content.start/0', label: 'Overview', viewName: 'content.start' },
+        { id: 'plugin-view/testPlugin/content.end/0', label: 'Support', viewName: 'content.end' },
       ])
     })
   })

--- a/packages/api-reference/src/plugins/plugin-manager.ts
+++ b/packages/api-reference/src/plugins/plugin-manager.ts
@@ -46,7 +46,7 @@ export const createPluginManager = ({ plugins = [] }: CreatePluginManagerParams)
     /**
      * Get all components for a specific view from registered plugins
      */
-    getViewComponents: (viewName: 'content.end'): ViewComponent[] => {
+    getViewComponents: (viewName: 'content.start' | 'content.end'): ViewComponent[] => {
       const components: ViewComponent[] = []
 
       for (const plugin of registeredPlugins.values()) {
@@ -99,6 +99,34 @@ export const createPluginManager = ({ plugins = [] }: CreatePluginManagerParams)
       }
 
       return apiClientPlugins
+    },
+
+    /**
+     * Get all sidebar entries from plugin views
+     */
+    getSidebarEntries: (): { label: string; icon?: string; viewName: string; index: number }[] => {
+      const entries: { label: string; icon?: string; viewName: string; index: number }[] = []
+
+      for (const plugin of registeredPlugins.values()) {
+        const viewNames = ['content.start', 'content.end'] as const
+        for (const viewName of viewNames) {
+          const viewComponents = plugin.views?.[viewName]
+          if (viewComponents) {
+            viewComponents.forEach((vc: ViewComponent, index: number) => {
+              if (vc.sidebar?.show && vc.sidebar?.label) {
+                entries.push({
+                  label: vc.sidebar.label,
+                  icon: vc.sidebar.icon,
+                  viewName,
+                  index,
+                })
+              }
+            })
+          }
+        }
+      }
+
+      return entries
     },
   }
 }

--- a/packages/api-reference/src/plugins/plugin-manager.ts
+++ b/packages/api-reference/src/plugins/plugin-manager.ts
@@ -11,6 +11,31 @@ type CreatePluginManagerParams = {
   plugins?: ApiReferencePlugin[]
 }
 
+/** Plugin view slots that can render custom components in the content area */
+const PLUGIN_VIEW_NAMES = ['content.start', 'content.end'] as const
+
+type PluginViewName = (typeof PLUGIN_VIEW_NAMES)[number]
+
+/** A plugin view component paired with the stable id used for the DOM and sidebar navigation */
+export type PluginViewComponent = ViewComponent & { id: string }
+
+/** A sidebar entry contributed by a plugin view */
+type PluginSidebarEntry = {
+  id: string
+  label: string
+  viewName: PluginViewName
+}
+
+/**
+ * Build a stable, unique id for a plugin view component.
+ *
+ * The same id is used as the DOM element id (so scroll navigation can find it) and as the
+ * sidebar navigation entry id (so clicking it scrolls to the element). Keeping both in sync
+ * is what lets plugin views participate in the existing scroll-spy and navigation logic.
+ */
+const getPluginViewId = (pluginName: string, viewName: PluginViewName, index: number): string =>
+  `plugin-view/${pluginName}/${viewName}/${index}`
+
 /**
  * Create the plugin manager store
  *
@@ -44,15 +69,20 @@ export const createPluginManager = ({ plugins = [] }: CreatePluginManagerParams)
     },
 
     /**
-     * Get all components for a specific view from registered plugins
+     * Get all components for a specific view from registered plugins.
+     *
+     * Each component carries a stable `id` so the rendered DOM element and the sidebar entry
+     * (see `getSidebarEntries`) share the same id and stay in sync for scroll navigation.
      */
-    getViewComponents: (viewName: 'content.start' | 'content.end'): ViewComponent[] => {
-      const components: ViewComponent[] = []
+    getViewComponents: (viewName: PluginViewName): PluginViewComponent[] => {
+      const components: PluginViewComponent[] = []
 
       for (const plugin of registeredPlugins.values()) {
         const viewComponents = plugin.views?.[viewName]
         if (viewComponents) {
-          components.push(...viewComponents)
+          viewComponents.forEach((component: ViewComponent, index: number) => {
+            components.push({ ...component, id: getPluginViewId(plugin.name, viewName, index) })
+          })
         }
       }
 
@@ -102,27 +132,27 @@ export const createPluginManager = ({ plugins = [] }: CreatePluginManagerParams)
     },
 
     /**
-     * Get all sidebar entries from plugin views
+     * Get all sidebar entries contributed by plugin views.
+     *
+     * Only views that opt in via `sidebar.show` are returned. Each entry's `id` matches the
+     * id of the rendered component (see `getViewComponents`), so the API Reference can add it
+     * to the sidebar navigation and scrolling/active-tracking work out of the box.
      */
-    getSidebarEntries: (): { label: string; icon?: string; viewName: string; index: number }[] => {
-      const entries: { label: string; icon?: string; viewName: string; index: number }[] = []
+    getSidebarEntries: (): PluginSidebarEntry[] => {
+      const entries: PluginSidebarEntry[] = []
 
       for (const plugin of registeredPlugins.values()) {
-        const viewNames = ['content.start', 'content.end'] as const
-        for (const viewName of viewNames) {
+        for (const viewName of PLUGIN_VIEW_NAMES) {
           const viewComponents = plugin.views?.[viewName]
-          if (viewComponents) {
-            viewComponents.forEach((vc: ViewComponent, index: number) => {
-              if (vc.sidebar?.show && vc.sidebar?.label) {
-                entries.push({
-                  label: vc.sidebar.label,
-                  icon: vc.sidebar.icon,
-                  viewName,
-                  index,
-                })
-              }
-            })
-          }
+          viewComponents?.forEach((component: ViewComponent, index: number) => {
+            if (component.sidebar?.show && component.sidebar.label) {
+              entries.push({
+                id: getPluginViewId(plugin.name, viewName, index),
+                label: component.sidebar.label,
+                viewName,
+              })
+            }
+          })
         }
       }
 

--- a/packages/api-reference/src/plugins/plugin-manager.ts
+++ b/packages/api-reference/src/plugins/plugin-manager.ts
@@ -32,9 +32,13 @@ type PluginSidebarEntry = {
  * The same id is used as the DOM element id (so scroll navigation can find it) and as the
  * sidebar navigation entry id (so clicking it scrolls to the element). Keeping both in sync
  * is what lets plugin views participate in the existing scroll-spy and navigation logic.
+ *
+ * The id is prefixed with the document slug so it matches the navigation id convention. That is
+ * what lets URL deep-linking work: `getIdFromUrl` re-prepends the document slug on initial load,
+ * so a hash like `plugin-view/<plugin>/<view>/<index>` resolves back to this exact id.
  */
-const getPluginViewId = (pluginName: string, viewName: PluginViewName, index: number): string =>
-  `plugin-view/${pluginName}/${viewName}/${index}`
+const getPluginViewId = (documentSlug: string, pluginName: string, viewName: PluginViewName, index: number): string =>
+  `${documentSlug}/plugin-view/${pluginName}/${viewName}/${index}`
 
 /**
  * Create the plugin manager store
@@ -71,17 +75,18 @@ export const createPluginManager = ({ plugins = [] }: CreatePluginManagerParams)
     /**
      * Get all components for a specific view from registered plugins.
      *
-     * Each component carries a stable `id` so the rendered DOM element and the sidebar entry
-     * (see `getSidebarEntries`) share the same id and stay in sync for scroll navigation.
+     * Each component carries a stable `id` (scoped to the active document slug) so the rendered
+     * DOM element and the sidebar entry (see `getSidebarEntries`) share the same id and stay in
+     * sync for scroll navigation and deep-linking.
      */
-    getViewComponents: (viewName: PluginViewName): PluginViewComponent[] => {
+    getViewComponents: (viewName: PluginViewName, documentSlug: string): PluginViewComponent[] => {
       const components: PluginViewComponent[] = []
 
       for (const plugin of registeredPlugins.values()) {
         const viewComponents = plugin.views?.[viewName]
         if (viewComponents) {
           viewComponents.forEach((component: ViewComponent, index: number) => {
-            components.push({ ...component, id: getPluginViewId(plugin.name, viewName, index) })
+            components.push({ ...component, id: getPluginViewId(documentSlug, plugin.name, viewName, index) })
           })
         }
       }
@@ -138,7 +143,7 @@ export const createPluginManager = ({ plugins = [] }: CreatePluginManagerParams)
      * id of the rendered component (see `getViewComponents`), so the API Reference can add it
      * to the sidebar navigation and scrolling/active-tracking work out of the box.
      */
-    getSidebarEntries: (): PluginSidebarEntry[] => {
+    getSidebarEntries: (documentSlug: string): PluginSidebarEntry[] => {
       const entries: PluginSidebarEntry[] = []
 
       for (const plugin of registeredPlugins.values()) {
@@ -147,7 +152,7 @@ export const createPluginManager = ({ plugins = [] }: CreatePluginManagerParams)
           viewComponents?.forEach((component: ViewComponent, index: number) => {
             if (component.sidebar?.show && component.sidebar.label) {
               entries.push({
-                id: getPluginViewId(plugin.name, viewName, index),
+                id: getPluginViewId(documentSlug, plugin.name, viewName, index),
                 label: component.sidebar.label,
                 viewName,
               })

--- a/packages/schemas/src/api-reference/api-reference-plugin.ts
+++ b/packages/schemas/src/api-reference/api-reference-plugin.ts
@@ -26,9 +26,22 @@ const viewComponentSchema = object({
   props: optional(record(string(), any()), {
     typeComment: 'Additional props to pass to the component',
   }),
+  sidebar: optional(
+    object({
+      show: any(),
+      label: string(),
+      icon: optional(string()),
+    }),
+    {
+      typeComment: 'Sidebar configuration. Set show: true to display in sidebar.',
+    },
+  ),
 })
 
 const viewsSchema = object({
+  'content.start': optional(array(viewComponentSchema), {
+    typeComment: 'Components to render before the Introduction/Info section',
+  }),
   'content.end': optional(array(viewComponentSchema), {
     typeComment: 'Components to render at specific views in the API Reference',
   }),

--- a/packages/schemas/src/api-reference/api-reference-plugin.ts
+++ b/packages/schemas/src/api-reference/api-reference-plugin.ts
@@ -1,4 +1,4 @@
-import { type Static, any, array, fn, object, optional, record, string, unknown } from '@scalar/validation'
+import { type Static, any, array, boolean, fn, object, optional, record, string, unknown } from '@scalar/validation'
 
 const openApiExtensionSchema = object({
   name: string({
@@ -28,9 +28,8 @@ const viewComponentSchema = object({
   }),
   sidebar: optional(
     object({
-      show: any(),
+      show: boolean(),
       label: string(),
-      icon: optional(string()),
     }),
     {
       typeComment: 'Sidebar configuration. Set show: true to display in sidebar.',

--- a/packages/types/src/api-reference/api-reference-plugin.ts
+++ b/packages/types/src/api-reference/api-reference-plugin.ts
@@ -35,9 +35,28 @@ const viewComponentSchema = z.object({
    * Additional props to pass to the component
    */
   props: z.record(z.string(), z.any()).optional(),
+  /**
+   * Sidebar configuration for this view component.
+   * If provided, an entry will be shown in the sidebar.
+   * Set to false or omit to hide from sidebar.
+   */
+  sidebar: z
+    .object({
+      /** Whether to show in sidebar */
+      show: z.boolean().default(false),
+      /** Label to display in the sidebar */
+      label: z.string(),
+      /** Optional icon name */
+      icon: z.string().optional(),
+    })
+    .optional(),
 })
 
 const viewsSchema = z.object({
+  /**
+   * Renders before the Introduction/Info section
+   */
+  'content.start': z.array(viewComponentSchema).optional(),
   /**
    * Renders after the Models section
    */

--- a/packages/types/src/api-reference/api-reference-plugin.ts
+++ b/packages/types/src/api-reference/api-reference-plugin.ts
@@ -37,8 +37,8 @@ const viewComponentSchema = z.object({
   props: z.record(z.string(), z.any()).optional(),
   /**
    * Sidebar configuration for this view component.
-   * If provided, an entry will be shown in the sidebar.
-   * Set to false or omit to hide from sidebar.
+   * If provided with `show: true`, an entry will be shown in the sidebar.
+   * Set `show: false` or omit to hide from the sidebar.
    */
   sidebar: z
     .object({
@@ -46,8 +46,6 @@ const viewComponentSchema = z.object({
       show: z.boolean().default(false),
       /** Label to display in the sidebar */
       label: z.string(),
-      /** Optional icon name */
-      icon: z.string().optional(),
     })
     .optional(),
 })

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -199,6 +199,11 @@ export type ViewComponent = {
   component: unknown
   renderer?: unknown
   props?: Record<string, any>
+  sidebar?: {
+    show: boolean
+    label: string
+    icon?: string
+  }
 }
 
 export type LifecycleHooks = {
@@ -211,6 +216,7 @@ export type ApiReferencePlugin = () => {
   name: string
   extensions: SpecificationExtension[]
   views?: {
+    'content.start'?: ViewComponent[]
     'content.end'?: ViewComponent[]
   }
   hooks?: LifecycleHooks

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -200,9 +200,10 @@ export type ViewComponent = {
   renderer?: unknown
   props?: Record<string, any>
   sidebar?: {
+    /** Whether to show an entry for this view in the sidebar */
     show: boolean
+    /** Label to display in the sidebar */
     label: string
-    icon?: string
   }
 }
 


### PR DESCRIPTION
# Feature: Plugin View Slots & Sidebar Visibility

## Summary

This PR adds two enhancements to the Scalar API Reference plugin system:

1. **`content.start` view slot** — Allows plugins to inject custom components **before** the Introduction/Info section (top of content).
2. **`sidebar` option for plugin views** — Plugins can now opt-in to show an entry in the sidebar for their custom page/component.

## Motivation

Previously, plugins could only inject content at `content.end` (after the Models section at the bottom). This made it impossible to render custom pages or banners at the top of the API reference. Additionally, there was no way for a plugin-injected view to appear in the sidebar navigation.

## Changes

### Modified Files

| File | Change |
|------|--------|
| `packages/types/src/api-reference/api-reference-plugin.ts` | Added `content.start` to `viewsSchema`; added `sidebar` config to `viewComponentSchema` |
| `packages/api-reference/src/plugins/plugin-manager.ts` | Updated `getViewComponents` to accept `'content.start'`; added `getSidebarEntries()` method |
| `packages/api-reference/src/components/RenderPlugins/RenderPlugins.vue` | Updated prop type to accept `'content.start' \| 'content.end'`; added `id` attr to each view wrapper |
| `packages/api-reference/src/components/Content/Content.vue` | Added `<RenderPlugins viewName="content.start" />` before the Introduction block |

### New Files

| File | Purpose |
|------|---------|
| `.changeset/add-content-start-view-and-plugin-sidebar.md` | Changeset for release |

## Usage

### `content.start` — Render at the top

```tsx
import { ReactRenderer } from '@scalar/react-renderer'
import type { ApiReferencePlugin } from '@scalar/types/api-reference'
import { MyBanner } from './MyBanner'

export const BannerPlugin = (): ApiReferencePlugin => {
  return () => ({
    name: 'banner-plugin',
    extensions: [],
    views: {
      'content.start': [
        {
          component: MyBanner,
          renderer: ReactRenderer,
        },
      ],
    },
  })
}
```

### Sidebar visibility toggle

```tsx
export const CustomPagePlugin = (): ApiReferencePlugin => {
  return () => ({
    name: 'custom-page-plugin',
    extensions: [],
    views: {
      'content.start': [
        {
          component: MyCustomPage,
          renderer: ReactRenderer,
          // ✅ Shows in sidebar
          sidebar: {
            show: true,
            label: 'Getting Started',
          },
        },
      ],
      'content.end': [
        {
          component: MyFooter,
          renderer: ReactRenderer,
          // ❌ Does NOT show in sidebar (omitted = hidden)
        },
      ],
    },
  })
}
```

### Available view slots

| Slot | Position |
|------|----------|
| `content.start` | Before Introduction/Info section |
| `content.end` | After Models section |

### Sidebar config schema

The `sidebar` option works on **both** `content.start` and `content.end` — it's per-component, not per-slot.

```ts
sidebar?: {
  show: boolean    // true = visible in sidebar, false/omitted = hidden
  label: string    // Display text in the sidebar
  icon?: string    // Optional icon name
}
```

### Sidebar with `content.end`

```tsx
export const SupportPlugin = (): ApiReferencePlugin => {
  return () => ({
    name: 'support-plugin',
    extensions: [],
    views: {
      'content.end': [
        {
          component: SupportPage,
          renderer: ReactRenderer,
          // ✅ Shows in sidebar even though it renders at the bottom
          sidebar: {
            show: true,
            label: 'Support',
            icon: 'help',
          },
        },
      ],
    },
  })
}
```

## React integration

Works with `@scalar/api-reference-react` — just pass the plugin in `configuration.plugins`:

```tsx
import { ApiReferenceReact } from '@scalar/api-reference-react'
import { CustomPagePlugin } from './customPagePlugin'

function App() {
  return (
    <ApiReferenceReact
      configuration={{
        url: '/openapi.json',
        plugins: [CustomPagePlugin()],
      }}
    />
  )
}
```

## Breaking Changes

None. This is fully backward-compatible. Existing plugins with only `content.end` continue to work as before.

## Testing

New test cases added to `plugin-manager.test.ts` covering:
- `content.start` view component retrieval
- `getSidebarEntries()` returns only entries with `sidebar.show: true`
- `getSidebarEntries()` returns empty when no sidebar config is set
- Mixed `content.start` and `content.end` with sidebar entries
