### PR TITLE
docs: fix CLI preview port typo (7971 -> 7970)

### DIFF
--- a/.agents/skills/scalar-docs/SKILL.md
+++ b/.agents/skills/scalar-docs/SKILL.md
@@ -368,7 +368,7 @@ npx @scalar/cli project preview
 | ------- | ----------- |
 | `npx @scalar/cli project init` | Create scalar.config.json |
 | `npx @scalar/cli project check-config` | Validate config |
-| `npx @scalar/cli project preview` | Local preview (port 7971) |
+| `npx @scalar/cli project preview` | Local preview (port 7970) |
 | `npx @scalar/cli project publish` | Publish from local files |
 | `npx @scalar/cli project publish --github` | Publish from linked GitHub repo |
 | `npx @scalar/cli project upgrade` | Migrate from Docs 1.0 |

--- a/documentation/guides/docs/starter-kit.md
+++ b/documentation/guides/docs/starter-kit.md
@@ -14,7 +14,7 @@ Run a local development server to see your changes in real-time:
 npx @scalar/cli project preview
 ```
 
-This starts a live preview at `http://localhost:7971` where every edit you make is instantly visible.
+This starts a live preview at `http://localhost:7970` where every edit you make is instantly visible.
 
 Read more about [Preview deployments](deployment/preview-deployments.md) and the [CLI](deployment/cli.md).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The documentation for the Docs Starter Kit incorrectly states that `npx @scalar/cli project preview` starts on port `7971`, but the actual default port is `7970` (as confirmed by the CLI commands reference and user reports).

## Solution

Fixed the port number from `7971` to `7970` in:
- `documentation/guides/docs/starter-kit.md` - the main docs page
- `.agents/skills/scalar-docs/SKILL.md` - the agent skill reference

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed for docs-only changes -->
- [ ] I added tests. <!-- Not applicable for docs changes -->
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07SL9L6SJ0/p1781804315272319?thread_ts=1781804315.272319&cid=C07SL9L6SJ0)

<div><a href="https://cursor.com/agents/bc-86948952-ffa5-5b7d-bf98-55db5e42b1c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86948952-ffa5-5b7d-bf98-55db5e42b1c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

