### PR TITLE
feat(docs): add entra .well-known

### DIFF
--- a/documentation/assets/.well-known/microsoft-identity-association.json
+++ b/documentation/assets/.well-known/microsoft-identity-association.json
@@ -1,0 +1,13 @@
+{
+  "associatedApplications": [
+    {
+      "applicationId": "b1cd9e4e-5b25-4c41-8a07-c42dacca6986"
+    },
+    {
+      "applicationId": "1e100813-887e-44a1-b984-d0cb773a1668"
+    },
+    {
+      "applicationId": "4e6ce4c2-71c1-4bba-bf33-3ce7dba0f908"
+    }
+  ]
+}


### PR DESCRIPTION
## Changes

Adds .well-known entra identity record for brand domain verification. Any application changes should be reflected here.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static documentation asset only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Adds **`documentation/assets/.well-known/microsoft-identity-association.json`** so Microsoft can verify the docs brand domain via the standard **`microsoft-identity-association`** well-known file.
> 
> The file lists **three Entra `applicationId` values** in `associatedApplications`; the PR description notes that **any related application changes should stay in sync** with this list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c88abfa13619a4ec7bbde758bf49b87dbb27e072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->