### PR TITLE
fix(api-client): replace selected auth scheme instead of appending

### DIFF
--- a/.changeset/auth-selector-replace-or-alternative.md
+++ b/.changeset/auth-selector-replace-or-alternative.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix the authentication dropdown for operations with multiple OR security alternatives: selecting a different method now replaces the previous one (and switches the fields panel) instead of appending a hidden tab. AND-combo requirements still activate both schemes at once.

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/AuthSelector.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/AuthSelector.test.ts
@@ -6,6 +6,9 @@ import { nextTick } from 'vue'
 import AuthSelector from './AuthSelector.vue'
 
 describe('AuthSelector', () => {
+  // The dropdown options are grouped (Required / Available); flatten them for lookups.
+  const flattenOptions = (options: any[]): any[] => options.flatMap((entry) => entry.options ?? [entry])
+
   const baseEnvironment = {
     uid: 'env-1' as any,
     name: 'Default',
@@ -50,6 +53,7 @@ describe('AuthSelector', () => {
       environment: any
       envVariables: any[]
       isStatic: boolean
+      createAnySecurityScheme: boolean
       securityRequirements: any
       selectedSecurity: any
       securitySchemes: any
@@ -243,7 +247,7 @@ describe('AuthSelector', () => {
   })
 
   describe('combobox interactions', () => {
-    it('updates selected auth when combobox selection changes', async () => {
+    it('emits the newly created scheme when adding via the dropdown', async () => {
       const eventBus = createWorkspaceEventBus()
       const fn = vi.fn()
       eventBus.on('auth:update:selected-security-schemes', fn)
@@ -272,6 +276,119 @@ describe('AuthSelector', () => {
             scheme: baseSecuritySchemes.BearerAuth,
           },
         ],
+        meta: { type: 'document' },
+      })
+    })
+
+    it('replaces the previous OR alternative instead of appending it', async () => {
+      const eventBus = createWorkspaceEventBus()
+      const fn = vi.fn()
+      eventBus.on('auth:update:selected-security-schemes', fn)
+      const wrapper = mountWithProps({
+        eventBus,
+        securityRequirements: [{ BearerAuth: [] }, { ApiKeyAuth: [] }],
+        selectedSecurity: { selectedIndex: 0, selectedSchemes: [{ BearerAuth: [] }] },
+      })
+
+      const combobox = wrapper.findComponent({ name: 'ScalarComboboxMultiselect' })
+
+      // The multiselect emits the full next selection (existing + newly added) on toggle.
+      const bearer = wrapper.vm.selectedSchemeOptions[0]
+      const apiKey = flattenOptions(wrapper.vm.schemeOptions).find((option: any) =>
+        Object.keys(option.value).includes('ApiKeyAuth'),
+      )
+
+      await combobox.vm?.$emit('update:modelValue', [bearer, apiKey])
+      await nextTick()
+
+      // Only the newly added alternative survives - the prior one is dropped.
+      expect(fn).toHaveBeenCalledTimes(1)
+      expect(fn).toHaveBeenCalledWith({
+        selectedRequirements: [{ ApiKeyAuth: [] }],
+        newSchemes: [],
+        meta: { type: 'document' },
+      })
+    })
+
+    it('activates both schemes when selecting an AND-combo requirement', async () => {
+      const eventBus = createWorkspaceEventBus()
+      const fn = vi.fn()
+      eventBus.on('auth:update:selected-security-schemes', fn)
+      const wrapper = mountWithProps({
+        eventBus,
+        securityRequirements: [{ BearerAuth: [] }, { ApiKeyAuth: [], OAuth2Auth: [] }],
+        selectedSecurity: { selectedIndex: 0, selectedSchemes: [{ BearerAuth: [] }] },
+      })
+
+      const combobox = wrapper.findComponent({ name: 'ScalarComboboxMultiselect' })
+
+      const bearer = wrapper.vm.selectedSchemeOptions[0]
+      const combo = flattenOptions(wrapper.vm.schemeOptions).find(
+        (option: any) =>
+          Object.keys(option.value).includes('ApiKeyAuth') && Object.keys(option.value).includes('OAuth2Auth'),
+      )
+
+      await combobox.vm?.$emit('update:modelValue', [bearer, combo])
+      await nextTick()
+
+      // The AND-combo is a single requirement that carries both schemes.
+      expect(fn).toHaveBeenCalledTimes(1)
+      expect(fn).toHaveBeenCalledWith({
+        selectedRequirements: [{ ApiKeyAuth: [], OAuth2Auth: [] }],
+        newSchemes: [],
+        meta: { type: 'document' },
+      })
+    })
+
+    it('clears the selection when the active option is deselected', async () => {
+      const eventBus = createWorkspaceEventBus()
+      const fn = vi.fn()
+      eventBus.on('auth:update:selected-security-schemes', fn)
+      const wrapper = mountWithProps({
+        eventBus,
+        securityRequirements: [{ BearerAuth: [] }, { ApiKeyAuth: [] }],
+        selectedSecurity: { selectedIndex: 0, selectedSchemes: [{ BearerAuth: [] }] },
+      })
+
+      const combobox = wrapper.findComponent({ name: 'ScalarComboboxMultiselect' })
+
+      await combobox.vm?.$emit('update:modelValue', [])
+      await nextTick()
+
+      expect(fn).toHaveBeenCalledTimes(1)
+      expect(fn).toHaveBeenCalledWith({
+        selectedRequirements: [],
+        newSchemes: [],
+        meta: { type: 'document' },
+      })
+    })
+
+    it('keeps additive behavior when createAnySecurityScheme is enabled', async () => {
+      const eventBus = createWorkspaceEventBus()
+      const fn = vi.fn()
+      eventBus.on('auth:update:selected-security-schemes', fn)
+      const wrapper = mountWithProps({
+        eventBus,
+        createAnySecurityScheme: true,
+        securityRequirements: [{ BearerAuth: [] }, { ApiKeyAuth: [] }],
+        selectedSecurity: { selectedIndex: 0, selectedSchemes: [{ BearerAuth: [] }] },
+      })
+
+      const combobox = wrapper.findComponent({ name: 'ScalarComboboxMultiselect' })
+
+      const bearer = wrapper.vm.selectedSchemeOptions[0]
+      const apiKey = flattenOptions(wrapper.vm.schemeOptions).find((option: any) =>
+        Object.keys(option.value).includes('ApiKeyAuth'),
+      )
+
+      await combobox.vm?.$emit('update:modelValue', [bearer, apiKey])
+      await nextTick()
+
+      // Both requirements are kept when composing auth schemes in the collection builder.
+      expect(fn).toHaveBeenCalledTimes(1)
+      expect(fn).toHaveBeenCalledWith({
+        selectedRequirements: [{ BearerAuth: [] }, { ApiKeyAuth: [] }],
+        newSchemes: [],
         meta: { type: 'document' },
       })
     })

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/AuthSelector.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/AuthSelector.vue
@@ -163,14 +163,27 @@ const handleAuthIndicatorClick = (event: Event): void => {
 
 /**
  * Updates the selected auth schemes.
- * Separates existing schemes from newly created ones for the event payload.
+ *
+ * The auth dropdown lists the operation's security requirements as mutually exclusive
+ * OR alternatives. Picking one should replace the previous selection rather than append
+ * to it, so we keep only the option the user just added and emit that single requirement.
+ * An AND-combo (e.g. `apiKeyHeader & apiKeyQuery`) is a single option whose value already
+ * holds both schemes, so a replacement naturally activates both at once.
+ *
+ * When `createAnySecurityScheme` is enabled (the collection builder, not the per-operation
+ * request flow) the dropdown stays additive so users can compose several auth schemes.
  */
 const handleSchemeSelection = (selected: SecuritySchemeOption[]): void => {
-  const existingSchemes = selected
+  // In additive mode keep every selected option; otherwise reduce to the newly added one.
+  const effectiveSelection = createAnySecurityScheme
+    ? selected
+    : getReplacementSelection(selected)
+
+  const existingSchemes = effectiveSelection
     .filter((option) => option.payload === undefined)
     .map((option) => unpackProxyObject(option.value, { depth: 2 }))
 
-  const newSchemes = selected
+  const newSchemes = effectiveSelection
     .filter((option) => option.payload !== undefined)
     .map((option) => ({
       name: option.label,
@@ -182,6 +195,30 @@ const handleSchemeSelection = (selected: SecuritySchemeOption[]): void => {
     newSchemes,
     meta,
   })
+}
+
+/**
+ * Reduces a multiselect emission to a single requirement for replacement behavior.
+ *
+ * The combobox emits the full next selection on every toggle. We diff it against the
+ * currently active options to find the one the user just added and select only that.
+ * Deselecting the last active option (empty emission) clears the selection.
+ */
+const getReplacementSelection = (
+  selected: SecuritySchemeOption[],
+): SecuritySchemeOption[] => {
+  if (selected.length === 0) {
+    return []
+  }
+
+  const activeIds = new Set(
+    activeSchemeOptions.value.map((option) => option.id),
+  )
+  const added = selected.find((option) => !activeIds.has(option.id))
+
+  // A newly added option replaces the previous selection; otherwise keep the last entry
+  // (e.g. re-selecting the only active option) so we never emit more than one requirement.
+  return [added ?? selected[selected.length - 1]!]
 }
 
 /** Shows the delete confirmation modal for the selected scheme */


### PR DESCRIPTION
The Authentication dropdown for an operation with multiple OR security alternatives was additive: picking another method only appended it as a hidden second tab while the active tab stayed on the first scheme, so the fields panel looked frozen. Now selecting an OR alternative replaces the active one and the fields switch to it immediately. AND-combo requirements (e.g. `apiKeyHeader & apiKeyQuery`) remain a single option that activates both schemes at once, and additive composition is preserved for the collection builder.