### PR TITLE
fix(api-reference): preserve `oneOf`/`anyOf` nested inside `allOf`

### DIFF
--- a/.changeset/merge-allof-oneof-preserve.md
+++ b/.changeset/merge-allof-oneof-preserve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix `oneOf`/`anyOf` being dropped when nested inside an `allOf`. The composition is now preserved so its variants keep rendering alongside the merged base properties, instead of only the first `allOf` member showing up.

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
@@ -416,4 +416,41 @@ describe('SchemaComposition', () => {
       },
     ])
   })
+
+  it('keeps a oneOf composition nested inside allOf (issue #5577)', () => {
+    const wrapper = mount(SchemaComposition, {
+      props: {
+        eventBus: null,
+        composition: 'allOf',
+        schema: coerceValue(SchemaObjectSchema, {
+          title: 'ConversionCreationRequest',
+          allOf: [
+            {
+              type: 'object',
+              properties: {
+                customerComment: { type: 'string' },
+              },
+            },
+            {
+              oneOf: [
+                { title: 'With Quote Id', type: 'object', properties: { quoteId: { type: 'string' } } },
+                { title: 'With Currency Pair', type: 'object', properties: { sourceCurrencyCode: { type: 'string' } } },
+              ],
+            },
+          ],
+        }),
+        level: 0,
+        options: {},
+      },
+    })
+
+    // The merged schema handed to Schema keeps both the base property and the
+    // oneOf variants, so the variant selector still renders.
+    const schemaValue = wrapper.findComponent({ name: 'Schema' }).props('schema') as any
+
+    expect(schemaValue.properties).toMatchObject({ customerComment: { type: 'string' } })
+    expect(schemaValue.oneOf).toHaveLength(2)
+    expect(schemaValue.oneOf[0].title).toBe('With Quote Id')
+    expect(schemaValue.oneOf[1].title).toBe('With Currency Pair')
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
@@ -586,15 +586,60 @@ describe('mergeAllOfSchemas', () => {
       ],
     }
 
+    // Base properties stay on the merged schema while the oneOf/anyOf
+    // compositions are preserved, so the variant selectors keep rendering
+    // instead of being flattened into a single object.
     expect(mergeAllOfSchemas(schema as any)).toEqual({
       properties: {
         a: { type: 'string', example: 'foo' },
-        b: { type: 'number', example: 42 },
-        c: { type: 'boolean', example: true },
-        d: { type: 'integer', example: 7 },
-        e: { type: 'array', items: { type: 'string' }, example: ['x', 'y'] },
       },
+      oneOf: [
+        { properties: { b: { type: 'number', example: 42 } } },
+        { properties: { c: { type: 'boolean', example: true } } },
+      ],
+      anyOf: [
+        { properties: { d: { type: 'integer', example: 7 } } },
+        { properties: { e: { type: 'array', items: { type: 'string' }, example: ['x', 'y'] } } },
+      ],
     })
+  })
+
+  it('preserves a oneOf composition nested inside allOf (issue #5577)', () => {
+    const schema = {
+      title: 'ConversionCreationRequest',
+      allOf: [
+        {
+          type: 'object',
+          properties: {
+            customerComment: { type: 'string' },
+          },
+        },
+        {
+          oneOf: [
+            {
+              allOf: [{ title: 'With Quote Id', type: 'object', properties: { quoteId: { type: 'string' } } }],
+            },
+            {
+              allOf: [
+                {
+                  title: 'With Currency Pair',
+                  type: 'object',
+                  properties: { sourceCurrencyCode: { type: 'string' }, destinationCurrencyCode: { type: 'string' } },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const merged = mergeAllOfSchemas(schema as any) as any
+
+    // The base property renders alongside the preserved oneOf variants.
+    expect(merged.properties).toEqual({ customerComment: { type: 'string' } })
+    expect(merged.oneOf).toHaveLength(2)
+    expect(merged.oneOf[0].allOf[0].title).toBe('With Quote Id')
+    expect(merged.oneOf[1].allOf[0].title).toBe('With Currency Pair')
   })
 
   it('preserves title from first schema that has them', () => {

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
@@ -171,18 +171,14 @@ const mergeSchemaIntoResult = (
     }
     // OneOf/AnyOf
     else if (key === 'oneOf' || key === 'anyOf') {
-      // Merge oneOf/anyOf subschema
-      if (Array.isArray(value)) {
-        if (!('properties' in result)) {
-          // @ts-expect-error
-          result.properties = {}
-        }
-        for (const _option of value) {
-          const option = resolve.schema(_option)
-          if (option && 'properties' in option && 'properties' in result) {
-            mergePropertiesIntoResult(result.properties, option.properties, seenRefs)
-          }
-        }
+      // Preserve the composition itself so its variants keep rendering as a
+      // selector. Flattening the option properties into the parent would drop
+      // the variant structure entirely and silently lose branches that have no
+      // top-level `properties` (for example branches that are themselves an
+      // `allOf`). The sibling `allOf` members stay on `result` as base
+      // properties, which the Schema component renders above the selector.
+      if (Array.isArray(value) && value.length > 0 && (override || result[key] === undefined)) {
+        result[key] = value
       }
     }
     // Skip allOf as it's handled at a higher level


### PR DESCRIPTION
When a `oneOf`/`anyOf` sits next to other members inside an `allOf`, we were flattening it away, so only the first member rendered and the variants disappeared (worst case: branches that are themselves an `allOf` left no trace at all).

Now the composition is kept, so the variant selector renders alongside the merged base properties.

## Ticket

Fixes #5577

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped display/merge change in `@scalar/api-reference` schema helpers with tests; no auth or runtime API behavior.
> 
> **Overview**
> **`mergeAllOfSchemas` no longer flattens `oneOf`/`anyOf` into merged `properties` when those compositions appear as siblings inside an `allOf`.** It now copies the composition arrays onto the merged schema (when not already set), so base fields from other `allOf` members still merge while variant selectors can render.
> 
> This fixes cases like **#5577** where a `oneOf` next to a base object in `allOf` disappeared from the docs—especially branches that only define an inner `allOf` without top-level `properties`. Unit expectations and a **`SchemaComposition`** mount test were updated to assert preserved `oneOf`/`anyOf` alongside merged properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d4b384469d797768cdf72860c360a973cbb1d86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->