### PR TITLE
fix(scalar-app): route URL imports through the desktop IPC fetch

### DIFF
--- a/.changeset/desktop-url-import-csp.md
+++ b/.changeset/desktop-url-import-csp.md
@@ -1,0 +1,5 @@
+---
+'scalar-app': patch
+---
+
+Fix importing OpenAPI documents from a URL in the desktop app. The temporary draft store used during import now reuses the IPC-backed fetch, so URL imports no longer get blocked by the Content Security Policy.

--- a/projects/scalar-app/src/App.vue
+++ b/projects/scalar-app/src/App.vue
@@ -276,6 +276,7 @@ const registry = reactive({
     :activeWorkspace="app.workspace.activeWorkspace.value"
     :darkMode="app.isDarkMode.value"
     :defaultProxyUrl="app.defaultProxyUrl.value"
+    :fetch="app.options?.customFetch"
     :fileLoader="fileLoader"
     :isOnlyOneWorkspace="filteredWorkspaces.length <= 1"
     :workspaceGroups

--- a/projects/scalar-app/src/features/command-palette/TheCommandPalette.vue
+++ b/projects/scalar-app/src/features/command-palette/TheCommandPalette.vue
@@ -254,6 +254,13 @@ const paletteProps = computed(() => {
     base.activeDocumentName = activeDocumentName.value
   }
 
+  // The import command fetches documents from a URL into a temporary draft
+  // store. On desktop that store needs the IPC-backed fetch, otherwise the
+  // renderer's global fetch is blocked by the Content Security Policy.
+  if (id === 'import-from-openapi-swagger-postman-curl') {
+    base.fetch = app.options?.customFetch
+  }
+
   return base
 })
 

--- a/projects/scalar-app/src/features/command-palette/components/CommandPaletteImport.test.ts
+++ b/projects/scalar-app/src/features/command-palette/components/CommandPaletteImport.test.ts
@@ -1,7 +1,7 @@
 import type { LoaderPlugin } from '@scalar/json-magic/bundle'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -835,6 +835,37 @@ describe('CommandPaletteImport', () => {
       'ui:open:command-palette',
       expect.objectContaining({ action: 'import-postman-collection' }),
     )
+  })
+
+  it('uses the provided fetch when importing from a URL', async () => {
+    const workspaceStore = createWorkspaceStore()
+    const eventBus = createWorkspaceEventBus()
+
+    // On desktop this stands in for the IPC-backed fetch. The temporary draft
+    // store has to use it, otherwise the renderer's global fetch is blocked by
+    // the Content Security Policy and the import fails.
+    const fetch = vi.fn(
+      async (_input: string | URL | globalThis.Request, _init?: RequestInit) =>
+        new Response(JSON.stringify({ openapi: '3.1.0', info: { title: 'Test API', version: '1.0.0' }, paths: {} }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    )
+
+    const wrapper = mount(CommandPaletteImport, {
+      props: { workspaceStore, eventBus, fetch },
+    })
+
+    const input = wrapper.findComponent({ name: 'CommandActionInput' })
+    await input.vm.$emit('update:modelValue', 'https://example.com/openapi.json')
+    await nextTick()
+
+    const form = wrapper.findComponent({ name: 'CommandActionForm' })
+    await form.vm.$emit('submit')
+    await flushPromises()
+
+    expect(fetch).toHaveBeenCalled()
+    expect(fetch.mock.calls[0]?.[0]?.toString()).toContain('https://example.com/openapi.json')
   })
 
   it('handles empty input after having content', async () => {

--- a/projects/scalar-app/src/features/command-palette/components/CommandPaletteImport.vue
+++ b/projects/scalar-app/src/features/command-palette/components/CommandPaletteImport.vue
@@ -45,13 +45,22 @@ import { isUrl } from '@/helpers/is-url'
 
 import WatchModeToggle from './WatchModeToggle.vue'
 
-const { workspaceStore, eventBus, fileLoader } = defineProps<{
+const { workspaceStore, eventBus, fileLoader, fetch } = defineProps<{
   /** The workspace store for adding documents */
   workspaceStore: WorkspaceStore
   /** Event bus for emitting operation creation events */
   eventBus: WorkspaceEventBus
   /** Loader plugin for file import */
   fileLoader?: LoaderPlugin
+  /**
+   * Custom fetch used to retrieve documents from a URL. On desktop this is the
+   * IPC-backed fetch; the temporary draft store needs it too, otherwise the
+   * renderer's global fetch is blocked by the Content Security Policy.
+   */
+  fetch?: (
+    input: string | URL | globalThis.Request,
+    init?: RequestInit,
+  ) => Promise<Response>
 }>()
 
 const emit = defineEmits<{
@@ -148,6 +157,7 @@ const handleImport = async (
   // This is to get the title of the document so we can generate a unique slug for store
   const draftStore = createWorkspaceStore({
     fileLoader,
+    fetch,
     meta: {
       /** Ensure we use the active proxy to fetch documents */
       'x-scalar-active-proxy':

--- a/projects/scalar-app/src/features/import-listener/ImportListener.vue
+++ b/projects/scalar-app/src/features/import-listener/ImportListener.vue
@@ -28,6 +28,7 @@ const {
   workspaceStore,
   darkMode,
   fileLoader,
+  fetch,
   isOnlyOneWorkspace,
   defaultProxyUrl,
 } = defineProps<{
@@ -51,6 +52,15 @@ const {
    * This is used to load files from the disk (for examole when you are on an Electron app).
    */
   fileLoader?: LoaderPlugin
+  /**
+   * Custom fetch used to retrieve documents from a URL. On desktop this is the
+   * IPC-backed fetch; the temporary draft store needs it too, otherwise the
+   * renderer's global fetch is blocked by the Content Security Policy.
+   */
+  fetch?: (
+    input: string | URL | globalThis.Request,
+    init?: RequestInit,
+  ) => Promise<Response>
   /** List of workspace groups */
   workspaceGroups: WorkspaceGroup[]
   /** The active workspace */
@@ -109,6 +119,7 @@ const directImport = async (
   // This is to get the title of the document so we can generate a unique slug for store
   const draftStore = createWorkspaceStore({
     fileLoader,
+    fetch,
     meta: {
       'x-scalar-active-proxy': defaultProxyUrl,
     },
@@ -221,6 +232,7 @@ onMounted(() => {
   <ImportModal
     :activeWorkspace="activeWorkspace"
     :defaultProxyUrl="defaultProxyUrl"
+    :fetch="fetch"
     :fileLoader="fileLoader"
     :importEventData="data"
     :isLoading="workspaceStore === null"

--- a/projects/scalar-app/src/features/import-listener/components/ImportModal.vue
+++ b/projects/scalar-app/src/features/import-listener/components/ImportModal.vue
@@ -30,6 +30,7 @@ const {
   modalState,
   isLoading = false,
   fileLoader,
+  fetch,
   defaultProxyUrl,
 } = defineProps<{
   /** The event data for the import */
@@ -40,6 +41,15 @@ const {
   isLoading?: boolean
   /** The file loader */
   fileLoader?: LoaderPlugin
+  /**
+   * Custom fetch used to retrieve documents from a URL. On desktop this is the
+   * IPC-backed fetch; the workspace store needs it too, otherwise the
+   * renderer's global fetch is blocked by the Content Security Policy.
+   */
+  fetch?: (
+    input: string | URL | globalThis.Request,
+    init?: RequestInit,
+  ) => Promise<Response>
   /** List of workspace groups */
   workspaceGroups: WorkspaceGroup[]
   /** The active workspace */
@@ -69,6 +79,7 @@ const watchMode = ref(false)
 // Create the workspace store with the file loader in order to import files
 const workspaceStore = createWorkspaceStore({
   fileLoader,
+  fetch,
   meta: {
     'x-scalar-active-proxy': defaultProxyUrl,
   },


### PR DESCRIPTION
Importing an OpenAPI document by URL in the desktop app failed with a CSP error. The import flow spins up a temporary draft store to read the document title, but that store wasn't given the IPC-backed `customFetch`. So it fell back to the renderer's global fetch, which the desktop CSP blocks for any non-Scalar host.

Pass `customFetch` into the draft stores in `CommandPaletteImport`, `ImportListener`, and `ImportModal`. On web `customFetch` is undefined, so behavior there is unchanged.

Added a regression test that a URL import uses the provided fetch.

<img width="826" height="310" alt="image" src="https://github.com/user-attachments/assets/a2ba105b-2705-4112-bef9-367a525ae3e5" />
