### PR TITLE
fix(api-reference): can't link to hidden parameters

### DIFF
--- a/.changeset/cool-pugs-attack.md
+++ b/.changeset/cool-pugs-attack.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix anchor links to schema properties that are hidden inside collapsed sections. Deep links now expand the disclosures on the path to the target property and scroll to it, so links work without enabling `expandAllSchemaProperties`.

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -1,8 +1,9 @@
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
 import { type SchemaObject, SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
+import { scrollTargetId } from '../../../helpers/lazy-bus'
 import Schema from './Schema.vue'
 
 describe('Schema', () => {
@@ -889,6 +890,104 @@ describe('Schema', () => {
       // The deepest property is visible and the collapse toggle remains available.
       expect(wrapper.text()).toContain('leaf')
       expect(wrapper.find('button').exists()).toBe(true)
+    })
+  })
+
+  describe('scroll target auto-expand', () => {
+    afterEach(() => {
+      // Reset the shared anchor target so it does not leak into other tests.
+      scrollTargetId.value = ''
+    })
+
+    it('stays collapsed when no anchor target points at a child property', () => {
+      const wrapper = mount(Schema, {
+        props: {
+          // This disclosure wraps the children of `foo` (breadcrumb root.foo).
+          schema: {
+            type: 'object',
+            properties: {
+              bar: { type: 'string' },
+            },
+          },
+          breadcrumb: ['root', 'foo'],
+          level: 1,
+          eventBus: null,
+          options: {},
+        },
+      })
+
+      // The disclosure is collapsed by default, so the child is not rendered.
+      expect(wrapper.text()).not.toContain('bar')
+    })
+
+    it('expands a collapsed disclosure when the anchor target is a child property', () => {
+      // Mimic landing on a deep link to `root.foo.bar` while `foo` is collapsed.
+      scrollTargetId.value = 'root.foo.bar'
+
+      const wrapper = mount(Schema, {
+        props: {
+          // This disclosure wraps the children of `foo` (breadcrumb root.foo).
+          schema: {
+            type: 'object',
+            properties: {
+              bar: { type: 'string' },
+            },
+          },
+          breadcrumb: ['root', 'foo'],
+          level: 1,
+          eventBus: null,
+          options: {},
+        },
+      })
+
+      // The disclosure on the path to the target opens itself so the target renders.
+      expect(wrapper.text()).toContain('bar')
+    })
+
+    it('expands a collapsed >12 properties section when the anchor target lives inside it', () => {
+      // The collapsed "additional properties" section hides overflow properties
+      // behind a toggle. A deep link to one of them must still reveal it.
+      scrollTargetId.value = 'root.overflowProp'
+
+      const wrapper = mount(Schema, {
+        props: {
+          schema: {
+            type: 'object',
+            properties: {
+              overflowProp: { type: 'string' },
+            },
+          },
+          breadcrumb: ['root'],
+          additionalProperties: true,
+          eventBus: null,
+          options: {},
+        },
+      })
+
+      expect(wrapper.text()).toContain('overflowProp')
+    })
+
+    it('does not expand unrelated collapsed disclosures', () => {
+      // A target for a different branch must not force this disclosure open.
+      scrollTargetId.value = 'root.somethingElse.bar'
+
+      const wrapper = mount(Schema, {
+        props: {
+          // This disclosure wraps the children of `foo` (breadcrumb root.foo).
+          schema: {
+            type: 'object',
+            properties: {
+              bar: { type: 'string' },
+            },
+          },
+          breadcrumb: ['root', 'foo'],
+          level: 1,
+          eventBus: null,
+          options: {},
+        },
+      })
+
+      expect(wrapper.text()).not.toContain('bar')
     })
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -11,6 +11,7 @@ import { computed, inject, provide } from 'vue'
 
 import type { SchemaOptions } from '@/components/Content/Schema/types'
 import ScreenReader from '@/components/ScreenReader.vue'
+import { scrollTargetId } from '@/helpers/lazy-bus'
 
 import { isEmptySchemaObject } from './helpers/is-empty-schema-object'
 import { isTypeObject } from './helpers/is-type-object'
@@ -108,13 +109,32 @@ const shouldForceExpand = computed(
 const shouldShowToggle = computed((): boolean => !noncollapsible && level > 0)
 
 /**
+ * Whether this schema sits on the path to the current anchor/scroll target.
+ *
+ * Property anchors are dot-joined breadcrumbs, so every disclosure that wraps
+ * the target has a breadcrumb that is a prefix of the target id. Opening those
+ * disclosures is what makes deep links to collapsed (hidden) properties work
+ * without forcing every schema open via `expandAllSchemaProperties`.
+ */
+const isOnScrollTargetPath = computed((): boolean => {
+  if (!breadcrumb?.length) {
+    return false
+  }
+  const path = breadcrumb.join('.')
+  const target = scrollTargetId.value
+  return target === path || target.startsWith(`${path}.`)
+})
+
+/**
  * Whether the disclosure starts expanded. Non-collapsible schemas are always
  * open. When `expandAllSchemaProperties` is enabled, finite branches start
  * expanded by default while cyclic branches remain collapsed to avoid recursion
- * loops.
+ * loops. We also open any disclosure on the path to the current scroll target so
+ * deep links resolve even when the property is collapsed.
  */
 const defaultOpen = computed(
-  (): boolean => noncollapsible || shouldForceExpand.value,
+  (): boolean =>
+    noncollapsible || shouldForceExpand.value || isOnScrollTargetPath.value,
 )
 
 /** Gets the description to show for the schema */

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -131,6 +131,10 @@ const isOnScrollTargetPath = computed((): boolean => {
  * expanded by default while cyclic branches remain collapsed to avoid recursion
  * loops. We also open any disclosure on the path to the current scroll target so
  * deep links resolve even when the property is collapsed.
+ *
+ * Note: the Disclosure only reads this at mount, so it expands collapsed
+ * properties on a fresh navigation (the schema mounts after the target is set),
+ * not when the target changes for an already-mounted disclosure.
  */
 const defaultOpen = computed(
   (): boolean =>

--- a/packages/api-reference/src/helpers/lazy-bus.ts
+++ b/packages/api-reference/src/helpers/lazy-bus.ts
@@ -24,6 +24,17 @@ const SCROLL_RETRY_MS = 3000
 /** Tracks when the initial load is complete. */
 export const firstLazyLoadComplete = ref(false)
 
+/**
+ * The id of the element we are currently scrolling to (the anchor target).
+ *
+ * Schema properties live inside collapsible disclosures that are not part of the
+ * navigation tree, so the lazy bus cannot expand them the way it expands sidebar
+ * parents. Instead we publish the active target here and let each collapsible
+ * schema disclosure open itself when its breadcrumb is on the path to the target.
+ * This is what makes deep links to hidden (collapsed) schema properties work.
+ */
+export const scrollTargetId = ref<string>('')
+
 /** List of unique identifiers that are blocking intersection */
 const intersectionBlockers = reactive<Set<string>>(new Set())
 
@@ -241,6 +252,11 @@ export const scrollToLazy = (
   // Disable intersection while we scroll to the element
   const unblock = blockIntersection()
   const { rawId } = getSchemaParamsFromId(id)
+
+  // Publish the target so collapsible schema disclosures on the path can open
+  // themselves. Schema properties are not in the navigation tree, so this is the
+  // only way the scroll target inside a collapsed schema becomes reachable.
+  scrollTargetId.value = id
 
   addToPriorityQueue(id)
   addToPriorityQueue(rawId)

--- a/packages/api-reference/src/helpers/lazy-bus.ts
+++ b/packages/api-reference/src/helpers/lazy-bus.ts
@@ -35,6 +35,17 @@ export const firstLazyLoadComplete = ref(false)
  */
 export const scrollTargetId = ref<string>('')
 
+/**
+ * Clears the scroll target once we are done with it, so a stale target cannot
+ * re-open a disclosure the user later collapsed (or that remounts). Guarded by
+ * the id so a newer navigation that started during the scroll retry is kept.
+ */
+const clearScrollTarget = (id: string): void => {
+  if (scrollTargetId.value === id) {
+    scrollTargetId.value = ''
+  }
+}
+
 /** List of unique identifiers that are blocking intersection */
 const intersectionBlockers = reactive<Set<string>>(new Set())
 
@@ -307,11 +318,13 @@ const tryScroll = (id: string, stopTime: number, onComplete: UnblockFn, onFailur
   const element = document.getElementById(id)
   if (element) {
     element.scrollIntoView({ block: 'start' })
+    clearScrollTarget(id)
     onComplete()
   } else if (Date.now() < stopTime) {
     requestAnimationFrame(() => tryScroll(id, stopTime, onComplete, onFailure))
   } else {
     // If the scroll has expired we enable intersection again
+    clearScrollTarget(id)
     onComplete()
     onFailure?.()
   }

--- a/packages/api-reference/test/features/parameter-linking.e2e.ts
+++ b/packages/api-reference/test/features/parameter-linking.e2e.ts
@@ -182,18 +182,19 @@ test.describe('parameter linking', () => {
     // The overflow property is hidden behind the collapsed section on load.
     await expect(hiddenButton).toHaveCount(0)
 
-    // Expand the collapsed section to grab the canonical deep link.
+    // Expand the collapsed section so the property's anchor exists, then read its
+    // id. We build the deep link from the id instead of going through the clipboard
+    // copy flow, which is flaky in CI.
     await page.getByRole('button', { name: /Show additional properties/ }).click()
-    await page.hover(`text=${hiddenProperty}`)
-    await hiddenButton.click()
-    await expect(page.getByRole('status').filter({ hasText: 'Copied' })).toBeVisible()
+    const anchorId = await page.locator(`[id$=".body.${hiddenProperty}"]`).first().getAttribute('id')
+    expect(anchorId).toBeTruthy()
 
-    const clipboard = await page.evaluate(() => navigator.clipboard.readText())
-    expect(clipboard).toContain(hiddenProperty)
+    // Path-routing deep link: base path + the id without the document slug segment.
+    const deepLink = `${example}/custom-base-path/${anchorId!.replace(/^[^/]+\//, '')}`
 
     // Fresh navigation: the section starts collapsed again, but the deep link
     // must reveal the hidden property and scroll it into view.
-    await page.goto(clipboard)
+    await page.goto(deepLink)
 
     await expect(hiddenButton).toBeInViewport()
   })

--- a/packages/api-reference/test/features/parameter-linking.e2e.ts
+++ b/packages/api-reference/test/features/parameter-linking.e2e.ts
@@ -1,5 +1,37 @@
-import { expect, test } from '@playwright/test'
+import { type Page, expect, test } from '@playwright/test'
 import { serveExample } from '@test/utils/serve-example'
+
+/**
+ * Mocks for lazy loading, remove after lazy bus is fixed.
+ *
+ * Runs idle/animation/timeout callbacks (almost) immediately so the lazy bus
+ * settles deterministically within the test.
+ */
+const mockLazyTimers = (page: Page) =>
+  page.addInitScript(() => {
+    // Mock requestIdleCallback to run immediately
+    window.requestIdleCallback = (cb: IdleRequestCallback): number => {
+      cb({
+        didTimeout: false,
+        timeRemaining: () => 0,
+      } as IdleDeadline)
+      return 1
+    }
+
+    // Mock requestAnimationFrame to run immediately
+    const originalRAF = window.requestAnimationFrame
+    window.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+      setTimeout(() => callback(performance.now()), 0)
+      return originalRAF(callback)
+    }
+
+    // Mock setTimeout to run faster in tests
+    const originalSetTimeout = window.setTimeout
+    window.setTimeout = ((callback: TimerHandler, delay?: number, ...args: any[]) => {
+      const testDelay = delay ? Math.min(delay / 10, 10) : 0
+      return originalSetTimeout(callback, testDelay, ...args)
+    }) as typeof setTimeout
+  })
 
 test.describe('parameter linking', () => {
   /* We need to retry this test because it's flaky on CI */
@@ -10,31 +42,7 @@ test.describe('parameter linking', () => {
   })
 
   test('requestBody parameters have anchor links', async ({ page }) => {
-    // Mocks for lazy loading, remove after lazy bus is fixed
-    await page.addInitScript(() => {
-      // Mock requestIdleCallback to run immediately
-      window.requestIdleCallback = (cb: IdleRequestCallback): number => {
-        cb({
-          didTimeout: false,
-          timeRemaining: () => 0,
-        } as IdleDeadline)
-        return 1
-      }
-
-      // Mock requestAnimationFrame to run immediately
-      const originalRAF = window.requestAnimationFrame
-      window.requestAnimationFrame = (callback: FrameRequestCallback): number => {
-        setTimeout(() => callback(performance.now()), 0)
-        return originalRAF(callback)
-      }
-
-      // Mock setTimeout to run faster in tests
-      const originalSetTimeout = window.setTimeout
-      window.setTimeout = ((callback: TimerHandler, delay?: number, ...args: any[]) => {
-        const testDelay = delay ? Math.min(delay / 10, 10) : 0
-        return originalSetTimeout(callback, testDelay, ...args)
-      }) as typeof setTimeout
-    })
+    await mockLazyTimers(page)
 
     const example = await serveExample({
       // If it works with pathRouting, it probably works without it too.
@@ -119,5 +127,74 @@ test.describe('parameter linking', () => {
     await page.goto(clipboard)
 
     await expect(button).toBeInViewport()
+  })
+
+  test('anchor links reveal requestBody parameters hidden in the collapsed section', async ({ page }) => {
+    await mockLazyTimers(page)
+
+    // More than 12 properties forces the overflow into a collapsed
+    // "Show additional properties" section that is hidden by default.
+    const properties = Object.fromEntries(
+      Array.from({ length: 13 }, (_, index) => [
+        `property${String(index + 1).padStart(2, '0')}`,
+        { type: 'string' as const },
+      ]),
+    )
+    /** The last property always lands in the collapsed (hidden) section. */
+    const hiddenProperty = 'property13'
+
+    const example = await serveExample({
+      pathRouting: {
+        basePath: '/custom-base-path',
+      },
+      content: {
+        openapi: '3.1.1',
+        info: {
+          title: 'Test API',
+          version: '1.0.0',
+        },
+        paths: {
+          '/users': {
+            get: {
+              summary: 'Get all users',
+              tags: ['user-tag'],
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    await page.setViewportSize({ width: 1024, height: 400 })
+    await page.goto(example)
+
+    const hiddenButton = page.getByRole('button', { name: `Copy link to ${hiddenProperty}`, exact: true })
+
+    // The overflow property is hidden behind the collapsed section on load.
+    await expect(hiddenButton).toHaveCount(0)
+
+    // Expand the collapsed section to grab the canonical deep link.
+    await page.getByRole('button', { name: /Show additional properties/ }).click()
+    await page.hover(`text=${hiddenProperty}`)
+    await hiddenButton.click()
+    await expect(page.getByRole('status').filter({ hasText: 'Copied' })).toBeVisible()
+
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText())
+    expect(clipboard).toContain(hiddenProperty)
+
+    // Fresh navigation: the section starts collapsed again, but the deep link
+    // must reveal the hidden property and scroll it into view.
+    await page.goto(clipboard)
+
+    await expect(hiddenButton).toBeInViewport()
   })
 })


### PR DESCRIPTION
Deep links to schema properties hidden inside collapsed sections didn't work. You needed `expandAllSchemaProperties` as a workaround.

Now the disclosures on the path to the linked property open themselves and the page scrolls to it.

Adds a component test and an e2e test that both failed before the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only navigation/deep-link behavior in api-reference with targeted tests; shared scroll state is cleared after scroll with a guard for concurrent navigations.
> 
> **Overview**
> Fixes **deep links to schema properties** that sit inside collapsed disclosures (nested objects and the “Show additional properties” overflow), so they work without turning on `expandAllSchemaProperties`.
> 
> The lazy scroll path now publishes the active anchor id in a shared **`scrollTargetId`** ref when `scrollToLazy` runs, and clears it after scroll succeeds or times out (without clobbering a newer navigation). **`Schema.vue`** treats disclosures whose dot-joined breadcrumb is a prefix of that id as **`defaultOpen`**, so the target property can mount and scroll into view.
> 
> Adds **unit tests** for path matching and unrelated branches staying collapsed, plus an **e2e** case for a property hidden behind the >12-properties collapse; lazy timer mocks are shared via **`mockLazyTimers`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e424668385fb66a28ef085f9b5267796d2fe1955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->