### PR TITLE
fix(api-reference): hide filters in classic layout for AsyncAPI documents

### DIFF
--- a/.changeset/hide-asyncapi-filters-classic.md
+++ b/.changeset/hide-asyncapi-filters-classic.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Hide the protocol and server filters in the classic layout for AsyncAPI documents

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -1540,11 +1540,6 @@ const showMCPButton = computed(() => {
                   :modelValue="activeSlug"
                   :options="documentOptionList"
                   @update:modelValue="changeSelectedDocument" />
-                <AsyncApiSidebarFilters
-                  is="div"
-                  v-model:protocol="selectedProtocol"
-                  v-model:server="selectedServer"
-                  :document="activeAsyncApiDocument" />
               </div>
               <SearchButton
                 v-if="!mergedConfig.hideSearch"


### PR DESCRIPTION
The classic layout showed the AsyncAPI protocol/server filters (`All protocols` / `All servers`) in the header. This removes them there, they stay in the modern sidebar.

<img width="360" height="360" alt="image" src="https://github.com/user-attachments/assets/8a8702de-7097-4eb9-9cb7-d46fed638e77" />

<img width="704" height="401" alt="Screenshot 2026-06-30 at 13 43 51" src="https://github.com/user-attachments/assets/fcb4fe0c-d980-4b4e-bf0b-e0dd8f393d57" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in one layout branch; filtering behavior for modern layout is unchanged.
> 
> **Overview**
> **Classic layout** no longer renders **AsyncAPI protocol/server filters** (`AsyncApiSidebarFilters`) in `ClassicHeader` next to the document selector—only the multi-document picker remains in that header slot when applicable.
> 
> Filter state and sidebar narrowing are unchanged for **modern** layout, where the same filters still appear in the sidebar `#before` section. A patch **changeset** documents the `@scalar/api-reference` release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e88addb1222f3f8b36a6acdae10d0d04d20743b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->