### PR TITLE
feat(code-highlight): add Mojo syntax highlighting

### DIFF
--- a/.changeset/mojo-language-highlighting.md
+++ b/.changeset/mojo-language-highlighting.md
@@ -1,5 +1,6 @@
 ---
 '@scalar/code-highlight': minor
+'@scalar/components': patch
 ---
 
 Add syntax highlighting for the Mojo programming language

--- a/.changeset/mojo-language-highlighting.md
+++ b/.changeset/mojo-language-highlighting.md
@@ -1,0 +1,5 @@
+---
+'@scalar/code-highlight': minor
+---
+
+Add syntax highlighting for the Mojo programming language

--- a/packages/code-highlight/index.html
+++ b/packages/code-highlight/index.html
@@ -10,7 +10,7 @@
       @import '@scalar/themes/style.css';
 
       :root {
-        --scalar-font: 'Inter';
+        --scalar-font: 'Inter', sans-serif;
       }
 
       body {
@@ -28,6 +28,7 @@
         margin: 36px 0 10px;
         padding: 0;
         border: none;
+        font-family: var(--scalar-font);
         font-size: 12px;
         font-weight: var(--scalar-semibold, 600);
         letter-spacing: 0.08em;
@@ -52,11 +53,94 @@
         scrollbar-width: thin;
       }
 
+      /* ----------------------------------------------------------- */
+      /* Markdown demo typography                                     */
+      /* The code-highlight package only ships syntax-highlighting    */
+      /* CSS (code.css); prose styling lives in @scalar/components's  */
+      /* ScalarMarkdown component, so we mirror a small subset here   */
+      /* just for the demo.                                           */
+      .markdown {
+        font-family: var(--scalar-font);
+        line-height: 1.625;
+        color: var(--scalar-color-1);
+      }
+      .markdown > * + * {
+        margin-top: 16px;
+      }
+      .markdown h1,
+      .markdown h2,
+      .markdown h3,
+      .markdown h4,
+      .markdown h5,
+      .markdown h6 {
+        font-weight: var(--scalar-bold, 700);
+        line-height: 1.15;
+        margin: 24px 0 12px;
+      }
+      .markdown h1 {
+        font-size: 1.5rem;
+      }
+      .markdown h2,
+      .markdown h3 {
+        font-size: 1.25rem;
+      }
+      .markdown h4,
+      .markdown h5,
+      .markdown h6 {
+        font-size: 1rem;
+      }
+      .markdown a {
+        color: var(--scalar-color-blue);
+        text-decoration: underline;
+      }
+      .markdown ul,
+      .markdown ol {
+        padding-left: 1.6em;
+      }
+      .markdown ul {
+        list-style: disc;
+      }
+      .markdown ol {
+        list-style: decimal;
+      }
+      .markdown li + li {
+        margin-top: 4px;
+      }
+      .markdown blockquote {
+        margin: 0;
+        padding-left: 14px;
+        border-left: 3px solid var(--scalar-border-color);
+        color: var(--scalar-color-2);
+      }
+      .markdown hr {
+        border: none;
+        border-top: 1px solid var(--scalar-border-color);
+      }
+      .markdown :not(pre) > code {
+        display: inline;
+        width: auto;
+        padding: 2px 5px;
+        border-radius: var(--scalar-radius, 4px);
+        background-color: var(--scalar-background-3);
+        font-family: var(--scalar-font-code);
+        font-size: 0.875em;
+      }
+      .markdown table {
+        border-collapse: collapse;
+      }
+      .markdown th,
+      .markdown td {
+        border: 1px solid var(--scalar-border-color);
+        padding: 6px 10px;
+        text-align: left;
+      }
+
       #dark-mode-btn {
         border: none;
         box-shadow: 0 0 0 1px var(--scalar-background-3);
         background-color: transparent;
         color: var(--scalar-color-1);
+        font-family: var(--scalar-font);
         padding: 8px 14px;
         margin-bottom: 8px;
         border-radius: var(--scalar-radius);

--- a/packages/code-highlight/index.html
+++ b/packages/code-highlight/index.html
@@ -16,18 +16,38 @@
       body {
         background-color: var(--scalar-background-1);
         color: var(--scalar-color-1);
+        font-family: var(--scalar-font);
+        max-width: 880px;
+        margin: 0 auto;
+        padding: 24px 24px 80px;
       }
 
+      /* Section labels above each code block */
       .section-header {
-        font-size: 40px;
         display: block;
-        border: 1px dotted var(--scalar-color-1);
-        padding: 12px;
+        margin: 36px 0 10px;
+        padding: 0;
+        border: none;
+        font-size: 12px;
+        font-weight: var(--scalar-semibold, 600);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--scalar-color-3);
+      }
+
+      /* Simple card wrapper around each highlighted block */
+      .code-card {
+        background-color: var(--scalar-background-2);
+        border: 1px solid var(--scalar-border-color);
+        border-radius: var(--scalar-radius-lg, 12px);
+        padding: 14px 18px;
+        overflow: hidden;
       }
 
       code {
-        background-color: var(--scalar-background-2);
-        width: 500px;
+        display: block;
+        width: 100%;
+        background-color: transparent;
         overflow-x: auto;
         scrollbar-width: thin;
       }
@@ -37,8 +57,10 @@
         box-shadow: 0 0 0 1px var(--scalar-background-3);
         background-color: transparent;
         color: var(--scalar-color-1);
-        padding: 12px;
+        padding: 8px 14px;
+        margin-bottom: 8px;
         border-radius: var(--scalar-radius);
+        cursor: pointer;
         transition: box-shadow 0.2s linear;
       }
 
@@ -53,7 +75,7 @@
     </style>
     <script type="module"></script>
   </head>
-  <body class="dark-mode">
+  <body class="scalar-app dark-mode">
     <button
       id="dark-mode-btn"
       type="button">

--- a/packages/code-highlight/playground/main.ts
+++ b/packages/code-highlight/playground/main.ts
@@ -27,6 +27,7 @@ function createHeader(text: string) {
 function createCodeBlock(content: string, name: string, lang: string, mask?: string[]) {
   createHeader(name)
   const el = document.createElement('div')
+  el.classList.add('code-card')
   el.innerHTML = syntaxHighlight(content, {
     lang,
     languages: standardLanguages,
@@ -312,6 +313,46 @@ response = requests.post(url, json=payload, headers=headers)
 print(response.json())`
 
 createCodeBlock(py, 'Python', 'python')
+
+// ---------------------------------------------------------------------------
+// Mojo
+
+const mojo = String.raw`from collections import List
+
+alias WIDTH = 8
+alias Floats = SIMD[DType.float32, WIDTH]
+
+trait Greetable:
+    fn greet(self) -> String:
+        ...
+
+struct Planet(Greetable):
+    var name: String
+    var radius: Float64
+
+    fn __init__(out self, name: String, radius: Float64):
+        self.name = name
+        self.radius = radius
+
+    fn greet(self) -> String:
+        return "Hello from " + self.name
+
+fn scale(inout values: Floats, owned factor: Float32):
+    values = values * factor
+
+fn main() raises:
+    var planets = List[Planet]()
+    planets.append(Planet("Mars", 3389.5))
+
+    for i in range(len(planets)):
+        print(planets[i].greet())
+
+    var vec = Floats(1.0)
+    scale(vec, 2.0)
+    print(vec)`
+
+createCodeBlock(mojo, 'Mojo', 'mojo')
+
 // ---------------------------------------------------------------------------
 // Markdown render example
 

--- a/packages/code-highlight/playground/main.ts
+++ b/packages/code-highlight/playground/main.ts
@@ -358,6 +358,6 @@ createCodeBlock(mojo, 'Mojo', 'mojo')
 
 createHeader('Markdown')
 const markdown = document.createElement('div')
-markdown.classList.add('markdown')
+markdown.classList.add('code-card', 'markdown')
 markdown.innerHTML = await htmlFromMarkdown(markdownFile)
 document.body.appendChild(markdown)

--- a/packages/code-highlight/src/languages/mojo.test.ts
+++ b/packages/code-highlight/src/languages/mojo.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { syntaxHighlight } from '../code/highlight'
+import { standardLanguages } from './index'
+
+/**
+ * These tests cover the custom Mojo grammar, which extends the bundled
+ * highlight.js Python grammar with Mojo keywords, types, and call-site
+ * highlighting.
+ */
+describe('mojo', () => {
+  const highlight = (code: string) => syntaxHighlight(code, { lang: 'mojo', languages: standardLanguages })
+
+  it('highlights Mojo-specific declaration keywords', () => {
+    const result = highlight('fn main():\n    var x = 1')
+
+    expect(result).toContain('<span class="hljs-keyword">fn</span>')
+    expect(result).toContain('<span class="hljs-keyword">var</span>')
+  })
+
+  it('highlights struct and trait declarations', () => {
+    const result = highlight('struct Point:\n    pass\n\ntrait Drawable:\n    pass')
+
+    expect(result).toContain('<span class="hljs-keyword">struct</span>')
+    expect(result).toContain('<span class="hljs-keyword">trait</span>')
+  })
+
+  it('highlights argument-convention modifiers', () => {
+    const result = highlight('fn take(owned value: String, inout other: Int):\n    pass')
+
+    expect(result).toContain('<span class="hljs-keyword">owned</span>')
+    expect(result).toContain('<span class="hljs-keyword">inout</span>')
+  })
+
+  it('highlights Mojo standard-library types', () => {
+    const result = highlight('var total: Int = 0\nvar name: String = "scalar"')
+
+    expect(result).toContain('<span class="hljs-type">Int</span>')
+    expect(result).toContain('<span class="hljs-type">String</span>')
+  })
+
+  it('highlights call sites as function titles', () => {
+    const result = highlight('var data = response.json()\nprocess(data)')
+
+    expect(result).toContain('<span class="hljs-title function_">json</span>')
+    expect(result).toContain('<span class="hljs-title function_">process</span>')
+  })
+
+  it('still highlights Python control-flow keywords', () => {
+    const result = highlight('if x:\n    return y')
+
+    expect(result).toContain('<span class="hljs-keyword">if</span>')
+    expect(result).toContain('<span class="hljs-keyword">return</span>')
+  })
+})

--- a/packages/code-highlight/src/languages/mojo.ts
+++ b/packages/code-highlight/src/languages/mojo.ts
@@ -1,0 +1,129 @@
+import type { LanguageFn } from 'highlight.js'
+import basePython from 'highlight.js/lib/languages/python'
+
+/**
+ * Mojo grammar.
+ *
+ * highlight.js does not ship a Mojo grammar and there is no community package
+ * for it (the only upstream "mojo" grammar is the unrelated Perl Mojolicious
+ * framework). We build one here. Mojo is a superset of Python, so we start from
+ * the bundled Python grammar and layer on the extra keywords, argument-convention
+ * modifiers, and standard-library types that Mojo adds. The keyword and type
+ * lists mirror Modular's official TextMate grammar (github.com/modular/mojo-syntax).
+ *
+ * As with our custom Python grammar, we also colour call sites as function
+ * titles so that API snippets, which are mostly method calls, do not render as a
+ * wall of unstyled grey text.
+ */
+const mojo: LanguageFn = (hljs) => {
+  const language = basePython(hljs)
+  const { regex } = hljs
+
+  // Mirrors the identifier pattern used by the bundled Python grammar.
+  const IDENT_RE = /[\p{XID_Start}_]\p{XID_Continue}*/u
+
+  const keywords = language.keywords as {
+    keyword?: string[]
+    built_in?: string[]
+    literal?: string[]
+    type?: string[]
+  }
+
+  // Keywords Mojo adds on top of Python: declarations, argument-convention
+  // modifiers, function effects, and the comptime metaprogramming family.
+  const mojoKeywords = [
+    'fn',
+    'struct',
+    'trait',
+    'var',
+    'let',
+    'alias',
+    'comptime',
+    'owned',
+    'borrowed',
+    'inout',
+    'ref',
+    'mut',
+    'read',
+    'out',
+    'raises',
+    'capturing',
+  ]
+
+  // Capitalised standard-library types. Python's lowercase builtins (`int`,
+  // `str`, ...) already come from the base grammar; these are the Mojo stdlib
+  // types that would otherwise render unstyled.
+  const mojoTypes = [
+    'Int',
+    'UInt',
+    'Int8',
+    'Int16',
+    'Int32',
+    'Int64',
+    'UInt8',
+    'UInt16',
+    'UInt32',
+    'UInt64',
+    'Float16',
+    'Float32',
+    'Float64',
+    'Bool',
+    'String',
+    'StringLiteral',
+    'StringSlice',
+    'SIMD',
+    'DType',
+    'Scalar',
+    'List',
+    'Dict',
+    'Set',
+    'Tuple',
+    'Optional',
+    'Variant',
+    'Span',
+    'Pointer',
+    'UnsafePointer',
+    'Reference',
+    'Error',
+  ]
+
+  const dedupe = (...lists: string[][]): string[] => Array.from(new Set(lists.flat()))
+
+  const mergedKeywords = {
+    ...keywords,
+    keyword: dedupe(keywords.keyword ?? [], mojoKeywords),
+    type: dedupe(keywords.type ?? [], mojoTypes),
+  }
+
+  // Words the grammar already scopes. Leaving these out of the call-site rule
+  // keeps keywords, built-ins, literals, and types coloured as before. Relevance
+  // hints such as `nonlocal|10` are stripped so the regex stays valid.
+  const reserved = [
+    ...(mergedKeywords.keyword ?? []),
+    ...(keywords.built_in ?? []),
+    ...(keywords.literal ?? []),
+    ...(mergedKeywords.type ?? []),
+  ].map((word) => word.replace(/\|\d+$/, ''))
+
+  // Negative lookahead that rejects an excluded word when it is the thing being
+  // called, so it keeps its original scope. A word boundary asserts the
+  // identifier is not exactly a reserved word without a `\s*` quantifier, which
+  // would otherwise scan in polynomial time on untrusted input.
+  const notReserved = regex.concat('(?!(?:', reserved.join('|'), ')\\b)')
+
+  const functionCall = {
+    scope: 'title.function',
+    relevance: 0,
+    match: regex.concat(/\b/, notReserved, IDENT_RE, regex.lookahead(/\s*\(/)),
+  }
+
+  return {
+    ...language,
+    name: 'Mojo',
+    aliases: ['mojo', '🔥'],
+    keywords: mergedKeywords,
+    contains: [...(language.contains ?? []), functionCall],
+  }
+}
+
+export default mojo

--- a/packages/code-highlight/src/languages/mojo.ts
+++ b/packages/code-highlight/src/languages/mojo.ts
@@ -107,14 +107,17 @@ const mojo: LanguageFn = (hljs) => {
 
   // Negative lookahead that rejects an excluded word when it is the thing being
   // called, so it keeps its original scope. A word boundary asserts the
-  // identifier is not exactly a reserved word without a `\s*` quantifier, which
-  // would otherwise scan in polynomial time on untrusted input.
+  // identifier is not exactly a reserved word.
   const notReserved = regex.concat('(?!(?:', reserved.join('|'), ')\\b)')
 
+  // The call lookahead asserts a `(` immediately after the identifier. We do not
+  // allow whitespace before it (no `\s*`): the grammar runs this rule at every
+  // identifier in untrusted input, so an unbounded whitespace scan would make
+  // matching polynomial. Real call sites are written `foo(`, not `foo (`.
   const functionCall = {
     scope: 'title.function',
     relevance: 0,
-    match: regex.concat(/\b/, notReserved, IDENT_RE, regex.lookahead(/\s*\(/)),
+    match: regex.concat(/\b/, notReserved, IDENT_RE, regex.lookahead(/\(/)),
   }
 
   return {

--- a/packages/code-highlight/src/languages/standard.ts
+++ b/packages/code-highlight/src/languages/standard.ts
@@ -45,6 +45,7 @@ import xml from 'highlight.js/lib/languages/xml'
 import yaml from 'highlight.js/lib/languages/yaml'
 
 import curl from './curl'
+import mojo from './mojo'
 import python from './python'
 
 /**
@@ -95,6 +96,7 @@ export const standardLanguages = {
   makefile,
   markdown,
   matlab,
+  mojo,
   nginx,
   objectivec,
   ocaml,

--- a/packages/components/src/components/ScalarCodeBlock/constants.ts
+++ b/packages/components/src/components/ScalarCodeBlock/constants.ts
@@ -30,6 +30,7 @@ export const LANGUAGE_LABELS = {
   makefile: 'Makefile',
   markdown: 'Markdown',
   matlab: 'MATLAB',
+  mojo: 'Mojo',
   nginx: 'Nginx',
   objectivec: 'Objective-C',
   ocaml: 'OCaml',


### PR DESCRIPTION
Mojo wasn't highlighted because highlight.js doesn't ship a grammar for it.

Since Mojo is a superset of Python, this adds a small custom grammar that extends the bundled Python one with Mojo's keywords (`fn`, `struct`, `trait`, `var`, `alias`, ...), argument-convention modifiers (`owned`, `inout`, ...), and stdlib types (`Int`, `String`, `SIMD`, ...). Keyword/type lists mirror Modular's official TextMate grammar. It also colours call sites as function titles, same as our custom Python grammar.

Registered in `standardLanguages`, so it flows through to `ScalarCodeBlock` and everything downstream automatically.

<img width="870" height="759" alt="Screenshot 2026-06-23 at 12 11 23" src="https://github.com/user-attachments/assets/e8f87239-8ada-42ff-b0e5-ee7a4ed45f8b" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and grammar additions only; no auth, data, or API behavior changes. Slightly larger default language bundle from registering Mojo in standard languages.
> 
> **Overview**
> Adds **Mojo** as a first-class highlighted language in `@scalar/code-highlight`, wired through `standardLanguages` and the **Mojo** label in `ScalarCodeBlock`.
> 
> The new grammar extends the bundled **Python** highlight.js definition with Mojo-only keywords (e.g. `fn`, `struct`, `trait`, `var`, argument conventions), stdlib types (`Int`, `String`, `SIMD`, …), and call-site styling like the custom Python grammar. Vitest coverage asserts those scopes in the HTML output.
> 
> The code-highlight **demo page** is restyled (card layout, typography, markdown prose subset) and includes a Mojo sample block alongside the existing language gallery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edc8ee92f85f466b7055688fbec816e65cdaf402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->