### PR TITLE
feat(api-reference): render AsyncAPI operations and messages inside channels

### DIFF
--- a/.changeset/asyncapi-channel-operations.md
+++ b/.changeset/asyncapi-channel-operations.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+Render AsyncAPI operations and their messages (with payload and header schemas) nested inside each channel, in both the modern and classic layouts

--- a/documentation/asyncapi.md
+++ b/documentation/asyncapi.md
@@ -2,7 +2,7 @@
 
 We're in the process of adding [AsyncAPI](https://www.asyncapi.com/) support.
 
-You can already load AsyncAPI documents. The rendering is very limited, though:
+You can load AsyncAPI documents the same way you load OpenAPI documents:
 
 ```javascript
 Scalar.createApiReference('#app', {
@@ -10,4 +10,18 @@ Scalar.createApiReference('#app', {
 })
 ```
 
-The process is tracked on GitHub in [issue #7080](https://github.com/scalar/scalar/issues/7080). You can subscribe to the issue to receive updates.
+## What renders
+
+The reference renders the AsyncAPI document grouped by channel. For each channel you'll see:
+
+- The channel title (or address) and description.
+- The channel address **parameters**.
+- Each **operation** on the channel, nested beneath it, with its `send`/`receive` action, title, and summary/description.
+- Each **message** under its operation, with the message description and its **headers** and **payload** schemas.
+
+Reusable schemas defined under `components.schemas` are rendered in the **Models** section, just like OpenAPI.
+
+Rendering works in both the `modern` and `classic` layouts.
+
+> [!NOTE]
+> AsyncAPI support is still a work in progress, so not every part of the specification is rendered yet. The progress is tracked on GitHub in [issue #7080](https://github.com/scalar/scalar/issues/7080) — subscribe there to receive updates.

--- a/documentation/asyncapi.md
+++ b/documentation/asyncapi.md
@@ -17,7 +17,7 @@ The reference renders the AsyncAPI document grouped by channel. For each channel
 - The channel title (or address) and description.
 - The channel address **parameters**.
 - Each **operation** on the channel, nested beneath it, with its `send`/`receive` action, title, and summary/description.
-- Each **message** under its operation, with the message description and its **headers** and **payload** schemas.
+- Each **message** under its operation, shown as a collapsible accordion. Expanding a message reveals its description and its **headers** and **payload** schemas. Messages start collapsed and stay in sync with the sidebar, so selecting a message in the navigation (or opening a deep link to it) expands it here too.
 
 Reusable schemas defined under `components.schemas` are rendered in the **Models** section, just like OpenAPI.
 

--- a/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.vue
@@ -97,6 +97,7 @@ const getModelSchema = (name: string) => getAsyncApiModelSchema(document, name)
       :channel="entry"
       :document="document"
       :eventBus="eventBus"
+      :expandedItems="expandedItems"
       :isCollapsed="!expandedItems[entry.id]"
       :layout="options.layout"
       :options="options" />

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
@@ -164,7 +164,7 @@ describe('Channel', () => {
       operations: {
         onUserSignedUp: { action: 'receive', channel: { $ref: '#/channels/userSignedUp' } },
       },
-    }) as AsyncApiDocument
+    }) as unknown as AsyncApiDocument
 
   const channelWithOperation = (): TraversedAsyncApiChannel =>
     createChannel({

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
@@ -154,4 +154,60 @@ describe('Channel', () => {
 
     expect(wrapper.text()).not.toContain('Parameters')
   })
+
+  const documentWithOperation = (): AsyncApiDocument =>
+    ({
+      asyncapi: '3.0.0',
+      info: { title: 'Streaming API', version: '1.0.0' },
+      'x-scalar-original-document-hash': '',
+      channels: { userSignedUp: { address: 'user/signedup' } },
+      operations: {
+        onUserSignedUp: { action: 'receive', channel: { $ref: '#/channels/userSignedUp' } },
+      },
+    }) as AsyncApiDocument
+
+  const channelWithOperation = (): TraversedAsyncApiChannel =>
+    createChannel({
+      children: [
+        {
+          type: 'asyncapi-operation',
+          id: 'doc/channel/userSignedUp/operation/onUserSignedUp',
+          title: 'On user signed up',
+          operationName: 'onUserSignedUp',
+          action: 'receive',
+          channelName: 'userSignedUp',
+          channelAddress: 'user/signedup',
+        },
+      ],
+    })
+
+  it('renders operation children nested under the channel in the modern layout', () => {
+    const wrapper = mount(Channel, {
+      props: {
+        channel: channelWithOperation(),
+        document: documentWithOperation(),
+        layout: 'modern',
+        isCollapsed: false,
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'Operation' }).exists()).toBe(true)
+    expect(wrapper.text()).toContain('On user signed up')
+  })
+
+  it('renders operation children nested under the channel in the classic layout', () => {
+    const wrapper = mount(Channel, {
+      props: {
+        channel: channelWithOperation(),
+        document: documentWithOperation(),
+        layout: 'classic',
+        isCollapsed: false,
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'Operation' }).exists()).toBe(true)
+    expect(wrapper.text()).toContain('On user signed up')
+  })
 })

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
@@ -210,4 +210,25 @@ describe('Channel', () => {
     expect(wrapper.findComponent({ name: 'Operation' }).exists()).toBe(true)
     expect(wrapper.text()).toContain('On user signed up')
   })
+
+  // Regression: both layouts must forward `expandedItems` to Operation so sidebar
+  // navigation can expand the nested message accordions.
+  it.each(['modern', 'classic'] as const)('forwards expandedItems to the operation in the %s layout', (layout) => {
+    const expandedItems = { 'doc/channel/userSignedUp/operation/onUserSignedUp': true }
+    const wrapper = mount(Channel, {
+      props: {
+        channel: channelWithOperation(),
+        document: documentWithOperation(),
+        layout,
+        isCollapsed: false,
+        eventBus: null,
+        expandedItems,
+      },
+    })
+
+    const operation = wrapper.findComponent({ name: 'Operation' })
+    expect(operation.exists()).toBe(true)
+    // The original bug passed a disconnected empty object here; assert the map is forwarded.
+    expect(operation.props('expandedItems')).toEqual(expandedItems)
+  })
 })

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
@@ -1,15 +1,8 @@
 <script setup lang="ts">
 import { ScalarMarkdown } from '@scalar/components/markdown'
 import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
-import type {
-  AsyncApiChannelObject,
-  AsyncApiDocument,
-} from '@scalar/types/asyncapi/3.1'
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
-import {
-  getResolvedRef,
-  mergeSiblingReferences,
-} from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type {
   TraversedAsyncApiChannel,
   TraversedAsyncApiOperation,
@@ -28,16 +21,18 @@ import {
 import ParameterList from '@/features/Operation/components/ParameterList.vue'
 
 import { adaptAsyncApiParameters } from './helpers/adapt-async-api-parameters'
+import {
+  resolveSchemaRenderOptions,
+  type AsyncApiSchemaRenderOptions,
+} from './helpers/async-api-render-options'
+import { filterChildrenByType } from './helpers/filter-children-by-type'
+import { pickHeading } from './helpers/pick-heading'
+import { resolveAsyncApiChannel } from './helpers/resolve-async-api-nodes'
 import Operation from './Operation.vue'
 
 /** Subset of the configuration the shared `ParameterList` renderer needs. */
-type ParameterListOptions = Pick<
-  ApiReferenceConfigurationRaw,
-  | 'hideModels'
-  | 'orderRequiredPropertiesFirst'
-  | 'orderSchemaPropertiesBy'
-  | 'expandAllSchemaProperties'
->
+type ParameterListOptions = AsyncApiSchemaRenderOptions &
+  Pick<ApiReferenceConfigurationRaw, 'hideModels'>
 
 const {
   channel,
@@ -64,10 +59,9 @@ const headerId = useId()
  * Resolve the channel from the document so we can read its description.
  * The navigation entry only carries the address and identifying keys.
  */
-const resolvedChannel = computed<AsyncApiChannelObject | undefined>(() => {
-  const node = document.channels?.[channel.channelName]
-  return node ? getResolvedRef(node, mergeSiblingReferences) : undefined
-})
+const resolvedChannel = computed(() =>
+  resolveAsyncApiChannel(document, channel.channelName),
+)
 
 const description = computed(() => resolvedChannel.value?.description ?? '')
 
@@ -75,14 +69,13 @@ const description = computed(() => resolvedChannel.value?.description ?? '')
  * Heading shown above each channel section.
  *
  * Prefers the human-friendly `channel.title` when it is set, then falls back
- * to `channel.address`, and finally to the channel map key.
- * `channel.channelAddress` already encodes the address-or-key fallback during
- * navigation traversal, so we only need to overlay `title` on top of it.
+ * to `channel.address`. `channel.channelAddress` already encodes the
+ * address-or-key fallback during navigation traversal, so we only need to
+ * overlay `title` on top of it.
  */
-const headingText = computed(() => {
-  const title = resolvedChannel.value?.title?.trim()
-  return title || channel.channelAddress
-})
+const headingText = computed(() =>
+  pickHeading(resolvedChannel.value?.title, channel.channelAddress),
+)
 
 /**
  * Channel address parameters mapped into the OpenAPI parameter shape so we can reuse the shared
@@ -95,16 +88,14 @@ const parameters = computed(() =>
 /** Fill in defaults so the shared renderer always receives a complete options object. */
 const parameterListOptions = computed<ParameterListOptions>(() => ({
   hideModels: options?.hideModels ?? false,
-  orderRequiredPropertiesFirst: options?.orderRequiredPropertiesFirst ?? false,
-  orderSchemaPropertiesBy: options?.orderSchemaPropertiesBy ?? 'preserve',
-  expandAllSchemaProperties: options?.expandAllSchemaProperties ?? false,
+  ...resolveSchemaRenderOptions(options),
 }))
 
 /** Operations that target this channel, rendered nested beneath the channel content. */
 const operations = computed(() =>
-  (channel.children ?? []).filter(
-    (child): child is TraversedAsyncApiOperation =>
-      child.type === 'asyncapi-operation',
+  filterChildrenByType<TraversedAsyncApiOperation>(
+    channel.children,
+    'asyncapi-operation',
   ),
 )
 </script>

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
@@ -10,7 +10,10 @@ import {
   getResolvedRef,
   mergeSiblingReferences,
 } from '@scalar/workspace-store/helpers/get-resolved-ref'
-import type { TraversedAsyncApiChannel } from '@scalar/workspace-store/schemas/navigation'
+import type {
+  TraversedAsyncApiChannel,
+  TraversedAsyncApiOperation,
+} from '@scalar/workspace-store/schemas/navigation'
 import { computed, useId } from 'vue'
 
 import { Anchor } from '@/components/Anchor'
@@ -25,6 +28,7 @@ import {
 import ParameterList from '@/features/Operation/components/ParameterList.vue'
 
 import { adaptAsyncApiParameters } from './helpers/adapt-async-api-parameters'
+import Operation from './Operation.vue'
 
 /** Subset of the configuration the shared `ParameterList` renderer needs. */
 type ParameterListOptions = Pick<
@@ -86,6 +90,14 @@ const parameterListOptions = computed<ParameterListOptions>(() => ({
   orderSchemaPropertiesBy: options?.orderSchemaPropertiesBy ?? 'preserve',
   expandAllSchemaProperties: options?.expandAllSchemaProperties ?? false,
 }))
+
+/** Operations that target this channel, rendered nested beneath the channel content. */
+const operations = computed(() =>
+  (channel.children ?? []).filter(
+    (child): child is TraversedAsyncApiOperation =>
+      child.type === 'asyncapi-operation',
+  ),
+)
 </script>
 
 <template>
@@ -121,6 +133,13 @@ const parameterListOptions = computed<ParameterListOptions>(() => ({
       :parameters="parameters">
       <template #title>Parameters</template>
     </ParameterList>
+    <Operation
+      v-for="operation in operations"
+      :key="operation.id"
+      :document="document"
+      :eventBus="eventBus"
+      :operation="operation"
+      :options="options" />
   </SectionContainerAccordion>
 
   <SectionContainer
@@ -156,6 +175,13 @@ const parameterListOptions = computed<ParameterListOptions>(() => ({
           :parameters="parameters">
           <template #title>Parameters</template>
         </ParameterList>
+        <Operation
+          v-for="operation in operations"
+          :key="operation.id"
+          :document="document"
+          :eventBus="eventBus"
+          :operation="operation"
+          :options="options" />
       </SectionContent>
     </Section>
   </SectionContainer>

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
@@ -39,15 +39,24 @@ type ParameterListOptions = Pick<
   | 'expandAllSchemaProperties'
 >
 
-const { channel, document, layout, isCollapsed, eventBus, options } =
-  defineProps<{
-    channel: TraversedAsyncApiChannel
-    document: AsyncApiDocument
-    layout: 'classic' | 'modern'
-    isCollapsed: boolean
-    eventBus: WorkspaceEventBus | null
-    options?: Partial<ParameterListOptions>
-  }>()
+const {
+  channel,
+  document,
+  layout,
+  isCollapsed,
+  eventBus,
+  options,
+  expandedItems = {},
+} = defineProps<{
+  channel: TraversedAsyncApiChannel
+  document: AsyncApiDocument
+  layout: 'classic' | 'modern'
+  isCollapsed: boolean
+  eventBus: WorkspaceEventBus | null
+  options?: Partial<ParameterListOptions>
+  /** Map of navigation item id to expanded state, shared with the sidebar. */
+  expandedItems?: Record<string, boolean>
+}>()
 
 const headerId = useId()
 
@@ -138,6 +147,7 @@ const operations = computed(() =>
       :key="operation.id"
       :document="document"
       :eventBus="eventBus"
+      :expandedItems="expandedItems"
       :operation="operation"
       :options="options" />
   </SectionContainerAccordion>
@@ -180,6 +190,7 @@ const operations = computed(() =>
           :key="operation.id"
           :document="document"
           :eventBus="eventBus"
+          :expandedItems="expandedItems"
           :operation="operation"
           :options="options" />
       </SectionContent>

--- a/packages/api-reference/src/components/Content/AsyncApi/Message.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Message.test.ts
@@ -1,0 +1,106 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import type { TraversedAsyncApiMessage } from '@scalar/workspace-store/schemas/navigation'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import Message from './Message.vue'
+
+function createMessage(overrides: Partial<TraversedAsyncApiMessage> = {}): TraversedAsyncApiMessage {
+  return {
+    type: 'asyncapi-message',
+    id: 'doc/channel/userSignedUp/operation/onUserSignedUp/message/userSignedUp',
+    title: 'User signed up',
+    messageName: 'userSignedUp',
+    channelName: 'userSignedUp',
+    ...overrides,
+  }
+}
+
+function createDocument(message: Record<string, unknown>): AsyncApiDocument {
+  return {
+    asyncapi: '3.0.0',
+    info: { title: 'Streaming API', version: '1.0.0' },
+    'x-scalar-original-document-hash': '',
+    channels: {
+      userSignedUp: {
+        address: 'user/signedup',
+        messages: { userSignedUp: message },
+      },
+    },
+  } as AsyncApiDocument
+}
+
+describe('Message', () => {
+  it('renders the message title and description', () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({ title: 'User signed up', description: 'Emitted on signup.' }),
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.text()).toContain('User signed up')
+    expect(wrapper.text()).toContain('Emitted on signup.')
+  })
+
+  it('renders the payload schema', () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({
+          payload: { type: 'object', properties: { id: { type: 'string' } } },
+        }),
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.text()).toContain('Payload')
+    expect(wrapper.text()).toContain('id')
+  })
+
+  it('unwraps a Multi Format Schema payload', () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({
+          payload: {
+            schemaFormat: 'application/vnd.aai.asyncapi+json;version=3.0.0',
+            schema: { type: 'object', properties: { email: { type: 'string' } } },
+          },
+        }),
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.text()).toContain('Payload')
+    expect(wrapper.text()).toContain('email')
+  })
+
+  it('renders message headers when present', () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({
+          headers: { type: 'object', properties: { 'x-token': { type: 'string' } } },
+        }),
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.text()).toContain('Headers')
+    expect(wrapper.text()).toContain('x-token')
+  })
+
+  it('does not render a payload section when the message has no payload', () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({ title: 'User signed up' }),
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.text()).not.toContain('Payload')
+  })
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/Message.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Message.test.ts
@@ -1,14 +1,17 @@
 import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import type { TraversedAsyncApiMessage } from '@scalar/workspace-store/schemas/navigation'
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick, reactive } from 'vue'
 
 import Message from './Message.vue'
+
+const MESSAGE_ID = 'doc/channel/userSignedUp/operation/onUserSignedUp/message/userSignedUp'
 
 function createMessage(overrides: Partial<TraversedAsyncApiMessage> = {}): TraversedAsyncApiMessage {
   return {
     type: 'asyncapi-message',
-    id: 'doc/channel/userSignedUp/operation/onUserSignedUp/message/userSignedUp',
+    id: MESSAGE_ID,
     title: 'User signed up',
     messageName: 'userSignedUp',
     channelName: 'userSignedUp',
@@ -30,21 +33,86 @@ function createDocument(message: Record<string, unknown>): AsyncApiDocument {
   } as AsyncApiDocument
 }
 
+/** Expand this message's accordion so the body (description, schemas) renders. */
+const expanded = { [MESSAGE_ID]: true }
+
 describe('Message', () => {
-  it('renders the message title and description', () => {
+  it('renders the message title in the collapsed header', () => {
     const wrapper = mount(Message, {
       props: {
         message: createMessage(),
-        document: createDocument({ title: 'User signed up', description: 'Emitted on signup.' }),
+        document: createDocument({ title: 'User signed up', payload: { type: 'object' } }),
         eventBus: null,
       },
     })
 
     expect(wrapper.text()).toContain('User signed up')
+  })
+
+  it('keeps the body collapsed by default and shows it once expanded', () => {
+    const props = {
+      message: createMessage(),
+      document: createDocument({ description: 'Emitted on signup.', payload: { type: 'object' } }),
+      eventBus: null,
+    }
+
+    const collapsed = mount(Message, { props })
+    expect(collapsed.text()).not.toContain('Emitted on signup.')
+
+    const open = mount(Message, { props: { ...props, expandedItems: expanded } })
+    expect(open.text()).toContain('Emitted on signup.')
+  })
+
+  it('opens the accordion on click even without an event bus', async () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({ description: 'Emitted on signup.', payload: { type: 'object' } }),
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.text()).not.toContain('Emitted on signup.')
+    await wrapper.find('.section-accordion-button').trigger('click')
     expect(wrapper.text()).toContain('Emitted on signup.')
   })
 
-  it('renders the payload schema', () => {
+  it('opens when the shared expandedItems map is updated (sidebar navigation)', async () => {
+    const expandedItems = reactive<Record<string, boolean>>({})
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({ description: 'Emitted on signup.', payload: { type: 'object' } }),
+        eventBus: null,
+        expandedItems,
+      },
+    })
+
+    expect(wrapper.text()).not.toContain('Emitted on signup.')
+
+    // Mirror what sidebarState.setExpanded does on navigation: mutate the shared map.
+    expandedItems[MESSAGE_ID] = true
+    await nextTick()
+
+    expect(wrapper.text()).toContain('Emitted on signup.')
+  })
+
+  it('emits toggle:nav-item when the accordion is toggled', async () => {
+    const emit = vi.fn()
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({ payload: { type: 'object' } }),
+        eventBus: { emit } as never,
+      },
+    })
+
+    await wrapper.find('.section-accordion-button').trigger('click')
+
+    expect(emit).toHaveBeenCalledWith('toggle:nav-item', { id: MESSAGE_ID, open: true })
+  })
+
+  it('renders the payload schema when expanded', () => {
     const wrapper = mount(Message, {
       props: {
         message: createMessage(),
@@ -52,6 +120,7 @@ describe('Message', () => {
           payload: { type: 'object', properties: { id: { type: 'string' } } },
         }),
         eventBus: null,
+        expandedItems: expanded,
       },
     })
 
@@ -59,7 +128,7 @@ describe('Message', () => {
     expect(wrapper.text()).toContain('id')
   })
 
-  it('unwraps a Multi Format Schema payload', () => {
+  it('unwraps a Multi Format Schema payload when expanded', () => {
     const wrapper = mount(Message, {
       props: {
         message: createMessage(),
@@ -70,6 +139,7 @@ describe('Message', () => {
           },
         }),
         eventBus: null,
+        expandedItems: expanded,
       },
     })
 
@@ -77,7 +147,7 @@ describe('Message', () => {
     expect(wrapper.text()).toContain('email')
   })
 
-  it('renders message headers when present', () => {
+  it('renders message headers when present and expanded', () => {
     const wrapper = mount(Message, {
       props: {
         message: createMessage(),
@@ -85,6 +155,7 @@ describe('Message', () => {
           headers: { type: 'object', properties: { 'x-token': { type: 'string' } } },
         }),
         eventBus: null,
+        expandedItems: expanded,
       },
     })
 
@@ -98,6 +169,7 @@ describe('Message', () => {
         message: createMessage(),
         document: createDocument({ title: 'User signed up' }),
         eventBus: null,
+        expandedItems: expanded,
       },
     })
 

--- a/packages/api-reference/src/components/Content/AsyncApi/Message.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Message.vue
@@ -11,12 +11,12 @@ import {
   mergeSiblingReferences,
 } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { TraversedAsyncApiMessage } from '@scalar/workspace-store/schemas/navigation'
-import { computed, useId, useTemplateRef } from 'vue'
+import { computed, ref, useId, useTemplateRef, watch } from 'vue'
 
 import { Anchor } from '@/components/Anchor'
 import { Schema } from '@/components/Content/Schema'
 import type { SchemaOptions } from '@/components/Content/Schema/types'
-import { SectionHeader, SectionHeaderTag } from '@/components/Section'
+import { SectionAccordion, SectionHeaderTag } from '@/components/Section'
 import {
   getAsyncApiMessageHeadersSchema,
   getAsyncApiMessagePayloadSchema,
@@ -31,11 +31,19 @@ type SchemaRenderOptions = Pick<
   | 'expandAllSchemaProperties'
 >
 
-const { message, document, eventBus, options } = defineProps<{
+const {
+  message,
+  document,
+  eventBus,
+  options,
+  expandedItems = {},
+} = defineProps<{
   message: TraversedAsyncApiMessage
   document: AsyncApiDocument
   eventBus: WorkspaceEventBus | null
   options?: Partial<SchemaRenderOptions>
+  /** Map of navigation item id to expanded state, shared with the sidebar. */
+  expandedItems?: Record<string, boolean>
 }>()
 
 const headerId = useId()
@@ -92,6 +100,28 @@ const schemaOptions = computed<SchemaOptions>(() => ({
   orderSchemaPropertiesBy: options?.orderSchemaPropertiesBy ?? 'preserve',
   expandAllSchemaProperties: options?.expandAllSchemaProperties ?? false,
 }))
+
+/**
+ * Accordion open state. Kept locally so clicking the header always toggles
+ * immediately, and seeded/synced from the shared sidebar expansion map so
+ * expanding the message in the sidebar (or deep-linking to it) opens it here too.
+ */
+const isExpanded = ref(expandedItems[message.id] ?? false)
+
+watch(
+  () => expandedItems[message.id],
+  (value) => {
+    if (value !== undefined) {
+      isExpanded.value = value
+    }
+  },
+)
+
+/** Toggling the accordion updates local state and keeps the sidebar in sync. */
+const onToggle = (open: boolean) => {
+  isExpanded.value = open
+  eventBus?.emit('toggle:nav-item', { id: message.id, open })
+}
 </script>
 
 <template>
@@ -99,57 +129,71 @@ const schemaOptions = computed<SchemaOptions>(() => ({
     :id="message.id"
     ref="section"
     class="message">
-    <SectionHeader>
-      <Anchor
-        @copyAnchorUrl="
-          () => eventBus?.emit('copy-url:nav-item', { id: message.id })
-        ">
-        <SectionHeaderTag
-          :id="headerId"
-          :level="4">
-          {{ headingText }}
-        </SectionHeaderTag>
-      </Anchor>
-    </SectionHeader>
+    <SectionAccordion
+      class="message-accordion"
+      :modelValue="isExpanded"
+      @update:modelValue="onToggle">
+      <template #title>
+        <Anchor
+          @copyAnchorUrl="
+            () => eventBus?.emit('copy-url:nav-item', { id: message.id })
+          ">
+          <SectionHeaderTag
+            :id="headerId"
+            class="message-title"
+            :level="4">
+            {{ headingText }}
+          </SectionHeaderTag>
+        </Anchor>
+      </template>
 
-    <ScalarMarkdown
-      v-if="description"
-      class="message-description"
-      :value="description"
-      withImages />
+      <ScalarMarkdown
+        v-if="description"
+        class="message-description"
+        :value="description"
+        withImages />
 
-    <div
-      v-if="headersSchema"
-      class="message-schema">
-      <div class="message-schema-title">Headers</div>
-      <Schema
-        compact
-        :eventBus="eventBus"
-        name="Headers"
-        noncollapsible
-        :options="schemaOptions"
-        :schema="headersSchema" />
-    </div>
+      <div
+        v-if="headersSchema"
+        class="message-schema">
+        <div class="message-schema-title">Headers</div>
+        <Schema
+          compact
+          :eventBus="eventBus"
+          name="Headers"
+          noncollapsible
+          :options="schemaOptions"
+          :schema="headersSchema" />
+      </div>
 
-    <div
-      v-if="payloadSchema"
-      class="message-schema">
-      <div class="message-schema-title">Payload</div>
-      <Schema
-        compact
-        :eventBus="eventBus"
-        name="Payload"
-        noncollapsible
-        :options="schemaOptions"
-        :schema="payloadSchema" />
-    </div>
+      <div
+        v-if="payloadSchema"
+        class="message-schema">
+        <div class="message-schema-title">Payload</div>
+        <Schema
+          compact
+          :eventBus="eventBus"
+          name="Payload"
+          noncollapsible
+          :options="schemaOptions"
+          :schema="payloadSchema" />
+      </div>
+    </SectionAccordion>
   </div>
 </template>
 
 <style scoped>
 .message {
-  margin-top: 24px;
   scroll-margin-top: var(--refs-viewport-offset);
+}
+.message-title {
+  font-size: var(--scalar-heading-4);
+  font-weight: var(--scalar-semibold);
+  color: var(--scalar-color-1);
+}
+/* Pad the expanded body so the description and schemas don't sit flush against the border. */
+.message-accordion :deep(.section-accordion-content-card) {
+  padding: 12px;
 }
 .message-description {
   padding-bottom: 4px;
@@ -157,6 +201,9 @@ const schemaOptions = computed<SchemaOptions>(() => ({
 }
 .message-schema {
   margin-top: 12px;
+}
+.message-schema:first-child {
+  margin-top: 0;
 }
 .message-schema-title {
   font-size: var(--scalar-font-size-2);

--- a/packages/api-reference/src/components/Content/AsyncApi/Message.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Message.vue
@@ -16,7 +16,7 @@ import { computed, useId, useTemplateRef } from 'vue'
 import { Anchor } from '@/components/Anchor'
 import { Schema } from '@/components/Content/Schema'
 import type { SchemaOptions } from '@/components/Content/Schema/types'
-import { SectionHeaderTag } from '@/components/Section'
+import { SectionHeader, SectionHeaderTag } from '@/components/Section'
 import {
   getAsyncApiMessageHeadersSchema,
   getAsyncApiMessagePayloadSchema,

--- a/packages/api-reference/src/components/Content/AsyncApi/Message.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Message.vue
@@ -1,15 +1,7 @@
 <script setup lang="ts">
 import { ScalarMarkdown } from '@scalar/components/markdown'
-import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
-import type {
-  AsyncApiDocument,
-  AsyncApiMessageObject,
-} from '@scalar/types/asyncapi/3.1'
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
-import {
-  getResolvedRef,
-  mergeSiblingReferences,
-} from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { TraversedAsyncApiMessage } from '@scalar/workspace-store/schemas/navigation'
 import { computed, ref, useId, useTemplateRef, watch } from 'vue'
 
@@ -23,13 +15,15 @@ import {
 } from '@/helpers/get-async-api-message-payload-schema'
 import { useIntersection } from '@/hooks/use-intersection'
 
+import {
+  resolveSchemaRenderOptions,
+  type AsyncApiSchemaRenderOptions,
+} from './helpers/async-api-render-options'
+import { pickHeading } from './helpers/pick-heading'
+import { resolveAsyncApiMessage } from './helpers/resolve-async-api-nodes'
+
 /** Subset of the configuration the shared `Schema` renderer needs. */
-type SchemaRenderOptions = Pick<
-  ApiReferenceConfigurationRaw,
-  | 'orderRequiredPropertiesFirst'
-  | 'orderSchemaPropertiesBy'
-  | 'expandAllSchemaProperties'
->
+type SchemaRenderOptions = AsyncApiSchemaRenderOptions
 
 const {
   message,
@@ -57,26 +51,18 @@ useIntersection(section, () =>
  * Resolve the message from the channel it lives on. The navigation entry only
  * carries the identifying keys, so we walk `document.channels[channelName].messages`.
  */
-const resolvedMessage = computed<AsyncApiMessageObject | undefined>(() => {
-  const channelNode = document.channels?.[message.channelName]
-  const channel = channelNode
-    ? getResolvedRef(channelNode, mergeSiblingReferences)
-    : undefined
-  const node = channel?.messages?.[message.messageName]
-  return node ? getResolvedRef(node, mergeSiblingReferences) : undefined
-})
+const resolvedMessage = computed(() =>
+  resolveAsyncApiMessage(document, message.channelName, message.messageName),
+)
 
 /** Heading prefers the human-friendly title, falling back to the message map key. */
-const headingText = computed(
-  () =>
-    resolvedMessage.value?.title?.trim() ||
-    message.title ||
-    message.messageName,
+const headingText = computed(() =>
+  pickHeading(resolvedMessage.value?.title, message.title, message.messageName),
 )
 
 const description = computed(
   () =>
-    resolvedMessage.value?.description ?? resolvedMessage.value?.summary ?? '',
+    resolvedMessage.value?.description || resolvedMessage.value?.summary || '',
 )
 
 /** Payload schema, unwrapped from `$ref`s and Multi Format Schema wrappers. */
@@ -96,9 +82,7 @@ const headersSchema = computed(() =>
 /** Fill in defaults so the shared Schema renderer always receives a complete options object. */
 const schemaOptions = computed<SchemaOptions>(() => ({
   hideReadOnly: false,
-  orderRequiredPropertiesFirst: options?.orderRequiredPropertiesFirst ?? false,
-  orderSchemaPropertiesBy: options?.orderSchemaPropertiesBy ?? 'preserve',
-  expandAllSchemaProperties: options?.expandAllSchemaProperties ?? false,
+  ...resolveSchemaRenderOptions(options),
 }))
 
 /**

--- a/packages/api-reference/src/components/Content/AsyncApi/Message.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Message.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import { ScalarMarkdown } from '@scalar/components/markdown'
+import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
+import type {
+  AsyncApiDocument,
+  AsyncApiMessageObject,
+} from '@scalar/types/asyncapi/3.1'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import {
+  getResolvedRef,
+  mergeSiblingReferences,
+} from '@scalar/workspace-store/helpers/get-resolved-ref'
+import type { TraversedAsyncApiMessage } from '@scalar/workspace-store/schemas/navigation'
+import { computed, useId, useTemplateRef } from 'vue'
+
+import { Anchor } from '@/components/Anchor'
+import { Schema } from '@/components/Content/Schema'
+import type { SchemaOptions } from '@/components/Content/Schema/types'
+import { SectionHeaderTag } from '@/components/Section'
+import {
+  getAsyncApiMessageHeadersSchema,
+  getAsyncApiMessagePayloadSchema,
+} from '@/helpers/get-async-api-message-payload-schema'
+import { useIntersection } from '@/hooks/use-intersection'
+
+/** Subset of the configuration the shared `Schema` renderer needs. */
+type SchemaRenderOptions = Pick<
+  ApiReferenceConfigurationRaw,
+  | 'orderRequiredPropertiesFirst'
+  | 'orderSchemaPropertiesBy'
+  | 'expandAllSchemaProperties'
+>
+
+const { message, document, eventBus, options } = defineProps<{
+  message: TraversedAsyncApiMessage
+  document: AsyncApiDocument
+  eventBus: WorkspaceEventBus | null
+  options?: Partial<SchemaRenderOptions>
+}>()
+
+const headerId = useId()
+const section = useTemplateRef<HTMLElement>('section')
+
+useIntersection(section, () =>
+  eventBus?.emit('intersecting:nav-item', { id: message.id }),
+)
+
+/**
+ * Resolve the message from the channel it lives on. The navigation entry only
+ * carries the identifying keys, so we walk `document.channels[channelName].messages`.
+ */
+const resolvedMessage = computed<AsyncApiMessageObject | undefined>(() => {
+  const channelNode = document.channels?.[message.channelName]
+  const channel = channelNode
+    ? getResolvedRef(channelNode, mergeSiblingReferences)
+    : undefined
+  const node = channel?.messages?.[message.messageName]
+  return node ? getResolvedRef(node, mergeSiblingReferences) : undefined
+})
+
+/** Heading prefers the human-friendly title, falling back to the message map key. */
+const headingText = computed(
+  () =>
+    resolvedMessage.value?.title?.trim() ||
+    message.title ||
+    message.messageName,
+)
+
+const description = computed(
+  () =>
+    resolvedMessage.value?.description ?? resolvedMessage.value?.summary ?? '',
+)
+
+/** Payload schema, unwrapped from `$ref`s and Multi Format Schema wrappers. */
+const payloadSchema = computed(() =>
+  resolvedMessage.value
+    ? getAsyncApiMessagePayloadSchema(resolvedMessage.value)
+    : undefined,
+)
+
+/** Header schema, unwrapped the same way as the payload. */
+const headersSchema = computed(() =>
+  resolvedMessage.value
+    ? getAsyncApiMessageHeadersSchema(resolvedMessage.value)
+    : undefined,
+)
+
+/** Fill in defaults so the shared Schema renderer always receives a complete options object. */
+const schemaOptions = computed<SchemaOptions>(() => ({
+  hideReadOnly: false,
+  orderRequiredPropertiesFirst: options?.orderRequiredPropertiesFirst ?? false,
+  orderSchemaPropertiesBy: options?.orderSchemaPropertiesBy ?? 'preserve',
+  expandAllSchemaProperties: options?.expandAllSchemaProperties ?? false,
+}))
+</script>
+
+<template>
+  <div
+    :id="message.id"
+    ref="section"
+    class="message">
+    <SectionHeader>
+      <Anchor
+        @copyAnchorUrl="
+          () => eventBus?.emit('copy-url:nav-item', { id: message.id })
+        ">
+        <SectionHeaderTag
+          :id="headerId"
+          :level="4">
+          {{ headingText }}
+        </SectionHeaderTag>
+      </Anchor>
+    </SectionHeader>
+
+    <ScalarMarkdown
+      v-if="description"
+      class="message-description"
+      :value="description"
+      withImages />
+
+    <div
+      v-if="headersSchema"
+      class="message-schema">
+      <div class="message-schema-title">Headers</div>
+      <Schema
+        compact
+        :eventBus="eventBus"
+        name="Headers"
+        noncollapsible
+        :options="schemaOptions"
+        :schema="headersSchema" />
+    </div>
+
+    <div
+      v-if="payloadSchema"
+      class="message-schema">
+      <div class="message-schema-title">Payload</div>
+      <Schema
+        compact
+        :eventBus="eventBus"
+        name="Payload"
+        noncollapsible
+        :options="schemaOptions"
+        :schema="payloadSchema" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.message {
+  margin-top: 24px;
+  scroll-margin-top: var(--refs-viewport-offset);
+}
+.message-description {
+  padding-bottom: 4px;
+  text-align: left;
+}
+.message-schema {
+  margin-top: 12px;
+}
+.message-schema-title {
+  font-size: var(--scalar-font-size-2);
+  font-weight: var(--scalar-semibold);
+  color: var(--scalar-color-1);
+  padding-bottom: 8px;
+  border-bottom: var(--scalar-border-width) solid var(--scalar-border-color);
+  margin-bottom: 8px;
+}
+</style>

--- a/packages/api-reference/src/components/Content/AsyncApi/Operation.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Operation.test.ts
@@ -5,10 +5,12 @@ import { describe, expect, it } from 'vitest'
 
 import Operation from './Operation.vue'
 
+const OPERATION_ID = 'doc/channel/userSignedUp/operation/onUserSignedUp'
+
 function createOperation(overrides: Partial<TraversedAsyncApiOperation> = {}): TraversedAsyncApiOperation {
   return {
     type: 'asyncapi-operation',
-    id: 'doc/channel/userSignedUp/operation/onUserSignedUp',
+    id: OPERATION_ID,
     title: 'On user signed up',
     operationName: 'onUserSignedUp',
     action: 'receive',
@@ -59,7 +61,7 @@ describe('Operation', () => {
     expect(wrapper.find('.operation-action').text()).toBe('send')
   })
 
-  it('renders the operation description', () => {
+  it('renders the operation description (the operation header is not collapsible)', () => {
     const wrapper = mount(Operation, {
       props: {
         operation: createOperation(),
@@ -75,7 +77,7 @@ describe('Operation', () => {
     expect(wrapper.text()).toContain('Fired whenever a user signs up.')
   })
 
-  it('renders nested message children', () => {
+  it('renders a message accordion for each message child', () => {
     const wrapper = mount(Operation, {
       props: {
         operation: createOperation({
@@ -109,6 +111,7 @@ describe('Operation', () => {
       },
     })
 
+    // Message renders (collapsed); its title shows in the accordion header.
     expect(wrapper.findComponent({ name: 'Message' }).exists()).toBe(true)
     expect(wrapper.text()).toContain('User signed up')
   })

--- a/packages/api-reference/src/components/Content/AsyncApi/Operation.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Operation.test.ts
@@ -27,7 +27,7 @@ function createDocument(operation: Record<string, unknown>): AsyncApiDocument {
       userSignedUp: { address: 'user/signedup' },
     },
     operations: { onUserSignedUp: operation },
-  } as AsyncApiDocument
+  } as unknown as AsyncApiDocument
 }
 
 describe('Operation', () => {
@@ -104,7 +104,7 @@ describe('Operation', () => {
           operations: {
             onUserSignedUp: { action: 'receive', channel: { $ref: '#/channels/userSignedUp' } },
           },
-        } as AsyncApiDocument,
+        } as unknown as AsyncApiDocument,
         eventBus: null,
       },
     })

--- a/packages/api-reference/src/components/Content/AsyncApi/Operation.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Operation.test.ts
@@ -1,0 +1,115 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import type { TraversedAsyncApiOperation } from '@scalar/workspace-store/schemas/navigation'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import Operation from './Operation.vue'
+
+function createOperation(overrides: Partial<TraversedAsyncApiOperation> = {}): TraversedAsyncApiOperation {
+  return {
+    type: 'asyncapi-operation',
+    id: 'doc/channel/userSignedUp/operation/onUserSignedUp',
+    title: 'On user signed up',
+    operationName: 'onUserSignedUp',
+    action: 'receive',
+    channelName: 'userSignedUp',
+    channelAddress: 'user/signedup',
+    ...overrides,
+  }
+}
+
+function createDocument(operation: Record<string, unknown>): AsyncApiDocument {
+  return {
+    asyncapi: '3.0.0',
+    info: { title: 'Streaming API', version: '1.0.0' },
+    'x-scalar-original-document-hash': '',
+    channels: {
+      userSignedUp: { address: 'user/signedup' },
+    },
+    operations: { onUserSignedUp: operation },
+  } as AsyncApiDocument
+}
+
+describe('Operation', () => {
+  it('renders the operation title and the action badge', () => {
+    const wrapper = mount(Operation, {
+      props: {
+        operation: createOperation(),
+        document: createDocument({
+          action: 'receive',
+          channel: { $ref: '#/channels/userSignedUp' },
+        }),
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.text()).toContain('On user signed up')
+    expect(wrapper.find('.operation-action').text()).toBe('receive')
+  })
+
+  it('renders the send action badge', () => {
+    const wrapper = mount(Operation, {
+      props: {
+        operation: createOperation({ action: 'send' }),
+        document: createDocument({ action: 'send', channel: { $ref: '#/channels/userSignedUp' } }),
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.find('.operation-action').text()).toBe('send')
+  })
+
+  it('renders the operation description', () => {
+    const wrapper = mount(Operation, {
+      props: {
+        operation: createOperation(),
+        document: createDocument({
+          action: 'receive',
+          channel: { $ref: '#/channels/userSignedUp' },
+          description: 'Fired whenever a user signs up.',
+        }),
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.text()).toContain('Fired whenever a user signs up.')
+  })
+
+  it('renders nested message children', () => {
+    const wrapper = mount(Operation, {
+      props: {
+        operation: createOperation({
+          children: [
+            {
+              type: 'asyncapi-message',
+              id: 'doc/channel/userSignedUp/operation/onUserSignedUp/message/userSignedUp',
+              title: 'User signed up',
+              messageName: 'userSignedUp',
+              channelName: 'userSignedUp',
+            },
+          ],
+        }),
+        document: {
+          asyncapi: '3.0.0',
+          info: { title: 'Streaming API', version: '1.0.0' },
+          'x-scalar-original-document-hash': '',
+          channels: {
+            userSignedUp: {
+              address: 'user/signedup',
+              messages: {
+                userSignedUp: { title: 'User signed up', payload: { type: 'object' } },
+              },
+            },
+          },
+          operations: {
+            onUserSignedUp: { action: 'receive', channel: { $ref: '#/channels/userSignedUp' } },
+          },
+        } as AsyncApiDocument,
+        eventBus: null,
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'Message' }).exists()).toBe(true)
+    expect(wrapper.text()).toContain('User signed up')
+  })
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/Operation.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Operation.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import { ScalarMarkdown } from '@scalar/components/markdown'
+import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
+import type {
+  AsyncApiDocument,
+  AsyncApiOperationObject,
+} from '@scalar/types/asyncapi/3.1'
+import { resolveOperationWithTraits } from '@scalar/workspace-store/channel-example'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import {
+  getResolvedRef,
+  mergeSiblingReferences,
+} from '@scalar/workspace-store/helpers/get-resolved-ref'
+import type {
+  TraversedAsyncApiMessage,
+  TraversedAsyncApiOperation,
+} from '@scalar/workspace-store/schemas/navigation'
+import { computed, useId, useTemplateRef } from 'vue'
+
+import { Anchor } from '@/components/Anchor'
+import { SectionHeader, SectionHeaderTag } from '@/components/Section'
+import { useIntersection } from '@/hooks/use-intersection'
+
+import Message from './Message.vue'
+
+/** Subset of the configuration the nested `Message`/`Schema` renderers need. */
+type OperationOptions = Pick<
+  ApiReferenceConfigurationRaw,
+  | 'orderRequiredPropertiesFirst'
+  | 'orderSchemaPropertiesBy'
+  | 'expandAllSchemaProperties'
+>
+
+const { operation, document, eventBus, options } = defineProps<{
+  operation: TraversedAsyncApiOperation
+  document: AsyncApiDocument
+  eventBus: WorkspaceEventBus | null
+  options?: Partial<OperationOptions>
+}>()
+
+const headerId = useId()
+const section = useTemplateRef<HTMLElement>('section')
+
+useIntersection(section, () =>
+  eventBus?.emit('intersecting:nav-item', { id: operation.id }),
+)
+
+/**
+ * Resolve the operation from the document so we can read its summary/description.
+ * Operation traits are merged in (matching the channel connection UI) so trait-only
+ * fields render as part of the operation.
+ */
+const resolvedOperation = computed<AsyncApiOperationObject | undefined>(() => {
+  const node = document.operations?.[operation.operationName]
+  if (!node) {
+    return undefined
+  }
+  return resolveOperationWithTraits(
+    getResolvedRef(node, mergeSiblingReferences),
+  )
+})
+
+/** Heading prefers title, then summary, then the operation map key. */
+const headingText = computed(
+  () =>
+    resolvedOperation.value?.title?.trim() ||
+    operation.title ||
+    operation.operationName,
+)
+
+const description = computed(
+  () =>
+    resolvedOperation.value?.description ??
+    resolvedOperation.value?.summary ??
+    '',
+)
+
+/** `send`/`receive` action shown as a small badge next to the heading. */
+const action = computed(() => operation.action)
+
+/** Only the message children of this operation. */
+const messages = computed(() =>
+  (operation.children ?? []).filter(
+    (child): child is TraversedAsyncApiMessage =>
+      child.type === 'asyncapi-message',
+  ),
+)
+</script>
+
+<template>
+  <div
+    :id="operation.id"
+    ref="section"
+    class="operation">
+    <SectionHeader>
+      <Anchor
+        @copyAnchorUrl="
+          () => eventBus?.emit('copy-url:nav-item', { id: operation.id })
+        ">
+        <span class="operation-heading">
+          <span
+            class="operation-action"
+            :class="`operation-action--${action}`">
+            {{ action }}
+          </span>
+          <SectionHeaderTag
+            :id="headerId"
+            :level="3">
+            {{ headingText }}
+          </SectionHeaderTag>
+        </span>
+      </Anchor>
+    </SectionHeader>
+
+    <ScalarMarkdown
+      v-if="description"
+      class="operation-description"
+      :value="description"
+      withImages />
+
+    <Message
+      v-for="message in messages"
+      :key="message.id"
+      :document="document"
+      :eventBus="eventBus"
+      :message="message"
+      :options="options" />
+  </div>
+</template>
+
+<style scoped>
+.operation {
+  margin-top: 24px;
+  scroll-margin-top: var(--refs-viewport-offset);
+}
+.operation-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.operation-action {
+  text-transform: uppercase;
+  font-size: var(--scalar-micro);
+  font-weight: var(--scalar-semibold);
+  letter-spacing: 0.05em;
+  border-radius: 16px;
+  border: var(--scalar-border-width) solid var(--scalar-border-color);
+  padding: 2px 8px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+}
+.operation-action--send {
+  color: var(--scalar-color-blue);
+}
+.operation-action--receive {
+  color: var(--scalar-color-green);
+}
+.operation-description {
+  padding-bottom: 4px;
+  text-align: left;
+}
+</style>

--- a/packages/api-reference/src/components/Content/AsyncApi/Operation.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Operation.vue
@@ -18,7 +18,7 @@ import type {
 import { computed, useId, useTemplateRef } from 'vue'
 
 import { Anchor } from '@/components/Anchor'
-import { SectionHeader, SectionHeaderTag } from '@/components/Section'
+import { SectionHeaderTag } from '@/components/Section'
 import { useIntersection } from '@/hooks/use-intersection'
 
 import Message from './Message.vue'
@@ -31,11 +31,19 @@ type OperationOptions = Pick<
   | 'expandAllSchemaProperties'
 >
 
-const { operation, document, eventBus, options } = defineProps<{
+const {
+  operation,
+  document,
+  eventBus,
+  options,
+  expandedItems = {},
+} = defineProps<{
   operation: TraversedAsyncApiOperation
   document: AsyncApiDocument
   eventBus: WorkspaceEventBus | null
   options?: Partial<OperationOptions>
+  /** Map of navigation item id to expanded state, shared with the sidebar. */
+  expandedItems?: Record<string, boolean>
 }>()
 
 const headerId = useId()
@@ -91,26 +99,26 @@ const messages = computed(() =>
   <div
     :id="operation.id"
     ref="section"
-    class="operation">
-    <SectionHeader>
+    class="operation"
+    :class="`operation--${action}`">
+    <div class="operation-header">
+      <span
+        class="operation-action"
+        :class="`operation-action--${action}`">
+        {{ action }}
+      </span>
       <Anchor
         @copyAnchorUrl="
           () => eventBus?.emit('copy-url:nav-item', { id: operation.id })
         ">
-        <span class="operation-heading">
-          <span
-            class="operation-action"
-            :class="`operation-action--${action}`">
-            {{ action }}
-          </span>
-          <SectionHeaderTag
-            :id="headerId"
-            :level="3">
-            {{ headingText }}
-          </SectionHeaderTag>
-        </span>
+        <SectionHeaderTag
+          :id="headerId"
+          class="operation-title"
+          :level="3">
+          {{ headingText }}
+        </SectionHeaderTag>
       </Anchor>
-    </SectionHeader>
+    </div>
 
     <ScalarMarkdown
       v-if="description"
@@ -123,6 +131,7 @@ const messages = computed(() =>
       :key="message.id"
       :document="document"
       :eventBus="eventBus"
+      :expandedItems="expandedItems"
       :message="message"
       :options="options" />
   </div>
@@ -130,34 +139,47 @@ const messages = computed(() =>
 
 <style scoped>
 .operation {
-  margin-top: 24px;
+  margin-top: 32px;
   scroll-margin-top: var(--refs-viewport-offset);
 }
-.operation-heading {
+
+.operation-header {
   display: flex;
   align-items: center;
   gap: 8px;
 }
+.operation-title {
+  font-size: var(--scalar-heading-3);
+  font-weight: var(--scalar-semibold);
+  color: var(--scalar-color-1);
+}
+
+/* Filled, color-coded pill carries the primary send/receive signal. */
 .operation-action {
   text-transform: uppercase;
-  font-size: var(--scalar-micro);
+  font-size: var(--scalar-mini);
   font-weight: var(--scalar-semibold);
   letter-spacing: 0.05em;
-  border-radius: 16px;
-  border: var(--scalar-border-width) solid var(--scalar-border-color);
+  border-radius: 12px;
   padding: 2px 8px;
-  height: 20px;
   display: inline-flex;
   align-items: center;
 }
 .operation-action--send {
   color: var(--scalar-color-blue);
+  background: color-mix(in srgb, var(--scalar-color-blue), transparent 88%);
 }
 .operation-action--receive {
   color: var(--scalar-color-green);
+  background: color-mix(in srgb, var(--scalar-color-green), transparent 88%);
 }
+
 .operation-description {
-  padding-bottom: 4px;
   text-align: left;
+  margin-top: 4px;
+}
+/* Space the first message accordion away from the operation header/description. */
+.operation > :deep(.message) {
+  margin-top: 12px;
 }
 </style>

--- a/packages/api-reference/src/components/Content/AsyncApi/Operation.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Operation.vue
@@ -1,16 +1,7 @@
 <script setup lang="ts">
 import { ScalarMarkdown } from '@scalar/components/markdown'
-import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
-import type {
-  AsyncApiDocument,
-  AsyncApiOperationObject,
-} from '@scalar/types/asyncapi/3.1'
-import { resolveOperationWithTraits } from '@scalar/workspace-store/channel-example'
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
-import {
-  getResolvedRef,
-  mergeSiblingReferences,
-} from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type {
   TraversedAsyncApiMessage,
   TraversedAsyncApiOperation,
@@ -21,15 +12,14 @@ import { Anchor } from '@/components/Anchor'
 import { SectionHeaderTag } from '@/components/Section'
 import { useIntersection } from '@/hooks/use-intersection'
 
+import type { AsyncApiSchemaRenderOptions } from './helpers/async-api-render-options'
+import { filterChildrenByType } from './helpers/filter-children-by-type'
+import { pickHeading } from './helpers/pick-heading'
+import { resolveAsyncApiOperation } from './helpers/resolve-async-api-nodes'
 import Message from './Message.vue'
 
 /** Subset of the configuration the nested `Message`/`Schema` renderers need. */
-type OperationOptions = Pick<
-  ApiReferenceConfigurationRaw,
-  | 'orderRequiredPropertiesFirst'
-  | 'orderSchemaPropertiesBy'
-  | 'expandAllSchemaProperties'
->
+type OperationOptions = AsyncApiSchemaRenderOptions
 
 const {
   operation,
@@ -58,39 +48,31 @@ useIntersection(section, () =>
  * Operation traits are merged in (matching the channel connection UI) so trait-only
  * fields render as part of the operation.
  */
-const resolvedOperation = computed<AsyncApiOperationObject | undefined>(() => {
-  const node = document.operations?.[operation.operationName]
-  if (!node) {
-    return undefined
-  }
-  return resolveOperationWithTraits(
-    getResolvedRef(node, mergeSiblingReferences),
-  )
-})
+const resolvedOperation = computed(() =>
+  resolveAsyncApiOperation(document, operation.operationName),
+)
 
 /** Heading prefers title, then summary, then the operation map key. */
-const headingText = computed(
-  () =>
-    resolvedOperation.value?.title?.trim() ||
-    operation.title ||
+const headingText = computed(() =>
+  pickHeading(
+    resolvedOperation.value?.title,
+    operation.title,
     operation.operationName,
+  ),
 )
 
 const description = computed(
   () =>
-    resolvedOperation.value?.description ??
-    resolvedOperation.value?.summary ??
+    resolvedOperation.value?.description ||
+    resolvedOperation.value?.summary ||
     '',
 )
 
-/** `send`/`receive` action shown as a small badge next to the heading. */
-const action = computed(() => operation.action)
-
 /** Only the message children of this operation. */
 const messages = computed(() =>
-  (operation.children ?? []).filter(
-    (child): child is TraversedAsyncApiMessage =>
-      child.type === 'asyncapi-message',
+  filterChildrenByType<TraversedAsyncApiMessage>(
+    operation.children,
+    'asyncapi-message',
   ),
 )
 </script>
@@ -100,12 +82,12 @@ const messages = computed(() =>
     :id="operation.id"
     ref="section"
     class="operation"
-    :class="`operation--${action}`">
+    :class="`operation--${operation.action}`">
     <div class="operation-header">
       <span
         class="operation-action"
-        :class="`operation-action--${action}`">
-        {{ action }}
+        :class="`operation-action--${operation.action}`">
+        {{ operation.action }}
       </span>
       <Anchor
         @copyAnchorUrl="

--- a/packages/api-reference/src/components/Content/AsyncApi/helpers/async-api-render-options.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/helpers/async-api-render-options.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveSchemaRenderOptions } from './async-api-render-options'
+
+describe('resolveSchemaRenderOptions', () => {
+  it('fills in defaults when no options are provided', () => {
+    expect(resolveSchemaRenderOptions()).toEqual({
+      orderRequiredPropertiesFirst: false,
+      orderSchemaPropertiesBy: 'preserve',
+      expandAllSchemaProperties: false,
+    })
+  })
+
+  it('keeps the provided values', () => {
+    expect(
+      resolveSchemaRenderOptions({
+        orderRequiredPropertiesFirst: true,
+        orderSchemaPropertiesBy: 'alpha',
+        expandAllSchemaProperties: true,
+      }),
+    ).toEqual({
+      orderRequiredPropertiesFirst: true,
+      orderSchemaPropertiesBy: 'alpha',
+      expandAllSchemaProperties: true,
+    })
+  })
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/helpers/async-api-render-options.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/helpers/async-api-render-options.ts
@@ -1,0 +1,24 @@
+import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
+
+/**
+ * Schema-ordering options shared by the AsyncAPI channel, operation, and message renderers.
+ *
+ * Each surface threads the same subset of the reference configuration through to the shared
+ * `Schema`/`ParameterList` components, so they extend this type rather than re-declaring it.
+ */
+export type AsyncApiSchemaRenderOptions = Pick<
+  ApiReferenceConfigurationRaw,
+  'orderRequiredPropertiesFirst' | 'orderSchemaPropertiesBy' | 'expandAllSchemaProperties'
+>
+
+/**
+ * Fill in defaults so the shared renderers always receive a complete ordering options object,
+ * regardless of which fields the caller provided.
+ */
+export const resolveSchemaRenderOptions = (
+  options?: Partial<AsyncApiSchemaRenderOptions>,
+): AsyncApiSchemaRenderOptions => ({
+  orderRequiredPropertiesFirst: options?.orderRequiredPropertiesFirst ?? false,
+  orderSchemaPropertiesBy: options?.orderSchemaPropertiesBy ?? 'preserve',
+  expandAllSchemaProperties: options?.expandAllSchemaProperties ?? false,
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/helpers/filter-children-by-type.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/helpers/filter-children-by-type.test.ts
@@ -1,0 +1,38 @@
+import type {
+  TraversedAsyncApiMessage,
+  TraversedAsyncApiOperation,
+  TraversedEntry,
+} from '@scalar/workspace-store/schemas/navigation'
+import { describe, expect, it } from 'vitest'
+
+import { filterChildrenByType } from './filter-children-by-type'
+
+const operation = {
+  id: 'op-1',
+  title: 'Send',
+  type: 'asyncapi-operation',
+  operationName: 'sendUserSignedUp',
+  action: 'send',
+  channelName: 'userSignedup',
+  channelAddress: 'user/signedup',
+} as TraversedAsyncApiOperation
+
+const message = {
+  id: 'msg-1',
+  title: 'User',
+  type: 'asyncapi-message',
+  messageName: 'UserMessage',
+  channelName: 'userSignedup',
+} as TraversedAsyncApiMessage
+
+describe('filterChildrenByType', () => {
+  it('keeps only the children matching the requested type', () => {
+    const children: TraversedEntry[] = [operation, message]
+
+    expect(filterChildrenByType<TraversedAsyncApiMessage>(children, 'asyncapi-message')).toEqual([message])
+  })
+
+  it('returns an empty array when children is undefined', () => {
+    expect(filterChildrenByType<TraversedAsyncApiOperation>(undefined, 'asyncapi-operation')).toEqual([])
+  })
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/helpers/filter-children-by-type.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/helpers/filter-children-by-type.ts
@@ -1,0 +1,12 @@
+import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
+
+/**
+ * Narrow a navigation entry's children down to a single AsyncAPI node type.
+ *
+ * The channel renderer needs its operations and the operation renderer needs its messages; both
+ * share this type-guarded filter so the cast lives in one place.
+ */
+export const filterChildrenByType = <T extends TraversedEntry>(
+  children: TraversedEntry[] | undefined,
+  type: T['type'],
+): T[] => (children ?? []).filter((child): child is T => child.type === type)

--- a/packages/api-reference/src/components/Content/AsyncApi/helpers/pick-heading.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/helpers/pick-heading.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { pickHeading } from './pick-heading'
+
+describe('pickHeading', () => {
+  it('returns the first non-empty candidate', () => {
+    expect(pickHeading('Title', 'Fallback')).toBe('Title')
+  })
+
+  it('skips empty and whitespace-only candidates', () => {
+    expect(pickHeading(undefined, '', '   ', 'Address')).toBe('Address')
+  })
+
+  it('trims the chosen candidate', () => {
+    expect(pickHeading('  Padded  ')).toBe('Padded')
+  })
+
+  it('returns an empty string when every candidate is blank', () => {
+    expect(pickHeading(undefined, '', '  ')).toBe('')
+  })
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/helpers/pick-heading.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/helpers/pick-heading.ts
@@ -1,0 +1,18 @@
+/**
+ * Pick the first non-empty heading from a list of candidates.
+ *
+ * Each candidate is trimmed and the first one with content wins, so the AsyncAPI channel, operation,
+ * and message renderers can share a single "prefer the human-friendly title, then fall back to a
+ * key" chain instead of repeating the same `title?.trim() || fallback` logic. Returns an empty
+ * string when every candidate is missing or blank.
+ */
+export const pickHeading = (...candidates: Array<string | undefined>): string => {
+  for (const candidate of candidates) {
+    const trimmed = candidate?.trim()
+    if (trimmed) {
+      return trimmed
+    }
+  }
+
+  return ''
+}

--- a/packages/api-reference/src/components/Content/AsyncApi/helpers/resolve-async-api-nodes.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/helpers/resolve-async-api-nodes.test.ts
@@ -1,0 +1,53 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import { describe, expect, it } from 'vitest'
+
+import { resolveAsyncApiChannel, resolveAsyncApiMessage, resolveAsyncApiOperation } from './resolve-async-api-nodes'
+
+const document = {
+  channels: {
+    userSignedup: {
+      address: 'user/signedup',
+      title: 'User signed up',
+      messages: {
+        UserMessage: { title: 'User', payload: { type: 'object' } },
+      },
+    },
+  },
+  operations: {
+    sendUserSignedUp: {
+      action: 'send',
+      title: 'Send user signed up',
+      channel: { $ref: '#/channels/userSignedup' },
+    },
+  },
+} as unknown as AsyncApiDocument
+
+describe('resolveAsyncApiChannel', () => {
+  it('resolves a channel by its map key', () => {
+    expect(resolveAsyncApiChannel(document, 'userSignedup')?.title).toBe('User signed up')
+  })
+
+  it('returns undefined for an unknown channel', () => {
+    expect(resolveAsyncApiChannel(document, 'missing')).toBeUndefined()
+  })
+})
+
+describe('resolveAsyncApiMessage', () => {
+  it('resolves a message from its channel', () => {
+    expect(resolveAsyncApiMessage(document, 'userSignedup', 'UserMessage')?.title).toBe('User')
+  })
+
+  it('returns undefined for an unknown message', () => {
+    expect(resolveAsyncApiMessage(document, 'userSignedup', 'missing')).toBeUndefined()
+  })
+})
+
+describe('resolveAsyncApiOperation', () => {
+  it('resolves an operation by its map key', () => {
+    expect(resolveAsyncApiOperation(document, 'sendUserSignedUp')?.title).toBe('Send user signed up')
+  })
+
+  it('returns undefined for an unknown operation', () => {
+    expect(resolveAsyncApiOperation(document, 'missing')).toBeUndefined()
+  })
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/helpers/resolve-async-api-nodes.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/helpers/resolve-async-api-nodes.ts
@@ -1,0 +1,50 @@
+import type {
+  AsyncApiChannelObject,
+  AsyncApiDocument,
+  AsyncApiMessageObject,
+  AsyncApiOperationObject,
+} from '@scalar/types/asyncapi/3.1'
+import { resolveOperationWithTraits } from '@scalar/workspace-store/channel-example'
+import { getResolvedRef, mergeSiblingReferences } from '@scalar/workspace-store/helpers/get-resolved-ref'
+
+/**
+ * Resolve a channel from the document by its `document.channels` key.
+ *
+ * Siblings are merged so keys declared alongside a `$ref` are kept rather than dropped, matching
+ * how the rest of the OpenAPI/AsyncAPI rendering resolves references.
+ */
+export const resolveAsyncApiChannel = (
+  document: AsyncApiDocument,
+  channelName: string,
+): AsyncApiChannelObject | undefined => {
+  const node = document.channels?.[channelName]
+  return node ? getResolvedRef(node, mergeSiblingReferences) : undefined
+}
+
+/**
+ * Resolve a message from the channel it lives on. The navigation entry only carries the identifying
+ * keys, so we walk `document.channels[channelName].messages[messageName]`.
+ */
+export const resolveAsyncApiMessage = (
+  document: AsyncApiDocument,
+  channelName: string,
+  messageName: string,
+): AsyncApiMessageObject | undefined => {
+  const channel = resolveAsyncApiChannel(document, channelName)
+  const node = channel?.messages?.[messageName]
+  return node ? getResolvedRef(node, mergeSiblingReferences) : undefined
+}
+
+/**
+ * Resolve an operation from the document by its `document.operations` key.
+ *
+ * Operation traits are merged in (matching the channel connection UI) so trait-only fields render
+ * as part of the operation.
+ */
+export const resolveAsyncApiOperation = (
+  document: AsyncApiDocument,
+  operationName: string,
+): AsyncApiOperationObject | undefined => {
+  const node = document.operations?.[operationName]
+  return node ? resolveOperationWithTraits(getResolvedRef(node, mergeSiblingReferences)) : undefined
+}

--- a/packages/api-reference/src/helpers/get-async-api-message-payload-schema.test.ts
+++ b/packages/api-reference/src/helpers/get-async-api-message-payload-schema.test.ts
@@ -1,0 +1,60 @@
+import type { AsyncApiMessageObject } from '@scalar/types/asyncapi/3.1'
+import { describe, expect, it } from 'vitest'
+
+import {
+  getAsyncApiMessageHeadersSchema,
+  getAsyncApiMessagePayloadSchema,
+  unwrapAsyncApiSchema,
+} from './get-async-api-message-payload-schema'
+
+const asMessage = (message: unknown): AsyncApiMessageObject => message as AsyncApiMessageObject
+
+describe('unwrapAsyncApiSchema', () => {
+  it('returns a plain JSON Schema object as-is', () => {
+    const schema = { type: 'object', properties: { id: { type: 'string' } } }
+    expect(unwrapAsyncApiSchema(schema)).toEqual(schema)
+  })
+
+  it('unwraps a Multi Format Schema Object to its inner payload', () => {
+    const inner = { type: 'object', properties: { name: { type: 'string' } } }
+    const wrapper = { schemaFormat: 'application/vnd.aai.asyncapi+json;version=3.0.0', schema: inner }
+    expect(unwrapAsyncApiSchema(wrapper)).toEqual(inner)
+  })
+
+  it('resolves a $ref to its embedded $ref-value', () => {
+    const target = { type: 'object', properties: { id: { type: 'string' } } }
+    const ref = { $ref: '#/components/schemas/Planet', '$ref-value': target }
+    expect(unwrapAsyncApiSchema(ref)).toEqual(target)
+  })
+
+  it('returns undefined for a missing value', () => {
+    expect(unwrapAsyncApiSchema(undefined)).toBeUndefined()
+  })
+
+  it('skips boolean schemas', () => {
+    expect(unwrapAsyncApiSchema(true)).toBeUndefined()
+    expect(unwrapAsyncApiSchema(false)).toBeUndefined()
+  })
+})
+
+describe('getAsyncApiMessagePayloadSchema', () => {
+  it('returns the unwrapped payload schema', () => {
+    const payload = { type: 'object', properties: { id: { type: 'string' } } }
+    expect(getAsyncApiMessagePayloadSchema(asMessage({ payload }))).toEqual(payload)
+  })
+
+  it('returns undefined when there is no payload', () => {
+    expect(getAsyncApiMessagePayloadSchema(asMessage({}))).toBeUndefined()
+  })
+})
+
+describe('getAsyncApiMessageHeadersSchema', () => {
+  it('returns the unwrapped headers schema', () => {
+    const headers = { type: 'object', properties: { 'x-token': { type: 'string' } } }
+    expect(getAsyncApiMessageHeadersSchema(asMessage({ headers }))).toEqual(headers)
+  })
+
+  it('returns undefined when there are no headers', () => {
+    expect(getAsyncApiMessageHeadersSchema(asMessage({}))).toBeUndefined()
+  })
+})

--- a/packages/api-reference/src/helpers/get-async-api-message-payload-schema.ts
+++ b/packages/api-reference/src/helpers/get-async-api-message-payload-schema.ts
@@ -1,0 +1,43 @@
+import { isObject } from '@scalar/helpers/object/is-object'
+import type { AsyncApiMessageObject } from '@scalar/types/asyncapi/3.1'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+
+/**
+ * A resolved schema-bearing value may be a JSON Schema object, a boolean (`true`/`false`)
+ * schema, or a Multi Format Schema wrapper, so accept only plain objects and treat them as the
+ * `SchemaObject` the shared Schema/Model rendering expects.
+ */
+const isSchemaObject = (value: unknown): value is SchemaObject => isObject(value)
+
+/**
+ * Unwraps an AsyncAPI schema-bearing value into the `SchemaObject` shape the shared OpenAPI
+ * `Schema`/`Model` components expect.
+ *
+ * AsyncAPI reuses JSON Schema, but a value may need extra handling:
+ * - The value itself may be a `$ref`; it is resolved to its `$ref-value`.
+ * - A Multi Format Schema Object (`schemaFormat` plus a nested `schema`) is unwrapped to its
+ *   payload, so we render the inner JSON Schema rather than the wrapper.
+ * - Boolean (`true`/`false`) and non-JSON-Schema payloads are skipped.
+ */
+export const unwrapAsyncApiSchema = (value: unknown): SchemaObject | undefined => {
+  if (value === undefined) {
+    return undefined
+  }
+
+  // Resolve the value the same way OpenAPI model rendering does (plain `$ref-value`).
+  const resolved = getResolvedRef(value)
+
+  // Multi Format Schema Objects carry the real schema under `schema`; unwrap to that payload.
+  const schema = isObject(resolved) && 'schemaFormat' in resolved ? getResolvedRef(resolved.schema) : resolved
+
+  return isSchemaObject(schema) ? schema : undefined
+}
+
+/** Resolves an AsyncAPI message `payload` into the `SchemaObject` the shared Schema component expects. */
+export const getAsyncApiMessagePayloadSchema = (message: AsyncApiMessageObject): SchemaObject | undefined =>
+  unwrapAsyncApiSchema(message.payload)
+
+/** Resolves an AsyncAPI message `headers` into the `SchemaObject` the shared Schema component expects. */
+export const getAsyncApiMessageHeadersSchema = (message: AsyncApiMessageObject): SchemaObject | undefined =>
+  unwrapAsyncApiSchema(message.headers)

--- a/packages/api-reference/src/helpers/get-async-api-model-schema.ts
+++ b/packages/api-reference/src/helpers/get-async-api-model-schema.ts
@@ -1,14 +1,8 @@
-import { isObject } from '@scalar/helpers/object/is-object'
 import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import { getResolvedRef, mergeSiblingReferences } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
-/**
- * A resolved `components.schemas` entry may be a JSON Schema object, a boolean (`true`/`false`)
- * schema, or a Multi Format Schema wrapper, so accept only plain objects and treat them as the
- * `SchemaObject` the shared Model rendering and search helpers expect.
- */
-const isSchemaObject = (value: unknown): value is SchemaObject => isObject(value)
+import { unwrapAsyncApiSchema } from './get-async-api-message-payload-schema'
 
 /**
  * Resolves a named schema from an AsyncAPI document's `components.schemas` into the `SchemaObject`
@@ -29,15 +23,7 @@ export const getAsyncApiModelSchema = (document: AsyncApiDocument, name: string)
   // Merge siblings at the components level so schemas declared alongside a `$ref` are kept.
   const components = getResolvedRef(document.components, mergeSiblingReferences)
   const entry = components.schemas?.[name]
-  if (entry === undefined) {
-    return undefined
-  }
 
-  // Resolve the schema itself the same way OpenAPI model rendering does (plain `$ref-value`).
-  const resolved = getResolvedRef(entry)
-
-  // Multi Format Schema Objects carry the real schema under `schema`; unwrap to that payload.
-  const schema = isObject(resolved) && 'schemaFormat' in resolved ? getResolvedRef(resolved.schema) : resolved
-
-  return isSchemaObject(schema) ? schema : undefined
+  // Resolve `$ref`s and unwrap Multi Format Schema Objects into the plain JSON Schema shape.
+  return unwrapAsyncApiSchema(entry)
 }


### PR DESCRIPTION
## Problem

Scalar already lists AsyncAPI operations and messages in the sidebar, but the content area stops at the channel — `Channel.vue` only renders the channel heading, description, and address parameters. The navigation traversal builds the full `channel → operations → messages` tree and gives every node an id, so clicking an operation or message in the sidebar scrolls to a channel that shows nothing about it.

This makes Scalar unusable for documenting my AsyncAPI: the operations and their message payloads never appear. I want Scalar to reach parity with the AsyncAPI UI (which does render operations and message payloads under each channel), since that tool doesn't fit my use case and I'd rather standardize on Scalar.

## Solution

Render the operations — and their messages with payload/header schemas — nested inside each channel, mirroring the existing channel → operation → message sidebar nesting.

- **`Operation.vue` (new):** renders an operation with a `send`/`receive` action badge, title, summary/description, and its nested messages. Resolves the operation from `document.operations` and merges traits via the existing `resolveOperationWithTraits` helper. Wires the operation id for sidebar anchor/scroll-spy.
- **`Message.vue` (new):** renders a message title/description plus its **Headers** and **Payload** schemas using the shared `Schema` component (same approach as `RequestBody.vue`).
- **`get-async-api-message-payload-schema.ts` (new):** `unwrapAsyncApiSchema` resolves `$ref`s and unwraps Multi-Format Schema wrappers into the `SchemaObject` the `Schema` component expects, plus payload/header accessors. The existing `get-async-api-model-schema.ts` was refactored to reuse this instead of duplicating the unwrap logic.
- **`Channel.vue` (modified):** renders its operation children inside the content area in both the classic (accordion body) and modern (`SectionContent`) layouts, after the existing parameters block.

Rendering goes directly through dedicated components (Channel → Operation → Message) rather than routing operations back through the recursive `AsyncApiTraversedEntry`, to avoid an import cycle and keep each level's layout self-contained.

### Verification

- New tests: `Operation.test.ts`, `Message.test.ts`, `get-async-api-message-payload-schema.test.ts`; extended `Channel.test.ts` to cover nested operation rendering in both layouts.
- `vitest --run` for the touched files: all green. `vue-tsc --noEmit`: 0 errors. `eslint`: 0 errors.
- Manually verified against the Galaxy AsyncAPI doc (the **Scalar Galaxy Events (AsyncAPI)** sources in the dev playground) in both modern and classic layouts.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation.