### PR TITLE
docs(blocks): add @scalar/blocks

### DIFF
--- a/documentation/guides/blocks/code-example.md
+++ b/documentation/guides/blocks/code-example.md
@@ -1,0 +1,60 @@
+# Code Example
+
+The Code Example block renders a copy-pasteable request snippet for a single operation. It comes with a client picker (curl, Node, Python, and more) and, when the operation has multiple request examples, an example selector — exactly like the snippets in a full API reference.
+
+The block mounts itself into a DOM element, so you do not need to set up Vue yourself.
+
+## Usage
+
+```ts
+import { createWorkspaceStore } from '@scalar/workspace-store/client'
+import { createCodeExample } from '@scalar/blocks/code-example'
+import '@scalar/blocks/style.css'
+
+const store = createWorkspaceStore()
+
+await store.addDocument({
+  name: 'default',
+  url: '/openapi.json',
+})
+
+const block = createCodeExample('#block', {
+  store,
+  path: '/users/{id}',
+  method: 'get',
+})
+
+// Later, when the block is no longer needed
+block.destroy()
+```
+
+`createCodeExample` accepts either a CSS selector or an `HTMLElement` as its first argument. It throws if the element cannot be found, or if the `path` and `method` do not point at an operation in the store.
+
+## Options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `store` | `WorkspaceStore` | **Required.** The workspace store that holds the OpenAPI document(s) to render from. |
+| `path` | `string` | **Required.** Path of the operation to render, e.g. `/users/{id}`. |
+| `method` | `HttpMethod` | **Required.** HTTP method of the operation to render. |
+| `selectedClient` | `AvailableClients[number]` | Pre-selected client ID, e.g. `shell/curl`. |
+| `selectedServer` | `ServerObject \| null` | Server override used to build the example. When omitted, the server is derived from the active document (operation, then path item, then document level). Pass `null` to force "no server". |
+| `selectedExample` | `string` | Pre-selected example key for parameters and the request body. |
+| `securitySchemes` | `SecuritySchemeObjectSecret[]` | Security schemes applicable to the operation. |
+| `darkMode` | `boolean` | Force a color mode. When omitted, the block inherits the ambient theme of the host page. |
+
+## The store is the source of truth
+
+The client and example selections round-trip through the store. Once a user picks a client or an example, that choice is written back to the store (`x-scalar-default-client` and `x-scalar-default-example`) and wins over the initial `selectedClient` / `selectedExample` seed.
+
+This means selections survive re-renders and stay in sync across every block reading from the same store — pick a client in one block and the others follow.
+
+## Cleaning up
+
+`createCodeExample` returns the underlying Vue `app` and a `destroy` function. Call `destroy()` to unsubscribe the block from the store and unmount it.
+
+```ts
+const block = createCodeExample('#block', { store, path: '/hello', method: 'post' })
+
+block.destroy()
+```

--- a/documentation/guides/blocks/getting-started.md
+++ b/documentation/guides/blocks/getting-started.md
@@ -1,0 +1,44 @@
+# Blocks
+
+Blocks are small, self-contained pieces of API documentation that you can mount anywhere in your own UI. Instead of rendering a full API reference, you pick exactly the part you need — like a code example for a single operation — and drop it into your page.
+
+Each block reads from a [workspace store](https://github.com/scalar/scalar/tree/main/packages/workspace-store) that holds your OpenAPI document(s). You create and control the store, then hand it to a block along with the operation you want to render.
+
+## Installation
+
+```bash
+npm install @scalar/blocks
+```
+
+## Usage
+
+```ts
+import { createWorkspaceStore } from '@scalar/workspace-store/client'
+import { createCodeExample } from '@scalar/blocks/code-example'
+import '@scalar/blocks/style.css'
+
+// Load your OpenAPI document(s) into a store
+const store = createWorkspaceStore()
+
+await store.addDocument({
+  name: 'default',
+  url: '/openapi.json',
+})
+
+// Mount a block into a DOM element
+createCodeExample('#block', {
+  store,
+  path: '/hello',
+  method: 'post',
+  selectedClient: 'node/undici',
+  selectedServer: {
+    url: 'https://api.example.com',
+  },
+})
+```
+
+## Available blocks
+
+- [Code Example](code-example.md) — Render a copy-pasteable request snippet for a single operation, with a client picker and example selector.
+
+More blocks are on the way.

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1702,6 +1702,24 @@
                     "filepath": "documentation/plugins.md",
                     "type": "page"
                   },
+                  "blocks": {
+                    "title": "Blocks",
+                    "type": "group",
+                    "mode": "flat",
+                    "icon": "phosphor/regular/squares-four",
+                    "children": {
+                      "getting-started": {
+                        "title": "Getting Started",
+                        "filepath": "documentation/guides/blocks/getting-started.md",
+                        "type": "page"
+                      },
+                      "code-example": {
+                        "title": "Code Example",
+                        "filepath": "documentation/guides/blocks/code-example.md",
+                        "type": "page"
+                      }
+                    }
+                  },
                   "openapi": {
                     "title": "OpenAPI",
                     "filepath": "documentation/openapi.md",


### PR DESCRIPTION
Adds a **Blocks** section to the docs, under Products › API References.

- Getting Started: install, store setup, and the usage pattern
- Code Example: options reference and how selections round-trip through the store

Set up as a group so more blocks can slot in later.

**Preview**

https://twk0bjfpqseodczpcevwf--scalar.apidocumentation.com/products/api-references/blocks/getting-started