### PR TITLE
chore: add @amritk as code owner for documentation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,6 +21,6 @@
 /packages/themes @marclave @hanspagel @amritk @bgrcs @hwkr @cameronrohani
 /packages/use-hooks @marclave @hanspagel @amritk @bgrcs @hwkr @cameronrohani
 /packages/use-toasts @marclave @hanspagel @amritk @bgrcs @hwkr @cameronrohani
-/documentation @marclave @hanspagel @bgrcs @hwkr @cameronrohani
+/documentation @marclave @hanspagel @amritk @bgrcs @hwkr @cameronrohani
 /scalar.config.json @marclave @hanspagel @bgrcs @hwkr @cameronrohani
 /*.md @marclave @hanspagel @bgrcs @hwkr @cameronrohani


### PR DESCRIPTION
Amrit can already approve `packages/mock-server` changes via the default rule, but his approval does not clear branch protection when a PR also touches `documentation/`. That path did not list him as a code owner. This adds him so doc changes (e.g. on mock-server PRs like #9486) can be approved by Amrit too.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only CODEOWNERS change with no runtime or application impact.
> 
> **Overview**
> Adds **@amritk** to the `/documentation` entry in `CODEOWNERS`, aligning that path with other Brynn + Cam package rules.
> 
> This lets Amrit’s review count toward required approvals when a PR changes docs (for example alongside `packages/mock-server`), instead of only the default `*` owners applying for non-doc paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b03b514ba63c56c7597343fcf3295c47acd1605b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->