### PR TITLE
feat(api-client): select multiple files for array form fields

### DIFF
--- a/.changeset/multi-file-upload.md
+++ b/.changeset/multi-file-upload.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client': minor
+---
+
+feat(api-client): select multiple files at once for array-typed form fields
+
+When a `multipart/form-data` field is declared as an array (e.g. `files: string[]`), the upload button now opens a multi-select picker. Each selected file becomes its own row reusing the field name, so the request sends one part per file (`files=@a`, `files=@b`) just like Postman.

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestBodyForm.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestBodyForm.test.ts
@@ -1,8 +1,10 @@
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
-import type { ExampleObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import type { ExampleObject, SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, readonly, ref } from 'vue'
+
+import { useFileDialog } from '@/hooks/use-file-dialog'
 
 import RequestBodyForm from './RequestBodyForm.vue'
 import RequestTable from './RequestTable.vue'
@@ -423,5 +425,80 @@ describe('RequestBodyForm', () => {
       // isDisabled should be false even though we tried to set it to true
       expect(newRow?.isDisabled).toBe(false)
     }
+  })
+
+  /** Build a FileList-like object from plain File instances for the file dialog mock. */
+  const toFileList = (files: File[]): FileList =>
+    ({
+      ...files,
+      length: files.length,
+      item: (index: number) => files[index] ?? null,
+      [Symbol.iterator]: function* () {
+        yield* files
+      },
+    }) as unknown as FileList
+
+  const arrayFieldSchema: SchemaObject = {
+    type: 'object',
+    properties: {
+      files: { type: 'array', items: { type: 'string', format: 'binary' } },
+    },
+  }
+
+  it('opens a multi-file picker for array-typed fields and adds one row per file', async () => {
+    const wrapper = mount(RequestBodyForm, {
+      props: {
+        example: { value: [{ name: 'files', value: '', isDisabled: false }] },
+        bodySchema: arrayFieldSchema,
+        selectedContentType: 'multipart/form-data',
+        environment: defaultEnvironment,
+      },
+    })
+    await nextTick()
+
+    await wrapper.findComponent(RequestTable).vm.$emit('uploadFile', 0)
+    await nextTick()
+
+    // The array field opts into a multi-select picker.
+    expect(vi.mocked(useFileDialog).mock.calls.at(-1)?.[0]?.multiple).toBe(true)
+
+    fileDialogOnChange?.(
+      toFileList([
+        new File(['a'], 'a.txt', { type: 'text/plain' }),
+        new File(['b'], 'b.txt', { type: 'text/plain' }),
+        new File(['c'], 'c.txt', { type: 'text/plain' }),
+      ]),
+    )
+    await nextTick()
+
+    const events = wrapper.emitted('update:formValue')
+    const lastEvent = events?.[events.length - 1]?.[0]
+    expect(Array.isArray(lastEvent)).toBe(true)
+    if (Array.isArray(lastEvent)) {
+      // Every selected file becomes its own row, all reusing the `files` field name.
+      expect(lastEvent).toHaveLength(3)
+      expect(lastEvent.map((row) => row.name)).toEqual(['files', 'files', 'files'])
+      expect(lastEvent.map((row) => (row.value as File).name)).toEqual(['a.txt', 'b.txt', 'c.txt'])
+    }
+  })
+
+  it('keeps the file picker single-select for non-array fields', async () => {
+    const wrapper = mount(RequestBodyForm, {
+      props: {
+        example: { value: [{ name: 'avatar', value: '', isDisabled: false }] },
+        bodySchema: {
+          type: 'object',
+          properties: { avatar: { type: 'string', format: 'binary' } },
+        },
+        selectedContentType: 'multipart/form-data',
+        environment: defaultEnvironment,
+      },
+    })
+    await nextTick()
+
+    await wrapper.findComponent(RequestTable).vm.$emit('uploadFile', 0)
+    await nextTick()
+
+    expect(vi.mocked(useFileDialog).mock.calls.at(-1)?.[0]?.multiple).toBe(false)
   })
 })

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestBodyForm.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestBodyForm.vue
@@ -83,21 +83,46 @@ const handleDeleteRow = (index: number) => {
   handleUpdateFormValue(localFormBodyRows.value)
 }
 
+/** True when the row's schema declares an array-typed property (e.g. `files: string[]`). */
+const isArrayField = (row: TableRow | undefined): boolean => {
+  const type = row?.schema && 'type' in row.schema ? row.schema.type : undefined
+  return Array.isArray(type) ? type.includes('array') : type === 'array'
+}
+
 /** Handle file upload for a specific row index */
 const handleFileUpload = (index: number) => {
+  const currentRow = localFormBodyRows.value[index]
+  // Array-typed fields (e.g. `files: string[]`) accept several files in a single pick, like
+  // Postman. Other fields stay single-file so an existing value is not silently replaced.
+  const allowMultiple = isArrayField(currentRow)
+
   const { open } = useFileDialog({
     onChange: (files) => {
-      const file = files?.[0]
+      const selected = files ? Array.from(files) : []
+      if (selected.length === 0) {
+        return
+      }
 
-      if (file) {
-        const currentRow = localFormBodyRows.value[index]
-        handleUpsertRow(index, {
-          name: currentRow?.name || file.name,
+      // Every selected file shares the field key, falling back to the first file name when
+      // the row has no name yet (e.g. schema-less requests).
+      const fieldName = currentRow?.name || selected[0]?.name || ''
+
+      // The first file fills the clicked row (handleUpsertRow appends if it is the new-row
+      // slot); any extras become additional rows reusing the same name, so the request sends
+      // one part per file (`files=@a`, `files=@b`) — the array/multipart wire shape.
+      handleUpsertRow(index, { name: fieldName, value: selected[0]! })
+
+      if (selected.length > 1) {
+        const extraRows: TableRow[] = selected.slice(1).map((file) => ({
+          name: fieldName,
           value: file,
-        })
+          isDisabled: false,
+        }))
+        localFormBodyRows.value = [...localFormBodyRows.value, ...extraRows]
+        handleUpdateFormValue(localFormBodyRows.value)
       }
     },
-    multiple: false,
+    multiple: allowMultiple,
     accept: '*/*',
   })
   open()


### PR DESCRIPTION
Array-typed multipart fields open a multi-select file picker. Each selected file becomes a separate neighboring row with the same field name, so the request sends one part per file. Single-file fields remain single-select. The selection is emitted in one update, preserving existing row metadata and neighboring fields.

With this API description, the `files` upload button previously selected one file at a time. It now accepts multiple files together:

```yaml
openapi: 3.0.4
info:
  title: Upload attachments
  version: 1.0.0
paths:
  /upload:
    post:
      requestBody:
        content:
          multipart/form-data:
            schema:
              type: object
              required: [files]
              properties:
                files:
                  type: array
                  items:
                    type: string
                    format: binary
                note:
                  type: string
      responses:
        '204':
          description: Uploaded
```

## Ticket

Part of #5553
