### PR TITLE
fix(api-client): let the test client attach any auth scheme

### DIFF
--- a/.changeset/wise-auth-schemes-return.md
+++ b/.changeset/wise-auth-schemes-return.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Let the embedded API client (the "Test Request" modal) attach any defined security scheme, like the standalone client already does. Since #9592 the modal respected the operation's declared `security`, so operations that opt out with `security: []` (or a subset) offered no way to set a token while testing. The reference docs auth block still respects the declared security.

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.test.ts
@@ -187,6 +187,35 @@ describe('RequestBlock', () => {
     expect(auth.isVisible()).toBe(true)
   })
 
+  // The client (including the embedded modal) is a testing affordance, so it must let people
+  // attach any defined scheme even when an operation opts out with `security: []`.
+  // See https://github.com/scalar/scalar/issues/9632
+  it('lets the modal attach any defined scheme', () => {
+    const wrapper = mount(RequestBlock, {
+      props: {
+        ...defaultProps,
+        layout: 'modal',
+        securityRequirements: [],
+        securitySchemes: {
+          a: {
+            type: 'apiKey',
+            'x-scalar-secret-token': '',
+            name: 'X-API-Key',
+            in: 'header',
+          },
+        },
+      },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    })
+
+    const auth = wrapper.findComponent(AuthSelector)
+    expect(auth.props('createAnySecurityScheme')).toBe(true)
+  })
+
   it('hides request body for methods without a body', () => {
     const wrapper = mount(RequestBlock, {
       props: { ...defaultProps, method: 'get' },

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
@@ -550,11 +550,17 @@ const updateOperationExtension = (
       :id="filterIds.All"
       class="request-section-content custom-scroll relative flex flex-1 flex-col"
       :role="selectedFilter === 'All' ? 'tabpanel' : 'none'">
-      <!-- Auth Selector -->
+      <!--
+        Auth Selector
+
+        The API client is a testing affordance, so let people attach any defined scheme even when
+        an operation opts out with `security: []`. Only the reference docs auth block respects the
+        declared security. See https://github.com/scalar/scalar/issues/9632
+      -->
       <AuthSelector
         v-show="isSectionVisible('Auth') && !isAuthHidden"
         :id="filterIds.Auth"
-        :createAnySecurityScheme="layout !== 'modal'"
+        createAnySecurityScheme
         :defaultOpen="isAuthDefaultOpen"
         :environment
         :eventBus


### PR DESCRIPTION
The Auth Type dropdown in the embedded "Test Request" client was empty, so you could not set a Bearer token. The standalone client was fine.

What I found:

- It is not a Safari z-index bug. The dropdown is genuinely empty, the caret just flips open over nothing.
- Since #9592 the embedded modal respects the operation's declared `security`. Operations that opt out with `security: []` (like the galaxy `POST /user/signup`) or that declare no security therefore offer nothing.
- But the embedded client is a testing tool, exactly like the standalone client — which already lets you attach any defined scheme via `createAnySecurityScheme`.

The fix:

- Treat the embedded modal like the standalone client: it can attach any defined scheme, even when an operation opts out with `security: []`.
- The reference docs auth block is unchanged and still respects the declared security (#7400).

Tests:

- Added a failing test first: the modal-layout auth selector now gets `createAnySecurityScheme: true`.

## Ticket

Fixes #9632