### PR TITLE
fix(api-client): do not send Basic auth header when credentials are empty

### DIFF
--- a/.changeset/basic-auth-empty-credentials.md
+++ b/.changeset/basic-auth-empty-credentials.md
@@ -1,6 +1,5 @@
 ---
 '@scalar/workspace-store': patch
-'@scalar/api-client': patch
 ---
 
-Do not send a Basic `Authorization` header (or fall back to `username:password` placeholders) when both the username and password are empty
+Do not send a Basic `Authorization` header when both the username and password are empty, instead of falling back to a `username:password` placeholder

--- a/.changeset/basic-auth-empty-credentials.md
+++ b/.changeset/basic-auth-empty-credentials.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-client': patch
+---
+
+Do not send a Basic `Authorization` header (or fall back to `username:password` placeholders) when both the username and password are empty

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-security-schemes.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-security-schemes.test.ts
@@ -372,10 +372,9 @@ describe('process-security-schemes', () => {
 
       const result = processSecuritySchemes(securitySchemes)
 
-      expect(result.headers).toEqual([
-        { name: 'Authorization', value: 'Basic username:password' },
-        { name: 'Authorization', value: 'Bearer YOUR_SECRET_TOKEN' },
-      ])
+      // Basic auth with both fields empty must not emit a header, so only the bearer
+      // placeholder remains.
+      expect(result.headers).toEqual([{ name: 'Authorization', value: 'Bearer YOUR_SECRET_TOKEN' }])
     })
 
     it('handles oauth2 without token', () => {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-security-schemes.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-security-schemes.test.ts
@@ -372,9 +372,10 @@ describe('process-security-schemes', () => {
 
       const result = processSecuritySchemes(securitySchemes)
 
-      // Basic auth with both fields empty must not emit a header, so only the bearer
-      // placeholder remains.
-      expect(result.headers).toEqual([{ name: 'Authorization', value: 'Bearer YOUR_SECRET_TOKEN' }])
+      expect(result.headers).toEqual([
+        { name: 'Authorization', value: 'Basic username:password' },
+        { name: 'Authorization', value: 'Bearer YOUR_SECRET_TOKEN' },
+      ])
     })
 
     it('handles oauth2 without token', () => {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-security-schemes.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-security-schemes.ts
@@ -52,13 +52,15 @@ export const processSecuritySchemes = (
         const username = scheme['x-scalar-secret-username'] || ''
         const password = scheme['x-scalar-secret-password'] || ''
 
-        const value = `${username}:${password}`
-        const auth = value === ':' ? 'username:password' : encode(value)
-
-        result.headers.push({
-          name: 'Authorization',
-          value: `Basic ${auth}`,
-        })
+        // When both fields are empty we must not emit any credentials. Falling back to
+        // placeholder values would produce `Basic username:password`, which mirrors the real
+        // request (we do not send the header in that case either).
+        if (username !== '' || password !== '') {
+          result.headers.push({
+            name: 'Authorization',
+            value: `Basic ${encode(`${username}:${password}`)}`,
+          })
+        }
       } else if (scheme.scheme === 'bearer') {
         const token = scheme['x-scalar-secret-token'] || 'YOUR_SECRET_TOKEN'
 

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-security-schemes.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-security-schemes.ts
@@ -52,15 +52,17 @@ export const processSecuritySchemes = (
         const username = scheme['x-scalar-secret-username'] || ''
         const password = scheme['x-scalar-secret-password'] || ''
 
-        // When both fields are empty we must not emit any credentials. Falling back to
-        // placeholder values would produce `Basic username:password`, which mirrors the real
-        // request (we do not send the header in that case either).
-        if (username !== '' || password !== '') {
-          result.headers.push({
-            name: 'Authorization',
-            value: `Basic ${encode(`${username}:${password}`)}`,
-          })
-        }
+        // The snippet is documentation, so we always show an Authorization header. When both
+        // fields are empty we render a readable `username:password` placeholder, mirroring the
+        // `YOUR_SECRET_TOKEN` placeholder used by the other schemes. (The real request omits the
+        // header entirely in that case — see buildRequestSecurity.)
+        const value = `${username}:${password}`
+        const auth = value === ':' ? 'username:password' : encode(value)
+
+        result.headers.push({
+          name: 'Authorization',
+          value: `Basic ${auth}`,
+        })
       } else if (scheme.scheme === 'bearer') {
         const token = scheme['x-scalar-secret-token'] || 'YOUR_SECRET_TOKEN'
 

--- a/packages/workspace-store/src/request-example/builder/security/build-request-security.test.ts
+++ b/packages/workspace-store/src/request-example/builder/security/build-request-security.test.ts
@@ -89,14 +89,21 @@ describe('buildRequestSecurity', () => {
       expect(result[0].in).toBe('header')
     })
 
-    it('handles basic auth with empty credentials', () => {
+    it('omits the Authorization header when both basic credentials are empty', () => {
       basic['x-scalar-secret-username'] = ''
+      basic['x-scalar-secret-password'] = ''
+      const result = buildRequestSecurity([basic])
+      expect(result).toEqual([])
+    })
+
+    it('keeps basic auth when only the username is set', () => {
+      basic['x-scalar-secret-username'] = 'scalar'
       basic['x-scalar-secret-password'] = ''
       const result = buildRequestSecurity([basic])
       expect(result).toHaveLength(1)
       assert(result[0])
       expect(result[0].name).toBe('Authorization')
-      expect(result[0].value).toBe('username:password')
+      expect(result[0].value).toBe('scalar:')
       expect(result[0].format).toBe('basic')
       expect(result[0].in).toBe('header')
     })

--- a/packages/workspace-store/src/request-example/builder/security/build-request-security.ts
+++ b/packages/workspace-store/src/request-example/builder/security/build-request-security.ts
@@ -93,15 +93,21 @@ export const buildRequestSecurity = (
     // HTTP
     if (scheme.type === 'http') {
       if (scheme.scheme === 'basic') {
-        const username = scheme['x-scalar-secret-username']
-        const password = scheme['x-scalar-secret-password']
-        const value = `${username}:${password}`
+        const username = scheme['x-scalar-secret-username'] || ''
+        const password = scheme['x-scalar-secret-password'] || ''
+
+        // When the user has cleared both fields we must not send any credentials.
+        // Falling back to placeholder values here would emit `Basic username:password`,
+        // which some servers accept as a valid (but bogus) credential instead of returning 401.
+        if (username === '' && password === '') {
+          return null
+        }
 
         return result.push({
           in: 'header',
           name: 'Authorization',
           // We encode the value when we build the request since we want to be able to replace the variables in the value
-          value: value === ':' ? 'username:password' : value,
+          value: `${username}:${password}`,
           format: 'basic',
         })
       }


### PR DESCRIPTION
After clearing the username and password of an HTTP Basic auth scheme, the client still sent `Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=` (the literal `username:password` placeholder) instead of no credentials.

The real request (`@scalar/workspace-store`) now omits the header entirely when both fields are empty. The header is still sent when at least one field is set, since Basic auth allows an empty password alongside a username.

The generated code snippet (`@scalar/api-client`) keeps its `Basic username:password` placeholder, consistent with the `YOUR_SECRET_TOKEN` placeholder shown for the other schemes. The snippet is documentation, so it should still show where credentials go.

<img width="716" height="244" alt="Screenshot 2026-06-10 at 11 02 21" src="https://github.com/user-attachments/assets/2f309001-913d-40d3-96e9-6a28f76cbef6" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request auth header construction, but the change is narrow, behavior-preserving when credentials exist, and covered by new tests.
> 
> **Overview**
> Clears a bug where **real HTTP requests** still sent `Authorization: Basic …` encoding the literal `username:password` placeholder after both Basic auth fields were cleared. **`buildRequestSecurity`** now returns no auth entry when username and password are both empty, and still emits Basic auth when at least one field is set (e.g. username only → `scalar:`).
> 
> **Generated code samples** in `@scalar/api-client` are unchanged in behavior: they still show a `Basic username:password` placeholder when both fields are empty, with comments explaining that snippets are documentation while live requests omit the header. Tests were updated to cover empty credentials and username-only cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a30765b63ca46a592347a629e79bb9bb2ad0b8d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->