### PR TITLE
docs: dedupe themes documentation pages

### DIFF
--- a/documentation/guides/docs/configuration/themes.md
+++ b/documentation/guides/docs/configuration/themes.md
@@ -19,27 +19,4 @@ Set the theme in the `siteConfig` object of your `scalar.config.json` file:
 
 ## Available Themes
 
-| Theme        | Description                         |
-| ------------ | ----------------------------------- |
-| `default`    | The default theme                   |
-| `alternate`  | An alternative light/dark theme     |
-| `moon`       | A softer, moon-inspired palette     |
-| `purple`     | Purple accent colors                |
-| `solarized`  | Based on the Solarized color scheme |
-| `bluePlanet` | Blue tones with a planetary feel    |
-| `deepSpace`  | Dark theme with deep space colors   |
-| `saturn`     | Warm, Saturn-inspired tones         |
-| `kepler`     | A cosmic, Kepler-inspired theme     |
-| `mars`       | Red and warm Mars-inspired colors   |
-| `laserwave`  | Retro synthwave-inspired colors     |
-
-To apply no theme at all (feeling dangerous, eh?), pass `none`:
-
-```json
-// scalar.config.json
-{
-  "siteConfig": {
-    "theme": "none"
-  }
-}
-```
+Your documentation site and your API references share the same theme system. For the full list of built-in themes, how to disable theming with `none`, and how to customize colors, fonts, and layouts with CSS variables, see the [Themes reference](../../../themes.md).


### PR DESCRIPTION
The Docs configuration themes page duplicated the built-in theme list and the `none` example that already live on the canonical API References themes page. Remove the duplicated content and link to the shared Themes reference instead, keeping only the scalar.config.json usage that is specific to the Docs product.

Part of DOC-5575

@marclave @cameronrohani Let me know if you want them consolidated into one page somewhere outside docs or refs instead

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
