### PR TITLE
fix(code-highlight): highlight python function and method call sites

### DIFF
--- a/.changeset/python-call-site-highlighting.md
+++ b/.changeset/python-call-site-highlighting.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+Fix Python code samples appearing mostly unstyled by highlighting function and method call sites

--- a/packages/code-highlight/src/css/code.css
+++ b/packages/code-highlight/src/css/code.css
@@ -188,7 +188,3 @@
 .hljs.language-objectivec .hljs-built_in {
   color: var(--scalar-color-orange);
 }
-
-.hljs-built_in {
-  color: var(--scalar-color-orange);
-}

--- a/packages/code-highlight/src/languages/basic.ts
+++ b/packages/code-highlight/src/languages/basic.ts
@@ -6,12 +6,13 @@ import json from 'highlight.js/lib/languages/json'
 import less from 'highlight.js/lib/languages/less'
 import markdown from 'highlight.js/lib/languages/markdown'
 import plaintext from 'highlight.js/lib/languages/plaintext'
-import python from 'highlight.js/lib/languages/python'
 import scss from 'highlight.js/lib/languages/scss'
 import shell from 'highlight.js/lib/languages/shell'
 import typescript from 'highlight.js/lib/languages/typescript'
 import xml from 'highlight.js/lib/languages/xml'
 import yaml from 'highlight.js/lib/languages/yaml'
+
+import python from './python'
 
 const basicLanguages: Record<string, LanguageFn> = {
   bash,

--- a/packages/code-highlight/src/languages/python.test.ts
+++ b/packages/code-highlight/src/languages/python.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { syntaxHighlight } from '../code/highlight'
+import { standardLanguages } from './index'
+
+/**
+ * These tests cover the custom Python grammar that adds call-site highlighting
+ * on top of the bundled highlight.js grammar (DOC-5618).
+ */
+describe('python', () => {
+  const highlight = (code: string) => syntaxHighlight(code, { lang: 'python', languages: standardLanguages })
+
+  it('highlights method and function call sites as function titles', () => {
+    const result = highlight('conn.request("POST", "/users")\nres.getresponse()')
+
+    expect(result).toContain('<span class="hljs-title function_">request</span>')
+    expect(result).toContain('<span class="hljs-title function_">getresponse</span>')
+  })
+
+  it('keeps reserved keywords coloured as keywords', () => {
+    const result = highlight('if x:\n    return foo')
+
+    expect(result).toContain('<span class="hljs-keyword">if</span>')
+    expect(result).toContain('<span class="hljs-keyword">return</span>')
+  })
+
+  it('does not treat keywords followed by parentheses as function calls', () => {
+    const result = highlight('if (x):\n    pass')
+
+    // `if` must remain a keyword even though a parenthesis follows it
+    expect(result).toContain('<span class="hljs-keyword">if</span>')
+    expect(result).not.toContain('<span class="hljs-title function_">if</span>')
+  })
+
+  it('keeps built-ins coloured as built-ins rather than function titles', () => {
+    const result = highlight('print(data)\nrange(10)')
+
+    expect(result).toContain('<span class="hljs-built_in">print</span>')
+    expect(result).toContain('<span class="hljs-built_in">range</span>')
+    expect(result).not.toContain('<span class="hljs-title function_">print</span>')
+  })
+
+  it('still highlights function and class definitions', () => {
+    const result = highlight('def get_user(id):\n    pass\n\nclass User:\n    pass')
+
+    expect(result).toContain('<span class="hljs-keyword">def</span>')
+    expect(result).toContain('<span class="hljs-title function_">get_user</span>')
+    expect(result).toContain('<span class="hljs-keyword">class</span>')
+    expect(result).toContain('<span class="hljs-title class_">User</span>')
+  })
+
+  it('highlights chained method calls in a realistic request snippet', () => {
+    const result = highlight('response = requests.get(url)\ndata = response.json()')
+
+    expect(result).toContain('<span class="hljs-title function_">get</span>')
+    expect(result).toContain('<span class="hljs-title function_">json</span>')
+  })
+})

--- a/packages/code-highlight/src/languages/python.ts
+++ b/packages/code-highlight/src/languages/python.ts
@@ -43,8 +43,12 @@ const python: LanguageFn = (hljs) => {
   ].map((word) => word.replace(/\|\d+$/, ''))
 
   // Negative lookahead that rejects an excluded word when it is the thing being
-  // called (for example `print(`), so it keeps its original scope.
-  const notReserved = regex.concat('(?!', reserved.map((word) => `${word}\\s*\\(`).join('|'), ')')
+  // called (for example `print(`), so it keeps its original scope. The trailing
+  // call lookahead below already guarantees a `(`, so we only need to assert the
+  // identifier is not exactly a reserved word; a word boundary does that without
+  // a `\s*` quantifier, which would otherwise let the lookahead backtrack over
+  // runs of whitespace and scan in polynomial time on untrusted input.
+  const notReserved = regex.concat('(?!(?:', reserved.join('|'), ')\\b)')
 
   const functionCall = {
     scope: 'title.function',

--- a/packages/code-highlight/src/languages/python.ts
+++ b/packages/code-highlight/src/languages/python.ts
@@ -1,0 +1,61 @@
+import type { LanguageFn } from 'highlight.js'
+import basePython from 'highlight.js/lib/languages/python'
+
+/**
+ * Python grammar that extends highlight.js' bundled grammar with call-site
+ * highlighting.
+ *
+ * The grammar shipped with highlight.js only scopes function and class
+ * *definitions* (`def name`, `class Name`) plus a fixed list of built-ins. It
+ * never scopes *call sites*, unlike the JavaScript, Go, and Ruby grammars which
+ * colour every `.method()` as a function title. Because real-world API snippets
+ * are almost entirely method calls (for example `conn.request(...)` or
+ * `response.json()`), Python code rendered as a wall of unstyled grey text and
+ * looked far less highlighted than other languages (DOC-5618).
+ *
+ * We add a single rule that colours any identifier immediately followed by `(`
+ * as a function title, mirroring how highlight.js' own JavaScript grammar
+ * handles this. Reserved words and the grammar's known built-ins, literals, and
+ * types are excluded so they keep their existing scopes, and the leading word
+ * boundary prevents the rule from matching the tail end of an excluded word.
+ */
+const python: LanguageFn = (hljs) => {
+  const language = basePython(hljs)
+  const { regex } = hljs
+
+  // Mirrors the identifier pattern used by the bundled Python grammar.
+  const IDENT_RE = /[\p{XID_Start}_]\p{XID_Continue}*/u
+
+  // Words the base grammar already scopes. Leaving these out of the call-site
+  // rule keeps keywords (`return`, `if`, ...) and built-ins (`print`, `range`,
+  // ...) coloured as before. Relevance hints such as `nonlocal|10` are stripped.
+  const keywords = language.keywords as {
+    keyword?: string[]
+    built_in?: string[]
+    literal?: string[]
+    type?: string[]
+  }
+  const reserved = [
+    ...(keywords.keyword ?? []),
+    ...(keywords.built_in ?? []),
+    ...(keywords.literal ?? []),
+    ...(keywords.type ?? []),
+  ].map((word) => word.replace(/\|\d+$/, ''))
+
+  // Negative lookahead that rejects an excluded word when it is the thing being
+  // called (for example `print(`), so it keeps its original scope.
+  const notReserved = regex.concat('(?!', reserved.map((word) => `${word}\\s*\\(`).join('|'), ')')
+
+  const functionCall = {
+    scope: 'title.function',
+    relevance: 0,
+    match: regex.concat(/\b/, notReserved, IDENT_RE, regex.lookahead(/\s*\(/)),
+  }
+
+  return {
+    ...language,
+    contains: [...(language.contains ?? []), functionCall],
+  }
+}
+
+export default python

--- a/packages/code-highlight/src/languages/standard.ts
+++ b/packages/code-highlight/src/languages/standard.ts
@@ -32,7 +32,6 @@ import php from 'highlight.js/lib/languages/php'
 import plaintext from 'highlight.js/lib/languages/plaintext'
 import powershell from 'highlight.js/lib/languages/powershell'
 import properties from 'highlight.js/lib/languages/properties'
-import python from 'highlight.js/lib/languages/python'
 import r from 'highlight.js/lib/languages/r'
 import ruby from 'highlight.js/lib/languages/ruby'
 import rust from 'highlight.js/lib/languages/rust'
@@ -44,7 +43,9 @@ import swift from 'highlight.js/lib/languages/swift'
 import typescript from 'highlight.js/lib/languages/typescript'
 import xml from 'highlight.js/lib/languages/xml'
 import yaml from 'highlight.js/lib/languages/yaml'
+
 import curl from './curl'
+import python from './python'
 
 /**
  * We group languages into three categories based on their popularity and usage.


### PR DESCRIPTION
## Problem

Python code samples looked mostly grey and unstyled next to other languages. Turns out highlight.js's Python grammar only colors `def`/`class` definitions and a fixed list of built-ins — it never colors call sites. Since our API snippets are basically all method calls (`conn.request(...)`, `response.json()`), almost everything fell back to the default grey text.

## Solution

* New custom Python grammar (`languages/python.ts`) that extends the bundled one to color function and method call sites as function titles — same trick highlight.js's own JavaScript grammar uses (word-boundary anchor + negative lookahead so keywords and built-ins keep their scopes)
* Also removed a dead duplicate `.hljs-built_in` rule in `code.css` — leftover from the Prism→highlight.js migration, it sat outside `.scalar-app` so it was already being overridden anyway

Before / After

<img width="49%" alt="CleanShot 2026-06-11 at 20 16 34@2x" src="https://github.com/user-attachments/assets/11d58f07-1157-4432-93d1-5709cdb9ebb3" />

<img width="49%" alt="CleanShot 2026-06-11 at 20 16 43@2x" src="https://github.com/user-attachments/assets/42db21b4-ac03-4c46-b179-3fb832e3e0ca" />


## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Fixes DOC-5618

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only syntax highlighting in `@scalar/code-highlight`; no auth, data, or runtime API changes, with regression tests for grammar edge cases.
> 
> **Overview**
> Python API snippets were mostly default grey because the bundled highlight.js grammar never scopes **call sites**—only `def`/`class` names and built-ins. This PR **replaces** the stock Python language with a wrapper in `languages/python.ts` that adds one rule: identifiers immediately before `(` get `title.function` (orange), with keywords/built-ins/literals/types excluded via negative lookahead and word boundaries (including a performance-conscious lookahead design for untrusted input).
> 
> **`basic.ts`** and **`standard.ts`** now import `./python` instead of `highlight.js/lib/languages/python`. **`code.css`** drops a redundant global `.hljs-built_in` block that duplicated styling already defined under `.scalar-app`. Vitest coverage in **`python.test.ts`** locks in call-site highlighting, keyword/`if (` edge cases, built-ins, and defs/classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 231e21102dd93a40b6e05a8083d1af9ee39fa37f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->