### PR TITLE
fix(api-client): show trailing brackets on `deepObject` array param rows

### DIFF
--- a/.changeset/deep-object-array-table-brackets.md
+++ b/.changeset/deep-object-array-table-brackets.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Show the trailing-bracket name (`filter[ids][]`) on expanded `deepObject` array parameter rows so the table matches the serialized request, and keep edited array leaves as arrays when writing the value back

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -226,6 +226,49 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('coerces a deepObject array leaf via its marker even when the property schema is not an array', () => {
+    // The `[]` marker is added when the schema OR the stored value is an array, so a leaf can carry it
+    // under a non-array (e.g. free-form) schema. The marker must still win, otherwise the array
+    // serializes comma-joined while the row label implies repeated `key[]=...` entries.
+    const parentParameter = {
+      name: 'filters',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+    } as const
+    const context: TableRow[] = [
+      {
+        name: 'filters[tags][]',
+        value: '1,2',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        schema: { type: 'string' },
+        sourceParameterValuePath: ['tags'],
+      },
+    ]
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, { context })
+
+    handlers.upsert(0, { name: 'filters[tags][]', value: '1,2', isDisabled: false })
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'filters',
+          value: { tags: ['1', '2'] },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-0',
+      },
+    )
+  })
+
   it('keeps form-style array leaves verbatim when an unrelated sibling row is edited', () => {
     // Form-style object parameter (the query default) with an array property whose value carries a
     // meaningful comma, e.g. Spring pageable `sort=username,asc`. Splitting it into ['username','asc']

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -498,6 +498,52 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('does not coerce a renamed deepObject array leaf to an array when the new key is a scalar', () => {
+    // Renaming a `...[in][]` leaf to a plain `...[status]` key drops the array marker. The row still
+    // carries the stale array schema and old name, so coercion must follow the freshly typed name and
+    // store the scalar verbatim instead of wrapping it in a one-element array.
+    const parentParameter = {
+      name: 'filters',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+    } as const
+    const row: TableRow = {
+      name: 'filters[applicationInstanceId][in][]',
+      value: 'active',
+      isDisabled: false,
+      originalParameter: parentParameter,
+      schema: { type: 'array', items: { type: 'string' } },
+      sourceParameterValuePath: ['applicationInstanceId', 'in'],
+    }
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, { context: [row] })
+
+    handlers.upsert(0, {
+      name: 'filters[applicationInstanceId][status]',
+      value: 'active',
+      isDisabled: false,
+      shouldRenameExpandedRow: true,
+    })
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'filters',
+          value: { applicationInstanceId: { status: 'active' } },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-0',
+      },
+    )
+  })
+
   it('treats a lone empty bracket group as a real key, not a stripped array marker', () => {
     // Regression guard for the marker stripping: the display-only `[]` is only ever appended after a
     // real path bracket (`filters[id][]`), so it always shows up as `][]`. A lone empty group

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -346,6 +346,59 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('ignores the display-only trailing brackets when renaming a deepObject array leaf', () => {
+    const parentParameter = {
+      name: 'filters',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+    } as const
+    const row: TableRow = {
+      name: 'filters[applicationInstanceId][in][]',
+      value: '1,2',
+      isDisabled: false,
+      originalParameter: parentParameter,
+      schema: { type: 'array', items: { type: 'string' } },
+      sourceParameterValuePath: ['applicationInstanceId', 'in'],
+    }
+    const onRenameExpandedRow = vi.fn()
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, {
+      context: [row],
+      onRenameExpandedRow,
+    })
+
+    // The user renames the leaf key; the trailing `[]` it still carries must not leak into the path.
+    handlers.upsert(0, {
+      name: 'filters[applicationInstanceId][notIn][]',
+      value: '1,2',
+      isDisabled: false,
+      shouldRenameExpandedRow: true,
+    })
+
+    expect(onRenameExpandedRow).toHaveBeenCalledWith(row, ['applicationInstanceId', 'notIn'])
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'filters',
+          value: {
+            applicationInstanceId: {
+              notIn: ['1', '2'],
+            },
+          },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-0',
+      },
+    )
+  })
+
   it('keeps expanded row values at their source path during partial key edits', () => {
     const parentParameter = {
       name: 'filter',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -180,6 +180,59 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('keeps form-style array leaves verbatim when an unrelated sibling row is edited', () => {
+    // Form-style object parameter (the query default) with an array property whose value carries a
+    // meaningful comma, e.g. Spring pageable `sort=username,asc`. Splitting it into ['username','asc']
+    // would change the emitted query, so the leaf must survive an unrelated edit untouched.
+    const parentParameter = {
+      name: 'pageable',
+      in: 'query',
+    } as const
+    const context: TableRow[] = [
+      {
+        name: 'sort',
+        value: 'username,asc',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        schema: { type: 'array', items: { type: 'string' } },
+        sourceParameterValuePath: ['sort'],
+      },
+      {
+        name: 'page',
+        value: '0',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        schema: { type: 'integer' },
+        sourceParameterValuePath: ['page'],
+      },
+    ]
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, { context })
+
+    // The user edits the unrelated "page" row.
+    handlers.upsert(1, { name: 'page', value: '1', isDisabled: false })
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'pageable',
+          value: {
+            sort: 'username,asc',
+            page: '1',
+          },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-1',
+      },
+    )
+  })
+
   it('renames a form-expanded property row by moving the value to the typed key', () => {
     const parentParameter = {
       name: 'filters',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -135,6 +135,51 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('stores array leaves of expanded deepObject rows as arrays, not comma-joined strings', () => {
+    const parentParameter = {
+      name: 'filters',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+    } as const
+    const context: TableRow[] = [
+      {
+        name: 'filters[applicationInstanceId][in][]',
+        // The table always shows the comma-joined display string for an array.
+        value: '1,2',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        schema: { type: 'array', items: { type: 'string' } },
+        sourceParameterValuePath: ['applicationInstanceId', 'in'],
+      },
+    ]
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, { context })
+
+    handlers.upsert(0, { name: 'filters[applicationInstanceId][in][]', value: '1,2', isDisabled: false })
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'filters',
+          value: {
+            applicationInstanceId: {
+              in: ['1', '2'],
+            },
+          },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-0',
+      },
+    )
+  })
+
   it('renames a form-expanded property row by moving the value to the typed key', () => {
     const parentParameter = {
       name: 'filters',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -180,6 +180,52 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('keeps a schema-less deepObject array leaf as an array via its trailing-bracket name', () => {
+    // Renamed and unmapped expanded rows carry no schema, but they keep the display-only `[]` marker.
+    // Editing such a leaf must still store an array so deepObject serialization repeats `key[]=...`.
+    const parentParameter = {
+      name: 'filters',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+    } as const
+    const context: TableRow[] = [
+      {
+        name: 'filters[applicationInstanceId][notIn][]',
+        value: '1,2',
+        isDisabled: false,
+        originalParameter: parentParameter,
+        schema: undefined,
+        sourceParameterValuePath: ['applicationInstanceId', 'notIn'],
+      },
+    ]
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, { context })
+
+    handlers.upsert(0, { name: 'filters[applicationInstanceId][notIn][]', value: '3,4', isDisabled: false })
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'filters',
+          value: {
+            applicationInstanceId: {
+              notIn: ['3', '4'],
+            },
+          },
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-0',
+      },
+    )
+  })
+
   it('keeps form-style array leaves verbatim when an unrelated sibling row is edited', () => {
     // Form-style object parameter (the query default) with an array property whose value carries a
     // meaningful comma, e.g. Spring pageable `sort=username,asc`. Splitting it into ['username','asc']

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.test.ts
@@ -498,6 +498,61 @@ describe('createParameterHandlers', () => {
     )
   })
 
+  it('treats a lone empty bracket group as a real key, not a stripped array marker', () => {
+    // Regression guard for the marker stripping: the display-only `[]` is only ever appended after a
+    // real path bracket (`filters[id][]`), so it always shows up as `][]`. A lone empty group
+    // (`filters[]`) is a genuine empty key and must keep its segment. Otherwise the rename collapses
+    // the path to `['filters']` and the value is written under the parameter name instead.
+    const parentParameter = {
+      name: 'filters',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+    } as const
+    const row: TableRow = {
+      name: 'filters[applicationInstanceId][in][]',
+      value: '1,2',
+      isDisabled: false,
+      originalParameter: parentParameter,
+      schema: { type: 'array', items: { type: 'string' } },
+      sourceParameterValuePath: ['applicationInstanceId', 'in'],
+    }
+    const onRenameExpandedRow = vi.fn()
+    const handlers = createParameterHandlers('query', mockEventBus, mockMeta, {
+      context: [row],
+      onRenameExpandedRow,
+    })
+
+    // The user renames the leaf to the empty key. The path is `['']`, not `['filters']`.
+    handlers.upsert(0, {
+      name: 'filters[]',
+      value: '1,2',
+      isDisabled: false,
+      shouldRenameExpandedRow: true,
+    })
+
+    expect(onRenameExpandedRow).toHaveBeenCalledWith(row, [''])
+    // `setValueAtPath` does not support empty keys, so the value is simply not stored — the point is
+    // that it is never misrouted to a `filters` key (which is what dropping the empty segment caused).
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'operation:upsert:parameter',
+      {
+        type: 'query',
+        payload: {
+          name: 'filters',
+          value: {},
+          isDisabled: false,
+        },
+        originalParameter: parentParameter,
+        meta: mockMeta,
+      },
+      {
+        skipUnpackProxy: true,
+        debounceKey: 'update:parameter-query-0',
+      },
+    )
+  })
+
   it('keeps expanded row values at their source path during partial key edits', () => {
     const parentParameter = {
       name: 'filter',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -15,16 +15,20 @@ type ParameterUpsertPayload = {
 
 const isEmptyValue = (value: unknown): boolean => value === undefined || value === null || value === ''
 
+/**
+ * Whether a row name carries the display-only deepObject array marker (`filters[id][in][]`). The
+ * marker is only ever appended after a real path bracket, so it always shows up as `][]`. That lets
+ * us tell it apart from a genuinely empty key: an interior empty (`filters[][in]`) or a lone empty
+ * group (`filters[]`, value path `['']`) is not a marker and keeps its segment.
+ */
+const hasArrayMarker = (name: string): boolean => name.endsWith('][]')
+
 /** Parse a parameter key like `filter[a][b]` into its path segments `['filter', 'a', 'b']`. */
 const parseBracketKey = (name: string): string[] => {
-  // Strip the trailing array marker first. The trailing brackets on a deepObject array leaf
-  // (`filters[id][in][]`) are display-only, not part of the value path — keeping them would add a
-  // bogus empty key that drops the value on write-back and corrupts rename tracking.
-  //
-  // The marker is only ever appended after a real path bracket, so it always shows up as `][]`. That
-  // lets us tell it apart from a genuinely empty key: an interior empty (`filters[][in]`) or a lone
-  // empty group (`filters[]`, value path `['']`) keeps its segment and still resolves to the right key.
-  const withoutArrayMarker = name.endsWith('][]') ? name.slice(0, -2) : name
+  // Strip the trailing array marker first. The trailing brackets on a deepObject array leaf are
+  // display-only, not part of the value path — keeping them would add a bogus empty key that drops
+  // the value on write-back and corrupts rename tracking.
+  const withoutArrayMarker = hasArrayMarker(name) ? name.slice(0, -2) : name
 
   const segments: string[] = []
   const head = withoutArrayMarker.match(/^[^[\]]*/)?.[0] ?? ''
@@ -96,9 +100,10 @@ const getExpandedObjectPayload = (
     // re-collapses it into a single `key[in]=1,2` entry instead of repeating `key[in][]=1&key[in][]=2`.
     //
     // The property schema is the primary signal, but renamed and unmapped rows clear it. Those rows
-    // still carry the display-only `[]` marker on their name, so fall back to it to keep recognizing
-    // the leaf as an array.
-    const leafSchema = contextRow.schema ?? (contextRow.name.endsWith('[]') ? ({ type: 'array' } as const) : undefined)
+    // still carry the display-only array marker on their name, so fall back to it to keep recognizing
+    // the leaf as an array. Use the same `][]` test as `parseBracketKey` so a genuinely empty key
+    // (`filters[]`) is not misread as an array and comma-split.
+    const leafSchema = contextRow.schema ?? (hasArrayMarker(contextRow.name) ? ({ type: 'array' } as const) : undefined)
     const leafValue = isDeepObjectParameter && leafSchema ? deSerializeSchemaValue(nextValue, leafSchema) : nextValue
 
     setValueAtPath(value, path, leafValue)

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -99,20 +99,20 @@ const getExpandedObjectPayload = (
     // ("1,2"). Coerce it back to an array before storing — otherwise deepObject serialization
     // re-collapses it into a single `key[in]=1,2` entry instead of repeating `key[in][]=1&key[in][]=2`.
     //
-    // A committed rename can turn the leaf into (or out of) an array, and at that point the row's
-    // `schema` and `name` both still describe the old key, so trust only the array marker on the
-    // freshly typed name. Renaming an array leaf to a scalar key must not store a one-element array.
-    //
-    // Otherwise the property schema is the primary signal, but renamed and unmapped rows clear it.
-    // Those rows still carry the display-only array marker on their name, so fall back to it to keep
-    // recognizing the leaf as an array. Use the same `][]` test as `parseBracketKey` so a genuinely
-    // empty key (`filters[]`) is not misread as an array and comma-split.
+    // The display-only `][]` marker is the authoritative array signal: a leaf gets it whenever its
+    // schema OR its stored value is an array, so it must win over a non-array property schema, which
+    // would otherwise skip the coercion and serialize the array comma-joined. A committed rename
+    // re-derives the marker from the freshly typed name, since the row's `schema` and `name` still
+    // describe the old key — renaming an array leaf to a scalar key must not store a one-element array.
+    // Non-array leaves fall back to the property schema so object leaves still coerce; renamed rows
+    // have no reliable schema, so they rely on the marker alone.
     const isCommittedRename = isEditedRow && Boolean(payload.shouldRenameExpandedRow)
-    const leafSchema = isCommittedRename
-      ? hasArrayMarker(payload.name)
-        ? ({ type: 'array' } as const)
-        : undefined
-      : (contextRow.schema ?? (hasArrayMarker(contextRow.name) ? ({ type: 'array' } as const) : undefined))
+    const hasArrayLeafMarker = hasArrayMarker(isCommittedRename ? payload.name : contextRow.name)
+    const leafSchema = hasArrayLeafMarker
+      ? ({ type: 'array' } as const)
+      : isCommittedRename
+        ? undefined
+        : contextRow.schema
     const leafValue = isDeepObjectParameter && leafSchema ? deSerializeSchemaValue(nextValue, leafSchema) : nextValue
 
     setValueAtPath(value, path, leafValue)

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -17,19 +17,22 @@ const isEmptyValue = (value: unknown): boolean => value === undefined || value =
 
 /** Parse a parameter key like `filter[a][b]` into its path segments `['filter', 'a', 'b']`. */
 const parseBracketKey = (name: string): string[] => {
+  // Strip the trailing array marker first. The trailing brackets on a deepObject array leaf
+  // (`filters[id][in][]`) are display-only, not part of the value path — keeping them would add a
+  // bogus empty key that drops the value on write-back and corrupts rename tracking.
+  //
+  // The marker is only ever appended after a real path bracket, so it always shows up as `][]`. That
+  // lets us tell it apart from a genuinely empty key: an interior empty (`filters[][in]`) or a lone
+  // empty group (`filters[]`, value path `['']`) keeps its segment and still resolves to the right key.
+  const withoutArrayMarker = name.endsWith('][]') ? name.slice(0, -2) : name
+
   const segments: string[] = []
-  const head = name.match(/^[^[\]]*/)?.[0] ?? ''
+  const head = withoutArrayMarker.match(/^[^[\]]*/)?.[0] ?? ''
   if (head) {
     segments.push(head)
   }
-  for (const match of name.matchAll(/\[([^\]]*)\]/g)) {
-    const segment = match[1] ?? ''
-    // Skip empty `[]` segments. The trailing brackets on a deepObject array leaf
-    // (`filters[id][in][]`) are display-only and are not part of the value path — keeping them would
-    // add a bogus empty key that drops the value on write-back and corrupts rename tracking.
-    if (segment !== '') {
-      segments.push(segment)
-    }
+  for (const match of withoutArrayMarker.matchAll(/\[([^\]]*)\]/g)) {
+    segments.push(match[1] ?? '')
   }
   return segments
 }

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -23,7 +23,13 @@ const parseBracketKey = (name: string): string[] => {
     segments.push(head)
   }
   for (const match of name.matchAll(/\[([^\]]*)\]/g)) {
-    segments.push(match[1] ?? '')
+    const segment = match[1] ?? ''
+    // Skip empty `[]` segments. The trailing brackets on a deepObject array leaf
+    // (`filters[id][in][]`) are display-only and are not part of the value path — keeping them would
+    // add a bogus empty key that drops the value on write-back and corrupts rename tracking.
+    if (segment !== '') {
+      segments.push(segment)
+    }
   }
   return segments
 }

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -89,11 +89,14 @@ const getExpandedObjectPayload = (
       : contextRow.sourceParameterValuePath
 
     // Rows always hold the string the user sees, so a deepObject array leaf arrives comma-joined
-    // ("1,2"). Coerce it back against the property schema before storing — otherwise deepObject
-    // serialization re-collapses it into a single `key[in]=1,2` entry instead of repeating
-    // `key[in][]=1&key[in][]=2`.
-    const leafValue =
-      isDeepObjectParameter && contextRow.schema ? deSerializeSchemaValue(nextValue, contextRow.schema) : nextValue
+    // ("1,2"). Coerce it back to an array before storing — otherwise deepObject serialization
+    // re-collapses it into a single `key[in]=1,2` entry instead of repeating `key[in][]=1&key[in][]=2`.
+    //
+    // The property schema is the primary signal, but renamed and unmapped rows clear it. Those rows
+    // still carry the display-only `[]` marker on their name, so fall back to it to keep recognizing
+    // the leaf as an array.
+    const leafSchema = contextRow.schema ?? (contextRow.name.endsWith('[]') ? ({ type: 'array' } as const) : undefined)
+    const leafValue = isDeepObjectParameter && leafSchema ? deSerializeSchemaValue(nextValue, leafSchema) : nextValue
 
     setValueAtPath(value, path, leafValue)
   }

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -99,11 +99,20 @@ const getExpandedObjectPayload = (
     // ("1,2"). Coerce it back to an array before storing — otherwise deepObject serialization
     // re-collapses it into a single `key[in]=1,2` entry instead of repeating `key[in][]=1&key[in][]=2`.
     //
-    // The property schema is the primary signal, but renamed and unmapped rows clear it. Those rows
-    // still carry the display-only array marker on their name, so fall back to it to keep recognizing
-    // the leaf as an array. Use the same `][]` test as `parseBracketKey` so a genuinely empty key
-    // (`filters[]`) is not misread as an array and comma-split.
-    const leafSchema = contextRow.schema ?? (hasArrayMarker(contextRow.name) ? ({ type: 'array' } as const) : undefined)
+    // A committed rename can turn the leaf into (or out of) an array, and at that point the row's
+    // `schema` and `name` both still describe the old key, so trust only the array marker on the
+    // freshly typed name. Renaming an array leaf to a scalar key must not store a one-element array.
+    //
+    // Otherwise the property schema is the primary signal, but renamed and unmapped rows clear it.
+    // Those rows still carry the display-only array marker on their name, so fall back to it to keep
+    // recognizing the leaf as an array. Use the same `][]` test as `parseBracketKey` so a genuinely
+    // empty key (`filters[]`) is not misread as an array and comma-split.
+    const isCommittedRename = isEditedRow && Boolean(payload.shouldRenameExpandedRow)
+    const leafSchema = isCommittedRename
+      ? hasArrayMarker(payload.name)
+        ? ({ type: 'array' } as const)
+        : undefined
+      : (contextRow.schema ?? (hasArrayMarker(contextRow.name) ? ({ type: 'array' } as const) : undefined))
     const leafValue = isDeepObjectParameter && leafSchema ? deSerializeSchemaValue(nextValue, leafSchema) : nextValue
 
     setValueAtPath(value, path, leafValue)

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -58,6 +58,13 @@ const getExpandedObjectPayload = (
 ): { name: string; value: Record<string, unknown>; isDisabled: boolean } => {
   const value: Record<string, unknown> = {}
 
+  // Only deepObject leaves use the comma-to-array coercion below. The trailing-bracket array
+  // convention (`key[]=1&key[]=2`) is deepObject-specific, and deepObject leaves never carry a
+  // meaningful comma. Form-style object parameters can (e.g. Spring `sort=username,asc`), so they
+  // keep their leaves verbatim.
+  const parameter = row.originalParameter
+  const isDeepObjectParameter = Boolean(parameter && 'style' in parameter && parameter.style === 'deepObject')
+
   for (const contextRow of context) {
     if (contextRow.originalParameter !== row.originalParameter || !contextRow.sourceParameterValuePath) {
       continue
@@ -81,10 +88,12 @@ const getExpandedObjectPayload = (
         : contextRow.sourceParameterValuePath
       : contextRow.sourceParameterValuePath
 
-    // Rows always hold the string the user sees, so an array leaf arrives comma-joined ("1,2").
-    // Coerce it back against the property schema before storing — otherwise deepObject/form
-    // serialization re-collapses it into a single `key=1,2` entry instead of repeating `key[]=1&key[]=2`.
-    const leafValue = contextRow.schema ? deSerializeSchemaValue(nextValue, contextRow.schema) : nextValue
+    // Rows always hold the string the user sees, so a deepObject array leaf arrives comma-joined
+    // ("1,2"). Coerce it back against the property schema before storing — otherwise deepObject
+    // serialization re-collapses it into a single `key[in]=1,2` entry instead of repeating
+    // `key[in][]=1&key[in][]=2`.
+    const leafValue =
+      isDeepObjectParameter && contextRow.schema ? deSerializeSchemaValue(nextValue, contextRow.schema) : nextValue
 
     setValueAtPath(value, path, leafValue)
   }

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-handlers.ts
@@ -1,5 +1,6 @@
 import { setValueAtPath } from '@scalar/helpers/object/set-value-at-path'
 import type { OperationExampleMeta, WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { deSerializeSchemaValue } from '@scalar/workspace-store/request-example'
 
 import type { TableRow } from '@/v2/blocks/request-block/components/RequestTableRow.vue'
 
@@ -74,7 +75,12 @@ const getExpandedObjectPayload = (
         : contextRow.sourceParameterValuePath
       : contextRow.sourceParameterValuePath
 
-    setValueAtPath(value, path, nextValue)
+    // Rows always hold the string the user sees, so an array leaf arrives comma-joined ("1,2").
+    // Coerce it back against the property schema before storing — otherwise deepObject/form
+    // serialization re-collapses it into a single `key=1,2` entry instead of repeating `key[]=1&key[]=2`.
+    const leafValue = contextRow.schema ? deSerializeSchemaValue(nextValue, contextRow.schema) : nextValue
+
+    setValueAtPath(value, path, leafValue)
   }
 
   return {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
@@ -184,6 +184,39 @@ describe('createParameterRows', () => {
     ])
   })
 
+  it('names an unmapped deepObject array leaf with the trailing bracket convention', () => {
+    // A value key the schema does not describe (e.g. after a rename) still serializes as an array,
+    // so the row must keep the `[]` marker even though it carries no schema.
+    const parameter: ParameterObject = {
+      name: 'filters',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+      schema: {
+        type: 'object',
+        properties: {
+          known: { type: 'string' },
+        },
+      },
+      examples: {
+        default: {
+          value: { notIn: [1, 2] },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    const rows = createParameterRows(parameter, 'default')
+    const unmapped = rows.find((row) => row.sourceParameterValuePath?.[0] === 'notIn')
+
+    expect(unmapped).toMatchObject({
+      name: 'filters[notIn][]',
+      value: '1,2',
+      schema: undefined,
+      sourceParameterValuePath: ['notIn'],
+    })
+  })
+
   it('round-trips edited expanded rows back through createParameterRows', () => {
     const parameter: ParameterObject = {
       name: 'pageable',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
@@ -139,6 +139,51 @@ describe('createParameterRows', () => {
     ])
   })
 
+  it('names deepObject array leaves with the trailing bracket convention', () => {
+    // Regression test for https://github.com/scalar/scalar/issues/9492
+    const inSchema = {
+      type: 'array',
+      items: { type: 'integer' },
+    } as const
+    const parameter: ParameterObject = {
+      name: 'filters',
+      in: 'query',
+      style: 'deepObject',
+      explode: true,
+      schema: {
+        type: 'object',
+        properties: {
+          applicationInstanceId: {
+            type: 'object',
+            properties: {
+              in: inSchema,
+            },
+          },
+        },
+      },
+      examples: {
+        default: {
+          value: { applicationInstanceId: { in: [1, 2] } },
+          'x-disabled': false,
+        },
+      },
+    }
+
+    expect(createParameterRows(parameter, 'default')).toStrictEqual([
+      {
+        name: 'filters[applicationInstanceId][in][]',
+        value: '1,2',
+        description: undefined,
+        schema: inSchema,
+        isRequired: false,
+        isDisabled: false,
+        originalParameter: parameter,
+        // The path stays bracket-free so edits reassemble the value object correctly.
+        sourceParameterValuePath: ['applicationInstanceId', 'in'],
+      },
+    ])
+  })
+
   it('round-trips edited expanded rows back through createParameterRows', () => {
     const parameter: ParameterObject = {
       name: 'pageable',

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -8,7 +8,7 @@ import type {
   ReferenceType,
   SchemaObject,
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-import { isObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
+import { isArraySchema, isObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
 
 import type { TableRow } from '../components/RequestTableRow.vue'
 import { getParameterSchema } from './get-parameter-schema'
@@ -241,11 +241,21 @@ const getExpandedPropertyRows = ({
       })
     }
 
+    const leafValue = getValueAtPath(value, path)
+
+    // deepObject array values serialize with the trailing-bracket convention
+    // (filter[ids][]=1&filter[ids][]=2), so mirror that in the displayed name. We base this on the
+    // resolved value too, since the schema can be a composition (anyOf) that hides the array type.
+    // The bracket is display-only — `sourceParameterValuePath` stays bracket-free so write-back
+    // still reassembles the value object correctly.
+    const displayName =
+      mode === 'deepObject' && (isArraySchema(resolvedPropertySchema) || Array.isArray(leafValue)) ? `${name}[]` : name
+
     return [
       toTableRow({
         parameter,
-        name,
-        value: getValueAtPath(value, path),
+        name: displayName,
+        value: leafValue,
         description: resolvedPropertySchema.description ?? parameter.description,
         schema: resolvedPropertySchema,
         isRequired: requiredProperties.has(propertyName),

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -119,6 +119,15 @@ const toTableRow = ({
 const getExpandedRowName = (parameter: ParameterObject, path: string[], mode: ExpansionMode): string =>
   mode === 'deepObject' ? `${parameter.name}${path.map((segment) => `[${segment}]`).join('')}` : (path[0] ?? '')
 
+/**
+ * Appends the display-only trailing `[]` to deepObject array leaves so the name matches the
+ * serialized `parent[ids][]=1&parent[ids][]=2` form. The bracket is display-only — the row's
+ * `sourceParameterValuePath` stays bracket-free. It also lets write-back recognize the leaf as an
+ * array even on renamed and unmapped rows, which carry no schema.
+ */
+const withArrayBracket = (name: string, mode: ExpansionMode, isArray: boolean): string =>
+  mode === 'deepObject' && isArray ? `${name}[]` : name
+
 /** Build the single-row representation used when a parameter is not expanded. */
 const toSingleParameterRow = (
   parameter: ParameterObject,
@@ -198,12 +207,14 @@ const getExpandedPropertyRows = ({
       // The value move is debounced, so until it lands the value still sits at the old schema path.
       // Fall back to it so the renamed row shows its value immediately instead of flickering empty.
       const renamedValue = getValueAtPath(value, renamedTo)
+      const effectiveValue = renamedValue === undefined ? getValueAtPath(value, path) : renamedValue
 
       return [
         toTableRow({
           parameter,
-          name: getExpandedRowName(parameter, renamedTo, mode),
-          value: renamedValue === undefined ? getValueAtPath(value, path) : renamedValue,
+          // The renamed key carries no schema, so the value's array-ness drives the `[]` marker.
+          name: withArrayBracket(getExpandedRowName(parameter, renamedTo, mode), mode, Array.isArray(effectiveValue)),
+          value: effectiveValue,
           description: parameter.description,
           // The renamed key no longer maps to the schema property, so it carries no schema.
           schema: undefined,
@@ -246,10 +257,7 @@ const getExpandedPropertyRows = ({
     // deepObject array values serialize with the trailing-bracket convention
     // (filter[ids][]=1&filter[ids][]=2), so mirror that in the displayed name. We base this on the
     // resolved value too, since the schema can be a composition (anyOf) that hides the array type.
-    // The bracket is display-only — `sourceParameterValuePath` stays bracket-free so write-back
-    // still reassembles the value object correctly.
-    const displayName =
-      mode === 'deepObject' && (isArraySchema(resolvedPropertySchema) || Array.isArray(leafValue)) ? `${name}[]` : name
+    const displayName = withArrayBracket(name, mode, isArraySchema(resolvedPropertySchema) || Array.isArray(leafValue))
 
     return [
       toTableRow({
@@ -326,18 +334,21 @@ const getUnmappedValueRows = ({
   // only suppresses empty schema suggestions, so it is intentionally not applied here.
   return collectValueLeafPaths(value, mode)
     .filter((path) => !seen.has(toPathKey(path)))
-    .map((path) =>
-      toTableRow({
+    .map((path) => {
+      const leafValue = getValueAtPath(value, path)
+
+      return toTableRow({
         parameter,
-        name: getExpandedRowName(parameter, path, mode),
-        value: getValueAtPath(value, path),
+        // No schema describes these rows, so the value's array-ness drives the `[]` marker.
+        name: withArrayBracket(getExpandedRowName(parameter, path, mode), mode, Array.isArray(leafValue)),
+        value: leafValue,
         description: parameter.description,
         schema: undefined,
         isRequired: false,
         isDisabled,
         sourceParameterValuePath: path,
-      }),
-    )
+      })
+    })
 }
 
 /**

--- a/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.ts
+++ b/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.ts
@@ -13,7 +13,7 @@ export const deSerializeParameter = (example: unknown, param: ParameterObject) =
     return deSerializeContentExample(example, Object.keys(param.content ?? {})[0] ?? '')
   }
   if ('schema' in param) {
-    return deSerializeSchemaExample(example, param.schema)
+    return deSerializeSchemaValue(example, param.schema)
   }
 
   return example
@@ -76,12 +76,18 @@ const getStructuredType = (schema: unknown): 'array' | 'object' | undefined => {
 }
 
 /**
- * Schema-based parameters from the request editor.
+ * Coerces a single schema-typed value from the request editor (always a string from CodeInput)
+ * back into the structure its schema describes.
  *
- * Primitives (`string`, `integer`, `number`, `boolean`, `null`) are left as the typed string
+ * Primitives (`string`, `integer`, `number`, `boolean`, `null`) are left as the typed string.
  * Only `array` and `object` values are parsed so OpenAPI style serialization can expand them.
+ *
+ * Exposed on its own (not just through {@link deSerializeParameter}) so callers that reassemble an
+ * expanded object parameter from individual rows — e.g. a `deepObject` query parameter edited row by
+ * row in the API client — can coerce each leaf against its property schema. Otherwise an edited array
+ * leaf stays the comma-joined display string and collapses back into a single `key=1,2` entry.
  */
-const deSerializeSchemaExample = (example: unknown, schema: ParameterWithSchemaObject['schema']) => {
+export const deSerializeSchemaValue = (example: unknown, schema: ParameterWithSchemaObject['schema']) => {
   if (typeof example === 'string') {
     const type = getStructuredType(schema)
 

--- a/packages/workspace-store/src/request-example/builder/index.ts
+++ b/packages/workspace-store/src/request-example/builder/index.ts
@@ -10,7 +10,7 @@ export {
   buildRequest,
   resolveExecutableRequestUrl,
 } from './build-request'
-export { deSerializeParameter } from './header/de-serialize-parameter'
+export { deSerializeParameter, deSerializeSchemaValue } from './header/de-serialize-parameter'
 export { filterGlobalCookie } from './header/filter-global-cookies'
 export { isParamDisabled } from './header/is-param-disabled'
 export {

--- a/packages/workspace-store/src/request-example/index.ts
+++ b/packages/workspace-store/src/request-example/index.ts
@@ -25,6 +25,7 @@ export {
   buildRequest,
   buildRequestSecurity,
   deSerializeParameter,
+  deSerializeSchemaValue,
   filterGlobalCookie,
   getEnvironmentVariables,
   getExample,


### PR DESCRIPTION
Follow-up to #9583. The parameter table showed `filters[id][in]`, which no longer matched the request. Now array leaves show the trailing `[]` too.

The bracket is display-only — the value path stays bracket-free, so editing a row still works and round-trips as an array.

## Ticket

Part of #9492

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query-parameter edit and serialization paths for expanded object params; mistakes could alter emitted URLs, though scope is limited to deepObject vs form and is heavily tested.
> 
> **Overview**
> Expanded **`deepObject`** query parameter rows now append a display-only **`[]`** on array leaves (e.g. `filters[id][in][]`) so names match serialized `key[]=1&key[]=2` query strings. **`sourceParameterValuePath`** stays bracket-free so reassembly and renames still work.
> 
> On write-back, **`create-parameter-handlers`** strips the **`][]`** marker when parsing keys, uses it (plus schema when present) to coerce comma-joined cell text back to **arrays** for **`deepObject`** only, and leaves **form-style** object params unchanged so values like `sort=username,asc` are not split. **`deSerializeSchemaValue`** is exported from **`workspace-store`** for per-leaf coercion.
> 
> Regression tests cover row naming, edit round-trip, renames, and form vs deepObject behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5a3d390abb9dedb41e66b75fbedc1f9e5698529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->