### PR TITLE
feat(api-reference): remove unused `isLoading` option

### DIFF
--- a/.changeset/remove-is-loading.md
+++ b/.changeset/remove-is-loading.md
@@ -1,0 +1,6 @@
+---
+'@scalar/types': patch
+'@scalar/schemas': patch
+---
+
+Remove the unused `isLoading` configuration option. It was never wired to a consumer, so it had no effect on the rendered references.

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -791,20 +791,6 @@ and each **value** specifies the visibility behavior for the clients of that lan
 }
 ```
 
-#### isLoading
-
-**Type:** `boolean`
-
-Controls whether the references show a loading state in the intro section. Useful when you want to indicate that content is being loaded.
-
-**Default:** `false`
-
-```javascript
-{
-  isLoading: true
-}
-```
-
 #### layout
 
 **Type:** `'modern' | 'classic'`

--- a/packages/schemas/src/api-reference/api-reference-configuration.ts
+++ b/packages/schemas/src/api-reference/api-reference-configuration.ts
@@ -43,10 +43,6 @@ export const apiReferenceConfigurationSchema = intersection([
       default: false,
       typeComment: 'Allows the user to inject an editor for the spec',
     }),
-    isLoading: boolean({
-      default: false,
-      typeComment: 'Controls whether the references show a loading state in the intro',
-    }),
     hideModels: boolean({
       default: false,
       typeComment: 'Whether to show models in the sidebar, search, and content.',

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -55,11 +55,6 @@ export const apiReferenceConfigurationSchema = baseConfigurationSchema.extend({
    */
   isEditable: z.boolean().optional().default(false).catch(false),
   /**
-   * Controls whether the references show a loading state in the intro
-   * @default false
-   */
-  isLoading: z.boolean().optional().default(false).catch(false),
-  /**
    * Whether to show models in the sidebar, search, and content.
    * @default false
    */

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -355,8 +355,6 @@ type ExtendedConfiguration = {
   plugins?: ApiReferencePlugin[]
   /** Allows the user to inject an editor for the spec */
   isEditable: boolean
-  /** Controls whether the references show a loading state in the intro */
-  isLoading: boolean
   /** Whether to show models in the sidebar, search, and content. */
   hideModels: boolean
   /** Label for the components.schemas section (`Models`, `Schemas`, or any custom string). */


### PR DESCRIPTION
`isLoading` was declared in the config types/schemas but never read by any consumer, so it had no effect on the rendered references. This removes it from the schema, types, and docs.

The internal `Tag` component prop of the same name is unrelated and stays.

Found while adding configuration test coverage (#9527).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead config removal only; no runtime behavior was wired to this option, though TypeScript users must drop the property from configs.
> 
> **Overview**
> Removes the **`isLoading`** API reference configuration option from **`@scalar/types`**, **`@scalar/schemas`**, and **`documentation/configuration.md`**, plus a patch changeset for both packages.
> 
> The option was documented as controlling an intro loading state but was never read by any consumer, so passing it had no effect. This is a **breaking type/schema surface** change for anyone who still set `isLoading` in config (behavior unchanged). Unrelated **`isLoading`** props elsewhere (e.g. internal **`Tag`**) are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a00df4dc2936a3498ebb8d64431a5ef8f8475405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->