### PR TITLE
fix(mock-server): prefer defined 2xx responses

### DIFF
--- a/.changeset/fair-moose-sip.md
+++ b/.changeset/fair-moose-sip.md
@@ -2,4 +2,4 @@
 '@scalar/mock-server': patch
 ---
 
-fix: prefer defined 2xx responses before error responses when mocking operations with multiple response codes.
+fix: improve default response selection when mocking operations with multiple response codes. The mock server now prefers `default`, then the lowest 2xx success, then the lowest non-informational code, only falling back to a 1xx response when nothing else is defined. Status code range patterns like `2XX` are supported too.

--- a/.changeset/fair-moose-sip.md
+++ b/.changeset/fair-moose-sip.md
@@ -2,4 +2,4 @@
 '@scalar/mock-server': patch
 ---
 
-fix: improve default response selection when mocking operations with multiple response codes. The mock server now prefers `default`, then the lowest 2xx success, then the lowest non-informational code, only falling back to a 1xx response when nothing else is defined. Status code range patterns like `2XX` are supported too.
+fix: improve default response selection when mocking operations with multiple response codes. The mock server now prefers the lowest 2xx success, then the lowest non-informational code, then the `default` catch-all, only falling back to a 1xx response when nothing else is defined. Status code range patterns like `2XX` are supported and treated as their lowest member, with explicit codes taking precedence over the range that covers them.

--- a/.changeset/fair-moose-sip.md
+++ b/.changeset/fair-moose-sip.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+fix: prefer defined 2xx responses before error responses when mocking operations with multiple response codes.

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -38,8 +38,11 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
     return c.json({ error: 'No response defined for this operation.' })
   }
 
-  // Status code
-  const statusCode = Number.parseInt(responseKey === 'default' ? '200' : (responseKey ?? '200'), 10) as StatusCode
+  // Status code. `default` and range patterns like `2XX` map to their lowest concrete code (e.g. 200).
+  const statusCode = Number.parseInt(
+    responseKey && responseKey !== 'default' ? responseKey.replace(/XX$/i, '00') : '200',
+    10,
+  ) as StatusCode
 
   // Headers
   const headers = selectedResponse?.headers ?? {}

--- a/packages/mock-server/src/utils/find-preferred-response-key.test.ts
+++ b/packages/mock-server/src/utils/find-preferred-response-key.test.ts
@@ -3,12 +3,20 @@ import { describe, expect, it } from 'vitest'
 import { findPreferredResponseKey } from './find-preferred-response-key'
 
 describe('findPreferredResponseKey', () => {
-  it('returns default over 200', () => {
-    expect(findPreferredResponseKey(['default', '200'])).toBe('default')
+  it('prefers a defined 2xx success over default', () => {
+    expect(findPreferredResponseKey(['default', '200'])).toBe('200')
   })
 
-  it('returns default over other success responses', () => {
-    expect(findPreferredResponseKey(['default', '202'])).toBe('default')
+  it('prefers a concrete error response over default', () => {
+    expect(findPreferredResponseKey(['default', '404'])).toBe('404')
+  })
+
+  it('falls back to default when only informational responses are defined alongside it', () => {
+    expect(findPreferredResponseKey(['default', '100'])).toBe('default')
+  })
+
+  it('uses default when it is the only response', () => {
+    expect(findPreferredResponseKey(['default'])).toBe('default')
   })
 
   it(`returns 201 if it's the only one`, () => {
@@ -49,6 +57,18 @@ describe('findPreferredResponseKey', () => {
 
   it('prefers an explicit 2xx code over a 2XX range', () => {
     expect(findPreferredResponseKey(['2XX', '200'])).toBe('200')
+  })
+
+  it('prefers an explicit 2xx code over a 2XX range even when the code is higher', () => {
+    expect(findPreferredResponseKey(['2XX', '201'])).toBe('201')
+  })
+
+  it('prefers an explicit error code over a 4XX range', () => {
+    expect(findPreferredResponseKey(['4XX', '404'])).toBe('404')
+  })
+
+  it('returns undefined when only non-status keys are defined', () => {
+    expect(findPreferredResponseKey(['x-extension'])).toBe(undefined)
   })
 
   it('ignores a 1XX range when other codes are defined', () => {

--- a/packages/mock-server/src/utils/find-preferred-response-key.test.ts
+++ b/packages/mock-server/src/utils/find-preferred-response-key.test.ts
@@ -7,12 +7,28 @@ describe('findPreferredResponseKey', () => {
     expect(findPreferredResponseKey(['default', '200'])).toBe('default')
   })
 
+  it('returns default over other success responses', () => {
+    expect(findPreferredResponseKey(['default', '202'])).toBe('default')
+  })
+
   it(`returns 201 if it's the only one`, () => {
     expect(findPreferredResponseKey(['201'])).toBe('201')
   })
 
   it('returns 200 over 201', () => {
     expect(findPreferredResponseKey(['200', '201'])).toBe('200')
+  })
+
+  it('returns a 2xx response over an error response', () => {
+    expect(findPreferredResponseKey(['202', '404'])).toBe('202')
+  })
+
+  it('returns the lowest 2xx response when multiple success responses are defined', () => {
+    expect(findPreferredResponseKey(['206', '202', '204'])).toBe('202')
+  })
+
+  it('returns the lowest status code when no success response is defined', () => {
+    expect(findPreferredResponseKey(['500', '404'])).toBe('404')
   })
 
   it(`uses what's there`, () => {

--- a/packages/mock-server/src/utils/find-preferred-response-key.test.ts
+++ b/packages/mock-server/src/utils/find-preferred-response-key.test.ts
@@ -31,6 +31,34 @@ describe('findPreferredResponseKey', () => {
     expect(findPreferredResponseKey(['500', '404'])).toBe('404')
   })
 
+  it('ignores informational 1xx responses when other codes are defined', () => {
+    expect(findPreferredResponseKey(['100', '404'])).toBe('404')
+  })
+
+  it('prefers a 2xx success over an informational 1xx response', () => {
+    expect(findPreferredResponseKey(['100', '200'])).toBe('200')
+  })
+
+  it('falls back to a 1xx response when nothing else is defined', () => {
+    expect(findPreferredResponseKey(['100'])).toBe('100')
+  })
+
+  it('treats a 2XX range as a success response', () => {
+    expect(findPreferredResponseKey(['2XX', '404'])).toBe('2XX')
+  })
+
+  it('prefers an explicit 2xx code over a 2XX range', () => {
+    expect(findPreferredResponseKey(['2XX', '200'])).toBe('200')
+  })
+
+  it('ignores a 1XX range when other codes are defined', () => {
+    expect(findPreferredResponseKey(['1XX', '500'])).toBe('500')
+  })
+
+  it('orders range patterns by their lowest member', () => {
+    expect(findPreferredResponseKey(['5XX', '4XX'])).toBe('4XX')
+  })
+
   it(`uses what's there`, () => {
     expect(findPreferredResponseKey(['301'])).toBe('301')
   })

--- a/packages/mock-server/src/utils/find-preferred-response-key.ts
+++ b/packages/mock-server/src/utils/find-preferred-response-key.ts
@@ -1,12 +1,23 @@
+const sortStatusCodes = (responses: string[]): string[] =>
+  responses
+    .filter((response) => /^\d{3}$/.test(response))
+    .sort((left, right) => Number.parseInt(left, 10) - Number.parseInt(right, 10))
+
 /**
- * Find the preferred response key: default, 200, 201 …
+ * Find the preferred response key: default, a 2xx success, then the lowest status code.
  */
 export function findPreferredResponseKey(responses?: string[]) {
+  if (!responses?.length) {
+    return undefined
+  }
+
+  if (responses.includes('default')) {
+    return 'default'
+  }
+
+  const statusCodes = sortStatusCodes(responses)
+
   return (
-    // Regular status codes
-    ['default', '200', '201', '204', '404', '500'].find((key) => responses?.includes(key) ?? false) ??
-    // Lowest status code
-    responses?.sort()[0] ??
-    undefined
+    statusCodes.find((response) => response.startsWith('2')) ?? statusCodes[0] ?? [...responses].sort()[0] ?? undefined
   )
 }

--- a/packages/mock-server/src/utils/find-preferred-response-key.ts
+++ b/packages/mock-server/src/utils/find-preferred-response-key.ts
@@ -4,6 +4,12 @@ const STATUS_CODE_REGEX = /^[1-5](\d{2}|XX)$/i
 /** Whether a status key is a range pattern (e.g. `2XX`) rather than an explicit code. */
 const isRange = (response: string): boolean => /XX$/i.test(response)
 
+/** Whether a status key is an informational 1xx response. */
+const isInformational = (response: string): boolean => response.startsWith('1')
+
+/** Whether a status key is a 2xx success response. */
+const isSuccess = (response: string): boolean => response.startsWith('2')
+
 /** Turn a status key into a comparable number, treating a range like `2XX` as its lowest member (`200`). */
 const toComparableStatus = (response: string): number => Number.parseInt(response.replace(/XX$/i, '00'), 10)
 
@@ -20,32 +26,33 @@ const sortStatusCodes = (responses: string[]): string[] =>
  * Find the preferred response key to mock.
  *
  * Preference order:
- * 1. `default` — the catch-all response always wins
- * 2. The lowest 2xx success response
- * 3. The lowest remaining status code, ignoring informational 1xx responses
+ * 1. The lowest 2xx success response
+ * 2. The lowest non-informational code (3xx/4xx/5xx)
+ * 3. `default` — the catch-all for undeclared responses (typically an error)
  * 4. An informational 1xx response, only when nothing else is defined
  *
- * Range patterns like `2XX` are supported and treated as their lowest member (e.g. `200`).
+ * Within each tier an explicit code wins over the range pattern that covers it (e.g. `200` over
+ * `2XX`), and range patterns are treated as their lowest member (e.g. `2XX` → `200`). `default`
+ * is the catch-all for codes not covered individually, so a defined success or error is preferred
+ * over it.
  *
- * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#patterned-fields-1
+ * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.2.md#responses-object
  */
 export function findPreferredResponseKey(responses?: string[]): string | undefined {
   if (!responses?.length) {
     return undefined
   }
 
-  if (responses.includes('default')) {
-    return 'default'
-  }
-
   const statusCodes = sortStatusCodes(responses)
 
-  // Prefer a 2xx success, then the lowest non-informational code. Informational 1xx responses
-  // are picked only as a last resort, since they are not meaningful to mock on their own.
+  // Within a tier, prefer an explicit status code over the range pattern that covers it.
+  const byPreference = (predicate: (response: string) => boolean): string | undefined =>
+    statusCodes.find((response) => predicate(response) && !isRange(response)) ?? statusCodes.find(predicate)
+
   return (
-    statusCodes.find((response) => response.startsWith('2')) ??
-    statusCodes.find((response) => !response.startsWith('1')) ??
-    statusCodes[0] ??
-    [...responses].sort()[0]
+    byPreference(isSuccess) ??
+    byPreference((response) => !isInformational(response)) ??
+    (responses.includes('default') ? 'default' : undefined) ??
+    byPreference(isInformational)
   )
 }

--- a/packages/mock-server/src/utils/find-preferred-response-key.ts
+++ b/packages/mock-server/src/utils/find-preferred-response-key.ts
@@ -1,12 +1,35 @@
+/** Matches an explicit HTTP status code (e.g. `200`) or a range pattern (e.g. `2XX`). */
+const STATUS_CODE_REGEX = /^[1-5](\d{2}|XX)$/i
+
+/** Whether a status key is a range pattern (e.g. `2XX`) rather than an explicit code. */
+const isRange = (response: string): boolean => /XX$/i.test(response)
+
+/** Turn a status key into a comparable number, treating a range like `2XX` as its lowest member (`200`). */
+const toComparableStatus = (response: string): number => Number.parseInt(response.replace(/XX$/i, '00'), 10)
+
 const sortStatusCodes = (responses: string[]): string[] =>
   responses
-    .filter((response) => /^\d{3}$/.test(response))
-    .sort((left, right) => Number.parseInt(left, 10) - Number.parseInt(right, 10))
+    .filter((response) => STATUS_CODE_REGEX.test(response))
+    .sort((left, right) => {
+      const difference = toComparableStatus(left) - toComparableStatus(right)
+      // On a tie, prefer an explicit code over a range pattern (e.g. `200` before `2XX`).
+      return difference !== 0 ? difference : Number(isRange(left)) - Number(isRange(right))
+    })
 
 /**
- * Find the preferred response key: default, a 2xx success, then the lowest status code.
+ * Find the preferred response key to mock.
+ *
+ * Preference order:
+ * 1. `default` — the catch-all response always wins
+ * 2. The lowest 2xx success response
+ * 3. The lowest remaining status code, ignoring informational 1xx responses
+ * 4. An informational 1xx response, only when nothing else is defined
+ *
+ * Range patterns like `2XX` are supported and treated as their lowest member (e.g. `200`).
+ *
+ * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#patterned-fields-1
  */
-export function findPreferredResponseKey(responses?: string[]) {
+export function findPreferredResponseKey(responses?: string[]): string | undefined {
   if (!responses?.length) {
     return undefined
   }
@@ -17,7 +40,12 @@ export function findPreferredResponseKey(responses?: string[]) {
 
   const statusCodes = sortStatusCodes(responses)
 
+  // Prefer a 2xx success, then the lowest non-informational code. Informational 1xx responses
+  // are picked only as a last resort, since they are not meaningful to mock on their own.
   return (
-    statusCodes.find((response) => response.startsWith('2')) ?? statusCodes[0] ?? [...responses].sort()[0] ?? undefined
+    statusCodes.find((response) => response.startsWith('2')) ??
+    statusCodes.find((response) => !response.startsWith('1')) ??
+    statusCodes[0] ??
+    [...responses].sort()[0]
   )
 }

--- a/packages/mock-server/test/prefer.test.ts
+++ b/packages/mock-server/test/prefer.test.ts
@@ -128,6 +128,62 @@ describe('Prefer header', () => {
       expect(response.status).toBe(200)
       expect(await response.json()).toEqual({ status: 'queued' })
     })
+
+    it('prefers a defined 2xx success over the default response', async () => {
+      const server = await createMockServer({
+        document: {
+          openapi: '3.1.0',
+          info: baseInfo,
+          paths: {
+            '/things': {
+              get: {
+                responses: {
+                  default: {
+                    description: 'Unexpected error',
+                    content: { 'application/json': { example: { error: 'unexpected' } } },
+                  },
+                  '200': {
+                    description: 'OK',
+                    content: { 'application/json': { example: { status: 'ok' } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      const response = await server.request('/things')
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ status: 'ok' })
+    })
+
+    it('falls back to the default response when no concrete code is defined', async () => {
+      const server = await createMockServer({
+        document: {
+          openapi: '3.1.0',
+          info: baseInfo,
+          paths: {
+            '/things': {
+              get: {
+                responses: {
+                  default: {
+                    description: 'Unexpected error',
+                    content: { 'application/json': { example: { error: 'unexpected' } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      const response = await server.request('/things')
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ error: 'unexpected' })
+    })
   })
 
   describe('example directive', () => {

--- a/packages/mock-server/test/prefer.test.ts
+++ b/packages/mock-server/test/prefer.test.ts
@@ -98,6 +98,36 @@ describe('Prefer header', () => {
       expect(response.status).toBe(202)
       expect(await response.json()).toEqual({ status: 'queued' })
     })
+
+    it('selects a 2XX range response and maps it to a concrete status', async () => {
+      const server = await createMockServer({
+        document: {
+          openapi: '3.1.0',
+          info: baseInfo,
+          paths: {
+            '/jobs': {
+              post: {
+                responses: {
+                  '2XX': {
+                    description: 'Success',
+                    content: { 'application/json': { example: { status: 'queued' } } },
+                  },
+                  '4XX': {
+                    description: 'Client Error',
+                    content: { 'application/json': { example: { error: 'bad request' } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      const response = await server.request('/jobs', { method: 'POST' })
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ status: 'queued' })
+    })
   })
 
   describe('example directive', () => {

--- a/packages/mock-server/test/prefer.test.ts
+++ b/packages/mock-server/test/prefer.test.ts
@@ -68,6 +68,36 @@ describe('Prefer header', () => {
       expect(response.status).toBe(200)
       expect(await response.json()).toEqual({ status: 'ok' })
     })
+
+    it('uses a success response by default when the operation also defines errors', async () => {
+      const server = await createMockServer({
+        document: {
+          openapi: '3.1.0',
+          info: baseInfo,
+          paths: {
+            '/jobs': {
+              post: {
+                responses: {
+                  '202': {
+                    description: 'Accepted',
+                    content: { 'application/json': { example: { status: 'queued' } } },
+                  },
+                  '404': {
+                    description: 'Not Found',
+                    content: { 'application/json': { example: { error: 'not found' } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      const response = await server.request('/jobs', { method: 'POST' })
+
+      expect(response.status).toBe(202)
+      expect(await response.json()).toEqual({ status: 'queued' })
+    })
   })
 
   describe('example directive', () => {


### PR DESCRIPTION
Prefer defined 2xx responses before error responses when mocking operations with multiple response codes.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to mock-server default response selection when no Prefer header is set; explicit Prefer codes and error handling paths are unchanged, with broad test coverage.
> 
> **Overview**
> **Default mocked responses** no longer follow a fixed key list that could pick `default` ahead of `200`. `findPreferredResponseKey` now ranks OpenAPI response keys in order: lowest **2xx**, then lowest non-1xx code, then **`default`**, then 1xx only if nothing else exists. Explicit codes beat range keys like **`2XX`** at the same tier; ranges sort by their lowest member (e.g. `2XX` → 200).
> 
> **HTTP status on the wire** in `mockAnyResponse` maps selected keys the same way: `default` still becomes **200**, and range keys get **`XX` → `00`** so a chosen `2XX` response returns status **200** while using that response’s body.
> 
> Unit and integration tests cover success-vs-error, default fallback, and range behavior. **`Prefer: code=`** selection is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81c078d9c126bc0e59209db5384f822fccb64884. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->