### PR TITLE
test(scalar-app): pre-build web app for e2e instead of dev server

### DIFF
--- a/projects/scalar-app/playwright.config.ts
+++ b/projects/scalar-app/playwright.config.ts
@@ -8,19 +8,22 @@ const isLinux = process.platform === 'linux' && !CI
 const APP_PORT = 5077
 
 /**
- * Vite dev server for the web entrypoint (`vite.config.ts` → `root: entrypoints/web`). Listens on
- * all interfaces so Docker (e.g. macOS `host.docker.internal`) can reach it when using
+ * Build the web entrypoint (`vite.config.ts` → `root: entrypoints/web`) once, then serve it with
+ * `vite preview`. Pre-building avoids paying Vite's on-demand compilation (Monaco, the API client,
+ * etc.) inside the first test's timeout budget, which made cold CI runs flaky. The preview server
+ * listens on all interfaces so Docker (e.g. macOS `host.docker.internal`) can reach it when using
  * {@link getDockerServer}.
- */
-/**
- * Force non-Mac hotkey glyphs in the browser so {@link ScalarHotkey} matches Linux CI when developers
- * run E2E on macOS (same OpenAPI client bundle as production; only symbol set is pinned).
+ *
+ * `VITE_SCALAR_HOTKEY_SYMBOL_SET=non-mac` forces non-Mac hotkey glyphs so {@link ScalarHotkey}
+ * matches Linux CI when developers run E2E on macOS. It is baked in at build time, so it must be set
+ * on `vite build` (not `vite preview`).
  */
 const viteWebPlayground = {
-  command: `VITE_SCALAR_HOTKEY_SYMBOL_SET=non-mac pnpm exec vite --config vite.config.ts --host 0.0.0.0 --port ${APP_PORT} --strictPort`,
+  command: `VITE_SCALAR_HOTKEY_SYMBOL_SET=non-mac pnpm exec vite build --config vite.config.ts && pnpm exec vite preview --config vite.config.ts --host 0.0.0.0 --port ${APP_PORT} --strictPort`,
   url: `http://127.0.0.1:${APP_PORT}`,
   reuseExistingServer: !CI,
-  timeout: 120_000,
+  // Generous timeout: the command builds the app before the preview server comes up.
+  timeout: 240_000,
 } as const
 
 /**

--- a/projects/scalar-app/vite.config.ts
+++ b/projects/scalar-app/vite.config.ts
@@ -54,4 +54,9 @@ export default defineConfig({
     // E2E: browsers in Docker hit the host Vite server with this Host header (see playwright.config baseURL).
     allowedHosts: ['host.docker.internal'],
   },
+  preview: {
+    // E2E pre-builds the app and serves it with `vite preview`; browsers in Docker reach it with
+    // this Host header (see playwright.config baseURL), so it must be allowed here too.
+    allowedHosts: ['host.docker.internal'],
+  },
 })


### PR DESCRIPTION
e2e served the app from the Vite dev server, so for the first test we were compiling Monaco, the API client, etc. on the fly.

Now we build once and serve with `vite preview`. 

Tests that took ~20–30s drop to a ~1-2s seconds. 🤯

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect Playwright E2E wiring and Vite preview host allowlisting; production dev/build paths are unchanged.
> 
> **Overview**
> **E2E now serves a production-like bundle instead of the Vite dev server.** Playwright’s web server command runs `vite build` then `vite preview` (replacing `vite --host`), so cold runs no longer compile Monaco and the API client during the first test’s timeout window.
> 
> Docs clarify that **`VITE_SCALAR_HOTKEY_SYMBOL_SET=non-mac` must be set on `vite build`**, not preview, because it is baked in at build time. The webServer **timeout is raised from 120s to 240s** to cover the upfront build.
> 
> **`vite.config.ts`** adds **`preview.allowedHosts: ['host.docker.internal']`** so Docker-based browsers can reach the preview server the same way they could the dev server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aa1422b1b032e29e589c385dd29434f7b4884ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->