### PR TITLE
fix(mock-server): emit single-line JSONL/NDJSON mock responses

### DIFF
--- a/.changeset/blue-buckets-listen.md
+++ b/.changeset/blue-buckets-listen.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+fix: compact generated JSON mock responses so finite JSONL and NDJSON bodies stay valid as single-line events.

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -72,9 +72,87 @@ describe('createMockServer', () => {
     const response = await server.request('/foobar')
 
     expect(response.status).toBe(200)
-    expect(await response.json()).toMatchObject({
-      foo: 'bar',
-    })
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+    expect(await response.text()).toBe('{"foo":"bar"}')
+  })
+
+  it('GET /foobar -> compact NDJSON example', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/x-ndjson': {
+                    example: {
+                      foo: 'bar',
+                      count: 1,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/x-ndjson')
+    expect(await response.text()).toBe('{"foo":"bar","count":1}')
+  })
+
+  it('GET /foobar -> compact JSONL schema-generated body', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/jsonl': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        foo: {
+                          type: 'string',
+                          example: 'bar',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/jsonl')
+    expect(await response.text()).toBe('{"foo":"bar"}')
   })
 
   it('GET /foobar -> omits writeOnly properties in responses', async () => {

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -104,7 +104,7 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
         acceptedContentType?.includes('xml')
         ? json2xml(body as Record<string, unknown>)
         : // JSON
-          JSON.stringify(body, null, 2)
+          JSON.stringify(body)
       : typeof body === 'string'
         ? // String
           body


### PR DESCRIPTION
Compact generated JSON mock responses so finite JSONL and NDJSON bodies stay valid as single-line events.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to mock-server response formatting with new tests; no auth, persistence, or production API behavior.
> 
> **Overview**
> **Mock responses no longer use pretty-printed JSON.** In `mock-any-response.ts`, object bodies serialized as JSON now use `JSON.stringify(body)` instead of `JSON.stringify(body, null, 2)`, so each response is a single compact line.
> 
> That fixes **JSONL** and **NDJSON** mock content types, where one record must be one line; indented JSON was invalid as a line-oriented event. Regular `application/json` mocks are compact too.
> 
> Tests now assert exact compact text and `Content-Type` for JSON, `application/x-ndjson`, and `application/jsonl` (examples and schema-generated bodies). A patch changeset was added for `@scalar/mock-server`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fec46ae7db1713d07d31fd55f67a19a1300a122d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->