### PR TITLE
fix(workspace-store): serialize `deepObject` array params with trailing brackets

### DIFF
--- a/.changeset/deep-object-array-brackets.md
+++ b/.changeset/deep-object-array-brackets.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Serialize array values inside `deepObject` query parameters with the trailing bracket convention (`filter[ids][]=1&filter[ids][]=2`) instead of collapsing them into a single comma-joined value

--- a/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-parameters.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-code-sample/helpers/operation-to-har/process-parameters.test.ts
@@ -771,6 +771,37 @@ describe('parameter styles', () => {
         { name: 'tags', value: 'c' },
       ])
     })
+
+    it('expands nested arrays with the trailing bracket convention', () => {
+      // Regression test for https://github.com/scalar/scalar/issues/9492
+      const result = runProcessParameters({
+        harRequest: createHarRequest('/api/users'),
+        parameters: [
+          {
+            name: 'filters',
+            in: 'query',
+            required: true,
+            style: 'deepObject',
+            explode: true,
+            schema: coerceValue(SchemaObjectSchema, {
+              type: 'object',
+              properties: {
+                applicationInstanceId: {
+                  type: 'object',
+                  properties: { in: { type: 'array', items: { type: 'integer' } } },
+                },
+              },
+              example: { applicationInstanceId: { in: [1, 2] } },
+            }),
+          },
+        ],
+      })
+
+      expect(result.queryString).toEqual([
+        { name: 'filters[applicationInstanceId][in][]', value: '1' },
+        { name: 'filters[applicationInstanceId][in][]', value: '2' },
+      ])
+    })
   })
 
   describe('header parameters', () => {

--- a/packages/workspace-store/src/request-example/builder/header/serialize-parameter.test.ts
+++ b/packages/workspace-store/src/request-example/builder/header/serialize-parameter.test.ts
@@ -743,6 +743,38 @@ describe('serializeDeepObjectStyle', () => {
     })
   })
 
+  describe('nested arrays', () => {
+    it('serializes nested arrays with the trailing bracket convention', () => {
+      // Regression test for https://github.com/scalar/scalar/issues/9492
+      // deepObject array values should expand to repeated `key[]` entries
+      // (filters[applicationInstanceId][in][]=1&filters[applicationInstanceId][in][]=2)
+      // instead of collapsing into a single comma-joined value.
+      const value = { applicationInstanceId: { in: [1, 2] } }
+      const result = serializeDeepObjectStyle('filters', value)
+      expect(result).toEqual([
+        { key: 'filters[applicationInstanceId][in][]', value: '1' },
+        { key: 'filters[applicationInstanceId][in][]', value: '2' },
+      ])
+    })
+
+    it('serializes a top-level array property with trailing brackets', () => {
+      const result = serializeDeepObjectStyle('filter', { tags: ['a', 'b'] })
+      expect(result).toEqual([
+        { key: 'filter[tags][]', value: 'a' },
+        { key: 'filter[tags][]', value: 'b' },
+      ])
+    })
+
+    it('keeps other properties alongside array values', () => {
+      const result = serializeDeepObjectStyle('filter', { ids: [1, 2], role: 'admin' })
+      expect(result).toEqual([
+        { key: 'filter[ids][]', value: '1' },
+        { key: 'filter[ids][]', value: '2' },
+        { key: 'filter[role]', value: 'admin' },
+      ])
+    })
+  })
+
   describe('edge cases', () => {
     it('handles empty objects', () => {
       const result = serializeDeepObjectStyle('filter', {})

--- a/packages/workspace-store/src/request-example/builder/header/serialize-parameter.ts
+++ b/packages/workspace-store/src/request-example/builder/header/serialize-parameter.ts
@@ -230,24 +230,36 @@ export const serializePipeDelimitedStyle = (value: unknown): string => {
  *
  * DeepObject: color[R]=100&color[G]=200&color[B]=150
  * Nested: user[name][first]=Alex&user[name][last]=Smith&user[role]=admin
+ * Arrays: filter[ids][]=1&filter[ids][]=2 (the common trailing-bracket convention)
  */
 export const serializeDeepObjectStyle = (paramName: string, value: unknown): Array<{ key: string; value: string }> => {
   const result: Array<{ key: string; value: string }> = []
+
+  /**
+   * Appends a single value at the given key, recursing into nested objects and arrays.
+   *
+   * Array values use the de-facto `key[]` convention (qs, PHP, Rails) so that each item becomes
+   * its own query entry instead of collapsing into a comma-joined string. The OpenAPI spec leaves
+   * deepObject-on-array undefined, but this matches what most servers expect.
+   */
+  const append = (fullKey: string, val: unknown): void => {
+    if (Array.isArray(val)) {
+      for (const item of val) {
+        append(`${fullKey}[]`, item)
+      }
+    } else if (typeof val === 'object' && val !== null) {
+      flatten(val as Record<string, unknown>, fullKey)
+    } else {
+      result.push({ key: fullKey, value: String(val) })
+    }
+  }
 
   /**
    * Recursively flattens nested objects into deepObject notation.
    */
   const flatten = (obj: Record<string, unknown>, prefix: string): void => {
     for (const [key, val] of Object.entries(obj)) {
-      const fullKey = `${prefix}[${key}]`
-
-      if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
-        // Recursively flatten nested objects
-        flatten(val as Record<string, unknown>, fullKey)
-      } else {
-        // Add primitive values
-        result.push({ key: fullKey, value: String(val) })
-      }
+      append(`${prefix}[${key}]`, val)
     }
   }
 


### PR DESCRIPTION
Array values in a `deepObject` query param were collapsed into one comma-joined value (`filters[id][in]=1,2`). Now each item is its own entry, using the common trailing-bracket convention:

```
filters[id][in][]=1&filters[id][in][]=2
```

This is the wire-format half. Table display + edit round-trip is #9584.

## Ticket

Part of #9492