### PR TITLE
revert(api-client): respect per-operation security in the auth dropdown

### DIFF
--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.test.ts
@@ -3,6 +3,7 @@ import { assert, describe, expect, it } from 'vitest'
 
 import {
   type SecuritySchemeGroup,
+  type SecuritySchemeOption,
   formatComplexScheme,
   formatScheme,
   getSecuritySchemeOptions,
@@ -420,8 +421,7 @@ describe('security-scheme', () => {
 
     it('should filter out required schemes from available options', () => {
       const security: NonNullable<OpenApiDocument['security']> = [{ apiKey: [] }]
-      // Offering schemes the operation does not declare only happens when arbitrary auth is allowed
-      const result = getSecuritySchemeOptions(security, securitySchemes, [], true)
+      const result = getSecuritySchemeOptions(security, securitySchemes, [])
 
       const groups = result as SecuritySchemeGroup[]
       const availableOptions = groups[1]!.options
@@ -464,8 +464,7 @@ describe('security-scheme', () => {
         undefinedScheme: undefined,
       } as unknown as NonNullable<ComponentsObject['securitySchemes']>
 
-      // Resolving every defined scheme into the available list only happens when arbitrary auth is allowed
-      const result = getSecuritySchemeOptions(security, securitySchemesWithUndefined, [], true)
+      const result = getSecuritySchemeOptions(security, securitySchemesWithUndefined, [])
 
       const groups = result as SecuritySchemeGroup[]
       const availableOptions = groups[1]!.options
@@ -650,55 +649,14 @@ describe('security-scheme', () => {
       expect(groups[2]!.options.length).toBeGreaterThan(0)
     })
 
-    it('returns no options for an empty security requirement when arbitrary auth is not allowed', () => {
-      // `security: []` removes the security declaration entirely, so nothing is selectable.
+    it('should return flat available list when canAddNewAuth is false and no required schemes', () => {
       const security: NonNullable<OpenApiDocument['security']> = []
       const result = getSecuritySchemeOptions(security, securitySchemes, [], false)
 
-      // Should return a flat SecuritySchemeOption[] (not grouped) with no entries
+      // Should return flat SecuritySchemeOption[] (not grouped)
       expect(Array.isArray(result)).toBe(true)
-      expect(result).toHaveLength(0)
-    })
-
-    /**
-     * Regression tests for https://github.com/scalar/scalar/issues/7400
-     *
-     * When arbitrary auth is not allowed (reference docs and the request modal), the operation's
-     * declared `security` is authoritative. Schemes that merely exist under
-     * `components.securitySchemes` must not be offered, otherwise users can pick auth a request
-     * does not accept.
-     */
-    describe('respects the declared operation security (issue #7400)', () => {
-      it('offers nothing when the operation opts out with security: []', () => {
-        const security: NonNullable<OpenApiDocument['security']> = []
-        const result = getSecuritySchemeOptions(security, securitySchemes, [], false)
-
-        expect(result).toHaveLength(0)
-      })
-
-      it('offers only the declared scheme and not the other defined ones', () => {
-        const security: NonNullable<OpenApiDocument['security']> = [{ apiKey: [] }]
-        const result = getSecuritySchemeOptions(security, securitySchemes, [], false)
-
-        const groups = result as SecuritySchemeGroup[]
-        const required = groups[0]!.options
-        const available = groups[1]!.options
-
-        // Only the declared scheme is selectable
-        expect(required.map((option) => option.label)).toStrictEqual(['apiKey'])
-        // Schemes the operation does not declare are not offered
-        expect(available).toHaveLength(0)
-      })
-
-      it('offers every declared alternative when the operation lists multiple', () => {
-        const security: NonNullable<OpenApiDocument['security']> = [{ apiKey: [] }, { httpBasic: [] }]
-        const result = getSecuritySchemeOptions(security, securitySchemes, [], false)
-
-        const groups = result as SecuritySchemeGroup[]
-        const required = groups[0]!.options
-
-        expect(required.map((option) => option.label)).toStrictEqual(['apiKey', 'httpBasic'])
-      })
+      expect(result.length).toBe(4)
+      expect((result[0] as SecuritySchemeOption).label).toBe('apiKey')
     })
 
     it('should handle when selected schemes do not exist in the available options but not duplicate them', () => {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.ts
@@ -118,26 +118,18 @@ export const getSecuritySchemeOptions = (
     },
   )
 
-  // Build available schemes (excluding schemes that are in the required list).
-  //
-  // We only offer schemes that are not declared by the operation when the user is
-  // allowed to attach arbitrary authentication (the standalone client). In the
-  // reference docs and the request modal, the operation's `security` is authoritative:
-  // per the OpenAPI spec, only the schemes a request lists may be used to authorize it,
-  // so a scheme that merely exists under `components.securitySchemes` must not be offered.
+  // Build available schemes (excluding schemes that are in the required list)
   const availableFormatted: SecuritySchemeOption[] = []
-  if (canAddNewAuth) {
-    for (const [name, schemeRef] of Object.entries(securitySchemes)) {
-      if (requiredSchemeNames.has(name)) {
-        continue
-      }
+  for (const [name, schemeRef] of Object.entries(securitySchemes)) {
+    if (requiredSchemeNames.has(name)) {
+      continue
+    }
 
-      const scheme = getResolvedRef(schemeRef)
-      if (scheme) {
-        const formatted = formatScheme({ name, value: { [name]: [] } })
-        availableFormatted.push(formatted)
-        existingIds.add(formatted.id)
-      }
+    const scheme = getResolvedRef(schemeRef)
+    if (scheme) {
+      const formatted = formatScheme({ name, value: { [name]: [] } })
+      availableFormatted.push(formatted)
+      existingIds.add(formatted.id)
     }
   }
 


### PR DESCRIPTION
Reverts scalar/scalar#9592

Closes #9632

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restores prior UX where users can pick auth schemes an operation did not declare in reference/request flows, which was intentionally tightened for spec correctness in #9592.
> 
> **Overview**
> Reverts the auth selector behavior that limited dropdown choices to schemes declared on the operation when arbitrary auth is disabled (reference docs / request modal).
> 
> **`getSecuritySchemeOptions`** again always fills **Available authentication** from every entry in `components.securitySchemes` (minus required names), instead of only doing that when `canAddNewAuth` is true. The OpenAPI-oriented comments and the `canAddNewAuth` gate around that loop are removed.
> 
> Tests are aligned with the old behavior: several cases no longer pass `canAddNewAuth: true` to get a full available list, the **#7400** regression block (empty `security`, single declared scheme, multiple alternatives) is deleted, and when `canAddNewAuth` is false with no required schemes the helper is expected to return a flat list of all component schemes—not zero options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 454255149157a908aa9324acb25f43d300d29fe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->