### PR TITLE
fix(api-reference): flatten AsyncAPI tag padding and list channels

### DIFF
--- a/.changeset/asyncapi-tag-channels.md
+++ b/.changeset/asyncapi-tag-channels.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': minor
+'@scalar/types': patch
+---
+
+Render AsyncAPI tags without the extra horizontal indentation on nested channels, and replace the empty "Operations" card in an AsyncAPI tag header with a "Channels" card that lists the channels in the tag.

--- a/.changeset/asyncapi-tag-channels.md
+++ b/.changeset/asyncapi-tag-channels.md
@@ -1,5 +1,5 @@
 ---
-'@scalar/api-reference': minor
+'@scalar/api-reference': patch
 '@scalar/types': patch
 ---
 

--- a/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/AsyncApiTraversedEntry.vue
@@ -100,6 +100,7 @@ const getModelSchema = (name: string) => getAsyncApiModelSchema(document, name)
       :expandedItems="expandedItems"
       :isCollapsed="!expandedItems[entry.id]"
       :layout="options.layout"
+      :level="level"
       :options="options" />
 
     <Tag

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
@@ -44,6 +44,7 @@ const {
   eventBus,
   options,
   expandedItems = {},
+  level = 0,
 } = defineProps<{
   channel: TraversedAsyncApiChannel
   document: AsyncApiDocument
@@ -53,6 +54,12 @@ const {
   options?: Partial<ParameterListOptions>
   /** Map of navigation item id to expanded state, shared with the sidebar. */
   expandedItems?: Record<string, boolean>
+  /**
+   * Nesting depth in the navigation tree. A channel nested inside a tag
+   * (`level !== 0`) inherits the tag's horizontal padding, so it skips its own
+   * `SectionContainer` padding to avoid doubling the indentation.
+   */
+  level?: number
 }>()
 
 const headerId = useId()
@@ -160,6 +167,7 @@ const operations = computed(() =>
   <SectionContainer
     v-else
     :aria-labelledby="headerId"
+    :omit="level !== 0"
     role="region">
     <Section
       :id="channel.id"

--- a/packages/api-reference/src/components/Content/AsyncApi/ChannelsList.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/ChannelsList.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import {
+  ScalarCard,
+  ScalarCardHeader,
+  ScalarCardSection,
+} from '@scalar/components/card'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import type {
+  TraversedAsyncApiChannel,
+  TraversedTag,
+} from '@scalar/workspace-store/schemas/navigation'
+import { computed } from 'vue'
+
+import ScreenReader from '@/components/ScreenReader.vue'
+import { useLocalization } from '@/features/localization'
+
+const { tag } = defineProps<{
+  tag: TraversedTag
+  eventBus: WorkspaceEventBus | null
+}>()
+const { translate } = useLocalization()
+
+/**
+ * Channels grouped under this tag. The OpenAPI `OperationsList` only knows about
+ * `operation`/`webhook` children, so AsyncAPI tags need their own list that links
+ * straight to each channel section.
+ */
+const channels = computed(
+  () =>
+    tag.children?.filter(
+      (child): child is TraversedAsyncApiChannel =>
+        child.type === 'asyncapi-channel',
+    ) ?? [],
+)
+</script>
+
+<template>
+  <ScalarCard
+    v-if="channels.length"
+    class="channels-card">
+    <ScalarCardHeader muted>
+      <ScreenReader>{{ tag.title }}</ScreenReader>
+      {{ translate('navigation.channels') }}
+    </ScalarCardHeader>
+    <ScalarCardSection class="custom-scroll max-h-[60vh]">
+      <ul
+        :aria-label="translate('navigation.channels')"
+        class="channels">
+        <li
+          v-for="channel in channels"
+          :key="channel.id"
+          class="contents">
+          <a
+            class="channel"
+            @click.prevent="
+              () => eventBus?.emit('scroll-to:nav-item', { id: channel.id })
+            ">
+            {{ channel.title || channel.channelAddress }}
+          </a>
+        </li>
+      </ul>
+    </ScalarCardSection>
+  </ScalarCard>
+</template>
+
+<style scoped>
+.channels-card {
+  position: sticky;
+  top: calc(var(--refs-viewport-offset) + 24px);
+  font-size: var(--scalar-font-size-3);
+}
+.channels {
+  overflow: auto;
+  background: var(--scalar-background-2);
+  padding: 10px 12px;
+  width: 100%;
+}
+.channel {
+  display: flex;
+  white-space: nowrap;
+  cursor: pointer;
+  text-decoration: none;
+  color: var(--scalar-color-1);
+  line-height: 1.55;
+  font-family: var(--scalar-font-code);
+  font-size: var(--scalar-small);
+}
+.channel:hover,
+.channel:focus-visible {
+  text-decoration: underline;
+}
+</style>

--- a/packages/api-reference/src/components/Content/Tags/components/TagSection.vue
+++ b/packages/api-reference/src/components/Content/Tags/components/TagSection.vue
@@ -2,8 +2,10 @@
 import { ScalarMarkdown } from '@scalar/components/markdown'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { TraversedTag } from '@scalar/workspace-store/schemas/navigation'
+import { computed } from 'vue'
 
 import { Anchor } from '@/components/Anchor'
+import ChannelsList from '@/components/Content/AsyncApi/ChannelsList.vue'
 import { OperationsList } from '@/components/OperationsList'
 import ScreenReader from '@/components/ScreenReader.vue'
 import {
@@ -24,6 +26,15 @@ const { tag, headerId, isCollapsed } = defineProps<{
   eventBus: WorkspaceEventBus | null
 }>()
 const { translate } = useLocalization()
+
+/**
+ * AsyncAPI tags carry `asyncapi-channel` children instead of `operation`/`webhook`,
+ * so they get a dedicated channel list rather than the (empty) operations card.
+ */
+const hasChannels = computed(
+  () =>
+    tag.children?.some((child) => child.type === 'asyncapi-channel') ?? false,
+)
 </script>
 <template>
   <Section
@@ -57,7 +68,12 @@ const { translate } = useLocalization()
             withImages />
         </SectionColumn>
         <SectionColumn>
+          <ChannelsList
+            v-if="hasChannels"
+            :eventBus="eventBus"
+            :tag="tag" />
           <OperationsList
+            v-else
             :eventBus="eventBus"
             :tag="tag" />
         </SectionColumn>

--- a/packages/api-reference/src/features/localization/locales/ar.ts
+++ b/packages/api-reference/src/features/localization/locales/ar.ts
@@ -63,6 +63,7 @@ export const ar = {
     mainContent: 'وثائق واجهة برمجة التطبيقات لـ {name}',
     collapsed: 'مطوي',
     webhooks: 'خطافات الويب',
+    channels: 'القنوات',
   },
   server: {
     label: 'الخادم',

--- a/packages/api-reference/src/features/localization/locales/de.ts
+++ b/packages/api-reference/src/features/localization/locales/de.ts
@@ -64,6 +64,7 @@ export const de = {
     mainContent: 'API-Dokumentation für {name}',
     collapsed: 'Eingeklappt',
     webhooks: 'Webhooks',
+    channels: 'Kanäle',
   },
   server: {
     label: 'Server',

--- a/packages/api-reference/src/features/localization/locales/en.ts
+++ b/packages/api-reference/src/features/localization/locales/en.ts
@@ -63,6 +63,7 @@ export const en = {
     mainContent: 'API documentation for {name}',
     collapsed: 'Collapsed',
     webhooks: 'Webhooks',
+    channels: 'Channels',
   },
   server: {
     label: 'Server',

--- a/packages/api-reference/src/features/localization/locales/es.ts
+++ b/packages/api-reference/src/features/localization/locales/es.ts
@@ -63,6 +63,7 @@ export const es = {
     mainContent: 'Documentación de la API de {name}',
     collapsed: 'Contraído',
     webhooks: 'Webhooks',
+    channels: 'Canales',
   },
   server: {
     label: 'Servidor',

--- a/packages/api-reference/src/features/localization/locales/fr.ts
+++ b/packages/api-reference/src/features/localization/locales/fr.ts
@@ -64,6 +64,7 @@ export const fr = {
     mainContent: 'Documentation de l’API pour {name}',
     collapsed: 'Réduit',
     webhooks: 'Webhooks',
+    channels: 'Canaux',
   },
   server: {
     label: 'Serveur',

--- a/packages/api-reference/src/features/localization/locales/ru.ts
+++ b/packages/api-reference/src/features/localization/locales/ru.ts
@@ -64,6 +64,7 @@ export const ru = {
     mainContent: 'Документация API для {name}',
     collapsed: 'Свернуто',
     webhooks: 'Вебхуки',
+    channels: 'Каналы',
   },
   server: {
     label: 'Сервер',

--- a/packages/api-reference/src/features/localization/locales/zh-cn.ts
+++ b/packages/api-reference/src/features/localization/locales/zh-cn.ts
@@ -63,6 +63,7 @@ export const zhCn = {
     mainContent: '{name} 的 API 文档',
     collapsed: '已折叠',
     webhooks: 'Webhooks',
+    channels: '频道',
   },
   server: {
     label: '服务器',

--- a/packages/api-reference/test/utils/sources.ts
+++ b/packages/api-reference/test/utils/sources.ts
@@ -30,12 +30,12 @@ export const sources = [
   {
     title: 'Scalar Galaxy Events (AsyncAPI)',
     slug: 'scalar-galaxy-events',
-    url: 'https://registry.scalar.com/@scalar/schemas/asyncapi?format=json',
+    url: 'https://registry.scalar.com/@scalar/apis/asyncapi/latest?format=json',
   },
   {
     title: 'Scalar Galaxy Events (AsyncAPI, Classic Layout)',
     slug: 'scalar-galaxy-events-classic',
-    url: 'https://registry.scalar.com/@scalar/schemas/asyncapi?format=json',
+    url: 'https://registry.scalar.com/@scalar/apis/asyncapi/latest?format=json',
     layout: 'classic',
   },
   {

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -412,6 +412,7 @@ export type ApiReferenceTranslations = {
     openMenu: string
     operations: string
     webhooks: string
+    channels: string
     endpoints: string
     showAllEndpoints: string
     sidebarFor: string


### PR DESCRIPTION
AsyncAPI tags had two rough edges in the tag header view.

**Padding:** a channel nested under a tag rendered its own `SectionContainer` on top of the tag's, so operations inside a tag were indented an extra 60px. The channel now skips its own container when nested (`level !== 0`), the same way OpenAPI operations already do.

**Empty card:** the tag header reused the OpenAPI `OperationsList`, which only knows about `operation`/`webhook` children — so AsyncAPI tags got an empty "Operations" card. It now shows a "Channels" card listing the channels in the tag.

**Before**

😱

<img width="1440" height="900" alt="615131977-f952ae26-bc42-4788-9bd2-d37ce8ccbd0e" src="https://github.com/user-attachments/assets/2bc23920-d7bb-494b-b31e-5013c9fad8c3" />

**After**

😊

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/3ea2d4cd-2944-4ecd-be66-21de85610c3e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only AsyncAPI tag rendering and localization; OpenAPI tag sections still use OperationsList when there are no channel children.
> 
> **Overview**
> Fixes **AsyncAPI tag headers** so nested channels align with OpenAPI operations and the sidebar card is useful instead of empty.
> 
> **Indentation:** Nested channels now receive navigation **`level`** from `AsyncApiTraversedEntry`. In modern layout, `Channel` sets **`SectionContainer` `:omit="level !== 0"`** so tag-wrapped channels do not stack a second container padding (same idea as OpenAPI `TraversedEntry`).
> 
> **Tag sidebar card:** Shared **`TagSection`** detects **`asyncapi-channel`** children and shows new **`ChannelsList`** (sticky card, scroll-to via `scroll-to:nav-item`) instead of **`OperationsList`**, which only lists operations/webhooks.
> 
> **i18n/types:** Adds **`navigation.channels`** to `ApiReferenceTranslations` and all shipped locales. AsyncAPI test fixtures point at the updated registry URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5fc2ee5ad1a63ccc8893bd9aa3f06d165aa0982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->