### PR TITLE
feat(api-reference): sync example pickers across operations

### DIFF
--- a/.changeset/sync-example-selection.md
+++ b/.changeset/sync-example-selection.md
@@ -1,0 +1,7 @@
+---
+'@scalar/workspace-store': minor
+'@scalar/api-client': minor
+'@scalar/api-reference': minor
+---
+
+Keep request and response example pickers in sync across operations. Selecting an example (e.g. "Use case 1") now selects the example with the same key on every other operation that defines it, mirroring how the programming-language selection already syncs. Operations that do not have a matching example keep their current selection.

--- a/.changeset/sync-example-selection.md
+++ b/.changeset/sync-example-selection.md
@@ -1,7 +1,7 @@
 ---
-'@scalar/workspace-store': minor
-'@scalar/api-client': minor
-'@scalar/api-reference': minor
+'@scalar/workspace-store': patch
+'@scalar/api-client': patch
+'@scalar/api-reference': patch
 ---
 
 Keep request and response example pickers in sync across operations. Selecting an example (e.g. "Use case 1") now selects the example with the same key on every other operation that defines it, mirroring how the programming-language selection already syncs. Operations that do not have a matching example keep their current selection.

--- a/packages/api-client/src/plugins/posthog/sanitize-event-payload.test.ts
+++ b/packages/api-client/src/plugins/posthog/sanitize-event-payload.test.ts
@@ -193,6 +193,7 @@ describe('TRACKED_EVENTS', () => {
     'workspace:update:color-mode',
     'workspace:update:theme',
     'workspace:update:selected-client',
+    'workspace:update:selected-example',
     'workspace:update:active-proxy',
     'workspace:update:active-environment',
     'update:dark-mode',

--- a/packages/api-client/src/plugins/posthog/sanitize-event-payload.ts
+++ b/packages/api-client/src/plugins/posthog/sanitize-event-payload.ts
@@ -107,6 +107,7 @@ export const TRACKED_EVENTS: TrackedEventsMap = {
   'workspace:update:color-mode': empty,
   'workspace:update:theme': empty,
   'workspace:update:selected-client': empty,
+  'workspace:update:selected-example': empty,
   'workspace:update:active-proxy': (payload) => ({ enabled: !!payload }),
   'workspace:update:active-environment': empty,
 

--- a/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.test.ts
@@ -456,6 +456,43 @@ describe('RequestExample', () => {
       expect(emitted?.[emitted.length - 1]).toEqual(['example2'])
     })
 
+    it('follows the document-wide selection after a content-type change when the new type has that example', async () => {
+      const operation: OperationObject = {
+        requestBody: {
+          content: {
+            'application/json': {
+              examples: {
+                jsonOnly: { value: { a: 1 } },
+              },
+            },
+            'text/plain': {
+              examples: {
+                // First key differs from the synced selection, so a naive reset would pick "other"
+                other: { value: 'other' },
+                shared: { value: 'shared' },
+              },
+            },
+          },
+        },
+      }
+
+      const wrapper = mount(RequestExample, {
+        props: {
+          ...defaultProps,
+          operation,
+          selectedContentType: 'application/json',
+          selectedExample: 'shared',
+        },
+      })
+
+      // Switch to a content type whose first example is not the synced one, but which still has it
+      await wrapper.setProps({ selectedContentType: 'text/plain' })
+      await nextTick()
+
+      const emitted = wrapper.emitted('update:exampleKey')
+      expect(emitted?.[emitted.length - 1]).toEqual(['shared'])
+    })
+
     it('selects first example by default when no example is provided', () => {
       const wrapper = mount(RequestExample, {
         props: {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.test.ts
@@ -401,6 +401,61 @@ describe('RequestExample', () => {
       }
     })
 
+    it('emits update:exampleKey with the resolved key on mount', () => {
+      const wrapper = mount(RequestExample, {
+        props: {
+          ...defaultProps,
+          selectedContentType: 'application/json',
+        },
+      })
+
+      const emitted = wrapper.emitted('update:exampleKey')
+      expect(emitted?.[emitted.length - 1]).toEqual(['example1'])
+    })
+
+    it('emits update:exampleKey with the document-wide selection when the operation has it', () => {
+      const wrapper = mount(RequestExample, {
+        props: {
+          ...defaultProps,
+          selectedContentType: 'application/json',
+          selectedExample: 'example2',
+        },
+      })
+
+      const emitted = wrapper.emitted('update:exampleKey')
+      expect(emitted?.[emitted.length - 1]).toEqual(['example2'])
+    })
+
+    it('emits update:exampleKey with the local key when the operation lacks the document-wide selection', () => {
+      const wrapper = mount(RequestExample, {
+        props: {
+          ...defaultProps,
+          selectedContentType: 'application/json',
+          // This operation does not define a "missing" example, so it should keep its own first one
+          selectedExample: 'missing',
+        },
+      })
+
+      const emitted = wrapper.emitted('update:exampleKey')
+      expect(emitted?.[emitted.length - 1]).toEqual(['example1'])
+    })
+
+    it('emits update:exampleKey when the user picks an example', async () => {
+      const wrapper = mount(RequestExample, {
+        props: {
+          ...defaultProps,
+          selectedContentType: 'application/json',
+        },
+      })
+
+      const examplePicker = wrapper.findComponent({ name: 'ExamplePicker' })
+      await examplePicker.vm.$emit('update:modelValue', 'example2')
+      await nextTick()
+
+      const emitted = wrapper.emitted('update:exampleKey')
+      expect(emitted?.[emitted.length - 1]).toEqual(['example2'])
+    })
+
     it('selects first example by default when no example is provided', () => {
       const wrapper = mount(RequestExample, {
         props: {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.vue
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.vue
@@ -31,7 +31,11 @@ export type OperationCodeSampleProps = {
    */
   selectedContentType?: string
   /**
-   * Example name to use for resolving example values for parameters AND requestBody
+   * Example name to use for resolving example values for parameters AND requestBody.
+   *
+   * This is the document-wide selection: it is honored only when this operation defines an example
+   * with the same key, so picking an example on one operation syncs the rest without blanking out
+   * operations that do not share that key.
    *
    * @example "limited"
    * ```ts
@@ -109,7 +113,7 @@ export type OperationCodeSampleProps = {
  * this component does not have much of its own state but operates on props and custom events
  *
  * @event workspace:update:selected-client - Emitted when the selected client changes
- * @event scalar-update-selected-example - removed for now, we can bring it back when we need it
+ * @event workspace:update:selected-example - Emitted when the selected example changes, so other operations can sync
  */
 export default {}
 </script>
@@ -167,6 +171,7 @@ const {
   selectedClient,
   selectedServer = null,
   selectedContentType,
+  selectedExample,
   securitySchemes = [],
   method,
   eventBus,
@@ -194,27 +199,58 @@ const requestBodyExamples = computed(() => {
   return examples
 })
 
-/** The currently selected example key with v-model support */
-const selectedExampleKey = defineModel<string>('selectedExample', {
-  default: '',
+/**
+ * The example key actually shown for this operation.
+ *
+ * `selectedExample` is the document-wide selection that syncs across operations. We honor it only
+ * when this operation actually defines that key, otherwise we keep the local example: a selection
+ * on one operation should never blank out an operation that does not share the same example.
+ */
+const localExampleKey = ref('')
+
+/** Resolve the key to display, preferring the document-wide selection when this operation has it */
+const resolveExampleKey = (preferred: string | undefined): string => {
+  const keys = Object.keys(requestBodyExamples.value)
+  if (preferred && keys.includes(preferred)) {
+    return preferred
+  }
+  // Keep the current local example when it is still valid, otherwise fall back to the first one
+  if (localExampleKey.value && keys.includes(localExampleKey.value)) {
+    return localExampleKey.value
+  }
+  return keys[0] ?? ''
+}
+
+// Set the initial example from the document-wide selection, falling back to the first example
+onBeforeMount(() => {
+  localExampleKey.value = resolveExampleKey(selectedExample)
 })
 
-// Set default value to the first example
-onBeforeMount(() => {
-  selectedExampleKey.value ||= Object.keys(requestBodyExamples.value)[0] ?? ''
-})
+// Follow the document-wide selection when it changes and this operation has that example
+watch(
+  () => selectedExample,
+  (preferred) => {
+    localExampleKey.value = resolveExampleKey(preferred)
+  },
+)
 
 /** Reset the selected example key if the content type changes and the new content type doesn't have the previously selected example */
 watch(
   () => selectedContentType,
   () => {
     if (
-      !Object.keys(requestBodyExamples.value).includes(selectedExampleKey.value)
+      !Object.keys(requestBodyExamples.value).includes(localExampleKey.value)
     ) {
-      selectedExampleKey.value = Object.keys(requestBodyExamples.value)[0] ?? ''
+      localExampleKey.value = Object.keys(requestBodyExamples.value)[0] ?? ''
     }
   },
 )
+
+/** Select an example locally and sync the choice across the document */
+const selectExample = (key: string) => {
+  localExampleKey.value = key
+  eventBus.emit('workspace:update:selected-example', key)
+}
 
 /** Grab any custom code samples from the operation */
 const customCodeSamples = computed(() => getCustomCodeSamples(operation))
@@ -260,7 +296,7 @@ const webhookHar = computed(() => {
       operation,
       method,
       path,
-      example: selectedExampleKey.value,
+      example: localExampleKey.value,
       requestBodyCompositionSelection,
       defaultDisabledParameters: false,
     })
@@ -287,7 +323,7 @@ const generatedCode = computed<string>(() => {
     contentType: selectedContentType,
     server: selectedServer,
     securitySchemes,
-    example: selectedExampleKey.value,
+    example: localExampleKey.value,
     globalCookies,
     requestBodyCompositionSelection,
   })
@@ -434,14 +470,15 @@ const id = useId()
         class="request-card-footer-addon">
         <template v-if="Object.keys(requestBodyExamples).length">
           <ExamplePicker
-            v-model="selectedExampleKey"
-            :examples="requestBodyExamples" />
+            :examples="requestBodyExamples"
+            :modelValue="localExampleKey"
+            @update:modelValue="selectExample" />
         </template>
       </div>
 
       <!-- Footer -->
       <slot
-        :exampleName="selectedExampleKey"
+        :exampleName="localExampleKey"
         name="footer" />
     </ScalarCardFooter>
   </ScalarCard>
@@ -459,7 +496,7 @@ const id = useId()
         <slot name="header" />
       </div>
       <slot
-        :exampleName="selectedExampleKey"
+        :exampleName="localExampleKey"
         name="footer" />
     </ScalarCardSection>
   </ScalarCard>

--- a/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.vue
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.vue
@@ -147,6 +147,7 @@ import {
   ref,
   useId,
   watch,
+  watchEffect,
   type ComponentPublicInstance,
 } from 'vue'
 
@@ -182,6 +183,17 @@ const {
   globalCookies,
   requestBodyCompositionSelection,
 } = defineProps<OperationCodeSampleProps>()
+
+const emit = defineEmits<{
+  /**
+   * Emitted whenever the example key actually shown for this operation changes.
+   *
+   * This is the resolved local key (not the raw document-wide selection), so layouts that render
+   * the test-request button outside this component can open the client with the same example the
+   * snippet displays.
+   */
+  (e: 'update:exampleKey', value: string): void
+}>()
 
 defineSlots<{
   header: () => unknown
@@ -245,6 +257,12 @@ watch(
     }
   },
 )
+
+// Keep the parent informed of the resolved key so a test-request button rendered outside this
+// component (e.g. the classic layout header) opens the client with the example the snippet shows
+watchEffect(() => {
+  emit('update:exampleKey', localExampleKey.value)
+})
 
 /** Select an example locally and sync the choice across the document */
 const selectExample = (key: string) => {

--- a/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.vue
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/components/OperationCodeSample.vue
@@ -253,7 +253,9 @@ watch(
     if (
       !Object.keys(requestBodyExamples.value).includes(localExampleKey.value)
     ) {
-      localExampleKey.value = Object.keys(requestBodyExamples.value)[0] ?? ''
+      // Re-resolve so the new content type still follows the document-wide selection when it has
+      // that key, instead of always snapping back to the first example
+      localExampleKey.value = resolveExampleKey(selectedExample)
     }
   },
 )

--- a/packages/api-client/src/v2/workspace-events.ts
+++ b/packages/api-client/src/v2/workspace-events.ts
@@ -92,6 +92,13 @@ export function initializeWorkspaceEventHandlers({
       hooks,
     )(payload),
   )
+  eventBus.on('workspace:update:selected-example', (payload) =>
+    withHook(
+      'workspace:update:selected-example',
+      mutators.value.workspace().workspace.updateSelectedExample,
+      hooks,
+    )(payload),
+  )
   eventBus.on('workspace:update:active-environment', (payload) =>
     withHook(
       'workspace:update:active-environment',

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -1302,6 +1302,9 @@ const showMCPButton = computed(() => {
           :options="mergedConfig"
           :xScalarDefaultClient="
             clientStore.workspace['x-scalar-default-client']
+          "
+          :xScalarDefaultExample="
+            clientStore.workspace['x-scalar-default-example']
           ">
           <template #start>
             <!-- Placeholder intersection observer that emits an empty string to clear the hash when scrolled to the top -->

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -86,6 +86,7 @@ const {
   clientDocument: WorkspaceDocument | undefined
   authStore: AuthStore
   xScalarDefaultClient: Workspace['x-scalar-default-client']
+  xScalarDefaultExample: Workspace['x-scalar-default-example']
   items: TraversedEntryType[]
   expandedItems: Record<string, boolean>
   eventBus: WorkspaceEventBus
@@ -302,6 +303,7 @@ onMounted(() => {
       :options
       :securitySchemes
       :selectedClient="xScalarDefaultClient"
+      :selectedExample="xScalarDefaultExample"
       :selectedServer>
     </TraversedEntry>
 

--- a/packages/api-reference/src/components/Content/Operations/TraversedEntry.test.ts
+++ b/packages/api-reference/src/components/Content/Operations/TraversedEntry.test.ts
@@ -126,6 +126,7 @@ const makeMockProps = (entries: TraversedEntry[]): ComponentProps<typeof Travers
   entries,
   selectedServer: mockServer,
   selectedClient: mockStore.workspace['x-scalar-default-client'],
+  selectedExample: mockStore.workspace['x-scalar-default-example'],
   expandedItems: {},
   securitySchemes: {},
   eventBus,

--- a/packages/api-reference/src/components/Content/Operations/TraversedEntry.vue
+++ b/packages/api-reference/src/components/Content/Operations/TraversedEntry.vue
@@ -63,6 +63,8 @@ const {
   securitySchemes: MergedSecuritySchemes
   /** Currently selected http client for the document */
   selectedClient: WorkspaceStore['workspace']['x-scalar-default-client']
+  /** Currently selected example key, shared across operations for in-sync example pickers */
+  selectedExample: WorkspaceStore['workspace']['x-scalar-default-example']
   /** Used to determine if an entry is collapsed */
   expandedItems: Record<string, boolean>
   /** The event bus for the handling all events. */
@@ -128,6 +130,7 @@ function getPathValue(entry: TraversedOperation | TraversedWebhook) {
         :pathValue="getPathValue(entry)"
         :securitySchemes="securitySchemes"
         :selectedClient="selectedClient"
+        :selectedExample="selectedExample"
         :server="selectedServer" />
     </SectionContainer>
 
@@ -153,6 +156,7 @@ function getPathValue(entry: TraversedOperation | TraversedWebhook) {
           :options
           :securitySchemes
           :selectedClient
+          :selectedExample
           :selectedServer>
         </TraversedEntry>
       </template>
@@ -179,6 +183,7 @@ function getPathValue(entry: TraversedOperation | TraversedWebhook) {
         :options
         :securitySchemes
         :selectedClient
+        :selectedExample
         :selectedServer>
       </TraversedEntry>
     </div>
@@ -202,6 +207,7 @@ function getPathValue(entry: TraversedOperation | TraversedWebhook) {
         :options
         :securitySchemes
         :selectedClient
+        :selectedExample
         :selectedServer>
       </TraversedEntry>
     </ModelTag>

--- a/packages/api-reference/src/features/Operation/Operation.test.ts
+++ b/packages/api-reference/src/features/Operation/Operation.test.ts
@@ -78,6 +78,7 @@ const mountOperationWithConfig = (
     authStore: workspaceStore.auth,
     isWebhook: false,
     selectedClient: 'c/fetch',
+    selectedExample: '',
     eventBus,
   }
 

--- a/packages/api-reference/src/features/Operation/Operation.vue
+++ b/packages/api-reference/src/features/Operation/Operation.vue
@@ -37,6 +37,8 @@ export type OperationProps = {
   isWebhook: boolean
   /** The currently selected client for the document */
   selectedClient: WorkspaceStore['workspace']['x-scalar-default-client']
+  /** The currently selected example key, shared across operations for in-sync example pickers */
+  selectedExample: WorkspaceStore['workspace']['x-scalar-default-example']
   /** The event bus */
   eventBus: WorkspaceEventBus
   /** The auth store */
@@ -159,6 +161,7 @@ const selectedSecuritySchemes = computed(() =>
       :path
       :requiredSecurity
       :selectedClient
+      :selectedExample
       :selectedSecuritySchemes
       :selectedServer />
     <ModernLayout
@@ -174,6 +177,7 @@ const selectedSecuritySchemes = computed(() =>
       :path
       :requiredSecurity
       :selectedClient
+      :selectedExample
       :selectedSecuritySchemes
       :selectedServer />
   </template>

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.test.ts
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.test.ts
@@ -135,6 +135,7 @@ const props: ExtractComponentProps<typeof ClassicLayout> = {
   path: '/widgets',
   requiredSecurity,
   selectedClient: 'shell/curl',
+  selectedExample: '',
   selectedSecuritySchemes: [],
   selectedServer,
 }

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.test.ts
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.test.ts
@@ -254,4 +254,47 @@ describe('ClassicLayout', () => {
     const codeSample = wrapper.findComponent({ name: 'OperationCodeSample' })
     expect(codeSample.props('selectedContentType')).toBe('application/x-www-form-urlencoded')
   })
+
+  it('opens the test request with the example shown in the snippet, even when the document-wide selection is missing', async () => {
+    const exampleProps: ExtractComponentProps<typeof ClassicLayout> = {
+      ...props,
+      id: 'create-widget-examples',
+      // The document-wide selection points at an example this operation does not define
+      selectedExample: 'missing',
+      options: { ...props.options, hideTestRequestButton: false },
+      operation: {
+        ...operation,
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              examples: {
+                first: { value: { foo: 'bar' } },
+                second: { value: { foo: 'baz' } },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const wrapper = mount(ClassicLayout, {
+      props: exampleProps,
+      global: {
+        stubs: {
+          RouterLink: {
+            name: 'RouterLink',
+            template: '<a><slot /></a>',
+          },
+        },
+      },
+    })
+
+    await nextTick()
+
+    const testButton = wrapper.findComponent({ name: 'TestRequestButton' })
+    expect(testButton.exists()).toBe(true)
+    // The button mirrors the snippet's resolved key (first example), not the missing document-wide one
+    expect(testButton.props('exampleName')).toBe('first')
+  })
 })

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -59,6 +59,7 @@ const {
   selectedServer,
   selectedSecuritySchemes,
   selectedClient,
+  selectedExample,
 } = defineProps<
   Omit<
     OperationProps,
@@ -79,9 +80,6 @@ const {
 
 const operationTitle = computed(() => operation.summary || path || '')
 const operationExtensions = computed(() => getXKeysFromObject(operation))
-
-/** Track the currently selected example for passing to the modal */
-const selectedExampleKey = ref<string>('')
 
 /** Track the selected request body content type so the code sample stays in sync */
 const selectedRequestBodyContentType = ref<string | undefined>()
@@ -170,7 +168,7 @@ const { copyToClipboard } = useClipboard()
           v-if="active && !isWebhook"
           :id
           :eventBus
-          :exampleName="selectedExampleKey"
+          :exampleName="selectedExample"
           :method
           :path
           :requestBodyCompositionSelection="
@@ -245,7 +243,9 @@ const { copyToClipboard } = useClipboard()
       <ExampleResponses
         v-if="operation.responses"
         class="operation-example-card"
-        :responses="operation.responses" />
+        :eventBus
+        :responses="operation.responses"
+        :selectedExample />
 
       <!-- New Example Request -->
       <div>
@@ -257,7 +257,6 @@ const { copyToClipboard } = useClipboard()
         <ScalarErrorBoundary>
           <OperationCodeSample
             :key="requestBodyCompositionSelectionKey"
-            v-model:selectedExample="selectedExampleKey"
             class="operation-example-card"
             :clientOptions
             :eventBus
@@ -272,6 +271,7 @@ const { copyToClipboard } = useClipboard()
             :securitySchemes="selectedSecuritySchemes"
             :selectedClient
             :selectedContentType="selectedRequestBodyContentType"
+            :selectedExample
             :selectedServer />
         </ScalarErrorBoundary>
       </div>

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -84,6 +84,16 @@ const operationExtensions = computed(() => getXKeysFromObject(operation))
 /** Track the selected request body content type so the code sample stays in sync */
 const selectedRequestBodyContentType = ref<string | undefined>()
 
+/**
+ * The example key actually shown in the request snippet for this operation.
+ *
+ * The test-request button lives in the accordion header, outside `OperationCodeSample`, so it
+ * cannot read the resolved key from the footer slot like the modern layout does. We mirror it here
+ * so the button opens the client with the same example the snippet displays, even when this
+ * operation does not share the document-wide selection.
+ */
+const resolvedExampleKey = ref<string>('')
+
 /** Selected request body oneOf/anyOf variants; synced with schema dropdowns and code sample */
 const requestBodyCompositionSelection = ref<RequestBodyCompositionSelection>({})
 
@@ -168,7 +178,7 @@ const { copyToClipboard } = useClipboard()
           v-if="active && !isWebhook"
           :id
           :eventBus
-          :exampleName="selectedExample"
+          :exampleName="resolvedExampleKey"
           :method
           :path
           :requestBodyCompositionSelection="
@@ -272,7 +282,8 @@ const { copyToClipboard } = useClipboard()
             :selectedClient
             :selectedContentType="selectedRequestBodyContentType"
             :selectedExample
-            :selectedServer />
+            :selectedServer
+            @update:exampleKey="resolvedExampleKey = $event" />
         </ScalarErrorBoundary>
       </div>
     </div>

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -53,6 +53,7 @@ const {
   selectedServer,
   selectedSecuritySchemes,
   selectedClient,
+  selectedExample,
 } = defineProps<
   Omit<
     OperationProps,
@@ -242,6 +243,7 @@ provide(REQUEST_BODY_COMPOSITION_INDEX_SYMBOL, requestBodyCompositionSelection)
               :securitySchemes="selectedSecuritySchemes"
               :selectedClient
               :selectedContentType="selectedRequestBodyContentType"
+              :selectedExample
               :selectedServer>
               <template #header>
                 <OperationPath
@@ -272,7 +274,9 @@ provide(REQUEST_BODY_COMPOSITION_INDEX_SYMBOL, requestBodyCompositionSelection)
           <ScalarErrorBoundary>
             <ExampleResponses
               v-if="operation.responses"
+              :eventBus
               :responses="operation.responses"
+              :selectedExample
               style="margin-top: 12px" />
           </ScalarErrorBoundary>
         </div>

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.test.ts
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.test.ts
@@ -710,6 +710,68 @@ describe('ExampleResponses', () => {
     expect(wrapper.text()).not.toContain('Example 2')
   })
 
+  it('keeps the document-wide example when the status code list shrinks and the index clamps', async () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        selectedExample: 'example2',
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                examples: {
+                  example1: { value: { message: 'TwoHundred One' } },
+                  example2: { value: { message: 'TwoHundred Two' } },
+                },
+              },
+            },
+          },
+          '404': {
+            description: 'Not found',
+            content: {
+              'application/json': {
+                examples: {
+                  example2: { value: { message: 'NotFound Two' } },
+                  example3: { value: { message: 'NotFound Three' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    // Move to the second tab (404), which also defines example2
+    const tabList = wrapper.findComponent({ name: 'ExampleResponseTabList' })
+    await tabList.vm.$emit('change', 1)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('NotFound Two')
+
+    // Drop the 404 response so the list shrinks and the index clamps back to 200
+    await wrapper.setProps({
+      responses: {
+        '200': {
+          description: 'OK',
+          content: {
+            'application/json': {
+              examples: {
+                example1: { value: { message: 'TwoHundred One' } },
+                example2: { value: { message: 'TwoHundred Two' } },
+              },
+            },
+          },
+        },
+      },
+    })
+    await wrapper.vm.$nextTick()
+
+    // The picker keeps the synced example (example2) instead of blanking out to the first one
+    const examplePicker = wrapper.findComponent({ name: 'ExamplePicker' })
+    expect(examplePicker.props('modelValue')).toBe('example2')
+    expect(wrapper.text()).toContain('TwoHundred Two')
+    expect(wrapper.text()).not.toContain('TwoHundred One')
+  })
+
   it('renders explicit 204 response tab and shows No Body', () => {
     const wrapper = mount(ExampleResponses, {
       props: {

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.vue
@@ -9,6 +9,7 @@ import { ScalarIcon } from '@scalar/components/icon'
 import { ScalarMarkdown } from '@scalar/components/markdown'
 import { objectKeys } from '@scalar/helpers/object/object-keys'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import { getExample } from '@scalar/workspace-store/request-example'
 import type {
@@ -30,8 +31,16 @@ import { normalizeMimeTypeObject } from './helpers/normalize-mime-type-object'
  * TODO: copyToClipboard isn't using the right content if there are multiple examples
  */
 
-const { responses } = defineProps<{
+const { responses, selectedExample, eventBus } = defineProps<{
   responses: ResponsesObject
+  /**
+   * The document-wide selected example key. Honored only when the current response defines an
+   * example with the same key, so response example pickers stay in sync between operations without
+   * blanking out responses that do not share that key.
+   */
+  selectedExample?: string
+  /** Event bus, used to broadcast the selected example so other operations can follow */
+  eventBus?: WorkspaceEventBus
 }>()
 
 const id = useId()
@@ -94,9 +103,37 @@ const hasMultipleExamples = computed<boolean>(
     Object.keys(currentResponseContent.value?.examples ?? {}).length > 1,
 )
 
-const selectedExampleKey = ref<string>(
-  Object.keys(currentResponseContent.value?.examples ?? {})[0] ?? '',
+const selectedExampleKey = ref<string>('')
+
+/** Resolve the example key to show, preferring the document-wide selection when this response has it */
+const resolveExampleKey = (preferred: string | undefined): string => {
+  const keys = Object.keys(currentResponseContent.value?.examples ?? {})
+  if (preferred && keys.includes(preferred)) {
+    return preferred
+  }
+  // Keep the current example when it is still valid, otherwise fall back to the first one
+  if (selectedExampleKey.value && keys.includes(selectedExampleKey.value)) {
+    return selectedExampleKey.value
+  }
+  return keys[0] ?? ''
+}
+
+// Initialize from the document-wide selection, falling back to the first example
+selectedExampleKey.value = resolveExampleKey(selectedExample)
+
+// Follow the document-wide selection when it changes and this response has that example
+watch(
+  () => selectedExample,
+  (preferred) => {
+    selectedExampleKey.value = resolveExampleKey(preferred)
+  },
 )
+
+/** Select an example and sync the choice across the document so other operations follow */
+const selectExample = (key: string) => {
+  selectedExampleKey.value = key
+  eventBus?.emit('workspace:update:selected-example', key)
+}
 
 /** Get the current example to display */
 const currentExample = computed(() => {
@@ -115,7 +152,8 @@ const currentExample = computed(() => {
 
 const changeTab = (index: number) => {
   selectedResponseIndex.value = index
-  selectedExampleKey.value = ''
+  // Re-apply the document-wide selection for the newly selected response, falling back to its first example
+  selectedExampleKey.value = resolveExampleKey(selectedExample)
 }
 
 const showSchema = ref(false)
@@ -177,9 +215,10 @@ const showSchema = ref(false)
       class="response-card-footer">
       <ExamplePicker
         v-if="hasMultipleExamples"
-        v-model="selectedExampleKey"
         class="response-example-selector px-0"
-        :examples="currentResponseContent?.examples" />
+        :examples="currentResponseContent?.examples"
+        :modelValue="selectedExampleKey"
+        @update:modelValue="selectExample" />
       <div class="response-description">
         <ScalarMarkdown
           v-if="currentResponse?.description"

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.vue
@@ -66,17 +66,18 @@ const selectedResponseIndex = ref<number>(0)
  * Without this, the index can become out of bounds and cause a mismatch
  * between the visible tabs and the displayed content.
  *
- * We also reset `selectedExampleKey` to match the behavior of `changeTab`,
- * since the new response may not have the same example keys.
+ * We re-resolve `selectedExampleKey` the same way `changeTab` does, so the picker keeps the
+ * document-wide selection when the newly active response defines it instead of being blanked out.
  */
 watch(statusCodesWithContent, (codes) => {
   if (codes.length === 0) {
     selectedResponseIndex.value = 0
-    selectedExampleKey.value = ''
   } else if (selectedResponseIndex.value >= codes.length) {
     selectedResponseIndex.value = codes.length - 1
-    selectedExampleKey.value = ''
+  } else {
+    return
   }
+  selectedExampleKey.value = resolveExampleKey(selectedExample)
 })
 
 // Return the whole response object

--- a/packages/workspace-store/src/events/definitions/workspace.ts
+++ b/packages/workspace-store/src/events/definitions/workspace.ts
@@ -24,6 +24,14 @@ export type WorkspaceEvents = {
    */
   'workspace:update:selected-client': string
   /**
+   * Update the selected example on the workspace.
+   *
+   * The payload is an example key (from an operation's `examples` map). Sharing it across the
+   * document keeps request and response example pickers in sync between operations: picking
+   * "Use case 1" on one operation selects the example with the same key everywhere it exists.
+   */
+  'workspace:update:selected-example': string
+  /**
    * Update the active environment on the workspace
    */
   'workspace:update:active-environment': string | null

--- a/packages/workspace-store/src/mutators/workspace.test.ts
+++ b/packages/workspace-store/src/mutators/workspace.test.ts
@@ -7,6 +7,7 @@ import {
   updateActiveProxy,
   updateColorMode,
   updateSelectedClient,
+  updateSelectedExample,
   updateTheme,
 } from './workspace'
 
@@ -265,6 +266,21 @@ describe('updateSelectedClient', () => {
     updateSelectedClient(workspace, 'js/fetch')
 
     expect(workspace['x-scalar-default-client']).toBe('js/fetch')
+  })
+})
+
+describe('updateSelectedExample', () => {
+  it('does nothing when workspace is null', () => {
+    updateSelectedExample(null, 'useCase1')
+    // Should not throw
+  })
+
+  it('sets x-scalar-default-example to an example key', () => {
+    const workspace = createWorkspace()
+
+    updateSelectedExample(workspace, 'useCase1')
+
+    expect(workspace['x-scalar-default-example']).toBe('useCase1')
   })
 })
 

--- a/packages/workspace-store/src/mutators/workspace.ts
+++ b/packages/workspace-store/src/mutators/workspace.ts
@@ -87,6 +87,22 @@ export const updateSelectedClient = (
   workspace['x-scalar-default-client'] = payload
 }
 
+/**
+ * Updates the selected example on the workspace
+ *
+ * @param workspace - The workspace to update the selected example in
+ * @param payload - The example key to select across the document
+ */
+export const updateSelectedExample = (
+  workspace: Workspace | null,
+  payload: WorkspaceEvents['workspace:update:selected-example'],
+) => {
+  if (!workspace) {
+    return
+  }
+  workspace['x-scalar-default-example'] = payload
+}
+
 export const workspaceMutatorsFactory = ({ workspace }: { workspace: Workspace | null }) => {
   return {
     updateActiveProxy: (payload: WorkspaceEvents['workspace:update:active-proxy']) =>
@@ -95,6 +111,8 @@ export const workspaceMutatorsFactory = ({ workspace }: { workspace: Workspace |
     updateTheme: (payload: WorkspaceEvents['workspace:update:theme']) => updateTheme(workspace, payload),
     updateSelectedClient: (payload: WorkspaceEvents['workspace:update:selected-client']) =>
       updateSelectedClient(workspace, payload),
+    updateSelectedExample: (payload: WorkspaceEvents['workspace:update:selected-example']) =>
+      updateSelectedExample(workspace, payload),
     updateActiveEnvironment: (payload: WorkspaceEvents['workspace:update:active-environment']) =>
       updateActiveEnvironment(workspace, payload),
   }

--- a/packages/workspace-store/src/schemas/extensions.ts
+++ b/packages/workspace-store/src/schemas/extensions.ts
@@ -6,6 +6,7 @@ export const extensions = {
     colorMode: 'x-scalar-color-mode',
     sidebarWidth: 'x-scalar-sidebar-width',
     defaultClient: 'x-scalar-default-client',
+    defaultExample: 'x-scalar-default-example',
     activeDocument: 'x-scalar-active-document',
     theme: 'x-scalar-theme',
   },

--- a/packages/workspace-store/src/schemas/workspace.ts
+++ b/packages/workspace-store/src/schemas/workspace.ts
@@ -37,6 +37,9 @@ export const WorkspaceMetaSchema = Type.Partial(
         ...AVAILABLE_CLIENTS.map((client) => Type.Literal(client)),
         Type.String({ pattern: '^custom/' }),
       ]),
+      // The example key (from an operation's `examples` map) selected across the document,
+      // so request and response example pickers stay in sync between operations
+      [extensions.workspace.defaultExample]: Type.String(),
       [extensions.workspace.activeDocument]: Type.String(),
       [extensions.workspace.theme]: Type.String(),
       [extensions.workspace.sidebarWidth]: Type.Number({ default: 288 }),
@@ -53,6 +56,8 @@ export type WorkspaceMeta = {
   // Typed as a plain string to avoid tripping TypeScript's "union too complex" limit when
   // this type flows into a Vue `defineProps`; valid values are enforced at runtime.
   [extensions.workspace.defaultClient]?: string
+  // The example key shared across the document so example pickers stay in sync between operations
+  [extensions.workspace.defaultExample]?: string
   [extensions.workspace.activeDocument]?: string
   [extensions.workspace.theme]?: string
   [extensions.workspace.sidebarWidth]?: number


### PR DESCRIPTION
Picking an example on one operation now selects the same example on every other operation that has it. For both request and response examples, just like the language selector already does. Operations that don't have that example keep their current pick.

Closes #6475

https://github.com/user-attachments/assets/d8cf6ef3-b3f5-495e-b5bd-3d7916d78871


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/state preference sync with graceful fallbacks when keys differ; no auth or data-path changes. Broad prop threading across reference components increases regression surface but is covered by new tests.
> 
> **Overview**
> **Example pickers now share one document-wide key**, stored on the workspace as `x-scalar-default-example` and updated via `workspace:update:selected-example` (same pattern as `x-scalar-default-client`).
> 
> Choosing an example in **request snippets** (`OperationCodeSample`) or **response examples** (`ExampleResponses`) broadcasts that key; every operation/response that defines the same key follows it. Operations without that key keep their resolved local example instead of clearing.
> 
> **API reference wiring** passes `xScalarDefaultExample` from the client store through `Content` → `TraversedEntry` → `Operation` layouts. Request pickers resolve a local key from the global preference; classic layout mirrors the resolved key via `update:exampleKey` so **Test request** uses the snippet’s example, not a missing global key.
> 
> PostHog treats the new workspace event as a preference signal (empty payload). Tests cover resolution, content-type changes, response tab clamping, and classic test-request behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7653848bca81d5376fc1c0460b1a5a76e609ec92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->