### PR TITLE
perf(server-side-rendering): faster config serialization

### DIFF
--- a/.changeset/perf-ssr-compact-hydration-config.md
+++ b/.changeset/perf-ssr-compact-hydration-config.md
@@ -1,0 +1,5 @@
+---
+'@scalar/server-side-rendering': patch
+---
+
+Serialize the hydration config compactly instead of pretty-printed. This shrinks the inline hydration script in every server-rendered page and speeds up serialization for large configs.

--- a/packages/server-side-rendering/src/ssr.test.ts
+++ b/packages/server-side-rendering/src/ssr.test.ts
@@ -261,7 +261,7 @@ describe('ssr', () => {
     it('serializes configuration into the hydration script', async () => {
       const html = await renderApiReference({ config: { url: 'https://example.com/api.json' }, css: '' })
 
-      expect(html).toContain('"url": "https://example.com/api.json"')
+      expect(html).toContain('"url":"https://example.com/api.json"')
     })
 
     it('prevents script breakout in hydration config serialization', async () => {
@@ -273,9 +273,7 @@ describe('ssr', () => {
       })
 
       expect(html).not.toContain('</script><script>window.__pwned=1</script>')
-      expect(html).toContain(
-        '"title": "\\u003c/script\\u003e\\u003cscript\\u003ewindow.__pwned=1\\u003c/script\\u003e"',
-      )
+      expect(html).toContain('"title":"\\u003c/script\\u003e\\u003cscript\\u003ewindow.__pwned=1\\u003c/script\\u003e"')
     })
 
     it('preserves top-level function properties in hydration config serialization', async () => {
@@ -288,7 +286,7 @@ describe('ssr', () => {
       })
 
       expect(html).toContain('Scalar.createApiReference')
-      expect(html).toContain('"url": "https://example.com/api.json"')
+      expect(html).toContain('"url":"https://example.com/api.json"')
       expect(html).toContain('"onLoaded": () => console.log("loaded")')
     })
 
@@ -315,7 +313,7 @@ describe('ssr', () => {
         ],
       })
 
-      expect(result).toContain('"theme": "kepler"')
+      expect(result).toContain('"theme":"kepler"')
       expect(result).toContain('"hooks": [() => "ready", {"label":"stable"}]')
     })
 

--- a/packages/server-side-rendering/src/ssr.ts
+++ b/packages/server-side-rendering/src/ssr.ts
@@ -254,22 +254,6 @@ function escapeFunctionSourceForInlineScript(source: string): string {
     .replace(/\u2029/g, '\\u2029')
 }
 
-/** Add consistent indentation to multiline strings embedded in HTML output. */
-const addIndent = (str: string, spaces: number = 2, initialIndent: boolean = false): string => {
-  const indent = ' '.repeat(spaces)
-  const lines = str.split('\n')
-
-  return lines
-    .map((line, index) => {
-      if (index === 0 && !initialIndent) {
-        return line
-      }
-
-      return `${indent}${line}`
-    })
-    .join('\n')
-}
-
 /**
  * Reject function values that would otherwise be silently dropped by JSON.stringify.
  * SSR only supports top-level function props and top-level arrays containing functions,
@@ -295,8 +279,7 @@ const assertNoNestedFunctions = (value: unknown, path: string): void => {
 
 const serializeJsonValue = (value: unknown): string => escapeJsonForInlineScript(JSON.stringify(value))
 
-const serializeJsonObject = (value: Record<string, unknown>): string =>
-  escapeJsonForInlineScript(JSON.stringify(value, null, 2))
+const serializeJsonObject = (value: Record<string, unknown>): string => escapeJsonForInlineScript(JSON.stringify(value))
 
 const serializePropertyKey = (key: string): string => escapeJsonForInlineScript(JSON.stringify(key))
 
@@ -320,14 +303,15 @@ const serializeArrayProperty = (key: string, value: unknown[]): string =>
   `${serializePropertyKey(key)}: ${serializeArrayWithFunctions(value, key)}`
 
 const mergeSerializedProperties = (jsonObjectLiteral: string, dynamicProperties: string[]): string => {
-  const formattedDynamicProperties = addIndent(dynamicProperties.join(',\n'), 8, true)
+  const joinedDynamicProperties = dynamicProperties.join(', ')
 
   if (jsonObjectLiteral === '{}') {
-    return `{\n${formattedDynamicProperties}\n      }`
+    return `{ ${joinedDynamicProperties} }`
   }
 
-  const jsonWithoutClosingBrace = jsonObjectLiteral.split('\n').slice(0, -1).join('\n')
-  return `${jsonWithoutClosingBrace},\n${formattedDynamicProperties}\n      }`
+  /** Drop the trailing `}` of the compact JSON literal so we can append the dynamic properties. */
+  const jsonWithoutClosingBrace = jsonObjectLiteral.slice(0, -1)
+  return `${jsonWithoutClosingBrace}, ${joinedDynamicProperties} }`
 }
 
 /**
@@ -356,13 +340,12 @@ export function serializeConfigToJs(config: Record<string, unknown>): string {
   })
 
   const jsonString = serializeJsonObject(restConfig)
-  const indentedJsonString = addIndent(jsonString, 6)
 
   if (dynamicProperties.length === 0) {
-    return indentedJsonString
+    return jsonString
   }
 
-  return mergeSerializedProperties(indentedJsonString, dynamicProperties)
+  return mergeSerializedProperties(jsonString, dynamicProperties)
 }
 
 /**


### PR DESCRIPTION
The inline hydration config was pretty-printed and then re-indented line by line, even though nothing ever reads it. 

Serializing it compactly shrinks every server-rendered page and is much faster to build for large API descriptions.

On a ~0.8 MB config: serialized output drops ~7× (5.9 MB → 0.8 MB) and the serialize step goes from ~31 ms to ~1.5 ms per render. Function props and arrays-with-functions are still preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is output formatting only; escaping and hydration semantics are preserved and covered by existing tests.
> 
> **Overview**
> SSR hydration config in `@scalar/server-side-rendering` is now emitted as **compact JSON** instead of pretty-printed, re-indented output. `serializeJsonObject` uses plain `JSON.stringify`, the **`addIndent`> helper is removed**, and merging JSON with top-level **function** / **array-with-functions** props uses single-line `{ ... }` joining via `slice(0, -1)` on the JSON literal rather than multiline splice.
> 
> Tests in `ssr.test.ts` now assert compact shapes (e.g. `"url":"..."` without spaces). **Inline-script escaping** and support for dynamic function properties are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39a9b3adbc4225d510ca3b18ce0da113bec97906. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->