### PR TITLE
feat(scalar-app): support OAuth2 on desktop via loopback redirect

### DIFF
--- a/.changeset/oauth-desktop-loopback.md
+++ b/.changeset/oauth-desktop-loopback.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client': minor
+---
+
+feat(api-client): support an injectable OAuth2 redirect capture for interactive flows
+
+Adds an optional `captureOAuth2Callback` option so environments that cannot use browser-popup polling (notably the Electron desktop app, where the renderer runs on `file://`) can run the authorization-code and implicit flows through the system browser and a host-owned redirect target. The desktop app uses this to capture the redirect on a `127.0.0.1` loopback server (RFC 8252).

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.test.ts
@@ -8,6 +8,7 @@ import { nextTick } from 'vue'
 import OAuth2 from '@/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue'
 import OAuthScopesInput from '@/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue'
 import RequestAuthDataTableInput from '@/v2/blocks/scalar-auth-selector-block/components/RequestAuthDataTableInput.vue'
+import type { CaptureOAuth2Callback } from '@/v2/blocks/scalar-auth-selector-block/helpers/oauth'
 
 describe('OAuth2', () => {
   const baseEnv = {
@@ -28,7 +29,9 @@ describe('OAuth2', () => {
       server: any
       proxyUrl: string
       scheme: any
-      configuration: Partial<ApiClientConfiguration>
+      configuration: Partial<ApiClientConfiguration> & {
+        captureOAuth2Callback?: CaptureOAuth2Callback
+      }
     }> = {},
   ) => {
     const flows =
@@ -286,6 +289,36 @@ describe('OAuth2', () => {
       },
       name: 'OAuth2',
     })
+  })
+
+  it('does not persist a redirect URI when captureOAuth2Callback is provided', async () => {
+    const emitted = vi.fn()
+    eventBus.on('auth:update:security-scheme-secrets', emitted)
+
+    mountWithProps({
+      configuration: {
+        oauth2RedirectUri: 'http://127.0.0.1',
+        captureOAuth2Callback: vi.fn(),
+      },
+      flows: {
+        authorizationCode: {
+          authorizationUrl: 'https://example.com/auth',
+          tokenUrl: 'https://example.com/token',
+          'x-scalar-secret-token': '',
+          'x-usePkce': 'no',
+          'x-scalar-secret-redirect-uri': '',
+          scopes: {},
+          'x-scalar-secret-client-id': '',
+          'x-scalar-secret-client-secret': '',
+        },
+      },
+    })
+
+    await nextTick()
+
+    // The desktop loopback path owns the redirect URI at runtime, so nothing is
+    // written into the document.
+    expect(emitted).not.toHaveBeenCalled()
   })
 
   it('does not pre-fill redirect URI on file protocol without config override', async () => {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
@@ -6,6 +6,8 @@ export type OAuth2Options = Pick<
 > & {
   /** Optional fetch override (IPC-backed on desktop) used for token exchange, refresh, and OIDC discovery */
   customFetch?: typeof fetch
+  /** Optional redirect capture (loopback-backed on desktop) for interactive OAuth2 flows */
+  captureOAuth2Callback?: CaptureOAuth2Callback
 }
 </script>
 
@@ -41,6 +43,7 @@ import OAuthScopesInput from '@/v2/blocks/scalar-auth-selector-block/components/
 import {
   authorizeOauth2,
   refreshOauth2Token,
+  type CaptureOAuth2Callback,
 } from '@/v2/blocks/scalar-auth-selector-block/helpers/oauth'
 import { resolveDefaultOAuth2RedirectUri } from '@/v2/blocks/scalar-auth-selector-block/helpers/resolve-default-oauth2-redirect-url'
 import { DataTableRow } from '@/v2/components/data-table'
@@ -259,6 +262,7 @@ const handleAuthorize = async (): Promise<void> => {
     proxyUrl,
     getEnvironmentVariables(environment),
     options.customFetch,
+    options.captureOAuth2Callback,
   )
 
   await loader.clear()

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
@@ -232,7 +232,14 @@ watch(
 
     hasHandledRedirectPrefill.value = true
 
-    if (newRedirectUri || !defaultRedirectUri) {
+    // The desktop loopback path computes the redirect URI at authorize time (an
+    // ephemeral 127.0.0.1 port), so persisting a default into the document would
+    // only bake in a stale, unused value. Leave it empty and show a hint instead.
+    if (
+      newRedirectUri ||
+      !defaultRedirectUri ||
+      options.captureOAuth2Callback
+    ) {
       return
     }
 
@@ -433,7 +440,11 @@ const handleSecretLocationUpdate = (value: string): void => {
       <RequestAuthDataTableInput
         :environment
         :modelValue="flow['x-scalar-secret-redirect-uri']"
-        placeholder="Optional redirect URL"
+        :placeholder="
+          options.captureOAuth2Callback
+            ? `${resolveDefaultOAuth2RedirectUri(options) || 'http://127.0.0.1'} (handled automatically)`
+            : 'Optional redirect URL'
+        "
         @update:modelValue="
           (v) => {
             hasHandledRedirectPrefill = true

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
@@ -107,6 +107,160 @@ describe('oauth', () => {
     })
   })
 
+  describe('Capture callback (desktop loopback)', () => {
+    const dynamicRedirectUri = 'http://127.0.0.1:54321/callback'
+
+    const authCodeScheme = {
+      authorizationCode: {
+        ...baseFlow,
+        'x-usePkce': 'no',
+        authorizationUrl,
+        tokenUrl,
+        'x-scalar-secret-redirect-uri': 'http://127.0.0.1',
+        'x-scalar-secret-token': '',
+        'x-scalar-secret-client-secret': clientSecret,
+      },
+    } satisfies OAuthFlowsObjectSecret
+
+    const implicitScheme = {
+      implicit: {
+        ...baseFlow,
+        authorizationUrl,
+        'x-scalar-secret-redirect-uri': 'http://127.0.0.1',
+        'x-scalar-secret-token': '',
+      },
+    } satisfies OAuthFlowsObjectSecret
+
+    it('builds the authorization URL without a redirect_uri and exchanges the captured code', async () => {
+      const accessToken = 'capture_access_token'
+      const capture = vi
+        .fn()
+        .mockResolvedValue([
+          null,
+          { callbackUrl: `${dynamicRedirectUri}?code=cap_code&state=${state}`, redirectUri: dynamicRedirectUri },
+        ])
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        json: () => Promise.resolve({ access_token: accessToken }),
+      })
+
+      const [error, result] = await authorizeOauth2(
+        authCodeScheme,
+        'authorizationCode',
+        selectedScopes,
+        mockServer,
+        '',
+        {},
+        undefined,
+        capture,
+      )
+
+      expect(error).toBe(null)
+      expect(result).toEqual({ accessToken })
+
+      // The capture path leaves redirect_uri to the host environment.
+      const passedUrl = new URL(capture.mock.calls[0]![0].authorizationUrl)
+      expect(passedUrl.searchParams.has('redirect_uri')).toBe(false)
+      expect(passedUrl.searchParams.get('state')).toBe(state)
+
+      // The token exchange must echo the exact redirect_uri the host used.
+      const body = vi.mocked(global.fetch).mock.calls[0]![1]?.body as URLSearchParams
+      expect(body.get('redirect_uri')).toBe(dynamicRedirectUri)
+      expect(body.get('code')).toBe('cap_code')
+    })
+
+    it('resolves the implicit access token from the captured fragment without a token exchange', async () => {
+      const accessToken = 'implicit_capture_token'
+      const capture = vi.fn().mockResolvedValue([
+        null,
+        {
+          callbackUrl: `${dynamicRedirectUri}#access_token=${accessToken}&state=${state}`,
+          redirectUri: dynamicRedirectUri,
+        },
+      ])
+      global.fetch = vi.fn()
+
+      const [error, result] = await authorizeOauth2(
+        implicitScheme,
+        'implicit',
+        selectedScopes,
+        mockServer,
+        '',
+        {},
+        undefined,
+        capture,
+      )
+
+      expect(error).toBe(null)
+      expect(result).toEqual({ accessToken })
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+
+    it('rejects when the captured state does not match', async () => {
+      const capture = vi
+        .fn()
+        .mockResolvedValue([
+          null,
+          { callbackUrl: `${dynamicRedirectUri}?code=cap_code&state=wrong`, redirectUri: dynamicRedirectUri },
+        ])
+
+      const [error, result] = await authorizeOauth2(
+        authCodeScheme,
+        'authorizationCode',
+        selectedScopes,
+        mockServer,
+        '',
+        {},
+        undefined,
+        capture,
+      )
+
+      expect(result).toBe(null)
+      expect(error?.message).toBe('State mismatch')
+    })
+
+    it('surfaces provider errors returned on the callback', async () => {
+      const capture = vi
+        .fn()
+        .mockResolvedValue([
+          null,
+          { callbackUrl: `${dynamicRedirectUri}?error=access_denied`, redirectUri: dynamicRedirectUri },
+        ])
+
+      const [error, result] = await authorizeOauth2(
+        implicitScheme,
+        'implicit',
+        selectedScopes,
+        mockServer,
+        '',
+        {},
+        undefined,
+        capture,
+      )
+
+      expect(result).toBe(null)
+      expect(error?.message).toContain('access_denied')
+    })
+
+    it('propagates a capture failure', async () => {
+      const capture = vi.fn().mockResolvedValue([new Error('Loopback bind failed'), null])
+
+      const [error, result] = await authorizeOauth2(
+        authCodeScheme,
+        'authorizationCode',
+        selectedScopes,
+        mockServer,
+        '',
+        {},
+        undefined,
+        capture,
+      )
+
+      expect(result).toBe(null)
+      expect(error?.message).toBe('Loopback bind failed')
+    })
+  })
+
   describe('Authorization Code Grant', () => {
     const scheme = {
       authorizationCode: {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
@@ -43,6 +43,29 @@ export type OAuth2Tokens = {
   refreshToken?: string
 }
 
+/**
+ * Captures the OAuth2 redirect for environments where the browser-popup polling
+ * approach cannot work (notably the Electron desktop app, where the renderer
+ * runs on `file://` and providers reject `file://` redirect URIs).
+ *
+ * The implementation opens the authorization URL in the system browser and
+ * resolves once the provider redirects back. Because the redirect target (for
+ * example an ephemeral loopback port) is only known to the host environment, the
+ * implementation appends the `redirect_uri` itself and reports back the exact
+ * value it used so the token exchange can send the matching `redirect_uri`.
+ */
+export type CaptureOAuth2Callback = (params: {
+  /** The fully built authorization URL, without a `redirect_uri` parameter. */
+  authorizationUrl: string
+}) => Promise<
+  ErrorResponse<{
+    /** The full callback URL the provider redirected to, including query and/or hash params. */
+    callbackUrl: string
+    /** The `redirect_uri` the host environment used, so the token exchange can match it. */
+    redirectUri: string
+  }>
+>
+
 /** Flow types that support token refresh (all except implicit) */
 type RefreshableFlows = Exclude<keyof OAuthFlowsObjectSecret, 'implicit'>
 
@@ -135,6 +158,12 @@ export const authorizeOauth2 = async (
   environmentVariables: Record<string, string> = {},
   /** Fetch used for the token request; the desktop app passes an IPC-backed fetch (see {@link authorizeServers}). */
   customFetch?: CustomFetch,
+  /**
+   * Optional redirect capture for interactive flows (authorization code and implicit).
+   * When provided, the system browser plus a host-owned redirect target replaces the
+   * default popup-polling approach. Required for the Electron desktop app.
+   */
+  captureCallback?: CaptureOAuth2Callback,
 ): Promise<ErrorResponse<OAuth2Tokens>> => {
   const flow = flows[type]
 
@@ -201,15 +230,19 @@ export const authorizeOauth2 = async (
 
     const typedFlow = flows[type]! // Safe to assert due to earlier check
 
-    // Handle relative redirect uris
-    if (typedFlow['x-scalar-secret-redirect-uri'].startsWith('/')) {
-      const baseUrl =
-        getServerUrl(activeServer, environmentVariables) || window.location.origin + window.location.pathname
-      const redirectUri = new URL(typedFlow['x-scalar-secret-redirect-uri'], baseUrl).toString()
+    // The capture path appends its own `redirect_uri` (it owns the target, for
+    // example an ephemeral loopback port), so we only set it here for the popup path.
+    if (!captureCallback) {
+      // Handle relative redirect uris
+      if (typedFlow['x-scalar-secret-redirect-uri'].startsWith('/')) {
+        const baseUrl =
+          getServerUrl(activeServer, environmentVariables) || window.location.origin + window.location.pathname
+        const redirectUri = new URL(typedFlow['x-scalar-secret-redirect-uri'], baseUrl).toString()
 
-      url.searchParams.set('redirect_uri', redirectUri)
-    } else {
-      url.searchParams.set('redirect_uri', typedFlow['x-scalar-secret-redirect-uri'])
+        url.searchParams.set('redirect_uri', redirectUri)
+      } else {
+        url.searchParams.set('redirect_uri', typedFlow['x-scalar-secret-redirect-uri'])
+      }
     }
 
     if (flow['x-scalar-security-query']) {
@@ -227,6 +260,55 @@ export const authorizeOauth2 = async (
     url.searchParams.set('state', state)
     if (scopes) {
       url.searchParams.set('scope', scopes)
+    }
+
+    // Capture path: open the system browser and let the host environment catch
+    // the redirect (used by the desktop app, where popup polling cannot work).
+    if (captureCallback) {
+      const [captureError, capture] = await captureCallback({ authorizationUrl: url.toString() })
+
+      if (captureError || !capture) {
+        return [captureError ?? new Error('Failed to capture the OAuth2 redirect'), null]
+      }
+
+      const { accessToken, accessTokenParams, code, codeParams, error, errorDescription, refreshToken } =
+        getOAuthCallbackData(() => capture.callbackUrl, flow['x-tokenName'] || 'access_token')
+
+      if (error) {
+        return [new Error(`OAuth error: ${error}${errorDescription ? ` (${errorDescription})` : ''}`), null]
+      }
+
+      // Implicit Flow
+      if (accessToken) {
+        if ((accessTokenParams?.get('state') ?? null) !== state) {
+          return [new Error('State mismatch'), null]
+        }
+        return [null, { accessToken, ...(refreshToken ? { refreshToken } : {}) }]
+      }
+
+      // Authorization Code Server Flow
+      if (code && type === 'authorizationCode') {
+        if ((codeParams?.get('state') ?? null) !== state) {
+          return [new Error('State mismatch'), null]
+        }
+        return authorizeServers(
+          flows,
+          type,
+          scopes,
+          {
+            code,
+            pkce,
+            proxyUrl,
+            customFetch,
+            // The token request must echo the exact redirect_uri used in the authorization request.
+            redirectUri: capture.redirectUri,
+          },
+          activeServer,
+          environmentVariables,
+        )
+      }
+
+      return [new Error('No authorization code or access token was returned'), null]
     }
 
     const windowFeatures = 'left=100,top=100,width=800,height=600'
@@ -318,11 +400,14 @@ const authorizeServers = async (
     pkce,
     proxyUrl,
     customFetch = fetch,
+    redirectUri,
   }: {
     code?: string
     pkce?: PKCEState | null
     proxyUrl?: string
     customFetch?: CustomFetch
+    /** Overrides the stored redirect_uri (the capture path owns the real target). */
+    redirectUri?: string
   } = {},
   activeServer: ServerObject | null,
   environmentVariables: Record<string, string> = {},
@@ -356,7 +441,9 @@ const authorizeServers = async (
   if (addCredentialsToBody && hasClientSecret) {
     formData.set('client_secret', flow['x-scalar-secret-client-secret'])
   }
-  if ('x-scalar-secret-redirect-uri' in flow && flow['x-scalar-secret-redirect-uri']) {
+  if (redirectUri) {
+    formData.set('redirect_uri', redirectUri)
+  } else if ('x-scalar-secret-redirect-uri' in flow && flow['x-scalar-secret-redirect-uri']) {
     formData.set('redirect_uri', flow['x-scalar-secret-redirect-uri'])
   }
 

--- a/packages/api-client/src/v2/types/options.ts
+++ b/packages/api-client/src/v2/types/options.ts
@@ -2,6 +2,7 @@ import type { ApiReferenceConfigurationRaw } from '@scalar/types/api-reference'
 import type { Ref } from 'vue'
 
 import type { CustomFetch } from '@/v2/blocks/operation-block/helpers/send-request'
+import type { CaptureOAuth2Callback } from '@/v2/blocks/scalar-auth-selector-block/helpers/oauth'
 
 /**
  * Configuration options for the API Client (app and modal).
@@ -23,6 +24,12 @@ export type ApiClientOptions = Partial<
    * When provided, replaces the global fetch in the request execution engine (sendRequest).
    */
   customFetch?: CustomFetch
+  /**
+   * Captures the OAuth2 redirect for interactive flows where browser-popup polling
+   * cannot work. The desktop app provides this to run authorization through the
+   * system browser plus a loopback redirect target.
+   */
+  captureOAuth2Callback?: CaptureOAuth2Callback
 }
 
 export type ApiClientOptionsRef = Ref<ApiClientOptions>

--- a/projects/scalar-app/entrypoints/electron/main/actions/authorize-oauth2.test.ts
+++ b/projects/scalar-app/entrypoints/electron/main/actions/authorize-oauth2.test.ts
@@ -1,0 +1,161 @@
+import http from 'node:http'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getAllWindowsMock, openExternalMock } = vi.hoisted(() => ({
+  getAllWindowsMock: vi.fn(() => []),
+  openExternalMock: vi.fn(),
+}))
+
+vi.mock('electron/common', () => ({
+  shell: {
+    openExternal: openExternalMock,
+  },
+}))
+
+vi.mock('electron/main', () => ({
+  BrowserWindow: {
+    getAllWindows: getAllWindowsMock,
+  },
+}))
+
+import { authorizeOauth2 } from './authorize-oauth2'
+
+type RawResponse = {
+  body: string
+  statusCode: number
+}
+
+const baseAuthorizationUrl = 'https://auth.example.com/authorize?response_type=code&client_id=abc&state=xyz'
+
+/** Reads the loopback redirect_uri the action appended to the opened URL. */
+const parseOpenedRedirectUri = (): { port: number; redirectUri: string } => {
+  const openedUrl = new URL(openExternalMock.mock.calls[0]![0]!)
+  const redirectUri = openedUrl.searchParams.get('redirect_uri')
+
+  if (!redirectUri) {
+    throw new Error('Expected the opened URL to include a redirect_uri')
+  }
+
+  return { port: Number(new URL(redirectUri).port), redirectUri }
+}
+
+const waitForBrowserToOpen = async (): Promise<void> => {
+  await vi.waitFor(() => {
+    expect(openExternalMock).toHaveBeenCalled()
+  })
+  // Give the loopback server a tick to settle before connecting.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+const sendRequest = ({ path, port }: { path: string; port: number }): Promise<RawResponse> =>
+  new Promise((resolve, reject) => {
+    const request = http.request({ host: '127.0.0.1', method: 'GET', path, port }, (response) => {
+      let body = ''
+      response.setEncoding('utf8')
+      response.on('data', (chunk) => {
+        body += chunk
+      })
+      response.on('end', () => {
+        resolve({ body, statusCode: response.statusCode ?? 0 })
+      })
+    })
+
+    request.on('error', reject)
+    request.end()
+  })
+
+describe('authorize-oauth2', () => {
+  beforeEach(() => {
+    getAllWindowsMock.mockReturnValue([])
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('opens the system browser with an appended loopback redirect_uri', async () => {
+    const resultPromise = authorizeOauth2({ authorizationUrl: baseAuthorizationUrl })
+    await waitForBrowserToOpen()
+
+    const { port, redirectUri } = parseOpenedRedirectUri()
+
+    expect(redirectUri).toBe(`http://127.0.0.1:${port}/callback`)
+    expect(openExternalMock).toHaveBeenCalledWith(expect.stringContaining('response_type=code'), { activate: true })
+
+    await sendRequest({ path: '/callback?code=auth_code&state=xyz', port })
+    await resultPromise
+  })
+
+  it('resolves with the callback URL once the provider redirects back', async () => {
+    const resultPromise = authorizeOauth2({ authorizationUrl: baseAuthorizationUrl })
+    await waitForBrowserToOpen()
+
+    const { port, redirectUri } = parseOpenedRedirectUri()
+    await sendRequest({ path: '/callback?code=auth_code&state=xyz', port })
+
+    const result = await resultPromise
+
+    expect(result).toEqual({
+      callbackUrl: `http://127.0.0.1:${port}/callback?code=auth_code&state=xyz`,
+      redirectUri,
+    })
+  })
+
+  it('serves a fragment-relay page when no params arrive, then captures the relayed params', async () => {
+    const resultPromise = authorizeOauth2({ authorizationUrl: baseAuthorizationUrl })
+    await waitForBrowserToOpen()
+
+    const { port } = parseOpenedRedirectUri()
+
+    // Implicit responses put the token in the fragment, which the browser does
+    // not send, so the first request has no params and gets the relay page.
+    const relay = await sendRequest({ path: '/callback', port })
+    expect(relay.statusCode).toBe(200)
+    expect(relay.body).toContain('location.replace')
+
+    // The relay page redirects back with the token in the query string.
+    await sendRequest({ path: '/callback?access_token=tok&state=xyz', port })
+
+    const result = await resultPromise
+    expect(result).toEqual({
+      callbackUrl: `http://127.0.0.1:${port}/callback?access_token=tok&state=xyz`,
+      redirectUri: `http://127.0.0.1:${port}/callback`,
+    })
+  })
+
+  it('ignores unrelated paths such as the favicon probe', async () => {
+    const resultPromise = authorizeOauth2({ authorizationUrl: baseAuthorizationUrl })
+    await waitForBrowserToOpen()
+
+    const { port } = parseOpenedRedirectUri()
+
+    const favicon = await sendRequest({ path: '/favicon.ico', port })
+    expect(favicon.statusCode).toBe(404)
+
+    // The flow is still pending and resolves only on the real callback.
+    await sendRequest({ path: '/callback?code=auth_code&state=xyz', port })
+    await resultPromise
+  })
+
+  it('returns an error when no callback arrives before the timeout', async () => {
+    vi.useFakeTimers()
+
+    const resultPromise = authorizeOauth2({ authorizationUrl: baseAuthorizationUrl })
+    await vi.dynamicImportSettled()
+
+    expect(openExternalMock).toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(3 * 60 * 1000)
+
+    await expect(resultPromise).resolves.toEqual({ error: 'OAuth2 authorization timed out' })
+  })
+
+  it('returns an error when the authorization URL is invalid', async () => {
+    const result = await authorizeOauth2({ authorizationUrl: 'not a url' })
+
+    expect(result).toHaveProperty('error')
+    expect(openExternalMock).not.toHaveBeenCalled()
+  })
+})

--- a/projects/scalar-app/entrypoints/electron/main/actions/authorize-oauth2.ts
+++ b/projects/scalar-app/entrypoints/electron/main/actions/authorize-oauth2.ts
@@ -1,0 +1,179 @@
+import http from 'node:http'
+
+import { shell } from 'electron/common'
+import { BrowserWindow } from 'electron/main'
+import { getPort } from 'get-port-please'
+
+/** Loopback interface for the OAuth2 redirect, per RFC 8252 section 7.3. */
+const CALLBACK_HOST = '127.0.0.1'
+const CALLBACK_PATH = '/callback'
+const CALLBACK_TIMEOUT_MS = 3 * 60 * 1000
+
+type AuthorizeOAuth2Params = {
+  /** The fully built authorization URL, without a `redirect_uri` parameter. */
+  authorizationUrl: string
+}
+
+type AuthorizeOAuth2Result =
+  | {
+      /** The full callback URL the provider redirected to, including query params. */
+      callbackUrl: string
+      /** The exact `redirect_uri` used, so the renderer can match it in the token exchange. */
+      redirectUri: string
+    }
+  | { error: string }
+
+/**
+ * Minimal page served once the provider redirects back. Doubles as a fragment
+ * relay: implicit flows return the token in the URL fragment, which browsers do
+ * not send to the server, so the page copies the fragment into a query-string
+ * redirect to the same path where the server can finally read it.
+ */
+const CALLBACK_PAGE = `<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>Scalar</title></head>
+  <body style="font-family: system-ui, sans-serif; padding: 2rem;">
+    <p id="message">Finishing authorization…</p>
+    <script>
+      var hash = window.location.hash.slice(1)
+      if (hash) {
+        window.location.replace('${CALLBACK_PATH}?' + hash)
+      } else {
+        document.getElementById('message').textContent = 'You can close this window now.'
+      }
+    </script>
+  </body>
+</html>`
+
+/**
+ * Starts the loopback server, resolving only after the `listening` event so the
+ * browser redirect cannot race ahead of the server being ready.
+ */
+const listenForCallback = (server: http.Server, port: number): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off('listening', onListening)
+      reject(error)
+    }
+    const onListening = () => {
+      server.off('error', onError)
+      resolve()
+    }
+
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen({ host: CALLBACK_HOST, port })
+  })
+
+/**
+ * Waits for the loopback server to stop accepting connections. `server.close()`
+ * is asynchronous, so callers await this before treating the flow as cleaned up.
+ */
+const closeCallbackServer = (server: http.Server): Promise<void> =>
+  new Promise((resolve) => {
+    if (!server.listening) {
+      resolve()
+      return
+    }
+
+    server.close(() => resolve())
+  })
+
+/** Returns true once a callback carries an authorization code, token, or error. */
+const hasCallbackParams = (params: URLSearchParams): boolean =>
+  params.has('code') || params.has('access_token') || params.has('error')
+
+/** Refocuses the app window after the user returns from the external browser. */
+const focusAppWindow = (): void => {
+  const [mainWindow] = BrowserWindow.getAllWindows()
+  if (!mainWindow) {
+    return
+  }
+  if (mainWindow.isMinimized()) {
+    mainWindow.restore()
+  }
+  mainWindow.focus()
+}
+
+/**
+ * Runs an interactive OAuth2 authorization for the desktop app.
+ *
+ * The renderer builds the authorization URL (including PKCE and state) but leaves
+ * out the `redirect_uri`, because only the main process knows the ephemeral
+ * loopback port. We append the `redirect_uri`, open the system browser (the
+ * external user-agent recommended by RFC 8252), and resolve once the provider
+ * redirects back to the loopback server.
+ */
+export const authorizeOauth2 = async ({ authorizationUrl }: AuthorizeOAuth2Params): Promise<AuthorizeOAuth2Result> => {
+  let port: number
+  let authUrl: URL
+  let redirectUri: string
+
+  try {
+    port = await getPort({ host: CALLBACK_HOST })
+    redirectUri = `http://${CALLBACK_HOST}:${port}${CALLBACK_PATH}`
+    authUrl = new URL(authorizationUrl)
+    authUrl.searchParams.set('redirect_uri', redirectUri)
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : 'Failed to prepare the OAuth2 redirect' }
+  }
+
+  const server = http.createServer()
+
+  try {
+    await listenForCallback(server, port)
+
+    const result = await new Promise<AuthorizeOAuth2Result>((resolve) => {
+      let isFinished = false
+
+      const finish = (value: AuthorizeOAuth2Result): void => {
+        if (isFinished) {
+          return
+        }
+        isFinished = true
+        clearTimeout(timeout)
+        resolve(value)
+      }
+
+      const timeout = setTimeout(() => {
+        finish({ error: 'OAuth2 authorization timed out' })
+      }, CALLBACK_TIMEOUT_MS)
+
+      server.on('request', (request, response) => {
+        const requestUrl = new URL(request.url ?? '/', `http://${CALLBACK_HOST}:${port}`)
+
+        // Ignore unrelated requests (for example the browser's favicon probe).
+        if (requestUrl.pathname !== CALLBACK_PATH) {
+          response.writeHead(404, { Connection: 'close' })
+          response.end()
+          return
+        }
+
+        response.writeHead(200, { 'Content-Type': 'text/html', Connection: 'close' })
+        response.end(CALLBACK_PAGE)
+
+        // No params yet means an implicit fragment response: the relay page will
+        // redirect back with the params in the query string, so keep waiting.
+        if (!hasCallbackParams(requestUrl.searchParams)) {
+          return
+        }
+
+        finish({ callbackUrl: requestUrl.toString(), redirectUri })
+      })
+
+      // Arm the handler before opening the browser so a fast redirect cannot
+      // arrive before the server is ready to process it.
+      void shell.openExternal(authUrl.toString(), { activate: true })
+    })
+
+    if ('callbackUrl' in result) {
+      focusAppWindow()
+    }
+
+    return result
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : 'Failed to authorize the OAuth2 flow' }
+  } finally {
+    await closeCallbackServer(server)
+  }
+}

--- a/projects/scalar-app/entrypoints/electron/main/actions/authorize-oauth2.ts
+++ b/projects/scalar-app/entrypoints/electron/main/actions/authorize-oauth2.ts
@@ -76,6 +76,11 @@ const closeCallbackServer = (server: http.Server): Promise<void> =>
       return
     }
 
+    // Force-close lingering keep-alive sockets. The browser keeps idle
+    // connections open, and `server.close()` waits for every socket to end, so
+    // without this the callback (and therefore the token exchange) can stall for
+    // minutes until those idle connections time out.
+    server.closeAllConnections()
     server.close(() => resolve())
   })
 

--- a/projects/scalar-app/entrypoints/electron/main/index.ts
+++ b/projects/scalar-app/entrypoints/electron/main/index.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 
+import { authorizeOauth2 } from '@electron/main/actions/authorize-oauth2'
 import { getExchangeToken } from '@electron/main/actions/get-exchange-token'
 import { electronApp, is, optimizer } from '@electron-toolkit/utils'
 import todesktop from '@todesktop/runtime'
@@ -98,6 +99,7 @@ app.whenReady().then(() => {
   onIpcEvent('openFilePicker', handlePickFile)
   onIpcEvent('readFile', handleReadFile)
   onIpcEvent('getExchangeToken', getExchangeToken)
+  onIpcEvent('authorizeOauth2', authorizeOauth2)
 
   // customFetch is registered with ipcMain.handle directly (not onIpcEvent) so
   // the handler receives event.sender — the WebContents needed to stream SSE

--- a/projects/scalar-app/entrypoints/electron/preload/index.ts
+++ b/projects/scalar-app/entrypoints/electron/preload/index.ts
@@ -17,6 +17,7 @@ try {
     },
     readFile: (filePath: string) => ipcRenderer.invoke('readFile', filePath),
     getExchangeToken: (flow: 'login' | 'register') => ipcRenderer.invoke('getExchangeToken', flow),
+    authorizeOauth2: (params) => ipcRenderer.invoke('authorizeOauth2', params),
     getPathForFile: (file: File) => webUtils.getPathForFile(file),
     customFetch: (request) => ipcRenderer.invoke('customFetch', request),
     customFetchStream: ({ streamId, callbacks }) => {

--- a/projects/scalar-app/entrypoints/electron/renderer/src/app-state.ts
+++ b/projects/scalar-app/entrypoints/electron/renderer/src/app-state.ts
@@ -12,6 +12,22 @@ export const appState = await createAppState({
   layout: 'desktop',
   options: {
     customFetch,
-    oauth2RedirectUri: '',
+    /**
+     * Loopback redirect, per RFC 8252 section 7.3. The main process owns the
+     * ephemeral port, so the value shown here is the port-agnostic origin users
+     * register with their OAuth2 provider.
+     */
+    oauth2RedirectUri: 'http://127.0.0.1',
+    /**
+     * Desktop interactive OAuth2 cannot use browser-popup polling (the renderer
+     * runs on `file://`). Instead, run authorization through the system browser
+     * and capture the redirect on a loopback server in the main process.
+     */
+    captureOAuth2Callback: async ({ authorizationUrl }) => {
+      const result = await window.api.authorizeOauth2({ authorizationUrl })
+      return 'callbackUrl' in result
+        ? [null, { callbackUrl: result.callbackUrl, redirectUri: result.redirectUri }]
+        : [new Error(result.error), null]
+    },
   },
 })

--- a/projects/scalar-app/entrypoints/electron/shims.d.ts
+++ b/projects/scalar-app/entrypoints/electron/shims.d.ts
@@ -35,6 +35,15 @@ declare global {
         accessToken: string
         refreshToken: string
       } | null>
+      /**
+       * Run an interactive OAuth2 authorization for the API being tested.
+       * Opens the system browser and captures the redirect on a loopback server.
+       * The main process owns the `redirect_uri` (an ephemeral loopback port) and
+       * reports it back so the renderer can match it in the token exchange.
+       */
+      authorizeOauth2: (params: {
+        authorizationUrl: string
+      }) => Promise<{ callbackUrl: string; redirectUri: string } | { error: string }>
       /** Get the file system path for a File object */
       getPathForFile: (file: File) => string
       /** Execute a fetch request via undici in the main process (bypasses CORS/Chromium) */

--- a/projects/scalar-app/src/features/app/helpers/create-api-client-app.ts
+++ b/projects/scalar-app/src/features/app/helpers/create-api-client-app.ts
@@ -7,7 +7,7 @@ import { ROUTES } from '@/features/app/helpers/routes'
  * Runtime behaviour overrides shared between the api client app and createAppState.
  * Derived from the canonical ApiClientOptions to guarantee structural compatibility.
  */
-export type ApiClientAppOptions = Pick<ApiClientOptions, 'customFetch' | 'oauth2RedirectUri'>
+export type ApiClientAppOptions = Pick<ApiClientOptions, 'customFetch' | 'oauth2RedirectUri' | 'captureOAuth2Callback'>
 
 /**
  * Creates the appropriate router with the appropriate routes based on the layout

--- a/projects/scalar-app/src/features/collection/components/Authentication.test.ts
+++ b/projects/scalar-app/src/features/collection/components/Authentication.test.ts
@@ -195,6 +195,17 @@ describe('document collection', () => {
     })
   })
 
+  it('forwards captureOAuth2Callback from route options into the AuthSelector options', () => {
+    const captureOAuth2Callback = vi.fn()
+    const { wrapper } = mountWithProps({
+      collectionType: 'document',
+      options: { captureOAuth2Callback, oauth2RedirectUri: 'http://127.0.0.1' },
+    })
+
+    const authSelector = wrapper.findComponent(AuthSelector)
+    expect(authSelector.props('options')?.captureOAuth2Callback).toBe(captureOAuth2Callback)
+  })
+
   it('forwards customFetch even without an oauth2RedirectUri', () => {
     const customFetch = vi.fn()
     const { wrapper } = mountWithProps({

--- a/projects/scalar-app/src/features/collection/components/Authentication.vue
+++ b/projects/scalar-app/src/features/collection/components/Authentication.vue
@@ -156,13 +156,18 @@ const server = computed(() => {
  */
 const authOptions = computed<OAuth2Options | undefined>(() => {
   const routeOptions = toValue(options)
-  if (!routeOptions?.oauth2RedirectUri && !routeOptions?.customFetch) {
+  if (
+    !routeOptions?.oauth2RedirectUri &&
+    !routeOptions?.customFetch &&
+    !routeOptions?.captureOAuth2Callback
+  ) {
     return undefined
   }
 
   return {
     oauth2RedirectUri: routeOptions.oauth2RedirectUri,
     customFetch: routeOptions.customFetch,
+    captureOAuth2Callback: routeOptions.captureOAuth2Callback,
   }
 })
 


### PR DESCRIPTION
Interactive OAuth2 (auth code + implicit) never actually worked in the desktop app. 🫨 

The renderer runs on `file://`, so the popup-polling that grabs the redirect can't read it, and providers reject `file://` redirect URIs. 

#8661 and #8933 added the config plumbing but it was only ever wired to an empty string.

This makes it work, reusing the loopback trick we already use for dashboard login.

- `@scalar/api-client` gains an optional `captureOAuth2Callback`. When it's set, we open the system browser and let the host catch the redirect instead of polling a popup. Web is unchanged.
- On desktop that host is a `127.0.0.1` loopback server (ephemeral port via `get-port-please`, per RFC 8252), with a tiny relay page so implicit flows work too. PKCE and state stay in the renderer.

Register `http://127.0.0.1` with your provider. `clientCredentials` / `password` / refresh are untouched.

Related issues: 

* #5233
* #5232
* #6412