### PR TITLE
fix(api-reference): SSR hydration mismatch from obtrusive scrollbar class

### DIFF
--- a/.changeset/fix-scrollbar-hydration.md
+++ b/.changeset/fix-scrollbar-hydration.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix an SSR hydration mismatch on the root element: the obtrusive-scrollbar class is now resolved after mount so the first client render matches the server.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -151,7 +151,17 @@ const { copyToClipboard } = useClipboard()
  */
 const isDevelopment = import.meta.env.DEV
 
-const obtrusiveScrollbars = computed(hasObtrusiveScrollbars)
+/**
+ * Whether scrollbars take up screen real estate.
+ *
+ * This defaults to `false` so the first client render matches the server (where
+ * there is no DOM to measure). The real value is resolved in `onMounted` to
+ * avoid a hydration mismatch on the root class.
+ */
+const obtrusiveScrollbars = ref(false)
+onMounted(() => {
+  obtrusiveScrollbars.value = hasObtrusiveScrollbars()
+})
 
 const eventBus = createWorkspaceEventBus({ debug: isDevelopment })
 const isSidebarOpen = ref(false)


### PR DESCRIPTION
Detecting obtrusive scrollbars needs the DOM, so the value was `false` on the server and `true` on the client, mismatching the root element class during hydration. Now it defaults to `false` and is resolved in `onMounted`.

Part of #4458

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small timing change for a CSS class; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes an **SSR hydration mismatch** on the API reference root element when `hasObtrusiveScrollbars()` disagrees between server and first client paint.
> 
> **`obtrusiveScrollbars`** is no longer a `computed` that calls the DOM probe during setup. It is a **`ref(false)`** so the initial client render matches the server (no DOM). The real value is set in **`onMounted`** via `hasObtrusiveScrollbars()`, which toggles **`scalar-scrollbars-obtrusive`** only after hydration.
> 
> Patch release noted in the changeset for `@scalar/api-reference`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e69fa7ab30a0316d5aff7c087d8111bee1facc7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->