### PR TITLE
feat(java): support more configuration options

### DIFF
--- a/.changeset/java-config-options.md
+++ b/.changeset/java-config-options.md
@@ -1,0 +1,5 @@
+---
+'@scalar/java-integration': patch
+---
+
+Add support for more configuration options: `modelsSectionLabel`, `expandAllSchemaProperties`, `defaultOpenFirstTag`, and `mcp`.

--- a/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/ScalarProperties.java
+++ b/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/ScalarProperties.java
@@ -3,6 +3,7 @@ package com.scalar.maven.core;
 import com.scalar.maven.core.authentication.ScalarAuthenticationOptions;
 import com.scalar.maven.core.config.DefaultHttpClient;
 import com.scalar.maven.core.config.ScalarAgentOptions;
+import com.scalar.maven.core.config.ScalarMcpOptions;
 import com.scalar.maven.core.config.ScalarServer;
 import com.scalar.maven.core.config.ScalarSource;
 import com.scalar.maven.core.enums.*;
@@ -216,6 +217,32 @@ public class ScalarProperties {
      * Defaults to false (shown).
      */
     private boolean hideClientButton = false;
+
+    /**
+     * Controls the label for the components.schemas section in the sidebar,
+     * content, and search. Use "Schemas" for OpenAPI terminology; "Models" is
+     * the default when left unset.
+     */
+    private String modelsSectionLabel;
+
+    /**
+     * Controls whether all nested schema properties are expanded by default.
+     * Defaults to false (collapsed).
+     */
+    private boolean expandAllSchemaProperties = false;
+
+    /**
+     * Controls whether the first tag is opened when the URL does not target a
+     * specific section.
+     * Defaults to true.
+     */
+    private boolean defaultOpenFirstTag = true;
+
+    /**
+     * Controls the MCP (Model Context Protocol) integration. When provided,
+     * users can connect the API Reference to MCP-compatible tools.
+     */
+    private ScalarMcpOptions mcp;
 
     // Primary enum properties (no suffix)
 
@@ -591,6 +618,38 @@ public class ScalarProperties {
 
     public void setAgent(ScalarAgentOptions agent) {
         this.agent = agent;
+    }
+
+    public String getModelsSectionLabel() {
+        return modelsSectionLabel;
+    }
+
+    public void setModelsSectionLabel(String modelsSectionLabel) {
+        this.modelsSectionLabel = modelsSectionLabel;
+    }
+
+    public boolean isExpandAllSchemaProperties() {
+        return expandAllSchemaProperties;
+    }
+
+    public void setExpandAllSchemaProperties(boolean expandAllSchemaProperties) {
+        this.expandAllSchemaProperties = expandAllSchemaProperties;
+    }
+
+    public boolean isDefaultOpenFirstTag() {
+        return defaultOpenFirstTag;
+    }
+
+    public void setDefaultOpenFirstTag(boolean defaultOpenFirstTag) {
+        this.defaultOpenFirstTag = defaultOpenFirstTag;
+    }
+
+    public ScalarMcpOptions getMcp() {
+        return mcp;
+    }
+
+    public void setMcp(ScalarMcpOptions mcp) {
+        this.mcp = mcp;
     }
 }
 

--- a/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/config/ScalarMcpOptions.java
+++ b/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/config/ScalarMcpOptions.java
@@ -1,0 +1,89 @@
+package com.scalar.maven.core.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * MCP (Model Context Protocol) configuration options.
+ * When provided, enables MCP integration so users can connect their API
+ * reference to MCP-compatible tools.
+ *
+ * @see <a href="https://github.com/scalar/scalar/blob/main/documentation/configuration.md">Configuration</a>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ScalarMcpOptions {
+
+    /**
+     * Display name for the MCP server.
+     */
+    private String name;
+
+    /**
+     * URL of the MCP server.
+     */
+    private String url;
+
+    /**
+     * When true, disables the MCP integration.
+     */
+    private Boolean disabled;
+
+    /**
+     * Creates empty MCP options.
+     */
+    public ScalarMcpOptions() {
+    }
+
+    /**
+     * Gets the display name for the MCP server.
+     *
+     * @return the name or null
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the display name for the MCP server.
+     *
+     * @param name the name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets the URL of the MCP server.
+     *
+     * @return the URL or null
+     */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * Sets the URL of the MCP server.
+     *
+     * @param url the URL
+     */
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    /**
+     * Gets whether the MCP integration is disabled.
+     *
+     * @return true if disabled, false if enabled, null if not set
+     */
+    public Boolean getDisabled() {
+        return disabled;
+    }
+
+    /**
+     * Sets whether the MCP integration is disabled.
+     *
+     * @param disabled true to disable, false or null to use default behavior
+     */
+    public void setDisabled(Boolean disabled) {
+        this.disabled = disabled;
+    }
+}

--- a/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/internal/ScalarConfiguration.java
+++ b/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/internal/ScalarConfiguration.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.scalar.maven.core.authentication.ScalarAuthenticationOptions;
 import com.scalar.maven.core.config.DefaultHttpClient;
 import com.scalar.maven.core.config.ScalarAgentOptions;
+import com.scalar.maven.core.config.ScalarMcpOptions;
 import com.scalar.maven.core.config.ScalarServer;
 import com.scalar.maven.core.config.ScalarSource;
 import com.scalar.maven.core.enums.*;
@@ -133,6 +134,18 @@ public class ScalarConfiguration {
 
     @JsonProperty("agent")
     private ScalarAgentOptions agent;
+
+    @JsonProperty("modelsSectionLabel")
+    private String modelsSectionLabel;
+
+    @JsonProperty("expandAllSchemaProperties")
+    private Boolean expandAllSchemaProperties;
+
+    @JsonProperty("defaultOpenFirstTag")
+    private Boolean defaultOpenFirstTag;
+
+    @JsonProperty("mcp")
+    private ScalarMcpOptions mcp;
 
     // Getters and setters
     public String getUrl() {
@@ -421,5 +434,37 @@ public class ScalarConfiguration {
 
     public void setAgent(ScalarAgentOptions agent) {
         this.agent = agent;
+    }
+
+    public String getModelsSectionLabel() {
+        return modelsSectionLabel;
+    }
+
+    public void setModelsSectionLabel(String modelsSectionLabel) {
+        this.modelsSectionLabel = modelsSectionLabel;
+    }
+
+    public Boolean getExpandAllSchemaProperties() {
+        return expandAllSchemaProperties;
+    }
+
+    public void setExpandAllSchemaProperties(Boolean expandAllSchemaProperties) {
+        this.expandAllSchemaProperties = expandAllSchemaProperties;
+    }
+
+    public Boolean getDefaultOpenFirstTag() {
+        return defaultOpenFirstTag;
+    }
+
+    public void setDefaultOpenFirstTag(Boolean defaultOpenFirstTag) {
+        this.defaultOpenFirstTag = defaultOpenFirstTag;
+    }
+
+    public ScalarMcpOptions getMcp() {
+        return mcp;
+    }
+
+    public void setMcp(ScalarMcpOptions mcp) {
+        this.mcp = mcp;
     }
 }

--- a/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/internal/ScalarConfigurationMapper.java
+++ b/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/internal/ScalarConfigurationMapper.java
@@ -63,6 +63,10 @@ public class ScalarConfigurationMapper {
         config.setOrderSchemaPropertiesBy(properties.getSchemaPropertyOrder());
         config.setShowDeveloperTools(properties.getShowDeveloperTools());
         config.setAgent(properties.getAgent());
+        config.setModelsSectionLabel(properties.getModelsSectionLabel());
+        config.setExpandAllSchemaProperties(properties.isExpandAllSchemaProperties());
+        config.setDefaultOpenFirstTag(properties.isDefaultOpenFirstTag());
+        config.setMcp(properties.getMcp());
 
         return config;
     }

--- a/integrations/java/scalar-core/src/test/java/com/scalar/maven/core/ScalarConfigurationTest.java
+++ b/integrations/java/scalar-core/src/test/java/com/scalar/maven/core/ScalarConfigurationTest.java
@@ -3,6 +3,7 @@ package com.scalar.maven.core;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.scalar.maven.core.config.ScalarAgentOptions;
+import com.scalar.maven.core.config.ScalarMcpOptions;
 import com.scalar.maven.core.enums.*;
 import com.scalar.maven.core.internal.ScalarConfiguration;
 import com.scalar.maven.core.internal.ScalarConfigurationMapper;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test class for ScalarConfiguration and related functionality.
@@ -125,6 +127,39 @@ public class ScalarConfigurationTest {
         assertNotNull(config.getAgent());
         assertEquals("production-agent-key", config.getAgent().getKey());
         assertEquals(false, config.getAgent().getDisabled());
+    }
+
+    @Test
+    public void testNewConfigurationOptionsSerialization() throws JsonProcessingException {
+        ScalarProperties properties = new ScalarProperties();
+        properties.setModelsSectionLabel("Schemas");
+        properties.setExpandAllSchemaProperties(true);
+        properties.setDefaultOpenFirstTag(false);
+
+        ScalarMcpOptions mcp = new ScalarMcpOptions();
+        mcp.setName("My API");
+        mcp.setUrl("https://mcp.example.com");
+        properties.setMcp(mcp);
+
+        ScalarConfiguration config = ScalarConfigurationMapper.map(properties);
+        String json = new ObjectMapper().writeValueAsString(config);
+
+        assertTrue(json.contains("\"modelsSectionLabel\":\"Schemas\""));
+        assertTrue(json.contains("\"expandAllSchemaProperties\":true"));
+        assertTrue(json.contains("\"defaultOpenFirstTag\":false"));
+        assertTrue(json.contains("\"mcp\":{"));
+        assertTrue(json.contains("\"name\":\"My API\""));
+        assertTrue(json.contains("\"url\":\"https://mcp.example.com\""));
+    }
+
+    @Test
+    public void testNewConfigurationOptionDefaults() throws JsonProcessingException {
+        ScalarConfiguration config = ScalarConfigurationMapper.map(new ScalarProperties());
+        String json = new ObjectMapper().writeValueAsString(config);
+
+        // Defaults follow the universal configuration
+        assertTrue(json.contains("\"defaultOpenFirstTag\":true"));
+        assertTrue(json.contains("\"expandAllSchemaProperties\":false"));
     }
 
     @Test


### PR DESCRIPTION
The Java integration was missing a few API Reference config options that have landed since. This adds the serializable ones so Spring Boot users can set them like any other property:

- `modelsSectionLabel`
- `expandAllSchemaProperties`
- `defaultOpenFirstTag`
- `mcp` (`{ name, url, disabled }`)

Function-only options (`customFetch`, `redirect`, `plugins`, the `generate*Slug` callbacks, …) can't be serialized from Java config, so they're left out. `hiddenClients` and `pathRouting` are skipped for now — `hiddenClients` needs a union type that deserves its own design pass.
