### PR TITLE
test(api-reference): fix flaky document-loading e2e test

### DIFF
--- a/packages/api-reference/test/standalone/document-loading.e2e.ts
+++ b/packages/api-reference/test/standalone/document-loading.e2e.ts
@@ -10,13 +10,12 @@ test.describe
 
       await page.goto(url)
 
-      // Need a small delay to ensure the content is loaded
-      await page.waitForTimeout(1000)
-
-      expect(page.getByRole('heading', { name: 'Scalar Galaxy' })).toBeVisible()
+      // Wait for the remote document to finish loading before navigating away,
+      // otherwise the deep link below races the in-flight fetch.
+      await expect(page.getByRole('heading', { name: 'Scalar Galaxy' })).toBeVisible()
 
       await page.goto(`${url}#tag/planets`)
-      expect(page.getByRole('heading', { name: 'Planets', level: 2 })).toBeVisible()
+      await expect(page.getByRole('heading', { name: 'Planets', level: 2 })).toBeVisible()
 
       shutdown()
     })
@@ -26,10 +25,7 @@ test.describe
 
       await page.goto(url)
 
-      // Need a small delay to ensure the content is loaded
-      await page.waitForTimeout(1000)
-
-      expect(page.getByRole('heading', { name: 'Hello World' })).toBeVisible()
+      await expect(page.getByRole('heading', { name: 'Hello World' })).toBeVisible()
 
       shutdown()
     })
@@ -39,10 +35,7 @@ test.describe
 
       await page.goto(url)
 
-      // Need a small delay to ensure the content is loaded
-      await page.waitForTimeout(1000)
-
-      expect(page.getByRole('heading', { name: 'Hello World' })).toBeVisible()
+      await expect(page.getByRole('heading', { name: 'Hello World' })).toBeVisible()
 
       shutdown()
     })

--- a/packages/api-reference/test/utils/serve-example.ts
+++ b/packages/api-reference/test/utils/serve-example.ts
@@ -96,7 +96,9 @@ export function serveExample(givenConfiguration?: Partial<HtmlRenderingConfigura
 
 export function serveHTMLExample(
   htmlPath: string,
-  port = 3745,
+  // Bind a random free port by default. A fixed port races when the previous
+  // server has not finished closing yet, surfacing as flaky `EADDRINUSE` errors.
+  port = 0,
 ): Promise<{
   url: string
   shutdown: () => void


### PR DESCRIPTION
The standalone `document-loading` e2e suite [fails intermittently](https://github.com/scalar/scalar/actions/runs/28435745888/job/84261570684). Two independent causes:

**1. Assertions were not awaited (the race).** `expect(...).toBeVisible()` was called without `await`, so the web-first assertion floated instead of gating the test. The js-object case then navigated to the `#tag/planets` deep link immediately after a fixed `waitForTimeout(1000)`, while the remote galaxy document was still loading — racing the navigation against the in-flight fetch. Now the assertions are awaited (they retry up to the timeout), and the brittle fixed delay is gone.

**2. Fixed port → `EADDRINUSE`.** `serveHTMLExample` bound port `3745`. `shutdown()` (`server.close()`) is async and unawaited, so the next serial test could collide with the not-yet-released port. It now binds a random free port; the helper already returns the actual assigned port, so URLs stay correct.

Verified by running the suite with `--repeat-each=5` (15/15 passing). Before the fixes, repeated runs reproduced both the heading-not-visible failure and `EADDRINUSE`.

Test-only change, so no changeset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to e2e helpers and assertions; no production or runtime behavior is modified.
> 
> **Overview**
> Stabilizes the standalone **document-loading** e2e suite by fixing two flake sources.
> 
> **Assertions:** Replaces fixed `waitForTimeout(1000)` with **`await expect(...).toBeVisible()`** so Playwright retries until content is ready. The js-object case now waits for the remote **Scalar Galaxy** heading before navigating to `#tag/planets`, avoiding a race with the in-flight fetch.
> 
> **Test server:** **`serveHTMLExample`** now defaults to port **`0`** (OS-assigned) instead of **`3745`**, so serial tests do not hit **`EADDRINUSE`** when the previous `shutdown()` has not released the port yet. Returned URLs still use the assigned port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e94c4339ac1b4b63cabffec737a256ded57e5f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->