### PR TITLE
fix(api-reference): align SDK install instructions

### DIFF
--- a/.changeset/sdk-install-code-panel.md
+++ b/.changeset/sdk-install-code-panel.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Render SDK installation instructions as plain text so they align with the client library footer without Markdown code highlighting.

--- a/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/components/SdkInstallationInstructions.test.ts
+++ b/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/components/SdkInstallationInstructions.test.ts
@@ -5,7 +5,6 @@ import SdkInstallationInstructions from './SdkInstallationInstructions.vue'
 
 describe('SdkInstallationInstructions', () => {
   const stubs = {
-    ScalarMarkdown: true,
     ScalarIcon: true,
   }
 
@@ -67,6 +66,26 @@ describe('SdkInstallationInstructions', () => {
 
     const panel = wrapper.get('[role="tabpanel"]')
     expect(panel.html()).toContain('Install for TypeScript')
+  })
+
+  it('renders fenced instructions as plain text without syntax highlighting', () => {
+    const wrapper = mount(SdkInstallationInstructions, {
+      props: {
+        xScalarSdkInstallation: [
+          {
+            lang: 'Python',
+            description: ['```properties', 'pip install scalar-warp-api', '```'].join('\n'),
+          },
+        ],
+      },
+      global: { stubs },
+    })
+
+    const panel = wrapper.get('[role="tabpanel"]')
+    expect(panel.text()).toBe('pip install scalar-warp-api')
+    expect(panel.find('pre').exists()).toBe(false)
+    expect(panel.find('code').exists()).toBe(false)
+    expect(panel.find('.hljs').exists()).toBe(false)
   })
 
   it('associates each tab with the panel and labels the panel by the active tab', () => {

--- a/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/components/SdkInstallationInstructions.vue
+++ b/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/components/SdkInstallationInstructions.vue
@@ -4,7 +4,6 @@ import {
   type ScalarComboboxOption,
 } from '@scalar/components/combobox'
 import { ScalarIcon } from '@scalar/components/icon'
-import { ScalarMarkdown } from '@scalar/components/markdown'
 import type { XScalarSdkInstallation } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-sdk-installation'
 import {
   computed,
@@ -301,7 +300,7 @@ onBeforeUnmount(() => {
       </div>
     </div>
 
-    <!-- Content: Markdown installation instructions (supports code blocks) -->
+    <!-- Content: selected SDK installation instruction -->
     <div
       v-if="selected?.description"
       :id="panelId"
@@ -309,24 +308,25 @@ onBeforeUnmount(() => {
       class="selected-client"
       role="tabpanel"
       tabindex="0">
-      <ScalarMarkdown :value="selected.description" />
+      {{ selected.description }}
     </div>
   </div>
 </template>
 <style scoped>
-/* One panel holds the Markdown installation instructions */
 .selected-client {
-  display: flex;
-  flex-direction: column;
-  gap: 9px;
   color: var(--scalar-color-1);
   font-size: var(--scalar-small);
+  font-family: var(--scalar-font-code);
   padding: 9px 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   background: var(--scalar-background-1);
   border: var(--scalar-border-width) solid var(--scalar-border-color);
   border-top: none;
   border-bottom-left-radius: var(--scalar-radius-xl);
   border-bottom-right-radius: var(--scalar-radius-xl);
+  min-height: fit-content;
 }
 .client-libraries-heading {
   font-size: var(--scalar-small);

--- a/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/helpers/renderable-sdks.test.ts
+++ b/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/helpers/renderable-sdks.test.ts
@@ -50,25 +50,41 @@ describe('getRenderableSdks', () => {
 
   it('uses the legacy source as the description when there is no description', () => {
     expect(getRenderableSdks([{ lang: 'Go', source: 'go get example.com/sdk' }])).toEqual([
-      { lang: 'Go', description: '```\ngo get example.com/sdk\n```' },
+      { lang: 'Go', description: 'go get example.com/sdk' },
     ])
   })
 
-  it('appends the legacy source to the description as a fenced code block', () => {
+  it('appends the legacy source to the description as plain text', () => {
     expect(
       getRenderableSdks([{ lang: 'Node', description: 'Install from npm:', source: 'npm install @scalar/sdk' }]),
-    ).toEqual([{ lang: 'Node', description: 'Install from npm:\n\n```\nnpm install @scalar/sdk\n```' }])
+    ).toEqual([{ lang: 'Node', description: 'Install from npm:\nnpm install @scalar/sdk' }])
   })
 
-  it('keeps the description verbatim so indented code blocks survive', () => {
+  it('collapses Markdown fenced code blocks to their contents', () => {
+    const description = ['```properties', 'pip install scalar-warp-api', '```'].join('\n')
+
+    expect(getRenderableSdks([{ lang: 'Python', description }])).toEqual([
+      { lang: 'Python', description: 'pip install scalar-warp-api' },
+    ])
+  })
+
+  it('collapses tilde fenced code blocks to their contents', () => {
+    const description = ['~~~sh', 'npm install scalar-warp-api', '~~~'].join('\n')
+
+    expect(getRenderableSdks([{ lang: 'TypeScript', description }])).toEqual([
+      { lang: 'TypeScript', description: 'npm install scalar-warp-api' },
+    ])
+  })
+
+  it('keeps indented code text when there are no Markdown fences', () => {
     const description = ['Install with Make:', '', '    make install'].join('\n')
 
     expect(getRenderableSdks([{ lang: 'C', description }])).toEqual([{ lang: 'C', description }])
   })
 
-  it('keeps the source inside one code block even when it contains backticks', () => {
+  it('keeps legacy source backticks as plain text', () => {
     expect(getRenderableSdks([{ lang: 'Shell', source: 'echo ```nested```' }])).toEqual([
-      { lang: 'Shell', description: '````\necho ```nested```\n````' },
+      { lang: 'Shell', description: 'echo ```nested```' },
     ])
   })
 

--- a/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/helpers/renderable-sdks.ts
+++ b/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/helpers/renderable-sdks.ts
@@ -3,37 +3,64 @@ import type { XScalarSdkInstallation } from '@scalar/workspace-store/schemas/ext
 /** The array shape stored under `x-scalar-sdk-installation`. */
 type SdkInstallationList = NonNullable<XScalarSdkInstallation['x-scalar-sdk-installation']>
 
-/** A renderable SDK entry whose `description` is the resolved Markdown to show. */
+/** A renderable SDK entry whose `description` is the resolved text to show. */
 type RenderableSdk = {
   lang: string
   description: string
 }
 
-/**
- * Wrap a raw install command in a fenced code block.
- *
- * The fence uses a run of backticks longer than the longest run inside the
- * source, so a `source` that itself contains backticks (or a nested fence)
- * still renders as a single code block instead of breaking out of it.
- */
-const toFencedCodeBlock = (source: string): string => {
-  const longestRun = Math.max(0, ...[...source.matchAll(/`+/g)].map((match) => match[0].length))
-  const fence = '`'.repeat(Math.max(3, longestRun + 1))
+const fenceStart = /^\s*(`{3,}|~{3,})/
 
-  return `${fence}\n${source}\n${fence}`
+/**
+ * Collapse Markdown fenced code blocks to their contents so SDK installation
+ * instructions render like the generic client-library footer instead of a
+ * highlighted Markdown code block.
+ */
+const textFromMarkdown = (markdown: string): string => {
+  const lines = markdown.split('\n')
+  const text: string[] = []
+  let fence: { marker: '`' | '~'; length: number } | undefined
+
+  for (const line of lines) {
+    if (fence) {
+      const closingFence = new RegExp(`^\\s*\\${fence.marker}{${fence.length},}\\s*$`)
+
+      if (closingFence.test(line)) {
+        fence = undefined
+        continue
+      }
+
+      text.push(line)
+      continue
+    }
+
+    const openingFence = line.match(fenceStart)
+
+    if (openingFence?.[1]) {
+      fence = {
+        marker: openingFence[1][0] as '`' | '~',
+        length: openingFence[1].length,
+      }
+      continue
+    }
+
+    text.push(line)
+  }
+
+  return text.join('\n').trim()
 }
 
 /**
  * The SDK installation entries that actually have something to render, each
- * resolved to a single Markdown `description`.
+ * resolved to a single plain-text `description`.
  *
  * A `description` is the promoted content, but the legacy `source` install
- * command is still supported: when both are present it is appended to the
- * description as a fenced code block, and when only `source` is present it
- * becomes the description on its own. Entries that carry neither are ignored so
- * the UI can fall back to the generic client selector instead of showing an
- * empty card. Both the gate in `Content.vue` and the tab list in the block rely
- * on this, so the "has instructions" rule lives in one place.
+ * command is still supported: when both are present it is appended to the text,
+ * and when only `source` is present it becomes the description on its own.
+ * Entries that carry neither are ignored so the UI can fall back to the generic
+ * client selector instead of showing an empty card. Both the gate in
+ * `Content.vue` and the tab list in the block rely on this, so the "has
+ * instructions" rule lives in one place.
  *
  * The value comes straight from an untrusted OpenAPI document, so anything
  * malformed — a non-array extension, a non-object entry, or an entry missing a
@@ -47,17 +74,15 @@ export const getRenderableSdks = (xScalarSdkInstallation: SdkInstallationList | 
           return []
         }
 
-        // Keep the description verbatim so indented code blocks and other
-        // significant whitespace survive; only a whitespace-only value counts
-        // as "no description".
-        const description = typeof sdk.description === 'string' && sdk.description.trim() ? sdk.description : ''
+        const description =
+          typeof sdk.description === 'string' && sdk.description.trim() ? textFromMarkdown(sdk.description) : ''
         const source = typeof sdk.source === 'string' ? sdk.source.trim() : ''
 
         if (!description && !source) {
           return []
         }
 
-        const resolved = [description, source && toFencedCodeBlock(source)].filter(Boolean).join('\n\n')
+        const resolved = [description, source].filter(Boolean).join('\n')
 
         return [{ lang: sdk.lang, description: resolved }]
       })


### PR DESCRIPTION
align client library panel w/ sdk panel

before:
<img width="209" height="163" alt="image" src="https://github.com/user-attachments/assets/30a5b162-2cfe-42fd-a2bd-5a2411f41760" />

after:
<img width="191" height="134" alt="image" src="https://github.com/user-attachments/assets/0eb7d96c-f085-4dbc-a58c-95a74204221f" />

