### PR TITLE
fix(api-reference): collapse single-item allOf/oneOf/anyOf array items

### DIFF
--- a/.changeset/allof-array-items-nesting.md
+++ b/.changeset/allof-array-items-nesting.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix extra nesting and duplicated description when array items are wrapped in a single-item `allOf`

--- a/.changeset/allof-array-items-nesting.md
+++ b/.changeset/allof-array-items-nesting.md
@@ -2,4 +2,4 @@
 '@scalar/api-reference': patch
 ---
 
-Fix extra nesting and duplicated description when array items are wrapped in a single-item `allOf`
+Fix extra nesting and duplicated description when array items are wrapped in a single-item composition (`allOf`, `oneOf`, or `anyOf`)

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -128,49 +128,52 @@ describe('SchemaProperty', () => {
       })
 
       // https://github.com/scalar/scalar/issues/5900
-      it('renders array items wrapped in a single-item allOf without extra nesting', async () => {
-        // An array whose items are wrapped in a single-item `allOf` is equivalent to
-        // an array whose items are a plain object. Both should render identically.
-        const allOfItems = mount(SchemaProperty, {
-          props: {
-            eventBus: null,
-            schema: coerceValue(SchemaObjectSchema, {
-              type: 'array',
-              title: 'foos array',
-              items: {
-                title: 'foos array element',
-                allOf: [{ type: 'object', properties: { foo: { title: 'foo value', type: 'string' } } }],
-              },
-            }),
-            options: {},
-          },
-        })
+      it.each(['allOf', 'oneOf', 'anyOf'] as const)(
+        'renders array items wrapped in a single-item %s without extra nesting',
+        async (composition) => {
+          // An array whose items are wrapped in a single-item composition is equivalent to
+          // an array whose items are a plain object. Both should render identically.
+          const compositionItems = mount(SchemaProperty, {
+            props: {
+              eventBus: null,
+              schema: coerceValue(SchemaObjectSchema, {
+                type: 'array',
+                title: 'foos array',
+                items: {
+                  title: 'foos array element',
+                  [composition]: [{ type: 'object', properties: { foo: { title: 'foo value', type: 'string' } } }],
+                },
+              }),
+              options: {},
+            },
+          })
 
-        const plainItems = mount(SchemaProperty, {
-          props: {
-            eventBus: null,
-            schema: coerceValue(SchemaObjectSchema, {
-              type: 'array',
-              title: 'bars array',
-              items: {
-                type: 'object',
-                title: 'bars array element',
-                properties: { bar: { title: 'bar value', type: 'string' } },
-              },
-            }),
-            options: {},
-          },
-        })
+          const plainItems = mount(SchemaProperty, {
+            props: {
+              eventBus: null,
+              schema: coerceValue(SchemaObjectSchema, {
+                type: 'array',
+                title: 'bars array',
+                items: {
+                  type: 'object',
+                  title: 'bars array element',
+                  properties: { bar: { title: 'bar value', type: 'string' } },
+                },
+              }),
+              options: {},
+            },
+          })
 
-        await allOfItems.find('.schema-card-title').trigger('click')
-        await plainItems.find('.schema-card-title').trigger('click')
+          await compositionItems.find('.schema-card-title').trigger('click')
+          await plainItems.find('.schema-card-title').trigger('click')
 
-        // The allOf variant must not introduce an additional level of Schema nesting.
-        expect(allOfItems.findAllComponents(Schema)).toHaveLength(plainItems.findAllComponents(Schema).length)
+          // The composition variant must not introduce an additional level of Schema nesting.
+          expect(compositionItems.findAllComponents(Schema)).toHaveLength(plainItems.findAllComponents(Schema).length)
 
-        // The element title must be shown exactly once (it was duplicated by the extra nesting).
-        expect(allOfItems.html().match(/foos array element/g)).toHaveLength(1)
-      })
+          // The element title must be shown exactly once (it was duplicated by the extra nesting).
+          expect(compositionItems.html().match(/foos array element/g)).toHaveLength(1)
+        },
+      )
 
       it('hides expand button for array with primitive items', () => {
         const wrapper = mount(SchemaProperty, {
@@ -476,7 +479,9 @@ describe('SchemaProperty', () => {
 
   describe('composition schemas', () => {
     describe('array compositions', () => {
-      it('renders composition schemas for array items with oneOf', async () => {
+      // A single-item composition is equivalent to its only member, so it is flattened and rendered
+      // like a plain object instead of through a composition panel. See #5900
+      it('flattens array items with a single-item oneOf composition', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
             eventBus: null,
@@ -496,15 +501,14 @@ describe('SchemaProperty', () => {
           },
         })
 
-        expect(wrapper.find('button[aria-expanded="false"]').exists()).toBe(true)
-
         await wrapper.find('.schema-card-title').trigger('click')
 
-        const foobar = wrapper.html().match(/foobar/g)
-        expect(foobar).toHaveLength(1)
+        // The member is rendered directly, with its description shown exactly once.
+        expect(wrapper.text()).toContain('test')
+        expect(wrapper.html().match(/foobar/g)).toHaveLength(1)
       })
 
-      it('renders array items with oneOf composition after expansion', async () => {
+      it('flattens array items with a single-item oneOf alongside a base type', async () => {
         const wrapper = mount(SchemaProperty, {
           props: {
             eventBus: null,
@@ -524,19 +528,14 @@ describe('SchemaProperty', () => {
           },
         })
 
-        // The composition description should not be visible before expanding
-        expect(wrapper.html().match(/foobar/g)).toBeNull()
-
-        // Expand all schema cards to reveal nested content
         const buttons = wrapper.findAll('button.schema-card-title')
         for (const button of buttons) {
           await button.trigger('click')
           await wrapper.vm.$nextTick()
         }
 
-        // Now "foobar" should be present
-        const foobar = wrapper.html().match(/foobar/g)
-        expect(foobar).toHaveLength(1)
+        expect(wrapper.text()).toContain('test')
+        expect(wrapper.html().match(/foobar/g)).toHaveLength(1)
       })
     })
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -127,6 +127,51 @@ describe('SchemaProperty', () => {
         expect(schemas).toHaveLength(1)
       })
 
+      // https://github.com/scalar/scalar/issues/5900
+      it('renders array items wrapped in a single-item allOf without extra nesting', async () => {
+        // An array whose items are wrapped in a single-item `allOf` is equivalent to
+        // an array whose items are a plain object. Both should render identically.
+        const allOfItems = mount(SchemaProperty, {
+          props: {
+            eventBus: null,
+            schema: coerceValue(SchemaObjectSchema, {
+              type: 'array',
+              title: 'foos array',
+              items: {
+                title: 'foos array element',
+                allOf: [{ type: 'object', properties: { foo: { title: 'foo value', type: 'string' } } }],
+              },
+            }),
+            options: {},
+          },
+        })
+
+        const plainItems = mount(SchemaProperty, {
+          props: {
+            eventBus: null,
+            schema: coerceValue(SchemaObjectSchema, {
+              type: 'array',
+              title: 'bars array',
+              items: {
+                type: 'object',
+                title: 'bars array element',
+                properties: { bar: { title: 'bar value', type: 'string' } },
+              },
+            }),
+            options: {},
+          },
+        })
+
+        await allOfItems.find('.schema-card-title').trigger('click')
+        await plainItems.find('.schema-card-title').trigger('click')
+
+        // The allOf variant must not introduce an additional level of Schema nesting.
+        expect(allOfItems.findAllComponents(Schema)).toHaveLength(plainItems.findAllComponents(Schema).length)
+
+        // The element title must be shown exactly once (it was duplicated by the extra nesting).
+        expect(allOfItems.html().match(/foos array element/g)).toHaveLength(1)
+      })
+
       it('hides expand button for array with primitive items', () => {
         const wrapper = mount(SchemaProperty, {
           props: {

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -35,6 +35,9 @@ import SchemaPropertyHeading from './SchemaPropertyHeading.vue'
  * So you should basically use the optimizedValue everywhere in the component.
  */
 
+/** Composition keywords that hold a list of schemas and can be flattened when they contain a single member. */
+const SINGLE_ITEM_COMPOSITIONS = ['oneOf', 'anyOf', 'allOf'] as const
+
 const props = withDefaults(
   defineProps<{
     is?: string | Component
@@ -165,10 +168,10 @@ const compositionsToRender = computed(() =>
 /**
  * Get resolved array items for rendering.
  *
- * When the items are wrapped in a single-item `allOf` (e.g. `items: { allOf: [{ type: 'object', ... }] }`), we
- * flatten that wrapper into its plain object form. The wrapper is equivalent to the bare object, but keeping the
- * `allOf` keyword makes the items render through an extra schema layer, which adds an unnecessary level of nesting
- * and duplicates the item description. See https://github.com/scalar/scalar/issues/5900
+ * When the items are wrapped in a single-item composition (e.g. `items: { allOf: [{ type: 'object', ... }] }`), we
+ * flatten that wrapper into its plain form. A composition with a single member is equivalent to that member, so
+ * keeping the composition keyword only makes the items render through an extra schema layer, which adds an
+ * unnecessary level of nesting and duplicates the item description. See https://github.com/scalar/scalar/issues/5900
  */
 const resolvedArrayItems = computed(() => {
   const value = optimizedValue.value
@@ -177,16 +180,12 @@ const resolvedArrayItems = computed(() => {
   }
 
   const items = resolve.schema(value.items)
-  if (
-    items &&
-    'allOf' in items &&
-    Array.isArray(items.allOf) &&
-    items.allOf.length === 1
-  ) {
-    return optimizeValueForDisplay(items)
-  }
+  const hasSingleItemComposition = SINGLE_ITEM_COMPOSITIONS.some(
+    (keyword) =>
+      Array.isArray(items?.[keyword]) && items[keyword]?.length === 1,
+  )
 
-  return items
+  return hasSingleItemComposition ? optimizeValueForDisplay(items) : items
 })
 
 /**

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -162,13 +162,31 @@ const compositionsToRender = computed(() =>
   getCompositionsToRender(optimizedValue.value, props.options.document),
 )
 
-/** Get resolved array items for rendering */
+/**
+ * Get resolved array items for rendering.
+ *
+ * When the items are wrapped in a single-item `allOf` (e.g. `items: { allOf: [{ type: 'object', ... }] }`), we
+ * flatten that wrapper into its plain object form. The wrapper is equivalent to the bare object, but keeping the
+ * `allOf` keyword makes the items render through an extra schema layer, which adds an unnecessary level of nesting
+ * and duplicates the item description. See https://github.com/scalar/scalar/issues/5900
+ */
 const resolvedArrayItems = computed(() => {
   const value = optimizedValue.value
   if (!value || !isArraySchema(value) || typeof value.items !== 'object') {
     return undefined
   }
-  return resolve.schema(value.items)
+
+  const items = resolve.schema(value.items)
+  if (
+    items &&
+    'allOf' in items &&
+    Array.isArray(items.allOf) &&
+    items.allOf.length === 1
+  ) {
+    return optimizeValueForDisplay(items)
+  }
+
+  return items
 })
 
 /**


### PR DESCRIPTION
Array items wrapped in a single-item composition (e.g. `items: { allOf: [{ type: 'object', ... }] }`) are equivalent to the bare member, but the composition keyword made them render through an extra schema layer — an extra level of nesting and a duplicated item description compared to plain object items.

A composition with a single member has nothing to merge or choose, so we now flatten `allOf`, `oneOf`, and `anyOf` wrappers before rendering. They render identically to a plain object.

Test covers all three composition keywords.

## Ticket

Closes #5900

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in schema rendering for a narrow OpenAPI pattern; covered by new/updated component tests.
> 
> **Overview**
> Fixes **#5900**: array `items` schemas like `items: { allOf: [{ type: 'object', ... }] }` no longer render through an extra composition layer, so nesting and item titles/descriptions match plain object `items`.
> 
> In `SchemaProperty.vue`, **`resolvedArrayItems`** now detects when resolved `items` have exactly one member under `allOf`, `oneOf`, or `anyOf` and passes them through **`optimizeValueForDisplay`** so the lone member is rendered directly instead of as a composition panel.
> 
> Tests assert parity with plain object items for all three keywords and that single-item **`oneOf`** on array items still shows nested properties and descriptions once after expand. Patch noted in changeset for **`@scalar/api-reference`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9877b5c263c8cc2e1102488c1a303e07c88c5f42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->