### PR TITLE
ci: retry changeset version on transient GitHub API failures

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -24,6 +24,9 @@
     "packages/oas-utils/src/migrations/*/types.generated.ts"
   ],
   "ignoreDependencies": [
+    // Invoked as `changeset version` via the retry wrapper in the release:version
+    // script, so knip cannot see the binary in the package.json script string
+    "@changesets/cli",
     // Used by GitHub Actions Cloudflare Pages deployment (`cloudflare/wrangler-action`)
     "wrangler",
     // Used by `.changeset/config.json`

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "types:build": "turbo types:build",
     "renovate:validate": "pnpm dlx --package renovate renovate-config-validator",
     "script": "pnpm --filter @scalar-internal/build-scripts start",
-    "release:version": "changeset version && pnpm --filter @scalar/release-notes... build && pnpm --filter @scalar/release-notes start --all && pnpm format"
+    "release:version": "./tooling/scripts/bash/retry.sh changeset version && pnpm --filter @scalar/release-notes... build && pnpm --filter @scalar/release-notes start --all && pnpm format"
   },
   "remarkConfig": {
     "plugins": [

--- a/tooling/scripts/bash/retry.sh
+++ b/tooling/scripts/bash/retry.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Retry a command a few times before giving up.
+#
+# We use this to wrap `changeset version` during releases. Its changelog
+# generator calls the GitHub GraphQL API for every changeset, and a single
+# dropped connection (ERR_STREAM_PREMATURE_CLOSE) fails the whole release even
+# though changesets cleanly escapes without touching any files. Retrying turns
+# those transient blips into a non-event.
+#
+# Usage: retry.sh <command> [args...]
+
+set -e
+
+ATTEMPTS=3
+DELAY=10
+
+i=1
+while [ "$i" -le "$ATTEMPTS" ]; do
+  if "$@"; then
+    exit 0
+  fi
+
+  if [ "$i" -lt "$ATTEMPTS" ]; then
+    echo "Attempt $i/$ATTEMPTS failed: $*. Retrying in ${DELAY}s…" >&2
+    sleep "$DELAY"
+  fi
+
+  i=$((i + 1))
+done
+
+echo "All $ATTEMPTS attempts failed: $*" >&2
+exit 1


### PR DESCRIPTION
The release on `main` failed because `changeset version` hit a dropped connection to the GitHub GraphQL API (`ERR_STREAM_PREMATURE_CLOSE`) while generating changelog entries. Changesets escaped cleanly without touching any files, so nothing half-released — but the whole release job failed over one network blip.

This wraps `changeset version` in a small retry helper (3 attempts, 10s apart). The changelog generator is the only network-dependent step, so a transient blip now just retries instead of failing the release.