### PR TITLE
fix(api-reference): show `propertyNames` format for `additionalProperties`

### DIFF
--- a/.changeset/property-names-format.md
+++ b/.changeset/property-names-format.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Show the `propertyNames` type and format (e.g. `string · uuid`) for a map of additional properties, so key constraints are no longer dropped from the rendered schema

--- a/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaObjectProperties.vue
@@ -111,6 +111,19 @@ const additionalPropertiesEnum = computed(() => {
 })
 
 /**
+ * The resolved propertyNames schema for the property keys.
+ *
+ * Surfaces key constraints such as `format` (for example `uuid`) so they are
+ * not lost when rendering a map of additional properties.
+ */
+const additionalPropertiesKeySchema = computed(() => {
+  if (!isTypeObject(schema) || !schema.additionalProperties) {
+    return undefined
+  }
+  return schema.propertyNames ? resolve.schema(schema.propertyNames) : undefined
+})
+
+/**
  * Keep sibling property descriptions separate from the referenced schema.
  *
  * This allows us to render both:
@@ -246,6 +259,7 @@ const getAdditionalPropertiesValue = (
       noncollapsible
       :options="options"
       :propertyNamesEnum="additionalPropertiesEnum"
+      :propertyNamesSchema="additionalPropertiesKeySchema"
       :schema="getAdditionalPropertiesValue(schema.additionalProperties)"
       :schemaContext="schemaContext"
       variant="additionalProperties" />

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -59,6 +59,8 @@ const props = withDefaults(
     options: SchemaOptions
     /** Enum values for property names (from JSON Schema propertyNames keyword). */
     propertyNamesEnum?: string[]
+    /** Resolved propertyNames schema, used to show key constraints like `format`. */
+    propertyNamesSchema?: SchemaObject
     /** When "requestBody", composition selection is synced with the example snippet */
     schemaContext?: string
     /** Internal path used to sync nested request body compositions with the code sample */
@@ -224,6 +226,7 @@ const isDiscriminatorProperty = computed(() =>
       :hideModelNames
       :isDiscriminator="isDiscriminatorProperty"
       :modelName="modelName"
+      :propertyNames="propertyNamesSchema"
       :required
       :value="optimizedValue">
       <template

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.propertyNames.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.propertyNames.test.ts
@@ -1,0 +1,42 @@
+import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
+import { type SchemaObject, SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import Schema from './Schema.vue'
+
+describe('propertyNames key constraints', () => {
+  it('surfaces the propertyNames format for a map of additional properties', () => {
+    const schema = coerceValue(SchemaObjectSchema, {
+      type: 'object',
+      additionalProperties: {
+        type: 'array',
+        items: { type: 'object', title: 'Resource', properties: { foo: { type: 'number' } } },
+      },
+      propertyNames: { title: 'Resource ID', type: 'string', format: 'uuid' },
+    }) as SchemaObject
+
+    const wrapper = mount(Schema, {
+      props: { schema, options: {}, eventBus: null, name: 'resource_timelines' },
+    })
+
+    const text = wrapper.text()
+    // The key title is used as the property name
+    expect(text).toContain('Resource ID')
+    // The key type and format are now shown instead of being dropped
+    expect(text).toContain('uuid')
+  })
+
+  it('does not render key details when there is no propertyNames schema', () => {
+    const schema = coerceValue(SchemaObjectSchema, {
+      type: 'object',
+      additionalProperties: { type: 'string' },
+    }) as SchemaObject
+
+    const wrapper = mount(Schema, {
+      props: { schema, options: {}, eventBus: null, name: 'map' },
+    })
+
+    expect(wrapper.text()).not.toContain('keys:')
+  })
+})

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -32,6 +32,8 @@ const props = withDefaults(
     hideModelNames?: boolean
     /** When the schema was resolved from a $ref, pass the ref name so it displays as e.g. "Data" instead of "object". */
     modelName?: string | null
+    /** Resolved propertyNames schema, used to surface key constraints like `format` for additional properties. */
+    propertyNames?: SchemaObject
     eventBus?: WorkspaceEventBus | null
   }>(),
   {
@@ -243,6 +245,27 @@ const displayType = computed(() => {
   return getSchemaType(props.value)
 })
 
+/**
+ * Type and format of the property keys, derived from the propertyNames schema.
+ *
+ * For a map keyed by UUIDs this renders e.g. "string · uuid" so the key
+ * constraints are not lost. Returns undefined when there is nothing to show.
+ */
+const propertyNamesDetail = computed(() => {
+  const schema = props.propertyNames
+  if (!schema) {
+    return undefined
+  }
+
+  const parts = [getSchemaType(schema)]
+  if ('format' in schema && typeof schema.format === 'string') {
+    parts.push(schema.format)
+  }
+
+  const detail = parts.filter(Boolean).join(' · ')
+  return detail.length > 0 ? detail : undefined
+})
+
 const exampleValue = computed(() => {
   // Treat only `undefined` as "not set" — `null` is a valid example value on a nullable schema.
   if (
@@ -299,6 +322,14 @@ const exampleValue = computed(() => {
           </LinkButton>
           <template v-else>{{ modelLink.label }}</template>
         </template>
+      </SchemaPropertyDetail>
+
+      <!-- Key constraints from propertyNames (e.g. "keys: string · uuid") -->
+      <SchemaPropertyDetail
+        v-if="propertyNamesDetail"
+        truncate>
+        <template #prefix>keys:</template>
+        {{ propertyNamesDetail }}
       </SchemaPropertyDetail>
 
       <!-- Dynamic validation properties from composable -->


### PR DESCRIPTION
A map keyed by UUIDs showed no hint that its keys are UUIDs. The `propertyNames` schema was only mined for its `title` and `enum`, so the `format` (and type) were dropped.

Now the key constraints render next to the key, e.g. `Resource ID` `keys: string · uuid`.

## Ticket

Closes #7204

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in schema rendering with no API or data-handling impact; behavior is gated on presence of `propertyNames`.
> 
> **Overview**
> **Schema docs for `additionalProperties` maps now show key constraints from `propertyNames`.** Previously only the key `title` and `enum` were used; **type** and **format** (e.g. UUID keys) were omitted.
> 
> The flow resolves `propertyNames` in `SchemaObjectProperties`, passes it through `SchemaProperty` as `propertyNamesSchema`, and `SchemaPropertyHeading` renders a **`keys:`** detail (e.g. `string · uuid`) when that schema has type/format. If there is no `propertyNames`, nothing new appears.
> 
> Coverage includes a changeset and component tests asserting `uuid` is shown and `keys:` is absent without `propertyNames`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 378fc8250c3e3d5603cc03710e51c39d206bdfcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->