### PR TITLE
feat(api-reference): add server and protocol labels to AsyncAPI chann…

### DIFF
--- a/.changeset/asyncapi-server-protocol-labels.md
+++ b/.changeset/asyncapi-server-protocol-labels.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+Show server and protocol labels when rendering AsyncAPI channels and messages: each channel header lists the servers it's available on and their protocols, and each message surfaces every protocol it's carried over (its channel's server protocols unioned with its own binding protocols)

--- a/documentation/asyncapi.md
+++ b/documentation/asyncapi.md
@@ -15,9 +15,10 @@ Scalar.createApiReference('#app', {
 The reference renders the AsyncAPI document grouped by channel. For each channel you'll see:
 
 - The channel title (or address) and description.
+- **Server** and **protocol** labels for the channel: the servers it's available on (from `document.servers`, restricted to `channel.servers` when declared) and their protocols (for example `wss`, `kafka`).
 - The channel address **parameters**.
 - Each **operation** on the channel, nested beneath it, with its `send`/`receive` action, title, and summary/description.
-- Each **message** under its operation, shown as a collapsible accordion. Expanding a message reveals its description and its **headers** and **payload** schemas. Messages start collapsed and stay in sync with the sidebar, so selecting a message in the navigation (or opening a deep link to it) expands it here too.
+- Each **message** under its operation, shown as a collapsible accordion. The message header shows **protocol** labels for every protocol it's carried over — its channel's server protocols unioned with any protocols it declares its own `bindings` for. Expanding a message reveals its description and its **headers** and **payload** schemas. Messages start collapsed and stay in sync with the sidebar, so selecting a message in the navigation (or opening a deep link to it) expands it here too.
 
 Reusable schemas defined under `components.schemas` are rendered in the **Models** section, just like OpenAPI.
 

--- a/packages/api-reference/src/components/Content/AsyncApi/AsyncApiLabels.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/AsyncApiLabels.test.ts
@@ -1,0 +1,31 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import AsyncApiLabels from './AsyncApiLabels.vue'
+
+describe('AsyncApiLabels', () => {
+  it('renders nothing when there are no labels', () => {
+    const wrapper = mount(AsyncApiLabels, { props: {} })
+
+    expect(wrapper.find('.async-api-labels').exists()).toBe(false)
+  })
+
+  it('renders a pill per server and per protocol with screen-reader prefixes', () => {
+    const wrapper = mount(AsyncApiLabels, {
+      props: { servers: ['production', 'development'], protocols: ['wss', 'ws'] },
+    })
+
+    expect(wrapper.findAll('.async-api-label--server').map((el) => el.text())).toEqual(['production', 'development'])
+    expect(wrapper.findAll('.async-api-label--protocol').map((el) => el.text())).toEqual(['wss', 'ws'])
+    expect(wrapper.text()).toContain('Servers:')
+    expect(wrapper.text()).toContain('Protocols:')
+  })
+
+  it('omits the server row when only protocols are provided', () => {
+    const wrapper = mount(AsyncApiLabels, { props: { protocols: ['kafka'] } })
+
+    expect(wrapper.findAll('.async-api-label--server')).toHaveLength(0)
+    expect(wrapper.findAll('.async-api-label--protocol')).toHaveLength(1)
+    expect(wrapper.text()).not.toContain('Servers:')
+  })
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/AsyncApiLabels.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/AsyncApiLabels.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const { servers = [], protocols = [] } = defineProps<{
+  /** Names of the servers an entry is available on. */
+  servers?: string[]
+  /** Protocol identifiers (for example `wss`, `kafka`) shown as uppercase pills. */
+  protocols?: string[]
+}>()
+
+/** Hide the whole row when there is nothing to show. */
+const hasLabels = computed(() => servers.length > 0 || protocols.length > 0)
+</script>
+
+<template>
+  <div
+    v-if="hasLabels"
+    class="async-api-labels">
+    <template v-if="servers.length">
+      <span class="sr-only">Servers:</span>
+      <span
+        v-for="server in servers"
+        :key="`server-${server}`"
+        class="async-api-label async-api-label--server"
+        :title="server">
+        {{ server }}
+      </span>
+    </template>
+    <template v-if="protocols.length">
+      <span class="sr-only">Protocols:</span>
+      <span
+        v-for="protocol in protocols"
+        :key="`protocol-${protocol}`"
+        class="async-api-label async-api-label--protocol"
+        :title="protocol">
+        {{ protocol }}
+      </span>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.async-api-labels {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+.async-api-label {
+  font-size: var(--scalar-mini);
+  font-weight: var(--scalar-semibold);
+  line-height: 1.4;
+  border-radius: 12px;
+  padding: 2px 8px;
+  display: inline-flex;
+  align-items: center;
+}
+.async-api-label--server {
+  color: var(--scalar-color-2);
+  background: var(--scalar-background-2);
+}
+.async-api-label--protocol {
+  color: var(--scalar-color-1);
+  background: var(--scalar-background-3);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+</style>

--- a/packages/api-reference/src/components/Content/AsyncApi/AsyncApiLabels.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/AsyncApiLabels.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
+import { Badge } from '@/components/Badge'
+
 const { servers = [], protocols = [] } = defineProps<{
   /** Names of the servers an entry is available on. */
   servers?: string[]
@@ -18,23 +20,23 @@ const hasLabels = computed(() => servers.length > 0 || protocols.length > 0)
     class="async-api-labels">
     <template v-if="servers.length">
       <span class="sr-only">Servers:</span>
-      <span
+      <Badge
         v-for="server in servers"
         :key="`server-${server}`"
-        class="async-api-label async-api-label--server"
+        class="async-api-label--server"
         :title="server">
         {{ server }}
-      </span>
+      </Badge>
     </template>
     <template v-if="protocols.length">
       <span class="sr-only">Protocols:</span>
-      <span
+      <Badge
         v-for="protocol in protocols"
         :key="`protocol-${protocol}`"
-        class="async-api-label async-api-label--protocol"
+        class="async-api-label--protocol"
         :title="protocol">
         {{ protocol }}
-      </span>
+      </Badge>
     </template>
   </div>
 </template>
@@ -46,22 +48,8 @@ const hasLabels = computed(() => servers.length > 0 || protocols.length > 0)
   align-items: center;
   gap: 6px;
 }
-.async-api-label {
-  font-size: var(--scalar-mini);
-  font-weight: var(--scalar-semibold);
-  line-height: 1.4;
-  border-radius: 12px;
-  padding: 2px 8px;
-  display: inline-flex;
-  align-items: center;
-}
-.async-api-label--server {
-  color: var(--scalar-color-2);
-  background: var(--scalar-background-2);
-}
+/* Protocols read as identifiers, so render them uppercase to set them apart from server names. */
 .async-api-label--protocol {
-  color: var(--scalar-color-1);
-  background: var(--scalar-background-3);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
@@ -211,6 +211,83 @@ describe('Channel', () => {
     expect(wrapper.text()).toContain('On user signed up')
   })
 
+  const documentWithServers = (channel: Record<string, unknown> = { address: 'user/signedup' }): AsyncApiDocument =>
+    ({
+      asyncapi: '3.0.0',
+      info: { title: 'Streaming API', version: '1.0.0' },
+      'x-scalar-original-document-hash': '',
+      servers: {
+        production: { host: 'galaxy.scalar.com', protocol: 'wss' },
+        development: { host: 'localhost', protocol: 'ws' },
+      },
+      channels: { userSignedUp: channel },
+    }) as unknown as AsyncApiDocument
+
+  it.each(['modern', 'classic'] as const)(
+    'renders server and protocol labels for every document server in the %s layout',
+    (layout) => {
+      const wrapper = mount(Channel, {
+        props: {
+          channel: createChannel(),
+          document: documentWithServers(),
+          layout,
+          isCollapsed: false,
+          eventBus: null,
+        },
+      })
+
+      const text = wrapper.text()
+      expect(text).toContain('production')
+      expect(text).toContain('development')
+      expect(text).toContain('wss')
+      expect(text).toContain('ws')
+    },
+  )
+
+  it('restricts labels to the servers the channel declares', () => {
+    const wrapper = mount(Channel, {
+      props: {
+        channel: createChannel(),
+        document: documentWithServers({
+          address: 'user/signedup',
+          servers: [{ $ref: '#/servers/production' }],
+        }),
+        layout: 'modern',
+        isCollapsed: false,
+        eventBus: null,
+      },
+    })
+
+    const text = wrapper.text()
+    expect(text).toContain('production')
+    expect(text).toContain('wss')
+    expect(text).not.toContain('development')
+  })
+
+  it('de-duplicates protocols shared across servers', () => {
+    const wrapper = mount(Channel, {
+      props: {
+        channel: createChannel(),
+        document: {
+          asyncapi: '3.0.0',
+          info: { title: 'Streaming API', version: '1.0.0' },
+          'x-scalar-original-document-hash': '',
+          servers: {
+            primary: { host: 'a.example.com', protocol: 'wss' },
+            secondary: { host: 'b.example.com', protocol: 'wss' },
+          },
+          channels: { userSignedUp: { address: 'user/signedup' } },
+        } as unknown as AsyncApiDocument,
+        layout: 'modern',
+        isCollapsed: false,
+        eventBus: null,
+      },
+    })
+
+    // Both server names show, but the shared protocol only renders once.
+    expect(wrapper.findAll('.async-api-label--protocol')).toHaveLength(1)
+  })
+
   // Regression: both layouts must forward `expandedItems` to Operation so sidebar
   // navigation can expand the nested message accordions.
   it.each(['modern', 'classic'] as const)('forwards expandedItems to the operation in the %s layout', (layout) => {

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
@@ -20,12 +20,14 @@ import {
 } from '@/components/Section'
 import ParameterList from '@/features/Operation/components/ParameterList.vue'
 
+import AsyncApiLabels from './AsyncApiLabels.vue'
 import { adaptAsyncApiParameters } from './helpers/adapt-async-api-parameters'
 import {
   resolveSchemaRenderOptions,
   type AsyncApiSchemaRenderOptions,
 } from './helpers/async-api-render-options'
 import { filterChildrenByType } from './helpers/filter-children-by-type'
+import { getChannelServerLabels } from './helpers/get-async-api-labels'
 import { pickHeading } from './helpers/pick-heading'
 import { resolveAsyncApiChannel } from './helpers/resolve-async-api-nodes'
 import Operation from './Operation.vue'
@@ -91,6 +93,14 @@ const parameterListOptions = computed<ParameterListOptions>(() => ({
   ...resolveSchemaRenderOptions(options),
 }))
 
+/**
+ * Server-name and protocol labels for the channel, resolved from `document.servers`
+ * (restricted to `channel.servers` when declared) and rendered as pills in the header.
+ */
+const labels = computed(() =>
+  getChannelServerLabels(document, resolvedChannel.value),
+)
+
 /** Operations that target this channel, rendered nested beneath the channel content. */
 const operations = computed(() =>
   filterChildrenByType<TraversedAsyncApiOperation>(
@@ -121,6 +131,10 @@ const operations = computed(() =>
           </SectionHeaderTag>
         </Anchor>
       </SectionHeader>
+      <AsyncApiLabels
+        class="channel-labels"
+        :protocols="labels.protocols"
+        :servers="labels.servers" />
       <ScalarMarkdown
         class="channel-description"
         :value="description"
@@ -166,6 +180,10 @@ const operations = computed(() =>
         </Anchor>
       </SectionHeader>
       <SectionContent>
+        <AsyncApiLabels
+          class="channel-labels"
+          :protocols="labels.protocols"
+          :servers="labels.servers" />
         <ScalarMarkdown
           :value="description"
           withImages />
@@ -192,6 +210,9 @@ const operations = computed(() =>
 <style scoped>
 .channel-section {
   margin-bottom: 48px;
+}
+.channel-labels {
+  margin-bottom: 8px;
 }
 .channel-description {
   padding-bottom: 4px;

--- a/packages/api-reference/src/components/Content/AsyncApi/Message.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Message.test.ts
@@ -175,4 +175,71 @@ describe('Message', () => {
 
     expect(wrapper.text()).not.toContain('Payload')
   })
+
+  const documentWithServers = (message: Record<string, unknown>): AsyncApiDocument =>
+    ({
+      asyncapi: '3.0.0',
+      info: { title: 'Streaming API', version: '1.0.0' },
+      'x-scalar-original-document-hash': '',
+      servers: {
+        production: { host: 'galaxy.scalar.com', protocol: 'wss' },
+        development: { host: 'localhost', protocol: 'ws' },
+      },
+      channels: {
+        userSignedUp: {
+          address: 'user/signedup',
+          messages: { userSignedUp: message },
+        },
+      },
+    }) as unknown as AsyncApiDocument
+
+  it("exposes every protocol the message's channel servers speak, even without bindings", () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: documentWithServers({ title: 'User signed up' }),
+        eventBus: null,
+      },
+    })
+
+    const protocols = wrapper.findAll('.async-api-label--protocol').map((el) => el.text())
+    expect(protocols).toContain('wss')
+    expect(protocols).toContain('ws')
+  })
+
+  it('unions message binding protocols with the channel server protocols', () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: documentWithServers({
+          title: 'User signed up',
+          // Declares a kafka binding that no server speaks; it should still surface.
+          bindings: { kafka: { groupId: 'g1' } },
+        }),
+        eventBus: null,
+      },
+    })
+
+    const protocols = wrapper.findAll('.async-api-label--protocol').map((el) => el.text())
+    expect(protocols).toContain('wss')
+    expect(protocols).toContain('ws')
+    expect(protocols).toContain('kafka')
+  })
+
+  it('falls back to message binding protocols when no servers are defined', () => {
+    const wrapper = mount(Message, {
+      props: {
+        message: createMessage(),
+        document: createDocument({
+          title: 'User signed up',
+          bindings: { ws: { method: 'GET' }, mqtt: {} },
+        }),
+        eventBus: null,
+      },
+    })
+
+    const protocols = wrapper.findAll('.async-api-label--protocol').map((el) => el.text())
+    expect(protocols).toContain('ws')
+    expect(protocols).toContain('mqtt')
+  })
 })

--- a/packages/api-reference/src/components/Content/AsyncApi/Message.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Message.vue
@@ -158,16 +158,16 @@ const onToggle = (open: boolean) => {
           @copyAnchorUrl="
             () => eventBus?.emit('copy-url:nav-item', { id: message.id })
           ">
-          <SectionHeaderTag
-            :id="headerId"
-            class="message-title"
-            :level="4">
-            {{ headingText }}
-          </SectionHeaderTag>
+          <span class="message-heading">
+            <SectionHeaderTag
+              :id="headerId"
+              class="message-title"
+              :level="4">
+              {{ headingText }}
+            </SectionHeaderTag>
+            <AsyncApiLabels :protocols="protocolLabels" />
+          </span>
         </Anchor>
-        <AsyncApiLabels
-          class="message-labels"
-          :protocols="protocolLabels" />
       </template>
 
       <ScalarMarkdown
@@ -214,9 +214,13 @@ const onToggle = (open: boolean) => {
   font-weight: var(--scalar-semibold);
   color: var(--scalar-color-1);
 }
-/* Lay the heading and protocol labels out on a single wrapping row. */
-.message-accordion :deep(.section-accordion-button-content) {
-  display: flex;
+/*
+ * Lay the heading and protocol labels out on one wrapping row. The labels live inside the
+ * Anchor slot so the copy-anchor "#" button (absolutely positioned just past the end of the
+ * slot content on hover) trails after the last pill instead of overlapping the first one.
+ */
+.message-heading {
+  display: inline-flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;

--- a/packages/api-reference/src/components/Content/AsyncApi/Message.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Message.vue
@@ -2,6 +2,7 @@
 import { ScalarMarkdown } from '@scalar/components/markdown'
 import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { TraversedAsyncApiMessage } from '@scalar/workspace-store/schemas/navigation'
 import { computed, ref, useId, useTemplateRef, watch } from 'vue'
 
@@ -15,12 +16,17 @@ import {
 } from '@/helpers/get-async-api-message-payload-schema'
 import { useIntersection } from '@/hooks/use-intersection'
 
+import AsyncApiLabels from './AsyncApiLabels.vue'
 import {
   resolveSchemaRenderOptions,
   type AsyncApiSchemaRenderOptions,
 } from './helpers/async-api-render-options'
+import { getChannelServerLabels } from './helpers/get-async-api-labels'
 import { pickHeading } from './helpers/pick-heading'
-import { resolveAsyncApiMessage } from './helpers/resolve-async-api-nodes'
+import {
+  resolveAsyncApiChannel,
+  resolveAsyncApiMessage,
+} from './helpers/resolve-async-api-nodes'
 
 /** Subset of the configuration the shared `Schema` renderer needs. */
 type SchemaRenderOptions = AsyncApiSchemaRenderOptions
@@ -64,6 +70,35 @@ const description = computed(
   () =>
     resolvedMessage.value?.description || resolvedMessage.value?.summary || '',
 )
+
+/**
+ * Protocol keys declared directly on the message's protocol-specific `bindings`
+ * (for example `ws`, `kafka`). The bindings object may be a `$ref`, so it is resolved
+ * before reading the keys.
+ */
+const messageBindingProtocols = computed(() => {
+  const bindings = resolvedMessage.value?.bindings
+  if (!bindings) {
+    return []
+  }
+  const resolved = getResolvedRef(bindings)
+  return Object.entries(resolved)
+    .filter(([, value]) => value != null)
+    .map(([protocol]) => protocol)
+})
+
+/**
+ * Protocol labels for the message. A message is carried over whatever protocols its
+ * channel's servers speak, so we start from the channel's server protocols and union in
+ * any extra protocols the message declares its own bindings for. Without this a
+ * multi-protocol message would only surface the single protocol it happens to declare a
+ * binding for (or none at all).
+ */
+const protocolLabels = computed(() => {
+  const channel = resolveAsyncApiChannel(document, message.channelName)
+  const { protocols } = getChannelServerLabels(document, channel)
+  return [...new Set([...protocols, ...messageBindingProtocols.value])]
+})
 
 /** Payload schema, unwrapped from `$ref`s and Multi Format Schema wrappers. */
 const payloadSchema = computed(() =>
@@ -129,6 +164,9 @@ const onToggle = (open: boolean) => {
             {{ headingText }}
           </SectionHeaderTag>
         </Anchor>
+        <AsyncApiLabels
+          class="message-labels"
+          :protocols="protocolLabels" />
       </template>
 
       <ScalarMarkdown
@@ -174,6 +212,13 @@ const onToggle = (open: boolean) => {
   font-size: var(--scalar-heading-4);
   font-weight: var(--scalar-semibold);
   color: var(--scalar-color-1);
+}
+/* Lay the heading and protocol labels out on a single wrapping row. */
+.message-accordion :deep(.section-accordion-button-content) {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
 }
 /* Pad the expanded body so the description and schemas don't sit flush against the border. */
 .message-accordion :deep(.section-accordion-content-card) {

--- a/packages/api-reference/src/components/Content/AsyncApi/Message.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Message.vue
@@ -74,7 +74,8 @@ const description = computed(
 /**
  * Protocol keys declared directly on the message's protocol-specific `bindings`
  * (for example `ws`, `kafka`). The bindings object may be a `$ref`, so it is resolved
- * before reading the keys.
+ * before reading the keys. Keys are lowercased to match the server protocols (which the
+ * helper normalizes), so the union below de-duplicates case-insensitively.
  */
 const messageBindingProtocols = computed(() => {
   const bindings = resolvedMessage.value?.bindings
@@ -84,7 +85,7 @@ const messageBindingProtocols = computed(() => {
   const resolved = getResolvedRef(bindings)
   return Object.entries(resolved)
     .filter(([, value]) => value != null)
-    .map(([protocol]) => protocol)
+    .map(([protocol]) => protocol.toLowerCase())
 })
 
 /**

--- a/packages/api-reference/src/components/Content/AsyncApi/helpers/get-async-api-labels.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/helpers/get-async-api-labels.test.ts
@@ -1,0 +1,61 @@
+import type { AsyncApiChannelObject, AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import { describe, expect, it } from 'vitest'
+
+import { getChannelServerLabels } from './get-async-api-labels'
+
+const createDocument = (servers: Record<string, unknown>): AsyncApiDocument =>
+  ({
+    asyncapi: '3.0.0',
+    info: { title: 'Streaming API', version: '1.0.0' },
+    'x-scalar-original-document-hash': '',
+    servers,
+    channels: {},
+  }) as unknown as AsyncApiDocument
+
+describe('getChannelServerLabels', () => {
+  it('returns every server name and its protocol', () => {
+    const document = createDocument({
+      production: { host: 'galaxy.scalar.com', protocol: 'wss' },
+      development: { host: 'localhost', protocol: 'ws' },
+    })
+
+    expect(getChannelServerLabels(document, null)).toEqual({
+      servers: ['production', 'development'],
+      protocols: ['wss', 'ws'],
+    })
+  })
+
+  it('de-duplicates protocols shared across servers while keeping declaration order', () => {
+    const document = createDocument({
+      primary: { host: 'a.example.com', protocol: 'wss' },
+      secondary: { host: 'b.example.com', protocol: 'wss' },
+    })
+
+    const { servers, protocols } = getChannelServerLabels(document, null)
+    expect(servers).toEqual(['primary', 'secondary'])
+    expect(protocols).toEqual(['wss'])
+  })
+
+  it('restricts servers to the ones the channel declares', () => {
+    const document = createDocument({
+      production: { host: 'galaxy.scalar.com', protocol: 'wss' },
+      development: { host: 'localhost', protocol: 'ws' },
+    })
+    const channel = {
+      address: 'user/signedup',
+      servers: [{ $ref: '#/servers/production' }],
+    } as unknown as AsyncApiChannelObject
+
+    expect(getChannelServerLabels(document, channel)).toEqual({
+      servers: ['production'],
+      protocols: ['wss'],
+    })
+  })
+
+  it('returns empty arrays when the document has no servers', () => {
+    expect(getChannelServerLabels(createDocument({}), null)).toEqual({
+      servers: [],
+      protocols: [],
+    })
+  })
+})

--- a/packages/api-reference/src/components/Content/AsyncApi/helpers/get-async-api-labels.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/helpers/get-async-api-labels.ts
@@ -1,0 +1,24 @@
+import type { AsyncApiChannelObject, AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import { getAsyncApiServers } from '@scalar/workspace-store/channel-example'
+
+/**
+ * Server names and protocols a channel is available on.
+ *
+ * Resolved from `document.servers`, restricted to `channel.servers` when the channel declares them.
+ * `webSocketOnly` is disabled so labels cover every protocol, not just WebSocket, and protocols are
+ * de-duplicated while preserving declaration order.
+ */
+export const getChannelServerLabels = (
+  document: AsyncApiDocument,
+  channel: AsyncApiChannelObject | null | undefined,
+): { servers: string[]; protocols: string[] } => {
+  const entries = getAsyncApiServers(document, {
+    channel: channel ?? null,
+    webSocketOnly: false,
+  })
+
+  return {
+    servers: entries.map((entry) => entry.name),
+    protocols: [...new Set(entries.map((entry) => entry.protocol).filter(Boolean))],
+  }
+}


### PR DESCRIPTION
## Problem

An AsyncAPI document can expose the same-looking channels, operations, and messages on different servers and protocols (e.g. the same event published over `wss` in production and `ws` in development, or a channel that also carries a `kafka` binding). When we render channels and their messages, none of that context was visible — readers couldn't tell which server(s) a channel lived on or which protocol(s) a given message was carried over without digging into the raw spec. That makes near-identical entries impossible to tell apart.

## Solution

Surface server and protocol labels inline:

- **Channels** show, in the header, the **servers** they're available on and those servers' **protocols** — in both the `modern` and `classic` layouts.
- **Messages** show **protocol** labels in their accordion header.

Implementation:

- New reusable `AsyncApiLabels.vue` renders a wrapping row of pills (neutral pills for server names, uppercase pills for protocols) with `sr-only` "Servers:" / "Protocols:" prefixes, and renders nothing when empty.
- New helper `getChannelServerLabels(document, channel)` resolves servers from `document.servers`, restricted to `channel.servers` when declared, and returns deduplicated `{ servers, protocols }` (declaration order preserved, all protocols — not just WebSocket).
- `Channel.vue` renders server + protocol labels; `Message.vue` renders protocol labels.

A message is carried over whatever protocols its **channel's servers** speak — `message.bindings` only declares per-protocol config and usually covers a single protocol (or none). So a message's protocol labels are the **union of its channel's server protocols and its own binding protocols**, deduplicated; otherwise a multi-protocol message would surface only the one protocol it happens to declare a binding for.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation.
