### PR TITLE
fix(docusaurus): preserve function config options like `onBeforeRequest`

### DIFF
--- a/.changeset/fix-docusaurus-onbeforerequest.md
+++ b/.changeset/fix-docusaurus-onbeforerequest.md
@@ -1,0 +1,6 @@
+---
+'@scalar/client-side-rendering': minor
+'@scalar/docusaurus': patch
+---
+
+Fix function-valued configuration options (like `onBeforeRequest` and the request hooks) being dropped in the Docusaurus integration. Docusaurus JSON-serializes route props, which silently strips functions, so the config is now serialized to JavaScript in the plugin and injected as a script. Exposes a reusable `serializeConfigToJs` helper from `@scalar/client-side-rendering`.

--- a/integrations/docusaurus/package.json
+++ b/integrations/docusaurus/package.json
@@ -54,6 +54,7 @@
     }
   },
   "dependencies": {
+    "@scalar/client-side-rendering": "workspace:*",
     "@scalar/types": "workspace:*"
   },
   "devDependencies": {

--- a/integrations/docusaurus/src/ScalarDocusaurus.tsx
+++ b/integrations/docusaurus/src/ScalarDocusaurus.tsx
@@ -1,12 +1,17 @@
-import type { AnyApiReferenceConfiguration, CreateApiReference } from '@scalar/types'
+import type { CreateApiReference } from '@scalar/types'
 import Layout from '@theme/Layout'
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useId, useRef } from 'react'
 
 import './theme.css'
 
 type Props = {
   route: {
-    configuration: AnyApiReferenceConfiguration
+    /**
+     * The API reference configuration, pre-serialized in the plugin (Node) to a JavaScript object
+     * literal string. We cannot receive it as a plain object because Docusaurus JSON-serializes route
+     * props, which drops function-valued options like `onBeforeRequest`. See issue #6933.
+     */
+    configuration: string
     /** Not sure where the route type is for docusaurus, couldn't find one with an ID, TODO: replace with that */
     id: string
   }
@@ -23,19 +28,31 @@ declare global {
 
 export const ScalarDocusaurus = ({ route }: Props) => {
   const ref = useRef<HTMLDivElement>(null)
+  const id = useId()
 
   useEffect(() => {
     if (!window.Scalar || !ref.current) {
       return
     }
 
-    // Create a new Scalar API Reference
-    window.Scalar.createApiReference(ref.current, { ...route.configuration, hideDarkModeToggle: true })
-  }, [ref])
+    // Inject the init call as a real <script> so the browser parses the serialized configuration —
+    // including any functions — as live JavaScript. Passing it as a prop is not an option, because
+    // functions do not survive Docusaurus' JSON serialization of route props (see #6933).
+    const script = document.createElement('script')
+    script.textContent = `window.Scalar.createApiReference(document.getElementById(${JSON.stringify(id)}), ${route.configuration})`
+    document.body.appendChild(script)
+
+    return () => {
+      script.remove()
+    }
+  }, [id, route.configuration])
 
   return (
     <Layout>
-      <div ref={ref} />
+      <div
+        id={id}
+        ref={ref}
+      />
     </Layout>
   )
 }

--- a/integrations/docusaurus/src/index.test.ts
+++ b/integrations/docusaurus/src/index.test.ts
@@ -455,6 +455,81 @@ describe('ScalarDocusaurus', () => {
       expect(route.configuration).toContain('"url": "https://example.com/openapi.json"')
     })
 
+    it('evaluates a function-valued content at build time instead of shipping it to the browser', () => {
+      const mockContext = {
+        siteConfig: {
+          baseUrl: '/',
+          themeConfig: {
+            navbar: {
+              items: [],
+            },
+          },
+        },
+      } as any
+
+      const mockActions = {
+        addRoute: vi.fn(),
+      } as any
+
+      const plugin = ScalarDocusaurus(mockContext, {
+        label: 'Scalar',
+        route: '/scalar',
+      })
+
+      plugin.contentLoaded?.({
+        content: {
+          configuration: {
+            content: () => ({ openapi: '3.1.0', info: { title: 'Generated', version: '1.0.0' } }),
+          },
+        } as any,
+        actions: mockActions,
+      })
+
+      const route = mockActions.addRoute.mock.calls[0][0]
+
+      // The function ran in Node and only its result is serialized, so no callback leaks into the browser.
+      expect(route.configuration).toContain('"openapi": "3.1.0"')
+      expect(route.configuration).toContain('"title": "Generated"')
+      expect(route.configuration).not.toContain('=>')
+    })
+
+    it('drops content when a url is also provided, matching the CDN HTML path', () => {
+      const mockContext = {
+        siteConfig: {
+          baseUrl: '/',
+          themeConfig: {
+            navbar: {
+              items: [],
+            },
+          },
+        },
+      } as any
+
+      const mockActions = {
+        addRoute: vi.fn(),
+      } as any
+
+      const plugin = ScalarDocusaurus(mockContext, {
+        label: 'Scalar',
+        route: '/scalar',
+      })
+
+      plugin.contentLoaded?.({
+        content: {
+          configuration: {
+            url: 'https://example.com/openapi.json',
+            content: () => ({ openapi: '3.1.0' }),
+          },
+        } as any,
+        actions: mockActions,
+      })
+
+      const route = mockActions.addRoute.mock.calls[0][0]
+
+      expect(route.configuration).toContain('"url": "https://example.com/openapi.json"')
+      expect(route.configuration).not.toContain('content')
+    })
+
     it('uses default route when none specified', () => {
       const mockContext = {
         siteConfig: {

--- a/integrations/docusaurus/src/index.test.ts
+++ b/integrations/docusaurus/src/index.test.ts
@@ -400,15 +400,59 @@ describe('ScalarDocusaurus', () => {
         actions: mockActions,
       })
 
-      expect(mockActions.addRoute).toHaveBeenCalledWith(
+      // The configuration is serialized to a JavaScript object literal string so it survives
+      // Docusaurus' JSON serialization of route props.
+      const route = mockActions.addRoute.mock.calls[0][0]
+      expect(route).toEqual(
         expect.objectContaining({
           path: '/scalar',
           exact: true,
-          configuration: {
-            theme: 'purple',
-          },
         }),
       )
+      expect(typeof route.configuration).toBe('string')
+      expect(route.configuration).toContain('"theme": "purple"')
+    })
+
+    it('preserves function-valued configuration options through serialization', () => {
+      const mockContext = {
+        siteConfig: {
+          baseUrl: '/',
+          themeConfig: {
+            navbar: {
+              items: [],
+            },
+          },
+        },
+      } as any
+
+      const mockActions = {
+        addRoute: vi.fn(),
+      } as any
+
+      const plugin = ScalarDocusaurus(mockContext, {
+        label: 'Scalar',
+        route: '/scalar',
+      })
+
+      plugin.contentLoaded?.({
+        content: {
+          configuration: {
+            url: 'https://example.com/openapi.json',
+            onBeforeRequest: ({ request }: { request: Request }) => {
+              request.headers.set('Authorization', 'Bearer token')
+            },
+          },
+        } as any,
+        actions: mockActions,
+      })
+
+      const route = mockActions.addRoute.mock.calls[0][0]
+
+      // The callback survives as live JavaScript source instead of being dropped by JSON.stringify.
+      expect(route.configuration).toContain('onBeforeRequest')
+      expect(route.configuration).toContain('request.headers.set')
+      expect(route.configuration).toContain('Authorization')
+      expect(route.configuration).toContain('"url": "https://example.com/openapi.json"')
     })
 
     it('uses default route when none specified', () => {

--- a/integrations/docusaurus/src/index.ts
+++ b/integrations/docusaurus/src/index.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 
 import type { LoadContext, Plugin } from '@docusaurus/types'
 import { normalizeUrl } from '@docusaurus/utils'
+import { serializeConfigToJs } from '@scalar/client-side-rendering'
 import type { AnyApiReferenceConfiguration } from '@scalar/types'
 
 export type ScalarOptions = {
@@ -79,12 +80,19 @@ const ScalarDocusaurus = (
         })
       }
 
+      // Serialize the configuration to a JavaScript object literal here, in Node, while the config
+      // functions (onBeforeRequest, request hooks, sorters, …) are still live. Docusaurus JSON-serializes
+      // route props when it generates its routes module, which would otherwise silently drop every
+      // function-valued option. See https://github.com/scalar/scalar/issues/6933.
+      const givenConfiguration = content.configuration ?? {}
+      const configuration = Array.isArray(givenConfiguration) ? (givenConfiguration[0] ?? {}) : givenConfiguration
+
       // Add the appropriate route based on the module system
       addRoute({
         path: normalizeUrl([baseUrl, defaultOptions.route ?? '/scalar']),
         component: path.resolve(__dirname, './ScalarDocusaurus'),
         exact: true,
-        ...content,
+        configuration: serializeConfigToJs({ ...configuration, hideDarkModeToggle: true } as Record<string, unknown>),
       })
     },
   }

--- a/integrations/docusaurus/src/index.ts
+++ b/integrations/docusaurus/src/index.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import type { LoadContext, Plugin } from '@docusaurus/types'
 import { normalizeUrl } from '@docusaurus/utils'
-import { serializeConfigToJs } from '@scalar/client-side-rendering'
+import { getConfiguration, serializeConfigToJs } from '@scalar/client-side-rendering'
 import type { AnyApiReferenceConfiguration } from '@scalar/types'
 
 export type ScalarOptions = {
@@ -87,12 +87,20 @@ const ScalarDocusaurus = (
       const givenConfiguration = content.configuration ?? {}
       const configuration = Array.isArray(givenConfiguration) ? (givenConfiguration[0] ?? {}) : givenConfiguration
 
+      // Normalize the configuration in Node first, exactly like the CDN HTML path does: this evaluates a
+      // function-valued `content` at build time (it must not be shipped to the browser) and reconciles
+      // `content` vs `url`. Only then do we serialize the remaining live functions for the browser.
+      const normalizedConfiguration = getConfiguration({ ...configuration, hideDarkModeToggle: true } as Record<
+        string,
+        unknown
+      >)
+
       // Add the appropriate route based on the module system
       addRoute({
         path: normalizeUrl([baseUrl, defaultOptions.route ?? '/scalar']),
         component: path.resolve(__dirname, './ScalarDocusaurus'),
         exact: true,
-        configuration: serializeConfigToJs({ ...configuration, hideDarkModeToggle: true } as Record<string, unknown>),
+        configuration: serializeConfigToJs(normalizedConfiguration),
       })
     },
   }

--- a/packages/client-side-rendering/package.json
+++ b/packages/client-side-rendering/package.json
@@ -21,6 +21,7 @@
     "types:check": "tsgo --noEmit"
   },
   "type": "module",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/client-side-rendering/src/html-rendering.test.ts
+++ b/packages/client-side-rendering/src/html-rendering.test.ts
@@ -6,7 +6,7 @@ import type { ApiReferenceConfigurationWithSource } from '@scalar/types/api-refe
 import { coerce } from '@scalar/validation'
 import { describe, expect, it } from 'vitest'
 
-import { getConfiguration, getScriptTags, renderApiReference } from './html-rendering'
+import { getConfiguration, getScriptTags, renderApiReference, serializeConfigToJs } from './html-rendering'
 
 describe('html-rendering', () => {
   describe('renderApiReference', () => {
@@ -375,6 +375,30 @@ describe('html-rendering', () => {
     it('returns custom CDN URL when provided', () => {
       const { cdn } = coerce(htmlRenderingConfigurationSchema, { cdn: 'https://example.com/script.js' })
       expect(cdn).toBe('https://example.com/script.js')
+    })
+  })
+
+  describe('serializeConfigToJs', () => {
+    it('serializes a plain configuration to a JSON-like object literal', () => {
+      const result = serializeConfigToJs({ url: 'https://example.com/openapi.json', theme: 'purple' })
+      expect(result).toContain('"url": "https://example.com/openapi.json"')
+      expect(result).toContain('"theme": "purple"')
+    })
+
+    it('preserves functions as live JavaScript source', () => {
+      const result = serializeConfigToJs({
+        url: 'https://example.com/openapi.json',
+        onBeforeRequest: ({ request }: { request: Request }) => request.headers.set('Authorization', 'Bearer token'),
+      })
+      expect(result).toContain('onBeforeRequest')
+      expect(result).toContain('request.headers.set')
+      expect(result).toContain('Authorization')
+      expect(result).toContain('Bearer token')
+    })
+
+    it('serializes a config that only contains functions', () => {
+      const result = serializeConfigToJs({ onLoaded: () => undefined })
+      expect(result).toContain('"onLoaded":')
     })
   })
 

--- a/packages/client-side-rendering/src/html-rendering.ts
+++ b/packages/client-side-rendering/src/html-rendering.ts
@@ -141,12 +141,17 @@ const serializeArrayWithFunctions = (arr: unknown[]): string => {
 }
 
 /**
- * The script tags to load the @scalar/api-reference package from the CDN.
+ * Serialize a configuration object to a JavaScript object literal string.
  *
- * When a `nonce` is provided it is applied to both script tags so they are allowed under a strict
- * `script-src` Content Security Policy.
+ * Unlike `JSON.stringify`, this preserves function-valued properties (for example `onBeforeRequest`
+ * or the request hooks) by emitting them as literal JavaScript source via `Function.prototype.toString()`.
+ * That is what lets callbacks survive being written into an inline `<script>` tag, or across any other
+ * boundary that would otherwise JSON-serialize the configuration and silently drop functions.
+ *
+ * Note: functions must be arrow functions or `function` expressions. Object method shorthand
+ * (`onBeforeRequest(request) {}`) does not serialize to a valid standalone expression.
  */
-export function getScriptTags(configuration: Record<string, unknown>, cdn?: string, nonce?: string): string {
+export function serializeConfigToJs(configuration: Record<string, unknown>): string {
   const restConfig = { ...configuration }
 
   const functionProps: string[] = []
@@ -167,16 +172,26 @@ export function getScriptTags(configuration: Record<string, unknown>, cdn?: stri
     .map((line, index) => (index === 0 ? line : `      ${line}`))
     .join('\n')
 
-  let configString = indentedJsonString
-
-  if (functionProps.length > 0) {
-    if (jsonString === '{}') {
-      configString = `{\n        ${functionProps.join(',\n        ')}\n      }`
-    } else {
-      const jsonWithoutClosingBrace = indentedJsonString.split('\n').slice(0, -1).join('\n')
-      configString = `${jsonWithoutClosingBrace},\n        ${functionProps.join(',\n        ')}\n      }`
-    }
+  if (functionProps.length === 0) {
+    return indentedJsonString
   }
+
+  if (jsonString === '{}') {
+    return `{\n        ${functionProps.join(',\n        ')}\n      }`
+  }
+
+  const jsonWithoutClosingBrace = indentedJsonString.split('\n').slice(0, -1).join('\n')
+  return `${jsonWithoutClosingBrace},\n        ${functionProps.join(',\n        ')}\n      }`
+}
+
+/**
+ * The script tags to load the @scalar/api-reference package from the CDN.
+ *
+ * When a `nonce` is provided it is applied to both script tags so they are allowed under a strict
+ * `script-src` Content Security Policy.
+ */
+export function getScriptTags(configuration: Record<string, unknown>, cdn?: string, nonce?: string): string {
+  const configString = serializeConfigToJs(configuration)
 
   const nonceAttr = nonceAttribute(nonce)
 

--- a/packages/client-side-rendering/src/index.ts
+++ b/packages/client-side-rendering/src/index.ts
@@ -5,4 +5,5 @@ export {
   getConfiguration,
   getScriptTags,
   renderApiReference,
+  serializeConfigToJs,
 } from './html-rendering'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -760,6 +760,9 @@ importers:
 
   integrations/docusaurus:
     dependencies:
+      '@scalar/client-side-rendering':
+        specifier: workspace:*
+        version: link:../../packages/client-side-rendering
       '@scalar/types':
         specifier: workspace:*
         version: link:../../packages/types


### PR DESCRIPTION
`onBeforeRequest` (and every other function-valued config option) silently does nothing in the Docusaurus integration. The config is passed through Docusaurus' route props, which get JSON-serialized when it generates its routes module — and `JSON.stringify` drops functions. So the callback never reaches the browser.

Fix: serialize the configuration to a JS object literal in the plugin (in Node, while the functions are still live) and inject it as a `<script>` in the route component, so the browser parses the callbacks as real JavaScript. This reuses the same `Function.prototype.toString()` trick `@scalar/client-side-rendering` already uses for the CDN HTML output — now extracted into a shared `serializeConfigToJs` helper.

Affects all function options: `onBeforeRequest`, the request hooks, `redirect`, the `generate*Slug` callbacks, `tagsSorter`/`operationsSorter`, etc.

Note: callbacks must be arrow or `function` expressions (object method shorthand does not serialize to a valid expression) — same constraint the CDN output already has.

## Ticket

Fixes #6933

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces inline script injection with user-supplied function source at runtime; build-time normalization changes how `content`/`url` reach the browser but aligns with the CDN path.
> 
> **Overview**
> Fixes **function-valued API reference options** (`onBeforeRequest`, request hooks, sorters, etc.) being silently dropped in the Docusaurus plugin because route props are JSON-serialized.
> 
> The plugin now **normalizes config in Node** via `getConfiguration` (evaluates function `content`, reconciles `url` vs `content`, sets `hideDarkModeToggle`) and passes a **pre-serialized JS object literal string** on the route instead of a plain object. The route component **injects an inline `<script>`** that calls `createApiReference` with that literal so callbacks parse as live JavaScript.
> 
> **`@scalar/client-side-rendering`** extracts the existing CDN inline-script serialization into a shared **`serializeConfigToJs`** export; `getScriptTags` delegates to it. Docusaurus adds a dependency on that package. Tests cover serialization, function preservation, build-time `content`, and `url`/`content` handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 104717205050451f39cdea3157740916c078375f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->