### PR TITLE
fix(code-highlight): add custom scroll to markdown code blocks

### DIFF
--- a/.changeset/soft-cooks-smile.md
+++ b/.changeset/soft-cooks-smile.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+Add Scalar scrollbar styling to highlighted Markdown code blocks.

--- a/packages/code-highlight/src/markdown/markdown.test.ts
+++ b/packages/code-highlight/src/markdown/markdown.test.ts
@@ -143,6 +143,16 @@ const x = 42;
     expect(html.trim()).toContain('hljs')
   })
 
+  it('adds custom scroll class to highlighted code blocks', () => {
+    const html = htmlFromMarkdown(`
+\`\`\`sh
+curl "https://api.tailscale.com/api/v2/tailnet/-/devices"
+\`\`\`
+`)
+
+    expect(html.trim()).toContain('class="hljs language-sh custom-scroll"')
+  })
+
   it('preserves class attributes on elements', () => {
     const html = htmlFromMarkdown('<div class="custom-class">Content</div>')
 

--- a/packages/code-highlight/src/markdown/markdown.ts
+++ b/packages/code-highlight/src/markdown/markdown.ts
@@ -74,25 +74,6 @@ const htmlFragmentParser = unified().use(rehypeParse, { fragment: true })
 const htmlFragmentStringifier = unified().use(rehypeStringify)
 
 /**
- * Adds Scalar's scrollbar styling to highlighted Markdown code blocks.
- */
-const addCustomScrollToHighlightedCode = () => (tree: HastRoot) => {
-  visit(tree, 'element', (node: HastElement) => {
-    if (node.tagName !== 'code') {
-      return
-    }
-
-    const className = node.properties.className
-
-    if (!Array.isArray(className) || !className.includes('hljs') || className.includes('custom-scroll')) {
-      return
-    }
-
-    className.push('custom-scroll')
-  })
-}
-
-/**
  * Parse inline markdown and return children from the generated paragraph.
  */
 const extractInlineChildrenFromMarkdown = (value: string): HastElementContent[] => {
@@ -201,9 +182,9 @@ export function htmlFromMarkdown(
       languages: standardLanguages,
       // Enable auto detection
       detect: true,
+      // Adds Scalar's custom scrollbar styling to highlighted code blocks
+      className: 'custom-scroll',
     })
-    // Adds Scalar's custom scrollbar class to highlighted code blocks
-    .use(addCustomScrollToHighlightedCode)
     // Adds target="_blank" to external links
     .use(rehypeExternalLinks, { target: '_blank' })
     // Formats the HTML

--- a/packages/code-highlight/src/markdown/markdown.ts
+++ b/packages/code-highlight/src/markdown/markdown.ts
@@ -74,6 +74,25 @@ const htmlFragmentParser = unified().use(rehypeParse, { fragment: true })
 const htmlFragmentStringifier = unified().use(rehypeStringify)
 
 /**
+ * Adds Scalar's scrollbar styling to highlighted Markdown code blocks.
+ */
+const addCustomScrollToHighlightedCode = () => (tree: HastRoot) => {
+  visit(tree, 'element', (node: HastElement) => {
+    if (node.tagName !== 'code') {
+      return
+    }
+
+    const className = node.properties.className
+
+    if (!Array.isArray(className) || !className.includes('hljs') || className.includes('custom-scroll')) {
+      return
+    }
+
+    className.push('custom-scroll')
+  })
+}
+
+/**
  * Parse inline markdown and return children from the generated paragraph.
  */
 const extractInlineChildrenFromMarkdown = (value: string): HastElementContent[] => {
@@ -183,6 +202,8 @@ export function htmlFromMarkdown(
       // Enable auto detection
       detect: true,
     })
+    // Adds Scalar's custom scrollbar class to highlighted code blocks
+    .use(addCustomScrollToHighlightedCode)
     // Adds target="_blank" to external links
     .use(rehypeExternalLinks, { target: '_blank' })
     // Formats the HTML

--- a/packages/code-highlight/src/rehype-highlight/rehype-highlight.ts
+++ b/packages/code-highlight/src/rehype-highlight/rehype-highlight.ts
@@ -21,6 +21,8 @@ type HighlightOptions = {
   subset?: ReadonlyArray<string> | null | undefined
   /** Option to autodetect languages */
   detect?: boolean
+  /** Extra class name(s) to add to highlighted `<code>` elements (optional) */
+  className?: ReadonlyArray<string> | string | null | undefined
 }
 
 const emptyOptions: HighlightOptions = {}
@@ -38,6 +40,7 @@ export function rehypeHighlight(options?: Readonly<HighlightOptions> | null | un
   const plainText = settings.plainText
   const prefix = settings.prefix
   const subset = settings.subset
+  const extraClassNames = typeof settings.className === 'string' ? [settings.className] : (settings.className ?? [])
   let name = 'hljs'
 
   // Create a lowlight instance if not provided
@@ -71,6 +74,13 @@ export function rehypeHighlight(options?: Readonly<HighlightOptions> | null | un
 
       if (!node.properties.className.includes(name)) {
         node.properties.className.unshift(name)
+      }
+
+      // Add any extra class names (e.g. Scalar's `custom-scroll` styling)
+      for (const extraClassName of extraClassNames) {
+        if (!node.properties.className.includes(extraClassName)) {
+          node.properties.className.push(extraClassName)
+        }
       }
 
       let result: Root | undefined


### PR DESCRIPTION
when we put markdown in HLJS we need to apply "custom-scroll" on it. 

working now! :) 

<img width="501" height="320" alt="image" src="https://github.com/user-attachments/assets/962db333-30e4-4ff2-b147-3f5111cc30fd" />
