### PR TITLE
fix(api-client): apply renamed keys on expanded query parameter rows

### DIFF
--- a/.changeset/rename-expanded-param-rows.md
+++ b/.changeset/rename-expanded-param-rows.md
@@ -2,4 +2,4 @@
 '@scalar/api-client': patch
 ---
 
-Fix renaming an auto-expanded query parameter row: the new key is now applied to the request and persists in the table, and the original key no longer reappears as an empty suggestion
+Fix renaming an auto-expanded query parameter row: the committed key is applied to the request and persists in the table without writing partial in-progress edits, and the original key no longer reappears as an empty suggestion

--- a/.changeset/rename-expanded-param-rows.md
+++ b/.changeset/rename-expanded-param-rows.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix renaming an auto-expanded query parameter row so the new key is applied to the request and persists in the table

--- a/.changeset/rename-expanded-param-rows.md
+++ b/.changeset/rename-expanded-param-rows.md
@@ -2,4 +2,4 @@
 '@scalar/api-client': patch
 ---
 
-Fix renaming an auto-expanded query parameter row so the new key is applied to the request and persists in the table
+Fix renaming an auto-expanded query parameter row: the new key is now applied to the request and persists in the table, and the original key no longer reappears as an empty suggestion

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.test.ts
@@ -447,6 +447,76 @@ describe('RequestBlock', () => {
     ])
   })
 
+  it('clears renamed expanded query rows when the operation changes', async () => {
+    const pageable = {
+      name: 'pageable',
+      in: 'query',
+      required: false,
+      schema: {
+        type: 'object',
+        properties: {
+          page: {
+            type: 'integer',
+            format: 'int32',
+          },
+          size: {
+            type: 'integer',
+            format: 'int32',
+          },
+        },
+      },
+    } satisfies NonNullable<OperationObject['parameters']>[number]
+    const wrapper = mount(RequestBlock, {
+      props: {
+        ...defaultProps,
+        operation: {
+          summary: '',
+          parameters: [pageable],
+        },
+      },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    })
+
+    const getQueryParams = () => {
+      const queryParams = wrapper
+        .findAllComponents({ name: 'RequestParams' })
+        .find((component) => (component.props() as { title: string }).title === 'Query Parameters')
+
+      if (!queryParams) {
+        throw new Error('Query parameters section not found')
+      }
+
+      return queryParams
+    }
+
+    // Rename the first expanded row ("page" -> "pageX") by committing the key edit on blur.
+    getQueryParams().vm.$emit('upsert', 0, {
+      name: 'pageX',
+      value: '',
+      isDisabled: false,
+      shouldRenameExpandedRow: true,
+    })
+    await nextTick()
+
+    expect((getQueryParams().props() as { rows: TableRow[] }).rows.map((row) => row.name)).toStrictEqual([
+      'pageX',
+      'size',
+    ])
+
+    // Switching to another operation must drop the rename mapping, otherwise it would leak onto a
+    // different request that happens to share the same query parameter name.
+    await wrapper.setProps({ path: 'http://example.com/bar' })
+
+    expect((getQueryParams().props() as { rows: TableRow[] }).rows.map((row) => row.name)).toStrictEqual([
+      'page',
+      'size',
+    ])
+  })
+
   it('re-emits parameter deleteAll for Cookies with mapped type', () => {
     const eventBus = createWorkspaceEventBus()
     const fn = vi.fn()

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
@@ -412,10 +412,14 @@ watch(
   },
 )
 
+// Expanded-row bookkeeping is keyed by `in:name`, which is not unique across operations or
+// examples. Reset both maps when the operation or example changes so stale delete/rename mappings
+// do not leak onto another request that happens to share a query parameter name.
 watch(
   () => [method, path, exampleKey],
   () => {
     deletedExpandedParameterPaths.value = {}
+    renamedExpandedParameterPaths.value = {}
   },
 )
 

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
@@ -112,6 +112,11 @@ const meta = computed(() => ({
 
 const deletedExpandedParameterPaths = ref<Record<string, string[][]>>({})
 
+/** Renamed expanded rows, tracked as old-schema-path -> typed-value-path per parameter. */
+const renamedExpandedParameterPaths = ref<
+  Record<string, { from: string[]; to: string[] }[]>
+>({})
+
 const getExpandedParameterKey = (parameter: {
   in: string
   name: string
@@ -122,6 +127,15 @@ const getHiddenValuePaths = (parameter: {
   name: string
 }): string[][] =>
   deletedExpandedParameterPaths.value[getExpandedParameterKey(parameter)] ?? []
+
+const getRenamedValuePaths = (parameter: {
+  in: string
+  name: string
+}): { from: string[]; to: string[] }[] =>
+  renamedExpandedParameterPaths.value[getExpandedParameterKey(parameter)] ?? []
+
+const pathsEqual = (a: string[], b: string[]): boolean =>
+  a.length === b.length && a.every((segment, index) => segment === b[index])
 
 /**
  * Hides the schema path of an expanded row so it does not reappear as an empty suggestion. Used
@@ -142,6 +156,38 @@ const hideExpandedRowPath = (row: TableRow): void => {
   }
 }
 
+/**
+ * Records that an expanded row was renamed from its current value path to the typed one, so the
+ * read side can render the renamed key in the original property's slot instead of appending it to
+ * the end of the table. Repeated renames of the same row stay anchored to the original schema path.
+ */
+const recordExpandedRowRename = (
+  row: TableRow,
+  newValuePath: string[],
+): void => {
+  if (!row.originalParameter || !row.sourceParameterValuePath) {
+    return
+  }
+
+  const from = row.sourceParameterValuePath
+  const key = getExpandedParameterKey(row.originalParameter)
+  const existing = renamedExpandedParameterPaths.value[key] ?? []
+
+  // If this row was already renamed, the row's current path is the previous target. Re-anchor that
+  // entry to the new target so a second rename does not create an orphaned mapping.
+  const chained = existing.find((entry) => pathsEqual(entry.to, from))
+  const next = chained
+    ? existing.map((entry) =>
+        entry === chained ? { from: entry.from, to: newValuePath } : entry,
+      )
+    : [...existing, { from, to: newValuePath }]
+
+  renamedExpandedParameterPaths.value = {
+    ...renamedExpandedParameterPaths.value,
+    [key]: next,
+  }
+}
+
 /** Parameters grouped by type (path, query, header, cookie) */
 const sections = computed(() =>
   groupBy(
@@ -151,6 +197,8 @@ const sections = computed(() =>
         createParameterRows(param, exampleKey, {
           hiddenValuePaths:
             param.in === 'query' ? getHiddenValuePaths(param) : [],
+          renamedValuePaths:
+            param.in === 'query' ? getRenamedValuePaths(param) : [],
         }).map((row) => ({
           ...row,
           in: param.in,
@@ -396,7 +444,7 @@ const parameterHandlers = computed(() => ({
   query: createParameterHandlers('query', eventBus, meta.value, {
     context: sections.value.query ?? [],
     onDeleteExpandedRow: hideExpandedRowPath,
-    onRenameExpandedRow: hideExpandedRowPath,
+    onRenameExpandedRow: recordExpandedRowRename,
   }),
 }))
 

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
@@ -123,6 +123,25 @@ const getHiddenValuePaths = (parameter: {
 }): string[][] =>
   deletedExpandedParameterPaths.value[getExpandedParameterKey(parameter)] ?? []
 
+/**
+ * Hides the schema path of an expanded row so it does not reappear as an empty suggestion. Used
+ * both when a row is deleted and when its key is renamed (the old key should not pop back up).
+ */
+const hideExpandedRowPath = (row: TableRow): void => {
+  if (!row.originalParameter || !row.sourceParameterValuePath) {
+    return
+  }
+
+  const key = getExpandedParameterKey(row.originalParameter)
+  deletedExpandedParameterPaths.value = {
+    ...deletedExpandedParameterPaths.value,
+    [key]: [
+      ...(deletedExpandedParameterPaths.value[key] ?? []),
+      row.sourceParameterValuePath,
+    ],
+  }
+}
+
 /** Parameters grouped by type (path, query, header, cookie) */
 const sections = computed(() =>
   groupBy(
@@ -376,20 +395,8 @@ const parameterHandlers = computed(() => ({
   }),
   query: createParameterHandlers('query', eventBus, meta.value, {
     context: sections.value.query ?? [],
-    onDeleteExpandedRow: (row) => {
-      if (!row.originalParameter || !row.sourceParameterValuePath) {
-        return
-      }
-
-      const key = getExpandedParameterKey(row.originalParameter)
-      deletedExpandedParameterPaths.value = {
-        ...deletedExpandedParameterPaths.value,
-        [key]: [
-          ...(deletedExpandedParameterPaths.value[key] ?? []),
-          row.sourceParameterValuePath,
-        ],
-      }
-    },
+    onDeleteExpandedRow: hideExpandedRowPath,
+    onRenameExpandedRow: hideExpandedRowPath,
   }),
 }))
 

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestParams.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestParams.vue
@@ -11,7 +11,7 @@ import { computed } from 'vue'
 import { CollapsibleSection } from '@/v2/components/layout'
 
 import RequestTable from './RequestTable.vue'
-import type { TableRow } from './RequestTableRow.vue'
+import type { TableRow, TableRowUpsertPayload } from './RequestTableRow.vue'
 
 const {
   rows,
@@ -37,7 +37,9 @@ const emit = defineEmits<{
   (
     e: 'upsert',
     index: number,
-    payload: ApiReferenceEvents['operation:upsert:parameter']['payload'],
+    payload: ApiReferenceEvents['operation:upsert:parameter']['payload'] & {
+      shouldRenameExpandedRow?: boolean
+    },
   ): void
   (e: 'delete', payload: { index: number }): void
   (e: 'deleteAll'): void
@@ -46,14 +48,7 @@ const emit = defineEmits<{
 const showTooltip = computed(() => rows.length > 1)
 
 /** Needed for type guard */
-const handleUpserRow = (
-  index: number,
-  payload: {
-    name: string
-    value: string | File | undefined
-    isDisabled: boolean
-  },
-) => {
+const handleUpserRow = (index: number, payload: TableRowUpsertPayload) => {
   const { value, ...rest } = payload
 
   // Type guard here as we cannot add files to params

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTable.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTable.vue
@@ -4,6 +4,7 @@ import { computed } from 'vue'
 
 import RequestTableRow, {
   type TableRow,
+  type TableRowUpsertPayload,
 } from '@/v2/blocks/request-block/components/RequestTableRow.vue'
 import {
   DataTable,
@@ -32,15 +33,7 @@ const {
  * Make this component more generic that can be used also for the operation body
  */
 const emit = defineEmits<{
-  (
-    e: 'upsertRow',
-    index: number,
-    payload: {
-      name: string
-      value: string | File | undefined
-      isDisabled: boolean
-    },
-  ): void
+  (e: 'upsertRow', index: number, payload: TableRowUpsertPayload): void
   (e: 'deleteRow', index: number): void
 
   /**

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
@@ -148,7 +148,7 @@ describe('RequestTableRow', () => {
       },
     })
 
-    const keyInput = wrapper.findAllComponents({ name: 'CodeInput' })[0]
+    const keyInput = wrapper.findAllComponents({ name: 'CodeInputLite' })[0]
     await keyInput?.vm.$emit('update:modelValue', 'filter[user]')
 
     expect(wrapper.emitted('upsertRow')).toBeUndefined()
@@ -159,6 +159,56 @@ describe('RequestTableRow', () => {
       name: 'filter[user][role]',
       value: 'admin',
       isDisabled: false,
+      shouldRenameExpandedRow: true,
+    })
+  })
+
+  it('does not emit when the key input is blurred without a change', async () => {
+    const wrapper = mount(RequestTableRow, {
+      props: {
+        data: { name: 'token', value: 'value', isDisabled: true },
+        environment,
+      },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    })
+
+    const keyInput = wrapper.findAllComponents({ name: 'CodeInputLite' })[0]
+    await keyInput?.vm.$emit('blur', 'token')
+
+    // Focusing and blurring without typing should neither re-emit the row nor re-enable it.
+    expect(wrapper.emitted('upsertRow')).toBeUndefined()
+  })
+
+  it('keeps the disabled state when an expanded row key is renamed on blur', async () => {
+    const wrapper = mount(RequestTableRow, {
+      props: {
+        data: {
+          name: 'filter[role]',
+          value: 'admin',
+          isDisabled: true,
+          originalParameter: { name: 'filter', in: 'query' },
+          sourceParameterValuePath: ['role'],
+        },
+        environment,
+      },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    })
+
+    const keyInput = wrapper.findAllComponents({ name: 'CodeInputLite' })[0]
+    await keyInput?.vm.$emit('blur', 'filter[user]')
+
+    expect(wrapper.emitted('upsertRow')?.[0]?.[0]).toStrictEqual({
+      name: 'filter[user]',
+      value: 'admin',
+      isDisabled: true,
       shouldRenameExpandedRow: true,
     })
   })

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
@@ -129,6 +129,40 @@ describe('RequestTableRow', () => {
     })
   })
 
+  it('keeps expanded row key edits local until blur', async () => {
+    const wrapper = mount(RequestTableRow, {
+      props: {
+        data: {
+          name: 'filter[role]',
+          value: 'admin',
+          isDisabled: false,
+          originalParameter: { name: 'filter', in: 'query' },
+          sourceParameterValuePath: ['role'],
+        },
+        environment,
+      },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    })
+
+    const keyInput = wrapper.findAllComponents({ name: 'CodeInput' })[0]
+    await keyInput?.vm.$emit('update:modelValue', 'filter[user]')
+
+    expect(wrapper.emitted('upsertRow')).toBeUndefined()
+
+    await keyInput?.vm.$emit('blur', 'filter[user][role]')
+
+    expect(wrapper.emitted('upsertRow')?.[0]?.[0]).toStrictEqual({
+      name: 'filter[user][role]',
+      value: 'admin',
+      isDisabled: false,
+      shouldRenameExpandedRow: true,
+    })
+  })
+
   it('emits upsertRow when value input changes', async () => {
     const wrapper = mount(RequestTableRow, {
       props: {

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -185,6 +185,23 @@ const handleUpdateRow = (
       : {}),
   })
 }
+
+/**
+ * Commit a key edit when the input loses focus. Expanded-object rows defer their rename to blur (see
+ * handleUpdateRow), so we only emit when the key actually changed — focusing and blurring the field
+ * without typing should not re-emit the row or silently reset its disabled state. The current
+ * disabled state is passed through so a renamed row keeps it.
+ */
+const handleKeyBlur = (newName: string): void => {
+  if (newName === data.name) {
+    return
+  }
+
+  handleUpdateRow(
+    { name: newName, isDisabled: isDisabled.value },
+    { shouldRenameExpandedRow: Boolean(data.sourceParameterValuePath) },
+  )
+}
 </script>
 
 <template>
@@ -209,15 +226,7 @@ const handleUpdateRow = (
         :modelValue="name"
         placeholder="Key"
         :required="Boolean(data.isRequired)"
-        @blur="
-          (v) =>
-            handleUpdateRow(
-              { name: v },
-              {
-                shouldRenameExpandedRow: Boolean(data.sourceParameterValuePath),
-              },
-            )
-        "
+        @blur="(v) => handleKeyBlur(v)"
         @navigate="(route) => emit('navigate', route)"
         @update:modelValue="(v) => handleUpdateRow({ name: v })" />
     </DataTableCell>

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -52,6 +52,13 @@ export type TableRow = {
   sourceParameterValuePath?: string[]
 }
 
+export type TableRowUpsertPayload = {
+  name: string
+  value: string | File
+  isDisabled: boolean
+  shouldRenameExpandedRow?: boolean
+}
+
 const {
   data,
   environment,
@@ -68,10 +75,7 @@ const {
 }>()
 
 const emit = defineEmits<{
-  (
-    e: 'upsertRow',
-    payload: { name: string; value: string | File; isDisabled: boolean },
-  ): void
+  (e: 'upsertRow', payload: TableRowUpsertPayload): void
   (e: 'deleteRow'): void
   (e: 'uploadFile'): void
   (e: 'removeFile'): void
@@ -150,6 +154,7 @@ const validationResult = computed(() =>
 /** Handle row updates while preserving existing properties */
 const handleUpdateRow = (
   payload: Partial<{ name: string; value: string; isDisabled: boolean }>,
+  options: { shouldRenameExpandedRow?: boolean } = {},
 ): void => {
   // Update our local state
   if (payload.name !== undefined) {
@@ -162,11 +167,22 @@ const handleUpdateRow = (
   // Is disabled should always be false unless you explicitly set it to true
   isDisabled.value = payload.isDisabled ?? false
 
+  if (
+    payload.name !== undefined &&
+    data.sourceParameterValuePath &&
+    !options.shouldRenameExpandedRow
+  ) {
+    return
+  }
+
   // Emit all of the local state
   emit('upsertRow', {
     name: name.value,
     value: value.value,
     isDisabled: isDisabled.value,
+    ...(options.shouldRenameExpandedRow
+      ? { shouldRenameExpandedRow: true }
+      : {}),
   })
 }
 </script>
@@ -193,6 +209,15 @@ const handleUpdateRow = (
         :modelValue="name"
         placeholder="Key"
         :required="Boolean(data.isRequired)"
+        @blur="
+          (v) =>
+            handleUpdateRow(
+              { name: v },
+              {
+                shouldRenameExpandedRow: Boolean(data.sourceParameterValuePath),
+              },
+            )
+        "
         @navigate="(route) => emit('navigate', route)"
         @update:modelValue="(v) => handleUpdateRow({ name: v })" />
     </DataTableCell>

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -173,6 +173,53 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('retires the old key when an expanded row is renamed', () => {
+    const parentParameter = {
+      name: 'filters',
+      in: 'query',
+    } as const
+    const row: TableRow = {
+      name: 'status',
+      value: 'active',
+      isDisabled: false,
+      originalParameter: parentParameter,
+      sourceParameterValuePath: ['status'],
+    }
+    const onRenameExpandedRow = vi.fn()
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, {
+      context: [row],
+      onRenameExpandedRow,
+    })
+
+    handlers.upsert(0, { name: 'state', value: 'active', isDisabled: false })
+
+    expect(onRenameExpandedRow).toHaveBeenCalledTimes(1)
+    expect(onRenameExpandedRow).toHaveBeenCalledWith(row)
+  })
+
+  it('does not retire the key when an expanded row value changes but the key does not', () => {
+    const parentParameter = {
+      name: 'filters',
+      in: 'query',
+    } as const
+    const row: TableRow = {
+      name: 'status',
+      value: 'active',
+      isDisabled: false,
+      originalParameter: parentParameter,
+      sourceParameterValuePath: ['status'],
+    }
+    const onRenameExpandedRow = vi.fn()
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, {
+      context: [row],
+      onRenameExpandedRow,
+    })
+
+    handlers.upsert(0, { name: 'status', value: 'inactive', isDisabled: false })
+
+    expect(onRenameExpandedRow).not.toHaveBeenCalled()
+  })
+
   it('renames a deepObject-expanded property row by stripping the parent prefix', () => {
     const parentParameter = {
       name: 'filter',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -152,7 +152,12 @@ describe('createParameterHandlers', () => {
     const handlers = createParameterHandlers('query', mockEventBus, mockMeta, { context })
 
     // The user renames the "status" key to "state".
-    handlers.upsert(0, { name: 'state', value: 'active', isDisabled: false })
+    handlers.upsert(0, {
+      name: 'state',
+      value: 'active',
+      isDisabled: false,
+      shouldRenameExpandedRow: true,
+    })
 
     expect(mockEventBus.emit).toHaveBeenCalledWith(
       'operation:upsert:parameter',
@@ -191,7 +196,12 @@ describe('createParameterHandlers', () => {
       onRenameExpandedRow,
     })
 
-    handlers.upsert(0, { name: 'state', value: 'active', isDisabled: false })
+    handlers.upsert(0, {
+      name: 'state',
+      value: 'active',
+      isDisabled: false,
+      shouldRenameExpandedRow: true,
+    })
 
     expect(onRenameExpandedRow).toHaveBeenCalledTimes(1)
     expect(onRenameExpandedRow).toHaveBeenCalledWith(row)
@@ -237,7 +247,12 @@ describe('createParameterHandlers', () => {
     const handlers = createParameterHandlers('query', mockEventBus, mockMeta, { context })
 
     // The user renames "filter[role]" to a nested "filter[user][role]".
-    handlers.upsert(0, { name: 'filter[user][role]', value: 'admin', isDisabled: false })
+    handlers.upsert(0, {
+      name: 'filter[user][role]',
+      value: 'admin',
+      isDisabled: false,
+      shouldRenameExpandedRow: true,
+    })
 
     expect(mockEventBus.emit).toHaveBeenCalledWith(
       'operation:upsert:parameter',
@@ -246,6 +261,48 @@ describe('createParameterHandlers', () => {
         payload: {
           name: 'filter',
           value: { user: { role: 'admin' } },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-0',
+      },
+    )
+  })
+
+  it('keeps expanded row values at their source path during partial key edits', () => {
+    const parentParameter = {
+      name: 'filter',
+      in: 'query',
+    } as const
+    const context: TableRow[] = [
+      {
+        name: 'filter[role]',
+        value: 'admin',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        sourceParameterValuePath: ['role'],
+      },
+    ]
+    const onRenameExpandedRow = vi.fn()
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, {
+      context,
+      onRenameExpandedRow,
+    })
+
+    handlers.upsert(0, { name: 'filter[user]', value: 'admin', isDisabled: false })
+
+    expect(onRenameExpandedRow).not.toHaveBeenCalled()
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'filter',
+          value: { role: 'admin' },
           isDisabled: false,
         },
         originalParameter: parentParameter,

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -178,7 +178,7 @@ describe('createParameterHandlers', () => {
     )
   })
 
-  it('retires the old key when an expanded row is renamed', () => {
+  it('reports the renamed value path when an expanded row is renamed', () => {
     const parentParameter = {
       name: 'filters',
       in: 'query',
@@ -204,7 +204,35 @@ describe('createParameterHandlers', () => {
     })
 
     expect(onRenameExpandedRow).toHaveBeenCalledTimes(1)
-    expect(onRenameExpandedRow).toHaveBeenCalledWith(row)
+    expect(onRenameExpandedRow).toHaveBeenCalledWith(row, ['state'])
+  })
+
+  it('reports the nested value path when a deepObject row is renamed', () => {
+    const parentParameter = {
+      name: 'filter',
+      in: 'query',
+    } as const
+    const row: TableRow = {
+      name: 'filter[role]',
+      value: 'admin',
+      isDisabled: false,
+      originalParameter: parentParameter,
+      sourceParameterValuePath: ['role'],
+    }
+    const onRenameExpandedRow = vi.fn()
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, {
+      context: [row],
+      onRenameExpandedRow,
+    })
+
+    handlers.upsert(0, {
+      name: 'filter[user][role]',
+      value: 'admin',
+      isDisabled: false,
+      shouldRenameExpandedRow: true,
+    })
+
+    expect(onRenameExpandedRow).toHaveBeenCalledWith(row, ['user', 'role'])
   })
 
   it('does not retire the key when an expanded row value changes but the key does not', () => {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -135,6 +135,82 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('renames a form-expanded property row by moving the value to the typed key', () => {
+    const parentParameter = {
+      name: 'filters',
+      in: 'query',
+    } as const
+    const context: TableRow[] = [
+      {
+        name: 'status',
+        value: 'active',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        sourceParameterValuePath: ['status'],
+      },
+    ]
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, { context })
+
+    // The user renames the "status" key to "state".
+    handlers.upsert(0, { name: 'state', value: 'active', isDisabled: false })
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'filters',
+          value: { state: 'active' },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-0',
+      },
+    )
+  })
+
+  it('renames a deepObject-expanded property row by stripping the parent prefix', () => {
+    const parentParameter = {
+      name: 'filter',
+      in: 'query',
+    } as const
+    const context: TableRow[] = [
+      {
+        name: 'filter[role]',
+        value: 'admin',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        sourceParameterValuePath: ['role'],
+      },
+    ]
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, { context })
+
+    // The user renames "filter[role]" to a nested "filter[user][role]".
+    handlers.upsert(0, { name: 'filter[user][role]', value: 'admin', isDisabled: false })
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'filter',
+          value: { user: { role: 'admin' } },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-0',
+      },
+    )
+  })
+
   it('deletes a parameter at the correct index', () => {
     const mockRow: TableRow = {
       name: 'id',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -5,6 +5,13 @@ import type { TableRow } from '@/v2/blocks/request-block/components/RequestTable
 
 type ParameterType = 'path' | 'cookie' | 'header' | 'query'
 
+type ParameterUpsertPayload = {
+  name: string
+  value: string
+  isDisabled: boolean
+  shouldRenameExpandedRow?: boolean
+}
+
 const isEmptyValue = (value: unknown): boolean => value === undefined || value === null || value === ''
 
 /** Parse a parameter key like `filter[a][b]` into its path segments `['filter', 'a', 'b']`. */
@@ -40,7 +47,7 @@ const getEditedValuePath = (typedName: string, parameterName: string | undefined
 const getExpandedObjectPayload = (
   row: TableRow,
   context: TableRow[],
-  payload?: { name: string; value: string; isDisabled: boolean },
+  payload?: ParameterUpsertPayload,
 ): { name: string; value: Record<string, unknown>; isDisabled: boolean } => {
   const value: Record<string, unknown> = {}
 
@@ -59,9 +66,12 @@ const getExpandedObjectPayload = (
       continue
     }
 
-    // For the edited row, honor the key the user typed so the rename reaches the query.
+    // Key edits are debounced while the user is still typing. Only committed key edits can move
+    // the value to a new object path; regular value updates keep the stable source path.
     const path = isEditedRow
-      ? getEditedValuePath(payload.name, row.originalParameter?.name, contextRow.sourceParameterValuePath)
+      ? payload.shouldRenameExpandedRow
+        ? getEditedValuePath(payload.name, row.originalParameter?.name, contextRow.sourceParameterValuePath)
+        : contextRow.sourceParameterValuePath
       : contextRow.sourceParameterValuePath
 
     setValueAtPath(value, path, nextValue)
@@ -135,8 +145,9 @@ export const createParameterHandlers = (
         type,
         meta,
       }),
-    upsert: (index: number, payload: { name: string; value: string; isDisabled: boolean }) => {
+    upsert: (index: number, payload: ParameterUpsertPayload) => {
       const row = context[index]
+      const { shouldRenameExpandedRow, ...parameterPayload } = payload
 
       if (index < defaultParameters + globalParameters) {
         const extraParameterType = index < defaultParameters ? 'default' : 'global'
@@ -154,11 +165,11 @@ export const createParameterHandlers = (
 
         // When the key of an expanded row changes, retire the old schema path so the original
         // property name does not pop back up as an empty suggestion next to the renamed row.
-        if (isExpandedRow && row && payload.name !== row.name) {
+        if (isExpandedRow && row && shouldRenameExpandedRow && payload.name !== row.name) {
           onRenameExpandedRow?.(row)
         }
 
-        const nextPayload = isExpandedRow && row ? getExpandedObjectPayload(row, context, payload) : payload
+        const nextPayload = isExpandedRow && row ? getExpandedObjectPayload(row, context, payload) : parameterPayload
 
         return eventBus.emit(
           'operation:upsert:parameter',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -7,6 +7,36 @@ type ParameterType = 'path' | 'cookie' | 'header' | 'query'
 
 const isEmptyValue = (value: unknown): boolean => value === undefined || value === null || value === ''
 
+/** Parse a parameter key like `filter[a][b]` into its path segments `['filter', 'a', 'b']`. */
+const parseBracketKey = (name: string): string[] => {
+  const segments: string[] = []
+  const head = name.match(/^[^[\]]*/)?.[0] ?? ''
+  if (head) {
+    segments.push(head)
+  }
+  for (const match of name.matchAll(/\[([^\]]*)\]/g)) {
+    segments.push(match[1] ?? '')
+  }
+  return segments
+}
+
+/**
+ * Derives the value path for an edited expanded row from the key the user typed, so renaming a
+ * property actually moves the value to the new key instead of being dropped. deepObject rows are
+ * prefixed with the parent parameter name (`filter[a]`), which we strip to get the path inside the
+ * value. Falls back to the row's original path when the typed name cannot be parsed.
+ */
+const getEditedValuePath = (typedName: string, parameterName: string | undefined, fallback: string[]): string[] => {
+  const segments = parseBracketKey(typedName)
+  if (segments.length === 0) {
+    return fallback
+  }
+  if (parameterName && segments[0] === parameterName && segments.length > 1) {
+    return segments.slice(1)
+  }
+  return segments
+}
+
 const getExpandedObjectPayload = (
   row: TableRow,
   context: TableRow[],
@@ -23,12 +53,18 @@ const getExpandedObjectPayload = (
       continue
     }
 
-    const nextValue = contextRow === row ? payload?.value : contextRow.value
+    const isEditedRow = contextRow === row && payload !== undefined
+    const nextValue = isEditedRow ? payload.value : contextRow.value
     if (isEmptyValue(nextValue)) {
       continue
     }
 
-    setValueAtPath(value, contextRow.sourceParameterValuePath, nextValue)
+    // For the edited row, honor the key the user typed so the rename reaches the query.
+    const path = isEditedRow
+      ? getEditedValuePath(payload.name, row.originalParameter?.name, contextRow.sourceParameterValuePath)
+      : contextRow.sourceParameterValuePath
+
+    setValueAtPath(value, path, nextValue)
   }
 
   return {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -100,7 +100,7 @@ export const createParameterHandlers = (
     defaultParameters?: number
     globalParameters?: number
     onDeleteExpandedRow?: (row: TableRow) => void
-    onRenameExpandedRow?: (row: TableRow) => void
+    onRenameExpandedRow?: (row: TableRow, newValuePath: string[]) => void
   },
 ) => {
   const offset = defaultParameters + globalParameters
@@ -163,10 +163,15 @@ export const createParameterHandlers = (
       if (index >= offset) {
         const isExpandedRow = Boolean(row?.sourceParameterValuePath && row.originalParameter)
 
-        // When the key of an expanded row changes, retire the old schema path so the original
-        // property name does not pop back up as an empty suggestion next to the renamed row.
+        // When the key of an expanded row changes, report the new value path so the row keeps its
+        // original slot (rendered in place of the old schema property) instead of jumping to the end.
         if (isExpandedRow && row && shouldRenameExpandedRow && payload.name !== row.name) {
-          onRenameExpandedRow?.(row)
+          const newValuePath = getEditedValuePath(
+            payload.name,
+            row.originalParameter?.name,
+            row.sourceParameterValuePath ?? [],
+          )
+          onRenameExpandedRow?.(row, newValuePath)
         }
 
         const nextPayload = isExpandedRow && row ? getExpandedObjectPayload(row, context, payload) : parameterPayload

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -84,11 +84,13 @@ export const createParameterHandlers = (
     defaultParameters = 0,
     globalParameters = 0,
     onDeleteExpandedRow,
+    onRenameExpandedRow,
   }: {
     context: TableRow[]
     defaultParameters?: number
     globalParameters?: number
     onDeleteExpandedRow?: (row: TableRow) => void
+    onRenameExpandedRow?: (row: TableRow) => void
   },
 ) => {
   const offset = defaultParameters + globalParameters
@@ -148,10 +150,15 @@ export const createParameterHandlers = (
       }
 
       if (index >= offset) {
-        const nextPayload =
-          row?.sourceParameterValuePath && row.originalParameter
-            ? getExpandedObjectPayload(row, context, payload)
-            : payload
+        const isExpandedRow = Boolean(row?.sourceParameterValuePath && row.originalParameter)
+
+        // When the key of an expanded row changes, retire the old schema path so the original
+        // property name does not pop back up as an empty suggestion next to the renamed row.
+        if (isExpandedRow && row && payload.name !== row.name) {
+          onRenameExpandedRow?.(row)
+        }
+
+        const nextPayload = isExpandedRow && row ? getExpandedObjectPayload(row, context, payload) : payload
 
         return eventBus.emit(
           'operation:upsert:parameter',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
@@ -332,6 +332,68 @@ describe('createParameterRows', () => {
     )
   })
 
+  it('does not duplicate a row when a property is renamed onto another schema property', () => {
+    const parameter: ParameterObject = {
+      name: 'filters',
+      in: 'query',
+      schema: {
+        type: 'object',
+        properties: {
+          status: { type: 'string' },
+          category: { type: 'string' },
+        },
+      },
+      examples: {
+        default: {
+          // "status" was renamed to the existing "category" property.
+          value: { category: 'active' },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    const rows = createParameterRows(parameter, 'default', {
+      renamedValuePaths: [{ from: ['status'], to: ['category'] }],
+    })
+
+    // Only the renamed row remains in the "status" slot; the schema row for "category" is suppressed
+    // so the same value path is not rendered twice.
+    expect(rows.map((row) => ({ name: row.name, value: row.value, path: row.sourceParameterValuePath }))).toStrictEqual(
+      [{ name: 'category', value: 'active', path: ['category'] }],
+    )
+  })
+
+  it('does not duplicate a deepObject row when a property is renamed onto another schema property', () => {
+    const parameter: ParameterObject = {
+      name: 'filter',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+      schema: {
+        type: 'object',
+        properties: {
+          role: { type: 'string' },
+          team: { type: 'string' },
+        },
+      },
+      examples: {
+        default: {
+          // "role" was renamed onto the existing "team" property.
+          value: { team: 'admin' },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    const rows = createParameterRows(parameter, 'default', {
+      renamedValuePaths: [{ from: ['role'], to: ['team'] }],
+    })
+
+    expect(rows.map((row) => ({ name: row.name, value: row.value, path: row.sourceParameterValuePath }))).toStrictEqual(
+      [{ name: 'filter[team]', value: 'admin', path: ['team'] }],
+    )
+  })
+
   it('hides a renamed row once its new path is also deleted', () => {
     const parameter: ParameterObject = {
       name: 'filters',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
@@ -232,6 +232,134 @@ describe('createParameterRows', () => {
     )
   })
 
+  it('keeps a renamed form property in its original slot via renamedValuePaths', () => {
+    const parameter: ParameterObject = {
+      name: 'filters',
+      in: 'query',
+      schema: {
+        type: 'object',
+        properties: {
+          status: { type: 'string' },
+          category: { type: 'string' },
+        },
+      },
+      examples: {
+        default: {
+          // "status" was renamed to "state", so the value carries the new key in the first slot.
+          value: { state: 'active', category: 'books' },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    const rows = createParameterRows(parameter, 'default', {
+      renamedValuePaths: [{ from: ['status'], to: ['state'] }],
+    })
+
+    // The renamed row stays where "status" was instead of being appended after "category".
+    expect(rows.map((row) => ({ name: row.name, value: row.value, path: row.sourceParameterValuePath }))).toStrictEqual(
+      [
+        { name: 'state', value: 'active', path: ['state'] },
+        { name: 'category', value: 'books', path: ['category'] },
+      ],
+    )
+  })
+
+  it('keeps a renamed deepObject property in its original slot via renamedValuePaths', () => {
+    const parameter: ParameterObject = {
+      name: 'filter',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+      schema: {
+        type: 'object',
+        properties: {
+          role: { type: 'string' },
+          team: { type: 'string' },
+        },
+      },
+      examples: {
+        default: {
+          value: { user: { role: 'admin' }, team: 'core' },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    const rows = createParameterRows(parameter, 'default', {
+      renamedValuePaths: [{ from: ['role'], to: ['user', 'role'] }],
+    })
+
+    expect(rows.map((row) => ({ name: row.name, value: row.value, path: row.sourceParameterValuePath }))).toStrictEqual(
+      [
+        { name: 'filter[user][role]', value: 'admin', path: ['user', 'role'] },
+        { name: 'filter[team]', value: 'core', path: ['team'] },
+      ],
+    )
+  })
+
+  it('does not duplicate the old key while the debounced value move is pending', () => {
+    const parameter: ParameterObject = {
+      name: 'filters',
+      in: 'query',
+      schema: {
+        type: 'object',
+        properties: {
+          status: { type: 'string' },
+          category: { type: 'string' },
+        },
+      },
+      examples: {
+        default: {
+          // The rename is recorded immediately, but the value move is debounced, so the value still
+          // carries the old "status" key for a moment.
+          value: { status: 'active', category: 'books' },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    const rows = createParameterRows(parameter, 'default', {
+      renamedValuePaths: [{ from: ['status'], to: ['state'] }],
+    })
+
+    // Only one row for the renamed property, showing the value from the old path as a fallback.
+    expect(rows.map((row) => ({ name: row.name, value: row.value, path: row.sourceParameterValuePath }))).toStrictEqual(
+      [
+        { name: 'state', value: 'active', path: ['state'] },
+        { name: 'category', value: 'books', path: ['category'] },
+      ],
+    )
+  })
+
+  it('hides a renamed row once its new path is also deleted', () => {
+    const parameter: ParameterObject = {
+      name: 'filters',
+      in: 'query',
+      schema: {
+        type: 'object',
+        properties: {
+          status: { type: 'string' },
+          category: { type: 'string' },
+        },
+      },
+      examples: {
+        default: {
+          // Deleting the renamed row removes its value, so only "category" remains.
+          value: { category: 'books' },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    const rows = createParameterRows(parameter, 'default', {
+      renamedValuePaths: [{ from: ['status'], to: ['state'] }],
+      hiddenValuePaths: [['state']],
+    })
+
+    expect(rows.map((row) => row.name)).toStrictEqual(['category'])
+  })
+
   it('omits expanded rows hidden by path', () => {
     const parameter: ParameterObject = {
       name: 'pageable',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
@@ -173,6 +173,65 @@ describe('createParameterRows', () => {
     expect(updatedRows[1]?.value).toBe('20')
   })
 
+  it('surfaces a renamed form property as its own row', () => {
+    const parameter: ParameterObject = {
+      name: 'filters',
+      in: 'query',
+      schema: {
+        type: 'object',
+        properties: {
+          status: { type: 'string' },
+        },
+      },
+      examples: {
+        default: {
+          // The user renamed "status" to "state", so the value carries a key the schema does not describe.
+          value: { state: 'active' },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    const rows = createParameterRows(parameter, 'default')
+
+    expect(rows.map((row) => ({ name: row.name, value: row.value, path: row.sourceParameterValuePath }))).toStrictEqual(
+      [
+        { name: 'status', value: '', path: ['status'] },
+        { name: 'state', value: 'active', path: ['state'] },
+      ],
+    )
+  })
+
+  it('surfaces a renamed deepObject property with bracket notation', () => {
+    const parameter: ParameterObject = {
+      name: 'filter',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+      schema: {
+        type: 'object',
+        properties: {
+          role: { type: 'string' },
+        },
+      },
+      examples: {
+        default: {
+          value: { user: { role: 'admin' } },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    const rows = createParameterRows(parameter, 'default')
+
+    expect(rows.map((row) => ({ name: row.name, value: row.value, path: row.sourceParameterValuePath }))).toStrictEqual(
+      [
+        { name: 'filter[role]', value: '', path: ['role'] },
+        { name: 'filter[user][role]', value: 'admin', path: ['user', 'role'] },
+      ],
+    )
+  })
+
   it('omits expanded rows hidden by path', () => {
     const parameter: ParameterObject = {
       name: 'pageable',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -158,6 +158,7 @@ const getExpandedPropertyRows = ({
   isDisabled,
   hiddenValuePaths,
   renamedValuePaths,
+  renameTargetPaths,
 }: {
   parameter: ParameterObject
   schema: Extract<SchemaObject, { type: 'object' }>
@@ -168,6 +169,7 @@ const getExpandedPropertyRows = ({
   isDisabled: boolean
   hiddenValuePaths: ReadonlySet<string>
   renamedValuePaths: ReadonlyMap<string, string[]>
+  renameTargetPaths: ReadonlySet<string>
 }): TableRow[] => {
   if (!schema.properties) {
     return []
@@ -213,6 +215,13 @@ const getExpandedPropertyRows = ({
       ]
     }
 
+    // Another property was renamed onto this path (for example "a" renamed to an existing "b").
+    // The renamed row already occupies this slot, so skip the schema-derived row to avoid rendering
+    // two rows for the same value path.
+    if (renameTargetPaths.has(toPathKey(path))) {
+      return []
+    }
+
     // Only deepObject style recurses into nested objects. The OpenAPI 3.1 spec says form-style
     // explode flattens only the top-level properties.
     const shouldRecurse =
@@ -229,6 +238,7 @@ const getExpandedPropertyRows = ({
         isDisabled,
         hiddenValuePaths,
         renamedValuePaths,
+        renameTargetPaths,
       })
     }
 
@@ -358,6 +368,8 @@ export const createParameterRows = (
 
   const hiddenValuePaths = new Set(options.hiddenValuePaths?.map(toPathKey) ?? [])
   const renamedValuePaths = new Map((options.renamedValuePaths ?? []).map(({ from, to }) => [toPathKey(from), to]))
+  // Paths a property was renamed onto, used to suppress the colliding schema-derived row.
+  const renameTargetPaths = new Set((options.renamedValuePaths ?? []).map(({ to }) => toPathKey(to)))
 
   const rows = getExpandedPropertyRows({
     parameter,
@@ -370,6 +382,7 @@ export const createParameterRows = (
     isDisabled,
     hiddenValuePaths,
     renamedValuePaths,
+    renameTargetPaths,
   })
 
   // Surface keys present in the value but not in the schema (for example a renamed property) so the

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -212,6 +212,74 @@ const getExpandedPropertyRows = ({
 }
 
 /**
+ * Collects the leaf paths of an object value. In `form` mode only the top-level keys are leaves
+ * (form-style explode does not flatten nested objects); in `deepObject` mode we recurse into nested
+ * objects, mirroring how the rows and serialization are built.
+ */
+const collectValueLeafPaths = (value: unknown, mode: ExpansionMode): string[][] => {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return []
+  }
+
+  const paths: string[][] = []
+
+  const walk = (node: Record<string, unknown>, prefix: string[]): void => {
+    for (const [key, val] of Object.entries(node)) {
+      const path = [...prefix, key]
+
+      if (mode === 'deepObject' && val !== null && typeof val === 'object' && !Array.isArray(val)) {
+        walk(val as Record<string, unknown>, path)
+      } else {
+        paths.push(path)
+      }
+    }
+  }
+
+  walk(value as Record<string, unknown>, [])
+
+  return paths
+}
+
+/**
+ * Builds rows for value paths that the schema does not describe. This keeps user-edited keys (for
+ * example a property that was renamed in the table) visible instead of snapping back to the
+ * schema-derived rows on the next render.
+ */
+const getUnmappedValueRows = ({
+  parameter,
+  value,
+  schemaRows,
+  mode,
+  isDisabled,
+  hiddenValuePaths,
+}: {
+  parameter: ParameterObject
+  value: unknown
+  schemaRows: TableRow[]
+  mode: ExpansionMode
+  isDisabled: boolean
+  hiddenValuePaths: ReadonlySet<string>
+}): TableRow[] => {
+  const seen = new Set(schemaRows.map((row) => toPathKey(row.sourceParameterValuePath ?? [])))
+
+  return collectValueLeafPaths(value, mode)
+    .filter((path) => !seen.has(toPathKey(path)) && !hiddenValuePaths.has(toPathKey(path)))
+    .map((path) =>
+      toTableRow({
+        parameter,
+        // deepObject names mirror the wire format (`parent[a][b]`); form-style uses the bare key.
+        name: mode === 'deepObject' ? `${parameter.name}${path.map((segment) => `[${segment}]`).join('')}` : path[0]!,
+        value: getValueAtPath(value, path),
+        description: parameter.description,
+        schema: undefined,
+        isRequired: false,
+        isDisabled,
+        sourceParameterValuePath: path,
+      }),
+    )
+}
+
+/**
  * Turns a single OpenAPI parameter into one or more table rows.
  *
  * For object-typed query parameters with `form`/`explode: true` (the default) or `deepObject`
@@ -257,5 +325,16 @@ export const createParameterRows = (
     hiddenValuePaths,
   })
 
-  return rows
+  // Surface keys present in the value but not in the schema (for example a renamed property) so the
+  // edited key keeps showing up instead of snapping back to the schema-derived rows.
+  const unmappedRows = getUnmappedValueRows({
+    parameter,
+    value,
+    schemaRows: rows,
+    mode,
+    isDisabled,
+    hiddenValuePaths,
+  })
+
+  return [...rows, ...unmappedRows]
 }

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -1,4 +1,5 @@
 import { getValueAtPath } from '@scalar/helpers/object/get-value-at-path'
+import { isObject } from '@scalar/helpers/object/is-object'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import { deSerializeParameter, getExample } from '@scalar/workspace-store/request-example'
 import type {
@@ -252,7 +253,7 @@ const getExpandedPropertyRows = ({
  * objects, mirroring how the rows and serialization are built.
  */
 const collectValueLeafPaths = (value: unknown, mode: ExpansionMode): string[][] => {
-  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+  if (!isObject(value)) {
     return []
   }
 
@@ -262,15 +263,15 @@ const collectValueLeafPaths = (value: unknown, mode: ExpansionMode): string[][] 
     for (const [key, val] of Object.entries(node)) {
       const path = [...prefix, key]
 
-      if (mode === 'deepObject' && val !== null && typeof val === 'object' && !Array.isArray(val)) {
-        walk(val as Record<string, unknown>, path)
+      if (mode === 'deepObject' && isObject(val)) {
+        walk(val, path)
       } else {
         paths.push(path)
       }
     }
   }
 
-  walk(value as Record<string, unknown>, [])
+  walk(value, [])
 
   return paths
 }

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -112,6 +112,13 @@ const toTableRow = ({
   sourceParameterValuePath,
 })
 
+/**
+ * Builds the row name for an expanded property at a given value path. deepObject rows mirror the
+ * wire format (`parent[a][b]`); form-style explode uses the bare top-level key.
+ */
+const getExpandedRowName = (parameter: ParameterObject, path: string[], mode: ExpansionMode): string =>
+  mode === 'deepObject' ? `${parameter.name}${path.map((segment) => `[${segment}]`).join('')}` : (path[0] ?? '')
+
 /** Build the single-row representation used when a parameter is not expanded. */
 const toSingleParameterRow = (
   parameter: ParameterObject,
@@ -149,6 +156,7 @@ const getExpandedPropertyRows = ({
   mode,
   isDisabled,
   hiddenValuePaths,
+  renamedValuePaths,
 }: {
   parameter: ParameterObject
   schema: Extract<SchemaObject, { type: 'object' }>
@@ -158,6 +166,7 @@ const getExpandedPropertyRows = ({
   mode: ExpansionMode
   isDisabled: boolean
   hiddenValuePaths: ReadonlySet<string>
+  renamedValuePaths: ReadonlyMap<string, string[]>
 }): TableRow[] => {
   if (!schema.properties) {
     return []
@@ -174,8 +183,33 @@ const getExpandedPropertyRows = ({
     const path = [...pathPrefix, propertyName]
     const name = namePrefix ? `${namePrefix}[${propertyName}]` : propertyName
 
-    if (hiddenValuePaths.has(toPathKey(path))) {
+    // When this property was renamed, the value lives at the typed key instead of the schema path.
+    // Keep the row in its original slot so it does not jump to the end of the table.
+    const renamedTo = renamedValuePaths.get(toPathKey(path))
+    const effectivePath = renamedTo ?? path
+
+    if (hiddenValuePaths.has(toPathKey(effectivePath))) {
       return []
+    }
+
+    if (renamedTo) {
+      // The value move is debounced, so until it lands the value still sits at the old schema path.
+      // Fall back to it so the renamed row shows its value immediately instead of flickering empty.
+      const renamedValue = getValueAtPath(value, renamedTo)
+
+      return [
+        toTableRow({
+          parameter,
+          name: getExpandedRowName(parameter, renamedTo, mode),
+          value: renamedValue === undefined ? getValueAtPath(value, path) : renamedValue,
+          description: parameter.description,
+          // The renamed key no longer maps to the schema property, so it carries no schema.
+          schema: undefined,
+          isRequired: false,
+          isDisabled,
+          sourceParameterValuePath: renamedTo,
+        }),
+      ]
     }
 
     // Only deepObject style recurses into nested objects. The OpenAPI 3.1 spec says form-style
@@ -193,6 +227,7 @@ const getExpandedPropertyRows = ({
         mode,
         isDisabled,
         hiddenValuePaths,
+        renamedValuePaths,
       })
     }
 
@@ -251,14 +286,21 @@ const getUnmappedValueRows = ({
   schemaRows,
   mode,
   isDisabled,
+  renamedValuePaths,
 }: {
   parameter: ParameterObject
   value: unknown
   schemaRows: TableRow[]
   mode: ExpansionMode
   isDisabled: boolean
+  renamedValuePaths: ReadonlyMap<string, string[]>
 }): TableRow[] => {
-  const seen = new Set(schemaRows.map((row) => toPathKey(row.sourceParameterValuePath ?? [])))
+  // Skip the renamed-away source paths too: the value move is debounced, so the old key lingers in
+  // the value for a moment and would otherwise flash as a duplicate row next to the renamed one.
+  const seen = new Set([
+    ...schemaRows.map((row) => toPathKey(row.sourceParameterValuePath ?? [])),
+    ...renamedValuePaths.keys(),
+  ])
 
   // These rows always render: a key that carries a value should stay visible. The hidden-path set
   // only suppresses empty schema suggestions, so it is intentionally not applied here.
@@ -267,8 +309,7 @@ const getUnmappedValueRows = ({
     .map((path) =>
       toTableRow({
         parameter,
-        // deepObject names mirror the wire format (`parent[a][b]`); form-style uses the bare key.
-        name: mode === 'deepObject' ? `${parameter.name}${path.map((segment) => `[${segment}]`).join('')}` : path[0]!,
+        name: getExpandedRowName(parameter, path, mode),
         value: getValueAtPath(value, path),
         description: parameter.description,
         schema: undefined,
@@ -290,7 +331,10 @@ const getUnmappedValueRows = ({
 export const createParameterRows = (
   parameter: ParameterObject,
   exampleKey: string,
-  options: { hiddenValuePaths?: readonly string[][] } = {},
+  options: {
+    hiddenValuePaths?: readonly string[][]
+    renamedValuePaths?: readonly { from: string[]; to: string[] }[]
+  } = {},
 ): TableRow[] => {
   const example = getExample(parameter, exampleKey, undefined)
   const isDisabled = isParamDisabled(parameter, example)
@@ -312,6 +356,7 @@ export const createParameterRows = (
   }
 
   const hiddenValuePaths = new Set(options.hiddenValuePaths?.map(toPathKey) ?? [])
+  const renamedValuePaths = new Map((options.renamedValuePaths ?? []).map(({ from, to }) => [toPathKey(from), to]))
 
   const rows = getExpandedPropertyRows({
     parameter,
@@ -323,6 +368,7 @@ export const createParameterRows = (
     mode,
     isDisabled,
     hiddenValuePaths,
+    renamedValuePaths,
   })
 
   // Surface keys present in the value but not in the schema (for example a renamed property) so the
@@ -333,6 +379,7 @@ export const createParameterRows = (
     schemaRows: rows,
     mode,
     isDisabled,
+    renamedValuePaths,
   })
 
   return [...rows, ...unmappedRows]

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -251,19 +251,19 @@ const getUnmappedValueRows = ({
   schemaRows,
   mode,
   isDisabled,
-  hiddenValuePaths,
 }: {
   parameter: ParameterObject
   value: unknown
   schemaRows: TableRow[]
   mode: ExpansionMode
   isDisabled: boolean
-  hiddenValuePaths: ReadonlySet<string>
 }): TableRow[] => {
   const seen = new Set(schemaRows.map((row) => toPathKey(row.sourceParameterValuePath ?? [])))
 
+  // These rows always render: a key that carries a value should stay visible. The hidden-path set
+  // only suppresses empty schema suggestions, so it is intentionally not applied here.
   return collectValueLeafPaths(value, mode)
-    .filter((path) => !seen.has(toPathKey(path)) && !hiddenValuePaths.has(toPathKey(path)))
+    .filter((path) => !seen.has(toPathKey(path)))
     .map((path) =>
       toTableRow({
         parameter,
@@ -333,7 +333,6 @@ export const createParameterRows = (
     schemaRows: rows,
     mode,
     isDisabled,
-    hiddenValuePaths,
   })
 
   return [...rows, ...unmappedRows]


### PR DESCRIPTION
Renaming the key of an auto-expanded query parameter row did nothing. 

The value was rebuilt from the original schema path, so the change never reached the request and the typed key vanished on the next render.

Now the edited row's value path is created from the key you type, and any value key the schema doesn't describe is surfaced as its own row, so a renamed property sticks in both the request and the table.

<img width="504" height="372" alt="Screenshot 2026-06-11 at 11 40 17" src="https://github.com/user-attachments/assets/4671744a-6102-4247-b846-4ee36b9b45c7" />

## Ticket

Part of #9492

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query parameter serialization and UI state for expanded object params; scope is limited to the api-client request block with broad test coverage, but incorrect path parsing could mis-serialize requests.
> 
> **Overview**
> Fixes **renaming keys on auto-expanded object query parameters** (form explode and `deepObject`) so edits actually update the outgoing request and stay visible in the table.
> 
> **Commit on blur, not while typing:** Expanded rows stop emitting parameter upserts on every keystroke in the key field; renames commit on blur with `shouldRenameExpandedRow`, so partial keys are not written to the example object.
> 
> **Write path:** Upsert logic parses bracket keys, moves values to the new object path on committed renames, and supports nested `deepObject` paths. `RequestBlock` tracks rename mappings per parameter and clears them when method, path, or example changes so renames do not leak across operations.
> 
> **Read path:** `createParameterRows` accepts `renamedValuePaths` to keep renamed rows in the original schema slot, show values before debounced persistence catches up, surface keys not in the schema, and avoid duplicate rows when renaming onto an existing property.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caa8d79591f6608ce0ebc37061f8eff55f07074c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->