### PR TITLE
fix(workspace-store): upgrade AsyncAPI documents on ingestion

### DIFF
--- a/.changeset/asyncapi-upgrade-on-ingestion.md
+++ b/.changeset/asyncapi-upgrade-on-ingestion.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Run the AsyncAPI upgrader when ingesting AsyncAPI documents so 1.x/2.x specs are converted to the 3.x shape the renderer expects. Previously a 2.x document (operations nested under channels as `publish`/`subscribe`) was passed through unchanged, leaving `operations` empty and dropping every channel from the navigation — the document rendered blank. The original version is preserved on `x-original-aas-version`.

--- a/documentation/asyncapi.md
+++ b/documentation/asyncapi.md
@@ -10,6 +10,12 @@ Scalar.createApiReference('#app', {
 })
 ```
 
+## Supported versions
+
+The reference renders against the AsyncAPI **3.x** shape. Older documents are upgraded automatically on load, so you can pass a **1.x** or **2.x** document and it renders the same way — there's nothing extra to configure.
+
+Behind the scenes the document is converted to the latest 3.x version (for example `subscribe`/`publish` operations nested under a channel are lifted into the top-level `operations` map, and a server `url` is split into `host` and `pathname`). The original version is preserved on the document as `x-original-aas-version` for reference.
+
 ## What renders
 
 The reference renders the AsyncAPI document grouped by channel. For each channel you'll see:

--- a/packages/asyncapi-upgrader/src/upgrade.ts
+++ b/packages/asyncapi-upgrader/src/upgrade.ts
@@ -7,9 +7,10 @@ import { upgradeFromThreeToThreeOne } from './3.0-to-3.1'
 /**
  * Upgrade an AsyncAPI document to the latest version.
  *
- * Each step only bumps the `asyncapi` version string for now — no structural
- * transformations are applied yet. The version-specific upgraders exist so the
- * real migration logic can be filled in later, mirroring `@scalar/openapi-upgrader`.
+ * Each step migrates the document through one major version, applying the structural
+ * transformations that version requires (for example 2.x → 3.0 lifts channel
+ * `publish`/`subscribe` operations into the top-level `operations` map and splits a
+ * server `url` into `host`/`pathname`), mirroring `@scalar/openapi-upgrader`.
  */
 export function upgrade(value: UnknownObject): UnknownObject {
   // AsyncAPI 1.x -> 2.6

--- a/packages/workspace-store/package.json
+++ b/packages/workspace-store/package.json
@@ -151,6 +151,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
+    "@scalar/asyncapi-upgrader": "workspace:*",
     "@scalar/helpers": "workspace:*",
     "@scalar/json-magic": "workspace:*",
     "@scalar/openapi-upgrader": "workspace:*",

--- a/packages/workspace-store/src/client.test.ts
+++ b/packages/workspace-store/src/client.test.ts
@@ -4009,7 +4009,8 @@ describe('create-workspace-store', () => {
       // the type discriminator. Asserting both presence and absence guards
       // against that regression.
       expect(document).toMatchObject({
-        asyncapi: '3.0.0',
+        // The upgrader canonicalizes 3.0 documents to 3.1 (the original is kept below).
+        asyncapi: '3.1.0',
         info: { title: 'Streetlights API', version: '1.0.0' },
         'x-original-aas-version': '3.0.0',
         'x-scalar-original-document-hash': expect.any(String),
@@ -4028,7 +4029,7 @@ describe('create-workspace-store', () => {
       })
     })
 
-    it('does not upgrade the asyncapi version during ingestion', async () => {
+    it('upgrades the asyncapi version during ingestion and records the original', async () => {
       const store = createWorkspaceStore()
 
       await store.addDocument({
@@ -4042,8 +4043,48 @@ describe('create-workspace-store', () => {
       const legacy = store.workspace.documents['legacy']
       expect(isAsyncApiDocument(legacy)).toBe(true)
       assert(isAsyncApiDocument(legacy))
-      expect(legacy.asyncapi).toBe('2.6.0')
+      // The AsyncAPI upgrader lifts the document to the latest 3.x shape the renderer expects.
+      expect(legacy.asyncapi).toBe('3.1.0')
+      // The original version is preserved for reference.
       expect(legacy['x-original-aas-version']).toBe('2.6.0')
+    })
+
+    it('lifts 2.x channel operations into top-level operations so they render', async () => {
+      const store = createWorkspaceStore()
+
+      await store.addDocument({
+        document: {
+          asyncapi: '2.4.0',
+          info: { title: 'Cube Local API', version: 'dev' },
+          servers: { local: { url: 'localhost:1883', protocol: 'mqtt' } },
+          channels: {
+            'devices/{deviceID}/logs': {
+              parameters: { deviceID: { description: 'The ID of the device', schema: { type: 'string' } } },
+              subscribe: {
+                operationId: 'subscribeLogMessage',
+                message: { $ref: '#/components/messages/subscribeLogMessage' },
+              },
+            },
+          },
+          components: {
+            messages: {
+              subscribeLogMessage: { name: 'LogMessage', payload: { type: 'object' } },
+            },
+          },
+        },
+        name: 'cube',
+      })
+
+      const cube = store.workspace.documents['cube']
+      assert(isAsyncApiDocument(cube))
+
+      // 2.x `subscribe` is lifted to a top-level operation, and the server `url` becomes `host`.
+      expect(cube.operations?.['subscribeLogMessage']).toBeDefined()
+      expect(cube.servers?.['local']).toMatchObject({ host: 'localhost:1883', protocol: 'mqtt' })
+
+      // The channel now surfaces in the navigation tree instead of being dropped.
+      const channelTitles = JSON.stringify(cube['x-scalar-navigation'])
+      expect(channelTitles).toContain('devices/{deviceID}/logs')
     })
 
     it('bundles external channel references when the document is not preprocessed', async () => {
@@ -4119,7 +4160,7 @@ describe('create-workspace-store', () => {
       await store.addDocument({ url: 'https://example.com/asyncapi.json', name: 'remote' })
 
       expect(store.workspace.documents['remote']).toMatchObject({
-        asyncapi: '3.0.0',
+        asyncapi: '3.1.0',
         'x-scalar-original-source-url': 'https://example.com/asyncapi.json',
       })
     })

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -1,3 +1,4 @@
+import { upgrade as upgradeAsyncApi } from '@scalar/asyncapi-upgrader'
 import { getValueAtPath } from '@scalar/helpers/object/get-value-at-path'
 import { isObject } from '@scalar/helpers/object/is-object'
 import { preventPollution } from '@scalar/helpers/object/prevent-pollution'
@@ -1000,12 +1001,23 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
 
     // AsyncAPI ingestion: skip the OpenAPI-specific upgrade and validation pipeline.
     // The OpenAPI `coerce` step would otherwise inject an empty `openapi: ''` field
-    // and break the type discriminator.
+    // and break the type discriminator. We still run the AsyncAPI-specific upgrader so
+    // 1.x/2.x documents are converted to the 3.x shape the renderer and traversal expect
+    // (e.g. lifting channel `publish`/`subscribe` into top-level `operations`).
     if (isAsyncApiDocument(clonedRawInputDocument)) {
+      // Capture the original version before the upgrader bumps `asyncapi` to the latest.
+      const originalAasVersion = clonedRawInputDocument.asyncapi
+      // The upgrader is typed against the loose `UnknownObject` shape; the result is a valid
+      // 3.x AsyncAPI document, so cast it back so the spread below still satisfies `AsyncApiDocument`.
+      const upgradedAsyncApiDocument = withMeasurementSync(
+        'upgrade',
+        () => upgradeAsyncApi(deepClone(clonedRawInputDocument)) as AsyncApiDocument,
+      )
+
       const asyncApiDocument = createMagicProxy({
-        ...clonedRawInputDocument,
+        ...upgradedAsyncApiDocument,
         ...meta,
-        'x-original-aas-version': clonedRawInputDocument.asyncapi,
+        'x-original-aas-version': originalAasVersion,
         'x-scalar-original-document-hash': input.documentHash,
         'x-scalar-original-source-url': input.documentSource,
       }) satisfies AsyncApiDocument

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2649,6 +2649,9 @@ importers:
 
   packages/workspace-store:
     dependencies:
+      '@scalar/asyncapi-upgrader':
+        specifier: workspace:*
+        version: link:../asyncapi-upgrader
       '@scalar/helpers':
         specifier: workspace:*
         version: link:../helpers


### PR DESCRIPTION
## Problem

AsyncAPI documents below 3.x render as a blank page. A user reported an AsyncAPI **2.4.0** (MQTT) spec that showed no channels and no operations — only the Models section.

The cause is that AsyncAPI ingestion in `workspace-store` deliberately skips the upgrade pipeline (to avoid the OpenAPI `coerce` step injecting `openapi: ''` and breaking the type discriminator), but never runs an AsyncAPI-specific upgrade in its place. So a 1.x/2.x document reaches the 3.x traversal unchanged.

In 3.x, operations live in a top-level `operations` map; in 2.x they're nested under each channel as `publish`/`subscribe`. With `operations` empty, every channel bucket ends up with zero operations, `createChannelEntry` drops the channel, and nothing renders.

`@scalar/asyncapi-upgrader` already does the full structural 1.x → 2.x → 3.x conversion — it just was never wired into the store.

## Solution

Wire `@scalar/asyncapi-upgrader` into the AsyncAPI ingestion branch in `client.ts`, mirroring how the OpenAPI path calls its own upgrader. The original document version is captured **before** the upgrade (which bumps `asyncapi` to the latest) and preserved on `x-original-aas-version`.

- `packages/workspace-store/src/client.ts` — run the AsyncAPI upgrader during ingestion; keep the pre-upgrade version on `x-original-aas-version`.
- `packages/workspace-store/package.json` + `pnpm-lock.yaml` — add the `@scalar/asyncapi-upgrader` workspace dependency.
- `packages/workspace-store/src/client.test.ts` — flip the old "does not upgrade" test, update two `3.0.0`→`3.1.0` expectations, and add a regression test for the reported 2.4.0 MQTT shape (asserts `subscribe` lifts to a top-level operation, `server.url`→`host`, and the channel appears in navigation).
- `documentation/asyncapi.md` — add a "Supported versions" section noting that 1.x/2.x documents are upgraded to 3.x automatically on load.
- `packages/asyncapi-upgrader/src/upgrade.ts` — correct the stale doc comment that claimed no structural transforms are applied.

Verified manually in the api-reference dev playground with the reported spec: channel, parameter, operation, and message now render correctly.

**Alternatives considered:** adding a 2.x adapter directly in the traversal layer — rejected because the dedicated upgrader already exists and the OpenAPI path establishes the "upgrade on ingestion" pattern this should match.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [x] I updated the documentation.

---

### Follow-ups (not blocking)

- The upgrader keeps the 2.x parameter `schema` field on channel parameters (not a 3.x Parameter field). `adaptAsyncApiParameters` ignores it, so it's harmless — optional cleanup in the upgrader's 2.6→3.0 step.
- The doc comment in `asyncapi-upgrader/src/upgrade.ts` ("only bumps the version string… no structural transformations") is stale; the 2.6→3.0 step does the full structural transform.

### Note

One pre-existing test failure in `client.test.ts` (`'resolves external references in file-loaded documents'`) is unrelated to this change — a Windows path-separator issue, confirmed failing identically on `main`.

