### PR TITLE
fix(api-reference): only show required parameters in code examples

### DIFF
--- a/.changeset/code-example-required-params.md
+++ b/.changeset/code-example-required-params.md
@@ -1,0 +1,5 @@
+---
+'@scalar/blocks': patch
+---
+
+Only show required parameters in code examples. Optional query, header, and cookie parameters are now omitted from the generated request snippets unless they are explicitly enabled via the `x-disabled: false` extension.

--- a/packages/blocks/src/code-example/components/CodeExample.test.ts
+++ b/packages/blocks/src/code-example/components/CodeExample.test.ts
@@ -1528,6 +1528,73 @@ describe('RequestExample', () => {
     })
   })
 
+  describe('Query parameters', () => {
+    const operationWithQueryParams: OperationObject = {
+      summary: 'Operation with query parameters',
+      parameters: [
+        {
+          name: 'requiredParam',
+          in: 'query',
+          required: true,
+          schema: { type: 'integer' },
+        },
+        {
+          name: 'optionalParam',
+          in: 'query',
+          required: false,
+          schema: { type: 'integer' },
+        },
+      ],
+    }
+
+    it('only includes required query parameters in the code example', () => {
+      const wrapper = mount(RequestExample, {
+        props: {
+          ...defaultProps,
+          operation: operationWithQueryParams,
+          selectedClient: 'shell/curl' as AvailableClient,
+        },
+      })
+
+      const content = wrapper.findComponent({ name: 'ScalarCodeBlock' }).props('content') as string
+
+      expect(content).toContain('requiredParam')
+      expect(content).not.toContain('optionalParam')
+    })
+
+    it('includes an optional query parameter when explicitly enabled via x-disabled', () => {
+      const operation: OperationObject = {
+        summary: 'Operation with an explicitly enabled optional parameter',
+        parameters: [
+          {
+            name: 'optionalParam',
+            in: 'query',
+            required: false,
+            schema: { type: 'integer' },
+            examples: {
+              default: {
+                'x-disabled': false,
+                value: 1,
+              },
+            },
+          },
+        ],
+      }
+
+      const wrapper = mount(RequestExample, {
+        props: {
+          ...defaultProps,
+          operation,
+          selectedClient: 'shell/curl' as AvailableClient,
+        },
+      })
+
+      const content = wrapper.findComponent({ name: 'ScalarCodeBlock' }).props('content') as string
+
+      expect(content).toContain('optionalParam')
+    })
+  })
+
   describe('Accessibility', () => {
     it('has proper ARIA labels', () => {
       const wrapper = mount(RequestExample, {

--- a/packages/blocks/src/code-example/components/CodeExample.vue
+++ b/packages/blocks/src/code-example/components/CodeExample.vue
@@ -317,7 +317,9 @@ const webhookHar = computed(() => {
       path,
       example: localExampleKey.value,
       requestBodyCompositionSelection,
-      defaultDisabledParameters: false,
+      // Only required parameters are shown in code examples; optional parameters
+      // are omitted unless explicitly enabled via `x-disabled: false`.
+      defaultDisabledParameters: true,
     })
   } catch (error) {
     console.error('[webhookHar]', error)
@@ -332,7 +334,9 @@ const generatedCode = computed<string>(() => {
   }
 
   return generateCodeSnippet({
-    defaultDisabledParameters: false,
+    // Only required parameters are shown in code examples; optional parameters
+    // are omitted unless explicitly enabled via `x-disabled: false`.
+    defaultDisabledParameters: true,
     includeDefaultHeaders: integration === 'client',
     clientId: localSelectedClient.value?.id,
     customCodeSamples: customCodeSamples.value.samples,


### PR DESCRIPTION
Code examples were appending every optional query parameter to the URL as long as it had a schema, so you would end up with `?a=1&b=1&c=1&...` for params nobody asked for.

Now code examples only include required parameters. Optional ones are left out unless you explicitly opt them back in with `x-disabled: false`. This matches what the API client already does.

## Ticket

Closes #9607