### PR TITLE
fix(java): support Jackson 2.x and 3.x

### DIFF
--- a/.changeset/java-jackson-3-support.md
+++ b/.changeset/java-jackson-3-support.md
@@ -1,0 +1,5 @@
+---
+'@scalar/java-integration': patch
+---
+
+Support both Jackson 2.x and Jackson 3.x. The Java integration now resolves the JSON serialization engine from whichever Jackson Databind the host application provides, so a single artifact works on both Jackson 2 and Jackson 3 (e.g. Spring Boot 3 and 4) without dependency conflicts.

--- a/integrations/java/scalar-core/pom.xml
+++ b/integrations/java/scalar-core/pom.xml
@@ -18,10 +18,23 @@
   <description>Core framework-agnostic module for Scalar API Reference</description>
 
   <dependencies>
-    <!-- Jackson for JSON serialization -->
+    <!--
+      Jackson annotations only. This is the same artifact and package
+      (com.fasterxml.jackson.annotation) for both Jackson 2.x and 3.x, so it
+      never conflicts with the host's Jackson. The serialization engine itself
+      is resolved at runtime from whichever Jackson Databind the host provides
+      (see JacksonJsonSerializer), keeping this module compatible with both.
+    -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <!-- A concrete Jackson Databind is needed to run the tests. -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <!-- Test Dependencies -->

--- a/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/ScalarHtmlRenderer.java
+++ b/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/ScalarHtmlRenderer.java
@@ -1,7 +1,6 @@
 package com.scalar.maven.core;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scalar.maven.core.internal.JacksonJsonSerializer;
 import com.scalar.maven.core.internal.ScalarConfiguration;
 import com.scalar.maven.core.internal.ScalarConfigurationMapper;
 
@@ -23,7 +22,6 @@ public final class ScalarHtmlRenderer {
 
     private static final String HTML_TEMPLATE_PATH = "/META-INF/resources/webjars/scalar/index.html";
     private static final String JS_BUNDLE_PATH = "/META-INF/resources/webjars/scalar/" + ScalarConstants.JS_FILENAME;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private ScalarHtmlRenderer() {
         // Utility class - prevent instantiation
@@ -108,12 +106,8 @@ public final class ScalarHtmlRenderer {
      * @return the configuration JSON as a string
      */
     private static String buildConfigurationJson(ScalarProperties properties) {
-        try {
-            ScalarConfiguration config = ScalarConfigurationMapper.map(properties);
-            return OBJECT_MAPPER.writeValueAsString(config);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to serialize Scalar configuration", e);
-        }
+        ScalarConfiguration config = ScalarConfigurationMapper.map(properties);
+        return JacksonJsonSerializer.serialize(config);
     }
 
     /**

--- a/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/internal/JacksonJsonSerializer.java
+++ b/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/internal/JacksonJsonSerializer.java
@@ -1,0 +1,133 @@
+package com.scalar.maven.core.internal;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Serializes the Scalar configuration to JSON using whichever Jackson Databind
+ * implementation is present on the runtime classpath.
+ *
+ * <p>
+ * Scalar only depends on {@code jackson-annotations} at build time, which is the
+ * same artifact and Java package ({@code com.fasterxml.jackson.annotation}) for
+ * both Jackson 2.x and Jackson 3.x. The serialization engine itself is resolved
+ * at runtime by reflection, so a single artifact works against either major
+ * version:
+ * </p>
+ * <ul>
+ *   <li>Jackson 3.x: {@code tools.jackson.databind.json.JsonMapper}</li>
+ *   <li>Jackson 2.x: {@code com.fasterxml.jackson.databind.ObjectMapper}</li>
+ * </ul>
+ *
+ * <p>
+ * A fresh mapper with default settings is used rather than the host
+ * application's configured mapper, so the rendered configuration is never
+ * affected by global Jackson customization such as a property naming strategy.
+ * </p>
+ *
+ * <p>
+ * <strong>Warning:</strong> This class is internal API and should not be used
+ * directly. It may change without notice in future versions.
+ * </p>
+ */
+public final class JacksonJsonSerializer {
+
+    /**
+     * The resolved mapper instance together with its
+     * {@code writeValueAsString(Object)} method, cached after the first lookup.
+     */
+    private static final class Engine {
+        private final Object mapper;
+        private final Method writeValueAsString;
+
+        private Engine(Object mapper, Method writeValueAsString) {
+            this.mapper = mapper;
+            this.writeValueAsString = writeValueAsString;
+        }
+    }
+
+    private static volatile Engine engine;
+
+    private JacksonJsonSerializer() {
+        // Utility class - prevent instantiation
+    }
+
+    /**
+     * Serializes the given value to a JSON string.
+     *
+     * @param value the value to serialize
+     * @return the JSON representation of the value
+     * @throws IllegalStateException if no Jackson Databind implementation is present on the classpath
+     * @throws RuntimeException      if serialization fails
+     */
+    public static String serialize(Object value) {
+        Engine resolved = resolveEngine();
+        try {
+            return (String) resolved.writeValueAsString.invoke(resolved.mapper, value);
+        } catch (InvocationTargetException e) {
+            // Unwrap the underlying Jackson failure (checked in v2, unchecked in v3).
+            throw new RuntimeException("Failed to serialize Scalar configuration", e.getCause());
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("Failed to serialize Scalar configuration", e);
+        }
+    }
+
+    private static Engine resolveEngine() {
+        Engine local = engine;
+        if (local == null) {
+            synchronized (JacksonJsonSerializer.class) {
+                local = engine;
+                if (local == null) {
+                    local = createEngine();
+                    engine = local;
+                }
+            }
+        }
+        return local;
+    }
+
+    private static Engine createEngine() {
+        // Prefer Jackson 3.x when present, falling back to Jackson 2.x. Either
+        // produces the same output for the annotation-driven configuration model.
+        Engine jackson3 = tryCreate("tools.jackson.databind.json.JsonMapper", true);
+        if (jackson3 != null) {
+            return jackson3;
+        }
+        Engine jackson2 = tryCreate("com.fasterxml.jackson.databind.ObjectMapper", false);
+        if (jackson2 != null) {
+            return jackson2;
+        }
+        throw new IllegalStateException(
+                "No Jackson Databind found on the classpath. Add either "
+                        + "com.fasterxml.jackson.core:jackson-databind (Jackson 2.x) or "
+                        + "tools.jackson.core:jackson-databind (Jackson 3.x) to your dependencies.");
+    }
+
+    private static Engine tryCreate(String mapperClassName, boolean useBuilder) {
+        final Class<?> mapperClass;
+        try {
+            mapperClass = Class.forName(mapperClassName);
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+        try {
+            Object mapper = useBuilder
+                    ? buildWithBuilder(mapperClass)
+                    : mapperClass.getDeclaredConstructor().newInstance();
+            Method writeValueAsString = mapper.getClass().getMethod("writeValueAsString", Object.class);
+            return new Engine(mapper, writeValueAsString);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to initialize Jackson mapper: " + mapperClassName, e);
+        }
+    }
+
+    /**
+     * Builds a mapper through its {@code builder().build()} chain. Jackson 3
+     * mappers are immutable and are constructed via a builder rather than a
+     * public no-argument constructor.
+     */
+    private static Object buildWithBuilder(Class<?> mapperClass) throws ReflectiveOperationException {
+        Object builder = mapperClass.getMethod("builder").invoke(null);
+        return builder.getClass().getMethod("build").invoke(builder);
+    }
+}

--- a/integrations/java/scalar-core/src/test/java/com/scalar/maven/core/internal/JacksonJsonSerializerTest.java
+++ b/integrations/java/scalar-core/src/test/java/com/scalar/maven/core/internal/JacksonJsonSerializerTest.java
@@ -1,0 +1,69 @@
+package com.scalar.maven.core.internal;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scalar.maven.core.authentication.ScalarAuthenticationOptions;
+import com.scalar.maven.core.authentication.schemes.ScalarApiKeySecurityScheme;
+import com.scalar.maven.core.enums.ScalarTheme;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link JacksonJsonSerializer}. The build classpath provides Jackson
+ * 2.x, so these exercise the Jackson 2 resolution branch. The output is parsed
+ * back with a real mapper to assert structure independently of field ordering.
+ */
+@DisplayName("JacksonJsonSerializer")
+class JacksonJsonSerializerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private JsonNode serializeAndParse(Object value) throws Exception {
+        return MAPPER.readTree(JacksonJsonSerializer.serialize(value));
+    }
+
+    @Test
+    @DisplayName("honors @JsonProperty renames and omits null fields")
+    void honorsJsonPropertyAndNonNull() throws Exception {
+        ScalarConfiguration config = new ScalarConfiguration();
+        config.setTheme(ScalarTheme.DEFAULT);
+
+        JsonNode json = serializeAndParse(config);
+
+        // @JsonValue enum is serialized as its string value
+        assertThat(json.get("theme").asText()).isEqualTo("default");
+        // @JsonInclude(NON_NULL) drops unset fields rather than emitting null
+        assertThat(json.has("url")).isFalse();
+        assertThat(json.has("customCss")).isFalse();
+    }
+
+    @Test
+    @DisplayName("serializes a polymorphic security scheme without a type discriminator")
+    void serializesSchemeWithoutDiscriminator() throws Exception {
+        ScalarApiKeySecurityScheme apiKey = new ScalarApiKeySecurityScheme("X-API-Key", "secret");
+        ScalarAuthenticationOptions authentication = new ScalarAuthenticationOptions();
+        authentication.setApiKey(java.util.Map.of("apiKeyAuth", apiKey));
+
+        JsonNode json = serializeAndParse(authentication);
+        JsonNode scheme = json.get("securitySchemes").get("apiKeyAuth");
+
+        assertThat(scheme.get("name").asText()).isEqualTo("X-API-Key");
+        assertThat(scheme.get("value").asText()).isEqualTo("secret");
+        // JsonTypeInfo.Id.DEDUCTION emits no type tag
+        assertThat(scheme.has("type")).isFalse();
+    }
+
+    @Test
+    @DisplayName("escapes special characters in strings")
+    void escapesSpecialCharacters() throws Exception {
+        ScalarConfiguration config = new ScalarConfiguration();
+        config.setCustomCss("a\"b\\c\n\t/* 🚀 */");
+
+        JsonNode json = serializeAndParse(config);
+
+        // Round-tripping through a real parser proves the escaping is valid
+        assertThat(json.get("customCss").asText()).isEqualTo("a\"b\\c\n\t/* 🚀 */");
+    }
+}


### PR DESCRIPTION
The Java integration pinned `jackson-databind` 2.x, so apps on Jackson 3 (e.g. Spring Boot 4) hit dependency conflicts.

`scalar-core` now compiles only against `jackson-annotations` — the same artifact and package for both Jackson 2 and 3 — and resolves the JSON serializer at runtime from whichever Jackson Databind the host provides (`tools.jackson` for 3.x, `com.fasterxml` for 2.x). One artifact, both worlds, no forced upgrade. If neither is on the classpath, it throws a clear error.

Verified the rendered config is byte-for-byte unchanged on Jackson 2, and serializes correctly on a Jackson-3-only classpath (`@JsonValue` enums, `@JsonInclude(NON_NULL)`, DEDUCTION schemes, escaping all intact).

Follow-up (not in this PR): a CI test matrix exercising the Jackson 3 branch, and a README note about the runtime Jackson requirement.

## Ticket

Fixes #9601