### PR TITLE
feat(api-reference): render `$dynamicRef` in schemas

### DIFF
--- a/.changeset/preserve-dynamic-ref-coercion.md
+++ b/.changeset/preserve-dynamic-ref-coercion.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Keep JSON Schema 2020-12 reference keywords (`$id`, `$anchor`, `$dynamicAnchor`, `$dynamicRef`) on Schema Objects when coercing documents during ingestion, so generic templates like `PaginatedResponse<T>` keep their dynamic item binding instead of having it dropped for schemas reachable from an operation

--- a/.changeset/render-dynamic-ref.md
+++ b/.changeset/render-dynamic-ref.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Render JSON Schema 2020-12 `$dynamicRef` in schemas, so generic patterns like `PaginatedResponse<T>` show their concrete bound item type (for example `User[]`) instead of an empty shape. The reference threads the active dynamic scope through the schema tree and binds each `$dynamicRef` to the matching `$dynamicAnchor`.

--- a/packages/api-reference/src/components/Content/Operations/TraversedEntry.vue
+++ b/packages/api-reference/src/components/Content/Operations/TraversedEntry.vue
@@ -5,6 +5,7 @@ import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { AuthStore } from '@scalar/workspace-store/entities/auth'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedPathItem } from '@scalar/workspace-store/helpers/for-each-path-item-operation'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { MergedSecuritySchemes } from '@scalar/workspace-store/request-example'
 import type {
   TraversedEntry,
@@ -219,7 +220,7 @@ function getPathValue(entry: TraversedOperation | TraversedWebhook) {
       :isCollapsed="!expandedItems[entry.id]"
       :name="entry.name"
       :options
-      :schema="document.components.schemas[entry.name]">
+      :schema="getResolvedRef(document.components.schemas[entry.name])">
     </Model>
   </Lazy>
 </template>

--- a/packages/api-reference/src/components/Content/Operations/TraversedEntry.vue
+++ b/packages/api-reference/src/components/Content/Operations/TraversedEntry.vue
@@ -5,7 +5,6 @@ import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import type { AuthStore } from '@scalar/workspace-store/entities/auth'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedPathItem } from '@scalar/workspace-store/helpers/for-each-path-item-operation'
-import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { MergedSecuritySchemes } from '@scalar/workspace-store/request-example'
 import type {
   TraversedEntry,
@@ -220,7 +219,7 @@ function getPathValue(entry: TraversedOperation | TraversedWebhook) {
       :isCollapsed="!expandedItems[entry.id]"
       :name="entry.name"
       :options
-      :schema="getResolvedRef(document.components.schemas[entry.name])">
+      :schema="document.components.schemas[entry.name]">
     </Model>
   </Lazy>
 </template>

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -116,12 +116,17 @@ const resolvedSchema = computed((): SchemaObject | undefined => {
  *
  * Built once at setup from the resource's stable identity (like the ancestor set below);
  * `pushDynamicScope` only grows the scope for schemas that can carry a `$dynamicAnchor`.
+ *
+ * The raw schema is pushed, not the merged {@link resolvedSchema}: merging through `resolve.schema`
+ * coerces the node and drops the resolved `$ref-value` from entries inside `$defs`, which
+ * `$dynamicAnchor` resolution relies on to dereference the bound type (e.g. `User`).
  */
+const scopeSchema = schema
+  ? resolveDynamicSchema(schema, dynamicScope)
+  : undefined
 provide(
   SCHEMA_DYNAMIC_SCOPE_SYMBOL,
-  resolvedSchema.value
-    ? pushDynamicScope(dynamicScope, resolvedSchema.value)
-    : dynamicScope,
+  scopeSchema ? pushDynamicScope(dynamicScope, scopeSchema) : dynamicScope,
 )
 
 /**

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -3,6 +3,8 @@ import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
 import { ScalarIcon } from '@scalar/components/icon'
 import { ScalarMarkdown } from '@scalar/components/markdown'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { pushDynamicScope } from '@scalar/workspace-store/helpers/dynamic-ref'
+import { resolve } from '@scalar/workspace-store/resolve'
 import type {
   DiscriminatorObject,
   SchemaObject,
@@ -14,6 +16,11 @@ import ScreenReader from '@/components/ScreenReader.vue'
 import { useLocalization } from '@/features/localization'
 import { scrollTargetId } from '@/helpers/lazy-bus'
 
+import {
+  resolveDynamicSchema,
+  SCHEMA_DYNAMIC_SCOPE_SYMBOL,
+  useDynamicScope,
+} from './helpers/dynamic-scope'
 import { inferDiscriminatorMappingComposition } from './helpers/get-compositions-to-render'
 import { isEmptySchemaObject } from './helpers/is-empty-schema-object'
 import { isTypeObject } from './helpers/is-type-object'
@@ -78,6 +85,44 @@ const {
   cycleKey?: unknown
 }>()
 const { translate } = useLocalization()
+
+/**
+ * The dynamic scope inherited from ancestor schema resources.
+ *
+ * Used to bind JSON Schema 2020-12 `$dynamicRef`s to the active `$dynamicAnchor` while walking the
+ * tree. Empty at the root. See {@link useDynamicScope}.
+ */
+const dynamicScope = useDynamicScope()
+
+/**
+ * The schema this node actually renders.
+ *
+ * Two normalizations happen here, both no-ops for ordinary schemas:
+ * - A top-level `$dynamicRef` is bound to its concrete type via the inherited dynamic scope.
+ * - A resource that extends a template through a root `$ref` (JSON Schema 2020-12 `$ref` alongside
+ *   `$defs`, e.g. a `PaginatedResponse` binding) is merged so its inherited properties render.
+ */
+const resolvedSchema = computed((): SchemaObject | undefined => {
+  if (!schema || typeof schema !== 'object') {
+    return schema
+  }
+
+  const bound = resolveDynamicSchema(schema, dynamicScope)
+  return '$ref' in bound ? resolve.schema(bound) : bound
+})
+
+/**
+ * Re-provide the dynamic scope grown with this resource so nested `$dynamicRef`s bind here.
+ *
+ * Built once at setup from the resource's stable identity (like the ancestor set below);
+ * `pushDynamicScope` only grows the scope for schemas that can carry a `$dynamicAnchor`.
+ */
+provide(
+  SCHEMA_DYNAMIC_SCOPE_SYMBOL,
+  resolvedSchema.value
+    ? pushDynamicScope(dynamicScope, resolvedSchema.value)
+    : dynamicScope,
+)
 
 /**
  * Cycle-safe `expandAllSchemaProperties`.
@@ -152,6 +197,8 @@ const childAttributesLabel = computed(
 
 /** Gets the description to show for the schema */
 const schemaDescription = computed(() => {
+  const value = resolvedSchema.value
+
   if (hideDescription) {
     return null
   }
@@ -166,26 +213,26 @@ const schemaDescription = computed(() => {
   }
 
   // Don't show description if there's no description or it's not a string
-  if (!schema?.description || typeof schema.description !== 'string') {
+  if (!value?.description || typeof value.description !== 'string') {
     return null
   }
 
   // Don't show description for enum schemas (they have special handling)
-  if (schema.enum) {
+  if (value.enum) {
     return null
   }
 
   // Will be shown in the properties anyway
   if (
-    !('properties' in schema) &&
-    !('patternProperties' in schema) &&
-    !('additionalProperties' in schema)
+    !('properties' in value) &&
+    !('patternProperties' in value) &&
+    !('additionalProperties' in value)
   ) {
     return null
   }
 
   // Return the schema's own description
-  return schema.description
+  return value.description
 })
 
 /**
@@ -217,7 +264,7 @@ const handleClick = (e: MouseEvent) => {
 </script>
 <template>
   <Disclosure
-    v-if="typeof schema === 'object' && Object.keys(schema).length"
+    v-if="resolvedSchema && Object.keys(resolvedSchema).length"
     v-slot="{ open }"
     :defaultOpen="defaultOpen">
     <div
@@ -234,7 +281,7 @@ const handleClick = (e: MouseEvent) => {
         <ScalarMarkdown :value="schemaDescription" />
       </div>
       <div
-        v-if="isEmptySchemaObject(schema)"
+        v-if="isEmptySchemaObject(resolvedSchema)"
         class="pt-2">
         {{ translate('schema.emptyObject') }}
       </div>
@@ -304,8 +351,8 @@ const handleClick = (e: MouseEvent) => {
               icon="Add"
               size="sm" />
             <SchemaHeading
-              :name="schema?.title ?? name"
-              :value="schema" />
+              :name="resolvedSchema?.title ?? name"
+              :value="resolvedSchema" />
           </template>
         </DisclosureButton>
         <DisclosurePanel
@@ -330,7 +377,7 @@ const handleClick = (e: MouseEvent) => {
             :schemaContext="schemaContext" />
           <!-- Object properties -->
           <SchemaObjectProperties
-            v-else-if="isTypeObject(schema)"
+            v-else-if="isTypeObject(resolvedSchema)"
             :breadcrumb
             :compact
             :compositionPath="compositionPath"
@@ -340,12 +387,12 @@ const handleClick = (e: MouseEvent) => {
             :hideModelNames
             :level="level + 1"
             :options
-            :schema
+            :schema="resolvedSchema"
             :schemaContext="schemaContext" />
           <!-- Not an object -->
           <template v-else>
             <SchemaProperty
-              v-if="schema"
+              v-if="resolvedSchema"
               :breadcrumb
               :compact
               :compositionPath="compositionPath"
@@ -354,7 +401,7 @@ const handleClick = (e: MouseEvent) => {
               :hideModelNames
               :level
               :options
-              :schema
+              :schema="resolvedSchema"
               :schemaContext="schemaContext" />
           </template>
         </DisclosurePanel>

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -2,6 +2,10 @@
 import { ScalarMarkdown } from '@scalar/components/markdown'
 import { ScalarWrappingText } from '@scalar/components/wrapping-text'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import {
+  isDynamicRef,
+  resolveDynamicRef,
+} from '@scalar/workspace-store/helpers/dynamic-ref'
 import { resolve } from '@scalar/workspace-store/resolve'
 import type {
   DiscriminatorObject,
@@ -11,6 +15,10 @@ import { isArraySchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-
 import { computed, type Component } from 'vue'
 
 import { WithBreadcrumb } from '@/components/Anchor'
+import {
+  resolveDynamicSchema,
+  useDynamicScope,
+} from '@/components/Content/Schema/helpers/dynamic-scope'
 import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
 import { getCycleKey } from '@/components/Content/Schema/helpers/schema-cycle'
 import type { SchemaOptions } from '@/components/Content/Schema/types'
@@ -78,8 +86,18 @@ const props = withDefaults(
   },
 )
 
-/** Simplified composition with `null` type. */
-const optimizedValue = computed(() => optimizeValueForDisplay(props.schema))
+/** The dynamic scope inherited from the enclosing schema resources, used to bind `$dynamicRef`s. */
+const dynamicScope = useDynamicScope()
+
+/**
+ * Simplified composition with `null` type.
+ *
+ * A top-level `$dynamicRef` (e.g. a linked-list `next` node) is bound to its concrete type via the
+ * dynamic scope first; for ordinary schemas this is a no-op.
+ */
+const optimizedValue = computed(() =>
+  optimizeValueForDisplay(resolveDynamicSchema(props.schema, dynamicScope)),
+)
 
 const childBreadcrumb = computed<string[] | undefined>(() =>
   props.breadcrumb && props.name
@@ -100,9 +118,25 @@ const arrayItemsCompositionPath = computed<string[]>(() => [
 
 const shouldHaveLink = computed(() => props.level <= 2)
 
+/**
+ * The array schema used for item inspection, with a `$dynamicRef` item bound to its concrete type.
+ *
+ * Returns the schema unchanged unless `items` is a `$dynamicRef` that resolves against the dynamic
+ * scope, so ordinary arrays (including `$ref` items) keep their existing behavior exactly.
+ */
+const arrayValueWithBoundItems = computed(() => {
+  const value = optimizedValue.value
+  if (!value || !isArraySchema(value) || !isDynamicRef(value.items)) {
+    return value
+  }
+
+  const bound = resolveDynamicRef(value.items.$dynamicRef, dynamicScope)
+  return bound ? ({ ...value, items: bound } as SchemaObject) : value
+})
+
 /** Checks if array items have complex structure */
 const hasComplexArrayItemsComputed = computed(() =>
-  hasComplexArrayItems(optimizedValue.value),
+  hasComplexArrayItems(arrayValueWithBoundItems.value),
 )
 
 /** Check if enum should be displayed (from value schema or from propertyNames) */
@@ -212,7 +246,7 @@ const compositionsToRender = computed(() =>
 )
 
 /**
- * Get resolved array items for rendering.
+ * Get resolved array items for rendering (with any `$dynamicRef` bound to the concrete type).
  *
  * When the items are wrapped in a single-item composition (e.g. `items: { allOf: [{ type: 'object', ... }] }`), we
  * flatten that wrapper into its plain form. A composition with a single member is equivalent to that member, so
@@ -220,7 +254,7 @@ const compositionsToRender = computed(() =>
  * unnecessary level of nesting and duplicates the item description. See https://github.com/scalar/scalar/issues/5900
  */
 const resolvedArrayItems = computed(() => {
-  const value = optimizedValue.value
+  const value = arrayValueWithBoundItems.value
   if (!value || !isArraySchema(value) || typeof value.items !== 'object') {
     return undefined
   }

--- a/packages/api-reference/src/components/Content/Schema/dynamic-ref.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/dynamic-ref.test.ts
@@ -1,0 +1,85 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import Schema from './Schema.vue'
+
+/**
+ * Builds a `PaginatedResponse<T>`-style resource as the workspace store represents it: a named schema
+ * that extends a shared template through a root `$ref`, binding the template's `$dynamicRef` item type
+ * via a sibling `$defs.itemType`. The `$ref`/`$ref-value` pairs mirror the store's resolved magic proxy.
+ */
+const buildPaginatedResource = (item: Record<string, unknown>) => {
+  const template = {
+    $id: 'https://example.com/schemas/PaginatedTemplate',
+    $defs: { itemType: { $dynamicAnchor: 'itemType', not: {} } },
+    type: 'object',
+    required: ['items', 'total'],
+    properties: {
+      items: { type: 'array', items: { $dynamicRef: '#itemType' } },
+      total: { type: 'integer' },
+    },
+  }
+
+  return {
+    $id: 'https://example.com/schemas/PaginatedResponse',
+    $defs: {
+      itemType: { $dynamicAnchor: 'itemType', $ref: '#/components/schemas/Item', '$ref-value': item },
+    },
+    $ref: '#/components/schemas/PaginatedTemplate',
+    '$ref-value': template,
+  } as unknown as Parameters<typeof mountSchema>[0]
+}
+
+const mountSchema = (schema: unknown) =>
+  mount(Schema, {
+    props: {
+      // Expanding everything lets us assert on nested item properties without driving disclosures.
+      options: { expandAllSchemaProperties: true },
+      eventBus: null,
+      schema: schema as never,
+      level: 1,
+      noncollapsible: true,
+    } as never,
+  })
+
+describe('Schema $dynamicRef rendering', () => {
+  it('renders a template resource by showing its inherited properties', () => {
+    const text = mountSchema(buildPaginatedResource({ type: 'object', properties: { id: { type: 'string' } } })).text()
+    expect(text).toContain('items')
+    expect(text).toContain('total')
+  })
+
+  it('binds the dynamic array item type to the concrete bound schema', () => {
+    const user = {
+      type: 'object',
+      required: ['id', 'email'],
+      properties: { id: { type: 'string' }, email: { type: 'string', format: 'email' } },
+    }
+    const text = mountSchema(buildPaginatedResource(user)).text()
+
+    // The shared `items: { $dynamicRef: '#itemType' }` slot now renders the bound `User` shape.
+    expect(text).toContain('email')
+    expect(text).toContain('id')
+  })
+
+  it('resolves the same template to different item types per binding', () => {
+    const groupText = mountSchema(
+      buildPaginatedResource({ type: 'object', properties: { groupName: { type: 'string' } } }),
+    ).text()
+
+    expect(groupText).toContain('groupName')
+    expect(groupText).not.toContain('email')
+  })
+
+  it('leaves an unresolved $dynamicRef array empty without crashing', () => {
+    // Rendering the bare template (no binding in scope) keeps prior behavior: the item type is unbound.
+    const template = {
+      $id: 'https://example.com/schemas/PaginatedTemplate',
+      $defs: { itemType: { $dynamicAnchor: 'itemType', not: {} } },
+      type: 'object',
+      properties: { items: { type: 'array', items: { $dynamicRef: '#itemType' } } },
+    }
+    const text = mountSchema(template).text()
+    expect(text).toContain('items')
+  })
+})

--- a/packages/api-reference/src/components/Content/Schema/helpers/dynamic-scope.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/dynamic-scope.ts
@@ -1,0 +1,38 @@
+import { type DynamicScope, isDynamicRef, resolveDynamicRef } from '@scalar/workspace-store/helpers/dynamic-ref'
+import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { type InjectionKey, inject } from 'vue'
+
+/**
+ * The dynamic scope — the outermost-first chain of schema resources on the current render path.
+ *
+ * JSON Schema 2020-12 `$dynamicRef` does not resolve to a fixed location. It binds to the active
+ * `$dynamicAnchor` in the chain of resources entered to reach it, so the same
+ * `{ "$dynamicRef": "#itemType" }` inside a shared generic template resolves to a different concrete
+ * type depending on the path taken (e.g. `User` via a user page, `Group` via a group page).
+ *
+ * Each object `Schema` node injects this scope, appends its own resource, and re-provides it to its
+ * descendants. `SchemaProperty` reads it to bind a `$dynamicRef` property or array item to the
+ * concrete schema while walking the tree. See https://github.com/scalar/scalar/issues/9414.
+ */
+export const SCHEMA_DYNAMIC_SCOPE_SYMBOL: InjectionKey<DynamicScope> = Symbol('schema-dynamic-scope')
+
+/** Shared empty scope used as the inject default at the root, where nothing has been entered yet. */
+const EMPTY_SCOPE: DynamicScope = []
+
+/** Read the dynamic scope provided by ancestor schema nodes (empty at the root of the tree). */
+export const useDynamicScope = (): DynamicScope => inject(SCHEMA_DYNAMIC_SCOPE_SYMBOL, EMPTY_SCOPE)
+
+/**
+ * Resolve a schema that may be a `$dynamicRef` against the active dynamic scope.
+ *
+ * Returns the bound concrete schema when the reference matches a `$dynamicAnchor` in scope. When
+ * nothing matches (or the schema is not a `$dynamicRef`) the input is returned unchanged, so
+ * rendering falls back to its prior behavior with no regression.
+ */
+export const resolveDynamicSchema = <T extends SchemaObject | undefined>(schema: T, scope: DynamicScope): T => {
+  if (isDynamicRef(schema)) {
+    return (resolveDynamicRef(schema.$dynamicRef, scope) as T) ?? schema
+  }
+
+  return schema
+}

--- a/packages/workspace-store/src/schemas/v3.1/openapi/dynamic-ref.test.ts
+++ b/packages/workspace-store/src/schemas/v3.1/openapi/dynamic-ref.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import { createWorkspaceStore } from '@/client'
+import { isOpenApiDocument } from '@/schemas/type-guards'
+
+/**
+ * Regression test for https://github.com/scalar/scalar/issues/9414.
+ *
+ * The ingestion pipeline coerces documents against the generated OpenAPI schema. Before the JSON
+ * Schema 2020-12 reference keywords were added to the Schema Object, that coercion dropped
+ * `$dynamicRef` (and friends) from schemas reachable from an operation, so generic templates such as
+ * `PaginatedResponse<T>` lost their dynamic item binding before anything could render it.
+ */
+describe('dynamic-ref coercion', () => {
+  it('keeps $dynamicRef / $dynamicAnchor through ingestion for an operation-reachable schema', async () => {
+    const store = createWorkspaceStore()
+
+    await store.addDocument({
+      name: 'default',
+      document: {
+        openapi: '3.1.0',
+        info: { title: 'DynamicRef', version: '0.0.0' },
+        paths: {
+          '/users': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'A page of users',
+                  content: {
+                    'application/json': { schema: { $ref: '#/components/schemas/PaginatedUserResponse' } },
+                  },
+                },
+              },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            User: { type: 'object', properties: { id: { type: 'string' }, email: { type: 'string' } } },
+            PaginatedTemplate: {
+              $id: 'https://example.com/PaginatedTemplate',
+              $defs: { itemType: { $dynamicAnchor: 'itemType', not: {} } },
+              type: 'object',
+              properties: { items: { type: 'array', items: { $dynamicRef: '#itemType' } } },
+            },
+            PaginatedUserResponse: {
+              $id: 'https://example.com/PaginatedUserResponse',
+              $defs: { itemType: { $dynamicAnchor: 'itemType', $ref: '#/components/schemas/User' } },
+              $ref: '#/components/schemas/PaginatedTemplate',
+            },
+          },
+        },
+      },
+    })
+
+    const document = store.workspace.activeDocument
+    expect(document && isOpenApiDocument(document)).toBe(true)
+    if (!document || !isOpenApiDocument(document)) {
+      return
+    }
+
+    const schemas = document.components?.schemas ?? {}
+
+    // The template keeps the dynamic reference on its array items.
+    const template = schemas.PaginatedTemplate
+    const templateItems = template && 'properties' in template ? template.properties?.items : undefined
+    const arrayItems = templateItems && 'items' in templateItems ? templateItems.items : undefined
+    expect(arrayItems).toMatchObject({ $dynamicRef: '#itemType' })
+
+    // The binding resource keeps its `$dynamicAnchor` so resolution can find the concrete item type.
+    const binding = (schemas.PaginatedUserResponse as { $defs?: { itemType?: { $dynamicAnchor?: string } } }).$defs
+      ?.itemType
+    expect(binding?.$dynamicAnchor).toBe('itemType')
+  })
+})

--- a/packages/workspace-store/src/schemas/v3.1/openapi/index.ts
+++ b/packages/workspace-store/src/schemas/v3.1/openapi/index.ts
@@ -259,6 +259,18 @@ export const generateSchema = (maybeRef: (inner: Schema) => Schema) => {
 
   const coreSchemaProperties = object({
     name: optional(string({ typeComment: 'Schema name (extension).' })),
+    // JSON Schema 2020-12 core reference keywords. OpenAPI 3.1 Schema Objects may carry these for
+    // generic and recursive patterns such as `PaginatedResponse<T>`; keep them typed so coercion
+    // does not drop them. Resolution of `$dynamicRef` against the active `$dynamicAnchor` happens
+    // separately, see https://github.com/scalar/scalar/issues/9414.
+    $id: optional(string({ typeComment: 'JSON Schema 2020-12 schema identifier.' })),
+    $anchor: optional(string({ typeComment: 'JSON Schema 2020-12 plain-name anchor.' })),
+    $dynamicAnchor: optional(
+      string({ typeComment: 'JSON Schema 2020-12 dynamic anchor; the target a matching `$dynamicRef` resolves to.' }),
+    ),
+    $dynamicRef: optional(
+      string({ typeComment: 'JSON Schema 2020-12 dynamic reference, resolved against the active `$dynamicAnchor`.' }),
+    ),
     title: optional(string({ typeComment: 'A title for the schema.' })),
     description: optional(string({ typeComment: 'A description of the schema.' })),
     default: optional(any({ typeComment: 'Default value for the schema.' })),


### PR DESCRIPTION
OpenAPI 3.1 schemas using JSON Schema 2020-12 `$dynamicRef` / `$dynamicAnchor` loaded fine but rendered as empty shapes, so a generic `PaginatedResponse<T>` showed nothing for its item type. Now `@scalar/api-reference` resolves the binding and renders the concrete type: `PaginatedUserResponse.items` shows `User`, and the same template bound to `Group` shows `Group`.

Two small pieces:

- **Rendering (`@scalar/api-reference`)** — carry the JSON Schema dynamic scope down the schema tree and bind each `$dynamicRef` to whatever the resource bound it to.
- **Ingestion (`@scalar/workspace-store`)** — the keywords were being dropped on ingestion, so I added `$id` / `$anchor` / `$dynamicAnchor` / `$dynamicRef` to the Schema Object to let them survive.

## Before

<img width="430" height="365" alt="Screenshot 2026-06-23 at 11 08 40" src="https://github.com/user-attachments/assets/aa6823d6-d345-485a-938e-037e12eb9ce9" />

## After

<img width="498" height="472" alt="Screenshot 2026-06-23 at 11 09 08" src="https://github.com/user-attachments/assets/e976b6d4-795e-4570-8b3d-e77ebc277fd5" />

## Example

```yaml
openapi: 3.1.0
info:
  title: DynamicRef demo
  version: 0.1.0
paths:
  /users:
    get:
      responses:
        '200':
          description: User page
          content:
            application/json:
              schema: { $ref: '#/components/schemas/PaginatedUserResponse' }
  /groups:
    get:
      responses:
        '200':
          description: Group page
          content:
            application/json:
              schema: { $ref: '#/components/schemas/PaginatedGroupResponse' }
components:
  schemas:
    User:
      type: object
      required: [id, email]
      properties:
        id: { type: string }
        email: { type: string, format: email }
    Group:
      type: object
      required: [id, groupName]
      properties:
        id: { type: string }
        groupName: { type: string }
    # Generic, reusable pagination template. Its item type is an unbound $dynamicRef.
    PaginatedTemplate:
      $id: https://example.com/schemas/PaginatedTemplate
      $defs:
        itemType: { $dynamicAnchor: itemType, not: {} }
      type: object
      required: [items, total]
      properties:
        items:
          type: array
          items: { $dynamicRef: '#itemType' }
        total: { type: integer }
    # Binds the template's itemType to User via a sibling $defs + root $ref.
    PaginatedUserResponse:
      $id: https://example.com/schemas/PaginatedUserResponse
      $defs:
        itemType: { $dynamicAnchor: itemType, $ref: '#/components/schemas/User' }
      $ref: '#/components/schemas/PaginatedTemplate'
    # Same template, bound to Group instead.
    PaginatedGroupResponse:
      $id: https://example.com/schemas/PaginatedGroupResponse
      $defs:
        itemType: { $dynamicAnchor: itemType, $ref: '#/components/schemas/Group' }
      $ref: '#/components/schemas/PaginatedTemplate'
```

`PaginatedUserResponse.items` renders the `User` shape (`id`, `email`); `PaginatedGroupResponse.items` renders `Group` (`id`, `groupName`) from the same template.

## Ticket

Part of #9414

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core schema rendering and document coercion across api-reference and workspace-store; behavior is guarded by tests but changes how many schemas display and what survives ingestion.
> 
> **Overview**
> Fixes **empty schema shapes** for OpenAPI 3.1 documents that use JSON Schema 2020-12 **`$dynamicRef` / `$dynamicAnchor`** (e.g. shared `PaginatedTemplate` with `items: { $dynamicRef: '#itemType' }` bound per response).
> 
> **Ingestion** adds `$id`, `$anchor`, `$dynamicAnchor`, and `$dynamicRef` to the OpenAPI 3.1 Schema Object in `@scalar/schemas`, `@scalar/types`, and `@scalar/workspace-store` so coercion no longer strips those keywords from operation-reachable schemas.
> 
> **Resolution** adds `resolveDynamicSchema` in workspace-store to bind a `$dynamicRef` to the active anchor in a dynamic scope, keeping sibling annotations. **API reference** threads that scope via Vue provide/inject (`dynamic-scope`), merges root `$ref` siblings for template bindings, passes **unresolved** component schemas from `TraversedEntry` (so `$defs` bindings survive), and applies the same logic in **ClassicLayout** for the models view. **`SchemaProperty`** binds `$dynamicRef` on array items and direct properties; recursive cases stay bounded via existing cycle detection.
> 
> Tests cover coercion, helper behavior, and `Schema` / `ClassicLayout` rendering for paginated bindings and recursive `$dynamicRef`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95ed74835175b2ff0f94d15a995e70ab8e16607a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->