### PR TITLE
fix(aspire): pin MessagePack to patched 2.5.301

### DIFF
--- a/.changeset/aspire-messagepack-pin.md
+++ b/.changeset/aspire-messagepack-pin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspire': patch
+---
+
+Pin MessagePack to 2.5.301 to resolve a transitive high-severity advisory (CVE-2026-48109) pulled in via Aspire.Hosting

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/Scalar.Aspire.csproj
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/Scalar.Aspire.csproj
@@ -34,6 +34,8 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting" Version="13.2.1" />
+    <!-- Aspire.Hosting pulls MessagePack 2.5.192 transitively via StreamJsonRpc, which has a known high-severity advisory (CVE-2026-48109 / GHSA-hv8m-jj95-wg3x). Pin the patched version until the upstream chain ships it. -->
+    <PackageReference Include="MessagePack" Version="2.5.301" />
     <PackageReference Include="NetEscapades.EnumGenerators.Generators" Version="1.0.0-beta21" PrivateAssets="all" ExcludeAssets="runtime" NoWarn="NU5104" />
   </ItemGroup>
 


### PR DESCRIPTION
Aspire pulls a vulnerable `MessagePack 2.5.192` transitively (via `Aspire.Hosting` → `StreamJsonRpc`), which trips NU1903 and fails `dotnet restore` in CI. No newer `Aspire.Hosting` (up to 13.4.4) fixes it, so this pins the patched `2.5.301` directly.

Fixes CVE-2026-48109 / GHSA-hv8m-jj95-wg3x.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version override only; no application logic changes, and it reduces security/advisory risk from the previous transitive package.
> 
> **Overview**
> Adds a direct **MessagePack 2.5.301** package reference on `Scalar.Aspire` so restore/build no longer resolve the vulnerable **2.5.192** version that `Aspire.Hosting` pulls in transitively (via StreamJsonRpc). A csproj comment documents **CVE-2026-48109** / **GHSA-hv8m-jj95-wg3x** and that the pin is temporary until upstream ships a fixed chain.
> 
> Includes a **@scalar/aspire** patch changeset for the release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe0e3bcfa7e5ca4351299a2bb7b60e995d8d229e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->