### PR TITLE
chore(api-reference): drop showToolbar override from dev tools tests

### DIFF
--- a/packages/api-reference/test/configuration/show-developer-tools.e2e.ts
+++ b/packages/api-reference/test/configuration/show-developer-tools.e2e.ts
@@ -4,9 +4,6 @@ import { serveExample } from '@test/utils/serve-example'
 test.describe('showDeveloperTools', () => {
   test('shows developer tools when enabled', async ({ page }) => {
     const example = await serveExample({
-      // TODO: Remove this once we release the next version (after 1.39.3)
-      // @ts-expect-error - override the default value in serveExample
-      showToolbar: 'always',
       showDeveloperTools: 'always',
     })
 
@@ -17,9 +14,6 @@ test.describe('showDeveloperTools', () => {
 
   test('hides developer tools if set to never', async ({ page }) => {
     const example = await serveExample({
-      // TODO: Remove this once we release the next version (after 1.39.3)
-      // @ts-expect-error - override the default value in serveExample
-      showToolbar: 'never',
       showDeveloperTools: 'never',
     })
 

--- a/packages/api-reference/test/utils/serve-example.ts
+++ b/packages/api-reference/test/utils/serve-example.ts
@@ -21,9 +21,6 @@ const DEFAULT_CONFIGURATION: Partial<HtmlRenderingConfiguration> = {
   // Title drives the document slug used in URLs (`scalar-galaxy`) so tests can
   // construct deterministic deep links without each one having to set this.
   title: 'Scalar Galaxy',
-  // TODO: Remove this once the CDN supports the showDeveloperTools attribute
-  // @ts-expect-error - we need this until next release (after 1.39.3)
-  showToolbar: 'never',
   showDeveloperTools: 'never', // Hide the toolbar by default for snapshots
 }
 


### PR DESCRIPTION
The CDN now ships `showDeveloperTools`, so the temporary `showToolbar` override (and its `@ts-expect-error`) is no longer needed. Removes it from the dev tools e2e tests and the shared `serveExample` default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only cleanup with no production or runtime behavior changes.
> 
> **Overview**
> Removes the temporary **`showToolbar`** workaround (and associated **`@ts-expect-error`** comments) from api-reference Playwright tests now that the CDN supports **`showDeveloperTools`**.
> 
> The **`showDeveloperTools`** e2e cases only pass **`showDeveloperTools: 'always'`** or **`'never'`** via **`serveExample`**, and the shared **`DEFAULT_CONFIGURATION`** in **`serve-example.ts`** no longer sets **`showToolbar`**—defaults stay on **`showDeveloperTools: 'never'`** for snapshot stability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a6eac5574510fd5ba8a3768a468c01ddebfea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->