### PR TITLE
feat(void): Add logging config to allow external loggers

### DIFF
--- a/.changeset/void-server-logger-options.md
+++ b/.changeset/void-server-logger-options.md
@@ -1,0 +1,5 @@
+---
+'@scalar/void-server': patch
+---
+
+Add logger options to `createVoidServer`.

--- a/packages/void-server/README.md
+++ b/packages/void-server/README.md
@@ -48,6 +48,25 @@ const httpServer = serve(
 attachVoidWebSocket(httpServer)
 ```
 
+### Request logging
+
+Void Server enables Hono request logging by default outside CI. Disable it when
+your platform already captures request logs:
+
+```ts
+const app = createVoidServer({
+  logger: false,
+})
+```
+
+Pass a custom logger function to control where access log lines are written:
+
+```ts
+const app = createVoidServer({
+  logger: (line) => console.info(line),
+})
+```
+
 ### WebSocket echo
 
 Call `attachVoidWebSocket(httpServer)` to enable the WebSocket echo on an existing Node HTTP server. Connect with any path (for example `ws://localhost:3000/chat`) and the server echoes any text or binary frame back unchanged.

--- a/packages/void-server/src/create-void-server.test.ts
+++ b/packages/void-server/src/create-void-server.test.ts
@@ -24,6 +24,24 @@ const extractStoredEntry = (bytes: Uint8Array): { content: string; fileName: str
 }
 
 describe('createVoidServer', () => {
+  it('can disable request logging', async () => {
+    const server = await createVoidServer({ logger: false })
+
+    expect(server.routes.some((route) => route.handler.name === 'logger2')).toBe(false)
+  })
+
+  it('accepts a custom request logger', async () => {
+    const logLines: string[] = []
+    const server = await createVoidServer({
+      logger: (line) => logLines.push(line),
+    })
+
+    await server.request('/logger-test')
+
+    expect(logLines[0]).toBe('<-- GET /logger-test')
+    expect(logLines[1]).toContain('--> GET /logger-test')
+  })
+
   it('GET /foobar', async () => {
     const server = await createVoidServer()
 

--- a/packages/void-server/src/create-void-server.ts
+++ b/packages/void-server/src/create-void-server.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { accepts } from 'hono/accepts'
 import { cors } from 'hono/cors'
-import { logger } from 'hono/logger'
+import { logger as honoLogger } from 'hono/logger'
 import type { StatusCode } from 'hono/utils/http-status'
 
 import { errors } from '@/utils/constants'
@@ -12,15 +12,28 @@ import { createXmlResponse } from '@/utils/create-xml-response'
 import { createZipFileResponse } from '@/utils/create-zip-file-response'
 import { getRequestData } from '@/utils/get-request-data'
 
+type VoidServerLogger = Parameters<typeof honoLogger>[0]
+
+export type CreateVoidServerOptions = {
+  /**
+   * Configure request logging.
+   *
+   * Defaults to the existing behavior: enabled outside CI, disabled in CI.
+   * Set to `false` to disable access logs, `true` to force Hono's default
+   * logger, or pass a function to customize where log lines are written.
+   */
+  logger?: boolean | VoidServerLogger
+}
+
 /**
  * Create a mock server instance
  */
-export function createVoidServer() {
+export function createVoidServer(options: CreateVoidServerOptions = {}) {
   const app = new Hono()
 
-  // Logger
-  if (!process.env.CI) {
-    app.use(logger())
+  const logger = options.logger ?? !process.env.CI
+  if (logger) {
+    app.use(honoLogger(typeof logger === 'function' ? logger : undefined))
   }
 
   // CORS headers

--- a/packages/void-server/src/index.ts
+++ b/packages/void-server/src/index.ts
@@ -1,2 +1,2 @@
-export { createVoidServer } from '@/create-void-server'
+export { type CreateVoidServerOptions, createVoidServer } from '@/create-void-server'
 export { DEFAULT_VOID_WEBSOCKET_TIMEOUT_MS, type VoidWebSocketOptions, attachVoidWebSocket } from '@/void-websocket'


### PR DESCRIPTION
## Problem

Exposes the logger interface for deployment flexibility. 

## Checklist

- [ ] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
