### PR TITLE
fix(api-reference): preserve schema property order by default 🌶️

### DIFF
--- a/.changeset/preserve-schema-property-order.md
+++ b/.changeset/preserve-schema-property-order.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+'@scalar/types': patch
+'@scalar/schemas': patch
+---
+
+Preserve the schema property order from the OpenAPI document by default. The `orderSchemaPropertiesBy` option now defaults to `'preserve'` instead of `'alpha'`, so the attribute list matches the order in your document (and the example response). Set `orderSchemaPropertiesBy: 'alpha'` to keep alphabetical sorting.

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -909,12 +909,12 @@ Control how schema properties are ordered in model definitions. Can be set to:
 - `'alpha'`: Sort properties alphabetically by name
 - `'preserve'`: Preserve the order from the OpenAPI Document
 
-**Default:** `'alpha'`
+**Default:** `'preserve'`
 
 ```javascript
-// Preserve original ordering
+// Sort properties alphabetically
 {
-  orderSchemaPropertiesBy: 'preserve'
+  orderSchemaPropertiesBy: 'alpha'
 }
 ```
 

--- a/packages/api-reference/src/components/ApiReference.config.test.ts
+++ b/packages/api-reference/src/components/ApiReference.config.test.ts
@@ -181,8 +181,9 @@ describe('ApiReference Configuration Tests', { timeout: 15_000 }, () => {
     // showOperationId: undefined -> false
     expect(wrapper.findComponent({ name: 'Content' }).exists()).toBe(true)
 
-    // orderSchemaPropertiesBy: undefined -> alpha
+    // orderSchemaPropertiesBy: undefined -> preserve
     // orderRequiredPropertiesFirst: undefined -> true
+    // Required properties first (in document order), then the rest in document order
     const propertyNames = wrapper
       .findComponent({ name: 'RequestBody' })
       .findAll('.property-name')
@@ -190,12 +191,12 @@ describe('ApiReference Configuration Tests', { timeout: 15_000 }, () => {
     expect(propertyNames).toStrictEqual([
       'isAdminCopy',
       'phoneCopy',
-      'addressCopy',
+      'nameCopy',
       'ageCopy',
       'createdAtCopy',
-      'emailCopy',
-      'nameCopy',
       'updatedAtCopy',
+      'addressCopy',
+      'emailCopy',
     ])
 
     // hideTestRequestButton: undefined -> false

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -415,7 +415,7 @@ describe('Schema', () => {
   })
 
   describe('object property order', () => {
-    it('should render properties by required alphabetical order', () => {
+    it('renders required properties first, then the document order', () => {
       const wrapper = mount(Schema, {
         props: {
           eventBus: null,
@@ -442,17 +442,17 @@ describe('Schema', () => {
       // Extract property names in the order they appear
       const propertyNames = schemaProperties.map((prop) => prop.props('name'))
 
-      // Expected order: required properties first (alphabetical), then optional properties (alphabetical)
+      // Expected order: required properties first (in document order), then optional properties (in document order)
       const expectedOrder = [
         // Required properties
-        'aRequired',
-        'bRequired',
-        'cRequired',
         'dRequired',
+        'bRequired',
+        'aRequired',
+        'cRequired',
         // Optional properties
-        'aOptional',
-        'bOptional',
         'gOptional',
+        'bOptional',
+        'aOptional',
       ]
 
       expect(propertyNames).toEqual(expectedOrder)

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.test.ts
@@ -203,7 +203,7 @@ describe('SchemaObjectProperties', () => {
     expect(wrapper.find('[data-name="propertyName"]').exists()).toBe(false)
   })
 
-  it('sorts properties alphabetically when all have same required status', () => {
+  it('preserves the original property order by default', () => {
     const schema = coerceValue(SchemaObjectSchema, {
       type: 'object',
       properties: {
@@ -215,6 +215,27 @@ describe('SchemaObjectProperties', () => {
 
     const wrapper = mount(SchemaObjectProperties, {
       props: { schema, options: {}, eventBus: null },
+    })
+
+    const props = wrapper.findAll('.schema-property')
+    expect(props).toHaveLength(3)
+    expect(props[0]?.attributes('data-name')).toBe('zebra')
+    expect(props[1]?.attributes('data-name')).toBe('alpha')
+    expect(props[2]?.attributes('data-name')).toBe('beta')
+  })
+
+  it('sorts properties alphabetically when orderSchemaPropertiesBy is alpha', () => {
+    const schema = coerceValue(SchemaObjectSchema, {
+      type: 'object',
+      properties: {
+        zebra: { type: 'string' },
+        alpha: { type: 'number' },
+        beta: { type: 'boolean' },
+      },
+    })
+
+    const wrapper = mount(SchemaObjectProperties, {
+      props: { schema, options: { orderSchemaPropertiesBy: 'alpha' }, eventBus: null },
     })
 
     const props = wrapper.findAll('.schema-property')
@@ -237,7 +258,7 @@ describe('SchemaObjectProperties', () => {
     })
 
     const wrapper = mount(SchemaObjectProperties, {
-      props: { schema, options: {}, eventBus: null },
+      props: { schema, options: { orderSchemaPropertiesBy: 'alpha' }, eventBus: null },
     })
 
     const props = wrapper.findAll('.schema-property')
@@ -266,6 +287,7 @@ describe('SchemaObjectProperties', () => {
       props: {
         schema,
         options: {
+          orderSchemaPropertiesBy: 'alpha',
           orderRequiredPropertiesFirst: false,
         },
         eventBus: null,
@@ -355,7 +377,7 @@ describe('SchemaObjectProperties', () => {
     const props = wrapper.findAll('.schema-property')
     expect(props).toHaveLength(3)
     // Properties with x-order should come first (sorted by x-order),
-    // then properties without x-order (sorted alphabetically)
+    // then properties without x-order (in their original order)
     expect(props[0]?.attributes('data-name')).toBe('zebra')
     expect(props[1]?.attributes('data-name')).toBe('beta')
     expect(props[2]?.attributes('data-name')).toBe('alpha')

--- a/packages/api-reference/src/components/Content/Schema/helpers/sort-property-names.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/sort-property-names.test.ts
@@ -91,7 +91,7 @@ describe('sortPropertyNames', () => {
       expect(result).toEqual([])
     })
 
-    it('should sort properties alphabetically by default', () => {
+    it('preserves the original order by default', () => {
       const schema: SchemaObject = {
         type: 'object',
         properties: {
@@ -103,7 +103,7 @@ describe('sortPropertyNames', () => {
 
       const result = sortPropertyNames(schema)
 
-      expect(result).toEqual(['apple', 'banana', 'zebra'])
+      expect(result).toEqual(['zebra', 'apple', 'banana'])
     })
 
     it('should handle schema with properties but no type when it has object-like properties', () => {
@@ -117,7 +117,7 @@ describe('sortPropertyNames', () => {
 
       const result = sortPropertyNames(schema)
 
-      expect(result).toEqual(['age', 'name'])
+      expect(result).toEqual(['name', 'age'])
     })
   })
 
@@ -137,7 +137,7 @@ describe('sortPropertyNames', () => {
         orderRequiredPropertiesFirst: true,
       })
 
-      expect(result).toEqual(['banana', 'zebra', 'apple'])
+      expect(result).toEqual(['zebra', 'banana', 'apple'])
     })
 
     it('should not prioritize required properties when orderRequiredPropertiesFirst is false', () => {
@@ -155,7 +155,7 @@ describe('sortPropertyNames', () => {
         orderRequiredPropertiesFirst: false,
       })
 
-      expect(result).toEqual(['apple', 'banana', 'zebra'])
+      expect(result).toEqual(['zebra', 'apple', 'banana'])
     })
 
     it('should handle empty required array', () => {
@@ -170,7 +170,7 @@ describe('sortPropertyNames', () => {
 
       const result = sortPropertyNames(schema)
 
-      expect(result).toEqual(['apple', 'zebra'])
+      expect(result).toEqual(['zebra', 'apple'])
     })
 
     it('should handle missing required property', () => {
@@ -184,7 +184,7 @@ describe('sortPropertyNames', () => {
 
       const result = sortPropertyNames(schema)
 
-      expect(result).toEqual(['apple', 'zebra'])
+      expect(result).toEqual(['zebra', 'apple'])
     })
   })
 
@@ -204,7 +204,7 @@ describe('sortPropertyNames', () => {
 
       const result = sortPropertyNames(schema, discriminator)
 
-      expect(result).toEqual(['type', 'apple', 'zebra'])
+      expect(result).toEqual(['type', 'zebra', 'apple'])
     })
 
     it('should put discriminator property first even before required properties', () => {
@@ -225,7 +225,7 @@ describe('sortPropertyNames', () => {
         orderRequiredPropertiesFirst: true,
       })
 
-      expect(result).toEqual(['type', 'apple', 'zebra'])
+      expect(result).toEqual(['type', 'zebra', 'apple'])
     })
 
     it('should handle discriminator property that does not exist in properties', () => {
@@ -242,7 +242,7 @@ describe('sortPropertyNames', () => {
 
       const result = sortPropertyNames(schema, discriminator)
 
-      expect(result).toEqual(['apple', 'zebra'])
+      expect(result).toEqual(['zebra', 'apple'])
     })
   })
 
@@ -299,7 +299,7 @@ describe('sortPropertyNames', () => {
         hideReadOnly: true,
       })
 
-      expect(result).toEqual(['email', 'name'])
+      expect(result).toEqual(['name', 'email'])
     })
 
     it('should include readOnly properties when hideReadOnly is false', () => {
@@ -316,7 +316,7 @@ describe('sortPropertyNames', () => {
         hideReadOnly: false,
       })
 
-      expect(result).toEqual(['email', 'id', 'name'])
+      expect(result).toEqual(['name', 'id', 'email'])
     })
 
     it('should filter out writeOnly properties when hideWriteOnly is true', () => {
@@ -333,7 +333,7 @@ describe('sortPropertyNames', () => {
         hideWriteOnly: true,
       })
 
-      expect(result).toEqual(['email', 'name'])
+      expect(result).toEqual(['name', 'email'])
     })
 
     it('should include writeOnly properties when hideWriteOnly is false', () => {
@@ -350,7 +350,7 @@ describe('sortPropertyNames', () => {
         hideWriteOnly: false,
       })
 
-      expect(result).toEqual(['email', 'name', 'password'])
+      expect(result).toEqual(['name', 'password', 'email'])
     })
 
     it('should handle both hideReadOnly and hideWriteOnly together', () => {
@@ -369,10 +369,8 @@ describe('sortPropertyNames', () => {
         hideWriteOnly: true,
       })
 
-      // Note: The current implementation only applies the first filter that is true
-      // Since hideReadOnly is checked first, it will filter out readOnly properties
-      // but won't check for writeOnly properties
-      expect(result).toEqual(['email', 'name'])
+      // Both filters apply, so the readOnly and writeOnly properties are removed
+      expect(result).toEqual(['name', 'email'])
     })
 
     it('should handle properties with $ref that resolve to readOnly', () => {
@@ -391,7 +389,7 @@ describe('sortPropertyNames', () => {
         hideReadOnly: true,
       })
 
-      expect(result).toEqual(['email', 'name'])
+      expect(result).toEqual(['name', 'email'])
     })
   })
 
@@ -440,7 +438,7 @@ describe('sortPropertyNames', () => {
 
       const result = sortPropertyNames(schema)
 
-      expect(result).toEqual(['@symbol', 'another_prop', 'normalProp', 'special-prop'])
+      expect(result).toEqual(['special-prop', 'another_prop', 'normalProp', '@symbol'])
     })
 
     it('should handle empty properties object', () => {
@@ -465,7 +463,7 @@ describe('sortPropertyNames', () => {
 
       const result = sortPropertyNames(schema)
 
-      expect(result).toEqual(['age', 'name'])
+      expect(result).toEqual(['name', 'age'])
     })
 
     it('should handle case-insensitive alphabetical sorting', () => {
@@ -479,7 +477,9 @@ describe('sortPropertyNames', () => {
         },
       }
 
-      const result = sortPropertyNames(schema)
+      const result = sortPropertyNames(schema, undefined, {
+        orderSchemaPropertiesBy: 'alpha',
+      })
 
       // localeCompare should handle case-insensitive sorting
       expect(result).toEqual(['apple', 'Banana', 'charlie', 'Zebra'])
@@ -669,7 +669,7 @@ describe('sortPropertyNames', () => {
 
       const result = sortPropertyNames(schema)
 
-      expect(result).toEqual(['age', 'name', 'undefinedProp'])
+      expect(result).toEqual(['name', 'undefinedProp', 'age'])
     })
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/sort-property-names.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/sort-property-names.ts
@@ -31,7 +31,7 @@ export const sortPropertyNames = (
   {
     hideReadOnly = false,
     hideWriteOnly = false,
-    orderSchemaPropertiesBy = 'alpha',
+    orderSchemaPropertiesBy = 'preserve',
     orderRequiredPropertiesFirst = true,
   }: Options = {},
 ): string[] => {

--- a/packages/api-reference/src/components/Content/Schema/types.ts
+++ b/packages/api-reference/src/components/Content/Schema/types.ts
@@ -11,7 +11,7 @@ export type SchemaOptions = {
   hideReadOnly?: boolean
   /** Hide write-only properties */
   hideWriteOnly?: boolean
-  /** Order schema properties, defaults to 'alpha' */
+  /** Order schema properties, defaults to 'preserve' */
   orderSchemaPropertiesBy?: ApiReferenceConfiguration['orderSchemaPropertiesBy']
   /** Order required properties first */
   orderRequiredPropertiesFirst?: ApiReferenceConfiguration['orderRequiredPropertiesFirst']

--- a/packages/schemas/src/api-reference/api-reference-configuration.ts
+++ b/packages/schemas/src/api-reference/api-reference-configuration.ts
@@ -226,7 +226,7 @@ export const apiReferenceConfigurationSchema = intersection([
     operationsSorter: optional(union([literal('alpha'), literal('method'), fn<(a: any, b: any) => number>()]), {
       typeComment: 'Function to sort operations',
     }),
-    orderSchemaPropertiesBy: union([literal('alpha'), literal('preserve')], {
+    orderSchemaPropertiesBy: union([literal('preserve'), literal('alpha')], {
       typeComment: 'Order the schema properties by',
     }),
     orderRequiredPropertiesFirst: boolean({

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -415,13 +415,13 @@ export const apiReferenceConfigurationSchema = baseConfigurationSchema.extend({
     .optional(),
   /**
    * Order the schema properties by
-   * @default 'alpha' for alphabetical sorting
+   * @default 'preserve' to keep the order from the OpenAPI document
    */
   orderSchemaPropertiesBy: z
     .union([z.literal('alpha'), z.literal('preserve')])
     .optional()
-    .default('alpha')
-    .catch('alpha'),
+    .default('preserve')
+    .catch('preserve'),
   /**
    * Sort the schema properties by required ones first
    * @default true


### PR DESCRIPTION
Schema attributes were sorted alphabetically by default, while the example response kept the document order. That mismatch was confusing (#9015).

This flips the `orderSchemaPropertiesBy` default from `'alpha'` to `'preserve'`, so the attribute list now follows the order in your OpenAPI document. Required properties still float to the top (`orderRequiredPropertiesFirst` is unchanged). If you preferred the old behavior, set `orderSchemaPropertiesBy: 'alpha'`.

## Ticket

Closes #9015
