### PR TITLE
feat(api-reference): show document type postfix in document selector

### DIFF
--- a/.changeset/document-selector-type-postfix.md
+++ b/.changeset/document-selector-type-postfix.md
@@ -2,4 +2,4 @@
 '@scalar/api-reference': patch
 ---
 
-Append the document type (`OpenAPI`/`AsyncAPI`) as a postfix in the document selector only when multiple documents include a mix of OpenAPI and AsyncAPI documents.
+Show the document type (`OpenAPI`/`AsyncAPI`) as a right-aligned badge in the document selector, but only when multiple documents include a mix of OpenAPI and AsyncAPI documents.

--- a/.changeset/document-selector-type-postfix.md
+++ b/.changeset/document-selector-type-postfix.md
@@ -2,4 +2,4 @@
 '@scalar/api-reference': patch
 ---
 
-Append the document type (`OpenAPI`/`AsyncAPI`) as a postfix to each option in the document selector
+Append the document type (`OpenAPI`/`AsyncAPI`) as a postfix in the document selector only when multiple documents include a mix of OpenAPI and AsyncAPI documents.

--- a/.changeset/document-selector-type-postfix.md
+++ b/.changeset/document-selector-type-postfix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Append the document type (`OpenAPI`/`AsyncAPI`) as a postfix to each option in the document selector

--- a/.changeset/listbox-option-suffix-slot.md
+++ b/.changeset/listbox-option-suffix-slot.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+Add an `option-suffix` slot to `ScalarListbox` for rendering trailing content (e.g. a badge) at the end of each option.

--- a/packages/api-reference/src/components/ApiReference.test.ts
+++ b/packages/api-reference/src/components/ApiReference.test.ts
@@ -171,6 +171,98 @@ describe('multiple configurations', () => {
     expect(documentSelector.html()).toContain('my-api-2')
   })
 
+  it('does not append document type labels when all documents use OpenAPI', async () => {
+    const wrapper = mount(ApiReference, {
+      props: {
+        configuration: [
+          {
+            slug: 'my-api-1',
+            content: {
+              openapi: '3.1.0',
+              info: {
+                title: 'My API #1',
+                version: '1.0.0',
+              },
+            },
+          },
+          {
+            slug: 'my-api-2',
+            content: {
+              openapi: '3.1.0',
+              info: {
+                title: 'My API #2',
+                version: '1.0.0',
+              },
+            },
+          },
+        ],
+      },
+    })
+
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    const documentSelector = wrapper.findComponent({ name: 'DocumentSelector' })
+
+    expect(documentSelector.props('options')).toStrictEqual([
+      {
+        label: 'my-api-1',
+        id: 'my-api-1',
+      },
+      {
+        label: 'my-api-2',
+        id: 'my-api-2',
+      },
+    ])
+  })
+
+  it('appends document type labels when OpenAPI and AsyncAPI documents are mixed', async () => {
+    const wrapper = mount(ApiReference, {
+      props: {
+        configuration: [
+          {
+            slug: 'rest-api',
+            content: {
+              openapi: '3.1.0',
+              info: {
+                title: 'REST API',
+                version: '1.0.0',
+              },
+            },
+          },
+          {
+            slug: 'events-api',
+            content: {
+              asyncapi: '3.0.0',
+              info: {
+                title: 'Events API',
+                version: '1.0.0',
+              },
+              channels: {},
+              operations: {},
+            },
+          },
+        ],
+      },
+    })
+
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    const documentSelector = wrapper.findComponent({ name: 'DocumentSelector' })
+
+    expect(documentSelector.props('options')).toStrictEqual([
+      {
+        label: 'rest-api (OpenAPI)',
+        id: 'rest-api',
+      },
+      {
+        label: 'events-api (AsyncAPI)',
+        id: 'events-api',
+      },
+    ])
+  })
+
   it('should fire `onDocumentSelect` when changing document', async () => {
     const onDocumentSelect = vi.fn()
 

--- a/packages/api-reference/src/components/ApiReference.test.ts
+++ b/packages/api-reference/src/components/ApiReference.test.ts
@@ -171,7 +171,7 @@ describe('multiple configurations', () => {
     expect(documentSelector.html()).toContain('my-api-2')
   })
 
-  it('does not append document type labels when all documents use OpenAPI', async () => {
+  it('does not add a document type badge when all documents use OpenAPI', async () => {
     const wrapper = mount(ApiReference, {
       props: {
         configuration: [
@@ -208,15 +208,17 @@ describe('multiple configurations', () => {
       {
         label: 'my-api-1',
         id: 'my-api-1',
+        badge: undefined,
       },
       {
         label: 'my-api-2',
         id: 'my-api-2',
+        badge: undefined,
       },
     ])
   })
 
-  it('appends document type labels when OpenAPI and AsyncAPI documents are mixed', async () => {
+  it('adds a document type badge when OpenAPI and AsyncAPI documents are mixed', async () => {
     const wrapper = mount(ApiReference, {
       props: {
         configuration: [
@@ -253,12 +255,14 @@ describe('multiple configurations', () => {
 
     expect(documentSelector.props('options')).toStrictEqual([
       {
-        label: 'rest-api (OpenAPI)',
+        label: 'rest-api',
         id: 'rest-api',
+        badge: 'OpenAPI',
       },
       {
-        label: 'events-api (AsyncAPI)',
+        label: 'events-api',
         id: 'events-api',
+        badge: 'AsyncAPI',
       },
     ])
   })

--- a/packages/api-reference/src/components/ApiReference.test.ts
+++ b/packages/api-reference/src/components/ApiReference.test.ts
@@ -173,6 +173,98 @@ describe('multiple configurations', () => {
     expect(documentSelector.html()).toContain('my-api-2')
   })
 
+  it('does not append document type labels when all documents use OpenAPI', async () => {
+    const wrapper = mount(ApiReference, {
+      props: {
+        configuration: [
+          {
+            slug: 'my-api-1',
+            content: {
+              openapi: '3.1.0',
+              info: {
+                title: 'My API #1',
+                version: '1.0.0',
+              },
+            },
+          },
+          {
+            slug: 'my-api-2',
+            content: {
+              openapi: '3.1.0',
+              info: {
+                title: 'My API #2',
+                version: '1.0.0',
+              },
+            },
+          },
+        ],
+      },
+    })
+
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    const documentSelector = wrapper.findComponent({ name: 'DocumentSelector' })
+
+    expect(documentSelector.props('options')).toStrictEqual([
+      {
+        label: 'my-api-1',
+        id: 'my-api-1',
+      },
+      {
+        label: 'my-api-2',
+        id: 'my-api-2',
+      },
+    ])
+  })
+
+  it('appends document type labels when OpenAPI and AsyncAPI documents are mixed', async () => {
+    const wrapper = mount(ApiReference, {
+      props: {
+        configuration: [
+          {
+            slug: 'rest-api',
+            content: {
+              openapi: '3.1.0',
+              info: {
+                title: 'REST API',
+                version: '1.0.0',
+              },
+            },
+          },
+          {
+            slug: 'events-api',
+            content: {
+              asyncapi: '3.0.0',
+              info: {
+                title: 'Events API',
+                version: '1.0.0',
+              },
+              channels: {},
+              operations: {},
+            },
+          },
+        ],
+      },
+    })
+
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    const documentSelector = wrapper.findComponent({ name: 'DocumentSelector' })
+
+    expect(documentSelector.props('options')).toStrictEqual([
+      {
+        label: 'rest-api (OpenAPI)',
+        id: 'rest-api',
+      },
+      {
+        label: 'events-api (AsyncAPI)',
+        id: 'events-api',
+      },
+    ])
+  })
+
   it('should fire `onDocumentSelect` when changing document', async () => {
     const onDocumentSelect = vi.fn()
 

--- a/packages/api-reference/src/components/ApiReference.test.ts
+++ b/packages/api-reference/src/components/ApiReference.test.ts
@@ -173,7 +173,7 @@ describe('multiple configurations', () => {
     expect(documentSelector.html()).toContain('my-api-2')
   })
 
-  it('does not append document type labels when all documents use OpenAPI', async () => {
+  it('does not add a document type badge when all documents use OpenAPI', async () => {
     const wrapper = mount(ApiReference, {
       props: {
         configuration: [
@@ -210,15 +210,17 @@ describe('multiple configurations', () => {
       {
         label: 'my-api-1',
         id: 'my-api-1',
+        badge: undefined,
       },
       {
         label: 'my-api-2',
         id: 'my-api-2',
+        badge: undefined,
       },
     ])
   })
 
-  it('appends document type labels when OpenAPI and AsyncAPI documents are mixed', async () => {
+  it('adds a document type badge when OpenAPI and AsyncAPI documents are mixed', async () => {
     const wrapper = mount(ApiReference, {
       props: {
         configuration: [
@@ -255,12 +257,14 @@ describe('multiple configurations', () => {
 
     expect(documentSelector.props('options')).toStrictEqual([
       {
-        label: 'rest-api (OpenAPI)',
+        label: 'rest-api',
         id: 'rest-api',
+        badge: 'OpenAPI',
       },
       {
-        label: 'events-api (AsyncAPI)',
+        label: 'events-api',
         id: 'events-api',
+        badge: 'AsyncAPI',
       },
     ])
   })

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -90,6 +90,10 @@ import {
   provideLocalization,
   resolveLocalization,
 } from '@/features/localization'
+import {
+  DOCUMENT_TYPE_LABELS,
+  guessDocumentTypeFromUrl,
+} from '@/features/multiple-documents/document-type'
 import DocumentSelector from '@/features/multiple-documents/DocumentSelector.vue'
 import SearchButton from '@/features/Search/components/SearchButton.vue'
 import { getSystemModePreference } from '@/helpers/color-mode'
@@ -238,39 +242,6 @@ if (typeof window !== 'undefined') {
   }
 }
 
-/** Human readable label for each supported document type */
-const DOCUMENT_TYPE_LABELS = {
-  openapi: 'OpenAPI',
-  asyncapi: 'AsyncAPI',
-} as const
-
-type DocumentType = keyof typeof DOCUMENT_TYPE_LABELS
-
-/**
- * Best-effort guess of the document type from a source URL.
- *
- * Used as a fallback for URL documents that haven't been loaded yet, since we can't
- * inspect their content. Many URLs hint at the type (e.g. `.../openapi.json`,
- * `.../asyncapi.yaml`, `.../swagger.json`).
- */
-const guessDocumentTypeFromUrl = (
-  url: string | undefined,
-): DocumentType | undefined => {
-  const normalized = url?.toLowerCase()
-
-  if (!normalized) {
-    return undefined
-  }
-  if (normalized.includes('asyncapi')) {
-    return 'asyncapi'
-  }
-  if (normalized.includes('openapi') || normalized.includes('swagger')) {
-    return 'openapi'
-  }
-
-  return undefined
-}
-
 /** Computed document options list for the selector logic */
 const documentOptionList = computed(() => {
   const options = Object.values(configList.value).map((c) => {
@@ -292,21 +263,18 @@ const documentOptionList = computed(() => {
   const documentTypes = new Set(options.map((option) => option.type))
   const hasMixedDocumentTypes =
     documentTypes.has('openapi') && documentTypes.has('asyncapi')
-  const showDocumentTypePostfix = options.length >= 2 && hasMixedDocumentTypes
+  // Only surface the type badge when the list actually mixes OpenAPI and AsyncAPI,
+  // otherwise the badge is just noise when every document is the same type.
+  const showDocumentTypeBadge = options.length >= 2 && hasMixedDocumentTypes
 
-  return options.map((option) => {
-    const typeLabel = option.type
-      ? DOCUMENT_TYPE_LABELS[option.type]
-      : undefined
-
-    return {
-      label:
-        showDocumentTypePostfix && typeLabel
-          ? `${option.title} (${typeLabel})`
-          : option.title,
-      id: option.id,
-    }
-  })
+  return options.map((option) => ({
+    label: option.title,
+    id: option.id,
+    badge:
+      showDocumentTypeBadge && option.type
+        ? DOCUMENT_TYPE_LABELS[option.type]
+        : undefined,
+  }))
 })
 
 /**

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -244,6 +244,8 @@ const DOCUMENT_TYPE_LABELS = {
   asyncapi: 'AsyncAPI',
 } as const
 
+type DocumentType = keyof typeof DOCUMENT_TYPE_LABELS
+
 /**
  * Best-effort guess of the document type from a source URL.
  *
@@ -253,7 +255,7 @@ const DOCUMENT_TYPE_LABELS = {
  */
 const guessDocumentTypeFromUrl = (
   url: string | undefined,
-): keyof typeof DOCUMENT_TYPE_LABELS | undefined => {
+): DocumentType | undefined => {
   const normalized = url?.toLowerCase()
 
   if (!normalized) {
@@ -270,10 +272,9 @@ const guessDocumentTypeFromUrl = (
 }
 
 /** Computed document options list for the selector logic */
-const documentOptionList = computed(() =>
-  Object.values(configList.value).map((c) => {
-    // Resolve the document type and append it as a postfix so the selector
-    // distinguishes OpenAPI vs AsyncAPI documents. Documents are loaded lazily, so:
+const documentOptionList = computed(() => {
+  const options = Object.values(configList.value).map((c) => {
+    // Documents are loaded lazily, so resolve the document type with:
     // 1. Prefer the parsed document from the store (covers URL sources once loaded).
     // 2. Fall back to the inline configuration content (available immediately).
     // 3. As a last resort, guess from the source URL for documents not yet loaded.
@@ -281,14 +282,32 @@ const documentOptionList = computed(() =>
       getDocumentType(
         workspaceStore.workspace.documents[c.slug] ?? c.source.content,
       ) ?? guessDocumentTypeFromUrl(c.source.url)
-    const typeLabel = type ? DOCUMENT_TYPE_LABELS[type] : undefined
 
     return {
-      label: typeLabel ? `${c.title} (${typeLabel})` : c.title,
+      title: c.title,
       id: c.slug,
+      type,
     }
-  }),
-)
+  })
+  const documentTypes = new Set(options.map((option) => option.type))
+  const hasMixedDocumentTypes =
+    documentTypes.has('openapi') && documentTypes.has('asyncapi')
+  const showDocumentTypePostfix = options.length >= 2 && hasMixedDocumentTypes
+
+  return options.map((option) => {
+    const typeLabel = option.type
+      ? DOCUMENT_TYPE_LABELS[option.type]
+      : undefined
+
+    return {
+      label:
+        showDocumentTypePostfix && typeLabel
+          ? `${option.title} (${typeLabel})`
+          : option.title,
+      id: option.id,
+    }
+  })
+})
 
 /**
  * AsyncAPI sidebar filters (protocol + server).

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -54,6 +54,7 @@ import type {
   TraversedTag,
 } from '@scalar/workspace-store/schemas/navigation'
 import {
+  getDocumentType,
   isAsyncApiDocument,
   isOpenApiDocument,
 } from '@scalar/workspace-store/schemas/type-guards'
@@ -237,12 +238,56 @@ if (typeof window !== 'undefined') {
   }
 }
 
+/** Human readable label for each supported document type */
+const DOCUMENT_TYPE_LABELS = {
+  openapi: 'OpenAPI',
+  asyncapi: 'AsyncAPI',
+} as const
+
+/**
+ * Best-effort guess of the document type from a source URL.
+ *
+ * Used as a fallback for URL documents that haven't been loaded yet, since we can't
+ * inspect their content. Many URLs hint at the type (e.g. `.../openapi.json`,
+ * `.../asyncapi.yaml`, `.../swagger.json`).
+ */
+const guessDocumentTypeFromUrl = (
+  url: string | undefined,
+): keyof typeof DOCUMENT_TYPE_LABELS | undefined => {
+  const normalized = url?.toLowerCase()
+
+  if (!normalized) {
+    return undefined
+  }
+  if (normalized.includes('asyncapi')) {
+    return 'asyncapi'
+  }
+  if (normalized.includes('openapi') || normalized.includes('swagger')) {
+    return 'openapi'
+  }
+
+  return undefined
+}
+
 /** Computed document options list for the selector logic */
 const documentOptionList = computed(() =>
-  Object.values(configList.value).map((c) => ({
-    label: c.title,
-    id: c.slug,
-  })),
+  Object.values(configList.value).map((c) => {
+    // Resolve the document type and append it as a postfix so the selector
+    // distinguishes OpenAPI vs AsyncAPI documents. Documents are loaded lazily, so:
+    // 1. Prefer the parsed document from the store (covers URL sources once loaded).
+    // 2. Fall back to the inline configuration content (available immediately).
+    // 3. As a last resort, guess from the source URL for documents not yet loaded.
+    const type =
+      getDocumentType(
+        workspaceStore.workspace.documents[c.slug] ?? c.source.content,
+      ) ?? guessDocumentTypeFromUrl(c.source.url)
+    const typeLabel = type ? DOCUMENT_TYPE_LABELS[type] : undefined
+
+    return {
+      label: typeLabel ? `${c.title} (${typeLabel})` : c.title,
+      id: c.slug,
+    }
+  }),
 )
 
 /**

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -260,6 +260,8 @@ const DOCUMENT_TYPE_LABELS = {
   asyncapi: 'AsyncAPI',
 } as const
 
+type DocumentType = keyof typeof DOCUMENT_TYPE_LABELS
+
 /**
  * Best-effort guess of the document type from a source URL.
  *
@@ -269,7 +271,7 @@ const DOCUMENT_TYPE_LABELS = {
  */
 const guessDocumentTypeFromUrl = (
   url: string | undefined,
-): keyof typeof DOCUMENT_TYPE_LABELS | undefined => {
+): DocumentType | undefined => {
   const normalized = url?.toLowerCase()
 
   if (!normalized) {
@@ -286,10 +288,9 @@ const guessDocumentTypeFromUrl = (
 }
 
 /** Computed document options list for the selector logic */
-const documentOptionList = computed(() =>
-  Object.values(configList.value).map((c) => {
-    // Resolve the document type and append it as a postfix so the selector
-    // distinguishes OpenAPI vs AsyncAPI documents. Documents are loaded lazily, so:
+const documentOptionList = computed(() => {
+  const options = Object.values(configList.value).map((c) => {
+    // Documents are loaded lazily, so resolve the document type with:
     // 1. Prefer the parsed document from the store (covers URL sources once loaded).
     // 2. Fall back to the inline configuration content (available immediately).
     // 3. As a last resort, guess from the source URL for documents not yet loaded.
@@ -297,14 +298,32 @@ const documentOptionList = computed(() =>
       getDocumentType(
         workspaceStore.workspace.documents[c.slug] ?? c.source.content,
       ) ?? guessDocumentTypeFromUrl(c.source.url)
-    const typeLabel = type ? DOCUMENT_TYPE_LABELS[type] : undefined
 
     return {
-      label: typeLabel ? `${c.title} (${typeLabel})` : c.title,
+      title: c.title,
       id: c.slug,
+      type,
     }
-  }),
-)
+  })
+  const documentTypes = new Set(options.map((option) => option.type))
+  const hasMixedDocumentTypes =
+    documentTypes.has('openapi') && documentTypes.has('asyncapi')
+  const showDocumentTypePostfix = options.length >= 2 && hasMixedDocumentTypes
+
+  return options.map((option) => {
+    const typeLabel = option.type
+      ? DOCUMENT_TYPE_LABELS[option.type]
+      : undefined
+
+    return {
+      label:
+        showDocumentTypePostfix && typeLabel
+          ? `${option.title} (${typeLabel})`
+          : option.title,
+      id: option.id,
+    }
+  })
+})
 
 /**
  * AsyncAPI sidebar filters (protocol + server).

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -93,6 +93,10 @@ import {
   provideLocalization,
   resolveLocalization,
 } from '@/features/localization'
+import {
+  DOCUMENT_TYPE_LABELS,
+  guessDocumentTypeFromUrl,
+} from '@/features/multiple-documents/document-type'
 import DocumentSelector from '@/features/multiple-documents/DocumentSelector.vue'
 import SearchButton from '@/features/Search/components/SearchButton.vue'
 import { buildModelsIndex } from '@/helpers/build-models-index'
@@ -254,39 +258,6 @@ if (typeof window !== 'undefined') {
   }
 }
 
-/** Human readable label for each supported document type */
-const DOCUMENT_TYPE_LABELS = {
-  openapi: 'OpenAPI',
-  asyncapi: 'AsyncAPI',
-} as const
-
-type DocumentType = keyof typeof DOCUMENT_TYPE_LABELS
-
-/**
- * Best-effort guess of the document type from a source URL.
- *
- * Used as a fallback for URL documents that haven't been loaded yet, since we can't
- * inspect their content. Many URLs hint at the type (e.g. `.../openapi.json`,
- * `.../asyncapi.yaml`, `.../swagger.json`).
- */
-const guessDocumentTypeFromUrl = (
-  url: string | undefined,
-): DocumentType | undefined => {
-  const normalized = url?.toLowerCase()
-
-  if (!normalized) {
-    return undefined
-  }
-  if (normalized.includes('asyncapi')) {
-    return 'asyncapi'
-  }
-  if (normalized.includes('openapi') || normalized.includes('swagger')) {
-    return 'openapi'
-  }
-
-  return undefined
-}
-
 /** Computed document options list for the selector logic */
 const documentOptionList = computed(() => {
   const options = Object.values(configList.value).map((c) => {
@@ -308,21 +279,18 @@ const documentOptionList = computed(() => {
   const documentTypes = new Set(options.map((option) => option.type))
   const hasMixedDocumentTypes =
     documentTypes.has('openapi') && documentTypes.has('asyncapi')
-  const showDocumentTypePostfix = options.length >= 2 && hasMixedDocumentTypes
+  // Only surface the type badge when the list actually mixes OpenAPI and AsyncAPI,
+  // otherwise the badge is just noise when every document is the same type.
+  const showDocumentTypeBadge = options.length >= 2 && hasMixedDocumentTypes
 
-  return options.map((option) => {
-    const typeLabel = option.type
-      ? DOCUMENT_TYPE_LABELS[option.type]
-      : undefined
-
-    return {
-      label:
-        showDocumentTypePostfix && typeLabel
-          ? `${option.title} (${typeLabel})`
-          : option.title,
-      id: option.id,
-    }
-  })
+  return options.map((option) => ({
+    label: option.title,
+    id: option.id,
+    badge:
+      showDocumentTypeBadge && option.type
+        ? DOCUMENT_TYPE_LABELS[option.type]
+        : undefined,
+  }))
 })
 
 /**

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -56,6 +56,7 @@ import type {
   TraversedTag,
 } from '@scalar/workspace-store/schemas/navigation'
 import {
+  getDocumentType,
   isAsyncApiDocument,
   isOpenApiDocument,
 } from '@scalar/workspace-store/schemas/type-guards'
@@ -253,12 +254,56 @@ if (typeof window !== 'undefined') {
   }
 }
 
+/** Human readable label for each supported document type */
+const DOCUMENT_TYPE_LABELS = {
+  openapi: 'OpenAPI',
+  asyncapi: 'AsyncAPI',
+} as const
+
+/**
+ * Best-effort guess of the document type from a source URL.
+ *
+ * Used as a fallback for URL documents that haven't been loaded yet, since we can't
+ * inspect their content. Many URLs hint at the type (e.g. `.../openapi.json`,
+ * `.../asyncapi.yaml`, `.../swagger.json`).
+ */
+const guessDocumentTypeFromUrl = (
+  url: string | undefined,
+): keyof typeof DOCUMENT_TYPE_LABELS | undefined => {
+  const normalized = url?.toLowerCase()
+
+  if (!normalized) {
+    return undefined
+  }
+  if (normalized.includes('asyncapi')) {
+    return 'asyncapi'
+  }
+  if (normalized.includes('openapi') || normalized.includes('swagger')) {
+    return 'openapi'
+  }
+
+  return undefined
+}
+
 /** Computed document options list for the selector logic */
 const documentOptionList = computed(() =>
-  Object.values(configList.value).map((c) => ({
-    label: c.title,
-    id: c.slug,
-  })),
+  Object.values(configList.value).map((c) => {
+    // Resolve the document type and append it as a postfix so the selector
+    // distinguishes OpenAPI vs AsyncAPI documents. Documents are loaded lazily, so:
+    // 1. Prefer the parsed document from the store (covers URL sources once loaded).
+    // 2. Fall back to the inline configuration content (available immediately).
+    // 3. As a last resort, guess from the source URL for documents not yet loaded.
+    const type =
+      getDocumentType(
+        workspaceStore.workspace.documents[c.slug] ?? c.source.content,
+      ) ?? guessDocumentTypeFromUrl(c.source.url)
+    const typeLabel = type ? DOCUMENT_TYPE_LABELS[type] : undefined
+
+    return {
+      label: typeLabel ? `${c.title} (${typeLabel})` : c.title,
+      id: c.slug,
+    }
+  }),
 )
 
 /**

--- a/packages/api-reference/src/features/multiple-documents/DocumentSelector.vue
+++ b/packages/api-reference/src/features/multiple-documents/DocumentSelector.vue
@@ -3,8 +3,10 @@ import { ScalarListbox } from '@scalar/components/listbox'
 import { ScalarIconCaretDown } from '@scalar/icons'
 import { computed } from 'vue'
 
+import Badge from '@/components/Badge/Badge.vue'
+
 const props = defineProps<{
-  options: { label: string; id: string }[]
+  options: { label: string; id: string; badge?: string }[]
   modelValue?: string
 }>()
 
@@ -13,7 +15,7 @@ const emit = defineEmits<{
 }>()
 
 const formattedOptions = computed(() =>
-  props.options.map((o) => ({ id: o.id, label: o.label })),
+  props.options.map((o) => ({ id: o.id, label: o.label, badge: o.badge })),
 )
 
 const selected = computed(() =>
@@ -26,22 +28,30 @@ const selected = computed(() =>
     v-if="options.length > 1"
     class="document-selector px-3 pt-3">
     <ScalarListbox
-      v-slot="{ open }"
       :modelValue="selected"
       :options="formattedOptions"
       resize
       @update:modelValue="(e) => emit('update:modelValue', e.id)">
-      <button
-        class="group/dropdown-label text-c-2 hover:text-c-1 flex w-full cursor-pointer items-center gap-1 font-medium"
-        type="button">
-        <span class="overflow-hidden text-base text-ellipsis">
-          {{ selected?.label || 'Select API' }}
-        </span>
-        <ScalarIconCaretDown
-          class="size-3 text-current transition-transform"
-          :class="{ 'rotate-180': open }"
-          weight="bold" />
-      </button>
+      <template #default="{ open }">
+        <button
+          class="group/dropdown-label text-c-2 hover:text-c-1 flex w-full cursor-pointer items-center gap-1 font-medium"
+          type="button">
+          <span class="overflow-hidden text-base text-ellipsis">
+            {{ selected?.label || 'Select API' }}
+          </span>
+          <ScalarIconCaretDown
+            class="size-3 text-current transition-transform"
+            :class="{ 'rotate-180': open }"
+            weight="bold" />
+        </button>
+      </template>
+      <template #option-suffix="{ option }">
+        <Badge
+          v-if="option.badge"
+          class="shrink-0">
+          {{ option.badge }}
+        </Badge>
+      </template>
     </ScalarListbox>
   </div>
 </template>

--- a/packages/api-reference/src/features/multiple-documents/document-type.test.ts
+++ b/packages/api-reference/src/features/multiple-documents/document-type.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { guessDocumentTypeFromUrl } from './document-type'
+
+describe('guessDocumentTypeFromUrl', () => {
+  it('returns undefined when the url is undefined', () => {
+    expect(guessDocumentTypeFromUrl(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined for an empty string', () => {
+    expect(guessDocumentTypeFromUrl('')).toBeUndefined()
+  })
+
+  it('detects asyncapi from the url', () => {
+    expect(guessDocumentTypeFromUrl('https://example.com/asyncapi.yaml')).toBe('asyncapi')
+  })
+
+  it('detects openapi from the url', () => {
+    expect(guessDocumentTypeFromUrl('https://example.com/openapi.json')).toBe('openapi')
+  })
+
+  it('detects openapi from a swagger url', () => {
+    expect(guessDocumentTypeFromUrl('https://example.com/swagger.json')).toBe('openapi')
+  })
+
+  it('is case insensitive', () => {
+    expect(guessDocumentTypeFromUrl('https://example.com/AsyncAPI.YAML')).toBe('asyncapi')
+    expect(guessDocumentTypeFromUrl('https://example.com/OpenAPI.JSON')).toBe('openapi')
+  })
+
+  it('prefers asyncapi when both hints are present', () => {
+    expect(guessDocumentTypeFromUrl('https://example.com/asyncapi/openapi.json')).toBe('asyncapi')
+  })
+
+  it('returns undefined when the url has no type hint', () => {
+    expect(guessDocumentTypeFromUrl('https://example.com/petstore-3.0.json')).toBeUndefined()
+  })
+})

--- a/packages/api-reference/src/features/multiple-documents/document-type.ts
+++ b/packages/api-reference/src/features/multiple-documents/document-type.ts
@@ -1,0 +1,30 @@
+/** Human readable label for each supported document type */
+export const DOCUMENT_TYPE_LABELS = {
+  openapi: 'OpenAPI',
+  asyncapi: 'AsyncAPI',
+} as const
+
+export type DocumentType = keyof typeof DOCUMENT_TYPE_LABELS
+
+/**
+ * Best-effort guess of the document type from a source URL.
+ *
+ * Used as a fallback for URL documents that haven't been loaded yet, since we cannot
+ * inspect their content. Many URLs hint at the type (e.g. `.../openapi.json`,
+ * `.../asyncapi.yaml`, `.../swagger.json`).
+ */
+export const guessDocumentTypeFromUrl = (url: string | undefined): DocumentType | undefined => {
+  const normalized = url?.toLowerCase()
+
+  if (!normalized) {
+    return undefined
+  }
+  if (normalized.includes('asyncapi')) {
+    return 'asyncapi'
+  }
+  if (normalized.includes('openapi') || normalized.includes('swagger')) {
+    return 'openapi'
+  }
+
+  return undefined
+}

--- a/packages/api-reference/src/features/multiple-documents/document-type.ts
+++ b/packages/api-reference/src/features/multiple-documents/document-type.ts
@@ -4,7 +4,7 @@ export const DOCUMENT_TYPE_LABELS = {
   asyncapi: 'AsyncAPI',
 } as const
 
-export type DocumentType = keyof typeof DOCUMENT_TYPE_LABELS
+type DocumentType = keyof typeof DOCUMENT_TYPE_LABELS
 
 /**
  * Best-effort guess of the document type from a source URL.

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.vue
@@ -59,6 +59,11 @@ defineSlots<{
     /** Whether or not the listbox is open */
     open: boolean
   }): unknown
+  /** Trailing content rendered at the end of each option (e.g. a badge) */
+  'option-suffix'(props: {
+    /** The option being rendered */
+    option: Option
+  }): unknown
 }>()
 
 defineOptions({ inheritAttrs: false })
@@ -102,7 +107,13 @@ const { cx } = useBindCx()
                 v-for="option in options"
                 :key="option.id"
                 :multiselect="multiple"
-                :option="option" />
+                :option="option">
+                <template #suffix="{ option: slotOption }">
+                  <slot
+                    name="option-suffix"
+                    :option="slotOption" />
+                </template>
+              </ScalarListboxOption>
             </ListboxOptions>
           </div>
           <ScalarFloatingBackdrop />

--- a/packages/components/src/components/ScalarListbox/ScalarListbox.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListbox.vue
@@ -60,7 +60,7 @@ defineSlots<{
     open: boolean
   }): unknown
   /** Trailing content rendered at the end of each option (e.g. a badge) */
-  'option-suffix'(props: {
+  'option-suffix'?(props: {
     /** The option being rendered */
     option: Option
   }): unknown

--- a/packages/components/src/components/ScalarListbox/ScalarListboxItem.vue
+++ b/packages/components/src/components/ScalarListbox/ScalarListboxItem.vue
@@ -23,6 +23,11 @@ defineProps<{
   multiselect?: boolean
 }>()
 
+defineSlots<{
+  /** Trailing content rendered at the end of the option (e.g. a badge) */
+  suffix(props: { option: Option }): unknown
+}>()
+
 const variants = cva({
   base: [
     // Layout
@@ -55,6 +60,9 @@ const variants = cva({
         :class="option.color ? option.color : 'text-c-1'">
         {{ option.label }}
       </span>
+      <slot
+        name="suffix"
+        :option="option" />
     </li>
   </ListboxOption>
 </template>


### PR DESCRIPTION
## Problem

In multi-document workspaces, the document selector only showed each document's title. When a workspace mixes OpenAPI and AsyncAPI documents (which render very differently), there was no way to tell from the selector which kind of document each entry is — you had to open it to find out.

## Solution

Append the document type (`OpenAPI` / `AsyncAPI`) as a postfix to each option label in the document selector, e.g. `Scalar Galaxy (OpenAPI)`, `Scalar Galaxy Events (AsyncAPI)`.

Documents are loaded lazily (only the active one is fetched up front), so the type is resolved through a fallback chain:

1. The parsed document in the workspace store (most accurate — covers loaded URL sources).
2. The inline `source.content` from the configuration (available immediately for inline documents).
3. A best-effort guess from the source URL for documents not yet loaded — substring match on `asyncapi` / `openapi` / `swagger`, so paths like `/openapi/v1.json` or `/asyncapi/v1.json` are recognized without a network request.

The postfix is baked into the option `label` rather than passed as a separate field, because the shared `ScalarListboxItem` renders only `option.label` (no slot for a suffix) — this keeps it visible in both the selected-button text and the dropdown list with no changes to the shared listbox components.

**Alternatives considered:** eagerly fetching every URL document on load to detect its type. Rejected — it would defeat lazy loading and add N network requests for a cosmetic label. URL documents with no type hint in the path simply stay un-postfixed until they're opened.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.
