### PR TITLE
docs(agents): update AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ This file helps AI coding agents (Cursor, Claude Code, GitHub Copilot, etc.) wor
 Scalar is a Vue 3 + TypeScript monorepo for API documentation and testing.
 
 - It produces `@scalar/api-reference` (renders OpenAPI docs) and `@scalar/api-client` (API testing client)
-- It includes 40+ supporting packages and 18 framework integrations (Express, Fastify, Hono, NestJS, Next.js, Nuxt, etc.)
-- It uses pnpm workspaces, Turbo for build orchestration, Vite for Vue packages, and esbuild for pure TypeScript packages
+- It includes 40+ supporting packages and 15 framework integrations (Express, Fastify, Hono, NestJS, Next.js, Nuxt, etc.)
+- It uses pnpm workspaces, Turbo for build orchestration, Vite for Vue packages, and `tsc` for pure TypeScript packages
 
 - **Frontend**: Vue 3, Composition API, TypeScript
 - **Styling**: Tailwind CSS
@@ -81,9 +81,9 @@ pnpm script wait -p 5051 5052
 
 ### Workspace Layout
 
-- `packages/` - Core libraries (45 packages). Each is an npm package under `@scalar/`.
+- `packages/` - Core libraries (42 packages). Each is an npm package under `@scalar/`.
 - `integrations/` - Framework-specific wrappers (Express, Fastify, Next.js, Nuxt, etc.)
-- `projects/` - Deployable apps (`scalar-app`, `proxy-scalar-com`, `client-scalar-com`)
+- `projects/` - Deployable apps (`scalar-app`, `proxy-scalar-com`, `galaxy-scalar-com`)
 - `examples/` - Usage examples for various frameworks
 - `tooling/` - Internal build scripts and changelog generator
 
@@ -504,4 +504,4 @@ Use consistent terminology:
 ## Further Reading
 
 - [CONTRIBUTING.md](./CONTRIBUTING.md) - PR requirements, changesets, auto-generated files
-- [.cursor/rules/cloud-agents-starter-skill.mdc](./.cursor/rules/cloud-agents-starter-skill.mdc) - Runbook for CI parity and test servers
+- [.agents/skills/cloud-agents-starter/SKILL.md](./.agents/skills/cloud-agents-starter/SKILL.md) - Runbook for CI parity and test servers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ pnpm script wait -p 5051 5052
 
 - `packages/` - Core libraries (42 packages). Each is an npm package under `@scalar/`.
 - `integrations/` - Framework-specific wrappers (Express, Fastify, Next.js, Nuxt, etc.)
-- `projects/` - Deployable apps (`scalar-app`, `proxy-scalar-com`, `galaxy-scalar-com`)
+- `projects/` - Deployable apps (`scalar-app`, `proxy-scalar-com`, `galaxy-scalar-com`). `scalar-app` builds both the Electron desktop app and client.scalar.com.
 - `examples/` - Usage examples for various frameworks
 - `tooling/` - Internal build scripts and changelog generator
 


### PR DESCRIPTION
Audited AGENTS.md against the current repo. Fixed four things that had drifted:

- Pure-TS packages build with `tsc`, not esbuild (the doc already said this elsewhere)
- `projects/` lists `galaxy-scalar-com`; `client-scalar-com` is gone
- Integration count is 15, package count is 42
- Cloud-agents runbook moved to `.agents/skills/cloud-agents-starter/SKILL.md`

Everything else in the file checked out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to the agent guide; no runtime, build, or application code changes.
> 
> **Overview**
> **AGENTS.md** is brought back in sync with the monorepo after drift in a few overview bullets and one Further Reading link.
> 
> The **Project Overview** and **Workspace Layout** sections now say **15** framework integrations and **42** core packages (down from 18 and 45), describe pure TypeScript builds as **`tsc`** instead of esbuild, and list **`galaxy-scalar-com`** under `projects/` while dropping **`client-scalar-com`**. **`scalar-app`** is called out as covering both the Electron desktop app and client.scalar.com.
> 
> The cloud-agents runbook pointer moves from **`.cursor/rules/cloud-agents-starter-skill.mdc`** to **`.agents/skills/cloud-agents-starter/SKILL.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b97a6f7afe7a82b357af7b4b471ac215310c311c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->