### PR TITLE
fix(api-reference): SSR hydration mismatch in injected style tag

### DIFF
--- a/.changeset/fix-style-escaping-hydration.md
+++ b/.changeset/fix-style-escaping-hydration.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix an SSR hydration mismatch in the injected `<style>` tag: the CSS is now rendered verbatim instead of being HTML-escaped on the server (`"` became `&quot;`), which broke font styles and caused a hydration mismatch.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -261,6 +261,18 @@ const themeStyle = computed(() =>
   }),
 )
 
+/**
+ * Custom CSS plus the theme styles, injected into a single `<style>` tag.
+ *
+ * This is rendered with `v-html` so the CSS is emitted verbatim. Interpolating
+ * it as text content makes Vue HTML-escape characters like `"` into `&quot;` on
+ * the server while the client keeps `"`, which both breaks the CSS and causes a
+ * hydration mismatch.
+ */
+const styleContent = computed(
+  () => `${mergedConfig.value.customCss ?? ''}\n${themeStyle.value}`,
+)
+
 /** Plugin injection is not reactive. All plugins must be provided at first render */
 const pluginManager = createPluginManager({
   plugins: Object.values(configList.value).flatMap(
@@ -1145,10 +1157,9 @@ const showMCPButton = computed(() => {
   <!-- SingleApiReference -->
   <div>
     <!-- Inject any custom CSS directly into a style tag -->
-    <component :is="'style'">
-      {{ mergedConfig.customCss }}
-      {{ themeStyle }}
-    </component>
+    <component
+      :is="'style'"
+      v-html="styleContent" />
     <div
       ref="documentEl"
       class="scalar-app scalar-api-reference references-layout"


### PR DESCRIPTION
The theme/custom CSS was interpolated as text into a `<style>` tag, so Vue HTML-escaped characters like `"` into `&quot;` on the server while the client kept `"`. That broke the font CSS and triggered a hydration mismatch. Now the CSS is rendered with `v-html` so it is emitted verbatim on both sides.

Verified in a dev-mode SSR repro: the `Hydration text mismatch in [node HTMLStyleElement]` warning is gone.

Part of #4458

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small rendering change limited to how existing theme/custom CSS is injected; no new data paths or security-sensitive logic.
> 
> **Overview**
> Fixes **SSR hydration** for the API reference’s injected theme/custom CSS by emitting CSS verbatim in the `<style>` tag instead of as escaped text content.
> 
> **`ApiReference.vue`** adds a `styleContent` computed that concatenates `customCss` and `getThemeStyles` output, and binds it with **`v-html`** on the dynamic `<style>` component. Previously, interpolating CSS as text made Vue HTML-escape quotes on the server (`"` → `&quot;`) while the client kept raw CSS, which broke font-related rules and triggered a `HTMLStyleElement` hydration mismatch.
> 
> Patch release noted in **`.changeset/fix-style-escaping-hydration.md`** for `@scalar/api-reference`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54d8266ee388fbd3425397ae95ac3dca60f9b5fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->