### PR TITLE
fix(scalar-app): watch mode for documents imported from local file paths

### DIFF
--- a/.changeset/watch-mode-preserve-document-settings.md
+++ b/.changeset/watch-mode-preserve-document-settings.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Preserve document-level UI settings (watch mode, selected server, environments, sidebar order) and user-configured servers across `rebaseDocument` — previously every rebase (e.g. a watch mode pull) silently wiped them

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -3867,6 +3867,13 @@ describe('create-workspace-store', () => {
       // Servers configured by the user — the upstream document defines none
       active.servers = [{ url: 'http://localhost:1234' }]
 
+      // Bake the settings into the saved baseline. This is what makes the test
+      // meaningful: as unsaved local edits they would survive the rebase merge
+      // on their own, so the regression would not be caught. Once they are part
+      // of the baseline, the incoming upstream diff carries a deletion for each
+      // (upstream has none), and only the explicit preservation keeps them.
+      await store.saveDocument(documentName)
+
       const upstream = {
         ...getDocument(),
         info: { title: 'Updated upstream', version: '1.0.0' },
@@ -3882,6 +3889,31 @@ describe('create-workspace-store', () => {
       expect(doc['x-scalar-selected-server']).toBe('my-server-uid')
       expect(doc['x-scalar-environments']).toEqual({ staging: { color: '#FFFFFF', variables: [] } })
       expect(doc.servers).toEqual([{ url: 'http://localhost:1234' }])
+    })
+
+    it('keeps upstream servers authoritative when the upstream document defines them', async () => {
+      const documentName = 'default'
+      const store = createWorkspaceStore()
+      await store.addDocument({ name: documentName, document: getDocument() })
+
+      const active = getActiveOpenApiDocument(store)!
+      // A user server baked into the baseline
+      active.servers = [{ url: 'http://localhost:1234' }]
+      await store.saveDocument(documentName)
+
+      // Upstream now ships its own servers — those must win over the local ones.
+      const upstream = {
+        ...getDocument(),
+        info: { title: 'Updated upstream', version: '1.0.0' },
+        servers: [{ url: 'https://api.example.com' }],
+      }
+
+      const result = await store.rebaseDocument({ name: documentName, document: upstream })
+      assert(result.ok)
+      await result.applyChanges({ resolvedConflicts: [] })
+
+      const doc = getOpenApiDocument(store, documentName)!
+      expect(doc.servers).toEqual([{ url: 'https://api.example.com' }])
     })
   })
 

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -3864,6 +3864,11 @@ describe('create-workspace-store', () => {
       active['x-scalar-watch-mode'] = true
       active['x-scalar-selected-server'] = 'my-server-uid'
       active['x-scalar-environments'] = { staging: { color: '#FFFFFF', variables: [] } }
+      // A custom sidebar order, expressed with the real navigation entry IDs.
+      // Reverse the default order so the rebase has something non-trivial to
+      // restore — without the preservation it resets to the default order.
+      const customOrder = [...(active['x-scalar-order'] ?? [])].reverse()
+      active['x-scalar-order'] = customOrder
       // Servers configured by the user — the upstream document defines none
       active.servers = [{ url: 'http://localhost:1234' }]
 
@@ -3888,6 +3893,7 @@ describe('create-workspace-store', () => {
       expect(doc['x-scalar-watch-mode']).toBe(true)
       expect(doc['x-scalar-selected-server']).toBe('my-server-uid')
       expect(doc['x-scalar-environments']).toEqual({ staging: { color: '#FFFFFF', variables: [] } })
+      expect(doc['x-scalar-order']).toEqual(customOrder)
       expect(doc.servers).toEqual([{ url: 'http://localhost:1234' }])
     })
 

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -3860,7 +3860,7 @@ describe('create-workspace-store', () => {
       const store = createWorkspaceStore()
       await store.addDocument({ name: documentName, document: getDocument() })
 
-      const active = store.workspace.activeDocument!
+      const active = getActiveOpenApiDocument(store)!
       active['x-scalar-watch-mode'] = true
       active['x-scalar-selected-server'] = 'my-server-uid'
       active['x-scalar-environments'] = { staging: { color: '#FFFFFF', variables: [] } }
@@ -3876,7 +3876,7 @@ describe('create-workspace-store', () => {
       assert(result.ok)
       await result.applyChanges({ resolvedConflicts: [] })
 
-      const doc = store.workspace.documents[documentName]!
+      const doc = getOpenApiDocument(store, documentName)!
       expect(doc.info?.title).toBe('Updated upstream')
       expect(doc['x-scalar-watch-mode']).toBe(true)
       expect(doc['x-scalar-selected-server']).toBe('my-server-uid')

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -3854,6 +3854,35 @@ describe('create-workspace-store', () => {
 
       expect(store.workspace.activeDocument?.['x-scalar-is-dirty']).toBe(false)
     })
+
+    it('preserves document-level UI settings and user servers across a rebase', async () => {
+      const documentName = 'default'
+      const store = createWorkspaceStore()
+      await store.addDocument({ name: documentName, document: getDocument() })
+
+      const active = store.workspace.activeDocument!
+      active['x-scalar-watch-mode'] = true
+      active['x-scalar-selected-server'] = 'my-server-uid'
+      active['x-scalar-environments'] = { staging: { color: '#FFFFFF', variables: [] } }
+      // Servers configured by the user — the upstream document defines none
+      active.servers = [{ url: 'http://localhost:1234' }]
+
+      const upstream = {
+        ...getDocument(),
+        info: { title: 'Updated upstream', version: '1.0.0' },
+      }
+
+      const result = await store.rebaseDocument({ name: documentName, document: upstream })
+      assert(result.ok)
+      await result.applyChanges({ resolvedConflicts: [] })
+
+      const doc = store.workspace.documents[documentName]!
+      expect(doc.info?.title).toBe('Updated upstream')
+      expect(doc['x-scalar-watch-mode']).toBe(true)
+      expect(doc['x-scalar-selected-server']).toBe('my-server-uid')
+      expect(doc['x-scalar-environments']).toEqual({ staging: { color: '#FFFFFF', variables: [] } })
+      expect(doc.servers).toEqual([{ url: 'http://localhost:1234' }])
+    })
   })
 
   describe('navigation generation', () => {

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -1617,6 +1617,28 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
           originalDocuments[name] = mergedDocument
           intermediateDocuments[name] = deepClone(mergedDocument)
 
+          // Document-level UI settings never come from the upstream source and
+          // would otherwise be wiped on every rebase. Carry over only the keys
+          // that are actually set so we don't spread `undefined` into the
+          // rebuilt document. The strict document type does not declare every
+          // x-scalar-* UI extension, so read them through an untyped view.
+          const isOpenApi = isOpenApiDocument(activeDocumentRaw)
+          const environments = isOpenApi ? activeDocumentRaw['x-scalar-environments'] : undefined
+          const order = isOpenApi ? activeDocumentRaw['x-scalar-order'] : undefined
+
+          // Keep user-configured servers when the merged document has none
+          // (build-time generated specs typically declare no servers). When the
+          // merged result already carries servers — whether from upstream or
+          // preserved local edits — those stay authoritative.
+          const mergedServers = (mergedDocument as Record<string, unknown>).servers
+          const activeServers = (activeDocumentRaw as Record<string, unknown>).servers
+          const mergedHasServers = Array.isArray(mergedServers) && mergedServers.length > 0
+          const activeHasServers = Array.isArray(activeServers) && activeServers.length > 0
+          const preservedServers =
+            !isAsyncApiDocument(mergedDocument) && !mergedHasServers && activeHasServers
+              ? deepClone(activeServers)
+              : undefined
+
           // add the new active document to the workspace but don't re-initialize
           await addInMemoryDocument({
             ...input,
@@ -1634,27 +1656,12 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
               ...input.meta,
               // Preserve the registry meta
               'x-scalar-registry-meta': activeDocumentRaw['x-scalar-registry-meta'],
-              // Preserve document-level UI settings — they never come from the
-              // upstream source and would otherwise be wiped on every rebase.
-              // The strict document type does not declare every x-scalar-* UI
-              // extension, so read them through an untyped view.
+              // Preserve document-level UI settings (see note above).
               'x-scalar-watch-mode': activeDocumentRaw['x-scalar-watch-mode'],
               'x-scalar-selected-server': activeDocumentRaw['x-scalar-selected-server'],
-              'x-scalar-environments': isOpenApiDocument(activeDocumentRaw)
-                ? activeDocumentRaw['x-scalar-environments']
-                : undefined,
-              'x-scalar-order': isOpenApiDocument(activeDocumentRaw) ? activeDocumentRaw['x-scalar-order'] : undefined,
-              // Keep user-configured servers when the upstream document does not
-              // define any (build-time generated specs typically have none).
-              ...(() => {
-                const mergedServers = (mergedDocument as Record<string, unknown>).servers
-                const activeServers = (activeDocumentRaw as Record<string, unknown>).servers
-                const upstreamHasServers = Array.isArray(mergedServers) && mergedServers.length > 0
-                const activeHasServers = Array.isArray(activeServers) && activeServers.length > 0
-                return !isAsyncApiDocument(mergedDocument) && !upstreamHasServers && activeHasServers
-                  ? { servers: deepClone(activeServers) }
-                  : {}
-              })(),
+              ...(environments !== undefined ? { 'x-scalar-environments': environments } : {}),
+              ...(order !== undefined ? { 'x-scalar-order': order } : {}),
+              ...(preservedServers !== undefined ? { servers: preservedServers } : {}),
               // Flag local edits that need pushing - see note above.
               'x-scalar-is-dirty': hasLocalChangesAgainstUpstream,
             },

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -1634,6 +1634,27 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
               ...input.meta,
               // Preserve the registry meta
               'x-scalar-registry-meta': activeDocumentRaw['x-scalar-registry-meta'],
+              // Preserve document-level UI settings — they never come from the
+              // upstream source and would otherwise be wiped on every rebase.
+              // The strict document type does not declare every x-scalar-* UI
+              // extension, so read them through an untyped view.
+              'x-scalar-watch-mode': activeDocumentRaw['x-scalar-watch-mode'],
+              'x-scalar-selected-server': activeDocumentRaw['x-scalar-selected-server'],
+              'x-scalar-environments': isOpenApiDocument(activeDocumentRaw)
+                ? activeDocumentRaw['x-scalar-environments']
+                : undefined,
+              'x-scalar-order': isOpenApiDocument(activeDocumentRaw) ? activeDocumentRaw['x-scalar-order'] : undefined,
+              // Keep user-configured servers when the upstream document does not
+              // define any (build-time generated specs typically have none).
+              ...(() => {
+                const mergedServers = (mergedDocument as Record<string, unknown>).servers
+                const activeServers = (activeDocumentRaw as Record<string, unknown>).servers
+                const upstreamHasServers = Array.isArray(mergedServers) && mergedServers.length > 0
+                const activeHasServers = Array.isArray(activeServers) && activeServers.length > 0
+                return !isAsyncApiDocument(mergedDocument) && !upstreamHasServers && activeHasServers
+                  ? { servers: deepClone(activeServers) }
+                  : {}
+              })(),
               // Flag local edits that need pushing - see note above.
               'x-scalar-is-dirty': hasLocalChangesAgainstUpstream,
             },

--- a/projects/scalar-app/src/features/app/hooks/use-document-watcher.test.ts
+++ b/projects/scalar-app/src/features/app/hooks/use-document-watcher.test.ts
@@ -127,6 +127,64 @@ describe('useDocumentWatcher', () => {
     await rm(directory, { recursive: true, force: true })
   })
 
+  it('keeps polling when the rebase throws, e.g. while the source file is missing', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'scalar-document-watcher-'))
+    const filePath = join(directory, 'openapi.json')
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'My API', version: '1.0.0' },
+      }),
+    )
+
+    // A loader that throws on read errors, like the IPC readFile rejection in the desktop app
+    const fileLoader: LoaderPlugin = {
+      type: 'loader',
+      validate: () => true,
+      exec: async (path) => {
+        const contents = await readFile(path, 'utf-8')
+        return { ok: true, data: JSON.parse(contents), raw: contents }
+      },
+    }
+
+    const store = createWorkspaceStore({ fileLoader })
+
+    await store.addDocument({
+      name: 'default',
+      path: filePath,
+    })
+
+    const defaultDocument = store.workspace.documents['default'] as OpenApiDocument | undefined
+    assert(defaultDocument)
+    defaultDocument['x-scalar-watch-mode'] = true
+
+    // Delete the source file so the first polls reject (e.g. a build wiped the generated spec)
+    await rm(filePath)
+
+    const initialTimeout = 200
+    useDocumentWatcher({ documentName: ref('default'), store, initialTimeout })
+
+    // First poll throws — the watcher must survive and back off
+    await vi.advanceTimersByTimeAsync(initialTimeout)
+    await vi.advanceTimersToNextTimerAsync()
+
+    // The file reappears with new content (e.g. the build regenerated it)
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        openapi: '3.1.0',
+        info: { title: 'Regenerated API', version: '1.0.0' },
+      }),
+    )
+
+    // The next scheduled poll picks up the new content
+    await vi.advanceTimersByTimeAsync(initialTimeout * 2)
+    await vi.waitFor(() => expect(store.workspace.documents['default']?.info?.title).toBe('Regenerated API'))
+
+    await rm(directory, { recursive: true, force: true })
+  })
+
   it('only keeps one timeout at a time, and it switches when the document changes', async () => {
     let callsA = 0
     let callsB = 0

--- a/projects/scalar-app/src/features/app/hooks/use-document-watcher.test.ts
+++ b/projects/scalar-app/src/features/app/hooks/use-document-watcher.test.ts
@@ -1,5 +1,9 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import type { AddressInfo } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
+import type { LoaderPlugin } from '@scalar/json-magic/bundle'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { type FastifyInstance, fastify } from 'fastify'
@@ -63,6 +67,64 @@ describe('useDocumentWatcher', () => {
     await vi.advanceTimersToNextTimerAsync()
 
     expect(store.workspace.documents['default']?.info?.title).toBe('New updated API')
+  })
+
+  it('watches documents imported from a local file path through the file loader', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'scalar-document-watcher-'))
+    const filePath = join(directory, 'openapi.json')
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'My API', version: '1.0.0' },
+      }),
+    )
+
+    // Reads files from disk like the desktop app's file loader (which goes through IPC)
+    const fileLoader: LoaderPlugin = {
+      type: 'loader',
+      validate: () => true,
+      exec: async (path) => {
+        try {
+          const contents = await readFile(path, 'utf-8')
+          return { ok: true, data: JSON.parse(contents), raw: contents }
+        } catch {
+          return { ok: false }
+        }
+      },
+    }
+
+    const store = createWorkspaceStore({ fileLoader })
+
+    await store.addDocument({
+      name: 'default',
+      path: filePath,
+    })
+
+    const defaultDocument = store.workspace.documents['default'] as OpenApiDocument | undefined
+    assert(defaultDocument)
+
+    // Enable watch mode on the document so the watcher starts polling
+    defaultDocument['x-scalar-watch-mode'] = true
+
+    // Update the file on disk
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        openapi: '3.1.0',
+        info: { title: 'New updated API', version: '1.0.0' },
+      }),
+    )
+
+    const initialTimeout = 200
+    useDocumentWatcher({ documentName: ref('default'), store, initialTimeout })
+
+    await vi.advanceTimersByTimeAsync(initialTimeout)
+
+    // File reads resolve on the real event loop, so wait for the rebase to land
+    await vi.waitFor(() => expect(store.workspace.documents['default']?.info?.title).toBe('New updated API'))
+
+    await rm(directory, { recursive: true, force: true })
   })
 
   it('only keeps one timeout at a time, and it switches when the document changes', async () => {

--- a/projects/scalar-app/src/features/app/hooks/use-document-watcher.ts
+++ b/projects/scalar-app/src/features/app/hooks/use-document-watcher.ts
@@ -188,9 +188,10 @@ export const useDocumentWatcher = ({
         // Exponential backoff on failure
         handleFailure()
       }
-    } catch {
+    } catch (error) {
       // A rebase that throws (e.g. a loader exception when the source file
       // disappeared) must not kill the polling loop — back off and retry.
+      console.error(`[document-watcher] Failed to rebase document '${documentNameValue}':`, error)
       handleFailure()
     }
   }

--- a/projects/scalar-app/src/features/app/hooks/use-document-watcher.ts
+++ b/projects/scalar-app/src/features/app/hooks/use-document-watcher.ts
@@ -168,21 +168,29 @@ export const useDocumentWatcher = ({
       return
     }
 
-    // Local file paths must go through the file loader — passing them as `url`
-    // would send them to the HTTP fetcher, which rejects non-http(s) sources.
-    const result = await storeValue.rebaseDocument(
-      isHttpUrl(sourceUrl) ? { name: documentNameValue, url: sourceUrl } : { name: documentNameValue, path: sourceUrl },
-    )
+    try {
+      // Local file paths must go through the file loader — passing them as `url`
+      // would send them to the HTTP fetcher, which rejects non-http(s) sources.
+      const result = await storeValue.rebaseDocument(
+        isHttpUrl(sourceUrl)
+          ? { name: documentNameValue, url: sourceUrl }
+          : { name: documentNameValue, path: sourceUrl },
+      )
 
-    if (result?.ok) {
-      // On conflicts, prefer remote changes by automatically choosing the first option for each conflict tuple
-      await result.applyChanges({ resolvedConflicts: resolveConflicts(result.conflicts) })
-      handleSuccess()
-    } else if (result?.ok === false && result.type === 'NO_CHANGES_DETECTED') {
-      // Still a successful call, just nothing changed
-      handleSuccess()
-    } else {
-      // Exponential backoff on failure
+      if (result?.ok) {
+        // On conflicts, prefer remote changes by automatically choosing the first option for each conflict tuple
+        await result.applyChanges({ resolvedConflicts: resolveConflicts(result.conflicts) })
+        handleSuccess()
+      } else if (result?.ok === false && result.type === 'NO_CHANGES_DETECTED') {
+        // Still a successful call, just nothing changed
+        handleSuccess()
+      } else {
+        // Exponential backoff on failure
+        handleFailure()
+      }
+    } catch {
+      // A rebase that throws (e.g. a loader exception when the source file
+      // disappeared) must not kill the polling loop — back off and retry.
       handleFailure()
     }
   }

--- a/projects/scalar-app/src/features/app/hooks/use-document-watcher.ts
+++ b/projects/scalar-app/src/features/app/hooks/use-document-watcher.ts
@@ -1,4 +1,5 @@
 import type { Difference } from '@scalar/json-magic/diff'
+import { isHttpUrl } from '@scalar/json-magic/helpers/is-http-url'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { type MaybeRefOrGetter, computed, onBeforeUnmount, toValue, watch } from 'vue'
@@ -167,10 +168,11 @@ export const useDocumentWatcher = ({
       return
     }
 
-    const result = await storeValue.rebaseDocument({
-      name: documentNameValue,
-      url: sourceUrl,
-    })
+    // Local file paths must go through the file loader — passing them as `url`
+    // would send them to the HTTP fetcher, which rejects non-http(s) sources.
+    const result = await storeValue.rebaseDocument(
+      isHttpUrl(sourceUrl) ? { name: documentNameValue, url: sourceUrl } : { name: documentNameValue, path: sourceUrl },
+    )
 
     if (result?.ok) {
       // On conflicts, prefer remote changes by automatically choosing the first option for each conflict tuple

--- a/projects/scalar-app/src/loaders/read-files/index.ts
+++ b/projects/scalar-app/src/loaders/read-files/index.ts
@@ -14,19 +14,27 @@ export const readFiles = (): LoaderPlugin => {
     type: 'loader',
     validate: isFilePath, // Validates the input is a file path
     exec: async (path) => {
-      // Read file content using Electron's exposed API
-      const content = await window.api.readFile(path)
+      try {
+        // Read file content using Electron's exposed API
+        const content = await window.api.readFile(path)
 
-      if (content === undefined) {
-        return {
-          ok: false, // File could not be read or doesn't exist
+        if (content === undefined) {
+          return {
+            ok: false, // File could not be read or doesn't exist
+          }
         }
-      }
 
-      return {
-        ok: true,
-        data: normalize(content), // Normalize the file contents (e.g., parse OpenAPI/YAML/JSON)
-        raw: content,
+        return {
+          ok: true,
+          data: normalize(content), // Normalize the file contents (e.g., parse OpenAPI/YAML/JSON)
+          raw: content,
+        }
+      } catch {
+        // The IPC call rejects when the file can't be read (e.g. it was
+        // deleted). Loader plugins must not throw, so report a failed load.
+        return {
+          ok: false,
+        }
       }
     },
   }


### PR DESCRIPTION
Fixes #9491

## What

In the desktop app, Watch Mode never worked for documents imported from a local file path. The watch poller always passed the document source as `url` to `rebaseDocument`, so local paths were handed to the HTTP fetcher (undici), which rejects anything that isn't http(s):

```
Error occurred in handler for 'customFetch': InvalidArgumentError: Invalid URL protocol: the URL must start with `http:` or `https:`.
```

The file loader branch in `loadDocument` was never reached by watch polling — only by the initial import.

## How

`useDocumentWatcher` now dispatches on the shape of the source using the existing `isHttpUrl` helper from `@scalar/json-magic`:

- `http(s)://…` sources → `{ url }` (unchanged behaviour)
- anything else (local file paths) → `{ path }`, which routes through the workspace store's `fileLoader` (the desktop app's IPC `readFile`)

`rebaseDocument` already accepted the `FileDoc` (`path`) input variant and forwards `workspaceProps.fileLoader` to `loadDocument`, so no store changes were needed.

## Tests

Added a test that imports a document from a real temp file via a `fileLoader`, enables watch mode, modifies the file on disk, and asserts the document gets rebased. (It uses an inline file loader because `readFiles()` from json-magic refuses to run in the jsdom test environment.)

No changeset added since `scalar-app` is private — happy to add one if you want it anyway.

---

**Update — two more fixes uncovered while testing this end-to-end on Windows:**

1. **The watcher died permanently when the source file was missing** (e.g. a build wiped a generated spec): the `readFile` IPC handler rejects on ENOENT, but the file loader assumed it resolves to `undefined` on failure. The rejection escaped through the unguarded poll and stopped polling forever after one failed attempt. Read errors are now caught in the loader (loader plugins must not throw), the poll is guarded with backoff as a second line of defense, and rebase failures are logged instead of swallowed. Regression test included (file disappears → watcher survives → file reappears → content syncs).

2. **Every rebase wiped document-level UI settings** — `x-scalar-watch-mode` (turning watch mode off after its first successful pull!), the selected server, environments, sidebar order and user-configured servers. They're now carried across rebases the same way `x-scalar-registry-meta` already was. User servers are only preserved when the upstream document defines none, so specs that declare servers stay authoritative. Regression test + changeset for `@scalar/workspace-store` included.
