### PR TITLE
fix(api-reference): use `generateHeadingSlug` in sidebar navigation

### DIFF
--- a/.changeset/honor-heading-slug.md
+++ b/.changeset/honor-heading-slug.md
@@ -1,0 +1,8 @@
+---
+'@scalar/workspace-store': minor
+'@scalar/api-reference': minor
+---
+
+Make sidebar navigation honor `generateHeadingSlug`, consistent with the other `generate*Slug` options. The custom value is now prefixed with `description/` (like `model/`, `tag/`, etc. are for the other generators), so clicking a description heading navigates to the custom slug instead of the plain anchor.
+
+Note: `generateHeadingSlug` should now return a bare slug segment (e.g. `heading.slug`) rather than a full hash like `#description/...`.

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -1155,19 +1155,19 @@ Custom [fetch function](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_A
 
 **Type:** `(heading: Heading) => string`
 
-Customize how heading URLs are generated. This function receives the heading and returns a string ID that controls the entire URL hash.
+Customize how heading URLs are generated. This function receives the heading and returns a string ID. Note that `description/` will automatically be prepended to the result.
 
 > Note: This must be passed through JavaScript, setting a data attribute will not work.
 
 ```javascript
 // Default behavior - results in hash: #description/heading-slug
 {
-  generateHeadingSlug: (heading) => `#description/${heading.slug}`
+  generateHeadingSlug: (heading) => heading.slug
 }
 
-// Custom example
+// Custom example - results in hash: #description/custom-heading-slug
 {
-  generateHeadingSlug: (heading) => `#custom-section/${heading.slug}`
+  generateHeadingSlug: (heading) => `custom-${heading.slug}`
 }
 ```
 

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -1244,8 +1244,8 @@ const showMCPButton = computed(() => {
           :eventBus
           :expandedItems="sidebarState.expandedItems.value"
           :headingSlugGenerator="
-            mergedConfig.generateHeadingSlug ??
-            ((heading) => `${activeSlug}/description/${heading.slug}`)
+            (heading) =>
+              `${activeSlug}/description/${mergedConfig.generateHeadingSlug?.({ slug: heading.slug }) ?? heading.slug}`
           "
           :infoSectionId
           :items="sidebarItems"

--- a/packages/api-reference/test/configuration/generate-heading-slug.e2e.ts
+++ b/packages/api-reference/test/configuration/generate-heading-slug.e2e.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test'
+import { serveExample } from '@test/utils/serve-example'
+
+const content = {
+  openapi: '3.1.1',
+  info: {
+    title: 'Test API',
+    version: '1.0.0',
+    // A level-2 sub-heading becomes a description heading entry in the sidebar
+    description: 'Some introduction text.\n\n## Overview\n\nMore details here.',
+  },
+  paths: {},
+}
+
+/** Expand the (collapsed) Introduction group and click the description heading. */
+const clickOverviewHeading = async (page: import('@playwright/test').Page) => {
+  await page.getByRole('navigation').getByRole('button', { name: 'Open Introduction' }).click()
+  await page.getByRole('navigation').getByRole('button', { name: 'Overview', exact: true }).click()
+}
+
+test.describe('generateHeadingSlug', () => {
+  test('uses the default description hash when not configured', async ({ page }) => {
+    const example = await serveExample({ content })
+
+    await page.goto(example)
+
+    await clickOverviewHeading(page)
+
+    await expect(page).toHaveURL(/#description\/overview/)
+  })
+
+  test('navigates to the custom heading slug', async ({ page }) => {
+    const example = await serveExample({
+      // The custom value is a bare slug segment; `description/` is prepended automatically
+      generateHeadingSlug: (heading: { slug?: string }) => `custom-${heading.slug}`,
+      content,
+    })
+
+    await page.goto(example)
+
+    await clickOverviewHeading(page)
+
+    await expect(page).toHaveURL(/#description\/custom-overview/)
+  })
+})

--- a/packages/workspace-store/src/navigation/get-navigation-options.test.ts
+++ b/packages/workspace-store/src/navigation/get-navigation-options.test.ts
@@ -100,7 +100,7 @@ describe('get-navigation-options', () => {
       depth: 1,
       value: 'Introduction',
     })
-    expect(id).toBe('custom-heading-intro')
+    expect(id).toBe('api/description/custom-heading-intro')
   })
 
   it('generates tag ID with default slug', () => {

--- a/packages/workspace-store/src/navigation/get-navigation-options.ts
+++ b/packages/workspace-store/src/navigation/get-navigation-options.ts
@@ -36,8 +36,11 @@ export const getNavigationOptions = (documentName: string, options?: NavigationO
 
     // -------- Default text id generation logic --------
     if (props.type === 'text') {
+      // Keep the `${documentId}/description/` prefix so heading ids round-trip
+      // through the URL the same way tags, models, operations, and webhooks do.
+      // The custom slug only replaces the trailing segment.
       if (options?.generateHeadingSlug) {
-        return options?.generateHeadingSlug({ slug: props.slug })
+        return `${documentId}/description/${options.generateHeadingSlug({ slug: props.slug })}`
       }
 
       if (props.slug) {


### PR DESCRIPTION
Sidebar navigation ignored `generateHeadingSlug`: clicking a description heading went to the plain anchor instead of the custom slug, unlike the other four `generate*Slug` options.

The cause is that the custom heading id was returned without the `${documentId}/description/` prefix the other generators get, so the URL round-trip (which strips the leading document segment) ate the custom part. This prefixes it consistently on both the navigation and content sides.

**Contract change:** `generateHeadingSlug` should now return a bare slug segment (e.g. `heading.slug`) rather than a full `#description/...` hash. Docs updated to match.

Verified in the browser: clicking a heading now navigates to `#description/custom-…`.

Note: the heading e2e test in #9527 asserts the old behavior and should be updated to assert the URL once this lands.

Found while adding configuration test coverage (#9527).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Minor semver bump reflects a breaking change for integrators who still return full `#description/...` hashes from `generateHeadingSlug`; navigation and deep-link behavior for description headings changes site-wide.
> 
> **Overview**
> Sidebar clicks on description headings now use **`generateHeadingSlug`** the same way as the other `generate*Slug` hooks, instead of falling back to the default anchor.
> 
> **`generateHeadingSlug` contract:** callers return only the trailing slug segment (e.g. `heading.slug` or `custom-${heading.slug}`). The framework prepends `${documentSlug}/description/` in **`getNavigationOptions`** (sidebar IDs) and in **`ApiReference.vue`** (content heading IDs), matching `model/`, `tag/`, etc.
> 
> Documentation and a Playwright e2e cover default and custom URL hashes (`#description/overview`, `#description/custom-overview`). Unit expectations in **`get-navigation-options.test.ts`** were updated for the prefixed IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fd9daf466ea7ec3153a34e72643b4ab7dfa9f7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->