### PR TITLE
fix(mock-server): singular examples in arrays when the response schema is an array

### DIFF
--- a/.changeset/warm-arrays-wrap.md
+++ b/.changeset/warm-arrays-wrap.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+fix: wrap singular examples in arrays when the response schema is an array.

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -495,6 +495,106 @@ describe('createMockServer', () => {
     })
   })
 
+  it('GET /foobar -> wraps schema examples for array responses', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          foo: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                      example: {
+                        foo: 'bar',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toStrictEqual([
+      {
+        foo: 'bar',
+      },
+    ])
+  })
+
+  it('GET /foobar -> wraps media type examples for array responses', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          foo: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                    example: {
+                      foo: 'bar',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toStrictEqual([
+      {
+        foo: 'bar',
+      },
+    ])
+  })
+
   it('GET /foobar/{id} -> example from schema', async () => {
     const document = {
       openapi: '3.1.0',

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -8,6 +8,7 @@ import { accepts } from 'hono/accepts'
 import type { StatusCode } from 'hono/utils/http-status'
 
 import { findPreferredResponseKey } from '@/utils/find-preferred-response-key'
+import { normalizeResponseBody } from '@/utils/normalize-response-body'
 import { parsePreferHeader } from '@/utils/parse-prefer-header'
 import { selectResponseExample } from '@/utils/select-response-example'
 
@@ -82,15 +83,19 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
   // Body: a named/singular/first example if one is defined, otherwise generate
   // a value from the schema. `Prefer: example=<name>` picks a named example.
   const selectedExample = selectResponseExample(acceptedResponse, prefer.example)
+  const responseSchema = acceptedResponse?.schema ? getResolvedRefDeep(acceptedResponse.schema) : undefined
 
   const body = selectedExample
-    ? selectedExample.value
-    : acceptedResponse?.schema
-      ? getExampleFromSchema(getResolvedRefDeep(acceptedResponse.schema), {
-          emptyString: 'string',
-          variables: c.req.param(),
-          mode: 'read',
-        })
+    ? normalizeResponseBody(selectedExample.value, responseSchema)
+    : responseSchema
+      ? normalizeResponseBody(
+          getExampleFromSchema(responseSchema, {
+            emptyString: 'string',
+            variables: c.req.param(),
+            mode: 'read',
+          }),
+          responseSchema,
+        )
       : null
 
   c.status(statusCode)

--- a/packages/mock-server/src/routes/mock-handler-response.ts
+++ b/packages/mock-server/src/routes/mock-handler-response.ts
@@ -1,6 +1,5 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
-import { getResolvedRefDeep } from '@scalar/workspace-store/helpers/get-resolved-ref-deep'
 import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
 import type { Context } from 'hono'
 import { accepts } from 'hono/accepts'
@@ -8,6 +7,7 @@ import type { StatusCode } from 'hono/utils/http-status'
 
 import { buildHandlerContext } from '@/utils/build-handler-context'
 import { executeHandler } from '@/utils/execute-handler'
+import { normalizeResponseBody } from '@/utils/normalize-response-body'
 import { parsePreferHeader } from '@/utils/parse-prefer-header'
 import { selectResponseExample } from '@/utils/select-response-example'
 
@@ -58,17 +58,22 @@ function getExampleFromResponse(
     return null
   }
 
+  const responseSchema = acceptedResponse.schema ? getResolvedRef(acceptedResponse.schema) : undefined
+
   // Extract example (named, singular, or first) or generate from schema
   const selectedExample = selectResponseExample(acceptedResponse, exampleName)
 
   return selectedExample
-    ? selectedExample.value
-    : acceptedResponse.schema
-      ? getExampleFromSchema(getResolvedRefDeep(acceptedResponse.schema), {
-          emptyString: 'string',
-          variables: c.req.param(),
-          mode: 'read',
-        })
+    ? normalizeResponseBody(selectedExample.value, responseSchema)
+    : responseSchema
+      ? normalizeResponseBody(
+          getExampleFromSchema(responseSchema, {
+            emptyString: 'string',
+            variables: c.req.param(),
+            mode: 'read',
+          }),
+          responseSchema,
+        )
       : null
 }
 

--- a/packages/mock-server/src/utils/build-handler-context.ts
+++ b/packages/mock-server/src/utils/build-handler-context.ts
@@ -7,6 +7,7 @@ import type { Context } from 'hono'
 import { accepts } from 'hono/accepts'
 
 import { store } from '../libs/store'
+import { normalizeResponseBody } from './normalize-response-body'
 import { type StoreOperationTracking, createStoreWrapper } from './store-wrapper'
 
 /**
@@ -73,15 +74,20 @@ function getExampleFromResponse(
     return null
   }
 
+  const responseSchema = acceptedResponse.schema ? getResolvedRefDeep(acceptedResponse.schema) : undefined
+
   // Extract example from example property or generate from schema
   return acceptedResponse.example !== undefined
-    ? acceptedResponse.example
-    : acceptedResponse.schema
-      ? getExampleFromSchema(getResolvedRefDeep(acceptedResponse.schema), {
-          emptyString: 'string',
-          variables: c.req.param(),
-          mode: 'read',
-        })
+    ? normalizeResponseBody(acceptedResponse.example, responseSchema)
+    : responseSchema
+      ? normalizeResponseBody(
+          getExampleFromSchema(responseSchema, {
+            emptyString: 'string',
+            variables: c.req.param(),
+            mode: 'read',
+          }),
+          responseSchema,
+        )
       : null
 }
 

--- a/packages/mock-server/src/utils/normalize-response-body.ts
+++ b/packages/mock-server/src/utils/normalize-response-body.ts
@@ -1,0 +1,36 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+
+type Schema = NonNullable<OpenAPIV3_1.ComponentsObject['schemas']>[string]
+
+const isArrayResponseSchema = (schema: Schema): boolean => {
+  if (!schema) {
+    return false
+  }
+
+  const resolvedSchema = getResolvedRef(schema)
+
+  if (!resolvedSchema || typeof resolvedSchema !== 'object') {
+    return false
+  }
+
+  if ('type' in resolvedSchema) {
+    if (resolvedSchema.type === 'array') {
+      return true
+    }
+
+    if (Array.isArray(resolvedSchema.type) && resolvedSchema.type.includes('array')) {
+      return true
+    }
+  }
+
+  return 'items' in resolvedSchema
+}
+
+export const normalizeResponseBody = (body: unknown, schema: Schema): unknown => {
+  if (body === null || body === undefined || Array.isArray(body) || !isArrayResponseSchema(schema)) {
+    return body
+  }
+
+  return [body]
+}


### PR DESCRIPTION
## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mock-server response shaping with tests; no auth, persistence, or API contract changes beyond fixing example shape for array schemas.
> 
> **Overview**
> Fixes mock responses that declare an **array** schema but supply a **single object** example (on the schema or on the media type). Those bodies are now wrapped as a one-element array so JSON matches the spec.
> 
> Adds `normalizeResponseBody`, which detects array response schemas (including `type: array`, union types with `array`, or schemas with `items`) and wraps non-array bodies in `[body]`. It is applied wherever mock bodies are built: default route mocking, x-handler fallback examples, and handler `res` examples.
> 
> Two integration tests cover schema-level and media-type-level singular examples for array responses. A patch changeset is included for `@scalar/mock-server`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70ae5b5dc1b411aabfdb8f4ab1410e1dc9cf02f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->