### PR TITLE
fix(api-client): prevent oauth2 scope checkbox from toggling twice

### DIFF
--- a/.changeset/fix-oauth2-scope-row-double-toggle.md
+++ b/.changeset/fix-oauth2-scope-row-double-toggle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Clicking an OAuth2 scope checkbox no longer toggles the scope twice. The click no longer bubbles to the surrounding row, which had its own toggle handler.

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue
@@ -309,8 +309,14 @@ const handleDeleteScope = (scopeKey: string) => {
                       @click.stop="handleDeleteScope(id)" />
                   </div>
                 </DataTableCell>
+                <!--
+                  Stop the click here so it does not also bubble to the row's `@click`
+                  toggle. The checkbox already drives the change via `@update:modelValue`;
+                  letting the row fire too would toggle the scope a second time.
+                -->
                 <DataTableCheckbox
                   :modelValue="selectedScopes.includes(id)"
+                  @click.stop
                   @update:modelValue="setScope(id, $event)" />
               </DataTableRow>
             </table>


### PR DESCRIPTION
Clicking directly on an OAuth2 scope checkbox toggled the scope twice:
* once from the checkbox and 
* once from the surrounding row's click handler
 
which made the click land on the wrong state. 

The checkbox now stops the click from bubbling to the row.

## Ticket

Part of #9589

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI event-handling change in OAuth scope selection with no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes OAuth2 scope selection in the auth selector so **clicking the row checkbox** updates selection once instead of appearing to do nothing or flip the wrong way.
> 
> `DataTableRow` already toggles a scope on row click while `DataTableCheckbox` updates via `@update:modelValue`. A direct checkbox click used to **bubble to the row** and run both handlers, toggling twice. **`@click.stop`** on the checkbox stops that propagation; a short comment documents why.
> 
> Includes a **patch changeset** for `@scalar/api-client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a082dc3484789d932db84c879353a15d54a40ea6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->