### PR TITLE
feat(scalar-app): update to new SDK

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ catalogs:
       specifier: 1.59.1
       version: 1.59.1
     '@scalar/sdk':
-      specifier: 0.1.5
-      version: 0.1.5
+      specifier: 0.2.6
+      version: 0.2.6
     '@scalar/typebox':
       specifier: 0.1.3
       version: 0.1.3
@@ -2701,7 +2701,7 @@ importers:
         version: link:../../packages/pre-post-request-scripts
       '@scalar/sdk':
         specifier: catalog:*
-        version: 0.1.5(zod@4.3.5)
+        version: 0.2.6
       '@scalar/sidebar':
         specifier: workspace:*
         version: link:../../packages/sidebar
@@ -8025,10 +8025,8 @@ packages:
   '@rushstack/ts-command-line@4.23.2':
     resolution: {integrity: sha512-JJ7XZX5K3ThBBva38aomgsPv1L7FV6XmSOcR6HtM7HDFZJkepqT65imw26h9ggGqMjsY0R9jcl30tzKcVj9aOQ==}
 
-  '@scalar/sdk@0.1.5':
-    resolution: {integrity: sha512-cy0CYFxes5K3ynL2geJideflngegtspD14p67qa0k3iaBFL4QwUJ3rKgMD4m8Qjmj1cTTRVLzQrg0bgXL+l+Ew==}
-    peerDependencies:
-      zod: '>= 3'
+  '@scalar/sdk@0.2.6':
+    resolution: {integrity: sha512-b42JORTKUuA32AqWFp4FtTuCJB4Ixqzy4gEQDrNsyO1ke2F6T1iSMEd2r4fgjFG+yw11MAnmsf459dvSrwFh5A==}
 
   '@scalar/typebox@0.1.3':
     resolution: {integrity: sha512-lU055AUccECZMIfGA0z/C1StYmboAYIPJLDFBzOO81yXBi35Pxdq+I4fWX6iUZ8qcoHneiLGk9jAUM1rA93iEg==}
@@ -25380,9 +25378,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@scalar/sdk@0.1.5(zod@4.3.5)':
-    dependencies:
-      zod: 4.3.5
+  '@scalar/sdk@0.2.6': {}
 
   '@scalar/typebox@0.1.3': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,7 +37,7 @@ catalogs:
     '@playwright/test': 1.59.1
     '@scalar/typebox': 0.1.3
     '@tailwindcss/cli': ^4.2.4
-    '@scalar/sdk': 0.1.5
+    '@scalar/sdk': 0.2.6
     '@tailwindcss/vite': ^4.2.0
     '@tanstack/vue-query': 5.100.5
     '@types/express': 5.0.3

--- a/projects/scalar-app/entrypoints/web/src/router.ts
+++ b/projects/scalar-app/entrypoints/web/src/router.ts
@@ -20,12 +20,12 @@ const { toast } = useToasts()
 const fetchCurrentTeamSlug = async (): Promise<string> => {
   const teamsData = await queryClient.fetchQuery({
     queryKey: ['teams'],
-    queryFn: () => scalarClient.teams.listTeams(),
+    queryFn: () => scalarClient.teams.list(),
     meta: {
       errorMessage: 'Failed to fetch teams. Please try logging in again.',
     },
   })
-  return teamsData?.teams?.find((t) => t.uid === tokenData.value?.teamUid)?.slug ?? 'local'
+  return teamsData?.find((t) => t.uid === tokenData.value?.teamUid)?.slug ?? 'local'
 }
 
 router.beforeEach(async (to) => {

--- a/projects/scalar-app/src/helpers/delete-registry-document.ts
+++ b/projects/scalar-app/src/helpers/delete-registry-document.ts
@@ -19,7 +19,7 @@ type DeleteRegistryDocument = RegistryAdapter['deleteDocument']
  */
 export const deleteRegistryDocument: DeleteRegistryDocument = async ({ namespace, slug }) => {
   try {
-    await scalarClient.registry.deleteApiDocument({ namespace, slug })
+    await scalarClient.registry.deleteAPIDocument(namespace, slug)
 
     return {
       ok: true,

--- a/projects/scalar-app/src/helpers/delete-registry-version.ts
+++ b/projects/scalar-app/src/helpers/delete-registry-version.ts
@@ -18,11 +18,7 @@ type DeleteRegistryVersion = RegistryAdapter['deleteVersion']
  */
 export const deleteRegistryVersion: DeleteRegistryVersion = async ({ namespace, slug, version }) => {
   try {
-    await scalarClient.registry.deleteApiDocumentVersion({
-      namespace,
-      slug,
-      semver: version,
-    })
+    await scalarClient.registry.deleteAPIDocumentVersion(namespace, slug, version)
 
     return {
       ok: true,

--- a/projects/scalar-app/src/helpers/fetch-registry-document.test.ts
+++ b/projects/scalar-app/src/helpers/fetch-registry-document.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchRegistryDocument } from './fetch-registry-document'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+/**
+ * The SDK call is `registry.retrieveAPIDocumentVersion(...).withResponse()`,
+ * so the mock returns an object exposing `withResponse`. Tests drive its
+ * resolved value to pin the new response contract: body on `.data`, version
+ * hash on `response.response.headers`.
+ */
+const { retrieveAPIDocumentVersion } = vi.hoisted(() => ({ retrieveAPIDocumentVersion: vi.fn() }))
+
+vi.mock('@/helpers/scalar-client', () => ({
+  scalarClient: {
+    registry: {
+      retrieveAPIDocumentVersion,
+    },
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const validDocument = { openapi: '3.1.0', info: { title: 'Test', version: '1.0.0' }, paths: {} }
+
+/** Builds a `withResponse()` result with an optional version-sha header. */
+const mockResponse = (data: unknown, versionSha?: string) => {
+  const headers = new Headers()
+  if (versionSha !== undefined) {
+    headers.set('x-scalar-version-sha', versionSha)
+  }
+  retrieveAPIDocumentVersion.mockReturnValue({
+    withResponse: () => Promise.resolve({ data, response: { headers } }),
+  })
+}
+
+/** Builds a rejected SDK call. */
+const mockRejection = (error: unknown) => {
+  retrieveAPIDocumentVersion.mockReturnValue({
+    withResponse: () => Promise.reject(error),
+  })
+}
+
+describe('fetch-registry-document', () => {
+  beforeEach(() => {
+    retrieveAPIDocumentVersion.mockReset()
+  })
+
+  it('parses the document from `response.data` and reads the version sha from the header', async () => {
+    mockResponse(JSON.stringify(validDocument), 'abc123')
+
+    const result = await fetchRegistryDocument({ namespace: 'ns', slug: 'my-api', version: '1.0.0' })
+
+    expect(result).toEqual({ ok: true, data: { document: validDocument, versionSha: 'abc123' } })
+  })
+
+  it('passes namespace, slug, and version as positional arguments', async () => {
+    mockResponse(JSON.stringify(validDocument), 'abc123')
+
+    await fetchRegistryDocument({ namespace: 'ns', slug: 'my-api', version: '2.1.0' })
+
+    expect(retrieveAPIDocumentVersion).toHaveBeenCalledWith('ns', 'my-api', '2.1.0')
+  })
+
+  it('defaults the version to "latest" when none is provided', async () => {
+    mockResponse(JSON.stringify(validDocument), 'abc123')
+
+    await fetchRegistryDocument({ namespace: 'ns', slug: 'my-api' })
+
+    expect(retrieveAPIDocumentVersion).toHaveBeenCalledWith('ns', 'my-api', 'latest')
+  })
+
+  it('leaves versionSha undefined when the header is absent', async () => {
+    mockResponse(JSON.stringify(validDocument))
+
+    const result = await fetchRegistryDocument({ namespace: 'ns', slug: 'my-api', version: 'latest' })
+
+    expect(result).toEqual({ ok: true, data: { document: validDocument, versionSha: undefined } })
+  })
+
+  it('returns UNKNOWN when the body is not a string', async () => {
+    mockResponse(undefined)
+
+    const result = await fetchRegistryDocument({ namespace: 'ns', slug: 'my-api', version: 'latest' })
+
+    expect(result).toEqual({ ok: false, error: 'UNKNOWN', message: 'Registry returned an empty document body' })
+  })
+
+  it('returns UNKNOWN when the body parses to a non-object', async () => {
+    mockResponse(JSON.stringify(42))
+
+    const result = await fetchRegistryDocument({ namespace: 'ns', slug: 'my-api', version: 'latest' })
+
+    expect(result).toEqual({ ok: false, error: 'UNKNOWN', message: 'Cannot parse document from registry' })
+  })
+
+  it('maps a 404 rejection to NOT_FOUND', async () => {
+    mockRejection({ status: 404 })
+
+    const result = await fetchRegistryDocument({ namespace: 'ns', slug: 'missing', version: 'latest' })
+
+    expect(result).toMatchObject({ ok: false, error: 'NOT_FOUND' })
+  })
+
+  it('maps a 401 rejection to UNAUTHORIZED', async () => {
+    mockRejection({ status: 401 })
+
+    const result = await fetchRegistryDocument({ namespace: 'ns', slug: 'my-api', version: 'latest' })
+
+    expect(result).toMatchObject({ ok: false, error: 'UNAUTHORIZED' })
+  })
+})

--- a/projects/scalar-app/src/helpers/fetch-registry-document.ts
+++ b/projects/scalar-app/src/helpers/fetch-registry-document.ts
@@ -19,13 +19,9 @@ type ImportDocumentFromRegistry = RegistryAdapter['fetchDocument']
  */
 export const fetchRegistryDocument: ImportDocumentFromRegistry = async ({ namespace, slug, version = 'latest' }) => {
   try {
-    const response = await scalarClient.registry.getApiDocumentVersion({
-      namespace,
-      slug,
-      semver: version,
-    })
+    const response = await scalarClient.registry.retrieveAPIDocumentVersion(namespace, slug, version).withResponse()
 
-    const documentString = response.res
+    const documentString = response.data
     if (typeof documentString !== 'string') {
       return { ok: false, error: 'UNKNOWN', message: 'Registry returned an empty document body' }
     }
@@ -39,7 +35,7 @@ export const fetchRegistryDocument: ImportDocumentFromRegistry = async ({ namesp
     // rather than baking it into the document body, so the sync flow
     // can treat it as an optimistic-concurrency token without parsing
     // the OpenAPI document itself.
-    const versionSha = response.httpMeta.response.headers.get('x-scalar-version-sha') ?? undefined
+    const versionSha = response.response.headers.get('x-scalar-version-sha') ?? undefined
 
     return { ok: true, data: { document, versionSha } }
   } catch (error) {

--- a/projects/scalar-app/src/helpers/publish-registry-document.ts
+++ b/projects/scalar-app/src/helpers/publish-registry-document.ts
@@ -9,10 +9,10 @@ type PublishRegistryDocument = RegistryAdapter['publishDocument']
  * Publishes a brand-new document to the Scalar registry under the given
  * namespace and slug.
  *
- * The registry's HTTP surface returns the standard `ScalarError` family
- * with a `statusCode` field, so we delegate to {@link mapRegistryError}
- * to translate the throw into the discriminated error union expected by
- * the API client adapter. The only endpoint-specific status here is
+ * The registry's HTTP surface returns the standard SDK error family,
+ * so we delegate to {@link mapRegistryError} to translate the throw into
+ * the discriminated error union expected by the API client adapter.
+ * The only endpoint-specific status here is
  * 409, which the registry uses for slug collisions when creating a new
  * document - 422 stays on the validation track and falls through to
  * `UNKNOWN`.
@@ -28,20 +28,17 @@ export const publishRegistryDocument: PublishRegistryDocument = async ({ namespa
   const description = typeof info?.description === 'string' ? info.description : undefined
 
   try {
-    const result = await scalarClient.registry.createApiDocument({
-      namespace,
-      requestBody: {
-        title,
-        description,
-        version,
-        slug,
-        document: JSON.stringify(document),
-      },
+    const result = await scalarClient.registry.createAPIDocument(namespace, {
+      title,
+      description,
+      version,
+      slug,
+      document: JSON.stringify(document),
     })
 
     return {
       ok: true,
-      data: { namespace, slug, version, commitHash: result.object?.versionSha },
+      data: { namespace, slug, version, commitHash: result?.versionSha },
     }
   } catch (error) {
     return mapRegistryError(error, { statusCodes: { 409: 'CONFLICT' } })

--- a/projects/scalar-app/src/helpers/publish-registry-version.ts
+++ b/projects/scalar-app/src/helpers/publish-registry-version.ts
@@ -29,20 +29,16 @@ export const publishRegistryVersion: PublishRegistryVersion = async ({
   commitHash,
 }) => {
   try {
-    const result = await scalarClient.registry.createApiDocumentVersion({
-      namespace,
-      slug,
-      requestBody: {
-        version,
-        document: JSON.stringify(document),
-        force: true,
-        lastKnownVersionSha: commitHash,
-      },
+    const result = await scalarClient.registry.createAPIDocumentVersion(namespace, slug, {
+      version,
+      document: JSON.stringify(document),
+      force: true,
+      lastKnownVersionSha: commitHash,
     })
 
     return {
       ok: true,
-      data: { namespace, slug, version, commitHash: result.managedDocVersion?.versionSha ?? '' },
+      data: { namespace, slug, version, commitHash: result.versionSha ?? '' },
     }
   } catch (error) {
     return mapRegistryError(error, {

--- a/projects/scalar-app/src/helpers/registry-error-status.test.ts
+++ b/projects/scalar-app/src/helpers/registry-error-status.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+
+import { mapRegistryError } from './registry-error-status'
+
+describe('registry-error-status', () => {
+  // -------------------------------------------------------------------------
+  // Status-code extraction (exercised through mapRegistryError)
+  // -------------------------------------------------------------------------
+  describe('status-code extraction', () => {
+    it('reads the status from the new SDK `error.status` field', () => {
+      expect(mapRegistryError({ status: 401 })).toEqual({ ok: false, error: 'UNAUTHORIZED', message: undefined })
+    })
+
+    it('falls back to `error.httpMeta.response.status` for older SDK builds', () => {
+      expect(mapRegistryError({ httpMeta: { response: { status: 403 } } })).toEqual({
+        ok: false,
+        error: 'UNAUTHORIZED',
+        message: undefined,
+      })
+    })
+
+    it('falls back to a top-level `error.statusCode` for the oldest shape', () => {
+      expect(mapRegistryError({ statusCode: 401 })).toEqual({ ok: false, error: 'UNAUTHORIZED', message: undefined })
+    })
+
+    it('prefers `error.status` over the legacy fallbacks when several are present', () => {
+      // `status` says 500 (network bucket), the legacy fields say 401. The new
+      // field has to win, otherwise the upgrade silently changes behavior.
+      expect(mapRegistryError({ status: 500, httpMeta: { response: { status: 401 } }, statusCode: 401 })).toEqual({
+        ok: false,
+        error: 'FETCH_FAILED',
+        message: undefined,
+      })
+    })
+
+    it('ignores non-numeric status values', () => {
+      // A stringified status is not a usable HTTP code, so we treat it the
+      // same as a request that never reached the registry.
+      expect(mapRegistryError({ status: 'nope' })).toEqual({ ok: false, error: 'FETCH_FAILED', message: undefined })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // mapRegistryError cascade
+  // -------------------------------------------------------------------------
+  describe('mapRegistryError', () => {
+    it('maps 401 and 403 to UNAUTHORIZED', () => {
+      expect(mapRegistryError({ status: 401 }).error).toBe('UNAUTHORIZED')
+      expect(mapRegistryError({ status: 403 }).error).toBe('UNAUTHORIZED')
+    })
+
+    it('applies caller-supplied status-code mappings', () => {
+      expect(mapRegistryError({ status: 404 }, { statusCodes: { 404: 'NOT_FOUND' } })).toEqual({
+        ok: false,
+        error: 'NOT_FOUND',
+        message: undefined,
+      })
+    })
+
+    it('lets a custom non-5xx mapping win over the network bucket', () => {
+      // 409 sits in the 4xx range, so the explicit mapping must be checked
+      // before the >=500 fallback can claim it.
+      expect(mapRegistryError({ status: 409 }, { statusCodes: { 409: 'CONFLICT' } }).error).toBe('CONFLICT')
+    })
+
+    it('keeps 401/403 as UNAUTHORIZED even when a custom mapping is provided', () => {
+      expect(mapRegistryError({ status: 401 }, { statusCodes: { 401: 'CONFLICT' } }).error).toBe('UNAUTHORIZED')
+    })
+
+    it('maps any 5xx to FETCH_FAILED', () => {
+      expect(mapRegistryError({ status: 500 }).error).toBe('FETCH_FAILED')
+      expect(mapRegistryError({ status: 503 }).error).toBe('FETCH_FAILED')
+    })
+
+    it('treats a missing status code as FETCH_FAILED (request never reached the registry)', () => {
+      expect(mapRegistryError(new Error('network down')).error).toBe('FETCH_FAILED')
+      expect(mapRegistryError({}).error).toBe('FETCH_FAILED')
+      expect(mapRegistryError(undefined).error).toBe('FETCH_FAILED')
+      expect(mapRegistryError('boom').error).toBe('FETCH_FAILED')
+    })
+
+    it('falls through to UNKNOWN for an unmapped 4xx', () => {
+      expect(mapRegistryError({ status: 418 }).error).toBe('UNKNOWN')
+    })
+
+    it('surfaces the original message for Error instances', () => {
+      expect(mapRegistryError(new Error('boom'), { statusCodes: { 404: 'NOT_FOUND' } })).toMatchObject({
+        message: 'boom',
+      })
+    })
+
+    it('uses the fallback message when the thrown value is not an Error', () => {
+      expect(mapRegistryError({ status: 500 }, { fallbackMessage: 'could not reach registry' })).toMatchObject({
+        message: 'could not reach registry',
+      })
+    })
+  })
+})

--- a/projects/scalar-app/src/helpers/registry-error-status.ts
+++ b/projects/scalar-app/src/helpers/registry-error-status.ts
@@ -2,12 +2,10 @@
  * Reads the HTTP status code off a thrown SDK error so the registry
  * adapters can map it onto our discriminated error union.
  *
- * The Scalar SDK exposes the HTTP response on `error.httpMeta.response`
- * for every `ScalarError` subclass (the generic `APIError` returned for
- * unmatched 4XX/5XX responses, plus the per-status `FourHundred`,
- * `FourHundredAndOne`, ... classes). Older SDK builds put `statusCode`
- * directly on the error, so we keep a fallback for that shape to stay
- * compatible while consumers upgrade.
+ * The Scalar SDK exposes the HTTP status directly on `error.status`.
+ * Older SDK builds put the response on `error.httpMeta.response`, or
+ * put `statusCode` directly on the error, so we keep fallbacks for
+ * those shapes to stay compatible while consumers upgrade.
  *
  * Returns `undefined` for non-HTTP errors (e.g. network or abort errors)
  * so callers can treat that case as "request never reached the server".
@@ -18,8 +16,13 @@ const getRegistryErrorStatusCode = (error: unknown): number | undefined => {
   }
 
   const candidate = error as {
+    status?: unknown
     statusCode?: unknown
     httpMeta?: { response?: { status?: unknown } }
+  }
+
+  if (typeof candidate.status === 'number') {
+    return candidate.status
   }
 
   const fromHttpMeta = candidate.httpMeta?.response?.status

--- a/projects/scalar-app/src/helpers/scalar-client.ts
+++ b/projects/scalar-app/src/helpers/scalar-client.ts
@@ -1,4 +1,4 @@
-import { Scalar } from '@scalar/sdk'
+import Scalar from '@scalar/sdk'
 
 import { env } from '@/environment'
 import { useAuth } from '@/hooks/use-auth'
@@ -14,7 +14,7 @@ export const DEFAULT_REFETCH_INTERVAL = 1000 * 60
 
 /** Single SDK client for the app */
 export const scalarClient = new Scalar({
-  serverURL: `${env.VITE_API_URL}`,
+  baseURL: `${env.VITE_API_URL}`,
   bearerAuth: async () => {
     // Ensure the access token is fresh
     await checkRefresh()

--- a/projects/scalar-app/src/hooks/use-registry-documents.ts
+++ b/projects/scalar-app/src/hooks/use-registry-documents.ts
@@ -20,7 +20,7 @@ export const useRegistryDocuments = (options?: Omit<UseQueryOptions, 'queryKey' 
   const query = useQuery(
     {
       queryKey,
-      queryFn: () => scalarClient.registry.listAllApiDocuments().then((response) => response.apiDocuments ?? []),
+      queryFn: () => scalarClient.registry.listAllAPIDocuments(),
       enabled: isLoggedIn,
       refetchOnMount: true,
       refetchInterval: DEFAULT_REFETCH_INTERVAL,

--- a/projects/scalar-app/src/hooks/use-registry-namespaces.test.ts
+++ b/projects/scalar-app/src/hooks/use-registry-namespaces.test.ts
@@ -50,7 +50,7 @@ vi.mock('@/helpers/scalar-client', () => ({
   DEFAULT_REFETCH_INTERVAL: 60_000,
   scalarClient: {
     namespaces: {
-      listNamespaces: vi.fn(),
+      list: vi.fn(),
     },
   },
 }))

--- a/projects/scalar-app/src/hooks/use-registry-namespaces.ts
+++ b/projects/scalar-app/src/hooks/use-registry-namespaces.ts
@@ -25,7 +25,7 @@ export const useRegistryNamespaces = (options?: Omit<UseQueryOptions, 'queryKey'
   const query = useQuery(
     {
       queryKey,
-      queryFn: () => scalarClient.namespaces.listNamespaces().then((response) => response.strings ?? []),
+      queryFn: () => scalarClient.namespaces.list(),
       enabled: isLoggedIn,
       refetchOnMount: true,
       refetchInterval: DEFAULT_REFETCH_INTERVAL,

--- a/projects/scalar-app/src/hooks/use-teams.test.ts
+++ b/projects/scalar-app/src/hooks/use-teams.test.ts
@@ -21,7 +21,7 @@ vi.mock('@/hooks/use-auth', () => ({
  * without actually hitting the network. The `queryFn` is never executed;
  * tests drive `mockQueryData` directly.
  */
-const mockQueryData = ref<{ teams?: Array<{ uid: string; slug: string; name: string }> } | undefined>(undefined)
+const mockQueryData = ref<Array<{ uid: string; slug: string; name: string }> | undefined>(undefined)
 vi.mock('@tanstack/vue-query', () => ({
   useQuery: () => ({
     data: mockQueryData,
@@ -37,7 +37,7 @@ vi.mock('@/helpers/scalar-client', () => ({
   DEFAULT_REFETCH_INTERVAL: 60_000,
   scalarClient: {
     teams: {
-      listTeams: vi.fn(),
+      list: vi.fn(),
     },
   },
 }))
@@ -70,7 +70,7 @@ describe('useTeams', () => {
     })
 
     it('returns the teams array when query resolves', () => {
-      mockQueryData.value = { teams: [teamAlpha, teamBeta] }
+      mockQueryData.value = [teamAlpha, teamBeta]
 
       const { teams } = useTeams()
       expect(teams.value).toEqual([teamAlpha, teamBeta])
@@ -82,7 +82,7 @@ describe('useTeams', () => {
   // -------------------------------------------------------------------------
   describe('currentTeam', () => {
     it('finds the team matching tokenData.teamUid', () => {
-      mockQueryData.value = { teams: [teamAlpha, teamBeta] }
+      mockQueryData.value = [teamAlpha, teamBeta]
       mockTokenData.value = { teamUid: 'team-beta-uid' }
 
       const { currentTeam } = useTeams()
@@ -90,7 +90,7 @@ describe('useTeams', () => {
     })
 
     it('is undefined when no team matches', () => {
-      mockQueryData.value = { teams: [teamAlpha, teamBeta] }
+      mockQueryData.value = [teamAlpha, teamBeta]
       mockTokenData.value = { teamUid: 'non-existent-uid' }
 
       const { currentTeam } = useTeams()
@@ -108,7 +108,7 @@ describe('useTeams', () => {
     })
 
     it('returns the team slug when a matching team exists', () => {
-      mockQueryData.value = { teams: [teamAlpha, teamBeta] }
+      mockQueryData.value = [teamAlpha, teamBeta]
       mockTokenData.value = { teamUid: 'team-alpha-uid' }
 
       const { currentTeamSlug } = useTeams()
@@ -121,7 +121,7 @@ describe('useTeams', () => {
   // -------------------------------------------------------------------------
   describe('reactivity', () => {
     it('updates currentTeamSlug when tokenData changes (team switch)', async () => {
-      mockQueryData.value = { teams: [teamAlpha, teamBeta] }
+      mockQueryData.value = [teamAlpha, teamBeta]
       mockTokenData.value = { teamUid: 'team-alpha-uid' }
 
       const { currentTeamSlug, currentTeam } = useTeams()

--- a/projects/scalar-app/src/hooks/use-teams.ts
+++ b/projects/scalar-app/src/hooks/use-teams.ts
@@ -21,7 +21,7 @@ export const useTeams = (options?: Omit<UseQueryOptions, 'queryKey' | 'queryFn'>
   const query = useQuery(
     {
       queryKey,
-      queryFn: () => scalarClient.teams.listTeams(),
+      queryFn: () => scalarClient.teams.list(),
       enabled: isLoggedIn,
       refetchOnMount: true,
       refetchInterval: DEFAULT_REFETCH_INTERVAL,
@@ -31,8 +31,8 @@ export const useTeams = (options?: Omit<UseQueryOptions, 'queryKey' | 'queryFn'>
     queryClient,
   )
 
-  const teams = computed(() => query.data.value?.teams)
-  const currentTeam = computed(() => query.data.value?.teams?.find((t) => t.uid === tokenData.value?.teamUid))
+  const teams = computed(() => query.data.value)
+  const currentTeam = computed(() => query.data.value?.find((t) => t.uid === tokenData.value?.teamUid))
   const currentTeamSlug = computed(() => currentTeam.value?.slug || 'local')
   /**
    * Stable identifier for the active team. Use this instead of the slug

--- a/projects/scalar-app/src/hooks/use-themes.test.ts
+++ b/projects/scalar-app/src/hooks/use-themes.test.ts
@@ -55,8 +55,8 @@ vi.mock('@/helpers/scalar-client', () => ({
   DEFAULT_REFETCH_INTERVAL: 60_000,
   scalarClient: {
     themes: {
-      listThemes: vi.fn(),
-      getTheme: vi.fn(),
+      list: vi.fn(),
+      retrieve: vi.fn(),
     },
   },
 }))

--- a/projects/scalar-app/src/hooks/use-themes.ts
+++ b/projects/scalar-app/src/hooks/use-themes.ts
@@ -57,14 +57,13 @@ export const useThemes = ({
     {
       queryKey,
       queryFn: async (): Promise<Theme[]> => {
-        const response = await scalarClient.themes.listThemes()
-        const themes = response.themes ?? []
+        const themes = await scalarClient.themes.list()
 
         const bodies: string[] = await Promise.all(
           themes.map((t: { slug: string }) =>
             queryClient.fetchQuery<string>({
               queryKey: ['themes', t.slug],
-              queryFn: () => scalarClient.themes.getTheme({ slug: t.slug }).then((r) => r.res ?? ''),
+              queryFn: () => scalarClient.themes.retrieve(t.slug),
               staleTime: DEFAULT_REFETCH_INTERVAL,
             }),
           ),

--- a/projects/scalar-app/src/hooks/use-user.test.ts
+++ b/projects/scalar-app/src/hooks/use-user.test.ts
@@ -21,7 +21,7 @@ vi.mock('@/hooks/use-auth', () => ({
  * without actually hitting the network. The `queryFn` is never executed;
  * tests drive `mockQueryData` directly.
  */
-const mockQueryData = ref<{ user?: { name: string; theme: string } | null } | undefined>(undefined)
+const mockQueryData = ref<{ name: string; theme: string } | null | undefined>(undefined)
 vi.mock('@tanstack/vue-query', () => ({
   useQuery: () => ({
     data: mockQueryData,
@@ -36,7 +36,7 @@ vi.mock('@/helpers/query-client', () => ({
 vi.mock('@/helpers/scalar-client', () => ({
   scalarClient: {
     authentication: {
-      getCurrentUser: vi.fn(),
+      listCurrentUser: vi.fn(),
     },
   },
 }))
@@ -63,21 +63,14 @@ describe('useUser', () => {
     })
 
     it('returns the user object when query resolves', () => {
-      mockQueryData.value = { user: { name: 'Test', theme: 'purple' } }
+      mockQueryData.value = { name: 'Test', theme: 'purple' }
 
       const { currentUser } = useUser()
       expect(currentUser.value).toEqual({ name: 'Test', theme: 'purple' })
     })
 
     it('is undefined when query resolves with null user', () => {
-      mockQueryData.value = { user: null }
-
-      const { currentUser } = useUser()
-      expect(currentUser.value).toBeUndefined()
-    })
-
-    it('is undefined when query resolves with no user field', () => {
-      mockQueryData.value = {}
+      mockQueryData.value = null
 
       const { currentUser } = useUser()
       expect(currentUser.value).toBeUndefined()
@@ -91,11 +84,11 @@ describe('useUser', () => {
     it('updates when mockQueryData changes', async () => {
       const { currentUser } = useUser()
 
-      mockQueryData.value = { user: { name: 'Alice', theme: 'default' } }
+      mockQueryData.value = { name: 'Alice', theme: 'default' }
       await nextTick()
       expect(currentUser.value).toEqual({ name: 'Alice', theme: 'default' })
 
-      mockQueryData.value = { user: { name: 'Bob', theme: 'solarized' } }
+      mockQueryData.value = { name: 'Bob', theme: 'solarized' }
       await nextTick()
       expect(currentUser.value).toEqual({ name: 'Bob', theme: 'solarized' })
     })

--- a/projects/scalar-app/src/hooks/use-user.ts
+++ b/projects/scalar-app/src/hooks/use-user.ts
@@ -19,7 +19,7 @@ export const useUser = (options?: Omit<UseQueryOptions, 'queryKey' | 'queryFn'>)
   const query = useQuery(
     {
       queryKey,
-      queryFn: () => scalarClient.authentication.getCurrentUser(),
+      queryFn: () => scalarClient.authentication.listCurrentUser(),
       enabled: isLoggedIn,
       meta: { errorMessage: 'Failed to fetch user' },
       ...options,
@@ -29,6 +29,6 @@ export const useUser = (options?: Omit<UseQueryOptions, 'queryKey' | 'queryFn'>)
 
   return {
     ...query,
-    currentUser: computed(() => query.data.value?.user ?? undefined),
+    currentUser: computed(() => query.data.value ?? undefined),
   }
 }


### PR DESCRIPTION
SDK Upgrade for scalar-app.

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth routing, registry sync (fetch/publish/delete), and error mapping across many API paths; behavior should stay equivalent but regressions would affect login, team resolution, and registry workflows.
> 
> **Overview**
> Bumps **`@scalar/sdk`** from **0.1.5** to **0.2.6** (catalog + lockfile) and rewires **scalar-app** to the new client API.
> 
> The shared client now uses a **default import**, **`baseURL`** instead of **`serverURL`**, and renamed methods (`teams.list`, `namespaces.list`, `themes.list` / `retrieve`, `authentication.listCurrentUser`, registry `*APIDocument*` helpers with positional args). List endpoints return **arrays or entities directly**, so hooks and the web router no longer unwrap nested `{ teams }` / `{ user }` / `{ apiDocuments }` shapes.
> 
> Registry adapters switch to **`retrieveAPIDocumentVersion(...).withResponse()`** (body on **`data`**, headers on **`response`**) and flatter create/delete/publish responses (`versionSha` on the result object). **`mapRegistryError`** prefers **`error.status`** while keeping legacy **`httpMeta`** / **`statusCode`** fallbacks.
> 
> Adds **`fetch-registry-document.test.ts`** and **`registry-error-status.test.ts`** to lock in the new response and error contracts; related hook tests updated for the new method names and payload shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46224015acb5685e90d1860cfdadf10d3ece6d0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->