### PR TITLE
feat(mock-server): mock AsyncAPI 3.1 documents over WebSocket and SSE

### DIFF
--- a/.changeset/mock-server-asyncapi.md
+++ b/.changeset/mock-server-asyncapi.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': minor
+---
+
+Add `createAsyncApiMockServer` to mock event-driven APIs from an AsyncAPI 3.1 document. Channels are served over WebSocket and SSE, with messages generated from each message's payload schema (the same generator the REST mocker uses). Additional protocols (e.g. SignalR) can be added through the `transports` extension point. The Docker mock server now auto-detects AsyncAPI documents.

--- a/documentation/guides/mock-server/asyncapi.md
+++ b/documentation/guides/mock-server/asyncapi.md
@@ -81,6 +81,8 @@ For each message the mock server, in order of preference:
 
 Channel addresses with path parameters (for example `rooms/{roomId}`) become route parameters (`/rooms/:roomId`).
 
+> The SSE transport emits one message per `receive` operation and then closes the stream, rather than streaming continuously. Reconnect (or let your SSE client reconnect) to get another batch.
+
 ## Document detection
 
 The Docker mock server and CLI automatically detect AsyncAPI documents (by their top-level `asyncapi` field) and start the AsyncAPI mock instead of the REST mock — no extra flag is required.

--- a/documentation/guides/mock-server/asyncapi.md
+++ b/documentation/guides/mock-server/asyncapi.md
@@ -1,0 +1,111 @@
+# AsyncAPI Mocking
+
+The mock server can mock **event-driven APIs** described with an [AsyncAPI 3.1](https://www.asyncapi.com/) document, alongside its OpenAPI/REST support. Each AsyncAPI channel is served as a live mock endpoint that emits realistic messages generated from the channel's message payload schemas — the event-driven counterpart of the HTTP responses the REST mocker generates.
+
+## Supported transports
+
+| Transport | When it is used | Behavior |
+| --- | --- | --- |
+| **WebSocket** (`ws` / `wss`) | Channels whose servers use the `ws`/`wss` protocol (or declare a WebSocket binding). | `receive` operations push a generated message when a client connects; `send` operations echo a generated reply to each inbound frame. |
+| **SSE** (`sse`, or `http`/`https` with a `receive` operation) | One-way, server-push channels over HTTP. | A `GET` on the channel route opens an SSE stream and emits a generated message per `receive` operation. |
+
+> Brokered protocols such as Kafka, MQTT, and AMQP require external broker infrastructure and are not served in-process. They can be added through the [transports extension point](#adding-custom-transports).
+
+## Usage
+
+WebSocket channels need to be attached to the HTTP server after `serve()`, so `createAsyncApiMockServer` returns both the Hono `app` and an `injectWebSocket` function:
+
+```typescript
+import { serve } from '@hono/node-server'
+import { createAsyncApiMockServer } from '@scalar/mock-server'
+
+const document = {
+  asyncapi: '3.1.0',
+  info: { title: 'Chat', version: '1.0.0' },
+  servers: {
+    production: { host: 'localhost:3000', protocol: 'ws' },
+  },
+  channels: {
+    messages: {
+      address: 'messages',
+      messages: {
+        chatMessage: {
+          contentType: 'application/json',
+          payload: {
+            type: 'object',
+            properties: {
+              user: { type: 'string' },
+              text: { type: 'string' },
+            },
+            required: ['user', 'text'],
+          },
+        },
+      },
+    },
+  },
+  operations: {
+    receiveMessage: { action: 'receive', channel: { $ref: '#/channels/messages' } },
+    sendMessage: { action: 'send', channel: { $ref: '#/channels/messages' } },
+  },
+}
+
+const { app, injectWebSocket } = await createAsyncApiMockServer({
+  document,
+  onMessage: ({ channel, direction, payload }) => console.log(direction, channel, payload),
+})
+
+const server = serve({ fetch: app.fetch, port: 3000 })
+
+// Required for WebSocket channels to accept connections.
+injectWebSocket(server)
+```
+
+Connect a WebSocket client to the channel route to receive a generated message and echo replies:
+
+```bash
+npx wscat -c ws://localhost:3000/messages
+```
+
+For an SSE channel, read the stream over HTTP:
+
+```bash
+curl -N http://localhost:3000/messages
+```
+
+## How messages are generated
+
+For each message the mock server, in order of preference:
+
+1. Uses a defined `examples` value, when present.
+2. Otherwise generates a value from the message `payload` schema, using the same generator as the REST mocker.
+
+Channel addresses with path parameters (for example `rooms/{roomId}`) become route parameters (`/rooms/:roomId`).
+
+## Document detection
+
+The Docker mock server and CLI automatically detect AsyncAPI documents (by their top-level `asyncapi` field) and start the AsyncAPI mock instead of the REST mock — no extra flag is required.
+
+## Adding custom transports
+
+Transports are pluggable. A transport declares which channels it owns via `supports()` and registers them via `register()`. The first transport whose `supports()` returns `true` for a channel owns it; built-in WebSocket and SSE transports are checked first.
+
+```typescript
+import { createAsyncApiMockServer, type MockTransport } from '@scalar/mock-server'
+
+const signalrTransport: MockTransport = {
+  name: 'signalr',
+  supports: (channel) => channel.protocols.includes('signalr'),
+  register: (channel, context) => {
+    // `context` exposes the Hono `app` (for HTTP handshakes), Hono's `upgradeWebSocket`
+    // helper (for socket upgrades), and `generateMessage(channel, messageId?)`.
+    context.app.post(`${channel.route}/negotiate`, (c) => c.json({ /* ... */ }))
+  },
+}
+
+const { app, injectWebSocket } = await createAsyncApiMockServer({
+  document,
+  transports: [signalrTransport], // appended after the built-in transports
+})
+```
+
+Because `register()` receives both the Hono `app` and the `upgradeWebSocket` helper, protocols that negotiate over HTTP before upgrading to a socket (such as SignalR) fit without any core changes.

--- a/documentation/guides/mock-server/docker.md
+++ b/documentation/guides/mock-server/docker.md
@@ -84,7 +84,7 @@ docker run -p 3000:3000 \
 
 The container automatically:
 - Scans the `/docs` directory recursively
-- Finds OpenAPI documents (`.json`, `.yaml`, `.yml` files)
+- Finds OpenAPI and AsyncAPI documents (`.json`, `.yaml`, `.yml` files)
 - Uses the first valid document found
 
 ### Priority Order
@@ -124,6 +124,23 @@ Your OpenAPI document is automatically served at:
 The format is automatically determined based on your source document.
 
 This helps with debugging and monitoring during development.
+
+### AsyncAPI Documents
+
+The Docker image also mocks event-driven APIs. When the provided document is an [AsyncAPI 3.1](https://www.asyncapi.com/) definition (detected by its top-level `asyncapi` field), the container starts the AsyncAPI mock instead of the REST mock — no extra flag is required. Each channel is served over **WebSocket** (`ws`/`wss` channels) or **Server-Sent Events** (`sse`, or `http`/`https` server-push channels), with messages generated from the channel's payload schemas.
+
+WebSocket and SSE channels are served on the same port as the rest of the server, so the usual port mapping is all you need:
+
+```bash
+docker run -p 3000:3000 \
+  -v ./asyncapi.yaml:/docs/asyncapi.yaml:ro \
+  scalarapi/mock-server
+
+# Connect a WebSocket client to a channel route, e.g.
+# npx wscat -c ws://localhost:3000/<channel-address>
+```
+
+See the [AsyncAPI mocking guide](asyncapi.md) for supported transports and how messages are generated.
 
 ## Docker Compose
 

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -14,6 +14,7 @@ A powerful Node.js mock server that automatically generates realistic API respon
 - Generates realistic mock data based on your schemas
 - Handles authentication and responds with defined HTTP headers
 - Supports Swagger 2.0 and OpenAPI 3.x documents
+- Mocks event-driven APIs from AsyncAPI 3.1 documents over WebSocket and SSE
 - Write custom JavaScript handlers for dynamic responses
 - Automatically seed initial data on server startup
 - Validates incoming requests against your OpenAPI contract
@@ -305,3 +306,9 @@ Use the `x-handler` extension to write custom JavaScript code for handling reque
 Use the `x-seed` extension on your schemas to automatically populate initial data when the server starts. Perfect for having realistic test data available immediately.
 
 [Learn more about data seeding →](data-seeding.md)
+
+### AsyncAPI Mocking
+
+Point the mock server at an AsyncAPI 3.1 document to mock event-driven APIs. Channels are served over WebSocket and Server-Sent Events, and messages are generated from each message's payload schema. Additional protocols can be plugged in through the `transports` extension point.
+
+[Learn more about AsyncAPI mocking →](asyncapi.md)

--- a/packages/mock-server/docker/src/document-loader.ts
+++ b/packages/mock-server/docker/src/document-loader.ts
@@ -92,7 +92,7 @@ function scanForDocument(dir: string): string | null {
           return found
         }
       } else if (file.match(/\.(json|ya?ml)$/i)) {
-        if (isOpenApiDocument(fullPath)) {
+        if (isApiDocument(fullPath)) {
           return fullPath
         }
       }
@@ -104,14 +104,16 @@ function scanForDocument(dir: string): string | null {
   return null
 }
 
-function isOpenApiDocument(filePath: string): boolean {
+function isApiDocument(filePath: string): boolean {
   try {
     const content = readFileSync(filePath, 'utf8')
     return (
       content.includes('openapi:') ||
       content.includes('"openapi"') ||
       content.includes('swagger:') ||
-      content.includes('"swagger"')
+      content.includes('"swagger"') ||
+      content.includes('asyncapi:') ||
+      content.includes('"asyncapi"')
     )
   } catch {
     return false

--- a/packages/mock-server/docker/src/server.test.ts
+++ b/packages/mock-server/docker/src/server.test.ts
@@ -11,6 +11,8 @@ vi.mock('@hono/node-server', () => ({
 // Mock @scalar/mock-server
 vi.mock('@scalar/mock-server', () => ({
   createMockServer: vi.fn(),
+  createAsyncApiMockServer: vi.fn(),
+  isAsyncApiDocument: vi.fn(() => false),
 }))
 
 // Mock @scalar/hono-api-reference
@@ -25,6 +27,8 @@ describe('startMockServer', () => {
   }
   let mockServe: ReturnType<typeof vi.fn>
   let mockCreateMockServer: ReturnType<typeof vi.fn>
+  let mockCreateAsyncApiMockServer: ReturnType<typeof vi.fn>
+  let mockIsAsyncApiDocument: ReturnType<typeof vi.fn>
   let mockScalar: ReturnType<typeof vi.fn>
 
   beforeEach(async () => {
@@ -32,12 +36,16 @@ describe('startMockServer', () => {
 
     // Import mocked modules
     const { serve } = await import('@hono/node-server')
-    const { createMockServer } = await import('@scalar/mock-server')
+    const { createMockServer, createAsyncApiMockServer, isAsyncApiDocument } = await import('@scalar/mock-server')
     const { Scalar } = await import('@scalar/hono-api-reference')
 
     mockServe = vi.mocked(serve)
     mockCreateMockServer = vi.mocked(createMockServer)
+    mockCreateAsyncApiMockServer = vi.mocked(createAsyncApiMockServer)
+    mockIsAsyncApiDocument = vi.mocked(isAsyncApiDocument)
     mockScalar = vi.mocked(Scalar)
+    // OpenAPI by default; individual tests opt into the AsyncAPI branch.
+    mockIsAsyncApiDocument.mockReturnValue(false)
 
     mockApp = {
       get: vi.fn(),
@@ -244,5 +252,28 @@ describe('startMockServer', () => {
     expect(consoleSpy).toHaveBeenCalledWith('📖 API Reference: http://0.0.0.0:3000/scalar')
 
     consoleSpy.mockRestore()
+  })
+
+  it('uses the AsyncAPI mock server and injects WebSocket support for AsyncAPI documents', async () => {
+    const document = '{"asyncapi":"3.1.0","info":{"title":"Test","version":"1.0.0"}}'
+    const mockInjectWebSocket = vi.fn()
+    const mockServer = { close: vi.fn() }
+
+    mockIsAsyncApiDocument.mockReturnValue(true)
+    mockCreateAsyncApiMockServer.mockResolvedValue({
+      app: mockApp as unknown as Hono,
+      injectWebSocket: mockInjectWebSocket,
+    })
+    mockServe.mockReturnValue(mockServer)
+
+    await startMockServer({ document, format: 'json' })
+
+    expect(mockCreateAsyncApiMockServer).toHaveBeenCalledWith(
+      expect.objectContaining({ document, onMessage: expect.any(Function), logger: expect.any(Function) }),
+    )
+    // The REST mocker is not used for AsyncAPI documents.
+    expect(mockCreateMockServer).not.toHaveBeenCalled()
+    // WebSocket handling is attached to the running server.
+    expect(mockInjectWebSocket).toHaveBeenCalledWith(mockServer)
   })
 })

--- a/packages/mock-server/docker/src/server.ts
+++ b/packages/mock-server/docker/src/server.ts
@@ -1,11 +1,25 @@
 import { serve } from '@hono/node-server'
 import { Scalar } from '@scalar/hono-api-reference'
-import { createMockServer } from '@scalar/mock-server'
+import { createAsyncApiMockServer, createMockServer, isAsyncApiDocument } from '@scalar/mock-server'
+import type { Hono } from 'hono'
 
 interface ServerConfig {
   document: string
   format: 'json' | 'yaml'
   port?: number
+}
+
+/** Parse the raw document just enough to tell whether it is an AsyncAPI definition. */
+function parseDocument(document: string, format: 'json' | 'yaml'): unknown {
+  if (format === 'json') {
+    try {
+      return JSON.parse(document)
+    } catch {
+      return undefined
+    }
+  }
+  // For YAML, a cheap top-level check avoids pulling a parser just for detection.
+  return /^asyncapi\s*:/m.test(document) ? { asyncapi: true } : undefined
 }
 
 export async function startMockServer(config: ServerConfig): Promise<void> {
@@ -15,27 +29,44 @@ export async function startMockServer(config: ServerConfig): Promise<void> {
   console.log('Starting mock server...')
   console.log()
 
-  const app = await createMockServer({
-    document,
-    onRequest({ context }) {
-      console.log(context.req.method, context.req.path)
-    },
-  })
+  const isAsyncApi = isAsyncApiDocument(parseDocument(document, format))
+
+  let app: Hono
+  // AsyncAPI WebSocket channels must be injected into the HTTP server after `serve()`.
+  let injectWebSocket: ((server: ReturnType<typeof serve>) => void) | undefined
+
+  if (isAsyncApi) {
+    const mock = await createAsyncApiMockServer({
+      document,
+      logger: (line) => console.log(line),
+      onMessage: ({ channel, direction, payload }) =>
+        console.log(`${direction === 'in' ? '→' : '←'} ${channel}`, payload),
+    })
+    app = mock.app
+    injectWebSocket = mock.injectWebSocket
+  } else {
+    app = await createMockServer({
+      document,
+      onRequest({ context }) {
+        console.log(context.req.method, context.req.path)
+      },
+    })
+  }
 
   // Determine endpoint and content type based on format
   const endpoint = format === 'json' ? '/openapi.json' : '/openapi.yaml'
   const contentType = format === 'json' ? 'application/json' : 'application/yaml; charset=UTF-8'
 
-  // Serve the OpenAPI document at the appropriate endpoint for the API Reference
+  // Serve the API document at the appropriate endpoint for the API Reference
   app.get(endpoint, (c) => {
     c.header('Content-Type', contentType)
     return c.text(document)
   })
 
-  // API Reference at /scalar
+  // API Reference at /scalar (renders both OpenAPI and AsyncAPI documents)
   app.get('/scalar', Scalar({ url: endpoint, theme: 'default' }))
 
-  serve(
+  const server = serve(
     {
       fetch: app.fetch,
       port,
@@ -45,4 +76,7 @@ export async function startMockServer(config: ServerConfig): Promise<void> {
       console.log(`📖 API Reference: http://${info.address}:${info.port}/scalar`)
     },
   )
+
+  // Attach WebSocket handling for AsyncAPI ws/wss channels.
+  injectWebSocket?.(server)
 }

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -57,10 +57,12 @@
   },
   "dependencies": {
     "@faker-js/faker": "catalog:*",
+    "@hono/node-ws": "catalog:*",
     "@scalar/helpers": "workspace:*",
     "@scalar/json-magic": "workspace:*",
     "@scalar/openapi-types": "workspace:*",
     "@scalar/openapi-upgrader": "workspace:*",
+    "@scalar/types": "workspace:*",
     "@scalar/workspace-store": "workspace:*",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/packages/mock-server/src/create-asyncapi-mock-server.test.ts
+++ b/packages/mock-server/src/create-asyncapi-mock-server.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createAsyncApiMockServer } from './create-asyncapi-mock-server'
+import type { MockTransport } from './transports/types'
+import { isAsyncApiDocument } from './utils/process-asyncapi-document'
+
+describe('createAsyncApiMockServer', () => {
+  it('serves SSE channels with a generated message', async () => {
+    const { app } = await createAsyncApiMockServer({
+      document: {
+        asyncapi: '3.1.0',
+        info: { title: 'Prices', version: '1.0.0' },
+        servers: { production: { host: 'localhost', protocol: 'sse' } },
+        channels: {
+          prices: {
+            address: 'prices',
+            messages: {
+              priceUpdate: {
+                contentType: 'application/json',
+                payload: {
+                  type: 'object',
+                  properties: { symbol: { type: 'string' }, price: { type: 'number' } },
+                  required: ['symbol', 'price'],
+                },
+              },
+            },
+          },
+        },
+        operations: {
+          streamPrices: { action: 'receive', channel: { $ref: '#/channels/prices' } },
+        },
+      },
+    })
+
+    const response = await app.request('/prices')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/event-stream')
+
+    const body = await response.text()
+    expect(body).toContain('event: priceUpdate')
+    expect(body).toContain('data:')
+    expect(body).toContain('symbol')
+  })
+
+  it('lets custom transports claim channels (extension point)', async () => {
+    const claimed: string[] = []
+    const signalr: MockTransport = {
+      name: 'signalr',
+      supports: (channel) => channel.protocols.includes('signalr'),
+      register: (channel) => {
+        claimed.push(channel.id)
+      },
+    }
+
+    await createAsyncApiMockServer({
+      document: {
+        asyncapi: '3.1.0',
+        info: { title: 'Hub', version: '1.0.0' },
+        servers: { production: { host: 'localhost', protocol: 'signalr' } },
+        channels: { hub: { address: 'hub', messages: { ping: { payload: { type: 'string' } } } } },
+        operations: { onPing: { action: 'receive', channel: { $ref: '#/channels/hub' } } },
+      },
+      transports: [signalr],
+    })
+
+    expect(claimed).toEqual(['hub'])
+  })
+
+  it('logs channels that no transport can serve', async () => {
+    const logger = vi.fn()
+
+    await createAsyncApiMockServer({
+      document: {
+        asyncapi: '3.1.0',
+        info: { title: 'Kafka', version: '1.0.0' },
+        servers: { broker: { host: 'localhost:9092', protocol: 'kafka' } },
+        channels: { events: { address: 'events', messages: { evt: { payload: { type: 'string' } } } } },
+        operations: { onEvent: { action: 'receive', channel: { $ref: '#/channels/events' } } },
+      },
+      logger,
+    })
+
+    expect(logger).toHaveBeenCalledWith(expect.stringContaining('no transport for channel "events"'))
+  })
+})
+
+describe('isAsyncApiDocument', () => {
+  it('detects AsyncAPI documents', () => {
+    expect(isAsyncApiDocument({ asyncapi: '3.1.0' })).toBe(true)
+    expect(isAsyncApiDocument({ openapi: '3.1.0' })).toBe(false)
+    expect(isAsyncApiDocument(null)).toBe(false)
+    expect(isAsyncApiDocument('asyncapi')).toBe(false)
+  })
+})

--- a/packages/mock-server/src/create-asyncapi-mock-server.ts
+++ b/packages/mock-server/src/create-asyncapi-mock-server.ts
@@ -1,0 +1,96 @@
+import { createNodeWebSocket } from '@hono/node-ws'
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+
+import { defaultTransports } from '@/transports'
+import type { MessageDirection, MockTransport, TransportContext } from '@/transports/types'
+import { generateMessage } from '@/utils/generate-message'
+import { processAsyncApiDocument } from '@/utils/process-asyncapi-document'
+import { resolveChannels } from '@/utils/resolve-channels'
+
+/** Options for {@link createAsyncApiMockServer}. */
+export type AsyncApiMockServerOptions = {
+  /**
+   * The AsyncAPI 3.1 document to mock. Can be a string (URL or file path), a raw JSON/YAML
+   * string, or an already-parsed object.
+   */
+  document?: string | Record<string, any>
+
+  /**
+   * Additional transports appended after the built-in WebSocket and SSE transports. Use this to
+   * support extra protocols (for example SignalR) without changing the core. The first transport
+   * whose `supports()` returns `true` for a channel owns it.
+   */
+  transports?: MockTransport[]
+
+  /** Called for every message flowing in or out of the mock, for logging or inspection. */
+  onMessage?: (event: { channel: string; direction: MessageDirection; payload: unknown }) => void
+
+  /** Optional sink for transport lifecycle log lines. Defaults to no-op. */
+  logger?: (line: string) => void
+}
+
+/** The result of {@link createAsyncApiMockServer}. */
+export type AsyncApiMockServer = {
+  /** The Hono app serving SSE channels and WebSocket upgrade routes. */
+  app: Hono
+  /**
+   * Attaches WebSocket handling to the running Node HTTP server returned by `@hono/node-server`'s
+   * `serve()`. Must be called for WebSocket channels to accept connections.
+   */
+  injectWebSocket: ReturnType<typeof createNodeWebSocket>['injectWebSocket']
+}
+
+/**
+ * Create a mock server for an AsyncAPI 3.1 document — the event-driven counterpart of
+ * {@link createMockServer}. Each channel is registered on a transport (WebSocket or SSE by
+ * default) that emits realistic mock messages generated from the channel's message payload
+ * schemas, the same way the REST mocker generates HTTP response bodies.
+ *
+ * WebSocket support requires attaching to the HTTP server after `serve()`:
+ *
+ * ```ts
+ * const { app, injectWebSocket } = await createAsyncApiMockServer({ document })
+ * const server = serve({ fetch: app.fetch, port: 3000 })
+ * injectWebSocket(server)
+ * ```
+ */
+export async function createAsyncApiMockServer(options: AsyncApiMockServerOptions): Promise<AsyncApiMockServer> {
+  const app = new Hono()
+
+  // The Node WebSocket adapter must be created against the app before routes are registered so the
+  // `upgradeWebSocket` helper shares this app's lifecycle. `injectWebSocket` is wired to the
+  // HTTP server by the caller after `serve()`.
+  const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app })
+
+  const document = await processAsyncApiDocument(options.document)
+  const channels = resolveChannels(document)
+
+  const transports = [...defaultTransports, ...(options.transports ?? [])]
+  const log = options.logger ?? (() => undefined)
+
+  // CORS for the SSE/HTTP routes (WebSocket upgrades are not subject to CORS).
+  app.use(cors())
+
+  const context: TransportContext = {
+    app,
+    upgradeWebSocket,
+    generateMessage,
+    onMessage: options.onMessage,
+    log,
+  }
+
+  for (const channel of channels) {
+    const transport = transports.find((candidate) => candidate.supports(channel))
+
+    if (!transport) {
+      log(`[asyncapi] no transport for channel "${channel.id}" (protocols: ${channel.protocols.join(', ') || 'none'})`)
+      continue
+    }
+
+    transport.register(channel, context)
+    log(`[asyncapi] ${transport.name} -> ${channel.route} (channel "${channel.id}")`)
+  }
+
+  return { app, injectWebSocket }
+}

--- a/packages/mock-server/src/index.ts
+++ b/packages/mock-server/src/index.ts
@@ -1,1 +1,17 @@
+export {
+  type AsyncApiMockServer,
+  type AsyncApiMockServerOptions,
+  createAsyncApiMockServer,
+} from './create-asyncapi-mock-server'
 export { createMockServer } from './create-mock-server'
+export { defaultTransports, sseTransport, websocketTransport } from './transports'
+export type {
+  MessageDirection,
+  MockMessage,
+  MockTransport,
+  ResolvedChannel,
+  ResolvedMessage,
+  ResolvedOperation,
+  TransportContext,
+} from './transports/types'
+export { isAsyncApiDocument } from './utils/process-asyncapi-document'

--- a/packages/mock-server/src/transports/index.ts
+++ b/packages/mock-server/src/transports/index.ts
@@ -9,15 +9,5 @@ import { websocketTransport } from './websocket'
  */
 export const defaultTransports: MockTransport[] = [websocketTransport, sseTransport]
 
-export type {
-  MessageDirection,
-  MockMessage,
-  MockTransport,
-  ResolvedChannel,
-  ResolvedMessage,
-  ResolvedOperation,
-  TransportContext,
-} from '@/transports/types'
-
 export { sseTransport } from './sse'
 export { websocketTransport } from './websocket'

--- a/packages/mock-server/src/transports/index.ts
+++ b/packages/mock-server/src/transports/index.ts
@@ -1,0 +1,23 @@
+import type { MockTransport } from '@/transports/types'
+
+import { sseTransport } from './sse'
+import { websocketTransport } from './websocket'
+
+/**
+ * Built-in transports, in match priority order. WebSocket is checked before SSE so a `ws`
+ * channel is never claimed by the SSE fallback. Consumer transports are appended after these.
+ */
+export const defaultTransports: MockTransport[] = [websocketTransport, sseTransport]
+
+export type {
+  MessageDirection,
+  MockMessage,
+  MockTransport,
+  ResolvedChannel,
+  ResolvedMessage,
+  ResolvedOperation,
+  TransportContext,
+} from '@/transports/types'
+
+export { sseTransport } from './sse'
+export { websocketTransport } from './websocket'

--- a/packages/mock-server/src/transports/sse.ts
+++ b/packages/mock-server/src/transports/sse.ts
@@ -1,0 +1,48 @@
+import { streamSSE } from 'hono/streaming'
+
+import type { MockTransport, ResolvedOperation } from '@/transports/types'
+
+/**
+ * Built-in Server-Sent Events transport. Serves one-way, server-push channels over HTTP: a `GET`
+ * on the channel route opens an SSE stream and emits a generated message per `receive` operation.
+ *
+ * Claims channels whose servers speak `sse`, or plain `http`/`https` channels that have at least
+ * one `receive` operation (a server-push channel). WebSocket takes precedence for `ws` channels
+ * because it is registered first in the default transport list.
+ */
+export const sseTransport: MockTransport = {
+  name: 'sse',
+  supports: (channel) => {
+    if (channel.protocols.includes('sse')) {
+      return true
+    }
+
+    const isHttp = channel.protocols.includes('http') || channel.protocols.includes('https')
+    const hasServerPush = channel.operations.some((operation) => operation.action === 'receive')
+    return isHttp && hasServerPush
+  },
+  register: (channel, context) => {
+    const { app, generateMessage, onMessage, log } = context
+
+    const receiveOperations = channel.operations.filter((operation) => operation.action === 'receive')
+    // Fall back to all channel messages when the channel has no explicit receive operation.
+    const operations: Pick<ResolvedOperation, 'messages'>[] =
+      receiveOperations.length > 0 ? receiveOperations : [{ messages: channel.messages }]
+
+    app.get(channel.route, (c) =>
+      streamSSE(c, async (stream) => {
+        log(`[sse] open ${channel.route}`)
+
+        for (const operation of operations) {
+          const message = generateMessage(channel, operation.messages[0]?.id)
+          if (message) {
+            await stream.writeSSE({ data: message.data, event: message.event })
+            onMessage?.({ channel: channel.id, direction: 'out', payload: message.data })
+          }
+        }
+
+        log(`[sse] close ${channel.route}`)
+      }),
+    )
+  },
+}

--- a/packages/mock-server/src/transports/types.ts
+++ b/packages/mock-server/src/transports/types.ts
@@ -1,0 +1,96 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { Hono } from 'hono'
+import type { UpgradeWebSocket } from 'hono/ws'
+
+/**
+ * A message resolved from an AsyncAPI channel/operation, with `$ref`s already resolved.
+ * The `payload` is a plain JSON Schema ready to feed to `getExampleFromSchema`.
+ */
+export type ResolvedMessage = {
+  /** The message id (its key in `channel.messages`), used as the default event name. */
+  id: string
+  /** The JSON Schema for the message payload, or `undefined` when the message has no payload. */
+  payload?: OpenAPIV3_1.SchemaObject
+  /** Named/inline examples defined on the message, preferred over generated payloads. */
+  examples: unknown[]
+  /** Content type used to encode the payload (defaults to the document's `defaultContentType`). */
+  contentType?: string
+}
+
+/** A single AsyncAPI operation (`send`/`receive`) bound to its channel. */
+export type ResolvedOperation = {
+  /** The operation id (its key in the document's `operations` map). */
+  id: string
+  /**
+   * `send`: the application sends to the channel, so the mock *receives* a client message
+   * and echoes a reply. `receive`: the application receives from the channel, so the mock
+   * *pushes* a message to the client.
+   */
+  action: 'send' | 'receive'
+  /** Messages this operation may carry (a subset of the channel's messages, or all of them). */
+  messages: ResolvedMessage[]
+}
+
+/** A normalized, dereferenced view of an AsyncAPI channel that a transport can serve. */
+export type ResolvedChannel = {
+  /** The channel id (its key in the document's `channels` map). */
+  id: string
+  /** The raw channel address, e.g. `user/signedup` or `rooms/{roomId}`. */
+  address: string
+  /** Hono-style route derived from the address (`rooms/{roomId}` -> `/rooms/:roomId`). */
+  route: string
+  /** Connection protocols advertised by the channel's servers, e.g. `['ws']`, `['sse']`. */
+  protocols: string[]
+  /** Operations targeting this channel. */
+  operations: ResolvedOperation[]
+  /** All messages declared on the channel. */
+  messages: ResolvedMessage[]
+}
+
+/** An encoded frame ready to write to a transport, plus the optional event name. */
+export type MockMessage = {
+  /** The wire payload (already encoded per the message `contentType`). */
+  data: string
+  /** Event name (the message id), surfaced by transports that support named events (SSE). */
+  event?: string
+}
+
+/** Direction of a message relative to the mock server. */
+export type MessageDirection = 'in' | 'out'
+
+/**
+ * Everything a transport needs to register a channel on the running server. The core builds
+ * this once and passes it to every transport's {@link MockTransport.register}.
+ */
+export type TransportContext = {
+  /** The Hono app. HTTP-based transports (SSE, SignalR negotiate) register routes here. */
+  app: Hono
+  /**
+   * Hono's WebSocket upgrade helper, bound to the Node adapter. Upgrade-based transports
+   * (WebSocket, SignalR) register sockets via `app.get(route, upgradeWebSocket(...))`.
+   */
+  upgradeWebSocket: UpgradeWebSocket
+  /**
+   * Generate an encoded mock message for a channel. When `messageId` is omitted the first
+   * available message is used. Returns `null` when the channel declares no messages.
+   */
+  generateMessage: (channel: ResolvedChannel, messageId?: string) => MockMessage | null
+  /** Notifies the caller about every message flowing in or out, for logging/inspection. */
+  onMessage?: (event: { channel: string; direction: MessageDirection; payload: unknown }) => void
+  /** Structured logger for transport lifecycle lines. */
+  log: (line: string) => void
+}
+
+/**
+ * A pluggable transport that knows how to serve a class of AsyncAPI channels (by protocol).
+ * Built-in transports cover WebSocket and SSE; consumers can append their own (e.g. SignalR)
+ * via {@link AsyncApiMockServerOptions.transports} without changing the core.
+ */
+export type MockTransport = {
+  /** Unique transport id, e.g. `websocket`, `sse`. */
+  name: string
+  /** Whether this transport should own the given channel. The first match wins. */
+  supports: (channel: ResolvedChannel) => boolean
+  /** Register the channel on the server. Called once per matching channel at startup. */
+  register: (channel: ResolvedChannel, context: TransportContext) => void
+}

--- a/packages/mock-server/src/transports/websocket.test.ts
+++ b/packages/mock-server/src/transports/websocket.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { generateMessage } from '@/utils/generate-message'
+
+import type { ResolvedChannel, TransportContext } from './types'
+import { websocketTransport } from './websocket'
+
+/** A channel with both a receive (push) and a send (echo) operation. */
+const channel: ResolvedChannel = {
+  id: 'echo',
+  address: 'echo',
+  route: '/echo',
+  protocols: ['ws'],
+  messages: [
+    {
+      id: 'message',
+      payload: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] } as any,
+      examples: [],
+      contentType: 'application/json',
+    },
+  ],
+  operations: [
+    { id: 'send', action: 'send', messages: [] },
+    { id: 'receive', action: 'receive', messages: [] },
+  ],
+}
+
+// Operations reference the same single message.
+channel.operations[0]!.messages = channel.messages
+channel.operations[1]!.messages = channel.messages
+
+/** Register the transport against fakes and return the captured WebSocket event handlers. */
+function register() {
+  let handlers: any
+  const context: TransportContext = {
+    app: {
+      get: (_route: string, _handler: unknown) => undefined,
+    } as any,
+    upgradeWebSocket: ((createHandlers: any) => {
+      handlers = createHandlers({})
+      return 'WS_ROUTE_HANDLER'
+    }) as any,
+    generateMessage,
+    onMessage: vi.fn(),
+    log: vi.fn(),
+  }
+
+  websocketTransport.register(channel, context)
+  return { handlers, onMessage: context.onMessage as ReturnType<typeof vi.fn> }
+}
+
+describe('websocketTransport', () => {
+  it('supports ws/wss channels only', () => {
+    expect(websocketTransport.supports({ ...channel, protocols: ['ws'] })).toBe(true)
+    expect(websocketTransport.supports({ ...channel, protocols: ['wss'] })).toBe(true)
+    expect(websocketTransport.supports({ ...channel, protocols: ['sse'] })).toBe(false)
+  })
+
+  it('pushes a generated message on open for receive operations', () => {
+    const { handlers, onMessage } = register()
+    const sent: string[] = []
+    const ws = { send: (data: string) => sent.push(data) }
+
+    handlers.onOpen({}, ws)
+
+    expect(sent).toHaveLength(1)
+    expect(JSON.parse(sent[0]!)).toHaveProperty('text')
+    expect(onMessage).toHaveBeenCalledWith(expect.objectContaining({ channel: 'echo', direction: 'out' }))
+  })
+
+  it('echoes a generated reply on inbound messages for send operations', () => {
+    const { handlers, onMessage } = register()
+    const sent: string[] = []
+    const ws = { send: (data: string) => sent.push(data) }
+
+    handlers.onMessage({ data: '{"text":"hi"}' }, ws)
+
+    // One inbound notification + one outbound echo.
+    expect(onMessage).toHaveBeenCalledWith(expect.objectContaining({ direction: 'in', payload: '{"text":"hi"}' }))
+    expect(sent).toHaveLength(1)
+    expect(JSON.parse(sent[0]!)).toHaveProperty('text')
+  })
+})

--- a/packages/mock-server/src/transports/websocket.test.ts
+++ b/packages/mock-server/src/transports/websocket.test.ts
@@ -30,7 +30,7 @@ channel.operations[0]!.messages = channel.messages
 channel.operations[1]!.messages = channel.messages
 
 /** Register the transport against fakes and return the captured WebSocket event handlers. */
-function register() {
+function register(target: ResolvedChannel = channel) {
   let handlers: any
   const context: TransportContext = {
     app: {
@@ -45,7 +45,7 @@ function register() {
     log: vi.fn(),
   }
 
-  websocketTransport.register(channel, context)
+  websocketTransport.register(target, context)
   return { handlers, onMessage: context.onMessage as ReturnType<typeof vi.fn> }
 }
 
@@ -79,5 +79,22 @@ describe('websocketTransport', () => {
     expect(onMessage).toHaveBeenCalledWith(expect.objectContaining({ direction: 'in', payload: '{"text":"hi"}' }))
     expect(sent).toHaveLength(1)
     expect(JSON.parse(sent[0]!)).toHaveProperty('text')
+  })
+
+  it('does not echo inbound messages on receive-only channels', () => {
+    // A channel with only a receive (push) operation should stay quiet on inbound frames.
+    const receiveOnly: ResolvedChannel = {
+      ...channel,
+      operations: [{ id: 'receive', action: 'receive', messages: channel.messages }],
+    }
+    const { handlers, onMessage } = register(receiveOnly)
+    const sent: string[] = []
+    const ws = { send: (data: string) => sent.push(data) }
+
+    handlers.onMessage({ data: '{"text":"hi"}' }, ws)
+
+    expect(sent).toHaveLength(0)
+    expect(onMessage).toHaveBeenCalledWith(expect.objectContaining({ direction: 'in', payload: '{"text":"hi"}' }))
+    expect(onMessage).not.toHaveBeenCalledWith(expect.objectContaining({ direction: 'out' }))
   })
 })

--- a/packages/mock-server/src/transports/websocket.ts
+++ b/packages/mock-server/src/transports/websocket.ts
@@ -36,8 +36,13 @@ export const websocketTransport: MockTransport = {
           log(`[ws] recv ${channel.route}: ${incoming}`)
           onMessage?.({ channel: channel.id, direction: 'in', payload: incoming })
 
-          // Echo a generated reply for the channel's send operation (if any).
-          const reply = generateMessage(channel, sendOperation?.messages[0]?.id)
+          // Only echo a reply when the channel declares a `send` operation. Receive-only channels
+          // (server push) stay quiet on inbound frames instead of fabricating an unsolicited reply.
+          if (!sendOperation) {
+            return
+          }
+
+          const reply = generateMessage(channel, sendOperation.messages[0]?.id)
           if (reply) {
             ws.send(reply.data)
             onMessage?.({ channel: channel.id, direction: 'out', payload: reply.data })

--- a/packages/mock-server/src/transports/websocket.ts
+++ b/packages/mock-server/src/transports/websocket.ts
@@ -1,0 +1,50 @@
+import type { MockTransport } from '@/transports/types'
+
+/**
+ * Built-in WebSocket transport. Serves channels whose servers speak `ws`/`wss` by upgrading the
+ * channel route to a WebSocket connection.
+ *
+ * - `receive` operations (server push): one message is emitted per operation when a client connects.
+ * - `send` operations (client -> server): each inbound frame is logged and echoed with a generated reply.
+ */
+export const websocketTransport: MockTransport = {
+  name: 'websocket',
+  supports: (channel) => channel.protocols.includes('ws') || channel.protocols.includes('wss'),
+  register: (channel, context) => {
+    const { app, upgradeWebSocket, generateMessage, onMessage, log } = context
+
+    const receiveOperations = channel.operations.filter((operation) => operation.action === 'receive')
+    const sendOperation = channel.operations.find((operation) => operation.action === 'send')
+
+    app.get(
+      channel.route,
+      upgradeWebSocket(() => ({
+        onOpen: (_event, ws) => {
+          log(`[ws] open ${channel.route}`)
+
+          // Push a single message per receive operation on connect (quiet, deterministic default).
+          for (const operation of receiveOperations) {
+            const message = generateMessage(channel, operation.messages[0]?.id)
+            if (message) {
+              ws.send(message.data)
+              onMessage?.({ channel: channel.id, direction: 'out', payload: message.data })
+            }
+          }
+        },
+        onMessage: (event, ws) => {
+          const incoming = typeof event.data === 'string' ? event.data : '[binary]'
+          log(`[ws] recv ${channel.route}: ${incoming}`)
+          onMessage?.({ channel: channel.id, direction: 'in', payload: incoming })
+
+          // Echo a generated reply for the channel's send operation (if any).
+          const reply = generateMessage(channel, sendOperation?.messages[0]?.id)
+          if (reply) {
+            ws.send(reply.data)
+            onMessage?.({ channel: channel.id, direction: 'out', payload: reply.data })
+          }
+        },
+        onClose: () => log(`[ws] close ${channel.route}`),
+      })),
+    )
+  },
+}

--- a/packages/mock-server/src/utils/generate-message.ts
+++ b/packages/mock-server/src/utils/generate-message.ts
@@ -1,0 +1,48 @@
+import { getResolvedRefDeep } from '@scalar/workspace-store/helpers/get-resolved-ref-deep'
+import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
+
+import type { MockMessage, ResolvedChannel, ResolvedMessage } from '@/transports/types'
+
+/** Encode a generated value to a wire string. Strings pass through; everything else is JSON. */
+function encode(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  return JSON.stringify(value ?? null)
+}
+
+/**
+ * Generate an encoded mock frame for a channel message — the AsyncAPI analogue of the REST
+ * mocker's response generation. Prefers a defined example, otherwise generates a value from the
+ * message payload schema with the same `getExampleFromSchema` the HTTP mocker uses.
+ *
+ * @param channel - The resolved channel to mock a message for.
+ * @param messageId - Which message to emit; defaults to the channel's first message.
+ * @returns The encoded message, or `null` when the channel declares no messages.
+ */
+export function generateMessage(channel: ResolvedChannel, messageId?: string): MockMessage | null {
+  const message: ResolvedMessage | undefined = messageId
+    ? channel.messages.find((candidate) => candidate.id === messageId)
+    : channel.messages[0]
+
+  if (!message) {
+    return null
+  }
+
+  let value: unknown = null
+  if (message.examples.length > 0) {
+    // Prefer an explicit example, mirroring response-example selection in the REST mocker.
+    value = message.examples[0]
+  } else if (message.payload) {
+    value = getExampleFromSchema(getResolvedRefDeep(message.payload) as Parameters<typeof getExampleFromSchema>[0], {
+      emptyString: 'string',
+      mode: 'read',
+    })
+  }
+
+  return {
+    data: encode(value),
+    event: message.id,
+  }
+}

--- a/packages/mock-server/src/utils/process-asyncapi-document.ts
+++ b/packages/mock-server/src/utils/process-asyncapi-document.ts
@@ -1,0 +1,64 @@
+import { bundle } from '@scalar/json-magic/bundle'
+import { fetchUrls, parseJson, parseYaml, readFiles } from '@scalar/json-magic/bundle/plugins/node'
+import { createMagicProxy } from '@scalar/json-magic/magic-proxy'
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+
+/**
+ * Processes an AsyncAPI document by bundling external references and wrapping it so internal
+ * references stay intact but resolve lazily — the AsyncAPI counterpart of
+ * {@link processOpenApiDocument}.
+ *
+ * Unlike a full dereference, the returned document keeps `$ref` nodes in place. Consumers resolve
+ * them on demand with `getResolvedRef` from `@scalar/workspace-store`, which reads the `$ref-value`
+ * exposed by the magic proxy. This avoids eagerly flattening (and duplicating) the whole document.
+ *
+ * Only AsyncAPI 3.1 is supported; 2.x documents should be upgraded before being passed in.
+ *
+ * @param document - The AsyncAPI document to process. Can be a string (URL/path) or an object.
+ * @returns A promise that resolves to the AsyncAPI document with lazily resolvable references.
+ * @throws Error if the document cannot be processed or is invalid.
+ */
+export async function processAsyncApiDocument(
+  document: string | Record<string, any> | undefined,
+): Promise<AsyncApiDocument> {
+  // Handle empty/undefined input gracefully with a minimal valid document.
+  if (!document || (typeof document === 'object' && Object.keys(document).length === 0)) {
+    return {
+      asyncapi: '3.1.0',
+      info: {
+        title: 'Mock API',
+        version: '1.0.0',
+      },
+      channels: {},
+      operations: {},
+    } as AsyncApiDocument
+  }
+
+  let bundled: Record<string, any>
+
+  try {
+    // Bundle external references; parse string inputs (JSON or YAML) along the way.
+    bundled = await bundle(document, {
+      plugins: [parseJson(), parseYaml(), readFiles(), fetchUrls()],
+      treeShake: false,
+    })
+  } catch (error) {
+    throw new Error(`Failed to bundle AsyncAPI document: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  if (!bundled || typeof bundled !== 'object') {
+    throw new Error('Bundled document is invalid: expected an object')
+  }
+
+  // Wrap the document in a magic proxy so internal references resolve lazily via `$ref-value`.
+  // External references were already pulled inline by `bundle` above, so only local `$ref`s remain.
+  return createMagicProxy(bundled) as AsyncApiDocument
+}
+
+/**
+ * Detects whether a loaded document describes an AsyncAPI API (rather than OpenAPI/Swagger).
+ * Used to route an incoming document to the right mock engine.
+ */
+export function isAsyncApiDocument(document: unknown): boolean {
+  return typeof document === 'object' && document !== null && 'asyncapi' in document
+}

--- a/packages/mock-server/src/utils/resolve-channels.test.ts
+++ b/packages/mock-server/src/utils/resolve-channels.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import { processAsyncApiDocument } from './process-asyncapi-document'
+import { resolveChannels } from './resolve-channels'
+
+describe('resolveChannels', () => {
+  it('derives route, protocols, operations and messages from a document', async () => {
+    const document = await processAsyncApiDocument({
+      asyncapi: '3.1.0',
+      info: { title: 'Chat', version: '1.0.0' },
+      servers: {
+        production: { host: 'localhost:3000', protocol: 'ws' },
+      },
+      channels: {
+        room: {
+          address: 'rooms/{roomId}',
+          messages: {
+            message: {
+              contentType: 'application/json',
+              payload: {
+                type: 'object',
+                properties: { text: { type: 'string' } },
+              },
+            },
+          },
+        },
+      },
+      operations: {
+        sendMessage: { action: 'send', channel: { $ref: '#/channels/room' } },
+        receiveMessage: { action: 'receive', channel: { $ref: '#/channels/room' } },
+      },
+    })
+
+    const channels = resolveChannels(document)
+
+    expect(channels).toHaveLength(1)
+    const room = channels[0]!
+    expect(room.id).toBe('room')
+    expect(room.address).toBe('rooms/{roomId}')
+    // Address path params become Hono route params.
+    expect(room.route).toBe('/rooms/:roomId')
+    expect(room.protocols).toEqual(['ws'])
+    expect(room.messages.map((message) => message.id)).toEqual(['message'])
+    expect(room.operations.map((operation) => operation.action).sort()).toEqual(['receive', 'send'])
+  })
+
+  it('resolves $ref messages and operation message subsets', async () => {
+    const document = await processAsyncApiDocument({
+      asyncapi: '3.1.0',
+      info: { title: 'Prices', version: '1.0.0' },
+      servers: { production: { host: 'localhost', protocol: 'sse' } },
+      channels: {
+        prices: {
+          address: 'prices',
+          messages: {
+            priceUpdate: { $ref: '#/components/messages/PriceUpdate' },
+            heartbeat: { payload: { type: 'string' } },
+          },
+        },
+      },
+      operations: {
+        // Operation scoped to a single message of the channel.
+        streamPrices: {
+          action: 'receive',
+          channel: { $ref: '#/channels/prices' },
+          messages: [{ $ref: '#/channels/prices/messages/priceUpdate' }],
+        },
+      },
+      components: {
+        messages: {
+          PriceUpdate: {
+            payload: {
+              type: 'object',
+              properties: { symbol: { type: 'string' }, price: { type: 'number' } },
+            },
+          },
+        },
+      },
+    })
+
+    const prices = resolveChannels(document)[0]!
+
+    expect(prices.messages.map((message) => message.id)).toEqual(['priceUpdate', 'heartbeat'])
+    // The $ref message payload was dereferenced.
+    expect(prices.messages[0]!.payload).toMatchObject({ type: 'object' })
+    // The operation only carries its subset of messages.
+    expect(prices.operations).toHaveLength(1)
+    expect(prices.operations[0]!.messages.map((message) => message.id)).toEqual(['priceUpdate'])
+  })
+
+  it('infers the ws protocol from channel bindings when servers are absent', async () => {
+    const document = await processAsyncApiDocument({
+      asyncapi: '3.1.0',
+      info: { title: 'Sockets', version: '1.0.0' },
+      channels: {
+        live: {
+          address: 'live',
+          bindings: { ws: { method: 'GET' } },
+          messages: { tick: { payload: { type: 'string' } } },
+        },
+      },
+    })
+
+    const live = resolveChannels(document)[0]!
+    expect(live.protocols).toEqual(['ws'])
+  })
+})

--- a/packages/mock-server/src/utils/resolve-channels.test.ts
+++ b/packages/mock-server/src/utils/resolve-channels.test.ts
@@ -88,6 +88,37 @@ describe('resolveChannels', () => {
     expect(prices.operations[0]!.messages.map((message) => message.id)).toEqual(['priceUpdate'])
   })
 
+  it('matches operation message subsets by channel key even when the message defines a different name', async () => {
+    const document = await processAsyncApiDocument({
+      asyncapi: '3.1.0',
+      info: { title: 'Named', version: '1.0.0' },
+      servers: { production: { host: 'localhost', protocol: 'sse' } },
+      channels: {
+        feed: {
+          address: 'feed',
+          messages: {
+            // The message key (`update`) differs from its declared `name` (`UpdateEvent`).
+            update: { name: 'UpdateEvent', payload: { type: 'object', properties: { id: { type: 'string' } } } },
+            heartbeat: { payload: { type: 'string' } },
+          },
+        },
+      },
+      operations: {
+        streamFeed: {
+          action: 'receive',
+          channel: { $ref: '#/channels/feed' },
+          messages: [{ $ref: '#/channels/feed/messages/update' }],
+        },
+      },
+    })
+
+    const feed = resolveChannels(document)[0]!
+
+    // The resolved id reflects the message `name`, while the operation still resolves via the key.
+    expect(feed.messages.map((message) => message.id)).toEqual(['UpdateEvent', 'heartbeat'])
+    expect(feed.operations[0]!.messages.map((message) => message.id)).toEqual(['UpdateEvent'])
+  })
+
   it('infers the ws protocol from channel bindings when servers are absent', async () => {
     const document = await processAsyncApiDocument({
       asyncapi: '3.1.0',

--- a/packages/mock-server/src/utils/resolve-channels.ts
+++ b/packages/mock-server/src/utils/resolve-channels.ts
@@ -85,12 +85,14 @@ export function resolveChannels(document: AsyncApiDocument): ResolvedChannel[] {
     const channel = getResolvedRef(rawChannel as any) as Record<string, any>
     const address = typeof channel.address === 'string' ? channel.address : channelId
 
-    // Channel-level messages, keyed by message id.
+    // Channel-level messages, keyed by their `channels.*.messages` key. Operation `$ref`s point at
+    // this key, which can differ from the message's `name` (and therefore from `message.id`), so the
+    // lookup map is keyed by the original key rather than the resolved id.
     const messageEntries = Object.entries((channel.messages ?? {}) as Record<string, unknown>)
     const messages = messageEntries.map(([messageId, message]) =>
       resolveMessage(messageId, message, document.defaultContentType),
     )
-    const messagesById = new Map(messages.map((message) => [message.id, message]))
+    const messagesByKey = new Map(messageEntries.map(([key], index) => [key, messages[index]!]))
 
     // Operations that target this channel, matched via their `channel` `$ref`.
     const channelOperations: ResolvedOperation[] = Object.entries(operations)
@@ -105,7 +107,7 @@ export function resolveChannels(document: AsyncApiDocument): ResolvedChannel[] {
           ? operation.messages
               .map((message: any) => message?.['$ref'])
               .filter((ref: unknown): ref is string => typeof ref === 'string')
-              .map((ref: string) => messagesById.get(refTail(ref)))
+              .map((ref: string) => messagesByKey.get(refTail(ref)))
               .filter((message: ResolvedMessage | undefined): message is ResolvedMessage => message !== undefined)
           : messages
 

--- a/packages/mock-server/src/utils/resolve-channels.ts
+++ b/packages/mock-server/src/utils/resolve-channels.ts
@@ -1,15 +1,17 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
-import type { AsyncApiDocument, AsyncApiServerObject } from '@scalar/types/asyncapi/3.1'
+import type { AsyncApiDocument, AsyncApiMessageObject } from '@scalar/types/asyncapi/3.1'
+import {
+  ASYNCAPI_WEBSOCKET_PROTOCOLS,
+  getAllChannelMessages,
+  getAsyncApiServers,
+  getChannelOperations,
+  resolveChannel,
+} from '@scalar/workspace-store/channel-example'
+import { getNameFromRef } from '@scalar/workspace-store/helpers/get-name-from-ref'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 
 import type { ResolvedChannel, ResolvedMessage, ResolvedOperation } from '@/transports/types'
 import { honoRouteFromPath } from '@/utils/hono-route-from-path'
-
-/** Decode the final segment of a JSON Pointer `$ref` (e.g. `#/channels/user~1signup` -> `user/signup`). */
-function refTail(ref: string): string {
-  const last = ref.split('/').pop() ?? ''
-  return last.replace(/~1/g, '/').replace(/~0/g, '~')
-}
 
 /** Extract a plain JSON Schema from a message `payload`, unwrapping the Multi Format Schema Object. */
 function extractPayloadSchema(payload: unknown): OpenAPIV3_1.SchemaObject | undefined {
@@ -26,11 +28,17 @@ function extractPayloadSchema(payload: unknown): OpenAPIV3_1.SchemaObject | unde
   return resolved as OpenAPIV3_1.SchemaObject
 }
 
-/** Build a {@link ResolvedMessage} from a (possibly `$ref`) message object. */
-function resolveMessage(id: string, message: unknown, defaultContentType?: string): ResolvedMessage {
-  const resolved = getResolvedRef(message as any) as Record<string, any> | undefined
+/**
+ * Adapt a resolved AsyncAPI message into the transport-facing {@link ResolvedMessage} shape: a plain
+ * payload schema (ready for `getExampleFromSchema`), any defined examples, and the content type.
+ *
+ * @param key - The message's key in `channel.messages` (what operation `$ref`s point at).
+ * @param message - The dereferenced AsyncAPI message object.
+ */
+function toResolvedMessage(key: string, message: AsyncApiMessageObject, defaultContentType?: string): ResolvedMessage {
+  const resolved = message as Record<string, any>
 
-  const examples = Array.isArray(resolved?.examples)
+  const examples = Array.isArray(resolved.examples)
     ? resolved.examples
         .map((example: unknown) => getResolvedRef(example as any))
         .filter((example: any): example is Record<string, any> => example?.payload !== undefined)
@@ -38,93 +46,86 @@ function resolveMessage(id: string, message: unknown, defaultContentType?: strin
     : []
 
   return {
-    id: resolved?.name ?? id,
-    payload: extractPayloadSchema(resolved?.payload),
+    id: resolved.name ?? key,
+    payload: extractPayloadSchema(resolved.payload),
     examples,
-    contentType: resolved?.contentType ?? defaultContentType,
+    contentType: resolved.contentType ?? defaultContentType,
   }
 }
 
-/** Collect the connection protocols (lower-cased) advertised for a channel. */
-function resolveProtocols(channel: Record<string, any>, document: AsyncApiDocument): string[] {
+/**
+ * Collect the connection protocols (lower-cased) advertised for a channel. Server protocols come
+ * from the shared workspace-store resolver (the same one the API client uses), so the mock and the
+ * client classify a document identically. A WebSocket binding is an additional reliable hint when
+ * the channel declares no servers.
+ */
+function resolveProtocols(document: AsyncApiDocument, channel: Record<string, any>): string[] {
   const protocols = new Set<string>()
 
-  const addServerProtocol = (server: unknown) => {
-    const resolved = getResolvedRef(server as any) as AsyncApiServerObject | undefined
-    if (resolved?.protocol) {
-      protocols.add(resolved.protocol.toLowerCase())
+  for (const server of getAsyncApiServers(document, { channel: channel as any, webSocketOnly: false })) {
+    if (server.protocol) {
+      protocols.add(server.protocol)
     }
   }
 
-  if (Array.isArray(channel.servers) && channel.servers.length > 0) {
-    // The channel restricts itself to specific servers.
-    channel.servers.forEach(addServerProtocol)
-  } else if (document.servers) {
-    // No restriction: the channel is available on every document server.
-    Object.values(document.servers).forEach(addServerProtocol)
-  }
-
-  // Binding presence is a reliable protocol hint even when servers are omitted.
   const bindings = getResolvedRef(channel.bindings) as Record<string, unknown> | undefined
   if (bindings?.ws) {
-    protocols.add('ws')
+    protocols.add(ASYNCAPI_WEBSOCKET_PROTOCOLS[0])
   }
 
   return [...protocols]
 }
 
 /**
- * Normalize an AsyncAPI 3.1 document into a flat list of {@link ResolvedChannel}s with all
- * `$ref`s resolved, so transports can serve channels without touching AsyncAPI document shape.
+ * Normalize an AsyncAPI 3.1 document into a flat list of {@link ResolvedChannel}s a transport can
+ * serve. Channel, message, operation, and server resolution are delegated to
+ * `@scalar/workspace-store/channel-example` — the same layer the API client uses to connect to
+ * channels — so the mock and the client agree on how a document maps to channels and operations
+ * (including operation traits). This function only adapts that output into the transport types.
  */
 export function resolveChannels(document: AsyncApiDocument): ResolvedChannel[] {
-  const channels = document.channels ?? {}
-  const operations = document.operations ?? {}
+  const channelNames = Object.keys(document.channels ?? {})
 
-  return Object.entries(channels).map(([channelId, rawChannel]) => {
-    const channel = getResolvedRef(rawChannel as any) as Record<string, any>
-    const address = typeof channel.address === 'string' ? channel.address : channelId
+  return channelNames.flatMap((channelName) => {
+    const resolved = resolveChannel(document, channelName)
+    if (!resolved) {
+      return []
+    }
 
-    // Channel-level messages, keyed by their `channels.*.messages` key. Operation `$ref`s point at
-    // this key, which can differ from the message's `name` (and therefore from `message.id`), so the
-    // lookup map is keyed by the original key rather than the resolved id.
-    const messageEntries = Object.entries((channel.messages ?? {}) as Record<string, unknown>)
-    const messages = messageEntries.map(([messageId, message]) =>
-      resolveMessage(messageId, message, document.defaultContentType),
+    const { channel, channelAddress } = resolved
+
+    const messageEntries = getAllChannelMessages(document, channel)
+    const messages = messageEntries.map(({ name, message }) =>
+      toResolvedMessage(name, message, document.defaultContentType),
     )
-    const messagesByKey = new Map(messageEntries.map(([key], index) => [key, messages[index]!]))
+    // Keyed by the `channels.*.messages` key (what operation `$ref`s point at), which can differ
+    // from a message's resolved `id` when the message declares a `name`.
+    const messagesByKey = new Map(messageEntries.map(({ name }, index) => [name, messages[index]!]))
 
-    // Operations that target this channel, matched via their `channel` `$ref`.
-    const channelOperations: ResolvedOperation[] = Object.entries(operations)
-      .map(([operationId, rawOperation]) => ({ operationId, operation: getResolvedRef(rawOperation as any) as any }))
-      .filter(({ operation }) => {
-        const ref = operation?.channel?.['$ref'] as string | undefined
-        return typeof ref === 'string' && refTail(ref) === channelId
-      })
-      .map(({ operationId, operation }) => {
+    const operations: ResolvedOperation[] = getChannelOperations(document, channelName).map(
+      ({ operationName, operation, action }) => {
         // An operation may scope itself to a subset of the channel's messages; otherwise use all.
         const operationMessages: ResolvedMessage[] = Array.isArray(operation.messages)
           ? operation.messages
               .map((message: any) => message?.['$ref'])
               .filter((ref: unknown): ref is string => typeof ref === 'string')
-              .map((ref: string) => messagesByKey.get(refTail(ref)))
+              .map((ref: string) => messagesByKey.get(getNameFromRef(ref, ['channels', channelName, 'messages']) ?? ''))
               .filter((message: ResolvedMessage | undefined): message is ResolvedMessage => message !== undefined)
           : messages
 
-        return {
-          id: operationId,
-          action: operation.action === 'send' ? 'send' : 'receive',
-          messages: operationMessages,
-        } satisfies ResolvedOperation
-      })
+        return { id: operationName, action, messages: operationMessages } satisfies ResolvedOperation
+      },
+    )
 
-    return {
-      id: channelId,
-      address,
-      route: honoRouteFromPath(`/${address.replace(/^\//, '')}`),
-      protocols: resolveProtocols(channel, document),
-      operations: channelOperations,
-      messages,
-    } satisfies ResolvedChannel
+    return [
+      {
+        id: channelName,
+        address: channelAddress,
+        route: honoRouteFromPath(`/${channelAddress.replace(/^\//, '')}`),
+        protocols: resolveProtocols(document, channel),
+        operations,
+        messages,
+      } satisfies ResolvedChannel,
+    ]
   })
 }

--- a/packages/mock-server/src/utils/resolve-channels.ts
+++ b/packages/mock-server/src/utils/resolve-channels.ts
@@ -1,0 +1,128 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import type { AsyncApiDocument, AsyncApiServerObject } from '@scalar/types/asyncapi/3.1'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+
+import type { ResolvedChannel, ResolvedMessage, ResolvedOperation } from '@/transports/types'
+import { honoRouteFromPath } from '@/utils/hono-route-from-path'
+
+/** Decode the final segment of a JSON Pointer `$ref` (e.g. `#/channels/user~1signup` -> `user/signup`). */
+function refTail(ref: string): string {
+  const last = ref.split('/').pop() ?? ''
+  return last.replace(/~1/g, '/').replace(/~0/g, '~')
+}
+
+/** Extract a plain JSON Schema from a message `payload`, unwrapping the Multi Format Schema Object. */
+function extractPayloadSchema(payload: unknown): OpenAPIV3_1.SchemaObject | undefined {
+  const resolved = getResolvedRef(payload as any)
+  if (!resolved || typeof resolved !== 'object') {
+    return undefined
+  }
+
+  // Multi Format Schema Object: `{ schemaFormat, schema }`. The actual schema lives under `schema`.
+  if ('schemaFormat' in resolved && 'schema' in resolved) {
+    return getResolvedRef((resolved as any).schema) as OpenAPIV3_1.SchemaObject
+  }
+
+  return resolved as OpenAPIV3_1.SchemaObject
+}
+
+/** Build a {@link ResolvedMessage} from a (possibly `$ref`) message object. */
+function resolveMessage(id: string, message: unknown, defaultContentType?: string): ResolvedMessage {
+  const resolved = getResolvedRef(message as any) as Record<string, any> | undefined
+
+  const examples = Array.isArray(resolved?.examples)
+    ? resolved.examples
+        .map((example: unknown) => getResolvedRef(example as any))
+        .filter((example: any): example is Record<string, any> => example?.payload !== undefined)
+        .map((example: Record<string, any>) => example.payload)
+    : []
+
+  return {
+    id: resolved?.name ?? id,
+    payload: extractPayloadSchema(resolved?.payload),
+    examples,
+    contentType: resolved?.contentType ?? defaultContentType,
+  }
+}
+
+/** Collect the connection protocols (lower-cased) advertised for a channel. */
+function resolveProtocols(channel: Record<string, any>, document: AsyncApiDocument): string[] {
+  const protocols = new Set<string>()
+
+  const addServerProtocol = (server: unknown) => {
+    const resolved = getResolvedRef(server as any) as AsyncApiServerObject | undefined
+    if (resolved?.protocol) {
+      protocols.add(resolved.protocol.toLowerCase())
+    }
+  }
+
+  if (Array.isArray(channel.servers) && channel.servers.length > 0) {
+    // The channel restricts itself to specific servers.
+    channel.servers.forEach(addServerProtocol)
+  } else if (document.servers) {
+    // No restriction: the channel is available on every document server.
+    Object.values(document.servers).forEach(addServerProtocol)
+  }
+
+  // Binding presence is a reliable protocol hint even when servers are omitted.
+  const bindings = getResolvedRef(channel.bindings) as Record<string, unknown> | undefined
+  if (bindings?.ws) {
+    protocols.add('ws')
+  }
+
+  return [...protocols]
+}
+
+/**
+ * Normalize an AsyncAPI 3.1 document into a flat list of {@link ResolvedChannel}s with all
+ * `$ref`s resolved, so transports can serve channels without touching AsyncAPI document shape.
+ */
+export function resolveChannels(document: AsyncApiDocument): ResolvedChannel[] {
+  const channels = document.channels ?? {}
+  const operations = document.operations ?? {}
+
+  return Object.entries(channels).map(([channelId, rawChannel]) => {
+    const channel = getResolvedRef(rawChannel as any) as Record<string, any>
+    const address = typeof channel.address === 'string' ? channel.address : channelId
+
+    // Channel-level messages, keyed by message id.
+    const messageEntries = Object.entries((channel.messages ?? {}) as Record<string, unknown>)
+    const messages = messageEntries.map(([messageId, message]) =>
+      resolveMessage(messageId, message, document.defaultContentType),
+    )
+    const messagesById = new Map(messages.map((message) => [message.id, message]))
+
+    // Operations that target this channel, matched via their `channel` `$ref`.
+    const channelOperations: ResolvedOperation[] = Object.entries(operations)
+      .map(([operationId, rawOperation]) => ({ operationId, operation: getResolvedRef(rawOperation as any) as any }))
+      .filter(({ operation }) => {
+        const ref = operation?.channel?.['$ref'] as string | undefined
+        return typeof ref === 'string' && refTail(ref) === channelId
+      })
+      .map(({ operationId, operation }) => {
+        // An operation may scope itself to a subset of the channel's messages; otherwise use all.
+        const operationMessages: ResolvedMessage[] = Array.isArray(operation.messages)
+          ? operation.messages
+              .map((message: any) => message?.['$ref'])
+              .filter((ref: unknown): ref is string => typeof ref === 'string')
+              .map((ref: string) => messagesById.get(refTail(ref)))
+              .filter((message: ResolvedMessage | undefined): message is ResolvedMessage => message !== undefined)
+          : messages
+
+        return {
+          id: operationId,
+          action: operation.action === 'send' ? 'send' : 'receive',
+          messages: operationMessages,
+        } satisfies ResolvedOperation
+      })
+
+    return {
+      id: channelId,
+      address,
+      route: honoRouteFromPath(`/${address.replace(/^\//, '')}`),
+      protocols: resolveProtocols(channel, document),
+      operations: channelOperations,
+      messages,
+    } satisfies ResolvedChannel
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ catalogs:
     '@hono/node-server':
       specifier: ^1.19.10
       version: 1.19.11
+    '@hono/node-ws':
+      specifier: ^1.2.0
+      version: 1.3.1
     '@nestjs/cli':
       specifier: ^11.0.14
       version: 11.0.14
@@ -1853,6 +1856,9 @@ importers:
       '@faker-js/faker':
         specifier: catalog:*
         version: 10.4.0
+      '@hono/node-ws':
+        specifier: catalog:*
+        version: 1.3.1(@hono/node-server@1.19.11(hono@4.12.9))(hono@4.12.9)
       '@scalar/helpers':
         specifier: workspace:*
         version: link:../helpers
@@ -1865,6 +1871,9 @@ importers:
       '@scalar/openapi-upgrader':
         specifier: workspace:*
         version: link:../openapi-upgrader
+      '@scalar/types':
+        specifier: workspace:*
+        version: link:../types
       '@scalar/workspace-store':
         specifier: workspace:*
         version: link:../workspace-store
@@ -5136,6 +5145,13 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@hono/node-ws@1.3.1':
+    resolution: {integrity: sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      '@hono/node-server': ^1.19.11
+      hono: ^4.6.0
 
   '@hono/zod-openapi@1.2.4':
     resolution: {integrity: sha512-cZu71bpODTbtIDoUsIIYPrs58wJ565Tbg6FE+JshU0irBAd6KxrP+k62Amm/mjA7tTOQ3+ingODHKGFOnv+Ibw==}
@@ -17560,6 +17576,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -18553,6 +18570,9 @@ packages:
 
   vue-component-type-helpers@3.3.3:
     resolution: {integrity: sha512-x4nsFpy5Pe8fqPzp/5vkTPeTTDBpAx4WVtV47Ejt0+2FQrq4pRRsJs7JmYRqMFzTu/LW+pCWEjQ3YVCkPV7f9g==}
+
+  vue-component-type-helpers@3.3.5:
+    resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -22387,6 +22407,15 @@ snapshots:
     dependencies:
       hono: 4.12.9
 
+  '@hono/node-ws@1.3.1(@hono/node-server@1.19.11(hono@4.12.9))(hono@4.12.9)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.9)
+      hono: 4.12.9
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@hono/zod-openapi@1.2.4(hono@4.12.9)(zod@4.3.5)':
     dependencies:
       '@asteasolutions/zod-to-openapi': 8.5.0(zod@4.3.5)
@@ -25606,7 +25635,7 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.30(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.3
+      vue-component-type-helpers: 3.3.5
 
   '@sveltejs/acorn-typescript@1.0.5(acorn@8.16.0)':
     dependencies:
@@ -38444,6 +38473,8 @@ snapshots:
   vue-component-type-helpers@2.2.10: {}
 
   vue-component-type-helpers@3.3.3: {}
+
+  vue-component-type-helpers@3.3.5: {}
 
   vue-demi@0.14.10(vue@3.5.30(typescript@5.9.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ catalogs:
     '@headlessui/tailwindcss': ^0.2.2
     '@headlessui/vue': 1.7.23
     '@hono/node-server': ^1.19.10
+    '@hono/node-ws': ^1.2.0
     '@modelcontextprotocol/sdk': 1.26.0
     '@nestjs/cli': '^11.0.14'
     '@nestjs/common': '^11.1.11'


### PR DESCRIPTION
# feat(mock-server): mock AsyncAPI 3.1 documents over WebSocket and SSE

## Problem

`@scalar/mock-server` could only mock **request/response (REST)** APIs from OpenAPI/Swagger documents — it walks `paths` → operations → methods and registers HTTP routes. It had no way to mock **event-driven** APIs.

Scalar already supports AsyncAPI elsewhere (the API reference renders AsyncAPI channels, the API client connects to channels over WebSocket), but there was no server to develop and test those event-driven clients against. Frontend and integration work that depends on a WebSocket/SSE backend had nothing to point at until the real service existed.

We want the same "point it at a document and get a working mock" experience for AsyncAPI that we already have for OpenAPI.

## Solution

Add `createAsyncApiMockServer`, the event-driven counterpart of `createMockServer`. It resolves an AsyncAPI 3.1 document into normalized channels and serves each one through a **transport**:

- **WebSocket** (`ws`/`wss`): `receive` operations push a generated message when a client connects; `send` operations echo a generated reply to each inbound frame. Built on `@hono/node-ws`.
- **SSE** (`sse`, or `http`/`https` server-push channels): a `GET` on the channel route opens an event stream. Pure Hono `streamSSE`, no extra runtime dependency.

Messages are generated from each message's `payload` schema using the **same `getExampleFromSchema` generator the REST mocker uses**, preferring defined `examples` — so mock data is consistent across REST and AsyncAPI.

Because WebSocket support needs the Node `http.Server` returned by `serve()`, the function returns `{ app, injectWebSocket }`; the caller attaches WebSocket handling after `serve()`.

### Extensibility

Transports are pluggable via the `transports` option. A transport declares the channels it owns via `supports()` and wires them up via `register()`, which receives both the Hono `app` (for HTTP handshakes) and Hono's `upgradeWebSocket` helper (for socket upgrades). This lets protocols that negotiate over HTTP before upgrading — e.g. **SignalR** — be added without changing the core. Brokered protocols (Kafka/MQTT/AMQP) are intentionally out of scope since they need external broker infrastructure.

### Docker

The Docker mock server now auto-detects AsyncAPI documents (top-level `asyncapi` field) and starts the AsyncAPI engine, injecting WebSocket support. The volume scan recognizes AsyncAPI files too.

### Alternatives considered

- **Overloading `createMockServer` with auto-detection** — rejected: WebSocket needs the `http.Server` handle that `createMockServer` does not own, and auto-detection muddied the return type. A separate entry point keeps types clean.
- **Mocking brokered protocols (Kafka/MQTT/AMQP)** — out of scope; requires running real brokers, not feasible for an in-process Node mock. The transport extension point leaves the door open later.
- **AsyncAPI 2.x support** — deferred; 3.1-only for now, with an upgrader path to follow (mirroring the OpenAPI upgrader).

### Scope notes

- The **Aspire** integration (`AddAsyncApiDocument`) lives on a separate branch and is a follow-up PR; it will mirror the existing `WithApiReference(...)` document-attach pattern.
- Inbound message validation is a planned follow-up (matches the REST mocker's `validateRequest`).

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [x] I updated the documentation.

