### PR TITLE
fix(types): stop deprecating per-source title and slug

### DIFF
--- a/.changeset/fix-source-title-deprecation.md
+++ b/.changeset/fix-source-title-deprecation.md
@@ -1,0 +1,6 @@
+---
+'@scalar/types': patch
+'@scalar/schemas': patch
+---
+
+Stop marking the per-source `title` and `slug` as deprecated. They are the supported way to name a document and its URL when using multiple `sources`, so the deprecation note (and editor strike-through) was misleading.

--- a/packages/schemas/src/api-reference/source-configuration.ts
+++ b/packages/schemas/src/api-reference/source-configuration.ts
@@ -26,11 +26,11 @@ export const sourceConfigurationSchema = object({
   }),
   title: optional(string(), {
     typeComment:
-      'The title of the OpenAPI document. @deprecated Please move `title` to the top level and remove the `spec` prefix.',
+      'The title of the OpenAPI document. Used for the page title and the document name in the dropdown. With multiple `sources`, set this per source.',
   }),
   slug: optional(string(), {
     typeComment:
-      'The slug of the OpenAPI document used in the URL. @deprecated Please move `slug` to the top level and remove the `spec` prefix.',
+      'The slug of the OpenAPI document used in the URL. If none is passed, the title will be used. With multiple `sources`, set this per source.',
   }),
   spec: optional(
     object({

--- a/packages/types/src/api-reference/source-configuration.ts
+++ b/packages/types/src/api-reference/source-configuration.ts
@@ -55,9 +55,9 @@ export const sourceConfigurationSchema = z.object({
   /**
    * The title of the OpenAPI document.
    *
-   * @example 'Scalar Galaxy'
+   * Used for the page title and the document name in the dropdown. With multiple `sources`, set this per source.
    *
-   * @deprecated Please move `title` to the top level and remove the `spec` prefix.
+   * @example 'Scalar Galaxy'
    */
   title: z.string().optional(),
   /**
@@ -67,9 +67,9 @@ export const sourceConfigurationSchema = z.object({
    *
    * If no title is used, it'll just use the index.
    *
-   * @example 'scalar-galaxy'
+   * With multiple `sources`, set this per source.
    *
-   * @deprecated Please move `slug` to the top level and remove the `spec` prefix.
+   * @example 'scalar-galaxy'
    */
   slug: z.string().optional(),
   /**

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -473,9 +473,9 @@ export type SourceConfiguration = {
   url?: string
   /** Directly embed the OpenAPI document. Can be a string, object, function returning an object, or null. It is recommended to pass a URL instead of content. */
   content?: string | null | Record<string, any> | (() => string | any)
-  /** The title of the OpenAPI document. @deprecated Please move `title` to the top level and remove the `spec` prefix. */
+  /** The title of the OpenAPI document. Used for the page title and the document name in the dropdown. With multiple `sources`, set this per source. */
   title?: string
-  /** The slug of the OpenAPI document used in the URL. @deprecated Please move `slug` to the top level and remove the `spec` prefix. */
+  /** The slug of the OpenAPI document used in the URL. If none is passed, the title will be used. With multiple `sources`, set this per source. */
   slug?: string
   /** @deprecated Use `url` and `content` on the top level instead. */
   spec?: {


### PR DESCRIPTION
The per-source `title` and `slug` were marked `@deprecated` with a note to "move them to the top level" — copy-pasted from the `spec` migration. That advice is wrong for multi-source configs (each source needs its own title/slug), and the editor strike-through pushed people toward unsupported shapes like a per-source `metaData` (see #7230).

This drops the deprecation and clarifies the docstring: `title` sets the page title and the dropdown name, set it per source.

```ts
sources: [
  { title: 'Russian', slug: 'ru', url: '/api/ru.yaml' },
  { title: 'English', slug: 'en', url: '/api/en.yaml' },
]
```

## Ticket

Closes #7230

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and schema comment-only changes with no runtime behavior; fixes misleading deprecation that could steer users away from supported multi-source config.
> 
> **Overview**
> Per-source **`title`** and **`slug`** on API reference **`SourceConfiguration`** are no longer documented as deprecated in `@scalar/types`, `@scalar/schemas`, and the exported **`SourceConfiguration`** type comments.
> 
> The old deprecation text (copied from the **`spec` → top-level `url`/`content`** migration) wrongly told users to move these fields to the top level. Updated comments explain that **`title`** drives the page title and document dropdown label, and **`slug`** drives the URL segment, with both set **per entry** when using multiple **`sources`**. The nested **`spec`** field remains deprecated.
> 
> A changeset records patch releases for **`@scalar/types`** and **`@scalar/schemas`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7933f66948dc2d8c352dcb0e72f614bf57cbddf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->