### PR TITLE
perf(api-reference): lazy-mount the agent chat client

### DIFF
--- a/.changeset/lazy-mount-agent-client.md
+++ b/.changeset/lazy-mount-agent-client.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Defer mounting the Agent Scalar chat (and its embedded api-client) until the agent is first opened, instead of mounting it eagerly on every agent-enabled page

--- a/packages/api-reference/src/components/AgentScalar/AgentScalarDrawer.vue
+++ b/packages/api-reference/src/components/AgentScalar/AgentScalarDrawer.vue
@@ -30,6 +30,10 @@ const AgentScalarChatInterface = defineAsyncComponent(
  * eagerly on every agent-enabled page — including on localhost, where the agent is on
  * by default — even when the user never opens the chat. We flip this flag on first open
  * and keep it true so the chat (and its state) stays mounted once the user has used it.
+ *
+ * `immediate` matters: the drawer can mount while the agent is already open (for example,
+ * when the agent gets disabled and re-enabled on a document switch), so we evaluate the
+ * current visibility on mount rather than only reacting to later changes.
  */
 const hasOpenedAgent = ref(false)
 watch(
@@ -39,6 +43,7 @@ watch(
       hasOpenedAgent.value = true
     }
   },
+  { immediate: true },
 )
 </script>
 

--- a/packages/api-reference/src/components/AgentScalar/AgentScalarDrawer.vue
+++ b/packages/api-reference/src/components/AgentScalar/AgentScalarDrawer.vue
@@ -6,7 +6,7 @@ import type {
   ExternalUrls,
 } from '@scalar/types/api-reference'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
-import { defineAsyncComponent } from 'vue'
+import { defineAsyncComponent, ref, watch } from 'vue'
 
 import { useAgentContext } from '@/hooks/use-agent'
 
@@ -20,6 +20,25 @@ const agentContext = useAgentContext()
 
 const AgentScalarChatInterface = defineAsyncComponent(
   async () => import('./AgentScalarChatInterface.vue'),
+)
+
+/**
+ * Defer mounting the chat interface until the agent is opened for the first time.
+ *
+ * The chat interface mounts its own api-client modal (a hidden CodeMirror-backed
+ * request editor). Rendering the drawer with `v-show` would mount that second client
+ * eagerly on every agent-enabled page — including on localhost, where the agent is on
+ * by default — even when the user never opens the chat. We flip this flag on first open
+ * and keep it true so the chat (and its state) stays mounted once the user has used it.
+ */
+const hasOpenedAgent = ref(false)
+watch(
+  () => agentContext.value?.showAgent.value,
+  (visible) => {
+    if (visible) {
+      hasOpenedAgent.value = true
+    }
+  },
 )
 </script>
 
@@ -50,6 +69,7 @@ const AgentScalarChatInterface = defineAsyncComponent(
       <div
         class="agent-scalar-container custom-scroll custom-scroll-self-contain-overflow overflow-auto px-6">
         <AgentScalarChatInterface
+          v-if="hasOpenedAgent"
           :agentScalarConfiguration
           :externalUrls
           :prefilledMessage="agentContext?.prefilledMessage"


### PR DESCRIPTION
The Agent Scalar drawer used `v-show`, so the chat and its own hidden api-client modal mounted as soon as the agent was enabled (always on localhost), even if you never opened it. That's a whole extra client app on the page for nothing.

Now it mounts on first open and stays mounted after.

Spotted while looking at #9482.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI lifecycle/performance change only; behavior after first open is unchanged, with an immediate watch to preserve already-open agent state.
> 
> **Overview**
> **Agent Scalar** no longer mounts the chat (and its embedded **api-client** / CodeMirror modal) just because the agent feature is enabled on the page. The drawer still uses **`v-show`** for open/close, but **`AgentScalarChatInterface`** is gated with **`v-if="hasOpenedAgent"`**, set the first time **`showAgent`** becomes true and left true so chat state survives after the user closes the drawer.
> 
> A **`watch(..., { immediate: true })`** on **`showAgent`** covers the case where the drawer mounts while the agent is already open (e.g. agent toggled off and on during a document switch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64aa7c291b5ec3fd6e3966aedc40b3ed5dda2527. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->