### PR TITLE
fix(api-client): auth token with multi-document sources dropped

### DIFF
--- a/.changeset/fix-runner-auth-token-sources.md
+++ b/.changeset/fix-runner-auth-token-sources.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix the request runner dropping a manually typed auth token when the document name is not slug-safe (e.g. documents loaded via `sources`). The modal now reads auth secrets under the same document key they are written to.

--- a/packages/api-client/src/v2/features/modal/Modal.test.ts
+++ b/packages/api-client/src/v2/features/modal/Modal.test.ts
@@ -371,6 +371,64 @@ describe('Modal', () => {
     expect(operation.props('layout')).toBe('modal')
   })
 
+  it('passes the document name (not the slugified navigation id) as documentSlug', async () => {
+    // The auth store keys secrets by the document name, but the navigation `id` is a
+    // slugified version of it. When the name is not slug-safe (common for `sources`
+    // documents with an explicit slug), passing the `id` here would make the runner
+    // read auth secrets under a different key than they were written, dropping the
+    // typed token. See https://github.com/scalar/scalar/issues/9554.
+    const rawName = 'My API'
+    const rawStore = createWorkspaceStore()
+    await rawStore.addDocument({
+      name: rawName,
+      document: getDocument({ paths: { '/users': { get: { summary: 'Get users' } } } }),
+    })
+    rawStore.update('x-scalar-active-document', rawName)
+
+    const rawDocumentSlug = computed<string | undefined>(() => rawName)
+    const rawPath = computed<string | undefined>(() => '/users')
+    const rawMethod = computed<'get' | 'post' | undefined>(() => 'get')
+    const rawExampleName = computed<string | undefined>(() => 'default')
+
+    const document = computed<OpenApiDocument | null>(
+      () => (rawStore.workspace.documents[rawName] as OpenApiDocument | undefined) ?? null,
+    )
+    const modalState = useModal()
+    modalState.open = true
+
+    const wrapper = mount(Modal, {
+      props: {
+        workspaceStore: rawStore,
+        document,
+        path: rawPath,
+        method: rawMethod,
+        options: createModalOptions(),
+        plugins: [],
+        exampleName: rawExampleName,
+        requestBodyCompositionSelection: ref<Record<string, number>>({}),
+        modalState,
+        sidebarState: useModalSidebar({
+          workspaceStore: rawStore,
+          documentSlug: rawDocumentSlug,
+          path: rawPath,
+          method: rawMethod,
+          exampleName: rawExampleName,
+          route: vi.fn(),
+        }),
+        eventBus: mockEventBus,
+      },
+      attachTo: '#scalar-modal-test',
+    })
+    await waitForUpdates()
+
+    const navigation = document.value?.['x-scalar-navigation']
+    expect(navigation?.name).toBe(rawName)
+    expect(navigation?.id).toBe('my-api')
+
+    const operation = wrapper.findComponent({ name: 'Operation' })
+    expect(operation.props('documentSlug')).toBe(rawName)
+  })
+
   it('has correct accessibility attributes', async () => {
     const { props, modalState } = createProps()
     modalState.open = true

--- a/packages/api-client/src/v2/features/modal/Modal.vue
+++ b/packages/api-client/src/v2/features/modal/Modal.vue
@@ -180,7 +180,7 @@ defineExpose({
         :activeWorkspace="activeWorkspace"
         class="flex-1"
         :document="document.value"
-        :documentSlug="document.value['x-scalar-navigation']?.id ?? ''"
+        :documentSlug="document.value['x-scalar-navigation']?.name ?? ''"
         :environment
         :eventBus
         :exampleName="exampleName?.value"


### PR DESCRIPTION
Typing a Bearer token in the request runner sent an empty `Authorization: Bearer` when the document was loaded via `sources` (single-document `content` worked fine).

The runner stores auth secrets under the document name but the modal handed the Operation the slugified navigation `id` instead. When the name was not slug-safe, reads and writes used different keys and the token was dropped. The modal now passes the document name.

## Ticket

Fixes #9554

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single prop wiring change in the modal plus a targeted test; aligns with existing auth store keying by document name.
> 
> **Overview**
> Fixes the request runner sending **`Authorization: Bearer`** with no token when a document name is not slug-safe (typical for **`sources`** loads), because auth secrets are stored under the **document name** while the modal passed the slugified navigation **`id`** to **`Operation`**.
> 
> **`Modal.vue`** now passes **`x-scalar-navigation.name`** as **`documentSlug`** so reads and writes use the same key. A regression test covers a document named **`My API`** where navigation **`id`** is **`my-api`** but **`documentSlug`** must stay **`My API`**. Patch notes are in the changeset for **`@scalar/api-client`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb36d7e4b47da92760b3ff90f46cc8b043382788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->