### PR TITLE
feat(api-reference): filter AsyncAPI sidebar by protocol and server

### DIFF
--- a/.changeset/asyncapi-protocol-filter.md
+++ b/.changeset/asyncapi-protocol-filter.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': minor
+'@scalar/api-reference': minor
+---
+
+Add AsyncAPI protocol and server pickers to the sidebar (like the multi-document picker) that filter the navigation down to the operations reachable over the selected protocol/server

--- a/documentation/asyncapi.md
+++ b/documentation/asyncapi.md
@@ -24,5 +24,16 @@ Reusable schemas defined under `components.schemas` are rendered in the **Models
 
 Rendering works in both the `modern` and `classic` layouts.
 
+## Filtering by protocol and server
+
+When a document defines more than one protocol or server, **filter pickers** appear at the top of the sidebar, stacked beneath the document picker and working just like it:
+
+- **Protocol** — shown when the servers use more than one `protocol` (for example a `wss` WebSocket server alongside an `mqtt` or `kafka` server). Selecting a protocol hides operations that aren't reachable over a server using it.
+- **Server** — shown when the document defines more than one server. Selecting a server hides operations whose channel isn't reachable through it.
+
+Both filters operate on the navigation tree itself: operations that don't match are hidden, and any channel or tag left empty is dropped. Channels that declare no `servers` are treated as available on every server (and therefore every protocol). Choosing **All protocols** / **All servers** clears that filter, and the filters reset when you switch documents.
+
+Each picker is only shown when there is more than one option to choose from.
+
 > [!NOTE]
 > AsyncAPI support is still a work in progress, so not every part of the specification is rendered yet. The progress is tracked on GitHub in [issue #7080](https://github.com/scalar/scalar/issues/7080) — subscribe there to receive updates.

--- a/packages/api-reference/playground/esm/index.html
+++ b/packages/api-reference/playground/esm/index.html
@@ -29,6 +29,10 @@
             title: 'Scalar Galaxy (YAML)',
             url: 'https://registry.scalar.com/@scalar/apis/galaxy?format=yaml',
           },
+          {
+            title: 'AsyncAPI Sidebar Filters',
+            url: '../../public/examples/asyncapi-filters.yaml',
+          },
           // {
           //   title: 'Stripe',
           //   url: 'https://raw.githubusercontent.com/stripe/openapi/refs/heads/master/openapi/spec3.yaml',

--- a/packages/api-reference/public/examples/asyncapi-filters.yaml
+++ b/packages/api-reference/public/examples/asyncapi-filters.yaml
@@ -1,0 +1,192 @@
+asyncapi: 3.0.0
+id: urn:com:scalar:examples:asyncapi-filters
+info:
+  title: AsyncAPI Sidebar Filters
+  version: 1.0.0
+  description: |
+    A compact AsyncAPI document for exercising the API reference sidebar filters.
+
+    Each channel is pinned to a different server so selecting a protocol or server
+    visibly narrows the navigation tree.
+defaultContentType: application/json
+servers:
+  websocket:
+    host: stream.example.com
+    pathname: /realtime
+    protocol: wss
+    protocolVersion: '13'
+    description: Browser clients subscribe to user-facing events over WebSockets.
+  mqtt:
+    host: mqtt.example.com
+    protocol: mqtt
+    protocolVersion: '5.0'
+    description: Devices publish telemetry over MQTT.
+  kafka:
+    host: kafka.example.com
+    protocol: kafka
+    description: Backend workers consume durable product events from Kafka.
+channels:
+  userNotifications:
+    address: users/{userId}/notifications
+    title: User notifications
+    summary: Notifications delivered to browser clients.
+    servers:
+      - $ref: '#/servers/websocket'
+    parameters:
+      userId:
+        $ref: '#/components/parameters/userId'
+    messages:
+      notification:
+        $ref: '#/components/messages/UserNotification'
+    bindings:
+      ws:
+        method: GET
+  deviceTelemetry:
+    address: devices/{deviceId}/telemetry
+    title: Device telemetry
+    summary: Sensor readings published by connected devices.
+    servers:
+      - $ref: '#/servers/mqtt'
+    parameters:
+      deviceId:
+        $ref: '#/components/parameters/deviceId'
+    messages:
+      telemetry:
+        $ref: '#/components/messages/DeviceTelemetry'
+    bindings:
+      mqtt:
+        qos: 1
+  inventoryEvents:
+    address: inventory.events
+    title: Inventory events
+    summary: Product inventory changes for backend consumers.
+    servers:
+      - $ref: '#/servers/kafka'
+    messages:
+      inventoryChanged:
+        $ref: '#/components/messages/InventoryChanged'
+    bindings:
+      kafka:
+        topic: inventory.events
+operations:
+  subscribeToUserNotifications:
+    action: receive
+    channel:
+      $ref: '#/channels/userNotifications'
+    title: Subscribe to user notifications
+    summary: Receive notifications for one user over WebSockets.
+    tags:
+      - name: Browser
+    messages:
+      - $ref: '#/channels/userNotifications/messages/notification'
+    bindings:
+      ws:
+        bindingVersion: 0.1.0
+        method: GET
+  publishDeviceTelemetry:
+    action: send
+    channel:
+      $ref: '#/channels/deviceTelemetry'
+    title: Publish device telemetry
+    summary: Send sensor readings from a device over MQTT.
+    tags:
+      - name: Devices
+    messages:
+      - $ref: '#/channels/deviceTelemetry/messages/telemetry'
+    bindings:
+      mqtt:
+        bindingVersion: 0.2.0
+        qos: 1
+  consumeInventoryEvents:
+    action: receive
+    channel:
+      $ref: '#/channels/inventoryEvents'
+    title: Consume inventory events
+    summary: Consume product inventory updates from Kafka.
+    tags:
+      - name: Backend
+    messages:
+      - $ref: '#/channels/inventoryEvents/messages/inventoryChanged'
+    bindings:
+      kafka:
+        bindingVersion: 0.5.0
+components:
+  parameters:
+    userId:
+      description: Unique user identifier.
+      examples:
+        - usr_123
+    deviceId:
+      description: Unique device identifier.
+      examples:
+        - sensor-7
+  messages:
+    UserNotification:
+      name: user.notification
+      title: User notification
+      summary: A notification shown to a user.
+      payload:
+        $ref: '#/components/schemas/UserNotificationPayload'
+    DeviceTelemetry:
+      name: device.telemetry
+      title: Device telemetry
+      summary: A batch of readings published by a device.
+      payload:
+        $ref: '#/components/schemas/DeviceTelemetryPayload'
+    InventoryChanged:
+      name: inventory.changed
+      title: Inventory changed
+      summary: A product inventory adjustment event.
+      payload:
+        $ref: '#/components/schemas/InventoryChangedPayload'
+  schemas:
+    UserNotificationPayload:
+      type: object
+      required:
+        - id
+        - message
+      properties:
+        id:
+          type: string
+          example: ntf_123
+        message:
+          type: string
+          example: Your report is ready.
+        severity:
+          type: string
+          enum:
+            - info
+            - warning
+            - critical
+    DeviceTelemetryPayload:
+      type: object
+      required:
+        - deviceId
+        - temperature
+      properties:
+        deviceId:
+          type: string
+          example: sensor-7
+        temperature:
+          type: number
+          example: 21.4
+        battery:
+          type: number
+          minimum: 0
+          maximum: 100
+          example: 87
+    InventoryChangedPayload:
+      type: object
+      required:
+        - sku
+        - available
+      properties:
+        sku:
+          type: string
+          example: hoodie-black-m
+        available:
+          type: integer
+          example: 42
+        warehouse:
+          type: string
+          example: vancouver

--- a/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/components/AsyncApiSidebarFilters.vue
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/components/AsyncApiSidebarFilters.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ScalarIconFunnel } from '@scalar/icons'
 import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import {
   getAsyncApiProtocols,
@@ -11,12 +12,14 @@ import SidebarFilter from './SidebarFilter.vue'
 /**
  * AsyncApiSidebarFilters
  *
- * The stacked protocol + server pickers shown at the top of the AsyncAPI sidebar.
- * Bundling them here keeps the two sidebar layouts (modern and classic) from each
- * repeating the picker pair and the option-building logic.
+ * The "Filters" card shown in the AsyncAPI sidebar: a bordered panel with a
+ * funnel header and the stacked protocol + server pickers. Bundling them here
+ * keeps the two sidebar layouts (modern and classic) from each repeating the
+ * picker pair and the option-building logic.
  *
- * Each picker hides itself when there is nothing to choose from, so passing an
- * OpenAPI document (or `null`) renders nothing.
+ * Each picker hides itself when there is nothing to choose from, and the whole
+ * card hides when neither picker has a real choice — so passing an OpenAPI
+ * document (or `null`) renders nothing.
  */
 const { document } = defineProps<{
   /** The active document, or `null` for OpenAPI documents (renders nothing). */
@@ -38,13 +41,31 @@ const protocolOptions = computed(() =>
 const serverOptions = computed(() =>
   document ? getAsyncApiServerOptions(document) : [],
 )
+
+/** Each picker is only worth showing when there is a choice beyond "All …". */
+const showProtocol = computed(() => protocolOptions.value.length > 2)
+const showServer = computed(() => serverOptions.value.length > 2)
 </script>
 
 <template>
-  <SidebarFilter
-    v-model="protocol"
-    :options="protocolOptions" />
-  <SidebarFilter
-    v-model="server"
-    :options="serverOptions" />
+  <div
+    v-if="showProtocol || showServer"
+    class="asyncapi-sidebar-filters mx-3 mt-3 rounded border p-3">
+    <div class="text-c-1 mb-2.5 flex items-center gap-2 font-medium">
+      <ScalarIconFunnel class="size-4" />
+      <span class="text-base">Filters</span>
+    </div>
+    <div class="flex flex-col gap-2.5 border-t pt-2.5">
+      <SidebarFilter
+        v-if="showProtocol"
+        v-model="protocol"
+        label="Protocol"
+        :options="protocolOptions" />
+      <SidebarFilter
+        v-if="showServer"
+        v-model="server"
+        label="Server"
+        :options="serverOptions" />
+    </div>
+  </div>
 </template>

--- a/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/components/AsyncApiSidebarFilters.vue
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/components/AsyncApiSidebarFilters.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import {
+  getAsyncApiProtocols,
+  getAsyncApiServerOptions,
+} from '@scalar/workspace-store/channel-example'
+import { computed } from 'vue'
+
+import SidebarFilter from './SidebarFilter.vue'
+
+/**
+ * AsyncApiSidebarFilters
+ *
+ * The stacked protocol + server pickers shown at the top of the AsyncAPI sidebar.
+ * Bundling them here keeps the two sidebar layouts (modern and classic) from each
+ * repeating the picker pair and the option-building logic.
+ *
+ * Each picker hides itself when there is nothing to choose from, so passing an
+ * OpenAPI document (or `null`) renders nothing.
+ */
+const { document } = defineProps<{
+  /** The active document, or `null` for OpenAPI documents (renders nothing). */
+  document: AsyncApiDocument | null
+}>()
+
+/** Selected protocol id; empty string clears the filter. */
+const protocol = defineModel<string>('protocol', { default: '' })
+
+/** Selected server name; empty string clears the filter. */
+const server = defineModel<string>('server', { default: '' })
+
+/** Protocol picker options, including the leading "All protocols" entry. */
+const protocolOptions = computed(() =>
+  document ? getAsyncApiProtocols(document) : [],
+)
+
+/** Server picker options, including the leading "All servers" entry. */
+const serverOptions = computed(() =>
+  document ? getAsyncApiServerOptions(document) : [],
+)
+</script>
+
+<template>
+  <SidebarFilter
+    v-model="protocol"
+    :options="protocolOptions" />
+  <SidebarFilter
+    v-model="server"
+    :options="serverOptions" />
+</template>

--- a/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/components/AsyncApiSidebarFilters.vue
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/components/AsyncApiSidebarFilters.vue
@@ -1,29 +1,30 @@
 <script setup lang="ts">
-import { ScalarIconFunnel } from '@scalar/icons'
+import { ScalarSidebarSection } from '@scalar/components/sidebar'
 import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import {
   getAsyncApiProtocols,
   getAsyncApiServerOptions,
 } from '@scalar/workspace-store/channel-example'
-import { computed } from 'vue'
+import { computed, type Component } from 'vue'
 
 import SidebarFilter from './SidebarFilter.vue'
 
 /**
  * AsyncApiSidebarFilters
  *
- * The "Filters" card shown in the AsyncAPI sidebar: a bordered panel with a
- * funnel header and the stacked protocol + server pickers. Bundling them here
- * keeps the two sidebar layouts (modern and classic) from each repeating the
- * picker pair and the option-building logic.
+ * The "Filters" sidebar section shown for AsyncAPI documents. Bundling the
+ * native sidebar title and picker pair here keeps the two sidebar layouts
+ * (modern and classic) from each repeating the option-building logic.
  *
  * Each picker hides itself when there is nothing to choose from, and the whole
- * card hides when neither picker has a real choice — so passing an OpenAPI
+ * section hides when neither picker has a real choice — so passing an OpenAPI
  * document (or `null`) renders nothing.
  */
-const { document } = defineProps<{
+const { document, is = 'li' } = defineProps<{
   /** The active document, or `null` for OpenAPI documents (renders nothing). */
   document: AsyncApiDocument | null
+  /** Render element for the sidebar section wrapper. */
+  is?: Component | string
 }>()
 
 /** Selected protocol id; empty string clears the filter. */
@@ -48,14 +49,12 @@ const showServer = computed(() => serverOptions.value.length > 2)
 </script>
 
 <template>
-  <div
+  <ScalarSidebarSection
+    :is
     v-if="showProtocol || showServer"
-    class="asyncapi-sidebar-filters mx-3 mt-3 rounded border p-3">
-    <div class="text-c-1 mb-2.5 flex items-center gap-2 font-medium">
-      <ScalarIconFunnel class="size-4" />
-      <span class="text-base">Filters</span>
-    </div>
-    <div class="flex flex-col gap-2.5 border-t pt-2.5">
+    class="asyncapi-sidebar-filters">
+    Filters
+    <template #items>
       <SidebarFilter
         v-if="showProtocol"
         v-model="protocol"
@@ -66,6 +65,6 @@ const showServer = computed(() => serverOptions.value.length > 2)
         v-model="server"
         label="Server"
         :options="serverOptions" />
-    </div>
-  </div>
+    </template>
+  </ScalarSidebarSection>
 </template>

--- a/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/components/SidebarFilter.vue
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/components/SidebarFilter.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { ScalarListbox } from '@scalar/components/listbox'
+import { ScalarIconCaretDown } from '@scalar/icons'
+import { computed } from 'vue'
+
+/**
+ * SidebarFilter
+ *
+ * A generic AsyncAPI sidebar filter that mirrors the multi-document `DocumentSelector`:
+ * a single `ScalarListbox` dropdown rendered at the top of the sidebar. It is reused
+ * for stacked filters (e.g. protocol, then server).
+ *
+ * `options` is expected to lead with an "All …" entry, which is also used as the
+ * fallback selection — so the first option doubles as the cleared state.
+ */
+const props = defineProps<{
+  /** Filter options, leading with the "All …" entry that clears the filter. */
+  options: { id: string; label: string }[]
+  /** The currently selected option id. */
+  modelValue?: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', id: string): void
+}>()
+
+/** Falls back to the first ("All …") option when nothing matches. */
+const selected = computed(
+  () =>
+    props.options.find((o) => o.id === props.modelValue) ?? props.options[0],
+)
+</script>
+
+<template>
+  <!-- Only worth showing when there is a real choice beyond the "All …" entry -->
+  <div
+    v-if="options.length > 2"
+    class="asyncapi-sidebar-filter px-3 pt-3">
+    <ScalarListbox
+      v-slot="{ open }"
+      :modelValue="selected"
+      :options="options"
+      resize
+      @update:modelValue="(e) => emit('update:modelValue', e.id)">
+      <button
+        class="group/dropdown-label text-c-2 hover:text-c-1 flex w-full cursor-pointer items-center gap-1 font-medium"
+        type="button">
+        <span class="overflow-hidden text-base text-ellipsis">
+          {{ selected?.label }}
+        </span>
+        <ScalarIconCaretDown
+          class="size-3 text-current transition-transform"
+          :class="{ 'rotate-180': open }"
+          weight="bold" />
+      </button>
+    </ScalarListbox>
+  </div>
+</template>

--- a/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/components/SidebarFilter.vue
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/components/SidebarFilter.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { ScalarListbox } from '@scalar/components/listbox'
-import { ScalarIconCaretDown } from '@scalar/icons'
+import { ScalarSidebarButton } from '@scalar/components/sidebar'
+import { ScalarIconCaretUpDown } from '@scalar/icons'
 import { computed } from 'vue'
 
 /**
  * SidebarFilter
  *
- * A single labeled row inside the AsyncAPI sidebar filter card: a left-aligned
- * label (e.g. "Protocol") next to a bordered `ScalarListbox` dropdown that fills
- * the remaining width. Reused for the stacked protocol and server filters.
+ * A compact picker inside the AsyncAPI sidebar filters section. Reused for the
+ * stacked protocol and server filters.
  *
  * `options` is expected to lead with an "All …" entry, which is also used as the
  * fallback selection — so the first option doubles as the cleared state.
@@ -34,28 +34,26 @@ const selected = computed(
 </script>
 
 <template>
-  <div class="asyncapi-sidebar-filter flex items-center gap-2">
-    <span class="text-c-1 w-20 shrink-0 text-base">{{ label }}</span>
-    <div class="min-w-0 flex-1">
-      <ScalarListbox
-        v-slot="{ open }"
-        :modelValue="selected"
-        :options="options"
-        resize
-        @update:modelValue="(e) => emit('update:modelValue', e.id)">
-        <button
-          class="text-c-1 hover:bg-b-2 flex w-full cursor-pointer items-center gap-1 rounded border px-2.5 py-1.5 font-medium"
-          type="button">
-          <span
-            class="overflow-hidden text-base text-ellipsis whitespace-nowrap">
-            {{ selected?.label }}
-          </span>
-          <ScalarIconCaretDown
-            class="ml-auto size-3 shrink-0 text-current transition-transform"
-            :class="{ 'rotate-180': open }"
+  <li class="asyncapi-sidebar-filter min-w-0">
+    <ScalarListbox
+      :label="label"
+      :modelValue="selected"
+      :options="options"
+      resize
+      teleport
+      @update:modelValue="(e) => emit('update:modelValue', e.id)">
+      <ScalarSidebarButton
+        is="button"
+        class="w-full items-center text-left">
+        <span class="text-c-1 truncate">
+          {{ selected?.label }}
+        </span>
+        <template #aside>
+          <ScalarIconCaretUpDown
+            class="text-c-1 ml-1 size-3 shrink-0 self-center"
             weight="bold" />
-        </button>
-      </ScalarListbox>
-    </div>
-  </div>
+        </template>
+      </ScalarSidebarButton>
+    </ScalarListbox>
+  </li>
 </template>

--- a/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/components/SidebarFilter.vue
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/components/SidebarFilter.vue
@@ -6,14 +6,16 @@ import { computed } from 'vue'
 /**
  * SidebarFilter
  *
- * A generic AsyncAPI sidebar filter that mirrors the multi-document `DocumentSelector`:
- * a single `ScalarListbox` dropdown rendered at the top of the sidebar. It is reused
- * for stacked filters (e.g. protocol, then server).
+ * A single labeled row inside the AsyncAPI sidebar filter card: a left-aligned
+ * label (e.g. "Protocol") next to a bordered `ScalarListbox` dropdown that fills
+ * the remaining width. Reused for the stacked protocol and server filters.
  *
  * `options` is expected to lead with an "All …" entry, which is also used as the
  * fallback selection — so the first option doubles as the cleared state.
  */
 const props = defineProps<{
+  /** Row label shown to the left of the dropdown (e.g. "Protocol"). */
+  label: string
   /** Filter options, leading with the "All …" entry that clears the filter. */
   options: { id: string; label: string }[]
   /** The currently selected option id. */
@@ -32,27 +34,28 @@ const selected = computed(
 </script>
 
 <template>
-  <!-- Only worth showing when there is a real choice beyond the "All …" entry -->
-  <div
-    v-if="options.length > 2"
-    class="asyncapi-sidebar-filter px-3 pt-3">
-    <ScalarListbox
-      v-slot="{ open }"
-      :modelValue="selected"
-      :options="options"
-      resize
-      @update:modelValue="(e) => emit('update:modelValue', e.id)">
-      <button
-        class="group/dropdown-label text-c-2 hover:text-c-1 flex w-full cursor-pointer items-center gap-1 font-medium"
-        type="button">
-        <span class="overflow-hidden text-base text-ellipsis">
-          {{ selected?.label }}
-        </span>
-        <ScalarIconCaretDown
-          class="size-3 text-current transition-transform"
-          :class="{ 'rotate-180': open }"
-          weight="bold" />
-      </button>
-    </ScalarListbox>
+  <div class="asyncapi-sidebar-filter flex items-center gap-2">
+    <span class="text-c-1 w-20 shrink-0 text-base">{{ label }}</span>
+    <div class="min-w-0 flex-1">
+      <ScalarListbox
+        v-slot="{ open }"
+        :modelValue="selected"
+        :options="options"
+        resize
+        @update:modelValue="(e) => emit('update:modelValue', e.id)">
+        <button
+          class="text-c-1 hover:bg-b-2 flex w-full cursor-pointer items-center gap-1 rounded border px-2.5 py-1.5 font-medium"
+          type="button">
+          <span
+            class="overflow-hidden text-base text-ellipsis whitespace-nowrap">
+            {{ selected?.label }}
+          </span>
+          <ScalarIconCaretDown
+            class="ml-auto size-3 shrink-0 text-current transition-transform"
+            :class="{ 'rotate-180': open }"
+            weight="bold" />
+        </button>
+      </ScalarListbox>
+    </div>
   </div>
 </template>

--- a/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/helpers/filter-async-api-navigation.test.ts
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/helpers/filter-async-api-navigation.test.ts
@@ -1,0 +1,86 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
+import { describe, expect, it } from 'vitest'
+
+import { filterAsyncApiNavigation } from './filter-async-api-navigation'
+
+const document: AsyncApiDocument = {
+  asyncapi: '3.0.0',
+  info: { title: 'Mixed Protocol API', version: '1.0.0' },
+  servers: {
+    websocket: { host: 'api.example.com', protocol: 'wss' },
+    mqtt: { host: 'mqtt.example.com', protocol: 'mqtt' },
+  },
+  channels: {
+    mqttEvents: { address: 'sensors/{id}', servers: [{ $ref: '#/servers/mqtt' }] },
+    wsChat: { address: '/chat', servers: [{ $ref: '#/servers/websocket' }] },
+  },
+  operations: {
+    receiveSensor: { action: 'receive', channel: { $ref: '#/channels/mqttEvents' } },
+    sendChat: { action: 'send', channel: { $ref: '#/channels/wsChat' } },
+  },
+} as unknown as AsyncApiDocument
+
+/** Minimal sidebar tree: one channel per operation. */
+const entries: TraversedEntry[] = [
+  {
+    type: 'asyncapi-channel',
+    id: 'mqttEvents',
+    title: 'mqttEvents',
+    channelName: 'mqttEvents',
+    channelAddress: 'sensors/{id}',
+    children: [
+      {
+        type: 'asyncapi-operation',
+        id: 'op-receiveSensor',
+        title: 'receiveSensor',
+        operationName: 'receiveSensor',
+        action: 'receive',
+        channelName: 'mqttEvents',
+        channelAddress: 'sensors/{id}',
+      },
+    ],
+  },
+  {
+    type: 'asyncapi-channel',
+    id: 'wsChat',
+    title: 'wsChat',
+    channelName: 'wsChat',
+    channelAddress: '/chat',
+    children: [
+      {
+        type: 'asyncapi-operation',
+        id: 'op-sendChat',
+        title: 'sendChat',
+        operationName: 'sendChat',
+        action: 'send',
+        channelName: 'wsChat',
+        channelAddress: '/chat',
+      },
+    ],
+  },
+] as TraversedEntry[]
+
+const channelIds = (result: TraversedEntry[]) => result.map((entry) => entry.id)
+
+describe('filterAsyncApiNavigation', () => {
+  it('returns the original tree when no filter is selected', () => {
+    expect(filterAsyncApiNavigation(entries, document, {})).toBe(entries)
+    expect(filterAsyncApiNavigation(entries, document, { protocol: 'all', server: 'all' })).toBe(entries)
+  })
+
+  it('drops channels whose only operation does not match the protocol', () => {
+    const result = filterAsyncApiNavigation(entries, document, { protocol: 'mqtt' })
+    expect(channelIds(result)).toEqual(['mqttEvents'])
+  })
+
+  it('drops channels whose only operation is not reachable through the server', () => {
+    const result = filterAsyncApiNavigation(entries, document, { server: 'websocket' })
+    expect(channelIds(result)).toEqual(['wsChat'])
+  })
+
+  it('applies protocol and server filters together', () => {
+    const result = filterAsyncApiNavigation(entries, document, { protocol: 'mqtt', server: 'mqtt' })
+    expect(channelIds(result)).toEqual(['mqttEvents'])
+  })
+})

--- a/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/helpers/filter-async-api-navigation.ts
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/helpers/filter-async-api-navigation.ts
@@ -9,7 +9,7 @@ import { getResolvedRef, mergeSiblingReferences } from '@scalar/workspace-store/
 import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
 
 /** The currently selected sidebar filters. Empty / sentinel values disable a filter. */
-export type AsyncApiNavigationFilter = {
+type AsyncApiNavigationFilter = {
   /** Selected protocol id, or {@link ALL} / undefined for no protocol filter. */
   protocol?: string
   /** Selected server name, or {@link ALL} / undefined for no server filter. */

--- a/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/helpers/filter-async-api-navigation.ts
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/helpers/filter-async-api-navigation.ts
@@ -1,0 +1,90 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import {
+  ALL_PROTOCOLS,
+  ALL_SERVERS,
+  operationMatchesProtocol,
+  operationMatchesServer,
+} from '@scalar/workspace-store/channel-example'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
+
+/** The currently selected sidebar filters. Empty / sentinel values disable a filter. */
+export type AsyncApiNavigationFilter = {
+  /** Selected protocol id, or {@link ALL_PROTOCOLS} / undefined for no protocol filter. */
+  protocol?: string
+  /** Selected server name, or {@link ALL_SERVERS} / undefined for no server filter. */
+  server?: string
+}
+
+/** Whether the filter would keep every entry, so the tree can be returned untouched. */
+const isNoopFilter = ({ protocol, server }: AsyncApiNavigationFilter): boolean =>
+  (!protocol || protocol === ALL_PROTOCOLS) && (!server || server === ALL_SERVERS)
+
+/**
+ * Filters one navigation entry against the selected protocol/server.
+ *
+ * - `asyncapi-operation` — kept only when the operation matches both filters.
+ * - `asyncapi-channel` / `tag` — recursed into, then dropped when they have no
+ *   children left (so empty channels and tags disappear from the sidebar).
+ * - Everything else (description, models, schemas) passes through unchanged.
+ *
+ * Returns `null` when the entry should be removed.
+ */
+const filterEntry = (
+  entry: TraversedEntry,
+  document: AsyncApiDocument,
+  filter: AsyncApiNavigationFilter,
+): TraversedEntry | null => {
+  if (entry.type === 'asyncapi-operation') {
+    const operationNode = document.operations?.[entry.operationName]
+    // If the operation can't be resolved we keep it rather than hide it by accident.
+    if (!operationNode) {
+      return entry
+    }
+
+    const operation = getResolvedRef(operationNode)
+    const keep =
+      operationMatchesProtocol(document, operation, filter.protocol) &&
+      operationMatchesServer(document, operation, filter.server)
+
+    return keep ? entry : null
+  }
+
+  if (entry.type === 'asyncapi-channel' || entry.type === 'tag') {
+    const originalChildren = entry.children ?? []
+    const children = originalChildren.flatMap((child) => {
+      const filtered = filterEntry(child, document, filter)
+      return filtered ? [filtered] : []
+    })
+
+    // Drop a container that had children but lost them all to the filter.
+    if (originalChildren.length > 0 && children.length === 0) {
+      return null
+    }
+
+    return { ...entry, children }
+  }
+
+  return entry
+}
+
+/**
+ * Filters the AsyncAPI sidebar tree by the selected protocol and/or server.
+ *
+ * Returns the original entries untouched when no filter is active, so OpenAPI
+ * documents and the unfiltered AsyncAPI case pay no cost.
+ */
+export const filterAsyncApiNavigation = (
+  entries: TraversedEntry[],
+  document: AsyncApiDocument,
+  filter: AsyncApiNavigationFilter,
+): TraversedEntry[] => {
+  if (isNoopFilter(filter)) {
+    return entries
+  }
+
+  return entries.flatMap((entry) => {
+    const filtered = filterEntry(entry, document, filter)
+    return filtered ? [filtered] : []
+  })
+}

--- a/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/helpers/filter-async-api-navigation.ts
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/helpers/filter-async-api-navigation.ts
@@ -1,24 +1,28 @@
 import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import {
-  ALL_PROTOCOLS,
-  ALL_SERVERS,
-  operationMatchesProtocol,
-  operationMatchesServer,
+  ALL,
+  type AsyncApiReachabilityContext,
+  createReachabilityContext,
+  getOperationReachability,
 } from '@scalar/workspace-store/channel-example'
-import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { getResolvedRef, mergeSiblingReferences } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
 
 /** The currently selected sidebar filters. Empty / sentinel values disable a filter. */
 export type AsyncApiNavigationFilter = {
-  /** Selected protocol id, or {@link ALL_PROTOCOLS} / undefined for no protocol filter. */
+  /** Selected protocol id, or {@link ALL} / undefined for no protocol filter. */
   protocol?: string
-  /** Selected server name, or {@link ALL_SERVERS} / undefined for no server filter. */
+  /** Selected server name, or {@link ALL} / undefined for no server filter. */
   server?: string
 }
 
 /** Whether the filter would keep every entry, so the tree can be returned untouched. */
 const isNoopFilter = ({ protocol, server }: AsyncApiNavigationFilter): boolean =>
-  (!protocol || protocol === ALL_PROTOCOLS) && (!server || server === ALL_SERVERS)
+  (!protocol || protocol === ALL) && (!server || server === ALL)
+
+/** Whether a selection (protocol or server) keeps an operation, given the set it is reachable through. */
+const selectionMatches = (reachable: Set<string>, selected: string | undefined): boolean =>
+  !selected || selected === ALL || reachable.has(selected)
 
 /**
  * Filters one navigation entry against the selected protocol/server.
@@ -28,12 +32,16 @@ const isNoopFilter = ({ protocol, server }: AsyncApiNavigationFilter): boolean =
  *   children left (so empty channels and tags disappear from the sidebar).
  * - Everything else (description, models, schemas) passes through unchanged.
  *
+ * `context` carries the document-level lookups so they are built once per filter
+ * pass rather than recomputed for every operation.
+ *
  * Returns `null` when the entry should be removed.
  */
 const filterEntry = (
   entry: TraversedEntry,
   document: AsyncApiDocument,
   filter: AsyncApiNavigationFilter,
+  context: AsyncApiReachabilityContext,
 ): TraversedEntry | null => {
   if (entry.type === 'asyncapi-operation') {
     const operationNode = document.operations?.[entry.operationName]
@@ -42,10 +50,13 @@ const filterEntry = (
       return entry
     }
 
-    const operation = getResolvedRef(operationNode)
-    const keep =
-      operationMatchesProtocol(document, operation, filter.protocol) &&
-      operationMatchesServer(document, operation, filter.server)
+    // Resolve the same way the navigation traversal did, so sibling overrides
+    // (e.g. an inline `channel` alongside a `$ref`) are honored consistently.
+    const operation = getResolvedRef(operationNode, mergeSiblingReferences)
+
+    // Resolve the operation's reachability once, then test both selections against it.
+    const { protocols, serverNames } = getOperationReachability(document, operation, context)
+    const keep = selectionMatches(protocols, filter.protocol) && selectionMatches(serverNames, filter.server)
 
     return keep ? entry : null
   }
@@ -53,7 +64,7 @@ const filterEntry = (
   if (entry.type === 'asyncapi-channel' || entry.type === 'tag') {
     const originalChildren = entry.children ?? []
     const children = originalChildren.flatMap((child) => {
-      const filtered = filterEntry(child, document, filter)
+      const filtered = filterEntry(child, document, filter, context)
       return filtered ? [filtered] : []
     })
 
@@ -83,8 +94,11 @@ export const filterAsyncApiNavigation = (
     return entries
   }
 
+  // Build the document-level reachability lookups once for the whole pass.
+  const context = createReachabilityContext(document)
+
   return entries.flatMap((entry) => {
-    const filtered = filterEntry(entry, document, filter)
+    const filtered = filterEntry(entry, document, filter, context)
     return filtered ? [filtered] : []
   })
 }

--- a/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/index.ts
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/index.ts
@@ -1,0 +1,3 @@
+export { default as SidebarFilter } from './components/SidebarFilter.vue'
+export type { AsyncApiNavigationFilter } from './helpers/filter-async-api-navigation'
+export { filterAsyncApiNavigation } from './helpers/filter-async-api-navigation'

--- a/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/index.ts
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/index.ts
@@ -1,3 +1,3 @@
-export { default as SidebarFilter } from './components/SidebarFilter.vue'
+export { default as AsyncApiSidebarFilters } from './components/AsyncApiSidebarFilters.vue'
 export type { AsyncApiNavigationFilter } from './helpers/filter-async-api-navigation'
 export { filterAsyncApiNavigation } from './helpers/filter-async-api-navigation'

--- a/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/index.ts
+++ b/packages/api-reference/src/blocks/scalar-asyncapi-sidebar-filters-block/index.ts
@@ -1,3 +1,2 @@
 export { default as AsyncApiSidebarFilters } from './components/AsyncApiSidebarFilters.vue'
-export type { AsyncApiNavigationFilter } from './helpers/filter-async-api-navigation'
 export { filterAsyncApiNavigation } from './helpers/filter-async-api-navigation'

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -39,11 +39,7 @@ import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { useColorMode } from '@scalar/use-hooks/useColorMode'
 import { ScalarToasts } from '@scalar/use-toasts'
 import { coerce } from '@scalar/validation'
-import {
-  getAsyncApiProtocols,
-  getAsyncApiServerOptions,
-  getAsyncApiServers,
-} from '@scalar/workspace-store/channel-example'
+import { getAsyncApiServers } from '@scalar/workspace-store/channel-example'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import {
@@ -74,8 +70,8 @@ import {
 } from 'vue'
 
 import {
+  AsyncApiSidebarFilters,
   filterAsyncApiNavigation,
-  SidebarFilter,
 } from '@/blocks/scalar-asyncapi-sidebar-filters-block'
 import {
   AgentScalarButton,
@@ -261,20 +257,6 @@ const activeAsyncApiDocument = computed(() => {
   const document = workspaceStore.workspace.activeDocument
   return isAsyncApiDocument(document) ? document : null
 })
-
-/** Protocol picker options, including the leading "All protocols" entry. */
-const protocolOptions = computed(() =>
-  activeAsyncApiDocument.value
-    ? getAsyncApiProtocols(activeAsyncApiDocument.value)
-    : [],
-)
-
-/** Server picker options, including the leading "All servers" entry. */
-const serverFilterOptions = computed(() =>
-  activeAsyncApiDocument.value
-    ? getAsyncApiServerOptions(activeAsyncApiDocument.value)
-    : [],
-)
 
 // Reset the filters when switching documents.
 watch(activeSlug, () => {
@@ -1417,12 +1399,10 @@ const showMCPButton = computed(() => {
                 @update:modelValue="changeSelectedDocument" />
 
               <!-- AsyncAPI protocol + server filters (only render with >1 choice) -->
-              <SidebarFilter
-                v-model="selectedProtocol"
-                :options="protocolOptions" />
-              <SidebarFilter
-                v-model="selectedServer"
-                :options="serverFilterOptions" />
+              <AsyncApiSidebarFilters
+                v-model:protocol="selectedProtocol"
+                v-model:server="selectedServer"
+                :document="activeAsyncApiDocument" />
 
               <!-- Search -->
               <div
@@ -1540,12 +1520,10 @@ const showMCPButton = computed(() => {
                   :modelValue="activeSlug"
                   :options="documentOptionList"
                   @update:modelValue="changeSelectedDocument" />
-                <SidebarFilter
-                  v-model="selectedProtocol"
-                  :options="protocolOptions" />
-                <SidebarFilter
-                  v-model="selectedServer"
-                  :options="serverFilterOptions" />
+                <AsyncApiSidebarFilters
+                  v-model:protocol="selectedProtocol"
+                  v-model:server="selectedServer"
+                  :document="activeAsyncApiDocument" />
               </div>
               <SearchButton
                 v-if="!mergedConfig.hideSearch"

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -1398,12 +1398,6 @@ const showMCPButton = computed(() => {
                 :options="documentOptionList"
                 @update:modelValue="changeSelectedDocument" />
 
-              <!-- AsyncAPI protocol + server filters (only render with >1 choice) -->
-              <AsyncApiSidebarFilters
-                v-model:protocol="selectedProtocol"
-                v-model:server="selectedServer"
-                :document="activeAsyncApiDocument" />
-
               <!-- Search -->
               <div
                 v-if="!mergedConfig.hideSearch"
@@ -1417,6 +1411,12 @@ const showMCPButton = computed(() => {
 
                 <AgentScalarButton v-if="agent.agentEnabled.value" />
               </div>
+
+              <!-- AsyncAPI protocol + server filters (only render with >1 choice) -->
+              <AsyncApiSidebarFilters
+                v-model:protocol="selectedProtocol"
+                v-model:server="selectedServer"
+                :document="activeAsyncApiDocument" />
               <!-- Sidebar Start -->
               <slot
                 name="sidebar-start"

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -19,7 +19,10 @@ import {
   ScalarColorModeToggleIcon,
 } from '@scalar/components/color-mode-toggle'
 import { addScalarClassesToHeadless } from '@scalar/components/helpers'
-import { ScalarSidebarFooter } from '@scalar/components/sidebar'
+import {
+  ScalarSidebarFooter,
+  ScalarSidebarSection,
+} from '@scalar/components/sidebar'
 import { slugify } from '@scalar/helpers/string/slugify'
 import { isLocalUrl } from '@scalar/helpers/url/is-local-url'
 import { apiReferenceConfigurationSchema } from '@scalar/schemas/api-reference'
@@ -1412,15 +1415,22 @@ const showMCPButton = computed(() => {
                 <AgentScalarButton v-if="agent.agentEnabled.value" />
               </div>
 
+              <!-- Sidebar Start -->
+              <slot
+                name="sidebar-start"
+                v-bind="slotProps" />
+            </template>
+            <template #before>
               <!-- AsyncAPI protocol + server filters (only render with >1 choice) -->
               <AsyncApiSidebarFilters
                 v-model:protocol="selectedProtocol"
                 v-model:server="selectedServer"
                 :document="activeAsyncApiDocument" />
-              <!-- Sidebar Start -->
-              <slot
-                name="sidebar-start"
-                v-bind="slotProps" />
+              <ScalarSidebarSection
+                v-if="activeAsyncApiDocument"
+                class="asyncapi-sidebar-document-section">
+                Document
+              </ScalarSidebarSection>
             </template>
             <template #footer>
               <slot
@@ -1521,6 +1531,7 @@ const showMCPButton = computed(() => {
                   :options="documentOptionList"
                   @update:modelValue="changeSelectedDocument" />
                 <AsyncApiSidebarFilters
+                  is="div"
                   v-model:protocol="selectedProtocol"
                   v-model:server="selectedServer"
                   :document="activeAsyncApiDocument" />
@@ -1591,6 +1602,10 @@ const showMCPButton = computed(() => {
 /** Used to check if css is loaded */
 :root {
   --scalar-loaded-api-reference: true;
+}
+
+.asyncapi-sidebar-document-section > .group\/spacer-after {
+  height: 0;
 }
 </style>
 <style scoped>

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -39,7 +39,11 @@ import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import { useColorMode } from '@scalar/use-hooks/useColorMode'
 import { ScalarToasts } from '@scalar/use-toasts'
 import { coerce } from '@scalar/validation'
-import { getAsyncApiServers } from '@scalar/workspace-store/channel-example'
+import {
+  getAsyncApiProtocols,
+  getAsyncApiServerOptions,
+  getAsyncApiServers,
+} from '@scalar/workspace-store/channel-example'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import {
@@ -69,6 +73,10 @@ import {
   watch,
 } from 'vue'
 
+import {
+  filterAsyncApiNavigation,
+  SidebarFilter,
+} from '@/blocks/scalar-asyncapi-sidebar-filters-block'
 import {
   AgentScalarButton,
   AgentScalarDrawer,
@@ -237,6 +245,42 @@ const documentOptionList = computed(() =>
     id: c.slug,
   })),
 )
+
+/**
+ * AsyncAPI sidebar filters (protocol + server).
+ *
+ * These mirror the document picker: stacked dropdowns at the top of the sidebar
+ * that narrow the visible operations. State resets whenever the active document
+ * changes so a filter never leaks across documents.
+ */
+const selectedProtocol = ref<string>('')
+const selectedServer = ref<string>('')
+
+/** The active document, narrowed to AsyncAPI (or `null` for OpenAPI documents). */
+const activeAsyncApiDocument = computed(() => {
+  const document = workspaceStore.workspace.activeDocument
+  return isAsyncApiDocument(document) ? document : null
+})
+
+/** Protocol picker options, including the leading "All protocols" entry. */
+const protocolOptions = computed(() =>
+  activeAsyncApiDocument.value
+    ? getAsyncApiProtocols(activeAsyncApiDocument.value)
+    : [],
+)
+
+/** Server picker options, including the leading "All servers" entry. */
+const serverFilterOptions = computed(() =>
+  activeAsyncApiDocument.value
+    ? getAsyncApiServerOptions(activeAsyncApiDocument.value)
+    : [],
+)
+
+// Reset the filters when switching documents.
+watch(activeSlug, () => {
+  selectedProtocol.value = ''
+  selectedServer.value = ''
+})
 
 /** Configuration overrides to apply to the selected document (from the localhost toolbar) */
 const configurationOverrides = ref<
@@ -584,10 +628,19 @@ const sidebarItems = computed<TraversedEntry[]>(() => {
     return []
   }
 
-  const docItems =
+  const rawDocItems =
     sidebarState.items.value.find(
       (item): item is TraversedTag => item.id === activeSlug.value,
     )?.children ?? []
+
+  // Apply the AsyncAPI protocol/server filters to the sidebar tree. This is a no-op
+  // for OpenAPI documents and when no filter is selected.
+  const docItems = activeAsyncApiDocument.value
+    ? filterAsyncApiNavigation(rawDocItems, activeAsyncApiDocument.value, {
+        protocol: selectedProtocol.value,
+        server: selectedServer.value,
+      })
+    : rawDocItems
 
   // When the default open all tags configuration is enabled we open all the children of the document
   if (config.defaultOpenAllTags) {
@@ -1363,6 +1416,14 @@ const showMCPButton = computed(() => {
                 :options="documentOptionList"
                 @update:modelValue="changeSelectedDocument" />
 
+              <!-- AsyncAPI protocol + server filters (only render with >1 choice) -->
+              <SidebarFilter
+                v-model="selectedProtocol"
+                :options="protocolOptions" />
+              <SidebarFilter
+                v-model="selectedServer"
+                :options="serverFilterOptions" />
+
               <!-- Search -->
               <div
                 v-if="!mergedConfig.hideSearch"
@@ -1479,6 +1540,12 @@ const showMCPButton = computed(() => {
                   :modelValue="activeSlug"
                   :options="documentOptionList"
                   @update:modelValue="changeSelectedDocument" />
+                <SidebarFilter
+                  v-model="selectedProtocol"
+                  :options="protocolOptions" />
+                <SidebarFilter
+                  v-model="selectedServer"
+                  :options="serverFilterOptions" />
               </div>
               <SearchButton
                 v-if="!mergedConfig.hideSearch"

--- a/packages/api-reference/test/utils/sources.ts
+++ b/packages/api-reference/test/utils/sources.ts
@@ -39,6 +39,11 @@ export const sources = [
     layout: 'classic',
   },
   {
+    title: 'AsyncAPI Sidebar Filters',
+    slug: 'asyncapi-sidebar-filters',
+    url: 'examples/asyncapi-filters.yaml',
+  },
+  {
     title: 'Tag Groups',
     slug: 'tag-groups',
     content: {

--- a/packages/workspace-store/src/channel-example/build-connection-url.ts
+++ b/packages/workspace-store/src/channel-example/build-connection-url.ts
@@ -66,6 +66,17 @@ const substituteTemplate = (template: string, options: SubstitutionOptions): str
   return result
 }
 
+/**
+ * Normalizes an AsyncAPI `protocol` for comparison: trimmed and lowercased.
+ *
+ * Returns `undefined` when the protocol is missing or blank, so callers can treat
+ * "no protocol" distinctly instead of comparing against an empty string.
+ */
+export const normalizeProtocol = (protocol: string | undefined): string | undefined => {
+  const normalized = protocol?.trim().toLowerCase()
+  return normalized ? normalized : undefined
+}
+
 /** Maps AsyncAPI `server.protocol` to a URL scheme (MVP: ws and wss). */
 export const getUrlSchemeFromProtocol = (protocol: string): string => protocol.trim().toLowerCase()
 

--- a/packages/workspace-store/src/channel-example/get-async-api-protocols.test.ts
+++ b/packages/workspace-store/src/channel-example/get-async-api-protocols.test.ts
@@ -2,11 +2,12 @@ import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import { describe, expect, it } from 'vitest'
 
 import {
-  ALL_PROTOCOLS,
-  ALL_SERVERS,
+  ALL,
+  createReachabilityContext,
   getAsyncApiProtocols,
   getAsyncApiServerOptions,
   getOperationProtocols,
+  getOperationReachability,
   getOperationServerNames,
   operationMatchesProtocol,
   operationMatchesServer,
@@ -48,16 +49,14 @@ const operation = (name: keyof NonNullable<AsyncApiDocument['operations']>) => {
 describe('getAsyncApiProtocols', () => {
   it('returns an "All protocols" entry plus each unique server protocol, sorted', () => {
     expect(getAsyncApiProtocols(document)).toEqual([
-      { id: ALL_PROTOCOLS, label: 'All protocols' },
+      { id: ALL, label: 'All protocols' },
       { id: 'mqtt', label: 'MQTT' },
       { id: 'wss', label: 'WSS' },
     ])
   })
 
   it('returns only the "All protocols" entry when the document has no servers', () => {
-    expect(getAsyncApiProtocols({ ...document, servers: undefined })).toEqual([
-      { id: ALL_PROTOCOLS, label: 'All protocols' },
-    ])
+    expect(getAsyncApiProtocols({ ...document, servers: undefined })).toEqual([{ id: ALL, label: 'All protocols' }])
   })
 })
 
@@ -74,7 +73,7 @@ describe('getOperationProtocols', () => {
 describe('operationMatchesProtocol', () => {
   it('keeps every operation when no protocol (or "all") is selected', () => {
     expect(operationMatchesProtocol(document, operation('receiveSensor'), undefined)).toBe(true)
-    expect(operationMatchesProtocol(document, operation('receiveSensor'), ALL_PROTOCOLS)).toBe(true)
+    expect(operationMatchesProtocol(document, operation('receiveSensor'), ALL)).toBe(true)
   })
 
   it('filters out operations whose channel cannot use the selected protocol', () => {
@@ -86,7 +85,7 @@ describe('operationMatchesProtocol', () => {
 describe('getAsyncApiServerOptions', () => {
   it('returns an "All servers" entry plus each server labelled with its protocol', () => {
     expect(getAsyncApiServerOptions(document)).toEqual([
-      { id: ALL_SERVERS, label: 'All servers' },
+      { id: ALL, label: 'All servers' },
       { id: 'websocket', label: 'websocket (wss)' },
       { id: 'mqtt', label: 'mqtt (mqtt)' },
     ])
@@ -106,11 +105,31 @@ describe('getOperationServerNames', () => {
 describe('operationMatchesServer', () => {
   it('keeps every operation when no server (or "all") is selected', () => {
     expect(operationMatchesServer(document, operation('receiveSensor'), undefined)).toBe(true)
-    expect(operationMatchesServer(document, operation('receiveSensor'), ALL_SERVERS)).toBe(true)
+    expect(operationMatchesServer(document, operation('receiveSensor'), ALL)).toBe(true)
   })
 
   it('filters out operations whose channel is not reachable through the selected server', () => {
     expect(operationMatchesServer(document, operation('receiveSensor'), 'websocket')).toBe(false)
     expect(operationMatchesServer(document, operation('receiveSensor'), 'mqtt')).toBe(true)
+  })
+})
+
+describe('getOperationReachability', () => {
+  it('resolves both the servers and their protocols for a pinned channel in one pass', () => {
+    const reachability = getOperationReachability(document, operation('receiveSensor'))
+    expect([...reachability.serverNames]).toEqual(['mqtt'])
+    expect([...reachability.protocols]).toEqual(['mqtt'])
+  })
+
+  it('reuses a shared context so matchers do not rebuild document-level lookups per operation', () => {
+    const context = createReachabilityContext(document)
+    expect(context.serverProtocols.get('websocket')).toBe('wss')
+    expect([...context.allServerNames].sort()).toEqual(['mqtt', 'websocket'])
+
+    // Passing the context yields the same result as computing it standalone.
+    expect([...getOperationReachability(document, operation('sendChat'), context).serverNames].sort()).toEqual([
+      'mqtt',
+      'websocket',
+    ])
   })
 })

--- a/packages/workspace-store/src/channel-example/get-async-api-protocols.test.ts
+++ b/packages/workspace-store/src/channel-example/get-async-api-protocols.test.ts
@@ -1,0 +1,116 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import { describe, expect, it } from 'vitest'
+
+import {
+  ALL_PROTOCOLS,
+  ALL_SERVERS,
+  getAsyncApiProtocols,
+  getAsyncApiServerOptions,
+  getOperationProtocols,
+  getOperationServerNames,
+  operationMatchesProtocol,
+  operationMatchesServer,
+} from '@/channel-example/get-async-api-protocols'
+
+/**
+ * Two channels:
+ * - `mqttEvents` is pinned to the `mqtt` server only.
+ * - `wsChat` declares no servers, so it is reachable over every server.
+ */
+const document: AsyncApiDocument = {
+  asyncapi: '3.0.0',
+  info: { title: 'Mixed Protocol API', version: '1.0.0' },
+  servers: {
+    websocket: { host: 'api.example.com', protocol: 'wss' },
+    mqtt: { host: 'mqtt.example.com', protocol: 'mqtt' },
+  },
+  channels: {
+    mqttEvents: {
+      address: 'sensors/{id}',
+      servers: [{ $ref: '#/servers/mqtt' }],
+    },
+    wsChat: { address: '/chat' },
+  },
+  operations: {
+    receiveSensor: { action: 'receive', channel: { $ref: '#/channels/mqttEvents' } },
+    sendChat: { action: 'send', channel: { $ref: '#/channels/wsChat' } },
+  },
+} as unknown as AsyncApiDocument
+
+const operation = (name: keyof NonNullable<AsyncApiDocument['operations']>) => {
+  const op = document.operations?.[name]
+  if (!op || '$ref' in op) {
+    throw new Error(`Expected inline ${String(name)} operation fixture`)
+  }
+  return op
+}
+
+describe('getAsyncApiProtocols', () => {
+  it('returns an "All protocols" entry plus each unique server protocol, sorted', () => {
+    expect(getAsyncApiProtocols(document)).toEqual([
+      { id: ALL_PROTOCOLS, label: 'All protocols' },
+      { id: 'mqtt', label: 'MQTT' },
+      { id: 'wss', label: 'WSS' },
+    ])
+  })
+
+  it('returns only the "All protocols" entry when the document has no servers', () => {
+    expect(getAsyncApiProtocols({ ...document, servers: undefined })).toEqual([
+      { id: ALL_PROTOCOLS, label: 'All protocols' },
+    ])
+  })
+})
+
+describe('getOperationProtocols', () => {
+  it('limits an operation to the protocols of the servers its channel is pinned to', () => {
+    expect([...getOperationProtocols(document, operation('receiveSensor'))]).toEqual(['mqtt'])
+  })
+
+  it('includes every server protocol when the channel declares no servers', () => {
+    expect([...getOperationProtocols(document, operation('sendChat')).values()].sort()).toEqual(['mqtt', 'wss'])
+  })
+})
+
+describe('operationMatchesProtocol', () => {
+  it('keeps every operation when no protocol (or "all") is selected', () => {
+    expect(operationMatchesProtocol(document, operation('receiveSensor'), undefined)).toBe(true)
+    expect(operationMatchesProtocol(document, operation('receiveSensor'), ALL_PROTOCOLS)).toBe(true)
+  })
+
+  it('filters out operations whose channel cannot use the selected protocol', () => {
+    expect(operationMatchesProtocol(document, operation('receiveSensor'), 'wss')).toBe(false)
+    expect(operationMatchesProtocol(document, operation('receiveSensor'), 'mqtt')).toBe(true)
+  })
+})
+
+describe('getAsyncApiServerOptions', () => {
+  it('returns an "All servers" entry plus each server labelled with its protocol', () => {
+    expect(getAsyncApiServerOptions(document)).toEqual([
+      { id: ALL_SERVERS, label: 'All servers' },
+      { id: 'websocket', label: 'websocket (wss)' },
+      { id: 'mqtt', label: 'mqtt (mqtt)' },
+    ])
+  })
+})
+
+describe('getOperationServerNames', () => {
+  it('limits an operation to the servers its channel is pinned to', () => {
+    expect([...getOperationServerNames(document, operation('receiveSensor'))]).toEqual(['mqtt'])
+  })
+
+  it('includes every server when the channel declares none', () => {
+    expect([...getOperationServerNames(document, operation('sendChat'))].sort()).toEqual(['mqtt', 'websocket'])
+  })
+})
+
+describe('operationMatchesServer', () => {
+  it('keeps every operation when no server (or "all") is selected', () => {
+    expect(operationMatchesServer(document, operation('receiveSensor'), undefined)).toBe(true)
+    expect(operationMatchesServer(document, operation('receiveSensor'), ALL_SERVERS)).toBe(true)
+  })
+
+  it('filters out operations whose channel is not reachable through the selected server', () => {
+    expect(operationMatchesServer(document, operation('receiveSensor'), 'websocket')).toBe(false)
+    expect(operationMatchesServer(document, operation('receiveSensor'), 'mqtt')).toBe(true)
+  })
+})

--- a/packages/workspace-store/src/channel-example/get-async-api-protocols.ts
+++ b/packages/workspace-store/src/channel-example/get-async-api-protocols.ts
@@ -1,32 +1,22 @@
 import { objectEntries } from '@scalar/helpers/object/object-entries'
 import { objectKeys } from '@scalar/helpers/object/object-keys'
-import type { AsyncApiChannelObject, AsyncApiDocument, AsyncApiOperationObject } from '@scalar/types/asyncapi/3.1'
+import type { AsyncApiDocument, AsyncApiOperationObject } from '@scalar/types/asyncapi/3.1'
 
-import { getNameFromRef } from '@/helpers/get-name-from-ref'
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
 
+import { normalizeProtocol } from './build-connection-url'
 import { resolveOperationChannel } from './resolve-operation-channel'
+import { getChannelServerNames } from './servers'
 
-/** Sentinel used by the protocol picker to mean "don't filter by protocol". */
-export const ALL_PROTOCOLS = 'all' as const
-
-/** Sentinel used by the server picker to mean "don't filter by server". */
-export const ALL_SERVERS = 'all' as const
+/** Sentinel used by the protocol and server pickers to mean "don't filter". */
+export const ALL = 'all' as const
 
 /** A single protocol option for the picker (e.g. `{ id: 'mqtt', label: 'MQTT' }`). */
 export type AsyncApiProtocolOption = {
-  /** The normalized protocol id (lowercase), or {@link ALL_PROTOCOLS}. */
+  /** The normalized protocol id (lowercase), or {@link ALL}. */
   id: string
   /** Human-friendly label shown in the dropdown. */
   label: string
-}
-
-const getServerNameFromRef = (ref: string): string | undefined => getNameFromRef(ref, ['servers'])
-
-/** Normalizes a protocol string the same way the server list does (trimmed + lowercased). */
-const normalizeProtocol = (protocol: string | undefined): string | undefined => {
-  const normalized = protocol?.trim().toLowerCase()
-  return normalized ? normalized : undefined
 }
 
 /**
@@ -37,37 +27,13 @@ const getServerProtocols = (document: AsyncApiDocument): Map<string, string> => 
   const protocols = new Map<string, string>()
 
   for (const [name, serverNode] of objectEntries(document.servers ?? {})) {
-    const server = getResolvedRef(serverNode)
-    const protocol = normalizeProtocol(server.protocol)
+    const protocol = normalizeProtocol(getResolvedRef(serverNode).protocol)
     if (protocol) {
       protocols.set(name, protocol)
     }
   }
 
   return protocols
-}
-
-/**
- * The server names a channel is available on.
- *
- * When the channel does not declare `servers`, it is available on every server,
- * so we return `undefined` to signal "all servers" (mirrors `getAsyncApiServers`).
- */
-const getChannelServerNames = (channel: AsyncApiChannelObject | undefined): Set<string> | undefined => {
-  if (!channel?.servers) {
-    return undefined
-  }
-
-  const names = new Set<string>()
-  for (const serverRef of channel.servers) {
-    if ('$ref' in serverRef) {
-      const name = getServerNameFromRef(serverRef.$ref)
-      if (name) {
-        names.add(name)
-      }
-    }
-  }
-  return names
 }
 
 /**
@@ -84,51 +50,12 @@ export const getAsyncApiProtocols = (document: AsyncApiDocument): AsyncApiProtoc
     .sort((a, b) => a.localeCompare(b))
     .map((protocol) => ({ id: protocol, label: protocol.toUpperCase() }))
 
-  return [{ id: ALL_PROTOCOLS, label: 'All protocols' }, ...options]
-}
-
-/**
- * Returns the set of protocols an operation is reachable over.
- *
- * Resolves the operation's channel, then maps the channel's servers (or all
- * servers when the channel declares none) to their protocols.
- */
-export const getOperationProtocols = (document: AsyncApiDocument, operation: AsyncApiOperationObject): Set<string> => {
-  const serverProtocols = getServerProtocols(document)
-  const channel = resolveOperationChannel(document, operation)?.channel
-  const channelServerNames = getChannelServerNames(channel)
-
-  const protocols = new Set<string>()
-  for (const [name, protocol] of serverProtocols) {
-    if (channelServerNames?.has(name) ?? true) {
-      protocols.add(protocol)
-    }
-  }
-
-  return protocols
-}
-
-/**
- * Whether an operation should be shown for the currently selected protocol.
- *
- * Selecting {@link ALL_PROTOCOLS} (or nothing) matches every operation; otherwise
- * the operation is kept only when one of its channel's servers uses that protocol.
- */
-export const operationMatchesProtocol = (
-  document: AsyncApiDocument,
-  operation: AsyncApiOperationObject,
-  protocol: string | undefined,
-): boolean => {
-  if (!protocol || protocol === ALL_PROTOCOLS) {
-    return true
-  }
-
-  return getOperationProtocols(document, operation).has(protocol)
+  return [{ id: ALL, label: 'All protocols' }, ...options]
 }
 
 /** A single server option for the picker (e.g. `{ id: 'mqtt-prod', label: 'mqtt-prod (mqtt)' }`). */
 export type AsyncApiServerOption = {
-  /** The server name (its key in `document.servers`), or {@link ALL_SERVERS}. */
+  /** The server name (its key in `document.servers`), or {@link ALL}. */
   id: string
   /** Human-friendly label: the server name, suffixed with its protocol when known. */
   label: string
@@ -147,44 +74,119 @@ export const getAsyncApiServerOptions = (document: AsyncApiDocument): AsyncApiSe
     return { id: name, label: protocol ? `${name} (${protocol})` : name }
   })
 
-  return [{ id: ALL_SERVERS, label: 'All servers' }, ...options]
+  return [{ id: ALL, label: 'All servers' }, ...options]
 }
 
 /**
- * Returns the names of the servers an operation is reachable through.
+ * Document-level lookups the per-operation reachability check needs.
  *
- * Resolves the operation's channel, then returns the channel's servers (or all
- * declared servers when the channel pins none).
+ * Building this once per filter pass (instead of recomputing it for every operation)
+ * keeps sidebar filtering at O(operations + servers) rather than O(operations × servers).
+ */
+export type AsyncApiReachabilityContext = {
+  /** Normalized protocol of every named server, keyed by server name. */
+  serverProtocols: Map<string, string>
+  /** Every server name declared on the document. */
+  allServerNames: Set<string>
+}
+
+/** Precomputes the document-level data shared across every operation in a filter pass. */
+export const createReachabilityContext = (document: AsyncApiDocument): AsyncApiReachabilityContext => ({
+  serverProtocols: getServerProtocols(document),
+  allServerNames: new Set(objectKeys(document.servers ?? {})),
+})
+
+/** The servers (and the protocols they speak) a single operation is reachable through. */
+export type OperationReachability = {
+  /** Server names the operation's channel can be reached through. */
+  serverNames: Set<string>
+  /** Protocols those servers use. */
+  protocols: Set<string>
+}
+
+/**
+ * Resolves the servers and protocols a single operation is reachable over.
+ *
+ * Resolves the operation's channel once, then intersects the channel's servers
+ * (or all servers, when the channel pins none) with the document's servers. The
+ * shared {@link AsyncApiReachabilityContext} is built once per filter pass; a fresh
+ * one is created when called standalone.
+ */
+export const getOperationReachability = (
+  document: AsyncApiDocument,
+  operation: AsyncApiOperationObject,
+  context: AsyncApiReachabilityContext = createReachabilityContext(document),
+): OperationReachability => {
+  const channel = resolveOperationChannel(document, operation)?.channel ?? null
+  const channelServerNames = getChannelServerNames(document, channel)
+
+  // A channel without declared servers is reachable on every server.
+  const serverNames = channelServerNames
+    ? new Set([...channelServerNames].filter((name) => context.allServerNames.has(name)))
+    : new Set(context.allServerNames)
+
+  const protocols = new Set<string>()
+  for (const [name, protocol] of context.serverProtocols) {
+    if (serverNames.has(name)) {
+      protocols.add(protocol)
+    }
+  }
+
+  return { serverNames, protocols }
+}
+
+/**
+ * Returns the set of protocols an operation is reachable over.
+ */
+export const getOperationProtocols = (
+  document: AsyncApiDocument,
+  operation: AsyncApiOperationObject,
+  context?: AsyncApiReachabilityContext,
+): Set<string> => getOperationReachability(document, operation, context).protocols
+
+/**
+ * Returns the names of the servers an operation is reachable through.
  */
 export const getOperationServerNames = (
   document: AsyncApiDocument,
   operation: AsyncApiOperationObject,
-): Set<string> => {
-  const allServerNames = new Set(objectKeys(document.servers ?? {}))
-  const channel = resolveOperationChannel(document, operation)?.channel
-  const channelServerNames = getChannelServerNames(channel)
+  context?: AsyncApiReachabilityContext,
+): Set<string> => getOperationReachability(document, operation, context).serverNames
 
-  if (!channelServerNames) {
-    return allServerNames
+/**
+ * Whether an operation should be shown for the currently selected protocol.
+ *
+ * Selecting {@link ALL} (or nothing) matches every operation; otherwise the
+ * operation is kept only when one of its channel's servers uses that protocol.
+ */
+export const operationMatchesProtocol = (
+  document: AsyncApiDocument,
+  operation: AsyncApiOperationObject,
+  protocol: string | undefined,
+  context?: AsyncApiReachabilityContext,
+): boolean => {
+  if (!protocol || protocol === ALL) {
+    return true
   }
 
-  return new Set([...channelServerNames].filter((name) => allServerNames.has(name)))
+  return getOperationProtocols(document, operation, context).has(protocol)
 }
 
 /**
  * Whether an operation should be shown for the currently selected server.
  *
- * Selecting {@link ALL_SERVERS} (or nothing) matches every operation; otherwise the
+ * Selecting {@link ALL} (or nothing) matches every operation; otherwise the
  * operation is kept only when its channel is reachable through that server.
  */
 export const operationMatchesServer = (
   document: AsyncApiDocument,
   operation: AsyncApiOperationObject,
   serverName: string | undefined,
+  context?: AsyncApiReachabilityContext,
 ): boolean => {
-  if (!serverName || serverName === ALL_SERVERS) {
+  if (!serverName || serverName === ALL) {
     return true
   }
 
-  return getOperationServerNames(document, operation).has(serverName)
+  return getOperationServerNames(document, operation, context).has(serverName)
 }

--- a/packages/workspace-store/src/channel-example/get-async-api-protocols.ts
+++ b/packages/workspace-store/src/channel-example/get-async-api-protocols.ts
@@ -1,0 +1,190 @@
+import { objectEntries } from '@scalar/helpers/object/object-entries'
+import { objectKeys } from '@scalar/helpers/object/object-keys'
+import type { AsyncApiChannelObject, AsyncApiDocument, AsyncApiOperationObject } from '@scalar/types/asyncapi/3.1'
+
+import { getNameFromRef } from '@/helpers/get-name-from-ref'
+import { getResolvedRef } from '@/helpers/get-resolved-ref'
+
+import { resolveOperationChannel } from './resolve-operation-channel'
+
+/** Sentinel used by the protocol picker to mean "don't filter by protocol". */
+export const ALL_PROTOCOLS = 'all' as const
+
+/** Sentinel used by the server picker to mean "don't filter by server". */
+export const ALL_SERVERS = 'all' as const
+
+/** A single protocol option for the picker (e.g. `{ id: 'mqtt', label: 'MQTT' }`). */
+export type AsyncApiProtocolOption = {
+  /** The normalized protocol id (lowercase), or {@link ALL_PROTOCOLS}. */
+  id: string
+  /** Human-friendly label shown in the dropdown. */
+  label: string
+}
+
+const getServerNameFromRef = (ref: string): string | undefined => getNameFromRef(ref, ['servers'])
+
+/** Normalizes a protocol string the same way the server list does (trimmed + lowercased). */
+const normalizeProtocol = (protocol: string | undefined): string | undefined => {
+  const normalized = protocol?.trim().toLowerCase()
+  return normalized ? normalized : undefined
+}
+
+/**
+ * Returns the protocol of every named server, keyed by server name.
+ * References are resolved so a `$ref`-only server still contributes its protocol.
+ */
+const getServerProtocols = (document: AsyncApiDocument): Map<string, string> => {
+  const protocols = new Map<string, string>()
+
+  for (const [name, serverNode] of objectEntries(document.servers ?? {})) {
+    const server = getResolvedRef(serverNode)
+    const protocol = normalizeProtocol(server.protocol)
+    if (protocol) {
+      protocols.set(name, protocol)
+    }
+  }
+
+  return protocols
+}
+
+/**
+ * The server names a channel is available on.
+ *
+ * When the channel does not declare `servers`, it is available on every server,
+ * so we return `undefined` to signal "all servers" (mirrors `getAsyncApiServers`).
+ */
+const getChannelServerNames = (channel: AsyncApiChannelObject | undefined): Set<string> | undefined => {
+  if (!channel?.servers) {
+    return undefined
+  }
+
+  const names = new Set<string>()
+  for (const serverRef of channel.servers) {
+    if ('$ref' in serverRef) {
+      const name = getServerNameFromRef(serverRef.$ref)
+      if (name) {
+        names.add(name)
+      }
+    }
+  }
+  return names
+}
+
+/**
+ * Builds the protocol options for the picker from a document's servers.
+ *
+ * Always prepends an "All protocols" entry so the picker can clear the filter,
+ * matching how the document picker always offers every document. Protocols are
+ * de-duplicated and sorted alphabetically for a stable order.
+ */
+export const getAsyncApiProtocols = (document: AsyncApiDocument): AsyncApiProtocolOption[] => {
+  const unique = new Set(getServerProtocols(document).values())
+
+  const options: AsyncApiProtocolOption[] = [...unique]
+    .sort((a, b) => a.localeCompare(b))
+    .map((protocol) => ({ id: protocol, label: protocol.toUpperCase() }))
+
+  return [{ id: ALL_PROTOCOLS, label: 'All protocols' }, ...options]
+}
+
+/**
+ * Returns the set of protocols an operation is reachable over.
+ *
+ * Resolves the operation's channel, then maps the channel's servers (or all
+ * servers when the channel declares none) to their protocols.
+ */
+export const getOperationProtocols = (document: AsyncApiDocument, operation: AsyncApiOperationObject): Set<string> => {
+  const serverProtocols = getServerProtocols(document)
+  const channel = resolveOperationChannel(document, operation)?.channel
+  const channelServerNames = getChannelServerNames(channel)
+
+  const protocols = new Set<string>()
+  for (const [name, protocol] of serverProtocols) {
+    if (channelServerNames?.has(name) ?? true) {
+      protocols.add(protocol)
+    }
+  }
+
+  return protocols
+}
+
+/**
+ * Whether an operation should be shown for the currently selected protocol.
+ *
+ * Selecting {@link ALL_PROTOCOLS} (or nothing) matches every operation; otherwise
+ * the operation is kept only when one of its channel's servers uses that protocol.
+ */
+export const operationMatchesProtocol = (
+  document: AsyncApiDocument,
+  operation: AsyncApiOperationObject,
+  protocol: string | undefined,
+): boolean => {
+  if (!protocol || protocol === ALL_PROTOCOLS) {
+    return true
+  }
+
+  return getOperationProtocols(document, operation).has(protocol)
+}
+
+/** A single server option for the picker (e.g. `{ id: 'mqtt-prod', label: 'mqtt-prod (mqtt)' }`). */
+export type AsyncApiServerOption = {
+  /** The server name (its key in `document.servers`), or {@link ALL_SERVERS}. */
+  id: string
+  /** Human-friendly label: the server name, suffixed with its protocol when known. */
+  label: string
+}
+
+/**
+ * Builds the server options for the picker from a document's servers.
+ *
+ * Like {@link getAsyncApiProtocols}, always prepends an "All servers" entry so the
+ * filter can be cleared. Each option is labelled with the server name and its
+ * protocol so the picker reads as `mqtt-prod (mqtt)`.
+ */
+export const getAsyncApiServerOptions = (document: AsyncApiDocument): AsyncApiServerOption[] => {
+  const options: AsyncApiServerOption[] = objectEntries(document.servers ?? {}).map(([name, serverNode]) => {
+    const protocol = normalizeProtocol(getResolvedRef(serverNode).protocol)
+    return { id: name, label: protocol ? `${name} (${protocol})` : name }
+  })
+
+  return [{ id: ALL_SERVERS, label: 'All servers' }, ...options]
+}
+
+/**
+ * Returns the names of the servers an operation is reachable through.
+ *
+ * Resolves the operation's channel, then returns the channel's servers (or all
+ * declared servers when the channel pins none).
+ */
+export const getOperationServerNames = (
+  document: AsyncApiDocument,
+  operation: AsyncApiOperationObject,
+): Set<string> => {
+  const allServerNames = new Set(objectKeys(document.servers ?? {}))
+  const channel = resolveOperationChannel(document, operation)?.channel
+  const channelServerNames = getChannelServerNames(channel)
+
+  if (!channelServerNames) {
+    return allServerNames
+  }
+
+  return new Set([...channelServerNames].filter((name) => allServerNames.has(name)))
+}
+
+/**
+ * Whether an operation should be shown for the currently selected server.
+ *
+ * Selecting {@link ALL_SERVERS} (or nothing) matches every operation; otherwise the
+ * operation is kept only when its channel is reachable through that server.
+ */
+export const operationMatchesServer = (
+  document: AsyncApiDocument,
+  operation: AsyncApiOperationObject,
+  serverName: string | undefined,
+): boolean => {
+  if (!serverName || serverName === ALL_SERVERS) {
+    return true
+  }
+
+  return getOperationServerNames(document, operation).has(serverName)
+}

--- a/packages/workspace-store/src/channel-example/index.ts
+++ b/packages/workspace-store/src/channel-example/index.ts
@@ -11,13 +11,19 @@ export {
 } from './build-connection-url'
 export type { ChannelMessageEntry } from './get-all-channel-messages'
 export { getAllChannelMessages } from './get-all-channel-messages'
-export type { AsyncApiProtocolOption, AsyncApiServerOption } from './get-async-api-protocols'
+export type {
+  AsyncApiProtocolOption,
+  AsyncApiReachabilityContext,
+  AsyncApiServerOption,
+  OperationReachability,
+} from './get-async-api-protocols'
 export {
-  ALL_PROTOCOLS,
-  ALL_SERVERS,
+  ALL,
+  createReachabilityContext,
   getAsyncApiProtocols,
   getAsyncApiServerOptions,
   getOperationProtocols,
+  getOperationReachability,
   getOperationServerNames,
   operationMatchesProtocol,
   operationMatchesServer,

--- a/packages/workspace-store/src/channel-example/index.ts
+++ b/packages/workspace-store/src/channel-example/index.ts
@@ -11,6 +11,17 @@ export {
 } from './build-connection-url'
 export type { ChannelMessageEntry } from './get-all-channel-messages'
 export { getAllChannelMessages } from './get-all-channel-messages'
+export type { AsyncApiProtocolOption, AsyncApiServerOption } from './get-async-api-protocols'
+export {
+  ALL_PROTOCOLS,
+  ALL_SERVERS,
+  getAsyncApiProtocols,
+  getAsyncApiServerOptions,
+  getOperationProtocols,
+  getOperationServerNames,
+  operationMatchesProtocol,
+  operationMatchesServer,
+} from './get-async-api-protocols'
 export { getAsyncApiSecurityRequirements } from './get-asyncapi-security-requirements'
 export { getChannelConnectionContext } from './get-channel-connection-context'
 export { getChannelConnectionSecurityRequirements } from './get-channel-connection-security'

--- a/packages/workspace-store/src/channel-example/servers.ts
+++ b/packages/workspace-store/src/channel-example/servers.ts
@@ -46,7 +46,7 @@ export type AsyncApiServerEntry = {
 const resolveServer = (server: NonNullable<AsyncApiDocument['servers']>[string]): AsyncApiServerObject =>
   getResolvedRef(server)
 
-export const getServerNameFromRef = (ref: string): string | undefined => getNameFromRef(ref, ['servers'])
+const getServerNameFromRef = (ref: string): string | undefined => getNameFromRef(ref, ['servers'])
 
 /**
  * Collects the names of `document.servers` entries that the channel is restricted to.

--- a/packages/workspace-store/src/channel-example/servers.ts
+++ b/packages/workspace-store/src/channel-example/servers.ts
@@ -46,7 +46,7 @@ export type AsyncApiServerEntry = {
 const resolveServer = (server: NonNullable<AsyncApiDocument['servers']>[string]): AsyncApiServerObject =>
   getResolvedRef(server)
 
-const getServerNameFromRef = (ref: string): string | undefined => getNameFromRef(ref, ['servers'])
+export const getServerNameFromRef = (ref: string): string | undefined => getNameFromRef(ref, ['servers'])
 
 /**
  * Collects the names of `document.servers` entries that the channel is restricted to.
@@ -54,7 +54,7 @@ const getServerNameFromRef = (ref: string): string | undefined => getNameFromRef
  * Returns `undefined` when the channel does not declare `servers`, signaling that every
  * top-level server is allowed.
  */
-const getChannelServerNames = (
+export const getChannelServerNames = (
   document: AsyncApiDocument,
   channel: AsyncApiChannelObject | null,
 ): Set<string> | undefined => {


### PR DESCRIPTION
## Problem

AsyncAPI documents that span multiple microservices often declare many
servers across several protocols (e.g. a `wss` WebSocket server alongside
`mqtt` and `kafka`). In those documents the sidebar lists every operation
at once, so finding the operations relevant to a particular protocol or
server means scrolling through a lot of noise. There was no way to narrow
the navigation down to what's reachable over a given protocol/server.

## Solution

Add **protocol** and **server** pickers to the AsyncAPI sidebar, stacked
beneath the existing document picker and behaving just like it. Selecting
a protocol or server filters the navigation tree down to the operations
reachable over that choice; channels and tags left empty are dropped.

Details:
- New `scalar-asyncapi-sidebar-filters-block` (`SidebarFilter.vue` +
  `filter-async-api-navigation` helper) renders the pickers and prunes the
  navigation tree.
- New `get-async-api-protocols` helper in `workspace-store` derives the
  available protocols/servers from a document.
- Wired the filters into `ApiReference.vue`.
- Channels that declare no `servers` are treated as available on every
  server (and therefore every protocol).
- Each picker only appears when there is more than one option to choose
  from, and choosing **All protocols** / **All servers** clears that
  filter. Filters reset when switching documents.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [x] I updated the documentation.
