### PR TITLE
fix(api-reference): sidebar overlaps content at exactly 1000px

### DIFF
--- a/.changeset/many-zebras-cheer.md
+++ b/.changeset/many-zebras-cheer.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix sidebar overlapping the content at exactly 1000px wide. The layout grid switched to the mobile (stacked) layout at `max-width: 1000px` while the sidebar visibility is driven by Tailwind's `lg:` variant (`min-width: 1000px`), so both fired at 1000px. The mobile breakpoint now uses `width < 1000px`, the exact complement of `lg:`, so 1000px is treated as desktop.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -1438,7 +1438,15 @@ const showMCPButton = computed(() => {
 /* ----------------------------------------------------- */
 /* Responsive / Mobile Layout */
 
-@media (max-width: 1000px) {
+/*
+ * Stop just below the `lg` breakpoint (1000px). The sidebar visibility is driven
+ * by Tailwind's `lg:` variant, which is `min-width: 1000px` and therefore treats
+ * exactly 1000px as desktop. A `max-width: 1000px` query would make the grid
+ * switch to the mobile (stacked) layout at the very same width, so the desktop
+ * sidebar would render on top of the content. `width < 1000px` is the exact
+ * complement of `lg:` (`width >= 1000px`), keeping the two in sync.
+ */
+@media (width < 1000px) {
   /* Keep toolbar hidden on mobile without forcing desktop display mode. */
   .references-developer-tools {
     display: none;
@@ -1478,7 +1486,8 @@ const showMCPButton = computed(() => {
 * TODO: @brynn move this to the sidebar block OR the ApiReferenceStandalone component
 * when the new elements are available
 */
-@media (max-width: 1000px) {
+/* Match the layout breakpoint above so the mobile header height is only applied below `lg`. */
+@media (width < 1000px) {
   .scalar-api-references-standalone-mobile:not(.references-classic) {
     --scalar-header-height: 50px;
   }


### PR DESCRIPTION
At exactly 1000px wide the sidebar rendered on top of the content.

The sidebar shows/hides via Tailwind's `lg:` variant (`min-width: 1000px`), but the layout grid switched to its stacked mobile mode at `max-width: 1000px`. At 1000px both fired and the full-height desktop sidebar landed in a collapsed grid row, overlapping everything.

The mobile breakpoint now uses `width < 1000px`, the exact complement of `lg:`, so 1000px is treated as desktop.

<img width="1756" height="2082" alt="image" src="https://github.com/user-attachments/assets/11ce1899-f27e-41bc-81b2-82317b96fe25" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only responsive breakpoint tweak with no logic, auth, or data changes; limited to layout behavior at the 1000px edge case.
> 
> **Overview**
> Fixes a **layout bug at exactly 1000px** where the sidebar covered the main content.
> 
> Responsive CSS in `ApiReference.vue` used `@media (max-width: 1000px)` for the stacked mobile grid and standalone mobile header height, while sidebar visibility follows Tailwind **`lg:`** (`min-width: 1000px`). At 1000px both rules applied: desktop sidebar with a collapsed mobile grid row.
> 
> Both breakpoints now use **`@media (width < 1000px)`**, aligned with `lg:`, so **1000px and wider use the desktop layout**. Comments document the mismatch. Patch changeset for `@scalar/api-reference`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f97add43fd671862f4ffecc6a5f4a15db65c7438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->