### PR TITLE
feat(api-reference): add `requestBuilt` hook and `onRequestBuilt` callback with the exact outgoing `Request`

### DIFF
--- a/.changeset/spicy-falcons-shake.md
+++ b/.changeset/spicy-falcons-shake.md
@@ -1,0 +1,11 @@
+---
+'@scalar/api-reference': minor
+'@scalar/oas-utils': minor
+'@scalar/api-client': minor
+'@scalar/schemas': minor
+'@scalar/types': minor
+---
+
+feat: add `requestReady` client plugin hook and `onRequestReady` configuration callback that receive the exact fetch `Request` that is sent over the wire
+
+The hook runs after the request has been built, right before it is sent. Header mutations apply to the outgoing request and the body bytes match what the server receives, which makes request signing possible: hashing the body of a rebuilt `multipart/form-data` request would produce a different multipart boundary than the request that is actually sent.

--- a/.changeset/spicy-falcons-shake.md
+++ b/.changeset/spicy-falcons-shake.md
@@ -6,6 +6,6 @@
 '@scalar/types': minor
 ---
 
-feat: add `requestReady` client plugin hook and `onRequestReady` configuration callback that receive the exact fetch `Request` that is sent over the wire
+feat: add `requestBuilt` client plugin hook and `onRequestBuilt` configuration callback that receive the exact fetch `Request` that is sent over the wire
 
 The hook runs after the request has been built, right before it is sent. Header mutations apply to the outgoing request and the body bytes match what the server receives, which makes request signing possible: hashing the body of a rebuilt `multipart/form-data` request would produce a different multipart boundary than the request that is actually sent.

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -1338,6 +1338,8 @@ Callback fired before the outbound request is sent from the embedded API client.
 
 **`request`** is a fetch API [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) built from the builder for backward compatibility. Using it as the primary way to customize outbound traffic is going to be **deprecated**; prefer **`requestBuilder`**. The API Reference passes both `request` and `requestBuilder` to this callback.
 
+> Note: The `request` here is **not** the object that is sent over the wire; the actual request is rebuilt from `requestBuilder` after this callback runs. If you need the exact outgoing request (for example, to hash a `multipart/form-data` body for request signing), use [`onRequestReady`](#onrequestready) instead.
+
 ```javascript
 {
   onBeforeRequest: ({ requestBuilder }) => {
@@ -1463,6 +1465,32 @@ Callback that triggers as soon as the references are lazy loaded.
 {
   onLoaded: () => {
     console.log('References loaded')
+  }
+}
+```
+
+#### onRequestReady
+
+**Type:** `({ request: Request; requestBuilder: RequestFactory; envVariables: Record<string, string> }) => void | Promise<void>`
+
+Callback fired after the outbound fetch [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) has been built, right before it is sent from the embedded API client. The `request` is the **exact object handed to fetch**: mutating its headers modifies the outgoing request, and hashing its body produces a hash that matches what the server receives.
+
+This makes it the right hook for request signing. A request rebuilt from the builder would not work for `multipart/form-data` bodies, because every rebuild generates a fresh random multipart boundary.
+
+Use [`onBeforeRequest`](#onbeforerequest) instead when you need to mutate the request builder (method, path, query, body, security); those mutations have no effect in `onRequestReady` because the request is already built.
+
+> **Experimental:** This API may change in minor releases.
+
+```javascript
+{
+  onRequestReady: async ({ request }) => {
+    // Hash the exact body bytes that are sent over the wire
+    const bodyBytes = await request.clone().arrayBuffer()
+    const digest = await crypto.subtle.digest('SHA-256', bodyBytes)
+    const bodyHashB64 = btoa(String.fromCharCode(...new Uint8Array(digest)))
+
+    // Header mutations apply to the outgoing request
+    request.headers.set('X-Body-Hash', bodyHashB64)
   }
 }
 ```

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -1338,7 +1338,7 @@ Callback fired before the outbound request is sent from the embedded API client.
 
 **`request`** is a fetch API [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) built from the builder for backward compatibility. Using it as the primary way to customize outbound traffic is going to be **deprecated**; prefer **`requestBuilder`**. The API Reference passes both `request` and `requestBuilder` to this callback.
 
-> Note: The `request` here is **not** the object that is sent over the wire; the actual request is rebuilt from `requestBuilder` after this callback runs. If you need the exact outgoing request (for example, to hash a `multipart/form-data` body for request signing), use [`onRequestReady`](#onrequestready) instead.
+> Note: The `request` here is **not** the object that is sent over the wire; the actual request is rebuilt from `requestBuilder` after this callback runs. If you need the exact outgoing request (for example, to hash a `multipart/form-data` body for request signing), use [`onRequestBuilt`](#onrequestbuilt) instead.
 
 ```javascript
 {
@@ -1469,7 +1469,7 @@ Callback that triggers as soon as the references are lazy loaded.
 }
 ```
 
-#### onRequestReady
+#### onRequestBuilt
 
 **Type:** `({ request: Request; requestBuilder: RequestFactory; envVariables: Record<string, string> }) => void | Promise<void>`
 
@@ -1477,13 +1477,13 @@ Callback fired after the outbound fetch [`Request`](https://developer.mozilla.or
 
 This makes it the right hook for request signing. A request rebuilt from the builder would not work for `multipart/form-data` bodies, because every rebuild generates a fresh random multipart boundary.
 
-Use [`onBeforeRequest`](#onbeforerequest) instead when you need to mutate the request builder (method, path, query, body, security); those mutations have no effect in `onRequestReady` because the request is already built.
+Use [`onBeforeRequest`](#onbeforerequest) instead when you need to mutate the request builder (method, path, query, body, security); those mutations have no effect in `onRequestBuilt` because the request is already built.
 
 > **Experimental:** This API may change in minor releases.
 
 ```javascript
 {
-  onRequestReady: async ({ request }) => {
+  onRequestBuilt: async ({ request }) => {
     // Hash the exact body bytes that are sent over the wire
     const bodyBytes = await request.clone().arrayBuffer()
     const digest = await crypto.subtle.digest('SHA-256', bodyBytes)

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
@@ -662,7 +662,7 @@ describe('OperationBlock', () => {
     })
   })
 
-  it('passes the exact Request observed by the requestReady hook to sendRequest', async () => {
+  it('passes the exact Request observed by the requestBuilt hook to sendRequest', async () => {
     vi.mocked(sendRequest).mockResolvedValue([
       null,
       {
@@ -679,10 +679,10 @@ describe('OperationBlock', () => {
 
     await triggerExecute(wrapper)
 
-    const requestReadyCall = vi.mocked(executeHook).mock.calls.find((call) => call[1] === 'requestReady')
-    expect(requestReadyCall).toBeDefined()
+    const requestBuiltCall = vi.mocked(executeHook).mock.calls.find((call) => call[1] === 'requestBuilt')
+    expect(requestBuiltCall).toBeDefined()
 
-    const hookRequest = (requestReadyCall?.[0] as { request: Request }).request
+    const hookRequest = (requestBuiltCall?.[0] as { request: Request }).request
     expect(hookRequest).toBeInstanceOf(Request)
 
     // The hook and the fetch call must observe the same Request instance, so header
@@ -691,7 +691,7 @@ describe('OperationBlock', () => {
     expect(sendRequestCall?.request).toBe(hookRequest)
   })
 
-  it('multipart body hash computed in the requestReady hook matches the request that is sent', async () => {
+  it('multipart body hash computed in the requestBuilt hook matches the request that is sent', async () => {
     const sha256Base64 = async (request: Request): Promise<string> => {
       const bytes = new Uint8Array(await request.clone().arrayBuffer())
       return createHash('sha256').update(bytes).digest('base64')
@@ -721,7 +721,7 @@ describe('OperationBlock', () => {
     let hookHash: string | undefined
     const signingPlugin: ClientPlugin = {
       hooks: {
-        requestReady: async ({ request }) => {
+        requestBuilt: async ({ request }) => {
           hookHash = await sha256Base64(request)
         },
       },

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
@@ -1,5 +1,9 @@
+import { createHash } from 'node:crypto'
+
 import { ERRORS } from '@scalar/helpers/errors/normalize-error'
+import { buildSafeBodyRequest } from '@scalar/helpers/http/can-method-have-body'
 import { err, ok } from '@scalar/helpers/types/result'
+import { type ClientPlugin, executeHook } from '@scalar/oas-utils/helpers'
 import { AVAILABLE_CLIENTS } from '@scalar/types/snippetz'
 import type { AuthMeta, WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { type RequestPayload, buildRequest, requestFactory } from '@scalar/workspace-store/request-example'
@@ -28,9 +32,14 @@ vi.mock('@scalar/workspace-store/request-example', async (importOriginal) => {
 
 vi.mock('./helpers/send-request')
 
-vi.mock('@scalar/oas-utils/helpers', () => ({
-  executeHook: vi.fn(async (payload: unknown) => payload),
-}))
+vi.mock('@scalar/oas-utils/helpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@scalar/oas-utils/helpers')>()
+  return {
+    ...actual,
+    // Wrap the real implementation so plugin hooks run while calls remain inspectable
+    executeHook: vi.fn(actual.executeHook),
+  }
+})
 
 /**
  * Mock the toast composable to capture toast calls in tests.
@@ -304,6 +313,7 @@ describe('OperationBlock', () => {
     expect(sendRequest).toHaveBeenCalledWith({
       isUsingProxy: false,
       requestPayload: ['https://api.example.com/api/users', expect.objectContaining({ method: 'GET' })],
+      request: expect.any(Request),
       plugins: [],
     })
   })
@@ -647,8 +657,92 @@ describe('OperationBlock', () => {
     expect(sendRequest).toHaveBeenCalledWith({
       isUsingProxy: true,
       requestPayload: [expect.any(String), expect.any(Object)],
+      request: expect.any(Request),
       plugins: [],
     })
+  })
+
+  it('passes the exact Request observed by the requestReady hook to sendRequest', async () => {
+    vi.mocked(sendRequest).mockResolvedValue([
+      null,
+      {
+        timestamp: Date.now(),
+        requestPayload: ['https://api.example.com/api/users', { method: 'GET', headers: new Headers() }],
+        response: {} as ResponseInstance,
+        originalResponse: createMockOriginalResponse(),
+      },
+    ])
+
+    const wrapper = mount(OperationBlock, {
+      props: createDefaultProps(),
+    })
+
+    await triggerExecute(wrapper)
+
+    const requestReadyCall = vi.mocked(executeHook).mock.calls.find((call) => call[1] === 'requestReady')
+    expect(requestReadyCall).toBeDefined()
+
+    const hookRequest = (requestReadyCall?.[0] as { request: Request }).request
+    expect(hookRequest).toBeInstanceOf(Request)
+
+    // The hook and the fetch call must observe the same Request instance, so header
+    // mutations apply and body hashes match what goes over the wire
+    const sendRequestCall = vi.mocked(sendRequest).mock.calls.at(-1)?.[0]
+    expect(sendRequestCall?.request).toBe(hookRequest)
+  })
+
+  it('multipart body hash computed in the requestReady hook matches the request that is sent', async () => {
+    const sha256Base64 = async (request: Request): Promise<string> => {
+      const bytes = new Uint8Array(await request.clone().arrayBuffer())
+      return createHash('sha256').update(bytes).digest('base64')
+    }
+
+    const formData = new FormData()
+    formData.append('field', 'value')
+
+    vi.mocked(buildRequest).mockReturnValue(
+      ok({
+        controller: new AbortController(),
+        requestPayload: ['https://api.example.com/upload', { method: 'POST', body: formData }],
+        isUsingProxy: false,
+      }),
+    )
+
+    vi.mocked(sendRequest).mockResolvedValue([
+      null,
+      {
+        timestamp: Date.now(),
+        requestPayload: ['https://api.example.com/upload', { method: 'POST' }],
+        response: {} as ResponseInstance,
+        originalResponse: createMockOriginalResponse(),
+      },
+    ])
+
+    let hookHash: string | undefined
+    const signingPlugin: ClientPlugin = {
+      hooks: {
+        requestReady: async ({ request }) => {
+          hookHash = await sha256Base64(request)
+        },
+      },
+    }
+
+    const wrapper = mount(OperationBlock, {
+      props: { ...createDefaultProps(), plugins: [signingPlugin] },
+    })
+
+    await triggerExecute(wrapper)
+
+    expect(hookHash).toBeDefined()
+
+    const sentRequest = vi.mocked(sendRequest).mock.calls.at(-1)?.[0].request
+    expect(sentRequest).toBeInstanceOf(Request)
+    expect(await sha256Base64(sentRequest as Request)).toBe(hookHash)
+
+    // Guards the regression this feature fixes: rebuilding from the same FormData
+    // generates a fresh random multipart boundary, so a rebuilt request hashes differently
+    const rebuiltRequest = buildSafeBodyRequest('https://api.example.com/upload', { method: 'POST', body: formData })
+    expect(await sha256Base64(rebuiltRequest)).not.toBe(hookHash)
   })
 
   it('stores response after successful request execution', async () => {

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -287,6 +287,24 @@ const handleExecute = async () => {
   // Store the abort controller for cancellation
   abortController.value = built.data.controller
 
+  // Build the fetch Request once so the requestReady hook observes the exact bytes that are
+  // sent. Rebuilding it later would generate a different multipart boundary, which breaks
+  // plugins that hash the body (for example, request signing).
+  const request = buildSafeBodyRequest(...built.data.requestPayload)
+
+  // Execute the requestReady hook (plugins receive the exact fetch Request that will be sent)
+  await executeHook(
+    {
+      request,
+      requestBuilder,
+      document,
+      operation,
+      variablesStore,
+    },
+    'requestReady',
+    plugins,
+  )
+
   // Execute the hooks
   eventBus.emit('hooks:on:request:sent', {
     meta: {
@@ -300,6 +318,7 @@ const handleExecute = async () => {
   const [sendError, sendResult] = await sendRequest({
     isUsingProxy: built.data.isUsingProxy,
     requestPayload: built.data.requestPayload,
+    request,
     plugins,
     customFetch: toValue(options)?.customFetch,
   })

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -287,12 +287,12 @@ const handleExecute = async () => {
   // Store the abort controller for cancellation
   abortController.value = built.data.controller
 
-  // Build the fetch Request once so the requestReady hook observes the exact bytes that are
+  // Build the fetch Request once so the requestBuilt hook observes the exact bytes that are
   // sent. Rebuilding it later would generate a different multipart boundary, which breaks
   // plugins that hash the body (for example, request signing).
   const request = buildSafeBodyRequest(...built.data.requestPayload)
 
-  // Execute the requestReady hook (plugins receive the exact fetch Request that will be sent)
+  // Execute the requestBuilt hook (plugins receive the exact fetch Request that will be sent)
   await executeHook(
     {
       request,
@@ -301,7 +301,7 @@ const handleExecute = async () => {
       operation,
       variablesStore,
     },
-    'requestReady',
+    'requestBuilt',
     plugins,
   )
 

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.test.ts
@@ -109,6 +109,26 @@ describe('sendRequest', () => {
     expect(result.response.status).toBe(200)
   })
 
+  it('sends the pre-built request as-is so hook mutations and body bytes are preserved', async () => {
+    const requestInit: RequestInit = { method: 'POST', body: '{"data":"test"}' }
+    const preBuiltRequest = new Request(MOCK_URL, requestInit)
+    preBuiltRequest.headers.set('X-Signature', 'abc123')
+
+    const customFetch = vi.fn().mockResolvedValueOnce(createMockEchoResponse(MOCK_URL, requestInit))
+
+    const [error] = await sendRequest({
+      isUsingProxy: false,
+      requestPayload: [MOCK_URL, requestInit],
+      request: preBuiltRequest,
+      customFetch,
+    })
+
+    expect(error).toBe(null)
+    expect(customFetch).toHaveBeenCalledTimes(1)
+    // The exact same Request instance must reach fetch, not a rebuilt copy
+    expect(customFetch).toHaveBeenCalledWith(preBuiltRequest)
+  })
+
   it('uses customFetch instead of global fetch when provided', async () => {
     const requestInit: RequestInit = {}
     const customFetch = vi.fn().mockResolvedValueOnce(createMockEchoResponse(MOCK_URL, requestInit))

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.ts
@@ -70,11 +70,18 @@ export type CustomFetch = typeof fetch
 export const sendRequest = async ({
   isUsingProxy,
   requestPayload,
+  request,
   plugins = [],
   customFetch = fetch,
 }: {
   isUsingProxy: boolean
   requestPayload: RequestPayload
+  /**
+   * Pre-built fetch Request to send as-is. When provided, it is used instead of rebuilding
+   * from the request payload so plugin hooks observe the exact bytes that go over the wire
+   * (rebuilding a multipart body generates a different boundary).
+   */
+  request?: Request
   /** Registered client plugins for custom content type handling */
   plugins?: ClientPlugin[]
   /** Optional custom fetch implementation, overrides the global fetch */
@@ -94,7 +101,7 @@ export const sendRequest = async ({
     // In electron we allow GET requests to have a body
     const response = isElectron()
       ? await customFetch(...requestPayload)
-      : await customFetch(buildSafeBodyRequest(...requestPayload))
+      : await customFetch(request ?? buildSafeBodyRequest(...requestPayload))
 
     const endTime = performance.now()
     const timestamp = Date.now()

--- a/packages/api-reference/src/helpers/map-config-plugins.test.ts
+++ b/packages/api-reference/src/helpers/map-config-plugins.test.ts
@@ -39,7 +39,7 @@ const beforePayload = (requestBuilder: RequestFactory) => ({
   operation,
 })
 
-const requestReadyPayload = (
+const requestBuiltPayload = (
   requestBuilder: RequestFactory,
   request: Request = new Request('https://example.com/api/test'),
 ) => ({
@@ -463,56 +463,56 @@ describe('mapConfigPlugins', () => {
     expect(capturedRequest.headers.get('X-Static')).toBe('static-value')
   })
 
-  it('transforms onRequestReady callback into a ClientPlugin with requestReady hook', async () => {
+  it('transforms onRequestBuilt callback into a ClientPlugin with requestBuilt hook', async () => {
     const mockRequestBuilder = createMockFactory()
     const fetchRequest = new Request('https://example.com/api/test', { method: 'GET' })
 
-    const onRequestReadyMock = vi.fn()
+    const onRequestBuiltMock = vi.fn()
 
     const config = computed(() => ({
-      onRequestReady: onRequestReadyMock as any,
+      onRequestBuilt: onRequestBuiltMock as any,
     })) as ComputedRef<ApiReferenceConfigurationRaw>
 
     const plugins: ClientPlugin[] = mapConfigPlugins(config, createMockEnvironment())
 
     expect(plugins).toHaveLength(1)
-    expect(plugins[0]?.hooks).toHaveProperty('requestReady')
+    expect(plugins[0]?.hooks).toHaveProperty('requestBuilt')
 
-    const requestReadyHook = plugins[0]?.hooks?.requestReady
-    assert(requestReadyHook)
+    const requestBuiltHook = plugins[0]?.hooks?.requestBuilt
+    assert(requestBuiltHook)
 
-    await requestReadyHook(requestReadyPayload(mockRequestBuilder, fetchRequest))
+    await requestBuiltHook(requestBuiltPayload(mockRequestBuilder, fetchRequest))
 
-    expect(onRequestReadyMock).toHaveBeenCalledTimes(1)
-    expect(onRequestReadyMock).toHaveBeenCalledWith({
+    expect(onRequestBuiltMock).toHaveBeenCalledTimes(1)
+    expect(onRequestBuiltMock).toHaveBeenCalledWith({
       envVariables: expect.any(Object),
       request: fetchRequest,
       requestBuilder: mockRequestBuilder,
     })
   })
 
-  it('passes the exact request instance to onRequestReady so header mutations apply', async () => {
+  it('passes the exact request instance to onRequestBuilt so header mutations apply', async () => {
     const fetchRequest = new Request('https://example.com/api/test', { method: 'GET' })
 
-    const onRequestReadyMock = vi.fn(({ request }: { request: Request }) => {
+    const onRequestBuiltMock = vi.fn(({ request }: { request: Request }) => {
       request.headers.set('X-Signature', 'abc123')
     })
 
     const config = computed(() => ({
-      onRequestReady: onRequestReadyMock as any,
+      onRequestBuilt: onRequestBuiltMock as any,
     })) as ComputedRef<ApiReferenceConfigurationRaw>
 
     const plugins: ClientPlugin[] = mapConfigPlugins(config, createMockEnvironment())
 
-    const requestReadyHook = plugins[0]?.hooks?.requestReady
-    assert(requestReadyHook)
+    const requestBuiltHook = plugins[0]?.hooks?.requestBuilt
+    assert(requestBuiltHook)
 
-    await requestReadyHook(requestReadyPayload(createMockFactory(), fetchRequest))
+    await requestBuiltHook(requestBuiltPayload(createMockFactory(), fetchRequest))
 
     expect(fetchRequest.headers.get('X-Signature')).toBe('abc123')
   })
 
-  it('lets onRequestReady hash the same multipart body bytes that are sent over the wire', async () => {
+  it('lets onRequestBuilt hash the same multipart body bytes that are sent over the wire', async () => {
     // Multipart bodies are the critical case: every `new Request` with a FormData body
     // generates a fresh random boundary, so only the exact request instance produces
     // a hash that matches what the server receives
@@ -524,27 +524,27 @@ describe('mapConfigPlugins', () => {
     })
 
     let observedBytes: Uint8Array | undefined
-    const onRequestReadyMock = vi.fn(async ({ request }: { request: Request }) => {
+    const onRequestBuiltMock = vi.fn(async ({ request }: { request: Request }) => {
       observedBytes = new Uint8Array(await request.clone().arrayBuffer())
     })
 
     const config = computed(() => ({
-      onRequestReady: onRequestReadyMock as any,
+      onRequestBuilt: onRequestBuiltMock as any,
     })) as ComputedRef<ApiReferenceConfigurationRaw>
 
     const plugins: ClientPlugin[] = mapConfigPlugins(config, createMockEnvironment())
 
-    const requestReadyHook = plugins[0]?.hooks?.requestReady
-    assert(requestReadyHook)
+    const requestBuiltHook = plugins[0]?.hooks?.requestBuilt
+    assert(requestBuiltHook)
 
-    await requestReadyHook(requestReadyPayload(createMockFactory(), fetchRequest))
+    await requestBuiltHook(requestBuiltPayload(createMockFactory(), fetchRequest))
 
     const sentBytes = new Uint8Array(await fetchRequest.arrayBuffer())
     assert(observedBytes)
     expect(observedBytes).toEqual(sentBytes)
   })
 
-  it('passes environment variables resolved from the environment to onRequestReady', async () => {
+  it('passes environment variables resolved from the environment to onRequestBuilt', async () => {
     const environment = createMockEnvironment([
       { name: 'API_TOKEN', value: 'secret-token-123' },
       {
@@ -555,27 +555,27 @@ describe('mapConfigPlugins', () => {
 
     let capturedEnvVariables: Record<string, string> | undefined
 
-    const onRequestReadyMock = vi.fn(({ envVariables }: { envVariables: Record<string, string> }) => {
+    const onRequestBuiltMock = vi.fn(({ envVariables }: { envVariables: Record<string, string> }) => {
       capturedEnvVariables = envVariables
     })
 
     const config = computed(() => ({
-      onRequestReady: onRequestReadyMock as any,
+      onRequestBuilt: onRequestBuiltMock as any,
     })) as ComputedRef<ApiReferenceConfigurationRaw>
 
     const plugins: ClientPlugin[] = mapConfigPlugins(config, environment)
 
-    const requestReadyHook = plugins[0]?.hooks?.requestReady
-    assert(requestReadyHook)
+    const requestBuiltHook = plugins[0]?.hooks?.requestBuilt
+    assert(requestBuiltHook)
 
-    await requestReadyHook(requestReadyPayload(createMockFactory()))
+    await requestBuiltHook(requestBuiltPayload(createMockFactory()))
 
     assert(capturedEnvVariables)
     expect(capturedEnvVariables['API_TOKEN']).toBe('secret-token-123')
     expect(capturedEnvVariables['ENV_WITH_DEFAULT']).toBe('default-value')
   })
 
-  it('adds and removes the requestReady hook when onRequestReady changes in config', async () => {
+  it('adds and removes the requestBuilt hook when onRequestBuilt changes in config', async () => {
     const fn = vi.fn()
 
     const config = ref({}) as unknown as Ref<ApiReferenceConfigurationRaw>
@@ -588,17 +588,17 @@ describe('mapConfigPlugins', () => {
     const hooks = plugins[0]?.hooks
     assert(hooks)
 
-    expect(hooks.requestReady).toBeUndefined()
+    expect(hooks.requestBuilt).toBeUndefined()
 
-    config.value.onRequestReady = fn
+    config.value.onRequestBuilt = fn
     await nextTick()
 
-    await hooks.requestReady?.(requestReadyPayload(createMockFactory()))
+    await hooks.requestBuilt?.(requestBuiltPayload(createMockFactory()))
     expect(fn).toHaveBeenCalledTimes(1)
 
-    config.value.onRequestReady = undefined
+    config.value.onRequestBuilt = undefined
     await nextTick()
 
-    expect(hooks.requestReady).toBeUndefined()
+    expect(hooks.requestBuilt).toBeUndefined()
   })
 })

--- a/packages/api-reference/src/helpers/map-config-plugins.test.ts
+++ b/packages/api-reference/src/helpers/map-config-plugins.test.ts
@@ -39,6 +39,16 @@ const beforePayload = (requestBuilder: RequestFactory) => ({
   operation,
 })
 
+const requestReadyPayload = (
+  requestBuilder: RequestFactory,
+  request: Request = new Request('https://example.com/api/test'),
+) => ({
+  request,
+  requestBuilder,
+  document,
+  operation,
+})
+
 const responsePayload = (requestBuilder: RequestFactory, fetchRequest: Request) => ({
   response: new Response('{"data": "test"}', {
     status: 200,
@@ -451,5 +461,144 @@ describe('mapConfigPlugins', () => {
 
     assert(capturedRequest)
     expect(capturedRequest.headers.get('X-Static')).toBe('static-value')
+  })
+
+  it('transforms onRequestReady callback into a ClientPlugin with requestReady hook', async () => {
+    const mockRequestBuilder = createMockFactory()
+    const fetchRequest = new Request('https://example.com/api/test', { method: 'GET' })
+
+    const onRequestReadyMock = vi.fn()
+
+    const config = computed(() => ({
+      onRequestReady: onRequestReadyMock as any,
+    })) as ComputedRef<ApiReferenceConfigurationRaw>
+
+    const plugins: ClientPlugin[] = mapConfigPlugins(config, createMockEnvironment())
+
+    expect(plugins).toHaveLength(1)
+    expect(plugins[0]?.hooks).toHaveProperty('requestReady')
+
+    const requestReadyHook = plugins[0]?.hooks?.requestReady
+    assert(requestReadyHook)
+
+    await requestReadyHook(requestReadyPayload(mockRequestBuilder, fetchRequest))
+
+    expect(onRequestReadyMock).toHaveBeenCalledTimes(1)
+    expect(onRequestReadyMock).toHaveBeenCalledWith({
+      envVariables: expect.any(Object),
+      request: fetchRequest,
+      requestBuilder: mockRequestBuilder,
+    })
+  })
+
+  it('passes the exact request instance to onRequestReady so header mutations apply', async () => {
+    const fetchRequest = new Request('https://example.com/api/test', { method: 'GET' })
+
+    const onRequestReadyMock = vi.fn(({ request }: { request: Request }) => {
+      request.headers.set('X-Signature', 'abc123')
+    })
+
+    const config = computed(() => ({
+      onRequestReady: onRequestReadyMock as any,
+    })) as ComputedRef<ApiReferenceConfigurationRaw>
+
+    const plugins: ClientPlugin[] = mapConfigPlugins(config, createMockEnvironment())
+
+    const requestReadyHook = plugins[0]?.hooks?.requestReady
+    assert(requestReadyHook)
+
+    await requestReadyHook(requestReadyPayload(createMockFactory(), fetchRequest))
+
+    expect(fetchRequest.headers.get('X-Signature')).toBe('abc123')
+  })
+
+  it('lets onRequestReady hash the same multipart body bytes that are sent over the wire', async () => {
+    // Multipart bodies are the critical case: every `new Request` with a FormData body
+    // generates a fresh random boundary, so only the exact request instance produces
+    // a hash that matches what the server receives
+    const formData = new FormData()
+    formData.append('field', 'value')
+    const fetchRequest = new Request('https://example.com/upload', {
+      method: 'POST',
+      body: formData,
+    })
+
+    let observedBytes: Uint8Array | undefined
+    const onRequestReadyMock = vi.fn(async ({ request }: { request: Request }) => {
+      observedBytes = new Uint8Array(await request.clone().arrayBuffer())
+    })
+
+    const config = computed(() => ({
+      onRequestReady: onRequestReadyMock as any,
+    })) as ComputedRef<ApiReferenceConfigurationRaw>
+
+    const plugins: ClientPlugin[] = mapConfigPlugins(config, createMockEnvironment())
+
+    const requestReadyHook = plugins[0]?.hooks?.requestReady
+    assert(requestReadyHook)
+
+    await requestReadyHook(requestReadyPayload(createMockFactory(), fetchRequest))
+
+    const sentBytes = new Uint8Array(await fetchRequest.arrayBuffer())
+    assert(observedBytes)
+    expect(observedBytes).toEqual(sentBytes)
+  })
+
+  it('passes environment variables resolved from the environment to onRequestReady', async () => {
+    const environment = createMockEnvironment([
+      { name: 'API_TOKEN', value: 'secret-token-123' },
+      {
+        name: 'ENV_WITH_DEFAULT',
+        value: { default: 'default-value', description: 'A variable with default' },
+      },
+    ])
+
+    let capturedEnvVariables: Record<string, string> | undefined
+
+    const onRequestReadyMock = vi.fn(({ envVariables }: { envVariables: Record<string, string> }) => {
+      capturedEnvVariables = envVariables
+    })
+
+    const config = computed(() => ({
+      onRequestReady: onRequestReadyMock as any,
+    })) as ComputedRef<ApiReferenceConfigurationRaw>
+
+    const plugins: ClientPlugin[] = mapConfigPlugins(config, environment)
+
+    const requestReadyHook = plugins[0]?.hooks?.requestReady
+    assert(requestReadyHook)
+
+    await requestReadyHook(requestReadyPayload(createMockFactory()))
+
+    assert(capturedEnvVariables)
+    expect(capturedEnvVariables['API_TOKEN']).toBe('secret-token-123')
+    expect(capturedEnvVariables['ENV_WITH_DEFAULT']).toBe('default-value')
+  })
+
+  it('adds and removes the requestReady hook when onRequestReady changes in config', async () => {
+    const fn = vi.fn()
+
+    const config = ref({}) as unknown as Ref<ApiReferenceConfigurationRaw>
+
+    const plugins: ClientPlugin[] = mapConfigPlugins(
+      computed(() => config.value),
+      createMockEnvironment(),
+    )
+
+    const hooks = plugins[0]?.hooks
+    assert(hooks)
+
+    expect(hooks.requestReady).toBeUndefined()
+
+    config.value.onRequestReady = fn
+    await nextTick()
+
+    await hooks.requestReady?.(requestReadyPayload(createMockFactory()))
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    config.value.onRequestReady = undefined
+    await nextTick()
+
+    expect(hooks.requestReady).toBeUndefined()
   })
 })

--- a/packages/api-reference/src/helpers/map-config-plugins.ts
+++ b/packages/api-reference/src/helpers/map-config-plugins.ts
@@ -8,11 +8,11 @@ import { type ComputedRef, watch } from 'vue'
 /**
  * Maps API reference configuration callbacks to client plugins.
  *
- * This function transforms the onBeforeRequest, onRequestReady, and onRequestSent
+ * This function transforms the onBeforeRequest, onRequestBuilt, and onRequestSent
  * callbacks into the new plugin hook system. The mapping is reactive, so changes
  * to the configuration will automatically update the plugin hooks.
  *
- * Note: onRequestReady is mapped to the requestReady hook so the callback receives
+ * Note: onRequestBuilt is mapped to the requestBuilt hook so the callback receives
  * the exact fetch Request that is sent over the wire. Mutating its headers modifies
  * the outgoing request, and hashing its body produces a hash that matches what the
  * server receives (a rebuilt multipart body would get a different boundary).
@@ -35,11 +35,11 @@ export const mapConfigPlugins = (
   watch(
     [
       () => config.value.onBeforeRequest,
-      () => config.value.onRequestReady,
+      () => config.value.onRequestBuilt,
       () => config.value.onRequestSent,
       () => environment.value,
     ],
-    ([onBeforeRequest, onRequestReady, onRequestSent, environment]) => {
+    ([onBeforeRequest, onRequestBuilt, onRequestSent, environment]) => {
       // Get the environment variables for the current environment
       const envVariables = getEnvironmentVariables(environment)
 
@@ -71,13 +71,13 @@ export const mapConfigPlugins = (
         : undefined
 
       /**
-       * Maps onRequestReady to the requestReady hook. The payload request is the
+       * Maps onRequestBuilt to the requestBuilt hook. The payload request is the
        * exact fetch Request that will be sent, so header mutations apply and body
        * hashes match what goes over the wire.
        */
-      plugin.hooks.requestReady = onRequestReady
+      plugin.hooks.requestBuilt = onRequestBuilt
         ? async (payload) => {
-            await onRequestReady({
+            await onRequestBuilt({
               request: payload.request,
               requestBuilder: payload.requestBuilder,
               envVariables,

--- a/packages/api-reference/src/helpers/map-config-plugins.ts
+++ b/packages/api-reference/src/helpers/map-config-plugins.ts
@@ -8,9 +8,14 @@ import { type ComputedRef, watch } from 'vue'
 /**
  * Maps API reference configuration callbacks to client plugins.
  *
- * This function transforms the legacy onBeforeRequest and onRequestSent callbacks
- * into the new plugin hook system. The mapping is reactive, so changes to the
- * configuration will automatically update the plugin hooks.
+ * This function transforms the onBeforeRequest, onRequestReady, and onRequestSent
+ * callbacks into the new plugin hook system. The mapping is reactive, so changes
+ * to the configuration will automatically update the plugin hooks.
+ *
+ * Note: onRequestReady is mapped to the requestReady hook so the callback receives
+ * the exact fetch Request that is sent over the wire. Mutating its headers modifies
+ * the outgoing request, and hashing its body produces a hash that matches what the
+ * server receives (a rebuilt multipart body would get a different boundary).
  *
  * Note: onRequestSent is mapped to responseReceived hook. This is not a perfect
  * one-to-one mapping, but it maintains backward compatibility with the old API.
@@ -28,8 +33,13 @@ export const mapConfigPlugins = (
   const plugin: ClientPlugin = { hooks: {} }
 
   watch(
-    [() => config.value.onBeforeRequest, () => config.value.onRequestSent, () => environment.value],
-    ([onBeforeRequest, onRequestSent, environment]) => {
+    [
+      () => config.value.onBeforeRequest,
+      () => config.value.onRequestReady,
+      () => config.value.onRequestSent,
+      () => environment.value,
+    ],
+    ([onBeforeRequest, onRequestReady, onRequestSent, environment]) => {
       // Get the environment variables for the current environment
       const envVariables = getEnvironmentVariables(environment)
 
@@ -54,6 +64,21 @@ export const mapConfigPlugins = (
             await onBeforeRequest({
               // We need to build the request to get the fetch `Request`
               request: buildSafeBodyRequest(...built.data.requestPayload),
+              requestBuilder: payload.requestBuilder,
+              envVariables,
+            })
+          }
+        : undefined
+
+      /**
+       * Maps onRequestReady to the requestReady hook. The payload request is the
+       * exact fetch Request that will be sent, so header mutations apply and body
+       * hashes match what goes over the wire.
+       */
+      plugin.hooks.requestReady = onRequestReady
+        ? async (payload) => {
+            await onRequestReady({
+              request: payload.request,
               requestBuilder: payload.requestBuilder,
               envVariables,
             })

--- a/packages/oas-utils/src/helpers/client-plugins.test.ts
+++ b/packages/oas-utils/src/helpers/client-plugins.test.ts
@@ -130,13 +130,13 @@ describe('executeHook', () => {
     expect(result.requestBuilder.headers.get('X-Async')).toBe('completed')
   })
 
-  it('executes requestReady hooks with the exact request instance so mutations apply', async () => {
+  it('executes requestBuilt hooks with the exact request instance so mutations apply', async () => {
     const requestBuilder = createFactory()
     const request = new Request('https://example.com/api/test', { method: 'GET' })
 
     const plugin: ClientPlugin = {
       hooks: {
-        requestReady: async (payload) => {
+        requestBuilt: async (payload) => {
           await new Promise((resolve) => setTimeout(resolve, 10))
 
           payload.request.headers.set('X-Signature', 'abc123')
@@ -146,7 +146,7 @@ describe('executeHook', () => {
 
     const result = await executeHook(
       { request, requestBuilder, document: {} as never, operation: {} as never },
-      'requestReady',
+      'requestBuilt',
       [plugin],
     )
 

--- a/packages/oas-utils/src/helpers/client-plugins.test.ts
+++ b/packages/oas-utils/src/helpers/client-plugins.test.ts
@@ -130,6 +130,30 @@ describe('executeHook', () => {
     expect(result.requestBuilder.headers.get('X-Async')).toBe('completed')
   })
 
+  it('executes requestReady hooks with the exact request instance so mutations apply', async () => {
+    const requestBuilder = createFactory()
+    const request = new Request('https://example.com/api/test', { method: 'GET' })
+
+    const plugin: ClientPlugin = {
+      hooks: {
+        requestReady: async (payload) => {
+          await new Promise((resolve) => setTimeout(resolve, 10))
+
+          payload.request.headers.set('X-Signature', 'abc123')
+        },
+      },
+    }
+
+    const result = await executeHook(
+      { request, requestBuilder, document: {} as never, operation: {} as never },
+      'requestReady',
+      [plugin],
+    )
+
+    expect(result.request).toBe(request)
+    expect(request.headers.get('X-Signature')).toBe('abc123')
+  })
+
   it('maintains type safety with HookPayloadMap for different hook types', async () => {
     const requestBuilder = createFactory()
     const beforeRequestPlugin: ClientPlugin = {

--- a/packages/oas-utils/src/helpers/client-plugins.ts
+++ b/packages/oas-utils/src/helpers/client-plugins.ts
@@ -48,6 +48,22 @@ type ClientPluginHooks = {
     variablesStore?: VariablesStore
   }) => void | Promise<void>
   /**
+   * Runs after the fetch `Request` has been built, right before it is sent. The request passed
+   * here is the exact object handed to fetch, so header mutations apply to the outgoing request
+   * and the body bytes match what goes over the wire (important for request signing, where a
+   * rebuilt multipart body would get a different boundary). Mutations to the request builder
+   * have no effect at this stage; use the `beforeRequest` hook for those.
+   */
+  requestReady: (payload: {
+    /** The exact fetch Request that will be sent. Mutate its headers to modify the outgoing request. */
+    request: Request
+    /** Request builder the request was built from. Mutating it has no effect at this stage. */
+    requestBuilder: RequestFactory
+    document: OpenApiDocument
+    operation: OperationObject
+    variablesStore?: VariablesStore
+  }) => void | Promise<void>
+  /**
    * Runs after a response is received. Receives the current document and operation so plugins can
    * modify the response after it is received (for example, adding headers or modifying the body).
    */

--- a/packages/oas-utils/src/helpers/client-plugins.ts
+++ b/packages/oas-utils/src/helpers/client-plugins.ts
@@ -39,6 +39,10 @@ type ClientPluginHooks = {
   /**
    * Runs before a request is sent. Receives the current document and operation so plugins can
    * modify the request before it is sent (for example, adding headers or modifying the body).
+   *
+   * Mutations here happen on the request builder, before the fetch `Request` exists. Use the
+   * `requestBuilt` hook instead when you need the exact outgoing request (for example, to hash a
+   * multipart body for request signing).
    */
   beforeRequest: (payload: {
     /** Workspace-store request spec; mutable by pre-request scripts (headers, method). */
@@ -54,7 +58,7 @@ type ClientPluginHooks = {
    * rebuilt multipart body would get a different boundary). Mutations to the request builder
    * have no effect at this stage; use the `beforeRequest` hook for those.
    */
-  requestReady: (payload: {
+  requestBuilt: (payload: {
     /** The exact fetch Request that will be sent. Mutate its headers to modify the outgoing request. */
     request: Request
     /** Request builder the request was built from. Mutating it has no effect at this stage. */

--- a/packages/schemas/src/api-reference/api-reference-configuration.ts
+++ b/packages/schemas/src/api-reference/api-reference-configuration.ts
@@ -130,7 +130,7 @@ export const apiReferenceConfigurationSchema = intersection([
           'Fired before the outbound request is built; callback receives a mutable request builder. Experimental API.',
       },
     ),
-    onRequestReady: optional(
+    onRequestBuilt: optional(
       fn<
         (input: {
           request: Request

--- a/packages/schemas/src/api-reference/api-reference-configuration.ts
+++ b/packages/schemas/src/api-reference/api-reference-configuration.ts
@@ -130,6 +130,19 @@ export const apiReferenceConfigurationSchema = intersection([
           'Fired before the outbound request is built; callback receives a mutable request builder. Experimental API.',
       },
     ),
+    onRequestReady: optional(
+      fn<
+        (input: {
+          request: Request
+          requestBuilder: unknown
+          envVariables: Record<string, string>
+        }) => Promise<void> | void
+      >(),
+      {
+        typeComment:
+          'Fired right before the outbound request is sent; callback receives the exact fetch Request that goes over the wire. Experimental API.',
+      },
+    ),
     onShowMore: optional(fn<(tagId: string) => Promise<void> | void>(), {
       typeComment: 'onShowMore is fired when the user clicks the "Show more" button on the references',
     }),

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -166,6 +166,23 @@ export const apiReferenceConfigurationSchema = baseConfigurationSchema.extend({
     | ((a: { request: Request; requestBuilder: any; envVariables: Record<string, string> }) => Promise<void> | void)
     | undefined
   >,
+  /** Fired right before the outbound request is sent; callback receives the exact fetch Request that goes over the wire. Experimental API. */
+  onRequestReady: z
+    .function({
+      input: [
+        z.object({
+          request: z.instanceof(Request),
+          requestBuilder: z.unknown(),
+          envVariables: z.record(z.string(), z.string()),
+        }),
+      ],
+      // Why no output? https://github.com/scalar/scalar/pull/7047
+      // output: z.union([z.void(), z.promise(z.void())]),
+    })
+    .optional() as z.ZodType<
+    | ((a: { request: Request; requestBuilder: any; envVariables: Record<string, string> }) => Promise<void> | void)
+    | undefined
+  >,
   /**
    * onShowMore is fired when the user clicks the "Show more" button on the references
    * @param tagId - The ID of the tag that was clicked
@@ -467,6 +484,35 @@ export type ApiReferenceConfiguration = ApiReferenceConfigurationRaw & {
    * ```
    */
   onBeforeRequest?: (input: {
+    request: Request
+    requestBuilder: any
+    envVariables: Record<string, string>
+  }) => void | Promise<void> | undefined
+  /**
+   * Fired after the outbound fetch `Request` has been built, right before it is sent. The `request` is the exact
+   * object handed to fetch: mutating its headers modifies the outgoing request, and hashing its body produces a
+   * hash that matches what the server receives (useful for request signing — a rebuilt `multipart/form-data` body
+   * would get a different boundary).
+   *
+   * Use `onBeforeRequest` instead when you need to mutate the request builder (method, path, query, body,
+   * security); those mutations have no effect at this stage because the request is already built.
+   *
+   * **Experimental:** This API may change in minor releases.
+   *
+   * @param input - Hook argument from the integration layer.
+   * @param input.request - The exact fetch API `Request` that will be sent. Mutate its headers to modify the outgoing request.
+   * @param input.requestBuilder - The builder the request was built from, for inspection. Mutating it has no effect at this stage.
+   * @param input.envVariables - Resolved environment variables for the active environment.
+   * @returns void or a promise that resolves when the hook finishes
+   * @example
+   * ```ts
+   * onRequestReady: async ({ request }) => {
+   *   const bodyHash = await hash(await request.clone().arrayBuffer())
+   *   request.headers.set('X-Body-Hash', bodyHash)
+   * }
+   * ```
+   */
+  onRequestReady?: (input: {
     request: Request
     requestBuilder: any
     envVariables: Record<string, string>

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -167,7 +167,7 @@ export const apiReferenceConfigurationSchema = baseConfigurationSchema.extend({
     | undefined
   >,
   /** Fired right before the outbound request is sent; callback receives the exact fetch Request that goes over the wire. Experimental API. */
-  onRequestReady: z
+  onRequestBuilt: z
     .function({
       input: [
         z.object({
@@ -467,6 +467,10 @@ export type ApiReferenceConfiguration = ApiReferenceConfigurationRaw & {
    * Fired before the outbound request is built and sent. Mutate the **request builder** so the eventual fetch call
    * reflects your changes (method, path, headers, body, and related fields).
    *
+   * The `request` passed here is **not** the object sent over the wire; the actual request is rebuilt from the builder
+   * afterwards. Use `onRequestBuilt` instead when you need the exact outgoing request (for example, to hash a
+   * `multipart/form-data` body for request signing).
+   *
    * **Experimental:** The builder matches {@link https://github.com/scalar/scalar/blob/main/packages/workspace-store/src/request-example/builder/request-factory.ts RequestFactory}
    * (`import type { RequestFactory } from '@scalar/workspace-store/request-example'`). That shape is still experimental and may change in minor releases.
    *
@@ -506,13 +510,13 @@ export type ApiReferenceConfiguration = ApiReferenceConfigurationRaw & {
    * @returns void or a promise that resolves when the hook finishes
    * @example
    * ```ts
-   * onRequestReady: async ({ request }) => {
+   * onRequestBuilt: async ({ request }) => {
    *   const bodyHash = await hash(await request.clone().arrayBuffer())
    *   request.headers.set('X-Body-Hash', bodyHash)
    * }
    * ```
    */
-  onRequestReady?: (input: {
+  onRequestBuilt?: (input: {
     request: Request
     requestBuilder: any
     envVariables: Record<string, string>

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -405,6 +405,10 @@ type ExtendedConfiguration = {
   onBeforeRequest?:
     | ((input: { request: Request; requestBuilder: any; envVariables: Record<string, string> }) => void | Promise<void>)
     | undefined
+  /** Fired right before the outbound request is sent; callback receives the exact fetch Request that goes over the wire. Experimental API. */
+  onRequestReady?:
+    | ((input: { request: Request; requestBuilder: any; envVariables: Record<string, string> }) => void | Promise<void>)
+    | undefined
   /** onShowMore is fired when the user clicks the "Show more" button on the references */
   onShowMore?: (tagId: string) => void | Promise<void>
   /** onSidebarClick is fired when the user clicks on a sidebar item */
@@ -526,6 +530,35 @@ export type ApiReferenceConfiguration = ApiReferenceConfigurationRaw & {
    * ```
    */
   onBeforeRequest?: (input: {
+    request: Request
+    requestBuilder: any
+    envVariables: Record<string, string>
+  }) => void | Promise<void> | undefined
+  /**
+   * Fired after the outbound fetch `Request` has been built, right before it is sent. The `request` is the exact
+   * object handed to fetch: mutating its headers modifies the outgoing request, and hashing its body produces a
+   * hash that matches what the server receives (useful for request signing — a rebuilt `multipart/form-data` body
+   * would get a different boundary).
+   *
+   * Use `onBeforeRequest` instead when you need to mutate the request builder (method, path, query, body,
+   * security); those mutations have no effect at this stage because the request is already built.
+   *
+   * **Experimental:** This API may change in minor releases.
+   *
+   * @param input - Hook argument from the integration layer.
+   * @param input.request - The exact fetch API `Request` that will be sent. Mutate its headers to modify the outgoing request.
+   * @param input.requestBuilder - The builder the request was built from, for inspection. Mutating it has no effect at this stage.
+   * @param input.envVariables - Resolved environment variables for the active environment.
+   * @returns void or a promise that resolves when the hook finishes
+   * @example
+   * ```ts
+   * onRequestReady: async ({ request }) => {
+   *   const bodyHash = await hash(await request.clone().arrayBuffer())
+   *   request.headers.set('X-Body-Hash', bodyHash)
+   * }
+   * ```
+   */
+  onRequestReady?: (input: {
     request: Request
     requestBuilder: any
     envVariables: Record<string, string>

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -406,7 +406,7 @@ type ExtendedConfiguration = {
     | ((input: { request: Request; requestBuilder: any; envVariables: Record<string, string> }) => void | Promise<void>)
     | undefined
   /** Fired right before the outbound request is sent; callback receives the exact fetch Request that goes over the wire. Experimental API. */
-  onRequestReady?:
+  onRequestBuilt?:
     | ((input: { request: Request; requestBuilder: any; envVariables: Record<string, string> }) => void | Promise<void>)
     | undefined
   /** onShowMore is fired when the user clicks the "Show more" button on the references */
@@ -513,6 +513,10 @@ export type ApiReferenceConfiguration = ApiReferenceConfigurationRaw & {
    * Fired before the outbound request is built and sent. Mutate the **request builder** so the eventual fetch call
    * reflects your changes (method, path, headers, body, and related fields).
    *
+   * The `request` passed here is **not** the object sent over the wire; the actual request is rebuilt from the builder
+   * afterwards. Use `onRequestBuilt` instead when you need the exact outgoing request (for example, to hash a
+   * `multipart/form-data` body for request signing).
+   *
    * **Experimental:** The builder matches {@link https://github.com/scalar/scalar/blob/main/packages/workspace-store/src/request-example/builder/request-factory.ts RequestFactory}
    * (`import type { RequestFactory } from '@scalar/workspace-store/request-example'`). That shape is still experimental and may change in minor releases.
    *
@@ -552,13 +556,13 @@ export type ApiReferenceConfiguration = ApiReferenceConfigurationRaw & {
    * @returns void or a promise that resolves when the hook finishes
    * @example
    * ```ts
-   * onRequestReady: async ({ request }) => {
+   * onRequestBuilt: async ({ request }) => {
    *   const bodyHash = await hash(await request.clone().arrayBuffer())
    *   request.headers.set('X-Body-Hash', bodyHash)
    * }
    * ```
    */
-  onRequestReady?: (input: {
+  onRequestBuilt?: (input: {
     request: Request
     requestBuilder: any
     envVariables: Record<string, string>


### PR DESCRIPTION
## Problem

- See #9512

`onBeforeRequest` used to make request signing possible: 
you could hash the request body and attach signature headers before the request was sent. 
This is no longer achievable.

The `request` passed to `onBeforeRequest` is built from the request builder *inside the hook wrapper*, and after the callback returns the actual fetch `Request` is rebuilt from the builder. 
For `multipart/form-data` bodies every rebuild generates a fresh random multipart boundary, so the bytes you hashed in the callback never match the bytes the server receives — signature verification always fails. 
Header mutations on `request` are silently discarded for the same reason.

Mutating `requestBuilder` (the documented path) does not help here: 
there is no way to know the final multipart body bytes before the fetch `Request` is built.

## Solution

Build the fetch `Request` once and send that exact instance, and expose it through a new hook that runs after the build:

- **`@scalar/oas-utils`**: new `requestReady` client plugin hook. It fires after the fetch `Request` is built, right before it is sent. The `request` in its payload is the exact object handed to fetch, so header mutations apply and body hashes match what goes over the wire.
- **`@scalar/api-client`**: `OperationBlock` builds the `Request` once after the `beforeRequest` hooks run, executes `requestReady` on it, and `sendRequest` sends that same instance instead of rebuilding it.
- **`@scalar/api-reference` / `@scalar/types` / `@scalar/schemas`**: new `onRequestReady` configuration callback (sibling of `onBeforeRequest`, same payload shape) mapped to the `requestReady` hook. It works through the HTML/CDN integrations (Fastify, Express, ...) the same way `onBeforeRequest` does.

`onBeforeRequest` is untouched, so the change is purely additive: builder mutations (method, path, query, body, `disableSecurity`, ...) keep working exactly as documented. 
The docs now clarify that the `request` passed to `onBeforeRequest` is not the wire request and point to `onRequestReady` for exact-bytes use cases.

Tests include a regression test that computes a SHA-256 hash of a multipart body inside the hook and asserts it equals the hash of the request handed to fetch — and that a request rebuilt from the same `FormData` hashes differently, so reintroducing a rebuild fails the test.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [x] I updated the documentation.
