### PR TITLE
fix(ci): make required-jobs aggregators actually block on failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -267,13 +267,6 @@ jobs:
       docker_changed: ${{ needs.check-changes.outputs.docker_changed }}
 
   required-jobs-main:
-    # `always()` is required so this aggregator runs even when a needed job
-    # fails. Without it the implicit success() gate skips this job whenever a need
-    # fails, the exit-1 guard never executes, and a skipped required check is
-    # treated as passing by branch protection. With `always()` the job runs and
-    # the guard flips it to failure on any failed/skipped/cancelled need — which
-    # also keeps the release gate (needs.required-jobs-main.result == 'success')
-    # honest.
     if: ${{ always() }}
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -267,6 +267,14 @@ jobs:
       docker_changed: ${{ needs.check-changes.outputs.docker_changed }}
 
   required-jobs-main:
+    # `always()` is required so this aggregator runs even when a needed job
+    # fails. Without it the implicit success() gate skips this job whenever a need
+    # fails, the exit-1 guard never executes, and a skipped required check is
+    # treated as passing by branch protection. With `always()` the job runs and
+    # the guard flips it to failure on any failed/skipped/cancelled need — which
+    # also keeps the release gate (needs.required-jobs-main.result == 'success')
+    # honest.
+    if: ${{ always() }}
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 1
     permissions: {}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -618,7 +618,13 @@ jobs:
           echo "Only Markdown files changed."
 
   required-jobs-pull-requests:
-    if: github.event_name == 'pull_request'
+    # `always()` is required so this aggregator runs even when a needed job
+    # fails. Without it the implicit success() gate skips this job the moment any
+    # need fails, the exit-1 guard below never executes, and branch protection
+    # treats the skipped required check as passing — letting a broken build (or
+    # any failed required job) merge. With `always()` the job always runs and the
+    # guard flips it to failure whenever a need failed, was skipped, or cancelled.
+    if: ${{ always() && github.event_name == 'pull_request' }}
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 1
     permissions: {}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -618,12 +618,6 @@ jobs:
           echo "Only Markdown files changed."
 
   required-jobs-pull-requests:
-    # `always()` is required so this aggregator runs even when a needed job
-    # fails. Without it the implicit success() gate skips this job the moment any
-    # need fails, the exit-1 guard below never executes, and branch protection
-    # treats the skipped required check as passing — letting a broken build (or
-    # any failed required job) merge. With `always()` the job always runs and the
-    # guard flips it to failure whenever a need failed, was skipped, or cancelled.
     if: ${{ always() && github.event_name == 'pull_request' }}
     runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 1


### PR DESCRIPTION
`required-jobs-pull-requests` (and `required-jobs-main`) list `build` and friends in `needs`, but the job-level `if` has no `always()`. So when a need fails, the implicit `success()` gate skips the whole aggregator before its `exit 1` guard can run — and a skipped required check is treated as passing by branch protection. A PR with a failing build could merge.

Adding `always()` at the job level makes the aggregator always run, so the existing guard flips it to failure whenever a need failed, was skipped, or cancelled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge/release gating behavior for branch protection; the fix is narrow but incorrect conditions could block or allow merges incorrectly.
> 
> **Overview**
> **Fixes branch-protection bypass when upstream CI jobs fail.** The `required-jobs-main` and `required-jobs-pull-requests` aggregator jobs now use job-level `always()` so they still run when a listed `needs` job fails, is skipped, or is cancelled.
> 
> Previously, GitHub’s default `success()` gate on `needs` could skip the whole aggregator before its existing `exit 1` step ran. A skipped required check can count as green, so failing builds/tests might not block merge or release gating.
> 
> On PRs, the job `if` is now `always() && github.event_name == 'pull_request'` instead of only checking the event name. On `main`, `required-jobs-main` gets `if: always()` with no other behavior change to the failure guard step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eabeec7b0ce91754ee6556a755f84a619a198b09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->