### PR TITLE
fix(internal): unbreak knip on main

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -12,7 +12,8 @@
     "documentation/assets/apollo.js",
     "documentation/assets/vector.js",
     "documentation/assets/brand.js",
-    "documentation/assets/enterprise-contact-form.js"
+    "documentation/assets/enterprise-contact-form.js",
+    "documentation/assets/company.js"
   ],
   "ignore": [
     // We will use this in the future, just removed it from the workspace store for now
@@ -32,9 +33,7 @@
     // Used by root tsconfig.json
     "tsconfig-paths",
     //
-    "typescript-language-server",
-    // Provides the `tsgo` binary used by package `types:check` scripts; knip cannot map the binary to the package name
-    "@typescript/native-preview"
+    "typescript-language-server"
   ],
   "ignoreBinaries": ["netlify"],
   "ignoreIssues": {
@@ -380,8 +379,6 @@
         "src/module.ts",
         "src/runtime/components/ScalarApiReference.vue",
         "src/runtime/pages/ScalarPage.vue",
-        "src/shims/extend.js",
-        "src/shims/debug.js",
         "playground/nuxt.config.ts",
         "playground/layouts/default.vue",
         "playground/pages/index.vue",


### PR DESCRIPTION
Knip is failing on `main` and blocking CI.

`documentation/assets/company.js` (added in #9564) is a standalone script knip can't trace, like the other `documentation/assets/*.js` entries — it just wasn't added to `ignoreFiles`. While here, dropped two stale config bits knip was warning about: the `@typescript/native-preview` ignore (knip resolves it on its own now) and the `integrations/nuxt/src/shims/*.js` entries (that directory is gone).

Knip now exits clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only config changes with no runtime, auth, or application logic impact.
> 
> **Overview**
> **Restores a clean Knip run on `main`** by aligning `knip.jsonc` with recent repo changes so CI stops failing on false positives.
> 
> Adds `documentation/assets/company.js` to `ignoreFiles`, matching the other documentation scripts referenced from `scalar.config.json` that static analysis cannot trace. Removes the root `ignoreDependencies` entry for `@typescript/native-preview` now that Knip resolves it without a manual ignore. Drops stale `integrations/nuxt` `entry` paths for `src/shims/extend.js` and `src/shims/debug.js` because that shim directory no longer exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a3601f81b6fdd30095720eff6982853d1ec9b51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->