### PR TITLE
feat(aspire): add `AddScalarMockServer` to run a mock server as an Aspi…

### DIFF
--- a/.changeset/aspire-mock-server.md
+++ b/.changeset/aspire-mock-server.md
@@ -1,0 +1,7 @@
+---
+'@scalar/aspire': minor
+---
+
+feat(dotnet): add `AddScalarMockServer` to run a Scalar Mock Server as an Aspire resource
+
+Adds `AddScalarMockServer`, which registers the `scalarapi/mock-server` container as an Aspire resource that generates realistic mock API responses from an OpenAPI/Swagger document — so other resources can depend on it as if it were the real service. The document can be supplied inline (`WithDocument`), from a local file (`WithDocumentFile`), from a URL (`WithDocumentUrl`), or derived from another resource's endpoint (`WithDocumentFrom`).

--- a/documentation/integrations/aspire.md
+++ b/documentation/integrations/aspire.md
@@ -388,6 +388,76 @@ var scalar = builder.AddScalarApiReference(options =>
 });
 ```
 
+## Mock Server
+
+`AddScalarMockServer` registers a [Scalar Mock Server](https://github.com/scalar/scalar/tree/main/packages/mock-server) as an Aspire resource. The mock server generates realistic API responses directly from an OpenAPI/Swagger document, so you can stand up a fake backend—for a service that does not exist yet, an external dependency, or a frontend that needs stable data—without writing any handlers. Other resources can depend on the mock via service discovery just like any real service.
+
+The mock server runs as the published `scalarapi/mock-server` container, so the same container [prerequisite](#prerequisites) (Docker or Podman) applies.
+
+### Quick Start
+
+```csharp
+using Scalar.Aspire;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+// Mock a backend straight from an OpenAPI document
+var petstore = builder.AddScalarMockServer("petstore", options =>
+{
+    options.WithDocumentUrl("https://example.com/openapi.json");
+});
+
+// Other resources can depend on the mock as if it were the real service
+builder.AddProject<Projects.BookService>("book-service")
+    .WithReference(petstore);
+
+builder.Build().Run();
+```
+
+The mock server serves the resolved OpenAPI document at `/openapi.json` and `/openapi.yaml`, and responds to every operation defined in the document.
+
+### Document Sources
+
+Exactly one document source must be configured. Choose the one that matches where your OpenAPI document lives:
+
+```csharp
+// Inline content (JSON or YAML), embedded into the container — no volume mount required
+builder.AddScalarMockServer("inline", options => options.WithDocument(openApiString));
+
+// Read a local file at AppHost build time and provide it inline
+builder.AddScalarMockServer("from-file", options => options.WithDocumentFile("./openapi/petstore.yaml"));
+
+// Fetch from an absolute URL on startup
+builder.AddScalarMockServer("from-url", options =>
+    options.WithDocumentUrl("https://example.com/openapi.json"));
+```
+
+### Deriving the Document From Another Resource
+
+Use `WithDocumentFrom` to point the mock server at another resource's OpenAPI endpoint. The endpoint is resolved through Aspire service discovery at runtime:
+
+```csharp
+var contract = builder.AddProject<Projects.ContractService>("contract");
+
+var mock = builder
+    .AddScalarMockServer("contract-mock")
+    .WithDocumentFrom(contract, routePattern: "/openapi/v1.json");
+```
+
+By default the resource's HTTP endpoint is used; pass `endpointName` to select a specific endpoint (for example, `"https"`).
+
+### Exposing and Rendering the Mock
+
+Call `WithExternalHttpEndpoints()` to reach the mock from outside the AppHost, and register it with the API Reference like any other service (its document is served at `/openapi.json`):
+
+```csharp
+var mock = builder
+    .AddScalarMockServer("petstore", options => options.WithDocumentUrl("https://example.com/openapi.json"))
+    .WithExternalHttpEndpoints();
+
+scalar.WithApiReference(mock, options => options.WithOpenApiRoutePattern("/openapi.json"));
+```
+
 ## Additional Resources
 
 For more advanced configuration options see the [.NET ASP.NET Core documentation](aspnetcore/integration.md#configuration-options). Many configuration options are similar between `Scalar.AspNetCore` and `Scalar.Aspire` integrations, including [Agent](aspnetcore/integration.md#agent) (AI chat).

--- a/integrations/dotnet/aspire/playground/Scalar.Aspire.AppHost/Program.cs
+++ b/integrations/dotnet/aspire/playground/Scalar.Aspire.AppHost/Program.cs
@@ -54,4 +54,15 @@ scalar
 
 bookService.WithEnvironment("Keycloak", keycloak.GetEndpoint("http"));
 
+// Mock a backend straight from an OpenAPI document — no real service required.
+// Other resources can depend on `petstoreMock` as if it were the real API, and the
+// mock serves its resolved document at `/openapi.json` for the API Reference to render.
+var petstoreMock = builder
+    .AddScalarMockServer("petstore-mock", options =>
+    {
+        options.WithDocumentUrl(
+            "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/refs/heads/main/_archive_/schemas/v3.0/pass/petstore.yaml");
+    })
+    .WithExternalHttpEndpoints();
+
 builder.Build().Run();

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/Constants.cs
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/Constants.cs
@@ -14,4 +14,26 @@ internal static class Constants
     public const string DefaultResourceName = "scalar";
 
     public const string DefaultEndpointName = "http";
+
+    /// <summary>
+    /// The published Docker image for the Scalar Mock Server.
+    /// </summary>
+    public const string MockServerImage = "scalarapi/mock-server";
+
+    /// <remarks>
+    /// This value is automatically updated by the pipeline.
+    /// </remarks>
+    public const string MockServerImageTag = "latest";
+
+    /// <summary>
+    /// The port the mock server listens on inside the container.
+    /// </summary>
+    public const int MockServerDefaultPort = 3000;
+
+    public const string MockServerDefaultResourceName = "mock-server";
+
+    /// <summary>
+    /// Default route used to resolve an OpenAPI document from a referenced resource.
+    /// </summary>
+    public const string MockServerDefaultDocumentRoute = "/openapi/v1.json";
 }

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/EnvironmentVariables.cs
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/EnvironmentVariables.cs
@@ -11,4 +11,14 @@ internal static class EnvironmentVariables
     public const string AllowSelfSignedCertificates = "ALLOW_SELF_SIGNED_CERTIFICATES";
 
     public const string ForwardOriginalHostHeader = "FORWARD_ORIGINAL_HOST_HEADER";
+
+    /// <summary>
+    /// Inline OpenAPI document (JSON or YAML) the mock server should mock.
+    /// </summary>
+    public const string OpenApiDocument = "OPENAPI_DOCUMENT";
+
+    /// <summary>
+    /// URL the mock server fetches the OpenAPI document from at startup.
+    /// </summary>
+    public const string OpenApiDocumentUrl = "OPENAPI_DOCUMENT_URL";
 }

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/Extensions/DistributedApplicationBuilderExtensions.cs
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/Extensions/DistributedApplicationBuilderExtensions.cs
@@ -78,7 +78,7 @@ public static class DistributedApplicationBuilderExtensions
             });
     }
 
-    internal static void RemoveOtlpExporterAnnotations(ScalarResource resource)
+    internal static void RemoveOtlpExporterAnnotations(IResource resource)
     {
         var otlpExporterAnnotations = resource.Annotations.OfType<OtlpExporterAnnotation>().ToArray();
         foreach (var annotation in otlpExporterAnnotations)

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/Extensions/ScalarMockServerBuilderExtensions.cs
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/Extensions/ScalarMockServerBuilderExtensions.cs
@@ -1,0 +1,134 @@
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Scalar.Aspire;
+
+/// <summary>
+/// Provides extension methods for adding and configuring a Scalar Mock Server in Aspire applications.
+/// </summary>
+public static class ScalarMockServerBuilderExtensions
+{
+    /// <summary>
+    /// Adds a Scalar Mock Server resource to the distributed application with the default name.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="configureOptions">Action to configure the document source via <see cref="ScalarMockServerOptions" />.</param>
+    /// <returns>A resource builder for the <see cref="ScalarMockServerResource" />.</returns>
+    public static IResourceBuilder<ScalarMockServerResource> AddScalarMockServer(
+        this IDistributedApplicationBuilder builder,
+        Action<ScalarMockServerOptions>? configureOptions = null)
+        => builder.AddScalarMockServer(MockServerDefaultResourceName, null, configureOptions);
+
+    /// <summary>
+    /// Adds a Scalar Mock Server resource to the distributed application with a specified name.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="name">The name of the mock server resource.</param>
+    /// <param name="configureOptions">Action to configure the document source via <see cref="ScalarMockServerOptions" />.</param>
+    /// <returns>A resource builder for the <see cref="ScalarMockServerResource" />.</returns>
+    public static IResourceBuilder<ScalarMockServerResource> AddScalarMockServer(
+        this IDistributedApplicationBuilder builder,
+        [ResourceName] string name,
+        Action<ScalarMockServerOptions> configureOptions)
+        => builder.AddScalarMockServer(name, null, configureOptions);
+
+    /// <summary>
+    /// Adds a Scalar Mock Server resource to the distributed application with detailed configuration.
+    /// </summary>
+    /// <param name="builder">The distributed application builder.</param>
+    /// <param name="name">The name of the mock server resource.</param>
+    /// <param name="port">Optional host port to expose the mock server on.</param>
+    /// <param name="configureOptions">Action to configure the document source via <see cref="ScalarMockServerOptions" />.</param>
+    /// <returns>A resource builder for the <see cref="ScalarMockServerResource" />.</returns>
+    public static IResourceBuilder<ScalarMockServerResource> AddScalarMockServer(
+        this IDistributedApplicationBuilder builder,
+        [ResourceName] string name,
+        int? port = null,
+        Action<ScalarMockServerOptions>? configureOptions = null)
+    {
+        var resource = new ScalarMockServerResource(name);
+        configureOptions?.Invoke(resource.Options);
+
+        // Mirror the API reference resource: drop OTLP exporter annotations so Aspire's
+        // universal container tunnel bootstrap does not block on telemetry endpoint allocation.
+        // The mock server does not require OTLP endpoint references to run.
+        builder.Eventing.Subscribe<BeforeStartEvent>((_, _) =>
+        {
+            RemoveOtlpExporterAnnotations(resource);
+            return Task.CompletedTask;
+        });
+
+        return builder
+            .AddResource(resource)
+            .WithImage(MockServerImage)
+            .WithImageTag(MockServerImageTag)
+            .WithHttpEndpoint(port, MockServerDefaultPort, DefaultEndpointName)
+            .WithUrlForEndpoint(DefaultEndpointName, x =>
+            {
+                x.DisplayText = "Scalar Mock Server";
+                x.Url = MockServerOpenApiEndpoint;
+            })
+            .WithHttpHealthCheck(MockServerOpenApiEndpoint)
+            .WithEnvironment(context => ConfigureEnvironment(resource, context));
+    }
+
+    /// <summary>
+    /// Configures the mock server to derive its OpenAPI document from another resource's endpoint.
+    /// </summary>
+    /// <param name="builder">The mock server resource builder.</param>
+    /// <param name="resourceBuilder">The resource that exposes the OpenAPI document.</param>
+    /// <param name="routePattern">The route the OpenAPI document is served at on the referenced resource.</param>
+    /// <param name="endpointName">The endpoint name to resolve on the referenced resource. Defaults to the HTTP endpoint.</param>
+    /// <returns>The mock server resource builder.</returns>
+    public static IResourceBuilder<ScalarMockServerResource> WithDocumentFrom(
+        this IResourceBuilder<ScalarMockServerResource> builder,
+        IResourceBuilder<IResourceWithServiceDiscovery> resourceBuilder,
+        string routePattern = MockServerDefaultDocumentRoute,
+        string? endpointName = null)
+    {
+        var endpoint = resourceBuilder.GetEndpoint(endpointName ?? DefaultEndpointName);
+        var expression = ReferenceExpression.Create($"{endpoint}/{routePattern.TrimStart('/')}");
+
+        builder.Resource.Options.WithDocumentExpression(expression);
+
+        // Reference the target so service discovery resolves the endpoint inside the container.
+        return builder.WithReference(resourceBuilder);
+    }
+
+    internal static void ConfigureEnvironment(ScalarMockServerResource resource, EnvironmentCallbackContext context)
+    {
+        var options = resource.Options;
+
+        if (!options.HasDocument)
+        {
+            throw new InvalidOperationException(
+                $"No OpenAPI document configured for mock server '{resource.Name}'. Configure a document source using " +
+                $"{nameof(ScalarMockServerOptions.WithDocument)}, {nameof(ScalarMockServerOptions.WithDocumentFile)}, " +
+                $"{nameof(ScalarMockServerOptions.WithDocumentUrl)}, or {nameof(WithDocumentFrom)}.");
+        }
+
+        var environmentVariables = context.EnvironmentVariables;
+
+        if (options.DocumentContent is not null)
+        {
+            environmentVariables.Add(OpenApiDocument, options.DocumentContent);
+        }
+        else if (options.DocumentUrlExpression is not null)
+        {
+            environmentVariables.Add(OpenApiDocumentUrl, options.DocumentUrlExpression);
+        }
+        else if (options.DocumentUrl is not null)
+        {
+            environmentVariables.Add(OpenApiDocumentUrl, options.DocumentUrl);
+        }
+    }
+
+    private static void RemoveOtlpExporterAnnotations(ScalarMockServerResource resource)
+    {
+        var otlpExporterAnnotations = resource.Annotations.OfType<OtlpExporterAnnotation>().ToArray();
+        foreach (var annotation in otlpExporterAnnotations)
+        {
+            resource.Annotations.Remove(annotation);
+        }
+    }
+}

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/Extensions/ScalarMockServerBuilderExtensions.cs
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/Extensions/ScalarMockServerBuilderExtensions.cs
@@ -54,7 +54,7 @@ public static class ScalarMockServerBuilderExtensions
         // The mock server does not require OTLP endpoint references to run.
         builder.Eventing.Subscribe<BeforeStartEvent>((_, _) =>
         {
-            RemoveOtlpExporterAnnotations(resource);
+            DistributedApplicationBuilderExtensions.RemoveOtlpExporterAnnotations(resource);
             return Task.CompletedTask;
         });
 
@@ -120,15 +120,6 @@ public static class ScalarMockServerBuilderExtensions
         else if (options.DocumentUrl is not null)
         {
             environmentVariables.Add(OpenApiDocumentUrl, options.DocumentUrl);
-        }
-    }
-
-    private static void RemoveOtlpExporterAnnotations(ScalarMockServerResource resource)
-    {
-        var otlpExporterAnnotations = resource.Annotations.OfType<OtlpExporterAnnotation>().ToArray();
-        foreach (var annotation in otlpExporterAnnotations)
-        {
-            resource.Annotations.Remove(annotation);
         }
     }
 }

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/Options/ScalarMockServerOptions.cs
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/Options/ScalarMockServerOptions.cs
@@ -1,0 +1,76 @@
+using Aspire.Hosting.ApplicationModel;
+
+namespace Scalar.Aspire;
+
+/// <summary>
+/// Configuration options for a <see cref="ScalarMockServerResource" />.
+/// Exactly one document source must be configured for the mock server to start.
+/// </summary>
+public sealed class ScalarMockServerOptions
+{
+    /// <summary>Inline OpenAPI document content (JSON or YAML), passed via <c>OPENAPI_DOCUMENT</c>.</summary>
+    internal string? DocumentContent { get; private set; }
+
+    /// <summary>A static URL the mock server fetches the document from, passed via <c>OPENAPI_DOCUMENT_URL</c>.</summary>
+    internal string? DocumentUrl { get; private set; }
+
+    /// <summary>
+    /// A resolvable URL (for example, another Aspire resource's endpoint) for the document.
+    /// Resolved at runtime and passed via <c>OPENAPI_DOCUMENT_URL</c>.
+    /// </summary>
+    internal ReferenceExpression? DocumentUrlExpression { get; private set; }
+
+    /// <summary>Whether any document source has been configured.</summary>
+    internal bool HasDocument => DocumentContent is not null || DocumentUrl is not null || DocumentUrlExpression is not null;
+
+    /// <summary>
+    /// Provides the OpenAPI document inline. The content is embedded into the container's
+    /// environment, so no volume mount is required.
+    /// </summary>
+    /// <param name="content">The raw OpenAPI document (JSON or YAML).</param>
+    public ScalarMockServerOptions WithDocument(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ClearDocument();
+        DocumentContent = content;
+        return this;
+    }
+
+    /// <summary>
+    /// Reads an OpenAPI document from disk at AppHost build time and provides it inline.
+    /// </summary>
+    /// <param name="path">Path to a local OpenAPI document (JSON or YAML).</param>
+    public ScalarMockServerOptions WithDocumentFile(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ClearDocument();
+        DocumentContent = File.ReadAllText(path);
+        return this;
+    }
+
+    /// <summary>
+    /// Points the mock server at a URL it fetches the OpenAPI document from on startup.
+    /// </summary>
+    /// <param name="url">An absolute URL to a reachable OpenAPI document.</param>
+    public ScalarMockServerOptions WithDocumentUrl(string url)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(url);
+        ClearDocument();
+        DocumentUrl = url;
+        return this;
+    }
+
+    /// <summary>Sets a resolvable document URL. Used by <c>WithDocumentFrom</c>.</summary>
+    internal void WithDocumentExpression(ReferenceExpression expression)
+    {
+        ClearDocument();
+        DocumentUrlExpression = expression;
+    }
+
+    private void ClearDocument()
+    {
+        DocumentContent = null;
+        DocumentUrl = null;
+        DocumentUrlExpression = null;
+    }
+}

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/RouteDefaults.cs
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/RouteDefaults.cs
@@ -9,4 +9,9 @@ internal static class RouteDefaults
     public const string ProxyEndpoint = "/scalar-proxy";
 
     public const string StaticFilesEndpoint = "/openapi";
+
+    /// <summary>
+    /// The mock server always serves the resolved OpenAPI document here; used for health checks.
+    /// </summary>
+    public const string MockServerOpenApiEndpoint = "/openapi.json";
 }

--- a/integrations/dotnet/aspire/src/Scalar.Aspire/ScalarMockServerResource.cs
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire/ScalarMockServerResource.cs
@@ -1,0 +1,19 @@
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Scalar.Aspire;
+
+/// <summary>
+/// Represents a Scalar Mock Server container resource. The mock server generates realistic
+/// mock API responses from an OpenAPI/Swagger document, so other resources can depend on it
+/// as if it were the real service.
+/// </summary>
+/// <param name="name">The unique name identifier for the mock server resource.</param>
+public sealed class ScalarMockServerResource(string name) : ContainerResource(name), IResourceWithServiceDiscovery
+{
+    /// <summary>
+    /// The document configuration for this mock server. Populated by <c>AddScalarMockServer</c>
+    /// and the <c>WithDocument*</c> extension methods.
+    /// </summary>
+    internal ScalarMockServerOptions Options { get; } = new();
+}

--- a/integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/ScalarMockServerTests.cs
+++ b/integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/ScalarMockServerTests.cs
@@ -1,0 +1,149 @@
+using System.Net.Sockets;
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Scalar.Aspire.Tests;
+
+/// <summary>
+/// Tests the document-source wiring for <see cref="ScalarMockServerResource" />. Each test builds the
+/// resource, runs <see cref="ScalarMockServerBuilderExtensions.ConfigureEnvironment" />, and asserts on
+/// the environment variables the mock server container reads at startup.
+/// </summary>
+public class ScalarMockServerTests
+{
+    private const string MockServerResourceName = "mock-server";
+    private const string ApiResourceName = "my-api";
+
+    [Fact]
+    public void Options_WithDocument_SetsInlineContentExclusively()
+    {
+        var options = new ScalarMockServerOptions().WithDocumentUrl("https://example.com/openapi.json");
+
+        options.WithDocument("openapi: 3.1.0");
+
+        options.HasDocument.Should().BeTrue();
+        options.DocumentContent.Should().Be("openapi: 3.1.0");
+        // Switching source clears the previous one — only one source is ever active.
+        options.DocumentUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ConfigureEnvironment_WithDocument_SetsOpenApiDocumentEnvVar()
+    {
+        var resource = new ScalarMockServerResource(MockServerResourceName);
+        resource.Options.WithDocument("openapi: 3.1.0");
+
+        var envVars = await ResolveEnvironmentAsync(resource);
+
+        envVars.Should().ContainKey(EnvironmentVariables.OpenApiDocument)
+            .WhoseValue.Should().Be("openapi: 3.1.0");
+        envVars.Should().NotContainKey(EnvironmentVariables.OpenApiDocumentUrl);
+    }
+
+    [Fact]
+    public async Task ConfigureEnvironment_WithDocumentUrl_SetsOpenApiDocumentUrlEnvVar()
+    {
+        var resource = new ScalarMockServerResource(MockServerResourceName);
+        resource.Options.WithDocumentUrl("https://example.com/openapi.json");
+
+        var envVars = await ResolveEnvironmentAsync(resource);
+
+        envVars.Should().ContainKey(EnvironmentVariables.OpenApiDocumentUrl)
+            .WhoseValue.Should().Be("https://example.com/openapi.json");
+        envVars.Should().NotContainKey(EnvironmentVariables.OpenApiDocument);
+    }
+
+    [Fact]
+    public async Task ConfigureEnvironment_WithoutDocument_Throws()
+    {
+        var resource = new ScalarMockServerResource(MockServerResourceName);
+
+        var act = async () => await ResolveEnvironmentAsync(resource);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage($"*{MockServerResourceName}*");
+    }
+
+    [Fact]
+    public async Task WithDocumentFrom_ResolvesReferencedEndpointIntoDocumentUrl()
+    {
+        var apiBuilder = BuildHttpApiResource();
+        var resource = new ScalarMockServerResource(MockServerResourceName);
+        var mockBuilder = new MinimalResourceBuilder<ScalarMockServerResource>(resource);
+
+        mockBuilder.WithDocumentFrom(apiBuilder, routePattern: "/openapi/v1.json");
+
+        var envVars = await ResolveEnvironmentAsync(resource);
+
+        envVars.Should().ContainKey(EnvironmentVariables.OpenApiDocumentUrl)
+            .WhoseValue.Should().Be("http://localhost:5000/openapi/v1.json");
+    }
+
+    // Runs ConfigureEnvironment and resolves any IValueProvider (e.g. endpoint references) to strings.
+    private static async Task<Dictionary<string, string>> ResolveEnvironmentAsync(ScalarMockServerResource resource)
+    {
+        var executionContext = new DistributedApplicationExecutionContext(
+            new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run)
+            {
+                ServiceProvider = new ServiceCollection().BuildServiceProvider()
+            });
+
+        var envVars = new Dictionary<string, object>();
+        var context = new EnvironmentCallbackContext(executionContext, resource, envVars);
+
+        ScalarMockServerBuilderExtensions.ConfigureEnvironment(resource, context);
+
+        var result = new Dictionary<string, string>();
+        foreach (var (key, value) in envVars)
+        {
+            result[key] = value switch
+            {
+                string s => s,
+                IValueProvider vp => await vp.GetValueAsync() ?? string.Empty,
+                _ => value.ToString() ?? string.Empty
+            };
+        }
+
+        return result;
+    }
+
+    // Creates an API resource with a resolvable http endpoint (localhost:5000).
+    private static MinimalResourceBuilder<TestApiResource> BuildHttpApiResource()
+    {
+        var apiResource = new TestApiResource(ApiResourceName);
+        var httpEndpoint = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http", targetPort: 5000) { Port = 5000 };
+        httpEndpoint.AllocatedEndpoint = new AllocatedEndpoint(httpEndpoint, "localhost", 5000);
+        apiResource.Annotations.Add(httpEndpoint);
+        return new MinimalResourceBuilder<TestApiResource>(apiResource);
+    }
+
+    private sealed class TestApiResource(string name) : ContainerResource(name), IResourceWithServiceDiscovery;
+
+    // Minimal IResourceBuilder<T> that only supports annotation mutations — all WithReference/WithDocumentFrom need.
+    private sealed class MinimalResourceBuilder<T>(T resource) : IResourceBuilder<T> where T : IResource
+    {
+        public T Resource { get; } = resource;
+
+        public IDistributedApplicationBuilder ApplicationBuilder =>
+            throw new NotSupportedException("ApplicationBuilder is not available in minimal tests.");
+
+        public IResourceBuilder<T> WithAnnotation<TAnnotation>(
+            TAnnotation annotation,
+            ResourceAnnotationMutationBehavior behavior = ResourceAnnotationMutationBehavior.Append)
+            where TAnnotation : IResourceAnnotation
+        {
+            if (behavior == ResourceAnnotationMutationBehavior.Replace)
+            {
+                var toRemove = Resource.Annotations.OfType<TAnnotation>().ToList();
+                foreach (var a in toRemove)
+                {
+                    Resource.Annotations.Remove(a);
+                }
+            }
+
+            Resource.Annotations.Add(annotation);
+            return this;
+        }
+    }
+}

--- a/integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/ScalarMockServerTests.cs
+++ b/integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/ScalarMockServerTests.cs
@@ -142,8 +142,11 @@ public class ScalarMockServerTests
             .AddScalarMockServer("contract-mock")
             .WithDocumentFrom(api, routePattern: "/openapi/v1.json");
 
-        // The target is referenced so service discovery resolves its endpoint inside the container.
-        mock.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>().Should().NotBeEmpty();
+        // WithReference relates the mock to the target so service discovery resolves its endpoint
+        // inside the container. A mock server without WithDocumentFrom has no such relationship, so this
+        // proves the reference was added rather than just any environment callback.
+        mock.Resource.Annotations.OfType<ResourceRelationshipAnnotation>()
+            .Should().Contain(relationship => relationship.Resource.Name == "contract");
     }
 
     // Runs ConfigureEnvironment and resolves any IValueProvider (e.g. endpoint references) to strings.

--- a/integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/ScalarMockServerTests.cs
+++ b/integrations/dotnet/aspire/tests/Scalar.Aspire.Tests/ScalarMockServerTests.cs
@@ -29,6 +29,30 @@ public class ScalarMockServerTests
     }
 
     [Fact]
+    public void Options_WithDocumentFile_ReadsFileAsInlineContentExclusively()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "openapi: 3.1.0");
+
+            var options = new ScalarMockServerOptions().WithDocumentUrl("https://example.com/openapi.json");
+
+            options.WithDocumentFile(path);
+
+            options.HasDocument.Should().BeTrue();
+            // The file is read at AppHost build time and provided inline.
+            options.DocumentContent.Should().Be("openapi: 3.1.0");
+            // Switching source clears the previous one — only one source is ever active.
+            options.DocumentUrl.Should().BeNull();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public async Task ConfigureEnvironment_WithDocument_SetsOpenApiDocumentEnvVar()
     {
         var resource = new ScalarMockServerResource(MockServerResourceName);
@@ -78,6 +102,48 @@ public class ScalarMockServerTests
 
         envVars.Should().ContainKey(EnvironmentVariables.OpenApiDocumentUrl)
             .WhoseValue.Should().Be("http://localhost:5000/openapi/v1.json");
+    }
+
+    [Fact]
+    public void AddScalarMockServer_WithoutName_UsesDefaultResourceName()
+    {
+        var builder = DistributedApplication.CreateBuilder([]);
+
+        var mock = builder.AddScalarMockServer(options => options.WithDocument("openapi: 3.1.0"));
+
+        mock.Resource.Name.Should().Be("mock-server");
+    }
+
+    [Fact]
+    public void AddScalarMockServer_WiresContainerImagePortAndHealthCheck()
+    {
+        var builder = DistributedApplication.CreateBuilder([]);
+
+        var mock = builder.AddScalarMockServer("petstore", options => options.WithDocument("openapi: 3.1.0"));
+
+        var image = mock.Resource.Annotations.OfType<ContainerImageAnnotation>().Should().ContainSingle().Subject;
+        image.Image.Should().Be("scalarapi/mock-server");
+
+        // The container listens on port 3000 internally.
+        mock.Resource.Annotations.OfType<EndpointAnnotation>()
+            .Should().ContainSingle(e => e.TargetPort == 3000);
+
+        // A health check is registered so dependents can wait on the mock being ready.
+        mock.Resource.Annotations.OfType<HealthCheckAnnotation>().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void WithDocumentFrom_AddsServiceDiscoveryReferenceToTarget()
+    {
+        var builder = DistributedApplication.CreateBuilder([]);
+
+        var api = builder.AddResource(new TestApiResource("contract"));
+        var mock = builder
+            .AddScalarMockServer("contract-mock")
+            .WithDocumentFrom(api, routePattern: "/openapi/v1.json");
+
+        // The target is referenced so service discovery resolves its endpoint inside the container.
+        mock.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>().Should().NotBeEmpty();
     }
 
     // Runs ConfigureEnvironment and resolves any IValueProvider (e.g. endpoint references) to strings.


### PR DESCRIPTION
## Problem

Sometimes I need to expose an API to another team before I've implemented it. With a contract-first workflow, the OpenAPI document exists well before the service does — the consuming team wants to start integrating immediately, but there's no running backend to point them at.

Scalar already ships a mock server (`@scalar/mock-server`, published as the `scalarapi/mock-server` container) that turns an OpenAPI document into a working, realistic API. But Aspire users had no first-class way to use it: to stand up that mock alongside the rest of their app, they had to hand-roll a container resource and wire up env vars and endpoints themselves.

The API Reference already has a clean `AddScalarApiReference` Aspire resource, so it felt natural for the mock server to have the same one-liner story: declare it from an OpenAPI document and let the consuming team (and other resources) depend on it like any real service — before a single handler is written.

## Solution

Added `AddScalarMockServer`, a thin Aspire hosting wrapper around the published `scalarapi/mock-server` image — cloned from the existing `AddScalarApiReference` resource pattern. Because the mock server already ships as a container, this needs no engine port and keeps full fidelity (`x-handler`/`x-seed`, validation, auth, Faker-based responses all run in the canonical Node implementation).

- `ScalarMockServerResource` is a `ContainerResource` implementing `IResourceWithServiceDiscovery`, so other resources can `.WithReference(mock)` it as if it were the real service.
- Document sources (mutually exclusive): `WithDocument` (inline), `WithDocumentFile` (read at AppHost build time), `WithDocumentUrl` (fetch on startup), and `WithDocumentFrom` (derive from another resource's endpoint, resolved via service discovery).
- Wires the image/tag, container port (3000), a `/openapi.json` health check, and removes OTLP exporter annotations to keep the container tunnel bootstrap non-blocking — mirroring the API Reference resource.

Alternatives considered: a native in-process ASP.NET port of the mock engine (`MapScalarMockServer`) and a sidecar-and-reverse-proxy approach. Both were set aside for now — the container model is the idiomatic Aspire composition unit and the lowest-risk, highest-fidelity path. The native/in-process story can follow later.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation.
