### PR TITLE
fix(api-client): respect per-operation security in the auth dropdown

### DIFF
--- a/.changeset/tidy-paths-grin.md
+++ b/.changeset/tidy-paths-grin.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: only offer the security schemes an operation actually declares
+
+The auth dropdown no longer lists every scheme from `components.securitySchemes`. In the reference docs and the request modal it now respects the operation's `security`: an operation with `security: []` offers no auth, and an operation that lists a subset of schemes only offers those. The standalone client keeps letting you attach any defined scheme.

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.test.ts
@@ -3,7 +3,6 @@ import { assert, describe, expect, it } from 'vitest'
 
 import {
   type SecuritySchemeGroup,
-  type SecuritySchemeOption,
   formatComplexScheme,
   formatScheme,
   getSecuritySchemeOptions,
@@ -421,7 +420,8 @@ describe('security-scheme', () => {
 
     it('should filter out required schemes from available options', () => {
       const security: NonNullable<OpenApiDocument['security']> = [{ apiKey: [] }]
-      const result = getSecuritySchemeOptions(security, securitySchemes, [])
+      // Offering schemes the operation does not declare only happens when arbitrary auth is allowed
+      const result = getSecuritySchemeOptions(security, securitySchemes, [], true)
 
       const groups = result as SecuritySchemeGroup[]
       const availableOptions = groups[1]!.options
@@ -464,7 +464,8 @@ describe('security-scheme', () => {
         undefinedScheme: undefined,
       } as unknown as NonNullable<ComponentsObject['securitySchemes']>
 
-      const result = getSecuritySchemeOptions(security, securitySchemesWithUndefined, [])
+      // Resolving every defined scheme into the available list only happens when arbitrary auth is allowed
+      const result = getSecuritySchemeOptions(security, securitySchemesWithUndefined, [], true)
 
       const groups = result as SecuritySchemeGroup[]
       const availableOptions = groups[1]!.options
@@ -649,14 +650,55 @@ describe('security-scheme', () => {
       expect(groups[2]!.options.length).toBeGreaterThan(0)
     })
 
-    it('should return flat available list when canAddNewAuth is false and no required schemes', () => {
+    it('returns no options for an empty security requirement when arbitrary auth is not allowed', () => {
+      // `security: []` removes the security declaration entirely, so nothing is selectable.
       const security: NonNullable<OpenApiDocument['security']> = []
       const result = getSecuritySchemeOptions(security, securitySchemes, [], false)
 
-      // Should return flat SecuritySchemeOption[] (not grouped)
+      // Should return a flat SecuritySchemeOption[] (not grouped) with no entries
       expect(Array.isArray(result)).toBe(true)
-      expect(result.length).toBe(4)
-      expect((result[0] as SecuritySchemeOption).label).toBe('apiKey')
+      expect(result).toHaveLength(0)
+    })
+
+    /**
+     * Regression tests for https://github.com/scalar/scalar/issues/7400
+     *
+     * When arbitrary auth is not allowed (reference docs and the request modal), the operation's
+     * declared `security` is authoritative. Schemes that merely exist under
+     * `components.securitySchemes` must not be offered, otherwise users can pick auth a request
+     * does not accept.
+     */
+    describe('respects the declared operation security (issue #7400)', () => {
+      it('offers nothing when the operation opts out with security: []', () => {
+        const security: NonNullable<OpenApiDocument['security']> = []
+        const result = getSecuritySchemeOptions(security, securitySchemes, [], false)
+
+        expect(result).toHaveLength(0)
+      })
+
+      it('offers only the declared scheme and not the other defined ones', () => {
+        const security: NonNullable<OpenApiDocument['security']> = [{ apiKey: [] }]
+        const result = getSecuritySchemeOptions(security, securitySchemes, [], false)
+
+        const groups = result as SecuritySchemeGroup[]
+        const required = groups[0]!.options
+        const available = groups[1]!.options
+
+        // Only the declared scheme is selectable
+        expect(required.map((option) => option.label)).toStrictEqual(['apiKey'])
+        // Schemes the operation does not declare are not offered
+        expect(available).toHaveLength(0)
+      })
+
+      it('offers every declared alternative when the operation lists multiple', () => {
+        const security: NonNullable<OpenApiDocument['security']> = [{ apiKey: [] }, { httpBasic: [] }]
+        const result = getSecuritySchemeOptions(security, securitySchemes, [], false)
+
+        const groups = result as SecuritySchemeGroup[]
+        const required = groups[0]!.options
+
+        expect(required.map((option) => option.label)).toStrictEqual(['apiKey', 'httpBasic'])
+      })
     })
 
     it('should handle when selected schemes do not exist in the available options but not duplicate them', () => {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.ts
@@ -118,18 +118,26 @@ export const getSecuritySchemeOptions = (
     },
   )
 
-  // Build available schemes (excluding schemes that are in the required list)
+  // Build available schemes (excluding schemes that are in the required list).
+  //
+  // We only offer schemes that are not declared by the operation when the user is
+  // allowed to attach arbitrary authentication (the standalone client). In the
+  // reference docs and the request modal, the operation's `security` is authoritative:
+  // per the OpenAPI spec, only the schemes a request lists may be used to authorize it,
+  // so a scheme that merely exists under `components.securitySchemes` must not be offered.
   const availableFormatted: SecuritySchemeOption[] = []
-  for (const [name, schemeRef] of Object.entries(securitySchemes)) {
-    if (requiredSchemeNames.has(name)) {
-      continue
-    }
+  if (canAddNewAuth) {
+    for (const [name, schemeRef] of Object.entries(securitySchemes)) {
+      if (requiredSchemeNames.has(name)) {
+        continue
+      }
 
-    const scheme = getResolvedRef(schemeRef)
-    if (scheme) {
-      const formatted = formatScheme({ name, value: { [name]: [] } })
-      availableFormatted.push(formatted)
-      existingIds.add(formatted.id)
+      const scheme = getResolvedRef(schemeRef)
+      if (scheme) {
+        const formatted = formatScheme({ name, value: { [name]: [] } })
+        availableFormatted.push(formatted)
+        existingIds.add(formatted.id)
+      }
     }
   }
 


### PR DESCRIPTION
The auth dropdown listed every scheme from `components.securitySchemes` for every operation, so users could pick auth a request does not accept — even on operations that opt out with `security: []`.

The OpenAPI spec is clear that an operation's `security` is the source of truth:

> Lists the required security schemes to execute this operation. The name used for each property MUST correspond to a security scheme declared in the Security Schemes under the Components Object.

> This definition overrides any declared top-level `security`. To remove a top-level security declaration, an empty array can be used.

Defining a scheme under `components.securitySchemes` only declares it — it does not make it usable on a request. So in the reference docs and the request modal the dropdown now offers only what the operation declares:

- `security: []` → no auth offered (e.g. the `Login` endpoint)
- a subset (e.g. `[{ BearerJwt: [] }]`) → only that scheme; others are no longer shown as "Available"
- multiple alternatives (e.g. `[{ ApiKey: [] }, { BearerJwt: [] }]`) → all of them selectable

The standalone client keeps letting you attach any defined scheme (`createAnySecurityScheme`), since that is an explicit testing affordance.

A follow-up PR will tidy the "Required" vs alternative labeling (OR-alternatives are currently all labeled "Required").

## Ticket

Fixes #7400

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request/auth UX in shared api-client logic; wrong gating could hide valid schemes or still expose invalid ones, but scope is limited to option building with solid regression tests.
> 
> **Overview**
> The auth dropdown no longer surfaces every entry in `components.securitySchemes` when the operation’s `security` should be authoritative (reference docs and the request modal).
> 
> **`getSecuritySchemeOptions`** now builds the “Available authentication” list from all defined schemes **only when** `canAddNewAuth` is true (standalone client via `createAnySecurityScheme`). When that flag is false, users see only schemes declared on the operation: **`security: []`** yields no options, a single declared scheme excludes the rest, and multiple OR-alternatives all remain selectable.
> 
> Standalone client behavior is unchanged—arbitrary schemes can still be attached for testing. Tests were adjusted for the new semantics and regression coverage was added for issue **#7400**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 988a8a7648246e24bae918a4921befe6e754a430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->