### PR TITLE
fix(workspace-store): expand `deepObject` array params with trailing brackets

### DIFF
--- a/.changeset/deep-object-array-brackets.md
+++ b/.changeset/deep-object-array-brackets.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Serialize array values inside `deepObject` query parameters with the trailing bracket convention (`filter[ids][]=1&filter[ids][]=2`) instead of collapsing them into a single comma-joined value

--- a/.changeset/deep-object-array-brackets.md
+++ b/.changeset/deep-object-array-brackets.md
@@ -1,5 +1,6 @@
 ---
 '@scalar/workspace-store': patch
+'@scalar/api-client': patch
 ---
 
-Serialize array values inside `deepObject` query parameters with the trailing bracket convention (`filter[ids][]=1&filter[ids][]=2`) instead of collapsing them into a single comma-joined value
+Expand array values inside `deepObject` query parameters with the trailing bracket convention (`filter[ids][]=1&filter[ids][]=2`) instead of collapsing them into a single comma-joined value, both in the request and in the parameter table

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-parameters.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-parameters.test.ts
@@ -771,6 +771,37 @@ describe('parameter styles', () => {
         { name: 'tags', value: 'c' },
       ])
     })
+
+    it('expands nested arrays with the trailing bracket convention', () => {
+      // Regression test for https://github.com/scalar/scalar/issues/9492
+      const result = runProcessParameters({
+        harRequest: createHarRequest('/api/users'),
+        parameters: [
+          {
+            name: 'filters',
+            in: 'query',
+            required: true,
+            style: 'deepObject',
+            explode: true,
+            schema: coerceValue(SchemaObjectSchema, {
+              type: 'object',
+              properties: {
+                applicationInstanceId: {
+                  type: 'object',
+                  properties: { in: { type: 'array', items: { type: 'integer' } } },
+                },
+              },
+              example: { applicationInstanceId: { in: [1, 2] } },
+            }),
+          },
+        ],
+      })
+
+      expect(result.queryString).toEqual([
+        { name: 'filters[applicationInstanceId][in][]', value: '1' },
+        { name: 'filters[applicationInstanceId][in][]', value: '2' },
+      ])
+    })
   })
 
   describe('header parameters', () => {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -346,6 +346,59 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('ignores the display-only trailing brackets when renaming a deepObject array leaf', () => {
+    const parentParameter = {
+      name: 'filters',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+    } as const
+    const row: TableRow = {
+      name: 'filters[applicationInstanceId][in][]',
+      value: '1,2',
+      isDisabled: false,
+      originalParameter: parentParameter,
+      schema: { type: 'array', items: { type: 'string' } },
+      sourceParameterValuePath: ['applicationInstanceId', 'in'],
+    }
+    const onRenameExpandedRow = vi.fn()
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, {
+      context: [row],
+      onRenameExpandedRow,
+    })
+
+    // The user renames the leaf key; the trailing `[]` it still carries must not leak into the path.
+    handlers.upsert(0, {
+      name: 'filters[applicationInstanceId][notIn][]',
+      value: '1,2',
+      isDisabled: false,
+      shouldRenameExpandedRow: true,
+    })
+
+    expect(onRenameExpandedRow).toHaveBeenCalledWith(row, ['applicationInstanceId', 'notIn'])
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'filters',
+          value: {
+            applicationInstanceId: {
+              notIn: ['1', '2'],
+            },
+          },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-0',
+      },
+    )
+  })
+
   it('keeps expanded row values at their source path during partial key edits', () => {
     const parentParameter = {
       name: 'filter',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -180,6 +180,59 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('keeps form-style array leaves verbatim when an unrelated sibling row is edited', () => {
+    // Form-style object parameter (the query default) with an array property whose value carries a
+    // meaningful comma, e.g. Spring pageable `sort=username,asc`. Splitting it into ['username','asc']
+    // would change the emitted query, so the leaf must survive an unrelated edit untouched.
+    const parentParameter = {
+      name: 'pageable',
+      in: 'query',
+    } as const
+    const context: TableRow[] = [
+      {
+        name: 'sort',
+        value: 'username,asc',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        schema: { type: 'array', items: { type: 'string' } },
+        sourceParameterValuePath: ['sort'],
+      },
+      {
+        name: 'page',
+        value: '0',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        schema: { type: 'integer' },
+        sourceParameterValuePath: ['page'],
+      },
+    ]
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, { context })
+
+    // The user edits the unrelated "page" row.
+    handlers.upsert(1, { name: 'page', value: '1', isDisabled: false })
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'pageable',
+          value: {
+            sort: 'username,asc',
+            page: '1',
+          },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-1',
+      },
+    )
+  })
+
   it('renames a form-expanded property row by moving the value to the typed key', () => {
     const parentParameter = {
       name: 'filters',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -135,6 +135,51 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('stores array leaves of expanded deepObject rows as arrays, not comma-joined strings', () => {
+    const parentParameter = {
+      name: 'filters',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+    } as const
+    const context: TableRow[] = [
+      {
+        name: 'filters[applicationInstanceId][in][]',
+        // The table always shows the comma-joined display string for an array.
+        value: '1,2',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        schema: { type: 'array', items: { type: 'string' } },
+        sourceParameterValuePath: ['applicationInstanceId', 'in'],
+      },
+    ]
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, { context })
+
+    handlers.upsert(0, { name: 'filters[applicationInstanceId][in][]', value: '1,2', isDisabled: false })
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'filters',
+          value: {
+            applicationInstanceId: {
+              in: ['1', '2'],
+            },
+          },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-0',
+      },
+    )
+  })
+
   it('renames a form-expanded property row by moving the value to the typed key', () => {
     const parentParameter = {
       name: 'filters',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -180,6 +180,52 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('keeps a schema-less deepObject array leaf as an array via its trailing-bracket name', () => {
+    // Renamed and unmapped expanded rows carry no schema, but they keep the display-only `[]` marker.
+    // Editing such a leaf must still store an array so deepObject serialization repeats `key[]=...`.
+    const parentParameter = {
+      name: 'filters',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+    } as const
+    const context: TableRow[] = [
+      {
+        name: 'filters[applicationInstanceId][notIn][]',
+        value: '1,2',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        schema: undefined,
+        sourceParameterValuePath: ['applicationInstanceId', 'notIn'],
+      },
+    ]
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, { context })
+
+    handlers.upsert(0, { name: 'filters[applicationInstanceId][notIn][]', value: '3,4', isDisabled: false })
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'filters',
+          value: {
+            applicationInstanceId: {
+              notIn: ['3', '4'],
+            },
+          },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-0',
+      },
+    )
+  })
+
   it('keeps form-style array leaves verbatim when an unrelated sibling row is edited', () => {
     // Form-style object parameter (the query default) with an array property whose value carries a
     // meaningful comma, e.g. Spring pageable `sort=username,asc`. Splitting it into ['username','asc']

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -23,7 +23,13 @@ const parseBracketKey = (name: string): string[] => {
     segments.push(head)
   }
   for (const match of name.matchAll(/\[([^\]]*)\]/g)) {
-    segments.push(match[1] ?? '')
+    const segment = match[1] ?? ''
+    // Skip empty `[]` segments. The trailing brackets on a deepObject array leaf
+    // (`filters[id][in][]`) are display-only and are not part of the value path — keeping them would
+    // add a bogus empty key that drops the value on write-back and corrupts rename tracking.
+    if (segment !== '') {
+      segments.push(segment)
+    }
   }
   return segments
 }

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -89,11 +89,14 @@ const getExpandedObjectPayload = (
       : contextRow.sourceParameterValuePath
 
     // Rows always hold the string the user sees, so a deepObject array leaf arrives comma-joined
-    // ("1,2"). Coerce it back against the property schema before storing — otherwise deepObject
-    // serialization re-collapses it into a single `key[in]=1,2` entry instead of repeating
-    // `key[in][]=1&key[in][]=2`.
-    const leafValue =
-      isDeepObjectParameter && contextRow.schema ? deSerializeSchemaValue(nextValue, contextRow.schema) : nextValue
+    // ("1,2"). Coerce it back to an array before storing — otherwise deepObject serialization
+    // re-collapses it into a single `key[in]=1,2` entry instead of repeating `key[in][]=1&key[in][]=2`.
+    //
+    // The property schema is the primary signal, but renamed and unmapped rows clear it. Those rows
+    // still carry the display-only `[]` marker on their name, so fall back to it to keep recognizing
+    // the leaf as an array.
+    const leafSchema = contextRow.schema ?? (contextRow.name.endsWith('[]') ? ({ type: 'array' } as const) : undefined)
+    const leafValue = isDeepObjectParameter && leafSchema ? deSerializeSchemaValue(nextValue, leafSchema) : nextValue
 
     setValueAtPath(value, path, leafValue)
   }

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -58,6 +58,13 @@ const getExpandedObjectPayload = (
 ): { name: string; value: Record<string, unknown>; isDisabled: boolean } => {
   const value: Record<string, unknown> = {}
 
+  // Only deepObject leaves use the comma-to-array coercion below. The trailing-bracket array
+  // convention (`key[]=1&key[]=2`) is deepObject-specific, and deepObject leaves never carry a
+  // meaningful comma. Form-style object parameters can (e.g. Spring `sort=username,asc`), so they
+  // keep their leaves verbatim.
+  const parameter = row.originalParameter
+  const isDeepObjectParameter = Boolean(parameter && 'style' in parameter && parameter.style === 'deepObject')
+
   for (const contextRow of context) {
     if (contextRow.originalParameter !== row.originalParameter || !contextRow.sourceParameterValuePath) {
       continue
@@ -81,10 +88,12 @@ const getExpandedObjectPayload = (
         : contextRow.sourceParameterValuePath
       : contextRow.sourceParameterValuePath
 
-    // Rows always hold the string the user sees, so an array leaf arrives comma-joined ("1,2").
-    // Coerce it back against the property schema before storing — otherwise deepObject/form
-    // serialization re-collapses it into a single `key=1,2` entry instead of repeating `key[]=1&key[]=2`.
-    const leafValue = contextRow.schema ? deSerializeSchemaValue(nextValue, contextRow.schema) : nextValue
+    // Rows always hold the string the user sees, so a deepObject array leaf arrives comma-joined
+    // ("1,2"). Coerce it back against the property schema before storing — otherwise deepObject
+    // serialization re-collapses it into a single `key[in]=1,2` entry instead of repeating
+    // `key[in][]=1&key[in][]=2`.
+    const leafValue =
+      isDeepObjectParameter && contextRow.schema ? deSerializeSchemaValue(nextValue, contextRow.schema) : nextValue
 
     setValueAtPath(value, path, leafValue)
   }

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -1,5 +1,6 @@
 import { setValueAtPath } from '@scalar/helpers/object/set-value-at-path'
 import type { OperationExampleMeta, WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { deSerializeSchemaValue } from '@scalar/workspace-store/request-example'
 
 import type { TableRow } from '@/v2/blocks/request-block/components/RequestTableRow.vue'
 
@@ -74,7 +75,12 @@ const getExpandedObjectPayload = (
         : contextRow.sourceParameterValuePath
       : contextRow.sourceParameterValuePath
 
-    setValueAtPath(value, path, nextValue)
+    // Rows always hold the string the user sees, so an array leaf arrives comma-joined ("1,2").
+    // Coerce it back against the property schema before storing — otherwise deepObject/form
+    // serialization re-collapses it into a single `key=1,2` entry instead of repeating `key[]=1&key[]=2`.
+    const leafValue = contextRow.schema ? deSerializeSchemaValue(nextValue, contextRow.schema) : nextValue
+
+    setValueAtPath(value, path, leafValue)
   }
 
   return {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
@@ -184,6 +184,39 @@ describe('createParameterRows', () => {
     ])
   })
 
+  it('names an unmapped deepObject array leaf with the trailing bracket convention', () => {
+    // A value key the schema does not describe (e.g. after a rename) still serializes as an array,
+    // so the row must keep the `[]` marker even though it carries no schema.
+    const parameter: ParameterObject = {
+      name: 'filters',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+      schema: {
+        type: 'object',
+        properties: {
+          known: { type: 'string' },
+        },
+      },
+      examples: {
+        default: {
+          value: { notIn: [1, 2] },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    const rows = createParameterRows(parameter, 'default')
+    const unmapped = rows.find((row) => row.sourceParameterValuePath?.[0] === 'notIn')
+
+    expect(unmapped).toMatchObject({
+      name: 'filters[notIn][]',
+      value: '1,2',
+      schema: undefined,
+      sourceParameterValuePath: ['notIn'],
+    })
+  })
+
   it('round-trips edited expanded rows back through createParameterRows', () => {
     const parameter: ParameterObject = {
       name: 'pageable',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
@@ -139,6 +139,51 @@ describe('createParameterRows', () => {
     ])
   })
 
+  it('names deepObject array leaves with the trailing bracket convention', () => {
+    // Regression test for https://github.com/scalar/scalar/issues/9492
+    const inSchema = {
+      type: 'array',
+      items: { type: 'integer' },
+    } as const
+    const parameter: ParameterObject = {
+      name: 'filters',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+      schema: {
+        type: 'object',
+        properties: {
+          applicationInstanceId: {
+            type: 'object',
+            properties: {
+              in: inSchema,
+            },
+          },
+        },
+      },
+      examples: {
+        default: {
+          value: { applicationInstanceId: { in: [1, 2] } },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    expect(createParameterRows(parameter, 'default')).toStrictEqual([
+      {
+        name: 'filters[applicationInstanceId][in][]',
+        value: '1,2',
+        description: undefined,
+        schema: inSchema,
+        isRequired: false,
+        isDisabled: false,
+        originalParameter: parameter,
+        // The path stays bracket-free so edits reassemble the value object correctly.
+        sourceParameterValuePath: ['applicationInstanceId', 'in'],
+      },
+    ])
+  })
+
   it('round-trips edited expanded rows back through createParameterRows', () => {
     const parameter: ParameterObject = {
       name: 'pageable',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -8,7 +8,7 @@ import type {
   ReferenceType,
   SchemaObject,
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-import { isObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
+import { isArraySchema, isObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
 
 import type { TableRow } from '../components/RequestTableRow.vue'
 import { getParameterSchema } from './get-parameter-schema'
@@ -242,11 +242,21 @@ const getExpandedPropertyRows = ({
       })
     }
 
+    const leafValue = getValueAtPath(value, path)
+
+    // deepObject array values serialize with the trailing-bracket convention
+    // (filter[ids][]=1&filter[ids][]=2), so mirror that in the displayed name. We base this on the
+    // resolved value too, since the schema can be a composition (anyOf) that hides the array type.
+    // The bracket is display-only — `sourceParameterValuePath` stays bracket-free so write-back
+    // still reassembles the value object correctly.
+    const displayName =
+      mode === 'deepObject' && (isArraySchema(resolvedPropertySchema) || Array.isArray(leafValue)) ? `${name}[]` : name
+
     return [
       toTableRow({
         parameter,
-        name,
-        value: getValueAtPath(value, path),
+        name: displayName,
+        value: leafValue,
         description: resolvedPropertySchema.description ?? parameter.description,
         schema: resolvedPropertySchema,
         isRequired: requiredProperties.has(propertyName),

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -120,6 +120,15 @@ const toTableRow = ({
 const getExpandedRowName = (parameter: ParameterObject, path: string[], mode: ExpansionMode): string =>
   mode === 'deepObject' ? `${parameter.name}${path.map((segment) => `[${segment}]`).join('')}` : (path[0] ?? '')
 
+/**
+ * Appends the display-only trailing `[]` to deepObject array leaves so the name matches the
+ * serialized `parent[ids][]=1&parent[ids][]=2` form. The bracket is display-only — the row's
+ * `sourceParameterValuePath` stays bracket-free. It also lets write-back recognize the leaf as an
+ * array even on renamed and unmapped rows, which carry no schema.
+ */
+const withArrayBracket = (name: string, mode: ExpansionMode, isArray: boolean): string =>
+  mode === 'deepObject' && isArray ? `${name}[]` : name
+
 /** Build the single-row representation used when a parameter is not expanded. */
 const toSingleParameterRow = (
   parameter: ParameterObject,
@@ -199,12 +208,14 @@ const getExpandedPropertyRows = ({
       // The value move is debounced, so until it lands the value still sits at the old schema path.
       // Fall back to it so the renamed row shows its value immediately instead of flickering empty.
       const renamedValue = getValueAtPath(value, renamedTo)
+      const effectiveValue = renamedValue === undefined ? getValueAtPath(value, path) : renamedValue
 
       return [
         toTableRow({
           parameter,
-          name: getExpandedRowName(parameter, renamedTo, mode),
-          value: renamedValue === undefined ? getValueAtPath(value, path) : renamedValue,
+          // The renamed key carries no schema, so the value's array-ness drives the `[]` marker.
+          name: withArrayBracket(getExpandedRowName(parameter, renamedTo, mode), mode, Array.isArray(effectiveValue)),
+          value: effectiveValue,
           description: parameter.description,
           // The renamed key no longer maps to the schema property, so it carries no schema.
           schema: undefined,
@@ -247,10 +258,7 @@ const getExpandedPropertyRows = ({
     // deepObject array values serialize with the trailing-bracket convention
     // (filter[ids][]=1&filter[ids][]=2), so mirror that in the displayed name. We base this on the
     // resolved value too, since the schema can be a composition (anyOf) that hides the array type.
-    // The bracket is display-only — `sourceParameterValuePath` stays bracket-free so write-back
-    // still reassembles the value object correctly.
-    const displayName =
-      mode === 'deepObject' && (isArraySchema(resolvedPropertySchema) || Array.isArray(leafValue)) ? `${name}[]` : name
+    const displayName = withArrayBracket(name, mode, isArraySchema(resolvedPropertySchema) || Array.isArray(leafValue))
 
     return [
       toTableRow({
@@ -327,18 +335,21 @@ const getUnmappedValueRows = ({
   // only suppresses empty schema suggestions, so it is intentionally not applied here.
   return collectValueLeafPaths(value, mode)
     .filter((path) => !seen.has(toPathKey(path)))
-    .map((path) =>
-      toTableRow({
+    .map((path) => {
+      const leafValue = getValueAtPath(value, path)
+
+      return toTableRow({
         parameter,
-        name: getExpandedRowName(parameter, path, mode),
-        value: getValueAtPath(value, path),
+        // No schema describes these rows, so the value's array-ness drives the `[]` marker.
+        name: withArrayBracket(getExpandedRowName(parameter, path, mode), mode, Array.isArray(leafValue)),
+        value: leafValue,
         description: parameter.description,
         schema: undefined,
         isRequired: false,
         isDisabled,
         sourceParameterValuePath: path,
-      }),
-    )
+      })
+    })
 }
 
 /**

--- a/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.ts
+++ b/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.ts
@@ -13,7 +13,7 @@ export const deSerializeParameter = (example: unknown, param: ParameterObject) =
     return deSerializeContentExample(example, Object.keys(param.content ?? {})[0] ?? '')
   }
   if ('schema' in param) {
-    return deSerializeSchemaExample(example, param.schema)
+    return deSerializeSchemaValue(example, param.schema)
   }
 
   return example
@@ -76,12 +76,18 @@ const getStructuredType = (schema: unknown): 'array' | 'object' | undefined => {
 }
 
 /**
- * Schema-based parameters from the request editor.
+ * Coerces a single schema-typed value from the request editor (always a string from CodeInput)
+ * back into the structure its schema describes.
  *
- * Primitives (`string`, `integer`, `number`, `boolean`, `null`) are left as the typed string
+ * Primitives (`string`, `integer`, `number`, `boolean`, `null`) are left as the typed string.
  * Only `array` and `object` values are parsed so OpenAPI style serialization can expand them.
+ *
+ * Exposed on its own (not just through {@link deSerializeParameter}) so callers that reassemble an
+ * expanded object parameter from individual rows — e.g. a `deepObject` query parameter edited row by
+ * row in the API client — can coerce each leaf against its property schema. Otherwise an edited array
+ * leaf stays the comma-joined display string and collapses back into a single `key=1,2` entry.
  */
-const deSerializeSchemaExample = (example: unknown, schema: ParameterWithSchemaObject['schema']) => {
+export const deSerializeSchemaValue = (example: unknown, schema: ParameterWithSchemaObject['schema']) => {
   if (typeof example === 'string') {
     const type = getStructuredType(schema)
 

--- a/packages/workspace-store/src/request-example/builder/header/serialize-parameter.test.ts
+++ b/packages/workspace-store/src/request-example/builder/header/serialize-parameter.test.ts
@@ -743,6 +743,38 @@ describe('serializeDeepObjectStyle', () => {
     })
   })
 
+  describe('nested arrays', () => {
+    it('serializes nested arrays with the trailing bracket convention', () => {
+      // Regression test for https://github.com/scalar/scalar/issues/9492
+      // deepObject array values should expand to repeated `key[]` entries
+      // (filters[applicationInstanceId][in][]=1&filters[applicationInstanceId][in][]=2)
+      // instead of collapsing into a single comma-joined value.
+      const value = { applicationInstanceId: { in: [1, 2] } }
+      const result = serializeDeepObjectStyle('filters', value)
+      expect(result).toEqual([
+        { key: 'filters[applicationInstanceId][in][]', value: '1' },
+        { key: 'filters[applicationInstanceId][in][]', value: '2' },
+      ])
+    })
+
+    it('serializes a top-level array property with trailing brackets', () => {
+      const result = serializeDeepObjectStyle('filter', { tags: ['a', 'b'] })
+      expect(result).toEqual([
+        { key: 'filter[tags][]', value: 'a' },
+        { key: 'filter[tags][]', value: 'b' },
+      ])
+    })
+
+    it('keeps other properties alongside array values', () => {
+      const result = serializeDeepObjectStyle('filter', { ids: [1, 2], role: 'admin' })
+      expect(result).toEqual([
+        { key: 'filter[ids][]', value: '1' },
+        { key: 'filter[ids][]', value: '2' },
+        { key: 'filter[role]', value: 'admin' },
+      ])
+    })
+  })
+
   describe('edge cases', () => {
     it('handles empty objects', () => {
       const result = serializeDeepObjectStyle('filter', {})

--- a/packages/workspace-store/src/request-example/builder/header/serialize-parameter.ts
+++ b/packages/workspace-store/src/request-example/builder/header/serialize-parameter.ts
@@ -230,24 +230,36 @@ export const serializePipeDelimitedStyle = (value: unknown): string => {
  *
  * DeepObject: color[R]=100&color[G]=200&color[B]=150
  * Nested: user[name][first]=Alex&user[name][last]=Smith&user[role]=admin
+ * Arrays: filter[ids][]=1&filter[ids][]=2 (the common trailing-bracket convention)
  */
 export const serializeDeepObjectStyle = (paramName: string, value: unknown): Array<{ key: string; value: string }> => {
   const result: Array<{ key: string; value: string }> = []
+
+  /**
+   * Appends a single value at the given key, recursing into nested objects and arrays.
+   *
+   * Array values use the de-facto `key[]` convention (qs, PHP, Rails) so that each item becomes
+   * its own query entry instead of collapsing into a comma-joined string. The OpenAPI spec leaves
+   * deepObject-on-array undefined, but this matches what most servers expect.
+   */
+  const append = (fullKey: string, val: unknown): void => {
+    if (Array.isArray(val)) {
+      for (const item of val) {
+        append(`${fullKey}[]`, item)
+      }
+    } else if (typeof val === 'object' && val !== null) {
+      flatten(val as Record<string, unknown>, fullKey)
+    } else {
+      result.push({ key: fullKey, value: String(val) })
+    }
+  }
 
   /**
    * Recursively flattens nested objects into deepObject notation.
    */
   const flatten = (obj: Record<string, unknown>, prefix: string): void => {
     for (const [key, val] of Object.entries(obj)) {
-      const fullKey = `${prefix}[${key}]`
-
-      if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
-        // Recursively flatten nested objects
-        flatten(val as Record<string, unknown>, fullKey)
-      } else {
-        // Add primitive values
-        result.push({ key: fullKey, value: String(val) })
-      }
+      append(`${prefix}[${key}]`, val)
     }
   }
 

--- a/packages/workspace-store/src/request-example/builder/index.ts
+++ b/packages/workspace-store/src/request-example/builder/index.ts
@@ -10,7 +10,7 @@ export {
   buildRequest,
   resolveExecutableRequestUrl,
 } from './build-request'
-export { deSerializeParameter } from './header/de-serialize-parameter'
+export { deSerializeParameter, deSerializeSchemaValue } from './header/de-serialize-parameter'
 export { filterGlobalCookie } from './header/filter-global-cookies'
 export {
   serializeContentValue,

--- a/packages/workspace-store/src/request-example/index.ts
+++ b/packages/workspace-store/src/request-example/index.ts
@@ -25,6 +25,7 @@ export {
   buildRequest,
   buildRequestSecurity,
   deSerializeParameter,
+  deSerializeSchemaValue,
   filterGlobalCookie,
   getEnvironmentVariables,
   getExample,


### PR DESCRIPTION
Array values inside a `deepObject` query parameter were collapsed into one comma-joined value, so `filters[applicationInstanceId][in]` ended up as `...[in]=1,2` instead of repeated entries — and the parameter table showed the same bracket-less name.

Now array leaves use the common trailing-bracket convention (qs/PHP/Rails) in both the request and the table:

```
filters[applicationInstanceId][in][]=1&filters[applicationInstanceId][in][]=2
```

The bracket is display-only in the table; the underlying value path stays bracket-free so editing a row still works.

This covers the trailing-bracket part of the issue. The auto-suggested parameter renaming is handled separately in #9497.

## Ticket

Part of #9492

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes emitted query strings for deepObject array properties (intentional fix); scope is limited to deepObject coercion and serialization, with tests guarding form-style edge cases.
> 
> **Overview**
> Fixes **deepObject** query parameters so nested **array** values emit repeated `key[]=1&key[]=2` entries instead of a single comma-joined `key=1,2`, and keeps the API client parameter table aligned with that wire format.
> 
> **Serialization** (`serializeDeepObjectStyle`): arrays at any nesting depth now recurse with a trailing `[]` on each repeated entry (qs/PHP/Rails-style), including alongside non-array siblings.
> 
> **Parameter table**: expanded **deepObject** array leaves show names like `filters[applicationInstanceId][in][]` while `sourceParameterValuePath` stays bracket-free; unmapped/renamed rows still get `[]` when the value is an array.
> 
> **Write-back** (`create-parameter-handlers`): display-only empty `[]` segments are stripped when parsing bracket keys; only **deepObject** leaves coerce comma-joined display strings back to arrays via newly exported **`deSerializeSchemaValue`**—**form**-style object params (e.g. `sort=username,asc`) are left unchanged.
> 
> Regression coverage spans HAR/code samples, request building, and handler/row helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f11c9d182113b50a9d9b90c109b4dec727bcb6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->