### PR TITLE
fix(code-highlight): improve SDK syntax highlighting

### DIFF
--- a/.changeset/quiet-crabs-highlight.md
+++ b/.changeset/quiet-crabs-highlight.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+Improve SDK snippet syntax highlighting with extra highlight.js call-site, type, property, constant, and operator scopes.

--- a/packages/code-highlight/index.html
+++ b/packages/code-highlight/index.html
@@ -27,7 +27,8 @@
 
       code {
         background-color: var(--scalar-background-2);
-        width: 500px;
+        display: block;
+        width: min(960px, calc(100vw - 32px));
         overflow-x: auto;
         scrollbar-width: thin;
       }
@@ -53,7 +54,7 @@
     </style>
     <script type="module"></script>
   </head>
-  <body class="dark-mode">
+  <body class="scalar-app dark-mode">
     <button
       id="dark-mode-btn"
       type="button">

--- a/packages/code-highlight/playground/main.ts
+++ b/packages/code-highlight/playground/main.ts
@@ -181,7 +181,7 @@ request.AddParameter("application/json", "{\n  \"id\": 1,\n  \"name\": \"Mars\",
 IRestResponse response = client.Execute(request);
 `
 
-createCodeBlock(csharp, 'C#', 'c++')
+createCodeBlock(csharp, 'C#', 'csharp')
 
 // ---------------------------------------------------------------------------
 // PHP

--- a/packages/code-highlight/src/css/code.css
+++ b/packages/code-highlight/src/css/code.css
@@ -65,6 +65,10 @@
     color: var(--scalar-color-purple);
   }
 
+  .hljs-operator {
+    color: var(--scalar-color-purple);
+  }
+
   /** Function names when declaring and calling */
   .hljs-title.function_ {
     color: var(--scalar-color-orange);

--- a/packages/code-highlight/src/languages/sdk.test.ts
+++ b/packages/code-highlight/src/languages/sdk.test.ts
@@ -224,10 +224,13 @@ const highlightedCoverage = (html: string, source: string): number => {
   return Number((highlightedChars / sourceChars).toFixed(2))
 }
 
+const htmlEntities = {
+  '&amp;': '&',
+  '&gt;': '>',
+  '&lt;': '<',
+  '&quot;': '"',
+  '&#x27;': "'",
+} as const satisfies Record<string, string>
+
 const decodeHtml = (value: string): string =>
-  value
-    .replaceAll('&quot;', '"')
-    .replaceAll('&#x27;', "'")
-    .replaceAll('&amp;', '&')
-    .replaceAll('&lt;', '<')
-    .replaceAll('&gt;', '>')
+  value.replace(/&(?:amp|gt|lt|quot|#x27);/g, (entity) => htmlEntities[entity as keyof typeof htmlEntities])

--- a/packages/code-highlight/src/languages/sdk.test.ts
+++ b/packages/code-highlight/src/languages/sdk.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest'
+
+import { syntaxHighlight } from '@/code'
+
+import { standardLanguages } from './standard'
+
+type SdkSample = {
+  code: string
+  expectedTokens: string[]
+  lang: keyof typeof standardLanguages
+  minCoverage: number
+}
+
+const samples = [
+  {
+    lang: 'kotlin',
+    minCoverage: 0.48,
+    code: String.raw`val client = OkHttpClient()
+val body = RequestBody.create(MediaType.parse("application/json"), "{\"name\":\"Marc\"}")
+val request = Request.Builder()
+  .url("https://galaxy.scalar.com/user/signup")
+  .post(body)
+  .addHeader("Content-Type", "application/json")
+  .build()
+val response = client.newCall(request).execute()`,
+    expectedTokens: [
+      '<span class="hljs-title class_">OkHttpClient</span>',
+      '<span class="hljs-title function_">parse</span>',
+      '<span class="hljs-title function_">addHeader</span>',
+      '<span class="hljs-title function_">execute</span>',
+      '<span class="hljs-operator">=</span>',
+    ],
+  },
+  {
+    lang: 'ruby',
+    minCoverage: 0.45,
+    code: String.raw`require "uri"
+require "net/http"
+
+uri = URI("https://galaxy.scalar.com/user/signup")
+https = Net::HTTP.new(uri.host, uri.port)
+https.use_ssl = true
+request = Net::HTTP::Post.new(uri)
+request["Content-Type"] = "application/json"
+response = https.request(request)
+puts response.read`,
+    expectedTokens: [
+      '<span class="hljs-title class_">URI</span>',
+      '<span class="hljs-title class_">Net</span>',
+      '<span class="hljs-attr">new</span>',
+      '<span class="hljs-attr">use_ssl</span>',
+      '<span class="hljs-title function_">request</span>',
+    ],
+  },
+  {
+    lang: 'java',
+    minCoverage: 0.48,
+    code: String.raw`OkHttpClient client = new OkHttpClient();
+MediaType mediaType = MediaType.parse("application/json");
+RequestBody body = RequestBody.create(mediaType, "{\"name\":\"Marc\"}");
+Request request = new Request.Builder()
+  .url("https://galaxy.scalar.com/user/signup")
+  .post(body)
+  .addHeader("Content-Type", "application/json")
+  .build();
+Response response = client.newCall(request).execute();`,
+    expectedTokens: [
+      '<span class="hljs-title class_">OkHttpClient</span>',
+      '<span class="hljs-title class_">RequestBody</span>',
+      '<span class="hljs-title function_">addHeader</span>',
+      '<span class="hljs-title function_">newCall</span>',
+      '<span class="hljs-operator">=</span>',
+    ],
+  },
+  {
+    lang: 'csharp',
+    minCoverage: 0.45,
+    code: String.raw`using System.Net.Http.Headers;
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Post,
+    RequestUri = new Uri("https://galaxy.scalar.com/user/signup"),
+    Content = new StringContent("{\"name\":\"Marc\"}")
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}`,
+    expectedTokens: [
+      '<span class="hljs-title class_">HttpClient</span>',
+      '<span class="hljs-title class_">HttpRequestMessage</span>',
+      '<span class="hljs-title function_">SendAsync</span>',
+      '<span class="hljs-title function_">WriteLine</span>',
+      '<span class="hljs-attr">Content</span>',
+    ],
+  },
+  {
+    lang: 'php',
+    minCoverage: 0.6,
+    code: String.raw`<?php
+$curl = curl_init();
+curl_setopt_array($curl, [
+  CURLOPT_URL => "https://galaxy.scalar.com/planets",
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_CUSTOMREQUEST => "POST",
+  CURLOPT_POSTFIELDS => json_encode(["name" => "Mars"]),
+]);
+$response = curl_exec($curl);
+curl_close($curl);`,
+    expectedTokens: [
+      '<span class="hljs-title function_ invoke__">curl_init</span>',
+      '<span class="hljs-title function_ invoke__">curl_setopt_array</span>',
+      '<span class="hljs-title function_ invoke__">json_encode</span>',
+      '<span class="hljs-title function_ invoke__">curl_exec</span>',
+      '<span class="hljs-variable">$response</span>',
+    ],
+  },
+  {
+    lang: 'swift',
+    minCoverage: 0.45,
+    code: String.raw`let url = URL(string: "https://galaxy.scalar.com/user/signup")!
+var request = URLRequest(url: url)
+request.httpMethod = "POST"
+request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+let task = URLSession.shared.dataTask(with: request) { data, response, error in
+  if let data = data {
+    print(String(data: data, encoding: .utf8)!)
+  }
+}
+task.resume()`,
+    expectedTokens: [
+      '<span class="hljs-title class_">URL</span>',
+      '<span class="hljs-title class_">URLRequest</span>',
+      '<span class="hljs-title function_">setValue</span>',
+      '<span class="hljs-attr">forHTTPHeaderField</span>',
+      '<span class="hljs-title function_">resume</span>',
+    ],
+  },
+  {
+    lang: 'rust',
+    minCoverage: 0.45,
+    code: String.raw`let client = reqwest::Client::new();
+let response = client
+    .post("https://galaxy.scalar.com/user/signup")
+    .header("Content-Type", "application/json")
+    .json(&serde_json::json!({ "name": "Marc" }))
+    .send()
+    .await?;
+println!("{}", response.text().await?);`,
+    expectedTokens: [
+      '<span class="hljs-title class_">Client</span>',
+      '<span class="hljs-title function_">post</span>',
+      '<span class="hljs-title function_">json</span>',
+      '<span class="hljs-title function_">send</span>',
+      '<span class="hljs-title function_">println!</span>',
+    ],
+  },
+  {
+    lang: 'dart',
+    minCoverage: 0.45,
+    code: String.raw`final request = http.Request("POST", Uri.parse("https://galaxy.scalar.com/user/signup"));
+request.headers.addAll({
+  "Content-Type": "application/json",
+});
+request.body = jsonEncode({"name": "Marc"});
+final response = await request.send();
+print(response.stream.bytesToString());`,
+    expectedTokens: [
+      '<span class="hljs-title class_">Request</span>',
+      '<span class="hljs-title function_">parse</span>',
+      '<span class="hljs-title function_">jsonEncode</span>',
+      '<span class="hljs-title function_">send</span>',
+      '<span class="hljs-attr">headers</span>',
+    ],
+  },
+  {
+    lang: 'cpp',
+    minCoverage: 0.42,
+    code: String.raw`CURL *curl = curl_easy_init();
+struct curl_slist *headers = NULL;
+headers = curl_slist_append(headers, "Content-Type: application/json");
+curl_easy_setopt(curl, CURLOPT_URL, "https://galaxy.scalar.com/planets");
+curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+CURLcode response = curl_easy_perform(curl);
+std::string body = "Mars";
+curl_easy_cleanup(curl);`,
+    expectedTokens: [
+      '<span class="hljs-title function_">curl_easy_init</span>',
+      '<span class="hljs-title class_">curl_slist</span>',
+      '<span class="hljs-variable constant_">CURLOPT_URL</span>',
+      '<span class="hljs-title function_">curl_easy_perform</span>',
+      '<span class="hljs-title class_">string</span>',
+    ],
+  },
+] satisfies SdkSample[]
+
+describe('sdk', () => {
+  it.each(samples)(
+    'highlights $lang SDK snippets with call-site coverage',
+    ({ code, expectedTokens, lang, minCoverage }) => {
+      const html = syntaxHighlight(code, {
+        lang,
+        languages: standardLanguages,
+      })
+
+      for (const token of expectedTokens) {
+        expect(html).toContain(token)
+      }
+
+      expect(highlightedCoverage(html, code)).toBeGreaterThanOrEqual(minCoverage)
+    },
+  )
+})
+
+const highlightedCoverage = (html: string, source: string): number => {
+  const highlightedChars = [...html.matchAll(/<span class="[^"]+">([^<]*)<\/span>/g)].reduce(
+    (count, [, token]) => count + decodeHtml(token ?? '').replace(/\s/g, '').length,
+    0,
+  )
+  const sourceChars = source.replace(/\s/g, '').length
+
+  return Number((highlightedChars / sourceChars).toFixed(2))
+}
+
+const decodeHtml = (value: string): string =>
+  value
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#x27;', "'")
+    .replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')

--- a/packages/code-highlight/src/languages/sdk.ts
+++ b/packages/code-highlight/src/languages/sdk.ts
@@ -1,0 +1,239 @@
+import type { HLJSApi, LanguageFn, Mode } from 'highlight.js'
+
+type LanguageModes = (hljs: HLJSApi) => Mode[]
+
+const functionCallName =
+  /\b(?!(?:as|await|catch|class|def|do|else|elsif|elif|enum|for|func|fun|guard|if|interface|new|return|sizeof|struct|switch|throw|try|typeof|using|when|while)\b)[A-Za-z_][A-Za-z0-9_]*[!?]?(?=\s*\()/
+
+const propertyName = /\b[A-Za-z_][A-Za-z0-9_]*[!?]?/
+
+const pascalTypeName = /\b[A-Z][A-Za-z0-9_]*(?:<[A-Za-z0-9_<>, ?:.]+>)?/
+
+const sdkTypeNames =
+  'Builder|Client|CURL|CURLcode|Console|Data|Error|HTTP|HTTPURLResponse|HeaderMap|HeaderValue|HttpClient|HttpMethod|HttpRequestMessage|IRestResponse|JSONSerialization|Map|MediaType|MediaTypeHeaderValue|Method|OkHttpClient|Object|ParameterType|Post|Request|RequestBody|Response|RestClient|RestRequest|String|StringContent|URL|URI|URLRequest|URLSession|Uri|curl_slist|string'
+
+const sdkTypeName = new RegExp(`\\b(?:${sdkTypeNames})\\b`)
+
+const sdkTypeCallName = new RegExp(`\\b(?:${sdkTypeNames})\\b(?=\\s*\\()`)
+
+const constantName = /\b(?:CURL[A-Z0-9_]*|CURLOPT_[A-Z0-9_]+|[A-Z][A-Z0-9_]{2,})\b/
+
+const namedArgument = /\b[A-Za-z_][A-Za-z0-9_]*(?=\s*:)/
+
+const operator = /=>|\?:|::|->|===|!==|==|!=|<=|>=|&&|\|\||[+\-*%=&|!<>?:]/
+
+const methodCall = {
+  match: [/(?:\.|::|->)/, functionCallName],
+  scope: {
+    1: 'punctuation',
+    2: 'title.function',
+  },
+  relevance: 0,
+} satisfies Mode
+
+const methodCallWithArguments = (hljs: HLJSApi): Mode => ({
+  begin: [/(?:\.|::|->)/, functionCallName],
+  beginScope: {
+    1: 'punctuation',
+    2: 'title.function',
+  },
+  end: /\)/,
+  excludeEnd: true,
+  contains: argumentModes(hljs),
+  relevance: 0,
+})
+
+const namespacedConstructorCallWithArguments = (hljs: HLJSApi): Mode => ({
+  begin: [/(?:\.|::|->)/, sdkTypeCallName],
+  beginScope: {
+    1: 'punctuation',
+    2: 'title.class',
+  },
+  end: /\)/,
+  excludeEnd: true,
+  contains: argumentModes(hljs),
+  relevance: 0,
+})
+
+const propertyAccess = {
+  match: [/(?:\.|::|->)/, propertyName],
+  scope: {
+    1: 'punctuation',
+    2: 'attr',
+  },
+  relevance: 0,
+} satisfies Mode
+
+const namespacedSdkType = {
+  match: [/(?:\.|::|->)/, sdkTypeName],
+  scope: {
+    1: 'punctuation',
+    2: 'title.class',
+  },
+  relevance: 0,
+} satisfies Mode
+
+const standaloneFunctionCall = {
+  match: functionCallName,
+  scope: 'title.function',
+  relevance: 0,
+} satisfies Mode
+
+const standaloneFunctionCallWithArguments = (hljs: HLJSApi): Mode => ({
+  begin: functionCallName,
+  beginScope: 'title.function',
+  end: /\)/,
+  excludeEnd: true,
+  contains: argumentModes(hljs),
+  relevance: 0,
+})
+
+const constructorCall = {
+  match: sdkTypeCallName,
+  scope: 'title.class',
+  relevance: 0,
+} satisfies Mode
+
+const constructorCallWithArguments = (hljs: HLJSApi): Mode => ({
+  begin: sdkTypeCallName,
+  beginScope: 'title.class',
+  end: /\)/,
+  excludeEnd: true,
+  contains: argumentModes(hljs),
+  relevance: 0,
+})
+
+const namedArgumentMode = {
+  match: namedArgument,
+  scope: 'attr',
+  relevance: 0,
+} satisfies Mode
+
+const sdkTypeMode = {
+  match: sdkTypeName,
+  scope: 'title.class',
+  relevance: 0,
+} satisfies Mode
+
+const pascalTypeMode = {
+  match: pascalTypeName,
+  scope: 'title.class',
+  relevance: 0,
+} satisfies Mode
+
+const constantMode = {
+  match: constantName,
+  scope: 'variable.constant',
+  relevance: 0,
+} satisfies Mode
+
+const operatorMode = {
+  match: operator,
+  scope: 'operator',
+  relevance: 0,
+} satisfies Mode
+
+const argumentModes = (hljs: HLJSApi): Mode[] => [
+  hljs.QUOTE_STRING_MODE,
+  hljs.APOS_STRING_MODE,
+  hljs.C_NUMBER_MODE,
+  namespacedSdkType,
+  methodCall,
+  constructorCall,
+  standaloneFunctionCall,
+  sdkTypeMode,
+  constantMode,
+  pascalTypeMode,
+  namedArgumentMode,
+  propertyAccess,
+  operatorMode,
+]
+
+const sdkModes = (hljs: HLJSApi): Mode[] => [
+  namespacedConstructorCallWithArguments(hljs),
+  methodCallWithArguments(hljs),
+  constructorCallWithArguments(hljs),
+  standaloneFunctionCallWithArguments(hljs),
+  ...argumentModes(hljs),
+]
+
+/**
+ * Highlight.js grammars skip many call-site and SDK-client tokens that dominate
+ * generated snippets. These additive modes keep the stock grammar behavior and
+ * fill the common gaps with existing Scalar theme scopes.
+ */
+export const extendSdkLanguage =
+  (language: LanguageFn, modes: LanguageModes = sdkModes): LanguageFn =>
+  (hljs) => {
+    const grammar = language(hljs)
+    const extraModes = modes(hljs)
+
+    return {
+      ...grammar,
+      contains: [...extraModes, ...(extendContains(grammar.contains, extraModes) as Mode[])],
+    }
+  }
+
+const extendContains = (
+  contains: ReadonlyArray<Mode | 'self'>,
+  modes: Mode[],
+  seen = new WeakMap<Mode, Mode>(),
+): Array<Mode | 'self'> => contains.map((mode) => extendMode(mode, modes, seen))
+
+const extendMode = (mode: Mode | 'self', modes: Mode[], seen: WeakMap<Mode, Mode>): Mode | 'self' => {
+  if (mode === 'self') {
+    return mode
+  }
+
+  const cachedMode = seen.get(mode)
+
+  if (cachedMode) {
+    return cachedMode
+  }
+
+  const extendedMode: Mode = { ...mode }
+  seen.set(mode, extendedMode)
+
+  const contains = getExtendedModeContains(mode, modes, seen)
+  const variants = mode.variants?.map((variant) => extendMode(variant, modes, seen) as Mode)
+
+  if (contains) {
+    extendedMode.contains = contains
+  }
+
+  if (variants) {
+    extendedMode.variants = variants
+  }
+
+  return extendedMode
+}
+
+const isLiteralMode = (mode: Mode): boolean => {
+  const scope = typeof mode.scope === 'string' ? mode.scope : mode.className
+
+  return scope === 'string' || scope === 'comment' || scope === 'regexp'
+}
+
+const isParameterMode = (mode: Mode): boolean => {
+  const scope = typeof mode.scope === 'string' ? mode.scope : mode.className
+
+  return scope === 'params'
+}
+
+const getExtendedModeContains = (
+  mode: Mode,
+  modes: Mode[],
+  seen: WeakMap<Mode, Mode>,
+): Array<Mode | 'self'> | undefined => {
+  if (!mode.contains) {
+    return undefined
+  }
+
+  if (isLiteralMode(mode)) {
+    return mode.contains
+  }
+
+  const contains = extendContains(mode.contains, modes, seen)
+
+  return isParameterMode(mode) ? [...modes, ...contains] : contains
+}

--- a/packages/code-highlight/src/languages/standard.ts
+++ b/packages/code-highlight/src/languages/standard.ts
@@ -44,7 +44,9 @@ import swift from 'highlight.js/lib/languages/swift'
 import typescript from 'highlight.js/lib/languages/typescript'
 import xml from 'highlight.js/lib/languages/xml'
 import yaml from 'highlight.js/lib/languages/yaml'
+
 import curl from './curl'
+import { extendSdkLanguage } from './sdk'
 
 /**
  * We group languages into three categories based on their popularity and usage.
@@ -67,28 +69,28 @@ import curl from './curl'
  */
 export const standardLanguages = {
   bash,
-  c,
+  c: extendSdkLanguage(c),
   clojure,
-  cpp,
-  csharp,
+  cpp: extendSdkLanguage(cpp),
+  csharp: extendSdkLanguage(csharp),
   css,
   curl,
-  dart,
+  dart: extendSdkLanguage(dart),
   diff,
   docker: dockerfile,
   dockerfile,
   elixir,
   fsharp,
-  go,
+  go: extendSdkLanguage(go),
   graphql,
   haskell,
   html: xml,
   http,
   ini,
-  java,
+  java: extendSdkLanguage(java),
   javascript,
   json,
-  kotlin,
+  kotlin: extendSdkLanguage(kotlin),
   less,
   lua,
   makefile,
@@ -102,15 +104,15 @@ export const standardLanguages = {
   plaintext,
   powershell,
   properties,
-  python,
+  python: extendSdkLanguage(python),
   r,
-  ruby,
-  rust,
+  ruby: extendSdkLanguage(ruby),
+  rust: extendSdkLanguage(rust),
   scala,
   scss,
   shell,
   sql,
-  swift,
+  swift: extendSdkLanguage(swift),
   toml: ini,
   typescript,
   xml,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

SDK-generated snippets looked mostly monochrome in several highlight.js languages because the stock grammars often skip call sites, property access, SDK types, constants, and operators.

## Solution

Added Option A highlight.js grammar extensions for SDK-heavy languages while keeping the existing synchronous `@scalar/code-highlight` pipeline. The extensions add reusable call-site, constructor/type, property, constant, named-argument, and operator modes, wire them into the standard language registry, and keep styling on Scalar token CSS variables. The playground now uses the same `.scalar-app` CSS scope and a wider code block so visual checks reflect product styling.

## Visual

<a href="https://cursor.com/agents/bc-4e387e97-7f00-4df9-b94f-41d949ba95f9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsdk_highlighting_playground.webm"><img src="https://cursor.com/artifacts/c/art-5e1e5c55-9a1d-49fb-ab99-a00aa49848ae" alt="sdk_highlighting_playground.webm" /></a>

![SDK highlighting in light mode](https://cursor.com/artifacts/c/art-fcb0c39f-a6f2-4485-88f2-b7cf03fe701a)

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

## Testing

- `pnpm --filter @scalar/code-highlight test`
- `pnpm --filter @scalar/code-highlight types:check`
- `pnpm changeset status`
- `pnpm knip`
- Manual visual validation in the `@scalar/code-highlight` playground with dark video and light screenshot artifacts.

## Ticket

Fixes DOC-5621
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e387e97-7f00-4df9-b94f-41d949ba95f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e387e97-7f00-4df9-b94f-41d949ba95f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

