### PR TITLE
feat(galaxy): add AsyncAPI document as a source on galaxy.scalar.com

### DIFF
--- a/.changeset/galaxy-asyncapi-source.md
+++ b/.changeset/galaxy-asyncapi-source.md
@@ -1,0 +1,5 @@
+---
+'galaxy-scalar-com': patch
+---
+
+Add the Scalar Galaxy AsyncAPI document as a source on galaxy.scalar.com, so the event-driven side of the Galaxy is rendered alongside the OpenAPI reference.

--- a/projects/galaxy-scalar-com/src/galaxy-scalar-com.test.ts
+++ b/projects/galaxy-scalar-com/src/galaxy-scalar-com.test.ts
@@ -101,5 +101,14 @@ describe('galaxy-scalar-com', () => {
       expect(mockApp.get).toHaveBeenCalledWith('/', expect.any(Function))
       expect(mockApp.get).toHaveBeenCalledWith('/scalar.js', expect.any(Function))
     })
+
+    it('includes the AsyncAPI document as a source', () => {
+      configureApiReference(mockApp as Hono)
+
+      const config = vi.mocked(Scalar).mock.calls[0]?.[0] as { sources?: Array<{ title?: string; content?: unknown }> }
+      const asyncApiSource = config.sources?.find((source) => source.title === 'Scalar Galaxy Events (AsyncAPI)')
+
+      expect(asyncApiSource?.content).toMatchObject({ asyncapi: expect.any(String) })
+    })
   })
 })

--- a/projects/galaxy-scalar-com/src/galaxy-scalar-com.ts
+++ b/projects/galaxy-scalar-com/src/galaxy-scalar-com.ts
@@ -1,6 +1,9 @@
 // The OpenAPI document is bundled at build time as a JSON import. Reading it
 // from the filesystem is not possible inside the Cloudflare Pages worker.
 import galaxyDocument from '@scalar/galaxy/3.1.json'
+// The AsyncAPI companion document is bundled the same way and rendered as an
+// extra source so the event-driven side of the Galaxy is documented too.
+import galaxyAsyncApiDocument from '@scalar/galaxy/asyncapi/3.0.json'
 import { PETSTORE_URL_2_0, PETSTORE_URL_3_1 } from '@scalar/helpers/url/oas-document-fixtures'
 import { Scalar } from '@scalar/hono-api-reference'
 import { createMockServer } from '@scalar/mock-server'
@@ -70,6 +73,10 @@ export const configureApiReference = (app: Hono): void => {
         {
           title: 'Scalar Galaxy',
           url: '/openapi.yaml',
+        },
+        {
+          title: 'Scalar Galaxy Events (AsyncAPI)',
+          content: galaxyAsyncApiDocument,
         },
         {
           title: 'Petstore (OpenAPI 3.1)',


### PR DESCRIPTION
Galaxy already ships an AsyncAPI companion document (`@scalar/galaxy/asyncapi`), but galaxy.scalar.com only rendered the OpenAPI side. This adds it as a second source so the event-driven Galaxy shows up next to the REST reference.

It is bundled as a JSON import (same as the OpenAPI doc) and passed as `content`, so no extra route or fetch is needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-site reference configuration only; no runtime API, auth, or data-path changes.
> 
> **Overview**
> **galaxy.scalar.com** now exposes the bundled **Scalar Galaxy Events (AsyncAPI)** spec as an additional Scalar `sources` entry, inline via `content` from `@scalar/galaxy/asyncapi/3.0.json`, so event-driven APIs appear in the same reference UI as the existing OpenAPI and Petstore sources.
> 
> A unit test asserts that `configureApiReference` passes that source with an `asyncapi` document, and a **galaxy-scalar-com** patch changeset records the release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8eeb8cb76f06d98316bc63b3462a4c9d1c02692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->