### PR TITLE
fix(api-client): keep DataTableCheckbox in sync with its model value

### DIFF
--- a/.changeset/fix-datatable-checkbox-controlled.md
+++ b/.changeset/fix-datatable-checkbox-controlled.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Keep `DataTableCheckbox` visually in sync with its value. When a click does not end up changing `modelValue`, the checkbox now reverts to the model state instead of showing the browser's optimistic toggle.

--- a/.changeset/fix-datatable-checkbox-controlled.md
+++ b/.changeset/fix-datatable-checkbox-controlled.md
@@ -2,4 +2,4 @@
 '@scalar/api-client': patch
 ---
 
-Keep `DataTableCheckbox` visually in sync with its value. When a click does not end up changing `modelValue`, the checkbox now reverts to the model state instead of showing the browser's optimistic toggle.
+Keep `DataTableCheckbox` visually in sync with its value. The checkbox now mirrors `modelValue` onto the native input whenever the value settles, including when the parent updates it asynchronously, so a successful toggle no longer flickers back before the update lands.

--- a/packages/api-client/src/v2/components/data-table/DataTableCheckbox.test.ts
+++ b/packages/api-client/src/v2/components/data-table/DataTableCheckbox.test.ts
@@ -1,0 +1,48 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+
+import DataTableCheckbox from './DataTableCheckbox.vue'
+
+describe('DataTableCheckbox', () => {
+  it('reflects the initial model value', () => {
+    const wrapper = mount(DataTableCheckbox, { props: { modelValue: true } })
+
+    expect(wrapper.get<HTMLInputElement>('input').element.checked).toBe(true)
+  })
+
+  it('emits the new checked value on change', async () => {
+    const wrapper = mount(DataTableCheckbox, { props: { modelValue: false } })
+
+    await wrapper.get('input').setValue(true)
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[true]])
+  })
+
+  it('mirrors the model value once it settles', async () => {
+    const wrapper = mount(DataTableCheckbox, { props: { modelValue: false } })
+
+    await wrapper.setProps({ modelValue: true })
+
+    expect(wrapper.get<HTMLInputElement>('input').element.checked).toBe(true)
+  })
+
+  it('does not revert the optimistic toggle while an async update is in flight', async () => {
+    const wrapper = mount(DataTableCheckbox, { props: { modelValue: false } })
+    const input = wrapper.get<HTMLInputElement>('input')
+
+    // The native input flips itself immediately on click.
+    input.element.checked = true
+    await input.trigger('change')
+
+    // The parent has not updated `modelValue` yet (it travels through the async event bus),
+    // so the checkbox must keep the optimistic state rather than flicker back to the stale value.
+    await nextTick()
+    await flushPromises()
+    expect(input.element.checked).toBe(true)
+
+    // Once the update lands, the input still reflects the settled model value.
+    await wrapper.setProps({ modelValue: true })
+    expect(input.element.checked).toBe(true)
+  })
+})

--- a/packages/api-client/src/v2/components/data-table/DataTableCheckbox.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTableCheckbox.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { ScalarIcon } from '@scalar/components/icon'
 import { cva } from '@scalar/use-hooks/useBindCx'
+import { nextTick, ref } from 'vue'
 
 import DataTableCell from './DataTableCell.vue'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     modelValue: boolean
     disabled?: boolean
@@ -15,9 +16,27 @@ withDefaults(
   },
 )
 
-defineEmits<{
+const emit = defineEmits<{
   (e: 'update:modelValue', v: boolean): void
 }>()
+
+const input = ref<HTMLInputElement | null>(null)
+
+/**
+ * Clicking a native checkbox flips its `checked` state immediately, before the parent has a
+ * chance to accept (or reject) the change. When the parent leaves `modelValue` unchanged the
+ * `:checked` binding has nothing to patch, so the box would stay visually out of sync with the
+ * value it represents. Re-asserting `modelValue` after the update keeps the rendered state and
+ * the source of truth aligned in both the accepted and rejected cases.
+ */
+const onChange = (event: Event) => {
+  emit('update:modelValue', (event.target as HTMLInputElement).checked)
+  nextTick(() => {
+    if (input.value) {
+      input.value.checked = props.modelValue
+    }
+  })
+}
 
 const variants = cva({
   base: 'w-8 h-8 flex items-center justify-center text-b-2 peer-checked:text-c-1 pointer-events-none absolute',
@@ -32,11 +51,12 @@ const variants = cva({
 <template>
   <DataTableCell class="group/cell relative flex min-w-8">
     <input
+      ref="input"
       :checked="modelValue"
       class="peer absolute inset-0 size-full cursor-pointer opacity-0 disabled:cursor-default"
       :disabled="Boolean(disabled)"
       type="checkbox"
-      @change="(e: any) => $emit('update:modelValue', e.target.checked)" />
+      @change="onChange" />
     <div :class="variants({ align })">
       <div
         class="absolute m-auto size-3/4 rounded border-[1px] opacity-0"

--- a/packages/api-client/src/v2/components/data-table/DataTableCheckbox.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTableCheckbox.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ScalarIcon } from '@scalar/components/icon'
 import { cva } from '@scalar/use-hooks/useBindCx'
-import { nextTick, ref } from 'vue'
+import { ref, watch } from 'vue'
 
 import DataTableCell from './DataTableCell.vue'
 
@@ -23,19 +23,24 @@ const emit = defineEmits<{
 const input = ref<HTMLInputElement | null>(null)
 
 /**
- * Clicking a native checkbox flips its `checked` state immediately, before the parent has a
- * chance to accept (or reject) the change. When the parent leaves `modelValue` unchanged the
- * `:checked` binding has nothing to patch, so the box would stay visually out of sync with the
- * value it represents. Re-asserting `modelValue` after the update keeps the rendered state and
- * the source of truth aligned in both the accepted and rejected cases.
+ * Clicking a native checkbox flips its `checked` state immediately, before the parent has had a
+ * chance to accept (or reject) the change. Once the model settles, mirror it back onto the input
+ * so the rendered state and the source of truth stay aligned. Parents often update `modelValue`
+ * asynchronously (scope toggles travel through the async workspace event bus), so we react to the
+ * value landing rather than resetting on a fixed tick, which would revert a successful toggle
+ * before the update arrives and cause a visible flicker.
  */
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (input.value) {
+      input.value.checked = value
+    }
+  },
+)
+
 const onChange = (event: Event) => {
   emit('update:modelValue', (event.target as HTMLInputElement).checked)
-  nextTick(() => {
-    if (input.value) {
-      input.value.checked = props.modelValue
-    }
-  })
 }
 
 const variants = cva({


### PR DESCRIPTION
A native checkbox flips itself the instant you click it. If the parent then leaves `modelValue` unchanged, the `:checked` binding has nothing to patch and the box stays visually wrong. This re-asserts `modelValue` after each change so the checkbox always reflects the value it represents.

Defensive hardening — `DataTableCheckbox` is a shared base component, so this affects every checkbox in the client. It is a no-op wherever the model already tracks the value.

## Ticket

Part of #9589

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI fix in a shared checkbox component with tests; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes **data table checkboxes** that could **flicker or look wrong** after a click when the parent updates `modelValue` slowly (e.g. scope toggles on the async workspace event bus).
> 
> `DataTableCheckbox` now **watches `modelValue`** and writes it to the native input’s `checked` state when the value settles, so the UI stays aligned with the source of truth without snapping back while an update is in flight. Change handling is routed through a small `onChange` helper with an input `ref` instead of an inline template emit.
> 
> Adds **unit tests** for initial state, emit behavior, prop updates, and the async “optimistic toggle” case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cd0096da2071ba09f1a823057624737ea4690b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->