### PR TITLE
fix(use-hooks): SSR hydration mismatch in color-mode toggle

### DIFF
--- a/.changeset/fix-color-mode-hydration.md
+++ b/.changeset/fix-color-mode-hydration.md
@@ -1,0 +1,5 @@
+---
+'@scalar/use-hooks': patch
+---
+
+Fix an SSR hydration mismatch in the color-mode toggle: the system preference is now resolved after mount so the first client render matches the server.

--- a/packages/use-hooks/src/useColorMode/useColorMode.test.ts
+++ b/packages/use-hooks/src/useColorMode/useColorMode.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
+import { nextTick, onMounted } from 'vue'
 
 import { useColorMode } from './useColorMode'
 
@@ -223,6 +223,28 @@ describe('useColorMode', () => {
 
     const { colorMode } = useColorMode({ initialColorMode: 'dark' })
     expect(colorMode.value).toBe('system')
+  })
+
+  it('defers the system preference to onMounted to stay hydration-safe', async () => {
+    // A dark system preference that, like the real one, only exists on the client.
+    vi.spyOn(window, 'matchMedia').mockImplementation(createMatchMediaMock('dark'))
+
+    // Capture the onMounted callback instead of running it right away, so we can
+    // inspect the pre-mount render that has to match the server.
+    let mountedCallback: (() => void) | undefined
+    vi.mocked(onMounted).mockImplementationOnce((fn) => {
+      mountedCallback = fn as () => void
+    })
+
+    const { darkLightMode } = useColorMode()
+
+    // Before mount it matches the server default, not the dark system preference.
+    expect(darkLightMode.value).toBe('light')
+
+    // After mount it upgrades to the real system preference.
+    mountedCallback?.()
+    await nextTick()
+    expect(darkLightMode.value).toBe('dark')
   })
 
   it('handles missing matchMedia gracefully', ({ onTestFinished }) => {

--- a/packages/use-hooks/src/useColorMode/useColorMode.test.ts
+++ b/packages/use-hooks/src/useColorMode/useColorMode.test.ts
@@ -31,6 +31,10 @@ describe('useColorMode', () => {
 
     // Provide a default matchMedia mock since jsdom does not implement it
     window.matchMedia = vi.fn().mockImplementation(createMatchMediaMock('light'))
+
+    // `systemPreference` is shared module state, so reset it to a fresh `'light'` baseline before
+    // each test. A throwaway hook resolves it via the immediate (mocked) `onMounted` above.
+    useColorMode()
   })
 
   it('defaults to system mode preference', () => {
@@ -245,6 +249,49 @@ describe('useColorMode', () => {
     mountedCallback?.()
     await nextTick()
     expect(darkLightMode.value).toBe('dark')
+  })
+
+  it('keeps the body class aligned with the toggle before mount', async () => {
+    // A dark system preference that only exists on the client (resolved in onMounted).
+    vi.spyOn(window, 'matchMedia').mockImplementation(createMatchMediaMock('dark'))
+
+    // Defer the mount so we can inspect the pre-mount render that has to match the server.
+    let mountedCallback: (() => void) | undefined
+    vi.mocked(onMounted).mockImplementationOnce((fn) => {
+      mountedCallback = fn as () => void
+    })
+
+    const { darkLightMode } = useColorMode()
+    await nextTick()
+
+    // Before mount the body must agree with the light toggle, not the dark system preference.
+    expect(darkLightMode.value).toBe('light')
+    expect(document.body.classList.contains('light-mode')).toBe(true)
+    expect(document.body.classList.contains('dark-mode')).toBe(false)
+
+    // After mount the body and the toggle upgrade to the real preference together.
+    mountedCallback?.()
+    await nextTick()
+    expect(darkLightMode.value).toBe('dark')
+    expect(document.body.classList.contains('dark-mode')).toBe(true)
+    expect(document.body.classList.contains('light-mode')).toBe(false)
+  })
+
+  it('shares the resolved system preference across instances', async () => {
+    vi.spyOn(window, 'matchMedia').mockImplementation(createMatchMediaMock('dark'))
+
+    // The first instance never mounts, so it still reports the server default on its own.
+    vi.mocked(onMounted).mockImplementationOnce(() => {})
+    const first = useColorMode()
+    expect(first.darkLightMode.value).toBe('light')
+
+    // A second instance mounts and resolves the real (dark) preference.
+    const second = useColorMode()
+    await nextTick()
+
+    // Because the preference is shared, the still-unmounted first instance agrees immediately.
+    expect(second.darkLightMode.value).toBe('dark')
+    expect(first.darkLightMode.value).toBe('dark')
   })
 
   it('handles missing matchMedia gracefully', ({ onTestFinished }) => {

--- a/packages/use-hooks/src/useColorMode/useColorMode.ts
+++ b/packages/use-hooks/src/useColorMode/useColorMode.ts
@@ -3,6 +3,18 @@ import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
 const colorMode = ref<ColorMode>('dark')
 
+/**
+ * Reactive snapshot of the system preference, shared across every `useColorMode` instance.
+ *
+ * It defaults to `'light'` so the first client render matches the server, where
+ * `window`/`matchMedia` do not exist. We resolve the real value in `onMounted` to avoid a
+ * hydration mismatch in anything bound to the color mode (for example the dark-mode toggle).
+ *
+ * It lives at module scope (like `colorMode`) so all instances agree on a single value instead
+ * of each holding its own copy that resolves at a different mount time.
+ */
+const systemPreference = ref<DarkLightMode>('light')
+
 const colorModeSchema = union([literal('system'), literal('dark'), literal('light')])
 
 /** Possible color modes */
@@ -57,16 +69,6 @@ export function useColorMode(
     return window?.matchMedia('(prefers-color-scheme: dark)')?.matches ? 'dark' : 'light'
   }
 
-  /**
-   * Reactive snapshot of the system preference.
-   *
-   * It defaults to `'light'` so the first client render matches the server,
-   * where `window`/`matchMedia` do not exist. We resolve the real value in
-   * `onMounted` to avoid a hydration mismatch in anything bound to the color
-   * mode (for example the dark-mode toggle).
-   */
-  const systemPreference = ref<DarkLightMode>('light')
-
   /** Writable computed ref for dark/light mode with system preference applied */
   const darkLightMode = computed<DarkLightMode>({
     get: () => (colorMode.value === 'system' ? systemPreference.value : colorMode.value),
@@ -80,12 +82,14 @@ export function useColorMode(
   })
 
   /** Applies the appropriate color mode class to the body. */
-  function applyColorMode(mode: ColorMode): void {
+  function applyColorMode(): void {
     if (typeof document === 'undefined' || typeof window === 'undefined') {
       return
     }
 
-    const classMode = overrideColorMode ?? (mode === 'system' ? getSystemModePreference() : mode)
+    // Read from the deferred `systemPreference` ref (not `getSystemModePreference()` directly) so
+    // the body class agrees with `darkLightMode`/the toggle before `onMounted` resolves the real value.
+    const classMode = overrideColorMode ?? (colorMode.value === 'system' ? systemPreference.value : colorMode.value)
 
     if (classMode === 'dark') {
       document.body.classList.add('dark-mode')
@@ -104,14 +108,12 @@ export function useColorMode(
 
   colorMode.value = overrideColorMode ?? savedColorMode ?? initialColorMode
 
-  // Watch for colorMode changes and update the body class
-  watch(colorMode, applyColorMode, { immediate: true })
+  // Watch for color mode or system preference changes and update the body class. Watching
+  // `systemPreference` means resolving it in `onMounted` (or an OS theme change) re-applies the class.
+  watch([colorMode, systemPreference], applyColorMode, { immediate: true })
 
   const handleChange = () => {
     systemPreference.value = getSystemModePreference()
-    if (colorMode.value === 'system') {
-      applyColorMode('system')
-    }
   }
 
   const mediaQuery = ref<MediaQueryList | null>(null)

--- a/packages/use-hooks/src/useColorMode/useColorMode.ts
+++ b/packages/use-hooks/src/useColorMode/useColorMode.ts
@@ -57,9 +57,19 @@ export function useColorMode(
     return window?.matchMedia('(prefers-color-scheme: dark)')?.matches ? 'dark' : 'light'
   }
 
+  /**
+   * Reactive snapshot of the system preference.
+   *
+   * It defaults to `'light'` so the first client render matches the server,
+   * where `window`/`matchMedia` do not exist. We resolve the real value in
+   * `onMounted` to avoid a hydration mismatch in anything bound to the color
+   * mode (for example the dark-mode toggle).
+   */
+  const systemPreference = ref<DarkLightMode>('light')
+
   /** Writable computed ref for dark/light mode with system preference applied */
   const darkLightMode = computed<DarkLightMode>({
-    get: () => (colorMode.value === 'system' ? getSystemModePreference() : colorMode.value),
+    get: () => (colorMode.value === 'system' ? systemPreference.value : colorMode.value),
     set: setColorMode,
   })
 
@@ -97,11 +107,20 @@ export function useColorMode(
   // Watch for colorMode changes and update the body class
   watch(colorMode, applyColorMode, { immediate: true })
 
-  const handleChange = () => colorMode.value === 'system' && applyColorMode('system')
+  const handleChange = () => {
+    systemPreference.value = getSystemModePreference()
+    if (colorMode.value === 'system') {
+      applyColorMode('system')
+    }
+  }
 
   const mediaQuery = ref<MediaQueryList | null>(null)
   // Listen to system preference changes
   onMounted(() => {
+    // Now that we are on the client, resolve the real system preference so the
+    // color mode updates after hydration instead of mismatching the server.
+    systemPreference.value = getSystemModePreference()
+
     if (typeof window !== 'undefined' && typeof window?.matchMedia === 'function') {
       mediaQuery.value = window.matchMedia('(prefers-color-scheme: dark)')
       mediaQuery.value?.addEventListener('change', handleChange)


### PR DESCRIPTION
The dark-mode toggle read the system preference (`matchMedia`) during render, so the server sent light and a dark-preferring client hydrated dark — a mismatch. Now we default to the server value and resolve the real preference in `onMounted`.

Part of #4458

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Theming/SSR-only behavior change in `@scalar/use-hooks`, covered by new unit tests; users on system-dark may see a brief light state after hydration before the preference applies.
> 
> **Overview**
> Fixes an SSR hydration mismatch when color mode is **system**: the hook no longer reads `matchMedia` during the first render, so the client’s initial HTML matches the server (which effectively renders as light).
> 
> **`useColorMode`** now keeps a shared module-level **`systemPreference`** ref defaulting to `'light'`. **`darkLightMode`**, body **`light-mode`/`dark-mode`** classes, and the color-mode toggle all use that ref instead of calling **`getSystemModePreference()`** synchronously. The real OS preference is set in **`onMounted`**, and OS theme changes update the same ref (with **`watch`** on **`colorMode`** + **`systemPreference`** driving **`applyColorMode`**).
> 
> Tests assert pre-mount vs post-mount behavior, body class alignment, and that multiple hook instances share one resolved preference. Changeset: patch for **`@scalar/use-hooks`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c0ced70b6728e5bdc8c05582b58209c3043d8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->