### PR TITLE
fix(api-client): keep oauth2 scope selection in sync on quick clicks

### DIFF
--- a/.changeset/fix-oauth2-scope-selection-race.md
+++ b/.changeset/fix-oauth2-scope-selection-race.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-client': patch
+---
+
+Fix OAuth2 scope checkboxes losing selections on quick clicks. Each scope is now toggled against the stored selection instead of a list computed in the component, so the "Scopes Selected" counter and the scopes sent to the token endpoint stay in sync with the checkboxes.

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
@@ -85,7 +85,10 @@ const {
 }>()
 
 const emits = defineEmits<{
-  (e: 'update:selectedScopes', payload: { scopes: string[] }): void
+  (
+    e: 'update:selectedScopes',
+    payload: { scopes?: string[]; scope?: string; selected?: boolean },
+  ): void
   (
     e: 'upsert:scope',
     payload: Omit<ApiReferenceEvents['auth:upsert:scopes'], 'name'>,

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.test.ts
@@ -87,20 +87,24 @@ describe('OAuthScopesInput', () => {
 
     // Select first scope
     await rows[0]!.trigger('click')
-    const firstEmit = wrapper.emitted('update:selectedScopes')?.at(-1)?.[0] as any
-    expect(firstEmit?.scopes).toEqual(['read:items'])
+    expect(wrapper.emitted('update:selectedScopes')?.at(-1)?.[0]).toEqual({
+      scope: 'read:items',
+      selected: true,
+    })
 
-    // Simulate v-model by updating props
-    await wrapper.setProps({ selectedScopes: firstEmit.scopes })
+    // Simulate the parent applying the selection
+    await wrapper.setProps({ selectedScopes: ['read:items'] })
     await nextTick()
     expect(wrapper.text()).toContain('1 / 2')
 
     // Deselect first scope
     await rows[0]!.trigger('click')
-    const secondEmit = wrapper.emitted('update:selectedScopes')?.at(-1)?.[0] as any
-    expect(secondEmit?.scopes).toEqual([])
+    expect(wrapper.emitted('update:selectedScopes')?.at(-1)?.[0]).toEqual({
+      scope: 'read:items',
+      selected: false,
+    })
 
-    await wrapper.setProps({ selectedScopes: secondEmit.scopes })
+    await wrapper.setProps({ selectedScopes: [] })
     await nextTick()
     expect(wrapper.text()).toContain('0 / 2')
   })
@@ -142,16 +146,20 @@ describe('OAuthScopesInput', () => {
 
     // Check first scope
     await checkboxes[0]!.setValue(true)
-    const emit1 = wrapper.emitted('update:selectedScopes')?.at(-1)?.[0] as any
-    expect(emit1?.scopes).toEqual(['read:items'])
-    await wrapper.setProps({ selectedScopes: emit1.scopes })
+    expect(wrapper.emitted('update:selectedScopes')?.at(-1)?.[0]).toEqual({
+      scope: 'read:items',
+      selected: true,
+    })
+    await wrapper.setProps({ selectedScopes: ['read:items'] })
     await nextTick()
     expect(wrapper.text()).toContain('1 / 2')
 
     // Uncheck first scope
     await checkboxes[0]!.setValue(false)
-    const emit2 = wrapper.emitted('update:selectedScopes')?.at(-1)?.[0] as any
-    expect(emit2?.scopes).toEqual([])
+    expect(wrapper.emitted('update:selectedScopes')?.at(-1)?.[0]).toEqual({
+      scope: 'read:items',
+      selected: false,
+    })
   })
 
   it('emits delete:scope when the delete button is clicked and leaves selection cleanup to the store', async () => {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue
@@ -28,7 +28,10 @@ const { selectedScopes, flow, flowType } = defineProps<{
 }>()
 
 const emits = defineEmits<{
-  (e: 'update:selectedScopes', payload: { scopes: string[] }): void
+  (
+    e: 'update:selectedScopes',
+    payload: { scopes?: string[]; scope?: string; selected?: boolean },
+  ): void
   (
     e: 'upsert:scope',
     payload: Omit<ApiReferenceEvents['auth:upsert:scopes'], 'name'>,
@@ -87,17 +90,10 @@ const allScopesSelected = computed(
 )
 
 const setScope = (scopeKey: string, checked: boolean) => {
-  if (checked) {
-    // Select the scope
-    return emits('update:selectedScopes', {
-      scopes: Array.from(new Set([...selectedScopes, scopeKey])),
-    })
-  }
-
-  // Deselect the scope
-  emits('update:selectedScopes', {
-    scopes: selectedScopes.filter((scope) => scope !== scopeKey),
-  })
+  // Emit a single-scope toggle rather than a freshly computed list. The store applies it
+  // against the currently selected scopes, so two quick clicks cannot overwrite each other
+  // with a list computed from a prop that has not updated yet.
+  emits('update:selectedScopes', { scope: scopeKey, selected: checked })
 }
 
 /** Select all scopes */

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.vue
@@ -210,7 +210,7 @@ const handleApiKeySecuritySchemeUpdate = (
 /** Handles scope selection updates for OAuth2 */
 const handleScopesUpdate = (
   name: string,
-  event: { scopes: string[] },
+  event: { scopes?: string[]; scope?: string; selected?: boolean },
 ): void => {
   emits('update:selectedScopes', {
     id: Object.keys(selectedSecuritySchemas),

--- a/packages/workspace-store/src/events/definitions/auth.ts
+++ b/packages/workspace-store/src/events/definitions/auth.ts
@@ -127,14 +127,24 @@ export type AuthEvents = {
   /**
    * Update the selected scopes for a given security scheme.
    * Triggers when the user selects/deselects scopes for an OAuth2 (or other scopes-supporting) scheme in the UI.
+   *
+   * Provide exactly one of:
+   * - `scopes`: the absolute scope list (used by bulk actions like "Select All" / "Deselect All").
+   * - `scope` + `selected`: a single-scope toggle applied against the scopes currently stored in the
+   *   auth state. Toggling against the stored value (rather than a snapshot computed in the component)
+   *   keeps rapid successive clicks from racing and dropping each other's changes.
    */
   'auth:update:selected-scopes': {
     /** The id of the security scheme to update the scopes for */
     id: string[]
     /** The name of the security scheme to update the scopes for */
     name: string
-    /** The scopes to update the selected scopes with */
-    scopes: string[]
+    /** The absolute scope list to store. Used by bulk actions. */
+    scopes?: string[]
+    /** The single scope to toggle. Applied against the currently stored scopes. */
+    scope?: string
+    /** Whether the toggled `scope` should be selected (added) or deselected (removed). */
+    selected?: boolean
     /** Meta information for the auth update */
     meta: AuthMeta
   }

--- a/packages/workspace-store/src/events/definitions/auth.ts
+++ b/packages/workspace-store/src/events/definitions/auth.ts
@@ -128,20 +128,23 @@ export type AuthEvents = {
    * Update the selected scopes for a given security scheme.
    * Triggers when the user selects/deselects scopes for an OAuth2 (or other scopes-supporting) scheme in the UI.
    *
-   * Provide exactly one of:
-   * - `scopes`: the absolute scope list (used by bulk actions like "Select All" / "Deselect All").
-   * - `scope` + `selected`: a single-scope toggle applied against the scopes currently stored in the
-   *   auth state. Toggling against the stored value (rather than a snapshot computed in the component)
-   *   keeps rapid successive clicks from racing and dropping each other's changes.
+   * Provide either:
+   * - `scopes`: the absolute scope list (used by bulk actions like "Select All" / "Deselect All"), or
+   * - `scope` together with `selected`: a single-scope toggle applied against the scopes currently
+   *   stored in the auth state. Toggling against the stored value (rather than a snapshot computed in
+   *   the component) keeps rapid successive clicks from racing and dropping each other's changes.
+   *
+   * A payload that provides neither (or `scope` without `selected`) is ignored, so a malformed event
+   * can never silently clear the selection.
    */
   'auth:update:selected-scopes': {
     /** The id of the security scheme to update the scopes for */
     id: string[]
     /** The name of the security scheme to update the scopes for */
     name: string
-    /** The absolute scope list to store. Used by bulk actions. */
+    /** The absolute scope list to store. Used by bulk actions. Mutually exclusive with `scope`. */
     scopes?: string[]
-    /** The single scope to toggle. Applied against the currently stored scopes. */
+    /** The single scope to toggle. Applied against the currently stored scopes. Requires `selected`. */
     scope?: string
     /** Whether the toggled `scope` should be selected (added) or deselected (removed). */
     selected?: boolean

--- a/packages/workspace-store/src/mutators/auth.test.ts
+++ b/packages/workspace-store/src/mutators/auth.test.ts
@@ -1037,6 +1037,47 @@ describe('updateSelectedScopes', () => {
     assert(selected)
     expect(selected.selectedSchemes[0]).toEqual({ oauth2: ['read'] })
   })
+
+  it('ignores a single-scope payload that omits `selected` instead of deselecting', async () => {
+    const documentName = 'test'
+    const store = createWorkspaceStore()
+    await store.addDocument({ name: documentName, document: createDocument({}) })
+    store.auth.setAuthSelectedSchemas(
+      { type: 'document', documentName },
+      { selectedIndex: 0, selectedSchemes: [{ OAuth: ['read'] }] },
+    )
+
+    updateSelectedScopes(store, store.workspace.activeDocument!, {
+      id: ['OAuth'],
+      name: 'OAuth',
+      scope: 'read',
+      meta: { type: 'document' },
+    })
+
+    const selected = store.auth.getAuthSelectedSchemas({ type: 'document', documentName })
+    assert(selected)
+    expect(selected.selectedSchemes[0]).toEqual({ OAuth: ['read'] })
+  })
+
+  it('ignores a payload that provides neither `scopes` nor `scope` instead of clearing', async () => {
+    const documentName = 'test'
+    const store = createWorkspaceStore()
+    await store.addDocument({ name: documentName, document: createDocument({}) })
+    store.auth.setAuthSelectedSchemas(
+      { type: 'document', documentName },
+      { selectedIndex: 0, selectedSchemes: [{ OAuth: ['read', 'write'] }] },
+    )
+
+    updateSelectedScopes(store, store.workspace.activeDocument!, {
+      id: ['OAuth'],
+      name: 'OAuth',
+      meta: { type: 'document' },
+    })
+
+    const selected = store.auth.getAuthSelectedSchemas({ type: 'document', documentName })
+    assert(selected)
+    expect(selected.selectedSchemes[0]).toEqual({ OAuth: ['read', 'write'] })
+  })
 })
 
 describe('deleteSecurityScheme', () => {

--- a/packages/workspace-store/src/mutators/auth.test.ts
+++ b/packages/workspace-store/src/mutators/auth.test.ts
@@ -908,6 +908,135 @@ describe('updateSelectedScopes', () => {
     // selectedIndex from the stored target is preserved (the fallback would have recomputed it).
     expect(selected.selectedIndex).toBe(0)
   })
+
+  it('toggles a single scope on against the stored selection', async () => {
+    const documentName = 'test'
+    const store = createWorkspaceStore()
+    await store.addDocument({ name: documentName, document: createDocument({}) })
+    store.auth.setAuthSelectedSchemas(
+      { type: 'document', documentName },
+      { selectedIndex: 0, selectedSchemes: [{ OAuth: ['read'] }] },
+    )
+
+    updateSelectedScopes(store, store.workspace.activeDocument!, {
+      id: ['OAuth'],
+      name: 'OAuth',
+      scope: 'write',
+      selected: true,
+      meta: { type: 'document' },
+    })
+
+    const selected = store.auth.getAuthSelectedSchemas({ type: 'document', documentName })
+    assert(selected)
+    expect(selected.selectedSchemes[0]).toEqual({ OAuth: ['read', 'write'] })
+  })
+
+  it('toggles a single scope off against the stored selection', async () => {
+    const documentName = 'test'
+    const store = createWorkspaceStore()
+    await store.addDocument({ name: documentName, document: createDocument({}) })
+    store.auth.setAuthSelectedSchemas(
+      { type: 'document', documentName },
+      { selectedIndex: 0, selectedSchemes: [{ OAuth: ['read', 'write'] }] },
+    )
+
+    updateSelectedScopes(store, store.workspace.activeDocument!, {
+      id: ['OAuth'],
+      name: 'OAuth',
+      scope: 'read',
+      selected: false,
+      meta: { type: 'document' },
+    })
+
+    const selected = store.auth.getAuthSelectedSchemas({ type: 'document', documentName })
+    assert(selected)
+    expect(selected.selectedSchemes[0]).toEqual({ OAuth: ['write'] })
+  })
+
+  it('does not duplicate a scope that is already selected when toggled on', async () => {
+    const documentName = 'test'
+    const store = createWorkspaceStore()
+    await store.addDocument({ name: documentName, document: createDocument({}) })
+    store.auth.setAuthSelectedSchemas(
+      { type: 'document', documentName },
+      { selectedIndex: 0, selectedSchemes: [{ OAuth: ['read'] }] },
+    )
+
+    updateSelectedScopes(store, store.workspace.activeDocument!, {
+      id: ['OAuth'],
+      name: 'OAuth',
+      scope: 'read',
+      selected: true,
+      meta: { type: 'document' },
+    })
+
+    const selected = store.auth.getAuthSelectedSchemas({ type: 'document', documentName })
+    assert(selected)
+    expect(selected.selectedSchemes[0]).toEqual({ OAuth: ['read'] })
+  })
+
+  it('composes successive single-scope toggles without dropping earlier ones (issue #9589)', async () => {
+    // Reproduces the rapid-click race: each toggle is applied against the stored selection, so two
+    // quick clicks accumulate instead of the second overwriting the first with a stale snapshot.
+    const documentName = 'test'
+    const store = createWorkspaceStore()
+    await store.addDocument({ name: documentName, document: createDocument({}) })
+    store.auth.setAuthSelectedSchemas(
+      { type: 'document', documentName },
+      { selectedIndex: 0, selectedSchemes: [{ OAuth: [] }] },
+    )
+    const document = store.workspace.activeDocument!
+
+    updateSelectedScopes(store, document, {
+      id: ['OAuth'],
+      name: 'OAuth',
+      scope: 'read',
+      selected: true,
+      meta: { type: 'document' },
+    })
+    updateSelectedScopes(store, document, {
+      id: ['OAuth'],
+      name: 'OAuth',
+      scope: 'write',
+      selected: true,
+      meta: { type: 'document' },
+    })
+
+    const selected = store.auth.getAuthSelectedSchemas({ type: 'document', documentName })
+    assert(selected)
+    expect(selected.selectedSchemes[0]).toEqual({ OAuth: ['read', 'write'] })
+  })
+
+  it('toggles a single scope on the preferredSecurityScheme fallback when nothing is stored', async () => {
+    const documentName = 'test'
+    const store = createWorkspaceStore()
+    await store.addDocument({
+      name: documentName,
+      document: createDocument({
+        components: {
+          securitySchemes: {
+            oauth2: {
+              type: 'oauth2',
+              flows: { clientCredentials: { tokenUrl: 'https://example.com/token', refreshUrl: '', scopes: {} } },
+            },
+          },
+        },
+      }),
+    })
+
+    // Nothing stored — simulates preferredSecurityScheme. The first toggle must still land.
+    updateSelectedScopes(store, store.workspace.activeDocument!, {
+      id: ['oauth2'],
+      name: 'oauth2',
+      scope: 'read',
+      selected: true,
+      meta: { type: 'document' },
+    })
+
+    const selected = store.auth.getAuthSelectedSchemas({ type: 'document', documentName })
+    assert(selected)
+    expect(selected.selectedSchemes[0]).toEqual({ oauth2: ['read'] })
+  })
 })
 
 describe('deleteSecurityScheme', () => {

--- a/packages/workspace-store/src/mutators/auth.ts
+++ b/packages/workspace-store/src/mutators/auth.ts
@@ -394,7 +394,7 @@ const securityRequirementIdsMatch = (requirement: SecurityRequirementObject, id:
 export const updateSelectedScopes = (
   store: WorkspaceStore | null,
   document: WorkspaceDocument | null,
-  { id, name, scopes, meta }: AuthEvents['auth:update:selected-scopes'],
+  { id, name, scopes, scope, selected, meta }: AuthEvents['auth:update:selected-scopes'],
 ) => {
   const documentName = getAuthDocumentName(document)
   if (!documentName) {
@@ -434,7 +434,18 @@ export const updateSelectedScopes = (
   if (!isNonOptionalSecurityRequirement(nextScheme)) {
     return
   }
-  nextScheme[name] = scopes
+
+  // Apply a single-scope toggle against the stored value, or replace the whole list for bulk actions.
+  // Toggling against the stored scopes (instead of a list the component computed from a possibly-stale
+  // prop) is what keeps rapid successive clicks from overwriting each other.
+  if (scope !== undefined) {
+    const currentScopes = Array.isArray(nextScheme[name]) ? nextScheme[name] : []
+    nextScheme[name] = selected
+      ? Array.from(new Set([...currentScopes, scope]))
+      : currentScopes.filter((current) => current !== scope)
+  } else {
+    nextScheme[name] = scopes ?? []
+  }
 
   store?.auth.setAuthSelectedSchemas(
     meta.type === 'document'

--- a/packages/workspace-store/src/mutators/auth.ts
+++ b/packages/workspace-store/src/mutators/auth.ts
@@ -435,17 +435,25 @@ export const updateSelectedScopes = (
     return
   }
 
-  // Apply a single-scope toggle against the stored value, or replace the whole list for bulk actions.
-  // Toggling against the stored scopes (instead of a list the component computed from a possibly-stale
-  // prop) is what keeps rapid successive clicks from overwriting each other.
-  if (scope !== undefined) {
-    const currentScopes = Array.isArray(nextScheme[name]) ? nextScheme[name] : []
-    nextScheme[name] = selected
-      ? Array.from(new Set([...currentScopes, scope]))
-      : currentScopes.filter((current) => current !== scope)
-  } else {
-    nextScheme[name] = scopes ?? []
+  // Resolve the next scope list. A single-scope toggle (`scope` + `selected`) is applied against the
+  // value currently in the store, which is what keeps rapid successive clicks from overwriting each
+  // other with a list the component computed from a possibly-stale prop. Bulk actions pass an absolute
+  // `scopes` list instead. A payload carrying neither is ignored rather than silently clearing.
+  const resolveNextScopes = (): string[] | undefined => {
+    if (scope !== undefined && selected !== undefined) {
+      const currentScopes = Array.isArray(nextScheme[name]) ? nextScheme[name] : []
+      return selected
+        ? Array.from(new Set([...currentScopes, scope]))
+        : currentScopes.filter((current) => current !== scope)
+    }
+    return scopes
   }
+
+  const nextScopes = resolveNextScopes()
+  if (nextScopes === undefined) {
+    return
+  }
+  nextScheme[name] = nextScopes
 
   store?.auth.setAuthSelectedSchemas(
     meta.type === 'document'


### PR DESCRIPTION
Selecting/deselecting OAuth2 scopes quickly could drop changes: the "Scopes Selected X / Y" counter, the checkboxes, and the scopes sent to the token endpoint would disagree. Clicking two scopes in quick succession could silently lose one.

The component was emitting a freshly computed scope list built from a prop that had not updated yet, so a second click overwrote the first. Now it emits a single-scope toggle and the store applies it against the currently stored scopes, so successive clicks compose correctly.

Tested at the store level (`updateSelectedScopes`), including the rapid-toggle case and the `preferredSecurityScheme` fallback.

## Ticket

Part of #9589

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how OAuth2 scope selection is persisted and affects token authorization scope lists, but behavior is narrowly scoped with new store tests and safer handling of invalid payloads.
> 
> **Overview**
> Fixes a race where **rapid OAuth2 scope checkbox clicks** could drop selections: the UI counter, checkboxes, and scopes sent to the token endpoint could disagree (#9589).
> 
> **`OAuthScopesInput`** no longer builds and emits a full `scopes` array from the current prop on each click. Single-scope changes now emit **`{ scope, selected }`**; **Select All / Deselect All** still send an absolute **`scopes`** list.
> 
> **`updateSelectedScopes`** in the workspace store applies single-scope toggles against **scopes already in auth state** (not a component snapshot), so successive clicks compose. Payloads with neither `scopes` nor a valid `scope` + `selected` pair are **ignored** so malformed events cannot wipe the selection.
> 
> Component and store tests cover toggles, rapid successive updates, and the preferred-scheme fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc51aad38093fd09d1aa558188db0e4c41c96f17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->