### PR TITLE
feat(code-highlight): improve Python syntax highlighting

### DIFF
--- a/.changeset/python-syntax-highlighting.md
+++ b/.changeset/python-syntax-highlighting.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': patch
+---
+
+Improve Python syntax highlighting: function and method calls, class instantiation, and keyword arguments are now colored. The built-in highlight.js Python grammar only tagged keywords, strings and definitions, which left most of a typical API reference snippet (mostly calls and keyword arguments) unstyled.

--- a/.changeset/python-syntax-highlighting.md
+++ b/.changeset/python-syntax-highlighting.md
@@ -2,4 +2,4 @@
 '@scalar/code-highlight': patch
 ---
 
-Improve Python syntax highlighting: constructor calls, function and method calls, attribute access, and keyword arguments are now colored. The built-in highlight.js Python grammar only tagged keywords, strings and definitions, which left most of a typical API reference snippet (mostly calls, attribute chains and keyword arguments) unstyled. Class titles are now colored green and property access gets a color in the theme, so method chains light up across all languages.
+Improve Python syntax highlighting: constructor calls, function and method calls, attribute access, and keyword arguments are now colored. The built-in highlight.js Python grammar only tagged keywords, strings and definitions, which left most of a typical API reference snippet (mostly calls, attribute chains and keyword arguments) unstyled. Class titles are now colored green and property access is colored yellow in the theme, so constructors and method chains light up across all languages.

--- a/.changeset/python-syntax-highlighting.md
+++ b/.changeset/python-syntax-highlighting.md
@@ -2,4 +2,4 @@
 '@scalar/code-highlight': patch
 ---
 
-Improve Python syntax highlighting: function and method calls, class instantiation, and keyword arguments are now colored. The built-in highlight.js Python grammar only tagged keywords, strings and definitions, which left most of a typical API reference snippet (mostly calls and keyword arguments) unstyled.
+Improve Python syntax highlighting: constructor calls, function and method calls, attribute access, and keyword arguments are now colored. The built-in highlight.js Python grammar only tagged keywords, strings and definitions, which left most of a typical API reference snippet (mostly calls, attribute chains and keyword arguments) unstyled. Class titles are now colored green and property access gets a color in the theme, so method chains light up across all languages.

--- a/packages/code-highlight/src/css/code.css
+++ b/packages/code-highlight/src/css/code.css
@@ -57,6 +57,11 @@
   /** Class initializers such as `Array` or `Date` */
   /** Type declarations such as `Record` */
   .hljs-title.class_ {
+    color: var(--scalar-color-green);
+  }
+
+  /** Attribute and property access such as `client.reports` */
+  .hljs-property {
     color: var(--scalar-color-1);
   }
 

--- a/packages/code-highlight/src/css/code.css
+++ b/packages/code-highlight/src/css/code.css
@@ -62,7 +62,7 @@
 
   /** Attribute and property access such as `client.reports` */
   .hljs-property {
-    color: var(--scalar-color-1);
+    color: var(--scalar-color-yellow);
   }
 
   /** Language indicators such as `new`, `const`, or `function` in JS  */

--- a/packages/code-highlight/src/languages/basic.ts
+++ b/packages/code-highlight/src/languages/basic.ts
@@ -6,12 +6,13 @@ import json from 'highlight.js/lib/languages/json'
 import less from 'highlight.js/lib/languages/less'
 import markdown from 'highlight.js/lib/languages/markdown'
 import plaintext from 'highlight.js/lib/languages/plaintext'
-import python from 'highlight.js/lib/languages/python'
 import scss from 'highlight.js/lib/languages/scss'
 import shell from 'highlight.js/lib/languages/shell'
 import typescript from 'highlight.js/lib/languages/typescript'
 import xml from 'highlight.js/lib/languages/xml'
 import yaml from 'highlight.js/lib/languages/yaml'
+
+import python from './python'
 
 const basicLanguages: Record<string, LanguageFn> = {
   bash,

--- a/packages/code-highlight/src/languages/python.test.ts
+++ b/packages/code-highlight/src/languages/python.test.ts
@@ -1,0 +1,65 @@
+import hljs from 'highlight.js/lib/core'
+import { describe, expect, it } from 'vitest'
+
+import python from './python'
+
+hljs.registerLanguage('python', python)
+
+/** Highlight a Python snippet with the extended grammar. */
+const highlight = (code: string) => hljs.highlight(code, { language: 'python' }).value
+
+describe('python', () => {
+  it('highlights function and method calls as function titles', () => {
+    const result = highlight('Profound(api_key="")')
+
+    expect(result).toContain('<span class="hljs-title function_">Profound</span>')
+  })
+
+  it('highlights chained method calls', () => {
+    const result = highlight('client.reports.visibility.query()')
+
+    expect(result).toContain('<span class="hljs-title function_">query</span>')
+  })
+
+  it('highlights keyword arguments and assignment targets as attributes', () => {
+    const result = highlight('visibility = client.query(date_interval="day")')
+
+    expect(result).toContain('<span class="hljs-attr">visibility</span>')
+    expect(result).toContain('<span class="hljs-attr">date_interval</span>')
+  })
+
+  it('does not treat control-flow keywords as function calls', () => {
+    const result = highlight('if (value):\n    return None')
+
+    expect(result).toContain('<span class="hljs-keyword">if</span>')
+    expect(result).not.toContain('<span class="hljs-title function_">if</span>')
+  })
+
+  it('does not treat comparisons as assignments', () => {
+    const result = highlight('while x == 0 and y != 1:\n    pass')
+
+    expect(result).not.toContain('<span class="hljs-attr">x</span>')
+    expect(result).not.toContain('<span class="hljs-attr">y</span>')
+  })
+
+  it('does not highlight tokens inside strings or comments', () => {
+    const result = highlight('text = "key=value call(x)"  # other=thing call(y)')
+
+    expect(result).not.toContain('<span class="hljs-attr">key</span>')
+    expect(result).not.toContain('<span class="hljs-title function_">call</span>')
+  })
+
+  it('keeps identifiers that merely start with a reserved word', () => {
+    const result = highlight('importlib.reload(module)')
+
+    expect(result).toContain('<span class="hljs-title function_">reload</span>')
+  })
+
+  it('keeps built-in functions and the def keyword intact', () => {
+    const result = highlight('def add(a, b):\n    return print(a)')
+
+    expect(result).toContain('<span class="hljs-keyword">def</span>')
+    expect(result).toContain('<span class="hljs-title function_">add</span>')
+    expect(result).toContain('<span class="hljs-built_in">print</span>')
+  })
+})

--- a/packages/code-highlight/src/languages/python.test.ts
+++ b/packages/code-highlight/src/languages/python.test.ts
@@ -9,16 +9,29 @@ hljs.registerLanguage('python', python)
 const highlight = (code: string) => hljs.highlight(code, { language: 'python' }).value
 
 describe('python', () => {
-  it('highlights function and method calls as function titles', () => {
+  it('highlights capitalized constructor calls as class titles', () => {
     const result = highlight('Profound(api_key="")')
 
-    expect(result).toContain('<span class="hljs-title function_">Profound</span>')
+    expect(result).toContain('<span class="hljs-title class_">Profound</span>')
   })
 
-  it('highlights chained method calls', () => {
+  it('highlights lowercase function calls as function titles', () => {
+    const result = highlight('get(value)')
+
+    expect(result).toContain('<span class="hljs-title function_">get</span>')
+  })
+
+  it('highlights chained method calls as function titles, not properties', () => {
     const result = highlight('client.reports.visibility.query()')
 
     expect(result).toContain('<span class="hljs-title function_">query</span>')
+  })
+
+  it('highlights intermediate attribute access as properties', () => {
+    const result = highlight('client.reports.visibility.query()')
+
+    expect(result).toContain('<span class="hljs-property">reports</span>')
+    expect(result).toContain('<span class="hljs-property">visibility</span>')
   })
 
   it('highlights keyword arguments and assignment targets as attributes', () => {

--- a/packages/code-highlight/src/languages/python.ts
+++ b/packages/code-highlight/src/languages/python.ts
@@ -55,20 +55,25 @@ const RESERVED_WORDS = [
  *
  * The upstream grammar only tags keywords, strings, numbers, decorators and the
  * names in `def`/`class` *definitions*. For typical API reference snippets,
- * which are mostly function calls and keyword arguments, that leaves the bulk of
- * the code unstyled. This wrapper adds two extra modes so that those tokens get
- * colored as well:
+ * which are mostly calls, attribute chains and keyword arguments, that leaves
+ * the bulk of the code unstyled. This wrapper adds four extra modes so that
+ * those tokens get colored as well:
  *
- * 1. Function and method *calls* (`Profound(`, `client.reports.get(`) become
+ * 1. Class or constructor *calls* (`Profound(`) become `title.class_`.
+ * 2. Function and method *calls* (`client.reports.get(`) become
  *    `title.function_`.
- * 2. Keyword arguments and assignment targets (`api_key_header=`, `client =`)
+ * 3. Attribute access in a chain (`client.reports`) becomes `property`.
+ * 4. Keyword arguments and assignment targets (`api_key_header=`, `client =`)
  *    become `attr`, matching how object keys are colored elsewhere.
  *
- * Both modes use a string `scope` with a lookahead so only the identifier is
- * captured and the trailing `(` or `=` is left untouched. They are appended to
- * the end of `contains` so that strings, comments and `def`/`class` titles keep
- * priority and the new modes never fire inside a string or comment. A relevance
- * of `0` keeps language auto-detection unaffected.
+ * All modes use a string `scope` with a lookahead or lookbehind so only the
+ * identifier is captured and the surrounding `(`, `.` or `=` is left untouched.
+ * Order matters: the class and function modes are listed before the property
+ * mode so that `.method(` is colored as a call rather than a plain attribute.
+ * They are appended after the upstream modes so that strings, comments and
+ * `def`/`class` titles keep priority and the new modes never fire inside a
+ * string or comment. A relevance of `0` keeps language auto-detection
+ * unaffected.
  */
 const pythonLanguage: LanguageFn = (hljs) => {
   const base = basePython(hljs)
@@ -78,9 +83,26 @@ const pythonLanguage: LanguageFn = (hljs) => {
   const notReserved = `(?!(?:${RESERVED_WORDS.join('|')})(?![\\w]))`
   const identifier = '[\\p{XID_Start}_]\\p{XID_Continue}*'
 
+  // Capitalized names used as a call, following the PEP 8 convention that class
+  // names use CapWords. Listed first so constructors win over the generic call.
+  const classCall = {
+    scope: 'title.class',
+    match: new RegExp(`\\b${notReserved}\\p{Lu}\\p{XID_Continue}*(?=\\s*\\()`, 'u'),
+    relevance: 0,
+  }
+
   const functionCall = {
     scope: 'title.function',
     match: new RegExp(`\\b${notReserved}${identifier}(?=\\s*\\()`, 'u'),
+    relevance: 0,
+  }
+
+  // Attribute access such as the `reports` and `visibility` in a method chain.
+  // The class and function modes above already claimed names before a `(`, so
+  // this only colors the remaining bare attributes.
+  const propertyAccess = {
+    scope: 'property',
+    match: new RegExp(`(?<=\\.)${identifier}`, 'u'),
     relevance: 0,
   }
 
@@ -94,7 +116,7 @@ const pythonLanguage: LanguageFn = (hljs) => {
 
   return {
     ...base,
-    contains: [...(base.contains ?? []), functionCall, keywordArgument],
+    contains: [...(base.contains ?? []), classCall, functionCall, propertyAccess, keywordArgument],
   }
 }
 

--- a/packages/code-highlight/src/languages/python.ts
+++ b/packages/code-highlight/src/languages/python.ts
@@ -1,0 +1,101 @@
+import type { LanguageFn } from 'highlight.js'
+import basePython from 'highlight.js/lib/languages/python'
+
+/**
+ * Reserved words that must never be treated as a function call or a keyword
+ * argument. The base grammar already colors these as keywords or literals, and
+ * statements such as `if (...)`, `while (...)`, or `return (...)` would
+ * otherwise be mistaken for function calls. `print` and `self` are kept here so
+ * they retain their more specific `built_in` and `variable.language` scopes.
+ */
+const RESERVED_WORDS = [
+  'and',
+  'as',
+  'assert',
+  'async',
+  'await',
+  'break',
+  'case',
+  'class',
+  'continue',
+  'def',
+  'del',
+  'elif',
+  'else',
+  'except',
+  'finally',
+  'for',
+  'from',
+  'global',
+  'if',
+  'import',
+  'in',
+  'is',
+  'lambda',
+  'match',
+  'nonlocal',
+  'not',
+  'or',
+  'pass',
+  'print',
+  'raise',
+  'return',
+  'self',
+  'try',
+  'while',
+  'with',
+  'yield',
+  'True',
+  'False',
+  'None',
+]
+
+/**
+ * Python grammar that extends the one shipped with highlight.js.
+ *
+ * The upstream grammar only tags keywords, strings, numbers, decorators and the
+ * names in `def`/`class` *definitions*. For typical API reference snippets,
+ * which are mostly function calls and keyword arguments, that leaves the bulk of
+ * the code unstyled. This wrapper adds two extra modes so that those tokens get
+ * colored as well:
+ *
+ * 1. Function and method *calls* (`Profound(`, `client.reports.get(`) become
+ *    `title.function_`.
+ * 2. Keyword arguments and assignment targets (`api_key_header=`, `client =`)
+ *    become `attr`, matching how object keys are colored elsewhere.
+ *
+ * Both modes use a string `scope` with a lookahead so only the identifier is
+ * captured and the trailing `(` or `=` is left untouched. They are appended to
+ * the end of `contains` so that strings, comments and `def`/`class` titles keep
+ * priority and the new modes never fire inside a string or comment. A relevance
+ * of `0` keeps language auto-detection unaffected.
+ */
+const pythonLanguage: LanguageFn = (hljs) => {
+  const base = basePython(hljs)
+
+  // Skip reserved words while still allowing identifiers that merely start with
+  // one (for example `importlib` must not be excluded by `import`).
+  const notReserved = `(?!(?:${RESERVED_WORDS.join('|')})(?![\\w]))`
+  const identifier = '[\\p{XID_Start}_]\\p{XID_Continue}*'
+
+  const functionCall = {
+    scope: 'title.function',
+    match: new RegExp(`\\b${notReserved}${identifier}(?=\\s*\\()`, 'u'),
+    relevance: 0,
+  }
+
+  // Match an identifier followed by a single `=`, but never `==`, `>=`, `<=`,
+  // `!=` or `:=`, so comparisons and the walrus operator are left alone.
+  const keywordArgument = {
+    scope: 'attr',
+    match: new RegExp(`\\b${notReserved}${identifier}(?=\\s*=(?!=))`, 'u'),
+    relevance: 0,
+  }
+
+  return {
+    ...base,
+    contains: [...(base.contains ?? []), functionCall, keywordArgument],
+  }
+}
+
+export default pythonLanguage

--- a/packages/code-highlight/src/languages/standard.ts
+++ b/packages/code-highlight/src/languages/standard.ts
@@ -32,7 +32,6 @@ import php from 'highlight.js/lib/languages/php'
 import plaintext from 'highlight.js/lib/languages/plaintext'
 import powershell from 'highlight.js/lib/languages/powershell'
 import properties from 'highlight.js/lib/languages/properties'
-import python from 'highlight.js/lib/languages/python'
 import r from 'highlight.js/lib/languages/r'
 import ruby from 'highlight.js/lib/languages/ruby'
 import rust from 'highlight.js/lib/languages/rust'
@@ -44,7 +43,9 @@ import swift from 'highlight.js/lib/languages/swift'
 import typescript from 'highlight.js/lib/languages/typescript'
 import xml from 'highlight.js/lib/languages/xml'
 import yaml from 'highlight.js/lib/languages/yaml'
+
 import curl from './curl'
+import python from './python'
 
 /**
  * We group languages into three categories based on their popularity and usage.


### PR DESCRIPTION
## What

Python code samples in the API reference were barely highlighted. The built-in highlight.js Python grammar only tags keywords, strings, numbers and the names in `def`/`class` _definitions_ — so a typical API snippet (mostly calls, attribute chains and keyword arguments) rendered almost entirely gray.

This extends the Python grammar and adds two theme colors so Python reads as richly as TypeScript.

## Changes

**Grammar — `packages/code-highlight/src/languages/python.ts`** (new)

A thin wrapper around the upstream highlight.js Python grammar that appends four modes, each using a string `scope` with a lookahead/lookbehind and `relevance: 0` (so auto-detection is unaffected):

| Token | Example | Scope |
|-------|---------|-------|
| Constructor / class call | `Profound(` | `title.class_` |
| Function / method call | `client.reports.get(` | `title.function_` |
| Attribute / property access | `client.reports` | `property` |
| Keyword argument / assignment | `api_key_header=`, `client =` | `attr` |

Ordering ensures `.method(` reads as a call rather than a plain attribute. The modes are appended after the upstream ones, so strings, comments and `def`/`class` titles keep priority and the new modes never fire inside a string or comment. Reserved words are excluded (so `if (...)` stays a keyword and `importlib` is not mistaken for `import`), and comparisons (`==`, `!=`, `>=`, `:=`) are not treated as assignments.

**Theme — `packages/code-highlight/src/css/code.css`**

- `.hljs-title.class_` now uses `--scalar-color-green` (was plain foreground) so constructors and types stand out.
- New `.hljs-property` rule uses `--scalar-color-yellow` (previously unused for syntax) so attribute chains get their own hue.

> Note: both theme rules are global, so **TypeScript and JavaScript** property chains and class names pick up the same colors. Worth an eyeball in `api-reference` during review.

**Tests** — `packages/code-highlight/src/languages/python.test.ts` (new), 10 cases covering class vs function vs property, comparisons, strings/comments and reserved-word edges. Includes a changeset.

## Visual

Before → after of the original snippet — constructor green, calls orange, property chain yellow, keyword args brightened:

| | Token | Color |
|---|---|---|
| Constructor / class | `Profound` | green |
| Function / method call | `get`, `query_…`, `print` | orange |
| Property / attribute access | `environ`, `reports`, `visibility` | yellow |
| Keyword arg / assignment / object key | `date_interval=` | bright foreground |
| Strings | `"day"` | blue |
| Keywords | `from`, `import` | purple |

_Before/after screenshots were shared with the maintainer in the working session._