### PR TITLE
fix(api-reference): render discriminator dropdown for object schemas with only a mapping

### DIFF
--- a/.changeset/discriminator-mapping-object-dropdown.md
+++ b/.changeset/discriminator-mapping-object-dropdown.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Render the discriminator variant dropdown for object schemas that only declare a `discriminator.mapping` (no explicit `oneOf`/`anyOf`), which is the shape NSwag emits for polymorphic types

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -206,6 +206,58 @@ describe('Schema', () => {
 
       expect(wrapper.text()).toContain('Parent schema description')
     })
+
+    // https://github.com/scalar/scalar/issues/7472
+    // NSwag emits the base type as a plain object with a `discriminator.mapping`
+    // but no `oneOf`/`anyOf`. The variant dropdown should still be inferred from
+    // the mapping.
+    it('renders a variant dropdown for an object schema with only discriminator mapping', () => {
+      const document = {
+        components: {
+          schemas: {
+            BaseClass: {
+              type: 'object',
+              discriminator: {
+                propertyName: '$type',
+                mapping: {
+                  Base: '#/components/schemas/BaseClass',
+                  Derived: '#/components/schemas/DerivedClass',
+                },
+              },
+              required: ['$type'],
+              properties: {
+                baseInt: { type: 'integer', format: 'int32' },
+                $type: { type: 'string' },
+              },
+            },
+            DerivedClass: {
+              allOf: [
+                { $ref: '#/components/schemas/BaseClass' },
+                { type: 'object', properties: { derivedInt: { type: 'integer' } } },
+              ],
+            },
+          },
+        },
+      }
+
+      const wrapper = mount(Schema, {
+        props: {
+          eventBus: null,
+          name: 'Request Body',
+          schema: coerceValue(SchemaObjectSchema, document.components.schemas.BaseClass),
+          options: { expandAllSchemaProperties: true, document: document as never },
+        },
+      })
+
+      // The composition selector (variant dropdown) should be rendered with the
+      // variants inferred from the mapping.
+      expect(wrapper.find('.composition-selector').exists()).toBe(true)
+      expect(wrapper.text()).toContain('One of')
+      expect(wrapper.text()).toContain('BaseClass')
+
+      // The discriminator property keeps its label inside the selected variant.
+      expect(wrapper.text()).toContain('Discriminator')
+    })
   })
 
   describe('additionalProperties Vue prop', () => {

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -258,6 +258,41 @@ describe('Schema', () => {
       // The discriminator property keeps its label inside the selected variant.
       expect(wrapper.text()).toContain('Discriminator')
     })
+
+    // https://github.com/scalar/scalar/issues/7472
+    // A schema may factor its common properties out alongside an explicit
+    // `oneOf` and a `discriminator.mapping`. The explicit composition already
+    // renders the selector, so the factored-out properties must not infer a
+    // second one from the same mapping.
+    it('does not infer a second selector for factored properties next to an explicit oneOf', () => {
+      const document = {
+        components: {
+          schemas: {
+            A: { type: 'object', title: 'A', properties: { aId: { type: 'string' } } },
+            B: { type: 'object', title: 'B', properties: { bId: { type: 'string' } } },
+          },
+        },
+      }
+
+      const wrapper = mount(Schema, {
+        props: {
+          eventBus: null,
+          name: 'Request Body',
+          schema: coerceValue(SchemaObjectSchema, {
+            discriminator: {
+              propertyName: 'kind',
+              mapping: { a: '#/components/schemas/A', b: '#/components/schemas/B' },
+            },
+            oneOf: [{ $ref: '#/components/schemas/A' }, { $ref: '#/components/schemas/B' }],
+            properties: { kind: { type: 'string' } },
+          }),
+          options: { expandAllSchemaProperties: true, document: document as never },
+        },
+      })
+
+      // Exactly one variant selector, from the explicit oneOf.
+      expect(wrapper.findAll('.composition-selector')).toHaveLength(1)
+    })
   })
 
   describe('additionalProperties Vue prop', () => {

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -345,6 +345,52 @@ describe('Schema', () => {
       // The object's own properties still render alongside the selector.
       expect(wrapper.text()).toContain('baseInt')
     })
+
+    // https://github.com/scalar/scalar/issues/7472
+    // A schema that carries its own `allOf` (plus a `discriminator.mapping`) must
+    // keep rendering the `allOf` members. Inference is gated to plain object
+    // schemas (`isTypeObject`), so the mapping does not replace the `allOf`
+    // output with a variant dropdown — the `allOf` members render as before.
+    it('keeps rendering allOf members for a schema that also has a discriminator mapping', () => {
+      const document = {
+        components: {
+          schemas: {
+            Base: {
+              type: 'object',
+              properties: { baseInt: { type: 'integer' } },
+            },
+            Derived: {
+              type: 'object',
+              properties: { derivedInt: { type: 'integer' } },
+            },
+          },
+        },
+      }
+
+      const wrapper = mount(Schema, {
+        props: {
+          eventBus: null,
+          name: 'Request Body',
+          schema: coerceValue(SchemaObjectSchema, {
+            // The `allOf` member carries a property that only appears when the
+            // merged `allOf` renders, not in the inferred oneOf variants.
+            allOf: [{ type: 'object', properties: { sharedAllOfProp: { type: 'string' } } }],
+            discriminator: {
+              propertyName: '$type',
+              mapping: {
+                Base: '#/components/schemas/Base',
+                Derived: '#/components/schemas/Derived',
+              },
+            },
+          }),
+          options: { expandAllSchemaProperties: true, document: document as never },
+        },
+      })
+
+      // The allOf member still renders — it was previously replaced by the
+      // inferred variant dropdown alone.
+      expect(wrapper.text()).toContain('sharedAllOfProp')
+    })
   })
 
   describe('additionalProperties Vue prop', () => {

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -293,6 +293,58 @@ describe('Schema', () => {
       // Exactly one variant selector, from the explicit oneOf.
       expect(wrapper.findAll('.composition-selector')).toHaveLength(1)
     })
+
+    // https://github.com/scalar/scalar/issues/7472
+    // A nested property whose schema only declares a `discriminator.mapping`
+    // already gets its selector from `SchemaProperty` (via
+    // `getCompositionsToRender`). The object-properties child must not infer a
+    // second, identical selector.
+    it('does not infer a duplicate selector for a nested discriminator-mapping property', () => {
+      const petSchema = {
+        type: 'object',
+        discriminator: {
+          propertyName: '$type',
+          mapping: {
+            Base: '#/components/schemas/BaseClass',
+            Derived: '#/components/schemas/DerivedClass',
+          },
+        },
+        properties: {
+          baseInt: { type: 'integer' },
+          $type: { type: 'string' },
+        },
+      }
+
+      const document = {
+        components: {
+          schemas: {
+            BaseClass: petSchema,
+            DerivedClass: {
+              allOf: [
+                { $ref: '#/components/schemas/BaseClass' },
+                { type: 'object', properties: { derivedInt: { type: 'integer' } } },
+              ],
+            },
+          },
+        },
+      }
+
+      const wrapper = mount(Schema, {
+        props: {
+          eventBus: null,
+          name: 'Request Body',
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: { pet: petSchema },
+          }),
+          options: { expandAllSchemaProperties: true, document: document as never },
+        },
+      })
+
+      expect(wrapper.findAll('.composition-selector')).toHaveLength(1)
+      // The object's own properties still render alongside the selector.
+      expect(wrapper.text()).toContain('baseInt')
+    })
   })
 
   describe('additionalProperties Vue prop', () => {

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -14,10 +14,12 @@ import ScreenReader from '@/components/ScreenReader.vue'
 import { useLocalization } from '@/features/localization'
 import { scrollTargetId } from '@/helpers/lazy-bus'
 
+import { inferDiscriminatorMappingComposition } from './helpers/get-compositions-to-render'
 import { isEmptySchemaObject } from './helpers/is-empty-schema-object'
 import { isTypeObject } from './helpers/is-type-object'
 import { mergeAllOfSchemas } from './helpers/merge-all-of-schemas'
 import { SCHEMA_ANCESTORS_SYMBOL } from './helpers/schema-cycle'
+import SchemaComposition from './SchemaComposition.vue'
 import SchemaHeading from './SchemaHeading.vue'
 import SchemaObjectProperties from './SchemaObjectProperties.vue'
 import SchemaProperty from './SchemaProperty.vue'
@@ -186,6 +188,21 @@ const schemaDescription = computed(() => {
   return schema.description
 })
 
+/**
+ * Some generators (for example NSwag) describe a polymorphic base type as a
+ * plain object with a `discriminator.mapping` but no explicit `oneOf`. We infer
+ * the variant composition from the mapping so the selector still renders.
+ *
+ * The `discriminator` prop is only set when this schema is already a variant
+ * being rendered inside a `SchemaComposition`; skipping the inference in that
+ * case avoids re-inferring (and recursing) on a self-referential mapping.
+ */
+const inferredDiscriminatorComposition = computed(() =>
+  schema && !discriminator
+    ? inferDiscriminatorMappingComposition(schema, options.document)
+    : null,
+)
+
 // Prevent click action if noncollapsible
 const handleClick = (e: MouseEvent) => {
   if (noncollapsible) {
@@ -290,9 +307,25 @@ const handleClick = (e: MouseEvent) => {
           v-if="!additionalProperties || open"
           as="ul"
           :static="!shouldShowToggle">
+          <!-- Variant selector inferred from a discriminator mapping -->
+          <SchemaComposition
+            v-if="inferredDiscriminatorComposition"
+            :breadcrumb
+            :compact
+            composition="oneOf"
+            :compositionPath="compositionPath"
+            :discriminator="schema?.discriminator"
+            :eventBus="eventBus"
+            :hideHeading
+            :hideModelNames
+            :level="level"
+            :name="name"
+            :options
+            :schema="inferredDiscriminatorComposition"
+            :schemaContext="schemaContext" />
           <!-- Object properties -->
           <SchemaObjectProperties
-            v-if="isTypeObject(schema)"
+            v-else-if="isTypeObject(schema)"
             :breadcrumb
             :compact
             :compositionPath="compositionPath"

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -196,9 +196,14 @@ const schemaDescription = computed(() => {
  * The `discriminator` prop is only set when this schema is already a variant
  * being rendered inside a `SchemaComposition`; skipping the inference in that
  * case avoids re-inferring (and recursing) on a self-referential mapping.
+ *
+ * The inference is restricted to plain object schemas (`isTypeObject`). A schema
+ * carrying its own composition keyword (`allOf`/`not`) is rendered by the
+ * `SchemaProperty` branch below; inferring a selector there would replace that
+ * keyword's output with the variant dropdown instead of rendering both.
  */
 const inferredDiscriminatorComposition = computed(() =>
-  schema && !discriminator
+  schema && !discriminator && isTypeObject(schema)
     ? inferDiscriminatorMappingComposition(schema, options.document)
     : null,
 )

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -169,6 +169,11 @@ const displayDescription = computed(() =>
  * properties. The compositions are rendered separately below; leaving them here
  * would route the nested `Schema` back through `SchemaProperty` and recurse.
  *
+ * The `discriminator` is stripped too: its variant selector is part of the
+ * composition rendered below (including the one inferred from a bare
+ * `discriminator.mapping`), so keeping it here would make the nested `Schema`
+ * infer and render a second, identical selector.
+ *
  * When the property already renders the description, we also drop it to avoid
  * repeating it in the nested object schema card.
  */
@@ -183,6 +188,7 @@ const objectSchemaForChildren = computed(() => {
     anyOf: _anyOf,
     allOf: _allOf,
     not: _not,
+    discriminator: _discriminator,
     ...objectSchema
   } = value as Record<string, unknown>
 

--- a/packages/api-reference/src/components/Content/Schema/helpers/get-compositions-to-render.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/get-compositions-to-render.ts
@@ -17,7 +17,16 @@ type DocumentSchemaLookup = Pick<OpenApiDocument, 'components'>
 const normalizeDiscriminatorMappingRef = (value: string) =>
   value.startsWith('#/') || value.includes('/') ? value : `#/components/schemas/${value}`
 
-const inferDiscriminatorMappingComposition = (
+/**
+ * Builds a synthetic `oneOf` composition from a `discriminator.mapping` when the
+ * schema declares a mapping but no explicit `oneOf`/`anyOf`. This is the shape
+ * NSwag emits for polymorphic types, where the base type is a plain object with
+ * a discriminator mapping pointing at the concrete variants.
+ *
+ * Returns `null` when there is nothing to infer (an explicit composition is
+ * already present, no document to resolve refs against, or no resolvable refs).
+ */
+export const inferDiscriminatorMappingComposition = (
   value: SchemaObject,
   document?: DocumentSchemaLookup,
 ): SchemaObject | null => {

--- a/packages/api-reference/src/features/Operation/components/RequestBody.test.ts
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.test.ts
@@ -284,4 +284,62 @@ describe('RequestBody', () => {
 
     expect(wrapper.props('selectedContentType')).toBe('application/x-www-form-urlencoded')
   })
+
+  // https://github.com/scalar/scalar/issues/7472
+  // A discriminator base renders as a single variant selector. When it has more
+  // than twelve properties the body is normally split into visible/collapsed
+  // blocks, but a discriminator schema must not be split, otherwise each block
+  // would render its own duplicate selector.
+  it('renders a single variant selector for a discriminator schema with many properties', () => {
+    const properties: Record<string, { type: string }> = { $type: { type: 'string' } }
+    for (let index = 0; index < 13; index++) {
+      properties[`prop${index}`] = { type: 'string' }
+    }
+
+    const baseClass = {
+      type: 'object',
+      discriminator: {
+        propertyName: '$type',
+        mapping: {
+          Base: '#/components/schemas/BaseClass',
+          Derived: '#/components/schemas/DerivedClass',
+        },
+      },
+      properties,
+    }
+
+    const document = {
+      components: {
+        schemas: {
+          BaseClass: baseClass,
+          DerivedClass: {
+            allOf: [
+              { $ref: '#/components/schemas/BaseClass' },
+              { type: 'object', properties: { derivedInt: { type: 'integer' } } },
+            ],
+          },
+        },
+      },
+    }
+
+    const wrapper = mount(RequestBody, {
+      props: {
+        eventBus: null,
+        // Expand everything so a duplicate selector in the collapsed block would
+        // also be rendered (and therefore caught) rather than hidden.
+        options: { ...defaultRequestOptions, expandAllSchemaProperties: true },
+        document: document as never,
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: coerceValue(SchemaObjectSchema, baseClass),
+            },
+          },
+        },
+      },
+      slots: { title: 'Body' },
+    })
+
+    expect(wrapper.findAll('.composition-selector')).toHaveLength(1)
+  })
 })

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -9,6 +9,7 @@ import type {
 import { computed } from 'vue'
 
 import { Schema } from '@/components/Content/Schema'
+import { inferDiscriminatorMappingComposition } from '@/components/Content/Schema/helpers/get-compositions-to-render'
 import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
 import { getModelNameFromSchema } from '@/components/Content/Schema/helpers/schema-name'
 import {
@@ -73,6 +74,14 @@ const modelLink = computed(
 const partitionedSchema = computed(() => {
   // Early return if not an object schema
   if (!schema.value || !isTypeObject(schema.value)) {
+    return null
+  }
+
+  // A schema whose variants are inferred from a `discriminator.mapping` renders
+  // as a single variant selector, not a flat property list. Splitting it would
+  // duplicate that selector across the visible and collapsed blocks, so we keep
+  // it whole. See https://github.com/scalar/scalar/issues/7472
+  if (inferDiscriminatorMappingComposition(schema.value, document)) {
     return null
   }
 


### PR DESCRIPTION
NSwag (and other generators) describe a polymorphic base type as a plain object with a `discriminator.mapping` but no explicit `oneOf`/`anyOf`. `Schema.vue` routed those object schemas to the properties view, which never infers the variant composition — so the variant dropdown disappeared.

We already infer the `oneOf` from the mapping for non-object schemas (`getCompositionsToRender`). This wires the same inference into `Schema.vue`'s object path, guarded by the `discriminator` prop so a self-referential mapping (e.g. `Base -> #/components/schemas/BaseClass`) does not recurse.

Result: the variant selector renders again and the discriminator property keeps its label.

## Ticket

Closes #7472

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema UI rendering only, with targeted guards and broad tests; no API runtime or security behavior changes.
> 
> **Overview**
> Restores the **polymorphic variant dropdown** for OpenAPI object schemas that define **`discriminator.mapping`** without **`oneOf`/`anyOf`** (common NSwag output). **`Schema.vue`** now infers a synthetic **`oneOf`** via **`inferDiscriminatorMappingComposition`** and renders **`SchemaComposition`** instead of only a flat property list, with guards so variants inside a composition, explicit **`oneOf`**, **`allOf`**, and nested properties do not get duplicate selectors.
> 
> **`SchemaProperty.vue`** drops **`discriminator`** from the nested object schema passed to child **`Schema`** so mapping-only properties do not infer a second dropdown. **`RequestBody.vue`** skips splitting large bodies into visible/collapsed property blocks when that inference applies, preventing duplicate composition selectors. The helper is **exported** and documented; tests cover NSwag-style bases, factored properties, nesting, and **`allOf`** coexistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02952494c5e27f37fcd1d231f852f449d086bbc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->