### PR TITLE
fix(api-reference): prevent stack overflow on `allOf` self-references

### DIFF
--- a/.changeset/witty-pugs-grin.md
+++ b/.changeset/witty-pugs-grin.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix `Maximum call stack size exceeded` crash when rendering a schema whose self-reference is reached through an `allOf` branch

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
@@ -1236,4 +1236,32 @@ describe('mergeAllOfSchemas', () => {
 
     expect(() => mergeAllOfSchemas({ allOf: [node, node] } as any)).not.toThrow()
   })
+
+  it('does not infinitely recurse when a self-reference is reached through allOf', () => {
+    // Reproduces https://github.com/scalar/scalar/issues/9570: a schema whose
+    // self-reference sits inside an `allOf` branch (common output from tools
+    // that model TypeScript inheritance as `allOf`).
+    //
+    //   Node:
+    //     allOf:
+    //       - { type: object, properties: { name: { type: string } } }
+    //       - { type: object, properties: { self: { $ref: '#/components/schemas/Node' } } }
+    //
+    // `self` only ever appears as a brand-new property, so it took the
+    // unguarded new-property branch and recursed forever.
+    const node: any = {
+      allOf: [
+        { type: 'object', properties: { name: { type: 'string' } } },
+        {
+          type: 'object',
+          properties: {
+            self: { $ref: '#/components/schemas/Node', '$ref-value': null },
+          },
+        },
+      ],
+    }
+    node.allOf[1].properties.self['$ref-value'] = node
+
+    expect(() => mergeAllOfSchemas(node)).not.toThrow()
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
@@ -230,9 +230,23 @@ const mergePropertiesIntoResult = (
     }
 
     if (!result[key]) {
+      // Break self-referential cycles reached through `allOf`. When a brand-new
+      // property's `$ref` is already being merged higher in the call stack,
+      // keep the raw reference instead of recursing into its `allOf` forever.
+      // This mirrors the guard in the "merge existing property" branch below and
+      // covers schemas that point back at themselves through an `allOf` member
+      // (e.g. a node whose `self` property $refs the node, which is an allOf).
+      const rawProperty = properties[key]
+      const newSchemaRef = (rawProperty as { $ref?: string })?.$ref
+      if (rawProperty && typeof newSchemaRef === 'string' && seenRefs.has(newSchemaRef)) {
+        result[key] = rawProperty
+        continue
+      }
+      const nextNewSeenRefs = typeof newSchemaRef === 'string' ? new Set(seenRefs).add(newSchemaRef) : seenRefs
+
       // Handle new property with allOf
       if (schema.allOf) {
-        result[key] = mergeAllOfSchemas(schema, undefined, seenRefs)
+        result[key] = mergeAllOfSchemas(schema, undefined, nextNewSeenRefs)
       } else if (isArraySchema(schema) && resolve.schema(schema.items)?.allOf) {
         result[key] = {
           ...schema,


### PR DESCRIPTION
A schema whose self-reference is reached through an `allOf` branch crashed the model renderer with `RangeError: Maximum call stack size exceeded`. A plain recursive `$ref` already rendered fine — only the `allOf` path blew up.

The cause is in `mergeAllOfSchemas`: `mergePropertiesIntoResult` guards its *existing property* branch against self-referential `$ref`s, but not its *new property* branch. The repro's `self` property only appears once, so it always took the unguarded branch and recursed forever.

The fix applies the same `seenRefs` guard to that branch and keeps the raw `$ref` when a cycle is detected, so the renderer's existing cycle detection bounds it. Verified the crash reproduces in a unit test (no rendering) and is gone after the fix; existing merge tests still pass.

## Ticket

Fixes #9570

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized fix in schema merge logic with a targeted regression test; behavior for non-cyclic schemas should match prior merge paths.
> 
> **Overview**
> Fixes a **Maximum call stack size exceeded** crash when the API reference merges and renders schemas whose self-`$ref` appears only on a **new** property inside an `allOf` branch (typical of TypeScript inheritance → OpenAPI).
> 
> `mergePropertiesIntoResult` already stopped cycles when merging an **existing** property or array items; the **first-time** property path could still call `mergeAllOfSchemas` on the resolved `$ref-value` without checking `seenRefs`, so a node like `self: { $ref: Node }` on an `allOf` member recursed forever.
> 
> The change adds the same guard: if the new property’s `$ref` is already in `seenRefs`, keep the raw property; otherwise pass an updated `seenRefs` into nested `mergeAllOfSchemas`. A unit test reproduces issue #9570; the changeset records a patch for `@scalar/api-reference`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47306f8906bb8e93e544c734d3eebffa6a91c71e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->