### PR TITLE
fix(api-reference): auth method dropdown doesn't open

### DIFF
--- a/.changeset/auth-dropdown-teleport-collision.md
+++ b/.changeset/auth-dropdown-teleport-collision.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix the auth scheme dropdown not opening when multiple client apps are on the page (for example, the API reference modal). Each modal app now gets a unique id prefix, so teleport targets no longer collide and the popover renders in the visible app instead of a hidden one

--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.test.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.test.ts
@@ -682,4 +682,29 @@ describe('createApiClientModal', () => {
       'x-scalar-is-dirty': true,
     })
   })
+
+  it('assigns a unique id prefix to each modal app instance', async () => {
+    const workspaceStore = await setupWorkspaceStore()
+
+    const first = createApiClientModal({
+      el: mountElement,
+      workspaceStore,
+      mountOnInitialize: false,
+      eventBus: createTestEventBus(),
+    })
+    const second = createApiClientModal({
+      el: mountElement,
+      workspaceStore,
+      mountOnInitialize: false,
+      eventBus: createTestEventBus(),
+    })
+    createdApps.push(first.app, second.app)
+
+    // Each app needs its own id namespace. Vue derives `useId()` (and our teleport
+    // target ids) from `idPrefix`, so a shared prefix makes two client apps emit
+    // colliding ids and a teleported popover can resolve to the wrong (hidden) app.
+    expect(first.app.config.idPrefix).toMatch(/^scalar-client-\d+$/)
+    expect(second.app.config.idPrefix).toMatch(/^scalar-client-\d+$/)
+    expect(first.app.config.idPrefix).not.toBe(second.app.config.idPrefix)
+  })
 })

--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
@@ -42,6 +42,18 @@ export type ApiClientModal = {
 }
 
 /**
+ * Monotonic counter used to give every modal Vue app a unique `idPrefix`.
+ *
+ * Vue derives `useId()` values (and therefore our teleport target ids) from the app's
+ * `idPrefix`. When more than one client app mounts on the same page — for example, the
+ * API reference embeds this modal alongside another client instance — a shared prefix
+ * makes both apps emit identical ids. A teleported popover then resolves to the first
+ * matching target in the DOM, which can be a hidden app, so the popover never appears.
+ * A per-app suffix keeps the ids unique across instances.
+ */
+let modalAppCount = 0
+
+/**
  * Creates the API Client Modal.
  *
  * The modal does not require a router. Instead, navigation is handled by setting
@@ -149,8 +161,9 @@ export const createApiClientModal = ({
     { immediate: true },
   )
 
-  // Use a unique id prefix to prevent collisions with other Vue apps on the page
-  app.config.idPrefix = 'scalar-client'
+  // Use a unique id prefix to prevent collisions with other Vue apps on the page.
+  // The suffix keeps the prefix unique even when several client apps mount together.
+  app.config.idPrefix = `scalar-client-${modalAppCount++}`
 
   /** Mount the modal to a given element. */
   const mount = (mountingEl: HTMLElement | null = el): void => {


### PR DESCRIPTION
Opening the auth scheme dropdown in the request modal did nothing. The chevron flipped but no menu appeared, so you were stuck on the first scheme (e.g. `basicAuth`) and could not pick another.

The cause: the API reference renders two client app instances on the page (a hidden one plus the visible modal), and both set `app.config.idPrefix = 'scalar-client'`. Vue derives `useId()` - and the teleport target ids built from it - from that prefix, so both apps emitted the same id (`scalar-teleport-scalar-client-0`). The dropdown teleported its popover to that id, `querySelector` returned the first match (the hidden app), and the menu rendered off in an invisible subtree.

The fix suffixes the prefix per instance (`scalar-client-0`, `scalar-client-1`, …) so the ids stay unique and the popover lands in its own visible app.

**Before**

<img width="733" height="251" alt="Screenshot 2026-06-10 at 11 45 26" src="https://github.com/user-attachments/assets/7eab017d-ddf0-4f87-aafb-dc0812bcd86d" />

**After**

<img width="730" height="434" alt="Screenshot 2026-06-10 at 12 41 13" src="https://github.com/user-attachments/assets/6152d55c-573a-41e1-9560-97db45640dc1" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to modal app initialization and a new unit test; no auth or API behavior changes beyond fixing DOM id collisions.
> 
> **Overview**
> Fixes the **auth scheme dropdown** in the request modal appearing to toggle but showing no menu when **more than one API client Vue app** is on the same page (typical API reference embed: a hidden client plus the visible modal).
> 
> Each modal app previously used the same `app.config.idPrefix` (`scalar-client`), so **`useId()` / teleport target ids collided**. The dropdown popover teleported to the first DOM match, often inside the hidden app, so it was invisible.
> 
> **`createApiClientModal`** now assigns a **monotonic per-instance prefix** (`scalar-client-0`, `scalar-client-1`, …) via a module-level counter, with a regression test asserting distinct prefixes across two modal instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be6c8988ef3bb1fbcf3b671f02a79639c721401. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->