### PR TITLE
fix(api-client): present multiple security requirements as alternatives

### DIFF
--- a/.changeset/great-laws-attack.md
+++ b/.changeset/great-laws-attack.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: label multiple security requirements as alternatives instead of required
+
+When an operation lists more than one security requirement, those are OR-alternatives — only one needs to be satisfied. The auth dropdown no longer labels them all as "Required authentication"; it presents them as available choices. A single requirement (including a combined AND requirement) stays marked as required.

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.test.ts
@@ -159,7 +159,9 @@ describe('security-scheme', () => {
       },
     } satisfies ComponentsObject['securitySchemes']
 
-    it('should return grouped options', () => {
+    it('lists multiple requirements as available alternatives, not as required', () => {
+      // Two requirement objects are OR-alternatives: only one needs to be satisfied, so neither is
+      // individually required.
       const security: NonNullable<OpenApiDocument['security']> = [{ apiKey: [] }, { httpBasic: [] }]
 
       const result = getSecuritySchemeOptions(security, securitySchemes, [], true)
@@ -177,20 +179,39 @@ describe('security-scheme', () => {
       expect(groups[1].label).toBe('Available authentication')
       expect(groups[2].label).toBe('Add new authentication')
 
-      // Check required authentication options
-      expect(groups[0].options).toHaveLength(2)
+      // Nothing is required since the operation offers a choice
+      expect(groups[0].options).toHaveLength(0)
 
-      expect(groups[0].options[0]!.id).toBe('a4da7d48d8af6c6b')
-      expect(groups[0].options[1]!.id).toBe('0ebf7bc7501f14c3')
-
-      // Check available authentication options
-      expect(groups[1].options).toHaveLength(2)
+      // Both declared alternatives are available to pick from
+      expect(groups[1].options.some((opt) => opt.id === 'a4da7d48d8af6c6b')).toBe(true)
+      expect(groups[1].options.some((opt) => opt.id === '0ebf7bc7501f14c3')).toBe(true)
       expect(groups[1].options.some((opt) => opt.id === '48cc5a8ff1d2df93')).toBe(true)
       expect(groups[1].options.some((opt) => opt.id === '8da8c10db72dcac3')).toBe(true)
 
       // Check add new authentication options
       expect(groups[2].options.length).toBeGreaterThan(0)
       expect(groups[2].options.every((opt) => opt.isDeletable === false)).toBe(true)
+    })
+
+    it('keeps a single requirement marked as required', () => {
+      const security: NonNullable<OpenApiDocument['security']> = [{ apiKey: [] }]
+
+      const result = getSecuritySchemeOptions(security, securitySchemes, [], true)
+      const groups = result as SecuritySchemeGroup[]
+
+      expect(groups[0]!.label).toBe('Required authentication')
+      expect(groups[0]!.options.map((opt) => opt.label)).toStrictEqual(['apiKey'])
+    })
+
+    it('keeps a single combined (AND) requirement marked as required', () => {
+      // A single requirement with multiple schemes is an AND group, which is genuinely required.
+      const security: NonNullable<OpenApiDocument['security']> = [{ apiKey: [], httpBasic: [] }]
+
+      const result = getSecuritySchemeOptions(security, securitySchemes, [], true)
+      const groups = result as SecuritySchemeGroup[]
+
+      expect(groups[0]!.label).toBe('Required authentication')
+      expect(groups[0]!.options.map((opt) => opt.label)).toStrictEqual(['apiKey & httpBasic'])
     })
 
     it('should return all options when it has required schemes and no selected schemes', () => {
@@ -509,16 +530,15 @@ describe('security-scheme', () => {
       ])
     })
 
-    it('should create proper value objects for required schemes', () => {
+    it('builds correct value objects for declared alternatives', () => {
       const security: NonNullable<OpenApiDocument['security']> = [{ apiKey: [] }, { httpBasic: [] }]
 
       const result = getSecuritySchemeOptions(security, securitySchemes, [])
 
-      const groups = result as SecuritySchemeGroup[]
-      const requiredOptions = groups[0]!.options
-
-      expect(requiredOptions[0]!.value).toEqual({ apiKey: [] })
-      expect(requiredOptions[1]!.value).toEqual({ httpBasic: [] })
+      // Alternatives are returned as a flat list of available choices
+      const options = result as SecuritySchemeOption[]
+      expect(options.find((opt) => opt.label === 'apiKey')!.value).toEqual({ apiKey: [] })
+      expect(options.find((opt) => opt.label === 'httpBasic')!.value).toEqual({ httpBasic: [] })
     })
 
     it('should handle same scheme with different scopes', () => {
@@ -563,22 +583,20 @@ describe('security-scheme', () => {
       }
 
       const result = getSecuritySchemeOptions(security, securitySchemes, [])
-      expect(result[0]).toStrictEqual({
-        label: 'Required authentication',
-        options: [
-          {
-            id: '8c854cac163762c9',
-            label: 'UserAccessToken',
-            isDeletable: true,
-            value: { UserAccessToken: ['read'] },
-          },
-          {
-            id: 'f7e1089e69466df6',
-            label: 'UserAccessToken',
-            isDeletable: true,
-            value: { UserAccessToken: ['write'] },
-          },
-        ],
+
+      // The two scopes are alternatives, so they appear as distinct available choices
+      const options = result as SecuritySchemeOption[]
+      expect(options).toContainEqual({
+        id: '8c854cac163762c9',
+        label: 'UserAccessToken',
+        isDeletable: true,
+        value: { UserAccessToken: ['read'] },
+      })
+      expect(options).toContainEqual({
+        id: 'f7e1089e69466df6',
+        label: 'UserAccessToken',
+        isDeletable: true,
+        value: { UserAccessToken: ['write'] },
       })
     })
 

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.ts
@@ -145,14 +145,22 @@ export const getSecuritySchemeOptions = (
     }
   }
 
+  // Per the OpenAPI spec, multiple security requirement objects are alternatives: "only one of the
+  // entries in the list needs to be satisfied to authorize the request". So when an operation lists
+  // more than one requirement, none of them is individually required — they are a choice. We present
+  // them as available options instead of marking them all as required.
+  const declaredAreAlternatives = requiredFormatted.length > 1
+  const requiredOptions = declaredAreAlternatives ? [] : requiredFormatted
+  const availableOptions = declaredAreAlternatives ? [...requiredFormatted, ...availableFormatted] : availableFormatted
+
   const options = [
-    { label: 'Required authentication', options: requiredFormatted },
-    { label: 'Available authentication', options: availableFormatted },
+    { label: 'Required authentication', options: requiredOptions },
+    { label: 'Available authentication', options: availableOptions },
   ]
 
   // We don't return the groups if we don't have any required schemes
   if (!canAddNewAuth) {
-    return requiredFormatted.length ? options : availableFormatted
+    return requiredOptions.length ? options : availableOptions
   }
 
   // Add new authentication options (unless explicitly hidden)


### PR DESCRIPTION
Follow-up to #9592. When an operation lists more than one security requirement, the auth dropdown labeled them all "Required authentication" — implying you need every one. They are actually a choice.

The OpenAPI spec:

> When the `security` field is defined on the OpenAPI Object or Operation Object and contains multiple Security Requirement Objects, only one of the entries in the list needs to be satisfied to authorize the request.

So multiple requirements are OR-alternatives. They now show as available choices instead of "Required". A single requirement — including a combined `{ A: [], B: [] }` AND requirement — stays marked as required. This matches the read-only auth badge, which already says "one of:" for alternatives.

## Ticket

Part of #7400

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI labeling logic in the auth selector only; no request signing or credential handling changes, with behavior covered by updated unit tests.
> 
> **Overview**
> Fixes the auth dropdown so it matches OpenAPI semantics when an operation declares **more than one** security requirement object.
> 
> **`getSecuritySchemeOptions`** now treats multiple top-level requirements as **OR alternatives**: the "Required authentication" group is empty and those schemes appear under **Available authentication** instead of all being labeled required. A **single** requirement—including one object with multiple schemes (AND, e.g. `apiKey & httpBasic`)—still shows as required.
> 
> Tests and a patch changeset for `@scalar/api-client` document the behavior (including scope variants as alternatives).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61303d1c386b43b0d41b5c230fbe4d6a72718baa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->