### PR TITLE
fix(api-reference): render factored-out properties alongside compositions

### DIFF
--- a/.changeset/factoring-schema-properties.md
+++ b/.changeset/factoring-schema-properties.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Render an object's own properties when they are factored out alongside a composition keyword (`anyOf`/`oneOf`/`allOf`/`not`)

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -1055,5 +1055,25 @@ describe('Schema', () => {
       expect(text).toContain('one')
       expect(text).toContain('another')
     })
+
+    it('does not duplicate properties factored out alongside allOf', () => {
+      // `allOf` already merges the factored-out sibling `properties` into its
+      // rendered result, so they must not also render in a separate object
+      // block. Two members keep the `allOf` intact (a single member is flattened
+      // away before rendering).
+      const text = renderText({
+        type: 'object',
+        allOf: [{ properties: { fromAllOfA: { type: 'string' } } }, { properties: { fromAllOfB: { type: 'string' } } }],
+        properties: {
+          factoredProperty: { type: 'string' },
+        },
+      })
+
+      const countOccurrences = (haystack: string, needle: string) => haystack.split(needle).length - 1
+
+      expect(countOccurrences(text, 'factoredProperty')).toBe(1)
+      expect(countOccurrences(text, 'fromAllOfA')).toBe(1)
+      expect(countOccurrences(text, 'fromAllOfB')).toBe(1)
+    })
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -990,4 +990,70 @@ describe('Schema', () => {
       expect(wrapper.text()).not.toContain('bar')
     })
   })
+
+  // See https://github.com/scalar/scalar/issues/8593
+  describe('factoring schemas', () => {
+    const renderText = (schema: unknown) =>
+      mount(Schema, {
+        props: {
+          options: { expandAllSchemaProperties: true },
+          eventBus: null,
+          schema: coerceValue(SchemaObjectSchema, schema),
+        },
+      }).text()
+
+    it('renders properties factored out alongside anyOf', () => {
+      const text = renderText({
+        type: 'object',
+        anyOf: [
+          { not: { required: ['another'] }, required: ['one'] },
+          { not: { required: ['one'] }, required: ['another'] },
+          { not: { required: ['one', 'another'] } },
+        ],
+        properties: {
+          one: { type: 'string', description: 'The one.' },
+          another: { type: 'string', description: 'Just another.' },
+        },
+      })
+
+      expect(text).toContain('one')
+      expect(text).toContain('another')
+    })
+
+    it('renders properties factored out alongside allOf containing anyOf', () => {
+      const text = renderText({
+        type: 'object',
+        allOf: [
+          {
+            anyOf: [
+              { not: { required: ['another'] }, required: ['one'] },
+              { not: { required: ['one'] }, required: ['another'] },
+              { not: { required: ['one', 'another'] } },
+            ],
+          },
+        ],
+        properties: {
+          one: { type: 'string' },
+          another: { type: 'string' },
+        },
+      })
+
+      expect(text).toContain('one')
+      expect(text).toContain('another')
+    })
+
+    it('renders object properties even when a not constraint is present', () => {
+      const text = renderText({
+        type: 'object',
+        properties: {
+          one: { type: 'string' },
+          another: { type: 'string' },
+        },
+        not: { required: ['one'] },
+      })
+
+      expect(text).toContain('one')
+      expect(text).toContain('another')
+    })
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -117,12 +117,20 @@ const shouldRenderObjectProperties = computed(() => {
     return false
   }
 
+  // `allOf` already merges the factored-out sibling `properties` into its
+  // rendered result (see `mergeAllOfSchemas`), so rendering a separate object
+  // block here would show those properties twice. Let the composition handle it.
+  if ('allOf' in value) {
+    return false
+  }
+
   // A schema may factor its common `properties` out to the top level alongside
-  // a composition keyword (anyOf/oneOf/allOf/not), as described in the JSON
-  // Schema "factoring schemas" guide. `isTypeObject` deliberately rejects such
-  // schemas so the composition is rendered, but the factored-out properties
-  // must still show. Render them unless the schema is an explicit non-object
-  // (scalar or array) type. See https://github.com/scalar/scalar/issues/8593
+  // a composition keyword (anyOf/oneOf/not), as described in the JSON Schema
+  // "factoring schemas" guide. `isTypeObject` deliberately rejects such schemas
+  // so the composition is rendered, but the factored-out properties must still
+  // show. Unlike `allOf`, these compositions do not merge sibling properties.
+  // Render them unless the schema is an explicit non-object (scalar or array)
+  // type. See https://github.com/scalar/scalar/issues/8593
   const type = (value as { type?: unknown }).type
   const isExplicitNonObject = typeof type === 'string' && type !== 'object'
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -113,10 +113,20 @@ const shouldRenderObjectProperties = computed(() => {
     return false
   }
 
-  return (
-    isTypeObject(value) &&
-    ('properties' in value || 'additionalProperties' in value)
-  )
+  if (!('properties' in value || 'additionalProperties' in value)) {
+    return false
+  }
+
+  // A schema may factor its common `properties` out to the top level alongside
+  // a composition keyword (anyOf/oneOf/allOf/not), as described in the JSON
+  // Schema "factoring schemas" guide. `isTypeObject` deliberately rejects such
+  // schemas so the composition is rendered, but the factored-out properties
+  // must still show. Render them unless the schema is an explicit non-object
+  // (scalar or array) type. See https://github.com/scalar/scalar/issues/8593
+  const type = (value as { type?: unknown }).type
+  const isExplicitNonObject = typeof type === 'string' && type !== 'object'
+
+  return isTypeObject(value) || !isExplicitNonObject
 })
 
 /** Determine if array of objects should be rendered */
@@ -143,16 +153,36 @@ const displayDescription = computed(() =>
 )
 
 /**
- * When the property already renders the description, avoid repeating it in the nested object schema card.
+ * The schema used to render the object's own properties.
+ *
+ * Composition keywords are stripped so the nested object renders only its
+ * properties. The compositions are rendered separately below; leaving them here
+ * would route the nested `Schema` back through `SchemaProperty` and recurse.
+ *
+ * When the property already renders the description, we also drop it to avoid
+ * repeating it in the nested object schema card.
  */
 const objectSchemaForChildren = computed(() => {
   const value = optimizedValue.value
-  if (!value || !displayDescription.value || !('description' in value)) {
+  if (!value) {
     return value
   }
 
-  const { description: _description, ...schemaWithoutDescription } = value
-  return schemaWithoutDescription as SchemaObject
+  const {
+    oneOf: _oneOf,
+    anyOf: _anyOf,
+    allOf: _allOf,
+    not: _not,
+    ...objectSchema
+  } = value as Record<string, unknown>
+
+  if (displayDescription.value && 'description' in objectSchema) {
+    const { description: _description, ...schemaWithoutDescription } =
+      objectSchema
+    return schemaWithoutDescription as SchemaObject
+  }
+
+  return objectSchema as SchemaObject
 })
 
 /** Determine if property heading should be displayed */


### PR DESCRIPTION
Schemas that factor common `properties` out to the top level next to an `anyOf`/`oneOf`/`allOf`/`not` showed the composition but dropped the properties. Now the object's own properties render too.

## Ticket

Fixes #8593

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in schema rendering with targeted tests; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes schema docs where **top-level `properties` sit next to composition keywords** (`anyOf`, `oneOf`, `not`, or nested cases like `allOf` + `anyOf`). The UI used to show the composition but **hide those shared properties** because `isTypeObject` treats composed schemas as non-objects.
> 
> **`SchemaProperty.vue`** now renders a separate object-properties block when `properties` / `additionalProperties` exist, except when **`allOf` is present** (merged rendering already includes sibling properties, so a second block would duplicate them). For other compositions it still shows factored-out fields unless the schema is an **explicit non-object** type.
> 
> Nested property rendering uses **`objectSchemaForChildren`** with composition keywords stripped so compositions stay in their own section and the nested `Schema` does not recurse.
> 
> Adds **`factoring schemas`** tests in `Schema.test.ts` (issue #8593) and a patch changeset for `@scalar/api-reference`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a13dab9607564719551919702d49687588238db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->