### PR TITLE
docs: fix spelling of Sébastien Chopin's name

### DIFF
--- a/documentation/guides/company.md
+++ b/documentation/guides/company.md
@@ -301,7 +301,7 @@ We are the API company, giving you industry-best interfaces for your APIs so you
       <span class="company-investor-title-line">Co-Founder, Streamyard</span>
     </article>
     <article class="company-investor-person">
-      <span class="company-investor-name-line">Sebastien Chopin</span>
+      <span class="company-investor-name-line">Sébastien Chopin</span>
       <span class="company-investor-title-line">Founder, Nuxt</span>
     </article>
     <article class="company-investor-person">


### PR DESCRIPTION
Fixes the spelling of Sébastien Chopin's name (missing accent) on the company page. Confirmed via https://atinux.com/.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation/copy change with no runtime, security, or data impact.
> 
> **Overview**
> Updates the **Our Investors** entry on the company page so **Sébastien Chopin** is spelled with the correct accent (**é**), replacing the previous **Sebastien** spelling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86503a37bd2b28a6928caab7240961a2911aabc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->