### PR TITLE
docs(navigation): add `singlePage` property for OpenAPI routes

### DIFF
--- a/.agents/skills/scalar-docs/SKILL.md
+++ b/.agents/skills/scalar-docs/SKILL.md
@@ -173,6 +173,17 @@ API reference from file, Registry, or URL:
 
 Display modes: `folder` (default), `flat`, `nested`.
 
+**Single page mode:** Set `singlePage: true` to render all operations on a single page instead of creating separate pages for each operation:
+
+```json
+"/api": {
+  "type": "openapi",
+  "title": "My API",
+  "filepath": "docs/api-reference/openapi.yaml",
+  "singlePage": true
+}
+```
+
 API Reference options (authentication, theme, etc.) go in a `config` object — same options as the [API Reference configuration](https://docs.scalar.com/configuration).
 
 #### Group (`type: "group"`)

--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -327,11 +327,42 @@ Fetch an OpenAPI document from a remote URL. The document is fetched on each pag
 }
 ```
 
+### Properties
+
+| Property     | Type                             | Required | Description                                                      |
+| ------------ | -------------------------------- | -------- | ---------------------------------------------------------------- |
+| `type`       | `"openapi"`                      | Yes      | Must be `"openapi"`                                              |
+| `title`      | `string`                         | No       | The display text in the navigation                               |
+| `filepath`   | `string`                         | No       | Relative path to the OpenAPI file                                |
+| `url`        | `string`                         | No       | URL to fetch the OpenAPI document from                           |
+| `namespace`  | `string`                         | No       | Registry namespace (when using Registry)                         |
+| `slug`       | `string`                         | No       | Registry slug (when using Registry)                              |
+| `version`    | `string`                         | No       | Registry version (when using Registry)                           |
+| `icon`       | `string`                         | No       | An icon to display next to the reference                         |
+| `mode`       | `"flat" \| "nested" \| "folder"` | No       | How the API reference is displayed in the sidebar                |
+| `singlePage` | `boolean`                        | No       | Render all operations on a single page (defaults to `false`)     |
+| `config`     | `object`                         | No       | API Reference configuration options                              |
+
 ### Display Modes
 
 - `folder` (default): Shows a single level of links with a folder icon
-- `flat` Shows a single level of links with a section title
-- `nested` Shows a sub-sidebar with breadcrumbs for deep navigation
+- `flat`: Shows a single level of links with a section title
+- `nested`: Shows a sub-sidebar with breadcrumbs for deep navigation
+
+### Single Page Mode
+
+By default, Docs creates a separate page for each API operation. Set `singlePage` to `true` to render all operations on a single page instead:
+
+```json
+"/api": {
+  "type": "openapi",
+  "title": "My API",
+  "filepath": "docs/api-reference/openapi.yaml",
+  "singlePage": true
+}
+```
+
+This is useful when you want a scrollable, single-page API reference similar to traditional API documentation layouts.
 
 ### API Reference configuration
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `singlePage` configuration option for OpenAPI route entries was missing from the documentation. Users were asking how to configure their API documentation to render all operations on a single page (like the `api-references` package does in Docusaurus) instead of creating separate pages for each operation.

Reference: Slack thread in #scalar-docs discussing this feature.

## Solution

Added documentation for the `singlePage` property in two places:

1. **Navigation configuration docs** (`documentation/guides/docs/configuration/navigation.md`):
   - Added a Properties table for OpenAPI route entries listing all available options
   - Added a "Single Page Mode" section explaining the `singlePage` option with an example
   - Fixed a minor typo in the Display Modes list (missing colon after "flat")

2. **Scalar Docs skill file** (`.agents/skills/scalar-docs/SKILL.md`):
   - Added documentation for `singlePage: true` in the OpenAPI route section

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed - documentation only change -->
- [ ] I added tests. <!-- Not applicable - documentation only -->
- [x] I updated the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07SL9L6SJ0/p1782259562881329?thread_ts=1782259562.881329&cid=C07SL9L6SJ0)

<div><a href="https://cursor.com/agents/bc-8f38acb0-4679-54f5-b485-5a35135573ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f38acb0-4679-54f5-b485-5a35135573ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

